### PR TITLE
Make mock cards and collections writable by default

### DIFF
--- a/frontend/src/metabase-types/api/mocks/card.ts
+++ b/frontend/src/metabase-types/api/mocks/card.ts
@@ -24,7 +24,7 @@ export const createMockCard = (opts?: Partial<Card>): Card => ({
   visualization_settings: createMockVisualizationSettings(),
   result_metadata: [],
   dataset: false,
-  can_write: false,
+  can_write: true,
   cache_ttl: null,
   collection_id: null,
   last_query_start: null,

--- a/frontend/src/metabase-types/api/mocks/collection.ts
+++ b/frontend/src/metabase-types/api/mocks/collection.ts
@@ -7,7 +7,7 @@ export const createMockCollection = (
   name: "Collection",
   description: null,
   location: "/",
-  can_write: false,
+  can_write: true,
   archived: false,
   ...opts,
 });


### PR DESCRIPTION
Most of our mock object factories return objects with `can_write: true`, but not for cards and collections. This caused a ton of confusion and wasted many hours of debugging. Let's finally make them writable out of the box