### PR TITLE
fix parameter mapping cropped

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-nested.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-nested.cy.spec.js
@@ -6,6 +6,7 @@ import {
   saveDashboard,
   visitDashboard,
   setFilter,
+  getDashboardCard,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
@@ -96,11 +97,11 @@ describe("scenarios > dashboard > filters > nested questions", () => {
     editDashboard();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(filter.name).find(".Icon-gear").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Column to filter on")
-      .parent()
-      .contains(/Category/i)
-      .click();
+
+    getDashboardCard().within(() => {
+      cy.findByText("Column to filter on");
+      cy.findByText("18113 Source.CATEGORY").click();
+    });
 
     // This part reproduces metabase#12614
     popover().within(() => {

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -309,7 +309,11 @@ describe("scenarios > dashboard > parameters", () => {
 
       // Confirm that the correct parameter type is connected to the native question's field filter
       cy.findByText(matchingFilterType.name).find(".Icon-gear").click();
-      cy.findByText("Column to filter on").parent().contains("Native Filter");
+
+      getDashboardCard().within(() => {
+        cy.findByText("Column to filter on");
+        cy.findByText("Native Filter");
+      });
 
       // Update the underlying question's query
       cy.request("PUT", `/api/card/${card_id}`, {

--- a/e2e/test/scenarios/dashboard-filters/reproductions/20656-dashboard-breaks-for-user-without-card-permissions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/20656-dashboard-breaks-for-user-without-card-permissions.cy.spec.js
@@ -3,6 +3,7 @@ import {
   filterWidget,
   visitDashboard,
   editDashboard,
+  getDashboardCard,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
@@ -74,10 +75,9 @@ describe("issue 20656", () => {
       .click();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Column to filter on")
-      .parent()
-      .within(() => {
-        cy.icon("key");
-      });
+    getDashboardCard().within(() => {
+      cy.findByText("Column to filter on");
+      cy.icon("key");
+    });
   });
 });

--- a/e2e/test/scenarios/dashboard-filters/reproductions/20656-dashboard-breaks-for-user-without-card-permissions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/20656-dashboard-breaks-for-user-without-card-permissions.cy.spec.js
@@ -74,7 +74,6 @@ describe("issue 20656", () => {
       .find(".Icon-gear")
       .click();
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     getDashboardCard().within(() => {
       cy.findByText("Column to filter on");
       cy.icon("key");

--- a/e2e/test/scenarios/dashboard-filters/reproductions/22788-flter-cc-dropped-on-second-edit.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/22788-flter-cc-dropped-on-second-edit.cy.spec.js
@@ -5,6 +5,7 @@ import {
   editDashboard,
   saveDashboard,
   sidebar,
+  getDashboardCard,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
@@ -75,12 +76,11 @@ describe("issue 22788", () => {
     openFilterSettings();
 
     // Make sure the filter is still connected to the custom column
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Column to filter on")
-      .parent()
-      .within(() => {
-        cy.findByText(ccDisplayName);
-      });
+
+    getDashboardCard().within(() => {
+      cy.findByText("Column to filter on");
+      cy.findByText(ccDisplayName);
+    });
 
     // need to actually change the dashboard to test a real save
     sidebar().within(() => {

--- a/e2e/test/scenarios/dashboard/chained-filters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/chained-filters.cy.spec.js
@@ -33,7 +33,7 @@ describe("scenarios > dashboard > chained filter", () => {
       // connect that to people.state
       getDashboardCard().within(() => {
         cy.findByText("Column to filter on");
-        cy.findByText("Select…");
+        cy.findByText("Select…").click();
       });
 
       popover().within(() => {
@@ -53,7 +53,7 @@ describe("scenarios > dashboard > chained filter", () => {
       // connect that to person.city
       getDashboardCard().within(() => {
         cy.findByText("Column to filter on");
-        cy.findByText("Select…");
+        cy.findByText("Select…").click();
       });
       popover().within(() => {
         cy.findByText("City").click();

--- a/e2e/test/scenarios/dashboard/chained-filters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/chained-filters.cy.spec.js
@@ -4,6 +4,7 @@ import {
   showDashboardCardActions,
   visitDashboard,
   addOrUpdateDashboardCard,
+  getDashboardCard,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
@@ -30,12 +31,11 @@ describe("scenarios > dashboard > chained filter", () => {
       });
 
       // connect that to people.state
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Column to filter on")
-        .parent()
-        .within(() => {
-          cy.findByText("Select…").click();
-        });
+      getDashboardCard().within(() => {
+        cy.findByText("Column to filter on");
+        cy.findByText("Select…");
+      });
+
       popover().within(() => {
         cy.findByText("State").click();
       });
@@ -52,11 +52,10 @@ describe("scenarios > dashboard > chained filter", () => {
 
       // connect that to person.city
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Column to filter on")
-        .parent()
-        .within(() => {
-          cy.findByText("Select…").click();
-        });
+      getDashboardCard().within(() => {
+        cy.findByText("Column to filter on");
+        cy.findByText("Select…");
+      });
       popover().within(() => {
         cy.findByText("City").click();
       });

--- a/e2e/test/scenarios/dashboard/chained-filters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/chained-filters.cy.spec.js
@@ -51,7 +51,6 @@ describe("scenarios > dashboard > chained filter", () => {
       });
 
       // connect that to person.city
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       getDashboardCard().within(() => {
         cy.findByText("Column to filter on");
         cy.findByText("Select…");

--- a/e2e/test/scenarios/models/reproductions/23024-cannot-apply-dash-filter-native-model.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/23024-cannot-apply-dash-filter-native-model.cy.spec.js
@@ -58,7 +58,6 @@ describe("issue 23024", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Is").click();
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     getDashboardCard().within(() => {
       cy.findByText("Column to filter on");
       cy.findByText("Select…").click();

--- a/e2e/test/scenarios/models/reproductions/23024-cannot-apply-dash-filter-native-model.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/23024-cannot-apply-dash-filter-native-model.cy.spec.js
@@ -5,6 +5,7 @@ import {
   restore,
   visitDashboard,
   setModelMetadata,
+  getDashboardCard,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
@@ -21,7 +22,8 @@ describe("issue 23024", () => {
     cy.createNativeQuestion(
       {
         native: {
-          query: `select * from products limit 5`,
+          query: `select *
+                  from products limit 5`,
         },
         dataset: true,
       },
@@ -57,11 +59,10 @@ describe("issue 23024", () => {
     cy.findByText("Is").click();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Column to filter on")
-      .parent()
-      .within(() => {
-        cy.findByText("Select…").click();
-      });
+    getDashboardCard().within(() => {
+      cy.findByText("Column to filter on");
+      cy.findByText("Select…").click();
+    });
 
     popover().contains("Category");
   });

--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -9,7 +9,7 @@ import "number-to-locale-string";
 // This is conditionally aliased in the webpack config.
 // If EE isn't enabled, it loads an empty file.
 // Should be imported before any other metabase import
-import "ee-overrides";
+import "ee-overrides"; // eslint-disable-line import/no-duplicates
 
 // If enabled this monkeypatches `t` and `jt` to return blacked out
 // strings/elements to assist in finding untranslated strings.
@@ -26,7 +26,7 @@ import "metabase/plugins/builtin";
 
 // This is conditionally aliased in the webpack config.
 // If EE isn't enabled, it loads an empty file.
-import "ee-plugins";
+import "ee-plugins"; // eslint-disable-line import/no-duplicates
 
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";

--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -9,7 +9,7 @@ import "number-to-locale-string";
 // This is conditionally aliased in the webpack config.
 // If EE isn't enabled, it loads an empty file.
 // Should be imported before any other metabase import
-import "ee-overrides"; // eslint-disable-line import/no-duplicates
+import "ee-overrides";
 
 // If enabled this monkeypatches `t` and `jt` to return blacked out
 // strings/elements to assist in finding untranslated strings.
@@ -26,7 +26,7 @@ import "metabase/plugins/builtin";
 
 // This is conditionally aliased in the webpack config.
 // If EE isn't enabled, it loads an empty file.
-import "ee-plugins"; // eslint-disable-line import/no-duplicates
+import "ee-plugins";
 
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
@@ -21,6 +21,7 @@ import {
 } from "metabase/dashboard/utils";
 
 import { isActionDashCard } from "metabase/actions/utils";
+import Ellipsified from "metabase/core/components/Ellipsified";
 import Question from "metabase-lib/Question";
 import { isDateParameter } from "metabase-lib/parameters/utils/parameter-type";
 import { isVariableTarget } from "metabase-lib/parameters/utils/targets";
@@ -220,7 +221,11 @@ export function DashCardCardParameterMapper({
         </NativeCardDefault>
       ) : (
         <>
-          {headerContent && <Header>{headerContent}</Header>}
+          {headerContent && (
+            <Header>
+              <Ellipsified>{headerContent}</Ellipsified>
+            </Header>
+          )}
           <Tooltip tooltip={buttonTooltip}>
             <TippyPopover
               visible={isDropdownVisible && !isDisabled && hasPermissionsToMap}
@@ -253,7 +258,9 @@ export function DashCardCardParameterMapper({
                 }}
               >
                 {buttonText && (
-                  <TargetButtonText>{buttonText}</TargetButtonText>
+                  <TargetButtonText>
+                    <Ellipsified>{buttonText}</Ellipsified>
+                  </TargetButtonText>
                 )}
                 {buttonIcon}
               </TargetButton>

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.styled.jsx
@@ -12,6 +12,8 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  width: 100%;
+  padding: 0.25rem;
 `;
 
 export const TextCardDefault = styled.div`
@@ -60,11 +62,14 @@ export const CardLabel = styled.div`
 `;
 
 export const Header = styled.h4`
+  width: 100%;
   color: ${color("text-medium")};
   margin-bottom: ${space(1)};
+  text-align: center;
 `;
 
 export const TargetButton = styled.div`
+  max-width: 100%;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -75,8 +80,8 @@ export const TargetButton = styled.div`
   border: 2px solid ${color("brand")};
   border-radius: 8px;
   min-height: 30px;
-  min-width: 100px;
   padding: 0.25em 0.5em;
+  margin: 0 0.25rem;
   color: ${color("text-medium")};
 
   ${({ variant }) =>
@@ -111,6 +116,7 @@ TargetButton.defaultProps = {
 };
 
 export const TargetButtonText = styled.span`
+  overflow: hidden;
   text-align: center;
   margin-right: ${space(1)};
 `;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardParameterMapper.jsx
@@ -4,6 +4,7 @@ import { t } from "ttag";
 import { color } from "metabase/lib/colors";
 
 import DashCardCardParameterMapper from "./DashCardCardParameterMapper";
+import { MapperSettingsContainer } from "./DashCardParameterMapper.styled";
 
 const DashCardParameterMapper = ({ dashcard, isMobile }) => (
   <div className="relative flex-full flex flex-column layout-centered">
@@ -19,7 +20,7 @@ const DashCardParameterMapper = ({ dashcard, isMobile }) => (
         {t`Make sure to make a selection for each series, or the filter won't work on this card.`}
       </div>
     )}
-    <div className="flex mx4 z1" style={{ justifyContent: "space-around" }}>
+    <MapperSettingsContainer>
       {[dashcard.card].concat(dashcard.series || []).map(card => (
         <DashCardCardParameterMapper
           key={`${dashcard.id},${card.id}`}
@@ -28,7 +29,7 @@ const DashCardParameterMapper = ({ dashcard, isMobile }) => (
           isMobile={isMobile}
         />
       ))}
-    </div>
+    </MapperSettingsContainer>
   </div>
 );
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardParameterMapper.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardParameterMapper.styled.tsx
@@ -1,0 +1,9 @@
+import styled from "@emotion/styled";
+
+export const MapperSettingsContainer = styled.div`
+  display: flex;
+  justify-content: space-around;
+  max-width: 100%;
+  margin: 0 2rem;
+  z-index: 1;
+`;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31586

### Description

After migrating to 24-column grid cards can get smaller which makes the overflow parameter mapping issue way more noticeable. This PR adds text ellipsifying with a tooltip on hover.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New -> Orders -> Summarize by Created At -> Switch viz type to trend
2. Add it on a dashboard, add any filter
3. Try connecting long enough dimension from the card to the filter

### Demo

#### Before
<img width="474" alt="Screen Shot 2023-06-14 at 7 01 53 PM" src="https://github.com/metabase/metabase/assets/14301985/94d027fb-e23e-43f6-8693-e54cf2574b57">

#### After
<img width="503" alt="Screen Shot 2023-06-14 at 7 00 19 PM" src="https://github.com/metabase/metabase/assets/14301985/7be09900-d8eb-4fa7-b889-e75d02344ab4">

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR — kind of a visual change, testing it in jsdom does not make much sense
