### PR TITLE
Fix dashboard grid doesn't resize in Firefox

### DIFF
--- a/e2e/test/scenarios/admin/databases/database-prompt-banner.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/database-prompt-banner.cy.spec.js
@@ -6,6 +6,8 @@ import {
   expectNoBadSnowplowEvents,
   resetSnowplow,
   restore,
+  rightSidebar,
+  visitDashboard,
 } from "e2e/support/helpers";
 
 describe("database prompt banner", () => {
@@ -54,6 +56,23 @@ describe("database prompt banner", () => {
         ).should("not.exist");
       });
   });
+
+  // Until we enable multi-browser support, this repro will be skipped by Cypress in CI
+  // Issue was specific to Firefox only - it is still possible to test it locally
+  it(
+    "should show info sidebar correctly on Firefox",
+    { browser: "firefox" },
+    function () {
+      visitDashboard(1);
+      cy.findByRole("main").findByText("Loading...").should("not.exist");
+      cy.findByRole("main").icon("info").click();
+
+      rightSidebar().within(() => {
+        cy.findByRole("heading", { name: "About" }).should("be.visible");
+        cy.findByRole("heading", { name: "History" }).should("be.visible");
+      });
+    },
+  );
 
   describe("embeddings", () => {
     // Public and signed embeds are tested in `PublicQuestion.unit.spec.tsx`

--- a/e2e/test/scenarios/admin/databases/database-prompt-banner.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/database-prompt-banner.cy.spec.js
@@ -8,7 +8,7 @@ import {
   restore,
 } from "e2e/support/helpers";
 
-describe("banner", () => {
+describe("database prompt banner", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
@@ -94,40 +94,37 @@ describe("banner", () => {
   });
 });
 
-describeWithSnowplow(
-  "should send snowplow events when clicking on links in the database prompt banner",
-  () => {
-    const PAGE_VIEW_EVENT = 1;
+describeWithSnowplow("database prompt banner", () => {
+  const PAGE_VIEW_EVENT = 1;
 
-    beforeEach(() => {
-      restore();
-      resetSnowplow();
-      cy.signInAsAdmin();
-      enableTracking();
-      cy.visit("/");
-      cy.findByRole("main").findByText("Loading...").should("not.exist");
-    });
+  beforeEach(() => {
+    restore();
+    resetSnowplow();
+    cy.signInAsAdmin();
+    enableTracking();
+    cy.visit("/");
+    cy.findByRole("main").findByText("Loading...").should("not.exist");
+  });
 
-    afterEach(() => {
-      expectNoBadSnowplowEvents();
-    });
+  afterEach(() => {
+    expectNoBadSnowplowEvents();
+  });
 
-    it("should send snowplow events when disabling auto-apply filters", () => {
-      expectNoBadSnowplowEvents();
-      expectGoodSnowplowEvents(PAGE_VIEW_EVENT);
-      cy.findAllByRole("banner")
-        .first()
-        .within(() => {
-          cy.findByRole("link", { name: "Get help connecting" }).click();
-          expectGoodSnowplowEvents(PAGE_VIEW_EVENT + 1);
+  it("should send snowplow events when clicking on links in the database prompt banner", () => {
+    expectNoBadSnowplowEvents();
+    expectGoodSnowplowEvents(PAGE_VIEW_EVENT);
+    cy.findAllByRole("banner")
+      .first()
+      .within(() => {
+        cy.findByRole("link", { name: "Get help connecting" }).click();
+        expectGoodSnowplowEvents(PAGE_VIEW_EVENT + 1);
 
-          cy.findByRole("link", { name: "Connect your database" }).click();
-          // clicking this link also brings us to the admin page causing a new page_view event
-          expectGoodSnowplowEvents(2 * PAGE_VIEW_EVENT + 2);
-        });
-    });
-  },
-);
+        cy.findByRole("link", { name: "Connect your database" }).click();
+        // clicking this link also brings us to the admin page causing a new page_view event
+        expectGoodSnowplowEvents(2 * PAGE_VIEW_EVENT + 2);
+      });
+  });
+});
 
 const visitUrl = url => {
   cy.visit({

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
@@ -80,6 +80,7 @@ export const HeaderContainer = styled.header`
 
 export const ParametersAndCardsContainer = styled.div`
   flex: auto;
+  min-width: 0;
   overflow-y: ${({ shouldMakeDashboardHeaderStickyAfterScrolling }) =>
     shouldMakeDashboardHeaderStickyAfterScrolling ? "auto" : "visible"};
   overflow-x: hidden;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31710

### Description

This is a problem introduced in https://github.com/metabase/metabase/pull/31610. So far the only reported problem occurred in FireFox, but may happen to other browsers as well. This should fix the problem.

You can visualize the problem in this Pen https://codepen.io/winlost-the-animator/pen/dyQXmPW. Using Firefox, you can uncomment the commented code and see how the flex item behaves.

### How to verify

0. Use firefox
1. Go to any dashboard
2. Click on the (i) icon at the top right to open the revision pane
3. The pane is overflowed to the right and has a very small width

Another way to verify this problem is to run Cypress using firefox locally 
1. `yarn build-hot` + `yarn test-cypress-open`
2. After Cypress open up close the browser and open Firefox in Cypress window
3. Run `e2e/test/scenarios/admin/databases/database-prompt-banner.cy.spec.js`, the test should pass
4. Comment out [this line](https://github.com/metabase/metabase/blob/38c95b047beddb1c9da00f9d845e1d00b8d41c1e/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx#L83), and the test should fail.

### Demo
#### Before
You could see that there is a horizontal scroll on the dashboard grid, and the info sidebar is invisible (unless we scroll to the right, but still squashed)
- ![Screenshot 2023-06-20 at 2 40 28 PM](https://github.com/metabase/metabase/assets/1937582/e2a49b3e-e2c9-4f28-8db3-8591d539789b)
- ![image](https://github.com/metabase/metabase/assets/1937582/80515483-10ac-4fcd-aaf0-a1f75968cd3b)


#### After
- ![Screenshot 2023-06-20 at 2 40 08 PM](https://github.com/metabase/metabase/assets/1937582/8c018922-01e4-4404-b696-3542519745aa)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR (it won't run on the CI yet, but at least we can run Firefox Cypress test locally)
