### PR TITLE
Run E2E tests using Replay browser weekly

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,7 +3,7 @@ name: E2E Tests
 on:
   # We'll record runs using Replay.io and their browser on a schedule as an experiment
   schedule:
-    - cron: '0 */8 * * *'
+    - cron: '* * * * 0'
   push:
     branches:
       - "master"


### PR DESCRIPTION
Replay is adding a significant overhead and is making every single run fail. This is messing with our statistics and analytics.

While the Replay.io team is working on some optimizations that would remove the overhead, we can significantly dial down the frequency of these runs. We'll switch to running them only once per week, on Sunday.

For now...