### PR TITLE
Check can_write() on upload db, e2e test

### DIFF
--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -287,11 +287,11 @@ function uploadFile(testFile, valid = true) {
   }
 }
 
-function enableUploads(dialect, schema) {
+function enableUploads(dialect) {
   const settings = {
     "uploads-enabled": true,
     "uploads-database-id": WRITABLE_DB_ID,
-    "uploads-schema-name": schema || dialect === "postgres" ? "public" : null,
+    "uploads-schema-name": dialect === "postgres" ? "public" : null,
     "uploads-table-prefix": dialect === "mysql" ? "upload_" : null,
   };
 

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -60,9 +60,11 @@ function mapStateToProps(state, props) {
   const canAccessUploadsDb =
     uploadsEnabled &&
     uploadDbId &&
-    !!Databases.selectors.getObject(state, {
-      entityId: uploadDbId,
-    });
+    Databases.selectors
+      .getObject(state, {
+        entityId: uploadDbId,
+      })
+      ?.canWrite();
 
   return {
     isAdmin: getUserIsAdmin(state),


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/32263

### Description
Checks that the user has _write_ access to the upload schema in the `canAccessUploadsDb` logic

### How to verify

1. Set up csv uploads, and ensure that the target schema has at least 1 table (can just upload a csv)
2. create a user that has sandboxed access to a table on the target schema, but no write access to the rest of the schema
3. Log in with your sandboxed user and you should see that the upload icon is gone on the collection screen, (drag and drop is disabled too)

_If someone has suggestions for the e2e test here, I'm all ears haha_

### Demo
![image](https://github.com/metabase/metabase/assets/1328979/5ee827a9-f062-408d-bef9-883f4ccfe558)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
