### PR TITLE
Fix granular `jwt` and `saml` flags on FE

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/auth/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/auth/index.js
@@ -29,14 +29,14 @@ PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections =>
       description: null,
       noHeader: true,
       widget: SamlAuthCard,
-      getHidden: () => !hasPremiumFeature("sso"),
+      getHidden: () => !hasPremiumFeature("sso_saml"),
     },
     {
       key: "jwt-enabled",
       description: null,
       noHeader: true,
       widget: JwtAuthCard,
-      getHidden: () => !hasPremiumFeature("sso"),
+      getHidden: () => !hasPremiumFeature("sso_jwt"),
     },
     {
       key: "enable-password-login",


### PR DESCRIPTION
#32399 introduced more granular feature flags for `sso`, but didn't update the frontend to reflect this.
That resulted in E2E test failures and in the absence of `jwt` and `saml` options from the admin authentication options when the token is present.

### How to test?
Both these specs should now pass in CI and/or locally:
- `e2e/test/scenarios/admin/settings/sso/jwt.cy.spec.js`
- `e2e/test/scenarios/admin/settings/sso/saml.cy.spec.js`

You can also check this manually by going to `/admin/settings/authentication` **with the active PRO token**. Make sure you can see JWT and SAML cards.

**Before**
![image](https://github.com/metabase/metabase/assets/31325167/719d5878-a3fa-41cc-8284-b03ab1d3eb5d)

**After**
![image](https://github.com/metabase/metabase/assets/31325167/b4d0d0cd-da74-4c5f-8d45-9fb714beef47)
