### PR TITLE
filter out bots in the auto assign workflow

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -29,6 +29,10 @@ jobs:
             const prAuthor = context.payload.pull_request.user.login;
             const prNumber = context.payload.pull_request.number;
 
+            if (prAuthor.endsWith('[bot]')) {
+              return false;
+            }
+
             // Assign PR author
             await github.rest.issues.addAssignees({
               owner: context.repo.owner,


### PR DESCRIPTION
Auto-backport PRs are created by `metabase-bot` which causes a failure of the `auto-assign` workflow. This PR filters out bots by checking if the PR author has "[bot]" suffix in their login which Github [adds](https://api.github.com/users/metabase-bot[bot]) to all bots.