### PR TITLE
Update row chart measuring function

### DIFF
--- a/e2e/test/scenarios/visualizations/rows.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/rows.cy.spec.js
@@ -43,4 +43,41 @@ describe("scenarios > visualizations > rows", () => {
       },
     );
   });
+
+  it(`should display a row chart`, () => {
+    cy.createNativeQuestion(
+      {
+        name: "14285",
+        native: {
+          query: `
+            with temp as (
+              select 'a' col1, 51 column_two union all
+              select 'b', 41 union all
+              select 'c', 31 union all
+              select 'd', 21 union all
+              select 'e', 11 union all
+              select 'f', 4
+            ) select * from temp
+            order by 2 desc
+          `,
+          "template-tags": {},
+        },
+        display: "row",
+        visualization_settings: {
+          "graph.show_values": true, // so we can assert on them
+        },
+      },
+      { visitQuestion: true },
+    );
+
+    cy.get(".Visualization").within(() => {
+      ["a", "b", "c", "d", "e", "f"].forEach(letter => {
+        cy.findByText(letter);
+      });
+      [51, 41, 31, 21, 11, 4].forEach(value => {
+        cy.findByText(value);
+      });
+      cy.findByText("COLUMN_TWO");
+    });
+  });
 });

--- a/frontend/src/metabase/static-viz/components/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/static-viz/components/RowChart/RowChart.tsx
@@ -1,8 +1,8 @@
 import { Group } from "@visx/group";
 import { RowChart } from "metabase/visualizations/shared/components/RowChart";
-import {
+import type {
   FontStyle,
-  TextWidthMeasurer,
+  TextMeasurer,
 } from "metabase/visualizations/shared/types/measure-text";
 import { measureText } from "metabase/static-viz/lib/text";
 import { getStackOffset } from "metabase/visualizations/lib/settings/stacking";
@@ -51,15 +51,18 @@ interface StaticRowChartProps {
   getColor: ColorGetter;
 }
 
-const staticTextMeasurer: TextWidthMeasurer = (
-  text: string,
-  style: FontStyle,
-) =>
-  measureText(
+const staticTextMeasurer: TextMeasurer = (text: string, style: FontStyle) => {
+  const textWidth = measureText(
     text,
     parseInt(style.size.toString(), 10),
     style.weight ? parseInt(style.weight.toString(), 10) : 400,
   );
+
+  return {
+    width: textWidth,
+    height: -1, // this will be ignored by RowChart
+  };
+};
 
 const StaticRowChart = ({ data, settings, getColor }: StaticRowChartProps) => {
   const remappedColumnsData = extractRemappedColumns(

--- a/frontend/src/metabase/visualizations/shared/components/RowChart/RowChart.stories.tsx
+++ b/frontend/src/metabase/visualizations/shared/components/RowChart/RowChart.stories.tsx
@@ -72,7 +72,7 @@ Default.args = {
 
   theme: getStaticChartTheme(color),
 
-  measureText: (text, style) => measureText(text, style).width,
+  measureText,
 
   style: { fontFamily: "Lato" },
 };

--- a/frontend/src/metabase/visualizations/shared/components/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/shared/components/RowChart/RowChart.tsx
@@ -1,9 +1,12 @@
-import { useMemo } from "react";
+import { useMemo, useCallback } from "react";
 import * as React from "react";
 
 import type { NumberValue } from "d3-scale";
 
-import { TextWidthMeasurer } from "metabase/visualizations/shared/types/measure-text";
+import type {
+  TextWidthMeasurer,
+  TextMeasurer,
+} from "metabase/visualizations/shared/types/measure-text";
 import { ChartTicksFormatters } from "metabase/visualizations/shared/types/format";
 import { HoveredData } from "metabase/visualizations/shared/types/events";
 import RowChartView, { RowChartViewProps } from "../RowChartView/RowChartView";
@@ -48,7 +51,7 @@ export interface RowChartProps<TDatum> {
 
   tickFormatters?: ChartTicksFormatters;
   labelsFormatter?: (value: NumberValue) => string;
-  measureText: TextWidthMeasurer;
+  measureText: TextMeasurer;
 
   xScaleType?: ContinuousScaleType;
 
@@ -89,7 +92,7 @@ export const RowChart = <TDatum,>({
 
   xScaleType = "linear",
 
-  measureText,
+  measureText: measureTextSize,
 
   style,
 
@@ -133,6 +136,12 @@ export const RowChart = <TDatum,>({
   );
 
   const { xTickFormatter, yTickFormatter } = tickFormatters;
+
+  // in this component, we expect a measurer that only measures width
+  const measureText: TextWidthMeasurer = useCallback(
+    (text, style) => measureTextSize(text, style)?.width,
+    [measureTextSize],
+  );
 
   const margin = useMemo(
     () =>

--- a/frontend/src/metabase/visualizations/shared/components/RowChart/RowChart.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/shared/components/RowChart/RowChart.unit.spec.tsx
@@ -1,10 +1,11 @@
 import { render, screen } from "@testing-library/react";
 import type { NumberValue } from "d3-scale";
 import userEvent from "@testing-library/user-event";
+import { measureText } from "metabase/lib/measure-text";
 import { ChartFont } from "../../types/style";
-import { FontStyle, TextWidthMeasurer } from "../../types/measure-text";
+import type { RowChartTheme } from "./types";
+
 import { RowChart, RowChartProps } from "./RowChart";
-import { RowChartTheme } from "./types";
 
 type TestDatum = { y: string; x: number; x1: number };
 
@@ -23,9 +24,6 @@ const theme: RowChartTheme = {
     color: "gray",
   },
 };
-
-const measureText: TextWidthMeasurer = (text: string, _style: FontStyle) =>
-  text.length * 10;
 
 const series1 = {
   seriesKey: "series 1",


### PR DESCRIPTION
closes https://github.com/metabase/metabase/issues/32044, except that the issue is much bigger than the issue stated, this broke all row charts 😳 

### Description

#31722 changed the way we measure text in several visualizations, and while it updated the types in RowChart, it didn't actually handle the fact that we are now passing it a function that returns width and height, while the RowChart component expects a function that only returns a width value.  This broke all row chart visualizations. Because we passed in a custom `measureText` function in the unit tests, unit tests did not catch it.

> 🤔 _I wonder if we should have unit tests at the `Visualization` level for all our visualizations_

This simply transforms the function that is actually passed into a form that RowChart expects.

### How to verify

make any question and make it into a rowChart

### Demo


Before | After
--- | ---
![Screen Shot 2023-06-30 at 12 20 52 PM](https://github.com/metabase/metabase/assets/30528226/aeddf05f-4369-4018-8c4e-79af9b9d2820) |  ![Screen Shot 2023-06-30 at 12 20 41 PM](https://github.com/metabase/metabase/assets/30528226/eebdf395-8dca-477e-8093-8e5b8dd3bc2a)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
