### PR TITLE
Fix dashboard revision false positive records

### DIFF
--- a/src/metabase/models/revision.clj
+++ b/src/metabase/models/revision.clj
@@ -1,5 +1,6 @@
 (ns metabase.models.revision
   (:require
+   [cheshire.core :as json]
    [clojure.data :as data]
    [metabase.db.util :as mdb.u]
    [metabase.models.interface :as mi]
@@ -172,7 +173,8 @@
         last-object       (t2/select-one-fn :object Revision :model (name entity) :model_id id {:order-by [[:id :desc]]})]
     ;; make sure we still have a map after calling out serialization function
     (assert (map? serialized-object))
-    (when-not (= serialized-object last-object)
+    (when-not (= (json/generate-string serialized-object)
+                 (json/generate-string last-object))
       (t2/insert! Revision
                   :model        (name entity)
                   :model_id     id
@@ -183,6 +185,16 @@
                   :message      message)
       (delete-old-revisions! entity id)
       object)))
+
+(let [entity :model/Dashboard
+      id 63
+      object (t2/select-one :model/Dashboard 63)
+      serialized-object (serialize-instance entity id object)
+      last-object       (t2/select-one-fn :object Revision :model (name entity) :model_id id {:order-by [[:id :desc]]})]
+  ;; make sure we still have a map after calling out serialization function
+  (= (json/generate-string serialized-object)
+     (json/generate-string last-object)))
+
 
 (defn revert!
   "Revert `entity` with `id` to a given Revision."

--- a/src/metabase/models/revision.clj
+++ b/src/metabase/models/revision.clj
@@ -186,16 +186,6 @@
       (delete-old-revisions! entity id)
       object)))
 
-(let [entity :model/Dashboard
-      id 63
-      object (t2/select-one :model/Dashboard 63)
-      serialized-object (serialize-instance entity id object)
-      last-object       (t2/select-one-fn :object Revision :model (name entity) :model_id id {:order-by [[:id :desc]]})]
-  ;; make sure we still have a map after calling out serialization function
-  (= (json/generate-string serialized-object)
-     (json/generate-string last-object)))
-
-
 (defn revert!
   "Revert `entity` with `id` to a given Revision."
   [& {:keys [entity id user-id revision-id]}]

--- a/test/metabase/models/revision_test.clj
+++ b/test/metabase/models/revision_test.clj
@@ -173,25 +173,24 @@
 
   (testing "Check that we don't record revision on dashboard if it has a filter"
     (t2.with-temp/with-temp
-      [:model/Dashboard     {dash-id :id} {:parameters [{:name       "Category Name"
-                                                         :slug       "category_name"
-                                                         :id         "_CATEGORY_NAME_"
-                                                         :type       "category"}]}
+      [:model/Dashboard     {dash-id :id} {:parameters [{:name "Category Name"
+                                                         :slug "category_name"
+                                                         :id   "_CATEGORY_NAME_"
+                                                         :type "category"}]}
        :model/Card          {card-id :id} {}
        :model/DashboardCard {}            {:dashboard_id       dash-id
                                            :card_id            card-id
                                            :parameter_mappings [{:parameter_id "_CATEGORY_NAME_"
                                                                  :card_id      card-id
                                                                  :target       [:dimension (mt/$ids $categories.name)]}]}]
-      (let [push-revision (fn []
-                            (revision/push-revision! :entity :model/Dashboard
-                                                     :id     dash-id
-                                                     :user-id (mt/user->id :rasta)
-                                                     :object (t2/select-one :model/Dashboard dash-id)))]
+      (let [push-revision (fn [] (revision/push-revision!
+                                   :entity :model/Dashboard
+                                   :id     dash-id
+                                   :user-id (mt/user->id :rasta)
+                                   :object (t2/select-one :model/Dashboard dash-id)))]
         (testing "first revision should be recorded"
           (push-revision)
           (is (= 1 (count (revision/revisions :model/Dashboard dash-id)))))
-
         (testing "push again without changes shouldn't record new revision"
           (push-revision)
           (is (= 1 (count (revision/revisions :model/Dashboard dash-id)))))

--- a/test/metabase/models/revision_test.clj
+++ b/test/metabase/models/revision_test.clj
@@ -163,13 +163,42 @@
           (new-revision 1)
           (is (= 1 (count (revision/revisions :model/FakedCard card-id)))))
 
-        (testing "repeatedly push reivisions with thesame object shouldn't create new revision"
+        (testing "repeatedly push reivisions with the same object shouldn't create new revision"
           (dorun (repeatedly 5 #(new-revision 1)))
           (is (= 1 (count (revision/revisions :model/FakedCard card-id)))))
 
         (testing "push a revision with different object should create new revision"
           (new-revision 2)
-          (is (= 2 (count (revision/revisions :model/FakedCard card-id)))))))))
+          (is (= 2 (count (revision/revisions :model/FakedCard card-id))))))))
+
+  (testing "Check that we don't record revision on dashboard if it has a filter"
+    (t2.with-temp/with-temp
+      [:model/Dashboard     {dash-id :id} {:parameters [{:name       "Category Name"
+                                                         :slug       "category_name"
+                                                         :id         "_CATEGORY_NAME_"
+                                                         :type       "category"}]}
+       :model/Card          {card-id :id} {}
+       :model/DashboardCard {}            {:dashboard_id       dash-id
+                                           :card_id            card-id
+                                           :parameter_mappings [{:parameter_id "_CATEGORY_NAME_"
+                                                                 :card_id      card-id
+                                                                 :target       [:dimension (mt/$ids $categories.name)]}]}]
+      (let [push-revision (fn []
+                            (revision/push-revision! :entity :model/Dashboard
+                                                     :id     dash-id
+                                                     :user-id (mt/user->id :rasta)
+                                                     :object (t2/select-one :model/Dashboard dash-id)))]
+        (testing "first revision should be recorded"
+          (push-revision)
+          (is (= 1 (count (revision/revisions :model/Dashboard dash-id)))))
+
+        (testing "push again without changes shouldn't record new revision"
+          (push-revision)
+          (is (= 1 (count (revision/revisions :model/Dashboard dash-id)))))
+        (testing "now do some updates and new revision should be reocrded"
+          (t2/update! :model/Dashboard :id dash-id {:name "New name"})
+          (push-revision)
+          (is (= 2 (count (revision/revisions :model/Dashboard dash-id)))))))))
 
 ;;; # REVISIONS+DETAILS
 


### PR DESCRIPTION
BE part of [Adding a filter to dashboard create 3 revisions](https://github.com/metabase/metabase/issues/31637).

In [Do not record revision if the object is not changed](https://github.com/metabase/metabase/pull/30285) we made it so that we don't record revision when there is no change.

By no change we did a check `(not= serialized-object last-object)`([code](https://github.com/metabase/metabase/blob/master/src/metabase/models/revision.clj#L175)), this is fine for cards because the serialized-object and last-object got transformed with the card's transformation.

But for dashboards, we also assoc `:cards` as part of the serialized object, and when we select it, we only transform the dashboard object, not the cards inside it. e.g:

```
serialized object is
{:id 1
 :name "a dashboard"
 :cards [{
          :parameter_mappings [{:card_id 3,
                                :parameter_id "8674b2fb",
                                :target [:dimension [:field 18 nil]]}]]}

but the last-object is
{:id 1
 :name "a dashboard"
 :cards [{
          :parameter_mappings [{:card_id 3,
                                :parameter_id "8674b2fb",
                                :target ["dimension" ["field"18 nil]]}]]}
```

Notice the difference in `paramter_mappings.target` between the two object, the reason for this is when fetching `last-object` we do a [post-select](https://github.com/metabase/metabase/blob/master/src/metabase/models/revision.clj#L91) on the outer object(the dashboard), but not doing post-select for individual cards, so the `parmater_mappings` didn't get transformed properly.

The fix is to change the check predicate to `(not= (json/generate-string serialized-object))`