### PR TITLE
Respect MB_COLORIZE_LOGS and MB_EMOJI_IN_LOGS environment variables

### DIFF
--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -322,7 +322,7 @@
   (or (nil? x)
       (f x)))
 
-(def ^String ^{:arglists '([emoji-string])} emoji
+(def ^String ^{:arglists '([emoji-string])} ^:redef emoji
   "Returns the `emoji-string` passed in if emoji in logs are enabled, otherwise always returns an empty string."
   #?(:clj  (if (config/config-bool :mb-emoji-in-logs)
              identity

--- a/src/metabase/util/format.cljc
+++ b/src/metabase/util/format.cljc
@@ -59,7 +59,7 @@
        false
        (config/config-bool :mb-colorize-logs))))
 
-(def ^{:arglists '(^String [color-symb x])} colorize
+(def ^{:arglists '(^String [color-symb x])} ^:redef colorize
   "Colorize string `x` using `color`, a symbol or keyword, but only if `MB_COLORIZE_LOGS` is enabled (the default).
   `color` can be `green`, `red`, `yellow`, `blue`, `cyan`, `magenta`, etc. See the entire list of avaliable
   colors [here](https://github.com/ibdknox/colorize/blob/master/src/colorize/core.clj)"


### PR DESCRIPTION
Due to AOT (Ahead Of Time) compilation (specifically direct linking),
the `MB_COLORIZE_LOGS` and `MB_EMOJI_IN_LOGS` env vars where not
respected.

Marking `metabase.util.format/colorize` and `metabase.util/emoji` with
`^:redef` metadata prevents the compiler from using direct linking for
calls to these functions (and thus evaluating the env vars at compile
time) and thus delays resolution of what function to call until runtime
when the actual user-provided value of the env var is known.
cf. https://clojure.org/reference/compilation#directlinking

Closes: https://github.com/metabase/metabase/issues/30518
