### PR TITLE
Custom Homepage Dashboard picker error

### DIFF
--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -13,6 +13,7 @@ import {
   main,
 } from "e2e/support/helpers";
 import { USERS } from "e2e/support/cypress_data";
+import { ADMIN_PERSONAL_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const { admin } = USERS;
 
@@ -210,6 +211,20 @@ describe("scenarios > home > custom homepage", () => {
     });
 
     it("should give you the option to set a custom home page using home page CTA", () => {
+      cy.request("POST", "/api/collection", {
+        name: "Personal nested Collection",
+        color: "#509ee3",
+        description: `nested 1 level`,
+        parent_id: ADMIN_PERSONAL_COLLECTION_ID,
+      }).then(({ body }) => {
+        cy.request("POST", "/api/collection", {
+          name: "Personal nested nested Collection",
+          color: "#509ee3",
+          description: `nested 2 leves`,
+          parent_id: body.id,
+        });
+      });
+
       cy.visit("/");
       cy.get("main").findByText("Customize").click();
 
@@ -221,6 +236,9 @@ describe("scenarios > home > custom homepage", () => {
       //Ensure that personal collections have been removed
       popover().contains("Your personal collection").should("not.exist");
       popover().contains("All personal collections").should("not.exist");
+      popover()
+        .contains(/nested/i)
+        .should("not.exist");
 
       popover().findByText("Orders in a dashboard").click();
       modal().findByRole("button", { name: "Save" }).click();

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -123,12 +123,8 @@ const SECTIONS = {
         ],
         getProps: setting => ({
           value: setting.value,
-          collectionFilter: (collection, index, allCollections) => {
-            return (
-              !isPersonalCollectionOrChild(collection, allCollections) ||
-              collection.id === "root"
-            );
-          },
+          collectionFilter: (collection, index, allCollections) =>
+            !isPersonalCollectionOrChild(collection, allCollections),
         }),
         onChanged: (oldVal, newVal) => {
           if (newVal && !oldVal) {

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -13,6 +13,9 @@ import { getUserIsAdmin } from "metabase/selectors/user";
 import Breadcrumbs from "metabase/components/Breadcrumbs";
 import { DashboardSelector } from "metabase/components/DashboardSelector";
 import { refreshCurrentUser } from "metabase/redux/user";
+
+import { isPersonalCollectionOrChild } from "metabase/collections/utils";
+
 import { updateSetting } from "./settings";
 
 import SettingCommaDelimitedInput from "./components/widgets/SettingCommaDelimitedInput";
@@ -120,8 +123,12 @@ const SECTIONS = {
         ],
         getProps: setting => ({
           value: setting.value,
-          collectionFilter: collection =>
-            collection.personal_owner_id === null || collection.id === "root",
+          collectionFilter: (collection, index, allCollections) => {
+            return (
+              !isPersonalCollectionOrChild(collection, allCollections) ||
+              collection.id === "root"
+            );
+          },
         }),
         onChanged: (oldVal, newVal) => {
           if (newVal && !oldVal) {

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -39,7 +39,7 @@ function getNonRootParentId(collection: Collection) {
     return nonRootParent ? nonRootParent.id : undefined;
   }
   // location is a string like "/1/4" where numbers are parent collection IDs
-  const nonRootParentId = collection.location?.split("/")?.[0];
+  const nonRootParentId = collection.location?.split("/")?.[1];
   return canonicalCollectionId(nonRootParentId);
 }
 
@@ -53,6 +53,16 @@ export function isPersonalCollectionChild(
   }
   const parentCollection = collectionList.find(c => c.id === nonRootParentId);
   return Boolean(parentCollection && !!parentCollection.personal_owner_id);
+}
+
+export function isPersonalCollectionOrChild(
+  collection: Collection,
+  collectionList: Collection[],
+): boolean {
+  return (
+    isPersonalCollection(collection) ||
+    isPersonalCollectionChild(collection, collectionList)
+  );
 }
 
 export function isRootCollection(collection: Pick<Collection, "id">): boolean {

--- a/frontend/src/metabase/components/DashboardSelector/DashboardSelector.tsx
+++ b/frontend/src/metabase/components/DashboardSelector/DashboardSelector.tsx
@@ -12,7 +12,11 @@ import {
 interface DashboardSelectorProps {
   onChange: (value?: DashboardId) => void;
   value?: DashboardId;
-  collectionFilter?: (collection: Collection) => boolean;
+  collectionFilter?: (
+    collection: Collection,
+    index: number,
+    allCollections: Collection[],
+  ) => boolean;
 }
 
 export const DashboardSelector = ({

--- a/frontend/src/metabase/containers/ItemPicker/ItemPicker.tsx
+++ b/frontend/src/metabase/containers/ItemPicker/ItemPicker.tsx
@@ -192,7 +192,7 @@ function ItemPicker<TId>({
       const collection = item.collection_id
         ? collectionsById[item.collection_id]
         : collectionsById["root"];
-      return collection.can_write;
+      return collection?.can_write;
     },
     [models, collectionsById],
   );

--- a/frontend/src/metabase/containers/ItemPicker/ItemPicker.unit.spec.js
+++ b/frontend/src/metabase/containers/ItemPicker/ItemPicker.unit.spec.js
@@ -17,6 +17,7 @@ import {
   createMockUser,
 } from "metabase-types/api/mocks";
 import SnippetCollections from "metabase/entities/snippet-collections";
+import { isPersonalCollectionOrChild } from "metabase/collections/utils";
 
 import { ROOT_COLLECTION } from "metabase/entities/collections";
 import ItemPicker from "./ItemPicker";
@@ -310,8 +311,9 @@ describe("ItemPicker", () => {
     it("should filter collections", async () => {
       await setup({
         query: "foo",
-        collectionFilter: collection =>
-          collection.personal_owner_id === null || collection.id === "root",
+        collectionFilter: (collection, _index, allCollections) =>
+          !isPersonalCollectionOrChild(collection, allCollections) ||
+          collection.id === "root",
       });
 
       expect(screen.queryByText(/personal/i)).not.toBeInTheDocument();

--- a/frontend/src/metabase/containers/ItemPicker/ItemPicker.unit.spec.js
+++ b/frontend/src/metabase/containers/ItemPicker/ItemPicker.unit.spec.js
@@ -312,8 +312,7 @@ describe("ItemPicker", () => {
       await setup({
         query: "foo",
         collectionFilter: (collection, _index, allCollections) =>
-          !isPersonalCollectionOrChild(collection, allCollections) ||
-          collection.id === "root",
+          !isPersonalCollectionOrChild(collection, allCollections),
       });
 
       expect(screen.queryByText(/personal/i)).not.toBeInTheDocument();
@@ -334,8 +333,8 @@ describe("ItemPicker", () => {
 
     it("should not show items of filtered collections when searching", async () => {
       await setup({
-        collectionFilter: collection =>
-          collection.personal_owner_id === null || collection.id === "root",
+        collectionFilter: (collection, _index, allCollections) =>
+          !isPersonalCollectionOrChild(collection, allCollections),
       });
 
       userEvent.click(screen.getByRole("img", { name: /search/ }));

--- a/frontend/src/metabase/entities/search.js
+++ b/frontend/src/metabase/entities/search.js
@@ -70,7 +70,22 @@ export default createEntity({
             : [],
         };
       } else {
-        return searchList(query);
+        const { data, ...rest } = await searchList(query);
+
+        return {
+          ...rest,
+          data: data
+            ? data.map(item => {
+                const collectionKey = item.collection
+                  ? { collection_id: item.collection.id }
+                  : {};
+                return {
+                  ...collectionKey,
+                  ...item,
+                };
+              })
+            : [],
+        };
       }
     },
   },

--- a/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.tsx
+++ b/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.tsx
@@ -113,10 +113,7 @@ export const CustomHomePageModal = ({
             collection: Collection,
             _index: number,
             allCollections: Collection[],
-          ) =>
-            !isPersonalCollectionOrChild(collection, allCollections) ||
-            collection.id === "root"
-          }
+          ) => !isPersonalCollectionOrChild(collection, allCollections)}
         />
       </ModalContent>
     </Modal>

--- a/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.tsx
+++ b/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.tsx
@@ -14,7 +14,9 @@ import ModalContent from "metabase/components/ModalContent";
 
 import { DashboardSelector } from "metabase/components/DashboardSelector/DashboardSelector";
 import Button from "metabase/core/components/Button/Button";
-import { Collection, DashboardId } from "metabase-types/api";
+import { isPersonalCollectionOrChild } from "metabase/collections/utils";
+
+import type { Collection, DashboardId } from "metabase-types/api";
 
 const CUSTOM_HOMEPAGE_SETTING_KEY = "custom-homepage";
 const CUSTOM_HOMEPAGE_DASHBOARD_SETTING_KEY = "custom-homepage-dashboard";
@@ -107,8 +109,13 @@ export const CustomHomePageModal = ({
         <DashboardSelector
           value={dashboardId}
           onChange={handleChange}
-          collectionFilter={(collection: Collection) =>
-            collection.personal_owner_id === null || collection.id === "root"
+          collectionFilter={(
+            collection: Collection,
+            index: number,
+            allCollections: Collection[],
+          ) =>
+            !isPersonalCollectionOrChild(collection, allCollections) ||
+            collection.id === "root"
           }
         />
       </ModalContent>

--- a/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.tsx
+++ b/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.tsx
@@ -111,7 +111,7 @@ export const CustomHomePageModal = ({
           onChange={handleChange}
           collectionFilter={(
             collection: Collection,
-            index: number,
+            _index: number,
             allCollections: Collection[],
           ) =>
             !isPersonalCollectionOrChild(collection, allCollections) ||


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/32337

### Description
There are a couple small pieces to this issue. The first one is that I introduced the idea of filtering out collections you did not want to see in the item picker. In the case of selecting a dashboard for a custom homepage, the filter was meant exclude any personal collections. However, this didn't account for any search results, as the API does not apply that same filter. This meant that if you did a search, it was possible to have a dashboard that was in your personal collection be returned. The change to `ItemPicker.tsx` made it so that if we couldn't find the collection that the dashboard was part of (IE, it had been filtered out), then it would be ignored.

The second issue came from the somewhat inconsistent API responses for dashboards. When grabbing a dashboard by ID, we get back a `collection_id` prop, but when we search for one, we don't. This meant that if you searched for a dashboard, and you didn't already have it in your state, you could get back a null collection ID (which the item picker treats as part of the root collection).  This was why in the issue, you needed to search twice, since the first time the item picker incorrectly thought the dashboard belonged to the root collection. The change to `search.js` should add the `collection_id` prop if a collection is returned as part of the item, but should not add anything if it was not.

### How to verify
1. Create a dashboard in your personal collection
2. go to admin -> general
3. try to search for that newly created dashboard (refresh the page and try again as well, to ensure a fresh redux state)
4. It should not appear in the search results. You can also try and search for dashboards in other user's personal collections.


### Demo
![chrome_ARAoOGqFGe](https://github.com/metabase/metabase/assets/1328979/ea93929e-1cac-4862-a3b6-11a21f904249)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
