### PR TITLE
Markdown support in pinned items - improvements

### DIFF
--- a/frontend/src/metabase/collections/components/BaseTableItem.jsx
+++ b/frontend/src/metabase/collections/components/BaseTableItem.jsx
@@ -129,7 +129,7 @@ export function BaseTableItem({
                 name="info"
                 size={16}
                 tooltip={
-                  <Markdown disallowHeading unstyleLinks>
+                  <Markdown dark disallowHeading unstyleLinks>
                     {item.description}
                   </Markdown>
                 }

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.unit.spec.js
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.unit.spec.js
@@ -130,6 +130,29 @@ describe("PinnedItemCard", () => {
   });
 
   describe("description", () => {
+    const originalScrollWidth = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "scrollWidth",
+    );
+
+    beforeAll(() => {
+      // emulate ellipsis
+      Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+        configurable: true,
+        value: 100,
+      });
+    });
+
+    afterAll(() => {
+      if (originalScrollWidth) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          "scrollWidth",
+          originalScrollWidth,
+        );
+      }
+    });
+
     it("should render description markdown as plain text", () => {
       setup({ item: getCollectionItem({ description: MARKDOWN }) });
 

--- a/frontend/src/metabase/core/components/Ellipsified/Ellipsified.tsx
+++ b/frontend/src/metabase/core/components/Ellipsified/Ellipsified.tsx
@@ -32,6 +32,32 @@ const getIsTruncated = (element: HTMLElement): boolean => {
   );
 };
 
+const useIsTruncated = <E extends HTMLElement>() => {
+  const ref = useRef<E | null>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useLayoutEffect(() => {
+    const element = ref.current;
+
+    if (!element) {
+      return;
+    }
+
+    const handleResize = () => {
+      setIsTruncated(getIsTruncated(element));
+    };
+
+    handleResize();
+    resizeObserver.subscribe(element, handleResize);
+
+    return () => {
+      resizeObserver.unsubscribe(element, handleResize);
+    };
+  }, []);
+
+  return { isTruncated, ref };
+};
+
 const Ellipsified = ({
   style,
   className,
@@ -44,23 +70,7 @@ const Ellipsified = ({
   placement = "top",
   "data-testid": dataTestId,
 }: EllipsifiedProps) => {
-  const [isTruncated, setIsTruncated] = useState(false);
-  const rootRef = useRef<HTMLDivElement | null>(null);
-
-  useLayoutEffect(() => {
-    const element = rootRef.current;
-    if (!element) {
-      return;
-    }
-    const handleResize = () => {
-      setIsTruncated(getIsTruncated(element));
-    };
-
-    handleResize();
-    resizeObserver.subscribe(element, handleResize);
-
-    return () => resizeObserver.unsubscribe(element, handleResize);
-  }, []);
+  const { isTruncated, ref } = useIsTruncated<HTMLDivElement>();
 
   return (
     <Tooltip
@@ -70,7 +80,7 @@ const Ellipsified = ({
       placement={placement}
     >
       <EllipsifiedRoot
-        ref={rootRef}
+        ref={ref}
         className={className}
         lines={lines}
         style={style}

--- a/frontend/src/metabase/core/components/Ellipsified/Ellipsified.tsx
+++ b/frontend/src/metabase/core/components/Ellipsified/Ellipsified.tsx
@@ -1,15 +1,10 @@
-import {
-  CSSProperties,
-  ReactNode,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
+import { CSSProperties, ReactNode } from "react";
 // eslint-disable-next-line import/named
 import { Placement } from "tippy.js";
 
 import Tooltip from "metabase/core/components/Tooltip";
-import resizeObserver from "metabase/lib/resize-observer";
+import { useIsTruncated } from "metabase/hooks/use-is-truncated";
+
 import { EllipsifiedRoot } from "./Ellipsified.styled";
 
 interface EllipsifiedProps {
@@ -24,39 +19,6 @@ interface EllipsifiedProps {
   placement?: Placement;
   "data-testid"?: string;
 }
-
-const getIsTruncated = (element: HTMLElement): boolean => {
-  return (
-    element.scrollHeight > element.clientHeight ||
-    element.scrollWidth > element.offsetWidth
-  );
-};
-
-const useIsTruncated = <E extends HTMLElement>() => {
-  const ref = useRef<E | null>(null);
-  const [isTruncated, setIsTruncated] = useState(false);
-
-  useLayoutEffect(() => {
-    const element = ref.current;
-
-    if (!element) {
-      return;
-    }
-
-    const handleResize = () => {
-      setIsTruncated(getIsTruncated(element));
-    };
-
-    handleResize();
-    resizeObserver.subscribe(element, handleResize);
-
-    return () => {
-      resizeObserver.unsubscribe(element, handleResize);
-    };
-  }, []);
-
-  return { isTruncated, ref };
-};
 
 const Ellipsified = ({
   style,

--- a/frontend/src/metabase/core/components/Ellipsified/Ellipsified.tsx
+++ b/frontend/src/metabase/core/components/Ellipsified/Ellipsified.tsx
@@ -25,6 +25,13 @@ interface EllipsifiedProps {
   "data-testid"?: string;
 }
 
+const getIsTruncated = (element: HTMLElement): boolean => {
+  return (
+    element.scrollHeight > element.clientHeight ||
+    element.scrollWidth > element.offsetWidth
+  );
+};
+
 const Ellipsified = ({
   style,
   className,
@@ -46,10 +53,7 @@ const Ellipsified = ({
       return;
     }
     const handleResize = () => {
-      const isTruncated =
-        element.scrollHeight > element.clientHeight ||
-        element.offsetWidth < element.scrollWidth;
-      setIsTruncated(isTruncated);
+      setIsTruncated(getIsTruncated(element));
     };
 
     handleResize();

--- a/frontend/src/metabase/core/components/Markdown/Markdown.styled.tsx
+++ b/frontend/src/metabase/core/components/Markdown/Markdown.styled.tsx
@@ -31,7 +31,8 @@ export const MarkdownRoot = styled(getComponent(ReactMarkdown))<MarkdownProps>`
 
   hr {
     border: none;
-    border-bottom: 1px solid ${color("border")};
+    border-bottom: 1px solid
+      ${props => (props.dark ? color("bg-dark") : color("border"))};
   }
 `;
 

--- a/frontend/src/metabase/core/components/Markdown/Markdown.styled.tsx
+++ b/frontend/src/metabase/core/components/Markdown/Markdown.styled.tsx
@@ -28,6 +28,11 @@ export const MarkdownRoot = styled(getComponent(ReactMarkdown))<MarkdownProps>`
     max-width: 100%;
     height: auto;
   }
+
+  hr {
+    border: none;
+    border-bottom: 1px solid ${color("border")};
+  }
 `;
 
 function getComponent<P>(component: (props: P) => ReactElement): FC<P> {

--- a/frontend/src/metabase/core/components/Markdown/Markdown.tsx
+++ b/frontend/src/metabase/core/components/Markdown/Markdown.tsx
@@ -8,6 +8,7 @@ const REMARK_PLUGINS = [remarkGfm];
 export interface MarkdownProps
   extends ComponentPropsWithRef<typeof ReactMarkdown> {
   className?: string;
+  dark?: boolean;
   disallowHeading?: boolean;
   unstyleLinks?: boolean;
   children: string;
@@ -16,6 +17,7 @@ export interface MarkdownProps
 const Markdown = ({
   className,
   children = "",
+  dark,
   disallowHeading = false,
   unstyleLinks = false,
   ...rest
@@ -30,6 +32,7 @@ const Markdown = ({
   return (
     <MarkdownRoot
       className={className}
+      dark={dark}
       remarkPlugins={REMARK_PLUGINS}
       linkTarget={"_blank"}
       unstyleLinks={unstyleLinks}

--- a/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.styled.tsx
+++ b/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.styled.tsx
@@ -1,5 +1,7 @@
 import styled from "@emotion/styled";
 
+import { color } from "metabase/lib/colors";
+
 import Markdown from "../Markdown/Markdown";
 
 export const TruncatedMarkdown = styled(Markdown)`
@@ -9,4 +11,11 @@ export const TruncatedMarkdown = styled(Markdown)`
   overflow: hidden;
   overflow-wrap: break-word;
   white-space: pre-line;
+`;
+
+export const TooltipMarkdown = styled(Markdown)`
+  hr {
+    border: none;
+    border-bottom: 1px solid ${color("bg-dark")};
+  }
 `;

--- a/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.styled.tsx
+++ b/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.styled.tsx
@@ -1,7 +1,5 @@
 import styled from "@emotion/styled";
 
-import { color } from "metabase/lib/colors";
-
 import Markdown from "../Markdown/Markdown";
 
 export const TruncatedMarkdown = styled(Markdown)`
@@ -11,11 +9,4 @@ export const TruncatedMarkdown = styled(Markdown)`
   overflow: hidden;
   overflow-wrap: break-word;
   white-space: pre-line;
-`;
-
-export const TooltipMarkdown = styled(Markdown)`
-  hr {
-    border: none;
-    border-bottom: 1px solid ${color("bg-dark")};
-  }
 `;

--- a/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.tsx
+++ b/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.tsx
@@ -1,4 +1,6 @@
-import { ComponentProps } from "react";
+import { ComponentProps, LegacyRef } from "react";
+
+import { useIsTruncated } from "metabase/hooks/use-is-truncated";
 
 import Markdown from "../Markdown";
 import Tooltip from "../Tooltip";
@@ -17,24 +19,38 @@ export const MarkdownPreview = ({
   children,
   className,
   tooltipMaxWidth,
-}: Props) => (
-  <Tooltip
-    maxWidth={tooltipMaxWidth}
-    placement="bottom"
-    tooltip={
-      <Markdown disallowHeading unstyleLinks>
-        {children}
-      </Markdown>
-    }
-  >
-    <div>
-      <TruncatedMarkdown
-        allowedElements={ALLOWED_ELEMENTS}
-        className={className}
-        unwrapDisallowed
-      >
-        {children}
-      </TruncatedMarkdown>
-    </div>
-  </Tooltip>
-);
+}: Props) => {
+  const { isTruncated, ref } = useIsTruncated();
+
+  const setReactMarkdownRef: LegacyRef<HTMLDivElement> = divRef => {
+    /**
+     * react-markdown API does not allow passing ref to the container div.
+     * We can acquire the reference through its parent.
+     */
+    const reactMarkdownRoot = divRef?.querySelector("div");
+    ref.current = reactMarkdownRoot || null;
+  };
+
+  return (
+    <Tooltip
+      maxWidth={tooltipMaxWidth}
+      placement="bottom"
+      isEnabled={isTruncated}
+      tooltip={
+        <Markdown disallowHeading unstyleLinks>
+          {children}
+        </Markdown>
+      }
+    >
+      <div ref={setReactMarkdownRef}>
+        <TruncatedMarkdown
+          allowedElements={ALLOWED_ELEMENTS}
+          className={className}
+          unwrapDisallowed
+        >
+          {children}
+        </TruncatedMarkdown>
+      </div>
+    </Tooltip>
+  );
+};

--- a/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.tsx
+++ b/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.tsx
@@ -2,10 +2,9 @@ import { ComponentProps, LegacyRef } from "react";
 
 import { useIsTruncated } from "metabase/hooks/use-is-truncated";
 
-import Markdown from "../Markdown";
 import Tooltip from "../Tooltip";
 
-import { TruncatedMarkdown } from "./MarkdownPreview.styled";
+import { TooltipMarkdown, TruncatedMarkdown } from "./MarkdownPreview.styled";
 
 interface Props {
   children: string;
@@ -37,9 +36,9 @@ export const MarkdownPreview = ({
       placement="bottom"
       isEnabled={isTruncated}
       tooltip={
-        <Markdown disallowHeading unstyleLinks>
+        <TooltipMarkdown disallowHeading unstyleLinks>
           {children}
-        </Markdown>
+        </TooltipMarkdown>
       }
     >
       <div ref={setReactMarkdownRef}>

--- a/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.tsx
+++ b/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.tsx
@@ -3,8 +3,9 @@ import { ComponentProps, LegacyRef } from "react";
 import { useIsTruncated } from "metabase/hooks/use-is-truncated";
 
 import Tooltip from "../Tooltip";
+import Markdown from "../Markdown";
 
-import { TooltipMarkdown, TruncatedMarkdown } from "./MarkdownPreview.styled";
+import { TruncatedMarkdown } from "./MarkdownPreview.styled";
 
 interface Props {
   children: string;
@@ -36,9 +37,9 @@ export const MarkdownPreview = ({
       placement="bottom"
       isEnabled={isTruncated}
       tooltip={
-        <TooltipMarkdown disallowHeading unstyleLinks>
+        <Markdown dark disallowHeading unstyleLinks>
           {children}
-        </TooltipMarkdown>
+        </Markdown>
       }
     >
       <div ref={setReactMarkdownRef}>

--- a/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.tsx
+++ b/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.tsx
@@ -2,8 +2,8 @@ import { ComponentProps, LegacyRef } from "react";
 
 import { useIsTruncated } from "metabase/hooks/use-is-truncated";
 
-import Tooltip from "../Tooltip";
 import Markdown from "../Markdown";
+import Tooltip from "../Tooltip";
 
 import { TruncatedMarkdown } from "./MarkdownPreview.styled";
 
@@ -22,12 +22,12 @@ export const MarkdownPreview = ({
 }: Props) => {
   const { isTruncated, ref } = useIsTruncated();
 
-  const setReactMarkdownRef: LegacyRef<HTMLDivElement> = divRef => {
+  const setReactMarkdownRef: LegacyRef<HTMLDivElement> = div => {
     /**
      * react-markdown API does not allow passing ref to the container div.
      * We can acquire the reference through its parent.
      */
-    const reactMarkdownRoot = divRef?.querySelector("div");
+    const reactMarkdownRoot = div?.firstElementChild;
     ref.current = reactMarkdownRoot || null;
   };
 

--- a/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.unit.spec.tsx
@@ -35,20 +35,52 @@ describe("MarkdownPreview", () => {
     expect(screen.getByText(MARKDOWN_AS_TEXT)).toBeInTheDocument();
   });
 
-  it("should show tooltip with markdown formatting on hover", () => {
+  it("should not show tooltip with markdown formatting on hover when text is not truncated", () => {
     setup();
 
     userEvent.hover(screen.getByText(MARKDOWN_AS_TEXT));
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
 
-    const tooltip = screen.getByRole("tooltip");
-    expect(tooltip).not.toHaveTextContent(MARKDOWN);
-    expect(tooltip).not.toHaveTextContent(HEADING_1_MARKDOWN);
-    expect(tooltip).not.toHaveTextContent(HEADING_2_MARKDOWN);
-    expect(tooltip).toHaveTextContent(MARKDOWN_AS_TEXT);
+  describe("Tooltip on ellipsis", () => {
+    const originalScrollWidth = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "scrollWidth",
+    );
 
-    const image = within(tooltip).getByRole("img");
-    expect(image).toBeInTheDocument();
-    expect(image).toHaveAttribute("alt", "alt");
-    expect(image).toHaveAttribute("src", "https://example.com/img.jpg");
+    beforeAll(() => {
+      // emulate ellipsis
+      Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+        configurable: true,
+        value: 100,
+      });
+    });
+
+    afterAll(() => {
+      if (originalScrollWidth) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          "scrollWidth",
+          originalScrollWidth,
+        );
+      }
+    });
+
+    it("should show tooltip with markdown formatting on hover when text is truncated", () => {
+      setup();
+
+      userEvent.hover(screen.getByText(MARKDOWN_AS_TEXT));
+
+      const tooltip = screen.getByRole("tooltip");
+      expect(tooltip).not.toHaveTextContent(MARKDOWN);
+      expect(tooltip).not.toHaveTextContent(HEADING_1_MARKDOWN);
+      expect(tooltip).not.toHaveTextContent(HEADING_2_MARKDOWN);
+      expect(tooltip).toHaveTextContent(MARKDOWN_AS_TEXT);
+
+      const image = within(tooltip).getByRole("img");
+      expect(image).toBeInTheDocument();
+      expect(image).toHaveAttribute("alt", "alt");
+      expect(image).toHaveAttribute("src", "https://example.com/img.jpg");
+    });
   });
 });

--- a/frontend/src/metabase/hooks/use-is-truncated.ts
+++ b/frontend/src/metabase/hooks/use-is-truncated.ts
@@ -1,0 +1,36 @@
+import { useLayoutEffect, useRef, useState } from "react";
+
+import resizeObserver from "metabase/lib/resize-observer";
+
+export const useIsTruncated = <E extends HTMLElement>() => {
+  const ref = useRef<E | null>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useLayoutEffect(() => {
+    const element = ref.current;
+
+    if (!element) {
+      return;
+    }
+
+    const handleResize = () => {
+      setIsTruncated(getIsTruncated(element));
+    };
+
+    handleResize();
+    resizeObserver.subscribe(element, handleResize);
+
+    return () => {
+      resizeObserver.unsubscribe(element, handleResize);
+    };
+  }, []);
+
+  return { isTruncated, ref };
+};
+
+const getIsTruncated = (element: HTMLElement): boolean => {
+  return (
+    element.scrollHeight > element.clientHeight ||
+    element.scrollWidth > element.offsetWidth
+  );
+};

--- a/frontend/src/metabase/hooks/use-is-truncated.ts
+++ b/frontend/src/metabase/hooks/use-is-truncated.ts
@@ -2,7 +2,7 @@ import { useLayoutEffect, useRef, useState } from "react";
 
 import resizeObserver from "metabase/lib/resize-observer";
 
-export const useIsTruncated = <E extends HTMLElement>() => {
+export const useIsTruncated = <E extends Element>() => {
   const ref = useRef<E | null>(null);
   const [isTruncated, setIsTruncated] = useState(false);
 
@@ -28,9 +28,9 @@ export const useIsTruncated = <E extends HTMLElement>() => {
   return { isTruncated, ref };
 };
 
-const getIsTruncated = (element: HTMLElement): boolean => {
+const getIsTruncated = (element: Element): boolean => {
   return (
     element.scrollHeight > element.clientHeight ||
-    element.scrollWidth > element.offsetWidth
+    element.scrollWidth > element.clientWidth
   );
 };

--- a/frontend/src/metabase/lib/resize-observer.ts
+++ b/frontend/src/metabase/lib/resize-observer.ts
@@ -17,13 +17,13 @@ function createResizeObserver() {
 
   return {
     observer,
-    subscribe(target: HTMLElement, callback: ResizeObserverCallback) {
+    subscribe(target: Element, callback: ResizeObserverCallback) {
       observer.observe(target);
       const callbacks = callbacksMap.get(target) ?? [];
       callbacks.push(callback);
       callbacksMap.set(target, callbacks);
     },
-    unsubscribe(target: HTMLElement, callback: ResizeObserverCallback) {
+    unsubscribe(target: Element, callback: ResizeObserverCallback) {
       const callbacks = callbacksMap.get(target) ?? [];
       if (callbacks.length === 1) {
         observer.unobserve(target);

--- a/frontend/src/metabase/visualizations/components/ScalarValue/ScalarValue.jsx
+++ b/frontend/src/metabase/visualizations/components/ScalarValue/ScalarValue.jsx
@@ -79,7 +79,7 @@ export const ScalarTitle = ({ title, description, onClick }) => (
       <ScalarDescriptionContainer className="hover-child">
         <Tooltip
           tooltip={
-            <Markdown disallowHeading unstyleLinks>
+            <Markdown dark disallowHeading unstyleLinks>
               {description}
             </Markdown>
           }

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption.jsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption.jsx
@@ -42,7 +42,7 @@ const LegendCaption = ({
         {description && (
           <Tooltip
             tooltip={
-              <Markdown disallowHeading unstyleLinks>
+              <Markdown dark disallowHeading unstyleLinks>
                 {description}
               </Markdown>
             }

--- a/frontend/src/metabase/visualizations/components/skeletons/SkeletonCaption/SkeletonCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/skeletons/SkeletonCaption/SkeletonCaption.tsx
@@ -38,7 +38,7 @@ const SkeletonCaption = ({
           <Tooltip
             maxWidth="22em"
             tooltip={
-              <Markdown disallowHeading unstyleLinks>
+              <Markdown dark disallowHeading unstyleLinks>
                 {description}
               </Markdown>
             }

--- a/frontend/src/metabase/visualizations/components/skeletons/StaticSkeleton/StaticSkeleton.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/skeletons/StaticSkeleton/StaticSkeleton.unit.spec.tsx
@@ -27,6 +27,29 @@ function setup({ description }: { description?: string } = {}) {
 
 describe("StaticSkeleton", () => {
   describe("description", () => {
+    const originalScrollWidth = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "scrollWidth",
+    );
+
+    beforeAll(() => {
+      // emulate ellipsis
+      Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+        configurable: true,
+        value: 100,
+      });
+    });
+
+    afterAll(() => {
+      if (originalScrollWidth) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          "scrollWidth",
+          originalScrollWidth,
+        );
+      }
+    });
+
     it("should render description markdown as plain text", () => {
       setup({ description: MARKDOWN });
 


### PR DESCRIPTION
Closes #31816

### Description

This PR addresses post-merge feedback for #31251 which was a fix for #30381

Changes:
- Show pinned item description tooltip only when ellipsis is applied
- Change `<hr>` color in markdown: [screenshot](https://github.com/metabase/metabase/assets/6830683/f012f746-49ad-432e-ba17-b96c129b11ff)
- Change `<hr>` color in markdown tooltip: [screenshot](https://github.com/metabase/metabase/assets/6830683/27f2d680-429f-41f3-8e4e-017060f00588)
  - this affects other markdown tooltips, e.g. these shown when "i" icon is hovered

### Demo

#### Before

https://github.com/metabase/metabase/assets/6830683/19c69f99-529a-413f-964b-713b9cc756ff


#### After

https://github.com/metabase/metabase/assets/6830683/6ca04d40-58c1-4e60-9a72-87a0db5b79fb

