### PR TITLE
Fix failing geocode test

### DIFF
--- a/test/metabase/server/request/util_test.clj
+++ b/test/metabase/server/request/util_test.clj
@@ -79,9 +79,10 @@
 (deftest ^:parallel geocode-ip-addresses-test
   (are [ip-addresses expected] (schema= (s/conditional some? expected nil? (s/eq nil))
                                         (request.u/geocode-ip-addresses ip-addresses))
+    ;; Google DNS
     ["8.8.8.8"]
-    {(s/required-key "8.8.8.8") {:description (s/eq "Los Angeles, California, United States")
-                                 :timezone    (s/eq (t/zone-id "America/Los_Angeles"))}}
+    {(s/required-key "8.8.8.8") {:description #"United States"
+                                 :timezone    (s/eq (t/zone-id "America/Chicago"))}}
 
     ;; this is from the MaxMind sample high-risk IP address list https://www.maxmind.com/en/high-risk-ip-sample-list
     ["185.233.100.23"]
@@ -99,9 +100,9 @@
     ;; multiple addresses at once
     ;; store.metabase.com, Google DNS
     ["52.206.149.9" "2001:4860:4860::8844"]
-    {(s/required-key "52.206.149.9")         {:description (s/eq "Ashburn, Virginia, United States")
+    {(s/required-key "52.206.149.9")         {:description #"United States"
                                               :timezone    (s/eq (t/zone-id "America/New_York"))}
-     (s/required-key "2001:4860:4860::8844") {:description (s/eq "United States")
+     (s/required-key "2001:4860:4860::8844") {:description #"United States"
                                               :timezone    (s/eq (t/zone-id "America/Chicago"))}}
 
     ["wow"] (s/eq nil)


### PR DESCRIPTION
Fix the geocoding changing in our login history test once again. It relies on an external service and from time to time the external service changes what it returns... I changed the description check to a regex comparison so we're slightly less likely to run into this issue in the future

Redux of https://github.com/metabase/metabase/pull/17707