### PR TITLE
Opaque JoinStrategy option type

### DIFF
--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -16,6 +16,8 @@ import type {
   ColumnDisplayInfo,
   ColumnGroup,
   ColumnMetadata,
+  JoinStrategy,
+  JoinStrategyDisplayInfo,
   MetadataProvider,
   MetricMetadata,
   MetricDisplayInfo,
@@ -81,6 +83,11 @@ declare function DisplayInfoFn(
   stageIndex: number,
   metric: MetricMetadata,
 ): MetricDisplayInfo;
+declare function DisplayInfoFn(
+  query: Query,
+  stageIndex: number,
+  joinStrategy: JoinStrategy,
+): JoinStrategyDisplayInfo;
 
 // x can be any sort of opaque object, e.g. a clause or metadata map. Values returned depend on what you pass in, but it
 // should always have display_name... see :metabase.lib.metadata.calculation/display-info schema

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -149,8 +149,11 @@ export type ExternalOp = {
 declare const Join: unique symbol;
 export type Join = unknown & { _opaque: typeof Join };
 
-export type JoinStrategy =
-  | "left-join"
-  | "right-join"
-  | "inner-join"
-  | "full-join";
+declare const JoinStrategy: unique symbol;
+export type JoinStrategy = unknown & { _opaque: typeof Join };
+
+export type JoinStrategyDisplayInfo = {
+  displayName: string;
+  default?: boolean;
+  shortName: string;
+};

--- a/src/metabase/lib/aggregation.cljc
+++ b/src/metabase/lib/aggregation.cljc
@@ -274,11 +274,11 @@
    [:map
     [:columns {:optional true} [:sequential lib.metadata/ColumnMetadata]]]])
 
-(defmethod lib.metadata.calculation/display-name-method :mbql.aggregation/operator
+(defmethod lib.metadata.calculation/display-name-method :operator/aggregation
   [_query _stage-number {:keys [display-info]} _display-name-style]
   (:display-name (display-info)))
 
-(defmethod lib.metadata.calculation/display-info-method :mbql.aggregation/operator
+(defmethod lib.metadata.calculation/display-info-method :operator/aggregation
   [_query _stage-number {:keys [display-info requires-column? selected?] short-name :short}]
   (cond-> (assoc (display-info)
                  :short-name (u/qualified-name short-name)
@@ -320,7 +320,7 @@
                             (let [feature (:driver-feature op)]
                               (or (nil? feature) (db-features feature)))))
                   (keep with-columns)
-                  (map #(assoc % :lib/type :mbql.aggregation/operator)))
+                  (map #(assoc % :lib/type :operator/aggregation)))
             lib.schema.aggregation/aggregation-operators)))))
 
 (mu/defn aggregation-clause :- ::lib.schema.aggregation/aggregation

--- a/src/metabase/lib/binning.cljc
+++ b/src/metabase/lib/binning.cljc
@@ -75,7 +75,7 @@
    :mbql         {:strategy :default}})
 
 (defn- with-binning-option-type [m]
-  (assoc m :lib/type ::binning-option))
+  (assoc m :lib/type :option/binning))
 
 (def ^:private *numeric-binning-strategies
   (delay (mapv with-binning-option-type
@@ -116,7 +116,7 @@
                         "°"))
       :default   (i18n/tru "Auto binned"))))
 
-(defmethod lib.metadata.calculation/display-info-method ::binning-option
+(defmethod lib.metadata.calculation/display-info-method :option/binning
   [_query _stage-number binning-option]
   (select-keys binning-option [:display-name :default :selected]))
 

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -172,6 +172,7 @@
    join-fields
    join-strategy
    joins
+   raw-join-strategy
    suggested-join-condition
    with-join-alias
    with-join-fields

--- a/src/metabase/lib/filter.cljc
+++ b/src/metabase/lib/filter.cljc
@@ -189,8 +189,8 @@
    (operator-def tag nil))
 
   ([tag alternate-display-name-style]
-   {:type/type :operator/filter
-    :short     tag
+   {:lib/type :operator/filter
+    :short    tag
     :display-name
     (clojure.core/case tag
       :=                (clojure.core/case alternate-display-name-style

--- a/src/metabase/lib/filter.cljc
+++ b/src/metabase/lib/filter.cljc
@@ -172,107 +172,151 @@
     stage-number :- [:maybe :int]]
    (clojure.core/not-empty (:filters (lib.util/query-stage query (clojure.core/or stage-number -1))))))
 
-(defmethod lib.metadata.calculation/display-name-method :mbql.filter/operator
+(defmethod lib.metadata.calculation/display-name-method :operator/filter
   [_query _stage-number {:keys [display-name]} _display-name-style]
   display-name)
 
-(defmethod lib.metadata.calculation/display-info-method :mbql.filter/operator
+(defmethod lib.metadata.calculation/display-info-method :operator/filter
   [_query _stage-number {:keys [display-name] short-name :short}]
   {:short-name (u/qualified-name short-name)
    :display-name display-name})
+
+(defn operator-def
+  "Get a filter operator definition for the MBQL filter with `tag`, e.g. `:=`. In some cases various tags have alternate
+  display names used for different situations e.g. for numbers vs temporal values; pass in the
+  `alternate-display-name-style` to choose a non-default display-name."
+  ([tag]
+   (operator-def tag nil))
+
+  ([tag alternate-display-name-style]
+   {:type/type :operator/filter
+    :short     tag
+    :display-name
+    (clojure.core/case tag
+      :=                (clojure.core/case alternate-display-name-style
+                          :equal-to (i18n/tru "Equal to")
+                          (i18n/tru "Is"))
+      :!=               (clojure.core/case alternate-display-name-style
+                          :not-equal-to (i18n/tru "Not equal to")
+                          :excludes     (i18n/tru "Excludes")
+                          (i18n/tru "Is not"))
+      :>                (clojure.core/case alternate-display-name-style
+                          :after (i18n/tru "After")
+                          (i18n/tru "Greater than"))
+      :<                (clojure.core/case alternate-display-name-style
+                          :before (i18n/tru "Before")
+                          (i18n/tru "Less than"))
+      :between          (i18n/tru "Between")
+      :>=               (i18n/tru "Greater than or equal to")
+      :<=               (i18n/tru "Less than or equal to")
+      :is-null          (clojure.core/case alternate-display-name-style
+                          :is-empty (i18n/tru "Is empty")
+                          (i18n/tru "Is null"))
+      :not-null         (clojure.core/case alternate-display-name-style
+                          :not-empty (i18n/tru "Not empty")
+                          (i18n/tru "Not null"))
+      :is-empty         (i18n/tru "Is empty")
+      :not-empty        (i18n/tru "Not empty")
+      :contains         (i18n/tru "Contains")
+      :does-not-contain (i18n/tru "Does not contain")
+      :starts-with      (i18n/tru "Starts with")
+      :ends-with        (i18n/tru "Ends with")
+      :inside           (i18n/tru "Inside"))}))
 
 (defn- filter-operators
   "The list of available filter operators.
    The order of operators is relevant for the front end.
    There are slight differences between names and ordering for the different base types."
   [column]
-  (let [key-operators [{:short := :display-name (i18n/tru "Is")}
-                       {:short :!= :display-name (i18n/tru "Is not")}
-                       {:short :> :display-name (i18n/tru "Greater than")}
-                       {:short :< :display-name (i18n/tru "Less than")}
-                       {:short :between :display-name (i18n/tru "Between")}
-                       {:short :>= :display-name (i18n/tru "Greater than or equal to")}
-                       {:short :<= :display-name (i18n/tru "Less than or equal to")}
-                       {:short :is-null :display-name (i18n/tru "Is empty")}
-                       {:short :not-null :display-name (i18n/tru "Not empty")}]]
+  ;; this is a function so we don't evaluate it unless we actually return it
+  (letfn [(key-operators []
+            [(operator-def :=)
+             (operator-def :!=)
+             (operator-def :>)
+             (operator-def :<)
+             (operator-def :between)
+             (operator-def :>=)
+             (operator-def :<=)
+             (operator-def :is-null :is-empty)
+             (operator-def :not-null :not-empty)])]
     ;; The order of these clauses is important since we want to match the most relevant type
     (condp #(lib.types.isa/isa? %2 %1) column
       :type/PK
-      key-operators
+      (key-operators)
 
       :type/FK
-      key-operators
+      (key-operators)
 
       :type/Location
-      [{:short := :display-name (i18n/tru "Is")}
-       {:short :!= :display-name (i18n/tru "Is not")}
-       {:short :is-empty :display-name (i18n/tru "Is empty")}
-       {:short :not-empty :display-name (i18n/tru "Not empty")}
-       {:short :contains :display-name (i18n/tru "Contains")}
-       {:short :does-not-contain :display-name (i18n/tru "Does not contain")}
-       {:short :starts-with :display-name (i18n/tru "Starts with")}
-       {:short :ends-with :display-name (i18n/tru "Ends with")}]
+      [(operator-def :=)
+       (operator-def :!=)
+       (operator-def :is-empty)
+       (operator-def :not-empty)
+       (operator-def :contains)
+       (operator-def :does-not-contain)
+       (operator-def :starts-with)
+       (operator-def :ends-with)]
 
       :type/Temporal
-      [{:short :!= :display-name (i18n/tru "Excludes")}
-       {:short := :display-name (i18n/tru "Is")}
-       {:short :< :display-name (i18n/tru "Before")}
-       {:short :> :display-name (i18n/tru "After")}
-       {:short :between :display-name (i18n/tru "Between")}
-       {:short :is-null :display-name (i18n/tru "Is empty")}
-       {:short :not-null :display-name (i18n/tru "Not empty")}]
+      [(operator-def :!= :excludes)
+       (operator-def :=)
+       (operator-def :< :before)
+       (operator-def :> :after)
+       (operator-def :between)
+       (operator-def :is-null :is-empty)
+       (operator-def :not-null :not-empty)]
 
       :type/Coordinate
-      [{:short := :display-name (i18n/tru "Is")}
-       {:short :!= :display-name (i18n/tru "Is not")}
-       {:short :inside :display-name (i18n/tru "Inside")}
-       {:short :> :display-name (i18n/tru "Greater than")}
-       {:short :< :display-name (i18n/tru "Less than")}
-       {:short :between :display-name (i18n/tru "Between")}
-       {:short :>= :display-name (i18n/tru "Greater than or equal to")}
-       {:short :<= :display-name (i18n/tru "Less than or equal to")}]
+      [(operator-def :=)
+       (operator-def :!=)
+       (operator-def :inside nil)
+       (operator-def :>)
+       (operator-def :<)
+       (operator-def :between)
+       (operator-def :>=)
+       (operator-def :<=)]
 
       :type/Number
-      [{:short := :display-name (i18n/tru "Equal to")}
-       {:short :!= :display-name (i18n/tru "Not equal to")}
-       {:short :> :display-name (i18n/tru "Greater than")}
-       {:short :< :display-name (i18n/tru "Less than")}
-       {:short :between :display-name (i18n/tru "Between")}
-       {:short :>= :display-name (i18n/tru "Greater than or equal to")}
-       {:short :<= :display-name (i18n/tru "Less than or equal to")}
-       {:short :is-null :display-name (i18n/tru "Is empty")}
-       {:short :not-null :display-name (i18n/tru "Not empty")}]
+      [(operator-def := :equal-to)
+       (operator-def :!= :not-equal-to)
+       (operator-def :>)
+       (operator-def :<)
+       (operator-def :between)
+       (operator-def :>=)
+       (operator-def :<=)
+       (operator-def :is-null :is-empty)
+       (operator-def :not-null :not-empty)]
 
       :type/Text
-      [{:short := :display-name (i18n/tru "Is")}
-       {:short :!= :display-name (i18n/tru "Is not")}
-       {:short :contains :display-name (i18n/tru "Contains")}
-       {:short :does-not-contain :display-name (i18n/tru "Does not contain")}
-       {:short :is-null :display-name (i18n/tru "Is null")}
-       {:short :not-null :display-name (i18n/tru "Not null")}
-       {:short :is-empty :display-name (i18n/tru "Is empty")}
-       {:short :not-empty :display-name (i18n/tru "Not empty")}
-       {:short :starts-with :display-name (i18n/tru "Starts with")}
-       {:short :ends-with :display-name (i18n/tru "Ends with")}]
+      [(operator-def :=)
+       (operator-def :!=)
+       (operator-def :contains)
+       (operator-def :does-not-contain)
+       (operator-def :is-null)
+       (operator-def :not-null)
+       (operator-def :is-empty)
+       (operator-def :not-empty)
+       (operator-def :starts-with)
+       (operator-def :ends-with)]
 
       :type/TextLike
-      [{:short := :display-name (i18n/tru "Is")}
-       {:short :!= :display-name (i18n/tru "Is not")}
-       {:short :is-null :display-name (i18n/tru "Is null")}
-       {:short :not-null :display-name (i18n/tru "Not null")}
-       {:short :is-empty :display-name (i18n/tru "Is empty")}
-       {:short :not-empty :display-name (i18n/tru "Not empty")}]
+      [(operator-def :=)
+       (operator-def :!=)
+       (operator-def :is-null)
+       (operator-def :not-null)
+       (operator-def :is-empty)
+       (operator-def :not-empty)]
 
       :type/Boolean
-      [{:short := :display-name (i18n/tru "Is")}
-       {:short :is-null :display-name (i18n/tru "Is empty")}
-       {:short :not-null :display-name (i18n/tru "Not empty")}]
+      [(operator-def :=)
+       (operator-def :is-null :is-empty)
+       (operator-def :not-null :not-empty)]
 
       ;; default
-      [{:short := :display-name (i18n/tru "Is")}
-       {:short :!= :display-name (i18n/tru "Is not")}
-       {:short :is-null :display-name (i18n/tru "Is null")}
-       {:short :not-null :display-name (i18n/tru "Not null")}])))
+      [(operator-def :=)
+       (operator-def :!=)
+       (operator-def :is-null)
+       (operator-def :not-null)])))
 
 (def ^:private ColumnWithOperators
   [:merge
@@ -308,9 +352,7 @@
    (let [stage (lib.util/query-stage query stage-number)
          columns (lib.metadata.calculation/visible-columns query stage-number stage)
          with-operators (fn [column]
-                          (when-let [operators (->> (filter-operators column)
-                                                    (mapv #(assoc % :lib/type :mbql.filter/operator))
-                                                    clojure.core/not-empty)]
+                          (when-let [operators (clojure.core/not-empty (filter-operators column))]
                             (assoc column :operators operators)))]
      (clojure.core/not-empty
        (into []

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -518,18 +518,13 @@
    (sort-join-condition-columns
     (lib.metadata.calculation/visible-columns query stage-number joinable {:include-implicitly-joinable? false}))))
 
-;;; TODO -- definitions duplicated with code in [[metabase.lib.filter]]
-
-(defn- equals-join-condition-operator-definition []
-  {:lib/type :mbql.filter/operator, :short :=, :display-name  (i18n/tru "Equal to")})
-
 (defn- join-condition-operator-definitions []
-  [(equals-join-condition-operator-definition)
-   {:lib/type :mbql.filter/operator, :short :>, :display-name  (i18n/tru "Greater than")}
-   {:lib/type :mbql.filter/operator, :short :<, :display-name  (i18n/tru "Less than")}
-   {:lib/type :mbql.filter/operator, :short :>=, :display-name (i18n/tru "Greater than or equal to")}
-   {:lib/type :mbql.filter/operator, :short :<=, :display-name (i18n/tru "Less than or equal to")}
-   {:lib/type :mbql.filter/operator, :short :!=, :display-name (i18n/tru "Not equal to")}])
+  [(lib.filter/operator-def := :equal-to)
+   (lib.filter/operator-def :>)
+   (lib.filter/operator-def :<)
+   (lib.filter/operator-def :>=)
+   (lib.filter/operator-def :<=)
+   (lib.filter/operator-def :!= :not-equal-to)])
 
 (mu/defn join-condition-operators :- [:sequential ::lib.schema.filter/operator]
   "Return a sequence of valid filter clause operators that can be used to build a join condition. In the Query Builder
@@ -578,7 +573,7 @@
     joinable]
    (when-let [pk-col (pk-column query stage-number joinable)]
      (when-let [fk-col (fk-column-for query stage-number pk-col)]
-       (lib.filter/filter-clause (equals-join-condition-operator-definition) fk-col pk-col)))))
+       (lib.filter/filter-clause (lib.filter/operator-def := :equal-to) fk-col pk-col)))))
 
 (mu/defn joined-thing :- [:maybe [:or lib.metadata/TableMetadata lib.metadata/CardMetadata]]
   "Return metadata about the origin of `a-join` using `metadata-providerable` as the source of information."

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -402,7 +402,7 @@
 
 (defn ^:export available-join-strategies
   "Get available join strategies for the current Database (based on the Database's
-  supported [[metabase.driver/driver-features]]) as strings like `left-join`."
+  supported [[metabase.driver/driver-features]]) as opaque JoinStrategy objects."
   [a-query stage-number]
   (to-array (map u/qualified-name (lib.core/available-join-strategies a-query stage-number))))
 

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -391,14 +391,14 @@
   (to-array (lib.core/fieldable-columns a-query stage-number)))
 
 (defn ^:export join-strategy
-  "Get the strategy (type) of a given join as a plain string like `left-join`."
+  "Get the strategy (type) of a given join as an opaque JoinStrategy object."
   [a-join]
-  (u/qualified-name (lib.core/join-strategy a-join)))
+  (lib.core/join-strategy a-join))
 
 (defn ^:export with-join-strategy
-  "Return a copy of `a-join` with its `:strategy` set to `strategy`."
+  "Return a copy of `a-join` with its `:strategy` set to an opaque JoinStrategy."
   [a-join strategy]
-  (lib.core/with-join-strategy a-join (keyword strategy)))
+  (lib.core/with-join-strategy a-join strategy))
 
 (defn ^:export available-join-strategies
   "Get available join strategies for the current Database (based on the Database's

--- a/src/metabase/lib/schema/aggregation.cljc
+++ b/src/metabase/lib/schema/aggregation.cljc
@@ -189,7 +189,7 @@
 
 (mr/def ::operator
   [:map
-   [:lib/type [:= :mbql.aggregation/operator]]
+   [:lib/type [:= :operator/aggregation]]
    [:short (into [:enum] (map :short) aggregation-operators)]
    [:supported-field {:optional true} [:maybe :keyword]] ; TODO more precise type?
    [:requires-column? :boolean]

--- a/src/metabase/lib/schema/binning.cljc
+++ b/src/metabase/lib/schema/binning.cljc
@@ -24,7 +24,7 @@
 
 (mr/def ::binning-option
   [:map
-   [:lib/type [:= :metabase.lib.binning/binning-option]]
+   [:lib/type [:= :option/binning]]
    [:display-name :string]
    [:mbql [:maybe ::binning]]
    [:default {:optional true} :boolean]])

--- a/src/metabase/lib/schema/filter.cljc
+++ b/src/metabase/lib/schema/filter.cljc
@@ -101,6 +101,6 @@
 
 (mr/def ::operator
   [:map
-   [:lib/type [:= :mbql.filter/operator]]
+   [:lib/type [:= :operator/filter]]
    [:short [:enum := :!= :inside :between :< :> :<= :>= :is-null :not-null :is-empty :not-empty :contains :does-not-contain :starts-with :ends-with]]
    [:display-name :string]])

--- a/src/metabase/lib/schema/join.cljc
+++ b/src/metabase/lib/schema/join.cljc
@@ -72,3 +72,9 @@
       (if-let [aliases (not-empty (filter some? (map :alias joins)))]
         (apply distinct? aliases)
         true))]])
+
+(mr/def ::strategy.option
+  [:map
+   [:lib/type [:= :option/join.strategy]]
+   [:strategy [:ref ::strategy]]
+   [:default {:optional true} :boolean]])

--- a/src/metabase/lib/schema/temporal_bucketing.cljc
+++ b/src/metabase/lib/schema/temporal_bucketing.cljc
@@ -150,6 +150,6 @@
 
 (mr/def ::option
   [:map
-   [:lib/type [:= :type/temporal-bucketing-option]]
+   [:lib/type [:= :option/temporal-bucketing]]
    [:unit ::unit]
    [:default {:optional true} :boolean]])

--- a/src/metabase/lib/temporal_bucket.cljc
+++ b/src/metabase/lib/temporal_bucket.cljc
@@ -142,13 +142,13 @@
   "Get the current temporal bucketing option associated with something, if any."
   [x]
   (when-let [unit (temporal-bucket-method x)]
-    {:lib/type :type/temporal-bucketing-option
+    {:lib/type :option/temporal-bucketing
      :unit unit}))
 
 (def time-bucket-options
   "The temporal bucketing options for time type expressions."
   (mapv (fn [unit]
-          (cond-> {:lib/type :type/temporal-bucketing-option
+          (cond-> {:lib/type :option/temporal-bucketing
                    :unit unit}
             (= unit :hour) (assoc :default true)))
         lib.schema.temporal-bucketing/ordered-time-bucketing-units))
@@ -156,7 +156,7 @@
 (def date-bucket-options
   "The temporal bucketing options for date type expressions."
   (mapv (fn [unit]
-          (cond-> {:lib/type :type/temporal-bucketing-option
+          (cond-> {:lib/type :option/temporal-bucketing
                    :unit unit}
             (= unit :day) (assoc :default true)))
         lib.schema.temporal-bucketing/ordered-date-bucketing-units))
@@ -164,16 +164,16 @@
 (def datetime-bucket-options
   "The temporal bucketing options for datetime type expressions."
   (mapv (fn [unit]
-          (cond-> {:lib/type :type/temporal-bucketing-option
+          (cond-> {:lib/type :option/temporal-bucketing
                    :unit unit}
             (= unit :day) (assoc :default true)))
         lib.schema.temporal-bucketing/ordered-datetime-bucketing-units))
 
-(defmethod lib.metadata.calculation/display-name-method :type/temporal-bucketing-option
+(defmethod lib.metadata.calculation/display-name-method :option/temporal-bucketing
   [_query _stage-number {:keys [unit]} _style]
   (describe-temporal-unit unit))
 
-(defmethod lib.metadata.calculation/display-info-method :type/temporal-bucketing-option
+(defmethod lib.metadata.calculation/display-info-method :option/temporal-bucketing
   [query stage-number option]
   (merge {:display-name (lib.metadata.calculation/display-name query stage-number option)}
          (select-keys option [:default :selected])))

--- a/test/metabase/lib/aggregation_test.cljc
+++ b/test/metabase/lib/aggregation_test.cljc
@@ -541,7 +541,7 @@
           aggregations (lib/aggregations query)
           aggregation-operators (lib/available-aggregation-operators query)]
       (testing "selected-aggregation-operators w/o column"
-        (is (=? [{:lib/type :mbql.aggregation/operator
+        (is (=? [{:lib/type :operator/aggregation
                   :short :max
                   :selected? true
                   :columns

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -217,7 +217,7 @@
     (is (=? [:field {:temporal-unit :day-of-month} (meta/id :checkins :date)]
             field))
     (testing "(lib/temporal-bucket <field-ref>)"
-      (is (= {:lib/type :type/temporal-bucketing-option
+      (is (= {:lib/type :option/temporal-bucketing
               :unit     :day-of-month}
              (lib/temporal-bucket field))))
     (is (= "Date: Day of month"
@@ -261,7 +261,7 @@
         (is (= effective-type
                (lib.metadata.calculation/type-of (:query temporal-bucketing-mock-metadata) x'))))
       (testing "lib/temporal-bucket should return the option"
-        (is (= {:lib/type :type/temporal-bucketing-option
+        (is (= {:lib/type :option/temporal-bucketing
                 :unit     unit}
                (lib/temporal-bucket x')))
         (testing "should generate a :field ref with correct :temporal-unit"
@@ -309,7 +309,7 @@
                  (lib/available-temporal-buckets (:query temporal-bucketing-mock-metadata) x)))
           (testing "Bucketing with any of the options should work"
             (doseq [expected-option expected-options]
-              (is (= {:lib/type :type/temporal-bucketing-option
+              (is (= {:lib/type :option/temporal-bucketing
                      :unit      (:unit expected-option)}
                      (lib/temporal-bucket (lib/with-temporal-bucket x expected-option))))))
           (let [bucketed (lib/with-temporal-bucket x selected-unit)

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -323,12 +323,16 @@
         [join] (lib/joins query)]
     (testing "join without :strategy"
       (is (= :left-join
+             (lib/raw-join-strategy join)))
+      (is (= {:lib/type :option/join.strategy, :strategy :left-join, :default true}
              (lib/join-strategy join))))
     (testing "join with explicit :strategy"
       (let [join' (lib/with-join-strategy join :right-join)]
         (is (=? {:strategy :right-join}
                 join'))
         (is (= :right-join
+               (lib/raw-join-strategy join')))
+        (is (= {:lib/type :option/join.strategy, :strategy :right-join}
                (lib/join-strategy join')))))))
 
 (deftest ^:parallel with-join-strategy-test

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -332,27 +332,44 @@
                (lib/join-strategy join')))))))
 
 (deftest ^:parallel with-join-strategy-test
-  (testing "Make sure `with-join-alias` works with unresolved functions"
-    (is (=? {:stages [{:joins [{:conditions [[:=
-                                              {}
-                                              [:field
-                                               {:join-alias (symbol "nil #_\"key is not present.\"")}
-                                               (meta/id :venues :category-id)]
-                                              [:field
-                                               {:join-alias "Categories"}
-                                               (meta/id :categories :id)]]],
-                                :strategy :right-join,
-                                :alias "Categories"}]}]}
-            (-> lib.tu/venues-query
-                (lib/join (-> (lib/join-clause (meta/table-metadata :categories)
-                                               [(lib/=
-                                                 (meta/field-metadata :venues :category-id)
-                                                 (lib/with-join-alias (meta/field-metadata :categories :id) "Cat"))])
-                              (lib/with-join-strategy :right-join))))))))
+  (are [strategy] (=? {:stages [{:joins [{:conditions [[:=
+                                                        {}
+                                                        [:field
+                                                         {:join-alias (symbol "nil #_\"key is not present.\"")}
+                                                         (meta/id :venues :category-id)]
+                                                        [:field
+                                                         {:join-alias "Categories"}
+                                                         (meta/id :categories :id)]]],
+                                          :strategy :right-join,
+                                          :alias "Categories"}]}]}
+                      (-> lib.tu/venues-query
+                          (lib/join (-> (lib/join-clause (meta/table-metadata :categories)
+                                                         [(lib/=
+                                                           (meta/field-metadata :venues :category-id)
+                                                           (lib/with-join-alias (meta/field-metadata :categories :id) "Cat"))])
+                                        (lib/with-join-strategy strategy)))))
+    :right-join
+    {:lib/type :option/join.strategy, :strategy :right-join}))
 
 (deftest ^:parallel available-join-strategies-test
-  (is (= [:left-join :right-join :inner-join]
+  (is (= [{:lib/type :option/join.strategy, :strategy :left-join, :default true}
+          {:lib/type :option/join.strategy, :strategy :right-join}
+          {:lib/type :option/join.strategy, :strategy :inner-join}]
          (lib/available-join-strategies (lib.tu/query-with-join)))))
+
+(deftest ^:parallel join-strategy-display-name-test
+  (let [query (lib.tu/query-with-join)]
+    (is (= ["Left outer join" "Right outer join" "Inner join"]
+           (map (partial lib.metadata.calculation/display-name query)
+                (lib/available-join-strategies query))))))
+
+(deftest ^:parallel join-strategy-display-info-test
+  (let [query (lib.tu/query-with-join)]
+    (is (= [{:short-name "left-join", :display-name "Left outer join", :default true}
+            {:short-name "right-join", :display-name "Right outer join"}
+            {:short-name "inner-join", :display-name "Inner join"}]
+           (map (partial lib.metadata.calculation/display-info query)
+                (lib/available-join-strategies query))))))
 
 (deftest ^:parallel with-join-fields-test
   (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))

--- a/test/metabase/lib/temporal_bucket_test.cljc
+++ b/test/metabase/lib/temporal_bucket_test.cljc
@@ -107,7 +107,7 @@
                          :minute-of-hour :hour-of-day
                          :day-of-week :day-of-month :day-of-year
                          :week-of-year :month-of-year :quarter-of-year}
-        expected-defaults [{:lib/type :type/temporal-bucketing-option, :unit :day, :default true}]]
+        expected-defaults [{:lib/type :option/temporal-bucketing, :unit :day, :default true}]]
     (testing "missing fingerprint"
       (let [column (dissoc column :fingerprint)
             options (lib.temporal-bucket/available-temporal-buckets-method nil -1 column)]


### PR DESCRIPTION
Resolves #32009

In this PR I also tried consolidating the names of the various different option map type keywords, from `:type/temporal-bucketing-option` and `:metabase.lib.binning/binning-option` to `:option/temporal-bucketing` and `:option/binning`. I also changed the filter and aggregation operator map types to start with the prefix `:operator/` for more consistency. The new Strategy type here is called `:option/join.strategy`.

