### PR TITLE
Apply draft parameters when turning on dashboard auto-apply filters

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
@@ -68,7 +68,9 @@ describe("scenarios > dashboards > filters > auto apply", () => {
     openDashboard();
     cy.wait("@cardQuery");
 
-    // changing parameter values by default should reload affected questions
+    cy.log(
+      "changing parameter values by default should reload affected questions",
+    );
     filterWidget().findByText(FILTER.name).click();
     popover().within(() => {
       cy.findByText("Gadget").click();
@@ -77,7 +79,9 @@ describe("scenarios > dashboards > filters > auto apply", () => {
     });
     getDashboardCard().findByText("Rows 1-5 of 53").should("be.visible");
 
-    // parameter values should be preserved when disabling auto applying filters
+    cy.log(
+      "parameter values should be preserved when disabling auto applying filters",
+    );
     toggleDashboardInfoSidebar();
     rightSidebar().within(() => {
       cy.findByLabelText("Auto-apply filters").click();
@@ -87,7 +91,7 @@ describe("scenarios > dashboards > filters > auto apply", () => {
     filterWidget().findByText("Gadget").should("be.visible");
     getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
 
-    // draft parameter values should be applied manually
+    cy.log("draft parameter values should be applied manually");
     filterWidget().findByText("Gadget").click();
     popover().within(() => {
       cy.findByText("Widget").click();
@@ -99,8 +103,11 @@ describe("scenarios > dashboards > filters > auto apply", () => {
       cy.wait("@cardQuery");
     });
     getDashboardCard().findByText("Rows 1-4 of 107").should("be.visible");
+    cy.get("@cardQuery.all").should("have.length", 3);
 
-    // draft parameter values should be discarded when enabling auto-applying filters
+    cy.log(
+      "draft parameter values should be applied when enabling auto-applying filters",
+    );
     filterWidget().findByText("2 selections").click();
     popover().within(() => {
       cy.findByText("Gadget").click();
@@ -113,22 +120,25 @@ describe("scenarios > dashboards > filters > auto apply", () => {
       cy.wait("@updateDashboard");
       cy.findByLabelText("Auto-apply filters").should("be.checked");
     });
-    filterWidget().within(() => {
-      cy.findByText("2 selections").should("be.visible");
-      cy.get("@cardQuery.all").should("have.length", 3);
-    });
+    filterWidget().findByText("Widget").should("be.visible");
+    getDashboardCard().findByText("Rows 1-4 of 54").should("be.visible");
+    cy.get("@cardQuery.all").should("have.length", 4);
 
-    // last applied parameter values should be used when disabling auto applying filters,
-    // even if previously there were draft parameter values
+    cy.log(
+      "last applied parameter values should be used when disabling auto applying filters, even if previously there were draft parameter values",
+    );
+    filterWidget().findByText("Widget").click();
+    popover().within(() => {
+      cy.findByText("Gadget").click();
+      cy.button("Update filter").click();
+    });
     rightSidebar().within(() => {
       cy.findByLabelText("Auto-apply filters").click();
       cy.wait("@updateDashboard");
       cy.findByLabelText("Auto-apply filters").should("not.be.checked");
     });
-    filterWidget().within(() => {
-      cy.findByText("2 selections").should("be.visible");
-      cy.get("@cardQuery.all").should("have.length", 3);
-    });
+    filterWidget().findByText("2 selections").should("be.visible");
+    cy.get("@cardQuery.all").should("have.length", 5);
   });
 
   it("should not preserve draft parameter values when editing the dashboard", () => {
@@ -189,7 +199,9 @@ describe("scenarios > dashboards > filters > auto apply", () => {
 
       getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
 
-      // parameter with default value should still be applied after turning auto-apply filter off
+      cy.log(
+        "parameter with default value should still be applied after turning auto-apply filter off",
+      );
       rightSidebar().within(() => {
         cy.findByLabelText("Auto-apply filters").should("be.checked").click();
         cy.wait("@updateDashboard");
@@ -198,7 +210,9 @@ describe("scenarios > dashboards > filters > auto apply", () => {
 
       getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
 
-      // card result should be updated after manually updating the filter
+      cy.log(
+        "card result should be updated after manually updating the filter",
+      );
       filterWidget().icon("close").click();
       dashboardParametersContainer()
         .button("Apply")
@@ -207,7 +221,9 @@ describe("scenarios > dashboards > filters > auto apply", () => {
 
       getDashboardCard().findByText("Rows 1-4 of 200").should("be.visible");
 
-      // should not use the default parameter after turning auto-apply filter on again since the parameter was manually updated
+      cy.log(
+        "should not use the default parameter after turning auto-apply filter on again since the parameter was manually updated",
+      );
       rightSidebar().within(() => {
         cy.findByLabelText("Auto-apply filters")
           .should("not.be.checked")

--- a/frontend/src/metabase/dashboard/actions/parameters.js
+++ b/frontend/src/metabase/dashboard/actions/parameters.js
@@ -337,6 +337,7 @@ export const toggleAutoApplyFilters = createThunkAction(
     const dashboardId = getDashboardId(getState());
 
     if (dashboardId) {
+      dispatch(applyDraftParameterValues());
       dispatch(
         setDashboardAttributes({
           id: dashboardId,


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/29267
Closes https://github.com/metabase/metabase/issues/32030

### Description

This PR implements a behavior that isn't originally specified in the product doc. [This is the discussion about the new behavior.](https://github.com/metabase/metabase/pull/31898#discussion_r1244768943)
### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a new dashboard, add a card, a filter, and connect them together.
1. Turn off the dashboard auto-apply filters.
1. Modify the filter, but don't hit the Apply button.
1. Turn the auto-apply filters back on. The draft filter should be applied to the dashboard and the dashboard should be refetched with the new applied filters.

### Demo

https://www.loom.com/share/de122589c08c48618b65a41b44a5fefb?sid=dfed7871-4522-44d1-9db1-291f2cf2cf47

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
