### PR TITLE
restrict mantine v6 specific api

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -70,7 +70,7 @@
     "react/no-unescaped-entities": 2,
     "react/jsx-no-target-blank": 2,
     "react/jsx-key": 2,
-    "react/forbid-component-props": [2, { "forbid": ["w", "h"] }],
+    "react/forbid-component-props": [2, { "forbid": ["w", "h", "sx"] }],
     "react-hooks/exhaustive-deps": [
       "warn",
       { "additionalHooks": "(useSyncedQueryString|useSafeAsyncFunction)" }

--- a/frontend/src/metabase/.eslintrc
+++ b/frontend/src/metabase/.eslintrc
@@ -13,6 +13,11 @@
             "name": "react-redux",
             "importNames": ["useSelector", "useDispatch"],
             "message": "Please import from `metabase/lib/redux` instead."
+          },
+          {
+            "name": "@mantine/core",
+            "importNames": ["createStyles"],
+            "message": "Avoid using `createStyles` because of breaking changes in the upcoming Mantine update"
           }
         ]
       }
@@ -34,16 +39,16 @@
     {
       "files": ["lib/redux/hooks.ts"],
       "rules": {
-        "no-restricted-imports": [
-          "error",
-          {
-            "patterns": [
-              "metabase-enterprise",
-              "metabase-enterprise/*",
-              "cljs/metabase.lib*"
-            ]
-          }
-        ]
+        // "no-restricted-imports": [
+        //   "error",
+        //   {
+        //     "patterns": [
+        //       "metabase-enterprise",
+        //       "metabase-enterprise/*",
+        //       "cljs/metabase.lib*"
+        //     ]
+        //   }
+        // ]
       }
     }
   ]

--- a/frontend/src/metabase/.eslintrc
+++ b/frontend/src/metabase/.eslintrc
@@ -39,16 +39,16 @@
     {
       "files": ["lib/redux/hooks.ts"],
       "rules": {
-        // "no-restricted-imports": [
-        //   "error",
-        //   {
-        //     "patterns": [
-        //       "metabase-enterprise",
-        //       "metabase-enterprise/*",
-        //       "cljs/metabase.lib*"
-        //     ]
-        //   }
-        // ]
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              "metabase-enterprise",
+              "metabase-enterprise/*",
+              "cljs/metabase.lib*"
+            ]
+          }
+        ]
       }
     }
   ]


### PR DESCRIPTION
### Description

Mantine will introduce breaking changes in v7 later this year. We want to restrict the usage of `sx` prop and `createStyles` function to simplify the migration later.

[Convo](https://metaboat.slack.com/archives/C057WD5L0JG/p1689097571146789)

### How to verify

1. Add `sx` prop
2. Import `createStyles` from `@mantine/core`
3. Ensure eslint catches both

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
