### PR TITLE
CSV: standardize error handling

### DIFF
--- a/src/metabase/api/routes/common.clj
+++ b/src/metabase/api/routes/common.clj
@@ -8,7 +8,7 @@
 (def +public-exceptions
   "Wrap `routes` so any Exception except 404 thrown is just returned as a generic 400, to prevent details from leaking in public
   endpoints."
-  #'mw.exceptions/public-execptions)
+  #'mw.exceptions/public-exceptions)
 
 (def +message-only-exceptions
   "Wrap `routes` so any Exception thrown is just returned as a 400 with only the message from the original

--- a/src/metabase/server/middleware/exceptions.clj
+++ b/src/metabase/server/middleware/exceptions.clj
@@ -14,7 +14,7 @@
 
 (declare api-exception-response)
 
-(defn public-execptions
+(defn public-exceptions
   "Catch any exceptions other than 404 thrown in the request handler body and rethrow a generic 400 exception instead.
   This minimizes information available to bad actors when exceptions occur on public endpoints."
   [handler]
@@ -88,7 +88,7 @@
   {:status-code 204, :body nil, :headers (mw.security/security-headers)})
 
 (defn catch-api-exceptions
-  "Middleware that catches API Exceptions and returns them in our normal-style format rather than the Jetty 500
+  "Middleware (with `[request respond raise]`) that catches API Exceptions and returns them in our normal-style format rather than the Jetty 500
   Stacktrace page, which is not so useful for our frontend."
   [handler]
   (fn [request respond _raise]
@@ -99,15 +99,15 @@
 
 
 (defn catch-uncaught-exceptions
-  "Middleware that catches any unexpected Exceptions that reroutes them thru `raise` where they can be handled
-  appropriately."
+  "Middleware (with `[request respond raise]`) that catches any unexpected Exceptions and reroutes them through `raise`
+  where they can be handled appropriately."
   [handler]
   (fn [request respond raise]
     (try
       (handler
        request
        ;; for people that accidentally pass along an Exception, e.g. from qp.async, do the nice thing and route it to
-       ;; the write place for them
+       ;; the right place for them
        (fn [response]
          ((if (instance? Throwable response)
             raise


### PR DESCRIPTION
All CSV-related errors will reliably have a `:message` key. The status code will be 422 if it's something we anticipated and 500 if it's not. There will no longer be a `:cause` key under any circumstance.