### PR TITLE
Potentially fix StackOverflow in flaky tests

### DIFF
--- a/src/metabase/models/permissions_group.clj
+++ b/src/metabase/models/permissions_group.clj
@@ -106,10 +106,10 @@
 (t2/define-before-update :model/PermissionsGroup
   [group]
   (let [changes (t2/changes group)]
-   (u/prog1 group
-     (check-not-magic-group group)
-     (when-let [group-name (:name changes)]
-       (check-name-not-already-taken group-name)))))
+    (u/prog1 group
+      (check-not-magic-group group)
+      (when-let [group-name (:name changes)]
+        (check-name-not-already-taken group-name)))))
 
 ;;; ---------------------------------------------------- Util Fns ----------------------------------------------------
 

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -92,19 +92,19 @@
   [{user-id :id, superuser? :is_superuser, :as user}]
   (u/prog1 user
     ;; add the newly created user to the magic perms groups.
-    (letfn [(create-group-membership! [perms-group]
-              ;; do a 'simple' insert against the Table name so we don't trigger the after-insert behavior
-              ;; for [[metabase.models.permissions-group-membership]]... we don't want it recursively trying to update
-              ;; the user
-              (t2/insert! (t2/table-name :model/PermissionsGroupMembership)
-                          :user_id  user-id
-                          :group_id (u/the-id perms-group)))]
+    (log/info (trs "Adding User {0} to All Users permissions group..." user-id))
+    (when superuser?
+      (log/info (trs "Adding User {0} to All Users permissions group..." user-id)))
+    (let [groups (filter some? [(perms-group/all-users)
+                                (when superuser? (perms-group/admin))])]
       (binding [perms-group-membership/*allow-changing-all-users-group-members* true]
-        (log/info (trs "Adding User {0} to All Users permissions group..." user-id))
-        (create-group-membership! (perms-group/all-users)))
-      (when superuser?
-        (log/info (trs "Adding User {0} to Admin permissions group..." user-id))
-        (create-group-membership! (perms-group/admin))))))
+        ;; do a 'simple' insert against the Table name so we don't trigger the after-insert behavior
+        ;; for [[metabase.models.permissions-group-membership]]... we don't want it recursively trying to update
+        ;; the user
+        (t2/insert! (t2/table-name :model/PermissionsGroupMembership)
+                    (for [group groups]
+                      {:user_id  user-id
+                       :group_id (u/the-id group)}))))))
 
 (t2/define-before-update :model/User
   [{:keys [id] :as user}]

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -91,17 +91,20 @@
 (t2/define-after-insert :model/User
   [{user-id :id, superuser? :is_superuser, :as user}]
   (u/prog1 user
-    ;; add the newly created user to the magic perms groups
-    (binding [perms-group-membership/*allow-changing-all-users-group-members* true]
-      (log/info (trs "Adding User {0} to All Users permissions group..." user-id))
-      (t2/insert! PermissionsGroupMembership
-        :user_id  user-id
-        :group_id (:id (perms-group/all-users))))
-    (when superuser?
-      (log/info (trs "Adding User {0} to Admin permissions group..." user-id))
-      (t2/insert! PermissionsGroupMembership
-        :user_id  user-id
-        :group_id (:id (perms-group/admin))))))
+    ;; add the newly created user to the magic perms groups.
+    (letfn [(create-group-membership! [perms-group]
+              ;; do a 'simple' insert against the Table name so we don't trigger the after-insert behavior
+              ;; for [[metabase.models.permissions-group-membership]]... we don't want it recursively trying to update
+              ;; the user
+              (t2/insert! (t2/table-name :model/PermissionsGroupMembership)
+                          :user_id  user-id
+                          :group_id (u/the-id perms-group)))]
+      (binding [perms-group-membership/*allow-changing-all-users-group-members* true]
+        (log/info (trs "Adding User {0} to All Users permissions group..." user-id))
+        (create-group-membership! (perms-group/all-users)))
+      (when superuser?
+        (log/info (trs "Adding User {0} to Admin permissions group..." user-id))
+        (create-group-membership! (perms-group/admin))))))
 
 (t2/define-before-update :model/User
   [{:keys [id] :as user}]


### PR DESCRIPTION
Fixes #32356

(hopefully)

The root issue here was that inserting a User would insert a couple of PermissionsGroupMemberships which would in turn trigger an update of User... Not 100% sure why this was causing a StackOverflow TBH since the PGM insert did not trigger any further Toucan calls, but at any rate we can eliminate the pointless call here and hopefully fix the StackOverflow. 

I also combined the separate inserts into one call which should very slightly improve performance in tests and when creating new admins