### PR TITLE
Only try to parse temporal values during xlsx export when effective type is temporal

### DIFF
--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -451,7 +451,13 @@
            (second (xlsx-export [{:id 0, :name "Col"}] {} [["2020-03-28T10:12:06.681"]]))))
     (binding [qp.xlsx/*parse-temporal-string-values* true]
       (is (= [#inst "2020-03-28T10:12:06.681"]
-             (second (xlsx-export [{:id 0, :name "Col"}] {} [["2020-03-28T10:12:06.681"]]))))))
+             (second (xlsx-export [{:id 0, :name "Col" :effective_type :type/Temporal}]
+                                  {}
+                                  [["2020-03-28T10:12:06.681"]]))))
+      (is (= ["2020-03-28T10:12:06.681"]
+             (second (xlsx-export [{:id 0, :name "Col" :effective_type :type/Text}]
+                                  {}
+                                  [["2020-03-28T10:12:06.681"]]))))))
   (mt/with-everything-store
     (binding [driver/*driver* :h2]
       (testing "OffsetDateTime"

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -454,10 +454,12 @@
              (second (xlsx-export [{:id 0, :name "Col" :effective_type :type/Temporal}]
                                   {}
                                   [["2020-03-28T10:12:06.681"]]))))
-      (is (= ["2020-03-28T10:12:06.681"]
-             (second (xlsx-export [{:id 0, :name "Col" :effective_type :type/Text}]
-                                  {}
-                                  [["2020-03-28T10:12:06.681"]]))))))
+      (testing "Values that are parseable as dates are not when effective_type is not temporal (#29708)"
+        (doseq [value ["0001" "4161" "02" "2020-03-28T10:12:06.681"]]
+          (is (= [value]
+                 (second (xlsx-export [{:id 0, :name "Col" :effective_type :type/Text}]
+                                      {}
+                                      [[value]]))))))))
   (mt/with-everything-store
     (binding [driver/*driver* :h2]
       (testing "OffsetDateTime"


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/29708

The issue boils down to this:
* During normal queries, the format-rows middleware will convert any temporal types to a string in the appropriate timezone.
* During export queries, this middleware is skipped, since each export type handles formatting differently.
* Subscription attachments are executed as normal queries, then the data is separately streamed through the XLSX export code to generate the attachments. This means that the format-rows middleware is included during the query execution, and all temporal values end up as plain strings during XLSX generation.
* Thus, we need to parse these values back to timestamps. However, we were attempting to parse every value, resulting in some strings being unintentionally interpreted as timestamps. I _think_ that checking the `:effective_type` to determine whether we parse the value is what we want here instead.