### PR TITLE
Fix `fetch-mock` behavior with hanging requests

### DIFF
--- a/frontend/test/jest-setup-env.js
+++ b/frontend/test/jest-setup-env.js
@@ -1,5 +1,5 @@
 import fetchMock from "fetch-mock";
 
-afterEach(() => {
+beforeEach(() => {
   fetchMock.restore();
 });


### PR DESCRIPTION
The PR fixes an issue with `fetch-mock` behavior with hanging requests that haven't been resolved after a test ends. As a result, some tests were failing with an error similar to:

```
FetchError: request to http://localhost/api failed, reason: connect ECONNREFUSED ::1:80
```

**Root cause**

The root cause is our `fetch-mock` cleanup lifecycle: [we're calling `fetchMock.restore` after each test](https://github.com/metabase/metabase/blob/master/frontend/test/jest-setup-env.js). If a test renders complex UI doing HTTP requests somewhere down the component tree, a request promise can be resolved after the test ends. In that case, we'd call `fetchMock.restore`, and there won't be any mocked response to use, causing an error.

This can happen when some HTTP requests are irrelevant for a test, and the test isn't doing any waits (like `findBy` or `waitFor`) to ensure it's resolved. For instance, I ran into this issue while testing the notebook editor's `JoinStep` component. It uses the `DataSelector` component for selecting a join table. When rendering `JoinStep`, `DataSelector` would fetch all the relevant metadata if it has database and table ID props. 

**Solution**

Fixed by doing `fetchMock.restore` in `beforeEach` instead of `afterEach`. That'd leave API mocks available for hanging promises, but would also guarantee a clean environment when another test begins. Given that we prefer setting up HTTP mocks inside a `setup` function instead of Jest hooks, it shouldn't cause trouble