### PR TITLE
Fix Filter Pill display names for dates

### DIFF
--- a/e2e/test/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -62,9 +62,11 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
 
     // new filter applied
     // Note: Test was flaking because apparently mouseup doesn't always happen at the same position.
-    //       It is enough that we assert that the filter exists and that it starts with May, 2022
+    //       It is enough that we assert that the filter exists and that it starts with May 2022.
+    //       The date range formatter sometimes omits the year of the first month (e.g. May–July 2022),
+    //       so checking that 2022 occurs after May ensures that May 2022 is in fact the first date.
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains(/^Created At between May, 2022/);
+    cy.contains(/^Created At between May.*2022/);
     // more granular axis labels
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("June, 2022");
@@ -111,7 +113,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
 
       granularity === "month"
         ? // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-          cy.findByText("Created At between September, 2022 February, 2023")
+          cy.findByText("Created At between September 2022 – February 2023")
         : // Once the issue gets fixed, figure out the positive assertion for the "month-of-year" granularity
           null;
 

--- a/e2e/test/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -66,7 +66,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     //       The date range formatter sometimes omits the year of the first month (e.g. May–July 2022),
     //       so checking that 2022 occurs after May ensures that May 2022 is in fact the first date.
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains(/^Created At between May.*2022/);
+    cy.contains(/^Created At is May.*2022/);
     // more granular axis labels
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("June, 2022");
@@ -113,7 +113,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
 
       granularity === "month"
         ? // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-          cy.findByText("Created At between September 2022 – February 2023")
+          cy.findByText("Created At is September 2022 – February 2023")
         : // Once the issue gets fixed, figure out the positive assertion for the "month-of-year" granularity
           null;
 
@@ -327,7 +327,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     cy.log("Filter should show the range between two dates");
     // Now click on the filter widget to see if the proper parameters got passed in
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("Created At between").click();
+    cy.contains(/^Created At is .*–/).click(); // en-dash to detect date range
   });
 
   it.skip("should drill-through on filtered aggregated results (metabase#13504)", () => {

--- a/e2e/test/scenarios/visualizations/reproductions/25007-week-tooltip-native.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/25007-week-tooltip-native.cy.spec.js
@@ -24,7 +24,7 @@ describe("issue 25007", () => {
   it("should display weeks correctly in tooltips for native questions (metabase#25007)", () => {
     cy.createNativeQuestion(questionDetails, { visitQuestion: true });
     clickLineDot({ index: 1 });
-    popover().findByTextEnsureVisible("May 1 – 7, 2022");
+    popover().findByTextEnsureVisible("May 1–7, 2022");
   });
 });
 

--- a/frontend/src/metabase-lib/queries/structured/Filter.ts
+++ b/frontend/src/metabase-lib/queries/structured/Filter.ts
@@ -72,7 +72,10 @@ export default class Filter extends MBQLClause {
     const betweenDates = op === "between" && isDate;
     const equalsWeek = op === "=" && unit === "week";
     if (allStrs && (betweenDates || equalsWeek)) {
-      return formatDateTimeRangeWithUnit(args, unit);
+      return formatDateTimeRangeWithUnit(args, unit, {
+        type: "tooltip",
+        date_resolution: unit === "week" ? "day" : unit,
+      });
     }
   }
 
@@ -98,6 +101,7 @@ export default class Filter extends MBQLClause {
         operator.moreVerboseName;
       const argumentNames =
         this.shortDateRangeLabel() ?? this.formattedArguments().join(" ");
+      // TODO: display "is" instead of "between" when shortDateRangeLabel is returned
       return `${dimensionName || ""} ${operatorName || ""} ${argumentNames}`;
     } else if (this.isCustom()) {
       return this._query.formatExpression(this);

--- a/frontend/src/metabase-lib/queries/structured/Filter.ts
+++ b/frontend/src/metabase-lib/queries/structured/Filter.ts
@@ -63,7 +63,7 @@ export default class Filter extends MBQLClause {
     return this._query.removeFilter(this._index);
   }
 
-  shortDateRangeLabel() {
+  betterDateLabel() {
     const dimension = this.dimension();
     const unit = dimension?.temporalUnit();
     const op = this.operatorName();
@@ -116,8 +116,7 @@ export default class Filter extends MBQLClause {
         !isStartingFrom(this) &&
         operator.moreVerboseName;
       const argumentNames =
-        this.shortDateRangeLabel() ?? this.formattedArguments().join(" ");
-      // TODO: display "is" instead of "between" when shortDateRangeLabel is returned
+        this.betterDateLabel() ?? this.formattedArguments().join(" ");
       return `${dimensionName || ""} ${operatorName || ""} ${argumentNames}`;
     } else if (this.isCustom()) {
       return this._query.formatExpression(this);

--- a/frontend/src/metabase-lib/queries/structured/Filter.ts
+++ b/frontend/src/metabase-lib/queries/structured/Filter.ts
@@ -67,12 +67,12 @@ export default class Filter extends MBQLClause {
     const unit = dimension?.temporalUnit();
     const op = this.operatorName();
     const args = this.arguments();
-    const allStrs = args.all(arg => typeof arg === "string");
+    const allStrs = args.every(arg => typeof arg === "string");
     const isDate = ["day", "week", "month", "quarter", "year"].includes(unit);
     const betweenDates = op === "between" && isDate;
     const equalsWeek = op === "=" && unit === "week";
     if (allStrs && (betweenDates || equalsWeek)) {
-      formatDateTimeRangeWithUnit(args, unit);
+      return formatDateTimeRangeWithUnit(args, unit);
     }
   }
 

--- a/frontend/src/metabase-lib/queries/structured/Filter.ts
+++ b/frontend/src/metabase-lib/queries/structured/Filter.ts
@@ -2,6 +2,7 @@
 // @ts-nocheck
 import { t, ngettext, msgid } from "ttag";
 import _ from "underscore";
+import moment from "moment-timezone";
 import type {
   Filter as FilterObject,
   FieldFilter,
@@ -71,11 +72,26 @@ export default class Filter extends MBQLClause {
     const isDate = ["day", "week", "month", "quarter", "year"].includes(unit);
     const betweenDates = op === "between" && isDate;
     const equalsWeek = op === "=" && unit === "week";
-    if (allStrs && (betweenDates || equalsWeek)) {
-      return formatDateTimeRangeWithUnit(args, unit, {
-        type: "tooltip",
-        date_resolution: unit === "week" ? "day" : unit,
-      });
+    // modifying some of DEFAULT_DATE_FORMATS
+    const sliceFormats = {
+      "hour-of-day": "[hour] H",
+      "minute-of-hour": "[minute] m",
+      "day-of-month": "Do [day of month]",
+      "day-of-year": "DDDo [day of year]",
+      "week-of-year": "wo [week of year]",
+    };
+    if (allStrs) {
+      if (betweenDates || equalsWeek) {
+        return formatDateTimeRangeWithUnit(args, unit, {
+          type: "tooltip",
+          date_resolution: unit === "week" ? "day" : unit,
+        });
+      } else if (op === "=" && unit in sliceFormats) {
+        const m = moment(args[0]);
+        if (m.isValid()) {
+          return m.format(sliceFormats[unit]);
+        }
+      }
     }
   }
 

--- a/frontend/src/metabase-lib/queries/structured/Filter.ts
+++ b/frontend/src/metabase-lib/queries/structured/Filter.ts
@@ -68,30 +68,34 @@ export default class Filter extends MBQLClause {
     if (!args.every(arg => typeof arg === "string")) {
       return undefined;
     }
-    const dimension = this.dimension();
-    const unit = dimension?.temporalUnit();
+    const unit = this.dimension()?.temporalUnit();
+    const isSupportedDateRangeUnit = [
+      "day",
+      "week",
+      "month",
+      "quarter",
+      "year",
+    ].includes(unit);
     const op = this.operatorName();
-    const isDate = ["day", "week", "month", "quarter", "year"].includes(unit);
-    const betweenDates = op === "between" && isDate;
+    const betweenDates = op === "between" && isSupportedDateRangeUnit;
     const equalsWeek = op === "=" && unit === "week";
-    // modifying some of DEFAULT_DATE_FORMATS
-    const sliceFormats = {
-      "hour-of-day": "[hour] H",
-      "minute-of-hour": "[minute] m",
-      "day-of-month": "Do [day of month]",
-      "day-of-year": "DDDo [day of year]",
-      "week-of-year": "wo [week of year]",
-    };
     if (betweenDates || equalsWeek) {
       return formatDateTimeRangeWithUnit(args, unit, {
         type: "tooltip",
         date_resolution: unit === "week" ? "day" : unit,
       });
-    } else if (op === "=" && unit in sliceFormats) {
-      const m = moment(args[0]);
-      if (m.isValid()) {
-        return m.format(sliceFormats[unit]);
-      }
+    }
+    const sliceFormat = {
+      // modified from DEFAULT_DATE_FORMATS in date.tsx to show extra context
+      "hour-of-day": "[hour] H",
+      "minute-of-hour": "[minute] m",
+      "day-of-month": "Do [day of month]",
+      "day-of-year": "DDDo [day of year]",
+      "week-of-year": "wo [week of year]",
+    }[unit];
+    const m = moment(args[0]);
+    if (op === "=" && sliceFormat && m.isValid()) {
+      return m.format(sliceFormat);
     }
   }
 

--- a/frontend/src/metabase-lib/queries/structured/Filter.ts
+++ b/frontend/src/metabase-lib/queries/structured/Filter.ts
@@ -106,18 +106,18 @@ export default class Filter extends MBQLClause {
       const segment = this.segment();
       return segment ? segment.displayName() : t`Unknown Segment`;
     } else if (this.isStandard()) {
-      const dimension = this.dimension();
-      const operator = this.operator();
-      const dimensionName =
-        dimension && includeDimension && dimension.displayName();
-      const operatorName =
-        operator &&
-        includeOperator &&
-        !isStartingFrom(this) &&
-        operator.moreVerboseName;
-      const argumentNames =
-        this.betterDateLabel() ?? this.formattedArguments().join(" ");
-      return `${dimensionName || ""} ${operatorName || ""} ${argumentNames}`;
+      if (isStartingFrom(this)) {
+        includeOperator = false;
+      }
+      const betterDate = this.betterDateLabel();
+      const op = betterDate ? "=" : this.operatorName();
+      return [
+        includeDimension && this.dimension()?.displayName(),
+        includeOperator && this.operator(op)?.moreVerboseName,
+        betterDate ?? this.formattedArguments().join(" "),
+      ]
+        .map(s => s || "")
+        .join(" ");
     } else if (this.isCustom()) {
       return this._query.formatExpression(this);
     } else {
@@ -238,9 +238,9 @@ export default class Filter extends MBQLClause {
     return this[0];
   }
 
-  operator(): FilterOperator | null | undefined {
+  operator(opName = this.operatorName()): FilterOperator | null | undefined {
     const dimension = this.dimension();
-    return dimension ? dimension.filterOperator(this.operatorName()) : null;
+    return dimension ? dimension.filterOperator(opName) : null;
   }
 
   setOperator(operatorName: string) {

--- a/frontend/src/metabase-lib/queries/structured/Filter.ts
+++ b/frontend/src/metabase-lib/queries/structured/Filter.ts
@@ -64,11 +64,13 @@ export default class Filter extends MBQLClause {
   }
 
   betterDateLabel() {
+    const args = this.arguments();
+    if (!args.every(arg => typeof arg === "string")) {
+      return undefined;
+    }
     const dimension = this.dimension();
     const unit = dimension?.temporalUnit();
     const op = this.operatorName();
-    const args = this.arguments();
-    const allStrs = args.every(arg => typeof arg === "string");
     const isDate = ["day", "week", "month", "quarter", "year"].includes(unit);
     const betweenDates = op === "between" && isDate;
     const equalsWeek = op === "=" && unit === "week";
@@ -80,17 +82,15 @@ export default class Filter extends MBQLClause {
       "day-of-year": "DDDo [day of year]",
       "week-of-year": "wo [week of year]",
     };
-    if (allStrs) {
-      if (betweenDates || equalsWeek) {
-        return formatDateTimeRangeWithUnit(args, unit, {
-          type: "tooltip",
-          date_resolution: unit === "week" ? "day" : unit,
-        });
-      } else if (op === "=" && unit in sliceFormats) {
-        const m = moment(args[0]);
-        if (m.isValid()) {
-          return m.format(sliceFormats[unit]);
-        }
+    if (betweenDates || equalsWeek) {
+      return formatDateTimeRangeWithUnit(args, unit, {
+        type: "tooltip",
+        date_resolution: unit === "week" ? "day" : unit,
+      });
+    } else if (op === "=" && unit in sliceFormats) {
+      const m = moment(args[0]);
+      if (m.isValid()) {
+        return m.format(sliceFormats[unit]);
       }
     }
   }

--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -13,7 +13,7 @@ import {
 
 import type { OptionsType } from "./types";
 
-const RANGE_SEPARATOR = ` – `;
+const EN_DASH = `–`;
 
 type DEFAULT_DATE_FORMATS_TYPE = { [key: string]: string };
 const DEFAULT_DATE_FORMATS: DEFAULT_DATE_FORMATS_TYPE = {
@@ -170,36 +170,40 @@ export function formatDateTimeRangeWithUnit(
     const date_resolution =
       (shift === 0 ? options.date_resolution : null) ?? "day";
 
-    const [startFormat, endFormat] = {
+    // Use Wikipedia’s date range formatting guidelines
+    // https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Dates_and_numbers#Ranges
+    const [startFormat, endFormat, pad = ""] = {
       year:
         !sameYear || !condensed
-          ? [Y, Y] // 2018 - 2019
+          ? [Y, Y] // 2018–2019
           : [Y], // 2018
       quarter:
         !sameYear || !condensed
-          ? [QY, QY] // Q2 2018 - Q3 2019
+          ? [QY, QY, " "] // Q2 2018 – Q3 2019
           : !sameQuarter
-          ? [Q, QY] // Q2 - Q4 2019
+          ? [Q, QY] // Q2–Q4 2019
           : [QY], // Q2 2018
       month:
         !sameYear || !condensed
-          ? [MY, MY] // September 2018 - January 2019
+          ? [MY, MY, " "] // September 2018 – January 2019
           : !sameMonth
-          ? [M, MY] // September - December 2018
+          ? [M, MY] // September–December 2018
           : [MY], // September 2018
       day:
         !sameYear || !condensed
-          ? [MDY, MDY] // January 1, 2018 - January 2, 2019
+          ? [MDY, MDY, " "] // January 1, 2018 – January 2, 2019
           : !sameMonth
-          ? [MD, MDY] // January 1 - February 2, 2018
+          ? [MD, MDY, " "] // January 1 – February 2, 2018
           : !sameDayOfMonth
-          ? [MD, DY] // January 1 - 2, 2018
+          ? [MD, DY] // January 1–2, 2018
           : [MDY], // January 1, 2018
     }[date_resolution];
 
     const startStr = start.format(startFormat);
     const endStr = end.format(endFormat ?? startFormat);
-    return startStr === endStr ? startStr : startStr + RANGE_SEPARATOR + endStr;
+    return startStr === endStr
+      ? startStr
+      : startStr + pad + EN_DASH + pad + endStr;
   } else {
     // TODO: when is this used?
     return formatWeek(a, options);
@@ -215,11 +219,11 @@ export function formatRange(
   if ((options.jsx && typeof start !== "string") || typeof end !== "string") {
     return (
       <span>
-        {start} {RANGE_SEPARATOR} {end}
+        {start} {EN_DASH} {end}
       </span>
     );
   } else {
-    return `${start} ${RANGE_SEPARATOR} ${end}`;
+    return `${start} ${EN_DASH} ${end}`;
   }
 }
 

--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -127,8 +127,8 @@ export function formatDateTimeForParameter(value: string, unit: DatetimeUnit) {
 
 /** This formats a time with unit as a date range */
 export function formatDateTimeRangeWithUnit(
-  value: string | number,
-  unit: DatetimeUnit,
+  value: string | number, // TODO: support array for value range
+  unit: DatetimeUnit, // TODO: support month and quarter abbreviations, e.g. [Jan - Feb 2017], [Q1 - Q3 2017]
   options: OptionsType = {},
 ) {
   const m = parseTimestamp(value, unit, options.local);

--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -152,21 +152,22 @@ export function formatDateTimeRangeWithUnit(
   [start, end].forEach(d => d.add(shift, "days"));
 
   // Drop down to day resolution if shift causes misalignment with desired resolution boundaries
-  const resolution = (shift === 0 ? options.date_resolution : null) ?? "day";
+  const date_resolution =
+    (shift === 0 ? options.date_resolution : null) ?? "day";
 
   if (start.isValid() && end.isValid()) {
-    const isDiffYear = start.year() !== end.year();
-    const isDiffQuarter = start.quarter() !== end.quarter();
-    const isDiffMonth = start.month() !== end.month();
-    const isDiffDay = start.date() !== end.date();
+    const sameYear = start.year() === end.year();
+    const sameQuarter = start.quarter() === end.quarter();
+    const sameMonth = start.month() === end.month();
+    const sameDayOfMonth = start.date() === end.date();
 
     let startFormat, endFormat;
 
-    switch (resolution) {
+    switch (date_resolution) {
       case "year": {
         const Y = "YYYY";
         [startFormat, endFormat] =
-          isDiffYear || !condensed
+          !sameYear || !condensed
             ? [Y, Y] // 2018 - 2019
             : [Y]; //   2018
         break;
@@ -175,9 +176,9 @@ export function formatDateTimeRangeWithUnit(
         const Q = "[Q]Q";
         const QY = "[Q]Q YYYY";
         [startFormat, endFormat] =
-          isDiffYear || !condensed
+          !sameYear || !condensed
             ? [QY, QY] // Q2 2018 - Q3 2019
-            : isDiffQuarter
+            : !sameQuarter
             ? [Q, QY] // Q2 - Q4 2019
             : [QY]; // Q3 2019
         break;
@@ -186,9 +187,9 @@ export function formatDateTimeRangeWithUnit(
         const M = monthFormat;
         const MY = `${monthFormat} YYYY`;
         [startFormat, endFormat] =
-          isDiffYear || !condensed
+          !sameYear || !condensed
             ? [MY, MY] // September 2018 - January 2019
-            : isDiffMonth
+            : !sameMonth
             ? [M, MY] // September - December 2018
             : [MY]; // October 2018
         break;
@@ -198,11 +199,11 @@ export function formatDateTimeRangeWithUnit(
         const MD = `${monthFormat} D`;
         const DY = `D, YYYY`;
         [startFormat, endFormat] =
-          isDiffYear || !condensed
+          !sameYear || !condensed
             ? [MDY, MDY] // January 1, 2018 - January 2, 2019
-            : isDiffMonth
+            : !sameMonth
             ? [MD, MDY] // January 1 - February 2, 2018
-            : isDiffDay
+            : !sameDayOfMonth
             ? [MD, DY] // January 1 - 2, 2018
             : [MDY]; // January 2, 2018
         break;

--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -151,67 +151,55 @@ export function formatDateTimeRangeWithUnit(
   const shift = a.diff(start, "days");
   [start, end].forEach(d => d.add(shift, "days"));
 
-  // Drop down to day resolution if shift causes misalignment with desired resolution boundaries
-  const date_resolution =
-    (shift === 0 ? options.date_resolution : null) ?? "day";
-
   if (start.isValid() && end.isValid()) {
     const sameYear = start.year() === end.year();
     const sameQuarter = start.quarter() === end.quarter();
     const sameMonth = start.month() === end.month();
     const sameDayOfMonth = start.date() === end.date();
 
-    let startFormat, endFormat;
+    const Y = "YYYY";
+    const Q = "[Q]Q";
+    const QY = "[Q]Q YYYY";
+    const M = monthFormat;
+    const MY = `${monthFormat} YYYY`;
+    const MDY = `${monthFormat} D, YYYY`;
+    const MD = `${monthFormat} D`;
+    const DY = `D, YYYY`;
 
-    switch (date_resolution) {
-      case "year": {
-        const Y = "YYYY";
-        [startFormat, endFormat] =
-          !sameYear || !condensed
-            ? [Y, Y] // 2018 - 2019
-            : [Y]; //   2018
-        break;
-      }
-      case "quarter": {
-        const Q = "[Q]Q";
-        const QY = "[Q]Q YYYY";
-        [startFormat, endFormat] =
-          !sameYear || !condensed
-            ? [QY, QY] // Q2 2018 - Q3 2019
-            : !sameQuarter
-            ? [Q, QY] // Q2 - Q4 2019
-            : [QY]; // Q3 2019
-        break;
-      }
-      case "month": {
-        const M = monthFormat;
-        const MY = `${monthFormat} YYYY`;
-        [startFormat, endFormat] =
-          !sameYear || !condensed
-            ? [MY, MY] // September 2018 - January 2019
-            : !sameMonth
-            ? [M, MY] // September - December 2018
-            : [MY]; // October 2018
-        break;
-      }
-      case "day": {
-        const MDY = `${monthFormat} D, YYYY`;
-        const MD = `${monthFormat} D`;
-        const DY = `D, YYYY`;
-        [startFormat, endFormat] =
-          !sameYear || !condensed
-            ? [MDY, MDY] // January 1, 2018 - January 2, 2019
-            : !sameMonth
-            ? [MD, MDY] // January 1 - February 2, 2018
-            : !sameDayOfMonth
-            ? [MD, DY] // January 1 - 2, 2018
-            : [MDY]; // January 2, 2018
-        break;
-      }
-    }
-    return !endFormat
-      ? start.format(startFormat)
-      : start.format(startFormat) + RANGE_SEPARATOR + end.format(endFormat);
+    // Drop down to day resolution if shift causes misalignment with desired resolution boundaries
+    const date_resolution =
+      (shift === 0 ? options.date_resolution : null) ?? "day";
+
+    const [startFormat, endFormat] = {
+      year:
+        !sameYear || !condensed
+          ? [Y, Y] // 2018 - 2019
+          : [Y], // 2018
+      quarter:
+        !sameYear || !condensed
+          ? [QY, QY] // Q2 2018 - Q3 2019
+          : !sameQuarter
+          ? [Q, QY] // Q2 - Q4 2019
+          : [QY], // Q2 2018
+      month:
+        !sameYear || !condensed
+          ? [MY, MY] // September 2018 - January 2019
+          : !sameMonth
+          ? [M, MY] // September - December 2018
+          : [MY], // September 2018
+      day:
+        !sameYear || !condensed
+          ? [MDY, MDY] // January 1, 2018 - January 2, 2019
+          : !sameMonth
+          ? [MD, MDY] // January 1 - February 2, 2018
+          : !sameDayOfMonth
+          ? [MD, DY] // January 1 - 2, 2018
+          : [MDY], // January 1, 2018
+    }[date_resolution];
+
+    const startStr = start.format(startFormat);
+    const endStr = end.format(endFormat ?? startFormat);
+    return startStr === endStr ? startStr : startStr + RANGE_SEPARATOR + endStr;
   } else {
     // TODO: when is this used?
     return formatWeek(a, options);

--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -141,11 +141,6 @@ export function formatDateTimeRangeWithUnit(
     return String(a);
   }
 
-  // Tooltips should show full month name, but condense "MMMM D, YYYY - MMMM D, YYYY" to "MMMM D - D, YYYY" etc
-  const monthFormat =
-    options.type === "tooltip" ? "MMMM" : getMonthFormat(options);
-  const condensed = options.compact || options.type === "tooltip";
-
   // The client's unit boundaries might not line up with the data returned from the server.
   // We shift the range so that the start lines up with the value.
   const start = a.clone().startOf(unit);
@@ -153,63 +148,68 @@ export function formatDateTimeRangeWithUnit(
   const shift = a.diff(start, "days");
   [start, end].forEach(d => d.add(shift, "days"));
 
-  if (start.isValid() && end.isValid()) {
-    const sameYear = start.year() === end.year();
-    const sameQuarter = start.quarter() === end.quarter();
-    const sameMonth = start.month() === end.month();
-    const sameDayOfMonth = start.date() === end.date();
-
-    const Y = "YYYY";
-    const Q = "[Q]Q";
-    const QY = "[Q]Q YYYY";
-    const M = monthFormat;
-    const MY = `${monthFormat} YYYY`;
-    const MDY = `${monthFormat} D, YYYY`;
-    const MD = `${monthFormat} D`;
-    const DY = `D, YYYY`;
-
-    // Drop down to day resolution if shift causes misalignment with desired resolution boundaries
-    const date_resolution =
-      (shift === 0 ? options.date_resolution : null) ?? "day";
-
-    // Use Wikipedia’s date range formatting guidelines
-    // https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Dates_and_numbers#Ranges
-    const [startFormat, endFormat, pad = ""] = {
-      year:
-        !sameYear || !condensed
-          ? [Y, Y] // 2018–2019
-          : [Y], // 2018
-      quarter:
-        !sameYear || !condensed
-          ? [QY, QY, " "] // Q2 2018 – Q3 2019
-          : !sameQuarter
-          ? [Q, QY] // Q2–Q4 2019
-          : [QY], // Q2 2018
-      month:
-        !sameYear || !condensed
-          ? [MY, MY, " "] // September 2018 – January 2019
-          : !sameMonth
-          ? [M, MY] // September–December 2018
-          : [MY], // September 2018
-      day:
-        !sameYear || !condensed
-          ? [MDY, MDY, " "] // January 1, 2018 – January 2, 2019
-          : !sameMonth
-          ? [MD, MDY, " "] // January 1 – February 2, 2018
-          : !sameDayOfMonth
-          ? [MD, DY] // January 1–2, 2018
-          : [MDY], // January 1, 2018
-    }[date_resolution];
-
-    const startStr = start.format(startFormat);
-    const endStr = end.format(endFormat ?? startFormat);
-    return startStr === endStr
-      ? startStr
-      : startStr + pad + EN_DASH + pad + endStr;
-  } else {
+  if (!start.isValid() || !end.isValid()) {
     // TODO: when is this used?
     return formatWeek(a, options);
   }
+
+  // Tooltips should show full month name, but condense "MMMM D, YYYY - MMMM D, YYYY" to "MMMM D - D, YYYY" etc
+  const monthFormat =
+    options.type === "tooltip" ? "MMMM" : getMonthFormat(options);
+  const condensed = options.compact || options.type === "tooltip";
+
+  const sameYear = start.year() === end.year();
+  const sameQuarter = start.quarter() === end.quarter();
+  const sameMonth = start.month() === end.month();
+  const sameDayOfMonth = start.date() === end.date();
+
+  const Y = "YYYY";
+  const Q = "[Q]Q";
+  const QY = "[Q]Q YYYY";
+  const M = monthFormat;
+  const MY = `${monthFormat} YYYY`;
+  const MDY = `${monthFormat} D, YYYY`;
+  const MD = `${monthFormat} D`;
+  const DY = `D, YYYY`;
+
+  // Drop down to day resolution if shift causes misalignment with desired resolution boundaries
+  const date_resolution =
+    (shift === 0 ? options.date_resolution : null) ?? "day";
+
+  // Use Wikipedia’s date range formatting guidelines
+  // https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Dates_and_numbers#Ranges
+  const [startFormat, endFormat, pad = ""] = {
+    year:
+      !sameYear || !condensed
+        ? [Y, Y] // 2018–2019
+        : [Y], // 2018
+    quarter:
+      !sameYear || !condensed
+        ? [QY, QY, " "] // Q2 2018 – Q3 2019
+        : !sameQuarter
+        ? [Q, QY] // Q2–Q4 2019
+        : [QY], // Q2 2018
+    month:
+      !sameYear || !condensed
+        ? [MY, MY, " "] // September 2018 – January 2019
+        : !sameMonth
+        ? [M, MY] // September–December 2018
+        : [MY], // September 2018
+    day:
+      !sameYear || !condensed
+        ? [MDY, MDY, " "] // January 1, 2018 – January 2, 2019
+        : !sameMonth
+        ? [MD, MDY, " "] // January 1 – February 2, 2018
+        : !sameDayOfMonth
+        ? [MD, DY] // January 1–2, 2018
+        : [MDY], // January 1, 2018
+  }[date_resolution];
+
+  const startStr = start.format(startFormat);
+  const endStr = end.format(endFormat ?? startFormat);
+  return startStr === endStr
+    ? startStr
+    : startStr + pad + EN_DASH + pad + endStr;
 }
 
 export function formatRange(

--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -125,9 +125,11 @@ export function formatDateTimeForParameter(value: string, unit: DatetimeUnit) {
   }
 }
 
+type DateVal = string | number;
+
 /** This formats a time with unit as a date range */
 export function formatDateTimeRangeWithUnit(
-  value: string | number | (string | number)[],
+  value: DateVal | [DateVal] | [DateVal, DateVal],
   unit: DatetimeUnit,
   options: OptionsType = {},
 ) {

--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -225,7 +225,7 @@ export function formatRange(
       </span>
     );
   } else {
-    return `${start} ${EN_DASH} ${end}`;
+    return `${start}  ${EN_DASH}  ${end}`;
   }
 }
 

--- a/frontend/src/metabase/lib/formatting/date.unit.spec.tsx
+++ b/frontend/src/metabase/lib/formatting/date.unit.spec.tsx
@@ -1,0 +1,89 @@
+import { formatDateTimeRangeWithUnit } from "metabase/lib/formatting/date";
+import { OptionsType } from "metabase/lib/formatting/types";
+
+describe("date range formatting", () => {
+  const format = formatDateTimeRangeWithUnit;
+
+  // use this to test that the variants of a single date (not a date range) will all be equal
+  const singleDateVariants = (date: any) => [date, [date], [date, date]];
+
+  // we use the tooltip type to test abbreviated dates
+  const abbrev: OptionsType = { type: "tooltip" };
+
+  it("should display year ranges", () => {
+    const opts: OptionsType = { date_resolution: "year" };
+    const unit = "year";
+    singleDateVariants("2018").forEach(d =>
+      expect(format(d, unit, opts)).toBe("2018"),
+    );
+    expect(format(["2018", "2020"], unit, opts)).toBe("2018 – 2020");
+  });
+  it("should display quarter ranges", () => {
+    const opts: OptionsType = { date_resolution: "quarter" };
+    const unit = "quarter";
+    singleDateVariants("2018-01-01").forEach(d =>
+      expect(format(d, unit, opts)).toBe("Q1 2018"),
+    );
+    expect(format(["2018-01-01", "2019-04-01"], unit, opts)).toBe(
+      "Q1 2018 – Q2 2019",
+    );
+    expect(format(["2018-01-01", "2018-04-01"], unit, opts)).toBe(
+      "Q1 2018 – Q2 2018",
+    );
+    expect(
+      format(["2018-01-01", "2018-04-01"], unit, { ...opts, ...abbrev }),
+    ).toBe("Q1 – Q2 2018");
+  });
+  it("should display month ranges", () => {
+    const opts: OptionsType = { date_resolution: "month" };
+    const unit = "month";
+    singleDateVariants("2018-01-01").forEach(d =>
+      expect(format(d, unit, opts)).toBe("January 2018"),
+    );
+    expect(format(["2018-01-01", "2019-04-01"], unit, opts)).toBe(
+      "January 2018 – April 2019",
+    );
+    expect(format(["2018-01-01", "2018-04-01"], unit, opts)).toBe(
+      "January 2018 – April 2018",
+    );
+    expect(
+      format(["2018-01-01", "2018-04-01"], unit, { ...opts, ...abbrev }),
+    ).toBe("January – April 2018");
+  });
+  it("should display day ranges for a single unit", () => {
+    const opts: OptionsType = { ...abbrev };
+    singleDateVariants("2018-01-01").forEach(d =>
+      expect(format(d, "day", opts)).toBe("January 1, 2018"),
+    );
+    singleDateVariants("2018-01-01").forEach(d =>
+      expect(format(d, "week", opts)).toBe("January 1 – 7, 2018"),
+    );
+    singleDateVariants("2018-01-01").forEach(d =>
+      expect(format(d, "month", opts)).toBe("January 1 – 31, 2018"),
+    );
+    singleDateVariants("2018-01-01").forEach(d =>
+      expect(format(d, "quarter", opts)).toBe("January 1 – March 31, 2018"),
+    );
+    singleDateVariants("2018-01-01").forEach(d =>
+      expect(format(d, "year", opts)).toBe("January 1 – December 31, 2018"),
+    );
+  });
+  it("should display day ranges between two units", () => {
+    const opts: OptionsType = { ...abbrev };
+    expect(format(["2018-01-01", "2018-01-02"], "day", opts)).toBe(
+      "January 1 – 2, 2018",
+    );
+    expect(format(["2018-01-01", "2018-01-08"], "week", opts)).toBe(
+      "January 1 – 14, 2018",
+    );
+    expect(format(["2018-01-01", "2018-02-01"], "month", opts)).toBe(
+      "January 1 – February 28, 2018",
+    );
+    expect(format(["2018-01-01", "2018-04-01"], "quarter", opts)).toBe(
+      "January 1 – June 30, 2018",
+    );
+    expect(format(["2018-01-01", "2019-01-01"], "year", opts)).toBe(
+      "January 1, 2018 – December 31, 2019",
+    );
+  });
+});

--- a/frontend/src/metabase/lib/formatting/date.unit.spec.tsx
+++ b/frontend/src/metabase/lib/formatting/date.unit.spec.tsx
@@ -16,7 +16,7 @@ describe("date range formatting", () => {
     singleDateVariants("2018").forEach(d =>
       expect(format(d, unit, opts)).toBe("2018"),
     );
-    expect(format(["2018", "2020"], unit, opts)).toBe("2018 – 2020");
+    expect(format(["2018", "2020"], unit, opts)).toBe("2018–2020");
   });
   it("should display quarter ranges", () => {
     const opts: OptionsType = { date_resolution: "quarter" };
@@ -32,7 +32,7 @@ describe("date range formatting", () => {
     );
     expect(
       format(["2018-01-01", "2018-04-01"], unit, { ...opts, ...abbrev }),
-    ).toBe("Q1 – Q2 2018");
+    ).toBe("Q1–Q2 2018");
   });
   it("should display month ranges", () => {
     const opts: OptionsType = { date_resolution: "month" };
@@ -48,7 +48,7 @@ describe("date range formatting", () => {
     );
     expect(
       format(["2018-01-01", "2018-04-01"], unit, { ...opts, ...abbrev }),
-    ).toBe("January – April 2018");
+    ).toBe("January–April 2018");
   });
   it("should display day ranges for a single unit", () => {
     const opts: OptionsType = { ...abbrev };
@@ -56,10 +56,10 @@ describe("date range formatting", () => {
       expect(format(d, "day", opts)).toBe("January 1, 2018"),
     );
     singleDateVariants("2018-01-01").forEach(d =>
-      expect(format(d, "week", opts)).toBe("January 1 – 7, 2018"),
+      expect(format(d, "week", opts)).toBe("January 1–7, 2018"),
     );
     singleDateVariants("2018-01-01").forEach(d =>
-      expect(format(d, "month", opts)).toBe("January 1 – 31, 2018"),
+      expect(format(d, "month", opts)).toBe("January 1–31, 2018"),
     );
     singleDateVariants("2018-01-01").forEach(d =>
       expect(format(d, "quarter", opts)).toBe("January 1 – March 31, 2018"),
@@ -71,10 +71,10 @@ describe("date range formatting", () => {
   it("should display day ranges between two units", () => {
     const opts: OptionsType = { ...abbrev };
     expect(format(["2018-01-01", "2018-01-02"], "day", opts)).toBe(
-      "January 1 – 2, 2018",
+      "January 1–2, 2018",
     );
     expect(format(["2018-01-01", "2018-01-08"], "week", opts)).toBe(
-      "January 1 – 14, 2018",
+      "January 1–14, 2018",
     );
     expect(format(["2018-01-01", "2018-02-01"], "month", opts)).toBe(
       "January 1 – February 28, 2018",

--- a/frontend/src/metabase/lib/formatting/date.unit.spec.tsx
+++ b/frontend/src/metabase/lib/formatting/date.unit.spec.tsx
@@ -1,7 +1,7 @@
 import { formatDateTimeRangeWithUnit } from "metabase/lib/formatting/date";
 import { OptionsType } from "metabase/lib/formatting/types";
 
-describe("date range formatting", () => {
+describe("formatDateTimeRangeWithUnit", () => {
   const format = formatDateTimeRangeWithUnit;
 
   // use this to test that the variants of a single date (not a date range) will all be equal

--- a/frontend/src/metabase/lib/formatting/types.ts
+++ b/frontend/src/metabase/lib/formatting/types.ts
@@ -24,6 +24,7 @@ export interface OptionsType {
   rich?: boolean;
   suffix?: string;
   time_enabled?: "minutes" | "milliseconds" | "seconds" | null;
+  date_resolution?: "day" | "month" | "quarter" | "year";
   time_format?: string;
   time_style?: string;
   type?: string;

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.unit.spec.js
@@ -158,7 +158,7 @@ describe("LineAreaBarRenderer", () => {
 
     const hover = onHoverChange.mock.calls[0][0];
     const [formattedWeek] = getFormattedTooltips(hover, settings);
-    expect(formattedWeek).toEqual("January 5 – 11, 2020");
+    expect(formattedWeek).toEqual("January 5–11, 2020");
 
     const ticks = qsa(".axis.x .tick text").map(e => e.textContent);
     expect(ticks).toEqual([

--- a/frontend/test/metabase-lib/lib/queries/structured/Filter.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Filter.unit.spec.js
@@ -32,6 +32,63 @@ describe("Filter", () => {
     it("should return the correct string for a segment filter", () => {
       expect(filter(["segment", 1]).displayName()).toEqual("Expensive Things");
     });
+    describe("better date labels", () => {
+      function createdAtFilter(op, unit, ...args) {
+        return filter([
+          op,
+          [
+            "field",
+            ORDERS.CREATED_AT,
+            {
+              "base-type": "type/DateTime",
+              "temporal-unit": unit,
+            },
+          ],
+          ...args,
+        ]);
+      }
+
+      it("should display is-week filter as a day range", () => {
+        expect(
+          createdAtFilter("=", "week", "2026-10-04").displayName(),
+        ).toEqual("Created At is October 4–10, 2026");
+      });
+      it("should display between-weeks filter as day range", () => {
+        expect(
+          createdAtFilter(
+            "between",
+            "week",
+            "2026-10-04",
+            "2026-10-11",
+          ).displayName(),
+        ).toEqual("Created At between October 4–17, 2026");
+      });
+      it("should display slice filters with enough context for understanding them", () => {
+        expect(
+          createdAtFilter(
+            "=",
+            "minute-of-hour",
+            "2023-07-03T18:31:00-05:00",
+          ).displayName(),
+        ).toEqual("Created At is minute 31");
+        expect(
+          createdAtFilter(
+            "=",
+            "hour-of-day",
+            "2023-07-03T10:00:00-05:00",
+          ).displayName(),
+        ).toEqual("Created At is hour 10");
+        expect(
+          createdAtFilter("=", "day-of-month", "2016-01-17").displayName(),
+        ).toEqual("Created At is 17th day of month");
+        expect(
+          createdAtFilter("=", "day-of-year", "2016-07-19").displayName(),
+        ).toEqual("Created At is 201st day of year");
+        expect(
+          createdAtFilter("=", "week-of-year", "2023-07-02").displayName(),
+        ).toEqual("Created At is 27th week of year");
+      });
+    });
   });
   describe("isValid", () => {
     describe("with a field filter", () => {

--- a/frontend/test/metabase-lib/lib/queries/structured/Filter.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Filter.unit.spec.js
@@ -32,7 +32,7 @@ describe("Filter", () => {
     it("should return the correct string for a segment filter", () => {
       expect(filter(["segment", 1]).displayName()).toEqual("Expensive Things");
     });
-    describe("better date labels", () => {
+    describe("betterDateLabel", () => {
       function createdAtFilter(op, unit, ...args) {
         return filter([
           op,
@@ -61,7 +61,7 @@ describe("Filter", () => {
             "2026-10-04",
             "2026-10-11",
           ).displayName(),
-        ).toEqual("Created At between October 4–17, 2026");
+        ).toEqual("Created At is October 4–17, 2026");
       });
       it("should display slice filters with enough context for understanding them", () => {
         expect(

--- a/frontend/test/metabase-lib/lib/queries/structured/Filter.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Filter.unit.spec.js
@@ -77,7 +77,7 @@ describe("Filter", () => {
             "hour-of-day",
             "2023-07-03T10:00:00-05:00",
           ).displayName(),
-        ).toEqual("Created At is hour 10");
+        ).toMatch(/^Created At is hour \d+$/); // GitHub CI is in different time zone
         expect(
           createdAtFilter("=", "day-of-month", "2016-01-17").displayName(),
         ).toEqual("Created At is 17th day of month");


### PR DESCRIPTION
Fixes display labels for weeks in https://github.com/metabase/metabase/issues/12496:

### Description 

Fixes the display names in the Filter Pills for various date-related filters.  DOES NOT fix the date picker for modifying the filter, just fixes the display name so that the filter is accurately represented.

✅ EDIT: All “between” labels in the screenshots below have been replaced with “is” after [design feedback](https://metaboat.slack.com/archives/C02H619CJ8K/p1688777083722309?thread_ts=1688776046.384209&cid=C02H619CJ8K)

#### 🐛 Bug fix: week-related filters

A filter for a single week was being displayed as a day instead of a range of days.  Also, the range of weeks was displayed as an incorrect range of days.

type  | before | after
---|---|---
single week | <img width="217" alt="CleanShot 2023-07-04 at 05 54 10@2x" src="https://github.com/metabase/metabase/assets/116838/9106fa89-525a-4647-8a1a-7ba51341eb1d"> | <img width="239" alt="CleanShot 2023-07-04 at 05 54 19@2x" src="https://github.com/metabase/metabase/assets/116838/d85181c9-c05e-4d3e-b108-6a2b17561224">
week range | <img width="413" alt="CleanShot 2023-07-04 at 06 09 01@2x" src="https://github.com/metabase/metabase/assets/116838/12fd51dd-204d-49ef-a0eb-e2071d09213e"> | <img width="382" alt="CleanShot 2023-07-04 at 06 10 04@2x" src="https://github.com/metabase/metabase/assets/116838/c8b30a63-f072-42b1-95e6-0cd9adf07f2b">

#### 🐛 Bug fix: splice-related filters

Splice filters select a slice of time, spliced across recurrent periods.  

type  | before | after
---|---|---
minute of hour | <img width="143" alt="CleanShot 2023-07-04 at 05 57 43@2x" src="https://github.com/metabase/metabase/assets/116838/85ca0d4d-3759-437c-9d7e-a9edea2a891f">  | <img width="190" alt="CleanShot 2023-07-04 at 05 57 09@2x" src="https://github.com/metabase/metabase/assets/116838/948071c0-fc5c-45fd-979a-28ac2076a5d4">
hour of day | <img width="280" alt="CleanShot 2023-07-04 at 06 00 35@2x" src="https://github.com/metabase/metabase/assets/116838/42534f2c-1e25-443d-8752-23abcc5cd115"> | <img width="179" alt="CleanShot 2023-07-04 at 06 02 29@2x" src="https://github.com/metabase/metabase/assets/116838/23a16e6c-8ace-41f4-b496-4a7ed2611a5f">
day of month | <img width="153" alt="CleanShot 2023-07-04 at 06 04 46@2x" src="https://github.com/metabase/metabase/assets/116838/9697deec-e6d5-4700-999f-16744a2803be"> | <img width="250" alt="CleanShot 2023-07-04 at 06 03 47@2x" src="https://github.com/metabase/metabase/assets/116838/e4f387ad-0eb9-4792-8a0b-afa162a84d78">
day of year | <img width="157" alt="CleanShot 2023-07-04 at 06 05 51@2x" src="https://github.com/metabase/metabase/assets/116838/4a08695b-3d51-47f6-a32e-5f4a75115d1b"> | <img width="244" alt="CleanShot 2023-07-04 at 06 06 38@2x" src="https://github.com/metabase/metabase/assets/116838/6f86504f-c99f-4720-9b98-922777c6db4d">
week of year | <img width="165" alt="CleanShot 2023-07-04 at 06 07 39@2x" src="https://github.com/metabase/metabase/assets/116838/de7cb16f-0cb2-4654-b7db-8280f0203357"> | <img width="245" alt="CleanShot 2023-07-04 at 06 07 02@2x" src="https://github.com/metabase/metabase/assets/116838/65ae8b96-3d66-48b2-99c5-9f7c2dc045cf">

#### 🔧 Improvement: properly formatted date ranges

> Go the extra mile to make the user experience pleasant
> _—The Zen of Metabase_

Dates in a range were originally formatted separately, then joined with a space between.  Since I needed to properly format a date range for the week-filter fix above, I added a general date range formatter based on [Wikipedia’s style guide for date ranges](https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Dates_and_numbers#Ranges).

type | before | after
---|---|---
day | <img width="435" alt="CleanShot 2023-07-04 at 06 31 31@2x" src="https://github.com/metabase/metabase/assets/116838/177bf73d-cc98-411c-933b-5acd253a83dd"> | <img width="330" alt="CleanShot 2023-07-04 at 06 27 49@2x" src="https://github.com/metabase/metabase/assets/116838/26a073d7-727e-4ee4-98fb-e88b1f61f613">
month | <img width="369" alt="CleanShot 2023-07-04 at 06 33 11@2x" src="https://github.com/metabase/metabase/assets/116838/ce25316a-cb71-406c-84be-14964c9a4b2a"> | <img width="331" alt="CleanShot 2023-07-04 at 06 27 11@2x" src="https://github.com/metabase/metabase/assets/116838/75db951d-1066-4c5c-8f0f-d2d0ea13cc3e">
month | <img width="322" alt="CleanShot 2023-07-04 at 06 34 39@2x" src="https://github.com/metabase/metabase/assets/116838/554d0c44-7174-4fa4-bda4-41944d4abb05"> | <img width="327" alt="CleanShot 2023-07-04 at 06 26 40@2x" src="https://github.com/metabase/metabase/assets/116838/1b16e823-3919-4bb8-8172-5385ccb1b78a">


### Implementation Notes

`Filter.displayName` touches a lot of date formatting functions used by other components.  To avoid disrupting the [delicate circuitry](https://github.com/metabase/metabase/assets/116838/67d4991b-7363-4060-b050-ff54a6572269) that other components might rely on, I re-route the display name to use its own internal `Filter.betterDateLabel` for only a specific set of filter types, then fall back to the original display name for others.

### How to verify

See https://github.com/metabase/metabase/issues/12496

Set the unit in the dropdown below to see the different [splice filters](https://github.com/metabase/metabase/assets/116838/9fd6b114-256f-4f74-9580-484fe94c67ca), then drag a range inside the plot.

### Demo

https://github.com/metabase/metabase/assets/116838/f39779d1-297a-40ae-999e-bcf16ed3e053



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
