### PR TITLE
🚧 Prototype: `useMetabaseLib` hook

### DIFF
--- a/frontend/src/metabase-lib/react.ts
+++ b/frontend/src/metabase-lib/react.ts
@@ -1,0 +1,44 @@
+import * as Lib from "./v2";
+
+export function useMetabaseLib(query: Lib.Query, stageIndex: number) {
+  return {
+    // Binning
+    binning: Lib.binning,
+    availableBinningStrategies: (column: Lib.ColumnMetadata) =>
+      Lib.availableBinningStrategies(query, stageIndex, column),
+    isBinnable: (column: Lib.ColumnMetadata) =>
+      Lib.isBinnable(query, stageIndex, column),
+    withBinning: Lib.withBinning,
+    withDefaultBinning: (column: Lib.ColumnMetadata) =>
+      Lib.withDefaultBinning(query, stageIndex, column),
+
+    // Breakout
+    breakoutableColumns: () => Lib.breakoutableColumns(query, stageIndex),
+    breakouts: () => Lib.breakouts(query, stageIndex),
+    breakout: (column: Lib.ColumnMetadata) =>
+      Lib.breakout(query, stageIndex, column),
+
+    // Temporal bucket
+    temporalBucket: Lib.temporalBucket,
+    availableTemporalBucketingStrategies: (column: Lib.ColumnMetadata) =>
+      Lib.availableTemporalBuckets(query, stageIndex, column),
+    isTemporalBucketable: (column: Lib.ColumnMetadata) =>
+      Lib.isTemporalBucketable(query, stageIndex, column),
+    withTemporalBucket: Lib.withTemporalBucket,
+    withDefaultTemporalBucket: (column: Lib.ColumnMetadata) =>
+      Lib.withDefaultTemporalBucket(query, stageIndex, column),
+
+    // Metadata
+    displayInfo: Lib.displayInfo.bind(null, query, stageIndex),
+    groupColumns: Lib.groupColumns,
+    getColumnsFromColumnGroup: Lib.getColumnsFromColumnGroup,
+
+    // Query
+    replaceClause: (
+      targetClause: Lib.Clause,
+      newClause: Lib.Clause | Lib.ColumnMetadata,
+    ) => Lib.replaceClause(query, stageIndex, targetClause, newClause),
+    removeClause: (clause: Lib.Clause) =>
+      Lib.removeClause(query, stageIndex, clause),
+  };
+}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.tsx
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 
-import * as Lib from "metabase-lib";
+import * as Types from "metabase-lib";
+import { useMetabaseLib } from "metabase-lib/react";
 
 import type { NotebookStepUiComponentProps } from "../../types";
 import ClauseStep from "../ClauseStep";
@@ -27,11 +28,12 @@ function BreakoutStep({
   updateQuery,
 }: NotebookStepUiComponentProps) {
   const { stageIndex } = step;
+  const Lib = useMetabaseLib(topLevelQuery, stageIndex);
 
-  const clauses = Lib.breakouts(topLevelQuery, stageIndex);
+  const clauses = Lib.breakouts();
 
   const checkColumnSelected = (
-    columnInfo: Lib.ColumnDisplayInfo,
+    columnInfo: Types.ColumnDisplayInfo,
     breakoutIndex?: number,
   ) => {
     return (
@@ -41,10 +43,10 @@ function BreakoutStep({
   };
 
   const getColumnGroups = (breakoutIndex?: number) => {
-    const columns = Lib.breakoutableColumns(topLevelQuery, stageIndex);
+    const columns = Lib.breakoutableColumns();
 
     const filteredColumns = columns.filter(column => {
-      const columnInfo = Lib.displayInfo(topLevelQuery, stageIndex, column);
+      const columnInfo = Lib.displayInfo(column);
 
       const isAlreadyUsed = columnInfo.breakoutPosition != null;
       const isSelected = checkColumnSelected(columnInfo, breakoutIndex);
@@ -55,31 +57,26 @@ function BreakoutStep({
     return Lib.groupColumns(filteredColumns);
   };
 
-  const handleAddBreakout = (column: Lib.ColumnMetadata) => {
-    const nextQuery = Lib.breakout(topLevelQuery, stageIndex, column);
+  const handleAddBreakout = (column: Types.ColumnMetadata) => {
+    const nextQuery = Lib.breakout(column);
     updateQuery(nextQuery);
   };
 
   const handleUpdateBreakoutField = (
-    clause: Lib.BreakoutClause,
-    column: Lib.ColumnMetadata,
+    clause: Types.BreakoutClause,
+    column: Types.ColumnMetadata,
   ) => {
-    const nextQuery = Lib.replaceClause(
-      topLevelQuery,
-      stageIndex,
-      clause,
-      column,
-    );
+    const nextQuery = Lib.replaceClause(clause, column);
     updateQuery(nextQuery);
   };
 
-  const handleRemoveBreakout = (clause: Lib.BreakoutClause) => {
-    const nextQuery = Lib.removeClause(topLevelQuery, stageIndex, clause);
+  const handleRemoveBreakout = (clause: Types.BreakoutClause) => {
+    const nextQuery = Lib.removeClause(clause);
     updateQuery(nextQuery);
   };
 
-  const renderBreakoutName = (clause: Lib.BreakoutClause) =>
-    Lib.displayInfo(topLevelQuery, stageIndex, clause).longDisplayName;
+  const renderBreakoutName = (clause: Types.BreakoutClause) =>
+    Lib.displayInfo(clause).longDisplayName;
 
   return (
     <ClauseStep
@@ -100,7 +97,7 @@ function BreakoutStep({
           checkIsColumnSelected={item =>
             checkColumnSelected(item, breakoutIndex)
           }
-          onSelect={(column: Lib.ColumnMetadata) => {
+          onSelect={(column: Types.ColumnMetadata) => {
             const isUpdate = breakout != null;
             if (isUpdate) {
               handleUpdateBreakoutField(breakout, column);


### PR DESCRIPTION
After porting various clauses and components to MLv2, I feel that passing around `query` and `stageIndex` everywhere can get annoying. Here's a quick & dirty prototype of a `useMetabaseLib` hook:

```tsx
import { useMetabaseLib } from "metabase-lib/react"
import type { ColumnMetadata } from "metabase-lib/types"

const Lib = useMetabaseLib(query, stageIndex)

const breakouts = Lib.breakouts() // no need to pass a query or stageIndex

const onAddBreakout = column => {
  const nextQuery = Lib.breakout(column)
  onQueryChange(nextQuery)
}
```

The PR also ports both `QueryColumnPicker` and `BreakoutStep` to it for demo purposes.

### Open questions

1. Is that a premature optimization?
2. How do we feel about having to copy-paste every MLv2 method to `useMetabaseLib`? Can we enforce that via typing/linting/whatever?
3. Maybe it should be `useMetabaseQuery` or whatever? So we can do `query.breakouts()` instead of `Lib.breakouts()`
4. How do we type `display-info`? I couldn't find a good way, but I didn't spend too much time on it really
5. Should it be a hook? So far it just binds `query` and `stageIndex` arguments