### PR TITLE
Limit uploads to 50mb

### DIFF
--- a/frontend/src/metabase/redux/uploads.ts
+++ b/frontend/src/metabase/redux/uploads.ts
@@ -24,8 +24,8 @@ export const UPLOAD_FILE_TO_COLLECTION_ERROR =
 export const UPLOAD_FILE_TO_COLLECTION_CLEAR =
   "metabase/collection/UPLOAD_FILE_CLEAR";
 
-const MAX_UPLOAD_SIZE = 200 * 1024 * 1024; // 200MB
-export const MAX_UPLOAD_STRING = "200mb";
+const MAX_UPLOAD_SIZE = 50 * 1024 * 1024;
+export const MAX_UPLOAD_STRING = "50mb";
 
 const CLEAR_AFTER_MS = 8000;
 

--- a/frontend/src/metabase/redux/uploads.ts
+++ b/frontend/src/metabase/redux/uploads.ts
@@ -25,7 +25,7 @@ export const UPLOAD_FILE_TO_COLLECTION_CLEAR =
   "metabase/collection/UPLOAD_FILE_CLEAR";
 
 const MAX_UPLOAD_SIZE = 50 * 1024 * 1024;
-export const MAX_UPLOAD_STRING = "50mb";
+export const MAX_UPLOAD_STRING = "50";
 
 const CLEAR_AFTER_MS = 8000;
 
@@ -62,7 +62,7 @@ export const uploadFile = createThunkAction(
         dispatch(
           uploadError({
             id,
-            message: t`You cannot upload files larger than ${MAX_UPLOAD_STRING}`,
+            message: t`You cannot upload files larger than ${MAX_UPLOAD_STRING}mb`,
           }),
         );
         clear();

--- a/frontend/src/metabase/redux/uploads.unit.spec.js
+++ b/frontend/src/metabase/redux/uploads.unit.spec.js
@@ -125,7 +125,7 @@ describe("csv uploads", () => {
         type: UPLOAD_FILE_TO_COLLECTION_ERROR,
         payload: {
           id: now,
-          message: `You cannot upload files larger than ${MAX_UPLOAD_STRING}`,
+          message: `You cannot upload files larger than ${MAX_UPLOAD_STRING}mb`,
         },
       });
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31772

### Description

@tsmacdonald identified potentially memory issues for large CSV uploads. for now, we'll limit to 50mb to make sure things run smoothly.

![Screen Shot 2023-06-21 at 9 19 56 AM](https://github.com/metabase/metabase/assets/30528226/ee8e713d-6955-4ed5-b0e2-ebb6c7597a5a)


### How to verify

- enable CSV uploads in settings
- upload a CSV that's more than 50mb, [like this one](https://www.notion.so/metabase/IMDB-dataset-csv-3a48295f48bd4a04b1fb066cb5953e79)
- see a nice little error message

