### PR TITLE
Manual backport - Markdown support in the pinned items (#31251)

### DIFF
--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.styled.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.styled.tsx
@@ -4,6 +4,7 @@ import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
 import Link from "metabase/core/components/Link";
 import Card from "metabase/components/Card";
+import { MarkdownPreview } from "metabase/core/components/MarkdownPreview";
 
 export const ItemCard = styled(Card)``;
 
@@ -37,11 +38,8 @@ export const Title = styled.div`
   overflow: hidden;
 `;
 
-export const Description = styled.div`
+export const Description = styled(MarkdownPreview)`
   color: ${color("text-medium")};
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
 `;
 
 export const Body = styled.div`

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { Dispatch, MouseEvent, SetStateAction, useState } from "react";
 import { t } from "ttag";
 
 import Tooltip from "metabase/core/components/Tooltip";
@@ -9,10 +9,10 @@ import ModelDetailLink from "metabase/models/components/ModelDetailLink";
 import type { Bookmark, Collection, CollectionItem } from "metabase-types/api";
 
 import {
+  ActionsContainer,
   Body,
   Description,
   Header,
-  ActionsContainer,
   ItemCard,
   ItemIcon,
   ItemLink,
@@ -32,13 +32,11 @@ type Props = {
 
 const TOOLTIP_MAX_WIDTH = 450;
 
-function getDefaultDescription(model: string) {
-  return {
-    card: t`A question`,
-    dashboard: t`A dashboard`,
-    dataset: t`A model`,
-  }[model];
-}
+const DEFAULT_DESCRIPTION: Record<string, string> = {
+  card: t`A question`,
+  dashboard: t`A dashboard`,
+  dataset: t`A model`,
+};
 
 function PinnedItemCard({
   bookmarks,
@@ -51,15 +49,13 @@ function PinnedItemCard({
   onMove,
 }: Props) {
   const [showTitleTooltip, setShowTitleTooltip] = useState(false);
-  const [showDescriptionTooltip, setShowDescriptionTooltip] = useState(false);
   const icon = item.getIcon().name;
   const { description, name, model } = item;
-
-  const defaultedDescription = description || getDefaultDescription(model);
+  const defaultedDescription = description || DEFAULT_DESCRIPTION[model] || "";
 
   const maybeEnableTooltip = (
-    event: React.MouseEvent<HTMLDivElement, MouseEvent>,
-    setterFn: React.Dispatch<React.SetStateAction<boolean>>,
+    event: MouseEvent<HTMLDivElement>,
+    setterFn: Dispatch<SetStateAction<boolean>>,
   ) => {
     const target = event.target as HTMLDivElement;
     const isTargetElWiderThanCard = target?.scrollWidth > target?.clientWidth;
@@ -101,22 +97,9 @@ function PinnedItemCard({
               {name}
             </Title>
           </Tooltip>
-          <Tooltip
-            tooltip={description}
-            placement="bottom"
-            maxWidth={TOOLTIP_MAX_WIDTH}
-            isEnabled={showDescriptionTooltip}
-          >
-            {defaultedDescription && (
-              <Description
-                onMouseEnter={e =>
-                  maybeEnableTooltip(e, setShowDescriptionTooltip)
-                }
-              >
-                {defaultedDescription}
-              </Description>
-            )}
-          </Tooltip>
+          <Description tooltipMaxWidth={TOOLTIP_MAX_WIDTH}>
+            {defaultedDescription}
+          </Description>
         </Body>
       </ItemCard>
     </ItemLink>

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.unit.spec.js
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.unit.spec.js
@@ -15,6 +15,23 @@ const defaultCollection = {
   archived: false,
 };
 
+const HEADING_1_TEXT = "Heading 1";
+const HEADING_1_MARKDOWN = `# ${HEADING_1_TEXT}`;
+const HEADING_2_TEXT = "Heading 2";
+const HEADING_2_MARKDOWN = `## ${HEADING_2_TEXT}`;
+const PARAGRAPH_TEXT = "Paragraph with link";
+const PARAGRAPH_MARKDOWN = "Paragraph with [link](https://example.com)";
+const IMAGE_MARKDOWN = "![alt](https://example.com/img.jpg)";
+const MARKDOWN = [
+  IMAGE_MARKDOWN,
+  HEADING_1_MARKDOWN,
+  HEADING_2_MARKDOWN,
+  PARAGRAPH_MARKDOWN,
+].join("\n\n");
+const MARKDOWN_AS_TEXT = [HEADING_1_TEXT, HEADING_2_TEXT, PARAGRAPH_TEXT].join(
+  " ",
+);
+
 function getCollectionItem({
   id = 1,
   model = "dashboard",
@@ -109,6 +126,22 @@ describe("PinnedItemCard", () => {
         "href",
         "/model/1-order/detail",
       );
+    });
+  });
+
+  describe("description", () => {
+    it("should render description markdown as plain text", () => {
+      setup({ item: getCollectionItem({ description: MARKDOWN }) });
+
+      expect(screen.getByText(MARKDOWN_AS_TEXT)).toBeInTheDocument();
+    });
+
+    it("should show description tooltip with markdown formatting on hover", () => {
+      setup({ item: getCollectionItem({ description: MARKDOWN }) });
+
+      userEvent.hover(screen.getByText(MARKDOWN_AS_TEXT));
+
+      expect(screen.getByRole("tooltip")).toHaveTextContent(MARKDOWN_AS_TEXT);
     });
   });
 });

--- a/frontend/src/metabase/core/components/Markdown/Markdown.styled.tsx
+++ b/frontend/src/metabase/core/components/Markdown/Markdown.styled.tsx
@@ -2,8 +2,9 @@ import { FC, ReactElement } from "react";
 import ReactMarkdown from "react-markdown";
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
+import type { MarkdownProps } from "./Markdown";
 
-export const MarkdownRoot = styled(getComponent(ReactMarkdown))`
+export const MarkdownRoot = styled(getComponent(ReactMarkdown))<MarkdownProps>`
   p {
     margin: 0;
     line-height: 1.57em;
@@ -16,11 +17,11 @@ export const MarkdownRoot = styled(getComponent(ReactMarkdown))`
   a {
     cursor: pointer;
     text-decoration: none;
-    color: ${color("brand")};
+    color: ${props => (props.unstyleLinks ? color("white") : color("brand"))};
   }
 
   a:hover {
-    text-decoration: underline;
+    text-decoration: ${props => (props.unstyleLinks ? "none" : "underline")};
   }
 
   img {

--- a/frontend/src/metabase/core/components/Markdown/Markdown.tsx
+++ b/frontend/src/metabase/core/components/Markdown/Markdown.tsx
@@ -1,20 +1,45 @@
-import React from "react";
+import React, { ComponentPropsWithRef } from "react";
 import remarkGfm from "remark-gfm";
+import ReactMarkdown from "react-markdown";
 import { MarkdownRoot } from "./Markdown.styled";
 
 const REMARK_PLUGINS = [remarkGfm];
 
-export interface MarkdownProps {
+export interface MarkdownProps
+  extends ComponentPropsWithRef<typeof ReactMarkdown> {
   className?: string;
-  children?: string;
+  disallowHeading?: boolean;
+  unstyleLinks?: boolean;
+  children: string;
 }
 
-const Markdown = ({ className, children = "" }: MarkdownProps): JSX.Element => {
+const Markdown = ({
+  className,
+  children = "",
+  disallowHeading = false,
+  unstyleLinks = false,
+  ...rest
+}: MarkdownProps): JSX.Element => {
+  const additionalOptions = {
+    ...(disallowHeading && {
+      disallowedElements: ["h1", "h2", "h3", "h4", "h5", "h6"],
+      unwrapDisallowed: true,
+    }),
+  };
+
   return (
-    <MarkdownRoot className={className} remarkPlugins={REMARK_PLUGINS}>
+    <MarkdownRoot
+      className={className}
+      remarkPlugins={REMARK_PLUGINS}
+      linkTarget={"_blank"}
+      unstyleLinks={unstyleLinks}
+      {...additionalOptions}
+      {...rest}
+    >
       {children}
     </MarkdownRoot>
   );
 };
 
+// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default Markdown;

--- a/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.stories.tsx
+++ b/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.stories.tsx
@@ -1,0 +1,38 @@
+import styled from "@emotion/styled";
+import type { ComponentStory } from "@storybook/react";
+import React from "react";
+
+import { MarkdownPreview } from "./MarkdownPreview";
+
+export default {
+  title: "Core/MarkdownPreview",
+  component: MarkdownPreview,
+};
+
+const Template: ComponentStory<typeof MarkdownPreview> = args => {
+  return (
+    <Container>
+      <MarkdownPreview {...args} />
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  width: 200px;
+`;
+
+export const PlainText = Template.bind({});
+PlainText.args = {
+  children: `Our first email blast to the mailing list not directly linked to the release of a new version. We wanted to see if this would effect visits to landing pages for the features in 0.41.`,
+};
+
+export const Markdown = Template.bind({});
+Markdown.args = {
+  children: `![Metabase logo](https://www.metabase.com/images/logo.svg)
+# New version
+Our first email blast to the mailing list not directly linked to the release
+of a new version. We wanted to see if this would effect visits to landing pages
+for the features in 0.41.
+----
+Here’s a [doc](https://metabase.test) with the findings.`,
+};

--- a/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.styled.tsx
+++ b/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.styled.tsx
@@ -1,0 +1,12 @@
+import styled from "@emotion/styled";
+
+import Markdown from "../Markdown/Markdown";
+
+export const TruncatedMarkdown = styled(Markdown)`
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  overflow-wrap: break-word;
+  white-space: pre-line;
+`;

--- a/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.tsx
+++ b/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.tsx
@@ -1,0 +1,40 @@
+import React, { ComponentProps } from "react";
+
+import Markdown from "../Markdown";
+import Tooltip from "../Tooltip";
+
+import { TruncatedMarkdown } from "./MarkdownPreview.styled";
+
+interface Props {
+  children: string;
+  className?: string;
+  tooltipMaxWidth?: ComponentProps<typeof Tooltip>["maxWidth"];
+}
+
+const ALLOWED_ELEMENTS: string[] = [];
+
+export const MarkdownPreview = ({
+  children,
+  className,
+  tooltipMaxWidth,
+}: Props) => (
+  <Tooltip
+    maxWidth={tooltipMaxWidth}
+    placement="bottom"
+    tooltip={
+      <Markdown disallowHeading unstyleLinks>
+        {children}
+      </Markdown>
+    }
+  >
+    <div>
+      <TruncatedMarkdown
+        allowedElements={ALLOWED_ELEMENTS}
+        className={className}
+        unwrapDisallowed
+      >
+        {children}
+      </TruncatedMarkdown>
+    </div>
+  </Tooltip>
+);

--- a/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.unit.spec.tsx
@@ -1,0 +1,55 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { MarkdownPreview } from "./MarkdownPreview";
+
+const HEADING_1_TEXT = "Heading 1";
+const HEADING_1_MARKDOWN = `# ${HEADING_1_TEXT}`;
+const HEADING_2_TEXT = "Heading 2";
+const HEADING_2_MARKDOWN = `## ${HEADING_2_TEXT}`;
+const PARAGRAPH_TEXT = "Paragraph with link";
+const PARAGRAPH_MARKDOWN = "Paragraph with [link](https://example.com)";
+const IMAGE_MARKDOWN = "![alt](https://example.com/img.jpg)";
+const MARKDOWN = [
+  IMAGE_MARKDOWN,
+  HEADING_1_MARKDOWN,
+  HEADING_2_MARKDOWN,
+  PARAGRAPH_MARKDOWN,
+].join("\n\n");
+const MARKDOWN_AS_TEXT = [HEADING_1_TEXT, HEADING_2_TEXT, PARAGRAPH_TEXT].join(
+  " ",
+);
+
+interface SetupOpts {
+  markdown?: string;
+}
+
+const setup = ({ markdown = MARKDOWN }: SetupOpts = {}) => {
+  render(<MarkdownPreview>{markdown}</MarkdownPreview>);
+};
+
+describe("MarkdownPreview", () => {
+  it("should render markdown as plain text in the preview", () => {
+    setup();
+
+    expect(screen.getByText(MARKDOWN_AS_TEXT)).toBeInTheDocument();
+  });
+
+  it("should show tooltip with markdown formatting on hover", () => {
+    setup();
+
+    userEvent.hover(screen.getByText(MARKDOWN_AS_TEXT));
+
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip).not.toHaveTextContent(MARKDOWN);
+    expect(tooltip).not.toHaveTextContent(HEADING_1_MARKDOWN);
+    expect(tooltip).not.toHaveTextContent(HEADING_2_MARKDOWN);
+    expect(tooltip).toHaveTextContent(MARKDOWN_AS_TEXT);
+
+    const image = within(tooltip).getByRole("img");
+    expect(image).toBeInTheDocument();
+    expect(image).toHaveAttribute("alt", "alt");
+    expect(image).toHaveAttribute("src", "https://example.com/img.jpg");
+  });
+});

--- a/frontend/src/metabase/core/components/MarkdownPreview/index.ts
+++ b/frontend/src/metabase/core/components/MarkdownPreview/index.ts
@@ -1,0 +1,1 @@
+export { MarkdownPreview } from "./MarkdownPreview";

--- a/frontend/src/metabase/visualizations/components/skeletons/SkeletonCaption/SkeletonCaption.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/skeletons/SkeletonCaption/SkeletonCaption.unit.spec.tsx
@@ -1,0 +1,46 @@
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { renderWithProviders, screen, within } from "__support__/ui";
+
+import SkeletonCaption from "./SkeletonCaption";
+
+const HEADING_1_TEXT = "Heading 1";
+const HEADING_1_MARKDOWN = `# ${HEADING_1_TEXT}`;
+const HEADING_2_TEXT = "Heading 2";
+const HEADING_2_MARKDOWN = `## ${HEADING_2_TEXT}`;
+const PARAGRAPH_TEXT = "Paragraph with link";
+const PARAGRAPH_MARKDOWN = "Paragraph with [link](https://example.com)";
+const IMAGE_MARKDOWN = "![alt](https://example.com/img.jpg)";
+const MARKDOWN = [
+  IMAGE_MARKDOWN,
+  HEADING_1_MARKDOWN,
+  HEADING_2_MARKDOWN,
+  PARAGRAPH_MARKDOWN,
+].join("\n\n");
+const MARKDOWN_AS_TEXT = [HEADING_1_TEXT, HEADING_2_TEXT, PARAGRAPH_TEXT].join(
+  " ",
+);
+
+function setup({ description }: { description?: string } = {}) {
+  return renderWithProviders(<SkeletonCaption description={description} />);
+}
+
+describe("SkeletonCaption", () => {
+  it("should show description tooltip with markdown formatting on hover", () => {
+    setup({ description: MARKDOWN });
+
+    userEvent.hover(screen.getByTestId("skeleton-description-icon"));
+
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip).not.toHaveTextContent(MARKDOWN);
+    expect(tooltip).not.toHaveTextContent(HEADING_1_MARKDOWN);
+    expect(tooltip).not.toHaveTextContent(HEADING_2_MARKDOWN);
+    expect(tooltip).toHaveTextContent(MARKDOWN_AS_TEXT);
+
+    const image = within(tooltip).getByRole("img");
+    expect(image).toBeInTheDocument();
+    expect(image).toHaveAttribute("alt", "alt");
+    expect(image).toHaveAttribute("src", "https://example.com/img.jpg");
+  });
+});

--- a/frontend/src/metabase/visualizations/components/skeletons/StaticSkeleton/StaticSkeleton.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/skeletons/StaticSkeleton/StaticSkeleton.styled.tsx
@@ -1,7 +1,9 @@
 import styled from "@emotion/styled";
+
 import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
 import Ellipsified from "metabase/core/components/Ellipsified";
+import { MarkdownPreview } from "metabase/core/components/MarkdownPreview";
 
 export const SkeletonRoot = styled.div`
   position: relative;
@@ -14,7 +16,7 @@ export const SkeletonTitle = styled(Ellipsified)`
   font-weight: bold;
 `;
 
-export const SkeletonDescription = styled(Ellipsified)`
+export const SkeletonDescription = styled(MarkdownPreview)`
   color: ${color("text-medium")};
   line-height: 1.5rem;
 `;

--- a/frontend/src/metabase/visualizations/components/skeletons/StaticSkeleton/StaticSkeleton.tsx
+++ b/frontend/src/metabase/visualizations/components/skeletons/StaticSkeleton/StaticSkeleton.tsx
@@ -28,6 +28,8 @@ const StaticSkeleton = ({
   tooltip,
   ...props
 }: StaticSkeletonProps): JSX.Element => {
+  const defaultedDescription = description || "";
+
   return (
     <SkeletonRoot {...props}>
       {icon && (
@@ -43,7 +45,7 @@ const StaticSkeleton = ({
         </Tooltip>
       )}
       <SkeletonTitle>{name}</SkeletonTitle>
-      {description && <SkeletonDescription>{description}</SkeletonDescription>}
+      <SkeletonDescription>{defaultedDescription}</SkeletonDescription>
     </SkeletonRoot>
   );
 };

--- a/frontend/src/metabase/visualizations/components/skeletons/StaticSkeleton/StaticSkeleton.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/skeletons/StaticSkeleton/StaticSkeleton.unit.spec.tsx
@@ -1,0 +1,45 @@
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { renderWithProviders, screen } from "__support__/ui";
+
+import StaticSkeleton from "./StaticSkeleton";
+
+const HEADING_1_TEXT = "Heading 1";
+const HEADING_1_MARKDOWN = `# ${HEADING_1_TEXT}`;
+const HEADING_2_TEXT = "Heading 2";
+const HEADING_2_MARKDOWN = `## ${HEADING_2_TEXT}`;
+const PARAGRAPH_TEXT = "Paragraph with link";
+const PARAGRAPH_MARKDOWN = "Paragraph with [link](https://example.com)";
+const IMAGE_MARKDOWN = "![alt](https://example.com/img.jpg)";
+const MARKDOWN = [
+  HEADING_1_MARKDOWN,
+  HEADING_2_MARKDOWN,
+  PARAGRAPH_MARKDOWN,
+  IMAGE_MARKDOWN,
+].join("\n\n");
+const MARKDOWN_AS_TEXT = [HEADING_1_TEXT, HEADING_2_TEXT, PARAGRAPH_TEXT].join(
+  " ",
+);
+
+function setup({ description }: { description?: string } = {}) {
+  return renderWithProviders(<StaticSkeleton description={description} />);
+}
+
+describe("StaticSkeleton", () => {
+  describe("description", () => {
+    it("should render description markdown as plain text", () => {
+      setup({ description: MARKDOWN });
+
+      expect(screen.getByText(MARKDOWN_AS_TEXT)).toBeInTheDocument();
+    });
+
+    it("should show description tooltip with markdown formatting on hover", () => {
+      setup({ description: MARKDOWN });
+
+      userEvent.hover(screen.getByText(MARKDOWN_AS_TEXT));
+
+      expect(screen.getByRole("tooltip")).toHaveTextContent(MARKDOWN_AS_TEXT);
+    });
+  });
+});


### PR DESCRIPTION
Manual backport of #31251 (which is a fix for #30381)

I had to copy the most recent version of `core/components/Markdown` into this backport.