### PR TITLE
Clean up `NotebookCell` component, forward refs

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/NotebookCell.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookCell.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/prop-types */
-import { isValidElement } from "react";
+import { forwardRef, isValidElement } from "react";
 
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
@@ -10,7 +9,9 @@ import { alpha } from "metabase/lib/colors";
 
 const CONTAINER_PADDING = "10px";
 
-const _NotebookCell = styled.div`
+type BorderSide = "top" | "right" | "bottom" | "left";
+
+const _NotebookCell = styled.div<{ color: string; padding?: string }>`
   display: flex;
   align-items: center;
   flex-wrap: wrap;
@@ -25,7 +26,10 @@ export const NotebookCell = Object.assign(_NotebookCell, {
   CONTAINER_PADDING,
 });
 
-const NotebookCellItemContainer = styled.div`
+const NotebookCellItemContainer = styled.div<{
+  color: string;
+  inactive?: boolean;
+}>`
   display: flex;
   align-items: center;
   font-weight: bold;
@@ -48,7 +52,12 @@ const NotebookCellItemContainer = styled.div`
   }
 `;
 
-const NotebookCellItemContentContainer = styled.div`
+const NotebookCellItemContentContainer = styled.div<{
+  color: string;
+  inactive?: boolean;
+  border?: BorderSide;
+  roundedCorners: BorderSide[];
+}>`
   display: flex;
   align-items: center;
   padding: ${CONTAINER_PADDING};
@@ -81,8 +90,24 @@ const NotebookCellItemContentContainer = styled.div`
   transition: background 300ms linear;
 `;
 
-export function NotebookCellItem(props) {
-  const {
+interface NotebookCellItemProps {
+  color: string;
+  inactive?: boolean;
+  readOnly?: boolean;
+  right?: React.ReactNode;
+  containerStyle?: React.CSSProperties;
+  rightContainerStyle?: React.CSSProperties;
+  children?: React.ReactNode;
+  onClick?: React.MouseEventHandler;
+  "data-testid"?: string;
+  ref?: React.Ref<HTMLDivElement>;
+}
+
+export const NotebookCellItem = forwardRef<
+  HTMLDivElement,
+  NotebookCellItemProps
+>(function NotebookCellItem(
+  {
     inactive,
     color,
     containerStyle,
@@ -91,10 +116,11 @@ export function NotebookCellItem(props) {
     children,
     readOnly,
     ...restProps
-  } = props;
-
+  },
+  ref,
+) {
   const hasRightSide = isValidElement(right) && !readOnly;
-  const mainContentRoundedCorners = ["left"];
+  const mainContentRoundedCorners: BorderSide[] = ["left"];
   if (!hasRightSide) {
     mainContentRoundedCorners.push("right");
   }
@@ -103,7 +129,8 @@ export function NotebookCellItem(props) {
       inactive={inactive}
       color={color}
       {...restProps}
-      data-testid={props["data-testid"] ?? "notebook-cell-item"}
+      data-testid={restProps["data-testid"] ?? "notebook-cell-item"}
+      ref={ref}
     >
       <NotebookCellItemContentContainer
         inactive={inactive}
@@ -126,14 +153,18 @@ export function NotebookCellItem(props) {
       )}
     </NotebookCellItemContainer>
   );
+});
+
+interface NotebookCellAddProps extends NotebookCellItemProps {
+  initialAddText?: React.ReactNode;
 }
 
-NotebookCellItem.displayName = "NotebookCellItem";
-
-export const NotebookCellAdd = ({ initialAddText, ...props }) => (
-  <NotebookCellItem {...props} inactive={!!initialAddText}>
-    {initialAddText || <Icon name="add" className="text-white" />}
-  </NotebookCellItem>
+export const NotebookCellAdd = forwardRef<HTMLDivElement, NotebookCellAddProps>(
+  function NotebookCellAdd({ initialAddText, ...props }, ref) {
+    return (
+      <NotebookCellItem {...props} inactive={!!initialAddText} ref={ref}>
+        {initialAddText || <Icon name="add" className="text-white" />}
+      </NotebookCellItem>
+    );
+  },
 );
-
-NotebookCellAdd.displayName = "NotebookCellAdd";

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookCell/NotebookCell.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookCell/NotebookCell.styled.tsx
@@ -1,0 +1,81 @@
+import styled from "@emotion/styled";
+import { css } from "@emotion/react";
+import { alpha } from "metabase/lib/colors";
+
+export type BorderSide = "top" | "right" | "bottom" | "left";
+
+export const CONTAINER_PADDING = "10px";
+
+export const NotebookCell = styled.div<{ color: string; padding?: string }>`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  border-radius: 8px;
+  background-color: ${props => alpha(props.color, 0.1)};
+  padding: ${props => props.padding || "14px"};
+  color: ${props => props.color};
+`;
+
+export const NotebookCellItemContainer = styled.div<{
+  color: string;
+  inactive?: boolean;
+}>`
+  display: flex;
+  align-items: center;
+  font-weight: bold;
+  color: ${props => (props.inactive ? props.color : "white")};
+  border-radius: 6px;
+  margin-right: 4px;
+
+  border: 2px solid transparent;
+  border-color: ${props =>
+    props.inactive ? alpha(props.color, 0.25) : "transparent"};
+
+  &:hover {
+    border-color: ${props => props.inactive && alpha(props.color, 0.8)};
+  }
+
+  transition: border 300ms linear;
+
+  .Icon-close {
+    opacity: 0.6;
+  }
+`;
+
+export const NotebookCellItemContentContainer = styled.div<{
+  color: string;
+  inactive?: boolean;
+  border?: BorderSide;
+  roundedCorners: BorderSide[];
+}>`
+  display: flex;
+  align-items: center;
+  padding: ${CONTAINER_PADDING};
+  background-color: ${props => (props.inactive ? "transparent" : props.color)};
+
+  &:hover {
+    background-color: ${props => !props.inactive && alpha(props.color, 0.8)};
+  }
+
+  ${props =>
+    !!props.border &&
+    css`
+    border-${props.border}: 1px solid ${alpha("white", 0.25)};
+  `}
+
+  ${props =>
+    props.roundedCorners.includes("left") &&
+    css`
+      border-top-left-radius: 6px;
+      border-bottom-left-radius: 6px;
+    `}
+
+  ${props =>
+    props.roundedCorners.includes("right") &&
+    css`
+      border-top-right-radius: 6px;
+      border-bottom-right-radius: 6px;
+    `}
+
+  transition: background 300ms linear;
+`;

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookCell/NotebookCell.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookCell/NotebookCell.tsx
@@ -1,94 +1,17 @@
 import { forwardRef, isValidElement } from "react";
-
-import styled from "@emotion/styled";
-import { css } from "@emotion/react";
-
 import { Icon } from "metabase/core/components/Icon";
-
-import { alpha } from "metabase/lib/colors";
-
-const CONTAINER_PADDING = "10px";
-
-type BorderSide = "top" | "right" | "bottom" | "left";
-
-const _NotebookCell = styled.div<{ color: string; padding?: string }>`
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  border-radius: 8px;
-  background-color: ${props => alpha(props.color, 0.1)};
-  padding: ${props => props.padding || "14px"};
-  color: ${props => props.color};
-`;
+import {
+  NotebookCell as _NotebookCell,
+  NotebookCellItemContainer,
+  NotebookCellItemContentContainer,
+  CONTAINER_PADDING,
+  BorderSide,
+} from "./NotebookCell.styled";
 
 export const NotebookCell = Object.assign(_NotebookCell, {
   displayName: "NotebookCell",
   CONTAINER_PADDING,
 });
-
-const NotebookCellItemContainer = styled.div<{
-  color: string;
-  inactive?: boolean;
-}>`
-  display: flex;
-  align-items: center;
-  font-weight: bold;
-  color: ${props => (props.inactive ? props.color : "white")};
-  border-radius: 6px;
-  margin-right: 4px;
-
-  border: 2px solid transparent;
-  border-color: ${props =>
-    props.inactive ? alpha(props.color, 0.25) : "transparent"};
-
-  &:hover {
-    border-color: ${props => props.inactive && alpha(props.color, 0.8)};
-  }
-
-  transition: border 300ms linear;
-
-  .Icon-close {
-    opacity: 0.6;
-  }
-`;
-
-const NotebookCellItemContentContainer = styled.div<{
-  color: string;
-  inactive?: boolean;
-  border?: BorderSide;
-  roundedCorners: BorderSide[];
-}>`
-  display: flex;
-  align-items: center;
-  padding: ${CONTAINER_PADDING};
-  background-color: ${props => (props.inactive ? "transparent" : props.color)};
-
-  &:hover {
-    background-color: ${props => !props.inactive && alpha(props.color, 0.8)};
-  }
-
-  ${props =>
-    !!props.border &&
-    css`
-    border-${props.border}: 1px solid ${alpha("white", 0.25)};
-  `}
-
-  ${props =>
-    props.roundedCorners.includes("left") &&
-    css`
-      border-top-left-radius: 6px;
-      border-bottom-left-radius: 6px;
-    `}
-
-  ${props =>
-    props.roundedCorners.includes("right") &&
-    css`
-      border-top-right-radius: 6px;
-      border-bottom-right-radius: 6px;
-    `}
-
-  transition: background 300ms linear;
-`;
 
 interface NotebookCellItemProps {
   color: string;

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookCell/index.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookCell/index.ts
@@ -1,0 +1,1 @@
+export * from "./NotebookCell";


### PR DESCRIPTION
Extracted from notebook join MLv2 migration

Cleans up the `NotebookCell` file:

* converts to TypeScript
* extracts styled components to `NotebookCell.styled.tsx` file
* wraps `NotebookCellItem` and `NotebookCellItemAdd` in `forwardRef`, so they can be used with `TippyPopoverWithTrigger`

No functional/visual changes expected

### To Verify

1. New > Question > Raw Data > Sample Database Orders
2. Add different clauses: join, a few filters, a few aggregations, and breakouts, etc.
3. Ensure the notebook looks the same as on `master`