### PR TITLE
Fix missing `slack_colorized` icon

### DIFF
--- a/frontend/src/metabase/core/components/Icon/icons/index.ts
+++ b/frontend/src/metabase/core/components/Icon/icons/index.ts
@@ -291,6 +291,8 @@ import sidebar_open_component from "./sidebar_open.svg?component";
 import sidebar_open_source from "./sidebar_open.svg?source";
 import slack_component from "./slack.svg?component";
 import slack_source from "./slack.svg?source";
+import slack_colorized_component from "./slack_colorized.svg?component";
+import slack_colorized_source from "./slack_colorized.svg?source";
 import smartscalar_component from "./smartscalar.svg?component";
 import smartscalar_source from "./smartscalar.svg?source";
 import snippet_component from "./snippet.svg?component";
@@ -928,6 +930,10 @@ export const Icons = {
   slack: {
     component: slack_component,
     source: slack_source,
+  },
+  slack_colorized: {
+    component: slack_colorized_component,
+    source: slack_colorized_source,
   },
   smartscalar: {
     component: smartscalar_component,

--- a/frontend/src/metabase/sharing/components/NewPulseSidebar.tsx
+++ b/frontend/src/metabase/sharing/components/NewPulseSidebar.tsx
@@ -1,6 +1,3 @@
-/* eslint "react/prop-types": "error" */
-
-import PropTypes from "prop-types";
 import cx from "classnames";
 import { t, jt } from "ttag";
 import { Icon } from "metabase/core/components/Icon";
@@ -9,13 +6,21 @@ import Link from "metabase/core/components/Link";
 import Sidebar from "metabase/dashboard/components/Sidebar";
 import { ChannelCard } from "metabase/sharing/components/NewPulseSidebar.styled";
 
-function NewPulseSidebar({
+interface NewPulseSidebarProps {
+  emailConfigured: boolean;
+  slackConfigured: boolean;
+  onNewEmailPulse: () => void;
+  onNewSlackPulse: () => void;
+  onCancel: () => void;
+}
+
+export function NewPulseSidebar({
   onCancel,
   emailConfigured,
   slackConfigured,
   onNewEmailPulse,
   onNewSlackPulse,
-}) {
+}: NewPulseSidebarProps) {
   return (
     <Sidebar onCancel={onCancel}>
       <div className="mt2 pt2 px4">
@@ -47,7 +52,6 @@ function NewPulseSidebar({
               >{t`Email it`}</h3>
             </div>
             <Text
-              lineHeight={1.5}
               className={cx("text-medium", {
                 "hover-child hover--inherit": emailConfigured,
               })}
@@ -86,7 +90,6 @@ function NewPulseSidebar({
               >{t`Send it to Slack`}</h3>
             </div>
             <Text
-              lineHeight={1.5}
               className={cx("text-medium", {
                 "hover-child hover--inherit": slackConfigured,
               })}
@@ -106,13 +109,3 @@ function NewPulseSidebar({
     </Sidebar>
   );
 }
-
-NewPulseSidebar.propTypes = {
-  onCancel: PropTypes.func.isRequired,
-  emailConfigured: PropTypes.bool.isRequired,
-  slackConfigured: PropTypes.bool.isRequired,
-  onNewEmailPulse: PropTypes.func.isRequired,
-  onNewSlackPulse: PropTypes.func.isRequired,
-};
-
-export default NewPulseSidebar;

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import _ from "underscore";
 
 import { connect } from "react-redux";
-import NewPulseSidebar from "metabase/sharing/components/NewPulseSidebar";
+import { NewPulseSidebar } from "metabase/sharing/components/NewPulseSidebar";
 import PulsesListSidebar from "metabase/sharing/components/PulsesListSidebar";
 import {
   AddEditSlackSidebar,


### PR DESCRIPTION
Fixes a `slack_colorized` icon that was missing in the icons map. As a result, we had an "unknown" icon in the dashboard subscription sidebar

### To Verify

1. Sign in as admin
2. Connect Slack to Metabase at `/admin/settings/slack`
3. Open any dashboard, click the envelope icon at the top right
4. Ensure you see a colorized slack icon next to "Send it to Slack"

### Demo

| Before | After  |
|--------|-------|
| <img width="390" alt="CleanShot 2023-07-05 at 14 07 47@2x" src="https://github.com/metabase/metabase/assets/17258145/fb078077-cad7-4522-90fc-390e7e9f85e5"> | <img width="387" alt="CleanShot 2023-07-05 at 14 06 25@2x" src="https://github.com/metabase/metabase/assets/17258145/694de4f4-7e80-491c-bc57-1b34e29814a9">
 