### PR TITLE
moving dashboard events 1-0-2 to 1-1-2

### DIFF
--- a/frontend/src/metabase/dashboard/analytics.ts
+++ b/frontend/src/metabase/dashboard/analytics.ts
@@ -9,7 +9,7 @@ export const trackAutoApplyFiltersDisabled = (dashboardId: DashboardId) => {
 };
 
 export const trackExportDashboardToPDF = (dashboardId: DashboardId) => {
-  trackSchemaEvent("dashboard", "1-0-2", {
+  trackSchemaEvent("dashboard", "1-1-2", {
     event: "dashboard_pdf_exported",
     dashboard_id: dashboardId,
   });

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-1-2
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-1-2
@@ -5,7 +5,7 @@
     "vendor": "com.metabase",
     "name": "dashboard",
     "format": "jsonschema",
-    "version": "1-1-1"
+    "version": "1-1-2"
   },
   "type": "object",
   "properties": {

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-1-2
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-1-2
@@ -5,7 +5,7 @@
     "vendor": "com.metabase",
     "name": "dashboard",
     "format": "jsonschema",
-    "version": "1-0-2"
+    "version": "1-1-1"
   },
   "type": "object",
   "properties": {
@@ -16,6 +16,13 @@
         "dashboard_created",
         "question_added_to_dashboard",
         "auto_apply_filters_disabled",
+        "dashboard_tab_created",
+        "dashboard_tab_deleted",
+        "new_text_card_created",
+        "new_heading_card_created",
+        "new_link_card_created",
+        "new_action_card_created",
+        "card_set_to_hide_when_no_results",
         "dashboard_pdf_exported"
       ],
       "maxLength": 1024
@@ -28,6 +35,24 @@
     },
     "question_id": {
       "description": "Unique identifier for a question added to a dashboard",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "num_tabs": {
+      "description": "Number of tabs affected after the event",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "total_num_tabs": {
+      "description": "Total number of active tabs after the events",
       "type": [
         "integer",
         "null"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/30793

### Description
My original snowplow PR for Dashboard events was outdated before it was merged, so my event is missing in the newer schema. This PR removes the old, unused schema and adds the new event on top.

