### PR TITLE
Add more e2e tests for drill options

### DIFF
--- a/e2e/test/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -640,6 +640,131 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       cy.findByText("Doohickey").should("not.exist");
     });
   });
+
+  it("should display proper drills on chart click for line chart", () => {
+    cy.createQuestion(
+      {
+        name: "Line chart drills",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            [
+              "field",
+              PRODUCTS.CREATED_AT,
+              { "source-field": ORDERS.PRODUCT_ID, "temporal-unit": "month" },
+            ],
+            ["field", PRODUCTS.CATEGORY, { "source-field": ORDERS.PRODUCT_ID }],
+          ],
+        },
+        display: "line",
+      },
+      { visitQuestion: true },
+    );
+
+    cy.get(".LineAreaBarChart").get(".dot").first().click({ force: true });
+    popover().within(() => {
+      cy.findByText(`See these Orders`).should("be.visible");
+
+      cy.findByText(`See this month by week`).should("be.visible");
+
+      cy.findByText(`Break out by…`).should("be.visible");
+      cy.findByText(`Automatic insights…`).should("be.visible");
+
+      cy.findByText(`>`).should("be.visible");
+      cy.findByText(`<`).should("be.visible");
+      cy.findByText(`=`).should("be.visible");
+      cy.findByText(`≠`).should("be.visible");
+    });
+
+    cy.findByTestId("timeseries-mode-bar").within(() => {
+      cy.findByText(`View`).should("be.visible");
+      cy.findByText(`All Time`).should("be.visible");
+      cy.findByText(`by`).should("be.visible");
+      cy.findByText(`Month`).should("be.visible");
+    });
+  });
+
+  it("should display proper drills on chart click for bar chart", () => {
+    cy.createQuestion(
+      {
+        name: "Line chart drills",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            [
+              "field",
+              PRODUCTS.CREATED_AT,
+              { "source-field": ORDERS.PRODUCT_ID, "temporal-unit": "month" },
+            ],
+            ["field", PRODUCTS.CATEGORY, { "source-field": ORDERS.PRODUCT_ID }],
+          ],
+        },
+        display: "bar",
+      },
+      { visitQuestion: true },
+    );
+
+    cy.get(".LineAreaBarChart").findAllByTestId("legend-item").first().click();
+
+    popover().within(() => {
+      cy.findByText(`See these Orders`).should("be.visible");
+      cy.findByText(`Automatic insights…`).should("be.visible");
+    });
+
+    cy.get(".LineAreaBarChart").get(".bar").first().click({ force: true });
+    popover().within(() => {
+      cy.findByText(`See these Orders`).should("be.visible");
+
+      cy.findByText(`See this month by week`).should("be.visible");
+
+      cy.findByText(`Break out by…`).should("be.visible");
+      cy.findByText(`Automatic insights…`).should("be.visible");
+
+      cy.findByText(`>`).should("be.visible");
+      cy.findByText(`<`).should("be.visible");
+      cy.findByText(`=`).should("be.visible");
+      cy.findByText(`≠`).should("be.visible");
+    });
+
+    cy.findByTestId("timeseries-mode-bar").within(() => {
+      cy.findByText(`View`).should("be.visible");
+      cy.findByText(`All Time`).should("be.visible");
+      cy.findByText(`by`).should("be.visible");
+      cy.findByText(`Month`).should("be.visible");
+    });
+  });
+
+  it("should display proper drills on chart click for query grouped by state", () => {
+    cy.createQuestion(
+      {
+        name: "Line chart drills",
+        query: {
+          "source-table": PEOPLE_ID,
+          aggregation: [["count"]],
+          breakout: [["field", PEOPLE.STATE, null]],
+        },
+        display: "map",
+      },
+      { visitQuestion: true },
+    );
+
+    cy.get(".CardVisualization").get("path.cursor-pointer").first().click();
+
+    popover().within(() => {
+      cy.findByText(`See these People`).should("be.visible");
+      cy.findByText(`Zoom in`).should("be.visible");
+
+      cy.findByText(`Break out by…`).should("be.visible");
+      cy.findByText(`Automatic insights…`).should("be.visible");
+
+      cy.findByText(`>`).should("be.visible");
+      cy.findByText(`<`).should("be.visible");
+      cy.findByText(`=`).should("be.visible");
+      cy.findByText(`≠`).should("be.visible");
+    });
+  });
 });
 
 function hoverLineDot({ index } = {}) {

--- a/e2e/test/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
@@ -1,4 +1,3 @@
-// Imported from drillthroughs.e2e.spec.js
 import {
   addOrUpdateDashboardCard,
   restore,

--- a/e2e/test/scenarios/visualizations/drillthroughs/table_drills.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/drillthroughs/table_drills.cy.spec.js
@@ -1,0 +1,201 @@
+import { openReviewsTable, popover, restore } from "e2e/support/helpers";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { REVIEWS, REVIEWS_ID } = SAMPLE_DATABASE;
+
+describe("scenarios > visualizations > drillthroughs > table_drills", function () {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should display proper drills on cell click for unaggregated query", () => {
+    openReviewsTable({ limit: 3 });
+
+    // FK cell drills
+    cy.get(".Table-FK").findByText("1").first().click();
+    popover().within(() => {
+      cy.findByText(`View this Product's Reviews`).should("be.visible");
+      cy.findByText(`View details`).should("be.visible");
+    });
+
+    // Short text cell drills
+    cy.get(".cellData").contains("christ").click();
+    popover().within(() => {
+      cy.findByText(`Is christ`).should("be.visible");
+      cy.findByText(`Is not christ`).should("be.visible");
+      cy.findByText(`View details`).should("be.visible");
+    });
+
+    // Number cell drills
+    cy.get(".cellData").contains("5").first().click();
+    popover().within(() => {
+      cy.findByText(`>`).should("be.visible");
+      cy.findByText(`<`).should("be.visible");
+      cy.findByText(`=`).should("be.visible");
+      cy.findByText(`≠`).should("be.visible");
+      cy.findByText(`View details`).should("be.visible");
+    });
+
+    cy.get(".cellData").contains("Ad perspiciatis quis").click();
+    popover().within(() => {
+      cy.findByText(`Contains…`).should("be.visible");
+      cy.findByText(`Does not contain…`).should("be.visible");
+      cy.findByText(`View details`).should("be.visible");
+    });
+
+    cy.get(".cellData").contains("May 15, 20").click();
+    popover().within(() => {
+      cy.findByText(`Before`).should("be.visible");
+      cy.findByText(`After`).should("be.visible");
+      cy.findByText(`On`).should("be.visible");
+      cy.findByText(`Not on`).should("be.visible");
+      cy.findByText(`View details`).should("be.visible");
+    });
+
+    cy.get(".cellData").contains("ID").click({ force: true });
+    popover().within(() => {
+      cy.icon("arrow_down").should("be.visible");
+      cy.icon("arrow_up").should("be.visible");
+      cy.icon("gear").should("be.visible");
+
+      cy.findByText(`Filter by this column`).should("be.visible");
+      cy.findByText(`Distinct values`).should("be.visible");
+    });
+
+    cy.get(".cellData").contains("Reviewer").click();
+    popover().within(() => {
+      cy.icon("arrow_down").should("be.visible");
+      cy.icon("arrow_up").should("be.visible");
+      cy.icon("gear").should("be.visible");
+
+      cy.findByText(`Filter by this column`).should("be.visible");
+      cy.findByText(`Distribution`).should("be.visible");
+      cy.findByText(`Distinct values`).should("be.visible");
+    });
+
+    cy.get(".cellData").contains("Rating").click();
+    popover().within(() => {
+      cy.icon("arrow_down").should("be.visible");
+      cy.icon("arrow_up").should("be.visible");
+      cy.icon("gear").should("be.visible");
+
+      cy.findByText(`Filter by this column`).should("be.visible");
+      cy.findByText(`Sum over time`).should("be.visible");
+      cy.findByText(`Distribution`).should("be.visible");
+
+      cy.findByText(`Sum`).should("be.visible");
+      cy.findByText(`Avg`).should("be.visible");
+      cy.findByText(`Distinct values`).should("be.visible");
+    });
+  });
+
+  it(`should display proper drills on cell click for query aggregated by category`, () => {
+    cy.createQuestion(
+      {
+        query: {
+          "source-table": REVIEWS_ID,
+          aggregation: [["count"]],
+          breakout: [["field", REVIEWS.REVIEWER, null]],
+          limit: 10,
+        },
+      },
+      { visitQuestion: true },
+    );
+
+    cy.get(".cellData").contains("abbey-heidenreich").click();
+    popover().within(() => {
+      cy.findByText(`Is abbey-heidenreich`).should("be.visible");
+      cy.findByText(`Is not abbey-heidenreich`).should("be.visible");
+    });
+
+    cy.get(".cellData").contains("1").first().click();
+    popover().within(() => {
+      cy.findByText(`See this Review`).should("be.visible");
+
+      cy.findByText(`Automatic insights…`).should("be.visible");
+
+      cy.findByText(`>`).should("be.visible");
+      cy.findByText(`<`).should("be.visible");
+      cy.findByText(`=`).should("be.visible");
+      cy.findByText(`≠`).should("be.visible");
+    });
+
+    cy.get(".cellData").contains("Reviewer").click();
+    popover().within(() => {
+      cy.icon("arrow_down").should("be.visible");
+      cy.icon("arrow_up").should("be.visible");
+      cy.icon("gear").should("be.visible");
+
+      cy.findByText(`Filter by this column`).should("be.visible");
+    });
+
+    cy.get(".cellData").contains("Count").click();
+    popover().within(() => {
+      cy.icon("arrow_down").should("be.visible");
+      cy.icon("arrow_up").should("be.visible");
+      cy.icon("gear").should("be.visible");
+
+      cy.findByText(`Filter by this column`).should("be.visible");
+    });
+  });
+
+  it(`should display proper drills on cell click for query aggregated by date`, () => {
+    cy.createQuestion(
+      {
+        query: {
+          "source-table": REVIEWS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["field", REVIEWS.CREATED_AT, { "temporal-unit": "month" }],
+          ],
+          limit: 10,
+        },
+      },
+      { visitQuestion: true },
+    );
+
+    cy.get(".cellData").contains("June,").first().click();
+    popover().within(() => {
+      cy.findByText(`Before`).should("be.visible");
+      cy.findByText(`After`).should("be.visible");
+      cy.findByText(`On`).should("be.visible");
+      cy.findByText(`Not on`).should("be.visible");
+    });
+
+    cy.get(".cellData").contains("4").first().click();
+    popover().within(() => {
+      cy.findByText(`See this month by week`).should("be.visible");
+
+      cy.findByText(`Break out by…`).should("be.visible");
+      cy.findByText(`Automatic insights…`).should("be.visible");
+
+      cy.findByText(`>`).should("be.visible");
+      cy.findByText(`<`).should("be.visible");
+      cy.findByText(`=`).should("be.visible");
+      cy.findByText(`≠`).should("be.visible");
+    });
+
+    cy.findByTestId("timeseries-mode-bar").within(() => {
+      cy.findByText(`View`).should("be.visible");
+      cy.findByText(`All Time`).should("be.visible");
+      cy.findByText(`by`).should("be.visible");
+      cy.findByText(`Month`).should("be.visible");
+    });
+  });
+
+  it(`should display proper drills for native query`, () => {
+    cy.createNativeQuestion(
+      {
+        name: "table_drills",
+        native: { query: `select * from orders limit 3` },
+      },
+      { visitQuestion: true },
+    );
+
+    cy.get(".cellData").contains("1").first().click();
+    popover()
+      .findByText(`Drill-through doesn’t work on SQL questions.`)
+      .should("be.visible");
+  });
+});

--- a/frontend/src/metabase-lib/drills.ts
+++ b/frontend/src/metabase-lib/drills.ts
@@ -1,0 +1,27 @@
+import * as ML from "cljs/metabase.lib.js";
+import type {
+  //ColumnMetadata,
+  DrillThruInputs,
+  Query,
+} from "./types";
+
+export function availableDrillThrus(
+  // TODO: What is the right type for a JS column? (Not types.ts ColumnMetadata; that's the opaque CLJS type.)
+  query: Query,
+  stageIndex: number,
+  inputs: DrillThruInputs,
+): DrillThru[] {
+  return ML.available_drill_thrus(query, stageIndex, inputs);
+}
+
+// TODO: Precise types for each of the various extra args?
+// Maybe not worth it - we can't easily match the `:type` field from TS. It would need to call through CLJS and
+// needs TS functions that return `DrillThru is SomeSpecificDrillThru` type predicates.
+export function drillThru(
+  query: Query,
+  stageIndex: number,
+  drillThru: DrillThru,
+  ...args: any[]
+): Query {
+  return ML.drill_thru(query, stageIndex, drillThru, ...args);
+}

--- a/frontend/src/metabase-lib/drills.ts
+++ b/frontend/src/metabase-lib/drills.ts
@@ -1,6 +1,8 @@
 import * as ML from "cljs/metabase.lib.js";
 import type { DataRow, Dimension, Query } from "./types";
 
+// NOTE: value might be null or undefined, and they mean different things!
+// null means a value of SQL NULL; undefined means no value, ie. a column header was clicked.
 export function availableDrillThrus(
   // TODO: What is the right type for a JS column? (Not types.ts ColumnMetadata; that's the opaque CLJS type.)
   query: Query,
@@ -10,7 +12,14 @@ export function availableDrillThrus(
   row: DataRow | null,
   dimensions: Dimension[] | null,
 ): DrillThru[] {
-  return ML.available_drill_thrus(query, stageIndex, column, value, row, dimensions);
+  return ML.available_drill_thrus(
+    query,
+    stageIndex,
+    column,
+    value,
+    row,
+    dimensions,
+  );
 }
 
 // TODO: Precise types for each of the various extra args?

--- a/frontend/src/metabase-lib/drills.ts
+++ b/frontend/src/metabase-lib/drills.ts
@@ -1,17 +1,15 @@
 import * as ML from "cljs/metabase.lib.js";
-import type {
-  //ColumnMetadata,
-  DrillThruInputs,
-  Query,
-} from "./types";
+import type { DataRow, Query } from "./types";
 
 export function availableDrillThrus(
   // TODO: What is the right type for a JS column? (Not types.ts ColumnMetadata; that's the opaque CLJS type.)
   query: Query,
   stageIndex: number,
-  inputs: DrillThruInputs,
+  column: Record<string, unknown>,
+  value: any,
+  row: DataRow | null,
 ): DrillThru[] {
-  return ML.available_drill_thrus(query, stageIndex, inputs);
+  return ML.available_drill_thrus(query, stageIndex, column, value, row);
 }
 
 // TODO: Precise types for each of the various extra args?

--- a/frontend/src/metabase-lib/drills.ts
+++ b/frontend/src/metabase-lib/drills.ts
@@ -1,5 +1,5 @@
 import * as ML from "cljs/metabase.lib.js";
-import type { DataRow, Query } from "./types";
+import type { DataRow, Dimension, Query } from "./types";
 
 export function availableDrillThrus(
   // TODO: What is the right type for a JS column? (Not types.ts ColumnMetadata; that's the opaque CLJS type.)
@@ -8,8 +8,9 @@ export function availableDrillThrus(
   column: Record<string, unknown>,
   value: any,
   row: DataRow | null,
+  dimensions: Dimension[] | null,
 ): DrillThru[] {
-  return ML.available_drill_thrus(query, stageIndex, column, value, row);
+  return ML.available_drill_thrus(query, stageIndex, column, value, row, dimensions);
 }
 
 // TODO: Precise types for each of the various extra args?

--- a/frontend/src/metabase-lib/drills.unit.spec.ts
+++ b/frontend/src/metabase-lib/drills.unit.spec.ts
@@ -20,28 +20,20 @@ describe("availableDrillThrus", () => {
         /* dimensions */ null,
       ).map(drill => displayInfo(query, stageIndex, drill)),
     ).toEqual([
-      {
-        type: "drill-thru/distribution",
-        table: {},
-      },
+      { type: "drill-thru/distribution" },
       {
         type: "drill-thru/column-filter",
-        table: {},
+        initialOp: expect.objectContaining({ short: "=" }),
       },
       {
         type: "drill-thru/sort",
-        table: {},
         directions: ["asc", "desc"],
       },
       {
         type: "drill-thru/summarize-column",
-        table: {},
         aggregations: ["distinct", "sum", "avg"],
       },
-      {
-        type: "drill-thru/summarize-column-by-time",
-        table: {},
-      },
+      { type: "drill-thru/summarize-column-by-time" },
     ]);
   });
 });

--- a/frontend/src/metabase-lib/drills.unit.spec.ts
+++ b/frontend/src/metabase-lib/drills.unit.spec.ts
@@ -7,7 +7,8 @@ describe("availableDrillThrus", () => {
     const query = createQuery();
     const stageIndex = -1;
     const columns = orderableColumns(query, stageIndex);
-    console.log(window.$CLJS.cljs.core.pr_str(query), columns);
+    //console.log(window.$CLJS.cljs.core.pr_str(query), columns);
+    console.log(window.$CLJS.cljs.core.pr_str(window.$CLJS.metabase.lib.metadata.calculation.visible_columns(query)));
     const column = columnFinder(query, columns)("ORDERS", "SUBTOTAL");
 
     expect(availableDrillThrus(query, stageIndex, column, /* row */ null, /* dimensions */ null)).toEqual([]);

--- a/frontend/src/metabase-lib/drills.unit.spec.ts
+++ b/frontend/src/metabase-lib/drills.unit.spec.ts
@@ -1,0 +1,15 @@
+import { availableDrillThrus } from "metabase-lib/drills";
+import { orderableColumns } from "metabase-lib/order_by";
+import { columnFinder, createQuery } from "./test-helpers";
+
+describe("availableDrillThrus", () => {
+  it("should return list of available drills", () => {
+    const query = createQuery();
+    const stageIndex = -1;
+    const columns = orderableColumns(query, stageIndex);
+    console.log(window.$CLJS.cljs.core.pr_str(query), columns);
+    const column = columnFinder(query, columns)("ORDERS", "SUBTOTAL");
+
+    expect(availableDrillThrus(query, stageIndex, column, /* row */ null, /* dimensions */ null)).toEqual([]);
+  });
+});

--- a/frontend/src/metabase-lib/drills.unit.spec.ts
+++ b/frontend/src/metabase-lib/drills.unit.spec.ts
@@ -1,4 +1,5 @@
 import { availableDrillThrus } from "metabase-lib/drills";
+import { displayInfo } from "metabase-lib/metadata";
 import { orderableColumns } from "metabase-lib/order_by";
 import { columnFinder, createQuery } from "./test-helpers";
 
@@ -7,10 +8,40 @@ describe("availableDrillThrus", () => {
     const query = createQuery();
     const stageIndex = -1;
     const columns = orderableColumns(query, stageIndex);
-    //console.log(window.$CLJS.cljs.core.pr_str(query), columns);
-    console.log(window.$CLJS.cljs.core.pr_str(window.$CLJS.metabase.lib.metadata.calculation.visible_columns(query)));
     const column = columnFinder(query, columns)("ORDERS", "SUBTOTAL");
 
-    expect(availableDrillThrus(query, stageIndex, column, /* row */ null, /* dimensions */ null)).toEqual([]);
+    expect(
+      availableDrillThrus(
+        query,
+        stageIndex,
+        column,
+        /* value */ undefined,
+        /* row */ null,
+        /* dimensions */ null,
+      ).map(drill => displayInfo(query, stageIndex, drill)),
+    ).toEqual([
+      {
+        type: "drill-thru/distribution",
+        table: {},
+      },
+      {
+        type: "drill-thru/column-filter",
+        table: {},
+      },
+      {
+        type: "drill-thru/sort",
+        table: {},
+        directions: ["asc", "desc"],
+      },
+      {
+        type: "drill-thru/summarize-column",
+        table: {},
+        aggregations: ["distinct", "sum", "avg"],
+      },
+      {
+        type: "drill-thru/summarize-column-by-time",
+        table: {},
+      },
+    ]);
   });
 });

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -166,8 +166,4 @@ export interface Dimension {
   value?: any;
 }
 
-export interface DrillThruInputs {
-  column: Record<string, unknown>;
-  value?: any;
-  dimensions?: Dimension[];
-}
+export type DataRow = Array<{ col: Record<string, unknown>; value: any }>;

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -157,3 +157,17 @@ export type JoinStrategyDisplayInfo = {
   default?: boolean;
   shortName: string;
 };
+
+declare const DrillThru: unique symbol;
+export type DrillThru = unknown & { _opaque: typeof DrillThru };
+
+export interface Dimension {
+  column: Record<string, unknown>;
+  value?: any;
+}
+
+export interface DrillThruInputs {
+  column: Record<string, unknown>;
+  value?: any;
+  dimensions?: Dimension[];
+}

--- a/frontend/src/metabase-lib/v2.ts
+++ b/frontend/src/metabase-lib/v2.ts
@@ -9,6 +9,7 @@ export * from "./common";
 export * from "./comparison";
 export * from "./metadata";
 export * from "./breakout";
+export * from "./drills";
 export * from "./fields";
 export * from "./limit";
 export * from "./order_by";

--- a/frontend/src/metabase/lib/settings.ts
+++ b/frontend/src/metabase/lib/settings.ts
@@ -219,7 +219,7 @@ class MetabaseSettings {
 
   /**
    * @deprecated use getSetting(state, "anon-tracking-enabled")
-   */
+   *a
   uploadsEnabled() {
     return !!(this.get("uploads-enabled") && this.get("uploads-database-id"));
   }
@@ -438,5 +438,11 @@ function makeRegexTest(property: string, regex: RegExp) {
 const initValues =
   typeof window !== "undefined" ? _.clone(window.MetabaseBootstrap) : null;
 
+const settings = new MetabaseSettings(initValues);
+
+if (typeof window !== "undefined") {
+  window.__metabaseSettings = settings;
+}
+
 // eslint-disable-next-line import/no-default-export -- deprecated usage
-export default new MetabaseSettings(initValues);
+export default settings;

--- a/frontend/src/metabase/lib/settings.ts
+++ b/frontend/src/metabase/lib/settings.ts
@@ -219,7 +219,7 @@ class MetabaseSettings {
 
   /**
    * @deprecated use getSetting(state, "anon-tracking-enabled")
-   *a
+   */
   uploadsEnabled() {
     return !!(this.get("uploads-enabled") && this.get("uploads-database-id"));
   }

--- a/frontend/src/metabase/modes/components/modes/TimeseriesMode.jsx
+++ b/frontend/src/metabase/modes/components/modes/TimeseriesMode.jsx
@@ -12,7 +12,7 @@ const TimeseriesModeFooter = props => {
   };
 
   return (
-    <div className="flex layout-centered">
+    <div className="flex layout-centered" data-testid="timeseries-mode-bar">
       <span className="mr1">{t`View`}</span>
       <TimeseriesFilterWidget {...props} card={props.lastRunCard} />
       <span className="mx1">{t`by`}</span>

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -32,6 +32,7 @@ import { getFont } from "metabase/styled-components/selectors";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
 import { isRegularClickAction } from "metabase/modes/types";
+import * as Lib from "metabase-lib";
 import Question from "metabase-lib/Question";
 import Mode from "metabase-lib/Mode";
 import { datasetContainsNoResults } from "metabase-lib/queries/utils/dataset";
@@ -235,12 +236,20 @@ class Visualization extends PureComponent {
     const question = this._getQuestionForCardCached(metadata, card);
     const mode = this.getMode(this.props.mode, question);
 
-    return mode
-      ? mode.actionsForClick(
-          { ...clicked, extraData: getExtraDataForClick(clicked) },
-          {},
-        )
-      : [];
+    const extraData = getExtraDataForClick(clicked);
+    if (extraData && Object.keys(extraData).length > 0) {
+      //debugger;
+    }
+
+    if (mode) {
+      window.__q = question._getMLv2Query();
+      const mlv2Drills = Lib.availableDrillThrus(window.__q, -1, clicked);
+      if (mlv2Drills && mlv2Drills.length > 0) {
+        //console.log(question, clicked?.column, clicked?.value, mlv2Drills);
+      }
+    }
+
+    return mode ? mode.actionsForClick({ ...clicked, extraData }, {}) : [];
   }
 
   visualizationIsClickable = clicked => {

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -243,7 +243,13 @@ class Visualization extends PureComponent {
 
     if (mode) {
       window.__q = question._getMLv2Query();
-      const mlv2Drills = Lib.availableDrillThrus(window.__q, -1, clicked);
+      const mlv2Drills = Lib.availableDrillThrus(
+        window.__q,
+        -1,
+        clicked.column,
+        clicked.value,
+        clicked.data,
+      );
       if (mlv2Drills && mlv2Drills.length > 0) {
         //console.log(question, clicked?.column, clicked?.value, mlv2Drills);
       }

--- a/src/metabase/lib/binning.cljc
+++ b/src/metabase/lib/binning.cljc
@@ -69,7 +69,11 @@
     x]
    (available-binning-strategies-method query stage-number x)))
 
-(defn- default-auto-bin []
+(defn default-auto-bin
+  "Returns the basic auto-binning strategy.
+
+  Public because it's used directly by some drill-thrus."
+  []
   {:display-name (i18n/tru "Auto bin")
    :default      true
    :mbql         {:strategy :default}})

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -36,6 +36,7 @@
          lib.card/keep-me
          lib.column-group/keep-me
          lib.common/keep-me
+         lib.drill-thru/keep-me
          lib.expression/keep-me
          lib.field/keep-me
          lib.filter/keep-me

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -10,6 +10,7 @@
    [metabase.lib.card :as lib.card]
    [metabase.lib.column-group :as lib.column-group]
    [metabase.lib.common :as lib.common]
+   [metabase.lib.drill-thru :as lib.drill-thru]
    [metabase.lib.expression :as lib.expression]
    [metabase.lib.field :as lib.field]
    [metabase.lib.filter :as lib.filter]
@@ -91,6 +92,11 @@
    group-columns]
   [lib.common
    external-op]
+  [lib.drill-thru
+   available-drill-thrus
+   drill-thru
+   pivot-columns-for-type
+   pivot-types]
   [lib.expression
    expression
    expressions

--- a/src/metabase/lib/drill_thru.cljc
+++ b/src/metabase/lib/drill_thru.cljc
@@ -1,0 +1,87 @@
+(ns metabase.lib.drill-thru
+  (:require
+    [metabase.lib.dispatch :as lib.dispatch]
+    [metabase.lib.hierarchy :as lib.hierarchy]
+    [metabase.lib.metadata :as lib.metadata]
+    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
+    [metabase.lib.options :as lib.options]
+    [metabase.lib.ref :as lib.ref]
+    [metabase.lib.schema :as lib.schema]
+    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
+    [metabase.lib.schema.expression :as lib.schema.expression]
+    [metabase.lib.types.isa :as lib.types.isa]
+    [metabase.lib.util :as lib.util]
+    [metabase.shared.util.i18n :as i18n]
+    [metabase.util.malli :as mu]))
+
+(defn- structured? [query stage-number]
+  (-> (lib.util/query-stage query stage-number)
+      :lib/type
+      (= :mbql.stage/mbql)))
+
+;;; ------------------------------------- Quick Filters ------------------------------------------
+(defn- operator [op & args]
+  (lib.options/ensure-uuid (into [op {}] args)))
+
+(mu/defn ^:private operators-for #_#_:- [:sequential [:map [:name string?] [:filter ::lib.schema.expression/boolean]]]
+  [column :- lib.metadata/ColumnMetadata
+   value]
+  (let [field-ref (lib.ref/ref column)]
+    (cond
+      (lib.types.isa/structured? column)  []
+      (nil? value)                        [{:name "=" :filter (operator :is-null  field-ref)}
+                                           {:name "≠" :filter (operator :not-null field-ref)}]
+      (or (lib.types.isa/numeric? column)
+          (lib.types.isa/date? column))   (for [[op label] [[:<  "<"]
+                                                            [:>  ">"]
+                                                            [:=  "="]
+                                                            [:!= "≠"]]]
+                                            {:name   label
+                                             :filter (operator op field-ref value)})
+      :else                               (for [[op label] [[:=  "="]
+                                                            [:!= "≠"]]]
+                                            {:name   label
+                                             :filter (operator op field-ref value)}))))
+
+(mu/defn ^:private quick-filter-drill :- [:maybe ::lib.schema.drill-thru/drill-thru]
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   column       :- lib.metadata/ColumnMetadata
+   value]
+  (when (and (structured? query stage-number)
+             ;(editable? query stage-number)
+             column
+             (some? value)
+             (not (lib.types.isa/primary-key? column))
+             (not (lib.types.isa/foreign-key? column)))
+    {:lib/type  ::drill-thru
+     :type      :drill-thru/quick-filter
+     :operators (operators-for column value)}))
+
+(mu/defn available-drill-thrus :- [:sequential [:ref ::lib.schema.drill-thru/drill-thru]]
+  "Get a list (possibly empty) of available drill-thrus for a column, or a column + value pair.
+
+  Note that `stage-number` is required because to avoid ambiguous arities."
+  ([query stage-number column]
+   (available-drill-thrus query stage-number column nil))
+
+  ([query        ;:- ::lib.schema/query
+    stage-number ;:- :int
+    column       :- lib.metadata/ColumnMetadata
+    value]
+   (keep #(% query stage-number column value)
+         [quick-filter-drill])))
+
+(comment
+  (let [query    (metabase.lib.dev/query-for-table-name
+                   (metabase.lib.metadata.jvm/application-database-metadata-provider 1)
+                   "ORDERS")
+        stage    (metabase.lib.util/query-stage query -1)
+        cols     (metabase.lib.metadata.calculation/visible-columns query -1 stage)
+        subtotal (nth cols 3)
+        ops      (operators-for subtotal 100)
+        filters  (map :filter ops)]
+    #_(quick-filter-drill query -1 subtotal 200)
+    (available-drill-thrus query -1 subtotal 100))
+  *e
+  )

--- a/src/metabase/lib/drill_thru.cljc
+++ b/src/metabase/lib/drill_thru.cljc
@@ -570,7 +570,7 @@
          sort-drill
          summarize-column-drill
          summarize-column-by-time-drill
-         #_underlying-records-drill]))
+         underlying-records-drill]))
 
 (mu/defn drill-thru :- ::lib.schema/query
   "`(drill-thru query stage-number drill-thru)`

--- a/src/metabase/lib/drill_thru.cljc
+++ b/src/metabase/lib/drill_thru.cljc
@@ -1,9 +1,11 @@
 (ns metabase.lib.drill-thru
   (:require
+   [metabase.lib.breakout :as lib.breakout]
    [metabase.lib.dispatch :as lib.dispatch]
    [metabase.lib.hierarchy :as lib.hierarchy]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
+   [metabase.lib.order-by :as lib.order-by]
    [metabase.lib.options :as lib.options]
    [metabase.lib.ref :as lib.ref]
    [metabase.lib.schema :as lib.schema]
@@ -137,6 +139,104 @@
      :type      :drill-thru/distribution
      :column    column}))
 
+;;; -------------------------------------- Pivot Drill--------------------------------------------
+(mu/defn ^:private pivot-drill-pred :- [:sequential lib.metadata/ColumnMetadata]
+  "Implementation for pivoting on various kinds of fields.
+
+  Don't call this directly; call [[pivot-drill]]."
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   column       :- lib.metadata/ColumnMetadata
+   value
+   field-pred   :- [:=> [:cat lib.metadata/ColumnMetadata] boolean?]]
+  (when (and (structured? query stage-number)
+             column
+             (some? value)
+             (= (:lib/source column) :source/aggregations))
+    (->> (lib.breakout/breakoutable-columns query stage-number)
+         (filter field-pred))))
+
+(mu/defn ^:private pivot-by-time-drill :- [:sequential lib.metadata/ColumnMetadata]
+  "Pivots this column and value on a time dimension."
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   column       :- lib.metadata/ColumnMetadata
+   value]
+  (pivot-drill-pred query stage-number column value lib.types.isa/date?))
+
+(mu/defn ^:private pivot-by-location-drill :- [:sequential lib.metadata/ColumnMetadata]
+  "Pivots this column and value on an address dimension."
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   column       :- lib.metadata/ColumnMetadata
+   value]
+  (pivot-drill-pred query stage-number column value lib.types.isa/address?))
+
+(mu/defn ^:private pivot-by-category-drill :- [:sequential lib.metadata/ColumnMetadata]
+  "Pivots this column and value on an category dimension."
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   column       :- lib.metadata/ColumnMetadata
+   value]
+  (pivot-drill-pred query stage-number column value
+                    (every-pred lib.types.isa/category?
+                                (complement lib.types.isa/address?))))
+
+(mu/defn ^:private pivot-drill :- [:maybe ::lib.schema.drill-thru/drill-thru]
+  "Return all possible pivoting options on the given column and value.
+
+  See `:pivots` key, which holds a map `{t [breakouts...]}` where `t` is `:category`, `:location`, or `:time`.
+  If a key is missing, there are no breakouts of that kind."
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   column       :- lib.metadata/ColumnMetadata
+   value]
+  (when (and (structured? query stage-number)
+             column
+             (some? value)
+             (= (:lib/source column) :source/aggregations))
+    (let [by-category (pivot-by-category-drill query stage-number column value)
+          by-location (pivot-by-location-drill query stage-number column value)
+          by-time     (pivot-by-time-drill     query stage-number column value)
+          pivots      (merge (when (seq by-category) {:category by-category})
+                             (when (seq by-location) {:location by-location})
+                             (when (seq by-time)     {:time     by-time}))]
+      ;; TODO: Do dimensions need to be attached? How is clicked.dimensions calculated in the FE?
+      (when-not (empty? pivots)
+        {:lib/type ::drill-thru
+         :type     :drill-thru/pivot
+         :pivots   pivots}))))
+
+;;; ----------------------------------------- Sort -----------------------------------------------
+(mu/defn ^:private sort-drill :- [:maybe ::lib.schema.drill-thru/drill-thru]
+  "Sorting on a clicked column."
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   column       :- lib.metadata/ColumnMetadata
+   value]
+  (when (and (structured? query stage-number)
+             column
+             (nil? value)
+             (not (lib.types.isa/structured? column))
+             (:lib/source column))
+    (let [orderable  (->> (lib.order-by/orderable-columns query stage-number)
+                          (map :id)
+                          set)
+          order-bys  (lib.order-by/order-bys query stage-number)
+          this-order (first (for [[dir [clause _opts arg :as field]] order-bys
+                                  :when (and (= clause :field)
+                                             (or (= arg (:id column))
+                                                 (= arg (:name column))))]
+                              dir))]
+      (when (orderable (:id column))
+        {:lib/type        ::drill-thru
+         :type            :drill-thru/sort
+         :column          column
+         :sort-directions (case this-order
+                            :asc  [:desc]
+                            :desc [:asc]
+                            [:asc :desc])}))))
+
 ;;; --------------------------------------- Top Level --------------------------------------------
 (mu/defn available-drill-thrus :- [:sequential [:ref ::lib.schema.drill-thru/drill-thru]]
   "Get a list (possibly empty) of available drill-thrus for a column, or a column + value pair.
@@ -145,15 +245,17 @@
   ([query stage-number column]
    (available-drill-thrus query stage-number column nil))
 
-  ([query        ;:- ::lib.schema/query
-    stage-number ;:- :int
+  ([query        :- ::lib.schema/query
+    stage-number :- :int
     column       :- lib.metadata/ColumnMetadata
     value]
    (keep #(% query stage-number column value)
          [distribution-drill
           foreign-key-drill
           object-detail-drill
-          quick-filter-drill])))
+          pivot-drill
+          quick-filter-drill
+          sort-drill])))
 
 (comment
   (let [query    (metabase.lib.dev/query-for-table-name
@@ -164,7 +266,19 @@
         subtotal (nth cols 3)
         user-id  (nth cols 1)
         ops      (operators-for subtotal 100)
-        filters  (map :filter ops)]
+        filters  (map :filter ops)
+        binned   (-> query
+                     (metabase.lib.breakout/breakout -1 (metabase.lib.binning/with-binning subtotal
+                                                          {:strategy :num-bins :num-bins 50}))
+                     (metabase.lib.aggregation/aggregate (metabase.lib.aggregation/count)))
+        counted  (metabase.lib.aggregation/aggregate query (metabase.lib.aggregation/count))
+        countcol (first (metabase.lib.metadata.calculation/metadata counted))
+        pivots   (->> (available-drill-thrus counted -1 countcol 0)
+                      (keep :pivots)
+                      first)
+        citycol  (->> pivots :category second)]
     #_(quick-filter-drill query -1 subtotal 200)
-    (available-drill-thrus query -1 user-id 10))
+    #_(metabase.lib.order-by/order-bys (metabase.lib.order-by/order-by query -1 subtotal :asc) -1)
+    (available-drill-thrus query -1 subtotal)
+    )
   *e)

--- a/src/metabase/lib/drill_thru.cljc
+++ b/src/metabase/lib/drill_thru.cljc
@@ -559,6 +559,7 @@
   [query        :- ::lib.schema/query
    stage-number :- :int
    context      :- ::lib.schema.drill-thru/context]
+  (prn context)
   (keep #(% query stage-number context)
         ;; TODO: Missing drills: automatic insights, format.
         [distribution-drill

--- a/src/metabase/lib/drill_thru.cljc
+++ b/src/metabase/lib/drill_thru.cljc
@@ -30,7 +30,7 @@
       :lib/type
       (= :mbql.stage/mbql)))
 
-(defn- drill-thru-dispatch [_query _stage-number drill-thru & _more]
+(defn- drill-thru-dispatch [_query _stage-number drill-thru]
   (:type drill-thru))
 
 (defmulti drill-thru-method

--- a/src/metabase/lib/drill_thru.cljc
+++ b/src/metabase/lib/drill_thru.cljc
@@ -1,18 +1,18 @@
 (ns metabase.lib.drill-thru
   (:require
-    [metabase.lib.dispatch :as lib.dispatch]
-    [metabase.lib.hierarchy :as lib.hierarchy]
-    [metabase.lib.metadata :as lib.metadata]
-    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
-    [metabase.lib.options :as lib.options]
-    [metabase.lib.ref :as lib.ref]
-    [metabase.lib.schema :as lib.schema]
-    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
-    [metabase.lib.schema.expression :as lib.schema.expression]
-    [metabase.lib.types.isa :as lib.types.isa]
-    [metabase.lib.util :as lib.util]
-    [metabase.shared.util.i18n :as i18n]
-    [metabase.util.malli :as mu]))
+   [metabase.lib.dispatch :as lib.dispatch]
+   [metabase.lib.hierarchy :as lib.hierarchy]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.metadata.calculation :as lib.metadata.calculation]
+   [metabase.lib.options :as lib.options]
+   [metabase.lib.ref :as lib.ref]
+   [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
+   [metabase.lib.schema.expression :as lib.schema.expression]
+   [metabase.lib.types.isa :as lib.types.isa]
+   [metabase.lib.util :as lib.util]
+   [metabase.shared.util.i18n :as i18n]
+   [metabase.util.malli :as mu]))
 
 ;; TODO: Different ways to apply drill-thru to a query.
 ;; So far:
@@ -48,6 +48,15 @@
                                              :filter (operator op field-ref value)}))))
 
 (mu/defn ^:private quick-filter-drill :- [:maybe ::lib.schema.drill-thru/drill-thru]
+  "Filter the current query based on the value clicked.
+
+  The options vary depending on the type of the field:
+  - `:is-null` and `:not-null` for a `NULL` value;
+  - `:=` and `:!=` for everything else;
+  - plus `:<` and `:>` for numeric and date columns.
+
+  Note that this returns a single `::drill-thru` value with 1 or more `:operators`; these are rendered as a set of small
+  buttons in a single row of the drop-down."
   [query        :- ::lib.schema/query
    stage-number :- :int
    column       :- lib.metadata/ColumnMetadata
@@ -62,8 +71,11 @@
      :type      :drill-thru/quick-filter
      :operators (operators-for column value)}))
 
-;;; ------------------------------------- Quick Filters ------------------------------------------
+;;; ------------------------------------ Object Details ------------------------------------------
 (mu/defn ^:private object-detail-drill :- [:maybe ::lib.schema.drill-thru/drill-thru]
+  "When clicking a foreign key or primary key value, drill through to the details for that specific object.
+
+  Contrast [[foreign-key-drill]], which filters this query to only those rows with a specific value for a FK column."
   [query        :- ::lib.schema/query
    stage-number :- :int
    column       :- lib.metadata/ColumnMetadata
@@ -76,12 +88,54 @@
                        (and (lib.types.isa/primary-key? column) many-pks?) :drill-thru/pk
                        ;; TODO: Figure out clicked.extraData and the dashboard flow.
                        (lib.types.isa/primary-key? column)                 :drill-thru/zoom
-                       (lib.types.isa/foreign-key? column)                 :drill-thru/fk)]
+                       (lib.types.isa/foreign-key? column)                 :drill-thru/fk-details)]
       (when drill-type
         {:lib/type  ::drill-thru
          :type      drill-type
          :object-id value
          :many-pks? many-pks?}))))
+
+;;; ------------------------------------- Foreign Key --------------------------------------------
+(mu/defn ^:private foreign-key-drill :- [:maybe ::lib.schema.drill-thru/drill-thru]
+  "When clicking on a foreign key value, filter this query by that column.
+
+  This has the same effect as the `=` filter on a generic field (ie. not a key), but renders differently.
+
+  Contrast [[object-detail-drill]], which shows the details of the foreign object."
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   column       :- lib.metadata/ColumnMetadata
+   value]
+  (when (and (structured? query stage-number)
+             column
+             (some? value)
+             (not (lib.types.isa/primary-key? column))
+             (lib.types.isa/foreign-key? column))
+    {:lib/type  ::drill-thru
+     :type      :drill-thru/fk-filter
+     :filter    (lib.options/ensure-uuid [:= {} (lib.ref/ref column) value])}))
+
+;;; ------------------------------------- Distribution -------------------------------------------
+(mu/defn ^:private distribution-drill :- [:maybe ::lib.schema.drill-thru/drill-thru]
+  "Select a column and see a histogram of how many rows fall into an automatic set of bins/buckets.
+  - For dates, breaks out by month by default.
+  - For numeric values, by an auto-selected set of bins
+  - For strings, by each distinct value (which might be = the number of rows)"
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   column       :- lib.metadata/ColumnMetadata
+   value]
+  (when (and (structured? query stage-number)
+             column
+             (nil? value)
+             (not (lib.types.isa/primary-key? column))
+             (not (lib.types.isa/foreign-key? column))
+             (not (lib.types.isa/structured?  column))
+             (not (lib.types.isa/comment?     column))
+             (not (lib.types.isa/description? column)))
+    {:lib/type  ::drill-thru
+     :type      :drill-thru/distribution
+     :column    column}))
 
 ;;; --------------------------------------- Top Level --------------------------------------------
 (mu/defn available-drill-thrus :- [:sequential [:ref ::lib.schema.drill-thru/drill-thru]]
@@ -96,20 +150,21 @@
     column       :- lib.metadata/ColumnMetadata
     value]
    (keep #(% query stage-number column value)
-         [object-detail-drill
+         [distribution-drill
+          foreign-key-drill
+          object-detail-drill
           quick-filter-drill])))
 
 (comment
   (let [query    (metabase.lib.dev/query-for-table-name
-                   (metabase.lib.metadata.jvm/application-database-metadata-provider 1)
-                   "ORDERS")
+                  (metabase.lib.metadata.jvm/application-database-metadata-provider 1)
+                  "ORDERS")
         stage    (metabase.lib.util/query-stage query -1)
         cols     (metabase.lib.metadata.calculation/visible-columns query -1 stage)
         subtotal (nth cols 3)
+        user-id  (nth cols 1)
         ops      (operators-for subtotal 100)
         filters  (map :filter ops)]
     #_(quick-filter-drill query -1 subtotal 200)
-    (available-drill-thrus query -1 (nth cols 1) 100)
-    )
-  *e
-  )
+    (available-drill-thrus query -1 user-id 10))
+  *e)

--- a/src/metabase/lib/drill_thru.cljc
+++ b/src/metabase/lib/drill_thru.cljc
@@ -559,7 +559,6 @@
   [query        :- ::lib.schema/query
    stage-number :- :int
    context      :- ::lib.schema.drill-thru/context]
-  (prn context)
   (keep #(% query stage-number context)
         ;; TODO: Missing drills: automatic insights, format.
         [distribution-drill

--- a/src/metabase/lib/drill_thru.cljc
+++ b/src/metabase/lib/drill_thru.cljc
@@ -336,24 +336,24 @@
          :type     :drill-thru/pivot
          :pivots   pivots}))))
 
+(defmethod drill-thru-info-method :drill-thru/pivot
+  [_query _stage-number drill-thru]
+  (select-keys drill-thru [:many-pks? :object-id :type]))
+
 ;; Note that pivot drills have specific public functions for accessing the nested pivoting options.
 ;; Therefore the [[drill-thru-info-method]] is just the default `{:type :drill-thru/pivot}`.
 
-(defmethod drill-thru-method :drill-thru/pivot
-  [query stage-number _drill-thru column & _]
-  ;; TODO: Figure out when the `dimensions` input to the original version is nonempty, and integrate that here.
-  ;; TODO: The FE follows a pivot of the query with `setDefaultDisplay()`; make sure that still happens.
-  (lib.breakout/breakout query stage-number column))
-
 (mu/defn pivot-types :- [:sequential ::lib.schema.drill-thru/drill-thru-pivot-types]
   "A helper for the FE. Returns the set of pivot types (category, location, time) that apply to this drill-thru."
-  [drill-thru :- ::lib.schema.drill-thru/drill-thru]
+  [drill-thru :- [:and ::lib.schema.drill-thru/drill-thru
+                  [:map [:type [:= :drill-thru/pivot]]]]]
   (keys (:pivots drill-thru)))
 
 (mu/defn pivot-columns-for-type :- [:sequential lib.metadata/ColumnMetadata]
   "A helper for the FE. Returns all the columns of the given type which can be used to pivot the query."
-  [drill-thru :- ::lib.schema.drill-thru/drill-thru
-   pivot-type :- ::lib.schema.drill-thru/drill-thru-pivot-types]
+  [drill-thru :- [:and ::lib.schema.drill-thru/drill-thru
+                  [:map [:type [:= :drill-thru/pivot]]]]
+   pivot-type :- ::lib.schema.drill-thru-pivot-types]
   (get-in drill-thru [:pivots pivot-type]))
 
 ;;; ----------------------------------------- Sort -----------------------------------------------

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -91,7 +91,10 @@
         ;; we should look in to fixing this if we can.
         stage-columns         (or (:metabase.lib.stage/cached-metadata stage)
                                   (get-in stage [:lib/stage-metadata :columns])
-                                  (when (:source-card stage)
+                                  (when (or (:source-card  stage)
+                                            (:source-table stage)
+                                            (:expressions  stage)
+                                            (:fields       stage))
                                     (lib.metadata.calculation/visible-columns query stage-number stage))
                                   (log/warn (i18n/tru "Cannot resolve column {0}: stage has no metadata" (pr-str column-name))))]
     (when-let [column (and (seq stage-columns)

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -526,10 +526,7 @@
                             (fn [column]
                               (let [col-ref (lib.ref/ref column)]
                                 (boolean
-                                 (some (fn [fields-ref]
-                                         ;; FIXME: This should use [[lib.equality/find-closest-matching-ref]] instead.
-                                         #_{:clj-kondo/ignore [:deprecated-var]}
-                                         (lib.equality/ref= col-ref fields-ref))
+                                 (some (constantly true)
                                        current-fields)))))]
      (mapv (fn [col]
              (assoc col :selected? (selected-column? col)))

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -634,9 +634,9 @@
 
   `stage-number` is required to avoid ambiguous arities."
   ([a-query stage-number column]
-   (available-drill-thrus query stage-number column nil))
+   (available-drill-thrus a-query stage-number column nil))
   ([a-query stage-number column value]
-   (to-array (lib.core/available-drill-thrus query stage-number (js.metadata/parse-column column) value))))
+   (to-array (lib.core/available-drill-thrus a-query stage-number (js.metadata/parse-column column) value))))
 
 (defn ^:export drill-thru
   "Applies the given `drill-thru` to the specified query and stage. Returns the updated query.

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -640,14 +640,15 @@
     {:column-name (.-name (col-fn cell))
      :value       (.-value cell)}))
 
-(def ^:private row-cell       (js-cells-by #(.-col %)))
-(def ^:private dimension-cell (js-cells-by #(.-column %)))
+(def ^:private row-cell       (js-cells-by #(.-col ^js %)))
+(def ^:private dimension-cell (js-cells-by #(.-column ^js %)))
 
 (defn ^:export available-drill-thrus
   "Return an array (possibly empty) of drill-thrus given:
   - Required column
   - Nullable value
-  - Nullable data row (the array of `{col, value}` pairs from `clicked.data`)"
+  - Nullable data row (the array of `{col, value}` pairs from `clicked.data`)
+  - Nullable dimensions list (`{column, value}` pairs from `clicked.dimensions`)"
   [a-query stage-number column value row dimensions]
   (->> (merge {:column (js.metadata/parse-column column)
                :value  (cond

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -122,7 +122,7 @@
       (lib.stage/ensure-previous-stages-have-metadata stage-number)
       (lib.core/display-info stage-number x)
       (update-keys u/->camelCaseEn)
-      (update :table update-keys u/->camelCaseEn)
+      (m/update-existing :table update-keys u/->camelCaseEn)
       (clj->js :keyword-fn u/qualified-name)))
 
 (defn ^:export order-by-clause

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -653,9 +653,9 @@
   [a-query stage-number column value row dimensions]
   (->> (merge {:column (js.metadata/parse-column column)
                :value  (cond
-                         (identical? value js/undefined) nil   ; Missing a value, ie. a column click
-                         (nil? value)                    :null ; Provided value is null, ie. database NULL
-                         :else                           value)}
+                         (undefined? value) nil   ; Missing a value, ie. a column click
+                         (nil? value)       :null ; Provided value is null, ie. database NULL
+                         :else              value)}
               (when row                    {:row        (mapv row-cell       row)})
               (when (not-empty dimensions) {:dimensions (mapv dimension-cell dimensions)}))
        (lib.core/available-drill-thrus a-query stage-number)

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -643,12 +643,12 @@
   - Nullable value
   - Nullable data row (the array of `{col, value}` pairs from `clicked.data`)"
   [a-query stage-number column value row]
-  (->> {:column (js.metadata/parse-column column)
-        :value  (cond
-                  (identical? value js/undefined) nil   ; Missing a value, ie. a column click
-                  (nil? value)                    :null ; Provided value is null, ie. database NULL
-                  :else                           value)
-        :row    (mapv row-cell row)}
+  (->> (merge {:column (js.metadata/parse-column column)
+               :value  (cond
+                         (identical? value js/undefined) nil   ; Missing a value, ie. a column click
+                         (nil? value)                    :null ; Provided value is null, ie. database NULL
+                         :else                           value)}
+              (when row {:row (mapv row-cell row)}))
        (lib.core/available-drill-thrus a-query stage-number)
        to-array))
 

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -14,6 +14,7 @@
    [metabase.lib.join :as lib.join]
    [metabase.lib.js.metadata :as js.metadata]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.order-by :as lib.order-by]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.stage :as lib.stage]
    [metabase.mbql.js :as mbql.js]
@@ -110,7 +111,7 @@
   "Return a sequence of Column metadatas about the columns you can add order bys for in a given stage of `a-query.` To
   add an order by, pass the result to [[order-by]]."
   [a-query stage-number]
-  (to-array (lib.core/orderable-columns a-query stage-number)))
+  (to-array (lib.order-by/orderable-columns a-query stage-number)))
 
 (defn ^:export display-info
   "Given an opaque Cljs object, return a plain JS object with info you'd need to implement UI for it.

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -628,3 +628,29 @@
   Returns `nil` if no matching metadata is found."
   [query-or-metadata-provider table-id]
   (lib.metadata/table-or-card query-or-metadata-provider table-id))
+
+(defn ^:export available-drill-thrus
+  "Return an array (possibly empty) of drill-thrus for a given column and optional value.
+
+  `stage-number` is required to avoid ambiguous arities."
+  ([a-query stage-number column]
+   (available-drill-thrus query stage-number column nil))
+  ([a-query stage-number column value]
+   (to-array (lib.core/available-drill-thrus query stage-number column value))))
+
+(defn ^:export drill-thru
+  "Applies the given `drill-thru` to the specified query and stage. Returns the updated query.
+
+  Each type of drill-thru has a different effect on the query."
+  [a-query stage-number drill-thru]
+  (lib.core/drill-thru query stage-number drill-thru))
+
+(defn ^:export pivot-types
+  "Returns an array of pivot types that are available in this drill-thru, which must be a pivot drill-thru."
+  [drill-thru]
+  (to-array (lib.core/pivot-types drill-thru)))
+
+(defn ^:export pivot-columns-for-type
+  "Returns an array of "
+  [drill-thru]
+  (lib.core/pivot-types drill-thru))

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -636,21 +636,21 @@
   ([a-query stage-number column]
    (available-drill-thrus query stage-number column nil))
   ([a-query stage-number column value]
-   (to-array (lib.core/available-drill-thrus query stage-number column value))))
+   (to-array (lib.core/available-drill-thrus query stage-number (js.metadata/parse-column column) value))))
 
 (defn ^:export drill-thru
   "Applies the given `drill-thru` to the specified query and stage. Returns the updated query.
 
   Each type of drill-thru has a different effect on the query."
-  [a-query stage-number drill-thru]
-  (lib.core/drill-thru query stage-number drill-thru))
+  [a-query stage-number a-drill-thru]
+  (lib.core/drill-thru a-query stage-number a-drill-thru))
 
 (defn ^:export pivot-types
   "Returns an array of pivot types that are available in this drill-thru, which must be a pivot drill-thru."
-  [drill-thru]
-  (to-array (lib.core/pivot-types drill-thru)))
+  [a-drill-thru]
+  (to-array (lib.core/pivot-types a-drill-thru)))
 
 (defn ^:export pivot-columns-for-type
-  "Returns an array of "
-  [drill-thru]
-  (lib.core/pivot-types drill-thru))
+  "Returns an array of pivotable columns of the specified type."
+  [a-drill-thru pivot-type]
+  (lib.core/pivot-columns-for-type a-drill-thru pivot-type))

--- a/src/metabase/lib/js/metadata.cljs
+++ b/src/metabase/lib/js/metadata.cljs
@@ -382,6 +382,9 @@
         :when              (and a-metric (= (:table-id a-metric) table-id))]
     a-metric))
 
+(defn- setting [key]
+  (.get js/__metabaseSettings (name key)))
+
 (defn metadata-provider
   "Use a `metabase-lib/metadata/Metadata` as a [[metabase.lib.metadata.protocols/MetadataProvider]]."
   [database-id unparsed-metadata]
@@ -397,6 +400,7 @@
       (tables   [_this]            (tables   metadata database-id))
       (fields   [_this table-id]   (fields   metadata table-id))
       (metrics  [_this table-id]   (metrics  metadata table-id))
+      (setting  [_this key]        (setting  key))
 
       ;; for debugging: call [[clojure.datafy/datafy]] on one of these to parse all of our metadata and see the whole
       ;; thing at once.

--- a/src/metabase/lib/js/metadata.cljs
+++ b/src/metabase/lib/js/metadata.cljs
@@ -102,7 +102,7 @@
      ;; convert keys to kebab-case keywords
      (map (fn [[k v]]
             [(cond-> (keyword (u/->kebab-case-en k))
-               rename-key #(or (rename-key %) %))
+               rename-key (#(or (rename-key %) %)))
              v]))
      ;; remove [[excluded-keys]]
      (if (empty? excluded-keys-set)

--- a/src/metabase/lib/metadata.cljc
+++ b/src/metabase/lib/metadata.cljc
@@ -224,12 +224,6 @@
     setting-key           :- [:or string? keyword?]]
    (lib.metadata.protocols/setting (->metadata-provider metadata-providerable) setting-key)))
 
-(mu/defn setting :- any?
-  "Get the value of a Metabase setting for the instance we're querying."
-  ([metadata-providerable :- MetadataProviderable
-    setting-key           :- [:or string? keyword?]]
-   (lib.metadata.protocols/setting (->metadata-provider metadata-providerable) setting-key)))
-
 ;;;; Stage metadata
 
 (def StageMetadata

--- a/src/metabase/lib/metadata.cljc
+++ b/src/metabase/lib/metadata.cljc
@@ -218,6 +218,12 @@
    field-id              :- ::lib.schema.id/field]
   (lib.metadata.protocols/field (->metadata-provider metadata-providerable) field-id))
 
+(mu/defn setting :- any?
+  "Get the value of a Metabase setting for the instance we're querying."
+  ([metadata-providerable :- MetadataProviderable
+    setting-key           :- [:or string? keyword?]]
+   (lib.metadata.protocols/setting (->metadata-provider metadata-providerable) setting-key)))
+
 ;;;; Stage metadata
 
 (def StageMetadata

--- a/src/metabase/lib/metadata.cljc
+++ b/src/metabase/lib/metadata.cljc
@@ -224,6 +224,12 @@
     setting-key           :- [:or string? keyword?]]
    (lib.metadata.protocols/setting (->metadata-provider metadata-providerable) setting-key)))
 
+(mu/defn setting :- any?
+  "Get the value of a Metabase setting for the instance we're querying."
+  ([metadata-providerable :- MetadataProviderable
+    setting-key           :- [:or string? keyword?]]
+   (lib.metadata.protocols/setting (->metadata-provider metadata-providerable) setting-key)))
+
 ;;;; Stage metadata
 
 (def StageMetadata

--- a/src/metabase/lib/metadata/cached_provider.cljc
+++ b/src/metabase/lib/metadata/cached_provider.cljc
@@ -62,6 +62,7 @@
   (tables   [_this]            (get-in-cache-or-fetch cache [::database-tables]             #(lib.metadata.protocols/tables   metadata-provider)))
   (fields   [_this table-id]   (get-in-cache-or-fetch cache [::table-fields table-id]       #(lib.metadata.protocols/fields   metadata-provider table-id)))
   (metrics  [_this table-id]   (get-in-cache-or-fetch cache [::table-metrics table-id]      #(lib.metadata.protocols/metrics  metadata-provider table-id)))
+  (setting  [_this setting]    (lib.metadata.protocols/setting metadata-provider setting))
 
   lib.metadata.protocols/CachedMetadataProvider
   (cached-database [_this]                           (get-in-cache    cache [:metadata/database]))

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -10,6 +10,7 @@
    [metabase.lib.schema.expression :as lib.schema.expresssion]
    [metabase.lib.schema.temporal-bucketing
     :as lib.schema.temporal-bucketing]
+   [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.util :as lib.util]
    [metabase.shared.util.i18n :as i18n]
    [metabase.util :as u]
@@ -514,3 +515,10 @@
     options        :- [:maybe VisibleColumnsOptions]]
    (let [options (merge (default-visible-columns-options) options)]
      (visible-columns-method query stage-number x options))))
+
+(mu/defn primary-keys :- [:sequential lib.metadata/ColumnMetadata]
+  "Returns a list of primary keys for the source table of this query."
+  [query        :- ::lib.schema/query]
+  (if-let [table-id (lib.util/source-table query)]
+    (filter lib.types.isa/primary-key? (lib.metadata/fields query table-id))
+    []))

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -519,6 +519,6 @@
 (mu/defn primary-keys :- [:sequential lib.metadata/ColumnMetadata]
   "Returns a list of primary keys for the source table of this query."
   [query        :- ::lib.schema/query]
-  (if-let [table-id (lib.util/source-table query)]
+  (if-let [table-id (lib.util/source-table-id query)]
     (filter lib.types.isa/primary-key? (lib.metadata/fields query table-id))
     []))

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -484,7 +484,6 @@
 ;;; default impl is just the impl for [[returned-columns-method]]
 (defmethod visible-columns-method :default
   [query stage-number x options]
-  (println "default VCM")
   (returned-columns-method query stage-number x options))
 
 (mu/defn visible-columns :- ColumnsWithUniqueAliases

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -484,6 +484,7 @@
 ;;; default impl is just the impl for [[returned-columns-method]]
 (defmethod visible-columns-method :default
   [query stage-number x options]
+  (println "default VCM")
   (returned-columns-method query stage-number x options))
 
 (mu/defn visible-columns :- ColumnsWithUniqueAliases

--- a/src/metabase/lib/metadata/jvm.clj
+++ b/src/metabase/lib/metadata/jvm.clj
@@ -79,7 +79,7 @@
     (fields table-id))
 
   (metrics [_this table-id]
-    (metrics table-id)
+    (metrics table-id))
 
   (setting [_this setting-name]
     (setting/get setting-name))

--- a/src/metabase/lib/metadata/jvm.clj
+++ b/src/metabase/lib/metadata/jvm.clj
@@ -3,6 +3,7 @@
   (:require
    [metabase.lib.metadata.cached-provider :as lib.metadata.cached-provider]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
+   [metabase.models.setting :as setting]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [potemkin :as p]
@@ -78,7 +79,10 @@
     (fields table-id))
 
   (metrics [_this table-id]
-    (metrics table-id))
+    (metrics table-id)
+
+  (setting [_this setting-name]
+    (setting/get setting-name))
 
   lib.metadata.protocols/BulkMetadataProvider
   (bulk-metadata [_this metadata-type ids]

--- a/src/metabase/lib/metadata/protocols.cljc
+++ b/src/metabase/lib/metadata/protocols.cljc
@@ -1,6 +1,6 @@
 (ns metabase.lib.metadata.protocols
-  (:require
-   #?@(:clj ([potemkin :as p]))))
+  #?(:clj (:require
+           [potemkin :as p])))
 
 (#?(:clj p/defprotocol+ :cljs defprotocol) MetadataProvider
   "Protocol for something that we can get information about Tables and Fields from. This can be provided in various ways
@@ -65,7 +65,10 @@
 
   (metrics [metadata-provider table-id]
     "Return a sequence of legacy v1 Metrics associated with a Table with the given `table-id`. Metrics should satisfy
-  the [[metabase.lib.metadata/MetricMetadata]] schema. If no such Table exists, this should error."))
+  the [[metabase.lib.metadata/MetricMetadata]] schema. If no such Table exists, this should error.")
+
+  (setting [metadata-provider setting-name]
+    "Return the value of the given Metabase setting, a keyword."))
 
 (defn metadata-provider?
   "Whether `x` is a valid [[MetadataProvider]]."

--- a/src/metabase/lib/order_by.cljc
+++ b/src/metabase/lib/order_by.cljc
@@ -170,3 +170,15 @@
      (mbql.u.match/replace query
        [direction (_ :guard #(= (:lib/uuid %) lib-uuid)) _]
        (assoc &match 0 (opposite-direction direction))))))
+
+
+(comment
+  (orderable-columns
+    (metabase.lib.query/query
+      metabase.lib.test-metadata/metadata-provider
+      {:lib/type :mbql/query
+       :database (metabase.lib.test-metadata/id)
+       :stages [{:lib/type     :mbql.stage/mbql
+                 :source-table (metabase.lib.test-metadata/id :orders)}]})
+    -1)
+  )

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -30,6 +30,7 @@
 
 (defmethod lib.metadata.calculation/returned-columns-method :mbql/query
   [query stage-number a-query options]
+  (println "query RCM")
   (lib.metadata.calculation/returned-columns query stage-number (lib.util/query-stage a-query stage-number) options))
 
 (defmethod lib.metadata.calculation/display-name-method :mbql/query

--- a/src/metabase/lib/schema/drill_thru.cljc
+++ b/src/metabase/lib/schema/drill_thru.cljc
@@ -19,6 +19,14 @@
    [:object-id :any]
    [:many-pks? :boolean]])
 
+(mr/def ::context
+  [:map
+   [:column lib.metadata/ColumnMetadata]
+   [:value  [:maybe :any]]
+   [:row    {:optional true} [:sequential [:map
+                                           [:column-name string?]
+                                           [:value       :any]]]]])
+
 (mr/def ::drill-thru
   [:multi {:dispatch :type}
    [:drill-thru/pk         ::drill-thru-keyed]

--- a/src/metabase/lib/schema/drill_thru.cljc
+++ b/src/metabase/lib/schema/drill_thru.cljc
@@ -50,4 +50,10 @@
     [:map
      [:type            keyword?]
      [:lib/type        [:= :metabase.lib.drill-thru/drill-thru]]
-     [:sort-directions [:sequential ::lib.schema.order-by/direction]]]]])
+     [:sort-directions [:sequential ::lib.schema.order-by/direction]]]]
+   [:drill-thru/summarize-column
+    [:map
+     [:type         keyword?]
+     [:lib/type     [:= :metabase.lib.drill-thru/drill-thru]]
+     [:column       lib.metadata/ColumnMetadata]
+     [:aggregations [:sequential [:enum :avg :distinct :sum]]]]]])

--- a/src/metabase/lib/schema/drill_thru.cljc
+++ b/src/metabase/lib/schema/drill_thru.cljc
@@ -11,6 +11,13 @@
 (mr/def ::drill-thru-types
   [:enum :drill-thru/quick-filter])
 
+(mr/def ::drill-thru-keyed
+  [:map
+   [:type      keyword?]
+   [:lib/type  [:= :metabase.lib.drill-thru/drill-thru]]
+   [:object-id :any]
+   [:many-pks? :boolean]])
+
 (mr/def ::drill-thru
   [:multi {:dispatch :type}
    [:drill-thru/quick-filter
@@ -19,4 +26,7 @@
      [:lib/type  [:= :metabase.lib.drill-thru/drill-thru]]
      [:operators [:sequential [:map
                                [:name   string?]
-                               [:filter ::mbql-clause/clause]]]]]]])
+                               [:filter ::mbql-clause/clause]]]]]]
+   [:drill-thru/pk   ::drill-thru-keyed]
+   [:drill-thru/fk   ::drill-thru-keyed]
+   [:drill-thru/zoom ::drill-thru-keyed]])

--- a/src/metabase/lib/schema/drill_thru.cljc
+++ b/src/metabase/lib/schema/drill_thru.cljc
@@ -9,8 +9,8 @@
    [metabase.lib.schema.order-by :as lib.schema.order-by]
    [metabase.util.malli.registry :as mr]))
 
-(mr/def ::drill-thru-types
-  [:enum :drill-thru/quick-filter])
+(mr/def ::drill-thru-pivot-types
+  [:enum :category :location :time])
 
 (mr/def ::drill-thru-keyed
   [:map
@@ -21,6 +21,9 @@
 
 (mr/def ::drill-thru
   [:multi {:dispatch :type}
+   [:drill-thru/pk         ::drill-thru-keyed]
+   [:drill-thru/fk-details ::drill-thru-keyed]
+   [:drill-thru/zoom       ::drill-thru-keyed]
    [:drill-thru/quick-filter
     [:map
      [:type      keyword?]
@@ -28,9 +31,6 @@
      [:operators [:sequential [:map
                                [:name   string?]
                                [:filter ::lib.schema.expression/boolean]]]]]]
-   [:drill-thru/pk         ::drill-thru-keyed]
-   [:drill-thru/fk-details ::drill-thru-keyed]
-   [:drill-thru/zoom       ::drill-thru-keyed]
    [:drill-thru/fk-filter
     [:map
      [:type      keyword?]
@@ -45,7 +45,7 @@
     [:map
      [:type      keyword?]
      [:lib/type  [:= :metabase.lib.drill-thru/drill-thru]]
-     [:pivots    [:map-of [:enum :category :location :time] [:sequential lib.metadata/ColumnMetadata]]]]]
+     [:pivots    [:map-of ::drill-thru-pivot-types [:sequential lib.metadata/ColumnMetadata]]]]]
    [:drill-thru/sort
     [:map
      [:type            keyword?]
@@ -56,4 +56,9 @@
      [:type         keyword?]
      [:lib/type     [:= :metabase.lib.drill-thru/drill-thru]]
      [:column       lib.metadata/ColumnMetadata]
-     [:aggregations [:sequential [:enum :avg :distinct :sum]]]]]])
+     [:aggregations [:sequential [:enum :avg :distinct :sum]]]]]
+   [:drill-thru/automatic-insights
+    [:map
+     [:type         keyword?]
+     [:lib/type     [:= :metabase.lib.drill-thru/drill-thru]]
+     [:column       lib.metadata/ColumnMetadata]]]])

--- a/src/metabase/lib/schema/drill_thru.cljc
+++ b/src/metabase/lib/schema/drill_thru.cljc
@@ -1,0 +1,22 @@
+(ns metabase.lib.schema.drill-thru
+  "Malli schemas for possible drill-thru operations.
+
+  Drill-thrus are not part of MBQL; they are a set of actions one can take to transform a query.
+  For example, adding a filter like `created_at < 2022-01-01`, or following a foreign key."
+  (:require
+   [metabase.lib.schema.common :as lib.schema.common]
+   [metabase.lib.schema.mbql-clause :as mbql-clause]
+   [metabase.util.malli.registry :as mr]))
+
+(mr/def ::drill-thru-types
+  [:enum :drill-thru/quick-filter])
+
+(mr/def ::drill-thru
+  [:multi {:dispatch :type}
+   [:drill-thru/quick-filter
+    [:map
+     [:type      keyword?]
+     [:lib/type  [:= :metabase.lib.drill-thru/drill-thru]]
+     [:operators [:sequential [:map
+                               [:name   string?]
+                               [:filter ::mbql-clause/clause]]]]]]])

--- a/src/metabase/lib/schema/drill_thru.cljc
+++ b/src/metabase/lib/schema/drill_thru.cljc
@@ -6,6 +6,7 @@
   (:require
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema.expression :as lib.schema.expression]
+   [metabase.lib.schema.filter :as lib.schema.filter]
    [metabase.lib.schema.order-by :as lib.schema.order-by]
    [metabase.util.malli.registry :as mr]))
 
@@ -65,6 +66,18 @@
      [:lib/type     [:= :metabase.lib.drill-thru/drill-thru]]
      [:column       lib.metadata/ColumnMetadata]
      [:aggregations [:sequential [:enum :avg :distinct :sum]]]]]
+   [:drill-thru/summarize-column-by-time
+    [:map
+     [:type         keyword?]
+     [:lib/type     [:= :metabase.lib.drill-thru/drill-thru]]
+     [:column       lib.metadata/ColumnMetadata]
+     [:breakout     lib.metadata/ColumnMetadata]]]
+   [:drill-thru/column-filter
+    [:map
+     [:type         keyword?]
+     [:lib/type     [:= :metabase.lib.drill-thru/drill-thru]]
+     [:column       lib.metadata/ColumnMetadata]
+     [:initial-op   [:maybe ::lib.schema.filter/operator]]]]
    [:drill-thru/automatic-insights
     [:map
      [:type         keyword?]

--- a/src/metabase/lib/schema/drill_thru.cljc
+++ b/src/metabase/lib/schema/drill_thru.cljc
@@ -4,8 +4,8 @@
   Drill-thrus are not part of MBQL; they are a set of actions one can take to transform a query.
   For example, adding a filter like `created_at < 2022-01-01`, or following a foreign key."
   (:require
-   [metabase.lib.schema.common :as lib.schema.common]
-   [metabase.lib.schema.mbql-clause :as mbql-clause]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.util.malli.registry :as mr]))
 
 (mr/def ::drill-thru-types
@@ -26,7 +26,17 @@
      [:lib/type  [:= :metabase.lib.drill-thru/drill-thru]]
      [:operators [:sequential [:map
                                [:name   string?]
-                               [:filter ::mbql-clause/clause]]]]]]
-   [:drill-thru/pk   ::drill-thru-keyed]
-   [:drill-thru/fk   ::drill-thru-keyed]
-   [:drill-thru/zoom ::drill-thru-keyed]])
+                               [:filter ::lib.schema.expression/boolean]]]]]]
+   [:drill-thru/pk         ::drill-thru-keyed]
+   [:drill-thru/fk-details ::drill-thru-keyed]
+   [:drill-thru/zoom       ::drill-thru-keyed]
+   [:drill-thru/fk-filter
+    [:map
+     [:type      keyword?]
+     [:lib/type  [:= :metabase.lib.drill-thru/drill-thru]]
+     [:filter    ::lib.schema.expression/boolean]]]
+   [:drill-thru/distribution
+    [:map
+     [:type      keyword?]
+     [:lib/type  [:= :metabase.lib.drill-thru/drill-thru]]
+     [:column    lib.metadata/ColumnMetadata]]]])

--- a/src/metabase/lib/schema/drill_thru.cljc
+++ b/src/metabase/lib/schema/drill_thru.cljc
@@ -6,6 +6,7 @@
   (:require
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema.expression :as lib.schema.expression]
+   [metabase.lib.schema.order-by :as lib.schema.order-by]
    [metabase.util.malli.registry :as mr]))
 
 (mr/def ::drill-thru-types
@@ -39,4 +40,14 @@
     [:map
      [:type      keyword?]
      [:lib/type  [:= :metabase.lib.drill-thru/drill-thru]]
-     [:column    lib.metadata/ColumnMetadata]]]])
+     [:column    lib.metadata/ColumnMetadata]]]
+   [:drill-thru/pivot
+    [:map
+     [:type      keyword?]
+     [:lib/type  [:= :metabase.lib.drill-thru/drill-thru]]
+     [:pivots    [:map-of [:enum :category :location :time] [:sequential lib.metadata/ColumnMetadata]]]]]
+   [:drill-thru/sort
+    [:map
+     [:type            keyword?]
+     [:lib/type        [:= :metabase.lib.drill-thru/drill-thru]]
+     [:sort-directions [:sequential ::lib.schema.order-by/direction]]]]])

--- a/src/metabase/lib/schema/expression.cljc
+++ b/src/metabase/lib/schema/expression.cljc
@@ -6,8 +6,7 @@
    [metabase.shared.util.i18n :as i18n]
    [metabase.types]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr])
-  #?(:cljs (:require-macros [metabase.lib.schema.expression])))
+   [metabase.util.malli.registry :as mr]))
 
 (comment metabase.types/keep-me)
 

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -311,7 +311,6 @@
 
 (defmethod lib.metadata.calculation/visible-columns-method ::stage
   [query stage-number _stage {:keys [unique-name-fn include-implicitly-joinable?], :as options}]
-  (println "stage VCM")
   (let [query            (ensure-previous-stages-have-metadata query stage-number)
         existing-columns (existing-visible-columns query stage-number options)]
     (->> (concat
@@ -326,7 +325,6 @@
 ;;; those and the joined columns. Otherwise return the defaults based on the source Table or previous stage + joins.
 (defmethod lib.metadata.calculation/returned-columns-method ::stage
   [query stage-number _stage {:keys [unique-name-fn], :as options}]
-  (println "stage RCM")
   (or
    (existing-stage-metadata query stage-number)
    (let [query        (ensure-previous-stages-have-metadata query stage-number)

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -311,6 +311,7 @@
 
 (defmethod lib.metadata.calculation/visible-columns-method ::stage
   [query stage-number _stage {:keys [unique-name-fn include-implicitly-joinable?], :as options}]
+  (println "stage VCM")
   (let [query            (ensure-previous-stages-have-metadata query stage-number)
         existing-columns (existing-visible-columns query stage-number options)]
     (->> (concat
@@ -325,6 +326,7 @@
 ;;; those and the joined columns. Otherwise return the defaults based on the source Table or previous stage + joins.
 (defmethod lib.metadata.calculation/returned-columns-method ::stage
   [query stage-number _stage {:keys [unique-name-fn], :as options}]
+  (println "stage RCM")
   (or
    (existing-stage-metadata query stage-number)
    (let [query        (ensure-previous-stages-have-metadata query stage-number)

--- a/src/metabase/lib/table.cljc
+++ b/src/metabase/lib/table.cljc
@@ -46,7 +46,6 @@
 
 (defmethod lib.metadata.calculation/returned-columns-method :metadata/table
   [query _stage-number table-metadata {:keys [unique-name-fn], :as _options}]
-  (prn "table RCM" query table-metadata (lib.metadata/fields query (:id table-metadata)))
   (when-let [field-metadatas (lib.metadata/fields query (:id table-metadata))]
     (->> field-metadatas
          remove-hidden-default-fields

--- a/src/metabase/lib/table.cljc
+++ b/src/metabase/lib/table.cljc
@@ -46,6 +46,7 @@
 
 (defmethod lib.metadata.calculation/returned-columns-method :metadata/table
   [query _stage-number table-metadata {:keys [unique-name-fn], :as _options}]
+  (prn "table RCM" query table-metadata (lib.metadata/fields query (:id table-metadata)))
   (when-let [field-metadatas (lib.metadata/fields query (:id table-metadata))]
     (->> field-metadatas
          remove-hidden-default-fields

--- a/src/metabase/lib/types/constants.cljc
+++ b/src/metabase/lib/types/constants.cljc
@@ -22,6 +22,9 @@
      (def ^:export key-coordinate "JS-friendly access for the coordinate type" ::coordinate)
      (def ^:export key-foreign-KEY "JS-friendly access for the foreign-key type" ::foreign-key)
      (def ^:export key-primary-KEY "JS-friendly access for the primary-key type" ::primary-key)
+     (def ^:export key-json "JS-friendly access for the JSON type" ::json)
+     (def ^:export key-xml "JS-friendly access for the JSON type" ::xml)
+     (def ^:export key-structured "JS-friendly access for the structured type" ::structured)
 
      ;; other types used for various purposes
      (def ^:export key-summable "JS-friendly access for the summable type" ::summable)
@@ -48,6 +51,9 @@
    ::entity      {:semantic-type [:type/FK :type/PK :type/Name]}
    ::foreign_key {:semantic-type [:type/FK]}
    ::primary_key {:semantic-type [:type/PK]}
+   ::json        {:effective-type [:type/SerializedJSON]}
+   ::xml         {:effective-type [:type/XML]}
+   ::structured  {:effective-type [:type/Structured]}
    ::summable    {:include [::number]
                   :exclude [::entity ::location ::temporal]}
    ::scope       {:include [::number ::temporal ::category ::entity ::string]

--- a/src/metabase/lib/types/isa.cljc
+++ b/src/metabase/lib/types/isa.cljc
@@ -129,6 +129,18 @@
   [column]
   (clojure.core/isa? (:semantic-type column) :type/Name))
 
+(defn ^:export json?
+  [column]
+  (clojure.core/isa? (:semantic-type column) :type/SerializedJSON))
+
+(defn ^:export xml?
+  [column]
+  (clojure.core/isa? (:semantic-type column) :type/XML))
+
+(defn ^:export structured?
+  [column]
+  (clojure.core/isa? (:semantic-type column) :type/Structured))
+
 (defn ^:export any?
   "Is this `_column` whatever (including nil)?"
   [_column]

--- a/test/metabase/lib/drill_thru_test.cljc
+++ b/test/metabase/lib/drill_thru_test.cljc
@@ -26,8 +26,116 @@
                  {:column-name "DISCOUNT" :value nil}
                  {:column-name "CREATED_AT" :value "2018-05-15T08:04:04.58Z"}
                  {:column-name "QUANTITY" :value 3}]]
-      (testing "with values"
-        (testing "click foreign key - FK filter and FK details"
+      (testing "column headers: click on"
+        (testing "primary key - column filter (default: Is), sort, summarize (distinct only)"
+          (is (=? [{:lib/type        :metabase.lib.drill-thru/drill-thru
+                    :type            :drill-thru/column-filter
+                    :column          (meta/field-metadata :orders :id)
+                    :initial-op      {:short := :display-name "Is"}}
+                   {:lib/type        :metabase.lib.drill-thru/drill-thru
+                    :type            :drill-thru/sort
+                    :column          (meta/field-metadata :orders :id)
+                    :sort-directions [:asc :desc]}
+                   {:lib/type        :metabase.lib.drill-thru/drill-thru
+                    :type            :drill-thru/summarize-column
+                    :column          (meta/field-metadata :orders :id)
+                    :aggregations    [:distinct]}]
+                  (lib/available-drill-thrus query -1 {:column (meta/field-metadata :orders :id)
+                                                       :value  nil}))))
+
+        (testing "foreign key - distribution, column filter (default: Is), sort, summarize (distinct only)"
+          (is (=? [{:lib/type        :metabase.lib.drill-thru/drill-thru
+                    :type            :drill-thru/distribution
+                    :column          (meta/field-metadata :orders :user-id)}
+                   {:lib/type        :metabase.lib.drill-thru/drill-thru
+                    :type            :drill-thru/column-filter
+                    :column          (meta/field-metadata :orders :user-id)
+                    :initial-op      {:short := :display-name "Is"}}
+                   {:lib/type        :metabase.lib.drill-thru/drill-thru
+                    :type            :drill-thru/sort
+                    :column          (meta/field-metadata :orders :user-id)
+                    :sort-directions [:asc :desc]}
+                   {:lib/type        :metabase.lib.drill-thru/drill-thru
+                    :type            :drill-thru/summarize-column
+                    :column          (meta/field-metadata :orders :user-id)
+                    :aggregations    [:distinct]}]
+                  (lib/available-drill-thrus query -1 {:column (meta/field-metadata :orders :user-id)
+                                                       :value  nil}))))
+
+        (testing "numeric column - distribution, column filter (default: Equal To), sort, summarize (all 3), summarize by time"
+          (is (=? [{:lib/type        :metabase.lib.drill-thru/drill-thru
+                    :type            :drill-thru/distribution
+                    :column          (meta/field-metadata :orders :subtotal)}
+                   {:lib/type        :metabase.lib.drill-thru/drill-thru
+                    :type            :drill-thru/column-filter
+                    :column          (meta/field-metadata :orders :subtotal)
+                    :initial-op      {:short := :display-name "Equal to"}}
+                   {:lib/type        :metabase.lib.drill-thru/drill-thru
+                    :type            :drill-thru/sort
+                    :column          (meta/field-metadata :orders :subtotal)
+                    :sort-directions [:asc :desc]}
+                   {:lib/type        :metabase.lib.drill-thru/drill-thru
+                    :type            :drill-thru/summarize-column
+                    :column          (meta/field-metadata :orders :subtotal)
+                    :aggregations    [:distinct :sum :avg]}
+                   {:lib/type        :metabase.lib.drill-thru/drill-thru
+                    :type            :drill-thru/summarize-column-by-time
+                    :column          (meta/field-metadata :orders :subtotal)
+                    :breakout        (meta/field-metadata :orders :created-at)}]
+                  (lib/available-drill-thrus query -1 {:column (meta/field-metadata :orders :subtotal)
+                                                       :value  nil}))))
+
+        (testing "date column - distribution, column filter (no default), sort, summarize (distinct only)"
+          (is (=? [{:lib/type        :metabase.lib.drill-thru/drill-thru
+                    :type            :drill-thru/distribution
+                    :column          (meta/field-metadata :orders :created-at)}
+                   {:lib/type        :metabase.lib.drill-thru/drill-thru
+                    :type            :drill-thru/column-filter
+                    :column          (meta/field-metadata :orders :created-at)
+                    :initial-op      nil}
+                   {:lib/type        :metabase.lib.drill-thru/drill-thru
+                    :type            :drill-thru/sort
+                    :column          (meta/field-metadata :orders :created-at)
+                    :sort-directions [:asc :desc]}
+                   {:lib/type        :metabase.lib.drill-thru/drill-thru
+                    :type            :drill-thru/summarize-column
+                    :column          (meta/field-metadata :orders :created-at)
+                    :aggregations    [:distinct]}]
+                  (lib/available-drill-thrus query -1 {:column (meta/field-metadata :orders :created-at)
+                                                       :value  nil}))))
+
+        (testing "a sorted column"
+          (let [expected [{:lib/type        :metabase.lib.drill-thru/drill-thru
+                           :type            :drill-thru/distribution
+                           :column          (meta/field-metadata :orders :subtotal)}
+                          {:lib/type        :metabase.lib.drill-thru/drill-thru
+                           :type            :drill-thru/column-filter
+                           :column          (meta/field-metadata :orders :subtotal)
+                           :initial-op      {:short := :display-name "Equal to"}}
+                          {:lib/type        :metabase.lib.drill-thru/drill-thru
+                           :type            :drill-thru/sort
+                           :column          (meta/field-metadata :orders :subtotal)
+                           ;; Starting off empty.
+                           :sort-directions []}
+                          {:lib/type        :metabase.lib.drill-thru/drill-thru
+                           :type            :drill-thru/summarize-column
+                           :column          (meta/field-metadata :orders :subtotal)
+                           :aggregations    [:distinct :sum :avg]}
+                          {:lib/type        :metabase.lib.drill-thru/drill-thru
+                           :type            :drill-thru/summarize-column-by-time
+                           :column          (meta/field-metadata :orders :subtotal)
+                           :breakout        (meta/field-metadata :orders :created-at)}]]
+            (doseq [[sort-dir other-option] [[:asc :desc]
+                                             [:desc :asc]]]
+              (testing (str "which is " sort-dir " and the sort drill only offers " other-option)
+                (is (=? (assoc-in expected [2 :sort-directions] [other-option])
+                        (-> query
+                            (lib/order-by -1 (meta/field-metadata :orders :subtotal) sort-dir)
+                            (lib/available-drill-thrus -1 {:column (meta/field-metadata :orders :subtotal)
+                                                           :value  nil})))))))))
+
+      (testing "table values: click on"
+        (testing "foreign key - FK filter and FK details"
           (is (=? [{:lib/type :metabase.lib.drill-thru/drill-thru
                     :type     :drill-thru/fk-filter
                     :filter   [:= {:lib/uuid string?}
@@ -41,7 +149,7 @@
                   (lib/available-drill-thrus query -1 {:column (meta/field-metadata :orders :user-id)
                                                        :value  1
                                                        :row    row}))))
-        (testing "click numeric value - numeric quick filters and object details *for the PK column*"
+        (testing "numeric value - numeric quick filters and object details *for the PK column*"
           (is (=? [{:lib/type  :metabase.lib.drill-thru/drill-thru
                     :type      :drill-thru/zoom
                     :column    (meta/field-metadata :orders :id) ; It should correctly find the PK column
@@ -60,7 +168,59 @@
                   (lib/available-drill-thrus query -1 {:column (meta/field-metadata :orders :subtotal)
                                                        :value  110.93
                                                        :row    row}))))
-        (testing "click nil value - basic quick filters and object details *for the PK column*"
+
+        (let [products-query (lib/query meta/metadata-provider (meta/table-metadata :products))
+              products-row   [{:column-name "ID" :value 118}
+                              {:column-name "EAN" :value "5291392809646"}
+                              {:column-name "TITLE" :value "Synergistic Rubber Shoes"}
+                              {:column-name "CATEGORY" :value "Gadget"}
+                              {:column-name "VENDOR" :value "Herta Skiles and Sons"}
+                              {:column-name "PRICE" :value 38.42}
+                              {:column-name "RATING" :value 3.5}
+                              {:column-name "CREATED_AT" :value "2016-10-19T12:34:56.789Z"}]]
+          (testing "category/enum value - filter is/is not, and object details *for the PK column*"
+            (is (=? [{:lib/type  :metabase.lib.drill-thru/drill-thru
+                      :type      :drill-thru/zoom
+                      :column    (meta/field-metadata :products :id) ; It should correctly find the PK column
+                      :object-id (-> products-row first :value)               ; And its value
+                      :many-pks? false}
+                     {:lib/type :metabase.lib.drill-thru/drill-thru
+                      :type     :drill-thru/quick-filter
+                      :operators (for [[op label] [[:=  "="]
+                                                   [:!= "≠"]]]
+                                   {:name label
+                                    :filter [op {:lib/uuid string?}
+                                             [:field {:lib/uuid string?} (meta/id :products :category)]
+                                             "Gadget"]})}]
+                    (lib/available-drill-thrus
+                      products-query
+                      -1
+                      {:column (meta/field-metadata :products :category)
+                       :value  "Gadget"
+                       :row    products-row}))))
+
+          (testing "string value - filter (not) equal, and object details *for the PK column*"
+            (is (=? [{:lib/type  :metabase.lib.drill-thru/drill-thru
+                      :type      :drill-thru/zoom
+                      :column    (meta/field-metadata :products :id) ; It should correctly find the PK column
+                      :object-id (-> products-row first :value)               ; And its value
+                      :many-pks? false}
+                     {:lib/type :metabase.lib.drill-thru/drill-thru
+                      :type     :drill-thru/quick-filter
+                      :operators (for [[op label] [[:=  "="]
+                                                   [:!= "≠"]]]
+                                   {:name label
+                                    :filter [op {:lib/uuid string?}
+                                             [:field {:lib/uuid string?} (meta/id :products :vendor)]
+                                             "Herta Skiles and Sons"]})}]
+                    (lib/available-drill-thrus
+                      products-query
+                      -1
+                      {:column (meta/field-metadata :products :vendor)
+                       :value  "Herta Skiles and Sons"
+                       :row    products-row})))))
+
+        (testing "NULL value - basic quick filters and object details *for the PK column*"
           (is (=? [{:lib/type  :metabase.lib.drill-thru/drill-thru
                     :type      :drill-thru/zoom
                     :column    (meta/field-metadata :orders :id) ; It should correctly find the PK column
@@ -68,15 +228,45 @@
                     :many-pks? false}
                    {:lib/type :metabase.lib.drill-thru/drill-thru
                     :type     :drill-thru/quick-filter
-                    :operators (for [[op label] [[:=  "="]
+                    :operators (for [[op label] [[:is-null  "="]
+                                                 [:not-null "≠"]]]
+                                 {:name label
+                                  :filter [op {:lib/uuid string?}
+                                           [:field {:lib/uuid string?} (meta/id :orders :discount)]]})}]
+                  (lib/available-drill-thrus query -1 {:column (meta/field-metadata :orders :discount)
+                                                       :value  :null
+                                                       :row    row}))))
+
+        (testing "date value - date quick filters and object details *for the PK column*"
+          (is (=? [{:lib/type  :metabase.lib.drill-thru/drill-thru
+                    :type      :drill-thru/zoom
+                    :column    (meta/field-metadata :orders :id) ; It should correctly find the PK column
+                    :object-id (-> row first :value)             ; And its value
+                    :many-pks? false}
+                   {:lib/type :metabase.lib.drill-thru/drill-thru
+                    :type     :drill-thru/quick-filter
+                    :operators (for [[op label] [[:<  "<"]
+                                                 [:>  ">"]
+                                                 [:=  "="]
                                                  [:!= "≠"]]]
                                  {:name label
                                   :filter [op {:lib/uuid string?}
-                                           [:field {:lib/uuid string?} (meta/id :orders :subtotal)]]})}]
-                  (lib/available-drill-thrus query -1 {:column (meta/field-metadata :orders :discount)
-                                                       :value  :null
+                                           [:field {:lib/uuid string?} (meta/id :orders :created-at)]
+                                           "2018-05-15T08:04:04.58Z"]})}]
+                  (lib/available-drill-thrus query -1 {:column (meta/field-metadata :orders :created-at)
+                                                       :value  "2018-05-15T08:04:04.58Z"
                                                        :row    row}))))))))
+(comment
+  (let [metadata-provider (metabase.lib.metadata.jvm/application-database-metadata-provider 1)
+        orders            2
+        orders-id         11
+        created-at        14
+        query             (lib/query metadata-provider (metabase.lib.metadata/table metadata-provider orders))]
+    (lib/available-drill-thrus query -1 {:column (metabase.lib.metadata/field metadata-provider created-at)
+                                         :value nil
+                                         #_#_:value  "2018-05-15T08:04:04.58Z"}))
+  (lib.order-by/order-bys query stage-number))
 
-;; START HERE - Keep debugging these tests
+;; START HERE - Keep testing more cases
 
 ;; TODO: Directly clicking on this table's primary key opens the object detail, with no popup? How does that work?

--- a/test/metabase/lib/drill_thru_test.cljc
+++ b/test/metabase/lib/drill_thru_test.cljc
@@ -1,0 +1,82 @@
+(ns metabase.lib.drill-thru-test
+  (:require
+    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
+    [clojure.test :refer [deftest is testing]]
+    [medley.core :as m]
+    [metabase.lib.core :as lib]
+    [metabase.lib.test-metadata :as meta]
+    [metabase.lib.test-util :as lib.tu]
+    [metabase.lib.util :as lib.util]
+    [metabase.util :as u]))
+
+#?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
+
+(defn- by-name [cols name]
+  (first (filter #(= (:name %) name) cols)))
+
+(deftest ^:parallel available-drill-thrus-test
+  (testing "table view"
+    (let [query (lib/query meta/metadata-provider (meta/table-metadata :orders))
+          row   [{:column-name "ID" :value 2}
+                 {:column-name "USER_ID" :value 1}
+                 {:column-name "PRODUCT_ID" :value 123}
+                 {:column-name "SUBTOTAL" :value 110.93}
+                 {:column-name "TAX" :value 6.10}
+                 {:column-name "TOTAL" :value 117.03}
+                 {:column-name "DISCOUNT" :value nil}
+                 {:column-name "CREATED_AT" :value "2018-05-15T08:04:04.58Z"}
+                 {:column-name "QUANTITY" :value 3}]]
+      (testing "with values"
+        (testing "click foreign key - FK filter and FK details"
+          (is (=? [{:lib/type :metabase.lib.drill-thru/drill-thru
+                    :type     :drill-thru/fk-filter
+                    :filter   [:= {:lib/uuid string?}
+                               [:field {:lib/uuid string?} (meta/id :orders :user-id)]
+                               1]}
+                   {:lib/type  :metabase.lib.drill-thru/drill-thru
+                    :type      :drill-thru/fk-details
+                    :column    (meta/field-metadata :orders :user-id)
+                    :object-id 1
+                    :many-pks? false}]
+                  (lib/available-drill-thrus query -1 {:column (meta/field-metadata :orders :user-id)
+                                                       :value  1
+                                                       :row    row}))))
+        (testing "click numeric value - numeric quick filters and object details *for the PK column*"
+          (is (=? [{:lib/type  :metabase.lib.drill-thru/drill-thru
+                    :type      :drill-thru/zoom
+                    :column    (meta/field-metadata :orders :id) ; It should correctly find the PK column
+                    :object-id (-> row first :value)             ; And its value
+                    :many-pks? false}
+                   {:lib/type :metabase.lib.drill-thru/drill-thru
+                    :type     :drill-thru/quick-filter
+                    :operators (for [[op label] [[:<  "<"]
+                                                 [:>  ">"]
+                                                 [:=  "="]
+                                                 [:!= "≠"]]]
+                                 {:name label
+                                  :filter [op {:lib/uuid string?}
+                                           [:field {:lib/uuid string?} (meta/id :orders :subtotal)]
+                                           110.93]})}]
+                  (lib/available-drill-thrus query -1 {:column (meta/field-metadata :orders :subtotal)
+                                                       :value  110.93
+                                                       :row    row}))))
+        (testing "click nil value - basic quick filters and object details *for the PK column*"
+          (is (=? [{:lib/type  :metabase.lib.drill-thru/drill-thru
+                    :type      :drill-thru/zoom
+                    :column    (meta/field-metadata :orders :id) ; It should correctly find the PK column
+                    :object-id (-> row first :value)             ; And its value
+                    :many-pks? false}
+                   {:lib/type :metabase.lib.drill-thru/drill-thru
+                    :type     :drill-thru/quick-filter
+                    :operators (for [[op label] [[:=  "="]
+                                                 [:!= "≠"]]]
+                                 {:name label
+                                  :filter [op {:lib/uuid string?}
+                                           [:field {:lib/uuid string?} (meta/id :orders :subtotal)]]})}]
+                  (lib/available-drill-thrus query -1 {:column (meta/field-metadata :orders :discount)
+                                                       :value  :null
+                                                       :row    row}))))))))
+
+;; START HERE - Keep debugging these tests
+
+;; TODO: Directly clicking on this table's primary key opens the object detail, with no popup? How does that work?

--- a/test/metabase/lib/drill_thru_test.cljc
+++ b/test/metabase/lib/drill_thru_test.cljc
@@ -31,7 +31,7 @@
           (is (=? [{:lib/type        :metabase.lib.drill-thru/drill-thru
                     :type            :drill-thru/column-filter
                     :column          (meta/field-metadata :orders :id)
-                    :initial-op      {:short := :display-name "Is"}}
+                    :initial-op      {:short := :display-name-variant :default}}
                    {:lib/type        :metabase.lib.drill-thru/drill-thru
                     :type            :drill-thru/sort
                     :column          (meta/field-metadata :orders :id)
@@ -50,7 +50,7 @@
                    {:lib/type        :metabase.lib.drill-thru/drill-thru
                     :type            :drill-thru/column-filter
                     :column          (meta/field-metadata :orders :user-id)
-                    :initial-op      {:short := :display-name "Is"}}
+                    :initial-op      {:short := :display-name-variant :default}}
                    {:lib/type        :metabase.lib.drill-thru/drill-thru
                     :type            :drill-thru/sort
                     :column          (meta/field-metadata :orders :user-id)
@@ -69,7 +69,7 @@
                    {:lib/type        :metabase.lib.drill-thru/drill-thru
                     :type            :drill-thru/column-filter
                     :column          (meta/field-metadata :orders :subtotal)
-                    :initial-op      {:short := :display-name "Equal to"}}
+                    :initial-op      {:short := :display-name-variant :equal-to}}
                    {:lib/type        :metabase.lib.drill-thru/drill-thru
                     :type            :drill-thru/sort
                     :column          (meta/field-metadata :orders :subtotal)
@@ -111,7 +111,7 @@
                           {:lib/type        :metabase.lib.drill-thru/drill-thru
                            :type            :drill-thru/column-filter
                            :column          (meta/field-metadata :orders :subtotal)
-                           :initial-op      {:short := :display-name "Equal to"}}
+                           :initial-op      {:short := :display-name-variant :equal-to}}
                           {:lib/type        :metabase.lib.drill-thru/drill-thru
                            :type            :drill-thru/sort
                            :column          (meta/field-metadata :orders :subtotal)
@@ -260,15 +260,15 @@
 (deftest ^:parallel histogram-available-drill-thrus-test
   (testing "histogram breakout view"
     (testing "broken out by state - click a state - underlying, zoom in, pivot (non-location), automatic insights, quick filter"
-      (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :products))
+      (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :people))
                       (lib/aggregate (lib/count))
-                      (lib/breakout (meta/field-metadata :products :state)))
+                      (lib/breakout (meta/field-metadata :people :state)))
             row   [{:column-name "STATE" :value "WI"}
                    {:column-name "COUNT" :value 96}]]
         (is (=? [{:lib/type        :metabase.lib.drill-thru/drill-thru
                   :type            :drill-thru/underlying-records
                   :column          (meta/field-metadata :orders :id)
-                  :initial-op      {:short := :display-name "Is"}}
+                  :initial-op      {:short := :display-name-variant :default}}
                  {:lib/type        :metabase.lib.drill-thru/drill-thru
                   :type            :drill-thru/sort
                   :column          (meta/field-metadata :orders :id)

--- a/test/metabase/lib/drill_thru_test.cljc
+++ b/test/metabase/lib/drill_thru_test.cljc
@@ -285,14 +285,19 @@
         orders            2
         orders-id         11
         created-at        14
+        subtotal          17
         people            5
         state             34
-        query             (-> (lib/query metadata-provider (metabase.lib.metadata/table metadata-provider people))
-                              (lib/aggregate (lib/count))
-                              (lib/breakout  (lib/ref (metabase.lib.metadata/field metadata-provider state))))]
-    (lib/available-drill-thrus query -1 {:column (metabase.lib.metadata/field metadata-provider created-at)
-                                         :value nil
-                                         #_#_:value  "2018-05-15T08:04:04.58Z"}))
+        query             (lib/query metadata-provider (metabase.lib.metadata/table metadata-provider orders))
+        #_(-> (lib/query metadata-provider (metabase.lib.metadata/table metadata-provider people))
+              (lib/aggregate (lib/count))
+              (lib/breakout  (lib/ref (metabase.lib.metadata/field metadata-provider state))))]
+    #_(metabase.lib.metadata/tables metadata-provider)
+    #_(metabase.lib.metadata/fields metadata-provider orders)
+    (->> (lib/available-drill-thrus query -1 {:column (metabase.lib.metadata/field metadata-provider subtotal)
+                                              :value nil
+                                              #_#_:value  "2018-05-15T08:04:04.58Z"})
+         (map #(metabase.lib.metadata.calculation/display-info query -1 %))))
   (lib.order-by/order-bys query stage-number))
 
 ;; START HERE - Keep testing more cases

--- a/test/metabase/lib/drill_thru_test.cljc
+++ b/test/metabase/lib/drill_thru_test.cljc
@@ -285,7 +285,11 @@
         orders            2
         orders-id         11
         created-at        14
-        query             (lib/query metadata-provider (metabase.lib.metadata/table metadata-provider orders))]
+        people            5
+        state             34
+        query             (-> (lib/query metadata-provider (metabase.lib.metadata/table metadata-provider people))
+                              (lib/aggregate (lib/count))
+                              (lib/breakout  (lib/ref (metabase.lib.metadata/field metadata-provider state))))]
     (lib/available-drill-thrus query -1 {:column (metabase.lib.metadata/field metadata-provider created-at)
                                          :value nil
                                          #_#_:value  "2018-05-15T08:04:04.58Z"}))

--- a/test/metabase/lib/test_metadata.cljc
+++ b/test/metabase/lib/test_metadata.cljc
@@ -1639,7 +1639,7 @@
   [_table-name _field-name]
   {:description                nil
    :database-type              "CHARACTER VARYING"
-   :semantic-type              nil
+   :semantic-type              :type/ZipCode
    :table-id                   (id :people)
    :coercion-strategy          nil
    :name                       "ZIP"


### PR DESCRIPTION
Relates to https://github.com/metabase/metabase/issues/31007

### Description

This adds more e2e tests to test displayed drills for various cases:

- table with unaggregated query
- table with aggregated query
- line chart with aggregated query
- bar chart with aggregated query

Tested drills:

- AutomaticInsightsDrill ✅
- ColumnFilterDrill ✅
- DashboardClickDrill
- DistributionDrill ✅
- ForeignKeyDrill ✅
- ObjectDetailDrill ✅
- SortDrill ✅
- SummarizeColumnDrill ✅
- UnderlyingRecordsDrill ✅
- ZoomDrill ✅
- FormatDrill ✅
- PivotDrill ✅
- QuickFilterDrill ✅
- NativeDrillFallback ✅
- TimeseriesModeFooter ✅

