### PR TITLE
add separate test setup file path to file-paths

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -27,6 +27,7 @@ frontend_sources: &frontend_sources
 frontend_specs: &frontend_specs
   - *shared_specs
   - "frontend/test/**"
+  - "frontend/**/tests/**"
   - "frontend/**/*.unit.*"
   - "jest.unit.conf.json"
   - "jest.tz.unit.conf.json"


### PR DESCRIPTION
### Description

To test OSS, Enterprise with disabled features, and Enterprise with enabled features and avoid code duplication we started extracting the test setup function to a separate file which is located inside a local `test` folder so this PR updates `file-paths.yaml` to keep CI efficient

