### PR TITLE
Add long column name handling for column filter

### DIFF
--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -292,3 +292,23 @@ export function visitPublicDashboard(id, { params = {} } = {}) {
     },
   );
 }
+
+/**
+ * Returns a matcher function to find text content that is broken up by multiple elements
+ * There is also a version of this for unit tests - frontend/test/__support__/ui.tsx
+ * In case of changes, please, add them there as well
+ *
+ * @param {string} textToFind
+ * @example
+ * cy.findByText(getBrokenUpTextMatcher("my text with a styled word"))
+ */
+export function getBrokenUpTextMatcher(textToFind) {
+  return (content, element) => {
+    const hasText = node => node?.textContent === textToFind;
+    const childrenDoNotHaveText = element
+      ? Array.from(element.children).every(child => !hasText(child))
+      : true;
+
+    return hasText(element) && childrenDoNotHaveText;
+  };
+}

--- a/e2e/support/helpers/e2e-scrollbar-helpers.js
+++ b/e2e/support/helpers/e2e-scrollbar-helpers.js
@@ -21,3 +21,40 @@ export const isScrollableVertically = element => {
 
   return isVerticalScrollbarVisible;
 };
+
+export const assertDescendantNotOverflowsContainer = (
+  descendant,
+  container,
+  message,
+) => {
+  const containerRect = container.getBoundingClientRect();
+  const descendantRect = descendant.getBoundingClientRect();
+
+  if (descendantRect.height === 0 || descendantRect.width === 0) {
+    return;
+  }
+
+  expect(descendantRect.bottom, `${message} bottom`).to.be.lte(
+    containerRect.bottom,
+  );
+  expect(descendantRect.top, `${message} top`).to.be.gte(containerRect.top);
+  expect(descendantRect.left, `${message} left`).to.be.gte(containerRect.left);
+  expect(descendantRect.right, `${message} right`).to.be.lte(
+    containerRect.right,
+  );
+};
+
+export const assertIsEllipsified = element => {
+  expect(isEllipsified(element), "is ellipsified").to.equal(true);
+};
+
+export const assertIsNotEllipsified = element => {
+  expect(isEllipsified(element), "is ellipsified").to.equal(false);
+};
+
+export const isEllipsified = element => {
+  return (
+    element.scrollHeight > element.clientHeight ||
+    element.scrollWidth > element.clientWidth
+  );
+};

--- a/e2e/test/scenarios/dashboard/reproductions/31628-responsive-scalars.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/31628-responsive-scalars.cy.spec.js
@@ -1,4 +1,7 @@
 import {
+  assertDescendantNotOverflowsContainer,
+  assertIsEllipsified,
+  assertIsNotEllipsified,
   cypressWaitAll,
   openNavigationSidebar,
   popover,
@@ -508,41 +511,4 @@ const assertDescendantsNotOverflowDashcards = descendantsSelector => {
       );
     });
   });
-};
-
-const assertDescendantNotOverflowsContainer = (
-  descendant,
-  container,
-  message,
-) => {
-  const containerRect = container.getBoundingClientRect();
-  const descendantRect = descendant.getBoundingClientRect();
-
-  if (descendantRect.height === 0 || descendantRect.width === 0) {
-    return;
-  }
-
-  expect(descendantRect.bottom, `${message} bottom`).to.be.lte(
-    containerRect.bottom,
-  );
-  expect(descendantRect.top, `${message} top`).to.be.gte(containerRect.top);
-  expect(descendantRect.left, `${message} left`).to.be.gte(containerRect.left);
-  expect(descendantRect.right, `${message} right`).to.be.lte(
-    containerRect.right,
-  );
-};
-
-const assertIsEllipsified = element => {
-  expect(isEllipsified(element), "is ellipsified").to.equal(true);
-};
-
-const assertIsNotEllipsified = element => {
-  expect(isEllipsified(element), "is ellipsified").to.equal(false);
-};
-
-const isEllipsified = element => {
-  return (
-    element.scrollHeight > element.clientHeight ||
-    element.scrollWidth > element.clientWidth
-  );
 };

--- a/e2e/test/scenarios/filters/reproductions/31340-long-column-name-search-results.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/31340-long-column-name-search-results.cy.spec.js
@@ -1,0 +1,86 @@
+import {
+  assertDescendantNotOverflowsContainer,
+  assertIsEllipsified,
+  getBrokenUpTextMatcher,
+  popover,
+  restore,
+} from "e2e/support/helpers";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { SAMPLE_DB_ID, SAMPLE_DB_SCHEMA_ID } from "e2e/support/cypress_data";
+
+const { PEOPLE_ID } = SAMPLE_DATABASE;
+
+const LONG_COLUMN_NAME =
+  "Some very very very very long column name that should have a line break";
+describe("issue 31340", function () {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.intercept("PUT", "/api/field/*").as("fieldUpdate");
+    cy.intercept("GET", "/api/field/*/search/*").as("search");
+
+    cy.visit(
+      `/admin/datamodel/database/${SAMPLE_DB_ID}/schema/${SAMPLE_DB_SCHEMA_ID}/table/${PEOPLE_ID}`,
+    );
+
+    cy.findByTestId("column-PASSWORD")
+      .findByDisplayValue("Password")
+      .type(`{selectAll}${LONG_COLUMN_NAME}`)
+      .blur();
+
+    cy.wait("@fieldUpdate");
+
+    cy.createQuestion(
+      {
+        query: {
+          "source-table": PEOPLE_ID,
+          limit: 2,
+        },
+      },
+      { visitQuestion: true },
+    );
+  });
+
+  it("should properly display long column names in filter options search results (metabase#31340)", () => {
+    cy.findAllByTestId("header-cell").contains(LONG_COLUMN_NAME).click();
+
+    popover().within(() => {
+      cy.findByText("Filter by this column").click();
+
+      cy.findByPlaceholderText(`Search by ${LONG_COLUMN_NAME}`).type(
+        "nonexistingvalue",
+      );
+
+      cy.wait("@search");
+
+      cy.findByText(
+        getBrokenUpTextMatcher(`No matching ${LONG_COLUMN_NAME} found.`),
+      )
+        .should("be.visible")
+        .then($container => {
+          cy.findByText(LONG_COLUMN_NAME).then($columnTextEl => {
+            // check that text block is not wider than the popover
+            assertDescendantNotOverflowsContainer(
+              $container[0],
+              $container.parent()[0],
+              "search results message",
+            );
+
+            // check that column name is within the text block
+            assertDescendantNotOverflowsContainer(
+              $columnTextEl[0],
+              $container[0],
+              "search results message",
+            );
+            // and it takes no more than 1 line
+            expect($columnTextEl[0].getBoundingClientRect().height).to.be.lte(
+              20,
+            ); // reasonable font size
+
+            assertIsEllipsified($columnTextEl[0]);
+          });
+        });
+    });
+  });
+});

--- a/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.jsx
@@ -45,16 +45,13 @@ import {
   canUseCardEndpoints,
   getTokenFieldPlaceholder,
 } from "./utils";
+import { OptionsMessage, StyledEllipsified } from "./FieldValuesWidget.styled";
 
 const MAX_SEARCH_RESULTS = 100;
 
 const fieldValuesWidgetPropTypes = {
   addRemappings: PropTypes.func,
   expand: PropTypes.bool,
-};
-
-const optionsMessagePropTypes = {
-  message: PropTypes.string.isRequired,
 };
 
 const mapDispatchToProps = {
@@ -442,31 +439,24 @@ const LoadingState = () => (
 );
 
 const NoMatchState = ({ fields }) => {
-  if (fields.length > 1) {
-    // if there is more than one field, don't name them
-    return <OptionsMessage message={t`No matching result`} />;
+  if (fields.length === 1) {
+    const [{ display_name }] = fields;
+
+    return (
+      <OptionsMessage>
+        {jt`No matching ${(
+          <StyledEllipsified>{display_name}</StyledEllipsified>
+        )} found.`}
+      </OptionsMessage>
+    );
   }
-  const [{ display_name }] = fields;
-  return (
-    <OptionsMessage
-      message={jt`No matching ${(
-        <strong>&nbsp;{display_name}&nbsp;</strong>
-      )} found.`}
-    />
-  );
+
+  return <OptionsMessage>{t`No matching result`}</OptionsMessage>;
 };
 
 const EveryOptionState = () => (
-  <OptionsMessage
-    message={t`Including every option in your filter probably won’t do much…`}
-  />
+  <OptionsMessage>{t`Including every option in your filter probably won’t do much…`}</OptionsMessage>
 );
-
-const OptionsMessage = ({ message }) => (
-  <div className="flex layout-centered p4">{message}</div>
-);
-
-OptionsMessage.propTypes = optionsMessagePropTypes;
 
 export default connect(mapStateToProps, mapDispatchToProps)(FieldValuesWidget);
 
@@ -523,7 +513,7 @@ function renderOptions({
   }
 }
 
-export function renderValue(fields, formatOptions, value, options) {
+function renderValue(fields, formatOptions, value, options) {
   return (
     <ValueComponent
       value={value}

--- a/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.styled.tsx
+++ b/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.styled.tsx
@@ -1,0 +1,21 @@
+import styled from "@emotion/styled";
+import Ellipsified from "metabase/core/components/Ellipsified";
+
+export const StyledEllipsified = styled(Ellipsified)`
+  font-weight: bold;
+  display: inline-block;
+
+  margin: 0 0.2rem;
+`;
+
+export const OptionsMessage = styled.div`
+  padding: 2rem;
+
+  position: relative;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  white-space: nowrap;
+`;

--- a/frontend/src/metabase/components/FieldValuesWidget/index.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget/index.jsx
@@ -1,2 +1,1 @@
-export { default } from "./FieldValuesWidget";
-export * from "./FieldValuesWidget";
+export { default, FieldValuesWidget } from "./FieldValuesWidget";

--- a/frontend/src/metabase/components/FieldValuesWidget/testMocks.js
+++ b/frontend/src/metabase/components/FieldValuesWidget/testMocks.js
@@ -10,6 +10,7 @@ import {
   createPeopleTable,
   createReviewsTable,
   REVIEWS_ID,
+  createPeoplePasswordField,
 } from "metabase-types/api/mocks/presets";
 import { createMockState } from "metabase-types/store/mocks";
 
@@ -83,3 +84,25 @@ export const state = createMockState({
 });
 
 export const metadata = getMetadata(state);
+
+const stateWithSearchValuesField = createMockState({
+  entities: createMockEntitiesState({
+    databases: [
+      createSampleDatabase({
+        tables: [
+          createPeopleTable({
+            fields: [
+              createPeoplePasswordField({
+                has_field_values: "search",
+              }),
+            ],
+          }),
+        ],
+      }),
+    ],
+  }),
+});
+
+export const metadataWithSearchValuesField = getMetadata(
+  stateWithSearchValuesField,
+);

--- a/frontend/test/__support__/server-mocks/field.ts
+++ b/frontend/test/__support__/server-mocks/field.ts
@@ -1,5 +1,5 @@
 import fetchMock from "fetch-mock";
-import { Field, FieldValues } from "metabase-types/api";
+import { Field, FieldId, FieldValues } from "metabase-types/api";
 import { PERMISSION_ERROR } from "./constants";
 
 export function setupFieldEndpoints(field: Field) {
@@ -23,4 +23,23 @@ export function setupUnauthorizedFieldValuesEndpoints(
 
 export function setupFieldsValuesEndpoints(fieldsValues: FieldValues[]) {
   fieldsValues.forEach(fieldValues => setupFieldValuesEndpoints(fieldValues));
+}
+
+export function setupFieldSearchValuesEndpoints<T>(
+  fieldId: FieldId,
+  searchValue: string,
+  result: T[] = [],
+) {
+  fetchMock.get(
+    {
+      url: `path:/api/field/${fieldId}/search/${fieldId}`,
+      query: {
+        value: searchValue,
+        limit: 100, // corresponds to MAX_SEARCH_RESULTS in FieldValuesWidget
+      },
+    },
+    {
+      body: result,
+    },
+  );
 }

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -172,13 +172,22 @@ export function queryIcon(name: string, role: ByRoleMatcher = "img") {
 
 /**
  * Returns a matcher function to find text content that is broken up by multiple elements
+ * There is also a version of this for e2e tests - e2e/support/helpers/e2e-misc-helpers.js
+ * In case of changes, please, add them there as well
  *
- * @param {string} textToFind
  * @example
  * screen.getByText(getBrokenUpTextMatcher("my text with a styled word"))
  */
 export function getBrokenUpTextMatcher(textToFind: string): MatcherFunction {
-  return (content, element) => element?.textContent === textToFind;
+  return (content, element) => {
+    const hasText = (node: Element | null | undefined) =>
+      node?.textContent === textToFind;
+    const childrenDoNotHaveText = element
+      ? Array.from(element.children).every(child => !hasText(child))
+      : true;
+
+    return hasText(element) && childrenDoNotHaveText;
+  };
 }
 
 export * from "@testing-library/react";


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31340

### Description

This fixes an issue with long column name being displayed weirdly in column filter search results.

In the next step I will add visualization settings usage. Right now we support native field display name only.

### Demo

#### For short column names:

![Screenshot 2023-07-03 at 21 53 26](https://github.com/metabase/metabase/assets/7983744/2ee05cbe-2b71-4f00-bf4d-1d031100c5cd)

#### For long column names (> 20 chars):

![Screenshot 2023-07-03 at 20 52 00](https://github.com/metabase/metabase/assets/7983744/7896fb2b-8bab-46e9-98f7-e7cb83ca1528)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
