### PR TITLE
handleSelectSeries uses ordered series

### DIFF
--- a/e2e/test/scenarios/visualizations/bar_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/bar_chart.cy.spec.js
@@ -180,6 +180,12 @@ describe("scenarios > visualizations > bar chart", () => {
           cy.findAllByTestId("legend-item").should("have.length", 4);
           cy.get(".enable-dots").should("have.length", 4);
         });
+
+      cy.findAllByTestId("legend-item").contains("Gadget").click();
+      popover().findByText("See these Orders").click();
+      cy.findByTestId("qb-filters-panel")
+        .findByText("Category is Gadget")
+        .should("exist");
     });
 
     it("should gracefully handle removing filtered items, and adding new items to the end of the list", () => {

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -262,15 +262,17 @@ export default class LineAreaBarChart extends Component {
     const {
       card,
       series,
+      settings,
       visualizationIsClickable,
       onEditSeries,
       onVisualizationClick,
       onChangeCardAndRun,
     } = this.props;
 
-    const single = isReversed
-      ? series[series.length - index - 1]
-      : series[index];
+    const orderedSeries = getOrderedSeries(series, settings, isReversed);
+
+    const single = orderedSeries[index];
+
     const hasBreakout = card._breakoutColumn != null;
 
     if (onEditSeries && !hasBreakout) {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31943

### Description
Small change in the `ChartWithLegend` component to use the ordered series when selecting the single series to transition to when one of the legend titles is clicked.

### How to verify

1. New question -> Sample Dataset -> Orders
2. Summarize by Count, Group by User -> Source and Product -> Category
3. Visualize, and open Viz settings. Change the order of the breakouts.
4. Click one of the titles in the legend header and select "See these Orders". You should be brought to the orders table with the correct filter applied.

### Demo
![chrome_HAdSoP5fYt](https://github.com/metabase/metabase/assets/1328979/9cca31d8-18e3-408b-a795-4394217a3a3b)

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
