### PR TITLE
FE: Show new syncing tables with spinners in /browse

### DIFF
--- a/frontend/src/metabase/browse/components/TableBrowser/TableBrowser.jsx
+++ b/frontend/src/metabase/browse/components/TableBrowser/TableBrowser.jsx
@@ -55,12 +55,10 @@ const TableBrowser = ({
       <Grid>
         {tables.map(table => (
           <TableGridItem key={table.id}>
-            <TableCard hoverable={!isTableLoading(table, database)}>
+            <TableCard hoverable={!isSyncInProgress(table)}>
               <TableLink
                 to={
-                  !isTableLoading(table, database)
-                    ? getTableUrl(table, metadata)
-                    : ""
+                  !isSyncInProgress(table) ? getTableUrl(table, metadata) : ""
                 }
                 data-metabase-event={`${ANALYTICS_CONTEXT};Table Click`}
               >
@@ -90,7 +88,7 @@ const itemPropTypes = {
 
 const TableBrowserItem = ({ database, table, dbId, xraysEnabled }) => {
   const isVirtual = isVirtualCardId(table.id);
-  const isLoading = isTableLoading(table, database);
+  const isLoading = isSyncInProgress(table);
 
   return (
     <EntityItem
@@ -142,10 +140,6 @@ const TableBrowserItemButtons = ({ tableId, dbId, xraysEnabled }) => {
 };
 
 TableBrowserItemButtons.propTypes = itemButtonsPropTypes;
-
-const isTableLoading = (table, database) => {
-  return database && isSyncInProgress(database) && isSyncInProgress(table);
-};
 
 const getDatabaseCrumbs = dbId => {
   if (dbId === SAVED_QUESTIONS_VIRTUAL_DB_ID) {

--- a/frontend/src/metabase/browse/components/TableBrowser/TableBrowser.unit.spec.js
+++ b/frontend/src/metabase/browse/components/TableBrowser/TableBrowser.unit.spec.js
@@ -24,28 +24,31 @@ describe("TableBrowser", () => {
     expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
   });
 
-  it("should render syncing tables", () => {
-    const database = getDatabase({
-      initial_sync_status: "incomplete",
-    });
+  it.each(["incomplete", "complete"])(
+    "should render syncing tables, regardless of the database's initial_sync_status",
+    initial_sync_status => {
+      const database = getDatabase({ initial_sync_status });
 
-    const tables = [
-      getTable({ id: 1, name: "Orders", initial_sync_status: "incomplete" }),
-    ];
+      const tables = [
+        getTable({ id: 1, name: "Orders", initial_sync_status: "incomplete" }),
+      ];
 
-    render(
-      <TableBrowser
-        database={database}
-        tables={tables}
-        getTableUrl={getTableUrl}
-        xraysEnabled={true}
-      />,
-    );
+      render(
+        <TableBrowser
+          database={database}
+          tables={tables}
+          getTableUrl={getTableUrl}
+          xraysEnabled={true}
+        />,
+      );
 
-    expect(screen.getByText("Orders")).toBeInTheDocument();
-    expect(screen.queryByLabelText("bolt_filled icon")).not.toBeInTheDocument();
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
-  });
+      expect(screen.getByText("Orders")).toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("bolt_filled icon"),
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    },
+  );
 
   it("should render tables with a sync error", () => {
     const database = getDatabase({

--- a/frontend/src/metabase/browse/containers/TableBrowser/TableBrowser.jsx
+++ b/frontend/src/metabase/browse/containers/TableBrowser/TableBrowser.jsx
@@ -31,7 +31,7 @@ const getSchemaName = props => {
   return props.schemaName || props.params.schemaName;
 };
 
-const getReloadInterval = (state, tables = []) => {
+const getReloadInterval = (state, _props, tables = []) => {
   if (tables.some(t => isSyncInProgress(t))) {
     return RELOAD_INTERVAL;
   } else {

--- a/frontend/src/metabase/browse/containers/TableBrowser/TableBrowser.jsx
+++ b/frontend/src/metabase/browse/containers/TableBrowser/TableBrowser.jsx
@@ -31,12 +31,8 @@ const getSchemaName = props => {
   return props.schemaName || props.params.schemaName;
 };
 
-const getReloadInterval = (state, { database }, tables = []) => {
-  if (
-    database &&
-    isSyncInProgress(database) &&
-    tables.some(t => isSyncInProgress(t))
-  ) {
+const getReloadInterval = (state, tables = []) => {
+  if (tables.some(t => isSyncInProgress(t))) {
     return RELOAD_INTERVAL;
   } else {
     return 0;


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/31082

Corresponds to [this block](https://www.notion.so/metabase/Provide-progress-on-initial-database-sync-16af8e79312a45ecb715d8e58801c52b?pvs=4#c72950a97cf14fd48e6ef2b6dfdd676b) in the spec.

This PR changes the /browse/:database page (aka the `TableBrowser` component) to show newly created and syncing tables with a spinner, and unable to be clicked.

Loom demo:
https://www.loom.com/share/e3e9b5a2c2a441aaba4c94ca4f01b776