### PR TITLE
Make the `fieldValuesWidget` a functional component

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.jsx
@@ -1,5 +1,8 @@
 /* eslint-disable react/prop-types */
-import { Component } from "react";
+import { useState, useRef } from "react";
+
+import { useMount, useUnmount } from "react-use";
+
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { jt, t } from "ttag";
@@ -10,16 +13,14 @@ import TokenField, {
   parseStringValue,
 } from "metabase/components/TokenField";
 import ListField from "metabase/components/ListField";
-import SingleSelectListField from "metabase/components/SingleSelectListField";
 import ValueComponent from "metabase/components/Value";
+import SingleSelectListField from "metabase/components/SingleSelectListField";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 
 import AutoExpanding from "metabase/hoc/AutoExpanding";
 
-import { MetabaseApi } from "metabase/services";
 import { addRemappings, fetchFieldValues } from "metabase/redux/metadata";
 import { defer } from "metabase/lib/promise";
-import { stripId } from "metabase/lib/formatting";
 import {
   fetchCardParameterValues,
   fetchDashboardParameterValues,
@@ -27,18 +28,23 @@ import {
 } from "metabase/parameters/actions";
 
 import Fields from "metabase/entities/fields";
+
 import {
-  isIdParameter,
-  isNumberParameter,
-  isStringParameter,
-} from "metabase-lib/parameters/utils/parameter-type";
-import {
-  canListFieldValues,
-  canListParameterValues,
-  canSearchFieldValues,
-  canSearchParameterValues,
-  getSourceType,
-} from "metabase-lib/parameters/utils/parameter-source";
+  canUseParameterEndpoints,
+  isNumeric,
+  hasList,
+  isSearchable,
+  isExtensionOfPreviousSearch,
+  showRemapping,
+  getNonVirtualFields,
+  dedupeValues,
+  searchFieldValues,
+  getValuesMode,
+  shouldList,
+  canUseDashboardEndpoints,
+  canUseCardEndpoints,
+  getTokenFieldPlaceholder,
+} from "./utils";
 
 const MAX_SEARCH_RESULTS = 100;
 
@@ -68,107 +74,95 @@ function mapStateToProps(state, { fields = [] }) {
   };
 }
 
-async function searchFieldValues(
-  { fields, value, disablePKRemappingForSearch, maxResults },
-  cancelled,
-) {
-  let options = dedupeValues(
-    await Promise.all(
-      fields.map(field =>
-        MetabaseApi.field_search(
-          {
-            value,
-            fieldId: field.id,
-            searchFieldId: field.searchField(disablePKRemappingForSearch).id,
-            limit: maxResults,
-          },
-          { cancelled },
-        ),
-      ),
-    ),
+function FieldValuesWidgetInner({
+  color = "purple",
+  maxResults = MAX_SEARCH_RESULTS,
+  alwaysShowOptions = true,
+  style = {},
+  formatOptions = {},
+  maxWidth = 500,
+  minWidth,
+  expand,
+  disableList = false,
+  disableSearch = false,
+  disablePKRemappingForSearch,
+  showOptionsInPopover = false,
+  fetchFieldValues: fetchFieldValuesProp,
+  fetchParameterValues: fetchParameterValuesProp,
+  fetchCardParameterValues: fetchCardParameterValuesProp,
+  fetchDashboardParameterValues: fetchDashboardParameterValuesProp,
+  addRemappings,
+  parameter,
+  parameters,
+  fields,
+  dashboard,
+  question,
+  value,
+  onChange,
+  multi,
+  autoFocus,
+  className,
+  prefix,
+  placeholder,
+  forceTokenField = false,
+  checkedColor,
+  valueRenderer,
+  optionRenderer,
+  layoutRenderer,
+}) {
+  const [options, setOptions] = useState([]);
+  const [loadingState, setLoadingState] = useState("INIT");
+  const [lastValue, setLastValue] = useState("");
+  const [valuesMode, setValuesMode] = useState(
+    getValuesMode({
+      parameter,
+      fields,
+      disableSearch,
+      disablePKRemappingForSearch,
+    }),
   );
 
-  options = options.map(result => [].concat(result));
-  return options;
-}
-
-function getNonVirtualFields(fields) {
-  return fields.filter(field => !field.isVirtual());
-}
-
-class FieldValuesWidgetInner extends Component {
-  constructor(props) {
-    super(props);
-    const { parameter, fields, disableSearch, disablePKRemappingForSearch } =
-      props;
-    this.state = {
-      options: [],
-      loadingState: "INIT",
-      lastValue: "",
-      valuesMode: getValuesMode({
-        parameter,
-        fields,
-        disableSearch,
-        disablePKRemappingForSearch,
-      }),
-    };
-  }
-
-  static defaultProps = {
-    color: "purple",
-    maxResults: MAX_SEARCH_RESULTS,
-    alwaysShowOptions: true,
-    style: {},
-    formatOptions: {},
-    maxWidth: 500,
-    disableList: false,
-    disableSearch: false,
-    showOptionsInPopover: false,
-  };
-
-  componentDidMount() {
-    const { parameter, fields, disableSearch } = this.props;
-
+  useMount(() => {
     if (shouldList({ parameter, fields, disableSearch })) {
-      this.fetchValues();
+      fetchValues();
     }
-  }
+  });
 
-  async fetchValues(query) {
-    this.setState({
-      loadingState: "LOADING",
-      options: [],
-    });
+  const _cancel = useRef(null);
 
-    let options = [];
-    let valuesMode = this.state.valuesMode;
+  useUnmount(() => {
+    if (_cancel.current) {
+      _cancel.current();
+    }
+  });
+
+  const fetchValues = async query => {
+    setLoadingState("LOADING");
+    setOptions([]);
+
+    let newOptions = [];
+    let newValuesMode = valuesMode;
     try {
-      if (canUseDashboardEndpoints(this.props.dashboard)) {
-        const { values, has_more_values } =
-          await this.fetchDashboardParameterValues(query);
-        options = values;
-        valuesMode = has_more_values ? "search" : valuesMode;
-      } else if (canUseCardEndpoints(this.props.question)) {
-        const { values, has_more_values } = await this.fetchCardParameterValues(
+      if (canUseDashboardEndpoints(dashboard)) {
+        const { values, has_more_values } = await fetchDashboardParameterValues(
           query,
         );
-        options = values;
-        valuesMode = has_more_values ? "search" : valuesMode;
-      } else if (canUseParameterEndpoints(this.props.parameter)) {
-        const { values, has_more_values } = await this.fetchParameterValues(
+        newOptions = values;
+        newValuesMode = has_more_values ? "search" : newValuesMode;
+      } else if (canUseCardEndpoints(question)) {
+        const { values, has_more_values } = await fetchCardParameterValues(
           query,
         );
-        options = values;
-        valuesMode = has_more_values ? "search" : valuesMode;
+        newOptions = values;
+        newValuesMode = has_more_values ? "search" : newValuesMode;
+      } else if (canUseParameterEndpoints(parameter)) {
+        const { values, has_more_values } = await fetchParameterValues(query);
+        newOptions = values;
+        newValuesMode = has_more_values ? "search" : newValuesMode;
       } else {
-        options = await this.fetchFieldValues(query);
-        const {
-          parameter,
-          fields,
-          disableSearch,
-          disablePKRemappingForSearch,
-        } = this.props;
-        valuesMode = getValuesMode({
+        newOptions = await fetchFieldValues(query);
+
+        newValuesMode = getValuesMode({
           parameter,
           fields,
           disableSearch,
@@ -176,34 +170,31 @@ class FieldValuesWidgetInner extends Component {
         });
       }
     } finally {
-      this.updateRemappings(options);
-      this.setState({
-        loadingState: "LOADED",
-        options,
-        valuesMode,
-      });
-    }
-  }
+      updateRemappings(newOptions);
 
-  fetchFieldValues = async query => {
+      setOptions(newOptions);
+      setLoadingState("LOADED");
+      setValuesMode(newValuesMode);
+    }
+  };
+
+  const fetchFieldValues = async query => {
     if (query == null) {
-      const { fetchFieldValues } = this.props;
       await Promise.all(
-        getNonVirtualFields(this.props.fields).map(field =>
-          fetchFieldValues(field.id),
+        getNonVirtualFields(fields).map(field =>
+          fetchFieldValuesProp(field.id),
         ),
       );
       // when field values are updated, new fields are created,
       // that's why we need to reference them as this.props.fields here
       return dedupeValues(
-        getNonVirtualFields(this.props.fields).map(field => field.values),
+        getNonVirtualFields(fields).map(field => field.values),
       );
     } else {
-      const { fields } = this.props;
       const cancelDeferred = defer();
       const cancelled = cancelDeferred.promise;
-      this._cancel = () => {
-        this._cancel = null;
+      _cancel.current = () => {
+        _cancel.current = null;
         cancelDeferred.resolve();
       };
 
@@ -211,40 +202,34 @@ class FieldValuesWidgetInner extends Component {
         {
           value: query,
           fields,
-          disablePKRemappingForSearch: this.props.disablePKRemappingForSearch,
-          maxResults: this.props.maxResults,
+          disablePKRemappingForSearch,
+          maxResults,
         },
         cancelled,
       );
 
-      this._cancel = null;
+      _cancel.current = null;
       return options;
     }
   };
 
-  fetchParameterValues = async query => {
-    const { parameter } = this.props;
-
-    return this.props.fetchParameterValues({
+  const fetchParameterValues = async query => {
+    return fetchParameterValuesProp({
       parameter,
       query,
     });
   };
 
-  fetchCardParameterValues = async query => {
-    const { question, parameter } = this.props;
-
-    return this.props.fetchCardParameterValues({
+  const fetchCardParameterValues = async query => {
+    return fetchCardParameterValuesProp({
       cardId: question.id(),
       parameter,
       query,
     });
   };
 
-  fetchDashboardParameterValues = async query => {
-    const { dashboard, parameter, parameters } = this.props;
-
-    return this.props.fetchDashboardParameterValues({
+  const fetchDashboardParameterValues = async query => {
+    return fetchDashboardParameterValuesProp({
       dashboardId: dashboard?.id,
       parameter,
       parameters,
@@ -252,220 +237,194 @@ class FieldValuesWidgetInner extends Component {
     });
   };
 
-  updateRemappings(options) {
-    const { fields } = this.props;
+  const updateRemappings = options => {
     if (showRemapping(fields)) {
       const [field] = fields;
       if (
-        field.remappedField() ===
-        field.searchField(this.props.disablePKRemappingForSearch)
+        field.remappedField() === field.searchField(disablePKRemappingForSearch)
       ) {
-        this.props.addRemappings(field.id, options);
+        addRemappings(field.id, options);
       }
     }
-  }
+  };
 
-  componentWillUnmount() {
-    if (this._cancel) {
-      this._cancel();
-    }
-  }
-
-  onInputChange = value => {
-    const { maxResults } = this.props;
-    const { lastValue, options } = this.state;
-    let { valuesMode } = this.state;
+  const onInputChange = value => {
+    let localValuesMode = valuesMode;
 
     // override "search" mode when searching is unnecessary
-    valuesMode = isExtensionOfPreviousSearch(
+    localValuesMode = isExtensionOfPreviousSearch(
       value,
       lastValue,
       options,
       maxResults,
     )
       ? "list"
-      : valuesMode;
+      : localValuesMode;
 
-    if (valuesMode === "search") {
-      this._search(value);
+    if (localValuesMode === "search") {
+      _search(value);
     }
 
     return value;
   };
 
-  search = _.debounce(async value => {
+  const search = _.debounce(async value => {
     if (!value) {
-      this.setState({
-        loadingState: "LOADED",
-      });
+      setLoadingState("LOADED");
       return;
     }
 
-    await this.fetchValues(value);
+    await fetchValues(value);
 
-    this.setState({
-      lastValue: value,
-    });
+    setLastValue(value);
   }, 500);
 
-  _search = value => {
-    if (this._cancel) {
-      this._cancel();
+  const _search = value => {
+    if (_cancel.current) {
+      _cancel.current();
     }
 
-    this.setState({
-      loadingState: "LOADING",
-    });
-    this.search(value);
+    setLoadingState("LOADING");
+    search(value);
   };
 
-  render() {
-    const {
-      value,
-      onChange,
-      fields,
-      multi,
-      autoFocus,
-      color,
-      className,
-      style,
-      parameter,
-      prefix,
-      disableSearch,
-      disableList,
-      disablePKRemappingForSearch,
-      formatOptions,
-      placeholder,
-      forceTokenField = false,
-      showOptionsInPopover,
-      checkedColor,
-      valueRenderer = value =>
-        renderValue(fields, formatOptions, value, {
-          autoLoad: true,
-          compact: false,
-        }),
-      optionRenderer = option =>
-        renderValue(fields, formatOptions, option[0], {
-          autoLoad: false,
-        }),
-      layoutRenderer = showOptionsInPopover
-        ? undefined
-        : layoutProps => (
-            <div>
-              {layoutProps.valuesList}
-              {renderOptions(this.state, this.props, layoutProps)}
-            </div>
-          ),
-    } = this.props;
-    const { loadingState, options = [], valuesMode } = this.state;
-
-    const tokenFieldPlaceholder = getTokenFieldPlaceholder({
-      fields,
-      parameter,
-      disableSearch,
-      placeholder,
-      disablePKRemappingForSearch,
-      loadingState,
-      options,
-      valuesMode,
-    });
-
-    const isListMode =
-      !disableList &&
-      shouldList({ parameter, fields, disableSearch }) &&
-      valuesMode === "list" &&
-      !forceTokenField;
-    const isLoading = loadingState === "LOADING";
-    const hasListValues = hasList({
-      parameter,
-      fields,
-      disableSearch,
-      options,
-    });
-
-    const parseFreeformValue = value => {
-      return isNumeric(fields[0], parameter)
-        ? parseNumberValue(value)
-        : parseStringValue(value);
-    };
-
-    return (
-      <div
-        style={{
-          width: this.props.expand ? this.props.maxWidth : null,
-          minWidth: this.props.minWidth,
-          maxWidth: this.props.maxWidth,
-        }}
-      >
-        {isListMode && isLoading ? (
-          <LoadingState />
-        ) : isListMode && hasListValues && multi ? (
-          <ListField
-            isDashboardFilter={parameter}
-            placeholder={tokenFieldPlaceholder}
-            value={value.filter(v => v != null)}
-            onChange={onChange}
-            options={options}
-            optionRenderer={optionRenderer}
-            checkedColor={checkedColor}
-          />
-        ) : isListMode && hasListValues && !multi ? (
-          <SingleSelectListField
-            isDashboardFilter={parameter}
-            placeholder={tokenFieldPlaceholder}
-            value={value.filter(v => v != null)}
-            onChange={onChange}
-            options={options}
-            optionRenderer={optionRenderer}
-            checkedColor={checkedColor}
-          />
-        ) : (
-          <TokenField
-            prefix={prefix}
-            value={value.filter(v => v != null)}
-            onChange={onChange}
-            placeholder={tokenFieldPlaceholder}
-            updateOnInputChange
-            // forwarded props
-            multi={multi}
-            autoFocus={autoFocus}
-            color={color}
-            style={{ ...style, minWidth: "inherit" }}
-            className={className}
-            optionsStyle={
-              !parameter && !showOptionsInPopover ? { maxHeight: "none" } : {}
-            }
-            // end forwarded props
-            options={options}
-            valueKey="0"
-            valueRenderer={valueRenderer}
-            optionRenderer={optionRenderer}
-            layoutRenderer={layoutRenderer}
-            filterOption={(option, filterString) => {
-              const lowerCaseFilterString = filterString.toLowerCase();
-              return option.some(
-                value =>
-                  value != null &&
-                  String(value).toLowerCase().includes(lowerCaseFilterString),
-              );
-            }}
-            onInputChange={this.onInputChange}
-            parseFreeformValue={parseFreeformValue}
-          />
-        )}
-      </div>
-    );
+  if (!valueRenderer) {
+    valueRenderer = value =>
+      renderValue(fields, formatOptions, value, {
+        autoLoad: true,
+        compact: false,
+      });
   }
+
+  if (!optionRenderer) {
+    optionRenderer = option =>
+      renderValue(fields, formatOptions, option[0], {
+        autoLoad: false,
+      });
+  }
+
+  if (!layoutRenderer) {
+    layoutRenderer = showOptionsInPopover
+      ? undefined
+      : layoutProps => (
+          <div>
+            {layoutProps.valuesList}
+            {renderOptions({
+              alwaysShowOptions,
+              parameter,
+              fields,
+              disableSearch,
+              disablePKRemappingForSearch,
+              loadingState,
+              options,
+              valuesMode,
+              ...layoutProps,
+            })}
+          </div>
+        );
+  }
+
+  const tokenFieldPlaceholder = getTokenFieldPlaceholder({
+    fields,
+    parameter,
+    disableSearch,
+    placeholder,
+    disablePKRemappingForSearch,
+    loadingState,
+    options,
+    valuesMode,
+  });
+
+  const isListMode =
+    !disableList &&
+    shouldList({ parameter, fields, disableSearch }) &&
+    valuesMode === "list" &&
+    !forceTokenField;
+  const isLoading = loadingState === "LOADING";
+  const hasListValues = hasList({
+    parameter,
+    fields,
+    disableSearch,
+    options,
+  });
+
+  const parseFreeformValue = value => {
+    return isNumeric(fields[0], parameter)
+      ? parseNumberValue(value)
+      : parseStringValue(value);
+  };
+
+  return (
+    <div
+      style={{
+        width: expand ? maxWidth : null,
+        minWidth: minWidth,
+        maxWidth: maxWidth,
+      }}
+    >
+      {isListMode && isLoading ? (
+        <LoadingState />
+      ) : isListMode && hasListValues && multi ? (
+        <ListField
+          isDashboardFilter={parameter}
+          placeholder={tokenFieldPlaceholder}
+          value={value.filter(v => v != null)}
+          onChange={onChange}
+          options={options}
+          optionRenderer={optionRenderer}
+          checkedColor={checkedColor}
+        />
+      ) : isListMode && hasListValues && !multi ? (
+        <SingleSelectListField
+          isDashboardFilter={parameter}
+          placeholder={tokenFieldPlaceholder}
+          value={value.filter(v => v != null)}
+          onChange={onChange}
+          options={options}
+          optionRenderer={optionRenderer}
+          checkedColor={checkedColor}
+        />
+      ) : (
+        <TokenField
+          prefix={prefix}
+          value={value.filter(v => v != null)}
+          onChange={onChange}
+          placeholder={tokenFieldPlaceholder}
+          updateOnInputChange
+          // forwarded props
+          multi={multi}
+          autoFocus={autoFocus}
+          color={color}
+          style={{ ...style, minWidth: "inherit" }}
+          className={className}
+          optionsStyle={
+            !parameter && !showOptionsInPopover ? { maxHeight: "none" } : {}
+          }
+          // end forwarded props
+          options={options}
+          valueKey="0"
+          valueRenderer={valueRenderer}
+          optionRenderer={optionRenderer}
+          layoutRenderer={layoutRenderer}
+          filterOption={(option, filterString) => {
+            const lowerCaseFilterString = filterString.toLowerCase();
+            return option.some(
+              value =>
+                value != null &&
+                String(value).toLowerCase().includes(lowerCaseFilterString),
+            );
+          }}
+          onInputChange={onInputChange}
+          parseFreeformValue={parseFreeformValue}
+        />
+      )}
+    </div>
+  );
 }
 
 export const FieldValuesWidget = AutoExpanding(FieldValuesWidgetInner);
 
 FieldValuesWidget.propTypes = fieldValuesWidgetPropTypes;
-
-function dedupeValues(valuesList) {
-  const uniqueValueMap = new Map(valuesList.flat().map(o => [o[0], o]));
-  return Array.from(uniqueValueMap.values());
-}
 
 const LoadingState = () => (
   <div className="flex layout-centered align-center" style={{ minHeight: 82 }}>
@@ -502,192 +461,20 @@ OptionsMessage.propTypes = optionsMessagePropTypes;
 
 export default connect(mapStateToProps, mapDispatchToProps)(FieldValuesWidget);
 
-function canUseParameterEndpoints(parameter) {
-  return parameter != null;
-}
-
-function canUseCardEndpoints(question) {
-  return question?.isSaved();
-}
-
-function canUseDashboardEndpoints(dashboard) {
-  return dashboard?.id;
-}
-
-function showRemapping(fields) {
-  return fields.length === 1;
-}
-
-function shouldList({ parameter, fields, disableSearch }) {
-  if (disableSearch) {
-    return false;
-  } else {
-    return parameter
-      ? canListParameterValues(parameter)
-      : canListFieldValues(fields);
-  }
-}
-
-function getNonSearchableTokenFieldPlaceholder(firstField, parameter) {
-  if (parameter) {
-    if (isIdParameter(parameter)) {
-      return t`Enter an ID`;
-    } else if (isStringParameter(parameter)) {
-      return t`Enter some text`;
-    } else if (isNumberParameter(parameter)) {
-      return t`Enter a number`;
-    }
-
-    // fallback
-    return t`Enter some text`;
-  } else if (firstField) {
-    if (firstField.isID()) {
-      return t`Enter an ID`;
-    } else if (firstField.isString()) {
-      return t`Enter some text`;
-    } else if (firstField.isNumeric()) {
-      return t`Enter a number`;
-    }
-
-    // fallback
-    return t`Enter some text`;
-  }
-
-  // fallback
-  return t`Enter some text`;
-}
-
-export function searchField(field, disablePKRemappingForSearch) {
-  return field.searchField(disablePKRemappingForSearch);
-}
-
-function getSearchableTokenFieldPlaceholder(
-  parameter,
-  fields,
-  firstField,
-  disablePKRemappingForSearch,
-) {
-  let placeholder;
-
-  const names = new Set(
-    fields.map(field =>
-      stripId(field.searchField(disablePKRemappingForSearch).display_name),
-    ),
-  );
-
-  if (
-    names.size !== 1 ||
-    (parameter != null && getSourceType(parameter) != null)
-  ) {
-    placeholder = t`Search`;
-  } else {
-    const [name] = names;
-
-    placeholder = t`Search by ${name}`;
-    if (
-      firstField &&
-      firstField.isID() &&
-      firstField !== firstField.searchField(disablePKRemappingForSearch)
-    ) {
-      placeholder += t` or enter an ID`;
-    }
-  }
-  return placeholder;
-}
-
-function hasList({ parameter, fields, disableSearch, options }) {
-  return (
-    shouldList({ parameter, fields, disableSearch }) && !_.isEmpty(options)
-  );
-}
-
-// if this search is just an extension of the previous search, and the previous search
-// wasn't truncated, then we don't need to do another search because TypeaheadListing
-// will filter the previous result client-side
-function isExtensionOfPreviousSearch(value, lastValue, options, maxResults) {
-  return (
-    lastValue &&
-    value.slice(0, lastValue.length) === lastValue &&
-    options.length < maxResults
-  );
-}
-
-export function isSearchable({
+function renderOptions({
+  alwaysShowOptions,
   parameter,
   fields,
   disableSearch,
   disablePKRemappingForSearch,
-  valuesMode,
-}) {
-  if (disableSearch) {
-    return false;
-  } else if (valuesMode === "search") {
-    return true;
-  } else if (parameter) {
-    return canSearchParameterValues(parameter, disablePKRemappingForSearch);
-  } else {
-    return canSearchFieldValues(fields, disablePKRemappingForSearch);
-  }
-}
-
-function getTokenFieldPlaceholder({
-  fields,
-  parameter,
-  disableSearch,
-  placeholder,
-  disablePKRemappingForSearch,
+  loadingState,
   options,
   valuesMode,
+  optionsList,
+  isFocused,
+  isAllSelected,
+  isFiltered,
 }) {
-  if (placeholder) {
-    return placeholder;
-  }
-
-  const [firstField] = fields;
-
-  if (
-    hasList({
-      parameter,
-      fields,
-      disableSearch,
-      options,
-    })
-  ) {
-    return t`Search the list`;
-  } else if (
-    isSearchable({
-      parameter,
-      fields,
-      disableSearch,
-      disablePKRemappingForSearch,
-      valuesMode,
-    })
-  ) {
-    return getSearchableTokenFieldPlaceholder(
-      parameter,
-      fields,
-      firstField,
-      disablePKRemappingForSearch,
-    );
-  } else {
-    return getNonSearchableTokenFieldPlaceholder(firstField, parameter);
-  }
-}
-
-function renderOptions(
-  state,
-  props,
-  { optionsList, isFocused, isAllSelected, isFiltered },
-) {
-  const {
-    alwaysShowOptions,
-    parameter,
-    fields,
-    disableSearch,
-    disablePKRemappingForSearch,
-  } = props;
-  const { loadingState, options, valuesMode } = state;
-
   if (alwaysShowOptions || isFocused) {
     if (optionsList) {
       return optionsList;
@@ -727,7 +514,7 @@ function renderOptions(
   }
 }
 
-function renderValue(fields, formatOptions, value, options) {
+export function renderValue(fields, formatOptions, value, options) {
   return (
     <ValueComponent
       value={value}
@@ -738,37 +525,4 @@ function renderValue(fields, formatOptions, value, options) {
       {...options}
     />
   );
-}
-
-export function getValuesMode({
-  parameter,
-  fields,
-  disableSearch,
-  disablePKRemappingForSearch,
-}) {
-  if (
-    isSearchable({
-      parameter,
-      fields,
-      disableSearch,
-      disablePKRemappingForSearch,
-      valuesMode: undefined,
-    })
-  ) {
-    return "search";
-  }
-
-  if (shouldList({ parameter, fields, disableSearch })) {
-    return "list";
-  }
-
-  return "none";
-}
-
-function isNumeric(field, parameter) {
-  if (parameter) {
-    return isNumberParameter(parameter);
-  }
-
-  return field.isNumeric();
 }

--- a/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.jsx
@@ -268,16 +268,18 @@ function FieldValuesWidgetInner({
     return value;
   };
 
-  const search = _.debounce(async value => {
-    if (!value) {
-      setLoadingState("LOADED");
-      return;
-    }
+  const search = useRef(
+    _.debounce(async value => {
+      if (!value) {
+        setLoadingState("LOADED");
+        return;
+      }
 
-    await fetchValues(value);
+      await fetchValues(value);
 
-    setLastValue(value);
-  }, 500);
+      setLastValue(value);
+    }, 500),
+  );
 
   const _search = value => {
     if (_cancel.current) {
@@ -285,7 +287,7 @@ function FieldValuesWidgetInner({
     }
 
     setLoadingState("LOADING");
-    search(value);
+    search.current(value);
   };
 
   if (!valueRenderer) {

--- a/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.unit.spec.js
+++ b/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.unit.spec.js
@@ -23,7 +23,9 @@ import {
 } from "./testMocks";
 
 async function setup({ fields, values, ...props }) {
-  const fetchFieldValues = jest.fn();
+  const fetchFieldValues = jest.fn(({ id }) => ({
+    payload: fields.find(f => f.id === id),
+  }));
 
   renderWithProviders(
     <FieldValuesWidget
@@ -73,7 +75,9 @@ describe("FieldValuesWidget", () => {
         const { fetchFieldValues } = await setup({
           fields: [field],
         });
-        expect(fetchFieldValues).toHaveBeenCalledWith(PRODUCTS.CATEGORY);
+        expect(fetchFieldValues).toHaveBeenCalledWith({
+          id: PRODUCTS.CATEGORY,
+        });
       });
 
       it("should not have 'Search the list' as the placeholder text for fields with less or equal than 10 values", async () => {
@@ -224,8 +228,12 @@ describe("FieldValuesWidget", () => {
       });
 
       expect(screen.getByText(LISTABLE_PK_FIELD_VALUE)).toBeInTheDocument();
-      expect(fetchFieldValues).toHaveBeenCalledWith(LISTABLE_PK_FIELD_ID);
-      expect(fetchFieldValues).not.toHaveBeenCalledWith(EXPRESSION_FIELD_ID);
+      expect(fetchFieldValues).toHaveBeenCalledWith({
+        id: LISTABLE_PK_FIELD_ID,
+      });
+      expect(fetchFieldValues).not.toHaveBeenCalledWith({
+        id: EXPRESSION_FIELD_ID,
+      });
     });
   });
 });

--- a/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.unit.spec.js
+++ b/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.unit.spec.js
@@ -1,99 +1,26 @@
 import "mutationobserver-shim";
 
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
-import { createMockEntitiesState } from "__support__/store";
 
 import { checkNotNull } from "metabase/core/utils/types";
-import {
-  FieldValuesWidget,
-  searchField,
-  isSearchable,
-  getValuesMode,
-} from "metabase/components/FieldValuesWidget";
-import { getMetadata } from "metabase/selectors/metadata";
+import { FieldValuesWidget } from "metabase/components/FieldValuesWidget";
 
-import { createMockField } from "metabase-types/api/mocks";
 import {
-  createSampleDatabase,
-  createOrdersTable,
-  createProductsTable,
-  createPeopleTable,
-  createReviewsTable,
   ORDERS,
   PRODUCTS,
   PEOPLE,
-  REVIEWS_ID,
   PRODUCT_CATEGORY_VALUES,
   PEOPLE_SOURCE_VALUES,
 } from "metabase-types/api/mocks/presets";
-import { createMockState } from "metabase-types/store/mocks";
 
-const LISTABLE_PK_FIELD_ID = 100;
-const LISTABLE_PK_FIELD_VALUE = "1234";
-const STRING_PK_FIELD_ID = 101;
-const SEARCHABLE_FK_FIELD_ID = 102;
-const LISTABLE_FIELD_WITH_MANY_VALUES_ID = 103;
-const EXPRESSION_FIELD_ID = ["field", "CC", { "base-type": "type/Text" }];
-
-const database = createSampleDatabase({
-  tables: [
-    createOrdersTable(),
-    createProductsTable(),
-    createPeopleTable(),
-    createReviewsTable({
-      fields: [
-        createMockField({
-          id: LISTABLE_PK_FIELD_ID,
-          table_id: REVIEWS_ID,
-          display_name: "ID",
-          base_type: "type/BigInteger",
-          effective_type: "type/BigInteger",
-          semantic_type: "type/PK",
-          has_field_values: "list",
-          values: [[LISTABLE_PK_FIELD_VALUE]],
-        }),
-        createMockField({
-          id: STRING_PK_FIELD_ID,
-          table_id: REVIEWS_ID,
-          display_name: "String ID",
-          base_type: "type/Text",
-          effective_type: "type/Text",
-          semantic_type: "type/PK",
-        }),
-        createMockField({
-          id: SEARCHABLE_FK_FIELD_ID,
-          table_id: REVIEWS_ID,
-          display_name: "Product ID",
-          base_type: "type/Text",
-          effective_type: "type/Text",
-          semantic_type: "type/FK",
-          has_field_values: "search",
-        }),
-        createMockField({
-          id: LISTABLE_FIELD_WITH_MANY_VALUES_ID,
-          table_id: REVIEWS_ID,
-          display_name: "Big list",
-          base_type: "type/Text",
-          effective_type: "type/Text",
-          has_field_values: "list",
-          has_more_values: true,
-        }),
-        createMockField({
-          id: EXPRESSION_FIELD_ID,
-          field_ref: ["expression", "CC"],
-        }),
-      ],
-    }),
-  ],
-});
-
-const state = createMockState({
-  entities: createMockEntitiesState({
-    databases: [database],
-  }),
-});
-
-const metadata = getMetadata(state);
+import {
+  state,
+  metadata,
+  LISTABLE_PK_FIELD_ID,
+  LISTABLE_PK_FIELD_VALUE,
+  SEARCHABLE_FK_FIELD_ID,
+  EXPRESSION_FIELD_ID,
+} from "./testMocks";
 
 async function setup({ fields, values, ...props }) {
   const fetchFieldValues = jest.fn();
@@ -284,132 +211,6 @@ describe("FieldValuesWidget", () => {
     it("should not render a prefix if omitted", async () => {
       await setup({ fields: [metadata.field(PRODUCTS.PRICE)] });
       expect(screen.queryByTestId("input-prefix")).not.toBeInTheDocument();
-    });
-  });
-
-  describe("searchField", () => {
-    describe("`disablePKRemappingForSearch` is true and field is a PK", () => {
-      const disablePKRemappingForSearch = true;
-
-      const stringPKField = metadata.field(STRING_PK_FIELD_ID);
-      const numberPKField = metadata.field(PRODUCTS.ID);
-
-      it("should return same field when the field is searchable (the field is a string AND a PK)", () => {
-        expect(searchField(stringPKField, disablePKRemappingForSearch)).toBe(
-          stringPKField,
-        );
-      });
-
-      it("should return null when field is not searchable (the field is NOT a string PK)", () => {
-        expect(
-          searchField(numberPKField, disablePKRemappingForSearch),
-        ).toBeNull();
-      });
-    });
-
-    describe("when the field is remapped to a searchable field", () => {
-      const stringField = metadata.field(PRODUCTS.TITLE);
-      const remappedField = metadata.field(PRODUCTS.CATEGORY).clone();
-      remappedField.remappedField = () => stringField;
-
-      it("should return the remapped field", () => {
-        expect(searchField(remappedField)).toBe(stringField);
-      });
-    });
-
-    describe("when the field is remapped to a non-searchable field", () => {
-      it("should ignore it and return the original field, assuming it is searchable", () => {
-        const numberField = metadata.field(ORDERS.TOTAL);
-
-        const remappedField = metadata.field(PRODUCTS.CATEGORY).clone();
-        remappedField.remappedField = () => numberField;
-
-        const nonSearchableRemappedField = metadata.field(PRODUCTS.ID);
-        nonSearchableRemappedField.remappedField = () => numberField;
-
-        expect(searchField(remappedField)).toBe(remappedField);
-        expect(searchField(nonSearchableRemappedField)).toBeNull();
-      });
-    });
-
-    it("should return the field if it is searchable", () => {
-      const searchableField = metadata.field(PRODUCTS.TITLE);
-      expect(searchField(searchableField)).toBe(searchableField);
-    });
-
-    it("should return null if the field is not searchable", () => {
-      const nonSearchableField = metadata.field(PRODUCTS.ID);
-      expect(searchField(nonSearchableField)).toBeNull();
-    });
-  });
-
-  describe("isSearchable", () => {
-    const listField = metadata.field(PRODUCTS.CATEGORY);
-    const searchField = metadata.field(PRODUCTS.VENDOR);
-    const nonExhaustiveListField = metadata.field(
-      LISTABLE_FIELD_WITH_MANY_VALUES_ID,
-    );
-
-    const idField = metadata.field(PRODUCTS.ID);
-
-    describe("when the `valuesMode` is already set to 'search'", () => {
-      it("should return return true unless fully disabled", () => {
-        expect(
-          isSearchable({ valuesMode: "search", disableSearch: true }),
-        ).toBe(false);
-        expect(isSearchable({ valuesMode: "search" })).toBe(true);
-      });
-    });
-
-    it("should be false when the list of fields includes one that is not searchable", () => {
-      const fields = [searchField, idField];
-      expect(isSearchable({ fields })).toBe(false);
-    });
-
-    describe("when all fields are searchable", () => {
-      it("should be false if there are no fields that require search", () => {
-        const fields = [listField];
-        expect(isSearchable({ fields })).toBe(false);
-      });
-
-      it("should be true if there is at least one field that requires search", () => {
-        const fields = [searchField, listField];
-        expect(isSearchable({ fields })).toBe(true);
-      });
-
-      it("should be true if there is at least one field that shows a list but said list is not exhaustive", () => {
-        const fields = [nonExhaustiveListField, listField];
-        expect(isSearchable({ fields })).toBe(true);
-      });
-    });
-  });
-
-  describe("getValuesMode", () => {
-    describe("when passed no fields", () => {
-      it("should return 'none'", () => {
-        expect(getValuesMode({ fields: [] })).toBe("none");
-      });
-    });
-
-    describe("when passed fields that are searchable", () => {
-      it("should return 'search'", () => {
-        const fields = [metadata.field(PRODUCTS.VENDOR)];
-        expect(getValuesMode({ fields })).toBe("search");
-      });
-    });
-
-    describe("when passed fields that are not searchable but listable", () => {
-      it("should return 'list'", () => {
-        const fields = [metadata.field(PRODUCTS.CATEGORY)];
-        expect(getValuesMode({ fields })).toBe("list");
-      });
-    });
-
-    describe("when passed fields that are not searchable and not listable", () => {
-      it("should return 'none'", () => {
-        const fields = [metadata.field(ORDERS.SUBTOTAL)];
-        expect(getValuesMode({ fields })).toBe("none");
-      });
     });
   });
 

--- a/frontend/src/metabase/components/FieldValuesWidget/testMocks.js
+++ b/frontend/src/metabase/components/FieldValuesWidget/testMocks.js
@@ -1,0 +1,85 @@
+import { createMockEntitiesState } from "__support__/store";
+
+import { getMetadata } from "metabase/selectors/metadata";
+
+import { createMockField } from "metabase-types/api/mocks";
+import {
+  createSampleDatabase,
+  createOrdersTable,
+  createProductsTable,
+  createPeopleTable,
+  createReviewsTable,
+  REVIEWS_ID,
+} from "metabase-types/api/mocks/presets";
+import { createMockState } from "metabase-types/store/mocks";
+
+export const LISTABLE_PK_FIELD_ID = 100;
+export const LISTABLE_PK_FIELD_VALUE = "1234";
+export const STRING_PK_FIELD_ID = 101;
+export const SEARCHABLE_FK_FIELD_ID = 102;
+export const LISTABLE_FIELD_WITH_MANY_VALUES_ID = 103;
+export const EXPRESSION_FIELD_ID = [
+  "field",
+  "CC",
+  { "base-type": "type/Text" },
+];
+
+const database = createSampleDatabase({
+  tables: [
+    createOrdersTable(),
+    createProductsTable(),
+    createPeopleTable(),
+    createReviewsTable({
+      fields: [
+        createMockField({
+          id: LISTABLE_PK_FIELD_ID,
+          table_id: REVIEWS_ID,
+          display_name: "ID",
+          base_type: "type/BigInteger",
+          effective_type: "type/BigInteger",
+          semantic_type: "type/PK",
+          has_field_values: "list",
+          values: [[LISTABLE_PK_FIELD_VALUE]],
+        }),
+        createMockField({
+          id: STRING_PK_FIELD_ID,
+          table_id: REVIEWS_ID,
+          display_name: "String ID",
+          base_type: "type/Text",
+          effective_type: "type/Text",
+          semantic_type: "type/PK",
+        }),
+        createMockField({
+          id: SEARCHABLE_FK_FIELD_ID,
+          table_id: REVIEWS_ID,
+          display_name: "Product ID",
+          base_type: "type/Text",
+          effective_type: "type/Text",
+          semantic_type: "type/FK",
+          has_field_values: "search",
+        }),
+        createMockField({
+          id: LISTABLE_FIELD_WITH_MANY_VALUES_ID,
+          table_id: REVIEWS_ID,
+          display_name: "Big list",
+          base_type: "type/Text",
+          effective_type: "type/Text",
+          has_field_values: "list",
+          has_more_values: true,
+        }),
+        createMockField({
+          id: EXPRESSION_FIELD_ID,
+          field_ref: ["expression", "CC"],
+        }),
+      ],
+    }),
+  ],
+});
+
+export const state = createMockState({
+  entities: createMockEntitiesState({
+    databases: [database],
+  }),
+});
+
+export const metadata = getMetadata(state);

--- a/frontend/src/metabase/components/FieldValuesWidget/utils.js
+++ b/frontend/src/metabase/components/FieldValuesWidget/utils.js
@@ -1,0 +1,261 @@
+import { t } from "ttag";
+import _ from "underscore";
+
+import { MetabaseApi } from "metabase/services";
+import { stripId } from "metabase/lib/formatting";
+
+import {
+  isIdParameter,
+  isNumberParameter,
+  isStringParameter,
+} from "metabase-lib/parameters/utils/parameter-type";
+import {
+  canListFieldValues,
+  canListParameterValues,
+  canSearchFieldValues,
+  canSearchParameterValues,
+  getSourceType,
+} from "metabase-lib/parameters/utils/parameter-source";
+
+export async function searchFieldValues(
+  { fields, value, disablePKRemappingForSearch, maxResults },
+  cancelled,
+) {
+  let options = dedupeValues(
+    await Promise.all(
+      fields.map(field =>
+        MetabaseApi.field_search(
+          {
+            value,
+            fieldId: field.id,
+            searchFieldId: field.searchField(disablePKRemappingForSearch).id,
+            limit: maxResults,
+          },
+          { cancelled },
+        ),
+      ),
+    ),
+  );
+
+  options = options.map(result => [].concat(result));
+  return options;
+}
+
+export function getNonVirtualFields(fields) {
+  return fields.filter(field => !field.isVirtual());
+}
+
+export function dedupeValues(valuesList) {
+  const uniqueValueMap = new Map(valuesList.flat().map(o => [o[0], o]));
+  return Array.from(uniqueValueMap.values());
+}
+
+export function canUseParameterEndpoints(parameter) {
+  return parameter != null;
+}
+
+export function canUseCardEndpoints(question) {
+  return question?.isSaved();
+}
+
+export function canUseDashboardEndpoints(dashboard) {
+  return dashboard?.id;
+}
+
+export function showRemapping(fields) {
+  return fields.length === 1;
+}
+
+export function shouldList({ parameter, fields, disableSearch }) {
+  if (disableSearch) {
+    return false;
+  } else {
+    return parameter
+      ? canListParameterValues(parameter)
+      : canListFieldValues(fields);
+  }
+}
+
+function getNonSearchableTokenFieldPlaceholder(firstField, parameter) {
+  if (parameter) {
+    if (isIdParameter(parameter)) {
+      return t`Enter an ID`;
+    } else if (isStringParameter(parameter)) {
+      return t`Enter some text`;
+    } else if (isNumberParameter(parameter)) {
+      return t`Enter a number`;
+    }
+
+    // fallback
+    return t`Enter some text`;
+  } else if (firstField) {
+    if (firstField.isID()) {
+      return t`Enter an ID`;
+    } else if (firstField.isString()) {
+      return t`Enter some text`;
+    } else if (firstField.isNumeric()) {
+      return t`Enter a number`;
+    }
+
+    // fallback
+    return t`Enter some text`;
+  }
+
+  // fallback
+  return t`Enter some text`;
+}
+
+export function searchField(field, disablePKRemappingForSearch) {
+  return field.searchField(disablePKRemappingForSearch);
+}
+
+function getSearchableTokenFieldPlaceholder(
+  parameter,
+  fields,
+  firstField,
+  disablePKRemappingForSearch,
+) {
+  let placeholder;
+
+  const names = new Set(
+    fields.map(field =>
+      stripId(field.searchField(disablePKRemappingForSearch).display_name),
+    ),
+  );
+
+  if (
+    names.size !== 1 ||
+    (parameter != null && getSourceType(parameter) != null)
+  ) {
+    placeholder = t`Search`;
+  } else {
+    const [name] = names;
+
+    placeholder = t`Search by ${name}`;
+    if (
+      firstField &&
+      firstField.isID() &&
+      firstField !== firstField.searchField(disablePKRemappingForSearch)
+    ) {
+      placeholder += t` or enter an ID`;
+    }
+  }
+  return placeholder;
+}
+
+export function hasList({ parameter, fields, disableSearch, options }) {
+  return (
+    shouldList({ parameter, fields, disableSearch }) && !_.isEmpty(options)
+  );
+}
+
+// if this search is just an extension of the previous search, and the previous search
+// wasn't truncated, then we don't need to do another search because TypeaheadListing
+// will filter the previous result client-side
+export function isExtensionOfPreviousSearch(
+  value,
+  lastValue,
+  options,
+  maxResults,
+) {
+  return (
+    lastValue &&
+    value.slice(0, lastValue.length) === lastValue &&
+    options.length < maxResults
+  );
+}
+
+export function isSearchable({
+  parameter,
+  fields,
+  disableSearch,
+  disablePKRemappingForSearch,
+  valuesMode,
+}) {
+  if (disableSearch) {
+    return false;
+  } else if (valuesMode === "search") {
+    return true;
+  } else if (parameter) {
+    return canSearchParameterValues(parameter, disablePKRemappingForSearch);
+  } else {
+    return canSearchFieldValues(fields, disablePKRemappingForSearch);
+  }
+}
+
+export function getTokenFieldPlaceholder({
+  fields,
+  parameter,
+  disableSearch,
+  placeholder,
+  disablePKRemappingForSearch,
+  options,
+  valuesMode,
+}) {
+  if (placeholder) {
+    return placeholder;
+  }
+
+  const [firstField] = fields;
+
+  if (
+    hasList({
+      parameter,
+      fields,
+      disableSearch,
+      options,
+    })
+  ) {
+    return t`Search the list`;
+  } else if (
+    isSearchable({
+      parameter,
+      fields,
+      disableSearch,
+      disablePKRemappingForSearch,
+      valuesMode,
+    })
+  ) {
+    return getSearchableTokenFieldPlaceholder(
+      parameter,
+      fields,
+      firstField,
+      disablePKRemappingForSearch,
+    );
+  } else {
+    return getNonSearchableTokenFieldPlaceholder(firstField, parameter);
+  }
+}
+
+export function getValuesMode({
+  parameter,
+  fields,
+  disableSearch,
+  disablePKRemappingForSearch,
+}) {
+  if (
+    isSearchable({
+      parameter,
+      fields,
+      disableSearch,
+      disablePKRemappingForSearch,
+      valuesMode: undefined,
+    })
+  ) {
+    return "search";
+  }
+
+  if (shouldList({ parameter, fields, disableSearch })) {
+    return "list";
+  }
+
+  return "none";
+}
+
+export function isNumeric(field, parameter) {
+  if (parameter) {
+    return isNumberParameter(parameter);
+  }
+
+  return field.isNumeric();
+}

--- a/frontend/src/metabase/components/FieldValuesWidget/utils.unit.spec.js
+++ b/frontend/src/metabase/components/FieldValuesWidget/utils.unit.spec.js
@@ -1,0 +1,137 @@
+import { ORDERS, PRODUCTS } from "metabase-types/api/mocks/presets";
+
+import { isSearchable, getValuesMode, searchField } from "./utils";
+
+import {
+  metadata,
+  LISTABLE_FIELD_WITH_MANY_VALUES_ID,
+  STRING_PK_FIELD_ID,
+} from "./testMocks";
+
+describe("Components > FieldValuesWidget > utils", () => {
+  describe("isSearchable", () => {
+    const listField = metadata.field(PRODUCTS.CATEGORY);
+    const searchField = metadata.field(PRODUCTS.VENDOR);
+    const nonExhaustiveListField = metadata.field(
+      LISTABLE_FIELD_WITH_MANY_VALUES_ID,
+    );
+
+    const idField = metadata.field(PRODUCTS.ID);
+
+    describe("when the `valuesMode` is already set to 'search'", () => {
+      it("should return return true unless fully disabled", () => {
+        expect(
+          isSearchable({ valuesMode: "search", disableSearch: true }),
+        ).toBe(false);
+        expect(isSearchable({ valuesMode: "search" })).toBe(true);
+      });
+    });
+
+    it("should be false when the list of fields includes one that is not searchable", () => {
+      const fields = [searchField, idField];
+      expect(isSearchable({ fields })).toBe(false);
+    });
+
+    describe("when all fields are searchable", () => {
+      it("should be false if there are no fields that require search", () => {
+        const fields = [listField];
+        expect(isSearchable({ fields })).toBe(false);
+      });
+
+      it("should be true if there is at least one field that requires search", () => {
+        const fields = [searchField, listField];
+        expect(isSearchable({ fields })).toBe(true);
+      });
+
+      it("should be true if there is at least one field that shows a list but said list is not exhaustive", () => {
+        const fields = [nonExhaustiveListField, listField];
+        expect(isSearchable({ fields })).toBe(true);
+      });
+    });
+  });
+
+  describe("getValuesMode", () => {
+    describe("when passed no fields", () => {
+      it("should return 'none'", () => {
+        expect(getValuesMode({ fields: [] })).toBe("none");
+      });
+    });
+
+    describe("when passed fields that are searchable", () => {
+      it("should return 'search'", () => {
+        const fields = [metadata.field(PRODUCTS.VENDOR)];
+        expect(getValuesMode({ fields })).toBe("search");
+      });
+    });
+
+    describe("when passed fields that are not searchable but listable", () => {
+      it("should return 'list'", () => {
+        const fields = [metadata.field(PRODUCTS.CATEGORY)];
+        expect(getValuesMode({ fields })).toBe("list");
+      });
+    });
+
+    describe("when passed fields that are not searchable and not listable", () => {
+      it("should return 'none'", () => {
+        const fields = [metadata.field(ORDERS.SUBTOTAL)];
+        expect(getValuesMode({ fields })).toBe("none");
+      });
+    });
+  });
+
+  describe("searchField", () => {
+    describe("`disablePKRemappingForSearch` is true and field is a PK", () => {
+      const disablePKRemappingForSearch = true;
+
+      const stringPKField = metadata.field(STRING_PK_FIELD_ID);
+      const numberPKField = metadata.field(PRODUCTS.ID);
+
+      it("should return same field when the field is searchable (the field is a string AND a PK)", () => {
+        expect(searchField(stringPKField, disablePKRemappingForSearch)).toBe(
+          stringPKField,
+        );
+      });
+
+      it("should return null when field is not searchable (the field is NOT a string PK)", () => {
+        expect(
+          searchField(numberPKField, disablePKRemappingForSearch),
+        ).toBeNull();
+      });
+    });
+
+    describe("when the field is remapped to a searchable field", () => {
+      const stringField = metadata.field(PRODUCTS.TITLE);
+      const remappedField = metadata.field(PRODUCTS.CATEGORY).clone();
+      remappedField.remappedField = () => stringField;
+
+      it("should return the remapped field", () => {
+        expect(searchField(remappedField)).toBe(stringField);
+      });
+    });
+
+    describe("when the field is remapped to a non-searchable field", () => {
+      it("should ignore it and return the original field, assuming it is searchable", () => {
+        const numberField = metadata.field(ORDERS.TOTAL);
+
+        const remappedField = metadata.field(PRODUCTS.CATEGORY).clone();
+        remappedField.remappedField = () => numberField;
+
+        const nonSearchableRemappedField = metadata.field(PRODUCTS.ID);
+        nonSearchableRemappedField.remappedField = () => numberField;
+
+        expect(searchField(remappedField)).toBe(remappedField);
+        expect(searchField(nonSearchableRemappedField)).toBeNull();
+      });
+    });
+
+    it("should return the field if it is searchable", () => {
+      const searchableField = metadata.field(PRODUCTS.TITLE);
+      expect(searchField(searchableField)).toBe(searchableField);
+    });
+
+    it("should return null if the field is not searchable", () => {
+      const nonSearchableField = metadata.field(PRODUCTS.ID);
+      expect(searchField(nonSearchableField)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
### Description

The Field Values Widget is big, ugly, and huge source of bugs. It will also need some updates in order to be used by MetabaseLibV2.

Along the way found https://github.com/metabase/metabase/issues/32158 and fixes https://github.com/metabase/metabase/issues/32158

This starts that process by converting it to a functional component and doing a little bit of organizing its helper functions and tests. The only real improvement here is that the component props are enumerated.

**Next**: convert to typescript
**After that**: make it better

### How to verify

You can test this component in the app in various places:
- filter dropdowns from table headings in question mode
- search values in the filter modal
- dashboard parameter/filter input

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
