### PR TITLE
Do not show edit model menu options without write permissions

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/moderation/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/index.js
@@ -41,26 +41,30 @@ if (hasPremiumFeature("content_management")) {
       const isVerified = isItemVerified(latestModerationReview);
 
       if (isModerator) {
-        return {
-          title: isVerified
-            ? t`Remove verification`
-            : isDataset
-            ? t`Verify this model`
-            : t`Verify this question`,
-          icon: isVerified ? "close" : verifiedIconName,
-          action: () => {
-            if (isVerified) {
-              removeReview({ itemId: id, itemType: "card" });
-            } else {
-              verifyItem({ itemId: id, itemType: "card" });
-            }
-            reload();
+        return [
+          {
+            title: isVerified
+              ? t`Remove verification`
+              : isDataset
+              ? t`Verify this model`
+              : t`Verify this question`,
+            icon: isVerified ? "close" : verifiedIconName,
+            action: () => {
+              if (isVerified) {
+                removeReview({ itemId: id, itemType: "card" });
+              } else {
+                verifyItem({ itemId: id, itemType: "card" });
+              }
+              reload();
+            },
+            testId: isVerified
+              ? "moderation-remove-verification-action"
+              : "moderation-verify-action",
           },
-          testId: isVerified
-            ? "moderation-remove-verification-action"
-            : "moderation-verify-action",
-        };
+        ];
       }
+
+      return [];
     },
   });
 }

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -198,7 +198,7 @@ export const PLUGIN_MODERATION = {
     question?: Question,
     isModerator?: boolean,
     reload?: () => void,
-  ) => ({}),
+  ) => [],
 };
 
 export const PLUGIN_CACHING = {

--- a/frontend/src/metabase/query_builder/components/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.tsx
@@ -135,7 +135,7 @@ const QuestionActions = ({
     ),
   );
 
-  if (isDataset) {
+  if (canWrite && isDataset) {
     extraButtons.push(
       {
         title: t`Edit query definition`,

--- a/frontend/src/metabase/query_builder/components/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.tsx
@@ -128,7 +128,7 @@ const QuestionActions = ({
   }
 
   extraButtons.push(
-    PLUGIN_MODERATION.getMenuItems(
+    ...PLUGIN_MODERATION.getMenuItems(
       question,
       isModerator,
       dispatchSoftReloadCard,
@@ -237,12 +237,14 @@ const QuestionActions = ({
           />
         </ViewHeaderIconButtonContainer>
       </Tooltip>
-      <EntityMenu
-        triggerAriaLabel={t`Move, archive, and more...`}
-        items={extraButtons}
-        triggerIcon="ellipsis"
-        tooltip={t`Move, archive, and more...`}
-      />
+      {extraButtons.length > 0 && (
+        <EntityMenu
+          triggerAriaLabel={t`Move, archive, and more...`}
+          items={extraButtons}
+          triggerIcon="ellipsis"
+          tooltip={t`Move, archive, and more...`}
+        />
+      )}
     </>
   );
 };

--- a/frontend/src/metabase/query_builder/components/QuestionActions.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.unit.spec.tsx
@@ -23,7 +23,7 @@ const ICON_CASES_LABELS = [
 ];
 
 const ICON_CASES = ICON_CASES_CARDS.flatMap(card =>
-  ICON_CASES_LABELS.map(details => ({ ...details, card })),
+  ICON_CASES_LABELS.map(labels => ({ ...labels, card })),
 );
 
 function setup({ card }: { card: Card }) {

--- a/frontend/src/metabase/query_builder/components/QuestionActions.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.unit.spec.tsx
@@ -8,10 +8,7 @@ import { getMetadata } from "metabase/selectors/metadata";
 import { Card } from "metabase-types/api";
 import Question from "metabase-lib/Question";
 
-const TEST_STRUCTURED_CARD = createMockCard();
-const TEST_NATIVE_CARD = createMockNativeCard();
-
-const iconList = [
+const ICON_INFO = [
   { label: "bookmark icon", tooltipText: "Bookmark" },
   { label: "info icon", tooltipText: "More info" },
   {
@@ -19,6 +16,15 @@ const iconList = [
     tooltipText: "Move, archive, and more...",
   },
 ];
+
+const ICON_CARDS = [
+  createMockCard({ name: "GUI" }),
+  createMockNativeCard({ name: "SQL" }),
+];
+
+const ICON_CASES = ICON_CARDS.flatMap(card =>
+  ICON_INFO.map(details => ({ ...details, card })),
+);
 
 function setup({ card }: { card: Card }) {
   const state = createMockState({
@@ -47,23 +53,17 @@ function setup({ card }: { card: Card }) {
 }
 
 describe("QuestionActions", () => {
-  ["structured", "native"].forEach(queryType => {
-    iconList.forEach(({ label, tooltipText }) => {
-      it(`should display the "${label}" icon with the "${tooltipText}" tooltip for ${queryType} questions`, async () => {
-        setup({
-          card:
-            queryType === "structured"
-              ? TEST_STRUCTURED_CARD
-              : TEST_NATIVE_CARD,
-        });
+  it.each(ICON_CASES)(
+    `should display the "$label" icon with the "$tooltipText" tooltip for $card.name questions`,
+    async ({ label, tooltipText, card }) => {
+      setup({ card });
 
-        await userEvent.hover(screen.getByRole("button", { name: label }));
-        const tooltip = screen.getByRole("tooltip", { name: tooltipText });
-        expect(tooltip).toHaveAttribute("data-placement", "top");
-        expect(tooltip).toHaveTextContent(tooltipText);
-      });
-    });
-  });
+      await userEvent.hover(screen.getByRole("button", { name: label }));
+      const tooltip = screen.getByRole("tooltip", { name: tooltipText });
+      expect(tooltip).toHaveAttribute("data-placement", "top");
+      expect(tooltip).toHaveTextContent(tooltipText);
+    },
+  );
 
   it("should allow to edit the model only with write permissions", () => {
     setup({

--- a/frontend/src/metabase/query_builder/components/QuestionActions.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.unit.spec.tsx
@@ -8,7 +8,12 @@ import { getMetadata } from "metabase/selectors/metadata";
 import { Card } from "metabase-types/api";
 import Question from "metabase-lib/Question";
 
-const ICON_INFO = [
+const ICON_CASES_CARDS = [
+  createMockCard({ name: "GUI" }),
+  createMockNativeCard({ name: "SQL" }),
+];
+
+const ICON_CASES_LABELS = [
   { label: "bookmark icon", tooltipText: "Bookmark" },
   { label: "info icon", tooltipText: "More info" },
   {
@@ -17,13 +22,8 @@ const ICON_INFO = [
   },
 ];
 
-const ICON_CARDS = [
-  createMockCard({ name: "GUI" }),
-  createMockNativeCard({ name: "SQL" }),
-];
-
-const ICON_CASES = ICON_CARDS.flatMap(card =>
-  ICON_INFO.map(details => ({ ...details, card })),
+const ICON_CASES = ICON_CASES_CARDS.flatMap(card =>
+  ICON_CASES_LABELS.map(details => ({ ...details, card })),
 );
 
 function setup({ card }: { card: Card }) {

--- a/frontend/src/metabase/query_builder/components/QuestionActions.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.unit.spec.tsx
@@ -1,5 +1,5 @@
 import userEvent from "@testing-library/user-event";
-import { renderWithProviders, screen } from "__support__/ui";
+import { getIcon, renderWithProviders, screen } from "__support__/ui";
 import { createMockState } from "metabase-types/store/mocks";
 import { createMockEntitiesState } from "__support__/store";
 import QuestionActions from "metabase/query_builder/components/QuestionActions";
@@ -46,7 +46,7 @@ function setup({ card }: { card: Card }) {
   );
 }
 
-describe("Question Actions | Icons", () => {
+describe("QuestionActions", () => {
   ["structured", "native"].forEach(queryType => {
     iconList.forEach(({ label, tooltipText }) => {
       it(`should display the "${label}" icon with the "${tooltipText}" tooltip for ${queryType} questions`, async () => {
@@ -63,5 +63,31 @@ describe("Question Actions | Icons", () => {
         expect(tooltip).toHaveTextContent(tooltipText);
       });
     });
+  });
+
+  it("should allow to edit the model only with write permissions", () => {
+    setup({
+      card: createMockCard({
+        can_write: true,
+        dataset: true,
+      }),
+    });
+
+    userEvent.click(getIcon("ellipsis"));
+    expect(screen.getByText("Edit query definition")).toBeInTheDocument();
+    expect(screen.getByText("Edit metadata")).toBeInTheDocument();
+  });
+
+  it("should not allow to edit the model without write permissions", () => {
+    setup({
+      card: createMockCard({
+        can_write: false,
+        dataset: true,
+      }),
+    });
+
+    userEvent.click(getIcon("ellipsis"));
+    expect(screen.queryByText("Edit query definition")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit metadata")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/25699

Fixes a UI edge case where we offered to edit a model when the user couldn't do it.

How to verify:
- CI is green

<img width="290" alt="Screenshot 2023-07-10 at 17 34 54" src="https://github.com/metabase/metabase/assets/8542534/7c8fdd48-bf89-4914-b570-0f6d374ec8c6">
