### PR TITLE
Fix missing React keys in embedding settings page

### DIFF
--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -471,7 +471,7 @@ const SECTIONS = {
         getHidden: (_, derivedSettings) => !derivedSettings["enable-embedding"],
       },
       {
-        key: "standalone-embeds",
+        key: "-standalone-embeds",
         widget: EmbeddingOption,
         getHidden: (_, derivedSettings) => !derivedSettings["enable-embedding"],
         embedName: t`Standalone embeds`,
@@ -479,7 +479,7 @@ const SECTIONS = {
         embedType: "standalone",
       },
       {
-        key: "full-app-embedding",
+        key: "-full-app-embedding",
         widget: EmbeddingOption,
         getHidden: (_, derivedSettings) => !derivedSettings["enable-embedding"],
         embedName: t`Full-app embedding`,

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -471,6 +471,7 @@ const SECTIONS = {
         getHidden: (_, derivedSettings) => !derivedSettings["enable-embedding"],
       },
       {
+        key: "standalone-embeds",
         widget: EmbeddingOption,
         getHidden: (_, derivedSettings) => !derivedSettings["enable-embedding"],
         embedName: t`Standalone embeds`,
@@ -478,6 +479,7 @@ const SECTIONS = {
         embedType: "standalone",
       },
       {
+        key: "full-app-embedding",
         widget: EmbeddingOption,
         getHidden: (_, derivedSettings) => !derivedSettings["enable-embedding"],
         embedName: t`Full-app embedding`,


### PR DESCRIPTION
[Resolves: #32395]

How to check:
1. there should be no console error about missing keys
2. sections should have unique test ids
    - `-standalone-embeds-setting`
    - `-full-app-embedding-setting`
