### PR TITLE
removing prefix and suffix from formatValueRaw

### DIFF
--- a/frontend/src/metabase/lib/formatting/value.tsx
+++ b/frontend/src/metabase/lib/formatting/value.tsx
@@ -36,7 +36,8 @@ const MARKDOWN_RENDERERS = {
   ),
 };
 
-export function formatValue(value: unknown, options: OptionsType = {}) {
+export function formatValue(value: unknown, _options: OptionsType = {}) {
+  let { prefix, suffix, ...options } = _options;
   // avoid rendering <ExternalLink> if we have click_behavior set
   if (
     options.click_behavior &&
@@ -76,17 +77,17 @@ export function formatValue(value: unknown, options: OptionsType = {}) {
       return formatted;
     }
   }
-  if (options.prefix || options.suffix) {
+  if (prefix || suffix) {
     if (options.jsx && typeof formatted !== "string") {
       return (
         <span>
-          {options.prefix || ""}
+          {prefix || ""}
           {formatted}
-          {options.suffix || ""}
+          {suffix || ""}
         </span>
       );
     } else {
-      return `${options.prefix || ""}${formatted}${options.suffix || ""}`;
+      return `${prefix || ""}${formatted}${suffix || ""}`;
     }
   } else {
     return formatted;

--- a/frontend/src/metabase/lib/formatting/value.unit.spec.tsx
+++ b/frontend/src/metabase/lib/formatting/value.unit.spec.tsx
@@ -1,0 +1,62 @@
+import { screen, render } from "__support__/ui";
+import { createMockColumn } from "metabase-types/api/mocks";
+import { formatValue } from "./value";
+
+import type { OptionsType } from "./types";
+
+const setup = (value: any, overrides: Partial<OptionsType> = {}) => {
+  const column = createMockColumn({
+    base_type: "type/Float",
+  });
+  const options: OptionsType = {
+    view_as: "auto",
+    column: column,
+    type: "cell",
+    jsx: true,
+    rich: true,
+    clicked: {
+      value: value,
+      column: column,
+      origin: {
+        rowIndex: 0,
+        row: [value],
+        cols: [column],
+      },
+      data: [
+        {
+          value: value,
+          col: column,
+        },
+      ],
+    },
+    ...overrides,
+  };
+  render(<>{formatValue(value, options)}</>);
+};
+
+describe("link", () => {
+  it("should not apply prefix or suffix more than once for links with no link_text", () => {
+    setup(23.12, {
+      view_as: "link",
+      prefix: "foo ",
+      suffix: " bar",
+      link_url: "http://google.ca",
+    });
+    expect(
+      screen.getByText((content, element) => content.startsWith("foo")),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText((content, element) => content.endsWith("bar")),
+    ).toBeInTheDocument();
+    expect(screen.getByText("23.12")).toBeInTheDocument();
+  });
+
+  it("should trim values to specified decimals", () => {
+    setup(23.123459, {
+      decimals: 5,
+      number_style: "decimal",
+      number_separators: ".",
+    });
+    expect(screen.getByText("23.12346")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31472

### Description
This bug was happening because when we don't have a `link_text` property but we want to display a link, we run the value and options back through `formatValue` to get the text to show. This causes the prefix and suffix to be added twice. Something to note is that in this scenario, the prefix and suffix aren't actually part of the link.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Orders -> Visualize
2. Edit the Subtotal column settings to display as a link
3. provide a link url, but no link text. Then add a prefix and/or suffix
4. You should now see that they are only applied once

### Demo
![image](https://github.com/metabase/metabase/assets/1328979/9a98ffae-39ba-4de5-9731-2e6059d6e365)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
