### PR TITLE
Do not record public info in revisions

### DIFF
--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -106,7 +106,7 @@
 ;;; --------------------------------------------------- Revisions ----------------------------------------------------
 
 (def ^:private excluded-columns-for-card-revision
-  [:id :created_at :updated_at :entity_id :creator_id])
+  [:id :created_at :updated_at :entity_id :creator_id :public_uuid :made_public_by_id])
 
 (defmethod revision/serialize-instance :model/Card
   ([instance]

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -184,6 +184,7 @@
    ;; > The position this Dashboard should appear in the Dashboards list,
    ;;   lower-numbered positions appearing before higher numbered ones.
    ;; TODO: querying on stats we don't have any dashboard that has a position, maybe we could just drop it?
+   :public_uuid :made_public_by_id
    :position])
 
 (def ^:private excluded-columns-for-dashcard-revision

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -60,10 +60,8 @@
               :archived            false
               :collection_position nil
               :enable_embedding    false
-              :made_public_by_id   nil
               :embedding_params    nil
-              :parameters          []
-              :public_uuid         nil}
+              :parameters          []}
              (update (revision/serialize-instance Dashboard (:id dashboard) dashboard)
                      :cards
                      (fn [[{:keys [id card_id series], :as card}]]
@@ -366,10 +364,8 @@
                                 :archived            false
                                 :collection_position nil
                                 :enable_embedding    false
-                                :made_public_by_id   nil
                                 :embedding_params    nil
-                                :parameters          []
-                                :public_uuid         nil}
+                                :parameters          []}
           serialized-dashboard (revision/serialize-instance Dashboard (:id dashboard) dashboard)]
       (testing "original state"
         (is (= {:name                "Test Dashboard"
@@ -393,10 +389,8 @@
                 :archived            false
                 :collection_position nil
                 :enable_embedding    false
-                :made_public_by_id   nil
                 :embedding_params    nil
-                :parameters          []
-                :public_uuid         nil}
+                :parameters          []}
                (update serialized-dashboard :cards check-ids))))
       (testing "delete the dashcard and modify the dash attributes"
         (dashboard-card/delete-dashboard-cards! [(:id dashboard-card)])
@@ -431,10 +425,8 @@
                 :archived            false
                 :collection_position nil
                 :enable_embedding    false
-                :made_public_by_id   nil
                 :embedding_params    nil
-                :parameters          []
-                :public_uuid         nil}
+                :parameters          []}
                (update (revision/serialize-instance Dashboard dashboard-id (t2/select-one Dashboard :id dashboard-id))
                        :cards check-ids))))
       (testing "revert back to the empty state"


### PR DESCRIPTION
Per [this](https://metaboat.slack.com/archives/C057T1QTB3L/p1686796397609119) discussion, we don't want the public info to be recorded in revision. The reasoning is: revert a Card/Dashboard to a previous revision shouldn't change the public settings.