### PR TITLE
Fix showing suggestions for an unfocused custom expression field

### DIFF
--- a/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
@@ -80,7 +80,7 @@ describe("scenarios > question > custom column > typing suggestion", () => {
     );
   });
 
-  it("should not show suggestions for an unfocused field", () => {
+  it("should not show suggestions for an unfocused field (metabase#31643)", () => {
     summarize({ mode: "notebook" });
     popover().findByText("Custom Expression").click();
     enterCustomColumnDetails({ formula: "Count{enter}" });

--- a/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
@@ -1,7 +1,9 @@
 import {
   enterCustomColumnDetails,
   openProductsTable,
+  popover,
   restore,
+  summarize,
 } from "e2e/support/helpers";
 
 describe("scenarios > question > custom column > typing suggestion", () => {
@@ -10,16 +12,16 @@ describe("scenarios > question > custom column > typing suggestion", () => {
     cy.signInAsAdmin();
 
     openProductsTable({ mode: "notebook" });
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Custom column").click();
   });
 
   it("should not suggest arithmetic operators", () => {
+    addCustomColumn();
     enterCustomColumnDetails({ formula: "[Price] " });
     cy.findByTestId("expression-suggestions-list").should("not.exist");
   });
 
   it("should correctly accept the chosen field suggestion", () => {
+    addCustomColumn();
     enterCustomColumnDetails({
       formula: "[Rating]{leftarrow}{leftarrow}{leftarrow}",
     });
@@ -34,6 +36,7 @@ describe("scenarios > question > custom column > typing suggestion", () => {
   });
 
   it("should correctly accept the chosen function suggestion", () => {
+    addCustomColumn();
     enterCustomColumnDetails({ formula: "LTRIM([Title])" });
 
     // Place the cursor between "is" and "empty"
@@ -47,6 +50,7 @@ describe("scenarios > question > custom column > typing suggestion", () => {
   });
 
   it("should correctly insert function suggestion with the opening parenthesis", () => {
+    addCustomColumn();
     enterCustomColumnDetails({ formula: "LOW{enter}" });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -54,6 +58,7 @@ describe("scenarios > question > custom column > typing suggestion", () => {
   });
 
   it("should show expression function helper if a proper function is typed", () => {
+    addCustomColumn();
     enterCustomColumnDetails({ formula: "lower(" });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -74,4 +79,16 @@ describe("scenarios > question > custom column > typing suggestion", () => {
       "be.visible",
     );
   });
+
+  it("should not show suggestions for an unfocused field", () => {
+    summarize({ mode: "notebook" });
+    popover().findByText("Custom Expression").click();
+    enterCustomColumnDetails({ formula: "Count{enter}" });
+    popover().findByLabelText("Name").focus();
+    cy.findByTestId("expression-suggestions-list").should("not.exist");
+  });
 });
+
+const addCustomColumn = () => {
+  cy.findByTestId("action-buttons").findByText("Custom column").click();
+};

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -407,7 +407,9 @@ class ExpressionEditorTextfield extends React.Component<
     });
 
     this.setState({ helpText: helpText || null });
-    this.updateSuggestions(suggestions);
+    if (this.state.isFocused) {
+      this.updateSuggestions(suggestions);
+    }
   }
 
   errorAsMarkers(errorMessage: ErrorWithMessage | null = null): IMarker[] {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/31643

Fixes a tricky case when a user hits enter + tab for an expression without parameters. In this case the suggestions popover was incorrectly open.

How to verify:
- New -> Question -> Orders
- Breakout -> Custom Expression
- Type `Count` then `Enter` then `Tab`
- Without the fix it should trigger the suggestion popover to appear again

Before
<img width="870" alt="Screenshot 2023-06-29 at 17 37 30" src="https://github.com/metabase/metabase/assets/8542534/20a17942-1d25-4a65-b939-c8bd1ad6070b">

After
<img width="471" alt="Screenshot 2023-06-29 at 17 36 43" src="https://github.com/metabase/metabase/assets/8542534/de4dc9fb-e75c-4cb2-b5ff-85e1c15dc018">
