### PR TITLE
Don't allow mapping a model FK to another model

### DIFF
--- a/e2e/test/scenarios/models/reproductions/31663-no-model-fks.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/31663-no-model-fks.cy.spec.js
@@ -1,0 +1,56 @@
+import { appBar, main, popover, restore } from "e2e/support/helpers";
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { ORDERS_ID, PRODUCTS_ID } = SAMPLE_DATABASE;
+
+// Should be removed once proper model FK support is implemented
+describe("issue 31663", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.intercept("GET", `/api/database/${SAMPLE_DB_ID}/idfields`).as(
+      "idFields",
+    );
+
+    cy.createQuestion({
+      name: "Orders Model",
+      dataset: true,
+      query: { "source-table": ORDERS_ID },
+    });
+
+    cy.createQuestion(
+      {
+        name: "Products Model",
+        dataset: true,
+        query: { "source-table": PRODUCTS_ID },
+      },
+      { visitQuestion: true },
+    );
+  });
+
+  it("shouldn't list model IDs as possible model FK targets (metabase#31663)", () => {
+    // It's important to have product model's metadata loaded to reproduce this
+    appBar().findByText("Our analytics").click();
+
+    main().findByText("Orders Model").click();
+    cy.wait("@dataset");
+    cy.findByLabelText("Move, archive, and more...").click();
+    popover().findByText("Edit metadata").click();
+
+    cy.findByTestId("TableInteractive-root").findByText("Product ID").click();
+    cy.wait("@idFields");
+    cy.findByLabelText("Foreign key target").click();
+    popover().within(() => {
+      cy.findByText("Orders Model → ID").should("not.exist");
+      cy.findByText("Products Model → ID").should("not.exist");
+
+      cy.findByText("Orders → ID").should("exist");
+      cy.findByText("People → ID").should("exist");
+      cy.findByText("Products → ID").should("exist");
+      cy.findByText("Reviews → ID").should("exist");
+    });
+  });
+});

--- a/frontend/src/metabase-lib/metadata/Database.ts
+++ b/frontend/src/metabase-lib/metadata/Database.ts
@@ -59,6 +59,11 @@ class Database {
     return Object.fromEntries(this.getTables().map(table => [table.id, table]));
   }
 
+  getFields() {
+    const tables = this.getTables();
+    return tables.flatMap(table => table.fields);
+  }
+
   // @deprecated: use tablesLookup
   get tables_lookup() {
     return this.tablesLookup();

--- a/frontend/src/metabase-lib/metadata/Database.ts
+++ b/frontend/src/metabase-lib/metadata/Database.ts
@@ -59,11 +59,6 @@ class Database {
     return Object.fromEntries(this.getTables().map(table => [table.id, table]));
   }
 
-  getFields() {
-    const tables = this.getTables();
-    return tables.flatMap(table => table.fields);
-  }
-
   // @deprecated: use tablesLookup
   get tables_lookup() {
     return this.tablesLookup();

--- a/frontend/src/metabase-lib/metadata/Metadata.ts
+++ b/frontend/src/metabase-lib/metadata/Metadata.ts
@@ -65,6 +65,10 @@ class Metadata {
     return Object.values(this.tables);
   }
 
+  fieldsList(): Field[] {
+    return Object.values(this.fields);
+  }
+
   /**
    * @deprecated this won't be sorted or filtered in a meaningful way
    * @returns {Metric[]}

--- a/frontend/src/metabase/entities/databases.js
+++ b/frontend/src/metabase/entities/databases.js
@@ -81,12 +81,11 @@ const Databases = createEntity({
       _.any(Databases.selectors.getList(state, props), db => db.is_sample),
 
     getIdFields: createSelector(
-      [state => getMetadata(state).fields, (state, props) => props.databaseId],
-      (fields, databaseId) =>
-        Object.values(fields).filter(f => {
-          const { db_id } = f.table || {}; // a field's table can be null
-          return db_id === databaseId && f.isPK();
-        }),
+      [state => getMetadata(state), (state, props) => props.databaseId],
+      (metadata, databaseId) => {
+        const database = metadata.database(databaseId);
+        return database.getFields().filter(field => field.isPK());
+      },
     ),
   },
 });

--- a/frontend/src/metabase/entities/databases.js
+++ b/frontend/src/metabase/entities/databases.js
@@ -20,6 +20,8 @@ import {
   getMetadataUnfiltered,
 } from "metabase/selectors/metadata";
 
+import { isVirtualCardId } from "metabase-lib/metadata/utils/saved-questions";
+
 // OBJECT ACTIONS
 export const FETCH_DATABASE_METADATA =
   "metabase/entities/database/FETCH_DATABASE_METADATA";
@@ -81,11 +83,16 @@ const Databases = createEntity({
       _.any(Databases.selectors.getList(state, props), db => db.is_sample),
 
     getIdFields: createSelector(
-      [state => getMetadata(state), (state, props) => props.databaseId],
-      (metadata, databaseId) => {
-        const database = metadata.database(databaseId);
-        return database.getFields().filter(field => field.isPK());
-      },
+      [
+        state => getMetadata(state).fieldsList(),
+        (state, props) => props.databaseId,
+      ],
+      (fields, databaseId) =>
+        fields.filter(field => {
+          const dbId = field?.table?.db_id;
+          const isRealField = !isVirtualCardId(field.table_id);
+          return dbId === databaseId && isRealField && field.isPK();
+        }),
     ),
   },
 });

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/SemanticTypePicker/FKTargetPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/SemanticTypePicker/FKTargetPicker.tsx
@@ -93,6 +93,9 @@ function FKTargetPicker({
       onChange={onChange}
       searchable
       searchProp={SEARCH_PROPERTIES}
+      buttonProps={{
+        "aria-label": t`Foreign key target`,
+      }}
       optionValueFn={getOptionValue}
       optionNameFn={getFieldName}
       optionIconFn={getOptionIcon}


### PR DESCRIPTION
Fixes #31663, reproduces #31663

Makes it impossible to map a model foreign key to another model with the model metadata editor

The editor's `FKTargetPicker` component [uses](https://github.com/metabase/metabase/blob/35c2acbf9b36ef0fa5f54284ca84363d045e614c/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/SemanticTypePicker/FKTargetPicker.tsx#L62) database entity's `fetchIdFields` action + `getIdFields` selector. `fetchIdFields` calls `/api/database/:id/idfields` endpoint that returns only real fields. After that, `getIdFields` selectors goes over all the fields in `Metadata` and filters out `type/PK` fields with `db_id` being the model database ID. The issue is that fields from other models on the same database would also meet that criteria and end up in `getIdFields` result.

Fixed by rewriting the `getIdFields` selector, so it only returns actual fields. Apart from the metadata editor, the selector is only used in the admin data model page, and it doesn't make a lot of sense to have models available there either. 

### To Verify

⚠️ Follow the steps without doing any page reloads. The original issue can only be reproduced if the models metadata is present in the redux store.

1. Create a model from the sample orders table
2. Create a model from the sample products table
3. Open the orders model in the metadata editor
4. Click on the "Product ID" column
5. Click on the FK target picker (right below the "Column type" selector)
6. Ensure you can only see "Orders → ID, Products → ID, Users → ID" (3 fields)