### PR TITLE
Increase frontend unit test timeout

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -79,7 +79,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.frontend_all == 'true'
     runs-on: buildjet-2vcpu-ubuntu-2204
-    timeout-minutes: 35
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v3
     - name: Prepare front-end environment


### PR DESCRIPTION
We've been getting timeouts for these tests on master
https://github.com/metabase/metabase/actions/runs/5322646810
https://github.com/metabase/metabase/actions/runs/5322587290

Moves from 35 -> 60 min.

would be nice if these ran faster though 😢 