### PR TITLE
Allow downloading native query results even after the query has changed

### DIFF
--- a/e2e/test/scenarios/sharing/downloads/reproductions/28834-modified-native-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/reproductions/28834-modified-native-question.cy.spec.js
@@ -7,7 +7,11 @@ const questionDetails = {
   },
 };
 
-describe("issue 28834", () => {
+describe("metabase#28834", () => {
+  // I have a test for saved native questions in `QueryBuilder.unit.spec.tsx`.
+  // Initially, this test was planned as a unit test, but with some technical
+  // difficulties, I've decided to test with Cypress instead.
+
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 

--- a/e2e/test/scenarios/sharing/downloads/reproductions/28834-modified-native-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/reproductions/28834-modified-native-question.cy.spec.js
@@ -1,0 +1,43 @@
+import { restore, downloadAndAssert } from "e2e/support/helpers";
+
+const questionDetails = {
+  name: "28834",
+  native: {
+    query: 'select 1 "column a"',
+  },
+};
+
+describe("issue 28834", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createNativeQuestion(questionDetails, {
+      loadMetadata: true,
+      wrapId: true,
+    });
+
+    cy.findByTestId("query-builder-main").findByText("Open Editor").click();
+    cy.get(".ace_editor").should("be.visible").type(', select 2 "column b"');
+  });
+
+  it("should be able to export unsaved native query results as CSV even after the query has changed", () => {
+    const fileType = "csv";
+    downloadAndAssert({ fileType, raw: true }, sheet => {
+      expect(sheet["A1"].v).to.equal("column a");
+      expect(sheet["A2"].v).to.equal("1");
+      expect(sheet["A3"]).to.be.undefined;
+    });
+  });
+
+  it("should be able to export unsaved native query results as XLSX even after the query has changed", () => {
+    const fileType = "xlsx";
+    downloadAndAssert({ fileType, raw: true }, sheet => {
+      expect(sheet["A1"].v).to.equal("column a");
+      expect(sheet["A2"].v).to.equal(1);
+      expect(sheet["A3"]).to.be.undefined;
+    });
+  });
+});

--- a/frontend/src/metabase/query_builder/components/QueryDownloadWidget/QueryDownloadWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadWidget/QueryDownloadWidget.tsx
@@ -98,7 +98,6 @@ QueryDownloadWidget.shouldRender = ({
   isResultDirty,
 }: QueryDownloadWidgetOpts) => {
   return (
-    !isResultDirty &&
     result &&
     !result.error &&
     PLUGIN_FEATURE_LEVEL_PERMISSIONS.canDownloadResults(result)

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -211,196 +211,6 @@ describe("QueryBuilder", () => {
     });
   });
 
-  describe("editing models", () => {
-    describe("editing queries", () => {
-      afterEach(() => {
-        jest.resetAllMocks();
-      });
-
-      it("should trigger beforeunload event when leaving edited query", async () => {
-        const { mockEventListener } = await setup({
-          card: TEST_MODEL_CARD,
-          initialRoute: `/model/${TEST_MODEL_CARD.id}/query`,
-        });
-
-        const rowLimitInput = await within(
-          screen.getByTestId("step-limit-0-0"),
-        ).findByPlaceholderText("Enter a limit");
-
-        userEvent.click(rowLimitInput);
-        userEvent.type(rowLimitInput, "0");
-
-        await waitFor(() => {
-          expect(rowLimitInput).toHaveValue(10);
-        });
-
-        userEvent.tab();
-
-        const mockEvent = callMockEvent(mockEventListener, "beforeunload");
-
-        expect(mockEvent.preventDefault).toHaveBeenCalled();
-        expect(mockEvent.returnValue).toBe(BEFORE_UNLOAD_UNSAVED_MESSAGE);
-      });
-
-      it("should not trigger beforeunload event when leaving unedited query", async () => {
-        const { mockEventListener } = await setup({
-          card: TEST_MODEL_CARD,
-          initialRoute: `/model/${TEST_MODEL_CARD.id}/query`,
-        });
-
-        const mockEvent = callMockEvent(mockEventListener, "beforeunload");
-        expect(mockEvent.preventDefault).not.toHaveBeenCalled();
-        expect(mockEvent.returnValue).toBe(undefined);
-      });
-    });
-
-    describe("editing metadata", () => {
-      afterEach(() => {
-        jest.resetAllMocks();
-      });
-
-      it("should trigger beforeunload event when leaving edited metadata", async () => {
-        const { mockEventListener } = await setup({
-          card: TEST_MODEL_CARD,
-          dataset: TEST_MODEL_DATASET,
-          initialRoute: `/model/${TEST_MODEL_CARD.id}/metadata`,
-        });
-
-        const columnDisplayName = await screen.findByTitle("Display name");
-
-        userEvent.click(columnDisplayName);
-        userEvent.type(columnDisplayName, "X");
-
-        await waitFor(() => {
-          expect(columnDisplayName).toHaveValue(
-            `${TEST_MODEL_DATASET_COLUMN.display_name}X`,
-          );
-        });
-
-        userEvent.tab();
-
-        const mockEvent = callMockEvent(mockEventListener, "beforeunload");
-        expect(mockEvent.preventDefault).not.toHaveBeenCalled();
-        expect(mockEvent.returnValue).toBe(undefined);
-      });
-
-      it("should not trigger beforeunload event when model metadata is unedited", async () => {
-        const { mockEventListener } = await setup({
-          card: TEST_MODEL_CARD,
-          dataset: TEST_MODEL_DATASET,
-          initialRoute: `/model/${TEST_MODEL_CARD.id}/metadata`,
-        });
-
-        const mockEvent = callMockEvent(mockEventListener, "beforeunload");
-        expect(mockEvent.preventDefault).not.toHaveBeenCalled();
-        expect(mockEvent.returnValue).toBe(undefined);
-      });
-    });
-  });
-
-  describe("beforeunload events in native queries", () => {
-    afterEach(() => {
-      jest.restoreAllMocks();
-    });
-
-    it("should trigger beforeunload event when leaving edited question", async () => {
-      const { mockEventListener } = await setup({
-        card: TEST_NATIVE_CARD,
-      });
-
-      const inputArea = within(
-        screen.getByTestId("mock-native-query-editor"),
-      ).getByRole("textbox");
-
-      userEvent.click(inputArea);
-      userEvent.type(inputArea, "0");
-
-      userEvent.tab();
-
-      // default native query is `SELECT 1`
-      expect(inputArea).toHaveValue("SELECT 10");
-
-      const mockEvent = callMockEvent(mockEventListener, "beforeunload");
-      expect(mockEvent.preventDefault).toHaveBeenCalled();
-      expect(mockEvent.returnValue).toEqual(BEFORE_UNLOAD_UNSAVED_MESSAGE);
-    });
-
-    it("should not trigger beforeunload event when user tries to leave an ad-hoc native query", async () => {
-      const { mockEventListener } = await setup({
-        card: TEST_UNSAVED_NATIVE_CARD,
-      });
-
-      const inputArea = within(
-        screen.getByTestId("mock-native-query-editor"),
-      ).getByRole("textbox");
-
-      userEvent.click(inputArea);
-      userEvent.type(inputArea, "0");
-
-      userEvent.tab();
-
-      const mockEvent = callMockEvent(mockEventListener, "beforeunload");
-      expect(mockEvent.preventDefault).not.toHaveBeenCalled();
-      expect(mockEvent.returnValue).not.toEqual(BEFORE_UNLOAD_UNSAVED_MESSAGE);
-    });
-
-    it("should not trigger beforeunload event when query is unedited", async () => {
-      const { mockEventListener } = await setup({
-        card: TEST_NATIVE_CARD,
-      });
-
-      const mockEvent = callMockEvent(mockEventListener, "beforeunload");
-      expect(mockEvent.preventDefault).not.toHaveBeenCalled();
-      expect(mockEvent.returnValue).not.toEqual(BEFORE_UNLOAD_UNSAVED_MESSAGE);
-    });
-  });
-
-  describe("beforeunload events in structured queries", () => {
-    afterEach(() => {
-      jest.restoreAllMocks();
-    });
-
-    it("should not trigger beforeunload event when leaving edited question which will turn the question ad-hoc", async () => {
-      const { mockEventListener } = await setup({
-        card: TEST_STRUCTURED_CARD,
-      });
-
-      expect(screen.queryByText("Count")).not.toBeInTheDocument();
-      userEvent.click(await screen.findByText("Summarize"));
-      userEvent.click(await screen.findByText("Done"));
-      expect(await screen.findByText("Count")).toBeInTheDocument();
-
-      const mockEvent = callMockEvent(mockEventListener, "beforeunload");
-      expect(mockEvent.preventDefault).not.toHaveBeenCalled();
-      expect(mockEvent.returnValue).not.toEqual(BEFORE_UNLOAD_UNSAVED_MESSAGE);
-    });
-
-    it("should not trigger beforeunload event when user tries to leave an ad-hoc native query", async () => {
-      const { mockEventListener } = await setup({
-        card: TEST_UNSAVED_STRUCTURED_CARD,
-      });
-
-      expect(screen.queryByText("Count")).not.toBeInTheDocument();
-      userEvent.click(await screen.findByText("Summarize"));
-      userEvent.click(await screen.findByText("Done"));
-      expect(await screen.findByText("Count")).toBeInTheDocument();
-
-      const mockEvent = callMockEvent(mockEventListener, "beforeunload");
-      expect(mockEvent.preventDefault).not.toHaveBeenCalled();
-      expect(mockEvent.returnValue).not.toEqual(BEFORE_UNLOAD_UNSAVED_MESSAGE);
-    });
-
-    it("should not trigger beforeunload event when query is unedited", async () => {
-      const { mockEventListener } = await setup({
-        card: TEST_STRUCTURED_CARD,
-      });
-
-      const mockEvent = callMockEvent(mockEventListener, "beforeunload");
-      expect(mockEvent.preventDefault).not.toHaveBeenCalled();
-      expect(mockEvent.returnValue).not.toEqual(BEFORE_UNLOAD_UNSAVED_MESSAGE);
-    });
-  });
-
   describe("renders the row count regardless of visualization type", () => {
     const dataset = TEST_MODEL_DATASET;
     const cards = [
@@ -425,5 +235,207 @@ describe("QueryBuilder", () => {
         expect(element).toBeVisible();
       },
     );
+  });
+
+  describe("beforeunload events", () => {
+    describe("editing models", () => {
+      describe("editing queries", () => {
+        afterEach(() => {
+          jest.resetAllMocks();
+        });
+
+        it("should trigger beforeunload event when leaving edited query", async () => {
+          const { mockEventListener } = await setup({
+            card: TEST_MODEL_CARD,
+            initialRoute: `/model/${TEST_MODEL_CARD.id}/query`,
+          });
+
+          const rowLimitInput = await within(
+            screen.getByTestId("step-limit-0-0"),
+          ).findByPlaceholderText("Enter a limit");
+
+          userEvent.click(rowLimitInput);
+          userEvent.type(rowLimitInput, "0");
+
+          await waitFor(() => {
+            expect(rowLimitInput).toHaveValue(10);
+          });
+
+          userEvent.tab();
+
+          const mockEvent = callMockEvent(mockEventListener, "beforeunload");
+
+          expect(mockEvent.preventDefault).toHaveBeenCalled();
+          expect(mockEvent.returnValue).toBe(BEFORE_UNLOAD_UNSAVED_MESSAGE);
+        });
+
+        it("should not trigger beforeunload event when leaving unedited query", async () => {
+          const { mockEventListener } = await setup({
+            card: TEST_MODEL_CARD,
+            initialRoute: `/model/${TEST_MODEL_CARD.id}/query`,
+          });
+
+          const mockEvent = callMockEvent(mockEventListener, "beforeunload");
+          expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+          expect(mockEvent.returnValue).toBe(undefined);
+        });
+      });
+
+      describe("editing metadata", () => {
+        afterEach(() => {
+          jest.resetAllMocks();
+        });
+
+        it("should trigger beforeunload event when leaving edited metadata", async () => {
+          const { mockEventListener } = await setup({
+            card: TEST_MODEL_CARD,
+            dataset: TEST_MODEL_DATASET,
+            initialRoute: `/model/${TEST_MODEL_CARD.id}/metadata`,
+          });
+
+          const columnDisplayName = await screen.findByTitle("Display name");
+
+          userEvent.click(columnDisplayName);
+          userEvent.type(columnDisplayName, "X");
+
+          await waitFor(() => {
+            expect(columnDisplayName).toHaveValue(
+              `${TEST_MODEL_DATASET_COLUMN.display_name}X`,
+            );
+          });
+
+          userEvent.tab();
+
+          const mockEvent = callMockEvent(mockEventListener, "beforeunload");
+          expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+          expect(mockEvent.returnValue).toBe(undefined);
+        });
+
+        it("should not trigger beforeunload event when model metadata is unedited", async () => {
+          const { mockEventListener } = await setup({
+            card: TEST_MODEL_CARD,
+            dataset: TEST_MODEL_DATASET,
+            initialRoute: `/model/${TEST_MODEL_CARD.id}/metadata`,
+          });
+
+          const mockEvent = callMockEvent(mockEventListener, "beforeunload");
+          expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+          expect(mockEvent.returnValue).toBe(undefined);
+        });
+      });
+    });
+
+    describe("native queries", () => {
+      afterEach(() => {
+        jest.restoreAllMocks();
+      });
+
+      it("should trigger beforeunload event when leaving edited question", async () => {
+        const { mockEventListener } = await setup({
+          card: TEST_NATIVE_CARD,
+        });
+
+        const inputArea = within(
+          screen.getByTestId("mock-native-query-editor"),
+        ).getByRole("textbox");
+
+        userEvent.click(inputArea);
+        userEvent.type(inputArea, "0");
+
+        userEvent.tab();
+
+        // default native query is `SELECT 1`
+        expect(inputArea).toHaveValue("SELECT 10");
+
+        const mockEvent = callMockEvent(mockEventListener, "beforeunload");
+        expect(mockEvent.preventDefault).toHaveBeenCalled();
+        expect(mockEvent.returnValue).toEqual(BEFORE_UNLOAD_UNSAVED_MESSAGE);
+      });
+
+      it("should not trigger beforeunload event when user tries to leave an ad-hoc native query", async () => {
+        const { mockEventListener } = await setup({
+          card: TEST_UNSAVED_NATIVE_CARD,
+        });
+
+        const inputArea = within(
+          screen.getByTestId("mock-native-query-editor"),
+        ).getByRole("textbox");
+
+        userEvent.click(inputArea);
+        userEvent.type(inputArea, "0");
+
+        userEvent.tab();
+
+        const mockEvent = callMockEvent(mockEventListener, "beforeunload");
+        expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+        expect(mockEvent.returnValue).not.toEqual(
+          BEFORE_UNLOAD_UNSAVED_MESSAGE,
+        );
+      });
+
+      it("should not trigger beforeunload event when query is unedited", async () => {
+        const { mockEventListener } = await setup({
+          card: TEST_NATIVE_CARD,
+        });
+
+        const mockEvent = callMockEvent(mockEventListener, "beforeunload");
+        expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+        expect(mockEvent.returnValue).not.toEqual(
+          BEFORE_UNLOAD_UNSAVED_MESSAGE,
+        );
+      });
+    });
+
+    describe("structured queries", () => {
+      afterEach(() => {
+        jest.restoreAllMocks();
+      });
+
+      it("should not trigger beforeunload event when leaving edited question which will turn the question ad-hoc", async () => {
+        const { mockEventListener } = await setup({
+          card: TEST_STRUCTURED_CARD,
+        });
+
+        expect(screen.queryByText("Count")).not.toBeInTheDocument();
+        userEvent.click(await screen.findByText("Summarize"));
+        userEvent.click(await screen.findByText("Done"));
+        expect(await screen.findByText("Count")).toBeInTheDocument();
+
+        const mockEvent = callMockEvent(mockEventListener, "beforeunload");
+        expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+        expect(mockEvent.returnValue).not.toEqual(
+          BEFORE_UNLOAD_UNSAVED_MESSAGE,
+        );
+      });
+
+      it("should not trigger beforeunload event when user tries to leave an ad-hoc native query", async () => {
+        const { mockEventListener } = await setup({
+          card: TEST_UNSAVED_STRUCTURED_CARD,
+        });
+
+        expect(screen.queryByText("Count")).not.toBeInTheDocument();
+        userEvent.click(await screen.findByText("Summarize"));
+        userEvent.click(await screen.findByText("Done"));
+        expect(await screen.findByText("Count")).toBeInTheDocument();
+
+        const mockEvent = callMockEvent(mockEventListener, "beforeunload");
+        expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+        expect(mockEvent.returnValue).not.toEqual(
+          BEFORE_UNLOAD_UNSAVED_MESSAGE,
+        );
+      });
+
+      it("should not trigger beforeunload event when query is unedited", async () => {
+        const { mockEventListener } = await setup({
+          card: TEST_STRUCTURED_CARD,
+        });
+
+        const mockEvent = callMockEvent(mockEventListener, "beforeunload");
+        expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+        expect(mockEvent.returnValue).not.toEqual(
+          BEFORE_UNLOAD_UNSAVED_MESSAGE,
+        );
+      });
+    });
   });
 });

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -214,46 +214,48 @@ const setup = async ({
 };
 
 describe("QueryBuilder", () => {
-  describe("renders structured queries", () => {
-    it("renders a structured question in the simple mode", async () => {
-      await setup();
+  describe("rendering", () => {
+    describe("renders structured queries", () => {
+      it("renders a structured question in the simple mode", async () => {
+        await setup();
 
-      expect(screen.getByDisplayValue(TEST_CARD.name)).toBeInTheDocument();
-    });
-
-    it("renders a structured question in the notebook mode", async () => {
-      await setup({
-        initialRoute: `/question/${TEST_CARD.id}/notebook`,
+        expect(screen.getByDisplayValue(TEST_CARD.name)).toBeInTheDocument();
       });
 
-      expect(screen.getByDisplayValue(TEST_CARD.name)).toBeInTheDocument();
-    });
-  });
-
-  describe("renders the row count regardless of visualization type", () => {
-    const dataset = TEST_MODEL_DATASET;
-    const cards = [
-      createMockCard({ ...TEST_CARD_VISUALIZATION, display: "table" }),
-      createMockCard({ ...TEST_CARD_VISUALIZATION, display: "line" }),
-    ];
-
-    it.each(cards)(
-      `renders the row count in "$display" visualization`,
-      async card => {
+      it("renders a structured question in the notebook mode", async () => {
         await setup({
-          card,
-          dataset,
+          initialRoute: `/question/${TEST_CARD.id}/notebook`,
         });
 
-        await waitFor(() => {
+        expect(screen.getByDisplayValue(TEST_CARD.name)).toBeInTheDocument();
+      });
+    });
+
+    describe("renders the row count regardless of visualization type", () => {
+      const dataset = TEST_MODEL_DATASET;
+      const cards = [
+        createMockCard({ ...TEST_CARD_VISUALIZATION, display: "table" }),
+        createMockCard({ ...TEST_CARD_VISUALIZATION, display: "line" }),
+      ];
+
+      it.each(cards)(
+        `renders the row count in "$display" visualization`,
+        async card => {
+          await setup({
+            card,
+            dataset,
+          });
+
+          await waitFor(() => {
+            const element = screen.getByTestId("question-row-count");
+            expect(element).toBeInTheDocument();
+          });
+
           const element = screen.getByTestId("question-row-count");
-          expect(element).toBeInTheDocument();
-        });
-
-        const element = screen.getByTestId("question-row-count");
-        expect(element).toBeVisible();
-      },
-    );
+          expect(element).toBeVisible();
+        },
+      );
+    });
   });
 
   describe("beforeunload events", () => {

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -461,6 +461,12 @@ describe("QueryBuilder", () => {
   });
 
   describe("downloading results", () => {
+    // I initially planned to test unsaved native (ad-hoc) queries here as well.
+    // But native queries won't run the query on first load, we need to manually
+    // click the run button, but our mock `NativeQueryEditor` doesn't have a run
+    // button wired up, and it's quite hard to do so (I've tried).
+    // So I test that case in Cypress in `28834-modified-native-question.cy.spec.js` instead.
+
     it("should allow downloading results for a native query", async () => {
       const mockDownloadEndpoint = fetchMock.post(
         `/api/card/${TEST_NATIVE_CARD.id}/query/csv`,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/28834
[Discussion](https://metaboat.slack.com/archives/C057T1QTB3L/p1688744293097179?thread_ts=1688727623.054379&cid=C057T1QTB3L)
### Description

Modify the behavior on the download button to show up even when the query has changed but not rerun. When downloading the result, use the same query as shown in the result, not the new one.

### How to verify

1. `+ New` > SQL query
2. type `SELECT 1`
3. Run the query and download the result, there should be 1 in the CSV file.
4. Change the query to `SELECT 2` but don't rerun the query. And download the result again, you should still see the same result (1 in the CSV file)
5. Run the query and download the result, there should be 2 in the CSV file.

### Demo

https://www.loom.com/share/dc123fc0d1674fa8bb81f659a524ad75

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
