### PR TITLE
Cache field values per-connection impersonation role

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/api/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/api/util.clj
@@ -7,9 +7,11 @@
    [metabase.util.i18n :refer [tru]]
    [toucan2.core :as t2]))
 
+;; TODO: this function should only return true if an impersonation policy is enforced for the user
 (defenterprise impersonated-user?
-  "Returns a boolean if the current user uses connection impersonation for any database. Will throw an error if
-  [[api/*current-user-id*]] is not bound."
+  "Returns a boolean if the current user is in a group that has a connection impersonation in place for any database.
+  Note: this function does not check whether the impersonation is *enforced* for the current user, since another group's
+  permissions may supercede it. Will throw an error if [[api/*current-user-id*]] is not bound."
   :feature :advanced-permissions
   []
   (boolean

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
@@ -1,31 +1,58 @@
 (ns metabase-enterprise.advanced-permissions.driver.impersonation
   (:require
+   [clojure.set :as set]
    [metabase.api.common :as api]
    [metabase.driver :as driver]
    [metabase.driver.sql :as driver.sql]
+   [metabase.models.permissions :as perms :refer [Permissions]]
    [metabase.models.permissions-group-membership
     :refer [PermissionsGroupMembership]]
    [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
-   [toucan2.core :as t2])
+   [toucan2.core :as t2]
+   [metabase.models.field :as field])
   (:import
    (java.sql Connection)))
 
 (set! *warn-on-reflection* true)
 
-(defn- connection-impersonation-role
+(defn- enforce-impersonation?
+  "Takes the permission set for each group a user is in, and an impersonation policy, and determines whether the policy
+  should be enforced. This is done by checking whether the union of permissions in all *other* groups provides full
+  data access to the database. If so, we don't enforce the policy, because theo ther groups' permissions supercede it."
+  [group-id->perms-set {group-id :group_id, db-id :db_id}]
+  (let [perms-set (->> (dissoc group-id->perms-set group-id)
+                       (vals)
+                       (apply set/union))]
+    (not (perms/set-has-full-permissions? perms-set (perms/all-schemas-path db-id)))))
+
+(defn- enforced-impersonations
+  "Given a list of Connection Impersonation policies and a list of permission group IDs that the current user is in,
+  filter the policies to only include ones that should be enforced for the current user. An impersonation policy is
+  not enforced if the user is in a different permission group that grants full access to the database."
+  [impersonations group-ids]
+  (let [perms               (when (seq group-ids)
+                             (t2/select Permissions {:where [:in :group_id group-ids]}))
+        group-id->perms-set (-> (group-by :group_id perms)
+                                (update-vals (fn [perms] (into #{} (map :object) perms))))]
+    (filter (partial enforce-impersonation? group-id->perms-set)
+            impersonations)))
+
+(defn connection-impersonation-role
   "Fetches the database role that should be used for the current user, if connection impersonation is in effect.
   Returns `nil` if connection impersonation should not be used for the current user. Throws an exception if multiple
   conflicting connection impersonation policies are found."
-  [database]
+  [database-or-id]
   (when-not api/*is-superuser?*
     (let [group-ids           (t2/select-fn-set :group_id PermissionsGroupMembership :user_id api/*current-user-id*)
-          conn-impersonations (when (seq group-ids)
-                                (t2/select :model/ConnectionImpersonation
-                                           :group_id [:in group-ids]
-                                           :db_id (u/the-id database)))
+          conn-impersonations (enforced-impersonations
+                               (when (seq group-ids)
+                                 (t2/select :model/ConnectionImpersonation
+                                            :group_id [:in group-ids]
+                                            :db_id (u/the-id database-or-id)))
+                               group-ids)
           role-attributes     (set (map :attribute conn-impersonations))]
       (when (> (count role-attributes) 1)
         (throw (ex-info (tru "Multiple conflicting connection impersonation policies found for current user")
@@ -36,6 +63,14 @@
               role-attribute     (:attribute conn-impersonation)
               user-attributes    (:login_attributes @api/*current-user*)]
           (get user-attributes role-attribute))))))
+
+(defenterprise hash-key-for-impersonation
+  "Returns a hash-key for FieldValues if the current user uses impersonation for the database."
+  :feature :advanced-permissions
+  [field-id]
+  ;; Include the role in the hash key, so that we can cache the results of the query for each role.
+  (let [db-id (field/field-id->database-id field-id)]
+   (str (hash [field-id (connection-impersonation-role db-id)]))))
 
 (defenterprise set-role-if-supported!
   "Executes a `USE ROLE` or similar statement on the given connection, if connection impersonation is enabled for the

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
@@ -4,6 +4,7 @@
    [metabase.api.common :as api]
    [metabase.driver :as driver]
    [metabase.driver.sql :as driver.sql]
+   [metabase.models.field :as field]
    [metabase.models.permissions :as perms :refer [Permissions]]
    [metabase.models.permissions-group-membership
     :refer [PermissionsGroupMembership]]
@@ -11,8 +12,7 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
-   [toucan2.core :as t2]
-   [metabase.models.field :as field])
+   [toucan2.core :as t2])
   (:import
    (java.sql Connection)))
 

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
@@ -22,10 +22,8 @@
   "Takes the permission set for each group a user is in, and an impersonation policy, and determines whether the policy
   should be enforced. This is done by checking whether the union of permissions in all *other* groups provides full
   data access to the database. If so, we don't enforce the policy, because theo ther groups' permissions supercede it."
-  [group-id->perms-set {group-id :group_id, db-id :db_id}]
-  (let [perms-set (->> (dissoc group-id->perms-set group-id)
-                       (vals)
-                       (apply set/union))]
+  [group-id->perms-set {db-id :db_id}]
+  (let [perms-set (apply set/union (vals group-id->perms-set))]
     (not (perms/set-has-full-permissions? perms-set (perms/all-schemas-path db-id)))))
 
 (defn- enforced-impersonations

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
@@ -70,7 +70,7 @@
   [field-id]
   ;; Include the role in the hash key, so that we can cache the results of the query for each role.
   (let [db-id (field/field-id->database-id field-id)]
-   (str (hash [field-id (connection-impersonation-role db-id)]))))
+    (str (hash [field-id (connection-impersonation-role db-id)]))))
 
 (defenterprise set-role-if-supported!
   "Executes a `USE ROLE` or similar statement on the given connection, if connection impersonation is enabled for the

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
@@ -1,8 +1,12 @@
 (ns metabase-enterprise.sandbox.models.params.field-values
   (:require
+   [metabase-enterprise.advanced-permissions.api.util
+    :as advanced-perms.api.u]
    [metabase-enterprise.sandbox.api.table :as table]
-   [metabase-enterprise.sandbox.models.group-table-access-policy :refer [GroupTableAccessPolicy]]
-   [metabase-enterprise.sandbox.query-processor.middleware.row-level-restrictions :as row-level-restrictions]
+   [metabase-enterprise.sandbox.models.group-table-access-policy
+    :refer [GroupTableAccessPolicy]]
+   [metabase-enterprise.sandbox.query-processor.middleware.row-level-restrictions
+    :as row-level-restrictions]
    [metabase.api.common :as api]
    [metabase.mbql.util :as mbql.u]
    [metabase.models :refer [Field PermissionsGroupMembership]]
@@ -100,8 +104,16 @@
   should be filtered as appropriate for the current User (currently this only applies to the EE impl)."
   :feature :sandboxes
   [field]
-  (if (field-is-sandboxed? field)
+  (cond
+    (field-is-sandboxed? field)
     (params.field-values/get-or-create-advanced-field-values! :sandbox field)
+
+    ;; Impersonation can have row-level security enforced by the database, so we still need to store field values per-user.
+    ;; TODO: only do this for DBs with impersonation in effect
+    (advanced-perms.api.u/impersonated-user?)
+    (params.field-values/get-or-create-advanced-field-values! :impersonation field)
+
+    :else
     (params.field-values/default-get-or-create-field-values-for-current-user! field)))
 
 (defenterprise hash-key-for-linked-filters
@@ -116,7 +128,7 @@
       (field-values/default-hash-key-for-linked-filters field-id constraints))))
 
 (defenterprise hash-key-for-sandbox
-  "Returns a hash-key for linked-filter FieldValues if the field is sandboxed, otherwise fallback to the OSS impl."
+  "Returns a hash-key for FieldValues if the field is sandboxed, otherwise fallback to the OSS impl."
   :feature :sandboxes
   [field-id]
   (let [field (t2/select-one Field :id field-id)]

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
@@ -110,7 +110,8 @@
 
     ;; Impersonation can have row-level security enforced by the database, so we still need to store field values per-user.
     ;; TODO: only do this for DBs with impersonation in effect
-    (advanced-perms.api.u/impersonated-user?)
+    (and api/*current-user-id*
+         (advanced-perms.api.u/impersonated-user?))
     (params.field-values/get-or-create-advanced-field-values! :impersonation field)
 
     :else

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/util_test.clj
@@ -32,8 +32,9 @@
             (perms/revoke-data-perms! (perms-group/all-users) (data/db))
             ;; create new perms group
             (test.users/with-group-for-user [group test-user-name-or-user-id]
-              ;; grant native access to the group
+              ;; grant full data access to the group
               (perms/update-data-perms-graph! [(u/the-id group) (data/id) :data :native] :write)
+              (perms/update-data-perms-graph! [(u/the-id group) (data/id) :data :schemas] :all)
               (let [{:keys [impersonations attributes]} args]
                 ;; set user login_attributes
                 (met/with-user-attributes test-user-name-or-user-id attributes

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
@@ -9,6 +9,8 @@
    [metabase.driver.postgres-test :as postgres-test]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.models.database :refer [Database]]
+   [metabase.models.permissions :as perms]
+   [metabase.models.permissions-group :as perms-group]
    [metabase.public-settings.premium-features-test
     :as premium-features-test]
    [metabase.server.middleware.session :as mw.session]
@@ -36,6 +38,14 @@
              clojure.lang.ExceptionInfo
              #"Multiple conflicting connection impersonation policies found for current user"
              (@#'impersonation/connection-impersonation-role (mt/db)))))))
+
+  (testing "Returns nil if the permissions in another group supercede the impersonation"
+    (advanced-perms.api.tu/with-impersonations {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                :attributes     {"impersonation_attr" "impersonation_role"}}
+      ;; `with-impersonations` creates a new group and revokes data perms in `all users`, so if we re-grant data perms
+      ;; for all users, it should supercede the impersonation policy in the new group
+      (perms/grant-full-data-permissions! (perms-group/all-users) (mt/id))
+      (is (nil? (@#'impersonation/connection-impersonation-role (mt/db))))))
 
   (testing "Returns nil for superuser, even if they are in a group with an impersonation policy defined"
     (advanced-perms.api.tu/with-impersonations {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
@@ -93,7 +93,7 @@
         ;; User with connection impersonation should not be able to query a table they don't have access to
         ;; (`limited_role` in CI Snowflake has no data access)
         (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                              #"You do not have permissions to run this query."
+                              #"SQL compilation error:\nDatabase.*does not exist or not authorized"
                               (mt/run-mbql-query venues
                                                  {:aggregation [[:count]]})))
         ;; Non-impersonated user should stil be able to query the table

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/field_values_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/field_values_test.clj
@@ -3,6 +3,8 @@
    [clojure.test :refer :all]
    [metabase-enterprise.advanced-permissions.api.util-test
     :as advanced-perms.api.tu]
+   [metabase-enterprise.advanced-permissions.driver.impersonation
+    :as impersonation]
    [metabase.models :refer [Field FieldValues]]
    [metabase.models.params.field-values :as params.field-values]
    [metabase.public-settings.premium-features-test
@@ -13,25 +15,29 @@
 
 (deftest get-or-create-advanced-field-values!
   (premium-features-test/with-premium-features #{:advanced-permissions}
-    (let [field (t2/select-one Field :id (mt/id :categories :id))]
+    (let [field      (t2/select-one Field :id (mt/id :categories :id))]
       (try
         (testing "creates new field values for user using impersonation"
           (advanced-perms.api.tu/with-impersonations {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
                                                       :attributes     {"impersonation_attr" "impersonation_role"}}
-            (params.field-values/get-or-create-advanced-field-values! :impersonation field)
-            (is (= #{"-1904413116"}
-                   (into #{} (map :hash_key (t2/select FieldValues :field_id (u/the-id field) :type :impersonation)))))
+            (let [hash-key-1 (impersonation/hash-key-for-impersonation (u/the-id field))]
+              (params.field-values/get-or-create-advanced-field-values! :impersonation field)
+              (is (= #{hash-key-1}
+                     (into #{}
+                           (map :hash_key (t2/select FieldValues :field_id (u/the-id field) :type :impersonation)))))
 
-            (testing "calling a second time shouldn't create new FieldValues"
-              (params.field-values/get-or-create-advanced-field-values! :impersonation field
-                                                                        (is (= 1 (t2/count FieldValues :field_id (u/the-id field) :type :impersonation)))))))
+              (testing "calling a second time shouldn't create new FieldValues"
+                (params.field-values/get-or-create-advanced-field-values! :impersonation field)
+                (is (= 1 (t2/count FieldValues :field_id (u/the-id field) :type :impersonation))))
 
-        (testing "changing the impersonation role creates new FieldValues"
-          (advanced-perms.api.tu/with-impersonations {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                      :attributes     {"impersonation_attr" "impersonation_role_2"}}
-            (params.field-values/get-or-create-advanced-field-values! :impersonation field)
-            (is (= #{"-1904413116" "-758143549"}
-                   (into #{} (map :hash_key (t2/select FieldValues :field_id (u/the-id field) :type :impersonation)))))
-            (is (= 2 (t2/count FieldValues :field_id (u/the-id field) :type :impersonation)))))
+              (testing "changing the impersonation role creates new FieldValues"
+                (advanced-perms.api.tu/with-impersonations {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                            :attributes     {"impersonation_attr" "impersonation_role_2"}}
+                  (let [hash-key-2 (impersonation/hash-key-for-impersonation (u/the-id field))]
+                    (params.field-values/get-or-create-advanced-field-values! :impersonation field)
+                    (is (= #{hash-key-1 hash-key-2}
+                           (into #{}
+                                 (map :hash_key (t2/select FieldValues :field_id (u/the-id field) :type :impersonation)))))
+                    (is (= 2 (t2/count FieldValues :field_id (u/the-id field) :type :impersonation)))))))))
         (finally
            (t2/delete! FieldValues :field_id (u/the-id field) :type :impersonation))))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/field_values_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/field_values_test.clj
@@ -1,0 +1,37 @@
+(ns metabase-enterprise.advanced-permissions.models.field-values-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.advanced-permissions.api.util-test
+    :as advanced-perms.api.tu]
+   [metabase.models :refer [Field FieldValues]]
+   [metabase.models.params.field-values :as params.field-values]
+   [metabase.public-settings.premium-features-test
+    :as premium-features-test]
+   [metabase.test :as mt]
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
+
+(deftest get-or-create-advanced-field-values!
+  (premium-features-test/with-premium-features #{:advanced-permissions}
+    (let [field (t2/select-one Field :id (mt/id :categories :id))]
+      (try
+        (testing "creates new field values for user using impersonation"
+          (advanced-perms.api.tu/with-impersonations {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                      :attributes     {"impersonation_attr" "impersonation_role"}}
+            (params.field-values/get-or-create-advanced-field-values! :impersonation field)
+            (is (= #{"-1904413116"}
+                   (into #{} (map :hash_key (t2/select FieldValues :field_id (u/the-id field) :type :impersonation)))))
+
+            (testing "calling a second time shouldn't create new FieldValues"
+              (params.field-values/get-or-create-advanced-field-values! :impersonation field
+                                                                        (is (= 1 (t2/count FieldValues :field_id (u/the-id field) :type :impersonation)))))))
+
+        (testing "changing the impersonation role creates new FieldValues"
+          (advanced-perms.api.tu/with-impersonations {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                      :attributes     {"impersonation_attr" "impersonation_role_2"}}
+            (params.field-values/get-or-create-advanced-field-values! :impersonation field)
+            (is (= #{"-1904413116" "-758143549"}
+                   (into #{} (map :hash_key (t2/select FieldValues :field_id (u/the-id field) :type :impersonation)))))
+            (is (= 2 (t2/count FieldValues :field_id (u/the-id field) :type :impersonation)))))
+        (finally
+           (t2/delete! FieldValues :field_id (u/the-id field) :type :impersonation))))))

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -65,8 +65,9 @@
 
 (def advanced-field-values-types
   "A class of fieldvalues that has additional constraints/filters."
-  #{:sandbox         ;; are fieldvalues but filtered by sandbox permissions
-    :linked-filter}) ;; are fieldvalues but has constraints from other linked parameters on dashboard/embedding
+  #{:sandbox         ;; field values filtered by sandbox permissions
+    :impersonation   ;; field values with connection impersonation enforced (db-level roles)
+    :linked-filter}) ;; field values with constraints from other linked parameters on dashboard/embedding
 
 (def ^:private field-values-types
   "All FieldValues type."
@@ -133,6 +134,7 @@
 
 (t2/define-before-insert :model/FieldValues
   [{:keys [field_id] :as field-values}]
+  (def field-values field-values)
   (u/prog1 (merge {:type :full}
                   field-values)
     (assert-valid-human-readable-values field-values)
@@ -274,6 +276,12 @@
 (defenterprise hash-key-for-sandbox
   "Return a hash-key that will be used for sandboxed fieldvalues."
   metabase-enterprise.sandbox.models.params.field-values
+  [_field-id]
+  nil)
+
+(defenterprise hash-key-for-impersonation
+  "Return a hash-key that will be used for impersonated fieldvalues."
+  metabase-enterprise.advanced-permissions.driver.impersonation
   [_field-id]
   nil)
 

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -134,7 +134,6 @@
 
 (t2/define-before-insert :model/FieldValues
   [{:keys [field_id] :as field-values}]
-  (def field-values field-values)
   (u/prog1 (merge {:type :full}
                   field-values)
     (assert-valid-human-readable-values field-values)

--- a/src/metabase/models/params/field_values.clj
+++ b/src/metabase/models/params/field_values.clj
@@ -87,7 +87,7 @@
                                 (count limited-values))
                              has_more_values)}))
 
-    :sandbox
+    (:sandbox :impersonation)
     (field-values/distinct-values field)))
 
 (defn hash-key-for-advanced-field-values
@@ -98,7 +98,10 @@
     (field-values/hash-key-for-linked-filters field-id constraints)
 
     :sandbox
-    (field-values/hash-key-for-sandbox field-id)))
+    (field-values/hash-key-for-sandbox field-id)
+
+    :impersonation
+    (field-values/hash-key-for-impersonation field-id)))
 
 (defn create-advanced-field-values!
   "Fetch and create a FieldValues for `field` with type `fv-type`.

--- a/src/metabase/models/params/field_values.clj
+++ b/src/metabase/models/params/field_values.clj
@@ -87,7 +87,6 @@
                                 (count limited-values))
                              has_more_values)}))
 
-    (:sandbox :impersonation)
     (field-values/distinct-values field)))
 
 (defn hash-key-for-advanced-field-values

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -350,8 +350,8 @@
 
       (testing "should be able to unset just the human-readable values"
         (t2.with-temp/with-temp [FieldValues _ {:values                (range 1 5)
-                                      :field_id              field-id
-                                      :human_readable_values ["$" "$$" "$$$" "$$$$"]}]
+                                                :field_id              field-id
+                                                :human_readable_values ["$" "$$" "$$$" "$$$$"]}]
           (testing "before updating values"
             (is (= {:values [[1 "$"] [2 "$$"] [3 "$$$"] [4 "$$$$"]], :field_id true, :has_more_values false}
                    (mt/boolean-ids-and-timestamps (mt/user-http-request :crowberto :get 200 (format "field/%d/values" field-id))))))
@@ -673,7 +673,7 @@
   (testing "PUT /api/field/:id"
     (testing "Changing a remapped field's type to something that can't be remapped will clear the dimension"
       (t2.with-temp/with-temp [Field {field-id :id} {:name      "Field Test"
-                                           :base_type "type/Integer"}]
+                                                     :base_type "type/Integer"}]
         (create-dimension-via-API! field-id {:name "some dimension name", :type "internal"})
         (testing "before API request"
           (is (= {:id                      true
@@ -692,7 +692,7 @@
 
     (testing "Change from supported type to supported type will leave the dimension"
       (t2.with-temp/with-temp [Field {field-id :id} {:name      "Field Test"
-                                           :base_type "type/Integer"}]
+                                                     :base_type "type/Integer"}]
         (create-dimension-via-API! field-id {:name "some dimension name", :type "internal"})
         (let [expected {:id                      true
                         :entity_id               true


### PR DESCRIPTION
* Adds a new `:impersonation` type for advanced field values which behaves similar to sandboxed field values, but for connection impersonation. Essentially, fetching the field values uses a custom database role when connection impersonation is in effect, so we should cache these values using a hash of the database role and field ID. If the role changes for any given user, we should re-fetch the values.
* Fixes a separate bug in precedence of permission enforcement that I discovered while working on this.

Left a couple TODO comments for things I noticed that will take a bit more work (and are relatively lower importance), so I don't want them to block RC2.

Epic: https://github.com/metabase/metabase/issues/29491