### PR TITLE
Automatically expand the native query editor when editing a question from a dashboard

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
@@ -71,6 +71,22 @@ describe("scenarios > dashboard > dashboard back navigation", () => {
     cy.findByLabelText(backButtonLabel).should("not.exist");
   });
 
+  it("should expand the native editor when editing a question from a dashboard", () => {
+    createDashboardWithNativeCard();
+    cy.get("@dashboardId").then(visitDashboard);
+    getDashboardCard().realHover();
+    getDashboardCardMenu().click();
+    popover().findByText("Edit question").click();
+    cy.findByTestId("native-query-editor").should("be.visible");
+
+    queryBuilderHeader().findByLabelText("Back to Test Dashboard").click();
+    getDashboardCard().findByText("Orders SQL").click();
+    cy.findByTestId("native-query-top-bar")
+      .findByText("This question is written in SQL.")
+      .should("be.visible");
+    cy.findByTestId("native-query-editor").should("not.be.visible");
+  });
+
   it("should display a back to the dashboard button in table x-ray dashboards", () => {
     const cardTitle = "Sales per state";
     cy.visit(`/auto/dashboard/table/${ORDERS_ID}`);
@@ -338,6 +354,19 @@ const createDashboardWithCards = () => {
 
     cy.wrap(dashboard_id).as("dashboardId");
   });
+};
+
+const createDashboardWithNativeCard = () => {
+  const questionDetails = {
+    name: "Orders SQL",
+    native: {
+      query: "SELECT * FROM ORDERS",
+    },
+  };
+
+  cy.createNativeQuestionAndDashboard({ questionDetails }).then(
+    ({ body: { dashboard_id } }) => cy.wrap(dashboard_id).as("dashboardId"),
+  );
 };
 
 const createDashboardWithSlowCard = () => {

--- a/frontend/src/metabase-types/store/mocks/qb.ts
+++ b/frontend/src/metabase-types/store/mocks/qb.ts
@@ -1,5 +1,5 @@
 import {
-  QueryBuilderDashboardControls,
+  QueryBuilderDashboardState,
   QueryBuilderState,
   QueryBuilderUIControls,
 } from "metabase-types/store";
@@ -27,9 +27,9 @@ export const createMockQueryBuilderUIControlsState = (
   ...opts,
 });
 
-export const createMockQueryBuilderDashboardControls = (
-  opts?: Partial<QueryBuilderDashboardControls>,
-): QueryBuilderDashboardControls => ({
+export const createMockQueryBuilderDashboardState = (
+  opts?: Partial<QueryBuilderDashboardState>,
+): QueryBuilderDashboardState => ({
   dashboardId: null,
   isEditing: false,
   ...opts,
@@ -44,7 +44,7 @@ export const createMockQueryBuilderState = (
     documentTitle: "",
     timeoutId: "",
   },
-  dashboardControls: createMockQueryBuilderDashboardControls(),
+  parentDashboard: createMockQueryBuilderDashboardState(),
 
   queryStatus: "complete",
   queryResults: null,

--- a/frontend/src/metabase-types/store/mocks/qb.ts
+++ b/frontend/src/metabase-types/store/mocks/qb.ts
@@ -1,4 +1,5 @@
 import {
+  QueryBuilderDashboardControls,
   QueryBuilderState,
   QueryBuilderUIControls,
 } from "metabase-types/store";
@@ -18,10 +19,19 @@ export const createMockQueryBuilderUIControlsState = (
   isShowingTimelineSidebar: false,
   initialChartSetting: null,
   isShowingRawTable: false,
+  isNativeEditorOpen: false,
   queryBuilderMode: "view",
   previousQueryBuilderMode: false,
   snippetCollectionId: null,
   datasetEditorTab: "query",
+  ...opts,
+});
+
+export const createMockQueryBuilderDashboardControls = (
+  opts?: Partial<QueryBuilderDashboardControls>,
+): QueryBuilderDashboardControls => ({
+  dashboardId: null,
+  isEditing: false,
   ...opts,
 });
 
@@ -34,6 +44,7 @@ export const createMockQueryBuilderState = (
     documentTitle: "",
     timeoutId: "",
   },
+  dashboardControls: createMockQueryBuilderDashboardControls(),
 
   queryStatus: "complete",
   queryResults: null,

--- a/frontend/src/metabase-types/store/qb.ts
+++ b/frontend/src/metabase-types/store/qb.ts
@@ -1,5 +1,6 @@
 import {
   Card,
+  DashboardId,
   Dataset,
   Field,
   ParameterValueOrArray,
@@ -25,6 +26,7 @@ export interface QueryBuilderUIControls {
   isShowingChartSettingsSidebar: boolean;
   isShowingQuestionDetailsSidebar: boolean;
   isShowingTimelineSidebar: boolean;
+  isNativeEditorOpen: boolean;
   initialChartSetting: null;
   isShowingRawTable: boolean;
   queryBuilderMode: QueryBuilderMode;
@@ -39,10 +41,15 @@ export interface QueryBuilderLoadingControls {
   timeoutId: string;
 }
 
+export interface QueryBuilderDashboardControls {
+  dashboardId: DashboardId | null;
+  isEditing: boolean;
+}
+
 export interface QueryBuilderState {
   uiControls: QueryBuilderUIControls;
-
   loadingControls: QueryBuilderLoadingControls;
+  dashboardControls: QueryBuilderDashboardControls;
   queryStatus: QueryBuilderQueryStatus;
   queryResults: Dataset[] | null;
   queryStartTime: number | null;

--- a/frontend/src/metabase-types/store/qb.ts
+++ b/frontend/src/metabase-types/store/qb.ts
@@ -41,7 +41,7 @@ export interface QueryBuilderLoadingControls {
   timeoutId: string;
 }
 
-export interface QueryBuilderDashboardControls {
+export interface QueryBuilderDashboardState {
   dashboardId: DashboardId | null;
   isEditing: boolean;
 }
@@ -49,7 +49,7 @@ export interface QueryBuilderDashboardControls {
 export interface QueryBuilderState {
   uiControls: QueryBuilderUIControls;
   loadingControls: QueryBuilderLoadingControls;
-  dashboardControls: QueryBuilderDashboardControls;
+  parentDashboard: QueryBuilderDashboardState;
   queryStatus: QueryBuilderQueryStatus;
   queryResults: Dataset[] | null;
   queryStartTime: number | null;

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -13,6 +13,7 @@ import Snippets from "metabase/entities/snippets";
 import Questions from "metabase/entities/questions";
 import { loadMetadataForCard } from "metabase/questions/actions";
 import { fetchAlertsForQuestion } from "metabase/alert/alert";
+import { getIsEditingInDashboard } from "metabase/query_builder/selectors";
 
 import { Card } from "metabase-types/api";
 import {
@@ -28,12 +29,12 @@ import Question from "metabase-lib/Question";
 import NativeQuery, {
   updateCardTemplateTagNames,
 } from "metabase-lib/queries/NativeQuery";
-import StructuredQuery from "metabase-lib/queries/StructuredQuery";
 
+import StructuredQuery from "metabase-lib/queries/StructuredQuery";
 import { getQueryBuilderModeFromLocation } from "../../typed-utils";
 import { updateUrl } from "../navigation";
-import { cancelQuery, runQuestionQuery } from "../querying";
 
+import { cancelQuery, runQuestionQuery } from "../querying";
 import { resetQB } from "./core";
 import {
   propagateDashboardParameters,
@@ -312,6 +313,11 @@ async function handleQBInit(
       uiControls.isShowingNewbModal = true;
       MetabaseAnalytics.trackStructEvent("QueryBuilder", "Show Newb Modal");
     }
+  }
+
+  if (question.isNative()) {
+    const isEditing = getIsEditingInDashboard(getState());
+    uiControls.isNativeEditorOpen = isEditing || !question.isSaved();
   }
 
   if (question.isNative() && !question.query().readOnly()) {

--- a/frontend/src/metabase/query_builder/components/QueryModals.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.tsx
@@ -31,7 +31,7 @@ import PreviewQueryModal from "metabase/query_builder/components/view/PreviewQue
 import ConvertQueryModal from "metabase/query_builder/components/view/ConvertQueryModal";
 import QuestionMoveToast from "metabase/questions/components/QuestionMoveToast";
 import { Alert, Card, Collection, User } from "metabase-types/api";
-import { QueryBuilderMode } from "metabase-types/store";
+import { QueryBuilderMode, QueryBuilderUIControls } from "metabase-types/store";
 import StructuredQuery from "metabase-lib/queries/StructuredQuery";
 import Question from "metabase-lib/Question";
 import { UpdateQuestionOpts } from "../actions/core/updateQuestion";
@@ -51,6 +51,7 @@ interface QueryModalsProps {
   initialCollectionId: number;
   updateQuestion: (question: Question, config?: UpdateQuestionOpts) => void;
   setQueryBuilderMode: (mode: QueryBuilderMode) => void;
+  setUIControls: (opts: Partial<QueryBuilderUIControls>) => void;
   originalQuestion: Question | null;
   card: Card;
   onCreate: (question: Question) => void;
@@ -99,6 +100,7 @@ class QueryModals extends Component<QueryModalsProps> {
       onOpenModal,
       updateQuestion,
       setQueryBuilderMode,
+      setUIControls,
     } = this.props;
 
     switch (modal) {
@@ -345,6 +347,7 @@ class QueryModals extends Component<QueryModalsProps> {
           <Modal fit onClose={onCloseModal}>
             <ConvertQueryModal
               onUpdateQuestion={updateQuestion}
+              onSetUIControls={setUIControls}
               onClose={onCloseModal}
             />
           </Modal>

--- a/frontend/src/metabase/query_builder/components/view/ConvertQueryModal/ConvertQueryModal.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ConvertQueryModal/ConvertQueryModal.tsx
@@ -9,7 +9,7 @@ import {
   getQuestion,
 } from "metabase/query_builder/selectors";
 import { NativeQueryForm } from "metabase-types/api";
-import { State } from "metabase-types/store";
+import { QueryBuilderUIControls, State } from "metabase-types/store";
 import Question from "metabase-lib/Question";
 
 import NativeQueryModal, { useNativeQuery } from "../NativeQueryModal";
@@ -33,7 +33,8 @@ interface UpdateQuestionOpts {
 interface ConvertQueryModalProps {
   question: Question;
   onLoadQuery: () => Promise<NativeQueryForm>;
-  onUpdateQuestion?: (question: Question, opts?: UpdateQuestionOpts) => void;
+  onUpdateQuestion: (question: Question, opts?: UpdateQuestionOpts) => void;
+  onSetUIControls: (changes: Partial<QueryBuilderUIControls>) => void;
   onClose?: () => void;
 }
 
@@ -41,6 +42,7 @@ const ConvertQueryModal = ({
   question,
   onLoadQuery,
   onUpdateQuestion,
+  onSetUIControls,
   onClose,
 }: ConvertQueryModalProps): JSX.Element => {
   const engineType = getEngineNativeType(question.database()?.engine);
@@ -55,8 +57,9 @@ const ConvertQueryModal = ({
     const newQuestion = question.setDatasetQuery(newDatasetQuery);
 
     onUpdateQuestion?.(newQuestion, { shouldUpdateUrl: true });
+    onSetUIControls({ isNativeEditorOpen: true });
     onClose?.();
-  }, [question, query, onUpdateQuestion, onClose]);
+  }, [question, query, onUpdateQuestion, onSetUIControls, onClose]);
 
   return (
     <NativeQueryModal

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -296,7 +296,8 @@ class View extends Component {
   };
 
   renderNativeQueryEditor = () => {
-    const { question, query, card, height, isDirty } = this.props;
+    const { question, query, card, height, isDirty, isNativeEditorOpen } =
+      this.props;
 
     // Normally, when users open native models,
     // they open an ad-hoc GUI question using the model as a data source
@@ -315,6 +316,7 @@ class View extends Component {
           {...this.props}
           viewHeight={height}
           isOpen={query.isEmpty() || isDirty}
+          isInitiallyOpen={isNativeEditorOpen}
           datasetQuery={card && card.dataset_query}
         />
       </NativeQueryEditorContainer>

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -97,7 +97,7 @@ const DEFAULT_LOADING_CONTROLS = {
   timeoutId: "",
 };
 
-const DEFAULT_DASHBOARD_CONTROLS = {
+const DEFAULT_DASHBOARD_STATE = {
   dashboardId: null,
   isEditing: false,
 };
@@ -554,7 +554,7 @@ export const currentState = handleActions(
   null,
 );
 
-export const dashboardControls = handleActions(
+export const parentDashboard = handleActions(
   {
     [NAVIGATE_TO_NEW_CARD]: {
       next: (state, { payload: { dashboardId } }) => ({
@@ -568,9 +568,9 @@ export const dashboardControls = handleActions(
         isEditing: true,
       }),
     },
-    [CLOSE_QB]: { next: () => DEFAULT_DASHBOARD_CONTROLS },
+    [CLOSE_QB]: { next: () => DEFAULT_DASHBOARD_STATE },
   },
-  DEFAULT_DASHBOARD_CONTROLS,
+  DEFAULT_DASHBOARD_STATE,
 );
 
 export const visibleTimelineEventIds = handleActions(

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -82,6 +82,7 @@ const DEFAULT_UI_CONTROLS = {
   isShowingChartSettingsSidebar: false,
   isShowingQuestionInfoSidebar: false,
   isShowingTimelineSidebar: false,
+  isNativeEditorOpen: false,
   initialChartSetting: null,
   isShowingRawTable: false, // table/viz toggle
   queryBuilderMode: false, // "view" | "notebook" | "dataset"
@@ -94,6 +95,11 @@ const DEFAULT_LOADING_CONTROLS = {
   showLoadCompleteFavicon: false,
   documentTitle: "",
   timeoutId: "",
+};
+
+const DEFAULT_DASHBOARD_CONTROLS = {
+  dashboardId: null,
+  isEditing: false,
 };
 
 const DEFAULT_QUERY_STATUS = "idle";
@@ -548,17 +554,23 @@ export const currentState = handleActions(
   null,
 );
 
-export const dashboardId = handleActions(
+export const dashboardControls = handleActions(
   {
     [NAVIGATE_TO_NEW_CARD]: {
-      next: (state, { payload: { dashboardId } }) => dashboardId,
+      next: (state, { payload: { dashboardId } }) => ({
+        dashboardId,
+        isEditing: false,
+      }),
     },
     [EDIT_QUESTION]: {
-      next: (state, { payload: { dashboardId } }) => dashboardId,
+      next: (state, { payload: { dashboardId } }) => ({
+        dashboardId,
+        isEditing: true,
+      }),
     },
-    [CLOSE_QB]: { next: () => null },
+    [CLOSE_QB]: { next: () => DEFAULT_DASHBOARD_CONTROLS },
   },
-  null,
+  DEFAULT_DASHBOARD_CONTROLS,
 );
 
 export const visibleTimelineEventIds = handleActions(

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -941,11 +941,11 @@ export const getNativeQueryFn = createSelector(
 );
 
 export const getDashboardId = state => {
-  return state.qb.dashboardControls.dashboardId;
+  return state.qb.parentDashboard.dashboardId;
 };
 
 export const getIsEditingInDashboard = state => {
-  return state.qb.dashboardControls.isEditing;
+  return state.qb.parentDashboard.isEditing;
 };
 
 export const getDashboard = state => {

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -941,7 +941,11 @@ export const getNativeQueryFn = createSelector(
 );
 
 export const getDashboardId = state => {
-  return state.qb.dashboardId;
+  return state.qb.dashboardControls.dashboardId;
+};
+
+export const getIsEditingInDashboard = state => {
+  return state.qb.dashboardControls.isEditing;
 };
 
 export const getDashboard = state => {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/31718

How to verify:
- Open a dashboard with native questions
- Click on the menu -> Edit question
- The native query editor should be automatically expanded
- Navigating to a saved question any other way shouldn't expand the editor by default, as before

<img width="1033" alt="Screenshot 2023-06-26 at 18 47 04" src="https://github.com/metabase/metabase/assets/8542534/4e1f2ddd-b9a0-4992-b1d3-d56d960d37e8">
<img width="1728" alt="Screenshot 2023-06-26 at 18 47 14" src="https://github.com/metabase/metabase/assets/8542534/08c9a735-59e6-4afb-be56-fef03160c9e3">
