### PR TITLE
Upgrade testing-library/user-event to 13.1.3

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingLinkUrlInput.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingLinkUrlInput.unit.spec.tsx
@@ -34,7 +34,7 @@ describe("ChartSettingLinkUrlInput", () => {
   it("Shows all options when {{ is typed", async () => {
     const { input, getOptions } = setup();
 
-    userEvent.type(input, "USE - {{");
+    userEvent.type(input, "USE - {{{{");
 
     const options = await getOptions();
 
@@ -46,7 +46,7 @@ describe("ChartSettingLinkUrlInput", () => {
   it("shows filter options while typing", async () => {
     const { input, getOptions } = setup();
 
-    userEvent.type(input, "USE - {{p");
+    userEvent.type(input, "USE - {{{{p");
 
     const options = await getOptions();
 
@@ -57,7 +57,7 @@ describe("ChartSettingLinkUrlInput", () => {
 
   it("shows filter options when clicked", async () => {
     const { input, getOptions } = setup({
-      value: "USE - {{p",
+      value: "USE - {{{{p",
     });
 
     userEvent.click(input);
@@ -75,7 +75,7 @@ describe("ChartSettingLinkUrlInput", () => {
       onChange,
     });
 
-    userEvent.type(input, "Address - {{p");
+    userEvent.type(input, "Address - {{{{p");
 
     const options = await getOptions();
 
@@ -91,7 +91,7 @@ describe("ChartSettingLinkUrlInput", () => {
       onChange,
     });
 
-    userEvent.type(input, "Address - {{p");
+    userEvent.type(input, "Address - {{{{p");
 
     const options = await getOptions();
     expect(options).toHaveLength(2);
@@ -110,7 +110,7 @@ describe("ChartSettingLinkUrlInput", () => {
       onChange,
     });
 
-    userEvent.type(input, "{{c");
+    userEvent.type(input, "{{{{c");
 
     const options = await getOptions();
 

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^11.0.2",
     "@testing-library/react-hooks": "^8.0.0",
-    "@testing-library/user-event": "^12.6.0",
+    "@testing-library/user-event": "^13.1.3",
     "@types/babel__core": "^7.1.16",
     "@types/babel__preset-env": "^7.9.2",
     "@types/color": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6870,10 +6870,10 @@
     "@babel/runtime" "^7.11.2"
     "@testing-library/dom" "^7.26.0"
 
-"@testing-library/user-event@^12.6.0":
-  version "12.6.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.6.0.tgz#2d0229e399eb5a0c6c112e848611432356cac886"
-  integrity sha512-FNEH/HLmOk5GO70I52tKjs7WvGYckeE/SrnLX/ip7z2IGbffyd5zOUM1tZ10vsTphqm+VbDFI0oaXu0wcfQsAQ==
+"@testing-library/user-event@^13.1.3":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.5.0.tgz#69d77007f1e124d55314a2b73fd204b333b13295"
+  integrity sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==
   dependencies:
     "@babel/runtime" "^7.12.5"
 


### PR DESCRIPTION
Version >=13.1.3 of testing-library/user-event is needed by https://github.com/metabase/metabase/pull/31661, since 13.1.3 ships with this feature https://github.com/testing-library/user-event/pull/647