### PR TITLE
[WIP] Retry e2e tests on beefier runners 🐄 

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -64,13 +64,28 @@ jobs:
       - name: Prepare uberjar artifact
         uses: ./.github/actions/prepare-uberjar-artifact
 
+  determine_runner:
+    runs-on: ubuntu-latest
+    outputs:
+      runner: ${{ steps.determine_runner.outputs.runner }}
+    steps:
+      - name: Determine runner
+        id: determine_runner
+        run: |
+          echo "run attempt: ${{ github.event.workflow_run.run_attempt}}"
+          if [ ${{ github.event.workflow_run.run_attempt || 0 }} -gt 1 ]; then
+            echo "runner=buildjet-4vcpu-ubuntu-2204" >> $GITHUB_OUTPUT
+          else
+            echo "runner=ubuntu-latest" >> $GITHUB_OUTPUT
+          fi
+
   e2e-tests:
-    needs: [build, files-changed, test-run-id]
+    needs: [build, files-changed, test-run-id, determine_runner]
     if: |
       always() &&
       needs.files-changed.outputs.e2e_all == 'true' &&
       needs.build.result == 'success'
-    runs-on: ubuntu-22.04
+    runs-on: ${{ needs.determine_runner.outputs.runner }}
     timeout-minutes: 90
     name: e2e-tests-${{ matrix.folder }}${{ matrix.context }}-${{ matrix.edition }}
     env:

--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -252,6 +252,9 @@ describe("scenarios > models", () => {
         cy.findByText("Raw Data").click();
         cy.findByText("Sample Database").click(); // go back to db list
         cy.findByText("Saved Questions").should("not.exist");
+
+        cy.findByText("Great Balls of Fire").should("be.visible"); // FIXME
+
         testDataPickerSearch({
           inputPlaceholderText: "Search for a table…",
           query: "Ord",


### PR DESCRIPTION
### Description

We've been seeing more and more e2e failures caused by things like slow api requests. This detects if an e2e job is a re-run and runs it on a 4vcpu runner.

You [can't put conditionals](https://github.com/actions/runner/issues/480) in `runs-on`, so you have to add a [separate step and use the output](https://stackoverflow.com/questions/71961921/specify-runner-to-be-used-depending-on-condition-in-a-github-actions-workflow)

