### PR TITLE
Fix - "A negative value is not valid" for height and width

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.jsx
@@ -408,7 +408,11 @@ export default class PieChart extends Component {
       slices.push(otherSlice);
     }
 
-    const side = Math.min(Math.min(width, height) - SIDE_PADDING, MAX_PIE_SIZE);
+    const side = Math.max(
+      Math.min(Math.min(width, height) - SIDE_PADDING, MAX_PIE_SIZE),
+      0,
+    );
+
     const outerRadius = side / 2;
     const labelFontSize = Math.max(
       MAX_LABEL_FONT_SIZE * (side / MAX_PIE_SIZE),

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.unit.spec.js
@@ -84,7 +84,7 @@ describe("PieChart", () => {
     expect(screen.getByTestId("pie-chart")).toBeInTheDocument();
   });
 
-  it("should not have negative dimensions", () => {
+  it("should not have negative dimensions (metabase#28677)", () => {
     setup();
 
     const pieChart = screen.getByTestId("pie-chart");

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.unit.spec.js
@@ -71,16 +71,28 @@ const setup = () => {
   renderWithProviders(<Container />);
 };
 
-describe("table settings", () => {
+describe("PieChart", () => {
   beforeAll(() => {
     //Append mocked style for .hide class
     const mockedStyle = document.createElement("style");
     mockedStyle.innerHTML = `.hide {display: none;}`;
     document.body.append(mockedStyle);
   });
+
   it("should render", () => {
     setup();
     expect(screen.getByTestId("pie-chart")).toBeInTheDocument();
+  });
+
+  it("should not have negative dimensions", () => {
+    setup();
+
+    const pieChart = screen.getByTestId("pie-chart");
+    const width = pieChart.getAttribute("width");
+    const height = pieChart.getAttribute("height");
+
+    expect(parseFloat(width)).toBeGreaterThanOrEqual(0);
+    expect(parseFloat(height)).toBeGreaterThanOrEqual(0);
   });
 
   it("should allow you to show and hide the grand total", async () => {


### PR DESCRIPTION
Closes #28677

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a question (e.g. Accounts summarized by Count grouped by Plan)
2. Visualize it as a Pie Chart
3. Add the question to a dashboard
4. Open that dashboard

There should be no `Error: <svg> attribute width: A negative value is not valid. ("-24")`-like errors in the JS console.


### Demo

Question used in this demo: [screenshot](https://github.com/metabase/metabase/assets/6830683/16afedf7-9369-4f32-b054-2757baa256d3)

#### Before



https://github.com/metabase/metabase/assets/6830683/d7a67091-f394-4019-806f-409d9c295393




#### After

https://github.com/metabase/metabase/assets/6830683/f516975e-e5fb-44ec-b1fb-628a755f9a82

