### PR TITLE
[E2E] Fix `models` 29951 flake

### DIFF
--- a/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
@@ -16,7 +16,7 @@ const questionDetails = {
       CC1: ["+", ["field", ORDERS.TOTAL], 1],
       CC2: ["+", ["field", ORDERS.TOTAL], 1],
     },
-    limit: 200,
+    limit: 5,
   },
   dataset: true,
 };
@@ -40,7 +40,7 @@ describe("issue 29951", () => {
     dragColumn(0, 100);
     cy.findAllByRole("button", { name: "Get Answer" }).first().click();
     cy.wait("@dataset");
-    cy.findByTestId("view-footer").should("contain", "Showing 200 rows");
+    cy.findByTestId("view-footer").should("contain", "Showing 5 rows");
   });
 });
 

--- a/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
@@ -22,7 +22,7 @@ const questionDetails = {
   dataset: true,
 };
 
-describe("issue 29951", () => {
+describe("issue 29951", { requestTimeout: 10000 }, () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
@@ -5,6 +5,7 @@ import {
   popover,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 
 const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
 
@@ -26,6 +27,9 @@ describe("issue 29951", () => {
     restore();
     cy.signInAsAdmin();
     cy.intercept("PUT", "/api/card/*").as("updateCard");
+    cy.intercept("GET", `/api/database/${SAMPLE_DB_ID}/schema/PUBLIC`).as(
+      "publicShema",
+    );
   });
 
   it("should allow to run the model query after changing custom columns (metabase#29951)", () => {
@@ -33,6 +37,7 @@ describe("issue 29951", () => {
 
     openQuestionActions();
     popover().findByText("Edit query definition").click();
+    cy.wait("@publicShema");
     removeExpression("CC2");
     cy.findByRole("button", { name: "Save changes" }).click();
     cy.wait(["@updateCard", "@dataset"]);

--- a/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
@@ -25,13 +25,11 @@ describe("issue 29951", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("PUT", "/api/card/*").as("updateCard");
   });
 
   it("should allow to run the model query after changing custom columns (metabase#29951)", () => {
     cy.createQuestion(questionDetails, { visitQuestion: true });
-    cy.wait("@dataset");
 
     openQuestionActions();
     popover().findByText("Edit query definition").click();

--- a/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
@@ -39,11 +39,14 @@ describe("issue 29951", () => {
     popover().findByText("Edit query definition").click();
     cy.wait("@publicShema");
     removeExpression("CC2");
+    // The UI shows us the "play" icon, indicating we should refresh the query,
+    // but the point of this repro is to save without refreshing
+    refreshButton().should("have.length", 1);
     cy.findByRole("button", { name: "Save changes" }).click();
     cy.wait(["@updateCard", "@dataset"]);
 
     dragColumn(0, 100);
-    cy.findAllByRole("button", { name: "Get Answer" }).first().click();
+    refreshButton().first().click();
     cy.wait("@dataset");
     cy.findByTestId("view-footer").should("contain", "Showing 5 rows");
   });
@@ -58,8 +61,13 @@ const removeExpression = name => {
 
 const dragColumn = (index, distance) => {
   cy.get(".react-draggable")
+    .should("have.length", 20) // 10 columns X 2 draggable elements
     .eq(index)
     .trigger("mousedown", 0, 0, { force: true })
     .trigger("mousemove", distance, 0, { force: true })
     .trigger("mouseup", distance, 0, { force: true });
 };
+
+function refreshButton() {
+  return cy.findAllByRole("button", { name: "Get Answer" });
+}


### PR DESCRIPTION
The PR fixes a stubborn flake 

Last 7 days on `master` (32% failure rate, 24% flake rate)
![image](https://github.com/metabase/metabase/assets/31325167/9a80aa9c-ebf3-4258-81c2-8c9eda0b561d)

As explained in [this comment](https://github.com/metabase/metabase/pull/32254#discussion_r1258099664), the cause was in a superfluous `cy.wait()`.

I've also limited the number of query results to speed test up a bit.

## Stress-test
https://github.com/metabase/metabase/actions/runs/5507311483/jobs/10037104438

```
  issue 29951
    ✓ should allow to run the model query after changing custom columns (metabase#29951): burning 1 of 10 (17262ms)
    ✓ should allow to run the model query after changing custom columns (metabase#29951): burning 2 of 10 (17257ms)
    ✓ should allow to run the model query after changing custom columns (metabase#29951): burning 3 of 10 (14225ms)
    ✓ should allow to run the model query after changing custom columns (metabase#29951): burning 4 of 10 (14133ms)
    ✓ should allow to run the model query after changing custom columns (metabase#29951): burning 5 of 10 (13954ms)
    ✓ should allow to run the model query after changing custom columns (metabase#29951): burning 6 of 10 (14063ms)
    ✓ should allow to run the model query after changing custom columns (metabase#29951): burning 7 of 10 (13058ms)
    ✓ should allow to run the model query after changing custom columns (metabase#29951): burning 8 of 10 (13239ms)
    ✓ should allow to run the model query after changing custom columns (metabase#29951): burning 9 of 10 (13651ms)
    ✓ should allow to run the model query after changing custom columns (metabase#29951): burning 10 of 10 (13259ms)
```

