### PR TITLE
Revert "BE: Make card and dashboard granular cache_ttl respect feature flagging"

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_config/caching.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/caching.clj
@@ -2,12 +2,9 @@
   (:require
    [metabase.public-settings.premium-features :refer [defenterprise]]))
 
-(defenterprise granular-ttl
-  "Returns the granular cache ttl (in seconds) for a card. On EE, this first checking whether there is a stored value
-   for the card, dashboard, or database (in that order of decreasing preference). Returns nil on OSS."
+(defenterprise db-cache-ttl
+  "Fetches the cache TTL set for a given database. Since this is EE-only functionality, the corresponding OSS function
+  always returns nil."
   :feature :advanced-config
-  [card dashboard database]
-  (let [ttls              [(:cache_ttl card) (:cache_ttl dashboard) (:cache_ttl database)]
-        most-granular-ttl (first (filter some? ttls))]
-    (when most-granular-ttl ; stored TTLs are in hours; convert to seconds
-      (* most-granular-ttl 3600))))
+  [database]
+  (:cache_ttl database))

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/caching_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/caching_test.clj
@@ -13,23 +13,10 @@
   (premium-features-test/with-premium-features #{:advanced-config}
     (mt/discard-setting-changes [enable-query-caching]
       (public-settings/enable-query-caching! true)
-      ;; corresponding OSS tests in metabase.query-processor.card-test
       (testing "database TTL takes effect when no dashboard or card TTLs are set"
+        ;; corresponding OSS tests in metabase-enterprise.advanced-config.caching-test
         (mt/with-temp* [Database [db {:cache_ttl 1337}]
                         Dashboard [dash]
                         Card [card {:database_id (u/the-id db)}]]
           (is (= (* 3600 1337)
-                 (:cache-ttl (#'qp.card/query-for-card card {} {} {} {:dashboard-id (u/the-id dash)}))))))
-      (testing "card ttl only"
-        (mt/with-temp* [Card [card {:cache_ttl 1337}]]
-          (is (= (* 3600 1337) (:cache-ttl (#'qp.card/query-for-card card {} {} {}))))))
-      (testing "multiple ttl, card wins if dash and database TTLs are set"
-        (mt/with-temp* [Database [db {:cache_ttl 1337}]
-                        Dashboard [dash {:cache_ttl 1338}]
-                        Card [card {:database_id (u/the-id db), :cache_ttl 1339}]]
-          (is (= (* 3600 1339) (:cache-ttl (#'qp.card/query-for-card card {} {} {} {:dashboard-id (u/the-id dash)}))))))
-      (testing "multiple ttl, dash wins when no card TTLs are set"
-        (mt/with-temp* [Database [db {:cache_ttl 1337}]
-                        Dashboard [dash {:cache_ttl 1338}]
-                        Card [card {:database_id (u/the-id db)}]]
-          (is (= (* 3600 1338) (:cache-ttl (#'qp.card/query-for-card card {} {} {} {:dashboard-id (u/the-id dash)})))))))))
+                 (:cache-ttl (#'qp.card/query-for-card card {} {} {} {:dashboard-id (u/the-id dash)})))))))))

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -12,7 +12,7 @@
    [metabase.models.database :refer [Database]]
    [metabase.models.query :as query]
    [metabase.public-settings :as public-settings]
-   [metabase.public-settings.premium-features :as premium-features :refer [defenterprise]]
+   [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.query-processor :as qp]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
@@ -42,20 +42,22 @@
                   (u/emoji "💾"))
         ttl-seconds))))
 
-(defenterprise granular-ttl
-  "Returns the granular cache ttl (in seconds) for a card. On EE, this first checking whether there is a stored value
-   for the card, dashboard, or database (in that order of decreasing preference). Returns nil on OSS."
+(defenterprise db-cache-ttl
+  "Fetches the cache TTL set for the given database. Returns nil on OSS."
   metabase-enterprise.advanced-config.caching
-  [_card _dashboard _database])
+  [_database])
 
 (defn- ttl-hierarchy
   "Returns the cache ttl (in seconds), by first checking whether there is a stored value for the database,
-    dashboard, or card (in that order of increasing preference), and if all of those don't exist, then the
-    `query-magic-ttl`, which is based on average execution time."
+  dashboard, or card (in that order of increasing preference), and if all of those don't exist, then the
+  `query-magic-ttl`, which is based on average execution time."
   [card dashboard database query]
   (when (public-settings/enable-query-caching)
-    (or (granular-ttl card dashboard database)
-        (query-magic-ttl query))))
+    (let [ttls              [(:cache_ttl card) (:cache_ttl dashboard) (db-cache-ttl database)]
+          most-granular-ttl (first (filter some? ttls))]
+      (or (when most-granular-ttl ; stored TTLs are in hours; convert to seconds
+            (* most-granular-ttl 3600))
+          (query-magic-ttl query)))))
 
 (defn query-for-card
   "Generate a query for a saved Card"

--- a/test/metabase/query_processor/card_test.clj
+++ b/test/metabase/query_processor/card_test.clj
@@ -34,15 +34,14 @@
           (t2.with-temp/with-temp [Card card]
             ;; the magic multiplier should be ttl-ratio times avg execution time
             (is (= (* 2 4) (:cache-ttl (#'qp.card/query-for-card card {} {} {}))))))))
-    ;; corresponding EE tests in metabase-enterprise.advanced-config.caching-test
-    (testing "card ttl only, does not take effect on OSS so nil result"
+    (testing "card ttl only"
       (mt/with-temp* [Card [card {:cache_ttl 1337}]]
-        (is (nil? (:cache-ttl (#'qp.card/query-for-card card {} {} {}))))))
-    (testing "dash ttl only, does not take effect on OSS so nil result"
-      (mt/with-temp* [Database [db]
+        (is (= (* 3600 1337) (:cache-ttl (#'qp.card/query-for-card card {} {} {}))))))
+    (testing "multiple ttl, dash wins"
+      (mt/with-temp* [Database [db {:cache_ttl 1337}]
                       Dashboard [dash {:cache_ttl 1338}]
                       Card [card {:database_id (u/the-id db)}]]
-        (is (nil? (:cache-ttl (#'qp.card/query-for-card card {} {} {} {:dashboard-id (u/the-id dash)}))))))
+        (is (= (* 3600 1338) (:cache-ttl (#'qp.card/query-for-card card {} {} {} {:dashboard-id (u/the-id dash)}))))))
     (testing "multiple ttl, db ttl does not take effect on OSS so nil result"
       ;; corresponding EE test in metabase-enterprise.advanced-config.caching-test
       (mt/with-temp* [Database [db {:cache_ttl 1337}]


### PR DESCRIPTION
Reverts https://github.com/metabase/metabase/pull/32152 if needed.