### PR TITLE
Fix Snowflake sync with uploaded private key

### DIFF
--- a/modules/drivers/snowflake/resources/metabase-plugin.yaml
+++ b/modules/drivers/snowflake/resources/metabase-plugin.yaml
@@ -10,7 +10,7 @@ driver:
   connection-properties:
     - name: account
       display-name: Account name
-      helper-text: Enter your Account ID with the region that your Snowflake cluster is running on e.g. "xxxxxxxx.us-east-2.aws". Some regions don't have this suffix.
+      helper-text: Enter your Account ID with the region that your Snowflake cluster is running on e.g. "xxxxxxxx.us-east-2.aws". Some regions don't have this suffix.
       placeholder: xxxxxxxx.us-east-2.aws
       required: true
     - user

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -20,7 +20,6 @@
    [metabase.driver.sql.util :as sql.u]
    [metabase.driver.sql.util.unprepare :as unprepare]
    [metabase.driver.sync :as driver.s]
-   [metabase.driver.util :as driver.u]
    [metabase.models.secret :as secret]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.store :as qp.store]
@@ -34,7 +33,6 @@
    [ring.util.codec :as codec])
   (:import
    (java.io File)
-   (java.nio.charset StandardCharsets)
    (java.sql Connection DatabaseMetaData ResultSet Types)
    (java.time OffsetDateTime ZonedDateTime)))
 

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -76,7 +76,10 @@
                                                           {:user (codec/url-encode user)
                                                            :private_key_file (codec/url-encode (.getCanonicalPath ^File private-key-file))})
         new-conn-uri (sql-jdbc.common/conn-str-with-additional-opts existing-conn-uri :url opts-str)]
-    (assoc details :connection-uri new-conn-uri)))
+    (-> details
+        (assoc :connection-uri new-conn-uri)
+        ;; The Snowflake driver uses the :account property, but we need to drop the region from it first
+        (assoc :account (first (str/split account #"\."))))))
 
 (defn- resolve-private-key
   "Convert the private-key secret properties into a private_key_file property in `details`.

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -427,7 +427,7 @@
                                           ;; version of the -value property (the :type "textFile" one)
                                           (let [textfile-prop (val-kw secrets-server->client)]
                                             (:treat-before-posting textfile-prop)))))
-                         value      (let [^String v (val-kw acc)]
+                         value      (when-let [^String v (val-kw acc)]
                                       (case (get-treat)
                                         "base64" (decode-uploaded v)
                                         v))]


### PR DESCRIPTION
This addresses a few issues in using uploaded private keys with Snowflake. This solves the problem with the `:account` key but I don't understand why we use both `:connection-uri` and other properties in the spec map. I'm not sure when `:connection-uri` would be in `:details` to begin with, but it gets added by `handle-conn-uri` anyway.

`clojure.java.jdbc` calls using the spec map with `:connection-uri` work, but setting the properties on the raw connection failed when `:account` was passed along with a region in it to the connection as a property in the pooled connection.

This only fails for the private key code path because we create a `:connection-uri` in that case, but not when using password authentication.

Resolves #30376