### PR TITLE
Adding toast when setting custom homepage

### DIFF
--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -226,10 +226,10 @@ describe("scenarios > home > custom homepage", () => {
       cy.location("pathname").should("equal", "/dashboard/1");
 
       cy.findByRole("status").within(() => {
-        cy.contains("This dashboard has been set as your homepage.").should(
+        cy.findByText("This dashboard has been set as your homepage.").should(
           "exist",
         );
-        cy.contains(
+        cy.findByText(
           "You can change this in Admin > Settings > General.",
         ).should("exist");
       });

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -224,6 +224,15 @@ describe("scenarios > home > custom homepage", () => {
       popover().findByText("Orders in a dashboard").click();
       modal().findByRole("button", { name: "Save" }).click();
       cy.location("pathname").should("equal", "/dashboard/1");
+
+      cy.findByRole("status").within(() => {
+        cy.contains("This dashboard has been set as your homepage.").should(
+          "exist",
+        );
+        cy.contains(
+          "You can change this in Admin > Settings > General.",
+        ).should("exist");
+      });
     });
   });
 

--- a/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.tsx
+++ b/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.tsx
@@ -51,7 +51,9 @@ export const CustomHomePageModal = ({
               fw={700}
             >{t`This dashboard has been set as your homepage.`}</Text>
             <br />
-            {t`You can change this in Admin > Settings > General.`}
+            <Text
+              span
+            >{t`You can change this in Admin > Settings > General.`}</Text>
           </Box>
         ),
         icon: "info",

--- a/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.tsx
+++ b/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.tsx
@@ -1,10 +1,13 @@
 import { useState, useCallback } from "react";
 import { t } from "ttag";
 
+import { Box, Text } from "metabase/ui";
+
 import { useDispatch } from "metabase/lib/redux";
 import { updateSettings } from "metabase/admin/settings/settings";
 import { trackCustomHomepageDashboardEnabled } from "metabase/admin/settings/analytics";
 import { refreshCurrentUser } from "metabase/redux/user";
+import { addUndo, dismissUndo } from "metabase/redux/undo";
 
 import Modal from "metabase/components/Modal";
 import ModalContent from "metabase/components/ModalContent";
@@ -35,6 +38,28 @@ export const CustomHomePageModal = ({
         [CUSTOM_HOMEPAGE_DASHBOARD_SETTING_KEY]: dashboardId,
         [CUSTOM_HOMEPAGE_SETTING_KEY]: true,
         [CUSTOM_HOMEPAGE_REDIRECT_TOAST_KEY]: true,
+      }),
+    );
+
+    const id = Date.now();
+    await dispatch(
+      addUndo({
+        message: () => (
+          <Box ml="0.5rem" mr="2.5rem">
+            <Text
+              span
+              fw={700}
+            >{t`This dashboard has been set as your homepage.`}</Text>
+            <br />
+            {t`You can change this in Admin > Settings > General.`}
+          </Box>
+        ),
+        icon: "info",
+        timeout: 10000,
+        id,
+        actions: [dismissUndo(id)],
+        actionLabel: "Got it",
+        canDismiss: false,
       }),
     );
     await dispatch(refreshCurrentUser());


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/32050

### Description
Adds a toast notification when the homepage is set to a dashboard using the CTA on the default homepage. Is only shown when set by the homepage modal, and not when set through admin settings.

### How to verify
Set a dashboard as the homepage using the customize button on the homepage.

### Demo
![chrome_8mYsSt0kPs](https://github.com/metabase/metabase/assets/1328979/444de54e-32ac-4357-bb3d-53902010ab23)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
