### PR TITLE
FE: Show new syncing tables with spinners in /browse (again)

### DIFF
--- a/frontend/src/metabase/browse/containers/TableBrowser/TableBrowser.jsx
+++ b/frontend/src/metabase/browse/containers/TableBrowser/TableBrowser.jsx
@@ -31,7 +31,7 @@ const getSchemaName = props => {
   return props.schemaName || props.params.schemaName;
 };
 
-const getReloadInterval = (state, tables = []) => {
+const getReloadInterval = (state, _props, tables = []) => {
   if (tables.some(t => isSyncInProgress(t))) {
     return RELOAD_INTERVAL;
   } else {

--- a/frontend/src/metabase/browse/containers/TableBrowser/TableBrowser.jsx
+++ b/frontend/src/metabase/browse/containers/TableBrowser/TableBrowser.jsx
@@ -31,12 +31,8 @@ const getSchemaName = props => {
   return props.schemaName || props.params.schemaName;
 };
 
-const getReloadInterval = (state, { database }, tables = []) => {
-  if (
-    database &&
-    isSyncInProgress(database) &&
-    tables.some(t => isSyncInProgress(t))
-  ) {
+const getReloadInterval = (state, tables = []) => {
+  if (tables.some(t => isSyncInProgress(t))) {
     return RELOAD_INTERVAL;
   } else {
     return 0;


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/31082

Corresponds to [this block](https://www.notion.so/metabase/Provide-progress-on-initial-database-sync-16af8e79312a45ecb715d8e58801c52b?pvs=4#c72950a97cf14fd48e6ef2b6dfdd676b) in the spec.

This PR changes the /browse/:database page (aka the `TableBrowser` component) to show newly created and syncing tables with a spinner, and unable to be clicked.

Loom demo:
https://www.loom.com/share/e3e9b5a2c2a441aaba4c94ca4f01b776