### PR TITLE
Allow a join-clause to specify which join is to be renamed

### DIFF
--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -593,16 +593,10 @@
     (with-join-alias field new-name)))
 
 (defn- rename-join-in-stage
-  [stage old-name-or-index new-name]
-  (let [the-joins (:joins stage)
-        idx       (if (integer? old-name-or-index)
-                    (when (< -1 old-name-or-index (count the-joins))
-                      old-name-or-index)
-                    (some (fn [[idx a-join]]
-                            (when (= (:alias a-join) old-name-or-index)
-                              idx))
-                          (m/indexed the-joins)))
-        old-name  (get-in the-joins [idx :alias])]
+  [stage idx new-name]
+  (let [the-joins      (:joins stage)
+        [idx old-name] (when (< -1 idx (count the-joins))
+                         [idx (get-in the-joins [idx :alias])])]
     (if (and idx (not= old-name new-name))
       (let [unique-name-fn (lib.util/unique-name-generator)
             _              (run! unique-name-fn (map :alias the-joins))
@@ -613,19 +607,27 @@
       stage)))
 
 (mu/defn rename-join :- ::lib.schema/query
-  "Rename the join named `old-name-or-index`or at the (zero based) index
-  `old-name-or-index`in `a-query` at `stage-number` to `new-name`.
+  "Rename the join specified by `join-spec` in `a-query` at `stage-number` to `new-name`.
+  The join can be specified either by itself (as returned by [[joins]]), by its alias
+  or by its index in the list of joins as returned by [[joins]].
   If `stage-number` is not provided, the last stage is used.
   If the specified join cannot be found, then `query` is returned as is.
   If renaming the join to `new-name` would clash with an existing join, a
   suffix is appended to `new-name` to make it unique."
-  ([query             :- ::lib.schema/query
-    old-name-or-index :- [:or :string :int]
-    new-name          :- ::lib.schema.common/non-blank-string]
-   (rename-join query -1 old-name-or-index new-name))
+  ([query join-spec new-name]
+   (rename-join query -1 join-spec new-name))
 
-  ([query             :- ::lib.schema/query
-    stage-number      :- :int
-    old-name-or-index :- [:or :string :int]
-    new-name          :- ::lib.schema.common/non-blank-string]
-   (lib.util/update-query-stage query stage-number rename-join-in-stage old-name-or-index new-name)))
+  ([query        :- ::lib.schema/query
+    stage-number :- :int
+    join-spec    :- [:or ::lib.schema.join/join :string :int]
+    new-name     :- ::lib.schema.common/non-blank-string]
+   (if-let [idx (if (integer? join-spec)
+                  join-spec
+                  (let [pred (cond-> #{join-spec}
+                               (string? join-spec) (comp :alias))]
+                    (some (fn [[idx a-join]]
+                            (when (pred a-join)
+                              idx))
+                          (m/indexed (:joins (lib.util/query-stage query stage-number))))))]
+     (lib.util/update-query-stage query stage-number rename-join-in-stage idx new-name)
+     query)))

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -509,13 +509,14 @@
   (to-array (lib.core/joins a-query stage-number)))
 
 (defn ^:export rename-join
-  "Rename the join named `old-name-or-index`or at the (zero based) index
-  `old-name-or-index`in `a-query` at `stage-number` to `new-name`.
-  If the specified join cannot be found, then `a-query` is returned as is.
+  "Rename the join specified by `join-spec` in `a-query` at `stage-number` to `new-name`.
+  The join can be specified either by itself (as returned by [[joins]]), by its alias
+  or by its index in the list of joins as returned by [[joins]].
+  If the specified join cannot be found, then `query` is returned as is.
   If renaming the join to `new-name` would clash with an existing join, a
   suffix is appended to `new-name` to make it unique."
-  [a-query stage-number old-name-or-index new-name]
-  (lib.core/rename-join a-query stage-number old-name-or-index new-name))
+  [a-query stage-number join-spec new-name]
+  (lib.core/rename-join a-query stage-number join-spec new-name))
 
 (defn ^:export external-op
   "Convert the internal operator `clause` to the external format."

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -513,112 +513,122 @@
             (lib/join-conditions (first joins))))))
 
 (deftest ^:parallel rename-join-test
-  (testing "Missing join"
-    (let [query (lib/query meta/metadata-provider (meta/table-metadata :checkins))]
-      (testing "by name"
-        (is (= query
-               (lib/rename-join query "old-name" "new-name"))))
-      (testing "by index"
-        (are [idx]
-             (= query
-                (lib/rename-join query idx "new-name"))
-          -1 0 1))))
   (let [joined-column (-> (meta/field-metadata :venues :id)
                           (lib/with-join-alias "alias"))
-        query (-> (lib/query meta/metadata-provider (meta/table-metadata :checkins))
-                  (lib/join (-> (lib/join-clause
-                                 (meta/table-metadata :venues)
-                                 [(lib/= (meta/field-metadata :checkins :venue-id)
-                                         joined-column)])
-                                (lib/with-join-alias "alias")))
-                  (lib/filter (lib/> joined-column 3)))]
-    (testing "Simple renaming"
-      (let [renamed {:lib/type :mbql/query
-                     :database (meta/id)
-                     :stages [{:lib/type :mbql.stage/mbql,
-                               :source-table (meta/id :checkins)
-                               :joins [{:lib/type :mbql/join
-                                        :stages [{:lib/type :mbql.stage/mbql
-                                                  :source-table (meta/id :venues)}]
-                                        :conditions [[:=
-                                                      {}
-                                                      [:field
-                                                       {:base-type :type/Integer
-                                                        :effective-type :type/Integer}
-                                                       (meta/id :checkins :venue-id)]
-                                                      [:field
-                                                       {:base-type :type/BigInteger
-                                                        :effective-type :type/BigInteger
-                                                        :join-alias "locale"}
-                                                       (meta/id :venues :id)]]],
-                                        :alias "locale"}]
-                               :filters [[:>
-                                          {}
-                                          [:field
-                                           {:base-type :type/BigInteger
-                                            :effective-type :type/BigInteger
-                                            :join-alias "locale"}
-                                           (meta/id :venues :id)]
-                                          3]]}]}]
+        join-clause (-> (lib/join-clause
+                         (meta/table-metadata :venues)
+                         [(lib/= (meta/field-metadata :checkins :venue-id)
+                                 joined-column)])
+                        (lib/with-join-alias "alias"))]
+    (testing "Missing join"
+      (let [query (lib/query meta/metadata-provider (meta/table-metadata :checkins))]
         (testing "by name"
-          (is (=? renamed
-                  (lib/rename-join query "alias" "locale"))))
+          (is (= query
+                 (lib/rename-join query "old-name" "new-name"))))
         (testing "by index"
-          (is (=? renamed
-                  (lib/rename-join query 0 "locale"))))))
-    (testing "Clashing renaming"
-      (let [query' (-> query
-                       (lib/join (-> (lib/join-clause
-                                      (meta/table-metadata :users)
-                                      [(lib/= (meta/field-metadata :checkins :user-id)
-                                              (-> (meta/field-metadata :users :id)
-                                                  (lib/with-join-alias "Users")))])
-                                     (lib/with-join-alias "Users"))))
-            renamed {:lib/type :mbql/query
-                     :database (meta/id)
-                     :stages [{:lib/type :mbql.stage/mbql,
-                               :source-table (meta/id :checkins)
-                               :joins [{:lib/type :mbql/join
-                                        :stages [{:lib/type :mbql.stage/mbql
-                                                  :source-table (meta/id :venues)}]
-                                        :conditions [[:=
-                                                      {}
-                                                      [:field
-                                                       {:base-type :type/Integer
-                                                        :effective-type :type/Integer}
-                                                       (meta/id :checkins :venue-id)]
-                                                      [:field
-                                                       {:base-type :type/BigInteger
-                                                        :effective-type :type/BigInteger
-                                                        :join-alias "alias"}
-                                                       (meta/id :venues :id)]]],
-                                        :alias "alias"}
-                                       {:lib/type :mbql/join
-                                        :stages [{:lib/type :mbql.stage/mbql
-                                                  :source-table (meta/id :users)}]
-                                        :conditions [[:=
-                                                      {}
-                                                      [:field
-                                                       {:base-type :type/Integer
-                                                        :effective-type :type/Integer}
-                                                       (meta/id :checkins :user-id)]
-                                                      [:field
-                                                       {:base-type :type/BigInteger
-                                                        :effective-type :type/BigInteger
-                                                        :join-alias "alias_2"}
-                                                       (meta/id :users :id)]]],
-                                        :alias "alias_2"}]
-                               :filters [[:>
-                                          {}
-                                          [:field
-                                           {:base-type :type/BigInteger
-                                            :effective-type :type/BigInteger
-                                            :join-alias "alias"}
-                                           (meta/id :venues :id)]
-                                          3]]}]}]
-        (testing "by name"
-          (is (=? renamed
-                  (lib/rename-join query' "Users" "alias"))))
-        (testing "by index"
-          (is (=? renamed
-                  (lib/rename-join query' 1 "alias"))))))))
+          (are [idx]
+              (= query
+                 (lib/rename-join query idx "new-name"))
+              -1 0 1))
+        (testing "by join clause"
+          (is (= query
+                 (lib/rename-join query join-clause "new-name"))))))
+    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :checkins))
+                    (lib/join join-clause)
+                    (lib/filter (lib/> joined-column 3)))]
+      (testing "Simple renaming"
+        (let [renamed {:lib/type :mbql/query
+                       :database (meta/id)
+                       :stages [{:lib/type :mbql.stage/mbql,
+                                 :source-table (meta/id :checkins)
+                                 :joins [{:lib/type :mbql/join
+                                          :stages [{:lib/type :mbql.stage/mbql
+                                                    :source-table (meta/id :venues)}]
+                                          :conditions [[:=
+                                                        {}
+                                                        [:field
+                                                         {:base-type :type/Integer
+                                                          :effective-type :type/Integer}
+                                                         (meta/id :checkins :venue-id)]
+                                                        [:field
+                                                         {:base-type :type/BigInteger
+                                                          :effective-type :type/BigInteger
+                                                          :join-alias "locale"}
+                                                         (meta/id :venues :id)]]],
+                                          :alias "locale"}]
+                                 :filters [[:>
+                                            {}
+                                            [:field
+                                             {:base-type :type/BigInteger
+                                              :effective-type :type/BigInteger
+                                              :join-alias "locale"}
+                                             (meta/id :venues :id)]
+                                            3]]}]}]
+          (testing "by name"
+            (is (=? renamed
+                    (lib/rename-join query "alias" "locale"))))
+          (testing "by index"
+            (is (=? renamed
+                    (lib/rename-join query 0 "locale"))))
+          (testing "by join clause"
+            (is (=? renamed
+                    (lib/rename-join query (first (lib/joins query)) "locale"))))))
+      (testing "Clashing renaming"
+        (let [query' (-> query
+                         (lib/join (-> (lib/join-clause
+                                        (meta/table-metadata :users)
+                                        [(lib/= (meta/field-metadata :checkins :user-id)
+                                                (-> (meta/field-metadata :users :id)
+                                                    (lib/with-join-alias "Users")))])
+                                       (lib/with-join-alias "Users"))))
+              renamed {:lib/type :mbql/query
+                       :database (meta/id)
+                       :stages [{:lib/type :mbql.stage/mbql,
+                                 :source-table (meta/id :checkins)
+                                 :joins [{:lib/type :mbql/join
+                                          :stages [{:lib/type :mbql.stage/mbql
+                                                    :source-table (meta/id :venues)}]
+                                          :conditions [[:=
+                                                        {}
+                                                        [:field
+                                                         {:base-type :type/Integer
+                                                          :effective-type :type/Integer}
+                                                         (meta/id :checkins :venue-id)]
+                                                        [:field
+                                                         {:base-type :type/BigInteger
+                                                          :effective-type :type/BigInteger
+                                                          :join-alias "alias"}
+                                                         (meta/id :venues :id)]]],
+                                          :alias "alias"}
+                                         {:lib/type :mbql/join
+                                          :stages [{:lib/type :mbql.stage/mbql
+                                                    :source-table (meta/id :users)}]
+                                          :conditions [[:=
+                                                        {}
+                                                        [:field
+                                                         {:base-type :type/Integer
+                                                          :effective-type :type/Integer}
+                                                         (meta/id :checkins :user-id)]
+                                                        [:field
+                                                         {:base-type :type/BigInteger
+                                                          :effective-type :type/BigInteger
+                                                          :join-alias "alias_2"}
+                                                         (meta/id :users :id)]]],
+                                          :alias "alias_2"}]
+                                 :filters [[:>
+                                            {}
+                                            [:field
+                                             {:base-type :type/BigInteger
+                                              :effective-type :type/BigInteger
+                                              :join-alias "alias"}
+                                             (meta/id :venues :id)]
+                                            3]]}]}]
+          (testing "by name"
+            (is (=? renamed
+                    (lib/rename-join query' "Users" "alias"))))
+          (testing "by index"
+            (is (=? renamed
+                    (lib/rename-join query' 1 "alias"))))
+          (testing "by join clause"
+            (is (=? renamed
+                    (lib/rename-join query' (second (lib/joins query')) "alias")))))))))


### PR DESCRIPTION
Part of #30093.

As discussed on [Slack](https://metaboat.slack.com/archives/C04CYTEL9N2/p1687465277891479), in FE code and for symmetry, the most natural way of specifying which join is to be renamed by the join clause itself.