### PR TITLE
fix dashboard tab zoom level bug

### DIFF
--- a/frontend/src/metabase/core/components/TabRow/TabRow.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.tsx
@@ -43,7 +43,7 @@ function TabRowInner<T>({
     }
 
     setShowScrollRight(
-      scrollPosition + width < tabListRef.current?.scrollWidth,
+      Math.round(scrollPosition + width) < tabListRef.current?.scrollWidth,
     );
   }, [children, scrollPosition, width]);
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31818

### Description

At certain zoom levels the right arrow would appear in the dashboard tabs component, despite it not being scroll-able.

The root cause was in the [`TabRow` component](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/core/components/TabRow/TabRow.tsx), where the `width` prop provided by the `ExplicitSize` HoC would at certain zoom levels have a value that was 0.5 less than the actual width. Below are some examples

<img width="312" alt="Screenshot 2023-06-23 at 7 29 55 AM" src="https://github.com/metabase/metabase/assets/37751258/d70bfde4-c18d-4d88-a269-0da33182a231">

The solution was to call `Math.round` when using this value to determine if the arrow should be visible, to fix the off by 0.5 error.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Created a tabbed dashboard
2. Play around with zoom levels and confirm arrow doesn't appear

### Demo

https://github.com/metabase/metabase/assets/37751258/bdbbc49b-a0d1-45cb-be9d-6cf9079a862e

### Checklist

- ~~[ ] Tests have been added/updated to cover changes in this PR~~

This is unfortunately not testable due to a limitation with Cypress. Cypress only allows you to set the viewport size, and not the zoom level in tests. [Instead the zoom scale is automatically computed](https://docs.cypress.io/api/commands/viewport#Auto-Scaling), and depends on the size of your browser's viewport (which depends on your window size and resolution). Because of this limitation there is no way to write a test that will be consistently reproducible across all machines.
