### PR TITLE
13455 column order after removal

### DIFF
--- a/e2e/test/scenarios/joins/reproductions/23293-drill-through-implicit-join-add-remove-column.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/23293-drill-through-implicit-join-add-remove-column.cy.spec.js
@@ -81,8 +81,7 @@ describe("issue 23293", () => {
 function modifyColumn(columnName, action) {
   const icon = action === "add" ? "add" : "eye_outline";
   const iconSelector = `.Icon-${icon}`;
-  const columnSeletor = `draggable-item-${columnName}`;
-  cy.findByTestId(columnSeletor).find(iconSelector).click();
+  cy.findAllByRole("listitem", { name: columnName }).find(iconSelector).click();
 }
 
 function saveQuestion() {

--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -137,12 +137,12 @@ describe("scenarios > question > settings", () => {
 
       reloadResults();
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("117.03").should("not.exist");
+      cy.findByTestId("query-builder-main")
+        .findByText("117.03")
+        .should("not.exist");
 
       // This click doesn't do anything, but simply allows the array to be updated (test gives false positive without this step)
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("More columns").click();
+      cy.findByTestId("sidebar-left").findByText("More columns").click();
 
       findColumnAtIndex("Products → Category", 5);
 
@@ -150,8 +150,6 @@ describe("scenarios > question > settings", () => {
       // https://github.com/metabase/metabase/pull/21338#pullrequestreview-928807257
 
       // Add "Address"
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      // cy.findByText("Address").siblings("button").find(".Icon-add").click();
       addColumn("Address");
 
       // The result automatically load when adding new fields but two requests are fired.

--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -171,7 +171,7 @@ describe("scenarios > question > settings", () => {
         .trigger("mousemove", 0, -100, { force: true })
         .trigger("mouseup", 0, -100, { force: true });
 
-      findColumnAtIndex("User → Address", -2);
+      findColumnAtIndex("User → Address", -3);
 
       /**
        * Helper functions related to THIS test only

--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -87,8 +87,8 @@ describe("scenarios > question > settings", () => {
       getSidebarColumns().eq("1").should("contain.text", "Total");
     });
 
-    it.skip("should preserve correct order of columns after column removal via sidebar (metabase#13455)", () => {
-      cy.viewport(2000, 1200);
+    it("should preserve correct order of columns after column removal via sidebar (metabase#13455)", () => {
+      cy.viewport(2000, 1600);
       // Orders join Products
       visitQuestionAdhoc({
         dataset_query: {
@@ -125,8 +125,8 @@ describe("scenarios > question > settings", () => {
       cy.get("@prod-category")
         .trigger("mousedown", 0, 0, { force: true })
         .trigger("mousemove", 5, 5, { force: true })
-        .trigger("mousemove", 0, -300, { force: true })
-        .trigger("mouseup", 0, -300, { force: true });
+        .trigger("mousemove", 0, -350, { force: true })
+        .trigger("mouseup", 0, -350, { force: true });
 
       reloadResults();
 
@@ -146,7 +146,7 @@ describe("scenarios > question > settings", () => {
 
       // This click doesn't do anything, but simply allows the array to be updated (test gives false positive without this step)
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Visible columns").click();
+      cy.findByText("More columns").click();
 
       findColumnAtIndex("Products → Category", 5);
 
@@ -155,7 +155,7 @@ describe("scenarios > question > settings", () => {
 
       // Add "Address"
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Address").siblings(".Icon-add").click();
+      cy.findByText("Address").siblings("button").find(".Icon-add").click();
 
       // The result automatically load when adding new fields but two requests are fired.
       // Please see: https://github.com/metabase/metabase/pull/21338#discussion_r842816687
@@ -165,10 +165,11 @@ describe("scenarios > question > settings", () => {
 
       // Move it one place up
       cy.get("@user-address")
+        .scrollIntoView()
         .trigger("mousedown", 0, 0, { force: true })
         .trigger("mousemove", 5, 5, { force: true })
-        .trigger("mousemove", 0, -50, { force: true })
-        .trigger("mouseup", 0, -50, { force: true });
+        .trigger("mousemove", 0, -100, { force: true })
+        .trigger("mouseup", 0, -100, { force: true });
 
       findColumnAtIndex("User → Address", -2);
 

--- a/e2e/test/scenarios/visualizations/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/table.cy.spec.js
@@ -32,10 +32,6 @@ describe("scenarios > visualizations > table", () => {
     selectFromDropdown("User ID");
     visualize();
 
-    function headerCells() {
-      return cy.findAllByTestId("header-cell");
-    }
-
     // Rename the first ID column, and make sure the second one is not updated
     headerCells().findByText("ID").click();
     popover().within(() => {
@@ -48,6 +44,27 @@ describe("scenarios > visualizations > table", () => {
     // click somewhere else to close the popover
     headerCells().last().click();
     headerCells().findAllByText("ID updated").should("have.length", 1);
+  });
+
+  it("should allow you to reorder columns in the table header", () => {
+    openNativeEditor().type("select * from orders LIMIT 2");
+    cy.get(".NativeQueryEditor .Icon-play").click();
+
+    cy.findByTestId("viz-settings-button").click();
+
+    cy.findByTestId(/subtotal-hide-button/i).click();
+    cy.findByTestId(/tax-hide-button/i).click();
+    cy.findByTestId("sidebar-left").findByText("Done").click();
+
+    headerCells().eq(3).should("contain.text", "TOTAL").as("total");
+
+    cy.get("@total")
+      .trigger("mousedown", 0, 0, { force: true })
+      .trigger("mousemove", 5, 5, { force: true })
+      .trigger("mousemove", -200, 0, { force: true })
+      .trigger("mouseup", -200, 0, { force: true });
+
+    headerCells().eq(1).should("contain.text", "TOTAL");
   });
 
   it("should allow to display any column as link with extrapolated url and text", () => {
@@ -253,3 +270,7 @@ describe("scenarios > visualizations > table", () => {
     popover().should("not.exist");
   });
 });
+
+function headerCells() {
+  return cy.findAllByTestId("header-cell");
+}

--- a/e2e/test/scenarios/visualizations/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/table.cy.spec.js
@@ -61,8 +61,8 @@ describe("scenarios > visualizations > table", () => {
     cy.get("@total")
       .trigger("mousedown", 0, 0, { force: true })
       .trigger("mousemove", 5, 5, { force: true })
-      .trigger("mousemove", -200, 0, { force: true })
-      .trigger("mouseup", -200, 0, { force: true });
+      .trigger("mousemove", -220, 0, { force: true })
+      .trigger("mouseup", -220, 0, { force: true });
 
     headerCells().eq(1).should("contain.text", "TOTAL");
   });

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -347,7 +347,19 @@ class TableInteractive extends Component {
   onColumnReorder(columnIndex, newColumnIndex) {
     const { settings, onUpdateVisualizationSettings } = this.props;
     const columns = settings["table.columns"].slice(); // copy since splice mutates
-    columns.splice(newColumnIndex, 0, columns.splice(columnIndex, 1)[0]);
+
+    const enabledColumns = columns
+      .map((c, index) => ({ ...c, index }))
+      .filter(c => c.enabled);
+
+    const adjustedColumnIndex = enabledColumns[columnIndex].index;
+    const adjustedNewColumnIndex = enabledColumns[newColumnIndex].index;
+
+    columns.splice(
+      adjustedNewColumnIndex,
+      0,
+      columns.splice(adjustedColumnIndex, 1)[0],
+    );
     onUpdateVisualizationSettings({
       "table.columns": columns,
     });

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
@@ -108,16 +108,18 @@ export const ChartSettingOrderedColumns = ({
   );
 
   return (
-    <div className="list">
+    <div className="list" role="list">
       {enabledColumns.length > 0 ? (
-        <ChartSettingOrderedItems
-          items={enabledColumns}
-          getItemName={getColumnName}
-          onEdit={handleEdit}
-          onRemove={handleDisable}
-          onSortEnd={handleSortEnd}
-          distance={5}
-        />
+        <div role="group" title="visible-columns">
+          <ChartSettingOrderedItems
+            items={enabledColumns}
+            getItemName={getColumnName}
+            onEdit={handleEdit}
+            onRemove={handleDisable}
+            onSortEnd={handleSortEnd}
+            distance={5}
+          />
+        </div>
       ) : (
         <div className="my2 p2 flex layout-centered bg-grey-0 text-light text-bold rounded">
           {t`Add fields from the list below`}
@@ -133,6 +135,7 @@ export const ChartSettingOrderedColumns = ({
             title={getColumnName(columnSetting)}
             onAdd={() => handleEnable(columnSetting)}
             onClick={() => handleEnable(columnSetting)}
+            role="listitem"
           />
         ))}
       </div>
@@ -143,6 +146,7 @@ export const ChartSettingOrderedColumns = ({
               key={index}
               title={dimension.displayName()}
               onAdd={() => handleAddNewField(dimension.mbql())}
+              role="listitem"
             />
           ))}
           {additionalFieldOptions.fks.map((fk, index) => (
@@ -158,6 +162,7 @@ export const ChartSettingOrderedColumns = ({
                   key={index}
                   title={dimension.displayName()}
                   onAdd={() => handleAddNewField(dimension.mbql())}
+                  role="listitem"
                 />
               ))}
             </div>

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
@@ -94,8 +94,21 @@ export const ChartSettingOrderedColumns = ({
 
   const handleAddNewField = useCallback(
     fieldRef => {
-      const columnSettings = [...value, { fieldRef, enabled: true }];
-      onChange(columnSettings);
+      const columnSettingIndex = value.findIndex(columnSetting =>
+        _.isEqual(fieldRef, columnSetting.fieldRef),
+      );
+
+      if (columnSettingIndex >= 0) {
+        const columnSettings = [...value];
+        columnSettings[columnSettingIndex] = {
+          ...columnSettings[columnSettingIndex],
+          enabled: true,
+        };
+        onChange(columnSettings);
+      } else {
+        const columnSettings = [...value, { fieldRef, enabled: true }];
+        onChange(columnSettings);
+      }
     },
     [value, onChange],
   );

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
@@ -24,10 +24,10 @@ export const ChartSettingOrderedColumns = ({
     () =>
       _.partition(
         value
+          .map((columnSetting, index) => ({ ...columnSetting, index }))
           .filter(columnSetting =>
             findColumnForColumnSetting(columns, columnSetting),
-          )
-          .map((columnSetting, index) => ({ ...columnSetting, index })),
+          ),
         columnSetting => columnSetting.enabled,
       ),
     [value, columns],

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems.tsx
@@ -58,6 +58,7 @@ const SortableColumn = SortableElement(function SortableColumn<
       }
       color={item.color}
       draggable={!isDragDisabled}
+      role="listitem"
     />
   );
 }) as unknown as <T extends SortableItem>(

--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem.jsx
@@ -42,6 +42,7 @@ const ColumnItem = ({
       isDraggable={draggable}
       data-testid={draggable ? `draggable-item-${title}` : null}
       {...props}
+      title={props.role ? title : null}
     >
       <ColumnItemContainer>
         {draggable && <ColumnItemDragHandle name="grabber" />}

--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem.jsx
@@ -33,13 +33,15 @@ const ColumnItem = ({
   onColorChange,
   draggable,
   className = "",
+  ...props
 }) => {
   return (
     <ColumnItemRoot
       className={className}
       onClick={onClick}
       isDraggable={draggable}
-      data-testid={draggable && `draggable-item-${title}`}
+      data-testid={draggable ? `draggable-item-${title}` : null}
+      {...props}
     >
       <ColumnItemContainer>
         {draggable && <ColumnItemDragHandle name="grabber" />}

--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem.jsx
@@ -39,7 +39,7 @@ const ColumnItem = ({
       className={className}
       onClick={onClick}
       isDraggable={draggable}
-      data-testid={`draggable-item-${title}`}
+      data-testid={draggable && `draggable-item-${title}`}
     >
       <ColumnItemContainer>
         {draggable && <ColumnItemDragHandle name="grabber" />}

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -534,19 +534,22 @@ export const tableColumnSettings = {
     title: t`Columns`,
     widget: ChartSettingOrderedColumns,
     getHidden: (series, vizSettings) => vizSettings["table.pivot"],
-    isValid: ([{ card, data }]) =>
+    isValid: ([{ card, data }]) => {
+      const columns = card.visualization_settings["table.columns"];
+      const enabledColumns = columns.filter(column => column.enabled);
       // If "table.columns" happened to be an empty array,
       // it will be treated as "all columns are hidden",
       // This check ensures it's not empty,
       // otherwise it will be overwritten by `getDefault` below
-      card.visualization_settings["table.columns"].length !== 0 &&
-      _.all(
-        card.visualization_settings["table.columns"].filter(
-          columnSetting => columnSetting.enabled,
-        ),
-        columnSetting =>
-          findColumnIndexForColumnSetting(data.cols, columnSetting) >= 0,
-      ),
+      return (
+        card.visualization_settings["table.columns"].length !== 0 &&
+        _.all(
+          enabledColumns,
+          columnSetting =>
+            findColumnIndexForColumnSetting(data.cols, columnSetting) >= 0,
+        )
+      );
+    },
     getDefault: ([
       {
         data: { cols },

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -541,7 +541,9 @@ export const tableColumnSettings = {
       // otherwise it will be overwritten by `getDefault` below
       card.visualization_settings["table.columns"].length !== 0 &&
       _.all(
-        card.visualization_settings["table.columns"],
+        card.visualization_settings["table.columns"].filter(
+          columnSetting => columnSetting.enabled,
+        ),
         columnSetting =>
           findColumnIndexForColumnSetting(data.cols, columnSetting) >= 0,
       ),


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/13455

### Description
2 main adjusts here is:
- `table.columns` is valid check only cares about enabled columns now. This makes sense as disabled columns won't come back in `data.cols`
- Another adjustment to `ChartSettingOrderedColumns` to apply original indexes *before* filtering out any settings that don't have a matching column.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Orders + Products
2. Move Products -> Category up above Total
3. Hide Total
4. Products -> Category should still be in it's original position

### Demo
![chrome_hlGp7z8Y1x](https://github.com/metabase/metabase/assets/1328979/2c2b9203-fca9-4842-9ade-ab3e7e63d809)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
