### PR TITLE
Disable audit v2 db installation

### DIFF
--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -140,7 +140,10 @@
       ;; otherwise update if appropriate
       (sample-data/update-sample-database-if-needed!))
     (init-status/set-progress! 0.9))
-  (ensure-audit-db-installed!)
+
+  ;; TODO uncomment when audit v2 is ready
+  ; (ensure-audit-db-installed!)
+
   ;; start scheduler at end of init!
   (task/start-scheduler!)
   (init-status/set-complete!)


### PR DESCRIPTION
Comments out the call to `ensure-audit-db-installed!` on startup so that the internal analytics database isn't added. We'll uncomment this once the rest of audit v2 is ready.