### PR TITLE
[MLv2] Native query manipulation functions for raw query and template tags

### DIFF
--- a/frontend/src/metabase-lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/queries/NativeQuery.ts
@@ -437,7 +437,7 @@ export default class NativeQuery extends AtomicQuery {
    */
   private _getUpdatedTemplateTags(queryText: string): TemplateTags {
     return queryText && this.supportsNativeParameters()
-      ? ML.template_tags(queryText, this.templateTagsMap())
+      ? ML.extract_template_tags(queryText, this.templateTagsMap())
       : {};
   }
 

--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -160,6 +160,10 @@
         (cond-> stage
           (:joins stage) (update :joins deduplicate-join-aliases))))))
 
+(defmethod ->pMBQL :mbql.stage/native
+  [stage]
+  (m/update-existing stage :template-tags update-vals (fn [tag] (m/update-existing tag :dimension ->pMBQL))))
+
 (defmethod ->pMBQL :mbql/join
   [join]
   (let [join (-> join

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -191,8 +191,12 @@
   [lib.native
    #?@(:cljs [->TemplateTags
               TemplateTags->])
-   recognize-template-tags
-   template-tags]
+   native-query
+   raw-native-query
+   with-native-query
+   template-tags
+   with-template-tags
+   extract-template-tags]
   [lib.order-by
    change-direction
    order-by
@@ -202,7 +206,6 @@
   [lib.normalize
    normalize]
   [lib.query
-   native-query
    query
    saved-question-query]
   [lib.ref

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -35,7 +35,7 @@
 
   Given the text of a native query, extract a possibly-empty set of template tag strings from it.
 
-  These looks like mustache templates. For variables, we only allow alphanumeric characters, eg. `{{foo}}`.
+  These look like mustache templates. For variables, we only allow alphanumeric characters, eg. `{{foo}}`.
   For snippets they start with `snippet:`, eg. `{{ snippet: arbitrary text here }}`.
   And for card references either `{{ #123 }}` or with the optional human label `{{ #123-card-title-slug }}`.
 

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -12,7 +12,8 @@
    [metabase.lib.schema.common :as common]
    [metabase.lib.util :as lib.util]
    [metabase.util.humanization :as u.humanization]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.shared.util.i18n :as i18n]))
 
 (def ^:private TemplateTag
   [:map
@@ -161,7 +162,8 @@
    inner-query :- ::common/non-blank-string]
   (lib.util/update-query-stage
     query 0
-    (fn [{existing-tags :template-tags :as stage}]
+    (fn [{existing-tags :template-tags stage-type :lib/type :as stage}]
+      (assert (= stage-type :mbql.stage/native) (i18n/tru "Must be a native query"))
       (assoc stage
         :native inner-query
         :template-tags (extract-template-tags inner-query existing-tags)))))
@@ -172,7 +174,8 @@
    tags :- TemplateTags]
   (lib.util/update-query-stage
     query 0
-    (fn [{existing-tags :template-tags :as stage}]
+    (fn [{existing-tags :template-tags stage-type :lib/type :as stage}]
+      (assert (= stage-type :mbql.stage/native) (i18n/tru "Must be a native query"))
       (let [valid-tags (keys existing-tags)]
         (assoc stage :template-tags
                (m/deep-merge existing-tags (select-keys tags valid-tags)))))))

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -175,7 +175,7 @@
     (fn [{existing-tags :template-tags :as stage}]
       (let [valid-tags (keys existing-tags)]
         (assoc stage :template-tags
-               (select-keys (m/deep-merge existing-tags tags) valid-tags))))))
+               (m/deep-merge existing-tags (select-keys tags valid-tags)))))))
 
 (mu/defn raw-native-query :- ::common/non-blank-string
   "Returns the native query string"

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -6,7 +6,6 @@
    [clojure.string :as str]
    [medley.core :as m]
    [metabase.lib.metadata :as lib.metadata]
-   [metabase.lib.native :as lib.native]
    [metabase.lib.options :as lib.options]
    [metabase.lib.query :as lib.query]
    [metabase.lib.schema :as lib.schema]

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -144,7 +144,7 @@
    (native-query metadata-providerable nil inner-query))
 
   ([metadata-providerable :- lib.metadata/MetadataProviderable
-    results-metadata      :- [:maybe [:sequential lib.metadata/ColumnMetadata]]
+    results-metadata      :- [:maybe lib.metadata/StageMetadata]
     inner-query :- ::common/non-blank-string]
    (let [tags (extract-template-tags inner-query)]
      (lib.query/query-with-stages metadata-providerable

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -11,9 +11,9 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.common :as common]
    [metabase.lib.util :as lib.util]
+   [metabase.shared.util.i18n :as i18n]
    [metabase.util.humanization :as u.humanization]
-   [metabase.util.malli :as mu]
-   [metabase.shared.util.i18n :as i18n]))
+   [metabase.util.malli :as mu]))
 
 (def ^:private TemplateTag
   [:map

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -1,13 +1,19 @@
 (ns metabase.lib.native
   "Functions for working with native queries."
   (:require
+   #?@(:cljs ([metabase.domain-entities.converters :as converters]))
    [clojure.set :as set]
    [clojure.string :as str]
    [medley.core :as m]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.native :as lib.native]
+   [metabase.lib.options :as lib.options]
+   [metabase.lib.query :as lib.query]
+   [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.common :as common]
+   [metabase.lib.util :as lib.util]
    [metabase.util.humanization :as u.humanization]
-   [metabase.util.malli :as mu]
-   #?@(:cljs ([metabase.domain-entities.converters :as converters]))))
+   [metabase.util.malli :as mu]))
 
 (def ^:private TemplateTag
   [:map
@@ -35,7 +41,7 @@
 (def ^:private tag-regexes
   [variable-tag-regex snippet-tag-regex card-tag-regex])
 
-(mu/defn recognize-template-tags :- [:set ::common/non-blank-string]
+(mu/defn ^:private recognize-template-tags :- [:set ::common/non-blank-string]
   "Given the text of a native query, extract a possibly-empty set of template tag strings from it."
   [query-text :- ::common/non-blank-string]
   (into #{}
@@ -95,15 +101,21 @@
                           (m/index-by :name (map fresh-tag new-tags))))]
     (update-vals tags finish-tag)))
 
-(mu/defn ^:export template-tags :- TemplateTags
+(mu/defn extract-template-tags :- TemplateTags
   "Extract the template tags from a native query's text.
 
   If the optional map of existing tags previously parsed is given, this will reuse the existing tags where
   they match up with the new one (in particular, it will preserve the UUIDs).
 
-  See [[recognize-template-tags]] for how the tags are parsed."
+  Given the text of a native query, extract a possibly-empty set of template tag strings from it.
+
+  These looks like mustache templates. For variables, we only allow alphanumeric characters, eg. `{{foo}}`.
+  For snippets they start with `snippet:`, eg. `{{ snippet: arbitrary text here }}`.
+  And for card references either `{{ #123 }}` or with the optional human label `{{ #123-card-title-slug }}`.
+
+  Invalid patterns are simply ignored, so something like `{{&foo!}}` is just disregarded."
   ([query-text :- ::common/non-blank-string]
-   (template-tags query-text nil))
+   (extract-template-tags query-text nil))
   ([query-text    :- ::common/non-blank-string
     existing-tags :- [:maybe TemplateTags]]
    (let [query-tag-names    (not-empty (recognize-template-tags query-text))
@@ -123,3 +135,55 @@
      (def TemplateTags->
        "Converter from a map of `TemplateTag`s keyed by their string names to vanilla JS."
        (converters/outgoing TemplateTags))))
+
+(mu/defn native-query :- ::lib.schema/query
+  "Create a new native query.
+
+  Native in this sense means a pMBQL query with a first stage that is a native query."
+  ([metadata-providerable :- lib.metadata/MetadataProviderable
+    inner-query :- ::common/non-blank-string]
+   (native-query metadata-providerable nil inner-query))
+
+  ([metadata-providerable :- lib.metadata/MetadataProviderable
+    results-metadata      :- [:maybe [:sequential lib.metadata/ColumnMetadata]]
+    inner-query :- ::common/non-blank-string]
+   (let [tags (extract-template-tags inner-query)]
+     (lib.query/query-with-stages metadata-providerable
+                                  [(-> {:lib/type           :mbql.stage/native
+                                        :lib/stage-metadata results-metadata
+                                        :template-tags      tags
+                                        :native             inner-query}
+                                       lib.options/ensure-uuid)]))))
+
+(mu/defn with-native-query :- ::lib.schema/query
+  "Update the raw native query, the first stage must already be a native type.
+   Replaces templates tags"
+  [query :- ::lib.schema/query
+   inner-query :- ::common/non-blank-string]
+  (lib.util/update-query-stage
+    query 0
+    (fn [{existing-tags :template-tags :as stage}]
+      (assoc stage
+        :native inner-query
+        :template-tags (extract-template-tags inner-query existing-tags)))))
+
+(mu/defn with-template-tags :- ::lib.schema/query
+  "Updates the native query's template tags."
+  [query :- ::lib.schema/query
+   tags :- TemplateTags]
+  (lib.util/update-query-stage
+    query 0
+    (fn [{existing-tags :template-tags :as stage}]
+      (let [valid-tags (keys existing-tags)]
+        (assoc stage :template-tags
+               (select-keys (m/deep-merge existing-tags tags) valid-tags))))))
+
+(mu/defn raw-native-query :- ::common/non-blank-string
+  "Returns the native query string"
+  [query :- ::lib.schema/query]
+  (:native (lib.util/query-stage query 0)))
+
+(mu/defn template-tags :- TemplateTags
+  "Returns the native query's template tags"
+  [query :- ::lib.schema/query]
+  (:template-tags (lib.util/query-stage query 0)))

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -7,7 +7,6 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.normalize :as lib.normalize]
-   [metabase.lib.options :as lib.options]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.util :as lib.util]
@@ -90,26 +89,6 @@
   [metadata-providerable :- lib.metadata/MetadataProviderable
    x]
   (->query metadata-providerable x))
-
-;;; TODO -- the stuff below will probably change in the near future, please don't read too much in to it.
-(mu/defn native-query :- ::lib.schema/query
-  "Create a new native query.
-
-  Native in this sense means a pMBQL query with a first stage that is a native query."
-  ([metadata-providerable :- lib.metadata/MetadataProviderable
-    inner-query]
-   (native-query metadata-providerable nil inner-query))
-
-  ;; TODO not sure if `results-metadata` should be StageMetadata (i.e., a map roughly matching the shape you get from
-  ;; the QP) or a sequence of ColumnMetadatas, like what would be saved in Card `result_metadata`.
-  ([metadata-providerable :- lib.metadata/MetadataProviderable
-    results-metadata      :- lib.metadata/StageMetadata
-    inner-query]
-   (query-with-stages metadata-providerable
-                      [(-> {:lib/type           :mbql.stage/native
-                            :lib/stage-metadata results-metadata
-                            :native             inner-query}
-                           lib.options/ensure-uuid)])))
 
 (mu/defn saved-question-query :- ::lib.schema/query
   "Convenience for creating a query from a Saved Question (i.e., a Card)."

--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -8,6 +8,7 @@
   future we can deprecate that namespace and eventually do away with it entirely."
   (:require
    [metabase.lib.schema.aggregation :as aggregation]
+   [metabase.lib.schema.common :as common]
    [metabase.lib.schema.expression :as expression]
    [metabase.lib.schema.expression.arithmetic]
    [metabase.lib.schema.expression.conditional]
@@ -19,6 +20,7 @@
    [metabase.lib.schema.literal]
    [metabase.lib.schema.order-by :as order-by]
    [metabase.lib.schema.ref :as ref]
+   [metabase.lib.schema.template-tag :as template-tag]
    [metabase.lib.schema.util :as lib.schema.util]
    [metabase.mbql.util.match :as mbql.match]
    [metabase.util.malli.registry :as mr]))
@@ -33,8 +35,19 @@
 (mr/def ::stage.native
   [:map
    [:lib/type [:= :mbql.stage/native]]
-   [:native any?]
-   [:args {:optional true} [:sequential any?]]])
+   ;; the actual native query, depends on the underlying database. Could be a raw SQL string or something like that.
+   ;; Only restriction is that it is non-nil.
+   [:native some?]
+   ;; any parameters that should be passed in along with the query to the underlying query engine, e.g. for JDBC these
+   ;; are the parameters we pass in for a `PreparedStatement` for `?` placeholders. These can be anything, including
+   ;; nil.
+   [:args {:optional true} [:sequential any?]]
+   ;; the Table/Collection/etc. that this query should be executed against; currently only used for MongoDB, where it
+   ;; is required.
+   [:collection {:optional true} ::common/non-blank-string]
+   ;; optional template tag declarations. Template tags are things like `{{x}}` in the query (the value of the
+   ;; `:native` key), but their definition lives under this key.
+   [:template-tags {:optional true} [:ref ::template-tag/template-tag-map]]])
 
 (mr/def ::breakouts
   [:sequential {:min 1} [:ref ::ref/ref]])

--- a/src/metabase/lib/schema/id.cljc
+++ b/src/metabase/lib/schema/id.cljc
@@ -29,3 +29,6 @@
 
 (mr/def ::metric
   ::common/int-greater-than-or-equal-to-zero)
+
+(mr/def ::snippet
+  ::common/int-greater-than-or-equal-to-zero)

--- a/src/metabase/lib/schema/template_tag.cljc
+++ b/src/metabase/lib/schema/template_tag.cljc
@@ -73,7 +73,7 @@
     [:type         [:= :snippet]]
     [:snippet-name ::common/non-blank-string]
     [:snippet-id   ::id/snippet]
-    ;; database to which this Snippet belongs. Doesn't always seen to be specified.
+    ;; database to which this Snippet belongs. Doesn't always seem to be specified.
     [:database {:optional true} ::id/database]]])
 
 ;; Example:

--- a/src/metabase/lib/schema/template_tag.cljc
+++ b/src/metabase/lib/schema/template_tag.cljc
@@ -1,0 +1,133 @@
+(ns metabase.lib.schema.template-tag
+  (:require
+   [malli.core :as mc]
+   [metabase.lib.schema.common :as common]
+   [metabase.lib.schema.id :as id]
+   [metabase.mbql.schema :as mbql.s]
+   [metabase.util.malli.registry :as mr]))
+
+;; Schema for valid values of `:widget-type` for a [[TemplateTag:FieldFilter]].
+(mr/def ::widget-type
+  (into
+   [:enum
+    ;; this will be a nicer error message than Malli trying to list every single possible allowed type.
+    {:error/message "Valid template tag :widget-type"}
+    :none]
+   (keys mbql.s/parameter-types)))
+
+;; Schema for valid values of template tag `:type`.
+(mr/def ::type
+  [:enum :snippet :card :dimension :number :text :date])
+
+;;; Things required by all template tag types.
+(mr/def ::common
+  [:map
+   [:name         ::common/non-blank-string]
+   [:display-name ::common/non-blank-string]
+   ;; TODO -- `:id` is actually 100% required but we have a lot of tests that don't specify it because this constraint
+   ;; wasn't previously enforced; we need to go in and fix those tests and make this non-optional
+   [:id {:optional true} [:or ::common/non-blank-string :uuid]]])
+
+;;; Stuff shared between the Field filter and raw value template tag schemas.
+(mr/def ::value.common
+  [:merge
+   [:ref ::common]
+   [:map
+    ;; default value for this parameter
+    [:default {:optional true} any?]
+    ;; whether or not a value for this parameter is required in order to run the query
+    [:required {:optional true} :boolean]]])
+
+;; Example:
+;;
+;;    {:id           "c20851c7-8a80-0ffa-8a99-ae636f0e9539"
+;;     :name         "date"
+;;     :display-name "Date"
+;;     :type         :dimension,
+;;     :dimension    [:field 4 nil]
+;;     :widget-type  :date/all-options}
+(mr/def ::field-filter
+  [:merge
+   [:ref ::value.common]
+   [:map
+    [:type        [:= :dimension]]
+    [:dimension   [:ref :mbql.clause/field]]
+    ;; which type of widget the frontend should show for this Field Filter; this also affects which parameter types
+    ;; are allowed to be specified for it.
+    [:widget-type [:ref ::widget-type]]
+    ;; optional map to be appended to filter clause
+    [:options {:optional true} :map]]])
+
+;; Example:
+;;
+;;    {:id           "c2fc7310-44eb-4f21-c3a0-63806ffb7ddd"
+;;     :name         "snippet: select"
+;;     :display-name "Snippet: select"
+;;     :type         :snippet
+;;     :snippet-name "select"
+;;     :snippet-id   1}
+(mr/def ::snippet
+  [:merge
+   [:ref ::common]
+   [:map
+    [:type         [:= :snippet]]
+    [:snippet-name ::common/non-blank-string]
+    [:snippet-id   ::id/snippet]
+    ;; database to which this Snippet belongs. Doesn't always seen to be specified.
+    [:database {:optional true} ::id/database]]])
+
+;; Example:
+;;
+;;    {:id           "fc5e14d9-7d14-67af-66b2-b2a6e25afeaf"
+;;     :name         "#1635"
+;;     :display-name "#1635"
+;;     :type         :card
+;;     :card-id      1635}
+(mr/def ::source-query
+  [:merge
+   [:ref ::common]
+   [:map
+    [:type    [:= :card]]
+    [:card-id ::id/card]]])
+
+;; Valid values of `:type` for raw value template tags.
+(mr/def ::raw-value.type
+  (into [:enum] mbql.s/raw-value-template-tag-types))
+
+;; Example:
+;;
+;;    {:id           "35f1ecd4-d622-6d14-54be-750c498043cb"
+;;     :name         "id"
+;;     :display-name "Id"
+;;     :type         :number
+;;     :required     true
+;;     :default      "1"}
+(mr/def ::raw-value
+  [:merge
+   [:ref ::value.common]
+   ;; `:type` is used be the FE to determine which type of widget to display for the template tag, and to determine
+   ;; which types of parameters are allowed to be passed in for this template tag.
+   [:map
+    [:type [:ref ::raw-value.type]]]])
+
+(mr/def ::template-tag
+  [:and
+   [:map
+    [:type [:ref ::type]]]
+   [:multi {:dispatch :type}
+    [:dimension   [:ref ::field-filter]]
+    [:snippet     [:ref ::snippet]]
+    [:card        [:ref ::source-query]]
+    ;; :number, :text, :date
+    [::mc/default [:ref ::raw-value]]]])
+
+(mr/def ::template-tag-map
+  [:and
+   [:map-of ::common/non-blank-string [:ref ::template-tag]]
+   ;; make sure people don't try to pass in a `:name` that's different from the actual key in the map.
+   [:fn
+    {:error/message "keys in template tag map must match the :name of their values"}
+    (fn [m]
+      (every? (fn [[tag-name tag-definition]]
+                (= tag-name (:name tag-definition)))
+              m))]])

--- a/src/metabase/metabot.clj
+++ b/src/metabase/metabot.clj
@@ -45,7 +45,7 @@
                                        (:id model)
                                        user_prompt
                                        final-sql)
-              template-tags (lib-native/template-tags inner_query)
+              template-tags (lib-native/extract-template-tags inner_query)
               dataset       {:dataset_query          {:database database_id
                                                       :type     "native"
                                                       :native   {:query         final-sql

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -1,10 +1,10 @@
 (ns metabase.lib.convert-test
   (:require
+   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
    [clojure.test :refer [are deftest is testing]]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
-   [metabase.lib.test-metadata :as meta]
-   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))))
+   [metabase.lib.test-metadata :as meta]))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 

--- a/test/metabase/lib/native_test.cljc
+++ b/test/metabase/lib/native_test.cljc
@@ -162,6 +162,20 @@
          (is (=         clj-tags (-> clj-tags (#'lib.native/TemplateTags->) (#'lib.native/->TemplateTags))))
          (is (test.js/= js-tags  (-> js-tags  (#'lib.native/->TemplateTags) (#'lib.native/TemplateTags->))))))))
 
+(deftest ^:parallel native-query-test
+  (is (=? {:lib/type :mbql/query
+           :database (meta/id)
+           :stages   [{:lib/type    :mbql.stage/native
+                       :lib/options {:lib/uuid string?}
+                       :native      "SELECT * FROM VENUES;"}]}
+          (lib/native-query meta/metadata-provider meta/qp-results-metadata "SELECT * FROM VENUES;"))))
+
+(deftest ^:parallel native-query-suggested-name-test
+  (let [query (lib/native-query meta/metadata-provider meta/qp-results-metadata "SELECT * FROM VENUES;")]
+    (is (= "Native query"
+           (lib.metadata.calculation/describe-query query)))
+    (is (nil? (lib.metadata.calculation/suggested-name query)))))
+
 (deftest ^:parallel native-query-building
   (let [query (lib/native-query meta/metadata-provider "select * from venues where id = {{myid}}")]
     (testing "Updating query keeps template tags in sync"

--- a/test/metabase/lib/native_test.cljc
+++ b/test/metabase/lib/native_test.cljc
@@ -5,6 +5,7 @@
    [clojure.test :refer [are deftest is testing]]
    [medley.core :as m]
    [metabase.lib.core :as lib]
+   [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.native :as lib.native]
    [metabase.lib.test-metadata :as meta]
    [metabase.util.humanization :as u.humanization]))
@@ -205,16 +206,16 @@
         original-tags (lib/template-tags query)]
     (is (= (assoc-in original-tags ["myid" :display-name] "My ID")
            (-> query
-               (lib/with-template-tags {"myid" {:display-name "My ID"}})
+               (lib/with-template-tags {"myid" (assoc (get original-tags "myid") :display-name "My ID")})
                lib/template-tags)))
     (testing "Changing query keeps updated template tags"
       (is (= (assoc-in original-tags ["myid" :display-name] "My ID")
              (-> query
-                 (lib/with-template-tags {"myid" {:display-name "My ID"}})
+                 (lib/with-template-tags {"myid" (assoc (get original-tags "myid") :display-name "My ID")})
                  (lib/with-native-query "select * from venues where category_id = {{myid}}")
                  lib/template-tags))))
     (testing "Doesn't introduce garbage"
       (is (= original-tags
              (-> query
-                 (lib/with-template-tags {"garbage" {:display-name "Foobar"}})
+                 (lib/with-template-tags {"garbage" (assoc (get original-tags "myid") :display-name "Foobar")})
                  lib/template-tags))))))

--- a/test/metabase/lib/native_test.cljc
+++ b/test/metabase/lib/native_test.cljc
@@ -10,7 +10,7 @@
    [metabase.util.humanization :as u.humanization]))
 
 (deftest ^:parallel variable-tag-test
-  (are [exp input] (= exp (lib.native/recognize-template-tags input))
+  (are [exp input] (= exp (set (keys (lib.native/extract-template-tags input))))
     #{"foo"} "SELECT * FROM table WHERE {{foo}} AND some_field IS NOT NULL"
     #{"foo" "bar"} "SELECT * FROM table WHERE {{foo}} AND some_field = {{bar}}"
     ;; Duplicates are flattened.
@@ -19,7 +19,7 @@
     #{} "SELECT * FROM table WHERE {{&foo}}"))
 
 (deftest ^:parallel snippet-tag-test
-  (are [exp input] (= exp (lib.native/recognize-template-tags input))
+  (are [exp input] (= exp (set (keys (lib.native/extract-template-tags input))))
     #{"snippet:   foo  "} "SELECT * FROM table WHERE {{snippet:   foo  }} AND some_field IS NOT NULL"
     #{"snippet:   foo  *#&@"} "SELECT * FROM table WHERE {{snippet:   foo  *#&@}}"
     ;; TODO: This logic should trim the whitespace and unify these two snippet names.
@@ -27,7 +27,7 @@
     #{"snippet: foo" "snippet:foo"} "SELECT * FROM table WHERE {{snippet: foo}} AND {{snippet:foo}}"))
 
 (deftest ^:parallel card-tag-test
-  (are [exp input] (= exp (lib.native/recognize-template-tags input))
+  (are [exp input] (= exp (set (keys (lib.native/extract-template-tags input))))
     #{"#123"} "SELECT * FROM table WHERE {{ #123 }} AND some_field IS NOT NULL"
     ;; TODO: This logic should trim the whitespace and unify these two card tags.
     ;; I think this is a bug in the original code but am aiming to reproduce it exactly for now.

--- a/test/metabase/lib/query_test.cljc
+++ b/test/metabase/lib/query_test.cljc
@@ -29,20 +29,6 @@
            (lib.metadata.calculation/describe-query query)
            (lib.metadata.calculation/suggested-name query)))))
 
-(deftest ^:parallel native-query-test
-  (is (=? {:lib/type :mbql/query
-           :database (meta/id)
-           :stages   [{:lib/type    :mbql.stage/native
-                       :lib/options {:lib/uuid string?}
-                       :native      "SELECT * FROM VENUES;"}]}
-          (lib/native-query meta/metadata-provider meta/qp-results-metadata "SELECT * FROM VENUES;"))))
-
-(deftest ^:parallel native-query-suggested-name-test
-  (let [query (lib/native-query meta/metadata-provider meta/qp-results-metadata "SELECT * FROM VENUES;")]
-    (is (= "Native query"
-           (lib.metadata.calculation/describe-query query)))
-    (is (nil? (lib.metadata.calculation/suggested-name query)))))
-
 (deftest ^:parallel card-source-query-test
   (is (=? {:lib/type :mbql/query
            :database (meta/id)

--- a/test/metabase/metabot/metabot_util_test.clj
+++ b/test/metabase/metabot/metabot_util_test.clj
@@ -180,7 +180,7 @@
                           :type     "native"
                           :native   {:query         sql
                                      :template-tags (update-vals
-                                                     (lib-native/template-tags inner_query)
+                                                     (lib-native/extract-template-tags inner_query)
                                                      (fn [m] (update m :id str)))}})]
             (is (some? (seq (get-in results [:data :rows]))))))))))
 


### PR DESCRIPTION
Part of #31006 

get/set a raw native query
get/set the current template tags

-update metabase.lib.convert to handle template tags however, e.g. the :dimension (field ref) gets converted back and forth properly

Still to do:
- For MongoDB, we also need functions for getting and setting the current Table (collection) -- we need a function to tell whether this is supported/required