### PR TITLE
frontend: Multiline column support

### DIFF
--- a/frontend/src/metabase/lib/formatting/value.tsx
+++ b/frontend/src/metabase/lib/formatting/value.tsx
@@ -120,8 +120,28 @@ function formatStringFallback(value: any, options: OptionsType = {}) {
     if (typeof value === "string") {
       value = formatImage(value, options);
     }
+    if (typeof value === "string") {
+      value = formatMultiline(value, options);
+    }
   }
   return value;
+}
+
+function formatMultiline(
+  value: string,
+  { jsx, rich, view_as = "auto", link_text }: OptionsType = {},
+) {
+  if (jsx && rich && view_as === "multiline") {
+    return (
+      <React.Fragment>
+        {value
+          .split("\n")
+          .map((str, i) => (i === 0 ? str : [<br key={i} />, str]))}
+      </React.Fragment>
+    );
+  } else {
+    return value;
+  }
 }
 
 export function formatValueRaw(

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
@@ -17,6 +17,7 @@ import {
 } from "metabase-lib/types/utils/isa";
 import { TYPE } from "metabase-lib/types/constants";
 import { findColumnIndexForColumnSetting } from "metabase-lib/queries/utils/dataset";
+import { getColumnKey } from "metabase-lib/queries/utils/get-column-key";
 
 import type { OnVisualizationClickType } from "./types";
 import {
@@ -73,10 +74,13 @@ export function DetailsTableCell({
       const formattedJson = JSON.stringify(value, null, 2);
       cellValue = <pre className="ObjectJSON">{formattedJson}</pre>;
     } else {
+      const tableColumnSettings =
+        settings.column_settings?.[getColumnKey(column)];
       cellValue = formatValue(value, {
         ...columnSettings,
         jsx: true,
         rich: true,
+        view_as: tableColumnSettings?.view_as,
       });
       if (typeof cellValue === "string") {
         cellValue = <ExpandableString str={cellValue} length={140} />;

--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -210,6 +210,7 @@ export default class Table extends Component {
 
     const options = [
       { name: t`Text`, value: null },
+      { name: t`Multiline`, value: "multiline" },
       { name: t`Link`, value: "link" },
     ];
 


### PR DESCRIPTION
This is my first contribution to Metabase and I have very little idea about how the frontend is structured 😬 but after some time hoping for #6178, I decided to read the wiki/docs and give it a try... If you're familiar with the frontend code and can give me some pointers, I'd love to get this in shape and ready to merge!

This introduces a new column formatting display option, "Multiline":

![Screenshot 2023-07-06 at 2 28 58 PM](https://github.com/metabase/metabase/assets/2248/7cde4168-b8d5-49ac-a373-faeadea5ad88)

This formats data to respect line breaks, and extends table rows to fit them:

![Screenshot 2023-07-13 at 3 33 16 PM](https://github.com/metabase/metabase/assets/2248/38a29a9f-f23a-426e-a425-aa5094e0fa10)

And also changes the item details popup:

![Screenshot 2023-07-06 at 2 29 41 PM](https://github.com/metabase/metabase/assets/2248/16fd819a-7238-4c1e-be2c-1d39b9617949)

Updates #6178