### PR TITLE
Fix runtime issue with binned date filter visualization

### DIFF
--- a/e2e/test/scenarios/visualizations/reproductions/31743-binned-date-chart-zoom.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/31743-binned-date-chart-zoom.cy.spec.js
@@ -1,0 +1,75 @@
+import { leftSidebar, queryBuilderMain, restore } from "e2e/support/helpers";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
+describe("issue 31743", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it(`should support line chart zoom for binned dates - "month-of-year" (metabase#31743)`, () => {
+    prepareLineChart("month-of-year");
+
+    // drag across to filter
+    cy.get(".Visualization")
+      .trigger("mousedown", 120, 200)
+      .trigger("mousemove", 330, 200)
+      .trigger("mouseup", 330, 200);
+
+    cy.findByTestId("qb-filters-panel")
+      .findByText(`Created At between 0.46523894212238215 2.7555128785983327`)
+      .should("be.visible");
+
+    cy.get(".LineAreaBarChart").within(() => {
+      cy.findByText("January").should("be.visible");
+      cy.findByText("February").should("be.visible");
+    });
+
+    queryBuilderMain().findByText("Month of year").should("be.visible");
+  });
+
+  it(`should support line chart zoom for binned dates - "day-of-week" (metabase#31743)`, () => {
+    prepareLineChart("day-of-week");
+
+    // drag across to filter
+    cy.get(".Visualization")
+      .trigger("mousedown", 120, 200)
+      .trigger("mousemove", 430, 200)
+      .trigger("mouseup", 430, 200);
+
+    cy.findByTestId("qb-filters-panel")
+      .findByText(`Created At between 0.35998539366111937 2.3992466915966215`)
+      .should("be.visible");
+
+    cy.get(".LineAreaBarChart").within(() => {
+      cy.findByText("Sunday").should("be.visible");
+      cy.findByText("Monday").should("be.visible");
+    });
+
+    queryBuilderMain().findByText("Day of week").should("be.visible");
+  });
+});
+
+function prepareLineChart(temporalUnit) {
+  cy.createQuestion(
+    {
+      query: {
+        "source-table": ORDERS_ID,
+        dataset: true,
+        aggregation: [["count"]],
+        breakout: [
+          ["field", ORDERS.CREATED_AT, { "temporal-unit": temporalUnit }],
+        ],
+      },
+    },
+    { visitQuestion: true },
+  );
+
+  cy.findByTestId("viz-type-button").click();
+
+  leftSidebar().within(() => {
+    cy.icon("line").click();
+    cy.button("Done").click();
+  });
+}

--- a/frontend/src/metabase-lib/queries/utils/actions.js
+++ b/frontend/src/metabase-lib/queries/utils/actions.js
@@ -233,6 +233,10 @@ export function updateLatLonFilter(
 }
 
 export function updateNumericFilter(query, column, start, end) {
-  const fieldRef = fieldRefForColumn(column);
+  // NOTE: if it is a date with binning, then we should use aggregated version
+  const fieldRef = isDate(column)
+    ? fieldRefWithTemporalUnitForColumn(column, column.unit)
+    : fieldRefForColumn(column);
+
   return addOrUpdateFilter(query, ["between", fieldRef, start, end]);
 }

--- a/frontend/src/metabase-lib/queries/utils/query-time.js
+++ b/frontend/src/metabase-lib/queries/utils/query-time.js
@@ -26,6 +26,14 @@ export const DATETIME_UNITS = [
   "quarter-of-year",
 ];
 
+const DATETIME_UNITS_WITH_NUMERIC_ARGUMENTS_FORMATTING = [
+  "day-of-week",
+  "day-of-month",
+  "week-of-year",
+  "month-of-year",
+  "quarter-of-year",
+];
+
 export function computeFilterTimeRange(filter) {
   let expandedFilter;
   let defaultUnit;
@@ -143,6 +151,11 @@ export function generateTimeFilterValuesDescriptions(filter) {
 function generateTimeValueDescription(value, bucketing, isExclude) {
   if (typeof value === "number" && bucketing === "hour-of-day") {
     return moment().hour(value).format("h A");
+  } else if (
+    typeof value === "number" &&
+    DATETIME_UNITS_WITH_NUMERIC_ARGUMENTS_FORMATTING.includes(bucketing)
+  ) {
+    return value;
   } else if (typeof value === "string") {
     const m = parseTimestamp(value, bucketing);
     if (bucketing) {

--- a/frontend/src/metabase-lib/queries/utils/query-time.unit.spec.ts
+++ b/frontend/src/metabase-lib/queries/utils/query-time.unit.spec.ts
@@ -1,0 +1,17 @@
+import { ORDERS } from "metabase-types/api/mocks/presets";
+import { generateTimeFilterValuesDescriptions } from "metabase-lib/queries/utils/query-time";
+
+describe("generateTimeFilterValuesDescriptions", () => {
+  it("should support date field with temporal-unit setting", () => {
+    const filter = [
+      "between",
+      ["field", ORDERS.CREATED_AT, { "temporal-unit": "month-of-year" }],
+      3.5518686127011723,
+      8.256492942128451,
+    ];
+
+    expect(generateTimeFilterValuesDescriptions(filter)).toStrictEqual([
+      3.5518686127011723, 8.256492942128451,
+    ]);
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/18011

### Description

This fixes runtime issue with binned date filter visualization. Binned date value is treated as a numeric value on the filter level, that's why we display a filter pill like other numeric filters.

**Even though it fixes reported issue, our support for binned dates is very far from ideal. We don't have proper filter selectors for such values.**

I added a request to propose a product solution for better support for such kind of date filters in slack.

### Demo


https://github.com/metabase/metabase/assets/7983744/c1dd2fb0-6fee-4e16-8677-930103eb584d



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
