### PR TITLE
Track dashcard events

### DIFF
--- a/e2e/support/helpers/e2e-snowplow-helpers.js
+++ b/e2e/support/helpers/e2e-snowplow-helpers.js
@@ -18,6 +18,22 @@ export const blockSnowplow = () => {
   blockSnowplowRequest("*/tp2");
 };
 
+/**
+ * Check for the existence of specific snowplow events.
+ *
+ * @param {object} eventData - object of key / value pairs you expect to see in the event
+ * @param {number} count - number of matching events you expect to find. defaults to 1
+ */
+export const expectGoodSnowplowEvent = (eventData, count = 1) => {
+  retrySnowplowRequest(
+    "micro/good",
+    ({ body }) =>
+      body.filter(snowplowEvent =>
+        _.isMatch(snowplowEvent?.event?.unstruct_event?.data?.data, eventData),
+      ).length === count,
+  ).should("be.ok");
+};
+
 export const expectGoodSnowplowEvents = count => {
   retrySnowplowRequest("micro/good", ({ body }) => body.length >= count)
     .its("body")

--- a/e2e/support/helpers/e2e-snowplow-helpers.js
+++ b/e2e/support/helpers/e2e-snowplow-helpers.js
@@ -40,22 +40,6 @@ export const expectGoodSnowplowEvents = count => {
     .should("have.length", count);
 };
 
-/**
- * Check for the existence of specific snowplow events.
- *
- * @param {object} eventData - object of key / value pairs you expect to see in the event
- * @param {number} count - number of matching events you expect to find. defaults to 1
- */
-export const expectGoodSnowplowEvent = (eventData, count = 1) => {
-  retrySnowplowRequest(
-    "micro/good",
-    ({ body }) =>
-      body.filter(snowplowEvent =>
-        _.isMatch(snowplowEvent?.event?.unstruct_event?.data?.data, eventData),
-      ).length === count,
-  ).should("be.ok");
-};
-
 export const expectNoBadSnowplowEvents = () => {
   sendSnowplowRequest("micro/bad").its("body").should("have.length", 0);
 };

--- a/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
@@ -36,7 +36,7 @@ const TEST_COLUMNS_TABLE = "many_data_types";
 const MODEL_NAME = "Test Action Model";
 
 ["mysql", "postgres"].forEach(dialect => {
-  describeWithSnowplow(
+  describe(
     `Write Actions on Dashboards (${dialect})`,
     { tags: ["@external", "@actions"] },
     () => {
@@ -59,7 +59,7 @@ const MODEL_NAME = "Test Action Model";
         );
       });
 
-      describe("adding and executing actions", () => {
+      describeWithSnowplow("adding and executing actions", () => {
         beforeEach(() => {
           resetSnowplow();
           resetTestTable({ type: dialect, table: TEST_TABLE });
@@ -75,9 +75,6 @@ const MODEL_NAME = "Test Action Model";
 
         afterEach(() => {
           expectNoBadSnowplowEvents();
-          expectGoodSnowplowEvent({
-            event: "new_action_card_created",
-          });
         });
 
         it("adds a custom query action to a dashboard and runs it", () => {
@@ -126,6 +123,10 @@ const MODEL_NAME = "Test Action Model";
             idFilter: true,
           });
 
+          expectGoodSnowplowEvent({
+            event: "new_action_card_created",
+          });
+
           filterWidget().click();
           addWidgetStringFilter("1");
 
@@ -157,6 +158,10 @@ const MODEL_NAME = "Test Action Model";
 
           createDashboardWithActionButton({
             actionName: "Create",
+          });
+
+          expectGoodSnowplowEvent({
+            event: "new_action_card_created",
           });
 
           cy.findByRole("button", { name: "Create" }).click();
@@ -193,6 +198,10 @@ const MODEL_NAME = "Test Action Model";
           createDashboardWithActionButton({
             actionName,
             idFilter: true,
+          });
+
+          expectGoodSnowplowEvent({
+            event: "new_action_card_created",
           });
 
           filterWidget().click();
@@ -246,6 +255,10 @@ const MODEL_NAME = "Test Action Model";
 
           createDashboardWithActionButton({
             actionName: "Delete",
+          });
+
+          expectGoodSnowplowEvent({
+            event: "new_action_card_created",
           });
 
           cy.findByRole("button", { name: "Delete" }).click();

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -14,6 +14,11 @@ import {
   getDashboardCardMenu,
   addOrUpdateDashboardCard,
   openQuestionsSidebar,
+  describeWithSnowplow,
+  resetSnowplow,
+  enableTracking,
+  expectNoBadSnowplowEvents,
+  expectGoodSnowplowEvent,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
@@ -734,6 +739,33 @@ describe("scenarios > dashboard", () => {
             testMarkdownContent.split("{enter}").length * lineHeight, // num of lines * lineHeight
           );
         });
+    });
+  });
+});
+
+describeWithSnowplow("scenarios > dashboard (snowplow)", () => {
+  beforeEach(() => {
+    resetSnowplow();
+    restore();
+    cy.signInAsAdmin();
+    enableTracking();
+  });
+
+  afterEach(() => {
+    expectNoBadSnowplowEvents();
+  });
+
+  it("should allow users to add link cards to dashboards", () => {
+    visitDashboard(1);
+    editDashboard();
+    cy.findByTestId("dashboard-header").icon("link").click();
+
+    cy.findByTestId("custom-edit-text-link").click().type("Orders");
+
+    saveDashboard();
+
+    expectGoodSnowplowEvent({
+      event: "new_link_card_created",
     });
   });
 });

--- a/e2e/test/scenarios/dashboard/text-dashcards.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/text-dashcards.cy.spec.js
@@ -6,17 +6,31 @@ import {
   addTextBox,
   editDashboard,
   saveDashboard,
+  describeWithSnowplow,
+  enableTracking,
+  resetSnowplow,
+  expectNoBadSnowplowEvents,
+  expectGoodSnowplowEvent,
 } from "e2e/support/helpers";
 
-describe("scenarios > dashboard > text and headings", () => {
+describeWithSnowplow("scenarios > dashboard > text and headings", () => {
   beforeEach(() => {
+    resetSnowplow();
     restore();
     cy.signInAsAdmin();
+    enableTracking();
   });
 
   describe("text", () => {
     beforeEach(() => {
       visitDashboard(1);
+    });
+
+    afterEach(() => {
+      expectNoBadSnowplowEvents();
+      expectGoodSnowplowEvent({
+        event: "new_text_card_created",
+      });
     });
 
     it("should allow creation, editing, and saving of text boxes", () => {
@@ -104,8 +118,8 @@ describe("scenarios > dashboard > text and headings", () => {
 
     it("should have a scroll bar for long text (metabase#8333)", () => {
       addTextBox(
-        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam ut fermentum erat, nec sagittis justo. Vivamus vitae ipsum semper, consectetur odio at, rutrum nisi. Fusce maximus consequat porta. Mauris libero mi, viverra ac hendrerit quis, rhoncus quis ante. Pellentesque molestie ut felis non congue. Vivamus finibus ligula id fringilla rutrum. Donec quis dignissim ligula, vitae tempor urna.\n\nDonec quis enim porta, porta lacus vel, maximus lacus. Sed iaculis leo tortor, vel tempor velit tempus vitae. Nulla facilisi. Vivamus quis sagittis magna. Aenean eu eros augue. Sed euismod pulvinar laoreet. Morbi commodo, sem sed dictum faucibus, sem ante ultrices libero, nec ornare risus lacus eget velit. Etiam sagittis lectus non erat tristique tempor. Sed in ipsum urna. Sed venenatis turpis at orci feugiat, ut gravida lectus luctus.",
-        { delay: 1 },
+        "Lorem ipsum dolor sit amet,\n\nfoo\n\nbar\n\nbaz\n\nboo\n\nDonec quis enim porta.",
+        { delay: 0.5 },
       );
       cy.findByTestId("edit-bar").findByText("Save").click();
 
@@ -137,6 +151,13 @@ describe("scenarios > dashboard > text and headings", () => {
   describe("heading", () => {
     beforeEach(() => {
       visitDashboard(1);
+    });
+
+    afterEach(() => {
+      expectNoBadSnowplowEvents();
+      expectGoodSnowplowEvent({
+        event: "new_heading_card_created",
+      });
     });
 
     it("should allow creation, editing, and saving of heading component", () => {

--- a/e2e/test/scenarios/dashboard/text-dashcards.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/text-dashcards.cy.spec.js
@@ -28,9 +28,6 @@ describeWithSnowplow("scenarios > dashboard > text and headings", () => {
 
     afterEach(() => {
       expectNoBadSnowplowEvents();
-      expectGoodSnowplowEvent({
-        event: "new_text_card_created",
-      });
     });
 
     it("should allow creation, editing, and saving of text boxes", () => {
@@ -38,6 +35,10 @@ describeWithSnowplow("scenarios > dashboard > text and headings", () => {
       editDashboard();
       cy.findByLabelText("Add a heading or text box").click();
       popover().findByText("Text").click();
+
+      expectGoodSnowplowEvent({
+        event: "new_text_card_created",
+      });
 
       getDashboardCard(1).within(() => {
         // textarea should:
@@ -121,6 +122,11 @@ describeWithSnowplow("scenarios > dashboard > text and headings", () => {
         "Lorem ipsum dolor sit amet,\n\nfoo\n\nbar\n\nbaz\n\nboo\n\nDonec quis enim porta.",
         { delay: 0.5 },
       );
+
+      expectGoodSnowplowEvent({
+        event: "new_text_card_created",
+      });
+
       cy.findByTestId("edit-bar").findByText("Save").click();
 
       // The test fails if there is no scroll bar
@@ -155,9 +161,6 @@ describeWithSnowplow("scenarios > dashboard > text and headings", () => {
 
     afterEach(() => {
       expectNoBadSnowplowEvents();
-      expectGoodSnowplowEvent({
-        event: "new_heading_card_created",
-      });
     });
 
     it("should allow creation, editing, and saving of heading component", () => {
@@ -165,6 +168,10 @@ describeWithSnowplow("scenarios > dashboard > text and headings", () => {
       editDashboard();
       cy.findByLabelText("Add a heading or text box").click();
       popover().findByText("Heading").click();
+
+      expectGoodSnowplowEvent({
+        event: "new_heading_card_created",
+      });
 
       getDashboardCard(1).within(() => {
         // heading input should

--- a/e2e/test/scenarios/dashboard/text-dashcards.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/text-dashcards.cy.spec.js
@@ -13,7 +13,7 @@ import {
   expectGoodSnowplowEvent,
 } from "e2e/support/helpers";
 
-describeWithSnowplow("scenarios > dashboard > text and headings", () => {
+describe("scenarios > dashboard > text and headings", () => {
   beforeEach(() => {
     resetSnowplow();
     restore();
@@ -21,7 +21,7 @@ describeWithSnowplow("scenarios > dashboard > text and headings", () => {
     enableTracking();
   });
 
-  describe("text", () => {
+  describeWithSnowplow("text", () => {
     beforeEach(() => {
       visitDashboard(1);
     });
@@ -154,7 +154,7 @@ describeWithSnowplow("scenarios > dashboard > text and headings", () => {
     });
   });
 
-  describe("heading", () => {
+  describeWithSnowplow("heading", () => {
     beforeEach(() => {
       visitDashboard(1);
     });

--- a/frontend/src/metabase/dashboard/actions/cards.js
+++ b/frontend/src/metabase/dashboard/actions/cards.js
@@ -8,6 +8,7 @@ import {
   getPositionForNewDashCard,
   DEFAULT_CARD_SIZE,
 } from "metabase/lib/dashboard_grid";
+import { trackSchemaEvent } from "metabase/lib/analytics";
 import { createCard } from "metabase/lib/card";
 
 import { getVisualizationRaw } from "metabase/visualizations";
@@ -100,6 +101,11 @@ export const addDashCardToDashboard = function ({
 };
 
 export const addMarkdownDashCardToDashboard = function ({ dashId, tabId }) {
+  trackSchemaEvent("dashboard", "1-2-0", {
+    event: "new_text_card_created",
+    dashboard_id: dashId,
+  });
+
   const virtualTextCard = {
     ...createCard(),
     display: "text",
@@ -120,6 +126,11 @@ export const addMarkdownDashCardToDashboard = function ({ dashId, tabId }) {
 };
 
 export const addHeadingDashCardToDashboard = function ({ dashId, tabId }) {
+  trackSchemaEvent("dashboard", "1-2-0", {
+    event: "new_heading_card_created",
+    dashboard_id: dashId,
+  });
+
   const virtualTextCard = {
     ...createCard(),
     display: "heading",
@@ -141,6 +152,11 @@ export const addHeadingDashCardToDashboard = function ({ dashId, tabId }) {
 };
 
 export const addLinkDashCardToDashboard = function ({ dashId, tabId }) {
+  trackSchemaEvent("dashboard", "1-2-0", {
+    event: "new_link_card_created",
+    dashboard_id: dashId,
+  });
+
   const virtualLinkCard = {
     ...createCard(),
     display: "link",
@@ -163,6 +179,11 @@ export const addLinkDashCardToDashboard = function ({ dashId, tabId }) {
 export const addActionToDashboard =
   async ({ dashId, tabId, action, displayType }) =>
   dispatch => {
+    trackSchemaEvent("dashboard", "1-2-0", {
+      event: "new_action_card_created",
+      dashboard_id: dashId,
+    });
+
     const virtualActionsCard = {
       ...createCard(),
       id: action.model_id,

--- a/frontend/src/metabase/dashboard/actions/cards.js
+++ b/frontend/src/metabase/dashboard/actions/cards.js
@@ -8,10 +8,10 @@ import {
   getPositionForNewDashCard,
   DEFAULT_CARD_SIZE,
 } from "metabase/lib/dashboard_grid";
-import { trackSchemaEvent } from "metabase/lib/analytics";
 import { createCard } from "metabase/lib/card";
 
 import { getVisualizationRaw } from "metabase/visualizations";
+import { trackCardCreated } from "../analytics";
 import { ADD_CARD_TO_DASH } from "./core";
 import { fetchCardData } from "./data-fetching";
 import { loadMetadataForDashboard } from "./metadata";
@@ -101,10 +101,7 @@ export const addDashCardToDashboard = function ({
 };
 
 export const addMarkdownDashCardToDashboard = function ({ dashId, tabId }) {
-  trackSchemaEvent("dashboard", "1-2-0", {
-    event: "new_text_card_created",
-    dashboard_id: dashId,
-  });
+  trackCardCreated("text", dashId);
 
   const virtualTextCard = {
     ...createCard(),
@@ -126,10 +123,7 @@ export const addMarkdownDashCardToDashboard = function ({ dashId, tabId }) {
 };
 
 export const addHeadingDashCardToDashboard = function ({ dashId, tabId }) {
-  trackSchemaEvent("dashboard", "1-2-0", {
-    event: "new_heading_card_created",
-    dashboard_id: dashId,
-  });
+  trackCardCreated("heading", dashId);
 
   const virtualTextCard = {
     ...createCard(),
@@ -152,10 +146,7 @@ export const addHeadingDashCardToDashboard = function ({ dashId, tabId }) {
 };
 
 export const addLinkDashCardToDashboard = function ({ dashId, tabId }) {
-  trackSchemaEvent("dashboard", "1-2-0", {
-    event: "new_link_card_created",
-    dashboard_id: dashId,
-  });
+  trackCardCreated("link", dashId);
 
   const virtualLinkCard = {
     ...createCard(),
@@ -179,10 +170,7 @@ export const addLinkDashCardToDashboard = function ({ dashId, tabId }) {
 export const addActionToDashboard =
   async ({ dashId, tabId, action, displayType }) =>
   dispatch => {
-    trackSchemaEvent("dashboard", "1-2-0", {
-      event: "new_action_card_created",
-      dashboard_id: dashId,
-    });
+    trackCardCreated("action", dashId);
 
     const virtualActionsCard = {
       ...createCard(),

--- a/frontend/src/metabase/dashboard/analytics.ts
+++ b/frontend/src/metabase/dashboard/analytics.ts
@@ -12,6 +12,7 @@ export const trackExportDashboardToPDF = (dashboardId: DashboardId) => {
   trackSchemaEvent("dashboard", "1-0-2", {
     event: "dashboard_pdf_exported",
     dashboard_id: dashboardId,
+  });
 };
 
 type CardTypes = "text" | "heading" | "link" | "action";

--- a/frontend/src/metabase/dashboard/analytics.ts
+++ b/frontend/src/metabase/dashboard/analytics.ts
@@ -21,7 +21,7 @@ export const trackCardCreated = (type: CardTypes, dashboard_id: number) => {
   if (!type) {
     return;
   }
-  trackSchemaEvent("dashboard", "1-2-0", {
+  trackSchemaEvent("dashboard", "1-1-1", {
     event: `new_${type}_card_created`,
     dashboard_id,
   });

--- a/frontend/src/metabase/dashboard/analytics.ts
+++ b/frontend/src/metabase/dashboard/analytics.ts
@@ -12,5 +12,16 @@ export const trackExportDashboardToPDF = (dashboardId: DashboardId) => {
   trackSchemaEvent("dashboard", "1-0-2", {
     event: "dashboard_pdf_exported",
     dashboard_id: dashboardId,
+};
+
+type CardTypes = "text" | "heading" | "link" | "action";
+
+export const trackCardCreated = (type: CardTypes, dashboard_id: number) => {
+  if (!type) {
+    return;
+  }
+  trackSchemaEvent("dashboard", "1-2-0", {
+    event: `new_${type}_card_created`,
+    dashboard_id,
   });
 };

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-1-1
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-1-1
@@ -5,7 +5,7 @@
     "vendor": "com.metabase",
     "name": "dashboard",
     "format": "jsonschema",
-    "version": "1-1-0"
+    "version": "1-1-1"
   },
   "type": "object",
   "properties": {

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-2-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-2-0
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Dashboard events",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "dashboard",
+    "format": "jsonschema",
+    "version": "1-1-0"
+  },
+  "type": "object",
+  "properties": {
+    "event": {
+      "description": "Event name",
+      "type": "string",
+      "enum": [
+        "dashboard_created",
+        "question_added_to_dashboard",
+        "auto_apply_filters_disabled",
+        "dashboard_tab_created",
+        "dashboard_tab_deleted",
+        "new_text_card_created",
+        "new_heading_card_created",
+        "new_link_card_created",
+        "new_action_card_created"
+      ],
+      "maxLength": 1024
+    },
+    "dashboard_id": {
+      "description": "Unique identifier for a dashboard within the Metabase instance",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "question_id": {
+      "description": "Unique identifier for a question added to a dashboard",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "num_tabs": {
+      "description": "Number of tabs affected after the event",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "total_num_tabs": {
+      "description": "Total number of active tabs after the events",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    }
+  },
+  "required": [
+    "event",
+    "dashboard_id"
+  ],
+  "additionalProperties": true
+}


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/31402
Closes https://github.com/metabase/metabase/issues/31403

Also handles

https://www.notion.so/metabase/New-action-card-created-53e78664bb174491afbe4967a0bdbd9e
https://www.notion.so/metabase/New-link-card-created-adf92fd3005648ff93249ca95b215a02


Adds dashboard snowplow events for:
- "new_text_card_created",
- "new_heading_card_created",
- "new_link_card_created",
- "new_action_card_created"


