### PR TITLE
i18n: safe to use trun for some plural BE messages

### DIFF
--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -34,7 +34,7 @@
    [metabase.sync.analyze.classify :as classify]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
-   [metabase.util.i18n :as i18n :refer [deferred-tru trs tru deferred-trun]]
+   [metabase.util.i18n :as i18n :refer [deferred-tru trs tru trun]]
    [metabase.util.log :as log]
    [metabase.util.schema :as su]
    [ring.util.codec :as codec]
@@ -186,7 +186,7 @@
   (let [table (->> metric :table_id (t2/select-one Table :id))]
     {:entity       metric
      :full-name    (if (:id metric)
-                     (deferred-trun "{0} metric" "{0} metrics" (:name metric))
+                     (trun "{0} metric" "{0} metrics" (:name metric))
                      (:name metric))
      :short-name   (:name metric)
      :source       table
@@ -200,7 +200,7 @@
   [field]
   (let [table (field/table field)]
     {:entity       field
-     :full-name    (deferred-trun "{0} field" "{0} fields" (:display_name field))
+     :full-name    (trun "{0} field" "{0} fields" (:display_name field))
      :short-name   (:display_name field)
      :source       table
      :database     (:db_id table)


### PR DESCRIPTION
This is a follow-up to PR #31501. After the fix from @noahmoss in PR #31861, now it's fine to use `trun` instead of `deferred-trun`.

How to check: run `./bin/i18n/update-translation-template` with `xgettext 0.21` (e.g. from Ubuntu 22.04, Debian 11, etc) and check the combined message catalogs, as generated in `locales/metabase.pot`, look for the messages for field and metric and they have to look like this:

```
#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:24
#: metabase/automagic_dashboards/core.clj:193                                           
#, fuzzy, javascript-format
msgid "{0} metric"
msgid_plural "{0} metrics"
msgstr[0] ""

#: frontend/src/metabase/models/components/ModelDetailPage/ModelSchemaDetails/ModelSchemaDetails.tsx:37
#: metabase/automagic_dashboards/core.clj:207
#, fuzzy, javascript-format                                                             
msgid "{0} field"
msgid_plural "{0} fields"
msgstr[0] ""
```