### PR TITLE
docs - upload size capped at 50 mb

### DIFF
--- a/docs/databases/uploads.md
+++ b/docs/databases/uploads.md
@@ -48,9 +48,9 @@ Admins can optionally specify a string of text to add in front of the table that
 
 ## File size limit
 
-CSV files cannot exceed 200 MB in size.
+CSV files cannot exceed 50 MB in size.
 
-> While Metabase limits uploads to 200 MB, the server you use to run your Metabase may impose a lower limit. For example, the default client upload limit for [NGINX is 1 MB](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size). So you may need to change your server settings to allow uploads up to 200 MB. People on Metabase Cloud don't have to worry about this.
+> While Metabase limits uploads to 50 MB, the server you use to run your Metabase may impose a lower limit. For example, the default client upload limit for [NGINX is 1 MB](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size). So you may need to change your server settings to allow uploads up to 200 MB. People on Metabase Cloud don't have to worry about this.
 
 If you have a file larger than 200 MB, the workaround here is to:
 

--- a/docs/databases/uploads.md
+++ b/docs/databases/uploads.md
@@ -50,7 +50,7 @@ Admins can optionally specify a string of text to add in front of the table that
 
 CSV files cannot exceed 50 MB in size.
 
-> While Metabase limits uploads to 50 MB, the server you use to run your Metabase may impose a lower limit. For example, the default client upload limit for [NGINX is 1 MB](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size). So you may need to change your server settings to allow uploads up to 200 MB. People on Metabase Cloud don't have to worry about this.
+> While Metabase limits uploads to 50 MB, the server you use to run your Metabase may impose a lower limit. For example, the default client upload limit for [NGINX is 1 MB](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size). So you may need to change your server settings to allow uploads up to 50 MB. People on Metabase Cloud don't have to worry about this.
 
 If you have a file larger than 200 MB, the workaround here is to:
 


### PR DESCRIPTION
Updates upload limit in docs from 200 to 50 MB.

Related: https://github.com/metabase/metabase/pull/31776