### PR TITLE
Add css nonce to emotion

### DIFF
--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -35,6 +35,8 @@ import { Provider } from "react-redux";
 import { Router, useRouterHistory } from "react-router";
 import { createHistory } from "history";
 import { syncHistoryWithStore } from "react-router-redux";
+import createCache from "@emotion/cache";
+import { CacheProvider } from "@emotion/react";
 
 // drag and drop
 import HTML5Backend from "react-dnd-html5-backend";
@@ -65,6 +67,7 @@ function _init(reducers, getRoutes, callback) {
   const store = getStore(reducers, browserHistory);
   const routes = getRoutes(store);
   const history = syncHistoryWithStore(browserHistory, store);
+  const cache = createCache({ key: "emotion", nonce: "2726c7f26c" });
 
   let root;
 
@@ -72,12 +75,14 @@ function _init(reducers, getRoutes, callback) {
 
   ReactDOM.render(
     <Provider store={store} ref={ref => (root = ref)}>
-      <DragDropContextProvider backend={HTML5Backend} context={{ window }}>
-        <ThemeProvider>
-          <GlobalStyles />
-          <Router history={history}>{routes}</Router>
-        </ThemeProvider>
-      </DragDropContextProvider>
+      <CacheProvider value={cache}>
+        <DragDropContextProvider backend={HTML5Backend} context={{ window }}>
+          <ThemeProvider>
+            <GlobalStyles />
+            <Router history={history}>{routes}</Router>
+          </ThemeProvider>
+        </DragDropContextProvider>
+      </CacheProvider>
     </Provider>,
     document.getElementById("root"),
   );

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -194,31 +194,8 @@ function getTextNodeAtPosition(root, index) {
   };
 }
 
-// https://davidwalsh.name/add-rules-stylesheets
-const STYLE_SHEET = (function () {
-  // Create the <style> tag
-  const style = document.createElement("style");
-
-  // WebKit hack :(
-  style.appendChild(document.createTextNode("/* dynamic stylesheet */"));
-
-  // Add the <style> element to the page
-  document.head.appendChild(style);
-
-  return style.sheet;
-})();
-
 export function addCSSRule(selector, rules, index = 0) {
-  if ("insertRule" in STYLE_SHEET) {
-    const ruleIndex = STYLE_SHEET.insertRule(
-      selector + "{" + rules + "}",
-      index,
-    );
-    return STYLE_SHEET.cssRules[ruleIndex];
-  } else if ("addRule" in STYLE_SHEET) {
-    const ruleIndex = STYLE_SHEET.addRule(selector, rules, index);
-    return STYLE_SHEET.rules[ruleIndex];
-  }
+  // noop to test emotion changes
 }
 
 export function constrainToScreen(element, direction, padding) {

--- a/package.json
+++ b/package.json
@@ -270,7 +270,6 @@
     "react-refresh": "^0.13.0",
     "shadow-cljs": "2.24.0",
     "source-map-loader": "^4.0.1",
-    "style-loader": "3.3.1",
     "typescript": "^4.7.2",
     "webpack": "^5.85.0",
     "webpack-cli": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@dnd-kit/core": "^6.0.8",
     "@dnd-kit/modifiers": "^6.0.1",
     "@dnd-kit/sortable": "^7.0.2",
+    "@emotion/cache": "^11.7.1",
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@mantine/core": "^6.0.13",

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -72,6 +72,9 @@
                                  "https://accounts.google.com"]
                   :style-src    ["'self'"
                                  "'nonce-2726c7f26c'"
+                                 ;; for webpack hot reloading
+                                 (when config/is-dev?
+                                   "http://localhost:8080")
                                  "https://accounts.google.com"]
                   :font-src     ["*"]
                   :img-src      ["*"

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -71,7 +71,7 @@
                                  ;; TODO - double check that we actually need this for Google Auth
                                  "https://accounts.google.com"]
                   :style-src    ["'self'"
-                                 "'unsafe-inline'"
+                                 "'nonce-2726c7f26c'"
                                  "https://accounts.google.com"]
                   :font-src     ["*"]
                   :img-src      ["*"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -105,14 +105,12 @@ const config = (module.exports = {
       {
         test: /\.css$/,
         use: [
-          devMode
-            ? "style-loader"
-            : {
-                loader: MiniCssExtractPlugin.loader,
-                options: {
-                  publicPath: "./",
-                },
-              },
+          {
+            loader: MiniCssExtractPlugin.loader,
+            options: {
+              publicPath: "./",
+            },
+          },
           { loader: "css-loader", options: CSS_CONFIG },
           { loader: "postcss-loader" },
         ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -23536,11 +23536,6 @@ strnum@^1.0.5:
   resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
   integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
 
-style-loader@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-3.3.1.tgz#057dfa6b3d4d7c7064462830f9113ed417d38575"
-  integrity sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==
-
 style-loader@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.3.0.tgz#828b4a3b3b7e7aa5847ce7bae9e874512114249e"


### PR DESCRIPTION
Related to https://github.com/metabase/metabase-private/issues/73

Adds nonce to `style-src` for emotion. This change blocks using inline styles tags. `LineAreaBarChart` and `Logs` shouldn't be working correctly since they depend on this API, however everything else (except whitelabel for now) should work as expected both in dev and prod modes. 

Note: `nonce` would be set dynamically later on.

How to verify:
- `yarn dev` - make sure the styles are correctly shown
- `./bin/build.sh` -> `cd ./target/uberjar` -> `java -jar metabase.jar` and make sure the styles are working in prod as well

<img width="1728" alt="Screenshot 2023-07-18 at 20 19 45" src="https://github.com/metabase/metabase/assets/8542534/5229ba50-a404-44e3-9eaa-dd8d26ae9a52">
