### PR TITLE
Simplify `QueryColumnPicker` column select handler

### DIFF
--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -85,27 +85,21 @@ function QueryColumnPicker({
         return;
       }
 
-      const isBinned = Lib.binning(item.column) != null;
-      const isBinnable =
-        isBinned || Lib.isBinnable(query, stageIndex, item.column);
-
+      const isBinnable = Lib.isBinnable(query, stageIndex, item.column);
       if (hasBinning && isBinnable) {
-        const column = isBinned
-          ? item.column
-          : Lib.withDefaultBinning(query, stageIndex, item.column);
-        handleSelect(column);
+        handleSelect(Lib.withDefaultBinning(query, stageIndex, item.column));
         return;
       }
 
-      const isBucketed = Lib.temporalBucket(item.column) != null;
-      const isBucketable =
-        isBucketed || Lib.isTemporalBucketable(query, stageIndex, item.column);
-
-      if (hasTemporalBucketing && isBucketable) {
-        const column = isBucketed
-          ? item.column
-          : Lib.withDefaultTemporalBucket(query, stageIndex, item.column);
-        handleSelect(column);
+      const isTemporalBucketable = Lib.isTemporalBucketable(
+        query,
+        stageIndex,
+        item.column,
+      );
+      if (hasTemporalBucketing && isTemporalBucketable) {
+        handleSelect(
+          Lib.withDefaultTemporalBucket(query, stageIndex, item.column),
+        );
         return;
       }
 


### PR DESCRIPTION
Slightly simplifies `handleSelectColumn` on the `QueryColumnPicker` by removing `Lib.binning` and `Lib.temporalBucket` `null` check

It actually shouldn't be possible to get a column with a bucket to `handleSelectColumn`. A column like that can only be passed from `TemporalBucketPickerPopover` or `BinningStrategyPickerPopover`. But these pickers actually use `QueryColumnPicker's` `handleSelect` to bypass the default bucket assignment. So a check doesn't really make sense there as they're always going to be `null`, we can just move forward without them and make this code a bit cleaner