### PR TITLE
Fix webpack warning from #31564

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx
@@ -1,32 +1,9 @@
 /* eslint-disable react/prop-types */
 import { t } from "ttag";
 
-import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
-
 import { color } from "metabase/lib/colors";
-import ViewPill from "./ViewPill";
 import ViewButton from "./ViewButton";
 import { HeaderButton } from "./ViewHeader.styled";
-
-import SummarizeSidebar from "./sidebars/SummarizeSidebar/SummarizeSidebar";
-
-const SummarizePill = props => (
-  <ViewPill icon="insight" color={color("summarize")} {...props} />
-);
-export default function QuestionSummaries({
-  question,
-  onEditSummary,
-  ...props
-}) {
-  return (
-    <PopoverWithTrigger
-      triggerElement={<SummarizePill {...props}>{t`Summarized`}</SummarizePill>}
-      sizeToFit
-    >
-      <SummarizeSidebar className="scroll-y" question={question} />
-    </PopoverWithTrigger>
-  );
-}
 
 export function QuestionSummarizeWidget({
   isShowingSummarySidebar,
@@ -82,17 +59,6 @@ export function MobileQuestionSummarizeWidget({
     </ViewButton>
   );
 }
-
-QuestionSummaries.shouldRender = ({
-  question,
-  queryBuilderMode,
-  isObjectDetail,
-}) =>
-  queryBuilderMode === "view" &&
-  question &&
-  question.isStructured() &&
-  question.query().topLevelQuery().hasAggregations() &&
-  !isObjectDetail;
 
 QuestionSummarizeWidget.shouldRender = ({
   question,


### PR DESCRIPTION
Fix the warning introduced by https://github.com/metabase/metabase/issues/31564

### Description

In https://github.com/metabase/metabase/pull/31564/, we change the way we export `SummarizeSidebar` from a default export to a named export [example](https://github.com/metabase/metabase/pull/31564/files#diff-bafbb71e5c89c78857aa749a008feabcefdbe2bca18da664562eecb1cc41ea0aR31).

This makes webpack throwing this warning when running dev server
```
[js]
[js] WARNING in ./query_builder/components/view/QuestionSummaries.jsx 175:32-48
[js] export 'default' (imported as 'SummarizeSidebar') was not found in './sidebars/SummarizeSidebar/SummarizeSidebar' (possible exports: SummarizeSidebar)
[js]  @ ./query_builder/components/view/ViewHeader.jsx 178:0-62 555:8-44 555:73-96
[js]  @ ./query_builder/components/view/View.styled.tsx 13:0-47 45:58-73
[js]  @ ./query_builder/components/view/View.jsx 222:0-237 483:36-67 484:41-64 518:31-57 553:32-48 556:82-108 562:31-51 667:38-58 669:80-108
[js]  @ ./query_builder/containers/QueryBuilder.jsx 193:0-43 529:27-31
[js]  @ ./routes.jsx 77:0-74 243:23-35 246:23-35 249:23-35 252:23-35 255:23-35 258:23-35 273:23-35 280:23-35 283:23-35 286:23-35 289:23-35 292:23-35 295:23-35 298:23-35 301:23-35 304:23-35
[js]  @ ./app-main.js 9:0-44 16:15-24
[js]
[js] webpack 5.85.0 compiled with 1 warning in 1676 ms
```

This, however, doesn't affect the application because it was a warning on an unused component. This PR fixes the warning by removing this unused component.

### How to verify

1. Metabase still runs fine
2. CI is green

### Demo

#### Before
![image](https://github.com/metabase/metabase/assets/1937582/e5b67743-050f-4da6-bc2e-c67f82bff328)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
