### PR TITLE
fix delayed cards rendering on dashboards

### DIFF
--- a/frontend/src/metabase/components/ExplicitSize.jsx
+++ b/frontend/src/metabase/components/ExplicitSize.jsx
@@ -8,7 +8,7 @@ import debounce from "lodash.debounce";
 import resizeObserver from "metabase/lib/resize-observer";
 import { isCypressActive } from "metabase/env";
 
-const WAIT_TIME = 1000;
+const WAIT_TIME = 300;
 
 const REFRESH_MODE = {
   throttle: fn => _.throttle(fn, WAIT_TIME),

--- a/frontend/src/metabase/components/ExplicitSize.jsx
+++ b/frontend/src/metabase/components/ExplicitSize.jsx
@@ -3,16 +3,19 @@ import { Component } from "react";
 import ReactDOM from "react-dom";
 import cx from "classnames";
 import _ from "underscore";
+import debounce from "lodash.debounce";
 
 import resizeObserver from "metabase/lib/resize-observer";
 import { isCypressActive } from "metabase/env";
 
-const WAIT_TIME = 300;
+const WAIT_TIME = 1000;
 
 const REFRESH_MODE = {
   throttle: fn => _.throttle(fn, WAIT_TIME),
-  debounce: fn => _.debounce(fn, WAIT_TIME),
-  debounceLeading: fn => _.debounce(fn, WAIT_TIME, true),
+  debounce: fn => debounce(fn, WAIT_TIME),
+  // Using lodash.debounce with leading=true to execute the function immediately and also at the end of the debounce period.
+  // Underscore debounce with immediate=true will not execute the function after the wait period unless it is called again.
+  debounceLeading: fn => debounce(fn, WAIT_TIME, { leading: true }),
   none: fn => fn,
 };
 

--- a/frontend/src/metabase/visualizations/components/CardRenderer.jsx
+++ b/frontend/src/metabase/visualizations/components/CardRenderer.jsx
@@ -106,5 +106,6 @@ class CardRenderer extends Component {
 
 export default ExplicitSize({
   wrapped: true,
-  refreshMode: props => (props.isDashboard ? "debounce" : "throttle"),
+  // Avoid using debounce when isDashboard=true because there should not be any initial delay when rendering cards
+  refreshMode: props => (props.isDashboard ? "debounceLeading" : "throttle"),
 })(CardRenderer);

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "leaflet": "^1.2.0",
     "leaflet-draw": "^0.4.9",
     "leaflet.heat": "^0.2.0",
+    "lodash.debounce": "^4.0.8",
     "moment-timezone": "^0.5.38",
     "mustache": "^2.3.2",
     "mysql2": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17537,7 +17537,7 @@ lodash._topath@^3.0.0:
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
-  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
+  integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
 lodash.get@^3.7.0:
   version "3.7.0"


### PR DESCRIPTION
Related to [this comment](https://github.com/metabase/metabase/issues/26534#issuecomment-1610121657) of the issue which escalated it even more but overall it is a completely separate problem that is not even related to the performance

### Description

Changes `debounceLeading` behavior of the `refreshMode` of `ExplicitSize` hoc to ensure it will invoke function immediately **and** after the debounce period. Previous implementation with underscore debounce with immediate=true triggered the function immediately and ignored further resize events within the wait time which led to another problem when charts did not always resize on dashboard. This bug was fixed by switching to just `debounce` but it delayed the initial rendering which we don't want.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a dashboard with two tabs
2. Add any line/area/bar chart on the first tab
3. Switch between tabs and ensure there is no any rendering delay

### Checklist

- [-] ~Tests have been added/updated to cover changes in this PR~ — I've spent half a day trying to write a meaningful test on it and it did not workout well because it would be a useless test that mocks internal implementation such as resize-observer dependency just to test the library debounce function is being applied

### Demo

<video src="https://github.com/metabase/metabase/assets/14301985/623bc6bd-205d-46ea-9adc-defa718eca6a" />
