### PR TITLE
Fix cronjob frequency for ReplayIO E2E tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,7 +3,7 @@ name: E2E Tests
 on:
   # We'll record runs using Replay.io and their browser on a schedule as an experiment
   schedule:
-    - cron: '* * * * 0'
+    - cron: '0 22 * * 0'
   push:
     branches:
       - "master"


### PR DESCRIPTION
[The previous setting](https://github.com/metabase/metabase/pull/32021) accidentally executed a scheduled job **every minute** on Sunday, when we actually wanted it to run only once on that day.

This PR fixes it and it will now run at 10PM every Sunday.
https://crontab.guru/#0_22_*_*_0

![image](https://github.com/metabase/metabase/assets/31325167/a4acc874-cd09-4e3f-adce-bf3c061e0dc9)
