### PR TITLE
Fix release docker latest adjustment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,15 +193,15 @@ jobs:
           }
 
           console.log();
-          console.log("Enumerating all git tag...");
+          console.log("Enumerating all git tags...");
           const allTags = execSync("git tag -l").toString("utf-8").split("\n");
           console.log("Found total", allTags.length, "tags");
 
           console.log();
-          console.log("Filtering for", currentVersion.isOSS ? "OSS" : "EE");
+          console.log("Filtering for", currentVersion.isOSS ? "OSS" : "EE", "which excludes prerelease tags...");
           const relevantTags = allTags.filter(tag => {
-            const { prefix } = parseVersion(tag);
-            return prefix === currentVersion.prefix;
+            const { prefix, prerelease } = parseVersion(tag);
+            return !prerelease && prefix === currentVersion.prefix;
           });
           console.log("Found total", relevantTags.length, "filtered tags");
           if (relevantTags.length < 10) {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,7 +223,7 @@ jobs:
           const isLatest = latestTag === currentTag;
           console.log();
           if (isLatest) {
-            console.log("Thus, the container image for ", currentTag, "must be marked as latest.");
+            console.log("Thus, the container image for", currentTag, "must be marked as latest.");
           } else {
             console.log("The latest container image stays as", latestTag);
             console.log("There is no need to tag the", currentTag, "container image as latest.");


### PR DESCRIPTION
As noted in https://github.com/metabase/metabase/issues/32036, the current logic doesn't account for the existence
of the N+1 RC tag when the current release is N. In other words, it
didn't promote `v1.46.6` to the latest Docker tag because it included
`v1.47.0-RC1` in the list of the relevant tags it compares against.

This PR fixes that and closes https://github.com/metabase/metabase/issues/32036.

**Before:**
```
Current version for v1.46.6 is {
  prefix: 'v1',
  feature: 46,
  maintenance: 6,
  build: NaN,
  isOSS: false,
  isEE: true,
  prerelease: false
}

Enumerating all git tag...
Found total 414 tags

Filtering for EE
Found total 116 filtered tags

Sorting tags to find the highest version numbers...
Showing 20 tags with the highest versions...
     v1.47.0-RC1
     v1.47.0-RC2
---> v1.46.6
     v1.46.5
     v1.46.4
     v1.46.3
     v1.46.2
     v1.46.1
     v1.46.0
     v1.46.0-RC1
     v1.46.0-RC2
     v1.46.0-RC3
     v1.46.0-RC4
     v1.45.4
     v1.45.3.1
     v1.45.3
     v1.45.2.1
     v1.45.2
     v1.45.1
     v1.45.0

The latest container image stays as v1.47.0-RC1
There is no need to tag the v1.46.6 container image as latest.
```

**After the fix:**
```
Current version for v1.46.6 is {
  prefix: 'v1',
  feature: 46,
  maintenance: 6,
  build: NaN,
  isOSS: false,
  isEE: true,
  prerelease: false
}

Enumerating all git tags...
Found total 430 tags

Filtering for EE which excludes prerelease tags...
Found total 94 filtered tags

Sorting tags to find the highest version numbers...
Showing 20 tags with the highest versions...
---> v1.46.6
     v1.46.5
     v1.46.4
     v1.46.3
     v1.46.2
     v1.46.1
     v1.46.0
     v1.45.4
     v1.45.3.1
     v1.45.3
     v1.45.2
     v1.45.1
     v1.45.0
     v1.44.7
     v1.44.6.1
     v1.44.6
     v1.44.5
     v1.44.4
     v1.44.3
     v1.44.2

Thus, the container image for v1.46.6 must be marked as latest.
```