### PR TITLE
Have Kondo enforce usage of `clojure.core/random-uuid`

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -137,6 +137,8 @@
    honeysql.core/call                   {:message "Use hx/call instead because it is Honey SQL 2 friendly"}
    honeysql.core/raw                    {:message "Use hx/raw instead because it is Honey SQL 2 friendly"}
    java-time/with-clock                 {:message "Use mt/with-clock"}
+   java.util.UUID/randomUUID            {:message "Use clojure.core/random-uuid instead of java.util.UUID/randomUUID"}
+   medley.core/random-uuid              {:message "Use clojure.core/random-uuid instead of medley.core/random-uuid"}
    metabase.test/with-temp              {:message "Use t2.with-temp/with-temp instead of metabase.test/with-temp"}
    ;; metabase.test/with-temp*             {:message "Use t2.with-temp/with-temp instead of metabase.test/with-temp*"}
    toucan.db/select                     {:message "Use t2/select instead of toucan.db/select"}

--- a/enterprise/backend/src/metabase_enterprise/serialization/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/load.clj
@@ -36,9 +36,7 @@
    [metabase.util.i18n :refer [trs]]
    [metabase.util.log :as log]
    [metabase.util.yaml :as yaml]
-   [toucan2.core :as t2])
-  (:import
-   (java.util UUID)))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -687,7 +685,7 @@
   "A function called on each User instance before it is inserted (via upsert)."
   [user]
   (log/infof "User with email %s is new to target DB; setting a random password" (:email user))
-  (assoc user :password (str (UUID/randomUUID))))
+  (assoc user :password (str (random-uuid))))
 
 ;; leaving comment out for now (deliberately), because this will send a password reset email to newly inserted users
 ;; when enabled in a future release; see `defmethod load "users"` below

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -133,7 +133,7 @@
     (try
       (let [idp-url      (sso-settings/saml-identity-provider-uri)
             saml-request (saml/request
-                           {:request-id (str "id-" (UUID/randomUUID))
+                           {:request-id (str "id-" (random-uuid))
                             :sp-name    (sso-settings/saml-application-name)
                             :issuer     (sso-settings/saml-application-name)
                             :acs-url    (acs-url)

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
@@ -13,8 +13,7 @@
    [schema.core :as s]
    [toucan2.core :as t2])
   (:import
-   (java.net MalformedURLException URL URLDecoder)
-   (java.util UUID)))
+   (java.net MalformedURLException URL URLDecoder)))
 
 (set! *warn-on-reflection* true)
 
@@ -32,7 +31,7 @@
   to refactor the `core_user` table structure and the function used to populate it so that the enterprise product can
   reuse it"
   [user :- UserAttributes]
-  (u/prog1 (first (t2/insert-returning-instances! User (merge user {:password (str (UUID/randomUUID))})))
+  (u/prog1 (first (t2/insert-returning-instances! User (merge user {:password (str (random-uuid))})))
     (log/info (trs "New SSO user created: {0} ({1})" (:common_name <>) (:email <>)))
     ;; send an email to everyone including the site admin if that's set
     (when (integrations.common/send-new-sso-user-admin-email?)

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/setting_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/setting_test.clj
@@ -11,9 +11,7 @@
     :as premium-features-test]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
-   [toucan2.tools.with-temp :as t2.with-temp])
-  (:import
-   (java.util UUID)))
+   [toucan2.tools.with-temp :as t2.with-temp]))
 
 (set! *warn-on-reflection* true)
 
@@ -180,7 +178,7 @@
 
                 (delete-public-dashboard! [user status]
                   (testing (format "delete public dashboard with %s user" (mt/user-descriptor user))
-                    (t2.with-temp/with-temp [Dashboard {dashboard-id :id} {:public_uuid       (str (UUID/randomUUID))
+                    (t2.with-temp/with-temp [Dashboard {dashboard-id :id} {:public_uuid       (str (random-uuid))
                                                                            :made_public_by_id (mt/user->id :crowberto)}]
                       (mt/user-http-request user :delete status (format "dashboard/%d/public_link" dashboard-id)))))]
 
@@ -221,7 +219,7 @@
 
                   (delete-public-action! [user status]
                     (testing (format "delete public action with %s user" (mt/user-descriptor user))
-                      (mt/with-actions [{:keys [action-id]} {:public_uuid       (str (UUID/randomUUID))
+                      (mt/with-actions [{:keys [action-id]} {:public_uuid       (str (random-uuid))
                                                              :made_public_by_id (mt/user->id :crowberto)}]
                         (mt/user-http-request user :delete status (format "action/%d/public_link" action-id)))))]
 
@@ -262,7 +260,7 @@
 
                 (delete-public-card! [user status]
                   (testing (format "delete public card with %s user" (mt/user-descriptor user))
-                    (t2.with-temp/with-temp [Card {card-id :id} {:public_uuid       (str (UUID/randomUUID))
+                    (t2.with-temp/with-temp [Card {card-id :id} {:public_uuid       (str (random-uuid))
                                                                  :made_public_by_id (mt/user->id :crowberto)}]
                       (mt/user-http-request user :delete status (format "card/%d/public_link" card-id)))))]
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
@@ -11,9 +11,7 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.yaml :as yaml]
-   [toucan2.core :as t2])
-  (:import
-   (java.util UUID)))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -33,7 +31,7 @@
                    :email        "nobody@nowhere.com"
                    :first_name   (mt/random-name)
                    :last_name    (mt/random-name)
-                   :password     (str (UUID/randomUUID))
+                   :password     (str (random-uuid))
                    :date_joined  :%now
                    :is_active    true
                    :is_superuser true)

--- a/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
@@ -132,7 +132,7 @@
       :else                                    :dimension)))
 
 (defn- random-query-id []
-  (str (java.util.UUID/randomUUID)))
+  (str (random-uuid)))
 
 (defn- query-type->default-query [query-type]
   (merge

--- a/src/metabase/api/action.clj
+++ b/src/metabase/api/action.clj
@@ -16,9 +16,7 @@
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
-   [toucan2.core :as t2])
-  (:import
-   (java.util UUID)))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -180,7 +178,7 @@
   (let [action (api/read-check Action id :archived false)]
     (actions/check-actions-enabled! action)
     {:uuid (or (:public_uuid action)
-               (u/prog1 (str (UUID/randomUUID))
+               (u/prog1 (str (random-uuid))
                  (t2/update! Action id
                              {:public_uuid <>
                               :made_public_by_id api/*current-user-id*})))}))

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -66,8 +66,7 @@
    [toucan2.core :as t2])
   (:import
    (clojure.core.async.impl.channels ManyToManyChannel)
-   (java.io File)
-   (java.util UUID)))
+   (java.io File)))
 
 (set! *warn-on-reflection* true)
 
@@ -987,7 +986,7 @@ saved later when it is ready."
   (api/check-not-archived (api/read-check Card card-id))
   (let [{existing-public-uuid :public_uuid} (t2/select-one [Card :public_uuid] :id card-id)]
     {:uuid (or existing-public-uuid
-               (u/prog1 (str (UUID/randomUUID))
+               (u/prog1 (str (random-uuid))
                  (t2/update! Card card-id
                              {:public_uuid       <>
                               :made_public_by_id api/*current-user-id*})))}))

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -44,9 +44,7 @@
    [metabase.util.malli.schema :as ms]
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan2.core :as t2])
-  (:import
-   (java.util UUID)))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -723,7 +721,7 @@
   (validation/check-public-sharing-enabled)
   (api/check-not-archived (api/read-check :model/Dashboard dashboard-id))
   {:uuid (or (t2/select-one-fn :public_uuid :model/Dashboard :id dashboard-id)
-             (u/prog1 (str (UUID/randomUUID))
+             (u/prog1 (str (random-uuid))
                (t2/update! :model/Dashboard dashboard-id
                            {:public_uuid       <>
                             :made_public_by_id api/*current-user-id*})))})

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -55,7 +55,7 @@
 
 (s/defmethod create-session! :sso :- {:id UUID, :type (s/enum :normal :full-app-embed) s/Keyword s/Any}
   [_ user :- CreateSessionUserInfo device-info :- request.u/DeviceInfo]
-  (let [session-uuid (UUID/randomUUID)
+  (let [session-uuid (random-uuid)
         session      (first (t2/insert-returning-instances! Session
                                                             :id      (str session-uuid)
                                                             :user_id (u/the-id user)))]

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -33,9 +33,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan2.core :as t2])
-  (:import
-   (java.util UUID)))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -57,12 +55,12 @@
     (throw (ex-info
             (tru "The /api/setup route can only be used to create the first user, however a user currently exists.")
             {:status-code 403})))
-  (let [session-id (str (UUID/randomUUID))
+  (let [session-id (str (random-uuid))
         new-user   (first (t2/insert-returning-instances! User
                                                           :email        email
                                                           :first_name   first-name
                                                           :last_name    last-name
-                                                          :password     (str (UUID/randomUUID))
+                                                          :password     (str (random-uuid))
                                                           :is_superuser true))
         user-id    (u/the-id new-user)]
     ;; this results in a second db call, but it avoids redundant password code so figure it's worth it

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -7,8 +7,7 @@
    [metabase.plugins.classloader :as classloader]
    [metabase.util.log :as log])
   (:import
-   (clojure.lang Keyword)
-   (java.util UUID)))
+   (clojure.lang Keyword)))
 
 (set! *warn-on-reflection* true)
 
@@ -128,7 +127,7 @@
                 this specifc run. Restarting the server will change this UUID, and each server in a horizontal cluster
                 will have its own ID, making this different from the `site-uuid` Setting."}
   local-process-uuid
-  (str (UUID/randomUUID)))
+  (str (random-uuid)))
 
 (defonce
   ^{:doc "A string that contains identifying information about the Metabase version and the local process."}

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -61,7 +61,7 @@
 (defn- fresh-tag [tag-name]
   {:type :text
    :name tag-name
-   :id   (str (m/random-uuid))})
+   :id   (str (random-uuid))})
 
 (defn- finish-tag [{tag-name :name :as tag}]
   (merge tag

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -24,9 +24,7 @@
    [methodical.core :as methodical]
    [schema.core :as schema]
    [toucan2.core :as t2]
-   [toucan2.tools.default-fields :as t2.default-fields])
-  (:import
-   (java.util UUID)))
+   [toucan2.tools.default-fields :as t2.default-fields]))
 
 (set! *warn-on-reflection* true)
 
@@ -317,7 +315,7 @@
 (schema/defn ^:private insert-new-user!
   "Creates a new user, defaulting the password when not provided"
   [new-user :- NewUser]
-  (first (t2/insert-returning-instances! User (update new-user :password #(or % (str (UUID/randomUUID)))))))
+  (first (t2/insert-returning-instances! User (update new-user :password #(or % (str (random-uuid)))))))
 
 (defn serdes-synthesize-user!
   "Creates a new user with a default password, when deserializing eg. a `:creator_id` field whose email address doesn't
@@ -372,7 +370,7 @@
   "Updates a given `User` and generates a password reset token for them to use. Returns the URL for password reset."
   [user-id]
   {:pre [(integer? user-id)]}
-  (u/prog1 (str user-id \_ (UUID/randomUUID))
+  (u/prog1 (str user-id \_ (random-uuid))
     (t2/update! User user-id
                 {:reset_token     <>
                  :reset_triggered (System/currentTimeMillis)})))

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -19,9 +19,7 @@
     :refer [available-locales-with-names deferred-tru trs tru]]
    [metabase.util.log :as log]
    [metabase.util.password :as u.password]
-   [toucan2.core :as t2])
-  (:import
-   (java.util UUID)))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -112,7 +110,7 @@
 (defmethod setting/get-value-of-type ::uuid-nonce
   [_ setting]
   (or (setting/get-value-of-type :string setting)
-      (let [value (str (UUID/randomUUID))]
+      (let [value (str (random-uuid))]
         (setting/set-value-of-type! :string setting value)
         value)))
 

--- a/src/metabase/server/middleware/browser_cookie.clj
+++ b/src/metabase/server/middleware/browser_cookie.clj
@@ -8,9 +8,7 @@
    [metabase.server.request.util :as request.u]
    [metabase.util.schema :as su]
    [ring.util.response :as response]
-   [schema.core :as s])
-  (:import
-   (java.util UUID)))
+   [schema.core :as s]))
 
 (set! *warn-on-reflection* true)
 
@@ -40,7 +38,7 @@
   (fn [request respond raise]
     (if-let [browser-id (get-in request [:cookies browser-id-cookie-name :value])]
       (handler (assoc request :browser-id browser-id) respond raise)
-      (let [browser-id (str (UUID/randomUUID))]
+      (let [browser-id (str (random-uuid))]
         (handler
          (assoc request :browser-id browser-id)
          (fn [response]

--- a/src/metabase/setup.clj
+++ b/src/metabase/setup.clj
@@ -4,9 +4,7 @@
    [metabase.db.connection :as mdb.connection]
    [metabase.models.setting :as setting :refer [defsetting Setting]]
    [metabase.models.user :refer [User]]
-   [toucan2.core :as t2])
-  (:import
-   (java.util UUID)))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -34,7 +32,7 @@
   (or (when-let [mb-setup-token (env/env :mb-setup-token)]
         (setting/set-value-of-type! :string :setup-token mb-setup-token))
       (t2/select-one-fn :value Setting :key "setup-token")
-      (setting/set-value-of-type! :string :setup-token (str (UUID/randomUUID)))))
+      (setting/set-value-of-type! :string :setup-token (str (random-uuid)))))
 
 (defsetting has-user-setup
   "A value that is true iff the metabase instance has one or more users registered."

--- a/src/metabase/sync/util.clj
+++ b/src/metabase/sync/util.clj
@@ -74,7 +74,7 @@
 
 (defn- with-sync-events
   "Publish events related to beginning and ending a sync-like process, e.g. `:sync-database` or `:cache-values`, for a
-  DATABASE-ID. F is executed between the logging of the two events."
+  `database-id`. `f` is executed between the logging of the two events."
   ;; we can do everyone a favor and infer the name of the individual begin and sync events
   ([event-name-prefix database-or-id f]
    (with-sync-events
@@ -85,7 +85,7 @@
   ([begin-event-name end-event-name database-or-id f]
    (fn []
      (let [start-time    (System/nanoTime)
-           tracking-hash (str (java.util.UUID/randomUUID))]
+           tracking-hash (str (random-uuid))]
        (events/publish-event! begin-event-name {:database_id (u/the-id database-or-id), :custom_id tracking-hash})
        (let [return        (f)
              total-time-ms (int (/ (- (System/nanoTime) start-time)

--- a/test/metabase/actions/test_util.clj
+++ b/test/metabase/actions/test_util.clj
@@ -147,7 +147,7 @@
                                            :required false
                                            :target [:variable [:template-tag "name"]]}]
                              :visualization_settings {:inline true}
-                             :public_uuid (str (java.util.UUID/randomUUID))
+                             :public_uuid (str (random-uuid))
                              :made_public_by_id (test.users/user->id :crowberto)
                              :database_id (data/id)
                              :creator_id (test.users/user->id :crowberto)
@@ -171,7 +171,7 @@
                                      {:type :implicit
                                       :name "Update Example"
                                       :kind "row/update"
-                                      :public_uuid (str (java.util.UUID/randomUUID))
+                                      :public_uuid (str (random-uuid))
                                       :made_public_by_id (test.users/user->id :crowberto)
                                       :creator_id (test.users/user->id :crowberto)
                                       :model_id model-id}
@@ -194,7 +194,7 @@
                                                     :target [:template-tag "fail"]}]
                                       :response_handle ".body"
                                       :model_id model-id
-                                      :public_uuid (str (java.util.UUID/randomUUID))
+                                      :public_uuid (str (random-uuid))
                                       :made_public_by_id (test.users/user->id :crowberto)
                                       :creator_id (test.users/user->id :crowberto)}
                                      options-map))]

--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -11,9 +11,7 @@
    [metabase.util.schema :as su]
    [schema.core :as s]
    [toucan2.core :as t2]
-   [toucan2.tools.with-temp :as t2.with-temp])
-  (:import
-   (java.util UUID)))
+   [toucan2.tools.with-temp :as t2.with-temp]))
 
 (set! *warn-on-reflection* true)
 
@@ -75,7 +73,7 @@
                                     :template          {:method "GET"
                                                         :url "https://example.com/{{x}}"}
                                     :parameters        [{:id "x" :type "text"}]
-                                    :public_uuid       (str (UUID/randomUUID))
+                                    :public_uuid       (str (random-uuid))
                                     :made_public_by_id (mt/user->id :crowberto)
                                     :response_handle   ".body"
                                     :error_handle      ".status >= 400"}
@@ -396,7 +394,7 @@
    :made_public_by_id nil})
 
 (defn- shared-action-opts []
-  {:public_uuid       (str (UUID/randomUUID))
+  {:public_uuid       (str (random-uuid))
    :made_public_by_id (mt/user->id :crowberto)})
 
 (deftest fetch-public-actions-test

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -60,7 +60,6 @@
    [toucan2.tools.with-temp :as t2.with-temp])
   (:import
    (java.io ByteArrayInputStream)
-   (java.util UUID)
    (org.quartz.impl StdSchedulerFactory)))
 
 (set! *warn-on-reflection* true)
@@ -2077,7 +2076,7 @@
             (testing "making public"
               (remains-verified
                (update-card card {:made_public_by_id (mt/user->id :rasta)
-                                  :public_uuid (UUID/randomUUID)})))
+                                  :public_uuid (random-uuid)})))
             (testing "Changing description"
               (remains-verified
                (update-card card {:description "foo"})))
@@ -2217,7 +2216,7 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defn- shared-card []
-  {:public_uuid       (str (UUID/randomUUID))
+  {:public_uuid       (str (random-uuid))
    :made_public_by_id (mt/user->id :crowberto)})
 
 (deftest share-card-test

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -52,9 +52,7 @@
    [schema.core :as s]
    [toucan2.core :as t2]
    [toucan2.protocols :as t2.protocols]
-   [toucan2.tools.with-temp :as t2.with-temp])
-  (:import
-   (java.util UUID)))
+   [toucan2.tools.with-temp :as t2.with-temp]))
 
 (set! *warn-on-reflection* true)
 
@@ -2212,7 +2210,7 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defn- shared-dashboard []
-  {:public_uuid       (str (UUID/randomUUID))
+  {:public_uuid       (str (random-uuid))
    :made_public_by_id (mt/user->id :crowberto)})
 
 ;;; -------------------------------------- POST /api/dashboard/:id/public_link ---------------------------------------

--- a/test/metabase/api/login_history_test.clj
+++ b/test/metabase/api/login_history_test.clj
@@ -27,7 +27,7 @@
 
 (deftest login-history-test
   (testing "GET /api/login-history/current"
-    (let [session-id (str (java.util.UUID/randomUUID))
+    (let [session-id (str (random-uuid))
           device-id  "e9b49ec7-bc64-4a83-9b1a-ecd3ae26ba9d"]
       (t2.with-temp/with-temp [User         user {}
                                Session      _    {:id session-id, :user_id (u/the-id user)}

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -34,15 +34,14 @@
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp])
   (:import
-   (java.io ByteArrayInputStream)
-   (java.util UUID)))
+   (java.io ByteArrayInputStream)))
 
 (set! *warn-on-reflection* true)
 
 ;;; --------------------------------------------------- Helper Fns ---------------------------------------------------
 
 (defn- shared-obj []
-  {:public_uuid       (str (UUID/randomUUID))
+  {:public_uuid       (str (random-uuid))
    :made_public_by_id (mt/user->id :crowberto)})
 
 (defn- native-query-with-template-tag []
@@ -133,7 +132,7 @@
       ;; endpoints in [[metabase.server.middleware.exceptions/genericize-exceptions]]
       (testing "should return 400 if Card doesn't exist"
         (is (= "Not found."
-               (client/client :get 404 (str "public/card/" (UUID/randomUUID))))))
+               (client/client :get 404 (str "public/card/" (random-uuid))))))
 
       (with-temp-public-card [{uuid :public_uuid, card-id :id}]
         (testing "Happy path -- should be able to fetch the Card"
@@ -186,7 +185,7 @@
 (deftest check-that-we-get-a-404-if-the-publiccard-doesn-t-exist-query
   (mt/with-temporary-setting-values [enable-public-sharing true]
     (is (= "Not found."
-           (client/client :get 404 (str "public/card/" (UUID/randomUUID) "/query"))))))
+           (client/client :get 404 (str "public/card/" (random-uuid) "/query"))))))
 
 (deftest check-that-we--cannot--execute-a-publiccard-if-the-card-has-been-archived
   (mt/with-temporary-setting-values [enable-public-sharing true]
@@ -379,7 +378,7 @@
     (testing "Should get a 400 if the Dashboard doesn't exist"
       (mt/with-temporary-setting-values [enable-public-sharing true]
         (is (= "Not found."
-               (client/client :get 404 (str "public/dashboard/" (UUID/randomUUID)))))))))
+               (client/client :get 404 (str "public/dashboard/" (random-uuid)))))))))
 
 (defn- fetch-public-dashboard [{uuid :public_uuid}]
   (-> (client/client :get 200 (str "public/dashboard/" uuid))
@@ -418,7 +417,7 @@
                                                                                             :hidden false}
                                                                                    "price" {:id     "price"
                                                                                             :hidden true}}}}]
-            (let [dashboard-uuid (str (UUID/randomUUID))]
+            (let [dashboard-uuid (str (random-uuid))]
               (mt/with-temp* [Dashboard [{dashboard-id :id} {:public_uuid dashboard-uuid}]
                               DashboardCard [dashcard {:dashboard_id dashboard-id
                                                        :action_id    action-id
@@ -481,7 +480,7 @@
         (with-temp-public-dashboard-and-card [dash card dashcard]
           (testing "if the Dashboard doesn't exist"
             (is (= "Not found."
-                   (client/client :get 404 (dashcard-url {:public_uuid (UUID/randomUUID)} card dashcard)))))
+                   (client/client :get 404 (dashcard-url {:public_uuid (random-uuid)} card dashcard)))))
 
           (testing "if the Card doesn't exist"
             (is (= "Not found."
@@ -918,7 +917,7 @@
       (mt/with-temporary-setting-values [enable-public-sharing true]
         (testing "should return 404 if Action doesn't exist"
           (is (= "Not found."
-                 (client/client :get 404 (str "public/action/" (UUID/randomUUID))))))
+                 (client/client :get 404 (str "public/action/" (random-uuid))))))
         (let [action-opts (assoc-in (shared-obj) [:visualization_settings :fields] {"id" {:id "id"
                                                                                           :hidden true}
                                                                                     "name" {:id "name"
@@ -1215,7 +1214,7 @@
   (mt/with-temporary-setting-values [enable-public-sharing true]
     (testing "with dashboard"
       (api.dashboard-test/with-chain-filter-fixtures [{:keys [dashboard param-keys]}]
-        (let [uuid (str (UUID/randomUUID))]
+        (let [uuid (str (random-uuid))]
           (is (= 1
                  (t2/update! Dashboard (u/the-id dashboard) {:public_uuid uuid})))
           (testing "GET /api/public/dashboard/:uuid/params/:param-key/values"
@@ -1316,7 +1315,7 @@
       (mt/with-temporary-setting-values [enable-public-sharing true]
         (testing "with dashboard"
           (api.dashboard-test/with-chain-filter-fixtures [{:keys [dashboard param-keys]}]
-            (let [uuid (str (UUID/randomUUID))]
+            (let [uuid (str (random-uuid))]
               (is (= 1
                      (t2/update! Dashboard (u/the-id dashboard) {:public_uuid uuid})))
               (testing "GET /api/public/dashboard/:uuid/params/:param-key/values"
@@ -1332,7 +1331,7 @@
 
         (testing "with card"
           (api.card-test/with-card-param-values-fixtures [{:keys [card param-keys]}]
-            (let [uuid (str (UUID/randomUUID))]
+            (let [uuid (str (random-uuid))]
              (is (= 1
                     (t2/update! Card (u/the-id card) {:public_uuid uuid})))
              (testing "GET /api/public/card/:uuid/params/:param-key/values"
@@ -1522,14 +1521,14 @@
               (is (= "Not found."
                      (client/client
                       :post 404
-                      (format "public/action/%s/execute" (str (UUID/randomUUID)))
+                      (format "public/action/%s/execute" (str (random-uuid)))
                       {:parameters {:id 1 :name "European"}})))))
           (mt/with-actions [{} action-opts]
             (testing "Check that we get a 400 if the action doesn't exist"
               (is (= "Not found."
                      (client/client
                       :post 404
-                      (format "public/action/%s/execute" (str (UUID/randomUUID)))
+                      (format "public/action/%s/execute" (str (random-uuid)))
                       {:parameters {:id 1 :name "European"}}))))
             (testing "Check that we get a 400 if sharing is disabled."
               (mt/with-temporary-setting-values [enable-public-sharing false]

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -22,9 +22,7 @@
    [metabase.util.schema :as su]
    [schema.core :as s]
    [toucan2.core :as t2]
-   [toucan2.tools.with-temp :as t2.with-temp])
-  (:import
-   (java.util UUID)))
+   [toucan2.tools.with-temp :as t2.with-temp]))
 
 (set! *warn-on-reflection* true)
 
@@ -281,7 +279,7 @@
         (let [password {:old "password"
                         :new "whateverUP12!!"}]
           (t2.with-temp/with-temp [User {:keys [email id]} {:password (:old password), :reset_triggered (System/currentTimeMillis)}]
-            (let [token (u/prog1 (str id "_" (UUID/randomUUID))
+            (let [token (u/prog1 (str id "_" (random-uuid))
                           (t2/update! User id {:reset_token <>}))
                   creds {:old {:password (:old password)
                                :username email}
@@ -325,7 +323,7 @@
                                                             :password "whateverUP12!!"}))))
 
     (testing "Test that an expired token doesn't work"
-      (let [token (str (mt/user->id :rasta) "_" (UUID/randomUUID))]
+      (let [token (str (mt/user->id :rasta) "_" (random-uuid))]
         (t2/update! User (mt/user->id :rasta) {:reset_token token, :reset_triggered 0})
         (is (= {:errors {:password "Invalid reset token"}}
                (mt/client :post 400 "session/reset_password" {:token    token
@@ -334,7 +332,7 @@
 (deftest check-reset-token-valid-test
   (testing "GET /session/password_reset_token_valid"
     (testing "Check that a valid, unexpired token returns true"
-      (let [token (str (mt/user->id :rasta) "_" (UUID/randomUUID))]
+      (let [token (str (mt/user->id :rasta) "_" (random-uuid))]
         (t2/update! User (mt/user->id :rasta) {:reset_token token, :reset_triggered (dec (System/currentTimeMillis))})
         (is (= {:valid true}
                (mt/client :get 200 "session/password_reset_token_valid", :token token)))))
@@ -344,7 +342,7 @@
              (mt/client :get 200 "session/password_reset_token_valid", :token "ABCDEFG"))))
 
     (testing "Check that an expired but valid token returns false"
-      (let [token (str (mt/user->id :rasta) "_" (UUID/randomUUID))]
+      (let [token (str (mt/user->id :rasta) "_" (random-uuid))]
         (t2/update! User (mt/user->id :rasta) {:reset_token token, :reset_triggered 0})
         (is (= {:valid false}
                (mt/client :get 200 "session/password_reset_token_valid", :token token)))))))

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -296,7 +296,7 @@
   (testing "GET /api/user/current"
     (testing "check that fetching current user will return extra fields like `is_active`"
       (mt/with-temp* [LoginHistory [_ {:user_id   (mt/user->id :rasta)
-                                       :device_id (str (java.util.UUID/randomUUID))
+                                       :device_id (str (random-uuid))
                                        :timestamp #t "2021-03-18T19:52:41.808482Z"}]
                       Card [_ {:name "card1" :display "table" :creator_id (mt/user->id :rasta)}]]
         (is (= (-> (merge

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -43,8 +43,7 @@
    [toucan2.core :as t2]
    [toucan2.execute :as t2.execute])
   (:import
-   (java.sql Connection)
-   (java.util UUID)))
+   (java.sql Connection)))
 
 (set! *warn-on-reflection* true)
 
@@ -97,7 +96,7 @@
                                          :email        email
                                          :first_name   (tu.random/random-name)
                                          :last_name    (tu.random/random-name)
-                                         :password     (str (UUID/randomUUID))
+                                         :password     (str (random-uuid))
                                          :date_joined  :%now
                                          :is_active    true
                                          :is_superuser false)))

--- a/test/metabase/driver/common/parameters/values_test.clj
+++ b/test/metabase/driver/common/parameters/values_test.clj
@@ -22,12 +22,11 @@
    [toucan2.tools.with-temp :as t2.with-temp])
   (:import
    (clojure.lang ExceptionInfo)
-   (java.util UUID)
    (metabase.driver.common.parameters ReferencedCardQuery)))
 
 (set! *warn-on-reflection* true)
 
-(def ^:private test-uuid (str (UUID/randomUUID)))
+(def ^:private test-uuid (str (random-uuid)))
 
 (deftest variable-value-test
   (mt/with-everything-store

--- a/test/metabase/events/activity_feed_test.clj
+++ b/test/metabase/events/activity_feed_test.clj
@@ -321,7 +321,7 @@
     (mt/with-model-cleanup [Activity]
       (events.activity-feed/process-activity-event! {:topic :user-login
                                                      :item  {:user_id     (mt/user->id :rasta)
-                                                             :session_id  (str (java.util.UUID/randomUUID))
+                                                             :session_id  (str (random-uuid))
                                                              :first_login true}})
       (is (= {:topic       :user-joined
               :user_id     (mt/user->id :rasta)

--- a/test/metabase/lib/native_test.cljc
+++ b/test/metabase/lib/native_test.cljc
@@ -3,7 +3,6 @@
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]
               [metabase.test.util.js :as test.js]))
    [clojure.test :refer [are deftest is testing]]
-   [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.native :as lib.native]
@@ -59,7 +58,7 @@
     (let [old-tag {:type         :text
                    :name         "foo"
                    :display-name "Foo"
-                   :id           (str (m/random-uuid))}]
+                   :id           (str (random-uuid))}]
       (testing "changes display-name if the original is not customized"
         (is (=? {"bar" {:type         :text
                         :name         "bar"
@@ -79,7 +78,7 @@
         (let [other {:type         :text
                      :name         "other"
                      :display-name "Some Var"
-                     :id           (str (m/random-uuid))}]
+                     :id           (str (random-uuid))}]
           (is (=? {"other" other
                    "bar"   {:type         :text
                             :name         "bar"

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -14,9 +14,7 @@
    [metabase.test.util :as tu]
    [metabase.util :as u]
    [toucan2.core :as t2]
-   [toucan2.tools.with-temp :as t2.with-temp])
-  (:import
-   (java.util UUID)))
+   [toucan2.tools.with-temp :as t2.with-temp]))
 
 (set! *warn-on-reflection* true)
 
@@ -82,13 +80,13 @@
 (deftest public-sharing-test
   (testing "test that a Card's :public_uuid comes back if public sharing is enabled..."
     (tu/with-temporary-setting-values [enable-public-sharing true]
-      (t2.with-temp/with-temp [:model/Card card {:public_uuid (str (java.util.UUID/randomUUID))}]
+      (t2.with-temp/with-temp [:model/Card card {:public_uuid (str (random-uuid))}]
         (is (schema= u/uuid-regex
                      (:public_uuid card)))))
 
     (testing "...but if public sharing is *disabled* it should come back as `nil`"
       (tu/with-temporary-setting-values [enable-public-sharing false]
-        (t2.with-temp/with-temp [:model/Card card {:public_uuid (str (java.util.UUID/randomUUID))}]
+        (t2.with-temp/with-temp [:model/Card card {:public_uuid (str (random-uuid))}]
           (is (= nil
                  (:public_uuid card))))))))
 
@@ -725,7 +723,7 @@
                             (= col :display)           :pie
                             (= col :made_public_by_id) (mt/user->id :crowberto)
                             (= col :embedding_params)  {:category_name "locked"}
-                            (= col :public_uuid)       (str (UUID/randomUUID))
+                            (= col :public_uuid)       (str (random-uuid))
                             (= col :table_id)          (mt/id :venues)
                             (= col :database_id)       (:id db)
                             (= col :query_type)        :native

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -23,7 +23,6 @@
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp])
   (:import
-   (java.util UUID)
    (java.time LocalDateTime)))
 
 (set! *warn-on-reflection* true)
@@ -266,7 +265,7 @@
                                                                 value)
                                (= col :made_public_by_id) (mt/user->id :crowberto)
                                (= col :embedding_params)  {:category_name "locked"}
-                               (= col :public_uuid)       (str (UUID/randomUUID))
+                               (= col :public_uuid)       (str (random-uuid))
                                (int? value)               (inc value)
                                (boolean? value)           (not value)
                                (string? value)            (str value "_changed")))]
@@ -640,13 +639,13 @@
 (deftest public-sharing-test
   (testing "test that a Dashboard's :public_uuid comes back if public sharing is enabled..."
     (tu/with-temporary-setting-values [enable-public-sharing true]
-      (t2.with-temp/with-temp [Dashboard dashboard {:public_uuid (str (java.util.UUID/randomUUID))}]
+      (t2.with-temp/with-temp [Dashboard dashboard {:public_uuid (str (random-uuid))}]
         (is (schema= u/uuid-regex
                      (:public_uuid dashboard)))))
 
     (testing "...but if public sharing is *disabled* it should come back as `nil`"
       (tu/with-temporary-setting-values [enable-public-sharing false]
-        (t2.with-temp/with-temp [Dashboard dashboard {:public_uuid (str (java.util.UUID/randomUUID))}]
+        (t2.with-temp/with-temp [Dashboard dashboard {:public_uuid (str (random-uuid))}]
           (is (= nil
                  (:public_uuid dashboard))))))))
 

--- a/test/metabase/models/login_history_test.clj
+++ b/test/metabase/models/login_history_test.clj
@@ -17,8 +17,8 @@
 (set! *warn-on-reflection* true)
 
 (deftest first-login-on-this-device?-test
-  (let [device-1 (str (java.util.UUID/randomUUID))
-        device-2 (str (java.util.UUID/randomUUID))]
+  (let [device-1 (str (random-uuid))
+        device-2 (str (random-uuid))]
     (mt/with-temp* [User         [{user-id :id}]
                     LoginHistory [history-1 {:user_id user-id, :device_id device-1}]]
       (testing "one login to device 1 -- should be the first login with this device"
@@ -42,7 +42,7 @@
 (deftest send-email-on-first-login-from-new-device-test
   (testing "User should get an email the first time they log in from a new device (#14313, #15603, #17495)"
     (t2.with-temp/with-temp [User {user-id :id, email :email, first-name :first_name}]
-      (let [device              (str (java.util.UUID/randomUUID))
+      (let [device              (str (random-uuid))
             original-maybe-send (var-get #'login-history/maybe-send-login-from-new-device-email)]
         (testing "send email on first login from *new* device (but not first login ever)"
           (mt/with-fake-inbox
@@ -59,7 +59,7 @@
                               ;; block in tests
                               (u/deref-with-timeout futur 10000)))]
               (mt/with-temp* [LoginHistory [_ {:user_id   user-id
-                                               :device_id (str (java.util.UUID/randomUUID))}]
+                                               :device_id (str (random-uuid))}]
                               LoginHistory [_ {:user_id   user-id
                                                :device_id device
                                                :timestamp #t "2021-04-02T15:52:00-07:00[US/Pacific]"}]]
@@ -97,7 +97,7 @@
       (mt/with-fake-inbox
         ;; can't use `mt/with-temporary-setting-values` here because it's a read-only setting
         (mt/with-temp-env-var-value [mb-send-email-on-first-login-from-new-device "FALSE"]
-          (mt/with-temp* [LoginHistory [_ {:user_id user-id, :device_id (str (java.util.UUID/randomUUID))}]
-                          LoginHistory [_ {:user_id user-id, :device_id (str (java.util.UUID/randomUUID))}]]
+          (mt/with-temp* [LoginHistory [_ {:user_id user-id, :device_id (str (random-uuid))}]
+                          LoginHistory [_ {:user_id user-id, :device_id (str (random-uuid))}]]
             (is (= {}
                    @mt/inbox))))))))

--- a/test/metabase/models/user_test.clj
+++ b/test/metabase/models/user_test.clj
@@ -416,7 +416,7 @@
     (testing "should clear out all existing Sessions"
       (t2.with-temp/with-temp [User {user-id :id} {}]
         (dotimes [_ 2]
-          (t2/insert! Session {:id (str (java.util.UUID/randomUUID)), :user_id user-id}))
+          (t2/insert! Session {:id (str (random-uuid)), :user_id user-id}))
         (letfn [(session-count [] (t2/count Session :user_id user-id))]
           (is (= 2
                  (session-count)))

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -20,8 +20,7 @@
    [toucan2.tools.with-temp :as t2.with-temp])
   (:import
    (jakarta.servlet AsyncContext ServletOutputStream)
-   (jakarta.servlet.http HttpServletResponse)
-   (java.util UUID)))
+   (jakarta.servlet.http HttpServletResponse)))
 
 (set! *warn-on-reflection* true)
 
@@ -237,7 +236,7 @@
   (testing message
     (let [query-json        (json/generate-string query)
           viz-settings-json (json/generate-string viz-settings)
-          public-uuid       (str (UUID/randomUUID))
+          public-uuid       (str (random-uuid))
           card-defaults     {:dataset_query query, :public_uuid public-uuid, :enable_embedding true}
           user              (or user :rasta)]
       (mt/with-temporary-setting-values [enable-public-sharing true

--- a/test/metabase/server/middleware/auth_test.clj
+++ b/test/metabase/server/middleware/auth_test.clj
@@ -10,9 +10,7 @@
    [metabase.test.data.users :as test.users]
    [metabase.test.fixtures :as fixtures]
    [ring.mock.request :as ring.mock]
-   [toucan2.core :as t2])
-  (:import
-   (java.util UUID)))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -36,7 +34,7 @@
       (assoc :metabase-session-id session-id)))
 
 (defn- random-session-id []
-  (str (UUID/randomUUID)))
+  (str (random-uuid)))
 
 (deftest wrap-current-user-info-test
   (testing "Valid requests should add `metabase-user-id` to requests with valid session info"

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -25,8 +25,7 @@
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp])
   (:import
-   (clojure.lang ExceptionInfo)
-   (java.util UUID)))
+   (clojure.lang ExceptionInfo)))
 
 (set! *warn-on-reflection* true)
 
@@ -59,7 +58,7 @@
 
 (deftest set-session-cookie-test
   (mt/with-temporary-setting-values [session-timeout nil]
-    (let [uuid (UUID/randomUUID)
+    (let [uuid (random-uuid)
           request-time (t/zoned-date-time "2022-07-06T02:00Z[UTC]")]
       (testing "should unset the old SESSION_ID if it's present"
         (is (= {:value     (str uuid)
@@ -102,7 +101,7 @@
                               [{"origin" "http://mysite.com"}   false]]]
     (testing (format "With headers %s we %s set the 'secure' attribute on the session cookie"
                      (pr-str headers) (if expected "SHOULD" "SHOULD NOT"))
-      (let [session {:id   (UUID/randomUUID)
+      (let [session {:id   (random-uuid)
                      :type :normal}
             actual  (-> (mw.session/set-session-cookies {:headers headers} {} session (t/zoned-date-time "2022-07-06T02:01Z[UTC]"))
                         (get-in [:cookies "metabase.SESSION" :secure])
@@ -119,7 +118,7 @@
                [(sql.qp/add-interval-honeysql-form (mdb/db-type) :%now -59 :second) false "session that is 59 seconds old"]]]
         (testing (format "\n%s %s be expired." msg (if expected "SHOULD" "SHOULD NOT"))
           (t2.with-temp/with-temp [User {user-id :id}]
-            (let [session-id (str (UUID/randomUUID))]
+            (let [session-id (str (random-uuid))]
               (t2/insert! (t2/table-name Session) {:id session-id, :user_id user-id, :created_at created-at})
               (let [session (#'mw.session/current-user-info-for-session session-id nil)]
                 (if expected
@@ -408,7 +407,7 @@
     (testing "w/ Session"
       (testing "for user with no `:locale`"
         (t2.with-temp/with-temp [User {user-id :id}]
-          (let [session-id (str (UUID/randomUUID))]
+          (let [session-id (str (random-uuid))]
             (t2/insert! Session {:id session-id, :user_id user-id})
             (is (= nil
                    (session-locale session-id)))
@@ -419,7 +418,7 @@
 
       (testing "for user *with* `:locale`"
         (t2.with-temp/with-temp [User {user-id :id} {:locale "es-MX"}]
-          (let [session-id (str (UUID/randomUUID))]
+          (let [session-id (str (random-uuid))]
             (t2/insert! Session {:id session-id, :user_id user-id, :created_at :%now})
             (is (= "es_MX"
                    (session-locale session-id)))

--- a/test/metabase/util/password_test.clj
+++ b/test/metabase/util/password_test.clj
@@ -97,7 +97,7 @@
 (deftest ^:parallel hash-bcrypt-tests
   ;; these functions were copied from cemerick/friend and just call out to org.mindrot.jbcrypt.BCrypt so these tests
   ;; are a bit perfunctory
-  (let [salt (str (java.util.UUID/randomUUID))
+  (let [salt (str (random-uuid))
         password (str salt "some-secure-password")
         hashed   (u.password/hash-bcrypt password)]
     (is (not= password hashed))


### PR DESCRIPTION
We currently have 3 ways to generate random UUIDs

1. `(java.util.UUID/randomUUID)`
2. `(medley.core/random-uuid)`
3. `(random-uuid)` (only added to Clojure fairly in 1.11 last year)

Let's standardize on one and use that everywhere. `(random-uuid)` is preferrable in my opinion because it doesn't introduce Java interop and is Cljc/Cljs compatible. So let's use Kondo to band the other two.

(Yes, Kondo works with static Java method calls like this one)