### PR TITLE
Don't display spinners next to schema in query database selector

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
@@ -92,7 +92,7 @@ const DataSelectorDatabaseSchemaPicker = ({
     return true;
   };
 
-  const showSpinner = ({ active }: { active?: boolean }) => !active;
+  const showSpinner = ({ active }: { active?: boolean }) => active === false;
 
   const renderSectionIcon = ({ icon }: { icon?: IconName }) =>
     icon && <Icon className="Icon text-default" name={icon} size={18} />;

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.unit.spec.js
@@ -99,7 +99,7 @@ describe("DataSelectorDatabaseSchemaPicker", () => {
       ],
     });
     setup({ database });
-    // There should only be one loading-spinner next to the database name
+    // There should only be one loading-spinner next to the database name, and not the schema names
     expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
     expect(screen.getByText("Schema 1")).toBeInTheDocument();
     expect(screen.getByText("Schema 2")).toBeInTheDocument();

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.unit.spec.js
@@ -1,6 +1,33 @@
-import { render, screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
 
+import { checkNotNull } from "metabase/core/utils/types";
+import { getMetadata } from "metabase/selectors/metadata";
+import { createMockDatabase, createMockSchema } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+import { createMockEntitiesState } from "__support__/store";
+import { renderWithProviders, screen } from "__support__/ui";
 import DataSelectorDatabaseSchemaPicker from "./DataSelectorDatabaseSchemaPicker";
+
+const setup = opts => {
+  const state = createMockState({
+    entities: createMockEntitiesState({ databases: [opts.database] }),
+  });
+  const metadata = getMetadata(state);
+  const database = checkNotNull(metadata.database(opts.database.id));
+  const schemas = database.getSchemas();
+
+  renderWithProviders(
+    <DataSelectorDatabaseSchemaPicker
+      selectedDatabase={database}
+      selectedSchema={schemas[0]}
+      databases={[database]}
+      schemas={schemas}
+      onChangeSchema={jest.fn()}
+      onChangeDatabase={jest.fn()}
+    />,
+    { storeInitialState: state },
+  );
+};
 
 describe("DataSelectorDatabaseSchemaPicker", () => {
   it("displays loading message when it has no databases", () => {
@@ -61,5 +88,20 @@ describe("DataSelectorDatabaseSchemaPicker", () => {
       expect(screen.queryByText(schemaName)).not.toBeInTheDocument();
       expect(screen.getByText("Saved Questions")).toBeInTheDocument();
     });
+  });
+
+  it("doesn't display a loading spinner next to a schema when the database has initial_sync_status='incomplete'", () => {
+    const database = createMockDatabase({
+      initial_sync_status: "incomplete",
+      schemas: [
+        createMockSchema({ id: 1, name: "Schema 1" }),
+        createMockSchema({ id: 2, name: "Schema 2" }),
+      ],
+    });
+    setup({ database });
+    // There should only be one loading-spinner next to the database name
+    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByText("Schema 1")).toBeInTheDocument();
+    expect(screen.getByText("Schema 2")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/32389

This bug was caused by changes in https://github.com/metabase/metabase/pull/31653, which was backported to 47. So this fix needs to be backported too.

Makes sure that only database names can have loading spinners next to them, and never their schema.

For example in the screenshot below, 'csvdb' is a database that has `initial_sync_status=true`, which means the loading spinner should be displayed. But the schemas listed under the database name should not have loading spinners.

<img width="351" alt="image" src="https://github.com/metabase/metabase/assets/39073188/6f242c8f-2094-4f95-bec8-65d253e496b3">