### PR TITLE
hide empty cards tracking

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -16,7 +16,6 @@ import {
   openQuestionsSidebar,
   describeWithSnowplow,
   expectNoBadSnowplowEvents,
-  expectGoodSnowplowEvents,
   resetSnowplow,
   enableTracking,
   expectGoodSnowplowEvent,

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -15,9 +15,10 @@ import {
   addOrUpdateDashboardCard,
   openQuestionsSidebar,
   describeWithSnowplow,
+  expectNoBadSnowplowEvents,
+  expectGoodSnowplowEvents,
   resetSnowplow,
   enableTracking,
-  expectNoBadSnowplowEvents,
   expectGoodSnowplowEvent,
 } from "e2e/support/helpers";
 
@@ -743,7 +744,7 @@ describe("scenarios > dashboard", () => {
   });
 });
 
-describeWithSnowplow("scenarios > dashboard (snowplow)", () => {
+describeWithSnowplow("scenarios > dashboard", () => {
   beforeEach(() => {
     resetSnowplow();
     restore();
@@ -766,6 +767,32 @@ describeWithSnowplow("scenarios > dashboard (snowplow)", () => {
 
     expectGoodSnowplowEvent({
       event: "new_link_card_created",
+    });
+  });
+
+  it("should track enabling the hide empty cards setting", () => {
+    visitDashboard(1);
+    editDashboard();
+
+    cy.findByTestId("dashboardcard-actions-panel").within(() => {
+      cy.icon("palette").click({ force: true });
+    });
+
+    cy.findByRole("dialog").within(() => {
+      cy.findByRole("switch", {
+        name: "Hide this card if there are no results",
+      })
+        .click() // enable
+        .click() // disable
+        .click(); // enable
+
+      expectGoodSnowplowEvent(
+        {
+          event: "card_set_to_hide_when_no_results",
+          dashboard_id: 1,
+        },
+        2,
+      );
     });
   });
 });

--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -155,13 +155,14 @@ class ChartSettings extends Component {
     if (this.props.widgets) {
       return this.props.widgets;
     } else {
-      const { isDashboard } = this.props;
+      const { isDashboard, dashboard } = this.props;
       const transformedSeries = this._getTransformedSeries();
 
       return getSettingsWidgetsForSeries(
         transformedSeries,
         this.handleChangeSettings,
         isDashboard,
+        { dashboardId: dashboard?.id },
       );
     }
   }

--- a/frontend/src/metabase/visualizations/lib/settings.js
+++ b/frontend/src/metabase/visualizations/lib/settings.js
@@ -132,6 +132,7 @@ function getSettingWidget(
       newSettings[settingId] = null;
     }
     onChangeSettings(newSettings);
+    settingDef.onUpdate?.(value, extra);
   };
   if (settingDef.useRawSeries && object._raw) {
     extra.transformedSeries = object;

--- a/frontend/src/metabase/visualizations/lib/settings/analytics.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/analytics.ts
@@ -1,0 +1,9 @@
+import { trackSchemaEvent } from "metabase/lib/analytics";
+import { DashboardId } from "metabase-types/api";
+
+export const trackCardSetToHideWhenNoResults = (dashboardId: DashboardId) => {
+  trackSchemaEvent("dashboard", "1-1-1", {
+    event: "card_set_to_hide_when_no_results",
+    dashboard_id: dashboardId,
+  });
+};

--- a/frontend/src/metabase/visualizations/lib/settings/visualization.js
+++ b/frontend/src/metabase/visualizations/lib/settings/visualization.js
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 import { assocIn } from "icepick";
 import { getVisualizationRaw } from "metabase/visualizations";
+import { trackCardSetToHideWhenNoResults } from "metabase/visualizations/lib/settings/analytics";
 import { isVirtualDashCard } from "metabase/dashboard/utils";
 import { normalizeFieldRef } from "metabase-lib/queries/utils/dataset";
 import {
@@ -31,6 +32,13 @@ const COMMON_SETTINGS = {
     inline: true,
     dashboard: true,
     getHidden: ([{ card }]) => isVirtualDashCard(card),
+    onUpdate: (value, extra) => {
+      if (!value) {
+        return;
+      }
+
+      trackCardSetToHideWhenNoResults(extra.dashboardId);
+    },
   },
   click_behavior: {},
 };
@@ -99,6 +107,7 @@ export function getSettingsWidgetsForSeries(
   series,
   onChangeSettings,
   isDashboard = false,
+  extra = {},
 ) {
   const settingsDefs = getSettingDefintionsForSeries(series);
   const storedSettings = getStoredSettingsForSeries(series);
@@ -110,7 +119,7 @@ export function getSettingsWidgetsForSeries(
     computedSettings,
     series,
     onChangeSettings,
-    { isDashboard },
+    { isDashboard, ...extra },
   ).filter(
     widget =>
       widget.dashboard === undefined || widget.dashboard === isDashboard,

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-1-1
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-1-1
@@ -21,7 +21,8 @@
         "new_text_card_created",
         "new_heading_card_created",
         "new_link_card_created",
-        "new_action_card_created"
+        "new_action_card_created",
+        "card_set_to_hide_when_no_results"
       ],
       "maxLength": 1024
     },


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31401

### Description

Adds tracking of enabling the "Hide this card if there are no results" setting

### How to verify

You need to enable anonymous tracking in the Admin -> General and [run](https://www.notion.so/metabase/Snowplow-integration-5da1f874beda4153b4fccfa6c1e77caa) the Snowplow Micro

- Open a dashboard with any card
- Edit dashboard -> open the card visualization settings
- Enable "Hide this card if there are no results"
- Ensure `card_set_to_hide_when_no_results` was sent
- Disable the setting
- Ensure `card_set_to_hide_when_no_results` was not sent

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
