### PR TITLE
Fix text card parameter mapping bug

### DIFF
--- a/e2e/test/scenarios/dashboard/text-parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/text-parameters.cy.spec.js
@@ -3,6 +3,7 @@ import {
   editDashboard,
   saveDashboard,
   visitDashboard,
+  getDashboardCard,
   setFilter,
   filterWidget,
   addTextBox,
@@ -63,6 +64,30 @@ describe("scenarios > dashboard > parameters in text cards", () => {
     cy.findByText("Equal to").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("foo").should("exist");
+  });
+
+  it("should not transform text variables to plain text (metabase#31626)", () => {
+    const textContent = "Variable: {{foo}}";
+    addTextBox(textContent, { parseSpecialCharSequences: false });
+    setFilter("Number", "Equal to");
+
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Select…").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("foo").click();
+    saveDashboard();
+
+    filterWidget().click();
+    cy.findByPlaceholderText("Enter a number").type(`1{enter}`);
+    cy.button("Add filter").click();
+
+    // view mode
+    getDashboardCard(0).click().findByText("Variable: 1").should("be.visible");
+
+    editDashboard();
+
+    // edit mode
+    getDashboardCard(0).click().findByText(textContent).should("be.visible");
   });
 
   it("should translate parameter values into the instance language", () => {

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
@@ -75,7 +75,7 @@ export function Text({
     }, {});
   }
 
-  let content = settings["text"];
+  let content = settings.text;
   if (!_.isEmpty(parametersByTag)) {
     // Temporarily override language to use site language, so that all viewers of a dashboard see parameter values
     // translated the same way.
@@ -84,7 +84,7 @@ export function Text({
     );
   }
 
-  const hasContent = !isEmpty(content);
+  const hasContent = !isEmpty(settings.text);
   const placeholder = t`You can use Markdown here, and include variables {{like_this}}`;
 
   if (isEditing) {
@@ -120,7 +120,7 @@ export function Text({
             data-testid="editing-dashboard-text-input"
             name="text"
             placeholder={placeholder}
-            value={content}
+            value={settings.text}
             autoFocus={justAdded || isFocused}
             onChange={e => handleTextChange(e.target.value)}
             onMouseDown={preventDragging}


### PR DESCRIPTION
**Problem:** After a refactor of the text card primitive, toggled parameters values were being displayed in edit mode instead of the variable name in text cards

**Context:**
https://www.loom.com/share/3ae97fa8abb54fee967b2fe4a61e027b

**Desired Behavior**
Parameter values should not replace the variable name in editing mode. It should show just the variable name `{{user}}`

**No**
![display-parameter-values-when-previewing](https://github.com/metabase/metabase/assets/22608765/f5b3f675-55dc-4123-a2d6-9d22aec42dc5)


**Yes**
![display-parameter-variable-when-previewing](https://github.com/metabase/metabase/assets/22608765/271c8f79-436b-44df-bd83-c525ccd5e777)

**Solution Implementation**
- Display raw text content in edit mode
  - Do not display parameter mapped content in edit mode

**Acceptance Criteria**
- [ ] In edit mode, variables mapped to parameters should not display parameters values. They should retain their name 
  - e.g.
    - `{{user}}` is mapped to `Text` parameter
    - `Text` parameter is set to "John"
    - `{{user}}` should remain as "{{user}}" (should not be replaced with "John")
- [ ] On a saved dashboard, variables mapped to parameters should display their connected parameters values
  - e.q. 
    - `{{user}}` is mapped to `Text` parameter
    - `Text` parameter is set to "John"
    - `{{user}}` should be replaced with "John"