### PR TITLE
Add test after speculative fix

### DIFF
--- a/test/metabase/lib/table_test.cljc
+++ b/test/metabase/lib/table_test.cljc
@@ -2,7 +2,10 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [metabase.lib.core :as lib]
-   [metabase.lib.test-metadata :as meta]))
+   [metabase.lib.metadata.calculation :as lib.metadata.calculation]
+   [metabase.lib.metadata.protocols :as metadata.protocols]
+   [metabase.lib.test-metadata :as meta]
+   [metabase.util.malli :as mu]))
 
 (deftest ^:parallel join-table-metadata-test
   (testing "You should be able to pass :metadata/table to lib/join"
@@ -22,3 +25,18 @@
                                          [:field {} (meta/id :venues :category-id)]
                                          [:field {:join-alias "Cat"} (meta/id :categories :id)]]]}]}]}
               query)))))
+
+(deftest ^:parallel nil-column-test
+  (testing "Fields with missing names shouldn't blow up visible-columns"
+    (let [metadata-provider
+          (reify
+            metadata.protocols/MetadataProvider
+            (database [_this]          (metadata.protocols/database meta/metadata-provider))
+            (table    [_this table-id] (metadata.protocols/table meta/metadata-provider table-id))
+            (field    [_this field-id] (assoc (metadata.protocols/field meta/metadata-provider field-id) :name nil))
+            (tables   [_this]          (metadata.protocols/tables meta/metadata-provider))
+            (fields   [_this table-id] (mapv #(assoc % :name nil)
+                                             (metadata.protocols/fields meta/metadata-provider table-id))))
+          query (lib/query-for-table-name metadata-provider "VENUES")]
+      (binding [mu/*enforce* false]
+        (is (sequential? (lib.metadata.calculation/visible-columns query)))))))


### PR DESCRIPTION
#31618 introduced a fix for handling columns without `:name`, a condition which shouldn't really happen, based on a munged stack trace. This PR adds a test checking that MLv2 can gracefully handle this situation.

Note that in Malli-instrumented code there is a schema failure even after the fix, because columns names should be non-blank strings. The test therefore disables schema checking to simulate how the code runs in the browser.