### PR TITLE
MLv2: Handle missing Field metadata as long as it is present in Saved Question metadata

### DIFF
--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -42,8 +42,12 @@
                                  (sequential? result-metadata) result-metadata))]
       (mapv (fn [col]
               (merge
+               {:base-type :type/*, :lib/type :metadata/field}
                (when-let [field-id (:id col)]
-                 (lib.metadata/field metadata-providerable field-id))
+                 (try
+                   (lib.metadata/field metadata-providerable field-id)
+                   (catch #?(:clj Throwable :cljs js/Error) _
+                     nil)))
                (update-keys col u/->kebab-case-en)
                {:lib/type                :metadata/field
                 :lib/source              :source/card
@@ -58,7 +62,7 @@
   ;; it seems like in some cases (unit tests) the FE is renaming `:result-metadata` to `:fields`, not 100% sure why
   ;; but handle that case anyway. (#29739)
   (when-let [card (lib.metadata/card metadata-providerable card-id)]
-    (card-metadata-columns metadata-providerable card)))
+    (not-empty (card-metadata-columns metadata-providerable card))))
 
 (defmethod lib.metadata.calculation/visible-columns-method :metadata/card
   [query _stage-number card {:keys [unique-name-fn], :as _options}]

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -46,7 +46,7 @@
                (when-let [field-id (:id col)]
                  (try
                    (lib.metadata/field metadata-providerable field-id)
-                   (catch #?(:clj Throwable :cljs js/Error) _
+                   (catch #?(:clj Throwable :cljs :default) _
                      nil)))
                (update-keys col u/->kebab-case-en)
                {:lib/type                :metadata/field
@@ -62,7 +62,7 @@
   ;; it seems like in some cases (unit tests) the FE is renaming `:result-metadata` to `:fields`, not 100% sure why
   ;; but handle that case anyway. (#29739)
   (when-let [card (lib.metadata/card metadata-providerable card-id)]
-    (not-empty (card-metadata-columns metadata-providerable card))))
+    (card-metadata-columns metadata-providerable card)))
 
 (defmethod lib.metadata.calculation/visible-columns-method :metadata/card
   [query _stage-number card {:keys [unique-name-fn], :as _options}]

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -62,7 +62,7 @@
                        card-metadata))))
    (try
      (lib.metadata/field query field-id)
-     (catch #?(:clj Throwable :cljs js/Error) _
+     (catch #?(:clj Throwable :cljs :default) _
        nil))))
 
 (mu/defn ^:private resolve-column-name-in-metadata :- [:maybe lib.metadata/ColumnMetadata]

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -4,6 +4,7 @@
    [medley.core :as m]
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.binning :as lib.binning]
+   [metabase.lib.card :as lib.card]
    [metabase.lib.equality :as lib.equality]
    [metabase.lib.expression :as lib.expression]
    [metabase.lib.join :as lib.join]
@@ -56,10 +57,13 @@
   (merge
    (when (lib.util/first-stage? query stage-number)
      (when-let [card-id (lib.util/string-table-id->card-id (lib.util/source-table query))]
-       (when-let [card-metadata (lib.metadata/card query card-id)]
+       (when-let [card-metadata (lib.card/saved-question-metadata query card-id)]
          (m/find-first #(= (:id %) field-id)
-                       (:result-metadata card-metadata)))))
-   (lib.metadata/field query field-id)))
+                       card-metadata))))
+   (try
+     (lib.metadata/field query field-id)
+     (catch #?(:clj Throwable :cljs js/Error) _
+       nil))))
 
 (mu/defn ^:private resolve-column-name-in-metadata :- [:maybe lib.metadata/ColumnMetadata]
   [column-name      :- ::lib.schema.common/non-blank-string

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -627,3 +627,45 @@
                 (lib/with-fields [(meta/field-metadata :venues :id)
                                   (meta/field-metadata :venues :name)])
                 lib/fieldable-columns)))))
+
+(deftest ^:parallel fallback-metadata-from-saved-question-when-missing-from-metadata-provider-test
+  (testing "Handle missing column metadata from the metadata provider; should still work if in Card result metadata (#31624)"
+    (let [provider (lib.tu/mock-metadata-provider
+                    {:database {:id   1
+                                :name "My Database"}
+                     :tables   [{:id   2
+                                 :name "My Table"}]
+                     :cards    [{:id              3
+                                 :name            "Card 3"
+                                 :dataset-query   {:lib/type :mbql/query
+                                                   :database 1
+                                                   :stages   [{:lib/type     :mbql.stage/mbql
+                                                               :source-table 2}]}
+                                 :result-metadata [{:id   4
+                                                    :name "Field 4"}]}]})
+          query    (lib/query provider {:lib/type :mbql/query
+                                        :database 1
+                                        :stages   [{:lib/type     :mbql.stage/mbql
+                                                    :source-table "card__3"}]})]
+      (is (= [{:lib/type                 :metadata/field
+               :base-type                :type/*
+               :id                       4
+               :name                     "Field 4"
+               :lib/source               :source/card
+               :lib/card-id              3
+               :lib/source-column-alias  "Field 4"
+               :lib/desired-column-alias "Field 4"}]
+             (lib.metadata.calculation/metadata query)))
+      (is (= {:lib/type                :metadata/field
+              :base-type               :type/Text
+              :effective-type          :type/Text
+              :id                      4
+              :name                    "Field 4"
+              :display-name            "Field 4"
+              :lib/card-id             3
+              :lib/source              :source/card
+              :lib/source-column-alias "Field 4"
+              :lib/source-uuid         "aa0e13af-29b3-4c27-a880-a10c33e55a3e"}
+             (lib.metadata.calculation/metadata
+              query
+              [:field {:lib/uuid "aa0e13af-29b3-4c27-a880-a10c33e55a3e", :base-type :type/Text} 4]))))))


### PR DESCRIPTION
Fixes #31624

Work around situtations where a Field that should be present in the MetadataProvider is not; as long as it is present in Saved Question result metadata, we should be able to use that. 