### PR TITLE
Fix failing `official-collections` test in feature-flags-integration branch

### DIFF
--- a/e2e/test/scenarios/organization/official-collections.cy.spec.js
+++ b/e2e/test/scenarios/organization/official-collections.cy.spec.js
@@ -44,7 +44,7 @@ describeEE("official collections", () => {
         },
       }).then(({ body, status, statusText }) => {
         expect(body).to.eq(
-          "Official collections is an Enterprise feature. Please upgrade to a paid plan to use this feature.",
+          "Official Collections is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/",
         );
         expect(status).to.eq(402);
         expect(statusText).to.eq("Payment Required");

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.js
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.js
@@ -41,7 +41,7 @@ const ENGINES_MOCK = {
 
 const ComponentMock = () => <div />;
 jest.mock(
-  "metabase/databases/containers/DatabaseHelpCard",
+  "metabase/databases/components/DatabaseHelpCard",
   () => ComponentMock,
 );
 


### PR DESCRIPTION
This PR fixes **only** `official-collections.cy.spec.js` test.

We changed the copy in the backend response from:
> Official collections is an Enterprise feature. Please upgrade to a paid plan to use this feature.

to
> Official Collections is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at [metabase.com/upgrade/](http://metabase.com/upgrade/)

## Out of scope
Please note that the other failures will be fixed in a separate PR
![image](https://github.com/metabase/metabase/assets/31325167/a82d9206-c1c7-4bd7-80b4-f1a4055e1235)

These rely on `isPaidPlan()` helper that checks for the existence of `sso` feature-flag, which was removed in #32399