### PR TITLE
Fix vendor for snowplow events

### DIFF
--- a/snowplow/iglu-client-embedded/schemas/com.metabase/model/jsonschema/1-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/model/jsonschema/1-0-0
@@ -2,7 +2,7 @@
   "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
   "description": "Search events",
   "self": {
-    "vendor": "com.example",
+    "vendor": "com.metabase",
     "name": "model",
     "format": "jsonschema",
     "version": "1-0-0"

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/search/jsonschema/1-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/search/jsonschema/1-0-0
@@ -2,7 +2,7 @@
   "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
   "description": "Search events",
   "self": {
-    "vendor": "com.example",
+    "vendor": "com.metabase",
     "name": "search",
     "format": "jsonschema",
     "version": "1-0-0"


### PR DESCRIPTION
The `vendor` in two snowplow event json schemas was incorrect.