### PR TITLE
Require table primary key to enable basic actions

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -486,7 +486,16 @@ class QuestionInner {
 
   supportsImplicitActions(): boolean {
     const query = this.query();
-    return query instanceof StructuredQuery && !query.hasAnyClauses();
+
+    // we want to check the metadata for the underlying table, not the model
+    const tableId = query.tableId();
+    const table = this.metadata().tables?.[tableId];
+    const hasSinglePk =
+      table?.fields?.filter(field => field.isPK())?.length === 1;
+
+    return (
+      query instanceof StructuredQuery && !query.hasAnyClauses() && hasSinglePk
+    );
   }
 
   canAutoRun(): boolean {

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -488,8 +488,8 @@ class QuestionInner {
     const query = this.query();
 
     // we want to check the metadata for the underlying table, not the model
-    const tableId = query.tableId();
-    const table = this.metadata().tables?.[tableId];
+    const table = query.sourceTable();
+
     const hasSinglePk =
       table?.fields?.filter(field => field.isPK())?.length === 1;
 

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -76,6 +76,7 @@ const TEST_TABLE_ID = 1;
 const TEST_FIELD = createMockField({
   id: 1,
   display_name: "Field 1",
+  semantic_type: TYPE.PK,
   table_id: TEST_TABLE_ID,
 });
 

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -46,6 +46,31 @@ const metadata = createMockMetadata({
   ],
 });
 
+const metadata_without_order_pk = createMockMetadata({
+  databases: [
+    createSampleDatabase({
+      tables: [
+        createProductsTable(),
+        createPeopleTable(),
+        createReviewsTable(),
+        createOrdersTable({
+          fields: [
+            createOrdersIdField({ semantic_type: "type/Integer" }),
+            createOrdersUserIdField(),
+            createOrdersProductIdField(),
+            createOrdersSubtotalField(),
+            createOrdersTaxField(),
+            createOrdersTotalField(),
+            createOrdersDiscountField(),
+            createOrdersCreatedAtField(),
+            createOrdersQuantityField(),
+          ],
+        }),
+      ],
+    }),
+  ],
+});
+
 const card = {
   display: "table",
   visualization_settings: {},
@@ -74,6 +99,30 @@ const orders_raw_card = {
   },
 };
 const orders_raw_question = new Question(orders_raw_card, metadata);
+
+const orders_card_without_pk = {
+  id: 1,
+  name: "Orders Model",
+  display: "table",
+  visualization_settings: {},
+  can_write: true,
+  dataset: true,
+  database_id: SAMPLE_DB_ID,
+  table_id: ORDERS_ID,
+  dataset_query: {
+    type: "query",
+    database: SAMPLE_DB_ID,
+    query: {
+      "source-table": ORDERS_ID,
+    },
+  },
+  result_metadata: [
+    createOrdersIdField({
+      semantic_type: "type/Integer",
+      field_ref: ["field", 11, null],
+    }),
+  ],
+};
 
 const orders_count_card = {
   id: 2,
@@ -257,6 +306,7 @@ const orders_count_by_id_card = {
     },
   },
 };
+
 const orders_count_by_id_question = new Question(
   orders_count_by_id_card,
   metadata,
@@ -1634,6 +1684,27 @@ describe("Question", () => {
 
     it("should not allow to create implicit actions for a model with filters", () => {
       const question = new Question(orders_filter_card, metadata);
+      expect(question.supportsImplicitActions()).toBeFalsy();
+    });
+
+    it("should allow to create implicit actions where the underlying table has a primary key but the model does not", () => {
+      const orders_question_without_pk = new Question(
+        orders_card_without_pk,
+        metadata,
+      );
+      expect(orders_question_without_pk.supportsImplicitActions()).toBeTruthy();
+    });
+
+    it("should not allow to create implicit actions where the underlying table has no primary key", () => {
+      const question = new Question(orders_raw_card, metadata_without_order_pk);
+      expect(question.supportsImplicitActions()).toBeFalsy();
+    });
+
+    it("should not allow to create implicit actions where the model has a primary key, but the underlying table does not", () => {
+      const question = new Question(
+        orders_card_without_pk,
+        metadata_without_order_pk,
+      );
       expect(question.supportsImplicitActions()).toBeFalsy();
     });
 


### PR DESCRIPTION
resolves https://github.com/metabase/metabase/issues/31867
related to, but doesn't ultimately address https://github.com/metabase/metabase/issues/31918

### Description

Implicit actions can only be executed on tables with a single primary key. This adds a check of the underlying table metadata to enable basic actions. This is a short-term fix to keep users from shooting themselves in the foot by enabling basic actions on models that cannot possibly support them.

If possible, longer-term, I think we want to support model-defined primary keys even if they differ from db-defined keys, but that's a bigger ask on the backend.

For now, this is how the UI looks

 . | Model has a pk | model does not have a pk
--- | --- | ---
**Table has a pk** | can enable basic actions | can enable basic actions
**Table does not have a pk** |  cannot enable basic actions | cannot enable basic actions

### How To test

✅ 
- Create a model based on a table with a primary key
- see that the option to enable basic actions appears in the model detail
- edit the model's metadata to not have a pk
- see that you can still enable basic actions

❌ 
- Edit a table database metadata and change the PK to an FK
- create a model based on that table
- see that you cannot enable basic actions for this model
- edit the model metadata to assign a pk to a column
- see that you still cannot enable basic actions



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
