### PR TITLE
changing chart settings labels to use htmlFor

### DIFF
--- a/e2e/test/scenarios/question/reproductions/30905-custom-columns-visualization-settings-trigger-dirty-flag.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/30905-custom-columns-visualization-settings-trigger-dirty-flag.cy.spec.js
@@ -27,10 +27,7 @@ describe("Custom columns visualization settings", () => {
   it("should not show 'Save' after modifying minibar settings for a custom column", () => {
     goToExpressionSidebarVisualizationSettings();
     popover().within(() => {
-      const miniBarSwitch = cy
-        .get("#show_mini_bar")
-        .parent()
-        .findByRole("switch");
+      const miniBarSwitch = cy.findByLabelText("Show a mini bar chart");
       miniBarSwitch.click();
       miniBarSwitch.should("be.checked");
     });
@@ -41,10 +38,7 @@ describe("Custom columns visualization settings", () => {
     goToExpressionSidebarVisualizationSettings();
 
     popover().within(() => {
-      const viewAsDropdown = cy
-        .get("#view_as")
-        .parent()
-        .findByTestId("select-button");
+      const viewAsDropdown = cy.findByLabelText("Display as");
       viewAsDropdown.click();
     });
 
@@ -63,10 +57,7 @@ describe("Custom columns visualization settings", () => {
       cy.findByRole("button", { name: /gear icon/i }).click();
     });
     popover().within(() => {
-      const miniBarSwitch = cy
-        .get("#show_mini_bar")
-        .parent()
-        .findByRole("switch");
+      const miniBarSwitch = cy.findByLabelText("Show a mini bar chart");
       miniBarSwitch.click();
       miniBarSwitch.should("be.checked");
     });

--- a/e2e/test/scenarios/visualizations/reproductions/18063-maps-null-location-wrong-tooltip.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/18063-maps-null-location-wrong-tooltip.cy.spec.js
@@ -26,7 +26,7 @@ describe("issue 18063", () => {
     // Click anywhere to close both popovers that open automatically.
     // Please see: https://github.com/metabase/metabase/issues/18063#issuecomment-927836691
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Map type").click();
+    cy.findByText("Latitude field").click();
   });
 
   it("should show the correct tooltip details for pin map even when some locations are null (metabase#18063)", () => {

--- a/e2e/test/scenarios/visualizations/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/table.cy.spec.js
@@ -63,18 +63,18 @@ describe("scenarios > visualizations > table", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Link").click();
 
-    cy.findByTestId("link_text").type("{{C");
+    cy.findByLabelText("Link text").type("{{C");
     cy.findByTestId("select-list").within(() => {
       cy.findAllByText("CITY").click();
     });
 
-    cy.findByTestId("link_text")
+    cy.findByLabelText("Link text")
       .type(" {{ID}} fixed text", {
         parseSpecialCharSequences: false,
       })
       .blur();
 
-    cy.findByTestId("link_url")
+    cy.findByLabelText("Link URL")
       .type("http://metabase.com/people/{{ID}}", {
         parseSpecialCharSequences: false,
       })

--- a/e2e/test/scenarios/visualizations/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/table.cy.spec.js
@@ -41,9 +41,9 @@ describe("scenarios > visualizations > table", () => {
     popover().within(() => {
       cy.findByText("Filter by this column");
       cy.icon("gear").click();
-      cy.findByTestId("column_title").type(" updated");
+      cy.findByLabelText("Column title").type(" updated");
       // This defocuses the input, which triggers the update
-      cy.get("#column_title").click();
+      cy.findByText("Column title").click();
     });
     // click somewhere else to close the popover
     headerCells().last().click();

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidget.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidget.tsx
@@ -62,7 +62,7 @@ const ChartSettingsWidget = ({
         <Title
           variant={variant}
           className={cx({ "Form-label": isFormField })}
-          id={extraWidgetProps.id}
+          htmlFor={extraWidgetProps.id}
         >
           {title}
           {hint && (

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.jsx
@@ -14,6 +14,7 @@ const ChartSettingSelect = ({
   className,
   placeholder,
   placeholderNoOptions,
+  id,
   ...props
 }) => (
   <SelectWithHighlightingIcon
@@ -26,6 +27,7 @@ const ChartSettingSelect = ({
     onChange={e => onChange(e.target.value)}
     placeholder={options.length === 0 ? placeholderNoOptions : placeholder}
     isInitiallyOpen={isInitiallyOpen}
+    buttonProps={{ id }}
     {...props}
   >
     {options.map(option => (

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingToggle.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingToggle.jsx
@@ -2,7 +2,7 @@
 import Toggle from "metabase/core/components/Toggle";
 
 const ChartSettingToggle = ({ value, onChange, id }) => (
-  <Toggle value={value} onChange={onChange} aria-labelledby={id} />
+  <Toggle value={value} onChange={onChange} id={id} />
 );
 
 export default ChartSettingToggle;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31657

### Description
Changing Chart Settings HTML structure so that input labels use `htmlFor` rather than id (id's are already set on many of the inputs). This will solve the issue of duplicate IDs in some situations for chart settings.

### How to verify
End user should not notice any changes. Verification will be posted below:

### Demo
![image](https://github.com/metabase/metabase/assets/1328979/7cbd8fd7-0ae5-4176-a84a-f364515fd363)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
