### PR TITLE
hiding Card Parameter Mapper header on small cards

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
@@ -173,6 +173,9 @@ export function DashCardCardParameterMapper({
 
   const headerContent = useMemo(() => {
     if (!isVirtual && !(isNative && isDisabled)) {
+      if (dashcard.size_y <= 2) {
+        return null;
+      }
       return t`Column to filter on`;
     } else if (dashcard.size_y !== 1 || isMobile) {
       return t`Variable to map to`;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
@@ -7,7 +7,7 @@ import { t } from "ttag";
 import {
   MOBILE_HEIGHT_BY_DISPLAY_TYPE,
   MOBILE_DEFAULT_CARD_HEIGHT,
-} from "metabase/dashboard/components/grid/utils";
+} from "metabase/visualizations/shared/utils/sizes";
 
 import { Icon } from "metabase/core/components/Icon";
 import Tooltip from "metabase/core/components/Tooltip";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
@@ -4,6 +4,11 @@ import { connect } from "react-redux";
 import _ from "underscore";
 import { t } from "ttag";
 
+import {
+  MOBILE_HEIGHT_BY_DISPLAY_TYPE,
+  MOBILE_DEFAULT_CARD_HEIGHT,
+} from "metabase/dashboard/components/grid/utils";
+
 import { Icon } from "metabase/core/components/Icon";
 import Tooltip from "metabase/core/components/Tooltip";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
@@ -172,16 +177,19 @@ export function DashCardCardParameterMapper({
     ]);
 
   const headerContent = useMemo(() => {
-    if (!isVirtual && !(isNative && isDisabled)) {
-      if (dashcard.size_y <= 2) {
-        return null;
+    const layoutHeight = isMobile
+      ? MOBILE_HEIGHT_BY_DISPLAY_TYPE[dashcard.card.display] ||
+        MOBILE_DEFAULT_CARD_HEIGHT
+      : dashcard.size_y;
+
+    if (layoutHeight > 2) {
+      if (!isVirtual && !(isNative && isDisabled)) {
+        return t`Column to filter on`;
+      } else {
+        return t`Variable to map to`;
       }
-      return t`Column to filter on`;
-    } else if (dashcard.size_y !== 1 || isMobile) {
-      return t`Variable to map to`;
-    } else {
-      return null;
     }
+    return null;
   }, [dashcard, isVirtual, isNative, isDisabled, isMobile]);
 
   const mappingInfoText =
@@ -192,7 +200,7 @@ export function DashCardCardParameterMapper({
     }[virtualCardType] ?? "";
 
   return (
-    <Container>
+    <Container isSmall={!isMobile && dashcard.size_y < 2}>
       {hasSeries && <CardLabel>{card.name}</CardLabel>}
       {isVirtual && isDisabled ? (
         showVirtualDashCardInfoText(dashcard, isMobile) ? (

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.styled.tsx
@@ -7,8 +7,8 @@ import { Icon } from "metabase/core/components/Icon";
 import Button from "metabase/core/components/Button";
 import ExternalLink from "metabase/core/components/ExternalLink";
 
-export const Container = styled.div`
-  margin: ${space(1)} 0;
+export const Container = styled.div<{ isSmall: boolean }>`
+  margin: ${({ isSmall }) => (isSmall ? 0 : space(1))} 0;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -76,7 +76,6 @@ export const TargetButton = styled.div<{ variant: string }>`
   background-color: ${color("white")};
   text-weight: bold;
   cursor: pointer;
-  font-size: 1.2em;
   border: 2px solid ${color("brand")};
   border-radius: 8px;
   min-height: 30px;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
@@ -5,6 +5,7 @@ import {
   createMockCard,
   createMockDashboardOrderedCard,
   createMockActionDashboardCard,
+  createMockStructuredDatasetQuery,
 } from "metabase-types/api/mocks";
 
 import { getMetadata } from "metabase/selectors/metadata";
@@ -88,5 +89,37 @@ describe("DashCardParameterMapper", () => {
     });
     expect(getIcon("info")).toBeInTheDocument();
     expect(screen.getByLabelText(/in text cards/i)).toBeInTheDocument();
+  });
+
+  it("should show header content when card is more than 2 units high", () => {
+    const numberCard = createMockCard({
+      dataset_query: createMockStructuredDatasetQuery({}),
+      display: "scalar",
+    });
+    setup({
+      card: numberCard,
+      dashcard: createMockDashboardOrderedCard({
+        card: numberCard,
+        size_y: 3,
+      }),
+      mappingOptions: ["foo", "bar"],
+    });
+    expect(screen.getByText(/Column to filter on/i)).toBeInTheDocument();
+  });
+
+  it("should hide header content when card is less than 3 units high", () => {
+    const numberCard = createMockCard({
+      dataset_query: createMockStructuredDatasetQuery({}),
+      display: "scalar",
+    });
+    setup({
+      card: numberCard,
+      dashcard: createMockDashboardOrderedCard({
+        card: numberCard,
+        size_y: 2,
+      }),
+      mappingOptions: ["foo", "bar"],
+    });
+    expect(screen.queryByText(/Column to filter on/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
@@ -91,6 +91,22 @@ describe("DashCardParameterMapper", () => {
     expect(screen.getByLabelText(/in text cards/i)).toBeInTheDocument();
   });
 
+  it("should render a different header for virtual cards", () => {
+    const textCard = createMockCard({ dataset_query: {}, display: "text" });
+    setup({
+      card: textCard,
+      dashcard: createMockDashboardOrderedCard({
+        card: textCard,
+        size_y: 3,
+        visualization_settings: {
+          virtual_card: textCard,
+        },
+      }),
+      mappingOptions: ["foo", "bar"],
+    });
+    expect(screen.getByText(/Variable to map to/i)).toBeInTheDocument();
+  });
+
   it("should show header content when card is more than 2 units high", () => {
     const numberCard = createMockCard({
       dataset_query: createMockStructuredDatasetQuery({}),
@@ -121,5 +137,41 @@ describe("DashCardParameterMapper", () => {
       mappingOptions: ["foo", "bar"],
     });
     expect(screen.queryByText(/Column to filter on/i)).not.toBeInTheDocument();
+  });
+
+  describe("mobile", () => {
+    it("should show header content when card is more than 2 units high", () => {
+      const numberCard = createMockCard({
+        dataset_query: createMockStructuredDatasetQuery({}),
+        display: "scalar",
+      });
+      setup({
+        card: numberCard,
+        dashcard: createMockDashboardOrderedCard({
+          card: numberCard,
+          size_y: 2,
+        }),
+        mappingOptions: ["foo", "bar"],
+        isMobile: true,
+      });
+      expect(screen.getByText(/Column to filter on/i)).toBeInTheDocument();
+    });
+
+    it("should hide header content when card is less than 3 units high", () => {
+      const textCard = createMockCard({ dataset_query: {}, display: "text" });
+      setup({
+        card: textCard,
+        dashcard: createMockDashboardOrderedCard({
+          card: textCard,
+          size_y: 3,
+          visualization_settings: {
+            virtual_card: textCard,
+          },
+        }),
+        mappingOptions: ["foo", "bar"],
+        isMobile: true,
+      });
+      expect(screen.queryByText(/Variable to map to/i)).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -30,7 +30,11 @@ import { addUndo } from "metabase/redux/undo";
 import { DashboardCard } from "./DashboardGrid.styled";
 
 import GridLayout from "./grid/GridLayout";
-import { generateMobileLayout } from "./grid/utils";
+import {
+  generateMobileLayout,
+  MOBILE_HEIGHT_BY_DISPLAY_TYPE,
+  MOBILE_DEFAULT_CARD_HEIGHT,
+} from "./grid/utils";
 import AddSeriesModal from "./AddSeriesModal/AddSeriesModal";
 import DashCard from "./DashCard";
 
@@ -233,14 +237,8 @@ class DashboardGrid extends Component {
     const desktop = cards.map(this.getLayoutForDashCard);
     const mobile = generateMobileLayout({
       desktopLayout: desktop,
-      defaultCardHeight: 6,
-      heightByDisplayType: {
-        action: 1,
-        link: 1,
-        text: 2,
-        heading: 2,
-        scalar: 4,
-      },
+      defaultCardHeight: MOBILE_DEFAULT_CARD_HEIGHT,
+      heightByDisplayType: MOBILE_HEIGHT_BY_DISPLAY_TYPE,
     });
     return { desktop, mobile };
   }

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -27,14 +27,16 @@ import {
 } from "metabase/lib/dashboard_grid";
 import { ContentViewportContext } from "metabase/core/context/ContentViewportContext";
 import { addUndo } from "metabase/redux/undo";
+import {
+  MOBILE_HEIGHT_BY_DISPLAY_TYPE,
+  MOBILE_DEFAULT_CARD_HEIGHT,
+} from "metabase/visualizations/shared/utils/sizes";
+
 import { DashboardCard } from "./DashboardGrid.styled";
 
 import GridLayout from "./grid/GridLayout";
-import {
-  generateMobileLayout,
-  MOBILE_HEIGHT_BY_DISPLAY_TYPE,
-  MOBILE_DEFAULT_CARD_HEIGHT,
-} from "./grid/utils";
+import { generateMobileLayout } from "./grid/utils";
+
 import AddSeriesModal from "./AddSeriesModal/AddSeriesModal";
 import DashCard from "./DashCard";
 

--- a/frontend/src/metabase/dashboard/components/grid/utils.js
+++ b/frontend/src/metabase/dashboard/components/grid/utils.js
@@ -16,17 +16,6 @@ export function sortCardsForMobile(a, b) {
   // for items on the same row, sort by x position
   return a.x - b.x;
 }
-
-export const MOBILE_HEIGHT_BY_DISPLAY_TYPE = {
-  action: 1,
-  link: 1,
-  text: 2,
-  heading: 2,
-  scalar: 4,
-};
-
-export const MOBILE_DEFAULT_CARD_HEIGHT = 6;
-
 export function generateMobileLayout({
   desktopLayout,
   defaultCardHeight,

--- a/frontend/src/metabase/dashboard/components/grid/utils.js
+++ b/frontend/src/metabase/dashboard/components/grid/utils.js
@@ -17,6 +17,16 @@ export function sortCardsForMobile(a, b) {
   return a.x - b.x;
 }
 
+export const MOBILE_HEIGHT_BY_DISPLAY_TYPE = {
+  action: 1,
+  link: 1,
+  text: 2,
+  heading: 2,
+  scalar: 4,
+};
+
+export const MOBILE_DEFAULT_CARD_HEIGHT = 6;
+
 export function generateMobileLayout({
   desktopLayout,
   defaultCardHeight,

--- a/frontend/src/metabase/visualizations/shared/utils/sizes.ts
+++ b/frontend/src/metabase/visualizations/shared/utils/sizes.ts
@@ -116,3 +116,13 @@ export const getMinSize = (
 export const getDefaultSize = (
   visualizationType: CardDisplayType,
 ): VisualizationSize => getSize(visualizationType, "default");
+
+export const MOBILE_HEIGHT_BY_DISPLAY_TYPE = {
+  action: 1,
+  link: 1,
+  text: 2,
+  heading: 2,
+  scalar: 4,
+};
+
+export const MOBILE_DEFAULT_CARD_HEIGHT = 6;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/32204

### Description
Applied some changes to how we deice if we render a card parameter mapping header:
- A height is decided based on whether or not we are in a mobile view. If so, we adjust using the same logic that the dashboard grid does. If it is not mobile, we look at `dashcard.size_y`
- if the effective height is less than 2, we no longer render header. If it is more than 2, then the existing logic is followed.
- Some maps were moved to constants and exported so that they could be used in multiple places. I considered making a small function to calculate effective height, but it was able to fit in an inline conditional.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a new scalar question (orders, count). Add it to a dashboard
2. Add a Month and Year filter to the dashboard
3. When applying the filter to the card, you should not see the heading `Column to filter on`.
4. Resize the card to be larger, and the heading should be visible in filter mapping mode.
5. Also test in mobile view

### Demo
![image](https://github.com/metabase/metabase/assets/1328979/70639800-3384-487e-a3d9-a19f3826095b)
![image](https://github.com/metabase/metabase/assets/1328979/f37ab296-b753-4102-97a7-a6abd21181b3)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
