### PR TITLE
Fix `revoke-db-schema-permissions!` helper function so that it never revokes native perms

### DIFF
--- a/e2e/test/scenarios/permissions/impersonated.cy.spec.js
+++ b/e2e/test/scenarios/permissions/impersonated.cy.spec.js
@@ -59,35 +59,24 @@ describeEE("impersonated permission", () => {
       cy.get("main").findByText("QA Postgres12").click();
 
       assertPermissionTable([
-        ["Accounts", "Impersonated", "No", "1 million rows", "No", "No"],
-        ["Analytic Events", "Impersonated", "No", "1 million rows", "No", "No"],
-        ["Feedback", "Impersonated", "No", "1 million rows", "No", "No"],
-        ["Invoices", "Impersonated", "No", "1 million rows", "No", "No"],
-        ["Orders", "Impersonated", "No", "1 million rows", "No", "No"],
+        ["Accounts", "Impersonated", "Yes", "1 million rows", "No", "No"],
+        [
+          "Analytic Events",
+          "Impersonated",
+          "Yes",
+          "1 million rows",
+          "No",
+          "No",
+        ],
+        ["Feedback", "Impersonated", "Yes", "1 million rows", "No", "No"],
+        ["Invoices", "Impersonated", "Yes", "1 million rows", "No", "No"],
+        ["Orders", "Impersonated", "Yes", "1 million rows", "No", "No"],
         ["People", "Impersonated", "Yes", "1 million rows", "No", "No"],
         ["Products", "Impersonated", "Yes", "1 million rows", "No", "No"],
         ["Reviews", "Impersonated", "Yes", "1 million rows", "No", "No"],
       ]);
 
-      cy.get("main")
-        .findByText("Orders")
-        .closest("tr")
-        .within(() => {
-          isPermissionDisabled(
-            DATA_ACCESS_PERMISSION_INDEX,
-            "Impersonated",
-            true,
-          ).click();
-          isPermissionDisabled(NATIVE_QUERIES_PERMISSION_INDEX, "No", true);
-
-          cy.findAllByText("No").eq(0).realHover();
-        });
-
-      // eslint-disable-next-line no-unscoped-text-selectors
-      cy.findByText(
-        "Native query editor access requires full data access.",
-      ).should("not.exist");
-
+      // Return back to the database view
       cy.get("main").findByText("All Users group").click();
 
       // Edit impersonated permission
@@ -112,6 +101,32 @@ describeEE("impersonated permission", () => {
         ],
         ["QA Postgres12", "Impersonated", "Yes", "1 million rows", "No", "No"],
       ]);
+
+      // Checking table permissions when the native access is disabled for impersonated users
+      modifyPermission("QA Postgres12", NATIVE_QUERIES_PERMISSION_INDEX, "No");
+      cy.get("main").findByText("QA Postgres12").click();
+
+      cy.get("main")
+        .findByText("Orders")
+        .closest("tr")
+        .within(() => {
+          isPermissionDisabled(
+            DATA_ACCESS_PERMISSION_INDEX,
+            "Impersonated",
+            true,
+          ).click();
+          isPermissionDisabled(NATIVE_QUERIES_PERMISSION_INDEX, "No", true);
+
+          cy.findAllByText("No").eq(0).realHover();
+        });
+
+      // eslint-disable-next-line no-unscoped-text-selectors
+      cy.findByText(
+        "Native query editor access requires full data access.",
+      ).should("not.exist");
+
+      // Return back to the database view
+      cy.get("main").findByText("All Users group").click();
 
       // Change from impersonated permission
       modifyPermission(

--- a/e2e/test/scenarios/permissions/impersonated.cy.spec.js
+++ b/e2e/test/scenarios/permissions/impersonated.cy.spec.js
@@ -52,14 +52,7 @@ describeEE("impersonated permission", () => {
           "No",
           "No",
         ],
-        [
-          "QA Postgres12",
-          "Impersonated",
-          "No", // FIXME: should be "Yes"
-          "1 million rows",
-          "No",
-          "No",
-        ],
+        ["QA Postgres12", "Impersonated", "Yes", "1 million rows", "No", "No"],
       ]);
 
       // Checking it shows the right state on the tables level
@@ -71,30 +64,9 @@ describeEE("impersonated permission", () => {
         ["Feedback", "Impersonated", "No", "1 million rows", "No", "No"],
         ["Invoices", "Impersonated", "No", "1 million rows", "No", "No"],
         ["Orders", "Impersonated", "No", "1 million rows", "No", "No"],
-        [
-          "People",
-          "Impersonated",
-          "No", // FIXME: should be "Yes"
-          "1 million rows",
-          "No",
-          "No",
-        ],
-        [
-          "Products",
-          "Impersonated",
-          "No", // FIXME: should be "Yes"
-          "1 million rows",
-          "No",
-          "No",
-        ],
-        [
-          "Reviews",
-          "Impersonated",
-          "No", // FIXME: should be "Yes"
-          "1 million rows",
-          "No",
-          "No",
-        ],
+        ["People", "Impersonated", "Yes", "1 million rows", "No", "No"],
+        ["Products", "Impersonated", "Yes", "1 million rows", "No", "No"],
+        ["Reviews", "Impersonated", "Yes", "1 million rows", "No", "No"],
       ]);
 
       cy.get("main")
@@ -138,14 +110,7 @@ describeEE("impersonated permission", () => {
           "No",
           "No",
         ],
-        [
-          "QA Postgres12",
-          "Impersonated",
-          "No", // FIXME: should be "Yes"
-          "1 million rows",
-          "No",
-          "No",
-        ],
+        ["QA Postgres12", "Impersonated", "Yes", "1 million rows", "No", "No"],
       ]);
 
       // Change from impersonated permission
@@ -245,8 +210,6 @@ describeEE("impersonated permission", () => {
       createTestRoles({ type: "postgres" });
       cy.signInAsAdmin();
 
-      // FIXME: two calls is a hack because BE will set the native permission to "write" only from the second call
-      setImpersonatedPermission();
       setImpersonatedPermission();
 
       cy.signInAsImpersonatedUser();

--- a/test/metabase/models/permissions_test.clj
+++ b/test/metabase/models/permissions_test.clj
@@ -9,6 +9,7 @@
     :as perms-group
     :refer [PermissionsGroup]]
    [metabase.models.table :refer [Table]]
+   [metabase.models.user :as user]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
@@ -796,6 +797,19 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                 Granting/Revoking Permissions Helper Functions                                 |
 ;;; +----------------------------------------------------------------------------------------------------------------+
+
+(deftest revoke-db-schema-permissions-test
+  (mt/with-temp* [Database [database]]
+    (testing "revoke-db-schema-permissions! should revoke all non-native permissions on a database"
+      (is (perms/set-has-full-permissions? (user/permissions-set (mt/user->id :rasta))
+                                           (perms/data-perms-path database)))
+      (is (perms/set-has-full-permissions? (user/permissions-set (mt/user->id :rasta))
+                                           (perms/adhoc-native-query-path database)))
+      (perms/revoke-db-schema-permissions! (perms-group/all-users) database)
+      (is (not (perms/set-has-full-permissions? (user/permissions-set (mt/user->id :rasta))
+                                                (perms/data-perms-path database))))
+      (is (perms/set-has-full-permissions? (user/permissions-set (mt/user->id :rasta))
+                                           (perms/adhoc-native-query-path database))))))
 
 (deftest revoke-permissions-helper-function-test
   (testing "Make sure if you try to use the helper function to *revoke* perms for a Personal Collection, you get an Exception"


### PR DESCRIPTION
Previous behavior:
* If a group has a `/db/1/` permission path, it would remove it entirely. This would remove both self-service and native perms.
* If a group instead had separate `/db/1/schema/` and `/db/1/native/` paths (functionally equivalent to `/db/1/`), it would only remove `/db/1/schema/` and leave native perms as-is.

Fix: Re-add native perms if they were removed, so that this function strictly removes self-service perms only.

Pursuant to https://github.com/metabase/metabase/issues/29491 (this bug caused `setting impersonated for the first time resets the native permission from Yes to No`)