### PR TITLE
Update root Dockerfile to Debian Bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # STAGE 1: builder
 ###################
 
-FROM node:18-slim as builder
+FROM node:18-bullseye as builder
 
 ARG MB_EDITION=oss
 


### PR DESCRIPTION
Debian Bookworm has Java 17 as the default and Java 11 has lots of steps to install. Going back to Bullseye with Node 18 where Java 11 is the default and can be installed with the package manager