### PR TITLE
Update `assert-has-feature` docstring, message and localization

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/content_management/api/collection_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_management/api/collection_test.clj
@@ -30,14 +30,14 @@
 
     (testing "fails to add an official collection if doesn't have any premium features"
       (premium-features-test/with-premium-features #{}
-        (is (= "Official collections is an Enterprise feature. Please upgrade to a paid plan to use this feature."
+        (is (= "Official collections is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
                (mt/user-http-request :crowberto :post 402 "collection" {:name            "An official collection"
                                                                         :color           "#000000"
                                                                         :authority_level "official"})))))
 
     (testing "fails to add an official collection if has :content-management feature"
       (premium-features-test/with-premium-features #{:content-management}
-        (is (= "Official collections is an Enterprise feature. Please upgrade to a paid plan to use this feature."
+        (is (= "Official collections is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
                (mt/user-http-request :crowberto :post 402 "collection" {:name            "An official collection"
                                                                         :color           "#000000"
                                                                         :authority_level "official"})))))))
@@ -77,14 +77,14 @@
       (premium-features-test/with-premium-features #{}
         (t2.with-temp/with-temp
           [:model/Collection {id :id} {:authority_level nil}]
-          (is (= "Official collections is an Enterprise feature. Please upgrade to a paid plan to use this feature."
+          (is (= "Official collections is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
                  (mt/user-http-request :crowberto :put 402 (format "collection/%d" id) {:authority_level "official"}))))))
 
     (testing "fails to update if has :content-management feature"
       (premium-features-test/with-premium-features #{:content-management}
         (t2.with-temp/with-temp
           [:model/Collection {id :id} {:authority_level nil}]
-          (is (= "Official collections is an Enterprise feature. Please upgrade to a paid plan to use this feature."
+          (is (= "Official collections is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
                  (mt/user-http-request :crowberto :put 402 (format "collection/%d" id) {:authority_level "official"}))))))))
 
 

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
@@ -309,6 +309,6 @@
              is not enabled"
       (with-redefs [premium-features/enable-sandboxes? (constantly false)]
         (mt/with-temporary-setting-values [premium-embedding-token nil]
-          (is (= "Sandboxes is an Enterprise feature. Please upgrade to a paid plan to use this feature."
+          (is (= "Sandboxes is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
                  (mt/user-http-request :crowberto :put 402 "permissions/graph"
                                        (assoc (perms/data-perms-graph) :sandboxes [{:card_id 1}])))))))))

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -33,7 +33,7 @@
    [metabase.server.middleware.offset-paging :as mw.offset-paging]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
-   [metabase.util.i18n :refer [deferred-tru]]
+   [metabase.util.i18n :refer [tru]]
    [metabase.util.malli.schema :as ms]
    [metabase.util.schema :as su]
    [schema.core :as s]
@@ -801,7 +801,7 @@
   (write-check-collection-or-root-collection parent_id namespace)
   (when (some? authority_level)
     ;; make sure only admin and an EE token is present to be able to create an Official token
-    (premium-features/assert-has-feature :official-collections (deferred-tru "Official Collections"))
+    (premium-features/assert-has-feature :official-collections (tru "Official Collections"))
     (api/check-superuser))
   ;; Now create the new Collection :)
   (first
@@ -891,7 +891,7 @@
     ;; if authority_level is changing, make sure we're allowed to do that
     (when (and (contains? collection-updates :authority_level)
                (not= (keyword authority_level) (:authority_level collection-before-update)))
-      (premium-features/assert-has-feature :official-collections (deferred-tru "Official Collections"))
+      (premium-features/assert-has-feature :official-collections (tru "Official Collections"))
       (api/check-403 (and api/*is-superuser?*
                           ;; pre-update of model checks if the collection is a personal collection and rejects changes
                           ;; to authority_level, but it doesn't check if it is a sub-collection of a personal one so we add that

--- a/src/metabase/api/permissions.clj
+++ b/src/metabase/api/permissions.clj
@@ -50,13 +50,13 @@
   "OSS implementation of `upsert-sandboxes!`. Errors since this is an enterprise feature."
   metabase-enterprise.sandbox.models.group-table-access-policy
   [_sandboxes]
- (throw (premium-features/ee-feature-error "Sandboxes")))
+ (throw (premium-features/ee-feature-error (tru "Sandboxes"))))
 
 (defenterprise upsert-impersonations!
   "OSS implementation of `upsert-impersonations!`. Errors since this is an enterprise feature."
   metabase-enterprise.advanced-permissions.models.connection-impersonation
   [_impersonations]
-  (throw (premium-features/ee-feature-error "Connection impersonation")))
+  (throw (premium-features/ee-feature-error (tru "Connection impersonation"))))
 
 (api/defendpoint PUT "/graph"
   "Do a batch update of Permissions by passing in a modified graph. This should return the same graph, in the same

--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -254,7 +254,7 @@
 (mu/defn assert-has-feature
   "Check if an token with `feature` is present. If not, throw an error.
 
-  (assert-has-feature :sandboxes \"Sandboxing\")
+  (assert-has-feature :sandboxes (tru \"Sandboxing\"))
 
   => throw an error with message \"Sandboxing is an enterprise feature. Please upgrade to a paid plan to use this feature.\""
   [feature-flag :- keyword?

--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -248,15 +248,15 @@
 (defn ee-feature-error
   "Returns an error that can be used to throw when an enterprise feature check fails."
   [feature-name]
-  (ex-info (tru "{0} is an Enterprise feature. Please upgrade to a paid plan to use this feature." (str/capitalize feature-name))
+  (ex-info (tru "{0} is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
+                (str/capitalize feature-name))
            {:status-code 402}))
 
 (mu/defn assert-has-feature
-  "Check if an token with `feature` is present. If not, throw an error.
+  "Check if an token with `feature` is present. If not, throw an error with a message using `feature-name`, which must be a localized string.
 
   (assert-has-feature :sandboxes (tru \"Sandboxing\"))
-
-  => throw an error with message \"Sandboxing is an enterprise feature. Please upgrade to a paid plan to use this feature.\""
+  => throws an error with a message using \"Sandboxing\" as the feature name."
   [feature-flag :- keyword?
    feature-name :- mu/localized-string-schema]
   (when-not (has-feature? feature-flag)

--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -253,12 +253,13 @@
            {:status-code 402}))
 
 (mu/defn assert-has-feature
-  "Check if an token with `feature` is present. If not, throw an error with a message using `feature-name`, which must be a localized string.
+  "Check if an token with `feature` is present. If not, throw an error with a message using `feature-name`.
+   `feature-name` should be a localized string unless used in a CLI context.
 
   (assert-has-feature :sandboxes (tru \"Sandboxing\"))
   => throws an error with a message using \"Sandboxing\" as the feature name."
   [feature-flag :- keyword?
-   feature-name :- mu/localized-string-schema]
+   feature-name :- [:or string? mu/localized-string-schema]]
   (when-not (has-feature? feature-flag)
     (throw (ee-feature-error feature-name))))
 

--- a/test/metabase/api/permissions_test.clj
+++ b/test/metabase/api/permissions_test.clj
@@ -253,7 +253,7 @@
 (deftest update-perms-graph-error-test
   (testing "PUT /api/permissions/graph"
     (testing "make sure an error is thrown if the :sandboxes key is included in an OSS request"
-      (is (= "Sandboxes is an Enterprise feature. Please upgrade to a paid plan to use this feature."
+      (is (= "Sandboxes is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
              (mt/user-http-request :crowberto :put 402 "permissions/graph"
                                    (assoc (perms/data-perms-graph) :sandboxes [{:card_id 1}])))))))
 (defn- ee-features-enabled? []


### PR DESCRIPTION
When the `assert-has-feature` was merged into the integration branch ([PR](https://github.com/metabase/metabase/pull/32113)), there were a few issues that I missed during review: 

1. The second arg should be a localized-string (except in CLI contexts), so I updated the example in the docstring to reinforce that
2. `deferred-tru` doesn't need to be used in API namespaces because the user's locale is in context
3. Some uses of `ee-feature-error` didn't include a translated `feature-name`
4. We need to relax the requirement that the `feature-name` be a localized-string, because it can be used in a CLI context

This PR addresses all 4. 

It also changes the error message as requested by Bruno ([slack context](https://metaboat.slack.com/archives/C05EWA11Z1V/p1689610610434549?thread_ts=1689605991.608249&cid=C05EWA11Z1V)).