### PR TITLE
Attempt to fix long-running dashboard test

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard-card-resizing.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-card-resizing.cy.spec.js
@@ -1,5 +1,6 @@
 import _ from "underscore";
 import {
+  cypressWaitAll,
   editDashboard,
   resizeDashboardCard,
   restore,
@@ -220,11 +221,14 @@ describe("scenarios > dashboard card resizing", () => {
 
   it(`should not allow cards to be resized smaller than min height`, () => {
     const cardIds = [];
-    TEST_QUESTIONS.forEach(question => {
-      cy.createQuestion(question).then(({ body: { id } }) => {
-        cardIds.push(id);
-      });
-    });
+    cypressWaitAll(
+      TEST_QUESTIONS.map(question => {
+        cy.createQuestion(question).then(({ body: { id } }) => {
+          cardIds.push(id);
+        });
+      }),
+    );
+
     cy.createDashboard().then(({ body: { id: dashId } }) => {
       cy.request("PUT", `/api/dashboard/${dashId}/cards`, {
         cards: cardIds.map((cardId, index) => ({


### PR DESCRIPTION
### Description

There's a possibility that the tests in `e2e/test/scenarios/dashboard/dashboard-card-resizing.cy.spec.js` will fail sporadically because `POST` requests for queries might take a while. This is an attempt to fix that.

I added `cypressWaitAll` to see if there's requests that Cypress still needs to wait for before continuing on, and it reduced the testing time on my local machine by 25%. So I'll see if it works here.