### PR TITLE
refactor `useDashboardTabs` and `useSyncURLSlug` to not nullify `selectedTabId` on unmount

### DIFF
--- a/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
@@ -60,6 +60,8 @@ describe("scenarios > public > dashboard", () => {
 
     cy.request("PUT", "/api/setting/enable-public-sharing", { value: true });
 
+    cy.intercept("/api/dashboard/*/public_link").as("publicLink");
+
     cy.createNativeQuestionAndDashboard({
       questionDetails,
       dashboardDetails,
@@ -99,6 +101,8 @@ describe("scenarios > public > dashboard", () => {
       .parent()
       .findByRole("switch")
       .check();
+
+    cy.wait("@publicLink");
 
     cy.findByRole("heading", { name: "Public link" })
       .parent()

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/use-dashboard-tabs.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/use-dashboard-tabs.ts
@@ -1,4 +1,4 @@
-import { useMount, useUnmount } from "react-use";
+import { useMount } from "react-use";
 import { t } from "ttag";
 import type { UniqueIdentifier } from "@dnd-kit/core";
 import type { Location } from "history";
@@ -28,7 +28,6 @@ export function useDashboardTabs({ location }: { location: Location }) {
 
   useSyncURLSlug({ location });
   useMount(() => dispatch(initTabs({ slug: parseSlug({ location }) })));
-  useUnmount(() => dispatch(selectTab({ tabId: null })));
 
   const deleteTab = (tabId: SelectedTabId) => {
     const tabName = tabs.find(({ id }) => id === tabId)?.name;

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/use-sync-url-slug.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/use-sync-url-slug.ts
@@ -86,11 +86,12 @@ export function useSyncURLSlug({ location }: { location: Location }) {
               tabId: selectedTabId,
               name: tabs.find(t => t.id === selectedTabId)?.name,
             });
+      updateURLSlug({
+        slug: newSlug,
+        shouldReplace: !tabInitialized,
+      });
+
       if (newSlug) {
-        updateURLSlug({
-          slug: newSlug,
-          shouldReplace: !tabInitialized,
-        });
         setTabInitialized(true);
       }
     }

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/use-sync-url-slug.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/use-sync-url-slug.ts
@@ -73,7 +73,6 @@ export function useSyncURLSlug({ location }: { location: Location }) {
     }
 
     const tabSelected = selectedTabId !== prevSelectedTabId;
-    // const tabInitialized = selectedTabId != null && prevSelectedTabId == null;
     const tabRenamed =
       tabs.find(t => t.id === selectedTabId)?.name !==
       prevTabs?.find(t => t.id === selectedTabId)?.name;

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/use-sync-url-slug.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/use-sync-url-slug.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { usePrevious } from "react-use";
 import { push, replace } from "react-router-redux";
 import type { Location } from "history";
@@ -52,6 +52,8 @@ function useUpdateURLSlug({ location }: { location: Location }) {
 }
 
 export function useSyncURLSlug({ location }: { location: Location }) {
+  const [tabInitialized, setTabInitialized] = useState(false);
+
   const slug = parseSlug({ location });
   const tabs = useSelector(getTabs);
   const selectedTabId = useSelector(getSelectedTabId);
@@ -71,25 +73,30 @@ export function useSyncURLSlug({ location }: { location: Location }) {
     }
 
     const tabSelected = selectedTabId !== prevSelectedTabId;
-    const tabInitialized = selectedTabId != null && prevSelectedTabId == null;
+    // const tabInitialized = selectedTabId != null && prevSelectedTabId == null;
     const tabRenamed =
       tabs.find(t => t.id === selectedTabId)?.name !==
       prevTabs?.find(t => t.id === selectedTabId)?.name;
     const penultimateTabDeleted = tabs.length === 1 && prevTabs?.length === 2;
 
     if (tabSelected || tabRenamed || penultimateTabDeleted) {
-      updateURLSlug({
-        slug:
-          tabs.length <= 1
-            ? ""
-            : getSlug({
-                tabId: selectedTabId,
-                name: tabs.find(t => t.id === selectedTabId)?.name,
-              }),
-        shouldReplace: tabInitialized,
-      });
+      const newSlug =
+        tabs.length <= 1
+          ? ""
+          : getSlug({
+              tabId: selectedTabId,
+              name: tabs.find(t => t.id === selectedTabId)?.name,
+            });
+      if (newSlug) {
+        updateURLSlug({
+          slug: newSlug,
+          shouldReplace: !tabInitialized,
+        });
+        setTabInitialized(true);
+      }
     }
   }, [
+    tabInitialized,
     slug,
     selectedTabId,
     tabs,


### PR DESCRIPTION
### Description

This is a non-functional change that refactors the logic for dashboard tabs to no longer set `selectedTabId` to `null` when unmounting the tabs component (e.g. when leaving a dashboard).

We are doing this so that later @uladzimirdev can write a PR that will make it so that clicking the back button on a question will navigate back to the specific tab the user was on in a dashboard.

### How to verify

1. Create a tabbed dashboard
2. Navigate to the dashboard from a collection
3. Confirm clicking back once goes back to the collection
4. Go forward to return to the dashboard
5. Click some tabs, then confirm clicking back will go back to the selected tabs.
6. Navigate directly to another dashboard (e.g. using search), confirm clicking back once goes to the first dashboard
7. Go into edit mode, confirm that selecting new unsaved tabs will remove the slug from the url
8. Delete all tabs (except the last, which is un-deleteable), confirm the slug is no longer in the url

### Demo

https://github.com/metabase/metabase/assets/37751258/080a764e-db81-47ec-b655-5740230f504a

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
