### PR TITLE
Adding cy.deleteDownloadsDirectory, updating tests

### DIFF
--- a/e2e/support/commands.js
+++ b/e2e/support/commands.js
@@ -32,3 +32,5 @@ import "./commands/visibility/isRenderedWithinViewport";
 import "./commands/overwrites/log";
 
 import "./commands/percy/createPercySnapshot";
+
+require("./commands/downloads/deleteDownloadsFolder").addCustomCommand();

--- a/e2e/support/commands/downloads/deleteDownloadsFolder.js
+++ b/e2e/support/commands/downloads/deleteDownloadsFolder.js
@@ -1,0 +1,21 @@
+const { rmdirSync } = require("fs");
+
+const removeDirectory = path => {
+  try {
+    rmdirSync(path, { maxRetries: 10, recursive: true });
+  } catch (error) {
+    throw Error(`Error while deleting ${path}. Original error: ${error}`);
+  }
+  return null;
+};
+
+const deleteDownloadsFolder = () =>
+  cy.task("removeDirectory", Cypress.config("downloadsFolder"));
+const addCustomCommand = () =>
+  Cypress.Commands.add("deleteDownloadsFolder", deleteDownloadsFolder);
+
+module.exports = {
+  removeDirectory,
+  deleteDownloadsFolder,
+  addCustomCommand,
+};

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -29,6 +29,9 @@ const runWithReplay = process.env["CYPRESS_REPLAYIO_ENABLED"];
 // the project's config changing)
 
 const createBundler = require("@bahmutov/cypress-esbuild-preprocessor");
+const {
+  removeDirectory,
+} = require("./commands/downloads/deleteDownloadsFolder");
 
 const defaultConfig = {
   // This is the functionality of the old cypress-plugins.js file
@@ -79,6 +82,7 @@ const defaultConfig = {
     on("task", {
       ...dbTasks,
       ...verifyDownloadTasks,
+      removeDirectory,
     });
 
     /********************************************************************

--- a/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
@@ -43,6 +43,7 @@ describe("scenarios > question > download", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
+    cy.deleteDownloadsFolder();
   });
 
   testCases.forEach(fileType => {
@@ -160,10 +161,12 @@ describe("scenarios > dashboard > download pdf", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
+    cy.deleteDownloadsFolder();
   });
   it("should allow you to download a PDF of a dashboard", () => {
+    const date = Date.now();
     cy.createDashboardWithQuestions({
-      dashboardName: "saving pdf dashboard",
+      dashboardName: `saving pdf dashboard - ${date}`,
       questions: [canSavePngQuestion, cannotSavePngQuestion],
     }).then(({ dashboard }) => {
       visitDashboard(dashboard.id);
@@ -174,7 +177,7 @@ describe("scenarios > dashboard > download pdf", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Export as PDF").click();
 
-    cy.verifyDownload("saving pdf dashboard.pdf", { contains: true });
+    cy.verifyDownload(`saving pdf dashboard - ${date}.pdf`);
   });
 });
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31297

### Description
The dashboard download test was flaky due to cypress checking for the file before it was available. The `verifyDownload` task would fail, causing the test to re run, and on the second attempt the `verifyDownload` task would end up finding the artifact from the first attempt, causing the test to pass.

This PR changes 2 things:
- For the dashboard download, the current time has been added to the name of the dashboard so that we can be very explicit on our filename check. The plugin now successfully re-tries until the file is found
- We clear the `cypress/downloads` folder before every test in this suite so that more generic file extension searches can be more accurate

### How to verify
CI should be green


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
