### PR TITLE
Sort dashboard cards for mobile

### DIFF
--- a/frontend/src/metabase/dashboard/components/grid/utils.js
+++ b/frontend/src/metabase/dashboard/components/grid/utils.js
@@ -5,7 +5,7 @@ function sumVerticalSpace(layout) {
   return layout.reduce((sum, current) => sum + current.h, 0);
 }
 
-function sortCardsForMobile(a, b) {
+export function sortCardsForMobile(a, b) {
   const yDiff = a.y - b.y;
 
   // sort by y position first

--- a/frontend/src/metabase/dashboard/components/grid/utils.js
+++ b/frontend/src/metabase/dashboard/components/grid/utils.js
@@ -5,13 +5,25 @@ function sumVerticalSpace(layout) {
   return layout.reduce((sum, current) => sum + current.h, 0);
 }
 
+function sortCardsForMobile(a, b) {
+  const yDiff = a.y - b.y;
+
+  // sort by y position first
+  if (yDiff !== 0) {
+    return yDiff;
+  }
+
+  // for items on the same row, sort by x position
+  return a.x - b.x;
+}
+
 export function generateMobileLayout({
   desktopLayout,
   defaultCardHeight,
   heightByDisplayType = {},
 }) {
   const mobile = [];
-  desktopLayout.forEach(item => {
+  desktopLayout.sort(sortCardsForMobile).forEach(item => {
     const card = item.dashcard.card;
     const height = heightByDisplayType[card.display] || defaultCardHeight;
     mobile.push({

--- a/frontend/src/metabase/dashboard/components/grid/utils.unit.spec.js
+++ b/frontend/src/metabase/dashboard/components/grid/utils.unit.spec.js
@@ -1,0 +1,36 @@
+import { sortCardsForMobile } from "./utils";
+
+describe("Dashcard > grid > utils", () => {
+  describe("sortCardsForMobile", () => {
+    it("should sort cards by y position first", () => {
+      const a = { id: "top", y: 1, x: 3 };
+      const b = { id: "middle", y: 2, x: 2 };
+      const c = { id: "bottom", y: 3, x: 1 };
+
+      const result = [b, a, c].sort(sortCardsForMobile);
+      expect(result).toEqual([a, b, c]);
+    });
+
+    it("should sort cards by x position if y position is the same", () => {
+      const a = { id: "left", y: 5, x: 1 };
+      const b = { id: "middle", y: 5, x: 2 };
+      const c = { id: "right", y: 5, x: 3 };
+
+      const result = [c, a, b].sort(sortCardsForMobile);
+      expect(result).toEqual([a, b, c]);
+    });
+
+    it("should sort cards by x and y positions", () => {
+      const a = { id: "top", y: 1, x: 3 };
+      const b = { id: "middle", y: 2, x: 2 };
+      const c = { id: "bottom", y: 3, x: 1 };
+
+      const d = { id: "left", y: 5, x: 1 };
+      const e = { id: "middle", y: 5, x: 2 };
+      const f = { id: "right", y: 5, x: 3 };
+
+      const result = [f, d, c, a, b, e].sort(sortCardsForMobile);
+      expect(result).toEqual([a, b, c, d, e, f]);
+    });
+  });
+});


### PR DESCRIPTION
resolves https://github.com/metabase/metabase/issues/32034

### Description

Sorts dashboard cards by y, then x position when transitioning to mobile layout. I don't think there's actually a regression here, there was actually never a defined sorting behavior on the frontend, so the cards just got added tot he mobile view in the order we got them from the backend, which was probably usually the order they were saved to the dashboard. Headings just made this super obvious

Before | After
---|---
![sortBefore](https://github.com/metabase/metabase/assets/30528226/e19d7491-430e-43a6-b835-fd4fff174855) | ![sortAfter](https://github.com/metabase/metabase/assets/30528226/5dbd6c9c-4b8d-42c1-9815-e7fe0a60645e)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
