### PR TITLE
Fix showing a banner for implicit actions

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreatorView.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreatorView.tsx
@@ -21,7 +21,6 @@ import {
 import { isNotNull } from "metabase/core/utils/types";
 import type { ActionFormSettings, WritebackAction } from "metabase-types/api";
 
-import { isActionPublic } from "metabase/actions/utils";
 import type { ActionCreatorUIProps, SideView } from "./types";
 import InlineActionSettings, {
   ActionSettingsTriggerButton,
@@ -126,7 +125,6 @@ export default function ActionCreatorView({
               parameters={action.parameters ?? []}
               formSettings={formSettings}
               isEditable={isEditable && canChangeFieldSettings}
-              isPublic={isActionPublic(action)}
               onChange={onChangeFormSettings}
             />
           ) : activeSideView === "dataReference" ? (

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreatorView.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreatorView.tsx
@@ -4,7 +4,7 @@ import { t } from "ttag";
 
 import Button from "metabase/core/components/Button";
 import ActionCreatorHeader from "metabase/actions/containers/ActionCreator/ActionCreatorHeader";
-import FormCreator from "metabase/actions/containers/ActionCreator/FormCreator";
+import { FormCreator } from "metabase/actions/containers/ActionCreator/FormCreator";
 import {
   DataReferenceTriggerButton,
   DataReferenceInline,
@@ -122,6 +122,7 @@ export default function ActionCreatorView({
         <ModalRight>
           {activeSideView === "actionForm" ? (
             <FormCreator
+              actionType={action.type ?? "query"}
               parameters={action.parameters ?? []}
               formSettings={formSettings}
               isEditable={isEditable && canChangeFieldSettings}

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.tsx
@@ -48,7 +48,6 @@ interface FormCreatorProps {
   parameters: Parameter[];
   formSettings?: ActionFormSettings;
   isEditable: boolean;
-  isPublic: boolean;
   onChange: (formSettings: ActionFormSettings) => void;
 }
 
@@ -56,7 +55,6 @@ function FormCreator({
   parameters,
   formSettings: passedFormSettings,
   isEditable,
-  isPublic,
   onChange,
 }: FormCreatorProps) {
   const [formSettings, setFormSettings] = useState<ActionFormSettings>(
@@ -75,8 +73,8 @@ function FormCreator({
   }, [parameters, formSettings]);
 
   const form = useMemo(
-    () => getForm(parameters, formSettings?.fields),
-    [parameters, formSettings?.fields],
+    () => getForm(parameters, formSettings.fields),
+    [parameters, formSettings.fields],
   );
 
   // Validation schema here should only be used to get default values
@@ -159,6 +157,16 @@ function FormCreator({
 
     if (!settings) {
       return false;
+    }
+
+    const isImplicitAction = Object.keys(settings).length === 2;
+
+    if (isImplicitAction) {
+      const parameter = parameters.find(
+        parameter => parameter.id === settings.id,
+      );
+
+      return parameter?.required && settings.hidden;
     }
 
     return (

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.tsx
@@ -21,6 +21,7 @@ import type {
   ActionFormSettings,
   FieldSettings,
   Parameter,
+  WritebackAction,
 } from "metabase-types/api";
 
 import {
@@ -48,13 +49,15 @@ interface FormCreatorProps {
   parameters: Parameter[];
   formSettings?: ActionFormSettings;
   isEditable: boolean;
+  actionType: WritebackAction["type"];
   onChange: (formSettings: ActionFormSettings) => void;
 }
 
-function FormCreator({
+export function FormCreator({
   parameters,
   formSettings: passedFormSettings,
   isEditable,
+  actionType,
   onChange,
 }: FormCreatorProps) {
   const [formSettings, setFormSettings] = useState<ActionFormSettings>(
@@ -159,9 +162,7 @@ function FormCreator({
       return false;
     }
 
-    const isImplicitAction = Object.keys(settings).length === 2;
-
-    if (isImplicitAction) {
+    if (actionType === "implicit") {
       const parameter = parameters.find(
         parameter => parameter.id === settings.id,
       );
@@ -229,6 +230,3 @@ function FormCreator({
     </SidebarContent>
   );
 }
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default FormCreator;

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.unit.spec.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import type {
   ActionFormSettings,
   FieldSettings,
+  WritebackAction,
   WritebackParameter,
 } from "metabase-types/api";
 import {
@@ -11,7 +12,7 @@ import {
   createMockImplicitActionFieldSettings,
 } from "metabase-types/api/mocks";
 
-import FormCreator from "./FormCreator";
+import { FormCreator } from "./FormCreator";
 
 const makeFieldSettings = (
   overrides: Partial<FieldSettings> = {},
@@ -43,9 +44,10 @@ const makeParameter = ({
 type SetupOpts = {
   parameters: WritebackParameter[];
   formSettings: ActionFormSettings;
+  actionType?: WritebackAction["type"];
 };
 
-const setup = ({ parameters, formSettings }: SetupOpts) => {
+const setup = ({ parameters, formSettings, actionType }: SetupOpts) => {
   const onChange = jest.fn();
 
   render(
@@ -54,6 +56,7 @@ const setup = ({ parameters, formSettings }: SetupOpts) => {
       formSettings={formSettings}
       isEditable
       onChange={onChange}
+      actionType={actionType || "query"}
     />,
   );
 
@@ -279,6 +282,7 @@ describe("actions > containers > ActionCreator > FormCreator", () => {
         });
 
         setup({
+          actionType: "implicit",
           parameters: [parameter],
           formSettings: {
             type: "form",
@@ -346,6 +350,7 @@ describe("actions > containers > ActionCreator > FormCreator", () => {
         });
 
         setup({
+          actionType: "implicit",
           parameters: [parameter],
           formSettings: {
             type: "form",

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.unit.spec.tsx
@@ -330,33 +330,34 @@ describe("actions > containers > ActionCreator > FormCreator", () => {
             screen.queryByText(WARNING_BANNER_TEXT),
           ).not.toBeInTheDocument();
         });
-
-        it("doesn't show a banner for implicit action", () => {
-          const defaultValue = "foo bar";
-          const parameter = makeParameter({ required });
-          const fieldSettings = createMockImplicitActionFieldSettings({
-            id: parameter.id,
-            required,
-            defaultValue: hasDefaultValue ? defaultValue : undefined,
-            hidden,
-          });
-
-          setup({
-            parameters: [parameter],
-            formSettings: {
-              type: "form",
-              fields: {
-                [parameter.id]: fieldSettings,
-              },
-            },
-          });
-
-          expect(
-            screen.queryByText(WARNING_BANNER_TEXT),
-          ).not.toBeInTheDocument();
-        });
       },
     );
+
+    describe.each([
+      { required: false, hidden: false },
+      { required: false, hidden: true },
+      { required: true, hidden: false },
+    ])(`when required: $required, hidden: $hidden`, ({ required, hidden }) => {
+      it("doesn't show a banner for implicit action", () => {
+        const parameter = makeParameter({ required });
+        const fieldSettings = createMockImplicitActionFieldSettings({
+          id: parameter.id,
+          hidden,
+        });
+
+        setup({
+          parameters: [parameter],
+          formSettings: {
+            type: "form",
+            fields: {
+              [parameter.id]: fieldSettings,
+            },
+          },
+        });
+
+        expect(screen.queryByText(WARNING_BANNER_TEXT)).not.toBeInTheDocument();
+      });
+    });
 
     describe("when settings are not available (e.g. before action is saved)", () => {
       it("does not show a warning banner for query action", () => {

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/index.ts
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/index.ts
@@ -1,3 +1,2 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./FormCreator";
+export { FormCreator } from "./FormCreator";
 export * from "./utils";

--- a/frontend/src/metabase/actions/utils.ts
+++ b/frontend/src/metabase/actions/utils.ts
@@ -211,10 +211,7 @@ const getFormField = (
   parameter: Parameter,
   fieldSettings: LocalFieldSettings,
 ) => {
-  if (
-    fieldSettings.field &&
-    !isEditableField(fieldSettings.field, parameter as Parameter)
-  ) {
+  if (fieldSettings.field && !isEditableField(fieldSettings.field, parameter)) {
     return undefined;
   }
 


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/30016

## Description

This change fixes showing a banner for required and hidden parameter in basic actions

## Demo
https://www.loom.com/share/1828805e1aa94cbfbb7d8913a1d5f836