### PR TITLE
Fix flake in `impersonated` E2E spec

### DIFF
--- a/e2e/test/scenarios/permissions/impersonated.cy.spec.js
+++ b/e2e/test/scenarios/permissions/impersonated.cy.spec.js
@@ -366,8 +366,11 @@ describeEE("impersonated permission", () => {
 });
 
 function savePermissions() {
-  cy.get("main").findByText("Save changes").click();
+  cy.findByTestId("edit-bar").button("Save changes").click();
   cy.findByRole("dialog").findByText("Yes").click();
+  cy.findByTestId("edit-bar")
+    .findByText("You've made changes to permissions.")
+    .should("not.exist");
 }
 
 function selectImpersonatedAttribute(attribute) {


### PR DESCRIPTION
Whenever hover is involved, we need to make sure UI is absolutely stable. In failed test cases, the top bar with the test id `edit-bar` was being removed at the very moment we're trying to hover the warning icon.

This PR makes sure UI updated before we even search for that icon.

