### PR TITLE
Fix typo in macro name in i18n build script

### DIFF
--- a/bin/build/src/i18n/enumerate.clj
+++ b/bin/build/src/i18n/enumerate.clj
@@ -60,7 +60,7 @@
     'metabase.shared.util.i18n/trs})
 
 (def ^:private plural-translation-macro-names
-  #{"trsn" "trsu" "deferred-trsn" "deferred-trun"})
+  #{"trsn" "trun" "deferred-trsn" "deferred-trun"})
 
 (s/def ::translate (s/and
                      (complement vector?)


### PR DESCRIPTION
The macro is called `trun` and not `trsn`, so it wasn't getting picked up correctly by the build script. Discovered in https://github.com/metabase/metabase/pull/31501 but fortunately nobody else has tried to use that macro yet in the code base so it hasn't been an issue. 