### PR TITLE
Fix MLv1 join validation

### DIFF
--- a/e2e/test/scenarios/joins/reproductions/31769-mlv2-join-dropped.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/31769-mlv2-join-dropped.cy.spec.js
@@ -1,0 +1,87 @@
+import {
+  popover,
+  restore,
+  startNewQuestion,
+  selectSavedQuestionsToJoin,
+  visualize,
+} from "e2e/support/helpers";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, PEOPLE, PEOPLE_ID } =
+  SAMPLE_DATABASE;
+
+const Q1 = {
+  "source-table": ORDERS_ID,
+  joins: [
+    {
+      fields: "all",
+      alias: "Products",
+      "source-table": PRODUCTS_ID,
+      condition: [
+        "=",
+        ["field", ORDERS.PRODUCT_ID, null],
+        ["field", PRODUCTS.ID, { "join-alias": "Products" }],
+      ],
+    },
+    {
+      fields: "all",
+      alias: "People — User",
+      "source-table": PEOPLE_ID,
+      condition: [
+        "=",
+        ["field", ORDERS.USER_ID, null],
+        ["field", PEOPLE.ID, { "join-alias": "People — User" }],
+      ],
+    },
+  ],
+  aggregation: [["count"]],
+  breakout: [
+    [
+      "field",
+      PRODUCTS.CATEGORY,
+      { "base-type": "type/Text", "join-alias": "Products" },
+    ],
+  ],
+};
+
+const Q2 = {
+  "source-table": PRODUCTS_ID,
+  aggregation: [["count"]],
+  breakout: [["field", PRODUCTS.CATEGORY, { "base-type": "type/Text" }]],
+};
+
+describe("issue 31769", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createQuestion({ name: "Q1", query: Q1 }).then(() => {
+      cy.createQuestion({ name: "Q2", query: Q2 }).then(response => {
+        cy.wrap(response.body.id).as("card_id_q2");
+        startNewQuestion();
+      });
+    });
+  });
+
+  it("shouldn't drop joins using MLv2 format (metabase#31769)", () => {
+    selectSavedQuestionsToJoin("Q1", "Q2");
+
+    popover().findByText("Products → Category").click();
+    popover().findByText("Category").click();
+
+    visualize();
+
+    // Asserting there're two columns from Q1 and two columns from Q2
+    cy.findAllByTestId("header-cell").should("have.length", 4);
+
+    cy.get("@card_id_q2").then(cardId => {
+      cy.findByTestId("TableInteractive-root")
+        .findByText(`Question ${cardId} → Category`)
+        .should("exist");
+    });
+
+    cy.findByTestId("TableInteractive-root")
+      .findByText("Products → Category")
+      .should("exist");
+  });
+});

--- a/frontend/src/metabase-lib/queries/structured/Join.ts
+++ b/frontend/src/metabase-lib/queries/structured/Join.ts
@@ -661,7 +661,9 @@ export default class Join extends MBQLObjectClause {
     const dimensions = [...this.parentDimensions(), ...this.joinDimensions()];
     return dimensions.every(
       dimension =>
-        dimensionOptions.hasDimension(dimension.getMLv1CompatibleDimension()) || // For some GUI queries created in earlier versions of Metabase,
+        dimensionOptions.hasDimension(dimension) ||
+        dimensionOptions.hasDimension(dimension.getMLv1CompatibleDimension()) ||
+        // For some GUI queries created in earlier versions of Metabase,
         // some dimensions are described as field literals
         // Usually it's [ "field", field_numeric_id, null|object ]
         // And field literals look like [ "field", "PRODUCT_ID", {'base-type': 'type/Integer' } ]


### PR DESCRIPTION
Fixes #31769

Earlier, we extended Join's `isValid` method with a `dimension.getMLv1CompatibleDimension` to ensure joins work well with columns coming from MLv2. I missed the point that query's `dimensionOptions` could have columns with MLv2-style field references. In #31769 it happened when trying to join to saved questions together by breakout columns. These breakout columns have a `base-type` option in their field references. When validating a join, dimension options would have this `base-type` there, but `dimension.getMLv1CompatibleDimension` would drop the option for a join dimension, and the whole join will end up invalid. Fixed by accepting `dimension || dimension.getMLv1CompatibleDimension()` as valid.

Note on tests: I'm adding an E2E here without unit test coverage for two reasons:

1. It'd help to ensure things are working as expected once joins are ported to MLv2
2. It turned out to be pretty hard to setup a Jest tests with two complex questions in `metadata` + an ad-hoc query joining them together. I'm worried spending more time on that will be useless as we'll drop the test suite anyway once joins are ported to MLv2

### How to verify

Follow to repro steps from #31769
On that branch, once you run the final query, the join shouldn't be dropped and you should see columns from both joined questions

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
