### PR TITLE
Improve Filter <> DatePicker compatibility

### DIFF
--- a/e2e/test/scenarios/filters/reproductions/12496-drill-through-filter-date.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/12496-drill-through-filter-date.cy.spec.js
@@ -7,68 +7,102 @@ describe("issue 12496", () => {
     restore();
     cy.signInAsAdmin();
   });
-  it("should display correct day range in filter pill when drilling into a week", () => {
+  const datePickerInput = (picker, input) =>
+    cy
+      .findAllByTestId("specific-date-picker")
+      .eq(picker)
+      .find("input")
+      .eq(input);
+  const setup = unit => {
     cy.createQuestion(
       {
-        name: "Orders by Created At: Week",
+        name: `Orders by Created At: ${unit}`,
         query: {
           "source-table": ORDERS_ID,
           aggregation: [["count"]],
-          breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "week" }]],
-        },
-        display: "line",
-      },
-      { visitQuestion: true },
-    );
-    cy.get(".dot").eq(0).click({ force: true });
-    popover().contains("See this Order").click();
-    cy.findByTestId("qb-filters-panel")
-      .contains("Created At is April 24–30, 2022")
-      .click();
-    cy.findByTestId("between-date-picker").within(() => {
-      cy.findAllByTestId("specific-date-picker")
-        .eq(0)
-        .within(() => {
-          cy.get("input").should("have.value", "04/24/2022");
-        });
-      cy.findAllByTestId("specific-date-picker")
-        .eq(1)
-        .within(() => {
-          cy.get("input").should("have.value", "04/30/2022");
-        });
-    });
-  });
-  it("should display correct day range in filter pill when drilling into a month", () => {
-    cy.createQuestion(
-      {
-        name: "Orders by Created At: Month",
-        query: {
-          "source-table": ORDERS_ID,
-          aggregation: [["count"]],
-          breakout: [
-            ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+          breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": unit }]],
+          filter: [
+            "between",
+            ["field", ORDERS.CREATED_AT, null],
+            "2022-04-01",
+            "2022-05-31",
           ],
         },
         display: "line",
       },
       { visitQuestion: true },
     );
+    // When a filter is added above, we have to unhide the filter pills:
+    cy.findByTestId("filters-visibility-control").click();
+  };
+  it("should display correct day range in filter pill when drilling into a week", () => {
+    setup("week");
+    cy.get(".dot").eq(0).click({ force: true });
+    popover().contains("See this Order").click();
+    cy.findByTestId("qb-filters-panel")
+      .contains("Created At is April 24–30, 2022")
+      .click();
+    popover().within(() => {
+      cy.findByTestId("between-date-picker").within(() => {
+        datePickerInput(0, 0).should("have.value", "04/24/2022");
+        datePickerInput(1, 0).should("have.value", "04/30/2022");
+      });
+    });
+  });
+  it("should display correct day range in filter pill when drilling into a month", () => {
+    setup("month");
     cy.get(".dot").eq(0).click({ force: true });
     popover().contains("See this Order").click();
     cy.findByTestId("qb-filters-panel")
       .contains("Created At is April 2022")
       .click();
-    cy.findByTestId("between-date-picker").within(() => {
-      cy.findAllByTestId("specific-date-picker")
-        .eq(0)
-        .within(() => {
-          cy.get("input").should("have.value", "04/01/2022");
-        });
-      cy.findAllByTestId("specific-date-picker")
-        .eq(1)
-        .within(() => {
-          cy.get("input").should("have.value", "04/30/2022");
-        });
+    popover().within(() => {
+      cy.findByTestId("between-date-picker").within(() => {
+        datePickerInput(0, 0).should("have.value", "04/01/2022");
+        datePickerInput(1, 0).should("have.value", "04/30/2022");
+      });
+    });
+  });
+  it("should display correct day range in filter pill when drilling into a hour", () => {
+    setup("hour");
+    cy.get(".dot").eq(0).click({ force: true });
+    popover().contains("See this Order").click();
+    cy.findByTestId("qb-filters-panel")
+      .contains("Created At is April 30, 2022, 6:00–59 PM")
+      .click();
+    popover().within(() => {
+      cy.findByTestId("between-date-picker").within(() => {
+        datePickerInput(0, 0).should("have.value", "04/30/2022");
+        datePickerInput(0, 1).should("have.value", "6");
+        datePickerInput(0, 2).should("have.value", "00");
+        datePickerInput(1, 0).should("have.value", "04/30/2022");
+        datePickerInput(1, 1).should("have.value", "6");
+        datePickerInput(1, 2).should("have.value", "59");
+      });
+    });
+  });
+  it("should display correct minute in filter pill when drilling into a minute", () => {
+    setup("minute");
+    cy.get(".dot").eq(0).click({ force: true });
+    popover().contains("See this Order").click();
+    cy.findByTestId("qb-filters-panel")
+      .contains("Created At is April 30, 2022, 6:56 PM")
+      .click();
+    popover().within(() => {
+      datePickerInput(0, 0).should("have.value", "04/30/2022");
+      datePickerInput(0, 1).should("have.value", "6");
+      datePickerInput(0, 2).should("have.value", "56");
+    });
+  });
+  it("should display correct minute in filter pill when drilling into a day", () => {
+    setup("day");
+    cy.get(".dot").eq(0).click({ force: true });
+    popover().contains("See this Order").click();
+    cy.findByTestId("qb-filters-panel")
+      .contains("Created At is April 30, 2022")
+      .click();
+    popover().within(() => {
+      datePickerInput(0, 0).should("have.value", "04/30/2022");
     });
   });
 });

--- a/e2e/test/scenarios/filters/reproductions/12496-drill-through-filter-date.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/12496-drill-through-filter-date.cy.spec.js
@@ -1,0 +1,74 @@
+import { popover, restore } from "e2e/support/helpers";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+describe("issue 12496", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+  it("should display correct day range in filter pill when drilling into a week", () => {
+    cy.createQuestion(
+      {
+        name: "Orders by Created At: Week",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "week" }]],
+        },
+        display: "line",
+      },
+      { visitQuestion: true },
+    );
+    cy.get(".dot").eq(0).click({ force: true });
+    popover().contains("See this Order").click();
+    cy.findByTestId("qb-filters-panel")
+      .contains("Created At is April 24–30, 2022")
+      .click();
+    cy.findByTestId("between-date-picker").within(() => {
+      cy.findAllByTestId("specific-date-picker")
+        .eq(0)
+        .within(() => {
+          cy.get("input").should("have.value", "04/24/2022");
+        });
+      cy.findAllByTestId("specific-date-picker")
+        .eq(1)
+        .within(() => {
+          cy.get("input").should("have.value", "04/30/2022");
+        });
+    });
+  });
+  it("should display correct day range in filter pill when drilling into a month", () => {
+    cy.createQuestion(
+      {
+        name: "Orders by Created At: Month",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+          ],
+        },
+        display: "line",
+      },
+      { visitQuestion: true },
+    );
+    cy.get(".dot").eq(0).click({ force: true });
+    popover().contains("See this Order").click();
+    cy.findByTestId("qb-filters-panel")
+      .contains("Created At is April 2022")
+      .click();
+    cy.findByTestId("between-date-picker").within(() => {
+      cy.findAllByTestId("specific-date-picker")
+        .eq(0)
+        .within(() => {
+          cy.get("input").should("have.value", "04/01/2022");
+        });
+      cy.findAllByTestId("specific-date-picker")
+        .eq(1)
+        .within(() => {
+          cy.get("input").should("have.value", "04/30/2022");
+        });
+    });
+  });
+});

--- a/e2e/test/scenarios/filters/reproductions/12496-drill-through-filter-date.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/12496-drill-through-filter-date.cy.spec.js
@@ -2,7 +2,7 @@ import { popover, restore } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
-describe("issue 12496", () => {
+describe.skip("issue 12496", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
**E2E Spec for this change has been added, but the implementation is removed as requested.
[Slack context](https://metaboat.slack.com/archives/C04CYTEL9N2/p1689943777033019)**

Original PR text below:

---

Fixes inability to modify week ranges in https://github.com/metabase/metabase/issues/12496

### Description

Adds a `filter.toDatePickerFilter()` function to create a DatePicker-compatible filter, because:

1. DatePicker cannot currently handle week/month/quarter/year units, so we convert them to day units instead.
2. DatePicker needs dates and times to be specifically formatted to detect if time component should be shown.
3. SpecificDatePicker will not display dates or times unless they match its own `DATE_FORMAT` or `DATE_TIME_FORMAT`.

single week | single month
---|---
<img width="432" alt="CleanShot 2023-07-19 at 22 09 30@2x" src="https://github.com/metabase/metabase/assets/116838/27aa5631-8a1d-45a3-9134-981f7b678d7d"> | <img width="429" alt="CleanShot 2023-07-19 at 22 11 59@2x" src="https://github.com/metabase/metabase/assets/116838/09ad7b8a-6323-4174-836c-ebf8adef3b81">


### Rationale

The integration between the Filter and DatePicker is somewhat tenuous:

1. When quick-drilling, sometimes date filters are created without a temporal unit, leaving the Filter and DatePicker guessing what type of date it is.
2. When editing a date, the DatePicker silently fails to recognize the date it’s given and displays the current date instead, or fails to detect time values.

Fixing these issues at their source might cause other problems, so I opted to have FilterPopover safely marshall date types from Filter to DatePicker, based on this guide:

> • Give the user value as soon as possible
> • Structure things so that we can automagically infer things for the user
> • Don’t leave the user booby traps
>
> —Zen of Metabase

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question > Raw Data > Sample Database > Accounts
2. Summarize: Count of Rows, by Created At: Week > Visualize
3. Click a point on the graph > See these Accounts
4. Click the filter pill > Verify the date picker is showing the correct dates
5. Repeat with Created At: Month, Quarter, etc.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
  - [x] unit: toDatePickerFilter
  - [x] integration: DatePicker inside FilterPopover should have correct text fields for different date filters
