### PR TITLE
Do not auto-run native queries after saving a question

### DIFF
--- a/e2e/test/scenarios/question/reproductions/30165-native-query-autorun.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/30165-native-query-autorun.cy.spec.js
@@ -1,0 +1,45 @@
+import {
+  modal,
+  openNativeEditor,
+  queryBuilderHeader,
+  restore,
+} from "e2e/support/helpers";
+
+describe("issue 30165", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+    cy.intercept("POST", "/api/card").as("createQuestion");
+    cy.intercept("PUT", "/api/card/*").as("updateQuestion");
+  });
+
+  it("should not autorun native queries after updating a question (metabase#30165)", () => {
+    openNativeEditor();
+    cy.findByTestId("native-query-editor").type("SELECT * FROM ORDERS");
+    queryBuilderHeader().findByText("Save").click();
+    modal().within(() => {
+      cy.findByLabelText("Name").clear().type("Q1");
+      cy.button("Save").click();
+    });
+    cy.wait("@createQuestion");
+    modal().button("Not now").click();
+
+    cy.findByTestId("native-query-editor").type(" WHERE TOTAL < 20");
+    queryBuilderHeader().findByText("Save").click();
+    modal().button("Save").click();
+    cy.wait("@updateQuestion");
+
+    cy.findByTestId("native-query-editor").type(" LIMIT 10");
+    queryBuilderHeader().findByText("Save").click();
+    modal().button("Save").click();
+    cy.wait("@updateQuestion");
+
+    cy.get("@dataset.all").should("have.length", 0);
+    cy.get("@cardQuery.all").should("have.length", 0);
+    cy.findByTestId("query-builder-main")
+      .findByText("Here's where your results will appear")
+      .should("be.visible");
+  });
+});

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -238,7 +238,9 @@ export const apiUpdateQuestion = (question, { rerunQuery } = {}) => {
       );
     }
 
-    rerunQuery = rerunQuery ?? isResultDirty;
+    if (question.isStructured()) {
+      rerunQuery = rerunQuery ?? isResultDirty;
+    }
 
     // Needed for persisting visualization columns for pulses/alerts, see #6749
     const series = getTransformedSeries(getState());


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/30165
Reproduces https://github.com/metabase/metabase/issues/30165
Regression since https://github.com/metabase/metabase/pull/25681

Previously we auto-run the query when it's changed when saving the question. Now we do that for GUI questions only.

How to verify:
- New -> SQL query
- Type some query and save the question
- Update the query and save it again
- The query should not run automatically now; you should see "Here's where your results will appear"

<img width="1727" alt="Screenshot 2023-06-27 at 15 42 23" src="https://github.com/metabase/metabase/assets/8542534/9dbee7a6-5b22-4380-9d8c-c0d6561b5dc8">


