### PR TITLE
Include refs for all expressions in :fields whenever present

### DIFF
--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -9,6 +9,7 @@
    [metabase.lib.hierarchy :as lib.hierarchy]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
+   [metabase.lib.options :as lib.options]
    [metabase.lib.ref :as lib.ref]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.common :as lib.schema.common]
@@ -20,8 +21,7 @@
    [metabase.shared.util.i18n :as i18n]
    [metabase.types :as types]
    [metabase.util :as u]
-   [metabase.util.malli :as mu]
-   [metabase.lib.options :as lib.options]))
+   [metabase.util.malli :as mu]))
 
 (mu/defn column-metadata->expression-ref :- :mbql.clause/expression
   "Given `:metadata/field` column metadata for an expression, construct an `:expression` reference."

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -20,7 +20,8 @@
    [metabase.shared.util.i18n :as i18n]
    [metabase.types :as types]
    [metabase.util :as u]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.lib.options :as lib.options]))
 
 (mu/defn column-metadata->expression-ref :- :mbql.clause/expression
   "Given `:metadata/field` column metadata for an expression, construct an `:expression` reference."
@@ -182,6 +183,13 @@
         expr-name (u/lower-case-en expression-name)]
     (some #(-> % :name u/lower-case-en (= expr-name)) cols)))
 
+(defn- add-expression-to-stage
+  [stage expression]
+  (cond-> (update stage :expressions (fnil conj []) expression)
+    ;; if there are explicit fields selected, add the expression to them
+    (vector? (:fields stage))
+    (update :fields conj (lib.options/ensure-uuid [:expression {} (lib.util/expression-name expression)]))))
+
 (mu/defn expression :- ::lib.schema/query
   "Adds an expression to query."
   ([query expression-name an-expression-clause]
@@ -192,11 +200,10 @@
        (throw (ex-info "Expression name conflicts with a column in the same query stage"
                        {:expression-name expression-name})))
      (lib.util/update-query-stage
-       query stage-number
-       update :expressions
-       (fnil conj [])
-       (-> (lib.common/->op-arg query stage-number an-expression-clause)
-           (lib.util/named-expression-clause expression-name))))))
+      query stage-number
+      add-expression-to-stage
+      (-> (lib.common/->op-arg query stage-number an-expression-clause)
+          (lib.util/named-expression-clause expression-name))))))
 
 (lib.common/defop + [x y & more])
 (lib.common/defop - [x y & more])

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -459,6 +459,12 @@
     (lib.join/joined-field-desired-alias join-alias (:name field-metadata))
     (:name field-metadata)))
 
+(defn- expression-refs
+  [query stage-number]
+  (for [col (lib.metadata.calculation/metadata query stage-number (lib.util/query-stage query stage-number))
+        :when (= (:lib/source col) :source/expressions)]
+    (lib.ref/ref col)))
+
 (mu/defn with-fields :- ::lib.schema/query
   "Specify the `:fields` for a query. Pass `nil` or an empty sequence to remove `:fields`."
   ([xs]
@@ -471,12 +477,17 @@
   ([query        :- ::lib.schema/query
     stage-number :- :int
     xs]
-   (let [xs (mapv (fn [x]
-                    (lib.ref/ref (if (fn? x)
-                                   (x query stage-number)
-                                   x)))
-                  xs)]
-     (lib.util/update-query-stage query stage-number u/assoc-dissoc :fields (not-empty xs)))))
+   (let [xs (not-empty
+             (mapv (fn [x]
+                     (lib.ref/ref (if (fn? x)
+                                    (x query stage-number)
+                                    x)))
+                   xs))
+         ;; if any fields are specified, include all expressions not yet included too
+         xs (some-> xs
+                    (into (remove #(lib.equality/find-closest-matching-ref % xs))
+                          (expression-refs query stage-number)))]
+     (lib.util/update-query-stage query stage-number u/assoc-dissoc :fields xs))))
 
 (mu/defn fields :- [:maybe [:ref ::lib.schema/fields]]
   "Fetches the `:fields` for a query. Returns `nil` if there are no `:fields`. `:fields` should never be empty; this is

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -581,18 +581,22 @@
 
 (deftest ^:parallel with-fields-test
   (let [query           (-> (lib/query-for-table-name meta/metadata-provider "VENUES")
+                            (lib/expression "myadd" (lib/+ 1 (lib/field "VENUES" "CATEGORY_ID")))
                             (lib/with-fields [(lib/field "VENUES" "ID") (lib/field "VENUES" "NAME")]))
         fields-metadata (fn [query]
                           (map (partial lib.metadata.calculation/metadata query)
                                (lib/fields query)))
         metadatas       (fields-metadata query)]
-    (is (=? [{:name "ID"}
-             {:name "NAME"}]
-            metadatas))
+    (testing "Expressions should be included in :fields by default (#31236)"
+      (is (=? [{:name "ID"}
+               {:name "NAME"}
+               {:name "myadd"}]
+              metadatas)))
     (testing "Set fields with metadatas"
-      (let [fields' [(last metadatas)]
+      (let [fields' [(second metadatas)]
             query'  (lib/with-fields query fields')]
-        (is (=? [{:name "NAME"}]
+        (is (=? [{:name "NAME"}
+                 {:name "myadd"}]
                 (fields-metadata query')))))
     (testing "remove fields by passing"
       (doseq [new-fields [nil []]]
@@ -604,6 +608,19 @@
               (is (has-fields? query)
                   "sanity check")
               (is (not (has-fields? query'))))))))))
+
+(deftest ^:parallel with-fields-plus-expression-test
+  (let [query           (-> (lib/query-for-table-name meta/metadata-provider "VENUES")
+                            (lib/with-fields [(lib/field "VENUES" "ID")])
+                            (lib/expression "myadd" (lib/+ 1 (lib/field "VENUES" "CATEGORY_ID"))))
+        fields-metadata (fn [query]
+                          (map (partial lib.metadata.calculation/metadata query)
+                               (lib/fields query)))
+        metadatas       (fields-metadata query)]
+    (testing "Expressions should be included in :fields by default (#31236)"
+      (is (=? [{:name "ID"}
+               {:name "myadd"}]
+              metadatas)))))
 
 (deftest ^:parallel fieldable-columns-test
   (testing "query with no :fields"

--- a/test/metabase/lib/stage_test.cljc
+++ b/test/metabase/lib/stage_test.cljc
@@ -148,33 +148,6 @@
                   "Cat → Name"]
                  (mapv #(lib.metadata.calculation/display-name query -1 % :long) metadata))))))))
 
-(deftest ^:parallel metadata-with-fields-only-include-expressions-in-fields-test
-  (testing "If query includes :fields, only return expressions that are in :fields"
-    (let [query     (query-with-expressions)
-          id-plus-1 (first (lib/expressions-metadata query))]
-      (is (=? {:lib/type     :metadata/field
-               :base-type    :type/Integer
-               :name         "ID + 1"
-               :display-name "ID + 1"
-               :lib/source   :source/expressions}
-              id-plus-1))
-      (let [query' (-> query
-                       (lib/with-fields [id-plus-1]))]
-        (is (=? {:stages [{:expressions [[:+ {:lib/expression-name "ID + 1"} [:field {} (meta/id :venues :id)] 1]
-                                         [:+ {:lib/expression-name "ID + 2"} [:field {} (meta/id :venues :id)] 2]]
-                           :fields      [[:expression {} "ID + 1"]]}]}
-                query'))
-        (testing "If `:fields` is specified, expressions should only come back if they are in `:fields`"
-          (is (=? [{:name       "ID + 1"
-                    ;; TODO -- I'm not really sure whether the source should be `:source/expressions` here, or
-                    ;; `:source/fields`, since it's present in BOTH...
-                    :lib/source :source/expressions}]
-                  (lib.metadata.calculation/metadata query')))
-          (testing "Should be able to convert the metadata back into a reference"
-            (let [[id-plus-1] (lib.metadata.calculation/metadata query')]
-              (is (=? [:expression {:base-type :type/Integer, :effective-type :type/Integer} "ID + 1"]
-                      (lib/ref id-plus-1))))))))))
-
 (deftest ^:parallel query-with-source-card-include-implicit-columns-test
   (testing "visible-columns should include implicitly joinable columns when the query has a source Card (#30046)"
     (doseq [varr [#'lib.tu/query-with-card-source-table


### PR DESCRIPTION
Fixes #31236.

Also, remove the :fields clause if only expressions remain in it.
