### PR TITLE
docs - note on email restriction

### DIFF
--- a/docs/configuring-metabase/settings.md
+++ b/docs/configuring-metabase/settings.md
@@ -42,7 +42,7 @@ This email address will be displayed in various messages throughout Metabase whe
 
 Allowed email address domain(s) for new [dashboard subscriptions](../dashboards/subscriptions.md) and [alerts](../questions/sharing/alerts.md).
 
-Adding approved domains allows you to restrict which email addresses people can send alerts and subscriptions to.
+Adding approved domains allows you to restrict which email addresses people can send alerts and subscriptions to. This restriction only applies to sending email to people who lack an account with that Metabase. People with accounts in a Metabase who aren't [sandboxed](../permissions/data-sandboxes.md) will be able to email any other person with an account in that same Metabase.
 
 To allow all domains, leave the field empty (allowing all domains is the default).
 

--- a/docs/permissions/notifications.md
+++ b/docs/permissions/notifications.md
@@ -40,9 +40,7 @@ Admins can add recipients without changing the permissions of the alert or subsc
 
 ## Restricting email domains
 
-{% include plans-blockquote.html feature="Approved domains for notifications" %}
-
-Admins can limit email recipients to people within an org by going to **Admin setting** > **General settings** > [Approved domains for notifications](../configuring-metabase/settings.md#approved-domains-for-notifications). 
+On some plans, Admins can limit email recipients to [approved domains for notifications](../configuring-metabase/settings.md#approved-domains-for-notifications). 
 
 ## Further reading
 


### PR DESCRIPTION
Clarifies that email domain restriction only applies to people without accounts for the relevant Metabase.