### PR TITLE
Fix creating new questions from the dashboard empty state

### DIFF
--- a/e2e/test/scenarios/dashboard/reproductions/31848-new-question-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/31848-new-question-dashboard.cy.spec.js
@@ -27,6 +27,7 @@ describe("issue 31848", () => {
     cy.findByTestId("dashboard-empty-state")
       .findByText("ask a new one")
       .click();
+
     popover().within(() => {
       cy.findByText("Sample Database").click();
       cy.findByText("Orders").click();

--- a/e2e/test/scenarios/dashboard/reproductions/31848-new-question-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/31848-new-question-dashboard.cy.spec.js
@@ -1,0 +1,50 @@
+import {
+  restore,
+  popover,
+  modal,
+  queryBuilderHeader,
+  getDashboardCard,
+} from "e2e/support/helpers";
+
+describe("issue 31848", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.intercept("POST", "/api/card").as("createQuestion");
+  });
+
+  it("should allow creating questions from an empty dashboard (metabase#31848)", () => {
+    const dashboardName = "New dashboard";
+    const questionName = "New question";
+
+    cy.visit("/");
+    cy.findByTestId("app-bar").findByText("New").click();
+    popover().findByText("Dashboard").click();
+    modal().within(() => {
+      cy.findByLabelText("Name").type(dashboardName);
+      cy.button("Create").click();
+    });
+    cy.findByTestId("dashboard-empty-state")
+      .findByText("ask a new one")
+      .click();
+    popover().within(() => {
+      cy.findByText("Sample Database").click();
+      cy.findByText("Orders").click();
+    });
+    queryBuilderHeader().findByText("Save").click();
+    modal().within(() => {
+      cy.findByLabelText("Name").clear().type(questionName);
+      cy.button("Save").click();
+    });
+    cy.wait("@createQuestion");
+    modal().within(() => {
+      cy.button("Yes please!").click();
+      cy.findByText(dashboardName).click();
+    });
+
+    cy.findByTestId("edit-bar")
+      .findByText("You're editing this dashboard.")
+      .should("be.visible");
+    getDashboardCard().findByText(questionName).should("be.visible");
+  });
+});

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -364,6 +364,7 @@ class Dashboard extends Component {
                     <TabEmptyState isNightMode={shouldRenderAsNightMode} />
                   ) : (
                     <DashboardEmptyState
+                      dashboard={dashboard}
                       isNightMode={shouldRenderAsNightMode}
                       addQuestion={this.onAddQuestion}
                       closeNavbar={this.props.closeNavbar}

--- a/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.tsx
@@ -1,9 +1,10 @@
 import { t } from "ttag";
 
+import * as Urls from "metabase/lib/urls";
 import Link from "metabase/core/components/Link";
 import Button from "metabase/core/components/Button";
 import EmptyState from "metabase/components/EmptyState";
-
+import { Dashboard } from "metabase-types/api";
 import { Container } from "./DashboardEmptyState.styled";
 
 function QuestionIllustration() {
@@ -11,18 +12,20 @@ function QuestionIllustration() {
 }
 
 interface DashboardEmptyStateProps {
+  dashboard: Dashboard;
   isNightMode: boolean;
   addQuestion: () => void;
   closeNavbar: () => void;
 }
 
 export function DashboardEmptyState({
+  dashboard,
   isNightMode,
   addQuestion,
   closeNavbar,
 }: DashboardEmptyStateProps) {
   return (
-    <Container isNightMode={isNightMode}>
+    <Container isNightMode={isNightMode} data-testid="dashboard-empty-state">
       <EmptyState
         illustrationElement={<QuestionIllustration />}
         title={t`This dashboard is looking empty.`}
@@ -34,7 +37,11 @@ export function DashboardEmptyState({
             {t`, or `}
             <Link
               variant="brandBold"
-              to="/question/new"
+              to={Urls.newQuestion({
+                mode: "notebook",
+                creationType: "custom_question",
+                collectionId: dashboard.collection_id ?? undefined,
+              })}
               className="text-bold text-brand"
               onClick={closeNavbar}
             >

--- a/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.unit.spec.tsx
@@ -1,11 +1,12 @@
 import { render, screen } from "@testing-library/react";
-
+import { createMockDashboard } from "metabase-types/api/mocks";
 import { DashboardEmptyState, TabEmptyState } from "./DashboardEmptyState";
 
 describe("DashboardEmptyState", () => {
   it("renders", () => {
     render(
       <DashboardEmptyState
+        dashboard={createMockDashboard()}
         isNightMode={false}
         addQuestion={jest.fn()}
         closeNavbar={jest.fn()}

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSelector.jsx
@@ -14,7 +14,7 @@ export default function QuestionDataSelector({
       selectedDatabaseId={query.databaseId()}
       selectedTableId={query.tableId()}
       setSourceTableFn={tableId =>
-        updateQuestion(query.setTableId(tableId), {
+        updateQuestion(query.setTableId(tableId).question(), {
           run: true,
         })
       }


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/31848
Reproduces https://github.com/metabase/metabase/issues/31848

How to verify:
- New -> Dashboard -> Create
- You should see an empty state. Click `ask a new one`
- Make sure it's possible to create a new question and save it back to the dashboard.

<img width="1108" alt="Screenshot 2023-06-27 at 16 46 32" src="https://github.com/metabase/metabase/assets/8542534/125924d9-45db-4601-b9b2-7c235fc4b985">
<img width="1459" alt="Screenshot 2023-06-27 at 16 46 16" src="https://github.com/metabase/metabase/assets/8542534/e1cce490-01be-470d-b165-9b5ca39640f5">
