### PR TITLE
Simplifying CustomHomePageModal unit test

### DIFF
--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -206,16 +206,18 @@ describe("scenarios > home > custom homepage", () => {
     it("should give you the option to set a custom home page using home page CTA", () => {
       cy.visit("/");
       cy.get("main").findByText("Customize").click();
-      modal()
-        .findByText(/Select a dashboard/i)
-        .click();
+
+      modal().within(() => {
+        cy.findByRole("button", { name: "Save" }).should("be.disabled");
+        cy.findByText(/Select a dashboard/i).click();
+      });
 
       //Ensure that personal collections have been removed
       popover().contains("Your personal collection").should("not.exist");
       popover().contains("All personal collections").should("not.exist");
 
       popover().findByText("Orders in a dashboard").click();
-      modal().findByText("Save").click();
+      modal().findByRole("button", { name: "Save" }).click();
       cy.location("pathname").should("equal", "/dashboard/1");
     });
   });

--- a/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.unit.spec.tsx
@@ -1,40 +1,9 @@
-import userEvent from "@testing-library/user-event";
 import { renderWithProviders, screen } from "__support__/ui";
 
-import {
-  setupCollectionsEndpoints,
-  setupCollectionItemsEndpoint,
-  setupDashboardEndpoints,
-} from "__support__/server-mocks";
-
-import {
-  createMockCollection,
-  createMockCollectionItem,
-  createMockDashboard,
-} from "metabase-types/api/mocks";
 import { CustomHomePageModal } from "./CustomHomePageModal";
-
-const ROOT_COLLECTION = createMockCollection({
-  id: "root",
-  can_write: true,
-  name: "Our Analytics",
-  location: undefined,
-});
-const COLLECTION_ITEM = createMockCollectionItem({
-  name: "Foo",
-  model: "dashboard",
-});
-
-const FOO_DASHBOARD = createMockDashboard({
-  name: "Foo",
-});
 
 const setup = ({ ...props } = {}) => {
   const onClose = jest.fn();
-
-  setupCollectionsEndpoints({ collections: [ROOT_COLLECTION] });
-  setupCollectionItemsEndpoint(ROOT_COLLECTION, [COLLECTION_ITEM]);
-  setupDashboardEndpoints(FOO_DASHBOARD);
 
   renderWithProviders(
     <CustomHomePageModal onClose={onClose} isOpen={true} {...props} />,
@@ -42,13 +11,8 @@ const setup = ({ ...props } = {}) => {
 };
 
 describe("custom hompage modal", () => {
-  it("should only enable the save button if a dashboard has been selected", async () => {
+  it("should only enable the save button if a dashboard has been selected", () => {
     setup();
-    expect(await screen.findByRole("button", { name: /save/i })).toBeDisabled();
-
-    userEvent.click(await screen.findByText("Select a dashboard"));
-    userEvent.click(await screen.findByText("Foo"));
-
-    expect(await screen.findByRole("button", { name: /save/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
   });
 });


### PR DESCRIPTION
### Description
The `CustomHomePageModal.unit.spec.js` suite is taking over 5 seconds to run. The main purpose of the test was to ensure that the save button was disabled when no dashboard was selected. This has been left in, but selecting a dashboard and ensuring that the save button is enabled has been removed. This is covered in `homepage.cy.spec.js`.

### How to verify
Green CI

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
