### PR TITLE
Object Detail Record Nav Bugfix

### DIFF
--- a/e2e/test/scenarios/visualizations/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/object_detail.cy.spec.js
@@ -332,6 +332,30 @@ function changeSorting(columnName, direction) {
           cy.findAllByText("Horse").should("have.length", 2);
         });
       });
+
+      it("cannot navigate past the end of the list of objects with the keyboard", () => {
+        // this bug only manifests on tables without single integer primary keys
+        // it is also reproducible on tables with string keys
+
+        getTableId({ name: TEST_TABLE }).then(tableId => {
+          cy.visit(`/question#?db=${WRITABLE_DB_ID}&table=${tableId}`);
+        });
+
+        cy.get("#main-data-grid").findByText("Rabbit").trigger("mouseover");
+
+        cy.icon("expand").first().click();
+
+        cy.findByRole("dialog").within(() => {
+          cy.findAllByText("Rabbit").should("have.length", 2);
+        });
+
+        cy.get("body").type("{downarrow}");
+
+        cy.findByRole("dialog").within(() => {
+          cy.findAllByText("Rabbit").should("have.length", 2);
+          cy.findByText("Empty").should("not.exist");
+        });
+      });
     },
   );
 

--- a/frontend/src/metabase/query_builder/actions/object-detail.js
+++ b/frontend/src/metabase/query_builder/actions/object-detail.js
@@ -11,6 +11,8 @@ import {
   getCard,
   getFirstQueryResult,
   getPKColumnIndex,
+  getCanZoomPreviousRow,
+  getCanZoomNextRow,
   getNextRowPKValue,
   getPreviousRowPKValue,
   getTableForeignKeys,
@@ -139,8 +141,8 @@ export const CLEAR_OBJECT_DETAIL_FK_REFERENCES =
 
 export const viewNextObjectDetail = () => {
   return (dispatch, getState) => {
-    const objectId = getNextRowPKValue(getState());
-    if (objectId != null) {
+    if (getCanZoomNextRow(getState())) {
+      const objectId = getNextRowPKValue(getState());
       dispatch(zoomInRow({ objectId }));
     }
   };
@@ -148,8 +150,8 @@ export const viewNextObjectDetail = () => {
 
 export const viewPreviousObjectDetail = () => {
   return (dispatch, getState) => {
-    const objectId = getPreviousRowPKValue(getState());
-    if (objectId != null) {
+    if (getCanZoomPreviousRow(getState())) {
+      const objectId = getPreviousRowPKValue(getState());
       dispatch(zoomInRow({ objectId }));
     }
   };


### PR DESCRIPTION
### Description

For tables without a single integer primary key, we use array indexes for ids to navigate object detail. The arrows on the UI accurately detect whether you can navigate forward and backward in all instances, but the functions we use to allow navigation with arrow keyboard keys used different functions which allowed users to get the application to a state where they navigated past the end of the list to an empty row if the table didn't have a single integer primary key.

### How to verify

- create or load a table with a single integer primary key, (if you have CSV uploads set up: [this dataset](https://gist.github.com/iethree/2e35583afb5220c36c885f44790b3c8a) will do it for you)
- open object detail on the last record and press down
- you should still see the last record instead of an empty record

### Demo

Before | After
--- | ---
![bugged](https://github.com/metabase/metabase/assets/30528226/e570319c-7cbd-49c3-8032-4ff6731eaf2c) | ![notbugged](https://github.com/metabase/metabase/assets/30528226/7dd281fe-3cef-4b08-ae95-b9d42b4a4d3f)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
