### PR TITLE
bump jest tests timeout (master)

### DIFF
--- a/jest.tz.unit.conf.json
+++ b/jest.tz.unit.conf.json
@@ -28,5 +28,5 @@
     "/frontend/src/metabase/visualizations/lib/errors.js"
   ],
   "testEnvironment": "jest-environment-jsdom",
-  "testTimeout": 20000
+  "testTimeout": 30000
 }

--- a/jest.tz.unit.conf.json
+++ b/jest.tz.unit.conf.json
@@ -27,5 +27,6 @@
     "/node_modules/",
     "/frontend/src/metabase/visualizations/lib/errors.js"
   ],
-  "testEnvironment": "jest-environment-jsdom"
+  "testEnvironment": "jest-environment-jsdom",
+  "testTimeout": 20000
 }

--- a/jest.unit.conf.json
+++ b/jest.unit.conf.json
@@ -59,5 +59,5 @@
     "jest-watch-typeahead/filename",
     "jest-watch-typeahead/testname"
   ],
-  "testTimeout": 20000
+  "testTimeout": 30000
 }

--- a/jest.unit.conf.json
+++ b/jest.unit.conf.json
@@ -58,5 +58,6 @@
   "watchPlugins": [
     "jest-watch-typeahead/filename",
     "jest-watch-typeahead/testname"
-  ]
+  ],
+  "testTimeout": 20000
 }


### PR DESCRIPTION
### Description

Our current approach of writing jest tests includes mocking huge parts of the entire app which makes them not so lightweight. In addition to that, free GHA CI agents are not powerful enough to run these specs within the default timeout.

**It currently block multiple PRs from being merged into the release branch.**
A dedicated PR for the release branch https://github.com/metabase/metabase/pull/31810

### How to verify

Ensure CI is green

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
