### PR TITLE
Fix quick filter drill for custom expressions

### DIFF
--- a/e2e/test/scenarios/custom-column/reproductions/32032-cc-quick-filter-drill.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/32032-cc-quick-filter-drill.cy.spec.js
@@ -1,0 +1,40 @@
+import { restore, main, popover } from "e2e/support/helpers";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { REVIEWS, REVIEWS_ID } = SAMPLE_DATABASE;
+
+const QUERY = {
+  "source-table": REVIEWS_ID,
+  expressions: {
+    "Custom Reviewer": ["field", REVIEWS.REVIEWER, null],
+  },
+  fields: [
+    ["field", REVIEWS.ID, { "base-type": "type/BigInteger" }],
+    ["field", REVIEWS.REVIEWER, { "base-type": "type/Text" }],
+    ["expression", "Custom Reviewer", { "base-type": "type/Text" }],
+  ],
+};
+
+describe("issue 32032", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.createQuestion({ query: QUERY }, { visitQuestion: true });
+    cy.intercept("POST", "/api/dataset").as("dataset");
+  });
+
+  it("should allow quick filter drills on custom columns", () => {
+    cy.findByTestId("TableInteractive-root")
+      .findAllByText("xavier")
+      .eq(1)
+      .click();
+    popover().findByText("Is xavier").click();
+    cy.wait("@dataset");
+    main()
+      .findByText(/There was a problem/i)
+      .should("not.exist");
+    cy.findByTestId("TableInteractive-root")
+      .findAllByText("xavier")
+      .should("have.length", 2);
+  });
+});

--- a/frontend/src/metabase-lib/queries/drills/quick-filter-drill.ts
+++ b/frontend/src/metabase-lib/queries/drills/quick-filter-drill.ts
@@ -119,9 +119,7 @@ function getOperatorsForColumn(
     return null;
   }
 
-  const fieldRef = dimension
-    ? dimension.mbql()
-    : getColumnFieldRef(column, baseType);
+  const fieldRef = getColumnFieldRef(column, baseType);
 
   if (!fieldRef || !isConcreteField(fieldRef)) {
     return null;


### PR DESCRIPTION
Fixes #32032, reproduces #32032

Fixes quick filter drill stopped working for custom columns. After the drills revamp, the quick filter drill was generating unexpected field references via `dimension.mbql()`.

For a custom column, `dimension.mbql()` would generate:

```ts
[ "expression", "EXPRESSION_NAME" ]
```

However, it's expected to reference expressions like via field literals like that:

```ts
[ "field", "EXPRESSION_NAME", { "base-type": "..." } ]
```

### How to verify

1. New > Question > Raw Data > Sample Database > Reviews
2. Open the notebook editor
3. Add a custom column (could be just `[Reviewer]` called "CC Reviewer")
4. Visualize
5. Click on any "CC Reviewer" cell in the results table
6. Click "Is ..." or "Is not ..." in the drill popover
7. Ensure you get filtered results

### Demo

https://github.com/metabase/metabase/assets/17258145/029943e7-88ce-4cae-8a03-0bad64cda0df

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
