### PR TITLE
1. Handle collection curate permission on dashboard auto-apply filters

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
@@ -284,6 +284,20 @@ describe("scenarios > dashboards > filters > auto apply", () => {
     cy.wait("@cardQuery");
     undoToast().should("not.exist");
   });
+
+  it("should not be able to toggle auto-apply filters toggle for user without dashboard permission", () => {
+    createDashboard();
+    cy.signIn("readonly");
+    openDashboard();
+    cy.wait("@cardQuery");
+
+    dashboardHeader().within(() => {
+      cy.icon("info").click();
+    });
+    rightSidebar().within(() => {
+      cy.findByLabelText("Auto-apply filters").should("be.disabled");
+    });
+  });
 });
 
 describeWithSnowplow("scenarios > dashboards > filters > auto apply", () => {

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
@@ -285,17 +285,31 @@ describe("scenarios > dashboards > filters > auto apply", () => {
     undoToast().should("not.exist");
   });
 
-  it("should not be able to toggle auto-apply filters toggle for user without dashboard permission", () => {
-    createDashboard();
-    cy.signIn("readonly");
-    openDashboard();
-    cy.wait("@cardQuery");
-
-    dashboardHeader().within(() => {
-      cy.icon("info").click();
+  describe("no collection curate permission", () => {
+    beforeEach(() => {
+      createDashboard();
+      cy.signIn("readonly");
     });
-    rightSidebar().within(() => {
-      cy.findByLabelText("Auto-apply filters").should("be.disabled");
+
+    it("should not be able to toggle auto-apply filters toggle", () => {
+      openDashboard();
+      cy.wait("@cardQuery");
+
+      dashboardHeader().within(() => {
+        cy.icon("info").click();
+      });
+      rightSidebar().within(() => {
+        cy.findByLabelText("Auto-apply filters").should("be.disabled");
+      });
+    });
+
+    it("should not display a toast even when a dashboard takes longer than 15s to load", () => {
+      cy.clock();
+      openSlowDashboard({ [FILTER.slug]: "Gadget" });
+
+      cy.tick(TOAST_TIMEOUT);
+      cy.wait("@cardQuery");
+      undoToast().should("not.exist");
     });
   });
 });

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -49,7 +49,6 @@ class Dashboard extends Component {
     isFullscreen: PropTypes.bool,
     isNightMode: PropTypes.bool,
     isSharing: PropTypes.bool,
-    isEditable: PropTypes.bool,
     isEditing: PropTypes.oneOfType([PropTypes.bool, PropTypes.object])
       .isRequired,
     isEditingParameter: PropTypes.bool.isRequired,
@@ -104,7 +103,6 @@ class Dashboard extends Component {
   };
 
   static defaultProps = {
-    isEditable: true,
     isSharing: false,
   };
 

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar.tsx
@@ -75,6 +75,7 @@ export function DashboardInfoSidebar({
   );
 
   const autoApplyFilterToggleId = useUniqueId();
+  const canWrite = dashboard.can_write;
 
   return (
     <DashboardInfoSidebarRoot data-testid="sidebar-right">
@@ -82,7 +83,7 @@ export function DashboardInfoSidebar({
         <DescriptionHeader>{t`About`}</DescriptionHeader>
         <EditableText
           initialValue={dashboard.description}
-          isDisabled={!dashboard.can_write}
+          isDisabled={!canWrite}
           onChange={handleDescriptionChange}
           isMultiline
           isMarkdown
@@ -98,6 +99,7 @@ export function DashboardInfoSidebar({
           htmlFor={autoApplyFilterToggleId}
         >
           <Toggle
+            disabled={!canWrite}
             id={autoApplyFilterToggleId}
             value={dashboard.auto_apply_filters}
             onChange={handleToggleAutoApplyFilters}
@@ -119,7 +121,7 @@ export function DashboardInfoSidebar({
           events={getTimelineEvents({ revisions, currentUser })}
           data-testid="dashboard-history-list"
           revert={revision => dispatch(revertToRevision(revision))}
-          canWrite={dashboard.can_write}
+          canWrite={canWrite}
         />
       </ContentSection>
     </DashboardInfoSidebarRoot>

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -76,7 +76,6 @@ class DashboardHeader extends Component {
 
   static propTypes = {
     dashboard: PropTypes.object.isRequired,
-    isEditable: PropTypes.bool.isRequired,
     isEditing: PropTypes.oneOfType([PropTypes.bool, PropTypes.object])
       .isRequired,
     isFullscreen: PropTypes.bool.isRequired,
@@ -233,7 +232,6 @@ class DashboardHeader extends Component {
       isBookmarked,
       isEditing,
       isFullscreen,
-      isEditable,
       location,
       onFullscreenChange,
       createBookmark,
@@ -246,7 +244,7 @@ class DashboardHeader extends Component {
       databases,
     } = this.props;
 
-    const canEdit = dashboard.can_write && isEditable && !!dashboard;
+    const canEdit = dashboard.can_write;
 
     const hasModelActionsEnabled = Object.values(databases).some(
       hasDatabaseActionsEnabled,

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.unit.spec.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.unit.spec.jsx
@@ -24,7 +24,6 @@ const setup = async ({ dashboard = TEST_DASHBOARD }) => {
 
   const dashboardHeaderProps = {
     dashboard,
-    isEditable: true,
     isEditing: false,
     isFullscreen: false,
     isNavBarOpen: false,

--- a/frontend/src/metabase/dashboard/selectors/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors/selectors.js
@@ -155,21 +155,22 @@ const getIsParameterValuesEmpty = createSelector(
 
 export const getCanShowAutoApplyFiltersToast = createSelector(
   [
-    getDashboardId,
+    getDashboard,
     getAutoApplyFiltersToastDashboardId,
     getIsAutoApplyFilters,
     getIsSlowDashboard,
     getIsParameterValuesEmpty,
   ],
   (
-    dashboardId,
+    dashboard,
     toastDashboardId,
     isAutoApply,
     isSlowDashboard,
     isParameterValuesEmpty,
   ) => {
     return (
-      dashboardId !== toastDashboardId &&
+      dashboard.can_write &&
+      dashboard.id !== toastDashboardId &&
       isAutoApply &&
       isSlowDashboard &&
       !isParameterValuesEmpty


### PR DESCRIPTION
part of https://github.com/metabase/metabase/issues/31288
Original Epic: https://github.com/metabase/metabase/issues/29267

### Description

This PR handles when users doesn't have collection curate permission then they should not:
1. Be able to toggle auto-apply filters toggle
2. See the auto-apply filters toast

### How to verify

1. Login with users with collection permission as `View`.
2. You should be able to see dashboards' auto-apply filters toggle, but not clickable.

Testing auto apply filters toast require tampering with code to simulate slow dashboard, otherwise it's virtually impossible to test.

Here are the steps to do that:
<details>
<summary>Steps to do that</summary>

1. Go to [`frontend/src/metabase/dashboard/constants.js`](https://github.com/metabase/metabase/blob/03a5c61fe9e10ff18a3ea31164e413f6a527c7c4/frontend/src/metabase/dashboard/constants.js#L10) and edit https://github.com/metabase/metabase/blob/03a5c61fe9e10ff18a3ea31164e413f6a527c7c4/frontend/src/metabase/dashboard/constants.js#L10
    to `2 * 1000`. That will make the slow toast appear after 2 seconds. You can adjust the number as you want, but I set it to a relatively low value so I feel I need to wait but not for too long.
2. go to `frontend/src/metabase/dashboard/actions/data-fetching.js` and paste these 2 functions at the bottom of the file
    ```ts
    function randomBetween(min, max) {
      return Math.random() * (max - min) + min;
    }

    function delay(timeout) {
      return new Promise(resolve => {
        setTimeout(resolve, timeout);
      });
    }
    ```
    Then add this expression at [line 362](https://github.com/metabase/metabase/blob/03a5c61fe9e10ff18a3ea31164e413f6a527c7c4/frontend/src/metabase/dashboard/actions/data-fetching.js#L362) `await delay(randomBetween(2000, 4000));`, that part should look something like this.
    ```ts
    await delay(randomBetween(2000, 4000));
    setFetchCardDataCancel(card.id, dashcard.id, null);
    clearTimeout(slowCardTimer);
    ```
     You can easily tweak this number to anything you like. This will mock the duration it takes to load each card on your dashboard. In this case, I random that a card would load between 2 and 4 seconds. You could even delay this longer to see the slow toast longer since it will disappear once all cards are loaded. And after that, you should be able to see the auto-apply filters notification toast (given all conditions are met, according to the spec i.e. the slow toast is shown + auto-apply filter is true, and there is at least a single parameter with values)
</details>

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
