### PR TITLE
[E2E] Test Entity ID Agnosticism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ xcuserdata
 dev/src/dev/nocommit/
 *~
 **/cypress_sample_database.json
+**/cypress_sample_instance_data.json
 /frontend/src/cljs
 /frontend/src/cljs_release
 .shadow-cljs

--- a/e2e/snapshot-creators/default.cy.snap.js
+++ b/e2e/snapshot-creators/default.cy.snap.js
@@ -47,8 +47,14 @@ describe("snapshots", () => {
         );
       });
 
-      snapshot("default");
+      const instanceData = getDefaultInstanceData();
 
+      cy.writeFile(
+        "e2e/support/cypress_sample_instance_data.json",
+        instanceData,
+      );
+
+      snapshot("default");
       restore("blank");
     });
   });
@@ -274,3 +280,29 @@ describe("snapshots", () => {
     });
   });
 });
+
+function getDefaultInstanceData() {
+  const instanceData = {};
+
+  cy.request("/api/card").then(({ body: cards }) => {
+    instanceData.questions = cards;
+  });
+
+  cy.request("/api/dashboard").then(({ body: dashboards }) => {
+    instanceData.dashboards = dashboards;
+  });
+
+  cy.request("/api/user").then(({ body: { data: users } }) => {
+    instanceData.users = users;
+  });
+
+  cy.request("/api/database").then(({ body: { data: databases } }) => {
+    instanceData.databases = databases;
+  });
+
+  cy.request("/api/collection").then(({ body: collections }) => {
+    instanceData.collections = collections;
+  });
+
+  return instanceData;
+}

--- a/e2e/support/cypress_data.js
+++ b/e2e/support/cypress_data.js
@@ -20,6 +20,9 @@
 export const SAMPLE_DB_ID = 1;
 export const SAMPLE_DB_SCHEMA_ID = "1:PUBLIC";
 
+// these should be dynamically built when starting cypress
+export * from "e2e/support/cypress_sample_instance_data";
+
 // Use only for e2e helpers and custom commands. Never in e2e tests directly!
 export const SAMPLE_DB_TABLES = {
   // old tables
@@ -201,7 +204,3 @@ export const WEBMAIL_CONFIG = {
   WEB_PORT: 1080,
   SMTP_PORT: 1025,
 };
-
-export const ORDERS_QUESTION_ID = 6;
-export const ORDERS_COUNT_QUESTION_ID = 7;
-export const ORDERS_BY_YEAR_QUESTION_ID = 8;

--- a/e2e/support/cypress_data.js
+++ b/e2e/support/cypress_data.js
@@ -20,9 +20,6 @@
 export const SAMPLE_DB_ID = 1;
 export const SAMPLE_DB_SCHEMA_ID = "1:PUBLIC";
 
-// these should be dynamically built when starting cypress
-export * from "e2e/support/cypress_sample_instance_data";
-
 // Use only for e2e helpers and custom commands. Never in e2e tests directly!
 export const SAMPLE_DB_TABLES = {
   // old tables

--- a/e2e/support/cypress_data.js
+++ b/e2e/support/cypress_data.js
@@ -203,3 +203,5 @@ export const WEBMAIL_CONFIG = {
 };
 
 export const ORDERS_QUESTION_ID = 6;
+export const ORDERS_COUNT_QUESTION_ID = 7;
+export const ORDERS_BY_YEAR_QUESTION_ID = 8;

--- a/e2e/support/cypress_data.js
+++ b/e2e/support/cypress_data.js
@@ -201,3 +201,5 @@ export const WEBMAIL_CONFIG = {
   WEB_PORT: 1080,
   SMTP_PORT: 1025,
 };
+
+export const ORDERS_QUESTION_ID = 6;

--- a/e2e/support/cypress_sample_instance_data.js
+++ b/e2e/support/cypress_sample_instance_data.js
@@ -1,0 +1,26 @@
+/**
+ *  This JSON file gets recreated every time Cypress starts.
+ *  See: `e2e/snapshot-creators/default.cy.snap.js:19`
+ *
+ *  - It had to be added to `.gitignore`.
+ *  - It contains extracted metadata from the default instance state (like question and dashboard ids)
+ */
+
+import _ from "underscore";
+// eslint-disable-next-line import/no-unresolved
+
+import SAMPLE_INSTANCE_DATA from "./cypress_sample_instance_data.json";
+
+export const ORDERS_QUESTION_ID = _.findWhere_(SAMPLE_INSTANCE_DATA.questions, {
+  name: "Orders",
+}).id;
+
+export const ORDERS_COUNT_QUESTION_ID = _.findWhere_(
+  SAMPLE_INSTANCE_DATA.questions,
+  { name: "Orders, Count" },
+).id;
+
+export const ORDERS_BY_YEAR_QUESTION_ID = _.findWhere_(
+  SAMPLE_INSTANCE_DATA.questions,
+  { name: "Orders, Count, Grouped by Created At (year)" },
+).id;

--- a/e2e/support/cypress_sample_instance_data.js
+++ b/e2e/support/cypress_sample_instance_data.js
@@ -7,8 +7,8 @@
  */
 
 import _ from "underscore";
-// eslint-disable-next-line import/no-unresolved
 
+// eslint-disable-next-line import/no-unresolved
 import SAMPLE_INSTANCE_DATA from "./cypress_sample_instance_data.json";
 
 export const ORDERS_QUESTION_ID = _.findWhere(SAMPLE_INSTANCE_DATA.questions, {
@@ -23,4 +23,9 @@ export const ORDERS_COUNT_QUESTION_ID = _.findWhere(
 export const ORDERS_BY_YEAR_QUESTION_ID = _.findWhere(
   SAMPLE_INSTANCE_DATA.questions,
   { name: "Orders, Count, Grouped by Created At (year)" },
+).id;
+
+export const ADMIN_PERSONAL_COLLECTION_ID = _.findWhere(
+  SAMPLE_INSTANCE_DATA.collections,
+  { name: "Bobby Tables's Personal Collection" },
 ).id;

--- a/e2e/support/cypress_sample_instance_data.js
+++ b/e2e/support/cypress_sample_instance_data.js
@@ -11,16 +11,16 @@ import _ from "underscore";
 
 import SAMPLE_INSTANCE_DATA from "./cypress_sample_instance_data.json";
 
-export const ORDERS_QUESTION_ID = _.findWhere_(SAMPLE_INSTANCE_DATA.questions, {
+export const ORDERS_QUESTION_ID = _.findWhere(SAMPLE_INSTANCE_DATA.questions, {
   name: "Orders",
 }).id;
 
-export const ORDERS_COUNT_QUESTION_ID = _.findWhere_(
+export const ORDERS_COUNT_QUESTION_ID = _.findWhere(
   SAMPLE_INSTANCE_DATA.questions,
   { name: "Orders, Count" },
 ).id;
 
-export const ORDERS_BY_YEAR_QUESTION_ID = _.findWhere_(
+export const ORDERS_BY_YEAR_QUESTION_ID = _.findWhere(
   SAMPLE_INSTANCE_DATA.questions,
   { name: "Orders, Count, Grouped by Created At (year)" },
 ).id;

--- a/e2e/test/scenarios/admin/databases/default-sample-database.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/default-sample-database.cy.spec.js
@@ -1,8 +1,8 @@
 import { restore, popover, modal, describeEE } from "e2e/support/helpers";
 
-import { SAMPLE_DB_ID, ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 import { visitDatabase } from "./helpers/e2e-database-helpers";
 
 const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/admin/databases/default-sample-database.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/default-sample-database.cy.spec.js
@@ -114,7 +114,7 @@ describe("scenarios > admin > databases > sample database", () => {
     );
     cy.intercept("DELETE", `/api/database/${SAMPLE_DB_ID}`).as("delete");
     // model
-    cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, { dataset: true });
+    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { dataset: true });
     // Create a segment through API
     cy.request("POST", "/api/segment", {
       name: "Small orders",

--- a/e2e/test/scenarios/admin/databases/default-sample-database.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/default-sample-database.cy.spec.js
@@ -1,6 +1,6 @@
 import { restore, popover, modal, describeEE } from "e2e/support/helpers";
 
-import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 import { visitDatabase } from "./helpers/e2e-database-helpers";
@@ -114,7 +114,7 @@ describe("scenarios > admin > databases > sample database", () => {
     );
     cy.intercept("DELETE", `/api/database/${SAMPLE_DB_ID}`).as("delete");
     // model
-    cy.request("PUT", "/api/card/1", { dataset: true });
+    cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, { dataset: true });
     // Create a segment through API
     cy.request("POST", "/api/segment", {
       name: "Small orders",

--- a/e2e/test/scenarios/admin/datamodel/table.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/table.cy.spec.js
@@ -1,5 +1,9 @@
 import { restore, filter, visitQuestion } from "e2e/support/helpers";
-import { SAMPLE_DB_ID, SAMPLE_DB_SCHEMA_ID } from "e2e/support/cypress_data";
+import {
+  SAMPLE_DB_ID,
+  SAMPLE_DB_SCHEMA_ID,
+  ORDERS_QUESTION_ID,
+} from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -77,7 +81,7 @@ describe("scenarios > admin > databases > table", () => {
   describe.skip("turning table visibility off shouldn't prevent editing related question (metabase#15947)", () => {
     it("simple question (metabase#15947-1)", () => {
       turnTableVisibilityOff(ORDERS_ID);
-      visitQuestion(1);
+      visitQuestion(ORDERS_QUESTION_ID);
       filter();
     });
 

--- a/e2e/test/scenarios/admin/datamodel/table.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/table.cy.spec.js
@@ -1,10 +1,7 @@
 import { restore, filter, visitQuestion } from "e2e/support/helpers";
-import {
-  SAMPLE_DB_ID,
-  SAMPLE_DB_SCHEMA_ID,
-  ORDERS_QUESTION_ID,
-} from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, SAMPLE_DB_SCHEMA_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 

--- a/e2e/test/scenarios/admin/settings/localization.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/localization.cy.spec.js
@@ -4,7 +4,7 @@ import {
   visitQuestion,
 } from "e2e/support/helpers";
 
-import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -189,7 +189,7 @@ describe("scenarios > admin > localization", () => {
     cy.wait("@updateFormatting");
     cy.findByDisplayValue("HH:mm").should("be.checked");
 
-    visitQuestion(1);
+    visitQuestion(ORDERS_QUESTION_ID);
 
     // create a date filter and set it to the 'On' view to see a specific date
     cy.findByTextEnsureVisible("Created At").click();

--- a/e2e/test/scenarios/admin/settings/localization.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/localization.cy.spec.js
@@ -4,8 +4,9 @@ import {
   visitQuestion,
 } from "e2e/support/helpers";
 
-import { SAMPLE_DB_ID, ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 

--- a/e2e/test/scenarios/admin/settings/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/whitelabel.cy.spec.js
@@ -1,4 +1,5 @@
 import { describeEE, restore } from "e2e/support/helpers";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 
 function checkFavicon() {
   cy.request("/api/setting/application-favicon-url")
@@ -103,19 +104,19 @@ describeEE("formatting > whitelabel", () => {
 
   describe("loading message", () => {
     it("should update loading message", () => {
-      cy.visit("/question/1");
+      cy.visit("/question/" + ORDERS_QUESTION_ID);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Doing science...");
 
       const runningQueryMessage = "Running query...";
       changeLoadingMessage(runningQueryMessage);
-      cy.visit("/question/1");
+      cy.visit("/question/" + ORDERS_QUESTION_ID);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(runningQueryMessage);
 
       const loadingResultsMessage = "Loading results...";
       changeLoadingMessage(loadingResultsMessage);
-      cy.visit("/question/1");
+      cy.visit("/question/" + ORDERS_QUESTION_ID);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(loadingResultsMessage);
     });

--- a/e2e/test/scenarios/admin/settings/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/whitelabel.cy.spec.js
@@ -1,5 +1,5 @@
 import { describeEE, restore } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 function checkFavicon() {
   cy.request("/api/setting/application-favicon-url")

--- a/e2e/test/scenarios/auditing/approved-domains.cy.spec.js
+++ b/e2e/test/scenarios/auditing/approved-domains.cy.spec.js
@@ -7,6 +7,7 @@ import {
   visitQuestion,
   visitDashboard,
 } from "e2e/support/helpers";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 
 const allowedDomain = "metabase.test";
 const deniedDomain = "metabase.example";
@@ -27,7 +28,7 @@ describeEE(
     });
 
     it("should validate approved email domains for a question alert in the audit app", () => {
-      visitQuestion(1);
+      visitQuestion(ORDERS_QUESTION_ID);
       cy.icon("bell").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Set up an alert").click();

--- a/e2e/test/scenarios/auditing/approved-domains.cy.spec.js
+++ b/e2e/test/scenarios/auditing/approved-domains.cy.spec.js
@@ -7,7 +7,7 @@ import {
   visitQuestion,
   visitDashboard,
 } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const allowedDomain = "metabase.test";
 const deniedDomain = "metabase.example";

--- a/e2e/test/scenarios/auditing/auditing.cy.spec.js
+++ b/e2e/test/scenarios/auditing/auditing.cy.spec.js
@@ -1,5 +1,9 @@
 import { restore, describeEE, visitQuestion } from "e2e/support/helpers";
-import { USERS } from "e2e/support/cypress_data";
+import {
+  USERS,
+  ORDERS_BY_YEAR_QUESTION_ID,
+  ORDERS_COUNT_QUESTION_ID,
+} from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 const { normal } = USERS;
 const { PRODUCTS } = SAMPLE_DATABASE;
@@ -47,7 +51,7 @@ describeEE("audit > auditing", () => {
     });
 
     cy.log("Download a question");
-    visitQuestion(3);
+    visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
     cy.icon("download").click();
     cy.request("POST", "/api/card/1/query/json");
 
@@ -63,7 +67,7 @@ describeEE("audit > auditing", () => {
     cy.findByText("My personal collection").should("not.exist");
 
     cy.log("View old existing question");
-    visitQuestion(2);
+    visitQuestion(ORDERS_COUNT_QUESTION_ID);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("18,760");
 

--- a/e2e/test/scenarios/auditing/auditing.cy.spec.js
+++ b/e2e/test/scenarios/auditing/auditing.cy.spec.js
@@ -1,10 +1,12 @@
 import { restore, describeEE, visitQuestion } from "e2e/support/helpers";
+import { USERS } from "e2e/support/cypress_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
 import {
-  USERS,
   ORDERS_BY_YEAR_QUESTION_ID,
   ORDERS_COUNT_QUESTION_ID,
-} from "e2e/support/cypress_data";
-import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+} from "e2e/support/cypress_sample_instance_data";
+
 const { normal } = USERS;
 const { PRODUCTS } = SAMPLE_DATABASE;
 const TOTAL_USERS = Object.entries(USERS).length;

--- a/e2e/test/scenarios/auditing/questions-audit.cy.spec.js
+++ b/e2e/test/scenarios/auditing/questions-audit.cy.spec.js
@@ -4,7 +4,7 @@ import {
   ORDERS_QUESTION_ID,
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_BY_YEAR_QUESTION_ID,
-} from "e2e/support/cypress_data";
+} from "e2e/support/cypress_sample_instance_data";
 
 describeEE("audit > auditing > questions", () => {
   beforeEach(() => {

--- a/e2e/test/scenarios/auditing/questions-audit.cy.spec.js
+++ b/e2e/test/scenarios/auditing/questions-audit.cy.spec.js
@@ -1,5 +1,10 @@
 import _ from "underscore";
 import { restore, describeEE, visitQuestion } from "e2e/support/helpers";
+import {
+  ORDERS_QUESTION_ID,
+  ORDERS_COUNT_QUESTION_ID,
+  ORDERS_BY_YEAR_QUESTION_ID,
+} from "e2e/support/cypress_data";
 
 describeEE("audit > auditing > questions", () => {
   beforeEach(() => {
@@ -17,9 +22,9 @@ describeEE("audit > auditing > questions", () => {
 
       const QUERY_RUNS_ASC_ORDER = [...QUERY_RUNS_DESC_ORDER].reverse();
 
-      _.times(1, () => visitQuestion(1));
-      _.times(2, () => visitQuestion(2));
-      _.times(3, () => visitQuestion(3));
+      _.times(1, () => visitQuestion(ORDERS_QUESTION_ID));
+      _.times(2, () => visitQuestion(ORDERS_COUNT_QUESTION_ID));
+      _.times(3, () => visitQuestion(ORDERS_BY_YEAR_QUESTION_ID));
 
       cy.visit("/admin/audit/questions/all");
 

--- a/e2e/test/scenarios/binning/qb-implicit-joins.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-implicit-joins.cy.spec.js
@@ -6,6 +6,8 @@ import {
   visitQuestion,
 } from "e2e/support/helpers";
 
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+
 /**
  * The list of issues this spec covers:
  *  - metabase#15648
@@ -22,7 +24,7 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
 
   context("via simple question", () => {
     beforeEach(() => {
-      visitQuestion(1);
+      visitQuestion(ORDERS_QUESTION_ID);
       summarize();
     });
 
@@ -75,7 +77,7 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
 
   context("via custom question", () => {
     beforeEach(() => {
-      cy.visit("/question/1/notebook");
+      cy.visit(`/question/${ORDERS_QUESTION_ID}/notebook"`);
       summarize({ mode: "notebook" });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count of rows").click();

--- a/e2e/test/scenarios/binning/qb-implicit-joins.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-implicit-joins.cy.spec.js
@@ -77,7 +77,7 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
 
   context("via custom question", () => {
     beforeEach(() => {
-      cy.visit(`/question/${ORDERS_QUESTION_ID}/notebook"`);
+      cy.visit(`/question/${ORDERS_QUESTION_ID}/notebook`);
       summarize({ mode: "notebook" });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count of rows").click();

--- a/e2e/test/scenarios/binning/qb-implicit-joins.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-implicit-joins.cy.spec.js
@@ -6,7 +6,7 @@ import {
   visitQuestion,
 } from "e2e/support/helpers";
 
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 /**
  * The list of issues this spec covers:

--- a/e2e/test/scenarios/collections/collection-items-listing.cy.spec.js
+++ b/e2e/test/scenarios/collections/collection-items-listing.cy.spec.js
@@ -26,10 +26,12 @@ describe("scenarios > collection items listing", () => {
 
   describe("pagination", () => {
     const SUBCOLLECTIONS = 1;
+    const INSTANCE_ANALYTICS = 1;
     const ADDED_QUESTIONS = 15;
     const ADDED_DASHBOARDS = 14;
 
-    const TOTAL_ITEMS = SUBCOLLECTIONS + ADDED_DASHBOARDS + ADDED_QUESTIONS;
+    const TOTAL_ITEMS =
+      SUBCOLLECTIONS + ADDED_DASHBOARDS + ADDED_QUESTIONS + INSTANCE_ANALYTICS;
 
     beforeEach(() => {
       // Removes questions and dashboards included in the default database,
@@ -149,6 +151,7 @@ describe("scenarios > collection items listing", () => {
         const dashboardsFirst = _.chain(sortedNames)
           .sortBy(name => name.toLowerCase().includes("question"))
           .sortBy(name => name.toLowerCase().includes("collection"))
+          .sortBy(name => name.toLowerCase().includes("instance analytics"))
           .value();
         expect(actualNames, "sorted dashboards first").to.deep.equal(
           dashboardsFirst,
@@ -211,6 +214,7 @@ describe("scenarios > collection items listing", () => {
           .reverse()
           .sortBy(name => name.toLowerCase().includes("collection"))
           .sortBy(name => name.toLowerCase().includes("personal"))
+          .sortBy(name => name.toLowerCase().includes("instance analytics"))
           .value();
         expect(actualNames, "sorted newest first").to.deep.equal(newestFirst);
       });

--- a/e2e/test/scenarios/collections/collection-items-listing.cy.spec.js
+++ b/e2e/test/scenarios/collections/collection-items-listing.cy.spec.js
@@ -26,12 +26,10 @@ describe("scenarios > collection items listing", () => {
 
   describe("pagination", () => {
     const SUBCOLLECTIONS = 1;
-    const INSTANCE_ANALYTICS = 1;
     const ADDED_QUESTIONS = 15;
     const ADDED_DASHBOARDS = 14;
 
-    const TOTAL_ITEMS =
-      SUBCOLLECTIONS + ADDED_DASHBOARDS + ADDED_QUESTIONS + INSTANCE_ANALYTICS;
+    const TOTAL_ITEMS = SUBCOLLECTIONS + ADDED_DASHBOARDS + ADDED_QUESTIONS;
 
     beforeEach(() => {
       // Removes questions and dashboards included in the default database,

--- a/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
+++ b/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
@@ -7,7 +7,7 @@ import {
   openUnpinnedItemMenu,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 

--- a/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
+++ b/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
@@ -7,6 +7,7 @@ import {
   openUnpinnedItemMenu,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -102,7 +103,7 @@ describe("scenarios > collection pinned items overview", () => {
   });
 
   it("should be able to pin a model", () => {
-    cy.request("PUT", "/api/card/1", { dataset: true });
+    cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, { dataset: true });
 
     openRootCollection();
     openUnpinnedItemMenu(MODEL_NAME);
@@ -113,7 +114,7 @@ describe("scenarios > collection pinned items overview", () => {
       cy.icon("model").should("be.visible");
       cy.findByText(MODEL_NAME).should("be.visible");
       cy.findByText("A model").click();
-      cy.url().should("include", "/model/1");
+      cy.url().should("include", `/model/${ORDERS_QUESTION_ID}`);
     });
   });
 

--- a/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
+++ b/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
@@ -103,7 +103,7 @@ describe("scenarios > collection pinned items overview", () => {
   });
 
   it("should be able to pin a model", () => {
-    cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, { dataset: true });
+    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { dataset: true });
 
     openRootCollection();
     openUnpinnedItemMenu(MODEL_NAME);

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -15,7 +15,11 @@ import {
   openUnpinnedItemMenu,
   getPinnedSection,
 } from "e2e/support/helpers";
-import { USERS, USER_GROUPS } from "e2e/support/cypress_data";
+import {
+  USERS,
+  USER_GROUPS,
+  ORDERS_QUESTION_ID,
+} from "e2e/support/cypress_data";
 import { displaySidebarChildOf } from "./helpers/e2e-collections-sidebar.js";
 
 const { nocollection } = USERS;
@@ -480,7 +484,7 @@ describe("scenarios > collection defaults", () => {
         });
 
         it("should clean up selection when opening another collection (metabase#16491)", () => {
-          cy.request("PUT", "/api/card/1", {
+          cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, {
             collection_id: 1,
           });
           cy.visit("/collection/root");
@@ -590,7 +594,7 @@ describe("scenarios > collection defaults", () => {
     });
 
     it("should allow to x-ray models from collection views", () => {
-      cy.request("PUT", "/api/card/1", { dataset: true });
+      cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, { dataset: true });
       cy.visit("/collection/root");
 
       openEllipsisMenuFor("Orders");

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -482,7 +482,7 @@ describe("scenarios > collection defaults", () => {
         });
 
         it("should clean up selection when opening another collection (metabase#16491)", () => {
-          cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, {
+          cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
             collection_id: 1,
           });
           cy.visit("/collection/root");
@@ -592,7 +592,7 @@ describe("scenarios > collection defaults", () => {
     });
 
     it("should allow to x-ray models from collection views", () => {
-      cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, { dataset: true });
+      cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { dataset: true });
       cy.visit("/collection/root");
 
       openEllipsisMenuFor("Orders");

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -15,11 +15,9 @@ import {
   openUnpinnedItemMenu,
   getPinnedSection,
 } from "e2e/support/helpers";
-import {
-  USERS,
-  USER_GROUPS,
-  ORDERS_QUESTION_ID,
-} from "e2e/support/cypress_data";
+import { USERS, USER_GROUPS } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+
 import { displaySidebarChildOf } from "./helpers/e2e-collections-sidebar.js";
 
 const { nocollection } = USERS;

--- a/e2e/test/scenarios/collections/revision-history.cy.spec.js
+++ b/e2e/test/scenarios/collections/revision-history.cy.spec.js
@@ -9,7 +9,7 @@ import {
   openQuestionsSidebar,
 } from "e2e/support/helpers";
 
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const PERMISSIONS = {
   curate: ["admin", "normal", "nodata"],

--- a/e2e/test/scenarios/collections/revision-history.cy.spec.js
+++ b/e2e/test/scenarios/collections/revision-history.cy.spec.js
@@ -9,6 +9,8 @@ import {
   openQuestionsSidebar,
 } from "e2e/support/helpers";
 
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+
 const PERMISSIONS = {
   curate: ["admin", "normal", "nodata"],
   view: ["readonly"],
@@ -56,7 +58,7 @@ describe("revision history", () => {
             beforeEach(() => {
               cy.signInAsAdmin();
               // Generate some history for the question
-              cy.request("PUT", "/api/card/1", {
+              cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, {
                 name: "Orders renamed",
               });
 
@@ -114,7 +116,7 @@ describe("revision history", () => {
             it("should be able to access the question's revision history via the revision history button in the header of the query builder", () => {
               cy.skipOn(user === "nodata");
 
-              visitQuestion(1);
+              visitQuestion(ORDERS_QUESTION_ID);
 
               cy.findByTestId("revision-history-button").click();
 
@@ -132,7 +134,7 @@ describe("revision history", () => {
             it("should be able to revert the question via the action button found in the saved question timeline", () => {
               cy.skipOn(user === "nodata");
 
-              visitQuestion(1);
+              visitQuestion(ORDERS_QUESTION_ID);
 
               questionInfoButton().click();
               // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -162,7 +164,7 @@ describe("revision history", () => {
                 "not.exist",
               );
 
-              visitQuestion(1);
+              visitQuestion(ORDERS_QUESTION_ID);
               cy.findByRole("button", { name: /Edited .*/ }).click();
 
               cy.findAllByRole("button", { name: "Revert" }).should(

--- a/e2e/test/scenarios/collections/revision-history.cy.spec.js
+++ b/e2e/test/scenarios/collections/revision-history.cy.spec.js
@@ -58,7 +58,7 @@ describe("revision history", () => {
             beforeEach(() => {
               cy.signInAsAdmin();
               // Generate some history for the question
-              cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, {
+              cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
                 name: "Orders renamed",
               });
 

--- a/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
@@ -91,7 +91,7 @@ describe("scenarios > dashboard > dashboard back navigation", () => {
 
   it("should display a back to the dashboard button in model x-ray dashboards", () => {
     const cardTitle = "Orders by Subtotal";
-    cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, { dataset: true });
+    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { dataset: true });
     cy.visit("/auto/dashboard/model/1");
     cy.wait("@dataset");
 

--- a/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
@@ -16,7 +16,8 @@ import {
   visualize,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { SAMPLE_DB_ID, ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 const PG_DB_ID = 2;

--- a/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
@@ -16,7 +16,7 @@ import {
   visualize,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 const PG_DB_ID = 2;
@@ -90,7 +90,7 @@ describe("scenarios > dashboard > dashboard back navigation", () => {
 
   it("should display a back to the dashboard button in model x-ray dashboards", () => {
     const cardTitle = "Orders by Subtotal";
-    cy.request("PUT", "/api/card/1", { dataset: true });
+    cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, { dataset: true });
     cy.visit("/auto/dashboard/model/1");
     cy.wait("@dataset");
 

--- a/e2e/test/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -4,6 +4,7 @@ import {
   appBar,
   restore,
 } from "e2e/support/helpers";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 
 describe("scenarios > embedding > full app", () => {
   beforeEach(() => {
@@ -33,7 +34,10 @@ describe("scenarios > embedding > full app", () => {
     });
 
     it("should not hide the top nav when the logo is still visible", () => {
-      visitUrl({ url: "/question/1", qs: { breadcrumbs: false } });
+      visitUrl({
+        url: "/question/" + ORDERS_QUESTION_ID,
+        qs: { breadcrumbs: false },
+      });
       cy.findByTestId("main-logo").should("be.visible");
       appBar().within(() => {
         cy.findByText("Our analytics").should("not.exist");
@@ -119,7 +123,7 @@ describe("scenarios > embedding > full app", () => {
 
   describe("questions", () => {
     it("should show the question header by default", () => {
-      visitQuestionUrl({ url: "/question/1" });
+      visitQuestionUrl({ url: "/question/" + ORDERS_QUESTION_ID });
 
       cy.findByTestId("qb-header").should("be.visible");
       cy.findByTestId("qb-header-left-side").realHover();
@@ -134,13 +138,19 @@ describe("scenarios > embedding > full app", () => {
     });
 
     it("should hide the question header by a param", () => {
-      visitQuestionUrl({ url: "/question/1", qs: { header: false } });
+      visitQuestionUrl({
+        url: "/question/" + ORDERS_QUESTION_ID,
+        qs: { header: false },
+      });
 
       cy.findByTestId("qb-header").should("not.exist");
     });
 
     it("should hide the question's additional info by a param", () => {
-      visitQuestionUrl({ url: "/question/1", qs: { additional_info: false } });
+      visitQuestionUrl({
+        url: "/question/" + ORDERS_QUESTION_ID,
+        qs: { additional_info: false },
+      });
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Our analytics").should("be.visible");
@@ -149,7 +159,10 @@ describe("scenarios > embedding > full app", () => {
     });
 
     it("should hide the question's action buttons by a param", () => {
-      visitQuestionUrl({ url: "/question/1", qs: { action_buttons: false } });
+      visitQuestionUrl({
+        url: "/question/" + ORDERS_QUESTION_ID,
+        qs: { action_buttons: false },
+      });
 
       cy.icon("refresh").should("be.visible");
       cy.icon("notebook").should("not.exist");
@@ -172,7 +185,7 @@ describe("scenarios > embedding > full app", () => {
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("New").click();
         popover().findByText("Question").click();
-        popover().findByText("Sample Database").click();
+        popover().findByText("Raw Data").click();
         popover().findByText("Orders").click();
       });
 
@@ -202,7 +215,7 @@ describe("scenarios > embedding > full app", () => {
       // This can't be unit test in AppBar since the logic to hide the AppBar is in its parent component
       it("should hide main header when there's nothing to display there", () => {
         visitQuestionUrl({
-          url: "/question/1",
+          url: "/question/" + ORDERS_QUESTION_ID,
           qs: { side_nav: false, logo: false, breadcrumbs: false },
         });
         cy.findByRole("banner").should("not.exist");
@@ -220,7 +233,7 @@ describe("scenarios > embedding > full app", () => {
       // This can't be unit test in AppBar since the logic to hide the AppBar is in its parent component
       it("should hide main header when there's nothing to display there", () => {
         visitQuestionUrl({
-          url: "/question/1",
+          url: "/question/" + ORDERS_QUESTION_ID,
           qs: { side_nav: false, logo: false, breadcrumbs: false },
         });
         cy.findByRole("banner").should("not.exist");
@@ -265,7 +278,7 @@ describe("scenarios > embedding > full app", () => {
     it("should preserve embedding options with click behavior (metabase#24756)", () => {
       addLinkClickBehavior({
         dashboardId: 1,
-        linkTemplate: "/question/1",
+        linkTemplate: "/question/" + ORDERS_QUESTION_ID,
       });
       visitDashboardUrl({
         url: "/dashboard/1",

--- a/e2e/test/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -185,7 +185,7 @@ describe("scenarios > embedding > full app", () => {
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("New").click();
         popover().findByText("Question").click();
-        popover().findByText("Raw Data").click();
+        popover().findByText("Sample Database").click();
         popover().findByText("Orders").click();
       });
 

--- a/e2e/test/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -4,7 +4,7 @@ import {
   appBar,
   restore,
 } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 describe("scenarios > embedding > full app", () => {
   beforeEach(() => {

--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -6,6 +6,7 @@ import {
   visitDashboard,
   visitIframe,
 } from "e2e/support/helpers";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 
 const embeddingPage = "/admin/settings/embedding-in-other-applications";
 const licenseUrl = "https://metabase.com/license/embedding";
@@ -232,9 +233,9 @@ describe("scenarios > embedding > smoke tests", () => {
   it("should not offer to share or embed models (metabase#20815)", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    cy.request("PUT", "/api/card/1", { dataset: true });
+    cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, { dataset: true });
 
-    cy.visit("/model/1");
+    cy.visit(`/model/${ORDERS_QUESTION_ID}`);
     cy.wait("@dataset");
 
     cy.icon("share").should("not.exist");

--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -6,7 +6,7 @@ import {
   visitDashboard,
   visitIframe,
 } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const embeddingPage = "/admin/settings/embedding-in-other-applications";
 const licenseUrl = "https://metabase.com/license/embedding";

--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -233,7 +233,7 @@ describe("scenarios > embedding > smoke tests", () => {
   it("should not offer to share or embed models (metabase#20815)", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, { dataset: true });
+    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { dataset: true });
 
     cy.visit(`/model/${ORDERS_QUESTION_ID}`);
     cy.wait("@dataset");

--- a/e2e/test/scenarios/embedding/embedding-snippets.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-snippets.cy.spec.js
@@ -5,7 +5,7 @@ import {
   visitQuestion,
   isEE,
 } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 import { JS_CODE, IFRAME_CODE } from "./shared/embedding-snippets";
 

--- a/e2e/test/scenarios/embedding/embedding-snippets.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-snippets.cy.spec.js
@@ -5,6 +5,7 @@ import {
   visitQuestion,
   isEE,
 } from "e2e/support/helpers";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 
 import { JS_CODE, IFRAME_CODE } from "./shared/embedding-snippets";
 
@@ -71,7 +72,7 @@ describe("scenarios > embedding > code snippets", () => {
   });
 
   it("question should have the correct embed snippet", () => {
-    visitQuestion(1);
+    visitQuestion(ORDERS_QUESTION_ID);
     cy.icon("share").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Embed in your application").click();

--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -13,6 +13,7 @@ import {
   mapColumnTo,
   setModelMetadata,
 } from "e2e/support/helpers";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { startQuestionFromModel } from "./helpers/e2e-models-helpers";
 
@@ -29,12 +30,12 @@ describe("scenarios > models metadata", () => {
   describe("GUI model", () => {
     beforeEach(() => {
       // Convert saved question "Orders" into a model
-      cy.request("PUT", "/api/card/1", {
+      cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, {
         name: "GUI Model",
         dataset: true,
       });
 
-      cy.visit("/model/1");
+      cy.visit(`/model/${ORDERS_QUESTION_ID}`);
     });
 
     it("should edit GUI model metadata", () => {

--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -30,7 +30,7 @@ describe("scenarios > models metadata", () => {
   describe("GUI model", () => {
     beforeEach(() => {
       // Convert saved question "Orders" into a model
-      cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, {
+      cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
         name: "GUI Model",
         dataset: true,
       });

--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -13,7 +13,7 @@ import {
   mapColumnTo,
   setModelMetadata,
 } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { startQuestionFromModel } from "./helpers/e2e-models-helpers";
 

--- a/e2e/test/scenarios/models/models-query-editor.cy.spec.js
+++ b/e2e/test/scenarios/models/models-query-editor.cy.spec.js
@@ -20,7 +20,7 @@ describe("scenarios > models query editor", () => {
 
   describe("GUI models", () => {
     beforeEach(() => {
-      cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, {
+      cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
         name: "Orders Model",
         dataset: true,
       });

--- a/e2e/test/scenarios/models/models-query-editor.cy.spec.js
+++ b/e2e/test/scenarios/models/models-query-editor.cy.spec.js
@@ -5,7 +5,7 @@ import {
   popover,
   openQuestionActions,
 } from "e2e/support/helpers";
-
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 import { selectFromDropdown } from "./helpers/e2e-models-helpers";
 
 describe("scenarios > models query editor", () => {
@@ -20,14 +20,14 @@ describe("scenarios > models query editor", () => {
 
   describe("GUI models", () => {
     beforeEach(() => {
-      cy.request("PUT", "/api/card/1", {
+      cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, {
         name: "Orders Model",
         dataset: true,
       });
     });
 
     it("allows to edit GUI model query", () => {
-      cy.visit("/model/1");
+      cy.visit(`/model/${ORDERS_QUESTION_ID}`);
       cy.wait("@dataset");
 
       cy.get(".cellData").should("contain", "37.65").and("contain", "109.22");
@@ -55,7 +55,9 @@ describe("scenarios > models query editor", () => {
       cy.button("Save changes").click();
       cy.wait("@updateCard");
 
-      cy.url().should("include", "/model/1").and("not.include", "/query");
+      cy.url()
+        .should("include", `/model/${ORDERS_QUESTION_ID}`)
+        .and("not.include", "/query");
       cy.location("hash").should("eq", "");
 
       cy.get(".cellData")
@@ -64,7 +66,7 @@ describe("scenarios > models query editor", () => {
     });
 
     it("allows for canceling changes", () => {
-      cy.visit("/model/1");
+      cy.visit(`/model/${ORDERS_QUESTION_ID}`);
       cy.wait("@dataset");
 
       cy.get(".cellData").should("contain", "37.65").and("contain", "109.22");
@@ -89,14 +91,16 @@ describe("scenarios > models query editor", () => {
       cy.button("Cancel").click();
       cy.wait("@cardQuery");
 
-      cy.url().should("include", "/model/1").and("not.include", "/query");
+      cy.url()
+        .should("include", `/model/${ORDERS_QUESTION_ID}`)
+        .and("not.include", "/query");
       cy.location("hash").should("eq", "");
 
       cy.get(".cellData").should("contain", "37.65").and("contain", "109.22");
     });
 
     it("locks display to table", () => {
-      cy.visit("/model/1/query");
+      cy.visit(`/model/${ORDERS_QUESTION_ID}/query`);
 
       summarize({ mode: "notebook" });
 

--- a/e2e/test/scenarios/models/models-query-editor.cy.spec.js
+++ b/e2e/test/scenarios/models/models-query-editor.cy.spec.js
@@ -5,7 +5,7 @@ import {
   popover,
   openQuestionActions,
 } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 import { selectFromDropdown } from "./helpers/e2e-models-helpers";
 
 describe("scenarios > models query editor", () => {

--- a/e2e/test/scenarios/models/models-revision-history.cy.spec.js
+++ b/e2e/test/scenarios/models/models-revision-history.cy.spec.js
@@ -1,5 +1,5 @@
 import { restore, questionInfoButton, visitModel } from "e2e/support/helpers";
-import { ORDERS_BY_YEAR_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_BY_YEAR_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 describe("scenarios > models > revision history", () => {
   beforeEach(() => {

--- a/e2e/test/scenarios/models/models-revision-history.cy.spec.js
+++ b/e2e/test/scenarios/models/models-revision-history.cy.spec.js
@@ -1,4 +1,5 @@
 import { restore, questionInfoButton, visitModel } from "e2e/support/helpers";
+import { ORDERS_BY_YEAR_QUESTION_ID } from "e2e/support/cypress_data";
 
 describe("scenarios > models > revision history", () => {
   beforeEach(() => {
@@ -14,7 +15,7 @@ describe("scenarios > models > revision history", () => {
   });
 
   it("should allow reverting to a saved question state and back into a model again", () => {
-    visitModel(3);
+    visitModel(ORDERS_BY_YEAR_QUESTION_ID);
 
     openRevisionHistory();
     revertTo("You created this");

--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -19,7 +19,11 @@ import {
   openQuestionsSidebar,
 } from "e2e/support/helpers";
 
-import { SAMPLE_DB_ID, ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import {
+  SAMPLE_DB_ID,
+  ORDERS_QUESTION_ID,
+  ORDERS_BY_YEAR_QUESTION_ID,
+} from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { questionInfoButton } from "e2e/support/helpers/e2e-ui-elements-helpers";
 
@@ -43,8 +47,10 @@ describe("scenarios > models", () => {
   });
 
   it("allows to turn a GUI question into a model", () => {
-    cy.request("PUT", "/api/card/1", { name: "Orders Model" });
-    visitQuestion(1);
+    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
+      name: "Orders Model",
+    });
+    visitQuestion(ORDERS_QUESTION_ID);
 
     turnIntoModel();
     openQuestionActions();
@@ -134,7 +140,7 @@ describe("scenarios > models", () => {
   });
 
   it("changes model's display to table", () => {
-    visitQuestion(3);
+    visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
 
     cy.get(".LineAreaBarChart");
     cy.get(".TableInteractive").should("not.exist");
@@ -146,7 +152,7 @@ describe("scenarios > models", () => {
   });
 
   it("allows to undo turning a question into a model", () => {
-    visitQuestion(3);
+    visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
     cy.get(".LineAreaBarChart");
 
     turnIntoModel();
@@ -161,9 +167,9 @@ describe("scenarios > models", () => {
   });
 
   it("allows to turn a model back into a saved question", () => {
-    cy.request("PUT", "/api/card/1", { dataset: true });
-    cy.intercept("PUT", "/api/card/1").as("cardUpdate");
-    cy.visit("/model/1");
+    cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, { dataset: true });
+    cy.intercept("PUT", `/api/card${ORDERS_QUESTION_ID}`).as("cardUpdate");
+    cy.visit(`/model/${ORDERS_QUESTION_ID}`);
 
     openQuestionActions();
     popover().within(() => {
@@ -185,14 +191,14 @@ describe("scenarios > models", () => {
   });
 
   it("shows 404 when opening a question with a /dataset URL", () => {
-    cy.visit("/model/1");
+    cy.visit(`/model/${ORDERS_QUESTION_ID}`);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/We're a little lost/i);
   });
 
   it("redirects to /model URL when opening a model with /question URL", () => {
-    cy.request("PUT", "/api/card/1", { dataset: true });
-    // Important - do not use visitQuestion(1) here!
+    cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, { dataset: true });
+    // Important - do not use visitQuestion(ORDERS_QUESTION_ID) here!
     cy.visit("/question/" + ORDERS_QUESTION_ID);
     cy.wait("@dataset");
     openQuestionActions();
@@ -203,7 +209,7 @@ describe("scenarios > models", () => {
   describe("data picker", () => {
     beforeEach(() => {
       cy.intercept("GET", "/api/search*").as("search");
-      cy.request("PUT", "/api/card/1", { dataset: true });
+      cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, { dataset: true });
     });
 
     it("transforms the data picker", () => {
@@ -310,14 +316,14 @@ describe("scenarios > models", () => {
 
   describe("simple mode", () => {
     beforeEach(() => {
-      cy.request("PUT", "/api/card/1", {
+      cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, {
         name: "Orders Model",
         dataset: true,
       });
     });
 
     it("can create a question by filtering and summarizing a model", () => {
-      cy.visit("/model/1");
+      cy.visit(`/model/${ORDERS_QUESTION_ID}`);
       cy.wait("@dataset");
 
       filter();
@@ -359,7 +365,7 @@ describe("scenarios > models", () => {
     });
 
     it("can create a question using table click actions", () => {
-      cy.visit("/model/1");
+      cy.visit(`/model/${ORDERS_QUESTION_ID}`);
       cy.wait("@dataset");
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -386,8 +392,8 @@ describe("scenarios > models", () => {
     });
 
     it("can edit model info", () => {
-      cy.intercept("PUT", "/api/card/1").as("updateCard");
-      cy.visit("/model/1");
+      cy.intercept("PUT", `/api/card${ORDERS_QUESTION_ID}`).as("updateCard");
+      cy.visit(`/model/${ORDERS_QUESTION_ID}`);
       cy.wait("@dataset");
 
       cy.findByTestId("saved-question-header-title").clear().type("M1").blur();
@@ -487,7 +493,7 @@ describe("scenarios > models", () => {
   });
 
   it("should automatically pin newly created models", () => {
-    visitQuestion(1);
+    visitQuestion(ORDERS_QUESTION_ID);
 
     turnIntoModel();
 
@@ -499,7 +505,7 @@ describe("scenarios > models", () => {
   });
 
   it("should undo pinning a question if turning into a model was undone", () => {
-    visitQuestion(1);
+    visitQuestion(ORDERS_QUESTION_ID);
 
     turnIntoModel();
     undo();
@@ -514,7 +520,10 @@ describe("scenarios > models", () => {
 
   describe("listing", () => {
     beforeEach(() => {
-      cy.request("PUT", "/api/card/1", { name: "Orders Model", dataset: true });
+      cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, {
+        name: "Orders Model",
+        dataset: true,
+      });
     });
 
     it("should allow adding models to dashboards", () => {

--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -19,11 +19,12 @@ import {
   openQuestionsSidebar,
 } from "e2e/support/helpers";
 
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import {
-  SAMPLE_DB_ID,
   ORDERS_QUESTION_ID,
   ORDERS_BY_YEAR_QUESTION_ID,
-} from "e2e/support/cypress_data";
+} from "e2e/support/cypress_sample_instance_data";
+
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { questionInfoButton } from "e2e/support/helpers/e2e-ui-elements-helpers";
 

--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -19,7 +19,7 @@ import {
   openQuestionsSidebar,
 } from "e2e/support/helpers";
 
-import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { questionInfoButton } from "e2e/support/helpers/e2e-ui-elements-helpers";
 
@@ -81,7 +81,7 @@ describe("scenarios > models", () => {
       cy.icon("table");
     });
 
-    cy.url().should("not.include", "/question/1");
+    cy.url().should("not.include", "/question/" + ORDERS_QUESTION_ID);
   });
 
   it("allows to turn a native question into a model", () => {
@@ -193,7 +193,7 @@ describe("scenarios > models", () => {
   it("redirects to /model URL when opening a model with /question URL", () => {
     cy.request("PUT", "/api/card/1", { dataset: true });
     // Important - do not use visitQuestion(1) here!
-    cy.visit("/question/1");
+    cy.visit("/question/" + ORDERS_QUESTION_ID);
     cy.wait("@dataset");
     openQuestionActions();
     assertIsModel();
@@ -355,7 +355,7 @@ describe("scenarios > models", () => {
         table: "Orders",
       });
 
-      cy.url().should("not.include", "/question/1");
+      cy.url().should("not.include", "/question/" + ORDERS_QUESTION_ID);
     });
 
     it("can create a question using table click actions", () => {
@@ -382,7 +382,7 @@ describe("scenarios > models", () => {
         table: "Orders",
       });
 
-      cy.url().should("not.include", "/question/1");
+      cy.url().should("not.include", "/question/" + ORDERS_QUESTION_ID);
     });
 
     it("can edit model info", () => {

--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -168,8 +168,8 @@ describe("scenarios > models", () => {
   });
 
   it("allows to turn a model back into a saved question", () => {
-    cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, { dataset: true });
-    cy.intercept("PUT", `/api/card${ORDERS_QUESTION_ID}`).as("cardUpdate");
+    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { dataset: true });
+    cy.intercept("PUT", `/api/card/${ORDERS_QUESTION_ID}`).as("cardUpdate");
     cy.visit(`/model/${ORDERS_QUESTION_ID}`);
 
     openQuestionActions();
@@ -198,7 +198,7 @@ describe("scenarios > models", () => {
   });
 
   it("redirects to /model URL when opening a model with /question URL", () => {
-    cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, { dataset: true });
+    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { dataset: true });
     // Important - do not use visitQuestion(ORDERS_QUESTION_ID) here!
     cy.visit("/question/" + ORDERS_QUESTION_ID);
     cy.wait("@dataset");
@@ -210,7 +210,7 @@ describe("scenarios > models", () => {
   describe("data picker", () => {
     beforeEach(() => {
       cy.intercept("GET", "/api/search*").as("search");
-      cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, { dataset: true });
+      cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { dataset: true });
     });
 
     it("transforms the data picker", () => {
@@ -317,7 +317,7 @@ describe("scenarios > models", () => {
 
   describe("simple mode", () => {
     beforeEach(() => {
-      cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, {
+      cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
         name: "Orders Model",
         dataset: true,
       });
@@ -393,7 +393,7 @@ describe("scenarios > models", () => {
     });
 
     it("can edit model info", () => {
-      cy.intercept("PUT", `/api/card${ORDERS_QUESTION_ID}`).as("updateCard");
+      cy.intercept("PUT", `/api/card/${ORDERS_QUESTION_ID}`).as("updateCard");
       cy.visit(`/model/${ORDERS_QUESTION_ID}`);
       cy.wait("@dataset");
 
@@ -521,7 +521,7 @@ describe("scenarios > models", () => {
 
   describe("listing", () => {
     beforeEach(() => {
-      cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, {
+      cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
         name: "Orders Model",
         dataset: true,
       });

--- a/e2e/test/scenarios/models/reproductions/19737-data-picker-not-showing-moved-model.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/19737-data-picker-not-showing-moved-model.cy.spec.js
@@ -4,7 +4,7 @@ import {
   popover,
   navigationSidebar,
 } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const modelName = "Orders Model";
 

--- a/e2e/test/scenarios/models/reproductions/19737-data-picker-not-showing-moved-model.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/19737-data-picker-not-showing-moved-model.cy.spec.js
@@ -4,6 +4,7 @@ import {
   popover,
   navigationSidebar,
 } from "e2e/support/helpers";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 
 const modelName = "Orders Model";
 
@@ -12,7 +13,10 @@ describe("issue 19737", () => {
     restore();
     cy.signInAsAdmin();
 
-    cy.request("PUT", "/api/card/1", { name: modelName, dataset: true });
+    cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, {
+      name: modelName,
+      dataset: true,
+    });
   });
 
   it("should show moved model in the data picker without refreshing (metabase#19737)", () => {

--- a/e2e/test/scenarios/models/reproductions/19737-data-picker-not-showing-moved-model.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/19737-data-picker-not-showing-moved-model.cy.spec.js
@@ -13,7 +13,7 @@ describe("issue 19737", () => {
     restore();
     cy.signInAsAdmin();
 
-    cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, {
+    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
       name: modelName,
       dataset: true,
     });

--- a/e2e/test/scenarios/models/reproductions/19776-data-picker-not-displayed-after-archiving-model.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/19776-data-picker-not-displayed-after-archiving-model.cy.spec.js
@@ -1,4 +1,5 @@
 import { restore, popover } from "e2e/support/helpers";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 
 const modelName = "Orders Model";
 
@@ -7,7 +8,10 @@ describe("issue 19776", () => {
     restore();
     cy.signInAsAdmin();
 
-    cy.request("PUT", "/api/card/1", { name: modelName, dataset: true });
+    cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, {
+      name: modelName,
+      dataset: true,
+    });
   });
 
   it("should show moved model in the data picker without refreshing (metabase#19776)", () => {

--- a/e2e/test/scenarios/models/reproductions/19776-data-picker-not-displayed-after-archiving-model.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/19776-data-picker-not-displayed-after-archiving-model.cy.spec.js
@@ -1,5 +1,5 @@
 import { restore, popover } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const modelName = "Orders Model";
 

--- a/e2e/test/scenarios/models/reproductions/19776-data-picker-not-displayed-after-archiving-model.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/19776-data-picker-not-displayed-after-archiving-model.cy.spec.js
@@ -8,7 +8,7 @@ describe("issue 19776", () => {
     restore();
     cy.signInAsAdmin();
 
-    cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, {
+    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
       name: modelName,
       dataset: true,
     });

--- a/e2e/test/scenarios/models/reproductions/20042-nodata-user-blank-screen.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/20042-nodata-user-blank-screen.cy.spec.js
@@ -8,7 +8,7 @@ describe("issue 20042", () => {
     restore();
     cy.signInAsAdmin();
 
-    cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, {
+    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
       name: "Orders Model",
       dataset: true,
     });

--- a/e2e/test/scenarios/models/reproductions/20042-nodata-user-blank-screen.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/20042-nodata-user-blank-screen.cy.spec.js
@@ -1,5 +1,5 @@
 import { restore } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 describe("issue 20042", () => {
   beforeEach(() => {

--- a/e2e/test/scenarios/models/reproductions/20042-nodata-user-blank-screen.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/20042-nodata-user-blank-screen.cy.spec.js
@@ -1,4 +1,5 @@
 import { restore } from "e2e/support/helpers";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 
 describe("issue 20042", () => {
   beforeEach(() => {
@@ -7,13 +8,16 @@ describe("issue 20042", () => {
     restore();
     cy.signInAsAdmin();
 
-    cy.request("PUT", "/api/card/1", { name: "Orders Model", dataset: true });
+    cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, {
+      name: "Orders Model",
+      dataset: true,
+    });
 
     cy.signIn("nodata");
   });
 
   it("nodata user should not see the blank screen when visiting model (metabase#20042)", () => {
-    cy.visit("/model/1");
+    cy.visit(`/model/${ORDERS_QUESTION_ID}`);
 
     cy.wait("@query");
 

--- a/e2e/test/scenarios/models/reproductions/20045-rerun-model-adds-hash.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/20045-rerun-model-adds-hash.cy.spec.js
@@ -1,5 +1,5 @@
 import { restore } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 describe("issue 20045", () => {
   beforeEach(() => {

--- a/e2e/test/scenarios/models/reproductions/20045-rerun-model-adds-hash.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/20045-rerun-model-adds-hash.cy.spec.js
@@ -1,4 +1,5 @@
 import { restore } from "e2e/support/helpers";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 
 describe("issue 20045", () => {
   beforeEach(() => {
@@ -7,22 +8,31 @@ describe("issue 20045", () => {
     restore();
     cy.signInAsAdmin();
 
-    cy.request("PUT", "/api/card/1", { name: "Orders Model", dataset: true });
+    cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, {
+      name: "Orders Model",
+      dataset: true,
+    });
   });
 
   it("should not add query hash on the rerun (metabase#20045)", () => {
-    cy.visit("/model/1");
+    cy.visit(`/model/${ORDERS_QUESTION_ID}`);
 
     cy.wait("@dataset");
 
-    cy.location("pathname").should("eq", "/model/1-orders-model");
+    cy.location("pathname").should(
+      "eq",
+      `/model/${ORDERS_QUESTION_ID}-orders-model`,
+    );
     cy.location("hash").should("eq", "");
 
     cy.findByTestId("qb-header-action-panel").find(".Icon-refresh").click();
 
     cy.wait("@dataset");
 
-    cy.location("pathname").should("eq", "/model/1-orders-model");
+    cy.location("pathname").should(
+      "eq",
+      `/model/${ORDERS_QUESTION_ID}-orders-model`,
+    );
     cy.location("hash").should("eq", "");
   });
 });

--- a/e2e/test/scenarios/models/reproductions/20045-rerun-model-adds-hash.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/20045-rerun-model-adds-hash.cy.spec.js
@@ -8,7 +8,7 @@ describe("issue 20045", () => {
     restore();
     cy.signInAsAdmin();
 
-    cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, {
+    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
       name: "Orders Model",
       dataset: true,
     });

--- a/e2e/test/scenarios/models/reproductions/20517-edit-metadata-empty-description.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/20517-edit-metadata-empty-description.cy.spec.js
@@ -3,12 +3,12 @@ import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 describe("issue 20517", () => {
   beforeEach(() => {
-    cy.intercept("PUT", `/api/card${ORDERS_QUESTION_ID}`).as("updateCard");
+    cy.intercept("PUT", `/api/card/${ORDERS_QUESTION_ID}`).as("updateCard");
 
     restore();
     cy.signInAsAdmin();
 
-    cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, { dataset: true });
+    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { dataset: true });
   });
 
   it("should be able to save metadata changes with empty description (metabase#20517)", () => {

--- a/e2e/test/scenarios/models/reproductions/20517-edit-metadata-empty-description.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/20517-edit-metadata-empty-description.cy.spec.js
@@ -1,17 +1,18 @@
 import { restore } from "e2e/support/helpers";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 
 describe("issue 20517", () => {
   beforeEach(() => {
-    cy.intercept("PUT", "/api/card/1").as("updateCard");
+    cy.intercept("PUT", `/api/card${ORDERS_QUESTION_ID}`).as("updateCard");
 
     restore();
     cy.signInAsAdmin();
 
-    cy.request("PUT", "/api/card/1", { dataset: true });
+    cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, { dataset: true });
   });
 
   it("should be able to save metadata changes with empty description (metabase#20517)", () => {
-    cy.visit("/model/1/metadata");
+    cy.visit(`/model/${ORDERS_QUESTION_ID}/metadata`);
 
     cy.findByLabelText("Description").clear().blur();
 

--- a/e2e/test/scenarios/models/reproductions/20517-edit-metadata-empty-description.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/20517-edit-metadata-empty-description.cy.spec.js
@@ -1,5 +1,5 @@
 import { restore } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 describe("issue 20517", () => {
   beforeEach(() => {

--- a/e2e/test/scenarios/models/reproductions/28193-cannot-use-custom-column.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/28193-cannot-use-custom-column.cy.spec.js
@@ -11,7 +11,7 @@ describe.skip("issue 28193", () => {
     cy.signInAsAdmin();
 
     // Turn the question into a model
-    cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, { dataset: true });
+    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { dataset: true });
   });
 
   it("should be able to use custom column in a model query (metabase#28193)", () => {

--- a/e2e/test/scenarios/models/reproductions/28193-cannot-use-custom-column.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/28193-cannot-use-custom-column.cy.spec.js
@@ -1,4 +1,5 @@
 import { restore, enterCustomColumnDetails } from "e2e/support/helpers";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 
 const ccName = "CTax";
 
@@ -10,12 +11,12 @@ describe.skip("issue 28193", () => {
     cy.signInAsAdmin();
 
     // Turn the question into a model
-    cy.request("PUT", "/api/card/1", { dataset: true });
+    cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, { dataset: true });
   });
 
   it("should be able to use custom column in a model query (metabase#28193)", () => {
     // Go directly to model's query definition
-    cy.visit("/model/1/query");
+    cy.visit(`/model/${ORDERS_QUESTION_ID}/query`);
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();

--- a/e2e/test/scenarios/models/reproductions/28193-cannot-use-custom-column.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/28193-cannot-use-custom-column.cy.spec.js
@@ -1,5 +1,5 @@
 import { restore, enterCustomColumnDetails } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const ccName = "CTax";
 

--- a/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
@@ -6,7 +6,7 @@ import {
   describeEE,
 } from "e2e/support/helpers";
 
-import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { PEOPLE_ID } = SAMPLE_DATABASE;
@@ -20,7 +20,7 @@ describe("search > recently viewed", () => {
     cy.findByTextEnsureVisible("Address");
 
     // "Orders" question
-    visitQuestion(1);
+    visitQuestion(ORDERS_QUESTION_ID);
 
     // "Orders in a dashboard" dashboard
     visitDashboard(1);
@@ -45,7 +45,12 @@ describe("search > recently viewed", () => {
       "Dashboard",
       "/dashboard/1-orders-in-a-dashboard",
     );
-    assertRecentlyViewedItem(1, "Orders", "Question", "/question/1-orders");
+    assertRecentlyViewedItem(
+      ORDERS_QUESTION_ID,
+      "Orders",
+      "Question",
+      `/question/${ORDERS_QUESTION_ID}-orders`,
+    );
     assertRecentlyViewedItem(
       2,
       "People",
@@ -76,7 +81,7 @@ describeEE("search > recently viewed > enterprise features", () => {
       moderated_item_type: "card",
     });
 
-    visitQuestion(1);
+    visitQuestion(ORDERS_QUESTION_ID);
 
     cy.findByTestId("qb-header-left-side").find(".Icon-verified");
   });

--- a/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
@@ -6,8 +6,9 @@ import {
   describeEE,
 } from "e2e/support/helpers";
 
-import { SAMPLE_DB_ID, ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const { PEOPLE_ID } = SAMPLE_DATABASE;
 

--- a/e2e/test/scenarios/onboarding/search/search.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search.cy.spec.js
@@ -1,4 +1,5 @@
 import { restore } from "e2e/support/helpers";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 
 describe("scenarios > auth > search", () => {
   beforeEach(restore);
@@ -54,7 +55,10 @@ describe("scenarios > auth > search", () => {
       cy.realPress("ArrowDown");
       cy.realPress("Enter");
 
-      cy.location("pathname").should("eq", "/question/1-orders");
+      cy.location("pathname").should(
+        "eq",
+        `/question/${ORDERS_QUESTION_ID}-orders`,
+      );
     });
   });
 });

--- a/e2e/test/scenarios/onboarding/search/search.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search.cy.spec.js
@@ -1,5 +1,5 @@
 import { restore } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 describe("scenarios > auth > search", () => {
   beforeEach(restore);

--- a/e2e/test/scenarios/onboarding/urls.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/urls.cy.spec.js
@@ -4,11 +4,11 @@ import {
   popover,
   getFullName,
 } from "e2e/support/helpers";
+import { USERS, SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import {
-  USERS,
-  SAMPLE_DB_ID,
   ORDERS_QUESTION_ID,
-} from "e2e/support/cypress_data";
+  ADMIN_PERSONAL_COLLECTION_ID,
+} from "e2e/support/cypress_sample_instance_data";
 
 import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase-lib/metadata/utils/saved-questions";
 
@@ -83,7 +83,9 @@ describe("URLs", () => {
       cy.findByText("Your personal collection").click();
       cy.location("pathname").should(
         "eq",
-        `/collection/1-${getUsersPersonalCollectionSlug(admin)}`,
+        `/collection/${ADMIN_PERSONAL_COLLECTION_ID}-${getUsersPersonalCollectionSlug(
+          admin,
+        )}`,
       );
     });
 
@@ -115,7 +117,11 @@ describe("URLs", () => {
         "First collection",
       );
 
-      cy.visit(`/collection/1-${getUsersPersonalCollectionSlug(admin)}`);
+      cy.visit(
+        `/collection/${ADMIN_PERSONAL_COLLECTION_ID}-${getUsersPersonalCollectionSlug(
+          admin,
+        )}`,
+      );
       cy.findByTestId("collection-name-heading").should(
         "have.text",
         `${getFullName(admin)}'s Personal Collection`,

--- a/e2e/test/scenarios/onboarding/urls.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/urls.cy.spec.js
@@ -4,7 +4,11 @@ import {
   popover,
   getFullName,
 } from "e2e/support/helpers";
-import { USERS, SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import {
+  USERS,
+  SAMPLE_DB_ID,
+  ORDERS_QUESTION_ID,
+} from "e2e/support/cypress_data";
 
 import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase-lib/metadata/utils/saved-questions";
 
@@ -58,7 +62,10 @@ describe("URLs", () => {
       cy.visit("/collection/root");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders").click();
-      cy.location("pathname").should("eq", "/question/1-orders");
+      cy.location("pathname").should(
+        "eq",
+        `/question/${ORDERS_QUESTION_ID}-orders`,
+      );
     });
   });
 

--- a/e2e/test/scenarios/organization/bookmarks-collection.cy.spec.js
+++ b/e2e/test/scenarios/organization/bookmarks-collection.cy.spec.js
@@ -6,6 +6,7 @@ import {
   visitCollection,
 } from "e2e/support/helpers";
 import { USERS, SAMPLE_DB_TABLES } from "e2e/support/cypress_data";
+import { ADMIN_PERSONAL_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 import { getSidebarSectionTitle as getSectionTitle } from "e2e/support/helpers/e2e-collection-helpers";
 
@@ -114,7 +115,7 @@ describe("scenarios > organization > bookmarks > collection", () => {
   });
 
   it("can remove bookmark from item in sidebar", () => {
-    cy.visit("/collection/1");
+    cy.visit(`/collection/${ADMIN_PERSONAL_COLLECTION_ID}`);
 
     // Add bookmark
     cy.icon("bookmark").click();
@@ -127,7 +128,7 @@ describe("scenarios > organization > bookmarks > collection", () => {
   });
 
   it("can toggle bookmark list visibility", () => {
-    cy.visit("/collection/1");
+    cy.visit(`/collection/${ADMIN_PERSONAL_COLLECTION_ID}`);
 
     // Add bookmark
     cy.icon("bookmark").click();

--- a/e2e/test/scenarios/organization/bookmarks-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/bookmarks-question.cy.spec.js
@@ -5,7 +5,7 @@ import {
   openNavigationSidebar,
   visitQuestion,
 } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 import { getSidebarSectionTitle as getSectionTitle } from "e2e/support/helpers/e2e-collection-helpers";
 

--- a/e2e/test/scenarios/organization/bookmarks-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/bookmarks-question.cy.spec.js
@@ -5,6 +5,8 @@ import {
   openNavigationSidebar,
   visitQuestion,
 } from "e2e/support/helpers";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+
 import { getSidebarSectionTitle as getSectionTitle } from "e2e/support/helpers/e2e-collection-helpers";
 
 describe("scenarios > question > bookmarks", () => {
@@ -15,7 +17,7 @@ describe("scenarios > question > bookmarks", () => {
   });
 
   it("should add, update bookmark name when question name is updated, then remove bookmark from question page", () => {
-    visitQuestion(1);
+    visitQuestion(ORDERS_QUESTION_ID);
     toggleBookmark();
 
     openNavigationSidebar();

--- a/e2e/test/scenarios/organization/edit-history-metadata.cy.spec.js
+++ b/e2e/test/scenarios/organization/edit-history-metadata.cy.spec.js
@@ -1,5 +1,6 @@
 import { restore, visitQuestion, visitDashboard } from "e2e/support/helpers";
-import { USERS, ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { USERS } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 describe("scenarios > collection items metadata", () => {
   beforeEach(() => {

--- a/e2e/test/scenarios/organization/edit-history-metadata.cy.spec.js
+++ b/e2e/test/scenarios/organization/edit-history-metadata.cy.spec.js
@@ -1,5 +1,5 @@
 import { restore, visitQuestion, visitDashboard } from "e2e/support/helpers";
-import { USERS } from "e2e/support/cypress_data";
+import { USERS, ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 
 describe("scenarios > collection items metadata", () => {
   beforeEach(() => {
@@ -19,7 +19,7 @@ describe("scenarios > collection items metadata", () => {
     });
 
     it("should display last edit moment for questions", () => {
-      visitQuestion(1);
+      visitQuestion(ORDERS_QUESTION_ID);
       changeQuestion();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Edited a few seconds ago/i);
@@ -32,7 +32,7 @@ describe("scenarios > collection items metadata", () => {
       visitDashboard(1);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Edited .* by you/i);
-      visitQuestion(1);
+      visitQuestion(ORDERS_QUESTION_ID);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Edited .* by you/i);
     });
@@ -46,7 +46,7 @@ describe("scenarios > collection items metadata", () => {
       visitDashboard(1);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(new RegExp(`Edited .* by ${expectedName}`, "i"));
-      visitQuestion(1);
+      visitQuestion(ORDERS_QUESTION_ID);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(new RegExp(`Edited .* by ${expectedName}`, "i"));
     });

--- a/e2e/test/scenarios/organization/moderation-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/moderation-question.cy.spec.js
@@ -7,11 +7,11 @@ import {
   getFullName,
 } from "e2e/support/helpers";
 
+import { USERS } from "e2e/support/cypress_data";
 import {
-  USERS,
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_BY_YEAR_QUESTION_ID,
-} from "e2e/support/cypress_data";
+} from "e2e/support/cypress_sample_instance_data";
 
 const { admin } = USERS;
 const adminFullName = getFullName(admin);

--- a/e2e/test/scenarios/organization/moderation-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/moderation-question.cy.spec.js
@@ -7,7 +7,11 @@ import {
   getFullName,
 } from "e2e/support/helpers";
 
-import { USERS } from "e2e/support/cypress_data";
+import {
+  USERS,
+  ORDERS_COUNT_QUESTION_ID,
+  ORDERS_BY_YEAR_QUESTION_ID,
+} from "e2e/support/cypress_data";
 
 const { admin } = USERS;
 const adminFullName = getFullName(admin);
@@ -20,7 +24,7 @@ describeEE("scenarios > saved question moderation", () => {
     });
 
     it("should be able to verify and unverify a saved question", () => {
-      visitQuestion(2);
+      visitQuestion(ORDERS_COUNT_QUESTION_ID);
 
       verifyQuestion();
 
@@ -53,7 +57,7 @@ describeEE("scenarios > saved question moderation", () => {
       cy.findByText("Orders, Count").closest("a").find(".Icon-verified");
 
       // Let's go back to the question and remove the verification
-      visitQuestion(2);
+      visitQuestion(ORDERS_COUNT_QUESTION_ID);
 
       removeQuestionVerification();
 
@@ -110,7 +114,7 @@ describeEE("scenarios > saved question moderation", () => {
     });
 
     it("should be able to see that a question has not been verified", () => {
-      visitQuestion(3);
+      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
 
       cy.icon("verified").should("not.exist");
 
@@ -133,7 +137,7 @@ describeEE("scenarios > saved question moderation", () => {
     });
 
     it("should be able to see that a question has been verified", () => {
-      visitQuestion(2);
+      visitQuestion(ORDERS_COUNT_QUESTION_ID);
 
       cy.icon("verified");
 

--- a/e2e/test/scenarios/organization/timelines-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-question.cy.spec.js
@@ -4,7 +4,10 @@ import {
   rightSidebar,
   visitQuestionAdhoc,
 } from "e2e/support/helpers";
-import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import {
+  SAMPLE_DB_ID,
+  ORDERS_BY_YEAR_QUESTION_ID,
+} from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -23,7 +26,7 @@ describe("scenarios > organization > timelines > question", () => {
     });
 
     it("should create the first event and timeline", () => {
-      visitQuestion(3);
+      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
       cy.wait("@getCollection");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
@@ -49,7 +52,7 @@ describe("scenarios > organization > timelines > question", () => {
         events: [{ name: "RC1", timestamp: "2018-10-20T00:00:00Z" }],
       });
 
-      visitQuestion(3);
+      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
       cy.wait("@getCollection");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
@@ -81,7 +84,7 @@ describe("scenarios > organization > timelines > question", () => {
         ],
       });
 
-      visitQuestion(3);
+      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
       cy.wait("@getCollection");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
@@ -109,7 +112,7 @@ describe("scenarios > organization > timelines > question", () => {
         events: [{ name: "RC1", timestamp: "2018-10-20T00:00:00Z" }],
       });
 
-      visitQuestion(3);
+      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
       cy.wait("@getCollection");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
@@ -141,7 +144,7 @@ describe("scenarios > organization > timelines > question", () => {
         events: [{ name: "RC2", timestamp: "2018-10-20T00:00:00Z" }],
       });
 
-      visitQuestion(3);
+      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
       cy.wait("@getCollection");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
@@ -169,7 +172,7 @@ describe("scenarios > organization > timelines > question", () => {
         events: [{ name: "RC1", timestamp: "2018-10-20T00:00:00Z" }],
       });
 
-      visitQuestion(3);
+      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
       cy.wait("@getCollection");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
@@ -204,7 +207,7 @@ describe("scenarios > organization > timelines > question", () => {
         ],
       });
 
-      visitQuestion(3);
+      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
       cy.icon("calendar").click();
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -312,7 +315,7 @@ describe("scenarios > organization > timelines > question", () => {
         ],
       });
 
-      visitQuestion(3);
+      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
@@ -408,7 +411,7 @@ describe("scenarios > organization > timelines > question", () => {
   describe("as readonly user", () => {
     it("should not allow creating default timelines", () => {
       cy.signIn("readonly");
-      visitQuestion(3);
+      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Created At").should("be.visible");
 
@@ -427,7 +430,7 @@ describe("scenarios > organization > timelines > question", () => {
       });
       cy.signOut();
       cy.signIn("readonly");
-      visitQuestion(3);
+      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Created At").should("be.visible");
 

--- a/e2e/test/scenarios/organization/timelines-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-question.cy.spec.js
@@ -4,11 +4,9 @@ import {
   rightSidebar,
   visitQuestionAdhoc,
 } from "e2e/support/helpers";
-import {
-  SAMPLE_DB_ID,
-  ORDERS_BY_YEAR_QUESTION_ID,
-} from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { ORDERS_BY_YEAR_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -15,7 +15,11 @@ import {
   selectPermissionRow,
 } from "e2e/support/helpers";
 
-import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
+import {
+  SAMPLE_DB_ID,
+  USER_GROUPS,
+  ORDERS_QUESTION_ID,
+} from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
@@ -709,7 +713,7 @@ describeEE("scenarios > admin > permissions", () => {
     });
 
     cy.signIn("nodata");
-    visitQuestion(1);
+    visitQuestion(ORDERS_QUESTION_ID);
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("There was a problem with your question");

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -15,12 +15,9 @@ import {
   selectPermissionRow,
 } from "e2e/support/helpers";
 
-import {
-  SAMPLE_DB_ID,
-  USER_GROUPS,
-  ORDERS_QUESTION_ID,
-} from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 

--- a/e2e/test/scenarios/permissions/application-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/application-permissions.cy.spec.js
@@ -8,7 +8,7 @@ import {
   visitDashboard,
 } from "e2e/support/helpers";
 
-import { USERS } from "e2e/support/cypress_data";
+import { USERS, ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
@@ -50,7 +50,7 @@ describeEE("scenarios > admin > permissions > application", () => {
         visitDashboard(1);
         cy.icon("subscription").should("not.exist");
 
-        visitQuestion(1);
+        visitQuestion(ORDERS_QUESTION_ID);
         cy.icon("bell").should("not.exist");
 
         cy.visit("/account/notifications");
@@ -73,7 +73,7 @@ describeEE("scenarios > admin > permissions > application", () => {
       });
 
       it("gives ability to create question alerts", () => {
-        visitQuestion(1);
+        visitQuestion(ORDERS_QUESTION_ID);
         cy.icon("bell").click();
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(

--- a/e2e/test/scenarios/permissions/application-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/application-permissions.cy.spec.js
@@ -8,8 +8,9 @@ import {
   visitDashboard,
 } from "e2e/support/helpers";
 
-import { USERS, ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { USERS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 

--- a/e2e/test/scenarios/permissions/permissions-baseline.cy.spec.js
+++ b/e2e/test/scenarios/permissions/permissions-baseline.cy.spec.js
@@ -3,12 +3,17 @@ import {
   visitQuestion,
   visitQuestionAdhoc,
 } from "e2e/support/helpers";
-import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 
 describe("scenarios > permissions", () => {
   beforeEach(restore);
 
-  const PATHS = ["/dashboard/1", "/question/1", "/collection/1", "/admin"];
+  const PATHS = [
+    "/dashboard/1",
+    "/question/" + ORDERS_QUESTION_ID,
+    "/collection/1",
+    "/admin",
+  ];
 
   for (const path of PATHS) {
     it(`should display the permissions screen on ${path}`, () => {

--- a/e2e/test/scenarios/permissions/permissions-baseline.cy.spec.js
+++ b/e2e/test/scenarios/permissions/permissions-baseline.cy.spec.js
@@ -53,7 +53,7 @@ describe("scenarios > permissions", () => {
 
   it("should let a user with no data permissions view questions", () => {
     cy.signIn("nodata");
-    visitQuestion(1);
+    visitQuestion(ORDERS_QUESTION_ID);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("February 11, 2019, 9:40 PM"); // check that the data loads
   });

--- a/e2e/test/scenarios/permissions/permissions-baseline.cy.spec.js
+++ b/e2e/test/scenarios/permissions/permissions-baseline.cy.spec.js
@@ -3,15 +3,19 @@ import {
   visitQuestion,
   visitQuestionAdhoc,
 } from "e2e/support/helpers";
-import { SAMPLE_DB_ID, ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import {
+  ORDERS_QUESTION_ID,
+  ADMIN_PERSONAL_COLLECTION_ID,
+} from "e2e/support/cypress_sample_instance_data";
 
 describe("scenarios > permissions", () => {
   beforeEach(restore);
 
   const PATHS = [
     "/dashboard/1",
-    "/question/" + ORDERS_QUESTION_ID,
-    "/collection/1",
+    `/question/${ORDERS_QUESTION_ID}`,
+    `/collection/${ADMIN_PERSONAL_COLLECTION_ID}`,
     "/admin",
   ];
 

--- a/e2e/test/scenarios/permissions/reproductions/22726-readonly-collection-duplicate-question.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/22726-readonly-collection-duplicate-question.cy.spec.js
@@ -5,11 +5,8 @@ import {
   openQuestionActions,
   getFullName,
 } from "e2e/support/helpers";
-import {
-  USERS,
-  USER_GROUPS,
-  ORDERS_QUESTION_ID,
-} from "e2e/support/cypress_data";
+import { USERS, USER_GROUPS } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const { nocollection } = USERS;
 

--- a/e2e/test/scenarios/permissions/reproductions/22726-readonly-collection-duplicate-question.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/22726-readonly-collection-duplicate-question.cy.spec.js
@@ -5,7 +5,11 @@ import {
   openQuestionActions,
   getFullName,
 } from "e2e/support/helpers";
-import { USERS, USER_GROUPS } from "e2e/support/cypress_data";
+import {
+  USERS,
+  USER_GROUPS,
+  ORDERS_QUESTION_ID,
+} from "e2e/support/cypress_data";
 
 const { nocollection } = USERS;
 
@@ -28,7 +32,7 @@ describe("issue 22726", () => {
   });
 
   it("should offer to duplicate a question in a view-only collection (metabase#22726)", () => {
-    visitQuestion(1);
+    visitQuestion(ORDERS_QUESTION_ID);
 
     openQuestionActions();
     popover().findByText("Duplicate").click();

--- a/e2e/test/scenarios/permissions/reproductions/22727-readonly-collection-offered-on-save.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/22727-readonly-collection-offered-on-save.cy.spec.js
@@ -1,5 +1,6 @@
 import { restore, visitQuestion, popover } from "e2e/support/helpers";
-import { USER_GROUPS, ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { USER_GROUPS } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const { ALL_USERS_GROUP } = USER_GROUPS;
 

--- a/e2e/test/scenarios/permissions/reproductions/22727-readonly-collection-offered-on-save.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/22727-readonly-collection-offered-on-save.cy.spec.js
@@ -1,5 +1,5 @@
 import { restore, visitQuestion, popover } from "e2e/support/helpers";
-import { USER_GROUPS } from "e2e/support/cypress_data";
+import { USER_GROUPS, ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 
 const { ALL_USERS_GROUP } = USER_GROUPS;
 
@@ -21,7 +21,7 @@ describe("issue 22727", () => {
   it("should not offer to save question in view only collection (metabase#22727, metabase#20717)", () => {
     // It is important to start from a saved question and to alter it.
     // We already have a reproduction that makes sure "Our analytics" is not offered when starting from an ad-hoc question (table).
-    visitQuestion(1);
+    visitQuestion(ORDERS_QUESTION_ID);
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("31.44").click();

--- a/e2e/test/scenarios/question/caching.cy.spec.js
+++ b/e2e/test/scenarios/question/caching.cy.spec.js
@@ -6,7 +6,7 @@ import {
   rightSidebar,
   popover,
 } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 describeEE("scenarios > question > caching", () => {
   beforeEach(() => {

--- a/e2e/test/scenarios/question/caching.cy.spec.js
+++ b/e2e/test/scenarios/question/caching.cy.spec.js
@@ -6,6 +6,7 @@ import {
   rightSidebar,
   popover,
 } from "e2e/support/helpers";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 
 describeEE("scenarios > question > caching", () => {
   beforeEach(() => {
@@ -15,8 +16,8 @@ describeEE("scenarios > question > caching", () => {
   });
 
   it("can set cache ttl for a saved question", () => {
-    cy.intercept("PUT", "/api/card/1").as("updateQuestion");
-    visitQuestion(1);
+    cy.intercept("PUT", `/api/card${ORDERS_QUESTION_ID}`).as("updateQuestion");
+    visitQuestion(ORDERS_QUESTION_ID);
 
     questionInfoButton().click();
 

--- a/e2e/test/scenarios/question/caching.cy.spec.js
+++ b/e2e/test/scenarios/question/caching.cy.spec.js
@@ -16,7 +16,7 @@ describeEE("scenarios > question > caching", () => {
   });
 
   it("can set cache ttl for a saved question", () => {
-    cy.intercept("PUT", `/api/card${ORDERS_QUESTION_ID}`).as("updateQuestion");
+    cy.intercept("PUT", `/api/card/${ORDERS_QUESTION_ID}`).as("updateQuestion");
     visitQuestion(ORDERS_QUESTION_ID);
 
     questionInfoButton().click();

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -131,7 +131,7 @@ describe("scenarios > question > new", () => {
         parent_id: null,
       }).then(({ body: { id: COLLECTION_ID } }) => {
         // Move question #1 ("Orders") to newly created collection
-        cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, {
+        cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
           collection_id: COLLECTION_ID,
         });
         // Sanity check: make sure Orders is indeed inside new collection
@@ -151,7 +151,7 @@ describe("scenarios > question > new", () => {
     it("'Saved Questions' prompt should respect nested collections structure (metabase#14178)", () => {
       getCollectionIdFromSlug("second_collection", id => {
         // Move first question in a DB snapshot ("Orders") to a "Second collection"
-        cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, {
+        cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
           collection_id: id,
         });
       });

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -12,12 +12,9 @@ import {
   modal,
 } from "e2e/support/helpers";
 
-import {
-  SAMPLE_DB_ID,
-  USERS,
-  ORDERS_QUESTION_ID,
-} from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, USERS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -12,7 +12,11 @@ import {
   modal,
 } from "e2e/support/helpers";
 
-import { SAMPLE_DB_ID, USERS } from "e2e/support/cypress_data";
+import {
+  SAMPLE_DB_ID,
+  USERS,
+  ORDERS_QUESTION_ID,
+} from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -130,7 +134,7 @@ describe("scenarios > question > new", () => {
         parent_id: null,
       }).then(({ body: { id: COLLECTION_ID } }) => {
         // Move question #1 ("Orders") to newly created collection
-        cy.request("PUT", "/api/card/1", {
+        cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, {
           collection_id: COLLECTION_ID,
         });
         // Sanity check: make sure Orders is indeed inside new collection
@@ -150,7 +154,7 @@ describe("scenarios > question > new", () => {
     it("'Saved Questions' prompt should respect nested collections structure (metabase#14178)", () => {
       getCollectionIdFromSlug("second_collection", id => {
         // Move first question in a DB snapshot ("Orders") to a "Second collection"
-        cy.request("PUT", "/api/card/1", {
+        cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, {
           collection_id: id,
         });
       });

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -16,7 +16,8 @@ import {
   expectGoodSnowplowEvents,
 } from "e2e/support/helpers";
 
-import { USERS, ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { USERS } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const PERMISSIONS = {
   curate: ["admin", "normal", "nodata"],

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -35,7 +35,7 @@ describe("managing question from the question's details sidebar", () => {
         onlyOn(permission === "curate", () => {
           describe(`${user} user`, () => {
             beforeEach(() => {
-              cy.intercept("PUT", `/api/card${ORDERS_QUESTION_ID}`).as(
+              cy.intercept("PUT", `/api/card/${ORDERS_QUESTION_ID}`).as(
                 "updateQuestion",
               );
 

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -35,10 +35,12 @@ describe("managing question from the question's details sidebar", () => {
         onlyOn(permission === "curate", () => {
           describe(`${user} user`, () => {
             beforeEach(() => {
-              cy.intercept("PUT", "/api/card/1").as("updateQuestion");
+              cy.intercept("PUT", `/api/card${ORDERS_QUESTION_ID}`).as(
+                "updateQuestion",
+              );
 
               cy.signIn(user);
-              visitQuestion(1);
+              visitQuestion(ORDERS_QUESTION_ID);
             });
 
             it("should be able to edit question details (metabase#11719-1)", () => {
@@ -196,7 +198,7 @@ describe("managing question from the question's details sidebar", () => {
           describe(`${user} user`, () => {
             beforeEach(() => {
               cy.signIn(user);
-              visitQuestion(1);
+              visitQuestion(ORDERS_QUESTION_ID);
             });
 
             it("should not be offered to add question to dashboard inside a collection they have `read` access to", () => {

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -16,7 +16,7 @@ import {
   expectGoodSnowplowEvents,
 } from "e2e/support/helpers";
 
-import { USERS } from "e2e/support/cypress_data";
+import { USERS, ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 
 const PERMISSIONS = {
   curate: ["admin", "normal", "nodata"],
@@ -170,7 +170,7 @@ describe("managing question from the question's details sidebar", () => {
               cy.findByText("Nothing here");
 
               // Check page for archived questions
-              cy.visit("/question/1");
+              cy.visit("/question/" + ORDERS_QUESTION_ID);
               // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText("This question has been archived");
             });

--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -191,7 +191,7 @@ describe("scenarios > question > saved", () => {
 
   it("should show collection breadcrumbs for a saved question in a non-root collection", () => {
     getCollectionIdFromSlug("second_collection", collection_id => {
-      cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, { collection_id });
+      cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { collection_id });
     });
 
     visitQuestion(ORDERS_QUESTION_ID);

--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -12,6 +12,8 @@ import {
   getCollectionIdFromSlug,
 } from "e2e/support/helpers";
 
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+
 describe("scenarios > question > saved", () => {
   beforeEach(() => {
     restore();
@@ -82,7 +84,7 @@ describe("scenarios > question > saved", () => {
   });
 
   it("view and filter saved question", () => {
-    visitQuestion(1);
+    visitQuestion(ORDERS_QUESTION_ID);
     cy.findAllByText("Orders"); // question and table name appears
 
     // filter to only orders with quantity=100
@@ -123,7 +125,7 @@ describe("scenarios > question > saved", () => {
   it("should duplicate a saved question", () => {
     cy.intercept("POST", "/api/card").as("cardCreate");
 
-    visitQuestion(1);
+    visitQuestion(ORDERS_QUESTION_ID);
 
     openQuestionActions();
     popover().within(() => {
@@ -148,7 +150,7 @@ describe("scenarios > question > saved", () => {
   it("should revert a saved question to a previous version", () => {
     cy.intercept("PUT", "/api/card/**").as("updateQuestion");
 
-    visitQuestion(1);
+    visitQuestion(ORDERS_QUESTION_ID);
     questionInfoButton().click();
 
     rightSidebar().within(() => {
@@ -172,14 +174,14 @@ describe("scenarios > question > saved", () => {
   });
 
   it("should show table name in header with a table info popover on hover", () => {
-    visitQuestion(1);
+    visitQuestion(ORDERS_QUESTION_ID);
     cy.findByTestId("question-table-badges").trigger("mouseenter");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("9 columns");
   });
 
   it("should show collection breadcrumbs for a saved question in the root collection", () => {
-    visitQuestion(1);
+    visitQuestion(ORDERS_QUESTION_ID);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     appBar().within(() => cy.findByText("Our analytics").click());
 
@@ -189,10 +191,10 @@ describe("scenarios > question > saved", () => {
 
   it("should show collection breadcrumbs for a saved question in a non-root collection", () => {
     getCollectionIdFromSlug("second_collection", collection_id => {
-      cy.request("PUT", "/api/card/1", { collection_id });
+      cy.request("PUT", `/api/card${ORDERS_QUESTION_ID}`, { collection_id });
     });
 
-    visitQuestion(1);
+    visitQuestion(ORDERS_QUESTION_ID);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     appBar().within(() => cy.findByText("Second collection").click());
 
@@ -201,7 +203,7 @@ describe("scenarios > question > saved", () => {
   });
 
   it("should show the question lineage when a saved question is changed", () => {
-    visitQuestion(1);
+    visitQuestion(ORDERS_QUESTION_ID);
 
     summarize();
     rightSidebar().within(() => {
@@ -218,7 +220,7 @@ describe("scenarios > question > saved", () => {
 
   it("'read-only' user should be able to resize column width (metabase#9772)", () => {
     cy.signIn("readonly");
-    visitQuestion(1);
+    visitQuestion(ORDERS_QUESTION_ID);
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Tax")

--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -12,7 +12,7 @@ import {
   getCollectionIdFromSlug,
 } from "e2e/support/helpers";
 
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 describe("scenarios > question > saved", () => {
   beforeEach(() => {

--- a/e2e/test/scenarios/question/summarization.cy.spec.js
+++ b/e2e/test/scenarios/question/summarization.cy.spec.js
@@ -14,7 +14,7 @@ import {
   checkExpressionEditorHelperPopoverPosition,
 } from "e2e/support/helpers";
 
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/question/summarization.cy.spec.js
+++ b/e2e/test/scenarios/question/summarization.cy.spec.js
@@ -14,6 +14,7 @@ import {
   checkExpressionEditorHelperPopoverPosition,
 } from "e2e/support/helpers";
 
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -25,7 +26,7 @@ describe("scenarios > question > summarize sidebar", () => {
 
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    visitQuestion(1);
+    visitQuestion(ORDERS_QUESTION_ID);
     summarize();
   });
 
@@ -147,7 +148,7 @@ describe("scenarios > question > summarize sidebar", () => {
   });
 
   it("breakout binning popover should have normal height even when it's rendered lower on the screen (metabase#15445)", () => {
-    visitQuestion(1);
+    visitQuestion(ORDERS_QUESTION_ID);
     cy.icon("notebook").click();
 
     summarize({ mode: "notebook" });

--- a/e2e/test/scenarios/sharing/alert/alert-permissions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert-permissions.cy.spec.js
@@ -4,12 +4,14 @@ import {
   visitQuestion,
   getFullName,
 } from "e2e/support/helpers";
+
+import { USERS } from "e2e/support/cypress_data";
+
 import {
-  USERS,
   ORDERS_QUESTION_ID,
   ORDERS_BY_YEAR_QUESTION_ID,
   ORDERS_COUNT_QUESTION_ID,
-} from "e2e/support/cypress_data";
+} from "e2e/support/cypress_sample_instance_data";
 
 const { normal, admin } = USERS;
 

--- a/e2e/test/scenarios/sharing/alert/alert-permissions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert-permissions.cy.spec.js
@@ -4,7 +4,12 @@ import {
   visitQuestion,
   getFullName,
 } from "e2e/support/helpers";
-import { USERS } from "e2e/support/cypress_data";
+import {
+  USERS,
+  ORDERS_QUESTION_ID,
+  ORDERS_BY_YEAR_QUESTION_ID,
+  ORDERS_COUNT_QUESTION_ID,
+} from "e2e/support/cypress_data";
 
 const { normal, admin } = USERS;
 
@@ -18,16 +23,16 @@ describe("scenarios > alert > alert permissions", { tags: "@external" }, () => {
     setupSMTP();
 
     // Create alert as admin
-    visitQuestion(1);
+    visitQuestion(ORDERS_QUESTION_ID);
     createBasicAlert({ firstAlert: true });
 
     // Create alert as admin that user can see
-    visitQuestion(2);
+    visitQuestion(ORDERS_COUNT_QUESTION_ID);
     createBasicAlert({ includeNormal: true });
 
     // Create alert as normal user
     cy.signInAsNormalUser();
-    visitQuestion(3);
+    visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
     createBasicAlert();
   });
 
@@ -44,7 +49,7 @@ describe("scenarios > alert > alert permissions", { tags: "@external" }, () => {
       cy.intercept("PUT", "/api/alert/1").as("updatedAlert");
 
       // Change alert
-      visitQuestion(1);
+      visitQuestion(ORDERS_QUESTION_ID);
       cy.icon("bell").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit").click();
@@ -67,7 +72,7 @@ describe("scenarios > alert > alert permissions", { tags: "@external" }, () => {
     beforeEach(cy.signInAsNormalUser);
 
     it("should not let you see other people's alerts", () => {
-      visitQuestion(1);
+      visitQuestion(ORDERS_QUESTION_ID);
       cy.icon("bell").click();
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -77,7 +82,7 @@ describe("scenarios > alert > alert permissions", { tags: "@external" }, () => {
     });
 
     it("should let you see other alerts where you are a recipient", () => {
-      visitQuestion(2);
+      visitQuestion(ORDERS_COUNT_QUESTION_ID);
       cy.icon("bell").click();
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -87,7 +92,7 @@ describe("scenarios > alert > alert permissions", { tags: "@external" }, () => {
     });
 
     it("should let you see your own alerts", () => {
-      visitQuestion(3);
+      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
       cy.icon("bell").click();
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -96,7 +101,7 @@ describe("scenarios > alert > alert permissions", { tags: "@external" }, () => {
 
     it("should let you unsubscribe from both your own and others' alerts", () => {
       // Unsubscribe from your own alert
-      visitQuestion(3);
+      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
       cy.icon("bell").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Unsubscribe").click();
@@ -105,7 +110,7 @@ describe("scenarios > alert > alert permissions", { tags: "@external" }, () => {
       cy.findByText("Okay, you're unsubscribed");
 
       // Unsubscribe from others' alerts
-      visitQuestion(2);
+      visitQuestion(ORDERS_COUNT_QUESTION_ID);
       cy.icon("bell").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Unsubscribe").click();

--- a/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
@@ -4,6 +4,10 @@ import {
   mockSlackConfigured,
   visitQuestion,
 } from "e2e/support/helpers";
+import {
+  ORDERS_QUESTION_ID,
+  ORDERS_COUNT_QUESTION_ID,
+} from "e2e/support/cypress_data";
 
 const channels = { slack: mockSlackConfigured, email: setupSMTP };
 
@@ -15,7 +19,7 @@ describe("scenarios > alert", () => {
 
   describe("with nothing set", () => {
     it("should prompt you to add email/slack credentials", () => {
-      visitQuestion(1);
+      visitQuestion(ORDERS_QUESTION_ID);
       cy.icon("bell").click();
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -27,7 +31,7 @@ describe("scenarios > alert", () => {
     it("should say to non-admins that admin must add email credentials", () => {
       cy.signInAsNormalUser();
 
-      visitQuestion(1);
+      visitQuestion(ORDERS_QUESTION_ID);
       cy.icon("bell").click();
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -46,7 +50,7 @@ describe("scenarios > alert", () => {
         cy.intercept("POST", "/api/card/2/query").as("questionLoaded");
 
         // Open the first alert screen and create an alert
-        visitQuestion(1);
+        visitQuestion(ORDERS_QUESTION_ID);
         cy.icon("bell").click();
 
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -69,7 +73,7 @@ describe("scenarios > alert", () => {
         cy.wait("@savedAlert");
 
         // Open the second alert screen
-        visitQuestion(2);
+        visitQuestion(ORDERS_COUNT_QUESTION_ID);
         cy.wait("@questionLoaded");
 
         cy.icon("bell").click();

--- a/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
@@ -4,10 +4,11 @@ import {
   mockSlackConfigured,
   visitQuestion,
 } from "e2e/support/helpers";
+
 import {
   ORDERS_QUESTION_ID,
   ORDERS_COUNT_QUESTION_ID,
-} from "e2e/support/cypress_data";
+} from "e2e/support/cypress_sample_instance_data";
 
 const channels = { slack: mockSlackConfigured, email: setupSMTP };
 

--- a/e2e/test/scenarios/sharing/approved-domains.cy.spec.js
+++ b/e2e/test/scenarios/sharing/approved-domains.cy.spec.js
@@ -6,6 +6,7 @@ import {
   visitQuestion,
   visitDashboard,
 } from "e2e/support/helpers";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 
 const allowedDomain = "metabase.test";
 const deniedDomain = "metabase.example";
@@ -25,7 +26,7 @@ describeEE(
     });
 
     it("should validate approved email domains for a question alert", () => {
-      visitQuestion(1);
+      visitQuestion(ORDERS_QUESTION_ID);
 
       cy.icon("bell").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/sharing/approved-domains.cy.spec.js
+++ b/e2e/test/scenarios/sharing/approved-domains.cy.spec.js
@@ -6,7 +6,7 @@ import {
   visitQuestion,
   visitDashboard,
 } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const allowedDomain = "metabase.test";
 const deniedDomain = "metabase.example";

--- a/e2e/test/scenarios/sharing/reproductions/16108-missing-tooltip.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/16108-missing-tooltip.cy.spec.js
@@ -1,5 +1,5 @@
 import { restore, visitQuestion } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 describe("issue 16108", () => {
   beforeEach(() => {

--- a/e2e/test/scenarios/sharing/reproductions/16108-missing-tooltip.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/16108-missing-tooltip.cy.spec.js
@@ -1,4 +1,5 @@
 import { restore, visitQuestion } from "e2e/support/helpers";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_data";
 
 describe("issue 16108", () => {
   beforeEach(() => {
@@ -7,7 +8,7 @@ describe("issue 16108", () => {
   });
 
   it("should display a tooltip for CTA icons on an individual question (metabase#16108)", () => {
-    visitQuestion(1);
+    visitQuestion(ORDERS_QUESTION_ID);
     cy.icon("download").realHover();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Download full results");


### PR DESCRIPTION
### Description

By changing the default state of a fresh metabase instance https://github.com/metabase/metabase/pull/31459, breaks a huge number of our tests.  This fixes those that rely on specific question IDs, and introduces a reliable and performant method of identifying questions, dashboards, collections, and users without hard-coded ids.

## Implementation
- at test spin-up, we cache a JSON of all our dashboards, collections, questions, and users.
- Then, at runtime we can access those ids (or any other information) statically without the need for additional API requests that could flake and/or slow down our tests
- This follows a similar pattern that we use for access table and field IDs in the sample database already.


## Usage
Now instead of 

```js
cy.visitQuestion(1);
```

you should

```js
import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";

// ...

cy.visitQuestion(ORDERS_QUESTION_ID);
```

### How to verify

Tests that rely on question IDs should pass.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
