### PR TITLE
updating chart settings popover logic

### DIFF
--- a/e2e/test/scenarios/dashboard/visualizaiton-options.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/visualizaiton-options.cy.spec.js
@@ -1,4 +1,9 @@
-import { popover, restore, visitDashboard } from "e2e/support/helpers";
+import {
+  popover,
+  restore,
+  visitDashboard,
+  getDashboardCard,
+} from "e2e/support/helpers";
 
 describe("scenarios > dashboard > visualization options", () => {
   beforeEach(() => {
@@ -8,9 +13,9 @@ describe("scenarios > dashboard > visualization options", () => {
 
   it("column reordering should work (metabase#16229)", () => {
     visitDashboard(1);
-    cy.icon("pencil").click();
-    cy.get(".Card").realHover();
-    cy.icon("palette").click();
+    cy.findByLabelText("Edit dashboard").click();
+    getDashboardCard().realHover();
+    cy.findByLabelText("Show visualization options").click();
     cy.findByTestId("chartsettings-sidebar").within(() => {
       cy.findByText("ID")
         .closest("[data-testid^=draggable-item]")
@@ -39,9 +44,9 @@ describe("scenarios > dashboard > visualization options", () => {
 
   it("should refelct column settings accurately when changing (metabase#30966)", () => {
     visitDashboard(1);
-    cy.icon("pencil").click();
-    cy.get(".Card").realHover();
-    cy.icon("palette").click();
+    cy.findByLabelText("Edit dashboard").click();
+    getDashboardCard().realHover();
+    cy.findByLabelText("Show visualization options").click();
     cy.findByTestId("Subtotal-settings-button").click();
     popover().findByLabelText("Show a mini bar chart").click();
     cy.findAllByTestId("mini-bar").should("have.length.above", 0);

--- a/e2e/test/scenarios/dashboard/visualizaiton-options.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/visualizaiton-options.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, visitDashboard } from "e2e/support/helpers";
+import { popover, restore, visitDashboard } from "e2e/support/helpers";
 
 describe("scenarios > dashboard > visualization options", () => {
   beforeEach(() => {
@@ -35,5 +35,15 @@ describe("scenarios > dashboard > visualization options", () => {
       .findAllByTestId("column-header")
       .first()
       .contains("User ID");
+  });
+
+  it("should refelct column settings accurately when changing (metabase#30966)", () => {
+    visitDashboard(1);
+    cy.icon("pencil").click();
+    cy.get(".Card").realHover();
+    cy.icon("palette").click();
+    cy.findByTestId("Subtotal-settings-button").click();
+    popover().findByLabelText("Show a mini bar chart").click();
+    cy.findAllByTestId("mini-bar").should("have.length.above", 0);
   });
 });

--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -275,7 +275,7 @@ class ChartSettings extends Component {
       dashcard,
       isDashboard,
     } = this.props;
-    const { currentWidget, popoverRef } = this.state;
+    const { popoverRef } = this.state;
 
     const settings = this._getSettings();
     const widgets = this._getWidgets();
@@ -411,9 +411,6 @@ class ChartSettings extends Component {
           </ChartSettingsPreview>
         )}
         <ChartSettingsWidgetPopover
-          currentWidgetKey={
-            currentWidget?.props?.initialKey || currentWidget?.props?.seriesKey
-          }
           anchor={popoverRef}
           widgets={[this.getFormattingWidget(), this.getStyleWidget()].filter(
             widget => !!widget,

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidgetPopover.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidgetPopover.tsx
@@ -7,6 +7,7 @@ import ChartSettingsWidget from "./ChartSettingsWidget";
 
 interface Widget {
   id: string;
+  section: string;
   props: Record<string, unknown>;
 }
 
@@ -14,30 +15,27 @@ interface ChartSettingsWidgetPopoverProps {
   anchor: HTMLElement;
   handleEndShowWidget: () => void;
   widgets: Widget[];
-  currentWidgetKey: string;
 }
 
 const ChartSettingsWidgetPopover = ({
   anchor,
   handleEndShowWidget,
   widgets,
-  currentWidgetKey,
 }: ChartSettingsWidgetPopoverProps) => {
-  const sections = useRef<Record<React.Key, Widget[]>>({});
+  const sections = useRef<string[]>([]);
   const contentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    sections.current = _.groupBy(widgets, "section");
+    sections.current = _.chain(widgets).pluck("section").unique().value();
   }, [widgets]);
 
   const [currentSection, setCurrentSection] = useState("");
 
   useEffect(() => {
-    setCurrentSection(Object.keys(sections.current)[0]);
-  }, [currentWidgetKey, sections]);
+    setCurrentSection(sections.current[0]);
+  }, [anchor, sections]);
 
-  const sectionNames = Object.keys(sections.current) || [];
-  const hasMultipleSections = sectionNames.length > 1;
+  const hasMultipleSections = sections.current.length > 1;
 
   const onClose = () => {
     const activeElement = document.activeElement as HTMLElement;
@@ -56,7 +54,7 @@ const ChartSettingsWidgetPopover = ({
             {hasMultipleSections && (
               <PopoverTabs
                 value={currentSection}
-                options={sectionNames.map((sectionName: string) => ({
+                options={sections.current.map((sectionName: string) => ({
                   name: sectionName,
                   value: sectionName,
                 }))}
@@ -64,9 +62,15 @@ const ChartSettingsWidgetPopover = ({
                 variant="underlined"
               />
             )}
-            {sections.current[currentSection]?.map(widget => (
-              <ChartSettingsWidget key={widget.id} {...widget} hidden={false} />
-            ))}
+            {widgets
+              .filter(widget => widget.section === currentSection)
+              ?.map(widget => (
+                <ChartSettingsWidget
+                  key={widget.id}
+                  {...widget}
+                  hidden={false}
+                />
+              ))}
           </PopoverRoot>
         ) : null
       }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/30966

### Description
Changes to column settings on dashcards were being reflected properly in the viz, but not in the settings view. This was because we were storing the widgets in a ref, but not re-computing them when needed. I'm honestly not entirely sure why this wasn't also an issue in the query builder... I'm guessing it's because in dashcards we store state until you save, and in the QB we update redux as you go. This changes makes it so that we compute the sections and store in the ref, but we render based on the widgets prop passed in.

### How to verify
1. Open any dashcard for a table viz
2. Modify a column setting and ensure the change is reflected in both the popover *and* the viz. (previously, it was only reflected in the viz).

### Demo
![chrome_bRpomhaBSu](https://github.com/metabase/metabase/assets/1328979/f4c66424-69d8-41db-961c-eb6cb6dcf7ab)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
