### PR TITLE
Improve consistency of dashboard/link e2e test

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -745,6 +745,7 @@ describe("scenarios > dashboard", () => {
 
 describeWithSnowplow("scenarios > dashboard", () => {
   beforeEach(() => {
+    cy.intercept("GET", "/api/activity/recent_views").as("recentViews");
     resetSnowplow();
     restore();
     cy.signInAsAdmin();
@@ -760,6 +761,7 @@ describeWithSnowplow("scenarios > dashboard", () => {
     editDashboard();
     cy.findByTestId("dashboard-header").icon("link").click();
 
+    cy.wait("@recentViews");
     cy.findByTestId("custom-edit-text-link").click().type("Orders");
 
     saveDashboard();


### PR DESCRIPTION

### Description

Seeing some failures of this test in CI

`AssertionError: Timed out retrying after 4000ms: Unable to find an element by: [data-testid="custom-edit-text-link"]`

https://github.com/metabase/metabase/actions/runs/5391784357/jobs/9821250655?pr=31904

