### PR TITLE
Fix MLv2 field reference to joined column from previous stage

### DIFF
--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -416,21 +416,21 @@
   (case source
     :source/aggregations (lib.aggregation/column-metadata->aggregation-ref metadata)
     :source/expressions  (lib.expression/column-metadata->expression-ref metadata)
-    (let [options          (merge
-                            {:lib/uuid       (str (random-uuid))
-                             :base-type      (:base-type metadata)
-                             :effective-type (column-metadata-effective-type metadata)}
-                            (when-let [join-alias (lib.join/current-join-alias metadata)]
-                              {:join-alias join-alias})
-                            (when-let [temporal-unit (::temporal-unit metadata)]
-                              {:temporal-unit temporal-unit})
-                            (when-let [binning (::binning metadata)]
-                              {:binning binning})
-                            (when-let [source-field-id (:fk-field-id metadata)]
-                              {:source-field source-field-id}))
-          always-use-name? (#{:source/card :source/native :source/previous-stage} (:lib/source metadata))]
-      [:field options (if always-use-name?
-                        (:name metadata)
+    (let [inherited-column? (#{:source/card :source/native :source/previous-stage} (:lib/source metadata))
+          options           (cond-> {:lib/uuid       (str (random-uuid))
+                                     :base-type      (:base-type metadata)
+                                     :effective-type (column-metadata-effective-type metadata)}
+                              (not inherited-column?)
+                              (merge (when-let [join-alias (lib.join/current-join-alias metadata)]
+                                       {:join-alias join-alias})
+                                     (when-let [temporal-unit (::temporal-unit metadata)]
+                                       {:temporal-unit temporal-unit})
+                                     (when-let [binning (::binning metadata)]
+                                       {:binning binning})
+                                     (when-let [source-field-id (:fk-field-id metadata)]
+                                       {:source-field source-field-id})))]
+      [:field options (if inherited-column?
+                        (or (:lib/desired-column-alias metadata) (:name metadata))
                         (or (:id metadata) (:name metadata)))])))
 
 (defn- implicit-join-name [query {:keys [fk-field-id table-id], :as _field-metadata}]

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -417,18 +417,17 @@
     :source/aggregations (lib.aggregation/column-metadata->aggregation-ref metadata)
     :source/expressions  (lib.expression/column-metadata->expression-ref metadata)
     (let [inherited-column? (#{:source/card :source/native :source/previous-stage} (:lib/source metadata))
-          options           (cond-> {:lib/uuid       (str (random-uuid))
-                                     :base-type      (:base-type metadata)
-                                     :effective-type (column-metadata-effective-type metadata)}
-                              (not inherited-column?)
-                              (merge (when-let [join-alias (lib.join/current-join-alias metadata)]
-                                       {:join-alias join-alias})
-                                     (when-let [temporal-unit (::temporal-unit metadata)]
-                                       {:temporal-unit temporal-unit})
-                                     (when-let [binning (::binning metadata)]
-                                       {:binning binning})
-                                     (when-let [source-field-id (:fk-field-id metadata)]
-                                       {:source-field source-field-id})))]
+          options           (merge {:lib/uuid       (str (random-uuid))
+                                    :base-type      (:base-type metadata)
+                                    :effective-type (column-metadata-effective-type metadata)}
+                                   (when-let [join-alias (lib.join/current-join-alias metadata)]
+                                     {:join-alias join-alias})
+                                   (when-let [temporal-unit (::temporal-unit metadata)]
+                                     {:temporal-unit temporal-unit})
+                                   (when-let [binning (::binning metadata)]
+                                     {:binning binning})
+                                   (when-let [source-field-id (:fk-field-id metadata)]
+                                     {:source-field source-field-id}))]
       [:field options (if inherited-column?
                         (or (:lib/desired-column-alias metadata) (:name metadata))
                         (or (:id metadata) (:name metadata)))])))

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -226,28 +226,30 @@
    stage-number                          :- :int
    {:keys [unique-name-fn], :as options} :- lib.metadata.calculation/VisibleColumnsOptions]
   {:pre [(fn? unique-name-fn)]}
-  (or
-   ;; 1a. columns returned by previous stage
-   (previous-stage-metadata query stage-number unique-name-fn)
-   ;; 1b or 1c
-   (let [{:keys [source-table source-card], :as this-stage} (lib.util/query-stage query stage-number)]
-     (or
-      ;; 1b: default visible Fields for the source Table
-      (when source-table
-        (assert (integer? source-table))
-        (let [table-metadata (lib.metadata/table query source-table)]
-          (lib.metadata.calculation/visible-columns query stage-number table-metadata options)))
-      ;; 1c. Metadata associated with a saved Question
-      (when source-card
-        (saved-question-metadata query stage-number source-card unique-name-fn))
-      ;; 1d: `:lib/stage-metadata` for the (presumably native) query
-      (for [col (:columns (:lib/stage-metadata this-stage))]
-        (assoc col
-               :lib/source :source/native
-               :lib/source-column-alias  (:name col)
-               ;; these should already be unique, but run them thru `unique-name-fn` anyway to make sure anything
-               ;; that gets added later gets deduplicated from these.
-               :lib/desired-column-alias (unique-name-fn (:name col))))))))
+  (mapv
+   #(dissoc % ::lib.join/join-alias ::lib.field/temporal-unit ::lib.field/binning :fk-field-id)
+   (or
+    ;; 1a. columns returned by previous stage
+    (previous-stage-metadata query stage-number unique-name-fn)
+    ;; 1b or 1c
+    (let [{:keys [source-table source-card], :as this-stage} (lib.util/query-stage query stage-number)]
+      (or
+       ;; 1b: default visible Fields for the source Table
+       (when source-table
+         (assert (integer? source-table))
+         (let [table-metadata (lib.metadata/table query source-table)]
+           (lib.metadata.calculation/visible-columns query stage-number table-metadata options)))
+       ;; 1c. Metadata associated with a saved Question
+       (when source-card
+         (saved-question-metadata query stage-number source-card unique-name-fn))
+       ;; 1d: `:lib/stage-metadata` for the (presumably native) query
+       (for [col (:columns (:lib/stage-metadata this-stage))]
+         (assoc col
+                :lib/source :source/native
+                :lib/source-column-alias  (:name col)
+                ;; these should already be unique, but run them thru `unique-name-fn` anyway to make sure anything
+                ;; that gets added later gets deduplicated from these.
+                :lib/desired-column-alias (unique-name-fn (:name col)))))))))
 
 (mu/defn ^:private existing-visible-columns :- lib.metadata.calculation/ColumnsWithUniqueAliases
   [query        :- ::lib.schema/query

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -182,13 +182,17 @@
                 (is (=? {:stages
                          [{:lib/type    :mbql.stage/mbql
                            :source-card 1
-                           :breakout    [[:field {:join-alias "Products"} "CATEGORY"]]}]}
+                           :breakout    [[:field
+                                           {:join-alias (symbol "nil #_\"key is not present.\"")}
+                                           "CATEGORY"]]}]}
                         query'))
                 (is (=? [{:name              "CATEGORY"
-                          :display-name      "Category"
+                          :display-name      (if (:result-metadata card-def)
+                                               "Products → Category"
+                                               "Category")
                           :long-display-name "Products → Category"
                           :effective-type    :type/Text}]
-                        (map (partial lib/display-info query')
+                        (map #(lib/display-info query' %)
                              (lib/breakouts query'))))))
             (when (:result-metadata card-def)
               (testing "\nwith broken breakout from broken drill-thru (#31482)"
@@ -684,3 +688,34 @@
              (lib.metadata.calculation/metadata
               query
               [:field {:lib/uuid "aa0e13af-29b3-4c27-a880-a10c33e55a3e", :base-type :type/Text} 4]))))))
+
+(deftest ^:parallel ref-to-joined-column-from-previous-stage-test
+  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                  (lib/join (-> (lib/join-clause
+                                 (meta/table-metadata :categories)
+                                 [(lib/=
+                                   (meta/field-metadata :venues :category-id)
+                                   (lib/with-join-alias (meta/field-metadata :categories :id) "Categories"))])
+                                (lib/with-join-fields [(lib/with-join-alias
+                                                         (meta/field-metadata :categories :name)
+                                                         "Categories")])))
+                  lib/append-stage)
+        joined-col (last (lib/breakoutable-columns query))]
+    (is (=? {:lib/type :metadata/field
+             :name "NAME"
+             :base-type :type/Text
+             :semantic-type :type/Name
+             :metabase.lib.join/join-alias "Categories",
+             :lib/source :source/previous-stage
+             :effective-type :type/Text
+             :lib/desired-column-alias "Categories__NAME"}
+            joined-col))
+    (testing "Reference a joined column from a previous stage w/ desired-column-alias and w/o join-alias"
+      (is (=? {:lib/type :mbql.stage/mbql,
+               :breakout [[:field
+                           {:lib/uuid string?
+                            :base-type :type/Text,
+                            :effective-type :type/Text
+                            :join-alias (symbol "nil #_\"key is not present.\"")}
+                           "Categories__NAME"]]}
+              (-> (lib/breakout query joined-col) :stages peek))))))


### PR DESCRIPTION
The join-alias of joined columns should not escape the stage of the join.
