### PR TITLE
Tweak behavior of `enabled?` fn on settings and add `:feature` option

### DIFF
--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -415,9 +415,8 @@
   [feature]
   (u/ignore-exceptions
    (classloader/require 'metabase.public-settings.premium-features))
-  (if-let [has-feature?' (resolve 'metabase.public-settings.premium-features/has-feature?)]
-    (has-feature?' feature)
-    false))
+  (let [has-feature?' (resolve 'metabase.public-settings.premium-features/has-feature?)]
+    (has-feature?' feature)))
 
 (defn has-advanced-setting-access?
   "If `advanced-permissions` is enabled, check if current user has permissions to edit `setting`.

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -814,7 +814,6 @@
   [setting-definition-or-name new-value]
   (let [{:keys [setter cache? enabled? feature], :as setting} (resolve-setting setting-definition-or-name)
         name                                                  (setting-name setting)]
-    (def enabled? enabled?)
     (when (and feature (not (has-feature? feature)))
       (throw (ex-info (tru "Setting {0} is not enabled because feature {1} is not available" name feature) setting)))
     (when (and enabled? (not (enabled?)))

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -415,8 +415,8 @@
   [feature]
   (u/ignore-exceptions
    (classloader/require 'metabase.public-settings.premium-features))
-  (if-let [has-feature? (resolve 'metabase.public-settings.premium-features/has-feature?)]
-    (has-feature? feature)
+  (if-let [has-feature?' (resolve 'metabase.public-settings.premium-features/has-feature?)]
+    (has-feature?' feature)
     false))
 
 (defn has-advanced-setting-access?

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -411,12 +411,8 @@
   set to true when settings are being written directly via /api/setting endpoints."
   false)
 
-(defn- has-feature?
-  [feature]
-  (u/ignore-exceptions
-   (classloader/require 'metabase.public-settings.premium-features))
-  (let [has-feature?' (resolve 'metabase.public-settings.premium-features/has-feature?)]
-    (has-feature?' feature)))
+;; Need to access `has-feature?` by resolving it at runtime to avoid circular dependency
+(def ^:private has-feature? (resolve 'metabase.public-settings.premium-features/has-feature?))
 
 (defn has-advanced-setting-access?
   "If `advanced-permissions` is enabled, check if current user has permissions to edit `setting`.

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -411,8 +411,12 @@
   set to true when settings are being written directly via /api/setting endpoints."
   false)
 
-;; Need to access `has-feature?` by resolving it at runtime to avoid circular dependency
-(def ^:private has-feature? (resolve 'metabase.public-settings.premium-features/has-feature?))
+(defn- has-feature?
+  [feature]
+  (u/ignore-exceptions
+   (classloader/require 'metabase.public-settings.premium-features))
+  (let [has-feature?' (resolve 'metabase.public-settings.premium-features/has-feature?)]
+    (has-feature?' feature)))
 
 (defn has-advanced-setting-access?
   "If `advanced-permissions` is enabled, check if current user has permissions to edit `setting`.

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -886,18 +886,22 @@
   (testing "Settings can be disabled"
     (testing "With no default returns nil"
       (is (nil? (test-enabled-setting-no-default)))
-      (testing "Updating the value succeeds but still get nil because no default"
-        (test-enabled-setting-default! "a value")
-        (is (nil? (test-enabled-setting-no-default)))))
+      (testing "Updating the value throws an exception"
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"Setting test-enabled-setting-no-default is not enabled"
+             (test-enabled-setting-no-default! "a value")))))
     (testing "Returns default value"
       (is (= "setting-default" (test-enabled-setting-default)))
-      (testing "Updating the value succeeds but still get default"
-        (test-enabled-setting-default! "non-default-value")
-        (is (= "setting-default" (test-enabled-setting-default))))))
-  (testing "When enabled get the value"
-    (test-enabled-setting-default! "custom")
-    (test-enabled-setting-no-default! "custom")
+      (testing "Updating the value throws an exception"
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"Setting test-enabled-setting-default is not enabled"
+             (test-enabled-setting-default! "a value"))))))
+  (testing "When enabled, the setting can be read and written as normal"
     (binding [*enabled?* true]
+      (test-enabled-setting-default! "custom")
+      (test-enabled-setting-no-default! "custom")
       (is (= "custom" (test-enabled-setting-default)))
       (is (= "custom" (test-enabled-setting-no-default))))))
 

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -925,7 +925,19 @@
            clojure.lang.ExceptionInfo
            #"Setting test-feature-setting is not enabled because feature :test-feature is not available"
            (test-feature-setting! "custom 2")))
-      (is (= "setting-default" (test-feature-setting))))))
+      (is (= "setting-default" (test-feature-setting)))))
+
+  (testing "A setting cannot have both the :enabled? and :feature options at once"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Setting :test-enabled-and-feature uses both :enabled\? and :feature options, which are mutually exclusive"
+         (defsetting test-enabled-and-feature
+           "Setting with both :enabled? and :feature options"
+           :visibility :internal
+           :type       :string
+           :default    "setting-default"
+           :enabled?   (fn [] false)
+           :feature    :test-feature)))))
 
 
 ;;; ------------------------------------------------- Misc tests -------------------------------------------------------


### PR DESCRIPTION
* Changes the behavior of `enabled?` to throw an exception if a setting is attempted to be set when the setting is not enabled. The previous behavior allowed the setting to be written, but would return the default when read. I'm changing this because in the majority of cases, it seems like we want to prevent writing a setting as well if it's disabled (e.g. if an EE feature is not available).
* Adds a `:feature` option which automatically checks for the presence of a feature flag to determine whether a setting is enabled. This is just a shorthand to make it easier to write EE-only settings.