### PR TITLE
[E2E] Finer premium features check

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -11,9 +11,11 @@ const {
  *
  * @type {boolean}
  */
-const hasEnterpriseToken =
+const hasPremiumFeatures =
   process.env["MB_PREMIUM_EMBEDDING_TOKEN"] &&
   process.env["MB_EDITION"] === "ee";
+
+const isEnterprise = process.env["MB_EDITION"] === "ee";
 
 const hasSnowplowMicro = process.env["MB_SNOWPLOW_AVAILABLE"];
 const snowplowMicroUrl = process.env["MB_SNOWPLOW_URL"];
@@ -98,7 +100,8 @@ const defaultConfig = {
     config.env.grepIntegrationFolder = "../../";
     config.env.grepFilterSpecs = true;
 
-    config.env.HAS_ENTERPRISE_TOKEN = hasEnterpriseToken;
+    config.env.IS_ENTERPRISE = isEnterprise;
+    config.env.HAS_PREMIUM_FEATURES = hasPremiumFeatures;
     config.env.HAS_SNOWPLOW_MICRO = hasSnowplowMicro;
     config.env.SNOWPLOW_MICRO_URL = snowplowMicroUrl;
     config.env.SOURCE_VERSION = sourceVersion;

--- a/e2e/support/helpers/e2e-enterprise-helpers.js
+++ b/e2e/support/helpers/e2e-enterprise-helpers.js
@@ -1,6 +1,8 @@
 export const isEE = Cypress.env("HAS_ENTERPRISE_TOKEN");
 export const isOSS = !isEE;
 
-export const describeEE = isEE ? describe : describe.skip;
+const conditionalDescribe = cond => (cond ? describe : describe.skip);
 
-export const describeOSS = isOSS ? describe : describe.skip;
+export const describeEE = conditionalDescribe(isEE);
+
+export const describeOSS = conditionalDescribe(isOSS);

--- a/e2e/support/helpers/e2e-enterprise-helpers.js
+++ b/e2e/support/helpers/e2e-enterprise-helpers.js
@@ -1,8 +1,18 @@
-export const isEE = Cypress.env("HAS_ENTERPRISE_TOKEN");
+/**
+ * Just because an instance is using an Enterprise artifact (jar or Docker image),
+ * doesn't mean that the token is active or that it has all feature flags enabled.
+ *
+ * 1. `isEE` means enterprise instance without a token.
+ * 2. `isPremium` means enterprise instance with all premium features enabled.
+ */
+export const isEE = Cypress.env("IS_ENTERPRISE");
+export const isPremium = Cypress.env("HAS_PREMIUM_FEATURES");
+
 export const isOSS = !isEE;
 
 const conditionalDescribe = cond => (cond ? describe : describe.skip);
 
 export const describeEE = conditionalDescribe(isEE);
+export const describePremium = conditionalDescribe(isPremium);
 
 export const describeOSS = conditionalDescribe(isOSS);

--- a/e2e/test/scenarios/admin/databases/database-exceptions.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/database-exceptions.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, typeAndBlurUsingLabel, isEE } from "e2e/support/helpers";
+import { restore, typeAndBlurUsingLabel, isPremium } from "e2e/support/helpers";
 
 describe("scenarios > admin > databases > exceptions", () => {
   beforeEach(() => {
@@ -66,7 +66,7 @@ describe("scenarios > admin > databases > exceptions", () => {
       {
         method: "GET",
         pathname: "/api/database",
-        query: isEE
+        query: isPremium
           ? {
               exclude_uneditable_details: "true",
             }

--- a/e2e/test/scenarios/admin/settings/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/settings.cy.spec.js
@@ -5,7 +5,7 @@ import {
   describeEE,
   setupMetabaseCloud,
   isOSS,
-  isEE,
+  isPremium,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
@@ -238,7 +238,7 @@ describe("scenarios > admin > settings", () => {
     "should display the order of the settings items consistently between OSS/EE versions (metabase#15441)",
     { tags: "@OSS" },
     () => {
-      const lastItem = isEE ? "Appearance" : "Caching";
+      const lastItem = isPremium ? "Appearance" : "Caching";
 
       cy.visit("/admin/settings/setup");
       cy.get(".AdminList .AdminList-item")

--- a/e2e/test/scenarios/admin/tools/erroring-questions.cy.spec.js
+++ b/e2e/test/scenarios/admin/tools/erroring-questions.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, isEE } from "e2e/support/helpers";
+import { restore, isPremium } from "e2e/support/helpers";
 
 const TOOLS_ERRORS_URL = "/admin/tools/errors";
 
@@ -26,13 +26,13 @@ const brokenQuestionDetails = {
 // UDATE:
 // We need to skip this completely! CI on `master` is almost constantly red.
 // TODO:
-// Once the underlying problem with H2 is solved, replace `describe.skip` with `describeEE`.
+// Once the underlying problem with H2 is solved, replace `describe.skip` with `describePremium`.
 describe.skip(
   "admin > tools > erroring questions ",
   { tags: "@quarantine" },
   () => {
     beforeEach(() => {
-      cy.onlyOn(isEE);
+      cy.onlyOn(isPremium);
 
       restore();
       cy.signInAsAdmin();

--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -2,6 +2,7 @@ import {
   restore,
   visitQuestion,
   isEE,
+  isPremium,
   isOSS,
   visitDashboard,
   visitIframe,
@@ -146,7 +147,7 @@ describe("scenarios > embedding > smoke tests", () => {
 
         visitAndEnableSharing(object);
 
-        if (isEE) {
+        if (isPremium) {
           cy.findByText("Font");
         }
 
@@ -176,13 +177,13 @@ describe("scenarios > embedding > smoke tests", () => {
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains("37.65");
 
-        if (isOSS) {
+        if (isPremium) {
+          cy.contains("Powered by Metabase").should("not.exist");
+        } else {
           cy.contains("Powered by Metabase")
             .closest("a")
             .should("have.attr", "href")
             .and("eq", "https://metabase.com/");
-        } else {
-          cy.contains("Powered by Metabase").should("not.exist");
         }
 
         cy.signInAsAdmin();

--- a/e2e/test/scenarios/embedding/embedding-snippets.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-snippets.cy.spec.js
@@ -3,7 +3,7 @@ import {
   popover,
   visitDashboard,
   visitQuestion,
-  isEE,
+  isPremium,
 } from "e2e/support/helpers";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
@@ -100,7 +100,7 @@ describe("scenarios > embedding > code snippets", () => {
       .should("match", JS_CODE({ type: "question", theme: "transparent" }));
 
     // hide download button for pro/enterprise users metabase#23477
-    if (isEE) {
+    if (isPremium) {
       cy.findByLabelText(
         "Enable users to download data from this embed?",
       ).click();

--- a/e2e/test/scenarios/permissions/reproductions/22447-illogical-UI-elements-for-nodata.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/22447-illogical-UI-elements-for-nodata.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, visitQuestion, isEE, popover } from "e2e/support/helpers";
+import {
+  restore,
+  visitQuestion,
+  isPremium,
+  popover,
+} from "e2e/support/helpers";
 import { USER_GROUPS, SAMPLE_DB_ID } from "e2e/support/cypress_data";
 
 const { ALL_USERS_GROUP, COLLECTION_GROUP } = USER_GROUPS;
@@ -50,7 +55,7 @@ describe("UI elements that make no sense for users without data permissions (met
   });
 
   it("should not show visualization or question settings to users with block data permissions", () => {
-    cy.onlyOn(isEE);
+    cy.onlyOn(isPremium);
 
     cy.signInAsAdmin();
     cy.updatePermissionsGraph({


### PR DESCRIPTION
This PR is the first step in series of commits that should allow us test our **feature flags** in a more granular fashion.
We first need to remove the confusion around the words `enterprise` and `premium`.

### Before
- `isEE` helper was used to mark setup with the premium token that has all feature-flags enabled.
- `isOSS` was used as the negation of the previous helper and as such wasn't strictly always true.
    - For example, `isOSS` would have resolved to `true` on enterprise instances without a token
    - This didn't backfire simply because we're running all EE instances with the token by default

### Now
There is a clear distinction between:
- OSS (literal open-source instance running on OSS artifract)
- EE (enterprise artifact without a token)
- PREMIUM (enterprise artifact with active premium token, with all feature flags enabled)

### How to test?
- Running any test should pass whether you're using open source JAR or Enterprise JAR with or without token
- All tests should pass in CI