### PR TITLE
Add define-before-update for :hook/updated-at-timestamped?

### DIFF
--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -474,6 +474,11 @@
   (-> instance
       add-updated-at-timestamp))
 
+(t2/define-before-update :hook/updated-at-timestamped?
+  [instance]
+  (-> instance
+      add-updated-at-timestamp))
+
 (t2/define-before-insert :hook/entity-id
   [instance]
   (-> instance


### PR DESCRIPTION
This PR solves a regression on master where models that derive from `:hook/updated-at-timestamped?` do not have their updated_at column update on every update with toucan2.

For example updating `model/User` with `t2/update!` will currently not change `core_user.updated_at`, but it did before we switched `User` to use toucan2.

This PR changes this so if a model derives from `:hook/updated-at-timestamped?`, the `updated_at` column of the model should update on every update.

The methods for these hooks were introduced [here](https://github.com/metabase/metabase/pull/29513/files#diff-c226a547c32573cbfe5731cdc8f092a130ea210039dda530207d3503203f6510R438-R441), where you can see the `define-before-update` for `:hook/updated-at-timestamped?` is missing, even though it is present for `:hook/timestamped?`.