### PR TITLE
Accept US/Pacific timezone in Athena timestamp with timezone test

### DIFF
--- a/modules/drivers/athena/test/metabase/driver/athena_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena_test.clj
@@ -81,8 +81,12 @@
             query        (-> (mt/native-query {:query sql, :params args})
                              (assoc-in [:middleware :format-rows?] false))]
         (mt/with-native-query-testing-context query
-          (is (= [#t "2022-11-16T04:21:00.000-08:00[America/Los_Angeles]" #t "05:03"]
-                 (mt/first-row (qp/process-query query)))))))))
+          (let [[ts t] (mt/first-row (qp/process-query query))]
+            (is (#{#t "2022-11-16T04:21:00.000-08:00[America/Los_Angeles]"
+                   #t "2022-11-16T04:21:00.000-08:00[US/Pacific]"}
+                   ts))
+            (is (= #t "05:03"
+                   t))))))))
 
 (deftest set-time-and-timestamp-with-time-zone-test
   (mt/test-driver :athena


### PR DESCRIPTION
It seems Athena's behavior has changed and now we get back exactly the same TZ as the input (US/Pacific).