### PR TITLE
Handle users without write access in question caching settings

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheSection/QuestionCacheSection.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheSection/QuestionCacheSection.styled.tsx
@@ -1,8 +1,0 @@
-import styled from "@emotion/styled";
-import { color } from "metabase/lib/colors";
-
-export const QueryStartLabel = styled.div`
-  color: ${color("text-dark")};
-  font-weight: bold;
-  margin-bottom: 0.5rem;
-`;

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheSection/QuestionCacheSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheSection/QuestionCacheSection.tsx
@@ -1,8 +1,8 @@
 import { t } from "ttag";
 import { getRelativeTime } from "metabase/lib/time";
+import { Stack, Text } from "metabase/ui";
 import Question from "metabase-lib/Question";
 import CacheSection from "../CacheSection";
-import { QueryStartLabel } from "./QuestionCacheSection.styled";
 
 export interface QuestionCacheSectionProps {
   question: Question;
@@ -18,16 +18,16 @@ const QuestionCacheSection = ({
   const cacheRelativeTime = cacheTimestamp && getRelativeTime(cacheTimestamp);
 
   return (
-    <div>
+    <Stack spacing="0.5rem">
       {cacheTimestamp && (
-        <QueryStartLabel>
+        <Text color="text.2" fw="bold">
           {t`Question last cached ${cacheRelativeTime}`}
-        </QueryStartLabel>
+        </Text>
       )}
       {canWrite && (
         <CacheSection initialCacheTTL={question.cacheTTL()} onSave={onSave} />
       )}
-    </div>
+    </Stack>
   );
 };
 

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheSection/QuestionCacheSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheSection/QuestionCacheSection.tsx
@@ -13,6 +13,7 @@ const QuestionCacheSection = ({
   question,
   onSave,
 }: QuestionCacheSectionProps) => {
+  const canWrite = question.canWrite();
   const cacheTimestamp = question.lastQueryStart();
   const cacheRelativeTime = cacheTimestamp && getRelativeTime(cacheTimestamp);
 
@@ -23,7 +24,9 @@ const QuestionCacheSection = ({
           {t`Question last cached ${cacheRelativeTime}`}
         </QueryStartLabel>
       )}
-      <CacheSection initialCacheTTL={question.cacheTTL()} onSave={onSave} />
+      {canWrite && (
+        <CacheSection initialCacheTTL={question.cacheTTL()} onSave={onSave} />
+      )}
     </div>
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheSection/QuestionCacheSection.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheSection/QuestionCacheSection.unit.spec.tsx
@@ -1,9 +1,30 @@
-import { render, screen } from "@testing-library/react";
+import { checkNotNull } from "metabase/core/utils/types";
+import { getMetadata } from "metabase/selectors/metadata";
+import { Card } from "metabase-types/api";
 import { createMockCard } from "metabase-types/api/mocks";
-import Question from "metabase-lib/Question";
-import QuestionCacheSection, {
-  QuestionCacheSectionProps,
-} from "./QuestionCacheSection";
+import { createMockState } from "metabase-types/store/mocks";
+import { createMockEntitiesState } from "__support__/store";
+import { renderWithProviders, screen } from "__support__/ui";
+import QuestionCacheSection from "./QuestionCacheSection";
+
+interface SetupOpts {
+  card?: Card;
+}
+
+const setup = ({ card = createMockCard() }: SetupOpts) => {
+  const state = createMockState({
+    entities: createMockEntitiesState({
+      questions: [card],
+    }),
+  });
+  const metadata = getMetadata(state);
+  const question = checkNotNull(metadata.question(card.id));
+
+  renderWithProviders(
+    <QuestionCacheSection question={question} onSave={jest.fn()} />,
+    { storeInitialState: state },
+  );
+};
 
 describe("QuestionCacheSection", () => {
   beforeEach(() => {
@@ -15,26 +36,29 @@ describe("QuestionCacheSection", () => {
     jest.useRealTimers();
   });
 
-  it("should show the time of the last cached query", () => {
-    const props = getProps({
-      question: new Question(
-        createMockCard({
-          last_query_start: "2020-01-05T00:00:00Z",
-        }),
-      ),
+  it("should show the time of the last cached query if the question is cached", () => {
+    setup({
+      card: createMockCard({
+        can_write: false,
+        last_query_start: "2020-01-05T00:00:00Z",
+      }),
     });
 
-    render(<QuestionCacheSection {...props} />);
-
-    const cacheLabel = screen.getByText("Question last cached 5 days ago");
-    expect(cacheLabel).toBeInTheDocument();
+    expect(
+      screen.getByText("Question last cached 5 days ago"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Cache Configuration")).not.toBeInTheDocument();
   });
-});
 
-const getProps = (
-  opts?: Partial<QuestionCacheSectionProps>,
-): QuestionCacheSectionProps => ({
-  question: new Question(createMockCard()),
-  onSave: jest.fn(),
-  ...opts,
+  it("should not show the last cached query time if the question is not cached", () => {
+    setup({
+      card: createMockCard({
+        can_write: true,
+        last_query_start: null,
+      }),
+    });
+
+    expect(screen.getByText("Cache Configuration")).toBeInTheDocument();
+    expect(screen.queryByText(/Question last cached/)).not.toBeInTheDocument();
+  });
 });

--- a/enterprise/frontend/src/metabase-enterprise/caching/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/caching/index.js
@@ -13,6 +13,7 @@ import {
   getQuestionsImplicitCacheTTL,
   validateCacheTTL,
   normalizeCacheTTL,
+  hasQuestionCacheSection,
 } from "./utils";
 
 function getDatabaseCacheTTLFieldDescription() {
@@ -56,4 +57,5 @@ if (hasPremiumFeature("advanced_config")) {
   PLUGIN_CACHING.DashboardCacheSection = DashboardCacheSection;
   PLUGIN_CACHING.QuestionCacheSection = QuestionCacheSection;
   PLUGIN_CACHING.isEnabled = () => true;
+  PLUGIN_CACHING.hasQuestionCacheSection = hasQuestionCacheSection;
 }

--- a/enterprise/frontend/src/metabase-enterprise/caching/utils.js
+++ b/enterprise/frontend/src/metabase-enterprise/caching/utils.js
@@ -58,7 +58,7 @@ export function normalizeCacheTTL(value) {
 export function hasQuestionCacheSection(question) {
   return (
     !question.isDataset() &&
-    (question.lastQueryStart() != null || question.canWrite()) &&
-    MetabaseSettings.get("enable-query-caching")
+    question.metadata().setting("enable-query-caching") &&
+    (question.canWrite() || question.lastQueryStart() != null)
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/caching/utils.js
+++ b/enterprise/frontend/src/metabase-enterprise/caching/utils.js
@@ -54,3 +54,11 @@ export function validateCacheTTL(value) {
 export function normalizeCacheTTL(value) {
   return value === 0 || value === undefined ? null : value;
 }
+
+export function hasQuestionCacheSection(question) {
+  return (
+    !question.isDataset() &&
+    (question.lastQueryStart() != null || question.canWrite()) &&
+    MetabaseSettings.get("enable-query-caching")
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/caching/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/caching/utils.unit.spec.ts
@@ -157,7 +157,7 @@ describe("hasQuestionCacheSection", () => {
     expect(hasQuestionCacheSection(question)).toBe(true);
   });
 
-  it("should have the cache section when the user has write access abd the question is cached", () => {
+  it("should have the cache section when the user has write access and the question is cached", () => {
     const question = setup({ canWrite: true, lastQueryStart: "2020-01-01" });
     expect(hasQuestionCacheSection(question)).toBe(true);
   });

--- a/enterprise/frontend/src/metabase-enterprise/caching/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/caching/utils.unit.spec.ts
@@ -1,3 +1,4 @@
+import { checkNotNull } from "metabase/core/utils/types";
 import { msToSeconds, hoursToSeconds } from "metabase/lib/time";
 import { createMockCard, createMockSettings } from "metabase-types/api/mocks";
 import { mockSettings } from "__support__/settings";
@@ -119,7 +120,7 @@ describe("hasQuestionCacheSection", () => {
       "enable-query-caching": isCachingEnabled,
     });
     const metadata = createMockMetadata({ questions: [card] }, settings);
-    return metadata.question(card.id);
+    return checkNotNull(metadata.question(card.id));
   }
 
   it("should not have the cache section for models", () => {

--- a/enterprise/frontend/src/metabase-enterprise/caching/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/caching/utils.unit.spec.ts
@@ -35,11 +35,17 @@ describe("getQuestionsImplicitCacheTTL", () => {
     databaseCacheTTL = null,
     cacheTTLMultiplier = DEFAULT_CACHE_TTL_MULTIPLIER,
     minCacheThreshold = 60,
+  }: {
+    cachingEnabled?: boolean;
+    avgQueryTime?: number | null;
+    databaseCacheTTL?: number | null;
+    cacheTTLMultiplier?: number;
+    minCacheThreshold?: number;
   } = {}) {
     mockSettings({
       "enable-query-caching": cachingEnabled,
-      "query-caching-ttl-ratio": cachingEnabled ? cacheTTLMultiplier : null,
-      "query-caching-min-ttl": cachingEnabled ? minCacheThreshold : null,
+      "query-caching-ttl-ratio": cachingEnabled ? cacheTTLMultiplier : 10,
+      "query-caching-min-ttl": cachingEnabled ? minCacheThreshold : 60,
     });
 
     return {
@@ -98,6 +104,11 @@ describe("hasQuestionCacheSection", () => {
     isCachingEnabled = true,
     canWrite = true,
     lastQueryStart = null,
+  }: {
+    isDataset?: boolean;
+    isCachingEnabled?: boolean;
+    canWrite?: boolean;
+    lastQueryStart?: string | null;
   }) {
     const card = createMockCard({
       dataset: isDataset,

--- a/enterprise/frontend/src/metabase-enterprise/caching/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/caching/utils.unit.spec.ts
@@ -1,6 +1,10 @@
 import { checkNotNull } from "metabase/core/utils/types";
 import { msToSeconds, hoursToSeconds } from "metabase/lib/time";
-import { createMockCard, createMockSettings } from "metabase-types/api/mocks";
+import {
+  createMockCard,
+  createMockDatabase,
+  createMockSettings,
+} from "metabase-types/api/mocks";
 import { mockSettings } from "__support__/settings";
 import { createMockMetadata } from "__support__/metadata";
 import {
@@ -49,14 +53,19 @@ describe("getQuestionsImplicitCacheTTL", () => {
       "query-caching-min-ttl": cachingEnabled ? minCacheThreshold : 60,
     });
 
-    return {
-      card: () => ({
-        average_query_time: avgQueryTime,
-      }),
-      database: () => ({
-        cache_ttl: databaseCacheTTL,
-      }),
-    };
+    const card = createMockCard({
+      average_query_time: avgQueryTime,
+    });
+    const database = createMockDatabase({
+      cache_ttl: databaseCacheTTL,
+    });
+
+    const metadata = createMockMetadata({
+      questions: [card],
+      databases: [database],
+    });
+
+    return checkNotNull(metadata.question(card.id));
   }
 
   it("returns database's cache TTL if set", () => {

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -20,6 +20,7 @@ export interface Card<Q = DatasetQuery> extends UnsavedCard<Q> {
 
   query_average_duration?: number | null;
   last_query_start: string | null;
+  average_query_time: number | null;
   cache_ttl: number | null;
 
   archived: boolean;

--- a/frontend/src/metabase-types/api/mocks/card.ts
+++ b/frontend/src/metabase-types/api/mocks/card.ts
@@ -28,6 +28,7 @@ export const createMockCard = (opts?: Partial<Card>): Card => ({
   cache_ttl: null,
   collection_id: null,
   last_query_start: null,
+  average_query_time: null,
   archived: false,
   ...opts,
 });

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -146,6 +146,8 @@ export const createMockSettings = (opts?: Partial<Settings>): Settings => ({
   "enable-enhancements?": false,
   "enable-nested-queries": true,
   "enable-query-caching": undefined,
+  "query-caching-ttl-ratio": 10,
+  "query-caching-min-ttl": 60,
   "enable-password-login": true,
   "enable-public-sharing": false,
   "enable-xrays": false,

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -187,6 +187,8 @@ export interface Settings {
   "enable-enhancements?": boolean;
   "enable-nested-queries": boolean;
   "enable-query-caching"?: boolean;
+  "query-caching-ttl-ratio": number;
+  "query-caching-min-ttl": number;
   "enable-password-login": boolean;
   "enable-public-sharing": boolean;
   "enable-xrays": boolean;

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionContext/QueryActionContextProvider/QueryActionContextProvider.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionContext/QueryActionContextProvider/QueryActionContextProvider.tsx
@@ -71,8 +71,8 @@ function convertActionToQuestionCard(
     collection_id: null,
     result_metadata: [],
     cache_ttl: null,
-    average_query_time: null,
     last_query_start: null,
+    average_query_time: null,
     archived: false,
   };
 }

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionContext/QueryActionContextProvider/QueryActionContextProvider.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionContext/QueryActionContextProvider/QueryActionContextProvider.tsx
@@ -71,6 +71,7 @@ function convertActionToQuestionCard(
     collection_id: null,
     result_metadata: [],
     cache_ttl: null,
+    average_query_time: null,
     last_query_start: null,
     archived: false,
   };

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -210,6 +210,7 @@ export const PLUGIN_CACHING = {
   DashboardCacheSection: PluginPlaceholder,
   DatabaseCacheTimeField: PluginPlaceholder,
   isEnabled: () => false,
+  hasQuestionCacheSection: (question: Question) => false,
 };
 
 export const PLUGIN_REDUCERS: {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
@@ -4,7 +4,6 @@ import EditableText from "metabase/core/components/EditableText";
 
 import { PLUGIN_MODERATION, PLUGIN_CACHING } from "metabase/plugins";
 
-import MetabaseSettings from "metabase/lib/settings";
 import * as Urls from "metabase/lib/urls";
 
 import Link from "metabase/core/components/Link";
@@ -32,10 +31,7 @@ export const QuestionInfoSidebar = ({
   const canWrite = question.canWrite();
   const isDataset = question.isDataset();
   const isPersisted = isDataset && question.isPersisted();
-  const isCachingAvailable =
-    !isDataset &&
-    PLUGIN_CACHING.isEnabled() &&
-    MetabaseSettings.get("enable-query-caching");
+  const hasCacheSection = PLUGIN_CACHING.hasQuestionCacheSection(question);
 
   const handleSave = (description: string | null) => {
     if (question.description() !== description) {
@@ -81,7 +77,7 @@ export const QuestionInfoSidebar = ({
         </ContentSection>
       )}
 
-      {isCachingAvailable && (
+      {hasCacheSection && (
         <ContentSection extraPadding>
           <PLUGIN_CACHING.QuestionCacheSection
             question={question}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.unit.spec.js
@@ -124,7 +124,9 @@ describe("QuestionInfoSidebar", () => {
       });
 
       it("is shown if caching is enabled", async () => {
-        await setup({ card: getQuestionCard({ cache_ttl: 2 }) });
+        await setup({
+          card: getQuestionCard({ can_write: true, cache_ttl: 2 }),
+        });
         expect(screen.getByText("Cache Configuration")).toBeInTheDocument();
       });
 

--- a/frontend/test/__support__/metadata.ts
+++ b/frontend/test/__support__/metadata.ts
@@ -1,13 +1,19 @@
-import { getMetadata, MetadataSelectorOpts } from "metabase/selectors/metadata";
-import { createMockState } from "metabase-types/store/mocks";
+import { getMetadata } from "metabase/selectors/metadata";
+import { Settings } from "metabase-types/api";
+import {
+  createMockSettingsState,
+  createMockState,
+} from "metabase-types/store/mocks";
 import { createMockEntitiesState, EntitiesStateOpts } from "./store";
 
 export function createMockMetadata(
   entities: EntitiesStateOpts,
-  opts?: MetadataSelectorOpts,
+  settings?: Settings,
 ) {
   const state = createMockState({
     entities: createMockEntitiesState(entities),
+    settings: createMockSettingsState(settings),
   });
-  return getMetadata(state, opts);
+
+  return getMetadata(state);
 }


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/28914

Previously we always showed cache configuration controls even when users aren't able to change them. Now we handle this case, and hide `Cache Configuration` popover. If the question was cached, we still show the timestamp for such users.

How to verify:
- Run Metabase EE
- Enable caching in Admin -> Caching
- Go to a question, set caching settings, refresh it - make sure it's cached and the last query run time is displayed
- Login as a user with View access to the collection where question is
- Make sure the user can see the timestamp but no caching controls

Admin - no changes:
<img width="364" alt="Screenshot 2023-06-29 at 15 29 45" src="https://github.com/metabase/metabase/assets/8542534/5bb6f3be-1479-4026-9efb-1941989979a4">

Users with view access:
<img width="365" alt="Screenshot 2023-06-29 at 15 34 32" src="https://github.com/metabase/metabase/assets/8542534/52b31efd-1613-44b8-9f3a-a2f49406d6d9">
