### PR TITLE
Migrate MetabaseSettings.isEnterprise to getIsPaidPlan selector

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx
@@ -123,13 +123,14 @@ class SettingsEmailForm extends Component {
   }
 }
 
-export default connect(
-  state => ({
-    isPaidPlan: getIsPaidPlan(state),
-  }),
-  {
-    sendTestEmail,
-    updateEmailSettings,
-    clearEmailSettings,
-  },
-)(SettingsEmailForm);
+const mapStateToProps = state => ({
+  isPaidPlan: getIsPaidPlan(state),
+});
+
+const mapDispatchToProps = {
+  sendTestEmail,
+  updateEmailSettings,
+  clearEmailSettings,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(SettingsEmailForm);

--- a/frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx
@@ -8,6 +8,7 @@ import MarginHostingCTA from "metabase/admin/settings/components/widgets/MarginH
 
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import MetabaseSettings from "metabase/lib/settings";
+import { getIsPaidPlan } from "metabase/selectors/settings";
 
 import {
   sendTestEmail,
@@ -30,6 +31,7 @@ class SettingsEmailForm extends Component {
 
   static propTypes = {
     elements: PropTypes.array.isRequired,
+    isPaidPlan: PropTypes.bool,
     sendTestEmail: PropTypes.func.isRequired,
     updateEmailSettings: PropTypes.func.isRequired,
     clearEmailSettings: PropTypes.func.isRequired,
@@ -81,7 +83,7 @@ class SettingsEmailForm extends Component {
 
   render() {
     const { sendingEmail } = this.state;
-    const { elements } = this.props;
+    const { elements, isPaidPlan } = this.props;
     const visibleElements = elements.filter(setting => !setting.getHidden?.());
     return (
       <EmailFormRoot>
@@ -113,7 +115,7 @@ class SettingsEmailForm extends Component {
             </Fragment>
           )}
         />
-        {!MetabaseSettings.isHosted() && !MetabaseSettings.isEnterprise() && (
+        {!MetabaseSettings.isHosted() && !isPaidPlan && (
           <MarginHostingCTA tagline={t`Have your email configured for you.`} />
         )}
       </EmailFormRoot>
@@ -121,8 +123,13 @@ class SettingsEmailForm extends Component {
   }
 }
 
-export default connect(null, {
-  sendTestEmail,
-  updateEmailSettings,
-  clearEmailSettings,
-})(SettingsEmailForm);
+export default connect(
+  state => ({
+    isPaidPlan: getIsPaidPlan(state),
+  }),
+  {
+    sendTestEmail,
+    updateEmailSettings,
+    clearEmailSettings,
+  },
+)(SettingsEmailForm);

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.unit.spec.js
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.unit.spec.js
@@ -1,11 +1,12 @@
-import { render, screen } from "@testing-library/react";
-import { setupEnterpriseTest } from "__support__/enterprise";
-import { mockSettings } from "__support__/settings";
 import {
+  createMockTokenFeatures,
   createMockVersion,
   createMockVersionInfo,
   createMockVersionInfoRecord,
 } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
 import SettingsUpdatesForm from "./SettingsUpdatesForm";
 
 const elements = [
@@ -17,6 +18,7 @@ const elements = [
 
 function setup({
   isHosted = false,
+  isPaid = false,
   currentVersion = "v1.0.0",
   latestVersion = "v2.0.0",
 } = {}) {
@@ -30,13 +32,22 @@ function setup({
       })
     : null;
 
-  mockSettings({
+  const settings = mockSettings({
     "is-hosted?": isHosted,
     version,
     "version-info": versionInfo,
+    "token-features": createMockTokenFeatures({
+      sso: isPaid,
+    }),
   });
 
-  render(<SettingsUpdatesForm elements={elements} />);
+  const state = createMockState({
+    settings,
+  });
+
+  renderWithProviders(<SettingsUpdatesForm elements={elements} />, {
+    storeInitialState: state,
+  });
 }
 
 describe("SettingsUpdatesForm", () => {
@@ -64,10 +75,8 @@ describe("SettingsUpdatesForm", () => {
     expect(screen.getByText("Migrate to Metabase Cloud.")).toBeInTheDocument();
   });
 
-  it("does not show upgrade call-to-action if in Enterprise plan", () => {
-    setupEnterpriseTest();
-
-    setup({ currentVersion: "v1.0.0", latestVersion: "v2.0.0" });
+  it("does not show upgrade call-to-action if is a paid plan", () => {
+    setup({ currentVersion: "v1.0.0", latestVersion: "v2.0.0", isPaid: true });
 
     expect(
       screen.queryByText("Migrate to Metabase Cloud."),

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/VersionUpdateNotice/VersionUpdateNotice.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/VersionUpdateNotice/VersionUpdateNotice.jsx
@@ -1,6 +1,8 @@
 import PropTypes from "prop-types";
 import { t } from "ttag";
 
+import { useSelector } from "metabase/lib/redux";
+import { getIsPaidPlan } from "metabase/selectors/settings";
 import HostingInfoLink from "metabase/admin/settings/components/widgets/HostingInfoLink";
 import { Icon } from "metabase/core/components/Icon";
 import Text from "metabase/components/type/Text";
@@ -45,14 +47,14 @@ CloudCustomers.propTypes = {
 };
 
 function OnLatestVersion({ currentVersion }) {
-  const shouldShowHostedCta = !MetabaseSettings.isEnterprise();
+  const isPaidPlan = useSelector(getIsPaidPlan);
 
   return (
     <div>
       <div className="p2 bg-brand bordered rounded border-brand text-white text-bold">
         {t`You're running Metabase ${currentVersion} which is the latest and greatest!`}
       </div>
-      {shouldShowHostedCta && <HostingCTA />}
+      {!isPaidPlan && <HostingCTA />}
     </div>
   );
 }
@@ -64,6 +66,7 @@ OnLatestVersion.propTypes = {
 function NewVersionAvailable({ currentVersion }) {
   const latestVersion = MetabaseSettings.latestVersion();
   const versionInfo = MetabaseSettings.versionInfo();
+  const isPaidPlan = useSelector(getIsPaidPlan);
 
   return (
     <div>
@@ -101,7 +104,7 @@ function NewVersionAvailable({ currentVersion }) {
           ))}
       </div>
 
-      {!MetabaseSettings.isHosted() && <HostingCTA />}
+      {!isPaidPlan && <HostingCTA />}
     </div>
   );
 }
@@ -111,10 +114,6 @@ NewVersionAvailable.propTypes = {
 };
 
 function HostingCTA() {
-  if (MetabaseSettings.isEnterprise()) {
-    return null;
-  }
-
   return (
     <HostingCTARoot className="rounded bg-light mt4 text-brand py2 px1">
       <HostingCTAContent>

--- a/frontend/src/metabase/admin/settings/setup/components/SetupCheckList/SetupCheckList.jsx
+++ b/frontend/src/metabase/admin/settings/setup/components/SetupCheckList/SetupCheckList.jsx
@@ -1,11 +1,13 @@
 /* eslint-disable react/prop-types */
 import { Component } from "react";
+import { connect } from "react-redux";
 import { Link } from "react-router";
 import { t } from "ttag";
 import { SetupApi } from "metabase/services";
 import { color } from "metabase/lib/colors";
 import MetabaseSettings from "metabase/lib/settings";
 import { isSameOrSiteUrlOrigin } from "metabase/lib/dom";
+import { getIsPaidPlan } from "metabase/selectors/settings";
 
 import { Icon } from "metabase/core/components/Icon";
 import ExternalLink from "metabase/core/components/ExternalLink";
@@ -86,7 +88,7 @@ const TaskLink = ({ className, link, children }) =>
     </ExternalLink>
   );
 
-export default class SetupCheckList extends Component {
+class SetupCheckList extends Component {
   constructor(props, context) {
     super(props, context);
     this.state = {
@@ -105,6 +107,8 @@ export default class SetupCheckList extends Component {
   }
 
   render() {
+    const { isPaidPlan } = this.props;
+
     let tasks, nextTask;
     if (this.state.tasks) {
       tasks = this.state.tasks.map(section => ({
@@ -143,10 +147,16 @@ export default class SetupCheckList extends Component {
           </LoadingAndErrorWrapper>
         </div>
 
-        {!MetabaseSettings.isHosted() && !MetabaseSettings.isEnterprise() && (
+        {!MetabaseSettings.isHosted() && !isPaidPlan && (
           <MarginHostingCTA tagline={t`Have your server maintained for you.`} />
         )}
       </SetupListRoot>
     );
   }
 }
+
+const mapStateToProps = state => ({
+  isPaidPlan: getIsPaidPlan(state),
+});
+
+export default connect(mapStateToProps)(SetupCheckList);


### PR DESCRIPTION
Removes deprecated `MetabaseSettings.isEnterprise` method and calls new `getIsPaidPlan` selector. `MetabaseSettings.isEnterprise` has proven to be faulty since it only checks that we run a EE image. There is a small user-observable change here, and it's been confirmed in this thread https://metaboat.slack.com/archives/C01LQQ2UW03/p1688380567792249?thread_ts=1688376029.853029&cid=C01LQQ2UW03.

How to verify:
- CI is green