### PR TITLE
🍒 [E2E] Add `actions` to stubbed skipped job (#31640)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -209,6 +209,7 @@ jobs:
         java-version: [11]
         edition: [ee]
         folder:
+          - "actions"
           - "admin"
           - "binning"
           - "collections"


### PR DESCRIPTION
Manual backport of #31640 

I forgot to do this in #31432.
As the result, some PRs have been stuck in CI due to the required check.

This PR will run the fallback job for `actions` E2E group when changed files don't require E2E tests to run.

