### PR TITLE
Backport sunset snowplow tracking for task history to 44

### DIFF
--- a/frontend/src/metabase/lib/urls/questions.ts
+++ b/frontend/src/metabase/lib/urls/questions.ts
@@ -137,15 +137,12 @@ export function tableRowsQuery(
   segmentId?: number | string,
 ) {
   let query = `?db=${databaseId}&table=${tableId}`;
-
   if (metricId) {
     query += `&metric=${metricId}`;
   }
-
   if (segmentId) {
     query += `&segment=${segmentId}`;
   }
-
   // This will result in a URL like "/question#?db=1&table=1"
   // The QB will parse the querystring and use DB and table IDs to create an ad-hoc question
   // We should refactor the initializeQB to avoid passing query string to hash as it's pretty confusing

--- a/frontend/test/metabase/scenarios/onboarding/setup/setup.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/setup/setup.cy.spec.js
@@ -244,17 +244,18 @@ describeWithSnowplow("scenarios > setup", () => {
   });
 
   it("should send snowplow events", () => {
-    // 1 - pageview
+    // 1 - new_instance_created
+    // 2 - pageview
     cy.visit(`/setup`);
 
-    // 2 - setup/step_seen
+    // 3 - setup/step_seen
     cy.findByText("Welcome to Metabase");
     cy.button("Let's get started").click();
 
-    // 3 - setup/step_seen
+    // 4 - setup/step_seen
     cy.findByText("What's your preferred language?");
 
-    expectGoodSnowplowEvents(3);
+    expectGoodSnowplowEvents(4);
   });
 
   it("should ignore snowplow failures and work as normal", () => {
@@ -264,6 +265,6 @@ describeWithSnowplow("scenarios > setup", () => {
     cy.findByText("Welcome to Metabase");
     cy.button("Let's get started").click();
 
-    expectGoodSnowplowEvents(0);
+    expectGoodSnowplowEvents(1);
   });
 });

--- a/src/metabase/models/task_history.clj
+++ b/src/metabase/models/task_history.clj
@@ -1,16 +1,11 @@
 (ns metabase.models.task-history
-  (:require [cheshire.core :as json]
-            [cheshire.generate :refer [add-encoder encode-map]]
+  (:require [cheshire.generate :refer [add-encoder encode-map]]
             [clojure.tools.logging :as log]
             [java-time :as t]
-            [metabase.analytics.snowplow :as snowplow]
-            [metabase.api.common :refer [*current-user-id*]]
-            [metabase.models.database :refer [Database]]
             [metabase.models.interface :as mi]
             [metabase.models.permissions :as perms]
             [metabase.public-settings.premium-features :as premium-features]
             [metabase.util :as u]
-            [metabase.util.date-2 :as u.date]
             [metabase.util.i18n :refer [trs]]
             [metabase.util.schema :as su]
             [schema.core :as s]
@@ -42,29 +37,11 @@
       (perms/application-perms-path :monitoring)
       "/")})
 
-(defn- task->snowplow-event
-  [task]
-  (let [task-details (:task_details task)]
-    (merge {:task_id      (:id task)
-            :task_name    (:task task)
-            :duration     (:duration task)
-            :task_details (json/generate-string task-details)
-            :started_at   (u.date/format-rfc3339 (:started_at task))
-            :ended_at     (u.date/format-rfc3339 (:ended_at task))}
-           (when-let [db-id (:db_id task)]
-             {:db_id     db-id
-              :db_engine (db/select-one-field :engine Database :id db-id)}))))
-
-(defn- post-insert
-  [task]
-  (u/prog1 task
-    (snowplow/track-event! ::snowplow/new-task-history *current-user-id* (task->snowplow-event <>))))
-
-(u/strict-extend (class TaskHistory)
+(u/strict-extend
+  (class TaskHistory)
   models/IModel
   (merge models/IModelDefaults
-         {:types      (constantly {:task_details :json})
-          :post-insert post-insert})
+         {:types (constantly {:task_details :json})})
 
   mi/IObjectPermissions
   (merge mi/IObjectPermissionsDefaults

--- a/test/metabase/models/task_history_test.clj
+++ b/test/metabase/models/task_history_test.clj
@@ -1,10 +1,7 @@
 (ns metabase.models.task-history-test
-  (:require [cheshire.core :as json]
-            [clojure.test :refer :all]
+  (:require [clojure.test :refer :all]
             [java-time :as t]
-            [metabase.analytics.snowplow-test :as snowplow-test]
-            [metabase.api.common :refer [*current-user-id*]]
-            [metabase.models :refer [Database TaskHistory]]
+            [metabase.models :refer [TaskHistory]]
             [metabase.models.task-history :as task-history]
             [metabase.test :as mt]
             [metabase.util :as u]
@@ -70,68 +67,4 @@
                (set (map :task (TaskHistory)))))
         (task-history/cleanup-task-history! 100)
         (is (= #{task-1 task-2}
-               (set (map :task (TaskHistory)))))))))
-
-(defn- insert-then-pop!
-  "Insert a task history and get the last snowplow event."
-  [task]
-  (db/insert! TaskHistory task)
-  (-> (snowplow-test/pop-event-data-and-user-id!)
-      last
-      mt/boolean-ids-and-timestamps
-      (update-in [:data "task_details"] json/parse-string)))
-
-(deftest snowplow-tracking-test
-  (snowplow-test/with-fake-snowplow-collector
-    (let [t (t/zoned-date-time)]
-      (testing "inserting a task history should track a snowplow event"
-        (is (= {:data   {"duration"     10
-                         "ended_at"     true
-                         "started_at"   true
-                         "event"        "new_task_history"
-                         "task_details" {"apple" 40, "orange" 2}
-                         "task_id"      true
-                         "task_name"   "a fake task"}
-                :user-id nil}
-               (insert-then-pop! (assoc (make-10-millis-task t)
-                                        :task         "a fake task"
-                                        :task_details {:apple  40
-                                                       :orange 2}))))
-
-        (testing "should have user id if *current-user-id* is bound"
-          (binding [*current-user-id* 1]
-            (is (= {:data    {"duration"     10
-                              "ended_at"     true
-                              "started_at"   true
-                              "event"        "new_task_history"
-                              "task_details" {"apple" 40, "orange" 2}
-                              "task_id"      true
-                              "task_name"   "a fake task"}
-                    :user-id "1"}
-                   (insert-then-pop! (assoc (make-10-millis-task t)
-                                            :task         "a fake task"
-                                            :task_details {:apple  40
-                                                           :orange 2}))))))
-
-        (testing "infer db_engine if db_id exists"
-          (mt/with-temp Database [{db-id :id} {:engine "postgres"}]
-            (is (= {:data    {"duration"     10
-                              "ended_at"     true
-                              "started_at"   true
-                              "db_id"        true
-                              "db_engine"    "postgres"
-                              "event"        "new_task_history"
-                              "task_details" {"apple" 40, "orange" 2}
-                              "task_id"      true
-                              "task_name"   "a fake task"}
-                    :user-id nil}
-                   (insert-then-pop! (assoc (make-10-millis-task t)
-                                            :task         "a fake task"
-                                            :db_id        db-id
-                                            :task_details {:apple  40
-                                                           :orange 2}))))))
-        (testing "date-time properties should be correctly formatted"
-          (db/insert! TaskHistory (assoc (make-10-millis-task t) :task "a fake task"))
-          (let [event (:data (first (snowplow-test/pop-event-data-and-user-id!)))]
-            (is (snowplow-test/valid-datetime-for-snowplow? (get event "started_at")))
-            (is (snowplow-test/valid-datetime-for-snowplow? (get event "ended_at")))))))))
+               (set (map :task (db/select TaskHistory)))))))))

--- a/test/metabase/sync/analyze_test.clj
+++ b/test/metabase/sync/analyze_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.sync.analyze-test
   (:require [clojure.test :refer :all]
-            [metabase.analytics.snowplow-test :as snowplow-test]
             [metabase.models.database :refer [Database]]
             [metabase.models.field :as field :refer [Field]]
             [metabase.models.table :refer [Table]]
@@ -253,24 +252,3 @@
         (is (= last-sync-time
                (latest-sync-time table))
             "sync time shouldn't change")))))
-
-(deftest analyze-should-send-a-snowplow-event-test
-  (testing "the recorded event should include db-id and db-engine"
-    (snowplow-test/with-fake-snowplow-collector
-      (mt/with-temp* [Table [table  (fake-table)]
-                      Field [_field (fake-field table)]]
-        (analyze-table! table)
-        (is (= {:data {"task_id"    true
-                       "event"      "new_task_history"
-                       "started_at" true
-                       "ended_at"   true
-                       "duration"   true
-                       "db_engine"  (name (db/select-one-field :engine Database :id (mt/id)))
-                       "db_id"      true
-                       "task_name"  "classify-tables"}
-                :user-id nil}
-               (-> (snowplow-test/pop-event-data-and-user-id!)
-                   last
-                   mt/boolean-ids-and-timestamps
-                   (update :data dissoc "task_details")
-                   (update-in [:data "duration"] some?))))))))


### PR DESCRIPTION
Backports [Sun set snowplow tracking for task history](https://github.com/metabase/metabase/pull/31182#top) to 44. Note there were a fair amount of merge conflicts so this demands careful review.