### PR TITLE
Amend tooltip laziness

### DIFF
--- a/frontend/src/metabase/components/Popover/TippyPopover.tsx
+++ b/frontend/src/metabase/components/Popover/TippyPopover.tsx
@@ -129,6 +129,10 @@ function TippyPopover({
     [flip, sizeToFit, popperOptions],
   );
 
+  if (!shouldShowContent) {
+    return null;
+  }
+
   return (
     <TippyComponent
       className={cx("popover", className)}
@@ -144,11 +148,7 @@ function TippyPopover({
       duration={animationDuration}
       delay={delay}
       content={
-        shouldShowContent ? (
-          <EventSandbox disabled={disableContentSandbox}>
-            {content}
-          </EventSandbox>
-        ) : null
+        <EventSandbox disabled={disableContentSandbox}>{content}</EventSandbox>
       }
       onShow={handleShow}
       onHide={handleHide}

--- a/jest.tz.unit.conf.json
+++ b/jest.tz.unit.conf.json
@@ -27,6 +27,5 @@
     "/node_modules/",
     "/frontend/src/metabase/visualizations/lib/errors.js"
   ],
-  "testEnvironment": "jest-environment-jsdom",
-  "testTimeout": 30000
+  "testEnvironment": "jest-environment-jsdom"
 }

--- a/jest.unit.conf.json
+++ b/jest.unit.conf.json
@@ -58,6 +58,5 @@
   "watchPlugins": [
     "jest-watch-typeahead/filename",
     "jest-watch-typeahead/testname"
-  ],
-  "testTimeout": 30000
+  ]
 }


### PR DESCRIPTION
# Checking CI

Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

<img width="1672" alt="Screen Shot 2023-06-23 at 10 15 28 AM" src="https://github.com/metabase/metabase/assets/14301985/fb59fb1c-057a-4ee6-8bc0-96b981cfa107">

Seems like there is a bug that does not hide the tippy tooltip in tests, we don't have this problem in browser obviously. Will investigate further.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
