### PR TITLE
Solve OOM failures for `be-cloverage` job

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -34,7 +34,7 @@ jobs:
   be-linter-cloverage:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: buildjet-2vcpu-ubuntu-2204
     timeout-minutes: 90
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -34,7 +34,7 @@ jobs:
   be-linter-cloverage:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     timeout-minutes: 90
     steps:
     - uses: actions/checkout@v3

--- a/deps.edn
+++ b/deps.edn
@@ -476,7 +476,7 @@
                 "metabase\\.driver\\.postgres.*"]}
    ;; different port from `:test` so you can run it at the same time as `:test`.
    :jvm-opts ["-Dmb.jetty.port=3002"
-              ;; default heap size is 1GB
+              ;; default heap size is 1GB, we were getting OOM on CI so we need to bump this
               "-Xmx4g"]}
 
 ;;; building Uberjar, build and release scripts

--- a/deps.edn
+++ b/deps.edn
@@ -475,7 +475,9 @@
                ["metabase\\.driver\\.mysql.*"
                 "metabase\\.driver\\.postgres.*"]}
    ;; different port from `:test` so you can run it at the same time as `:test`.
-   :jvm-opts ["-Dmb.jetty.port=3002"]}
+   :jvm-opts ["-Dmb.jetty.port=3002"
+              ;; default heap size is 1GB
+              "-Xmx2g"]}
 
 ;;; building Uberjar, build and release scripts
 

--- a/deps.edn
+++ b/deps.edn
@@ -477,7 +477,7 @@
    ;; different port from `:test` so you can run it at the same time as `:test`.
    :jvm-opts ["-Dmb.jetty.port=3002"
               ;; default heap size is 1GB
-              "-Xmx2g"]}
+              "-Xmx4g"]}
 
 ;;; building Uberjar, build and release scripts
 


### PR DESCRIPTION
We're seeing OOM failures in `be-linter-cloverage` job in CI.
~~This PR will switch to the custom BuildJet runner for this job. In particular, we'll try out `buildjet-2vcpu-ubuntu-2204` with 8GB of RAM.~~

@qnkhuat later determined the custom runner is not needed.
We're increasing the JVM heap size instead.


