### PR TITLE
Fix flaky dashboard tab tests

### DIFF
--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -345,6 +345,14 @@
              dashcards))
       dashcards)))
 
+(defn dashcard-comparator
+  "Comparator that determines which of two dashcards comes first in the layout order used for pulses.
+  This is the same order used on the frontend for the mobile layout. Orders cards left-to-right, then top-to-bottom"
+  [dashcard-1 dashcard-2]
+  (if-not (= (:row dashcard-1) (:row dashcard-2))
+    (compare (:row dashcard-1) (:row dashcard-2))
+    (compare (:col dashcard-1) (:col dashcard-2))))
+
 ;;; ----------------------------------------------- SERIALIZATION ----------------------------------------------------
 ;; DashboardCards are not serialized as their own, separate entities. They are inlined onto their parent Dashboards.
 ;; If the parent dashboard has tabs, the dashcards are inlined under each DashboardTab, which are inlined on the Dashboard.

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -348,10 +348,10 @@
 (defn dashcard-comparator
   "Comparator that determines which of two dashcards comes first in the layout order used for pulses.
   This is the same order used on the frontend for the mobile layout. Orders cards left-to-right, then top-to-bottom"
-  [dashcard-1 dashcard-2]
-  (if-not (= (:row dashcard-1) (:row dashcard-2))
-    (compare (:row dashcard-1) (:row dashcard-2))
-    (compare (:col dashcard-1) (:col dashcard-2))))
+  [{row-1 :row col-1 :col} {row-2 :row col-2 :col}]
+  (if (= row-1 row-2)
+    (compare col-1 col-2)
+    (compare row-1 row-2)
 
 ;;; ----------------------------------------------- SERIALIZATION ----------------------------------------------------
 ;; DashboardCards are not serialized as their own, separate entities. They are inlined onto their parent Dashboards.

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -351,7 +351,7 @@
   [{row-1 :row col-1 :col} {row-2 :row col-2 :col}]
   (if (= row-1 row-2)
     (compare col-1 col-2)
-    (compare row-1 row-2)
+    (compare row-1 row-2)))
 
 ;;; ----------------------------------------------- SERIALIZATION ----------------------------------------------------
 ;; DashboardCards are not serialized as their own, separate entities. They are inlined onto their parent Dashboards.

--- a/src/metabase/models/dashboard_tab.clj
+++ b/src/metabase/models/dashboard_tab.clj
@@ -1,6 +1,7 @@
 (ns metabase.models.dashboard-tab
   (:require
    [medley.core :as m]
+   [metabase.models.dashboard-card :as dashboard-card]
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
    [metabase.util :as u]
@@ -28,14 +29,6 @@
   [_original-model _dest-key _hydrating-model]
   [:dashboard_tab_id])
 
-(defn- dashcard-comparator
-  "Comparator that determines which of two dashcards comes first in the layout order used for pulses.
-  This is the same order used on the frontend for the mobile layout. Orders cards left-to-right, then top-to-bottom"
-  [dashcard-1 dashcard-2]
-  (if-not (= (:row dashcard-1) (:row dashcard-2))
-    (compare (:row dashcard-1) (:row dashcard-2))
-    (compare (:col dashcard-1) (:col dashcard-2))))
-
 (methodical/defmethod t2.hydrate/batched-hydrate [:default :ordered-tab-cards]
   "Given a list of tabs, return a seq of ordered tabs, in which each tabs contain a seq of orderd cards."
   [_model _k tabs]
@@ -44,7 +37,7 @@
         tab-ids           (map :id tabs)
         dashcards         (t2/select :model/DashboardCard :dashboard_id dashboard-id :dashboard_tab_id [:in tab-ids])
         tab-id->dashcards (-> (group-by :dashboard_tab_id dashcards)
-                              (update-vals #(sort dashcard-comparator %)))
+                              (update-vals #(sort dashboard-card/dashcard-comparator %)))
         ordered-tabs      (sort-by :position tabs)]
     (for [{:keys [id] :as tab} ordered-tabs]
       (assoc tab :cards (get tab-id->dashcards id)))))

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -92,14 +92,6 @@
     (catch Throwable e
       (log/warn e (trs "Error running query for Card {0}" card-or-id)))))
 
-(defn- dashcard-comparator
-  "Comparator that determines which of two dashcards comes first in the layout order used for pulses.
-  This is the same order used on the frontend for the mobile layout. Orders cards left-to-right, then top-to-bottom"
-  [dashcard-1 dashcard-2]
-  (if-not (= (:row dashcard-1) (:row dashcard-2))
-    (compare (:row dashcard-1) (:row dashcard-2))
-    (compare (:col dashcard-1) (:col dashcard-2))))
-
 (defn virtual-card-of-type?
   "Check if dashcard is a virtual with type `ttype`, if `true` returns the dashcard, else returns `nil`.
 
@@ -180,7 +172,7 @@
 
 (defn- dashcards->part
   [dashcards pulse dashboard]
-  (let [ordered-dashcards (sort dashcard-comparator dashcards)]
+  (let [ordered-dashcards (sort dashboard-card/dashcard-comparator dashcards)]
     (doall (for [dashcard ordered-dashcards
                  :let  [part (dashcard->part dashcard pulse dashboard)]
                  :when (some? part)]
@@ -463,7 +455,7 @@
                               (construct-pulse-email email-subject user (messages/render-alert-email timezone pulse channel parts (ui-logic/find-goal-value first-part))))
         email-to-nonusers   (for [non-user (map :email non-user-recipients)]
                               (construct-pulse-email email-subject non-user (messages/render-alert-email timezone pulse channel parts (ui-logic/find-goal-value first-part))))]
-        (concat email-to-users email-to-nonusers)))
+       (concat email-to-users email-to-nonusers)))
 
 (defmethod notification [:alert :slack]
   [pulse parts {{channel-id :channel} :details}]

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1146,9 +1146,10 @@
                                             {:order-by [[:position :asc]]})
               new->old-tab-id   (zipmap (map :id new-tabs) (map :id original-tabs))]
          (testing "Cards are located correctly between tabs"
-           (is (= (map #(select-keys % [:name :display :dashboard_tab_id]) (dashboard/ordered-cards dashboard-id))
-                  (map #(select-keys % [:name :display :dashboard_tab_id])
-                       (for [card (dashboard/ordered-cards new-dash-id)]
+           (is (= (map #(select-keys % [:dashboard_tab_id :card_id :row :col :size_x :size_y :dashboard_tab_id])
+                       (ordered-cards-by-position dashboard-id))
+                  (map #(select-keys % [:dashboard_tab_id :card_id :row :col :size_x :size_y :dashboard_tab_id])
+                       (for [card (ordered-cards-by-position new-dash-id)]
                          (assoc card :dashboard_tab_id (new->old-tab-id (:dashboard_tab_id card))))))))
 
          (testing "new tabs should have the same name and position"
@@ -1630,7 +1631,7 @@
                                  :dashboard_id dashboard-id
                                  :name         "New Tab 2"
                                  :position     1}]}
-               resp))))))
+                (update resp :cards #(sort dashboard-card/dashcard-comparator %))))))))
 
 (deftest update-cards-error-handling-test
   (testing "PUT /api/dashboard/:id/cards"

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1130,6 +1130,11 @@
                      (set (map :name cards-in-coll)))
                   "Cards should have \"-- Duplicate\" appended"))))))))
 
+(defn- ordered-cards-by-position
+  "Returned dashcards for a dashboard ordred by its position instead of creation like [[dashboard/ordered-cards]] did."
+  [dashboard-or-id]
+  (sort dashboard-card/dashcard-comparator (dashboard/ordered-cards dashboard-or-id)))
+
 (deftest copy-dashboard-with-tab-test
   (testing "POST /api/dashboard/:id/copy"
     (testing "for a dashboard that has tabs"

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -143,10 +143,12 @@
                                              :position     1}
      DashboardCard       {dashcard-id-1 :id} {:dashboard_id     dashboard-id
                                               :card_id          card-id-1
-                                              :dashboard_tab_id dashtab-id-1}
+                                              :dashboard_tab_id dashtab-id-1
+                                              :row              1}
      DashboardCard       {dashcard-id-2 :id} {:dashboard_id     dashboard-id
                                               :card_id          card-id-2
-                                              :dashboard_tab_id dashtab-id-2}]
+                                              :dashboard_tab_id dashtab-id-2
+                                              :row              2}]
     (f {:dashboard-id  dashboard-id
         :card-id-1     card-id-1
         :card-id-2     card-id-1
@@ -1144,10 +1146,10 @@
                                             {:order-by [[:position :asc]]})
               new->old-tab-id   (zipmap (map :id new-tabs) (map :id original-tabs))]
          (testing "Cards are located correctly between tabs"
-                     (is (= (map #(select-keys % [:name :display :dashboard_tab_id]) (dashboard/ordered-cards dashboard-id))
-                            (map #(select-keys % [:name :display :dashboard_tab_id])
-                                 (for [card (dashboard/ordered-cards new-dash-id)]
-                                   (assoc card :dashboard_tab_id (new->old-tab-id (:dashboard_tab_id card))))))))
+           (is (= (map #(select-keys % [:name :display :dashboard_tab_id]) (dashboard/ordered-cards dashboard-id))
+                  (map #(select-keys % [:name :display :dashboard_tab_id])
+                       (for [card (dashboard/ordered-cards new-dash-id)]
+                         (assoc card :dashboard_tab_id (new->old-tab-id (:dashboard_tab_id card))))))))
 
          (testing "new tabs should have the same name and position"
            (is (= (map #(dissoc % :id) original-tabs)
@@ -1596,14 +1598,14 @@
                                             :size_x           4
                                             :size_y           4
                                             :col              1
-                                            :row              1
+                                            :row              2
                                             :dashboard_tab_id -1
                                             :card_id          card-id-1}
                                            {:id               -1
                                             :size_x           4
                                             :size_y           4
                                             :col              1
-                                            :row              1
+                                            :row              3
                                             :dashboard_tab_id -2
                                             :card_id          card-id-2}]})
             tab-1-id (t2/select-one-pk :model/DashboardTab :name "New Tab 1" :dashboard_id dashboard-id)

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1131,7 +1131,7 @@
                   "Cards should have \"-- Duplicate\" appended"))))))))
 
 (defn- ordered-cards-by-position
-  "Returned dashcards for a dashboard ordred by its position instead of creation like [[dashboard/ordered-cards]] did."
+  "Returns dashcards for a dashboard ordered by their position instead of creation like [[dashboard/ordered-cards]] does."
   [dashboard-or-id]
   (sort dashboard-card/dashcard-comparator (dashboard/ordered-cards dashboard-or-id)))
 


### PR DESCRIPTION
the root cause for these flake is that the `dashboard/ordered-cards` are ordered by creation time and sometimes in can change order.

I switched to a more reliable method by using position ordering.