### PR TITLE
Show all breakouts and metrics in tooltip when merging stacked bar charts

### DIFF
--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.js
@@ -331,16 +331,12 @@ export const getStackedTooltipModel = (
   }));
 
   const hoveredSeries = seriesWithGroupedData[hoveredIndex];
-  const hoveredCardId = hoveredSeries?.card?.id;
-  const hoveredCardSeries = seriesWithGroupedData.filter(
-    series => series.card?.id === hoveredCardId,
-  );
-  const hasBreakout = hoveredCardSeries?.some(
+  const hasBreakout = seriesWithGroupedData.some(
     series => series.card?._breakoutColumn != null,
   );
 
   const seriesToShow = hasBreakout
-    ? hoveredCardSeries
+    ? seriesWithGroupedData
     : seriesWithGroupedData.filter(
         series => series.card?._breakoutColumn == null,
       );

--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.js
@@ -335,12 +335,6 @@ export const getStackedTooltipModel = (
     series => series.card?._breakoutColumn != null,
   );
 
-  const seriesToShow = hasBreakout
-    ? seriesWithGroupedData
-    : seriesWithGroupedData.filter(
-        series => series.card?._breakoutColumn == null,
-      );
-
   const formattedXValue = formatValueForTooltip({
     value: xValue,
     column: hoveredSeries?.data?.cols[DIMENSION_INDEX],
@@ -353,7 +347,7 @@ export const getStackedTooltipModel = (
       column: hoveredSeries?.data?.cols[METRIC_INDEX],
     });
 
-  const tooltipRows = seriesToShow
+  const tooltipRows = seriesWithGroupedData
     .map(series => {
       const { card, groupedData, data } = series;
       const datum = groupedData?.find(
@@ -417,9 +411,9 @@ export const getStackedTooltipModel = (
     headerTitle: formattedXValue,
     headerRows,
     bodyRows,
-    totalFormatter: hasBreakout ? totalFormatter : undefined,
-    showTotal: hasBreakout,
-    showPercentages: hasBreakout,
+    totalFormatter,
+    showTotal: true,
+    showPercentages: true,
   };
 };
 

--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.unit.spec.js
@@ -267,38 +267,6 @@ describe("getStackedTooltipModel", () => {
       }),
     );
   });
-
-  it("sets showTotal and showPercentages to true for charts with breakouts", () => {
-    const series = getMockSeries(true);
-    const datas = getDatas({ series, settings });
-    const { showTotal, showPercentages } = getStackedTooltipModel(
-      series,
-      datas,
-      settings,
-      hoveredIndex,
-      dashboard,
-      xValue,
-    );
-
-    expect(showTotal).toBe(true);
-    expect(showPercentages).toBe(true);
-  });
-
-  it("sets showTotal and showPercentages to false for charts without breakouts", () => {
-    const series = getMockSeries();
-    const datas = getDatas({ series, settings });
-    const { showTotal, showPercentages } = getStackedTooltipModel(
-      series,
-      datas,
-      settings,
-      hoveredIndex,
-      dashboard,
-      xValue,
-    );
-
-    expect(showTotal).toBe(false);
-    expect(showPercentages).toBe(false);
-  });
 });
 
 function seriesAndData({ cols, rows, settings = {} }) {

--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.unit.spec.js
@@ -211,27 +211,27 @@ describe("getStackedTooltipModel", () => {
     ordered_cards: [],
   };
   const cols = [StringColumn(), NumberColumn()];
-  const getMockSerie = ({ card, rows, hasBreakout }) => {
+  const getMockSeries = ({ card, rows, hasBreakout }) => {
     const _breakoutColumn = hasBreakout ? StringColumn() : undefined;
     return {
       data: { cols, rows, _breakoutColumn },
       card: { ...card, _breakoutColumn },
     };
   };
-  const getMockSeries = hasBreakout => [
-    getMockSerie({
+  const getMockMultipleSeries = hasBreakout => [
+    getMockSeries({
       card: { id: 1, name: "Series 1" },
       rows: [["foo", 100]],
       hasBreakout,
     }),
-    getMockSerie({ card: { id: 2, name: "Series 2" }, rows: [["foo", 200]] }),
+    getMockSeries({ card: { id: 2, name: "Series 2" }, rows: [["foo", 200]] }),
   ];
 
   const hoveredIndex = 0;
   const xValue = "foo";
 
   it("sets tooltip model rows", () => {
-    const series = getMockSeries();
+    const series = getMockMultipleSeries();
     const datas = getDatas({ series, settings });
     const { bodyRows, headerRows, headerTitle } = getStackedTooltipModel(
       series,
@@ -265,10 +265,10 @@ describe("getStackedTooltipModel", () => {
     const cardB = { id: 2, name: "Series 2" };
     const hasBreakout = true;
     const series = [
-      getMockSerie({ card: cardA, rows: [["foo", 100]], hasBreakout }),
-      getMockSerie({ card: cardA, rows: [["foo", 200]], hasBreakout }),
-      getMockSerie({ card: cardB, rows: [["foo", 300]], hasBreakout }),
-      getMockSerie({ card: cardB, rows: [["foo", 400]], hasBreakout }),
+      getMockSeries({ card: cardA, rows: [["foo", 100]], hasBreakout }),
+      getMockSeries({ card: cardA, rows: [["foo", 200]], hasBreakout }),
+      getMockSeries({ card: cardB, rows: [["foo", 300]], hasBreakout }),
+      getMockSeries({ card: cardB, rows: [["foo", 400]], hasBreakout }),
     ];
     const datas = getDatas({ series, settings });
     const { bodyRows, headerRows, showTotal, showPercentages } =
@@ -290,10 +290,10 @@ describe("getStackedTooltipModel", () => {
     const cardB = { id: 2, name: "Series 2" };
     const hasBreakout = true;
     const series = [
-      getMockSerie({ card: cardA, rows: [["foo", 100]], hasBreakout }),
-      getMockSerie({ card: cardA, rows: [["foo", 200]], hasBreakout }),
-      getMockSerie({ card: cardB, rows: [["foo", 300]] }),
-      getMockSerie({ card: cardB, rows: [["foo", 400]] }),
+      getMockSeries({ card: cardA, rows: [["foo", 100]], hasBreakout }),
+      getMockSeries({ card: cardA, rows: [["foo", 200]], hasBreakout }),
+      getMockSeries({ card: cardB, rows: [["foo", 300]] }),
+      getMockSeries({ card: cardB, rows: [["foo", 400]] }),
     ];
     const datas = getDatas({ series, settings });
     const { bodyRows, headerRows, showTotal, showPercentages } =

--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.unit.spec.js
@@ -211,27 +211,20 @@ describe("getStackedTooltipModel", () => {
     ordered_cards: [],
   };
   const cols = [StringColumn(), NumberColumn()];
+  const getMockSerie = ({ card, rows, hasBreakout }) => {
+    const _breakoutColumn = hasBreakout ? StringColumn() : undefined;
+    return {
+      data: { cols, rows, _breakoutColumn },
+      card: { ...card, _breakoutColumn },
+    };
+  };
   const getMockSeries = hasBreakout => [
-    {
-      data: {
-        cols,
-        rows: [["foo", 100]],
-        settings: {},
-        _breakoutColumn: hasBreakout ? StringColumn() : undefined,
-      },
-      card: {
-        name: "Series 1",
-        _breakoutColumn: hasBreakout ? StringColumn() : undefined,
-      },
-    },
-    {
-      data: {
-        cols,
-        rows: [["foo", 200]],
-        settings: {},
-      },
-      card: { name: "Series 2" },
-    },
+    getMockSerie({
+      card: { id: 1, name: "Series 1" },
+      rows: [["foo", 100]],
+      hasBreakout,
+    }),
+    getMockSerie({ card: { id: 2, name: "Series 2" }, rows: [["foo", 200]] }),
   ];
 
   const hoveredIndex = 0;
@@ -266,6 +259,56 @@ describe("getStackedTooltipModel", () => {
         value: 200,
       }),
     );
+  });
+  it("should include breakouts from all cards", () => {
+    const cardA = { id: 1, name: "Series 1" };
+    const cardB = { id: 2, name: "Series 2" };
+    const hasBreakout = true;
+    const series = [
+      getMockSerie({ card: cardA, rows: [["foo", 100]], hasBreakout }),
+      getMockSerie({ card: cardA, rows: [["foo", 200]], hasBreakout }),
+      getMockSerie({ card: cardB, rows: [["foo", 300]], hasBreakout }),
+      getMockSerie({ card: cardB, rows: [["foo", 400]], hasBreakout }),
+    ];
+    const datas = getDatas({ series, settings });
+    const { bodyRows, headerRows, showTotal, showPercentages } =
+      getStackedTooltipModel(
+        series,
+        datas,
+        settings,
+        hoveredIndex,
+        dashboard,
+        xValue,
+      );
+    expect(headerRows).toHaveLength(1);
+    expect(bodyRows).toHaveLength(3);
+    expect(showTotal).toBe(true);
+    expect(showPercentages).toBe(true);
+  });
+  it("should include metrics and breakouts from all cards", () => {
+    const cardA = { id: 1, name: "Series 1" };
+    const cardB = { id: 2, name: "Series 2" };
+    const hasBreakout = true;
+    const series = [
+      getMockSerie({ card: cardA, rows: [["foo", 100]], hasBreakout }),
+      getMockSerie({ card: cardA, rows: [["foo", 200]], hasBreakout }),
+      getMockSerie({ card: cardB, rows: [["foo", 300]] }),
+      getMockSerie({ card: cardB, rows: [["foo", 400]] }),
+    ];
+    const datas = getDatas({ series, settings });
+    const { bodyRows, headerRows, showTotal, showPercentages } =
+      getStackedTooltipModel(
+        series,
+        datas,
+        settings,
+        hoveredIndex,
+        dashboard,
+        xValue,
+      );
+    expect(headerRows).toHaveLength(1);
+    expect(bodyRows).toHaveLength(3);
+    expect(showTotal).toBe(true);
+    expect(showPercentages).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/30561

### Description

* When multiple stacked bar charts are merged, the bars belonging to the same original chart are grouped into a logical “card”.
* The new v46 tooltip shows all percentages inside a given card, but the v45 tooltip had only a single absolute percentage.
* [The design team and product team commented about this here](https://metaboat.slack.com/archives/C02H619CJ8K/p1687916296041109), and recommended that we display percentages for the whole stack instead of just the card.

v45 | v46 (regression) | fixed here
---|---|---
<img width="285" alt="CleanShot 2023-06-27 at 19 21 08@2x" src="https://github.com/metabase/metabase/assets/116838/173e373f-7189-44a7-8f46-5e2f57433fee"> | <img width="347" alt="CleanShot 2023-06-27 at 19 22 01@2x" src="https://github.com/metabase/metabase/assets/116838/3f2e18fa-259a-4974-98fb-69197261110c"> | <img width="330" alt="CleanShot 2023-06-29 at 15 36 27@2x" src="https://github.com/metabase/metabase/assets/116838/613c372f-749c-4be5-8660-daffd2ada6cc">

### How to verify

Follow steps in the linked issue.

### Checklist

- [x] Write tests.
