### PR TITLE
Drop unused computation_job table

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15921,8 +15921,18 @@ databaseChangeLog:
                   remarks: 'Was the table created from user-uploaded (i.e., from a CSV) data?'
                   constraints:
                     nullable: false
+
   - changeSet:
       id: v48.00-003
+      author: qnkhuat
+      comment: Added 0.48.0 - drop computation_job_result table
+      changes:
+          - dropTable:
+              tableName: computation_job_result
+      rollback: # no rollback needed since this table has been unused since 2018
+
+  - changeSet:
+      id: v48.00-004
       author: qnkhuat
       comment: Added 0.48.0 - drop computation_job table
       changes:

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15921,6 +15921,14 @@ databaseChangeLog:
                   remarks: 'Was the table created from user-uploaded (i.e., from a CSV) data?'
                   constraints:
                     nullable: false
+  - changeSet:
+      id: v48.00-003
+      author: qnkhuat
+      comment: Added 0.48.0 - drop computation_job table
+      changes:
+          - dropTable:
+              tableName: computation_job
+      rollback: # no rollback needed since this table has been unused since 2018
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15926,6 +15926,10 @@ databaseChangeLog:
       id: v48.00-003
       author: qnkhuat
       comment: Added 0.48.0 - drop computation_job_result table
+      preConditions:
+        - onFail: MARK_RAN
+        - tableExists:
+            tableName: computation_job_result
       changes:
           - dropTable:
               tableName: computation_job_result
@@ -15935,6 +15939,10 @@ databaseChangeLog:
       id: v48.00-004
       author: qnkhuat
       comment: Added 0.48.0 - drop computation_job table
+      preConditions:
+        - onFail: MARK_RAN
+        - tableExists:
+            tableName: computation_job
       changes:
           - dropTable:
               tableName: computation_job


### PR DESCRIPTION
Drop 2 tables:
- computation_job_result
- computation_job

the models were removed 5 years ago https://github.com/metabase/metabase/pull/7862 but we haven't dropped these tables.
