### PR TITLE
🍒 Exclude ReplayIO scheduled E2E tests from re-run (#31983)

### DIFF
--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -10,7 +10,8 @@ jobs:
   rerun-on-failure:
     name: 'Re-run ''${{ github.event.workflow_run.name }}'' workflow'
     runs-on: ubuntu-22.04
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    # Do not re-run scheduled workflow runs. That's only Replay.io E2E tests for now.
+    if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event != 'schedule'
     steps:
       - name: Generate job summary
         run: |


### PR DESCRIPTION
Manual backport of #31983 

Running E2E tests using ReplayIO still adds a significant overhead, which leads to a lot of failed runs. There's no point in re-running those tests for at least two reasons:
1. they will fail again and we're just wasting CI infrastructure
2. our slack-failure-alert-bot will spam our Slack with the reports of the failed runs that we don't (currently) care about