### PR TITLE
Show a banner for hidden required fields without default value

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.tsx
@@ -154,13 +154,11 @@ function FormCreator({
     >{t`Learn more`}</ExternalLink>
   );
 
-  const showWarning =
-    isPublic &&
-    form.fields.some(field => {
-      const settings = fieldSettings[field.name];
+  const showWarning = form.fields.some(field => {
+    const { hidden, required, defaultValue } = fieldSettings[field.name];
 
-      return settings.hidden && !field.optional;
-    });
+    return hidden && required && defaultValue == null;
+  });
 
   return (
     <SidebarContent title={t`Action parameters`}>
@@ -171,7 +169,7 @@ function FormCreator({
         {showWarning && (
           <WarningBanner data-testid="action-warning-banner">
             <b>{t`Heads up.`}</b>{" "}
-            {t`Your action is public and has a hidden required field. There's a good chance this will cause the action to fail.`}
+            {t`Your action has a hidden required field with no default value. There's a good chance this will cause the action to fail.`}
           </WarningBanner>
         )}
         <FormProvider

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.tsx
@@ -155,9 +155,15 @@ function FormCreator({
   );
 
   const showWarning = form.fields.some(field => {
-    const { hidden, required, defaultValue } = fieldSettings[field.name];
+    const settings = fieldSettings[field.name];
 
-    return hidden && required && defaultValue == null;
+    if (!settings) {
+      return false;
+    }
+
+    return (
+      settings.hidden && settings.required && settings.defaultValue == null
+    );
   });
 
   return (

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.tsx
@@ -173,7 +173,7 @@ function FormCreator({
           {jt`Configure your parameters' types and properties here. The values for these parameters can come from user input, or from a dashboard filter. ${docsLink}`}
         </InfoText>
         {showWarning && (
-          <WarningBanner data-testid="action-warning-banner">
+          <WarningBanner>
             <b>{t`Heads up.`}</b>{" "}
             {t`Your action has a hidden required field with no default value. There's a good chance this will cause the action to fail.`}
           </WarningBanner>

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.unit.spec.tsx
@@ -244,95 +244,131 @@ describe("actions > containers > ActionCreator > FormCreator", () => {
   });
 
   describe("Warning banner", () => {
-    it("shows a warning banner", () => {
-      const defaultValue = "foo bar";
-      const parameter = makeParameter({ required: true });
-      const fieldSettings = makeFieldSettings({
-        inputType: "string",
-        required: true,
-        defaultValue,
-        hidden: true,
-      });
+    describe.each([{ isPublic: true }, { isPublic: false }])(
+      "when public: $isPublic",
+      ({ isPublic }) => {
+        describe("when there is hidden, required parameter without default value", () => {
+          it("shows a warning banner for query action", () => {
+            const parameter = makeParameter({ required: true });
+            const fieldSettings = makeFieldSettings({
+              inputType: "string",
+              required: true,
+              defaultValue: undefined,
+              hidden: true,
+            });
 
-      setup({
-        parameters: [parameter],
-        formSettings: {
-          type: "form",
-          fields: {
-            [parameter.id]: fieldSettings,
+            setup({
+              parameters: [parameter],
+              formSettings: {
+                type: "form",
+                fields: {
+                  [parameter.id]: fieldSettings,
+                },
+              },
+              isPublic,
+            });
+
+            expect(
+              screen.getByTestId("action-warning-banner"),
+            ).toBeInTheDocument();
+          });
+
+          it("shows a warning banner for implicit action", () => {
+            const parameter = makeParameter({ required: true });
+            const fieldSettings = createMockImplicitActionFieldSettings({
+              id: parameter.id,
+              required: true,
+              defaultValue: undefined,
+              hidden: true,
+            });
+
+            setup({
+              parameters: [parameter],
+              formSettings: {
+                type: "form",
+                fields: {
+                  [parameter.id]: fieldSettings,
+                },
+              },
+              isPublic,
+            });
+
+            expect(
+              screen.getByTestId("action-warning-banner"),
+            ).toBeInTheDocument();
+          });
+        });
+      },
+    );
+
+    describe.each([{ isPublic: true }, { isPublic: false }])(
+      "when public: $isPublic",
+      ({ isPublic }) => {
+        describe.each([
+          { required: false, hidden: false, hasDefaultValue: false },
+          { required: false, hidden: false, hasDefaultValue: true },
+          { required: false, hidden: true, hasDefaultValue: false },
+          { required: false, hidden: true, hasDefaultValue: true },
+          { required: true, hidden: false, hasDefaultValue: false },
+          { required: true, hidden: false, hasDefaultValue: true },
+          { required: true, hidden: true, hasDefaultValue: true },
+        ])(
+          `when there is no hidden, required parameter without default value`,
+          ({ required, hidden, hasDefaultValue }) => {
+            it("does not show a warning banner for query action", () => {
+              const defaultValue = "foo bar";
+              const parameter = makeParameter({ required });
+              const fieldSettings = makeFieldSettings({
+                id: parameter.id,
+                inputType: "string",
+                required,
+                defaultValue: hasDefaultValue ? defaultValue : undefined,
+                hidden,
+              });
+
+              setup({
+                parameters: [parameter],
+                formSettings: {
+                  type: "form",
+                  fields: {
+                    [parameter.id]: fieldSettings,
+                  },
+                },
+              });
+
+              expect(
+                screen.queryByTestId("action-warning-banner"),
+              ).not.toBeInTheDocument();
+            });
+
+            it("doesn't show a banner for implicit action", () => {
+              const defaultValue = "foo bar";
+              const parameter = makeParameter({ required });
+              const fieldSettings = createMockImplicitActionFieldSettings({
+                id: parameter.id,
+                required,
+                defaultValue: hasDefaultValue ? defaultValue : undefined,
+                hidden,
+              });
+
+              setup({
+                parameters: [parameter],
+                formSettings: {
+                  type: "form",
+                  fields: {
+                    [parameter.id]: fieldSettings,
+                  },
+                },
+                isPublic,
+              });
+
+              expect(
+                screen.queryByTestId("action-warning-banner"),
+              ).not.toBeInTheDocument();
+            });
           },
-        },
-        isPublic: true,
-      });
-
-      expect(screen.getByTestId("action-warning-banner")).toBeInTheDocument();
-    });
-
-    it("shows a banner for implicit action params", () => {
-      const parameter = makeParameter({ required: true });
-      const fieldSettings = createMockImplicitActionFieldSettings({
-        id: parameter.id,
-        hidden: true,
-      });
-
-      setup({
-        parameters: [parameter],
-        formSettings: {
-          type: "form",
-          fields: {
-            [parameter.id]: fieldSettings,
-          },
-        },
-        isPublic: true,
-      });
-
-      expect(screen.getByTestId("action-warning-banner")).toBeInTheDocument();
-    });
-
-    it("doesn't show a warning banner for nonpublic action", () => {
-      const parameter = makeParameter({ required: true });
-      const fieldSettings = createMockImplicitActionFieldSettings({
-        id: parameter.id,
-        hidden: true,
-      });
-
-      setup({
-        parameters: [parameter],
-        formSettings: {
-          type: "form",
-          fields: {
-            [parameter.id]: fieldSettings,
-          },
-        },
-        isPublic: false,
-      });
-
-      expect(
-        screen.queryByTestId("action-warning-banner"),
-      ).not.toBeInTheDocument();
-    });
-
-    it("doesn't show a warning banner if no required params hidden", () => {
-      const parameter = makeParameter({ required: true });
-      const fieldSettings = createMockImplicitActionFieldSettings({
-        id: parameter.id,
-        hidden: false,
-      });
-
-      setup({
-        parameters: [parameter],
-        formSettings: {
-          type: "form",
-          fields: {
-            [parameter.id]: fieldSettings,
-          },
-        },
-        isPublic: true,
-      });
-
-      expect(
-        screen.queryByTestId("action-warning-banner"),
-      ).not.toBeInTheDocument();
-    });
+        );
+      },
+    );
   });
 });


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/30016
Discussion: https://metaboat.slack.com/archives/C057T1QTB3L/p1686786524811949?thread_ts=1686774888.731569&cid=C057T1QTB3L

## Description

Show banner for required, hidden parameters without default value