### PR TITLE
impersonatied FE fixes

### DIFF
--- a/e2e/support/helpers/e2e-permissions-helpers.js
+++ b/e2e/support/helpers/e2e-permissions-helpers.js
@@ -36,7 +36,7 @@ export function selectPermissionRow(item, permissionIndex) {
   getPermissionRowPermissions(item).eq(permissionIndex).click();
 }
 
-function getPermissionRowPermissions(item) {
+export function getPermissionRowPermissions(item) {
   return cy
     .findByTestId("permission-table")
     .find("tbody > tr")

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
@@ -81,6 +81,17 @@ if (hasPremiumFeature("advanced_permissions")) {
   PLUGIN_ADVANCED_PERMISSIONS.isBlockPermission = value =>
     value === BLOCK_PERMISSION_OPTION.value;
 
+  PLUGIN_ADVANCED_PERMISSIONS.getDatabaseLimitedAccessPermission = value => {
+    if (
+      value === BLOCK_PERMISSION_OPTION.value ||
+      value === IMPERSONATED_PERMISSION_OPTION.value
+    ) {
+      return "none";
+    }
+
+    return null;
+  };
+
   PLUGIN_ADVANCED_PERMISSIONS.isAccessPermissionDisabled = (value, subject) => {
     return (
       ["tables", "fields"].includes(subject) &&

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
@@ -19,7 +19,6 @@ import {
   getPermissionWarningModal,
 } from "metabase/admin/permissions/selectors/confirmations";
 import { getGroupFocusPermissionsUrl } from "metabase/admin/permissions/utils/urls";
-import { PLUGIN_ADVANCED_PERMISSIONS } from "metabase/plugins";
 
 export const UNABLE_TO_DOWNLOAD_RESULTS = t`Groups with Block data access can't download results`;
 
@@ -105,10 +104,9 @@ export const buildDownloadPermission = (
   permissionSubject: PermissionSubject,
 ) => {
   const hasChildEntities = permissionSubject !== "fields";
+  const isBlockPermission = dataAccessPermissionValue === "block";
 
-  const value = PLUGIN_ADVANCED_PERMISSIONS.isBlockPermission(
-    dataAccessPermissionValue,
-  )
+  const value = isBlockPermission
     ? DOWNLOAD_PERMISSION_OPTIONS.none.value
     : getPermissionValue(permissions, groupId, entityId, permissionSubject);
 
@@ -119,14 +117,9 @@ export const buildDownloadPermission = (
     permissionSubject,
   );
 
-  const isDisabled =
-    isAdmin ||
-    PLUGIN_ADVANCED_PERMISSIONS.isBlockPermission(dataAccessPermissionValue);
+  const isDisabled = isAdmin || isBlockPermission;
 
-  const disabledTooltip = getTooltipMessage(
-    isAdmin,
-    PLUGIN_ADVANCED_PERMISSIONS.isBlockPermission(dataAccessPermissionValue),
-  );
+  const disabledTooltip = getTooltipMessage(isAdmin, isBlockPermission);
 
   const warning = getPermissionWarning(
     value,

--- a/frontend/src/metabase/admin/permissions/permissions.js
+++ b/frontend/src/metabase/admin/permissions/permissions.js
@@ -2,7 +2,10 @@ import { t } from "ttag";
 import { push } from "react-router-redux";
 import { assocIn } from "icepick";
 
-import { PLUGIN_DATA_PERMISSIONS } from "metabase/plugins";
+import {
+  PLUGIN_DATA_PERMISSIONS,
+  PLUGIN_ADVANCED_PERMISSIONS,
+} from "metabase/plugins";
 import {
   createAction,
   createThunkAction,
@@ -71,7 +74,12 @@ export const LIMIT_DATABASE_PERMISSION =
   "metabase/admin/permissions/LIMIT_DATABASE_PERMISSION";
 export const limitDatabasePermission = createThunkAction(
   LIMIT_DATABASE_PERMISSION,
-  (groupId, entityId, newValue) => dispatch => {
+  (groupId, entityId, accessPermissionValue) => dispatch => {
+    const newValue =
+      PLUGIN_ADVANCED_PERMISSIONS.getDatabaseLimitedAccessPermission(
+        accessPermissionValue,
+      );
+
     if (newValue) {
       dispatch(
         updateDataPermission({

--- a/frontend/src/metabase/admin/permissions/selectors/confirmations.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/confirmations.ts
@@ -18,7 +18,15 @@ export const getDefaultGroupHasHigherAccessText = (defaultGroup: Group) =>
   t`The "${defaultGroup.name}" group has a higher level of access than this, which will override this setting. You should limit or revoke the "${defaultGroup.name}" group's access to this item.`;
 
 // these are all the permission levels ordered by level of access
-const PERM_LEVELS = ["write", "read", "all", "controlled", "none", "block"];
+const PERM_LEVELS = [
+  "write",
+  "read",
+  "all",
+  "impersonated",
+  "controlled",
+  "none",
+  "block",
+];
 function hasGreaterPermissions(
   a: string,
   b: string,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
@@ -78,13 +78,7 @@ const buildAccessPermission = (
     ),
     postActions: {
       controlled: () =>
-        limitDatabasePermission(
-          groupId,
-          entityId,
-          PLUGIN_ADVANCED_PERMISSIONS.isBlockPermission(accessPermissionValue)
-            ? DATA_PERMISSION_OPTIONS.noSelfService.value
-            : null,
-        ),
+        limitDatabasePermission(groupId, entityId, accessPermissionValue),
       ...PLUGIN_ADMIN_PERMISSIONS_DATABASE_POST_ACTIONS,
     },
     actions: PLUGIN_ADMIN_PERMISSIONS_DATABASE_ACTIONS,

--- a/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
@@ -1,10 +1,7 @@
 import { getIn, setIn } from "icepick";
 import _ from "underscore";
 
-import {
-  PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_PERMISSION_VALUE,
-  PLUGIN_ADVANCED_PERMISSIONS,
-} from "metabase/plugins";
+import { PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_PERMISSION_VALUE } from "metabase/plugins";
 import type { GroupsPermissions, ConcreteTableId } from "metabase-types/api";
 import type Database from "metabase-lib/metadata/Database";
 import type Table from "metabase-lib/metadata/Table";
@@ -17,7 +14,7 @@ import type {
 } from "../../types";
 
 export const isRestrictivePermission = (value: string) =>
-  PLUGIN_ADVANCED_PERMISSIONS.isBlockPermission(value) || value === "none";
+  value === "block" || value === "none";
 
 export function getPermission(
   permissions: GroupsPermissions,

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -229,7 +229,7 @@ export const PLUGIN_ADVANCED_PERMISSIONS = {
     permissions,
   addTablePermissionOptions: (permissions: any[], _value: string) =>
     permissions,
-  isBlockPermission: (_value: string) => false,
+  getDatabaseLimitedAccessPermission: (_value: string) => null,
   isAccessPermissionDisabled: (
     _value: string,
     _subject: "schemas" | "tables" | "fields",


### PR DESCRIPTION
[Slack convo](https://metaboat.slack.com/archives/C056QEW4KNF/p1687962412096919)

### Description

Fixes a couple of minor FE bugs around the impersonated permission.

### How to verify

You need to have a postgres DB and run Metabase EE to test it.

#### 1) When All Users group has a unrestricted access and users set other group's permissions to `impersontaed` it whould warn that "All Users" provide a superior access.

Steps:
- Go to Admin -> Permissions
- Set Unrestricted data access on All Users for the postgres db
- Select any other group, and set the impersonated access for the postgres db
- Ensure it shows the warning modal about the All Users group having a superior access
- After change ensure it shows a warning icon with the tooltip that also warns about the All Users group


  
####  2) Fixes changing data access from "Impersonated" to "Granular" leads to the Tables view but everything is set to Impersonated and disabled. On schemas and tables levels when we show "Impersonated" and "Block" permissions, we also disable the select requiring to change the DB permission first. However, when on the DB level we switch from "Block" to "Granular", we reset the database level access to "No self-service" which allows editing tables access. This was missing for the "Impersonated" permission.

Steps:
- Go to Admin -> Permissions
- Set Impersonated data access on All Users for the postgres db and save
- Switch from Impersonated to Granular
- Ensure it shows schemas or tables view with "No self-service" access

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
