### PR TITLE
[Question]: Add e2e test for preselecting the most recently visited dashboard

### DIFF
--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -327,7 +327,7 @@ describe("scenarios > collection defaults", () => {
                 // Access to everything else is revoked by default - that's why we chose `Data` group
                 groups[DATA_GROUP][CHILD_COLLECTION_ID] = "write";
 
-                // We're chaining these 2 requestes in order to match shema (passing it from GET to PUT)
+                // We're chaining these 2 requestes in order to match schema (passing it from GET to PUT)
                 // Similar to what we did in `sandboxes.cy.spec.js` with the permission graph
                 cy.request("PUT", "/api/collection/graph", {
                   // Pass previously mutated `groups` object

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -193,24 +193,27 @@ describe("managing question from the question's details sidebar", () => {
                 cy.get(".DashCard").should("have.length", 2);
               });
 
-              it("should preselect the most recently visited dashboard", () => {
-                openQuestionActions();
-                cy.findByTestId("add-to-dashboard-button").click();
-
-                findSelectedItem().should("not.exist");
-
-                // before visiting the dashboard, we don't have any history
-                visitDashboard(1);
-
-                visitQuestion(ORDERS_QUESTION_ID);
-
-                openQuestionActions();
-                cy.findByTestId("add-to-dashboard-button").click();
-
-                findSelectedItem().should("have.text", "Orders in a dashboard");
-              });
-
               onlyOn(user === "normal", () => {
+                it("should preselect the most recently visited dashboard", () => {
+                  openQuestionActions();
+                  cy.findByTestId("add-to-dashboard-button").click();
+
+                  findSelectedItem().should("not.exist");
+
+                  // before visiting the dashboard, we don't have any history
+                  visitDashboard(1);
+
+                  visitQuestion(ORDERS_QUESTION_ID);
+
+                  openQuestionActions();
+                  cy.findByTestId("add-to-dashboard-button").click();
+
+                  findSelectedItem().should(
+                    "have.text",
+                    "Orders in a dashboard",
+                  );
+                });
+
                 it("should handle lost access", () => {
                   cy.intercept(
                     "GET",
@@ -220,12 +223,7 @@ describe("managing question from the question's details sidebar", () => {
                   openQuestionActions();
                   cy.findByTestId("add-to-dashboard-button").click();
 
-                  cy.wait("@mostRecentlyViewedDashboard").then(
-                    ({ response }) => {
-                      // no recently viewed dashboard
-                      expect(response.statusCode).to.eq(204);
-                    },
-                  );
+                  cy.wait("@mostRecentlyViewedDashboard");
 
                   findSelectedItem().should("not.exist");
 
@@ -236,11 +234,7 @@ describe("managing question from the question's details sidebar", () => {
                   openQuestionActions();
                   cy.findByTestId("add-to-dashboard-button").click();
 
-                  cy.wait("@mostRecentlyViewedDashboard").then(
-                    ({ response }) => {
-                      expect(response.statusCode).to.eq(200);
-                    },
-                  );
+                  cy.wait("@mostRecentlyViewedDashboard");
 
                   findSelectedItem().should(
                     "have.text",
@@ -263,12 +257,7 @@ describe("managing question from the question's details sidebar", () => {
                   openQuestionActions();
                   cy.findByTestId("add-to-dashboard-button").click();
 
-                  cy.wait("@mostRecentlyViewedDashboard").then(
-                    ({ response }) => {
-                      // no access to recently viewed dashboard
-                      expect(response.statusCode).to.eq(204);
-                    },
-                  );
+                  cy.wait("@mostRecentlyViewedDashboard");
 
                   // no access - no dashboard
                   findSelectedItem().should("not.exist");

--- a/frontend/src/metabase/containers/ItemPicker/Item.tsx
+++ b/frontend/src/metabase/containers/ItemPicker/Item.tsx
@@ -60,6 +60,8 @@ function Item<TId>({
       isSelected={selected}
       hasChildren={hasChildren}
       data-testid="item-picker-item"
+      aria-selected={selected}
+      role="option"
     >
       <ItemContent>
         <Icon {...iconProps} />

--- a/frontend/src/metabase/containers/ItemPicker/ItemPickerView.tsx
+++ b/frontend/src/metabase/containers/ItemPicker/ItemPickerView.tsx
@@ -212,7 +212,7 @@ function ItemPickerView<TId>({
   return (
     <ItemPickerRoot className={className} style={style}>
       {renderHeader()}
-      <ItemPickerList data-testid="item-picker-list">
+      <ItemPickerList data-testid="item-picker-list" role="list">
         {!searchString && collections.map(renderCollectionListItem)}
         {canFetch && (
           <Search.ListLoader query={searchQuery} wrapped>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31290

### Description

Covers with test cases
- permissions
- lost access
- happy path

### How to verify

run e2e test locally `question-management`

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
