### PR TITLE
Make setting/getting JWT and SAML settings respect feature flag

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/api/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/saml.clj
@@ -5,9 +5,9 @@
    [compojure.core :refer [PUT]]
    [metabase.api.common :as api]
    [metabase.models.setting :as setting]
+   [metabase.public-settings.premium-features :as premium-features]
    [metabase.util.i18n :refer [tru]]
-   [saml20-clj.core :as saml]
-   [metabase.public-settings.premium-features :as premium-features]))
+   [saml20-clj.core :as saml]))
 
 (set! *warn-on-reflection* true)
 

--- a/enterprise/backend/src/metabase_enterprise/sso/api/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/saml.clj
@@ -5,7 +5,9 @@
    [compojure.core :refer [PUT]]
    [metabase.api.common :as api]
    [metabase.models.setting :as setting]
-   [saml20-clj.core :as saml]))
+   [metabase.util.i18n :refer [tru]]
+   [saml20-clj.core :as saml]
+   [metabase.public-settings.premium-features :as premium-features]))
 
 (set! *warn-on-reflection* true)
 
@@ -14,6 +16,7 @@
   [:as {settings :body}]
   {settings :map}
   (api/check-superuser)
+  (premium-features/assert-has-feature :sso-saml (tru "SAML-based authentication"))
   (let [filename (:saml-keystore-path settings)
         password (:saml-keystore-password settings)
         alias (:saml-keystore-alias settings)]

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_settings.clj
@@ -23,7 +23,8 @@
 
 (defsetting saml-identity-provider-uri
   (deferred-tru "This is the URL where your users go to log in to your identity provider. Depending on which IdP you''re
-using, this usually looks like https://your-org-name.example.com or https://example.com/app/my_saml_app/abc123/sso/saml"))
+using, this usually looks like https://your-org-name.example.com or https://example.com/app/my_saml_app/abc123/sso/saml")
+  :feature :sso-saml)
 
 (s/defn ^:private validate-saml-idp-cert
   "Validate that an encoded identity provider certificate is valid, or throw an Exception."
@@ -38,53 +39,64 @@ using, this usually looks like https://your-org-name.example.com or https://exam
 (defsetting saml-identity-provider-certificate
   (deferred-tru "Encoded certificate for the identity provider. Depending on your IdP, you might need to download this,
 open it in a text editor, then copy and paste the certificate's contents here.")
-  :setter (fn [new-value]
+  :feature :sso-saml
+  :setter  (fn [new-value]
             ;; when setting the idp cert validate that it's something we
-            (when new-value
-              (validate-saml-idp-cert new-value))
-            (setting/set-value-of-type! :string :saml-identity-provider-certificate new-value)))
+             (when new-value
+               (validate-saml-idp-cert new-value))
+             (setting/set-value-of-type! :string :saml-identity-provider-certificate new-value)))
 
 (defsetting saml-identity-provider-issuer
   (deferred-tru "This is a unique identifier for the IdP. Often referred to as Entity ID or simply 'Issuer'. Depending
-on your IdP, this usually looks something like http://www.example.com/141xkex604w0Q5PN724v"))
+on your IdP, this usually looks something like http://www.example.com/141xkex604w0Q5PN724v")
+  :feature :sso-saml)
 
 (defsetting saml-application-name
   (deferred-tru "This application name will be used for requests to the Identity Provider")
-  :default "Metabase")
+  :default "Metabase"
+  :feature :sso-saml)
 
 (defsetting saml-keystore-path
-  (deferred-tru "Absolute path to the Keystore file to use for signing SAML requests"))
+  (deferred-tru "Absolute path to the Keystore file to use for signing SAML requests")
+  :feature :sso-saml)
 
 (defsetting saml-keystore-password
   (deferred-tru "Password for opening the keystore")
-  :default "changeit"
-  :sensitive? true)
+  :default    "changeit"
+  :sensitive? true
+  :feature    :sso-saml)
 
 (defsetting saml-keystore-alias
   (deferred-tru "Alias for the key that {0} should use for signing SAML requests"
                 (public-settings/application-name-for-setting-descriptions))
-  :default "metabase")
+  :default "metabase"
+  :feature :sso-saml)
 
 (defsetting saml-attribute-email
   (deferred-tru "SAML attribute for the user''s email address")
-  :default "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress")
+  :default "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
+  :feature :sso-saml)
 
 (defsetting saml-attribute-firstname
   (deferred-tru "SAML attribute for the user''s first name")
-  :default "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname")
+  :default "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname"
+  :feature :sso-saml)
 
 (defsetting saml-attribute-lastname
   (deferred-tru "SAML attribute for the user''s last name")
-  :default "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname")
+  :default "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname"
+  :feature :sso-saml)
 
 (defsetting saml-group-sync
   (deferred-tru "Enable group membership synchronization with SAML.")
   :type    :boolean
-  :default false)
+  :default false
+  :feature :sso-saml)
 
 (defsetting saml-attribute-group
   (deferred-tru "SAML attribute for group syncing")
-  :default "member_of")
+  :default "member_of"
+  :feature :sso-saml)
 
 (defsetting saml-group-mappings
   ;; Should be in the form: {"groupName": [1, 2, 3]} where keys are SAML groups and values are lists of MB groups IDs
@@ -93,20 +105,23 @@ on your IdP, this usually looks something like http://www.example.com/141xkex604
   :type    :json
   :cache?  false
   :default {}
-  :setter (comp (partial setting/set-value-of-type! :json :saml-group-mappings) validate-group-mappings))
+  :feature :sso-saml
+  :setter  (comp (partial setting/set-value-of-type! :json :saml-group-mappings) validate-group-mappings))
 
 (defsetting saml-configured
   (deferred-tru "Are the mandatory SAML settings configured?")
-  :type   :boolean
-  :setter :none
-  :getter (fn [] (boolean
-                  (and (saml-identity-provider-uri)
-                       (saml-identity-provider-certificate)))))
+  :type    :boolean
+  :feature :sso-saml
+  :setter  :none
+  :getter  (fn [] (boolean
+                   (and (saml-identity-provider-uri)
+                        (saml-identity-provider-certificate)))))
 
 (defsetting saml-enabled
   (deferred-tru "Is SAML authentication configured and enabled?")
   :type    :boolean
   :default false
+  :feature :sso-saml
   :getter  (fn []
              (if (saml-configured)
                (setting/get-value-of-type :boolean :saml-enabled)
@@ -119,28 +134,34 @@ on your IdP, this usually looks something like http://www.example.com/141xkex604
   (deferred-tru (str "String used to seed the private key used to validate JWT messages."
                      " "
                      "A hexadecimal-encoded 256-bit key (i.e., a 64-character string) is strongly recommended."))
-  :type :string)
+  :type    :string
+  :feature :sso-jwt)
 
 (defsetting jwt-attribute-email
   (deferred-tru "Key to retrieve the JWT user's email address")
-  :default "email")
+  :default "email"
+  :feature :sso-jwt)
 
 (defsetting jwt-attribute-firstname
   (deferred-tru "Key to retrieve the JWT user's first name")
-  :default "first_name")
+  :default "first_name"
+  :feature :sso-jwt)
 
 (defsetting jwt-attribute-lastname
   (deferred-tru "Key to retrieve the JWT user's last name")
-  :default "last_name")
+  :default "last_name"
+  :feature :sso-jwt)
 
 (defsetting jwt-attribute-groups
   (deferred-tru "Key to retrieve the JWT user's groups")
-  :default "groups")
+  :default "groups"
+  :feature :sso-jwt)
 
 (defsetting jwt-group-sync
   (deferred-tru "Enable group membership synchronization with JWT.")
   :type    :boolean
-  :default false)
+  :default false
+  :feature :sso-jwt)
 
 (defsetting jwt-group-mappings
   ;; Should be in the form: {"groupName": [1, 2, 3]} where keys are JWT groups and values are lists of MB groups IDs
@@ -149,20 +170,24 @@ on your IdP, this usually looks something like http://www.example.com/141xkex604
   :type    :json
   :cache?  false
   :default {}
+  :feature :sso-jwt
   :setter  (comp (partial setting/set-value-of-type! :json :jwt-group-mappings) validate-group-mappings))
 
 (defsetting jwt-configured
   (deferred-tru "Are the mandatory JWT settings configured?")
-  :type   :boolean
-  :setter :none
-  :getter (fn [] (boolean
-                  (and (jwt-identity-provider-uri)
-                       (jwt-shared-secret)))))
+  :type    :boolean
+  :default false
+  :feature :sso-jwt
+  :setter  :none
+  :getter  (fn [] (boolean
+                   (and (jwt-identity-provider-uri)
+                        (jwt-shared-secret)))))
 
 (defsetting jwt-enabled
   (deferred-tru "Is JWT authentication configured and enabled?")
   :type    :boolean
   :default false
+  :feature :sso-jwt
   :getter  (fn []
              (if (jwt-configured)
                (setting/get-value-of-type :boolean :jwt-enabled)

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_settings.clj
@@ -111,6 +111,7 @@ on your IdP, this usually looks something like http://www.example.com/141xkex604
 (defsetting saml-configured
   (deferred-tru "Are the mandatory SAML settings configured?")
   :type    :boolean
+  :default false
   :feature :sso-saml
   :setter  :none
   :getter  (fn [] (boolean
@@ -128,7 +129,8 @@ on your IdP, this usually looks something like http://www.example.com/141xkex604
                false)))
 
 (defsetting jwt-identity-provider-uri
-  (deferred-tru "URL of JWT based login page"))
+  (deferred-tru "URL of JWT based login page")
+  :feature :sso-jwt)
 
 (defsetting jwt-shared-secret
   (deferred-tru (str "String used to seed the private key used to validate JWT messages."

--- a/enterprise/backend/test/metabase_enterprise/public_settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/public_settings_test.clj
@@ -9,20 +9,20 @@
 (use-fixtures :once (fixtures/initialize :db))
 
 (deftest can-turn-off-password-login-with-jwt-enabled
-  (tu/with-temporary-setting-values [jwt-enabled               true
-                                     jwt-identity-provider-uri "example.com"
-                                     jwt-shared-secret         "0123456789012345678901234567890123456789012345678901234567890123"
-                                     enable-password-login     true]
+  (premium-features-test/with-premium-features #{:sso-jwt}
+    (tu/with-temporary-setting-values [jwt-enabled               true
+                                       jwt-identity-provider-uri "example.com"
+                                       jwt-shared-secret         "0123456789012345678901234567890123456789012345678901234567890123"
+                                       enable-password-login     true]
 
-    (testing "can't change enable-password-login setting if disabled-password-login feature is disabled"
-      (premium-features-test/with-premium-features #{}
+      (testing "can't change enable-password-login setting if disabled-password-login feature is disabled"
         (is (thrown-with-msg?
-              clojure.lang.ExceptionInfo
-              #"Setting enable-password-login is not enabled because feature :disable-password-login is not available"
-             (public-settings/enable-password-login! false)))))
+             clojure.lang.ExceptionInfo
+             #"Setting enable-password-login is not enabled because feature :disable-password-login is not available"
+             (public-settings/enable-password-login! false))))
 
-   (testing "can change enable-password-login setting if jwt enabled and have disabled-password-login feature"
-     (premium-features-test/with-premium-features #{:disable-password-login}
-       (public-settings/enable-password-login! false)
-       (is (= false
-              (public-settings/enable-password-login)))))))
+      (testing "can change enable-password-login setting if jwt enabled and have disabled-password-login feature"
+        (premium-features-test/with-additional-premium-features #{:disable-password-login}
+          (public-settings/enable-password-login! false)
+          (is (= false
+                 (public-settings/enable-password-login))))))))

--- a/enterprise/backend/test/metabase_enterprise/sso/api/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/api/saml_test.clj
@@ -1,8 +1,8 @@
 (ns metabase-enterprise.sso.api.saml-test
   (:require
    [clojure.test :refer :all]
-   [metabase.test :as mt]
-   [metabase.public-settings.premium-features-test :as premium-features-test]))
+   [metabase.public-settings.premium-features-test :as premium-features-test]
+   [metabase.test :as mt]))
 
 (deftest saml-settings-test
   (testing "PUT /api/saml/settings"

--- a/enterprise/backend/test/metabase_enterprise/sso/api/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/api/saml_test.clj
@@ -1,20 +1,28 @@
 (ns metabase-enterprise.sso.api.saml-test
   (:require
    [clojure.test :refer :all]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.public-settings.premium-features-test :as premium-features-test]))
 
 (deftest saml-settings-test
   (testing "PUT /api/saml/settings"
-    (testing "Valid SAML settings can be saved via an API call"
-      (mt/user-http-request :crowberto :put 200 "saml/settings" {:saml-keystore-path "test_resources/keystore.jks"
-                                                                 :saml-keystore-password "123456"
-                                                                 :saml-keystore-alias "sp"}))
-    (testing "Blank SAML settings returns 200"
-      (mt/user-http-request :crowberto :put 200 "saml/settings" {:saml-keystore-path nil
-                                                                 :saml-keystore-password nil
-                                                                 :saml-keystore-alias nil}))
+    (premium-features-test/with-premium-features #{}
+      (testing "SAML settings cannot be saved without SAML feature flag enabled"
+        (is (= "SAML-based authentication is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
+               (mt/user-http-request :crowberto :put 402 "saml/settings" {:saml-keystore-path "test_resources/keystore.jks"
+                                                                          :saml-keystore-password "123456"
+                                                                          :saml-keystore-alias "sp"})))))
+    (premium-features-test/with-premium-features #{:sso-saml}
+      (testing "Valid SAML settings can be saved via an API call"
+        (mt/user-http-request :crowberto :put 200 "saml/settings" {:saml-keystore-path "test_resources/keystore.jks"
+                                                                   :saml-keystore-password "123456"
+                                                                   :saml-keystore-alias "sp"}))
+      (testing "Blank SAML settings returns 200"
+        (mt/user-http-request :crowberto :put 200 "saml/settings" {:saml-keystore-path nil
+                                                                   :saml-keystore-password nil
+                                                                   :saml-keystore-alias nil}))
 
-    (testing "Invalid SAML settings returns 400"
-      (mt/user-http-request :crowberto :put 400 "saml/settings" {:saml-keystore-path "/path/to/keystore"
-                                                                 :saml-keystore-password "password"
-                                                                 :saml-keystore-alias "alias"}))))
+      (testing "Invalid SAML settings returns 400"
+        (mt/user-http-request :crowberto :put 400 "saml/settings" {:saml-keystore-path "/path/to/keystore"
+                                                                   :saml-keystore-password "password"
+                                                                   :saml-keystore-alias "alias"})))))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -141,8 +141,8 @@
   (testing "SSO requests fail if they don't have a valid premium-features token"
     (premium-features-test/with-premium-features #{}
       (with-default-saml-config
-        (is (= "SAML-based authentication is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
-               (client :get 402 "/auth/sso")))))))
+        (is (= "SSO has not been enabled and/or configured"
+               (client :get 400 "/auth/sso")))))))
 
 (deftest require-saml-enabled-test
   (with-sso-saml-token

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/sso_settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/sso_settings_test.clj
@@ -1,0 +1,192 @@
+(ns metabase-enterprise.sso.integrations.sso-settings-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.test.util :as tu]
+   [metabase.public-settings.premium-features-test :as premium-features-test]
+   [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]))
+
+(def ^:private default-idp-uri "http://test.idp.metabase.com")
+(def ^:private default-idp-cert (slurp "test_resources/sso/auth0-public-idp.cert"))
+
+(deftest get-saml-settings-token-features-test
+  (testing "Getting SAML settings should return their default values without :sso-saml feature flag enabled"
+    (premium-features-test/with-premium-features #{:sso-saml}
+      (tu/with-temporary-setting-values [saml-identity-provider-uri         default-idp-uri
+                                         saml-identity-provider-certificate default-idp-cert
+                                         saml-identity-provider-issuer      "54321"
+                                         saml-application-name              "Not Metabase"
+                                         saml-keystore-path                 "test_resources/keystore.jks"
+                                         saml-keystore-password             "123456"
+                                         saml-keystore-alias                "sp"
+                                         saml-attribute-email               "not default email"
+                                         saml-attribute-firstname           "not default first_name"
+                                         saml-attribute-lastname            "not default last_name"
+                                         saml-group-sync                    true
+                                         saml-attribute-group               "group"
+                                         saml-group-mappings                {:group_1 [1]}
+                                         saml-enabled                       true]
+        (doseq [feature? [true false]]
+          (premium-features-test/with-premium-features (if feature? #{:sso-saml} #{})
+            (is (= (if feature? default-idp-uri nil)
+                   (sso-settings/saml-identity-provider-uri)))
+            (is (= (if feature? default-idp-cert nil)
+                   (sso-settings/saml-identity-provider-certificate)))
+            (is (= (if feature? "54321" nil)
+                   (sso-settings/saml-identity-provider-issuer)))
+            (is (= (if feature? "Not Metabase" "Metabase")
+                   (sso-settings/saml-application-name)))
+            (is (= (if feature? "test_resources/keystore.jks" nil)
+                   (sso-settings/saml-keystore-path)))
+            (is (= (if feature? "123456" "changeit")
+                   (sso-settings/saml-keystore-password)))
+            (is (= (if feature? "sp" "metabase")
+                   (sso-settings/saml-keystore-alias)))
+            (is (= (if feature? "not default email" "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress")
+                   (sso-settings/saml-attribute-email)))
+            (is (= (if feature? "not default first_name" "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname")
+                   (sso-settings/saml-attribute-firstname)))
+            (is (= (if feature? "not default last_name" "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname")
+                   (sso-settings/saml-attribute-lastname)))
+            (is (= (if feature? true false)
+                   (sso-settings/saml-group-sync)))
+            (is (= (if feature? "group" "member_of")
+                   (sso-settings/saml-attribute-group)))
+            (is (= (if feature? {:group_1 [1]} {})
+                   (sso-settings/saml-group-mappings)))
+            (is (= (if feature? true false)
+                   (sso-settings/saml-configured)))
+            (is (= (if feature? true false)
+                   (sso-settings/saml-enabled)))))))))
+
+(deftest set-saml-settings-token-features-test
+  (testing "Setting SAML settings should error without the :sso-saml feature flag enabled"
+    (premium-features-test/with-premium-features #{}
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Setting saml-identity-provider-uri is not enabled because feature :sso-saml is not available"
+           (sso-settings/saml-identity-provider-uri! default-idp-uri)))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Setting saml-identity-provider-certificate is not enabled because feature :sso-saml is not available"
+           (sso-settings/saml-identity-provider-certificate! default-idp-cert)))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Setting saml-identity-provider-issuer is not enabled because feature :sso-saml is not available"
+           (sso-settings/saml-identity-provider-issuer! "54321")))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Setting saml-application-name is not enabled because feature :sso-saml is not available"
+           (sso-settings/saml-application-name! "Not Metabase")))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Setting saml-keystore-path is not enabled because feature :sso-saml is not available"
+           (sso-settings/saml-keystore-path! "test_resources/keystore.jks")))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Setting saml-keystore-password is not enabled because feature :sso-saml is not available"
+           (sso-settings/saml-keystore-password! "123456")))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Setting saml-keystore-alias is not enabled because feature :sso-saml is not available"
+           (sso-settings/saml-keystore-alias! "sp")))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Setting saml-attribute-email is not enabled because feature :sso-saml is not available"
+           (sso-settings/saml-attribute-email! "email")))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Setting saml-attribute-firstname is not enabled because feature :sso-saml is not available"
+           (sso-settings/saml-attribute-firstname! "firstname")))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Setting saml-attribute-lastname is not enabled because feature :sso-saml is not available"
+           (sso-settings/saml-attribute-lastname! "lastname")))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Setting saml-group-sync is not enabled because feature :sso-saml is not available"
+           (sso-settings/saml-group-sync! true)))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Setting saml-attribute-group is not enabled because feature :sso-saml is not available"
+           (sso-settings/saml-attribute-group! "group")))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Setting saml-group-mappings is not enabled because feature :sso-saml is not available"
+           (sso-settings/saml-group-mappings! {:group_1 [1]})))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Setting saml-enabled is not enabled because feature :sso-saml is not available"
+           (sso-settings/saml-enabled! true))))))
+
+(deftest jwt-settings-token-features-test
+  (testing "Getting JWT settings should return their default values without :sso-jwt feature flag enabled"
+    (doseq [feature? [true false]]
+      (premium-features-test/with-premium-features #{:sso-jwt}
+        (tu/with-temporary-setting-values [jwt-identity-provider-uri default-idp-uri
+                                           jwt-shared-secret         "01234"
+                                           jwt-attribute-email       "not default email"
+                                           jwt-attribute-firstname   "not default first_name"
+                                           jwt-attribute-lastname    "not default last_name"
+                                           jwt-attribute-groups      "not default groups"
+                                           jwt-group-sync            true
+                                           jwt-group-mappings        {:group_id [1]}
+                                           jwt-enabled               true]
+          (premium-features-test/with-premium-features (if feature? #{:sso-jwt} #{})
+            (is (= (if feature? default-idp-uri nil)
+                   (sso-settings/jwt-identity-provider-uri)))
+            (is (= (if feature? "01234" nil)
+                   (sso-settings/jwt-shared-secret)))
+            (is (= (if feature? "not default email" "email")
+                   (sso-settings/jwt-attribute-email)))
+            (is (= (if feature? "not default first_name" "first_name")
+                   (sso-settings/jwt-attribute-firstname)))
+            (is (= (if feature? "not default last_name" "last_name")
+                   (sso-settings/jwt-attribute-lastname)))
+            (is (= (if feature? true false)
+                   (sso-settings/jwt-group-sync)))
+            (is (= (if feature? "not default groups" "groups")
+                   (sso-settings/jwt-attribute-groups)))
+            (is (= (if feature? {:group_id [1]} {})
+                   (sso-settings/jwt-group-mappings)))
+            (is (= (if feature? true false)
+                   (sso-settings/jwt-enabled)))))))))
+
+(deftest set-jwt-settings-token-features-test
+  (testing "Setting JWT settings should error without the :sso-jwt feature flag enabled"
+    (premium-features-test/with-premium-features #{}
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Setting jwt-identity-provider-uri is not enabled because feature :sso-jwt is not available"
+           (sso-settings/jwt-identity-provider-uri! default-idp-uri)))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+          #"Setting jwt-shared-secret is not enabled because feature :sso-jwt is not available"
+          (sso-settings/jwt-shared-secret! "01234")))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Setting jwt-attribute-email is not enabled because feature :sso-jwt is not available"
+           (sso-settings/jwt-attribute-email! "email")))
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo
+            #"Setting jwt-attribute-firstname is not enabled because feature :sso-jwt is not available"
+            (sso-settings/jwt-attribute-firstname! "first_name")))
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo
+            #"Setting jwt-attribute-lastname is not enabled because feature :sso-jwt is not available"
+            (sso-settings/jwt-attribute-lastname! "last_name")))
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo
+            #"Setting jwt-group-sync is not enabled because feature :sso-jwt is not available"
+            (sso-settings/jwt-group-sync! true)))
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo
+            #"Setting jwt-attribute-groups is not enabled because feature :sso-jwt is not available"
+            (sso-settings/jwt-attribute-groups! "groups")))
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo
+            #"Setting jwt-group-mappings is not enabled because feature :sso-jwt is not available"
+            (sso-settings/jwt-group-mappings! {:group_id [1]})))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Setting jwt-enabled is not enabled because feature :sso-jwt is not available"
+           (sso-settings/jwt-enabled! true))))))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/sso_settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/sso_settings_test.clj
@@ -1,9 +1,9 @@
 (ns metabase-enterprise.sso.integrations.sso-settings-test
   (:require
    [clojure.test :refer :all]
-   [metabase.test.util :as tu]
+   [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]
    [metabase.public-settings.premium-features-test :as premium-features-test]
-   [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]))
+   [metabase.test.util :as tu]))
 
 (def ^:private default-idp-uri "http://test.idp.metabase.com")
 (def ^:private default-idp-cert (slurp "test_resources/sso/auth0-public-idp.cert"))


### PR DESCRIPTION
This PR blocks setting JWT and SAML SSO settings if the corresponding feature flags are not enabled (sso-jwt and sso-saml, respectfully).

Getting the setting values without the feature flag enabled will also return the default value for the setting, or nil if no default exists.

Pursuant towards:
- https://github.com/metabase/metabase-private/issues/83
- https://github.com/metabase/metabase-private/issues/82