### PR TITLE
adjusting minimum size for scalar (number) cards

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard-card-resizing.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-card-resizing.cy.spec.js
@@ -80,7 +80,7 @@ const VISUALIZATION_SIZES = {
     default: { width: 12, height: 9 },
   },
   scalar: {
-    min: { width: 1, height: 1 },
+    min: { width: 2, height: 2 },
     default: { width: 4, height: 3 },
   },
   smartscalar: {
@@ -215,8 +215,11 @@ describe("scenarios > dashboard card resizing", () => {
         cy.findByLabelText("Add questions").click();
       });
 
+      cy.intercept("POST", /\/api\/card\/(pivot\/)?.*\/query/).as("card-query");
+
       TEST_QUESTIONS.forEach(question => {
         cy.findByLabelText(question.name).click();
+        cy.wait("@card-query");
       });
 
       saveDashboard();

--- a/e2e/test/scenarios/dashboard/dashboard-card-resizing.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-card-resizing.cy.spec.js
@@ -215,11 +215,8 @@ describe("scenarios > dashboard card resizing", () => {
         cy.findByLabelText("Add questions").click();
       });
 
-      cy.intercept("POST", "/api/card/**/query").as("card-query");
-
       TEST_QUESTIONS.forEach(question => {
         cy.findByLabelText(question.name).click();
-        cy.wait("@card-query");
       });
 
       saveDashboard();

--- a/e2e/test/scenarios/dashboard/dashboard-card-resizing.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-card-resizing.cy.spec.js
@@ -215,7 +215,7 @@ describe("scenarios > dashboard card resizing", () => {
         cy.findByLabelText("Add questions").click();
       });
 
-      cy.intercept("POST", /\/api\/card\/(pivot\/)?.*\/query/).as("card-query");
+      cy.intercept("POST", "/api/card/**/query").as("card-query");
 
       TEST_QUESTIONS.forEach(question => {
         cy.findByLabelText(question.name).click();

--- a/frontend/src/metabase/visualizations/shared/utils/sizes.ts
+++ b/frontend/src/metabase/visualizations/shared/utils/sizes.ts
@@ -74,7 +74,7 @@ const VISUALIZATION_SIZES: {
     default: { width: 12, height: 9 },
   },
   scalar: {
-    min: { width: 1, height: 1 },
+    min: { width: 2, height: 2 },
     default: { width: 4, height: 3 },
   },
   smartscalar: {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/32206

### Description
Very simple PR to adjust the minimum size of a scalar card

### How to verify

1. Create a new scalar card (Orders -> count) and add it to a dashboard.
2. Try resizing it as small as you can.
3. The minimum size possible should be 2x2

Note that any existing cards that are smaller than 2x2 will continue to render, and can be edited/resized freely. If a card is made bigger and saved, then it's minimum size will be set to 2x2.

This PR also includes a small change to the `dashboard-card-resizing.cy.spec.js suite, which should help with [this particular flake](https://www.deploysentinel.com/ci/runs/64ad8dc724c76fd6f3e42e9e)

~_I'm having a hard time coming up with a useful test for this... I'd welcome any suggestions anyone has :/_~
_Turns out we had an e2e tests for minimum sizes. Updated that._

### Demo
![chrome_irILlWbrrs](https://github.com/metabase/metabase/assets/1328979/c70f2fa3-76f6-4a24-8bb6-0cf0871fe290)

### Acceptance Criteria
**Newly created scalar cards**
- [x] should have minimum size of 2x2

**Pre-existing scalar cards**
- [x] should maintain their current sizes - even if the card has a dimension smaller than 2 cells
- [x] cards smaller than 2x2 can only be resized to be larger
- [x] if a card is resized bigger than 2x2 and saved, it should now have minimum size of 2x2

**Tests**
- [x] e2e test updated to cover new minimum size for scalar cards
- [ ] e2e flake test fixed
