### PR TITLE
[MLv2] Add a better effective-type when missing from value clause

### DIFF
--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -10,6 +10,7 @@
    [metabase.lib.hierarchy :as lib.hierarchy]
    [metabase.lib.options :as lib.options]
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.lib.util :as lib.util]
    [metabase.util :as u]
    [metabase.util.log :as log]))
@@ -201,10 +202,10 @@
                                     :semantic_type :semantic-type
                                     :database_type :database-type})
         ;; in pMBQL, `:effective-type` is a required key for `:value`. `:value` SHOULD have always had `:base-type`,
-        ;; but on the off chance it did not give this `:type/*` so the schema doesn't fail entirely.
+        ;; but on the off chance it did not, get the type from value so the schema doesn't fail entirely.
         opts (assoc opts :effective-type (or (:effective-type opts)
                                              (:base-type opts)
-                                             :type/*))]
+                                             (lib.schema.expression/type-of value)))]
     (lib.options/ensure-uuid [:value opts value])))
 
 (defmethod ->pMBQL :case

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -244,6 +244,8 @@
 
     [:value nil {:base_type :type/Number}]
 
+    [:value "TX" nil]
+
     [:expression "expr" {:display-name "Iambic Diameter"}]
 
     ;; (#29950)
@@ -456,7 +458,10 @@
                 pMBQL)))
       (testing "Round trip: make sure we convert back to `snake_case` when converting back."
         (is (= original
-               (lib.convert/->legacy-MBQL pMBQL)))))))
+               (lib.convert/->legacy-MBQL pMBQL))))))
+  (testing "Type is filled in properly when missing"
+    (is (=? [:value {:effective-type :type/Text} "TX"]
+            (lib.convert/->pMBQL [:value "TX" nil])))))
 
 (deftest ^:parallel clean-test
   (testing "irrecoverable queries"


### PR DESCRIPTION
Fixes #31775

There could be a couple strange things going on here. This fixes the one related to MLv2.
We were falling back to `type/*`when converting value queries, but we can be smarter about it by inferring a type from the `value`. 

In the repro: The `case` statement was invalid because the `=` could not determine that `:type/Text` and `:type/*` are comparable. This caused `something2` to be cleaned and confused the query processor that was trying to split the stage for the aggregation.

Open questions:
1. I'm not sure why `"TX"` is replaced with `[:value "TX" nil]` without an effective-type by the preprocessor.
2. It seems that `lib.convert/->pMBQL` is called on the original query and also the preprocessed query (and possibly at more points), but I didn't investigate this.
