### PR TITLE
Fix back to dashboard to select correct tab and preserve filters

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
@@ -13,7 +13,11 @@ import {
   setActionsEnabledForDB,
   summarize,
   visitDashboard,
+  visitDashboardAndCreateTab,
   visualize,
+  openQuestionsSidebar,
+  sidebar,
+  saveDashboard,
   filterWidget,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
@@ -217,6 +221,29 @@ describe("scenarios > dashboard > dashboard back navigation", () => {
     getDashboardCard(1).findByText(PERMISSION_ERROR);
     cy.get("@dashboard.all").should("have.length", 1);
     cy.get("@dashcardQuery.all").should("have.length", 1);
+  });
+
+  it("should return to dashboard with specific tab selected", () => {
+    visitDashboardAndCreateTab({ dashboardId: 1, save: false });
+
+    // Add card to second tab
+    cy.icon("pencil").click();
+    openQuestionsSidebar();
+    sidebar().within(() => {
+      cy.findByText("Orders, Count").click();
+    });
+    saveDashboard();
+
+    getDashboardCard().within(() => {
+      cy.findByText("Orders, Count").click();
+      cy.wait("@card");
+    });
+
+    queryBuilderHeader()
+      .findByLabelText("Back to Orders in a dashboard")
+      .click();
+
+    cy.findByRole("tab", { selected: true }).should("have.text", "Tab 2");
   });
 });
 

--- a/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
@@ -14,6 +14,7 @@ import {
   summarize,
   visitDashboard,
   visualize,
+  filterWidget,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
@@ -233,7 +234,7 @@ describe(
       );
     });
 
-    it("should restore a dashboard with loading cards", () => {
+    it("should restore a dashboard with loading cards and re-fetch query data", () => {
       createDashboardWithSlowCard();
       cy.get("@dashboardId").then(dashboardId => {
         cy.visit({
@@ -256,8 +257,36 @@ describe(
       });
 
       getDashboardCard().within(() => {
-        cy.findByText("0").should("be.visible");
+        cy.findByText("Sleep card").should("be.visible");
       });
+    });
+
+    it("should preserve filter value when navigating between the dashboard and the question", () => {
+      createDashboardWithSlowCard();
+      cy.get("@dashboardId").then(visitDashboard);
+
+      cy.get("@dashcardQuery.all").should("have.length", 1);
+
+      filterWidget().findByPlaceholderText("sleep").type("5{enter}");
+
+      cy.get("@dashcardQuery.all").should("have.length", 2);
+
+      getDashboardCard().within(() => {
+        cy.findByText("Sleep card").click();
+        cy.wait("@card");
+      });
+
+      filterWidget().findByPlaceholderText("sleep").should("have.value", "5");
+
+      queryBuilderHeader().findByLabelText("Back to Sleep dashboard").click();
+
+      getDashboardCard().within(() => {
+        cy.findByText("Sleep card").should("be.visible");
+      });
+
+      cy.log("Dashcard data is re-requested");
+      cy.get("@dashcardQuery.all").should("have.length", 3);
+      filterWidget().findByPlaceholderText("sleep").should("have.value", "5");
     });
   },
 );

--- a/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
@@ -2,6 +2,7 @@ import {
   getNotebookStep,
   openQuestionActions,
   restore,
+  popover,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
@@ -33,18 +34,15 @@ describe("issue 29951", () => {
     cy.wait("@dataset");
 
     openQuestionActions();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Edit query definition").click();
+    popover().findByText("Edit query definition").click();
     removeExpression("CC2");
     cy.findByRole("button", { name: "Save changes" }).click();
-    cy.wait("@updateCard");
-    cy.wait("@dataset");
+    cy.wait(["@updateCard", "@dataset"]);
 
     dragColumn(0, 100);
     cy.findAllByRole("button", { name: "Get Answer" }).first().click();
     cy.wait("@dataset");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Showing 200 rows").should("be.visible");
+    cy.findByTestId("view-footer").should("contain", "Showing 200 rows");
   });
 });
 

--- a/frontend/src/metabase/components/LastEditInfoLabel/LastEditInfoLabel.jsx
+++ b/frontend/src/metabase/components/LastEditInfoLabel/LastEditInfoLabel.jsx
@@ -20,8 +20,8 @@ LastEditInfoLabel.propTypes = {
     "last-edit-info": PropTypes.shape({
       id: PropTypes.number.isRequired,
       email: PropTypes.string.isRequired,
-      first_name: PropTypes.string.isRequired,
-      last_name: PropTypes.string.isRequired,
+      first_name: PropTypes.string,
+      last_name: PropTypes.string,
       timestamp: PropTypes.string.isRequired,
     }).isRequired,
   }),

--- a/frontend/src/metabase/components/tree/TreeNode.styled.tsx
+++ b/frontend/src/metabase/components/tree/TreeNode.styled.tsx
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import { color, lighten } from "metabase/lib/colors";
 import { Icon, IconProps } from "metabase/core/components/Icon";
+import { shouldForwardNonTransientProp } from "metabase/lib/styling/emotion";
 
 interface TreeNodeRootProps {
   isSelected: boolean;
@@ -37,7 +38,9 @@ interface ExpandToggleIconProps {
   isExpanded: boolean;
 }
 
-export const ExpandToggleIcon = styled(Icon)<ExpandToggleIconProps & IconProps>`
+export const ExpandToggleIcon = styled(Icon, {
+  shouldForwardProp: shouldForwardNonTransientProp,
+})<ExpandToggleIconProps & IconProps>`
   transition: transform 200ms;
 
   ${props =>

--- a/frontend/src/metabase/core/components/BookmarkToggle/BookmarkToggle.styled.tsx
+++ b/frontend/src/metabase/core/components/BookmarkToggle/BookmarkToggle.styled.tsx
@@ -3,6 +3,7 @@ import { keyframes } from "@emotion/react";
 import { color } from "metabase/lib/colors";
 import { Icon } from "metabase/core/components/Icon";
 import Button from "metabase/core/components/Button";
+import { shouldForwardNonTransientProp } from "metabase/lib/styling/emotion";
 
 const expandKeyframes = keyframes`
   50% {
@@ -22,7 +23,9 @@ export interface BookmarkIconProps {
   onAnimationEnd: () => void;
 }
 
-export const BookmarkIcon = styled(Icon)<BookmarkIconProps>`
+export const BookmarkIcon = styled(Icon, {
+  shouldForwardProp: shouldForwardNonTransientProp,
+})<BookmarkIconProps>`
   color: ${props => (props.isBookmarked ? color("brand") : "")};
   animation-name: ${props =>
     props.isBookmarked ? expandKeyframes : shrinkKeyframes};

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -186,6 +186,7 @@ class Dashboard extends Component {
     try {
       await fetchDashboard(dashboardId, location.query, {
         clearCache: !isNavigatingBackToDashboard,
+        preserveParameters: isNavigatingBackToDashboard,
       });
       if (editingOnLoad) {
         this.setEditing(this.props.dashboard);

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
@@ -2,7 +2,7 @@ import { Link, Route } from "react-router";
 import userEvent from "@testing-library/user-event";
 import type { Location } from "history";
 
-import { renderWithProviders, screen, fireEvent } from "__support__/ui";
+import { renderWithProviders, screen } from "__support__/ui";
 import { DashboardState, State } from "metabase-types/store";
 import { DashboardOrderedTab } from "metabase-types/api";
 import { getDefaultTab, resetTempTabId } from "metabase/dashboard/actions";
@@ -79,7 +79,7 @@ function setup({
 
 function queryTab(numOrName: number | string) {
   const name = typeof numOrName === "string" ? numOrName : `Tab ${numOrName}`;
-  return screen.queryByRole("tab", { name });
+  return screen.queryByRole("tab", { name, hidden: true });
 }
 
 function selectTab(num: number) {
@@ -95,9 +95,10 @@ function createNewTab() {
 async function selectTabMenuItem(num: number, name: "Delete" | "Rename") {
   const dropdownIcons = screen.getAllByRole("img", {
     name: "chevrondown icon",
+    hidden: true,
   });
   userEvent.click(dropdownIcons[num - 1]);
-  (await screen.findByRole("option", { name })).click();
+  (await screen.findByRole("option", { name, hidden: true })).click();
 }
 
 async function deleteTab(num: number) {
@@ -107,9 +108,11 @@ async function deleteTab(num: number) {
 async function renameTab(num: number, name: string) {
   await selectTabMenuItem(num, "Rename");
 
-  const inputEl = screen.getByRole("textbox", { name: `Tab ${num}` });
-  userEvent.type(inputEl, name);
-  fireEvent.keyPress(inputEl, { key: "Enter", charCode: 13 });
+  const inputEl = screen.getByRole("textbox", {
+    name: `Tab ${num}`,
+    hidden: true,
+  });
+  userEvent.type(inputEl, `${name}{enter}`);
 }
 
 async function findSlug({ tabId, name }: { tabId: number; name: string }) {
@@ -333,9 +336,11 @@ describe("DashboardTabs", () => {
         const inputWrapperEl = screen.getAllByTestId(INPUT_WRAPPER_TEST_ID)[0];
         userEvent.dblClick(inputWrapperEl);
 
-        const inputEl = screen.getByRole("textbox", { name: "Tab 1" });
-        userEvent.type(inputEl, name);
-        fireEvent.keyPress(inputEl, { key: "Enter", charCode: 13 });
+        const inputEl = screen.getByRole("textbox", {
+          name: "Tab 1",
+          hidden: true,
+        });
+        userEvent.type(inputEl, `${name}{enter}`);
 
         expect(queryTab(name)).toBeInTheDocument();
         expect(await findSlug({ tabId: 1, name })).toBeInTheDocument();

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.jsx
@@ -1,5 +1,5 @@
-/* eslint-disable react/prop-types */
 import { useCallback, useEffect } from "react";
+import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { push } from "react-router-redux";
 import _ from "underscore";
@@ -71,26 +71,26 @@ function getDashboardId({ dashboardId, params }) {
   return Urls.extractEntityId(params.slug);
 }
 
-const mapStateToProps = (state, props) => {
+const mapStateToProps = state => {
   const metadata = getMetadata(state);
+
   return {
-    dashboardId: getDashboardId(props),
-    canManageSubscriptions: canManageSubscriptions(state, props),
-    isAdmin: getUserIsAdmin(state, props),
+    canManageSubscriptions: canManageSubscriptions(state),
+    isAdmin: getUserIsAdmin(state),
     isNavbarOpen: getIsNavbarOpen(state),
-    isEditing: getIsEditing(state, props),
-    isSharing: getIsSharing(state, props),
-    dashboardBeforeEditing: getDashboardBeforeEditing(state, props),
-    isEditingParameter: getIsEditingParameter(state, props),
-    isDirty: getIsDirty(state, props),
-    dashboard: getDashboardComplete(state, props),
-    dashcardData: getCardData(state, props),
-    slowCards: getSlowCards(state, props),
+    isEditing: getIsEditing(state),
+    isSharing: getIsSharing(state),
+    dashboardBeforeEditing: getDashboardBeforeEditing(state),
+    isEditingParameter: getIsEditingParameter(state),
+    isDirty: getIsDirty(state),
+    dashboard: getDashboardComplete(state),
+    dashcardData: getCardData(state),
+    slowCards: getSlowCards(state),
     databases: metadata.databases,
-    editingParameter: getEditingParameter(state, props),
-    parameters: getParameters(state, props),
-    parameterValues: getParameterValues(state, props),
-    draftParameterValues: getDraftParameterValues(state, props),
+    editingParameter: getEditingParameter(state),
+    parameters: getParameters(state),
+    parameterValues: getParameterValues(state),
+    draftParameterValues: getDraftParameterValues(state),
     metadata,
     loadingStartTime: getLoadingStartTime(state),
     clickBehaviorSidebarDashcard: getClickBehaviorSidebarDashcard(state),
@@ -119,14 +119,7 @@ const mapDispatchToProps = {
 
 // NOTE: should use DashboardControls and DashboardData HoCs here?
 const DashboardApp = props => {
-  const {
-    isRunning,
-    isLoadingComplete,
-    dashboard,
-    closeDashboard,
-    isEditing,
-    isDirty,
-  } = props;
+  const { dashboard, isRunning, isLoadingComplete, isEditing, isDirty } = props;
 
   const options = parseHashOptions(window.location.hash);
   const editingOnLoad = options.edit;
@@ -134,9 +127,12 @@ const DashboardApp = props => {
 
   const dispatch = useDispatch();
 
-  const [requestPermission, showNotification] = useWebNotification();
+  const { requestPermission, showNotification } = useWebNotification();
 
-  useUnmount(props.reset);
+  useUnmount(() => {
+    dispatch(dashboardActions.reset());
+    dispatch(dashboardActions.closeDashboard());
+  });
 
   const slowToastId = useUniqueId();
   useBeforeUnload(isEditing && isDirty);
@@ -190,13 +186,10 @@ const DashboardApp = props => {
     onTimeout,
   });
 
-  useUnmount(() => {
-    closeDashboard();
-  });
-
   return (
     <div className="shrink-below-content-size full-height">
       <Dashboard
+        dashboardId={getDashboardId(props)}
         editingOnLoad={editingOnLoad}
         addCardOnLoad={addCardOnLoad}
         {...props}
@@ -205,6 +198,38 @@ const DashboardApp = props => {
       {props.children}
     </div>
   );
+};
+
+DashboardApp.propTypes = {
+  dashboardId: PropTypes.number,
+  isEditing: PropTypes.bool,
+  isDirty: PropTypes.bool,
+  isRunning: PropTypes.bool,
+  isLoadingComplete: PropTypes.bool,
+  dashboard: PropTypes.object,
+  closeDashboard: PropTypes.func,
+  reset: PropTypes.func,
+  pageFavicon: PropTypes.string,
+  documentTitle: PropTypes.string,
+  loadingStartTime: PropTypes.number,
+  isEditable: PropTypes.bool,
+  isFullscreen: PropTypes.bool,
+  isNightMode: PropTypes.bool,
+  isNavBarOpen: PropTypes.bool,
+  isAdditionalInfoVisible: PropTypes.bool,
+  refreshPeriod: PropTypes.number,
+  setRefreshElapsedHook: PropTypes.func,
+  createBookmark: PropTypes.func,
+  deleteBookmark: PropTypes.func,
+  onChangeLocation: PropTypes.func,
+  toggleSidebar: PropTypes.func,
+  addActionToDashboard: PropTypes.func,
+  triggerToast: PropTypes.func,
+  saveDashboard: PropTypes.func,
+  invalidateCollections: PropTypes.func,
+  related: PropTypes.arrayOf(PropTypes.object),
+  hasSidebar: PropTypes.bool,
+  children: PropTypes.node,
 };
 
 export default _.compose(

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -309,7 +309,11 @@ const slowCards = handleActions(
 
 const parameterValues = handleActions(
   {
-    [INITIALIZE]: { next: () => ({}) }, // reset values
+    [INITIALIZE]: {
+      next: (state, { payload: { clearCache = true } = {} }) => {
+        return clearCache ? {} : state;
+      },
+    },
     [FETCH_DASHBOARD]: {
       next: (state, { payload: { parameterValues } }) => parameterValues,
     },
@@ -328,7 +332,6 @@ const parameterValues = handleActions(
     [REMOVE_PARAMETER]: {
       next: (state, { payload: { id } }) => dissoc(state, id),
     },
-    [RESET]: { next: state => ({}) },
   },
   INITIAL_DASHBOARD_STATE.parameterValues,
 );

--- a/frontend/src/metabase/hooks/use-web-notification.ts
+++ b/frontend/src/metabase/hooks/use-web-notification.ts
@@ -43,5 +43,5 @@ export function useWebNotification() {
     );
   }, []);
 
-  return [requestPermission, showNotification];
+  return { requestPermission, showNotification };
 }

--- a/frontend/src/metabase/nav/components/AppBar/AppBarToggle.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarToggle.styled.tsx
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
 import { Icon } from "metabase/core/components/Icon";
+import { shouldForwardNonTransientProp } from "metabase/lib/styling/emotion";
 import { AppBarLeftContainer } from "./AppBarLarge.styled";
 
 interface SidebarButtonProps {
@@ -32,7 +33,9 @@ interface SidebarIconProps {
   isLogoVisible?: boolean;
 }
 
-export const SidebarIcon = styled(Icon)<SidebarIconProps>`
+export const SidebarIcon = styled(Icon, {
+  shouldForwardProp: shouldForwardNonTransientProp,
+})<SidebarIconProps>`
   color: ${color("brand")};
   display: block;
   transform: translateY(2px) translateX(2px);

--- a/frontend/src/metabase/nav/components/SearchBar.styled.tsx
+++ b/frontend/src/metabase/nav/components/SearchBar.styled.tsx
@@ -11,6 +11,7 @@ import {
   breakpointMaxSmall,
   breakpointMinSmall,
 } from "metabase/styled-components/theme";
+import { shouldForwardNonTransientProp } from "metabase/lib/styling/emotion";
 
 const activeInputCSS = css`
   border-radius: 6px;
@@ -105,7 +106,9 @@ export const SearchInput = styled.input<{ isActive: boolean }>`
 
 const ICON_MARGIN = "10px";
 
-export const SearchIcon = styled(Icon)<{ isActive: boolean }>`
+export const SearchIcon = styled(Icon, {
+  shouldForwardProp: shouldForwardNonTransientProp,
+})<{ isActive: boolean }>`
   ${breakpointMaxSmall} {
     transition: margin 0.3s;
 

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
@@ -9,8 +9,11 @@ import Link from "metabase/core/components/Link";
 import { NAV_SIDEBAR_WIDTH } from "metabase/nav/constants";
 
 import { darken, color, alpha } from "metabase/lib/colors";
+import { shouldForwardNonTransientProp } from "metabase/lib/styling/emotion";
 
-export const SidebarIcon = styled(Icon)<{
+export const SidebarIcon = styled(Icon, {
+  shouldForwardProp: shouldForwardNonTransientProp,
+})<{
   color?: string | null;
   isSelected: boolean;
 }>`

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -378,7 +378,7 @@ function QueryBuilder(props) {
     onTimeout,
   });
 
-  const [requestPermission, showNotification] = useWebNotification();
+  const { requestPermission, showNotification } = useWebNotification();
 
   useEffect(() => {
     if (isLoadingComplete) {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31786

### Description

We cover two things on navigating back from the question to dashboard in this PR:
- preserve filters, which were applied before you navigated from dashboard to the question
- preserve tab, from which you navigated away from dashboard

### How to verify

- go to dashboard with tabs, add a filter, select some tab, not first one, and click on question to drilldown into it
- click "back" button
- make sure that on dashboard filters are restored and the tab you visited last is selected

### Demo
https://www.loom.com/share/4ba8f5eee3ee463f841fd4a871635bc5
https://www.loom.com/share/8b1ebde1f23e428b915e60e9b3c9c59e
