### PR TITLE
Allow inline edit of implicit actions

### DIFF
--- a/frontend/src/metabase-types/api/mocks/actions.ts
+++ b/frontend/src/metabase-types/api/mocks/actions.ts
@@ -77,21 +77,22 @@ export const createMockImplicitQueryAction = ({
 
 export const createMockImplicitCUDActions = (
   modelId: CardId,
+  startId: number = 0,
 ): WritebackImplicitQueryAction[] => [
   createMockImplicitQueryAction({
-    id: 1,
+    id: startId + 1,
     name: "Create",
     kind: "row/create",
     model_id: modelId,
   }),
   createMockImplicitQueryAction({
-    id: 2,
+    id: startId + 2,
     name: "Update",
     kind: "row/update",
     model_id: modelId,
   }),
   createMockImplicitQueryAction({
-    id: 3,
+    id: startId + 3,
     name: "Delete",
     kind: "row/delete",
     model_id: modelId,

--- a/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.unit.spec.tsx
@@ -1,6 +1,11 @@
 import * as React from "react";
 import userEvent from "@testing-library/user-event";
-import { renderWithProviders, screen, within } from "__support__/ui";
+import {
+  renderWithProviders,
+  screen,
+  waitForElementToBeRemoved,
+  within,
+} from "__support__/ui";
 
 import {
   setupActionsEndpoints,
@@ -18,6 +23,7 @@ import {
   createMockActionParameter,
   createMockCollectionItem,
   createMockFieldSettings,
+  createMockImplicitCUDActions,
 } from "metabase-types/api/mocks";
 
 import { WritebackParameter } from "metabase-types/api";
@@ -59,6 +65,8 @@ const actions2 = [
   }),
 ];
 
+const implicitActions = createMockImplicitCUDActions(models[1].id, 123);
+
 const dashcard = createMockDashboardOrderedCard();
 const actionDashcard = createMockActionDashboardCard({ id: 2 });
 const actionDashcardWithAction = createMockActionDashboardCard({
@@ -85,7 +93,7 @@ const setup = (
 
   setupSearchEndpoints(searchItems);
   setupCardsEndpoints(models);
-  setupActionsEndpoints([...actions1, ...actions2]);
+  setupActionsEndpoints([].concat(actions1, actions2, implicitActions));
 
   renderWithProviders(
     <ConnectedActionDashcardSettings
@@ -455,6 +463,29 @@ describe("ActionViz > ActionDashcardSettings", () => {
     });
     expect(screen.getByText("Action Parameter 1")).toBeInTheDocument();
     expect(screen.getByText("Action Parameter 2")).toBeInTheDocument();
+  });
+
+  it("supports inline edit for implit and query actions", async () => {
+    setup({
+      dashcard: actionDashcardWithAction,
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
+
+    const queryAction = screen.getByTestId(`action-item-${actions2[0].name}`);
+    const implicitAction = screen.getByTestId(
+      `action-item-${implicitActions[0].name}`,
+    );
+
+    expect(queryAction).toBeInTheDocument();
+    expect(implicitAction).toBeInTheDocument();
+
+    expect(
+      within(queryAction).getByRole("button", { name: "pencil icon" }),
+    ).toBeInTheDocument();
+    expect(
+      within(implicitAction).getByRole("button", { name: "pencil icon" }),
+    ).toBeInTheDocument();
   });
 
   it("can close the modal with the done button", () => {

--- a/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.unit.spec.tsx
@@ -93,7 +93,7 @@ const setup = (
 
   setupSearchEndpoints(searchItems);
   setupCardsEndpoints(models);
-  setupActionsEndpoints([].concat(actions1, actions2, implicitActions));
+  setupActionsEndpoints([...actions1, ...actions2, ...implicitActions]);
 
   renderWithProviders(
     <ConnectedActionDashcardSettings

--- a/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.tsx
+++ b/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.tsx
@@ -102,30 +102,29 @@ function ModelActionPicker({
         header={<h4>{model.name}</h4>}
         initialState={hasCurrentAction ? "expanded" : "collapsed"}
       >
-        {actions?.length ? (
+        {actions.length ? (
           <ActionsList>
-            {actions?.map(action => (
+            {actions.map(action => (
               <ActionItem
                 key={action.id}
                 role="button"
                 isSelected={currentAction?.id === action.id}
                 aria-selected={currentAction?.id === action.id}
                 onClick={() => onClick(action)}
+                data-testid={`action-item-${action.name}`}
               >
                 <span>{action.name}</span>
-                {action.type !== "implicit" && (
-                  <EditButton
-                    icon="pencil"
-                    onlyIcon
-                    onClick={(event: MouseEvent<HTMLButtonElement>) => {
-                      // we have a click listener on the parent
-                      event.stopPropagation();
+                <EditButton
+                  icon="pencil"
+                  onlyIcon
+                  onClick={(event: MouseEvent<HTMLButtonElement>) => {
+                    // we have a click listener on the parent
+                    event.stopPropagation();
 
-                      setEditingActionId(action.id);
-                      toggleIsActionCreatorVisible();
-                    }}
-                  />
-                )}
+                    setEditingActionId(action.id);
+                    toggleIsActionCreatorVisible();
+                  }}
+                />
               </ActionItem>
             ))}
             <NewActionButton onlyText onClick={toggleIsActionCreatorVisible}>


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/30016
Context: https://metaboat.slack.com/archives/C057T1QTB3L/p1686850703802809?thread_ts=1686774888.731569&cid=C057T1QTB3L

## Description

with the latest changes it makes sense to allow inline edit of the implicit actions

<img width="792" alt="image" src="https://github.com/metabase/metabase/assets/125459446/fe05c34d-acd0-4982-b8dd-144af307f411">

- [x] - Add unit test