### PR TITLE
Fade Link Cards When Mapping Parameters

### DIFF
--- a/frontend/src/metabase-types/api/mocks/dashboard.ts
+++ b/frontend/src/metabase-types/api/mocks/dashboard.ts
@@ -97,6 +97,27 @@ export const createMockHeadingDashboardCard = (
   ...opts,
 });
 
+export const createMockLinkDashboardCard = (
+  opts?: Partial<DashboardOrderedCard> & { url?: string },
+): DashboardOrderedCard => ({
+  ...createMockDashboardCardWithVirtualCard({
+    id: 1,
+    visualization_settings: {
+      link: {
+        url: opts?.url ?? "Link url",
+      },
+      virtual_card: {
+        archived: false,
+        dataset_query: {},
+        display: "link",
+        name: "",
+        visualization_settings: {},
+      } as VirtualCard,
+    },
+  }),
+  ...opts,
+});
+
 export const createMockDashboardCardWithVirtualCard = (
   opts?: Partial<DashboardOrderedCard>,
 ): DashboardOrderedCard => ({

--- a/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
@@ -9,6 +9,7 @@ import {
   createMockTextDashboardCard,
   createMockHeadingDashboardCard,
   createMockParameter,
+  createMockLinkDashboardCard,
 } from "metabase-types/api/mocks";
 import { createMockMetadata } from "__support__/metadata";
 
@@ -135,6 +136,44 @@ describe("DashCard", () => {
     });
     expect(screen.getByText("What a cool section")).toBeVisible();
     expect(screen.getByText("What a cool section")).toHaveStyle({
+      opacity: 0.25,
+    });
+  });
+
+  it("shows a link visualization", () => {
+    const linkCard = createMockLinkDashboardCard({
+      url: "https://xkcd.com/327",
+    });
+    const board = {
+      ...dashboard,
+      ordered_cards: [linkCard],
+    };
+    setup({
+      dashboard: board,
+      dashcard: linkCard,
+      dashcardData: {},
+    });
+    expect(screen.getByText("https://xkcd.com/327")).toBeVisible();
+  });
+
+  it("in parameter editing mode, shows faded link dashcard", () => {
+    const linkCard = createMockLinkDashboardCard({
+      url: "https://xkcd.com/327",
+    });
+    const board = {
+      ...dashboard,
+      ordered_cards: [linkCard],
+    };
+    setup({
+      dashboard: board,
+      dashcard: linkCard,
+      dashcardData: {},
+      isEditing: true,
+      isEditingParameter: true,
+    });
+
+    expect(screen.getByText("https://xkcd.com/327")).toBeVisible();
+    expect(screen.getByTestId("custom-view-text-link")).toHaveStyle({
       opacity: 0.25,
     });
   });

--- a/frontend/src/metabase/dashboard/components/DashCard/utils.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/utils.ts
@@ -1,4 +1,5 @@
 import type { DashboardOrderedCard } from "metabase-types/api";
+import { getVirtualCardType } from "metabase/dashboard/utils";
 
 export function shouldShowParameterMapper({
   dashcard,
@@ -7,5 +8,8 @@ export function shouldShowParameterMapper({
   dashcard: DashboardOrderedCard;
   isEditingParameter?: boolean;
 }) {
-  return isEditingParameter && dashcard?.card?.display !== "heading";
+  return (
+    isEditingParameter &&
+    !["heading", "link"].includes(getVirtualCardType(dashcard) ?? "")
+  );
 }

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.styled.tsx
@@ -9,8 +9,8 @@ export const DisplayLinkCardWrapper = styled.div<{ fade?: boolean }>`
   display: flex;
   width: 100%;
   height: 100%;
-  pointer-events: all;
   align-items: center;
+  pointer-events: ${({ fade }) => (fade ? "none" : "all")};
   opacity: ${({ fade }) => (fade ? 0.25 : 1)};
 `;
 
@@ -21,7 +21,7 @@ export const EditLinkCardWrapper = styled.div<{ fade?: boolean }>`
   justify-content: center;
   width: 100%;
   height: 100%;
-  pointer-events: all;
+  pointer-events: ${({ fade }) => (fade ? "none" : "all")};
   opacity: ${({ fade }) => (fade ? 0.25 : 1)};
 `;
 

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.styled.tsx
@@ -4,16 +4,17 @@ import Link from "metabase/core/components/Link";
 import { Icon } from "metabase/core/components/Icon";
 import RecentsList from "metabase/nav/components/RecentsList";
 
-export const DisplayLinkCardWrapper = styled.div`
+export const DisplayLinkCardWrapper = styled.div<{ fade?: boolean }>`
   padding: 0 0.5rem;
   display: flex;
   width: 100%;
   height: 100%;
   pointer-events: all;
   align-items: center;
+  opacity: ${({ fade }) => (fade ? 0.25 : 1)};
 `;
 
-export const EditLinkCardWrapper = styled.div`
+export const EditLinkCardWrapper = styled.div<{ fade?: boolean }>`
   padding: 0 1rem;
   display: flex;
   flex-direction: column;
@@ -21,6 +22,7 @@ export const EditLinkCardWrapper = styled.div`
   width: 100%;
   height: 100%;
   pointer-events: all;
+  opacity: ${({ fade }) => (fade ? 0.25 : 1)};
 `;
 
 export const CardLink = styled(Link)`

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
@@ -101,7 +101,7 @@ function LinkViz({
   if (entity) {
     if (isRestrictedLinkEntity(entity)) {
       return (
-        <EditLinkCardWrapper>
+        <EditLinkCardWrapper fade={isEditingParameter}>
           <RestrictedEntityDisplay />
         </EditLinkCardWrapper>
       );

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
@@ -52,6 +52,7 @@ export interface LinkVizProps {
   settings: DashboardOrderedCard["visualization_settings"] & {
     link: LinkCardSettings;
   };
+  isEditingParameter?: boolean;
 }
 
 function LinkViz({
@@ -59,6 +60,7 @@ function LinkViz({
   isEditing,
   onUpdateVisualizationSettings,
   settings,
+  isEditingParameter,
 }: LinkVizProps) {
   const {
     link: { url, entity },
@@ -114,7 +116,10 @@ function LinkViz({
 
     if (isEditing) {
       return (
-        <EditLinkCardWrapper data-testid="entity-edit-display-link">
+        <EditLinkCardWrapper
+          data-testid="entity-edit-display-link"
+          fade={isEditingParameter}
+        >
           <EntityDisplay entity={wrappedEntity} showDescription={false} />
         </EditLinkCardWrapper>
       );
@@ -137,7 +142,7 @@ function LinkViz({
     );
   }
 
-  if (isEditing) {
+  if (isEditing && !isEditingParameter) {
     return (
       <EditLinkCardWrapper data-testid="custom-edit-text-link">
         <TippyPopover
@@ -175,7 +180,10 @@ function LinkViz({
   }
 
   return (
-    <DisplayLinkCardWrapper data-testid="custom-view-text-link">
+    <DisplayLinkCardWrapper
+      data-testid="custom-view-text-link"
+      fade={isEditingParameter}
+    >
       <CardLink to={url ?? ""} target="_blank" rel="noreferrer">
         <UrlLinkDisplay url={url} />
       </CardLink>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/32264

### Description

There are no parameters to map for link cards, so instead of showing some useless info text, we'll just show faded link cards

![Screen Shot 2023-07-10 at 1 24 33 PM](https://github.com/metabase/metabase/assets/30528226/8473b85a-c81c-4e7e-af94-a6ed5f9e5d7c)


### How to verify

- create a dashboard with at least 1 filter
- add some link cards
- click on the dashboard filter to enter parameter mapping mode
- see the faded link cards instead of info text
- link cards should not be editable in this mode

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
