### PR TITLE
Add a single bucket picker component for MLv2

### DIFF
--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BinningStrategyPickerPopover.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BinningStrategyPickerPopover.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import * as Lib from "metabase-lib";
-import type { BucketPickerPopoverProps } from "./types";
+import type { CommonBucketPickerProps } from "./types";
 import type { BucketListItem } from "./BaseBucketPickerPopover";
 import {
   BaseBucketPickerPopover,
@@ -16,7 +16,7 @@ export function BinningStrategyPickerPopover({
   isEditing,
   onSelect,
   ...props
-}: BucketPickerPopoverProps) {
+}: CommonBucketPickerProps) {
   const selectedBucket = useMemo(() => Lib.binning(column), [column]);
 
   const items = useMemo(

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BucketPickerPopover.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BucketPickerPopover.tsx
@@ -1,0 +1,53 @@
+import * as Lib from "metabase-lib";
+import { BinningStrategyPickerPopover } from "./BinningStrategyPickerPopover";
+import { TemporalBucketPickerPopover } from "./TemporalBucketPickerPopover";
+import { BucketPickerPopoverProps as BaseBucketPickerPopoverProps } from "./types";
+
+interface BucketPickerPopoverProps
+  extends Omit<BaseBucketPickerPopoverProps, "buckets"> {
+  hasBinning?: boolean;
+  hasTemporalBucketing?: boolean;
+}
+
+export function BucketPickerPopover({
+  query,
+  stageIndex,
+  column,
+  hasBinning = false,
+  hasTemporalBucketing = false,
+  ...props
+}: BucketPickerPopoverProps) {
+  if (hasBinning) {
+    const buckets = Lib.availableBinningStrategies(query, stageIndex, column);
+
+    if (buckets.length > 0) {
+      return (
+        <BinningStrategyPickerPopover
+          {...props}
+          query={query}
+          stageIndex={stageIndex}
+          column={column}
+          buckets={buckets}
+        />
+      );
+    }
+  }
+
+  if (hasTemporalBucketing) {
+    const buckets = Lib.availableTemporalBuckets(query, stageIndex, column);
+
+    if (buckets.length > 0) {
+      return (
+        <TemporalBucketPickerPopover
+          {...props}
+          query={query}
+          stageIndex={stageIndex}
+          column={column}
+          buckets={buckets}
+        />
+      );
+    }
+  }
+
+  return null;
+}

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BucketPickerPopover.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BucketPickerPopover.tsx
@@ -1,10 +1,10 @@
 import * as Lib from "metabase-lib";
 import { BinningStrategyPickerPopover } from "./BinningStrategyPickerPopover";
 import { TemporalBucketPickerPopover } from "./TemporalBucketPickerPopover";
-import { BucketPickerPopoverProps as BaseBucketPickerPopoverProps } from "./types";
+import { CommonBucketPickerProps } from "./types";
 
 interface BucketPickerPopoverProps
-  extends Omit<BaseBucketPickerPopoverProps, "buckets"> {
+  extends Omit<CommonBucketPickerProps, "buckets"> {
   hasBinning?: boolean;
   hasTemporalBucketing?: boolean;
 }

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/TemporalBucketPickerPopover.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/TemporalBucketPickerPopover.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import * as Lib from "metabase-lib";
-import type { BucketPickerPopoverProps } from "./types";
+import type { CommonBucketPickerProps } from "./types";
 import type { BucketListItem } from "./BaseBucketPickerPopover";
 import {
   BaseBucketPickerPopover,
@@ -19,7 +19,7 @@ export function TemporalBucketPickerPopover({
   buckets,
   onSelect,
   ...props
-}: BucketPickerPopoverProps) {
+}: CommonBucketPickerProps) {
   const selectedBucket = useMemo(() => Lib.temporalBucket(column), [column]);
 
   const items = useMemo(

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/index.ts
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/index.ts
@@ -1,2 +1,1 @@
-export * from "./BinningStrategyPickerPopover";
-export * from "./TemporalBucketPickerPopover";
+export * from "./BucketPickerPopover";

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/types.ts
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/types.ts
@@ -6,7 +6,7 @@ type CommonProps = Pick<
   "query" | "stageIndex" | "isEditing"
 >;
 
-export interface BucketPickerPopoverProps extends CommonProps {
+export interface CommonBucketPickerProps extends CommonProps {
   column: Lib.ColumnMetadata;
   buckets: Lib.Bucket[];
   onSelect: (column: Lib.ColumnMetadata) => void;

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -7,10 +7,7 @@ import { singularize } from "metabase/lib/formatting";
 
 import * as Lib from "metabase-lib";
 
-import {
-  BinningStrategyPickerPopover,
-  TemporalBucketPickerPopover,
-} from "./BucketPickerPopover";
+import { BucketPickerPopover } from "./BucketPickerPopover";
 
 const DEFAULT_MAX_HEIGHT = 610;
 
@@ -123,50 +120,18 @@ function QueryColumnPicker({
   );
 
   const renderItemExtra = useCallback(
-    (item: ColumnListItem) => {
-      if (hasBinning && Lib.isBinnable(query, stageIndex, item.column)) {
-        const buckets = Lib.availableBinningStrategies(
-          query,
-          stageIndex,
-          item.column,
-        );
-        const isEditing = checkIsColumnSelected(item);
-        return (
-          <BinningStrategyPickerPopover
-            query={query}
-            stageIndex={stageIndex}
-            column={item.column}
-            buckets={buckets}
-            isEditing={isEditing}
-            onSelect={handleSelect}
-          />
-        );
-      }
-
-      if (
-        hasTemporalBucketing &&
-        Lib.isTemporalBucketable(query, stageIndex, item.column)
-      ) {
-        const buckets = Lib.availableTemporalBuckets(
-          query,
-          stageIndex,
-          item.column,
-        );
-        const isEditing = checkIsColumnSelected(item);
-        return (
-          <TemporalBucketPickerPopover
-            query={query}
-            stageIndex={stageIndex}
-            column={item.column}
-            buckets={buckets}
-            isEditing={isEditing}
-            onSelect={handleSelect}
-          />
-        );
-      }
-
-      return null;
-    },
+    (item: ColumnListItem) =>
+      hasBinning || hasTemporalBucketing ? (
+        <BucketPickerPopover
+          query={query}
+          stageIndex={stageIndex}
+          column={item.column}
+          isEditing={checkIsColumnSelected(item)}
+          hasBinning={hasBinning}
+          hasTemporalBucketing={hasTemporalBucketing}
+          onSelect={handleSelect}
+        />
+      ) : null,
     [
       query,
       stageIndex,


### PR DESCRIPTION
Before, `QueryColumnPicker` was deciding if it should display the binning picker or the temporal bucket picker
Once we get to the `SummarizeSidebar`, it won't be great if we had to repeat that

The PR adds a single `BucketPickerPopover` component that will decide which picker to display based on the `column` prop

### To Verify

1. New > Question > Raw Data > Sample Database > Orders
2. Click "Pick a column to group by"
3. Play around with numeric (e.g. Orders > Total), coordinate (e.g. People > Longitude), and temporal (e.g. Orders > Created At) columns
4. Ensure you can pick different binning strategies and temporal buckets