### PR TITLE
Add settings to Metadata

### DIFF
--- a/frontend/src/metabase-lib/metadata/Metadata.ts
+++ b/frontend/src/metabase-lib/metadata/Metadata.ts
@@ -7,6 +7,8 @@ import {
   MetricId,
   SchemaId,
   SegmentId,
+  SettingKey,
+  Settings,
   TableId,
 } from "metabase-types/api";
 import type Question from "../Question";
@@ -26,6 +28,7 @@ interface MetadataOpts {
   metrics?: Record<string, Metric>;
   segments?: Record<string, Segment>;
   questions?: Record<string, Question>;
+  settings?: Settings;
 }
 
 class Metadata {
@@ -36,6 +39,7 @@ class Metadata {
   metrics: Record<string, Metric> = {};
   segments: Record<string, Segment> = {};
   questions: Record<string, Question> = {};
+  settings?: Settings;
 
   constructor(opts?: MetadataOpts) {
     Object.assign(this, opts);
@@ -112,6 +116,10 @@ class Metadata {
 
   question(cardId: CardId | undefined | null): Question | null {
     return (cardId != null && this.questions[cardId]) || null;
+  }
+
+  setting<T extends SettingKey>(key: T): Settings[T] | null {
+    return this.settings ? this.settings[key] : null;
   }
 }
 

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-permissions.unit.spec.fixtures.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-permissions.unit.spec.fixtures.ts
@@ -1,3 +1,5 @@
+import { createMockSettingsState } from "metabase-types/store/mocks";
+
 // Database 2 contains an imaginary multi-schema database (like Redshift for instance)
 // Database 3 contains an imaginary database which doesn't have any schemas (like MySQL)
 export const normalizedMetadata = {
@@ -192,4 +194,5 @@ export const state = {
     },
   },
   entities: normalizedMetadata,
+  settings: createMockSettingsState(),
 };

--- a/frontend/src/metabase/dashboard/selectors.unit.spec.js
+++ b/frontend/src/metabase/dashboard/selectors.unit.spec.js
@@ -8,6 +8,7 @@ import {
   getIsEditingParameter,
   getClickBehaviorSidebarDashcard,
 } from "metabase/dashboard/selectors";
+import { createMockSettingsState } from "metabase-types/store/mocks";
 import Field from "metabase-lib/metadata/Field";
 import { SIDEBAR_NAME } from "./constants";
 
@@ -56,6 +57,7 @@ const STATE = {
     segments: {},
     questions: {},
   },
+  settings: createMockSettingsState(),
 };
 
 describe("dashboard/selectors", () => {

--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -382,6 +382,7 @@ export function createEntity(def) {
   // SELECTORS
 
   const getEntities = state => state.entities;
+  const getSettings = state => state.settings;
 
   // OBJECT SELECTORS
 
@@ -425,12 +426,14 @@ export function createEntity(def) {
   );
 
   const getList = createCachedSelector(
-    [getEntities, getEntityIds],
+    [getEntities, getEntityIds, getSettings],
     // delegate to getObject
-    (entities, entityIds) =>
+    (entities, entityIds, settings) =>
       entityIds &&
       entityIds
-        .map(entityId => entity.selectors.getObject({ entities }, { entityId }))
+        .map(entityId =>
+          entity.selectors.getObject({ entities, settings }, { entityId }),
+        )
         .filter(e => e != null), // deleted entities might remain in lists,
   )((state, { entityQuery } = {}) =>
     entityQuery ? JSON.stringify(entityQuery) : "",

--- a/frontend/src/metabase/selectors/metadata.ts
+++ b/frontend/src/metabase/selectors/metadata.ts
@@ -26,6 +26,7 @@ import {
   getFieldValues,
   getRemappings,
 } from "metabase-lib/queries/utils/field";
+import { getSettings } from "./settings";
 
 type TableSelectorOpts = {
   includeHiddenTables?: boolean;
@@ -100,9 +101,19 @@ export const getMetadata: (
     getNormalizedSegments,
     getNormalizedMetrics,
     getNormalizedQuestions,
+    getSettings,
   ],
-  (databases, schemas, tables, fields, segments, metrics, questions) => {
-    const metadata = new Metadata();
+  (
+    databases,
+    schemas,
+    tables,
+    fields,
+    segments,
+    metrics,
+    questions,
+    settings,
+  ) => {
+    const metadata = new Metadata({ settings });
 
     metadata.databases = Object.fromEntries(
       Object.values(databases).map(d => [d.id, createDatabase(d, metadata)]),

--- a/frontend/src/metabase/selectors/metadata.unit.spec.ts
+++ b/frontend/src/metabase/selectors/metadata.unit.spec.ts
@@ -5,6 +5,7 @@ import {
   createMockDatabase,
   createMockMetric,
   createMockSegment,
+  createMockSettings,
 } from "metabase-types/api/mocks";
 import {
   createSampleDatabase,
@@ -12,7 +13,10 @@ import {
   ORDERS_ID,
   SAMPLE_DB_ID,
 } from "metabase-types/api/mocks/presets";
-import { createMockState } from "metabase-types/store/mocks";
+import {
+  createMockSettingsState,
+  createMockState,
+} from "metabase-types/store/mocks";
 import Metadata from "metabase-lib/metadata/Metadata";
 
 function setup() {
@@ -34,22 +38,25 @@ function setup() {
     createMockSegment({ id: 2, name: "Segment 2" }),
   ];
 
+  const settings = createMockSettings();
+
   const state = createMockState({
     entities: createMockEntitiesState({
       databases,
       metrics,
       segments,
     }),
+    settings: createMockSettingsState(settings),
   });
 
   const metadata = getMetadata(state);
 
-  return { metadata, sampleDatabase, metrics, segments };
+  return { metadata, sampleDatabase, metrics, segments, settings };
 }
 
 describe("getMetadata", () => {
   it("should properly transfer metadata", () => {
-    const { metadata, sampleDatabase, metrics, segments } = setup();
+    const { metadata, sampleDatabase, metrics, segments, settings } = setup();
     const sampleDatabaseTables = checkNotNull(sampleDatabase.tables);
 
     expect(metadata).toBeInstanceOf(Metadata);
@@ -65,6 +72,8 @@ describe("getMetadata", () => {
     );
     expect(Object.keys(metadata.metrics).length).toEqual(metrics.length);
     expect(Object.keys(metadata.segments).length).toEqual(segments.length);
+    expect(metadata.settings).toEqual(settings);
+    expect(metadata.setting("site-url")).toEqual(settings["site-url"]);
   });
 
   describe("connected table", () => {


### PR DESCRIPTION
Adds `settings` to `Metadata` for use in CLJS. You can access the raw object by `metadata.settings` or individual values via `metadata.setting("key")` method.