### PR TITLE
Fix dashboard scroll jank when there are no filters

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -40,7 +40,6 @@ class Dashboard extends Component {
     error: null,
     isParametersWidgetSticky: false,
     parametersListLength: 0,
-    parametersWidgetOffsetTop: null,
   };
 
   static propTypes = {

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -40,6 +40,7 @@ class Dashboard extends Component {
     error: null,
     isParametersWidgetSticky: false,
     parametersListLength: 0,
+    parametersWidgetOffsetTop: null,
   };
 
   static propTypes = {
@@ -340,7 +341,7 @@ class Dashboard extends Component {
                 {shouldRenderParametersWidgetInViewMode && (
                   <ParametersWidgetContainer
                     data-testid="dashboard-parameters-widget-container"
-                    ref={element => (this.parametersWidgetRef = element)}
+                    ref={this.parametersWidgetRef}
                     isNavbarOpen={isNavbarOpen}
                     isSticky={isParametersWidgetSticky}
                     topNav={embedOptions?.top_nav}

--- a/frontend/src/metabase/dashboard/components/Dashboard/stickyParameters.js
+++ b/frontend/src/metabase/dashboard/components/Dashboard/stickyParameters.js
@@ -20,9 +20,14 @@ export const updateParametersWidgetStickiness = dashboard => {
 };
 
 const initializeWidgetOffsetTop = dashboard => {
-  if (!dashboard.state.parametersWidgetOffsetTop) {
+  if (
+    dashboard.parametersWidgetRef.current !== null &&
+    dashboard.parametersWidgetRef.current.offsetTop !==
+      dashboard.state.parametersWidgetOffsetTop
+  ) {
     dashboard.setState({
-      parametersWidgetOffsetTop: dashboard.parametersWidgetRef.offsetTop,
+      parametersWidgetOffsetTop:
+        dashboard.parametersWidgetRef.current.offsetTop,
     });
   }
 };

--- a/frontend/src/metabase/dashboard/components/Dashboard/stickyParameters.js
+++ b/frontend/src/metabase/dashboard/components/Dashboard/stickyParameters.js
@@ -3,8 +3,6 @@ import { isSmallScreen, getMainElement } from "metabase/lib/dom";
 export const MAXIMUM_PARAMETERS_FOR_STICKINESS = 6;
 
 export const updateParametersWidgetStickiness = dashboard => {
-  initializeWidgetOffsetTop(dashboard);
-
   const shouldBeSticky = checkIfParametersWidgetShouldBeSticky(dashboard);
 
   const shouldToggleStickiness = checkIfShouldToggleStickiness(
@@ -15,19 +13,6 @@ export const updateParametersWidgetStickiness = dashboard => {
   if (shouldToggleStickiness) {
     dashboard.setState({
       isParametersWidgetSticky: shouldBeSticky,
-    });
-  }
-};
-
-const initializeWidgetOffsetTop = dashboard => {
-  if (
-    dashboard.parametersWidgetRef.current !== null &&
-    dashboard.parametersWidgetRef.current.offsetTop !==
-      dashboard.state.parametersWidgetOffsetTop
-  ) {
-    dashboard.setState({
-      parametersWidgetOffsetTop:
-        dashboard.parametersWidgetRef.current.offsetTop,
     });
   }
 };
@@ -57,6 +42,12 @@ const checkIfParametersWidgetShouldBeSticky = dashboard => {
   return getMainElement().scrollTop > offsetTop;
 };
 
-const getOffsetTop = dashboard =>
-  dashboard.state.parametersWidgetOffsetTop ||
-  dashboard.parametersWidgetRef.offsetTop;
+const getOffsetTop = dashboard => {
+  const parametersWidget = dashboard.parametersWidgetRef.current;
+
+  if (parametersWidget) {
+    return parametersWidget.offsetTop;
+  } else {
+    return 0;
+  }
+};

--- a/frontend/src/metabase/dashboard/components/Dashboard/stickyParameters.unit.spec.js
+++ b/frontend/src/metabase/dashboard/components/Dashboard/stickyParameters.unit.spec.js
@@ -8,40 +8,6 @@ function mockMainElementScroll(scrollTop) {
 }
 
 describe("updateParametersWidgetStickiness", () => {
-  it("initializes parametersWidgetOffsetTop", () => {
-    const setState = jest.fn();
-
-    mockMainElementScroll(0);
-
-    const dashboard = {
-      parametersWidgetRef: { current: { offsetTop } },
-      state: {},
-      setState,
-    };
-
-    updateParametersWidgetStickiness(dashboard);
-
-    expect(setState).toHaveBeenCalledWith({
-      parametersWidgetOffsetTop: offsetTop,
-    });
-  });
-
-  it("do not initialize parametersWidgetOffsetTop if there's no parametersWidgetRef", () => {
-    const setState = jest.fn();
-
-    mockMainElementScroll(0);
-
-    const dashboard = {
-      parametersWidgetRef: { current: null },
-      state: {},
-      setState,
-    };
-
-    updateParametersWidgetStickiness(dashboard);
-
-    expect(setState).toHaveBeenCalledTimes(0);
-  });
-
   it("makes filters sticky with enough scrolling down", () => {
     const setState = jest.fn();
 
@@ -87,7 +53,6 @@ describe("updateParametersWidgetStickiness", () => {
       parametersWidgetRef: { current: { offsetTop } },
       state: {
         isParametersWidgetSticky: true,
-        parametersWidgetOffsetTop: offsetTop,
       },
       setState,
     };
@@ -106,7 +71,6 @@ describe("updateParametersWidgetStickiness", () => {
       parametersWidgetRef: { current: { offsetTop } },
       state: {
         isParametersWidgetSticky: false,
-        parametersWidgetOffsetTop: offsetTop,
       },
       setState,
     };

--- a/frontend/src/metabase/dashboard/components/Dashboard/stickyParameters.unit.spec.js
+++ b/frontend/src/metabase/dashboard/components/Dashboard/stickyParameters.unit.spec.js
@@ -14,7 +14,7 @@ describe("updateParametersWidgetStickiness", () => {
     mockMainElementScroll(0);
 
     const dashboard = {
-      parametersWidgetRef: { offsetTop },
+      parametersWidgetRef: { current: { offsetTop } },
       state: {},
       setState,
     };
@@ -26,13 +26,29 @@ describe("updateParametersWidgetStickiness", () => {
     });
   });
 
+  it("do not initialize parametersWidgetOffsetTop if there's no parametersWidgetRef", () => {
+    const setState = jest.fn();
+
+    mockMainElementScroll(0);
+
+    const dashboard = {
+      parametersWidgetRef: { current: null },
+      state: {},
+      setState,
+    };
+
+    updateParametersWidgetStickiness(dashboard);
+
+    expect(setState).toHaveBeenCalledTimes(0);
+  });
+
   it("makes filters sticky with enough scrolling down", () => {
     const setState = jest.fn();
 
     mockMainElementScroll(offsetTop + 1);
 
     const dashboard = {
-      parametersWidgetRef: { offsetTop },
+      parametersWidgetRef: { current: { offsetTop } },
       state: {},
       setState,
     };
@@ -50,7 +66,7 @@ describe("updateParametersWidgetStickiness", () => {
     mockMainElementScroll(offsetTop - 1);
 
     const dashboard = {
-      parametersWidgetRef: { offsetTop },
+      parametersWidgetRef: { current: { offsetTop } },
       state: {},
       setState,
     };
@@ -68,7 +84,7 @@ describe("updateParametersWidgetStickiness", () => {
     mockMainElementScroll(offsetTop + 1);
 
     const dashboard = {
-      parametersWidgetRef: { offsetTop },
+      parametersWidgetRef: { current: { offsetTop } },
       state: {
         isParametersWidgetSticky: true,
         parametersWidgetOffsetTop: offsetTop,
@@ -87,7 +103,7 @@ describe("updateParametersWidgetStickiness", () => {
     mockMainElementScroll(offsetTop - 1);
 
     const dashboard = {
-      parametersWidgetRef: { offsetTop },
+      parametersWidgetRef: { current: { offsetTop } },
       state: {
         isParametersWidgetSticky: false,
         parametersWidgetOffsetTop: offsetTop,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/26534

### Description

The behavior defined by stickyParameters.js was updating the dashboard's parametersWidgetOffsetTop state with undefined at every scroll event, causing jank. This was caused by mistakenly assuming that a dashboard component always has its parametersWidgetRef set to something other than an empty React ref, when in fact it can be null when the dashboard has no filters. This changes also fix how a React ref is used to make parametersWidgetRef reference the HTMLElement the parameters widget.

### How to verify
Before this changes, if you:

1.  Create a new dashboard
2. Add a few questions until the dashboard is tall enough to have a scrollbar
3. Make sure that there are no filter in this dashboard and that you are in view mode (as opposed to edit mode)
4. Scroll and witness how janky it is (meaning that the scroll does not update at your monitors refresh rate)

Your hardware might be too fast or your dashboard too simple for you to notice any problem, but if you record a performance trace (with Chrome), you'll see that every scroll event is followed by a huge amount of function call:

![Screenshot from 2023-07-07 21-06-22](https://github.com/metabase/metabase/assets/1111598/a028e932-85c9-44da-ae72-ad6241bb11cb)

This problem can also be exacerbated by not having hardware acceleration on on your browser.

If you try these same steps after applying these changes, you'll get:

![Screenshot from 2023-07-07 21-03-44](https://github.com/metabase/metabase/assets/1111598/8c852c49-43ee-45f6-83db-38abcc2a74ce)


### Checklist
- [x] Jank has been dealt with 
- [x] Tests have been added and updated to cover changes in this PR
