### PR TITLE
[E2E] Fix public dashboard flake

### DIFF
--- a/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
@@ -100,15 +100,19 @@ describe("scenarios > public > dashboard", () => {
     cy.findByRole("heading", { name: "Enable sharing" })
       .parent()
       .findByRole("switch")
-      .check()
-      .as("toggle");
-
-    cy.get("@toggle").should("be.checked");
+      .check();
 
     cy.wait("@publicLink").then(({ response }) => {
       expect(response.body.uuid).not.to.be.null;
 
       cy.findByRole("heading", { name: "Public link" })
+        // This click doesn't have any meaning in the context of the correctness of this test!
+        // It's simply here to prevent test flakiness, which happens because the Modal overlay
+        // is animating (disappearing) and we need to wait for it to stop the transition.
+        // Cypress will retry clicking this text until the DOM element is "actionable", or in
+        // our case - until there's no element on top of it blocking it. That's also when we
+        // expect this input field to be populated with the actual value.
+        .click()
         .parent()
         .findByDisplayValue(/^http/)
         .then($input => {

--- a/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
@@ -100,7 +100,10 @@ describe("scenarios > public > dashboard", () => {
     cy.findByRole("heading", { name: "Enable sharing" })
       .parent()
       .findByRole("switch")
-      .check();
+      .check()
+      .as("toggle");
+
+    cy.get("@toggle").should("be.checked");
 
     cy.wait("@publicLink").then(({ response }) => {
       expect(response.body.uuid).not.to.be.null;

--- a/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
@@ -102,14 +102,16 @@ describe("scenarios > public > dashboard", () => {
       .findByRole("switch")
       .check();
 
-    cy.wait("@publicLink");
+    cy.wait("@publicLink").then(({ response }) => {
+      expect(response.body.uuid).not.to.be.null;
 
-    cy.findByRole("heading", { name: "Public link" })
-      .parent()
-      .findByDisplayValue(/^http/)
-      .then($input => {
-        expect($input.val()).to.match(PUBLIC_DASHBOARD_REGEX);
-      });
+      cy.findByRole("heading", { name: "Public link" })
+        .parent()
+        .findByDisplayValue(/^http/)
+        .then($input => {
+          expect($input.val()).to.match(PUBLIC_DASHBOARD_REGEX);
+        });
+    });
   });
 
   Object.entries(USERS).map(([userType, setUser]) =>


### PR DESCRIPTION
I tried out a few different approaches until all 30 runs in a stress test came back green.
https://github.com/metabase/metabase/actions/runs/5534140897/jobs/10098692281
![image](https://github.com/metabase/metabase/assets/31325167/07bd2dd6-a7b8-4937-b170-985c948edd69)

In the past, the input field would sometimes still display `/public/dashboard/null` in the UI when Cypress tries to assert on its value. That happens because the test didn't wait for the modal overlay to completely disappear before asserting.

This test was always correct, but flaky simply because of the transition and how it plays with UI elements.

Closes https://github.com/metabase/metabase/issues/32334.