### PR TITLE
Custom Homepage Dashboard Polish

### DIFF
--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -170,6 +170,25 @@ describe("scenarios > home > custom homepage", () => {
 
       cy.findByRole("status").findByText("Saved");
 
+      cy.log(
+        "disabling custom-homepge-setting should also remove custom-homepage-dashboard-setting",
+      );
+
+      cy.findByTestId("custom-homepage-setting").findByRole("switch").click();
+      cy.findByRole("status").findByText("Saved");
+
+      cy.findByTestId("custom-homepage-setting").findByRole("switch").click();
+      cy.findByTestId("custom-homepage-dashboard-setting").should(
+        "contain",
+        "Select a dashboard",
+      );
+
+      cy.findByTestId("custom-homepage-dashboard-setting")
+        .findByRole("button")
+        .click();
+
+      popover().findByText("Orders in a dashboard").click();
+
       cy.findByRole("navigation").findByText("Exit admin").click();
       cy.location("pathname").should("equal", "/dashboard/1");
 

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -93,6 +93,11 @@ const SECTIONS = updateSectionsWithPlugins({
         display_name: t`Custom Homepage`,
         type: "boolean",
         postUpdateActions: [refreshCurrentUser],
+        onChanged: (oldVal, newVal, _settings, handleChangeSetting) => {
+          if (!newVal && oldVal) {
+            handleChangeSetting("custom-homepage-dashboard", null);
+          }
+        },
       },
       {
         key: "custom-homepage-dashboard",

--- a/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.tsx
+++ b/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.tsx
@@ -49,16 +49,26 @@ export const CustomHomePageModal = ({
     [setDashboardId],
   );
 
+  const handleClose = useCallback(() => {
+    setDashboardId(undefined);
+    onClose();
+  }, [onClose, setDashboardId]);
+
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalContent
         title="Customize Homepage"
-        onClose={onClose}
+        onClose={handleClose}
         footer={[
-          <Button onClick={onClose} key="custom-homepage-modal-cancel">
+          <Button onClick={handleClose} key="custom-homepage-modal-cancel">
             Cancel
           </Button>,
-          <Button primary onClick={handleSave} key="custom-homepage-modal-save">
+          <Button
+            primary
+            onClick={handleSave}
+            key="custom-homepage-modal-save"
+            disabled={!dashboardId}
+          >
             Save
           </Button>,
         ]}

--- a/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.unit.spec.tsx
@@ -1,0 +1,47 @@
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders, screen } from "__support__/ui";
+
+import {
+  setupCollectionsEndpoints,
+  setupCollectionItemsEndpoint,
+} from "__support__/server-mocks";
+
+import {
+  createMockCollection,
+  createMockCollectionItem,
+} from "metabase-types/api/mocks";
+import { CustomHomePageModal } from "./CustomHomePageModal";
+
+const ROOT_COLLECTION = createMockCollection({
+  id: "root",
+  can_write: true,
+  name: "Our Analytics",
+  location: undefined,
+});
+const COLLECTION_ITEM = createMockCollectionItem({
+  name: "Foo",
+  model: "dashboard",
+});
+
+const setup = ({ ...props } = {}) => {
+  const onClose = jest.fn();
+
+  setupCollectionsEndpoints({ collections: [ROOT_COLLECTION] });
+  setupCollectionItemsEndpoint(ROOT_COLLECTION, [COLLECTION_ITEM]);
+
+  renderWithProviders(
+    <CustomHomePageModal onClose={onClose} isOpen={true} {...props} />,
+  );
+};
+
+describe("custom hompage modal", () => {
+  it("should only enable the save button if a dashboard has been selected", async () => {
+    setup();
+    expect(await screen.findByRole("button", { name: /save/i })).toBeDisabled();
+
+    userEvent.click(await screen.findByText("Select a dashboard"));
+    userEvent.click(await screen.findByText("Foo"));
+
+    expect(await screen.findByRole("button", { name: /save/i })).toBeEnabled();
+  });
+});

--- a/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.unit.spec.tsx
@@ -4,11 +4,13 @@ import { renderWithProviders, screen } from "__support__/ui";
 import {
   setupCollectionsEndpoints,
   setupCollectionItemsEndpoint,
+  setupDashboardEndpoints,
 } from "__support__/server-mocks";
 
 import {
   createMockCollection,
   createMockCollectionItem,
+  createMockDashboard,
 } from "metabase-types/api/mocks";
 import { CustomHomePageModal } from "./CustomHomePageModal";
 
@@ -23,11 +25,16 @@ const COLLECTION_ITEM = createMockCollectionItem({
   model: "dashboard",
 });
 
+const FOO_DASHBOARD = createMockDashboard({
+  name: "Foo",
+});
+
 const setup = ({ ...props } = {}) => {
   const onClose = jest.fn();
 
   setupCollectionsEndpoints({ collections: [ROOT_COLLECTION] });
   setupCollectionItemsEndpoint(ROOT_COLLECTION, [COLLECTION_ITEM]);
+  setupDashboardEndpoints(FOO_DASHBOARD);
 
   renderWithProviders(
     <CustomHomePageModal onClose={onClose} isOpen={true} {...props} />,


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/31601
Closes https://github.com/metabase/metabase/issues/31602

### Description
A couple small changes to Custom Homepage Dashboards. One simply disables the save button in the modal if no dashboard is selected, and the other clears the selected dashboard from app settings when the feature is disabled.

### How to verify

1. On the homepage, click Customize on the top right corner
2. Notice that the save button is disabled. Select a dashboard and it should be possible to save.
3. After selecting a dashboard, go to admin settings -> general
4. Disable "Custom Homepage", then re-enable. The dashboard selector should not have a value

### Demo
<img width="532" alt="image" src="https://github.com/metabase/metabase/assets/1328979/6803eec8-a554-44da-ad18-16ba80bc7945">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
