### PR TITLE
Updates v1 load to resolve Dashboard filter source card IDs

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/load.clj
@@ -431,6 +431,13 @@
       (pull-unresolved-names-up entity [:visualization_settings] resolved-vs))
     entity))
 
+(defn- resolve-dashboard-parameters
+  [parameters]
+  (for [p parameters]
+    ;; Note: not using the full ::unresolved-names functionality here because this is a fix
+    ;; for a deprecated feature
+    (m/update-existing-in p [:values_source_config :card_id] fully-qualified-name->card-id)))
+
 (defn load-dashboards
   "Loads `dashboards` (which is a sequence of maps parsed from a YAML dump of dashboards) in a given `context`."
   {:added "0.40.0"}
@@ -438,6 +445,7 @@
   (let [dashboard-ids   (maybe-upsert-many! context Dashboard
                                             (for [dashboard dashboards]
                                               (-> dashboard
+                                                  (update :parameters resolve-dashboard-parameters)
                                                   (dissoc :dashboard_cards)
                                                   (assoc :collection_id (:collection context)
                                                          :creator_id    (default-user-id)))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/load_test.clj
@@ -5,6 +5,7 @@
    [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing use-fixtures]]
    [metabase-enterprise.serialization.cmd :refer [v1-dump v1-load]]
+   [metabase-enterprise.serialization.load :as load]
    [metabase-enterprise.serialization.test-util :as ts]
    [metabase.models
     :refer [Card
@@ -408,3 +409,8 @@
             fingerprint))))
     (finally
       (delete-directory! dump-dir))))
+
+(deftest resolve-dashboard-parameters-test
+  (let [parameters [{:values_source_config {:card_id "foo"}}]]
+    (with-redefs [load/fully-qualified-name->card-id {"foo" 1}]
+      (is (= [1] (mapv (comp :card_id :values_source_config) (#'load/resolve-dashboard-parameters parameters)))))))


### PR DESCRIPTION
When loading a Dashboard from a v1 dump, IDs in `:parameters` were not being resolved. Updated to fix `:card_id` in `:values_source_config`.

Resolves #31596