### PR TITLE
[E2E] Fix failing audit tests

### DIFF
--- a/e2e/test/scenarios/auditing/ad-hoc.cy.spec.js
+++ b/e2e/test/scenarios/auditing/ad-hoc.cy.spec.js
@@ -60,9 +60,10 @@ describeEE("audit > ad-hoc", () => {
 
       // Sign in as admin to be able to access audit logs in tests
       cy.signInAsAdmin();
+      setTokenFeatures("all");
     });
 
-    it("should appear in audit log #29456", () => {
+    it("should appear in audit log (metabase#29456)", () => {
       cy.visit("/admin/audit/members/log");
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/permissions/impersonated.cy.spec.js
+++ b/e2e/test/scenarios/permissions/impersonated.cy.spec.js
@@ -371,9 +371,7 @@ describeEE("impersonated permission", () => {
 function savePermissions() {
   cy.findByTestId("edit-bar").button("Save changes").click();
   cy.findByRole("dialog").findByText("Yes").click();
-  cy.findByTestId("edit-bar")
-    .findByText("You've made changes to permissions.")
-    .should("not.exist");
+  cy.findByTestId("edit-bar").should("not.exist");
 }
 
 function selectImpersonatedAttribute(attribute) {


### PR DESCRIPTION
The failure was caused by the change in the token activation logic in E2E tests.
Most likely because https://github.com/metabase/metabase/pull/32186 was longer in queue than https://github.com/metabase/metabase/pull/32212.

By the time #32212 landed, E2E tests were still starting with the full premium token active by default.
#32186 changed that and that's when we see the first failure for this test.
