### PR TITLE
Add fonts in Dockerfile to fix pulses

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ FROM --platform=linux/amd64 eclipse-temurin:11-jre-alpine as runner
 ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 
 # dependencies
-RUN apk add -U bash ttf-dejavu fontconfig curl java-cacerts && \
+RUN apk add -U bash ttf-dejavu fontconfig font-noto curl java-cacerts && \
     apk upgrade && \
     rm -rf /var/cache/apk/* && \
     mkdir -p /app/certs && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ FROM --platform=linux/amd64 eclipse-temurin:11-jre-alpine as runner
 ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 
 # dependencies
-RUN apk add -U bash ttf-dejavu fontconfig font-noto font-noto-cjk curl java-cacerts && \
+RUN apk add -U bash fontconfig curl font-noto font-noto-arabic font-noto-hebrew font-noto-emoji font-noto-cjk java-cacerts && \
     apk upgrade && \
     rm -rf /var/cache/apk/* && \
     mkdir -p /app/certs && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ FROM --platform=linux/amd64 eclipse-temurin:11-jre-alpine as runner
 ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 
 # dependencies
-RUN apk add -U bash ttf-dejavu fontconfig font-noto curl java-cacerts && \
+RUN apk add -U bash ttf-dejavu fontconfig font-noto font-noto-cjk curl java-cacerts && \
     apk upgrade && \
     rm -rf /var/cache/apk/* && \
     mkdir -p /app/certs && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ FROM --platform=linux/amd64 eclipse-temurin:11-jre-alpine as runner
 ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 
 # dependencies
-RUN apk add -U bash fontconfig curl font-noto font-noto-arabic font-noto-hebrew font-noto-emoji font-noto-cjk java-cacerts && \
+RUN apk add -U bash fontconfig curl font-noto font-noto-arabic font-noto-hebrew font-noto-cjk java-cacerts && \
     apk upgrade && \
     rm -rf /var/cache/apk/* && \
     mkdir -p /app/certs && \

--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=linux/amd64 eclipse-temurin:11-jre-alpine
 ENV FC_LANG=en-US LC_CTYPE=en_US.UTF-8
 
 # dependencies
-RUN apk add -U bash fontconfig curl font-noto font-noto-arabic font-noto-hebrew font-noto-emoji font-noto-cjk java-cacerts && \
+RUN apk add -U bash fontconfig curl font-noto font-noto-arabic font-noto-hebrew font-noto-cjk java-cacerts && \
     apk upgrade && \
     rm -rf /var/cache/apk/* && \
     mkdir -p /app/certs && \

--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=linux/amd64 eclipse-temurin:11-jre-alpine
 ENV FC_LANG=en-US LC_CTYPE=en_US.UTF-8
 
 # dependencies
-RUN apk add -U bash ttf-dejavu fontconfig font-noto curl java-cacerts && \
+RUN apk add -U bash ttf-dejavu fontconfig font-noto font-noto-cjk curl java-cacerts && \
     apk upgrade && \
     rm -rf /var/cache/apk/* && \
     mkdir -p /app/certs && \

--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=linux/amd64 eclipse-temurin:11-jre-alpine
 ENV FC_LANG=en-US LC_CTYPE=en_US.UTF-8
 
 # dependencies
-RUN apk add -U bash ttf-dejavu fontconfig font-noto font-noto-cjk curl java-cacerts && \
+RUN apk add -U bash fontconfig curl font-noto font-noto-arabic font-noto-hebrew font-noto-emoji font-noto-cjk java-cacerts && \
     apk upgrade && \
     rm -rf /var/cache/apk/* && \
     mkdir -p /app/certs && \

--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=linux/amd64 eclipse-temurin:11-jre-alpine
 ENV FC_LANG=en-US LC_CTYPE=en_US.UTF-8
 
 # dependencies
-RUN apk add -U bash ttf-dejavu fontconfig curl java-cacerts && \
+RUN apk add -U bash ttf-dejavu fontconfig font-noto curl java-cacerts && \
     apk upgrade && \
     rm -rf /var/cache/apk/* && \
     mkdir -p /app/certs && \

--- a/bin/docker/Dockerfile_ubuntu
+++ b/bin/docker/Dockerfile_ubuntu
@@ -5,7 +5,7 @@ ENV FC_LANG=en-US LC_CTYPE=en_US.UTF-8
 # Dependencies
 RUN apt-get update && \
   apt-get upgrade -y && \
-  apt-get install -y ca-certificates ca-certificates-java fonts-dejavu fonts-noto fonts-noto-cjk && \
+  apt-get install -y ca-certificates ca-certificates-java fonts-dejavu fonts-noto fonts-noto-arabic fonts-noto-hebrew fonts-noto-emoji fonts-noto-cjk fontconfig curl && \
   apt-get clean && \
   curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -o /usr/local/share/ca-certificates/rds-combined-ca-bundle.pem && \
   curl https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem -o /usr/local/share/ca-certificates/DigiCertGlobalRootG2.crt.pem && \

--- a/bin/docker/Dockerfile_ubuntu
+++ b/bin/docker/Dockerfile_ubuntu
@@ -5,7 +5,7 @@ ENV FC_LANG=en-US LC_CTYPE=en_US.UTF-8
 # Dependencies
 RUN apt-get update && \
   apt-get upgrade -y && \
-  apt-get install -y ca-certificates ca-certificates-java fonts-dejavu fonts-noto fonts-noto-arabic fonts-noto-hebrew fonts-noto-emoji fonts-noto-cjk fontconfig curl && \
+  apt-get install -y ca-certificates ca-certificates-java fonts-noto fonts-noto-arabic fonts-noto-hebrew fonts-noto-emoji fonts-noto-cjk && \
   apt-get clean && \
   curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -o /usr/local/share/ca-certificates/rds-combined-ca-bundle.pem && \
   curl https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem -o /usr/local/share/ca-certificates/DigiCertGlobalRootG2.crt.pem && \

--- a/bin/docker/Dockerfile_ubuntu
+++ b/bin/docker/Dockerfile_ubuntu
@@ -5,7 +5,7 @@ ENV FC_LANG=en-US LC_CTYPE=en_US.UTF-8
 # Dependencies
 RUN apt-get update && \
   apt-get upgrade -y && \
-  apt-get install -y ca-certificates ca-certificates-java fonts-noto fonts-noto-arabic fonts-noto-hebrew fonts-noto-emoji fonts-noto-cjk && \
+  apt-get install -y ca-certificates ca-certificates-java fonts-noto fonts-noto-arabic fonts-noto-hebrew fonts-noto-cjk && \
   apt-get clean && \
   curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -o /usr/local/share/ca-certificates/rds-combined-ca-bundle.pem && \
   curl https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem -o /usr/local/share/ca-certificates/DigiCertGlobalRootG2.crt.pem && \

--- a/bin/docker/Dockerfile_ubuntu
+++ b/bin/docker/Dockerfile_ubuntu
@@ -5,7 +5,7 @@ ENV FC_LANG=en-US LC_CTYPE=en_US.UTF-8
 # Dependencies
 RUN apt-get update && \
   apt-get upgrade -y && \
-  apt-get install -y ca-certificates ca-certificates-java fonts-dejavu fonts-lato && \
+  apt-get install -y ca-certificates ca-certificates-java fonts-dejavu fonts-noto fonts-noto-cjk && \
   apt-get clean && \
   curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -o /usr/local/share/ca-certificates/rds-combined-ca-bundle.pem && \
   curl https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem -o /usr/local/share/ca-certificates/DigiCertGlobalRootG2.crt.pem && \

--- a/bin/docker/Dockerfile_ubuntu
+++ b/bin/docker/Dockerfile_ubuntu
@@ -5,7 +5,7 @@ ENV FC_LANG=en-US LC_CTYPE=en_US.UTF-8
 # Dependencies
 RUN apt-get update && \
   apt-get upgrade -y && \
-  apt-get install -y ca-certificates ca-certificates-java fonts-dejavu && \
+  apt-get install -y ca-certificates ca-certificates-java fonts-dejavu fonts-lato && \
   apt-get clean && \
   curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -o /usr/local/share/ca-certificates/rds-combined-ca-bundle.pem && \
   curl https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem -o /usr/local/share/ca-certificates/DigiCertGlobalRootG2.crt.pem && \


### PR DESCRIPTION
Adding Noto fonts, it fixes #2342

I just tested with the current build and we get
![image](https://github.com/metabase/metabase/assets/1711649/aacff1d3-d4b4-4fef-b468-c28e1e0920f2)

while with the noto fonts, we get
![image](https://github.com/metabase/metabase/assets/1711649/f7f833cd-078f-4ad8-b319-95da115a52ef)
