### PR TITLE
47 revert annotate changes

### DIFF
--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -4,26 +4,21 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [medley.core :as m]
+   [metabase.driver :as driver]
    [metabase.driver.common :as driver.common]
-   [metabase.lib.convert :as lib.convert]
-   [metabase.lib.core :as lib]
-   [metabase.lib.metadata.calculation :as lib.metadata.calculation]
-   [metabase.lib.schema.common :as lib.schema.common]
-   [metabase.mbql.normalize :as mbql.normalize]
+   [metabase.mbql.predicates :as mbql.preds]
    [metabase.mbql.schema :as mbql.s]
    [metabase.mbql.util :as mbql.u]
    [metabase.mbql.util.match :as mbql.match]
    [metabase.models.humanization :as humanization]
    [metabase.query-processor.error-type :as qp.error-type]
-   [metabase.query-processor.middleware.escape-join-aliases
-    :as escape-join-aliases]
+   [metabase.query-processor.middleware.escape-join-aliases :as escape-join-aliases]
    [metabase.query-processor.reducible :as qp.reducible]
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.util :as qp.util]
    [metabase.sync.analyze.fingerprint.fingerprinters :as fingerprinters]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru tru]]
-   [metabase.util.malli :as mu]
    [metabase.util.schema :as su]
    [schema.core :as s]))
 
@@ -312,53 +307,183 @@
     (throw (ex-info (tru "Don''t know how to get information about Field: {0}" &match)
                     {:field &match}))))
 
-(defn- mlv2-query [inner-query]
-  (qp.store/cached [:mlv2-query (hash inner-query)]
-    (try
-      (lib/query
-       (qp.store/metadata-provider)
-       (lib.convert/->pMBQL (lib.convert/legacy-query-from-inner-query
-                             (:id (qp.store/database))
-                             (mbql.normalize/normalize-fragment [:query] inner-query))))
-      (catch Throwable e
-        (throw (ex-info (tru "Error converting query to pMBQL: {0}" (ex-message e))
-                        {:inner-query inner-query, :type qp.error-type/qp}
-                        e))))))
 
-(s/defn ^:private col-info-for-aggregation-clause
-  "Return appropriate column metadata for an `:aggregation` clause."
-  ;; `clause` is normally an aggregation clause but this function can call itself recursively; see comments by the
-  ;; `match` pattern for field clauses below
-  [inner-query :- su/Map clause]
-  (let [mlv2-clause (lib.convert/->pMBQL clause)]
-    ;; for some mystery reason it seems like the annotate code uses `:long` style display names when something appears
-    ;; inside an aggregation clause, e.g.
-    ;;
-    ;;    Distinct values of Category → Name
-    ;;
-    ;; but `:default` style names when they appear on their own or in breakouts, e.g.
-    ;;
-    ;;    Name
-    ;;
-    ;; why is this the case? Who knows! But that's the old pre-MLv2 behavior. I think we should try to fix it, but it's
-    ;; probably going to involve updating a ton of tests that encode the old behavior.
-    (binding [lib.metadata.calculation/*display-name-style* :long]
-      (-> (lib.metadata.calculation/metadata (mlv2-query inner-query) -1 mlv2-clause)
-          (update-keys u/->snake_case_en)
-          (dissoc :lib/type)))))
+;;; ---------------------------------------------- Aggregate Field Info ----------------------------------------------
 
-(mu/defn aggregation-name :- ::lib.schema.common/non-blank-string
+(defn- expression-arg-display-name
+  "Generate an appropriate name for an `arg` in an expression aggregation."
+  [recursive-name-fn arg]
+  (mbql.u/match-one arg
+    ;; if the arg itself is a nested expression, recursively find a name for it, and wrap in parens
+    [(_ :guard #{:+ :- :/ :*}) & _]
+    (str "(" (recursive-name-fn &match) ")")
+
+    ;; if the arg is another aggregation, recurse to get its name. (Only aggregations, nested expressions, or numbers
+    ;; are allowed as args to expression aggregations; thus anything that's an MBQL clause, but not a nested
+    ;; expression, is a ag clause.)
+    [(_ :guard keyword?) & _]
+    (recursive-name-fn &match)
+
+    ;; otherwise for things like numbers just use that directly
+    _ &match))
+
+(s/defn aggregation-name :- su/NonBlankString
   "Return an appropriate aggregation name/alias *used inside a query* for an `:aggregation` subclause (an aggregation
   or expression). Takes an options map as schema won't support passing keypairs directly as a varargs.
 
   These names are also used directly in queries, e.g. in the equivalent of a SQL `AS` clause."
-  [inner-query :- [:and
-                   [:map]
-                   [:fn
-                    {:error/message "legacy inner-query with :source-table or :source-query"}
-                    (some-fn :source-table :source-query)]]
-   ag-clause]
-  (lib.metadata.calculation/column-name (mlv2-query inner-query) (lib.convert/->pMBQL ag-clause)))
+  ;; in 48+, `inner-query` is a required param; allow it here so other code can be updated to pass it in without it
+  ;; breaking between versions.
+  ([_inner-query ag-clause]
+   (aggregation-name ag-clause))
+
+  ([ag-clause :- mbql.s/Aggregation]
+   (when-not driver/*driver*
+     (throw (Exception. (tru "*driver* is unbound."))))
+   (mbql.u/match-one ag-clause
+     [:aggregation-options _ (options :guard :name)]
+     (:name options)
+
+     [:aggregation-options ag _]
+     #_:clj-kondo/ignore
+     (recur ag)
+
+     ;; For unnamed expressions, just compute a name like "sum + count"
+     ;; Top level expressions need a name without a leading __ as those are automatically removed from the results
+     [(operator :guard #{:+ :- :/ :*}) & args]
+     "expression"
+
+     ;; for historic reasons a distinct count clause is still named "count". Don't change this or you might break FE
+     ;; stuff that keys off of aggregation names.
+     ;;
+     ;; `cum-count` and `cum-sum` get the same names as the non-cumulative versions, due to limitations (they are
+     ;; written out of the query before we ever see them). For other code that makes use of this function give them
+     ;; the correct names to expect.
+     [(_ :guard #{:distinct :cum-count}) _]
+     "count"
+
+     [:cum-sum _]
+     "sum"
+
+     ;; for any other aggregation just use the name of the clause e.g. `sum`.
+     [clause-name & _]
+     (name clause-name))))
+
+(declare aggregation-display-name)
+
+(s/defn ^:private aggregation-arg-display-name :- su/NonBlankString
+  "Name to use for an aggregation clause argument such as a Field when constructing the complete aggregation name."
+  [inner-query, ag-arg :- Object]
+  (or (when (mbql.preds/Field? ag-arg)
+        (when-let [info (col-info-for-field-clause inner-query ag-arg)]
+          (some info [:display_name :name])))
+      (aggregation-display-name inner-query ag-arg)))
+
+(s/defn aggregation-display-name :- su/NonBlankString
+  "Return an appropriate user-facing display name for an aggregation clause."
+  [inner-query ag-clause]
+  (mbql.u/match-one ag-clause
+    [:aggregation-options _ (options :guard :display-name)]
+    (:display-name options)
+
+    [:aggregation-options ag _]
+    #_:clj-kondo/ignore
+    (recur ag)
+
+    [(operator :guard #{:+ :- :/ :*}) & args]
+    (str/join (format " %s " (name operator))
+              (for [arg args]
+                (expression-arg-display-name (partial aggregation-arg-display-name inner-query) arg)))
+
+    [:count]             (tru "Count")
+    [:case]              (tru "Case")
+    [:distinct    arg]   (tru "Distinct values of {0}"    (aggregation-arg-display-name inner-query arg))
+    [:count       arg]   (tru "Count of {0}"              (aggregation-arg-display-name inner-query arg))
+    [:avg         arg]   (tru "Average of {0}"            (aggregation-arg-display-name inner-query arg))
+    ;; cum-count and cum-sum get names for count and sum, respectively (see explanation in `aggregation-name`)
+    [:cum-count   arg]   (tru "Count of {0}"              (aggregation-arg-display-name inner-query arg))
+    [:cum-sum     arg]   (tru "Sum of {0}"                (aggregation-arg-display-name inner-query arg))
+    [:stddev      arg]   (tru "SD of {0}"                 (aggregation-arg-display-name inner-query arg))
+    [:sum         arg]   (tru "Sum of {0}"                (aggregation-arg-display-name inner-query arg))
+    [:min         arg]   (tru "Min of {0}"                (aggregation-arg-display-name inner-query arg))
+    [:max         arg]   (tru "Max of {0}"                (aggregation-arg-display-name inner-query arg))
+    [:var         arg]   (tru "Variance of {0}"           (aggregation-arg-display-name inner-query arg))
+    [:median      arg]   (tru "Median of {0}"             (aggregation-arg-display-name inner-query arg))
+    [:percentile  arg p] (tru "{0}th percentile of {1}" p (aggregation-arg-display-name inner-query arg))
+
+    ;; until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
+    [:sum-where   arg _] (tru "Sum of {0} matching condition" (aggregation-arg-display-name inner-query arg))
+    [:share       _]     (tru "Share of rows matching condition")
+    [:count-where _]     (tru "Count of rows matching condition")
+
+    (_ :guard mbql.preds/Field?)
+    (:display_name (col-info-for-field-clause inner-query ag-clause))
+
+    _
+    (aggregation-name ag-clause)))
+
+(s/defn ^:private ag->name-info
+  [inner-query :- su/Map
+   ag          :- mbql.s/Aggregation]
+  {:name         (aggregation-name ag)
+   :display_name (aggregation-display-name inner-query ag)})
+
+(s/defn col-info-for-aggregation-clause
+  "Return appropriate column metadata for an `:aggregation` clause."
+  ;; `clause` is normally an aggregation clause but this function can call itself recursively; see comments by the
+  ;; `match` pattern for field clauses below
+  [inner-query :- su/Map, clause]
+  (mbql.u/match-one clause
+    ;; ok, if this is a aggregation w/ options recurse so we can get information about the ag it wraps
+    [:aggregation-options ag _]
+    (merge
+     (col-info-for-aggregation-clause inner-query ag)
+     (ag->name-info inner-query &match))
+
+    ;; Always treat count or distinct count as an integer even if the DB in question returns it as something
+    ;; wacky like a BigDecimal or Float
+    [(_ :guard #{:count :distinct}) & args]
+    (merge
+     (col-info-for-aggregation-clause inner-query args)
+     {:base_type     :type/Integer
+      :semantic_type :type/Quantity}
+     (ag->name-info inner-query &match))
+
+    [:count-where _]
+    (merge
+     {:base_type     :type/Integer
+      :semantic_type :type/Quantity}
+     (ag->name-info inner-query &match))
+
+    [:share _]
+    (merge
+     {:base_type     :type/Float
+      :semantic_type :type/Share}
+     (ag->name-info inner-query &match))
+
+    ;; get info from a Field if we can (theses Fields are matched when ag clauses recursively call
+    ;; `col-info-for-ag-clause`, and this info is added into the results)
+    (_ :guard mbql.preds/Field?)
+    (select-keys (col-info-for-field-clause inner-query &match) [:base_type :semantic_type :settings])
+    #{:expression :+ :- :/ :*}
+    (merge
+     (infer-expression-type &match)
+     (when (mbql.preds/Aggregation? &match)
+       (ag->name-info inner-query &match)))
+
+    ;; the type returned by a case statement depends on what its expressions are; we'll just return the type info for
+    ;; the first expression for the time being. I guess it's possible the expression might return a string for one
+    ;; case and a number for another, but I think in post cases it should be the same type for every clause.
+    [:case & _]
+    (merge
+     (infer-expression-type &match)
+     (ag->name-info inner-query &match))
+
+    ;; get name/display-name of this ag
+    [(_ :guard keyword?) arg & _]
+    (merge
+     (col-info-for-aggregation-clause inner-query arg)
+     (ag->name-info inner-query &match))))
 
 
 ;;; ----------------------------------------- Putting it all together (MBQL) -----------------------------------------
@@ -402,6 +527,8 @@
   (concat
    (cols-for-ags-and-breakouts inner-query)
    (cols-for-fields inner-query)))
+
+
 
 (s/defn ^:private merge-source-metadata-col :- (s/maybe su/Map)
   [source-metadata-col :- (s/maybe su/Map) col :- (s/maybe su/Map)]

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -528,8 +528,6 @@
    (cols-for-ags-and-breakouts inner-query)
    (cols-for-fields inner-query)))
 
-
-
 (s/defn ^:private merge-source-metadata-col :- (s/maybe su/Map)
   [source-metadata-col :- (s/maybe su/Map) col :- (s/maybe su/Map)]
   (merge

--- a/test/metabase/query_processor/middleware/add_source_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/add_source_metadata_test.clj
@@ -82,7 +82,8 @@
                                 (venues-source-metadata :price)
                                 [{:name          "avg"
                                   :display_name  "Average of ID"
-                                  :base_type     :type/Float
+                                  :base_type     :type/BigInteger
+                                  :semantic_type :type/PK
                                   :settings      nil
                                   :field_ref     [:aggregation 0]}])})
            (add-source-metadata
@@ -105,11 +106,12 @@
                                   :breakout     [$price]}
                 :source-metadata (concat
                                   (venues-source-metadata :price)
-                                  [{:name         "some_generated_name"
-                                    :display_name "My Cool Ag"
-                                    :base_type    :type/Float
-                                    :settings     nil
-                                    :field_ref    [:aggregation 0]}])})
+                                  [{:name          "some_generated_name"
+                                    :display_name  "My Cool Ag"
+                                    :base_type     :type/BigInteger
+                                    :semantic_type :type/PK
+                                    :settings      nil
+                                    :field_ref     [:aggregation 0]}])})
              (add-source-metadata
               (mt/mbql-query venues
                 {:source-query {:source-table $$venues
@@ -122,27 +124,29 @@
   (testing "w/ `:name` only"
     (is (= [{:name         "some_generated_name"
              :display_name "Average of ID"
-             :base_type    :type/Float
+             :base_type     :type/BigInteger
+             :semantic_type :type/PK
              :settings     nil
              :field_ref    [:aggregation 0]}]
            (source-metadata
             (add-source-metadata
              (mt/mbql-query venues
-                            {:source-query {:source-table $$venues
-                                            :aggregation  [[:aggregation-options [:avg $id] {:name "some_generated_name"}]]}})))))))
+               {:source-query {:source-table $$venues
+                               :aggregation  [[:aggregation-options [:avg $id] {:name "some_generated_name"}]]}})))))))
 
 (deftest ^:parallel named-aggregations-display-name-only-test
   (testing "w/ `:display-name` only"
-    (is (= [{:name         "avg"
-             :display_name "My Cool Ag"
-             :base_type    :type/Float
-             :settings     nil
-             :field_ref    [:aggregation 0]}]
+    (is (= [{:name          "avg"
+             :display_name  "My Cool Ag"
+             :base_type     :type/BigInteger
+             :semantic_type :type/PK
+             :settings      nil
+             :field_ref     [:aggregation 0]}]
            (source-metadata
             (add-source-metadata
              (mt/mbql-query venues
-                            {:source-query {:source-table $$venues
-                                            :aggregation  [[:aggregation-options [:avg $id] {:display-name "My Cool Ag"}]]}})))))))
+               {:source-query {:source-table $$venues
+                               :aggregation  [[:aggregation-options [:avg $id] {:display-name "My Cool Ag"}]]}})))))))
 
 (deftest ^:parallel nested-sources-test
   (testing (str "Can we automatically add source metadata to the parent level of a query? If the source query has a "

--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -69,81 +69,61 @@
         (is (= [(merge (info-for-field :venues :price)
                        {:source    :fields
                         :field_ref $price})]
-               (annotate/column-info
-                {:type :query, :query {:fields [$price]}}
-                {:columns [:price]})))))))
-
-(deftest ^:parallel col-info-for-implicit-joins-test
-  (mt/with-everything-store
-    (mt/$ids venues
-      (testing (str "when a `:field` with `:source-field` (implicit join) is used, we should add in `:fk_field_id` "
-                    "info about the source Field")
-        (is (= [(merge (info-for-field :categories :name)
-                       {:fk_field_id  %category_id
-                        :source       :fields
-                        :field_ref    $category_id->categories.name
-                        ;; for whatever reason this is what the `annotate` middleware traditionally returns here, for
-                        ;; some reason we use the `:long` style inside aggregations and the `:default` style elsewhere,
-                        ;; who knows why. See notes
-                        ;; on [[metabase.query-processor.middleware.annotate/col-info-for-aggregation-clause]]
-                        :display_name "Name"})]
-               (annotate/column-info
-                {:type :query, :query {:fields [$category_id->categories.name]}}
-                {:columns [:name]})))))))
-
-(deftest ^:parallel col-info-for-implicit-joins-aggregation-test
-  (mt/with-everything-store
-    (mt/$ids venues
-      (testing (str "when a `:field` with `:source-field` (implicit join) is used, we should add in `:fk_field_id` "
-                    "info about the source Field")
-        (is (=? [{:source       :aggregation
-                  :field_ref    [:aggregation 0]
-                  :display_name "Distinct values of Category → Name"}]
+               (doall
                 (annotate/column-info
-                 {:type  :query
-                  :query {:source-table $$venues
-                          :aggregation  [[:distinct $category_id->categories.name]]}}
-                 {:columns [:name]})))))))
+                 {:type :query, :query {:fields [$price]}}
+                 {:columns [:price]}))))))))
 
-(deftest ^:parallel col-info-for-explicit-joins-with-fk-field-id-test
+(deftest ^:parallel col-info-for-fks-and-joins-test
   (mt/with-everything-store
     (mt/$ids venues
-      (testing (str "we should get `:fk_field_id` and information where possible when using joins; "
-                    "display_name should include the display name of the FK field (for IMPLICIT JOINS)")
+      (testing (str "when a `:field` with `:source-field` (implicit join) is used, we should add in `:fk_field_id` "
+                    "info about the source Field")
         (is (= [(merge (info-for-field :categories :name)
-                       {:display_name "Category → Name"
-                        :source       :fields
-                        :field_ref    $category_id->categories.name
-                        :fk_field_id  %category_id
-                        :source_alias "CATEGORIES__via__CATEGORY_ID"})]
-               (annotate/column-info
-                {:type  :query
-                 :query {:fields [&CATEGORIES__via__CATEGORY_ID.categories.name]
-                         :joins  [{:alias        "CATEGORIES__via__CATEGORY_ID"
-                                   :source-table $$venues
-                                   :condition    [:= $category_id &CATEGORIES__via__CATEGORY_ID.categories.id]
-                                   :strategy     :left-join
-                                   :fk-field-id  %category_id}]}}
-                {:columns [:name]})))))))
+                       {:fk_field_id %category_id
+                        :source      :fields
+                        :field_ref   $category_id->categories.name})]
+               (doall
+                (annotate/column-info
+                 {:type :query, :query {:fields [$category_id->categories.name]}}
+                 {:columns [:name]})))))
 
-(deftest ^:parallel col-info-for-explicit-joins-without-fk-field-id-test
-  (mt/with-everything-store
-    (mt/$ids venues
-      (testing (str "for EXPLICIT JOINS (which do not include an `:fk-field-id` in the Join info) the returned "
-                    "`:field_ref` should be have only `:join-alias`, and no `:source-field`")
-        (is (= [(merge (info-for-field :categories :name)
-                       {:display_name "Categories → Name"
-                        :source       :fields
-                        :field_ref    &Categories.categories.name
-                        :source_alias "Categories"})]
-               (annotate/column-info
-                {:type  :query
-                 :query {:fields [&Categories.categories.name]
-                         :joins  [{:alias        "Categories"
-                                   :source-table $$venues
-                                   :condition    [:= $category_id &Categories.categories.id]
-                                   :strategy     :left-join}]}}
-                {:columns [:name]})))))))
+      (testing "joins"
+        (testing (str "we should get `:fk_field_id` and information where possible when using joins; "
+                      "display_name should include the display name of the FK field (for IMPLICIT JOINS)")
+          (is (= [(merge (info-for-field :categories :name)
+                         {:display_name "Category → Name"
+                          :source       :fields
+                          :field_ref    $category_id->categories.name
+                          :fk_field_id  %category_id
+                          :source_alias "CATEGORIES__via__CATEGORY_ID"})]
+                 (doall
+                  (annotate/column-info
+                   {:type  :query
+                    :query {:fields [&CATEGORIES__via__CATEGORY_ID.categories.name]
+                            :joins  [{:alias        "CATEGORIES__via__CATEGORY_ID"
+                                      :source-table $$venues
+                                      :condition    [:= $category_id &CATEGORIES__via__CATEGORY_ID.categories.id]
+                                      :strategy     :left-join
+                                      :fk-field-id  %category_id}]}}
+                   {:columns [:name]})))))
+
+        (testing (str "for EXPLICIT JOINS (which do not include an `:fk-field-id` in the Join info) the returned "
+                      "`:field_ref` should be have only `:join-alias`, and no `:source-field`")
+          (is (= [(merge (info-for-field :categories :name)
+                         {:display_name "Categories → Name"
+                          :source       :fields
+                          :field_ref    &Categories.categories.name
+                          :source_alias "Categories"})]
+                 (doall
+                  (annotate/column-info
+                   {:type  :query
+                    :query {:fields [&Categories.categories.name]
+                            :joins  [{:alias        "Categories"
+                                      :source-table $$venues
+                                      :condition    [:= $category_id &Categories.categories.id]
+                                      :strategy     :left-join}]}}
+                   {:columns [:name]})))))))))
 
 (deftest ^:parallel col-info-for-field-with-temporal-unit-test
   (mt/with-everything-store
@@ -156,11 +136,8 @@
                (doall
                 (annotate/column-info
                  {:type :query, :query {:fields (mt/$ids venues [!month.price])}}
-                 {:columns [:price]}))))))))
+                 {:columns [:price]})))))
 
-(deftest ^:parallel col-info-for-field-literal-with-temporal-unit-test
-  (mt/with-everything-store
-    (mt/$ids venues
       (testing "datetime unit should work on field literals too"
         (is (= [{:name         "price"
                  :base_type    :type/Number
@@ -171,10 +148,8 @@
                (doall
                 (annotate/column-info
                  {:type :query, :query {:fields [[:field "price" {:base-type :type/Number, :temporal-unit :month}]]}}
-                 {:columns [:price]}))))))))
+                 {:columns [:price]}))))))
 
-(deftest ^:parallel col-info-for-field-with-temporal-unit-from-nested-query-test
-  (mt/with-everything-store
     (testing "should add the correct info if the Field originally comes from a nested query"
       (mt/$ids checkins
         (is (= [{:name "DATE", :unit :month, :field_ref [:field %date {:temporal-unit :default}]}
@@ -255,9 +230,8 @@
                 :display_name    "Child"
                 :fingerprint     nil
                 :base_type       :type/Text}
-               (into {} (#'annotate/col-info-for-field-clause {} [:field (u/the-id child) nil]))))))))
+               (into {} (#'annotate/col-info-for-field-clause {} [:field (u/the-id child) nil])))))))
 
-(deftest col-info-combine-grandparent-field-names-test
   (testing "nested-nested fields should include grandparent name (etc)"
     (t2.with-temp/with-temp [Field grandparent {:name "grandparent", :table_id (mt/id :venues)}
                              Field parent      {:name "parent", :table_id (mt/id :venues), :parent_id (u/the-id grandparent)}
@@ -348,12 +322,13 @@
 ;; test that added information about aggregations looks the way we'd expect
 (defn- aggregation-names
   ([ag-clause]
-   (aggregation-names {:source-table (mt/id :venues)} ag-clause))
+   (aggregation-names {} ag-clause))
 
   ([inner-query ag-clause]
    (binding [driver/*driver* :h2]
      (mt/with-everything-store
-       (select-keys (#'annotate/col-info-for-aggregation-clause inner-query ag-clause) [:name :display_name])))))
+       {:name         (annotate/aggregation-name ag-clause)
+        :display_name (annotate/aggregation-display-name inner-query ag-clause)}))))
 
 (deftest ^:parallel aggregation-names-test
   (testing "basic aggregations"
@@ -375,14 +350,14 @@
              (aggregation-names [:+ [:count] 1]))))
 
     (testing "expression with nested expressions"
-      (is (= {:name "expression", :display_name "Min of ID + (2 × Average of Price)"}
+      (is (= {:name "expression", :display_name "Min of ID + (2 * Average of Price)"}
              (aggregation-names
               [:+
                [:min [:field (mt/id :venues :id) nil]]
                [:* 2 [:avg [:field (mt/id :venues :price) nil]]]]))))
 
     (testing "very complicated expression"
-      (is (= {:name "expression", :display_name "Min of ID + (2 × Average of Price × 3 × (Max of Category ID - 4))"}
+      (is (= {:name "expression", :display_name "Min of ID + (2 * Average of Price * 3 * (Max of Category ID - 4))"}
              (aggregation-names
               [:+
                [:min [:field (mt/id :venues :id) nil]]
@@ -401,7 +376,7 @@
                {:name "generated_name", :display-name "User-specified Name"}]))))
 
     (testing "`:name` only"
-      (is (= {:name "generated_name", :display_name "Min of ID + (2 × Average of Price)"}
+      (is (= {:name "generated_name", :display_name "Min of ID + (2 * Average of Price)"}
              (aggregation-names
               [:aggregation-options
                [:+ [:min [:field (mt/id :venues :id) nil]] [:* 2 [:avg [:field (mt/id :venues :price) nil]]]]
@@ -416,7 +391,7 @@
 
 (defn- col-info-for-aggregation-clause
   ([clause]
-   (col-info-for-aggregation-clause {:source-table (mt/id :venues)} clause))
+   (col-info-for-aggregation-clause {} clause))
 
   ([inner-query clause]
    (binding [driver/*driver* :h2]
@@ -426,60 +401,60 @@
   (mt/with-everything-store
     (testing "basic aggregation clauses"
       (testing "`:count` (no field)"
-        (is (=? {:base_type :type/Float, :name "expression", :display_name "Count ÷ 2"}
-                (col-info-for-aggregation-clause [:/ [:count] 2]))))
+        (is (= {:base_type :type/Float, :name "expression", :display_name "Count / 2"}
+               (col-info-for-aggregation-clause [:/ [:count] 2]))))
 
       (testing "`:sum`"
-        (is (=? {:base_type :type/Integer, :name "sum", :display_name "Sum of Price + 1"}
-                (mt/$ids venues
-                  (col-info-for-aggregation-clause [:sum [:+ $price 1]]))))))
+        (is (= {:base_type :type/Float, :name "sum", :display_name "Sum of Price + 1"}
+               (mt/$ids venues
+                 (col-info-for-aggregation-clause [:sum [:+ $price 1]]))))))
 
     (testing "`:aggregation-options`"
       (testing "`:name` and `:display-name`"
-        (is (=? {:base_type     :type/Integer
-                 :settings      nil
-                 :name          "sum_2"
-                 :display_name  "My custom name"}
-                (mt/$ids venues
-                  (col-info-for-aggregation-clause
-                   [:aggregation-options [:sum $price] {:name "sum_2", :display-name "My custom name"}])))))
+        (is (= {:base_type     :type/Integer
+                :semantic_type :type/Category
+                :settings      nil
+                :name          "sum_2"
+                :display_name  "My custom name"}
+               (mt/$ids venues
+                 (col-info-for-aggregation-clause
+                  [:aggregation-options [:sum $price] {:name "sum_2", :display-name "My custom name"}])))))
 
       (testing "`:name` only"
-        (is (=? {:base_type     :type/Integer
-                 :settings      nil
-                 :name          "sum_2"
-                 :display_name  "Sum of Price"}
-                (mt/$ids venues
-                  (col-info-for-aggregation-clause [:aggregation-options [:sum $price] {:name "sum_2"}])))))
+        (is (= {:base_type     :type/Integer
+                :semantic_type :type/Category
+                :settings      nil
+                :name          "sum_2"
+                :display_name  "Sum of Price"}
+               (mt/$ids venues
+                 (col-info-for-aggregation-clause [:aggregation-options [:sum $price] {:name "sum_2"}])))))
 
       (testing "`:display-name` only"
-        (is (=? {:base_type     :type/Integer
-                 :settings      nil
-                 :name          "sum"
-                 :display_name  "My Custom Name"}
-                (mt/$ids venues
-                  (col-info-for-aggregation-clause
-                   [:aggregation-options [:sum $price] {:display-name "My Custom Name"}]))))))
+        (is (= {:base_type     :type/Integer
+                :semantic_type :type/Category
+                :settings      nil
+                :name          "sum"
+                :display_name  "My Custom Name"}
+               (mt/$ids venues
+                 (col-info-for-aggregation-clause
+                  [:aggregation-options [:sum $price] {:display-name "My Custom Name"}]))))))
 
     (testing (str "if a driver is kind enough to supply us with some information about the `:cols` that come back, we "
                   "should include that information in the results. Their information should be preferred over ours")
-      (is (=? {:cols [{:name         "metric"
-                       :display_name "Total Events"
-                       :base_type    :type/Text
-                       :effective_type :type/Text
-                       :source       :aggregation
-                       :field_ref    [:aggregation 0]}]}
-              (add-column-info
-               (mt/mbql-query venues {:aggregation [[:metric "ga:totalEvents"]]})
-               {:cols [{:name "totalEvents", :display_name "Total Events", :base_type :type/Text}]}))))
+      (is (= {:cols [{:name         "metric"
+                      :display_name "Total Events"
+                      :base_type    :type/Text
+                      :effective_type :type/Text
+                      :source       :aggregation
+                      :field_ref    [:aggregation 0]}]}
+             (add-column-info
+              (mt/mbql-query venues {:aggregation [[:metric "ga:totalEvents"]]})
+              {:cols [{:name "totalEvents", :display_name "Total Events", :base_type :type/Text}]}))))
 
     (testing "col info for an `expression` aggregation w/ a named expression should work as expected"
-      (is (=? {:base_type :type/Integer, :name "sum", :display_name "Sum of double-price"}
-              (mt/$ids venues
-                (col-info-for-aggregation-clause
-                 {:source-table (mt/id :venues)
-                  :expressions {"double-price" [:* $price 2]}}
-                 [:sum [:expression "double-price"]])))))))
+      (is (= {:base_type :type/Float, :name "sum", :display_name "Sum of double-price"}
+             (mt/$ids venues
+               (col-info-for-aggregation-clause {:expressions {"double-price" [:* $price 2]}} [:sum [:expression "double-price"]])))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -575,71 +550,71 @@
 
 (deftest ^:parallel test-string-extracts
   (is (= {:base_type :type/Text}
-         (infered-col-type [:trim "foo"])))
+         (infered-col-type  [:trim "foo"])))
   (is (= {:base_type :type/Text}
-         (infered-col-type [:ltrim "foo"])))
+         (infered-col-type  [:ltrim "foo"])))
   (is (= {:base_type :type/Text}
-         (infered-col-type [:rtrim "foo"])))
+         (infered-col-type  [:rtrim "foo"])))
   (is (= {:base_type :type/BigInteger}
-         (infered-col-type [:length "foo"])))
+         (infered-col-type  [:length "foo"])))
   (is (= {:base_type :type/Text}
-         (infered-col-type [:upper "foo"])))
+         (infered-col-type  [:upper "foo"])))
   (is (= {:base_type :type/Text}
-         (infered-col-type [:lower "foo"])))
+         (infered-col-type  [:lower "foo"])))
   (is (= {:base_type :type/Text}
-         (infered-col-type [:substring "foo" 2])))
+         (infered-col-type  [:substring "foo" 2])))
   (is (= {:base_type :type/Text}
-         (infered-col-type [:replace "foo" "f" "b"])))
+         (infered-col-type  [:replace "foo" "f" "b"])))
   (is (= {:base_type :type/Text}
-         (infered-col-type [:regex-match-first "foo" "f"])))
+         (infered-col-type  [:regex-match-first "foo" "f"])))
   (is (= {:base_type :type/Text}
-         (infered-col-type [:concat "foo" "bar"])))
+         (infered-col-type  [:concat "foo" "bar"])))
   (is (= {:base_type :type/Text}
-         (infered-col-type [:coalesce "foo" "bar"])))
+         (infered-col-type  [:coalesce "foo" "bar"])))
   (is (= {:base_type     :type/Text
           :semantic_type :type/Name}
-         (infered-col-type [:coalesce [:field (mt/id :venues :name) nil] "bar"]))))
+         (infered-col-type  [:coalesce [:field (mt/id :venues :name) nil] "bar"]))))
 
 (deftest ^:parallel unique-name-key-test
   (testing "Make sure `:cols` always come back with a unique `:name` key (#8759)"
-    (is (=? {:cols
-             [{:base_type     :type/Number
-               :effective_type :type/Number
-               :semantic_type :type/Quantity
-               :name          "count"
-               :display_name  "count"
-               :source        :aggregation
-               :field_ref     [:aggregation 0]}
-              {:source       :aggregation
-               :name         "sum"
-               :display_name "sum"
-               :base_type    :type/Number
-               :effective_type :type/Number
-               :field_ref    [:aggregation 1]}
-              {:base_type     :type/Number
-               :effective_type :type/Number
-               :semantic_type :type/Quantity
-               :name          "count_2"
-               :display_name  "count"
-               :source        :aggregation
-               :field_ref     [:aggregation 2]}
-              {:base_type     :type/Number
-               :effective_type :type/Number
-               :semantic_type :type/Quantity
-               :name          "count_3"
-               :display_name  "count_2"
-               :source        :aggregation
-               :field_ref     [:aggregation 3]}]}
-            (add-column-info
-             (mt/mbql-query venues
-               {:aggregation [[:count]
-                              [:sum]
-                              [:count]
-                              [:aggregation-options [:count] {:display-name "count_2"}]]})
-             {:cols [{:name "count", :display_name "count", :base_type :type/Number}
-                     {:name "sum", :display_name "sum", :base_type :type/Number}
-                     {:name "count", :display_name "count", :base_type :type/Number}
-                     {:name "count_2", :display_name "count_2", :base_type :type/Number}]})))))
+    (is (= {:cols
+            [{:base_type     :type/Number
+              :effective_type :type/Number
+              :semantic_type :type/Quantity
+              :name          "count"
+              :display_name  "count"
+              :source        :aggregation
+              :field_ref     [:aggregation 0]}
+             {:source       :aggregation
+              :name         "sum"
+              :display_name "sum"
+              :base_type    :type/Number
+              :effective_type :type/Number
+              :field_ref    [:aggregation 1]}
+             {:base_type     :type/Number
+              :effective_type :type/Number
+              :semantic_type :type/Quantity
+              :name          "count_2"
+              :display_name  "count"
+              :source        :aggregation
+              :field_ref     [:aggregation 2]}
+             {:base_type     :type/Number
+              :effective_type :type/Number
+              :semantic_type :type/Quantity
+              :name          "count_3"
+              :display_name  "count_2"
+              :source        :aggregation
+              :field_ref     [:aggregation 3]}]}
+           (add-column-info
+            (mt/mbql-query venues
+              {:aggregation [[:count]
+                             [:sum]
+                             [:count]
+                             [:aggregation-options [:count] {:display-name "count_2"}]]})
+            {:cols [{:name "count", :display_name "count", :base_type :type/Number}
+                    {:name "sum", :display_name "sum", :base_type :type/Number}
+                    {:name "count", :display_name "count", :base_type :type/Number}
+                    {:name "count_2", :display_name "count_2", :base_type :type/Number}]})))))
 
 (deftest ^:parallel expressions-keys-test
   (testing "make sure expressions come back with the right set of keys, including `:expression_name` (#8854)"
@@ -661,20 +636,20 @@
 (deftest ^:parallel deduplicate-expression-names-test
   (testing "make sure multiple expressions come back with deduplicated names"
     (testing "expressions in aggregations"
-      (is (=? [{:base_type :type/Float, :name "expression", :display_name "0.9 × Average of Price", :source :aggregation, :field_ref [:aggregation 0]}
-               {:base_type :type/Float, :name "expression_2", :display_name "0.8 × Average of Price", :source :aggregation, :field_ref [:aggregation 1]}]
-              (:cols (add-column-info
-                      (mt/mbql-query venues
-                        {:aggregation [[:* 0.9 [:avg $price]] [:* 0.8 [:avg $price]]]
-                         :limit       10})
-                      {})))))
+      (is (= [{:base_type :type/Float, :name "expression", :display_name "0.9 * Average of Price", :source :aggregation, :field_ref [:aggregation 0]}
+              {:base_type :type/Float, :name "expression_2", :display_name "0.8 * Average of Price", :source :aggregation, :field_ref [:aggregation 1]}]
+             (:cols (add-column-info
+                     (mt/mbql-query venues
+                                      {:aggregation [[:* 0.9 [:avg $price]] [:* 0.8 [:avg $price]]]
+                                       :limit       10})
+                     {})))))
     (testing "named :expressions"
-      (is (=? [{:name "prev_month", :display_name "prev_month", :base_type :type/DateTime, :expression_name "prev_month", :source :fields, :field_ref [:expression "prev_month"]}]
-              (:cols (add-column-info
-                      (mt/mbql-query users
-                        {:expressions {:prev_month [:+ $last_login [:interval -1 :month]]}
-                         :fields      [[:expression "prev_month"]], :limit 10})
-                      {})))))))
+      (is (= [{:name "prev_month", :display_name "prev_month", :base_type :type/DateTime, :expression_name "prev_month", :source :fields, :field_ref [:expression "prev_month"]}]
+             (:cols (add-column-info
+                     (mt/mbql-query users
+                                      {:expressions {:prev_month [:+ $last_login [:interval -1 :month]]}
+                                       :fields      [[:expression "prev_month"]], :limit 10})
+                     {})))))))
 
 (deftest mbql-cols-nested-queries-test
   (testing "Should be able to infer MBQL columns with nested queries"
@@ -702,38 +677,39 @@
 
   (testing "Aggregated question with source is an aggregated models should infer display_name correctly (#23248)"
     (mt/dataset sample-dataset
-      (t2.with-temp/with-temp [Card {card-id :id} {:dataset true
-                                                   :dataset_query
-                                                   (mt/$ids :products
-                                                     {:type     :query
-                                                      :database (mt/id)
-                                                      :query    {:source-table $$products
-                                                                 :aggregation
-                                                                 [[:aggregation-options
-                                                                   [:sum $price]
-                                                                   {:name "sum"}]
-                                                                  [:aggregation-options
-                                                                   [:max $rating]
-                                                                   {:name "max"}]]
-                                                                 :breakout     $category
-                                                                 :order-by     [[:asc $category]]}})}]
-        (let [query (qp/preprocess
+     (mt/with-temp* [Card [{card-id :id}
+                           {:dataset true
+                            :dataset_query
+                            (mt/$ids :products
+                                     {:type     :query
+                                      :database (mt/id)
+                                      :query    {:source-table $$products
+                                                 :aggregation
+                                                 [[:aggregation-options
+                                                   [:sum $price]
+                                                   {:name "sum"}]
+                                                  [:aggregation-options
+                                                   [:max $rating]
+                                                   {:name "max"}]]
+                                                 :breakout     $category
+                                                 :order-by     [[:asc $category]]}})}]]
+       (let [query (qp/preprocess
                      (mt/mbql-query nil
-                       {:source-table (str "card__" card-id)
-                        :aggregation  [[:aggregation-options
-                                        [:sum
-                                         [:field
-                                          "sum"
-                                          {:base-type :type/Float}]]
-                                        {:name "sum"}]
-                                       [:aggregation-options
-                                        [:count]
-                                        {:name "count"}]]
-                        :limit        1}))]
-          (is (= ["Sum of Sum of Price" "Count"]
-                 (->> (add-column-info query {})
-                      :cols
-                      (map :display_name)))))))))
+                                    {:source-table (str "card__" card-id)
+                                     :aggregation  [[:aggregation-options
+                                                     [:sum
+                                                      [:field
+                                                       "sum"
+                                                       {:base-type :type/Float}]]
+                                                     {:name "sum"}]
+                                                    [:aggregation-options
+                                                     [:count]
+                                                     {:name "count"}]]
+                                     :limit        1}))]
+        (is (= ["Sum of Sum of Price" "Count"]
+              (->> (add-column-info query {})
+                  :cols
+                  (map :display_name)))))))))
 
 (deftest ^:parallel inception-test
   (testing "Should return correct metadata for an 'inception-style' nesting of source > source > source with a join (#14745)"
@@ -765,43 +741,42 @@
                               :field_ref    &Products.ean})
                            (ean-metadata (add-column-info nested-query {}))))))))))))))
 
+;; metabase#14787
 (deftest col-info-for-fields-from-card-test
-  (testing "#14787"
-    (mt/dataset sample-dataset
-      (let [card-1-query (mt/mbql-query orders
-                           {:joins [{:fields       :all
-                                     :source-table $$products
-                                     :condition    [:= $product_id &Products.products.id]
-                                     :alias        "Products"}]})]
-        (t2.with-temp/with-temp [Card {card-1-id :id} {:dataset_query card-1-query}
-                                 Card {card-2-id :id} {:dataset_query (mt/mbql-query people)}]
-          (testing "when a nested query is from a saved question, there should be no `:join-alias` on the left side"
-            (mt/$ids nil
-              (let [base-query (qp/preprocess
-                                (mt/mbql-query nil
-                                  {:source-table (str "card__" card-1-id)
-                                   :joins        [{:fields       :all
-                                                   :source-table (str "card__" card-2-id)
-                                                   :condition    [:= $orders.user_id &Products.products.id]
-                                                   :alias        "Q"}]
-                                   :limit        1}))
-                    fields     #{%orders.discount %products.title %people.source}]
-                (is (= [{:display_name "Discount" :field_ref [:field %orders.discount nil]}
-                        {:display_name "Products → Title" :field_ref [:field %products.title nil]}
-                        {:display_name "Q → Source" :field_ref [:field %people.source {:join-alias "Q"}]}]
-                       (->> (:cols (add-column-info base-query {}))
-                            (filter #(fields (:id %)))
-                            (map #(select-keys % [:display_name :field_ref])))))))))))))
+  (mt/dataset sample-dataset
+    (let [card-1-query (mt/mbql-query orders
+                         {:joins [{:fields       :all
+                                   :source-table $$products
+                                   :condition    [:= $product_id &Products.products.id]
+                                   :alias        "Products"}]})]
+      (mt/with-temp* [Card [{card-1-id :id} {:dataset_query card-1-query}]
+                      Card [{card-2-id :id} {:dataset_query (mt/mbql-query people)}]]
+        (testing "when a nested query is from a saved question, there should be no `:join-alias` on the left side"
+          (mt/$ids nil
+            (let [base-query (qp/preprocess
+                              (mt/mbql-query nil
+                                {:source-table (str "card__" card-1-id)
+                                 :joins        [{:fields       :all
+                                                 :source-table (str "card__" card-2-id)
+                                                 :condition    [:= $orders.user_id &Products.products.id]
+                                                 :alias        "Q"}]
+                                 :limit        1}))
+                  fields     #{%orders.discount %products.title %people.source}]
+              (is (= [{:display_name "Discount" :field_ref [:field %orders.discount nil]}
+                      {:display_name "Products → Title" :field_ref [:field %products.title nil]}
+                      {:display_name "Q → Source" :field_ref [:field %people.source {:join-alias "Q"}]}]
+                     (->> (:cols (add-column-info base-query {}))
+                          (filter #(fields (:id %)))
+                          (map #(select-keys % [:display_name :field_ref])))))))))))
 
-(deftest col-info-for-joined-fields-from-card-test
-  (testing "Has the correct display names for joined fields from cards (#14787)"
+  (testing "Has the correct display names for joined fields from cards"
     (letfn [(native [query] {:type :native
                              :native {:query query :template-tags {}}
                              :database (mt/id)})]
-      (t2.with-temp/with-temp [Card {card1-id :id} {:dataset_query
-                                                    (native "select 'foo' as A_COLUMN")}
-                               Card {card2-id :id} {:dataset_query
-                                                    (native "select 'foo' as B_COLUMN")}]
+      (mt/with-temp* [Card [{card1-id :id} {:dataset_query
+                                            (native "select 'foo' as A_COLUMN")}]
+                      Card [{card2-id :id} {:dataset_query
+                                            (native "select 'foo' as B_COLUMN")}]]
         (doseq [card-id [card1-id card2-id]]
           ;; populate metadata
           (mt/user-http-request :rasta :post 202 (format "card/%d/query" card-id)))

--- a/test/metabase/query_processor/util/nest_query_test.clj
+++ b/test/metabase/query_processor/util/nest_query_test.clj
@@ -366,7 +366,7 @@
                                                                                            ::add/source-alias  "MaxPrice"
                                                                                            ::add/desired-alias "CategoriesStats__MaxPrice"
                                                                                            ::add/position      8}]
-                                                                       [:field "AvgPrice" {:base-type          :type/Float
+                                                                       [:field "AvgPrice" {:base-type          :type/Integer
                                                                                            :join-alias         "CategoriesStats"
                                                                                            ::add/source-table  "CategoriesStats"
                                                                                            ::add/source-alias  "AvgPrice"
@@ -426,7 +426,7 @@
                                                                            ::add/source-alias  "MaxPrice"
                                                                            ::add/desired-alias "CategoriesStats__MaxPrice"
                                                                            ::add/position      8}]
-                                                       [:field "AvgPrice" {:base-type          :type/Float
+                                                       [:field "AvgPrice" {:base-type          :type/Integer
                                                                            :join-alias         "CategoriesStats"
                                                                            ::add/source-table  "CategoriesStats"
                                                                            ::add/source-alias  "AvgPrice"


### PR DESCRIPTION
Reverts the changes from #29583 that change the QP `annotate` middleware to use MLv2. This was (probably) causing performance issues because it had to convert the query to MLv2 a bunch of times to calculate display names and stuff like that.

Fixes #32149

(probably)

I don't think this really warrants a nitpicky review since I'm just reverting code to what it was prior to #29583. So don't poke holes in how stuff used to work 🙃 

If this doesn't solve our performance woes then I'll unrevert and investigate further