### PR TITLE
Update bigquery doc

### DIFF
--- a/docs/databases/connections/bigquery.md
+++ b/docs/databases/connections/bigquery.md
@@ -25,10 +25,21 @@ To create the service account JSON file, follow Google's documentation on [setti
 3. **Grant the service account access to this project**. You'll need to add **roles** to the service account so that Metabase will have permission to view and run queries against your dataset. Make sure you add the following roles to the service account:
 
    - BigQuery Data Viewer
-   - BigQuery Metadata Viewer
    - BigQuery Job User (distinct from BigQuery User)
 
 For more information on **roles** in BigQuery, see [Google Cloud Platform's documentation](https://cloud.google.com/bigquery/docs/access-control).
+
+Or you can [create a custom GCP role](https://cloud.google.com/iam/docs/creating-custom-roles) with the following permissions:
+
+```
+bigquery.config.get
+bigquery.datasets.get
+bigquery.datasets.listTagBindings
+bigquery.jobs.create
+bigquery.tables.get
+bigquery.tables.getData
+bigquery.tables.list
+```
 
 4. **Create key**. Once you have assigned roles to the service account, click on the **Create Key** button, and select **JSON** for the **key type**. The JSON file will download to your computer.
 


### PR DESCRIPTION
### Description

remove `BigQuery Metadata Viewer` because the permissions in this role are already included in the `Bigquery Data Viewer` role.

Also add the possibility to create a custom role with minimal permissions.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. create a service account on gcp
2. create a key and save it in local
3. grant him the role data viewer and job user
4. in metabase create a new bigquery database and use the key created earlier 

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR