### PR TITLE
[ci] Pin node version for rerun job

### DIFF
--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version-file: '.nvmrc'
+          node-version: lts/Hydrogen # 18.x.x
       - run: npm install @slack/web-api
       - name: Trigger a re-run
         uses: actions/github-script@v6


### PR DESCRIPTION
### Description

Turns out the lack of red master notifications wasn't because master was green all week. When we upgraded node we tried to pin the node version to our `.nvmrc` file, but this workflow doesn't ever pull the repo, so it just failed.

This pins this workflow to a specific node version

