### PR TITLE
Prevent reading environment variables during compilation

### DIFF
--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -220,7 +220,7 @@
     (or (t2/select-one Database :name "Application Database")
         (let [details (#'metabase.db.env/broken-out-details
                        (mdb.connection/db-type)
-                       @#'metabase.db.env/env)
+                       (#'metabase.db.env/env))
               app-db  (first (t2/insert-returning-instances! Database
                                                              {:name    "Application Database"
                                                               :engine  (mdb.connection/db-type)

--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/common/cards.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/common/cards.clj
@@ -59,14 +59,15 @@
 
 (def dashboards-ids
   "HoneySQL for a CTE to enumerate the dashboards for a Card. We get the actual ID's"
-  [:dash_card {:select [:card_id [(common/group-concat (h2x/cast
-                                                        (if (= (mdb.connection/db-type) :mysql) :char :text)
-                                                        :report_dashboard.name)
-                                                       "|")
-                                  :name_str]]
-               :from [:report_dashboardcard]
-               :join [:report_dashboard [:= :report_dashboardcard.dashboard_id :report_dashboard.id]]
-               :group-by [:card_id]}])
+  (delay ; << We use DB connection info that is not available at compile time.
+    [:dash_card {:select [:card_id [(common/group-concat (h2x/cast
+                                                          (if (= (mdb.connection/db-type) :mysql) :char :text)
+                                                          :report_dashboard.name)
+                                                         "|")
+                                    :name_str]]
+                 :from [:report_dashboardcard]
+                 :join [:report_dashboard [:= :report_dashboardcard.dashboard_id :report_dashboard.id]]
+                 :group-by [:card_id]}]))
 
 (def views
   "HoneySQL for a CTE to include the total view count for each Card."

--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/common/cards.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/common/cards.clj
@@ -57,17 +57,17 @@
                :from [:report_dashboardcard]
                :group-by [:card_id]}])
 
-(def dashboards-ids
+(defn dashboards-ids
   "HoneySQL for a CTE to enumerate the dashboards for a Card. We get the actual ID's"
-  (delay ; << We use DB connection info that is not available at compile time.
-    [:dash_card {:select [:card_id [(common/group-concat (h2x/cast
-                                                          (if (= (mdb.connection/db-type) :mysql) :char :text)
-                                                          :report_dashboard.name)
-                                                         "|")
-                                    :name_str]]
-                 :from [:report_dashboardcard]
-                 :join [:report_dashboard [:= :report_dashboardcard.dashboard_id :report_dashboard.id]]
-                 :group-by [:card_id]}]))
+  []
+  [:dash_card {:select [:card_id [(common/group-concat (h2x/cast
+                                                        (if (= (mdb.connection/db-type) :mysql) :char :text)
+                                                        :report_dashboard.name)
+                                                       "|")
+                                  :name_str]]
+               :from [:report_dashboardcard]
+               :join [:report_dashboard [:= :report_dashboardcard.dashboard_id :report_dashboard.id]]
+               :group-by [:card_id]}])
 
 (def views
   "HoneySQL for a CTE to include the total view count for each Card."

--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/query_detail.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/query_detail.clj
@@ -31,7 +31,7 @@
    :results (common/reducible-query
               {:with      [cards/query-runs
                            cards/latest-qe
-                           cards/dashboards-ids]
+                           @cards/dashboards-ids]
                :select    [[:card.id :card_id]
                            [:card.name :card_name]
                            [:latest_qe.error :error_str]

--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/query_detail.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/query_detail.clj
@@ -31,7 +31,7 @@
    :results (common/reducible-query
               {:with      [cards/query-runs
                            cards/latest-qe
-                           @cards/dashboards-ids]
+                           (cards/dashboards-ids)]
                :select    [[:card.id :card_id]
                            [:card.name :card_name]
                            [:latest_qe.error :error_str]

--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -42,17 +42,18 @@
 
   The return values indicate what action was taken."
   []
-  (let [audit-db (t2/select-one Database :is_audit true)]
+  (let [db-type  @mdb.env/db-type
+        audit-db (t2/select-one Database :is_audit true)]
     (cond
       (nil? audit-db)
       (u/prog1 ::installed
         (log/info "Installing Audit DB...")
-        (install-database! mdb.env/db-type))
+        (install-database! db-type))
 
-      (not= mdb.env/db-type (:engine audit-db))
+      (not= db-type (:engine audit-db))
       (u/prog1 ::updated
-        (log/infof "App DB change detected. Changing Audit DB source to match: %s." (name mdb.env/db-type))
-        (t2/update! Database :is_audit true {:engine mdb.env/db-type})
+        (log/infof "App DB change detected. Changing Audit DB source to match: %s." (name db-type))
+        (t2/update! Database :is_audit true {:engine db-type})
         (ensure-db-installed!))
 
       :else

--- a/src/metabase/async/streaming_response/thread_pool.clj
+++ b/src/metabase/async/streaming_response/thread_pool.clj
@@ -7,19 +7,17 @@
 
 (set! *warn-on-reflection* true)
 
-(def ^:private ^Long thread-pool-max-size
-  (or (config/config-int :mb-async-query-thread-pool-size)
-      (config/config-int :mb-jetty-maxthreads)
-      50))
-
 (defonce ^:private thread-pool*
   (delay
-    (Executors/newFixedThreadPool thread-pool-max-size
-                                  (.build
-                                   (doto (BasicThreadFactory$Builder.)
-                                     (.namingPattern "streaming-response-thread-pool-%d")
-                                     ;; Daemon threads do not block shutdown of the JVM
-                                     (.daemon true))))))
+    (let [thread-pool-max-size (or (config/config-int :mb-async-query-thread-pool-size)
+                                   (config/config-int :mb-jetty-maxthreads)
+                                   50)]
+      (Executors/newFixedThreadPool thread-pool-max-size
+                                    (.build
+                                     (doto (BasicThreadFactory$Builder.)
+                                       (.namingPattern "streaming-response-thread-pool-%d")
+                                       ;; Daemon threads do not block shutdown of the JVM
+                                       (.daemon true)))))))
 
 (defn thread-pool
   "Thread pool for asynchronously running streaming responses."

--- a/src/metabase/cmd/rotate_encryption_key.clj
+++ b/src/metabase/cmd/rotate_encryption_key.clj
@@ -18,7 +18,7 @@
   (when-not (mdb/db-is-set-up?)
     (log/warnf "Database not found. Metabase will create a new database at %s and proceeed encrypting." "2")
     (mdb/setup-db!))
-  (log/infof "%s: %s | %s" (trs "Connected to") mdb.env/db-type (mdb.env/db-file))
+  (log/infof "%s: %s | %s" (trs "Connected to") @mdb.env/db-type (mdb.env/db-file))
   (let [make-encrypt-fn   (fn [maybe-encrypt-fn]
                             (if to-key
                               (partial maybe-encrypt-fn (encryption/validate-and-hash-secret-key to-key))

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -47,7 +47,7 @@
 (defn db-is-set-up?
   "True if the Metabase DB is setup and ready."
   []
-  (= @(:status mdb.connection/*application-db*) ::setup-finished))
+  (= (some-> mdb.connection/*application-db* :status deref) ::setup-finished))
 
 (defn setup-db!
   "Do general preparation of database by validating that we can connect. Caller can specify if we should run any pending

--- a/src/metabase/db/connection.clj
+++ b/src/metabase/db/connection.clj
@@ -86,7 +86,8 @@
 (def ^:dynamic ^ApplicationDB *application-db*
   "Type info and [[javax.sql.DataSource]] for the current Metabase application database. Create a new instance
   with [[application-db]]."
-  (application-db mdb.env/db-type mdb.env/data-source :create-pool? true))
+  (when-not *compile-files* ; << Do not initialize this at compile time.
+    (application-db @mdb.env/db-type @mdb.env/data-source :create-pool? true)))
 
 (defn db-type
   "Keyword type name of the application DB. Matches corresponding db-type name e.g. `:h2`, `:mysql`, or `:postgres`."

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -38,7 +38,8 @@
 
 (def ^:dynamic *backend*
   "Current cache backend. Dynamically rebindable primary for test purposes."
-  (i/cache-backend (config/config-kw :mb-qp-cache-backend)))
+  (when-not *compile-files* ; << Do not initialize this at compile time.
+    (i/cache-backend (config/config-kw :mb-qp-cache-backend))))
 
 
 ;;; ------------------------------------------------------ Save ------------------------------------------------------

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -81,7 +81,7 @@
 (defmethod default-session-cookie-attributes :normal
   [_ request]
   (merge
-   {:same-site config/mb-session-cookie-samesite
+   {:same-site (config/mb-session-cookie-samesite)
     ;; TODO - we should set `site-path` as well. Don't want to enable this yet so we don't end
     ;; up breaking things
     :path      "/" #_(site-path)}
@@ -156,7 +156,7 @@
                         ;; max-session age-is in minutes; Max-Age= directive should be in seconds
                         (when (use-permanent-cookies? request)
                           {:max-age (* 60 (config/config-int :max-session-age))}))]
-    (when (and (= config/mb-session-cookie-samesite :none) (request.u/https? request))
+    (when (and (= (config/mb-session-cookie-samesite) :none) (request.u/https? request))
       (log/warn
        (str (deferred-trs "Session cookie's SameSite is configured to \"None\", but site is served over an insecure connection. Some browsers will reject cookies under these conditions.")
             " "

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -322,12 +322,14 @@
   (or (nil? x)
       (f x)))
 
-(def ^String ^{:arglists '([emoji-string])} emoji
+#_{:clj-kondo/ignore #?(:clj [] :cljs [:unused-binding])}
+(defn emoji
   "Returns the `emoji-string` passed in if emoji in logs are enabled, otherwise always returns an empty string."
+  ^String [emoji-string]
   #?(:clj  (if (config/config-bool :mb-emoji-in-logs)
-             identity
-             (constantly ""))
-     :cljs (constantly "")))
+             emoji-string
+             "")
+     :cljs ""))
 
 (defn round-to-decimals
   "Round (presumabily floating-point) `number` to `decimal-place`. Returns a `Double`.

--- a/src/metabase/util/format.cljc
+++ b/src/metabase/util/format.cljc
@@ -52,24 +52,17 @@
       (recur (/ n 1024.0) more)
       (format-with-unit n suffix))))
 
-#?(:clj
-   (def ^:private colorize?
-     ;; As of 0.35.0 we support the NO_COLOR env var. See https://no-color.org/ (But who hates color logs?)
-     (if (config/config-str :no-color)
-       false
-       (config/config-bool :mb-colorize-logs))))
-
-(def ^{:arglists '(^String [color-symb x])} colorize
+#_{:clj-kondo/ignore #?(:clj [] :cljs [:unused-binding])}
+(defn colorize
   "Colorize string `x` using `color`, a symbol or keyword, but only if `MB_COLORIZE_LOGS` is enabled (the default).
   `color` can be `green`, `red`, `yellow`, `blue`, `cyan`, `magenta`, etc. See the entire list of avaliable
   colors [here](https://github.com/ibdknox/colorize/blob/master/src/colorize/core.clj)"
-  #?(:clj  (if colorize?
-             (fn [color x]
-               (colorize/color (keyword color) (str x)))
-             (fn [_ x]
-               (str x)))
-     :cljs (fn [_ x]
-             (str x))))
+  ^String [color x]
+  #?(:clj  (if (and (not (config/config-str :no-color))
+                    (config/config-bool :mb-colorize-logs))
+             (colorize/color (keyword color) (str x))
+             (str x))
+     :cljs (str x)))
 
 (defn format-color
   "With one arg, converts something to a string and colorizes it. With two args, behaves like `format`, but colorizes

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -42,19 +42,19 @@
   (testing "`SameSite` value is read from config (env)"
     (is (= :lax ; Default value
            (with-redefs [env/env (dissoc env/env :mb-session-cookie-samesite)]
-             (#'config/mb-session-cookie-samesite*))))
+             (config/mb-session-cookie-samesite))))
 
     (is (= :strict
            (with-redefs [env/env (assoc env/env :mb-session-cookie-samesite "StRiCt")]
-             (#'config/mb-session-cookie-samesite*))))
+             (config/mb-session-cookie-samesite))))
 
     (is (= :none
            (with-redefs [env/env (assoc env/env :mb-session-cookie-samesite "NONE")]
-             (#'config/mb-session-cookie-samesite*))))
+             (config/mb-session-cookie-samesite))))
 
     (is (thrown-with-msg? ExceptionInfo #"Invalid value for MB_COOKIE_SAMESITE"
           (with-redefs [env/env (assoc env/env :mb-session-cookie-samesite "invalid value")]
-            (#'config/mb-session-cookie-samesite*))))))
+            (config/mb-session-cookie-samesite))))))
 
 (deftest set-session-cookie-test
   (mt/with-temporary-setting-values [session-timeout nil]


### PR DESCRIPTION
If `metabase.config/config-str` is called during compilation, the value of
an environment variable that is supposed to be set at runtime is used
at build time, with potentially harmful consequences (cf. #30518).
By using `defn`, `(delay ,,,)` or `(when-not *compile-files* ,,,)` we prevent
that.  To prevent accidental uses in the future we throw if the function
is called at compile time.

Initializing the database connection or cache backend during compilation
seemed wrong in any case, since we do not have a proper environment for them
to work, so we make sure to skip that at compile time.

See-also: https://metaboat.slack.com/archives/CKZEMT1MJ/p1687195726609149?thread_ts=1686910161.093389&cid=CKZEMT1MJ
Replaces: https://github.com/metabase/metabase/pull/31612
Closes: https://github.com/metabase/metabase/issues/30518
