### PR TITLE
Add mb to upload limit tooltip

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionUpload.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionUpload.tsx
@@ -93,7 +93,7 @@ const UploadTooltip = ({
         <TooltipTitle>{t`Upload data to ${collection.name}`}</TooltipTitle>
         <TooltipSubtitle>{t`${UPLOAD_FILE_TYPES.join(
           ",",
-        )} (${MAX_UPLOAD_STRING} max)`}</TooltipSubtitle>
+        )} (${MAX_UPLOAD_STRING} mb max)`}</TooltipSubtitle>
       </TooltipContainer>
     }
     placement="bottom"

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionUpload.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionUpload.tsx
@@ -93,7 +93,7 @@ const UploadTooltip = ({
         <TooltipTitle>{t`Upload data to ${collection.name}`}</TooltipTitle>
         <TooltipSubtitle>{t`${UPLOAD_FILE_TYPES.join(
           ",",
-        )} (${MAX_UPLOAD_STRING} mb max)`}</TooltipSubtitle>
+        )} (${MAX_UPLOAD_STRING} MB max)`}</TooltipSubtitle>
       </TooltipContainer>
     }
     placement="bottom"

--- a/frontend/src/metabase/redux/uploads.ts
+++ b/frontend/src/metabase/redux/uploads.ts
@@ -65,7 +65,7 @@ export const uploadFile = createThunkAction(
         dispatch(
           uploadError({
             id,
-            message: t`You cannot upload files larger than ${MAX_UPLOAD_STRING}mb`,
+            message: t`You cannot upload files larger than ${MAX_UPLOAD_STRING} MB`,
           }),
         );
         clear();

--- a/frontend/src/metabase/redux/uploads.unit.spec.js
+++ b/frontend/src/metabase/redux/uploads.unit.spec.js
@@ -119,7 +119,7 @@ describe("csv uploads", () => {
         type: UPLOAD_FILE_TO_COLLECTION_ERROR,
         payload: {
           id: now,
-          message: `You cannot upload files larger than ${MAX_UPLOAD_STRING}mb`,
+          message: `You cannot upload files larger than ${MAX_UPLOAD_STRING} MB`,
         },
       });
     });


### PR DESCRIPTION
https://metaboat.slack.com/archives/C04S696LRUM/p1688665691696579

### Description

We switched around the string localization interpolation here in another component and forgot to change the mb in this string.

![Screen Shot 2023-07-06 at 12 09 55 PM](https://github.com/metabase/metabase/assets/30528226/2931caee-bb6a-4587-9a0a-df8c3dce1060)

