### PR TITLE
Standardize month-year and quarter-year formats (frontend only)

### DIFF
--- a/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
@@ -262,7 +262,7 @@ describe("binning related reproductions", () => {
       // ALl of these are implicit assertions and will fail if there's more than one string
       cy.findByText("Count");
       cy.findByText("Created At: Month");
-      cy.findByText("June, 2022");
+      cy.findByText("June 2022");
     });
   });
 

--- a/e2e/test/scenarios/binning/correctness/shared/constants.js
+++ b/e2e/test/scenarios/binning/correctness/shared/constants.js
@@ -20,7 +20,7 @@ export const TIME_OPTIONS = {
   },
   Month: {
     selected: "by month",
-    representativeValues: ["April, 2022", "May, 2022"],
+    representativeValues: ["April 2022", "May 2022"],
   },
   Quarter: {
     selected: "by quarter",

--- a/e2e/test/scenarios/binning/correctness/shared/constants.js
+++ b/e2e/test/scenarios/binning/correctness/shared/constants.js
@@ -24,7 +24,7 @@ export const TIME_OPTIONS = {
   },
   Quarter: {
     selected: "by quarter",
-    representativeValues: ["Q2 - 2022", "Q1 - 2023", "Q1 - 2024", "Q1 - 2025"],
+    representativeValues: ["Q2 2022", "Q1 2023", "Q1 2024", "Q1 2025"],
   },
   Year: {
     selected: "by year",

--- a/e2e/test/scenarios/binning/qb-explicit-joins.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-explicit-joins.cy.spec.js
@@ -217,9 +217,9 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
       assertOnXYAxisLabels({ xLabel: "People → Birth Date", yLabel: "Count" });
 
       cy.get(".axis.x", { timeout: 1000 })
-        .should("contain", "January, 1960")
-        .and("contain", "January, 1965")
-        .and("contain", "January, 2000");
+        .should("contain", "January 1960")
+        .and("contain", "January 1965")
+        .and("contain", "January 2000");
 
       cy.get("circle");
 

--- a/e2e/test/scenarios/binning/qb-explicit-joins.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-explicit-joins.cy.spec.js
@@ -91,9 +91,9 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
 
       cy.wait("@dataset");
       cy.get(".axis.x")
-        .should("contain", "Q1 - 1960")
-        .and("contain", "Q1 - 1965")
-        .and("contain", "Q1 - 2000");
+        .should("contain", "Q1 1960")
+        .and("contain", "Q1 1965")
+        .and("contain", "Q1 2000");
     });
 
     it("should work for number", () => {
@@ -160,9 +160,9 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
 
       cy.wait("@dataset");
       cy.get(".axis.x")
-        .should("contain", "Q1 - 1960")
-        .and("contain", "Q1 - 1965")
-        .and("contain", "Q1 - 2000");
+        .should("contain", "Q1 1960")
+        .and("contain", "Q1 1965")
+        .and("contain", "Q1 2000");
     });
 
     it("should work for number", () => {
@@ -233,9 +233,9 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
       cy.findByText("Count by People → Birth Date: Quarter");
 
       cy.get(".axis.x")
-        .should("contain", "Q1 - 1960")
-        .and("contain", "Q1 - 1965")
-        .and("contain", "Q1 - 2000");
+        .should("contain", "Q1 1960")
+        .and("contain", "Q1 1965")
+        .and("contain", "Q1 2000");
     });
 
     it("should work for number", () => {

--- a/e2e/test/scenarios/binning/qb-implicit-joins.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-implicit-joins.cy.spec.js
@@ -45,7 +45,7 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Month").click();
 
-      cy.get(".cellData").should("contain", "April, 1958").and("contain", "37");
+      cy.get(".cellData").should("contain", "April 1958").and("contain", "37");
     });
 
     it("should work for number", () => {
@@ -110,7 +110,7 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Month").click();
 
-      cy.get(".cellData").should("contain", "April, 1958").and("contain", "37");
+      cy.get(".cellData").should("contain", "April 1958").and("contain", "37");
     });
 
     it("should work for number", () => {

--- a/e2e/test/scenarios/binning/qb-regular-table.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-regular-table.cy.spec.js
@@ -138,7 +138,7 @@ describe("scenarios > binning > binning options", () => {
 
       cy.get("circle");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("January, 2023");
+      cy.findByText("January 2023");
     });
 
     it("should work for longitude/latitude", () => {

--- a/e2e/test/scenarios/binning/qb-regular-table.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-regular-table.cy.spec.js
@@ -43,7 +43,7 @@ describe("scenarios > binning > binning options", () => {
 
       cy.get("circle");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Q1 - 2023");
+      cy.findByText("Q1 2023");
     });
 
     it("should work for longitude/latitude", () => {
@@ -92,7 +92,7 @@ describe("scenarios > binning > binning options", () => {
 
       cy.get("circle");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Q1 - 2023");
+      cy.findByText("Q1 2023");
     });
 
     it("should work for longitude/latitude", () => {

--- a/e2e/test/scenarios/binning/sql.cy.spec.js
+++ b/e2e/test/scenarios/binning/sql.cy.spec.js
@@ -189,7 +189,7 @@ describe("scenarios > binning > from a saved sql question", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by CREATED_AT: Quarter");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Q1 - 2023");
+      cy.findByText("Q1 2023");
     });
 
     it("should work for number", () => {

--- a/e2e/test/scenarios/cross-version/target/smoke.cy.spec.js
+++ b/e2e/test/scenarios/cross-version/target/smoke.cy.spec.js
@@ -31,10 +31,10 @@ describe(`smoke test the migration to the version ${version}`, () => {
     cy.get(".x-axis-label").invoke("text").should("eq", "Created At");
     cy.get(".y-axis-label").invoke("text").should("eq", "Revenue");
     cy.get(".x.axis .tick")
-      .should("contain", "Q1 - 2023")
-      .and("contain", "Q1 - 2024")
-      .and("contain", "Q1 - 2025")
-      .and("contain", "Q1 - 2026");
+      .should("contain", "Q1 2023")
+      .and("contain", "Q1 2024")
+      .and("contain", "Q1 2025")
+      .and("contain", "Q1 2026");
 
     cy.get(".y.axis .tick")
       .should("contain", "20,000")

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
@@ -80,7 +80,7 @@ describe("scenarios > dashboard > filters > date", () => {
 
     // Make sure we can override the default value
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("November, 2022").click();
+    cy.findByText("November 2022").click();
     popover().contains("June").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("33.9");

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-date.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-date.cy.spec.js
@@ -82,7 +82,7 @@ describe("scenarios > dashboard > filters > SQL > date", () => {
 
     // Make sure we can override the default value
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("October, 2022").click();
+    cy.findByText("October 2022").click();
     popover().contains("August").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Macy Olson");

--- a/e2e/test/scenarios/embedding/embedding-native.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-native.cy.spec.js
@@ -80,7 +80,7 @@ describe("scenarios > embedding > native questions", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Twitter").should("not.exist");
 
-      // Created At: Q2, 2023
+      // Created At: Q2 2023
       filterWidget().contains("Created At").click();
       cy.findByTestId("select-button").click();
       popover().last().contains("2023").click();
@@ -105,7 +105,7 @@ describe("scenarios > embedding > native questions", () => {
 
       // Let's try to remove one filter
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Q2, 2023")
+      cy.findByText("Q2 2023")
         .closest("fieldset")
         .within(() => {
           cy.icon("close").click();
@@ -192,7 +192,7 @@ describe("scenarios > embedding > native questions", () => {
         filterWidget()
           .should("have.length", 4)
           .and("contain", "OR")
-          .and("contain", "Q2, 2025");
+          .and("contain", "Q2 2025");
         // Why do we use input field in one filter widget but a simple `span` in the other one?
         cy.findByDisplayValue("Organic");
 

--- a/e2e/test/scenarios/embedding/embedding-questions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-questions.cy.spec.js
@@ -94,9 +94,7 @@ describe("scenarios > embedding > questions ", () => {
 
     assertOnXYAxisLabels({ xLabel: "Created At", yLabel: "Count" });
 
-    cy.get(".x.axis .tick")
-      .should("have.length", 5)
-      .and("contain", "Apr, 2022");
+    cy.get(".x.axis .tick").should("have.length", 5).and("contain", "Apr 2022");
 
     cy.get(".y.axis .tick").should("contain", "60");
 
@@ -104,7 +102,7 @@ describe("scenarios > embedding > questions ", () => {
     cy.get(".dot").last().realHover();
 
     popover().within(() => {
-      testPairedTooltipValues("Created At", "Aug, 2022");
+      testPairedTooltipValues("Created At", "Aug 2022");
       testPairedTooltipValues("Math", "2");
       testPairedTooltipValues("Count", "79");
     });

--- a/e2e/test/scenarios/joins/reproductions/18502-cannot-join-two-saved-questions-same-table.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/18502-cannot-join-two-saved-questions-same-table.cy.spec.js
@@ -38,7 +38,7 @@ describe("issue 18502", () => {
     });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("April, 2022");
+    cy.findByText("April 2022");
   });
 });
 

--- a/e2e/test/scenarios/models/reproductions/29517-native-remapped-model-drill-through-click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29517-native-remapped-model-drill-through-click-behavior.cy.spec.js
@@ -88,7 +88,7 @@ describe("issue 29517 - nested question based on native model with remapped valu
 
     cy.findByTestId("qb-filters-panel").should(
       "contain",
-      "Created At is May, 2024",
+      "Created At is May 2024",
     );
     cy.findByTestId("view-footer").should("contain", "Showing 520 rows");
   });

--- a/e2e/test/scenarios/question/nested.cy.spec.js
+++ b/e2e/test/scenarios/question/nested.cy.spec.js
@@ -145,7 +145,7 @@ describe("scenarios > question > nested", () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("10511");
-    cy.findAllByText("June, 2022");
+    cy.findAllByText("June 2022");
     cy.findAllByText("13");
   });
 

--- a/e2e/test/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -51,7 +51,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Gadget");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("January, 2023");
+    cy.contains("January 2023");
     cy.wait(100); // wait longer to avoid grabbing the svg before a chart redraw
 
     // drag across to filter
@@ -69,7 +69,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     cy.contains(/^Created At is May.*2022/);
     // more granular axis labels
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("June, 2022");
+    cy.contains("June 2022");
     // confirm that product category is still broken out
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Gadget");
@@ -313,7 +313,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Orders by Created At: Week").click({ force: true });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("January, 2025");
+    cy.contains("January 2025");
 
     // drill into a recent week
     cy.get(".dot").eq(-4).click({ force: true });

--- a/e2e/test/scenarios/visualizations/drillthroughs/table_drills.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/drillthroughs/table_drills.cy.spec.js
@@ -155,7 +155,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", function (
       { visitQuestion: true },
     );
 
-    cy.get(".cellData").contains("June,").first().click();
+    cy.get(".cellData").contains("June").first().click();
     popover().within(() => {
       cy.findByText(`Before`).should("be.visible");
       cy.findByText(`After`).should("be.visible");

--- a/e2e/test/scenarios/visualizations/reproductions/13504-post-aggregation-drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/13504-post-aggregation-drill.cy.spec.js
@@ -39,6 +39,6 @@ describe("issue 13504", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Total is greater than 50").should("be.visible");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Created At is March, 2023").should("be.visible");
+    cy.findByText("Created At is March 2023").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/visualizations/reproductions/21504-pie-settings-formatting.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/21504-pie-settings-formatting.cy.spec.js
@@ -30,6 +30,6 @@ describe("issue 21504", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Display").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("April, 2022").should("be.visible");
+    cy.findByText("April 2022").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/visualizations/reproductions/23076.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/23076.cy.spec.js
@@ -46,6 +46,6 @@ describe("issue 23076", () => {
       .should("be.visible")
       .eq(1)
       .invoke("text")
-      .should("eq", "Summen für Mai, 2023");
+      .should("eq", "Summen für Mai 2023");
   });
 });

--- a/e2e/test/scenarios/visualizations/reproductions/6010-metric-filter-drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/6010-metric-filter-drill.cy.spec.js
@@ -21,7 +21,7 @@ describe("issue 6010", () => {
     cy.wait("@dataset");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Created At is January, 2024").should("be.visible");
+    cy.findByText("Created At is January 2024").should("be.visible");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Total is greater than 150").should("be.visible");
   });

--- a/frontend/src/metabase-lib/parameters/constants.ts
+++ b/frontend/src/metabase-lib/parameters/constants.ts
@@ -71,13 +71,13 @@ export const PARAMETER_OPERATOR_TYPES = {
       type: "date/month-year",
       operator: "month-year",
       name: t`Month and Year`,
-      description: t`Like January, 2016`,
+      description: t`Like January 2016`,
     },
     {
       type: "date/quarter-year",
       operator: "quarter-year",
       name: t`Quarter and Year`,
-      description: t`Like Q1, 2016`,
+      description: t`Like Q1 2016`,
     },
     {
       type: "date/single",

--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -18,7 +18,7 @@ const EN_DASH = `–`;
 type DEFAULT_DATE_FORMATS_TYPE = { [key: string]: string };
 const DEFAULT_DATE_FORMATS: DEFAULT_DATE_FORMATS_TYPE = {
   year: "YYYY",
-  quarter: "[Q]Q - YYYY",
+  quarter: "[Q]Q YYYY",
   "minute-of-hour": "m",
   "day-of-week": "dddd",
   "day-of-month": "D",
@@ -44,14 +44,14 @@ const DATE_STYLE_TO_FORMAT: DATE_STYLE_TO_FORMAT_TYPE = {
     quarter: "YYYY - [Q]Q",
   },
   "MMMM D, YYYY": {
-    month: "MMMM, YYYY",
+    month: "MMMM YYYY",
   },
   "D MMMM, YYYY": {
-    month: "MMMM, YYYY",
+    month: "MMMM YYYY",
   },
   "dddd, MMMM D, YYYY": {
     week: "MMMM D, YYYY",
-    month: "MMMM, YYYY",
+    month: "MMMM YYYY",
   },
 };
 

--- a/frontend/src/metabase/parameters/utils/date-formatting.ts
+++ b/frontend/src/metabase/parameters/utils/date-formatting.ts
@@ -140,12 +140,12 @@ export function formatSingleWidget(value: string) {
 
 export function formatMonthYearWidget(value: string) {
   const m = moment(value, "YYYY-MM");
-  return m.isValid() ? m.format("MMMM, YYYY") : "";
+  return m.isValid() ? m.format("MMMM YYYY") : "";
 }
 
 export function formatQuarterYearWidget(value: string) {
   const m = moment(value, "[Q]Q-YYYY");
-  return m.isValid() ? m.format("[Q]Q, YYYY") : "";
+  return m.isValid() ? m.format("[Q]Q YYYY") : "";
 }
 
 export function formatRelativeWidget(value: string) {

--- a/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
+++ b/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
@@ -48,12 +48,12 @@ describe("metabase/parameters/utils/formatting", () => {
       {
         type: "date/month-year",
         value: "2018-01",
-        expected: "January, 2018",
+        expected: "January 2018",
       },
       {
         type: "date/quarter-year",
         value: "Q1-2018",
-        expected: "Q1, 2018",
+        expected: "Q1 2018",
       },
       {
         type: "date/relative",

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.tz.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.tz.unit.spec.js
@@ -100,8 +100,8 @@ describe("LineAreaBarRenderer-bar", () => {
     sharedIntervalTests("hour", "ddd, MMMM D, YYYY, h:mm A");
     sharedIntervalTests("day", "ddd, MMMM D, YYYY");
     // sharedIntervalTests("week", "wo - gggg"); // weeks have differing formats for ticks and tooltips, disable this test for now
-    sharedIntervalTests("month", "MMMM, YYYY");
-    sharedIntervalTests("quarter", "[Q]Q - YYYY");
+    sharedIntervalTests("month", "MMMM YYYY");
+    sharedIntervalTests("quarter", "[Q]Q YYYY");
     sharedIntervalTests("year", "YYYY");
 
     function sharedMonthTests(rows, description) {
@@ -147,7 +147,7 @@ describe("LineAreaBarRenderer-bar", () => {
 
           expect(getTooltipDimensionValueText()).toEqual(
             rows.map(([timestamp]) =>
-              moment.tz(timestamp, reportTz).format("MMMM, YYYY"),
+              moment.tz(timestamp, reportTz).format("MMMM YYYY"),
             ),
           );
         });
@@ -248,22 +248,22 @@ function renderTimeseries(element, unit, timezone, rows, props = {}) {
 
 // just hard code these to make sure we don't accidentally generate incorrect month labels
 const MONTHS_IN_ORDER = [
-  "October, 2015",
-  "November, 2015",
-  "December, 2015",
-  "January, 2016",
-  "February, 2016",
-  "March, 2016",
-  "April, 2016",
-  "May, 2016",
-  "June, 2016",
-  "July, 2016",
-  "August, 2016",
-  "September, 2016",
-  "October, 2016",
-  "November, 2016",
-  "December, 2016",
-  "January, 2017",
+  "October 2015",
+  "November 2015",
+  "December 2015",
+  "January 2016",
+  "February 2016",
+  "March 2016",
+  "April 2016",
+  "May 2016",
+  "June 2016",
+  "July 2016",
+  "August 2016",
+  "September 2016",
+  "October 2016",
+  "November 2016",
+  "December 2016",
+  "January 2017",
 ];
 
 function assertSequentialMonths(months) {

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.unit.spec.js
@@ -162,10 +162,10 @@ describe("LineAreaBarRenderer", () => {
 
     const ticks = qsa(".axis.x .tick text").map(e => e.textContent);
     expect(ticks).toEqual([
-      "January, 2020",
-      "February, 2020",
-      "March, 2020",
-      "April, 2020",
+      "January 2020",
+      "February 2020",
+      "March 2020",
+      "April 2020",
     ]);
   });
 

--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.unit.spec.js
@@ -53,7 +53,7 @@ describe("getClickHoverObject", () => {
 
     const obj = getClickHoverObject(d, otherArgs);
 
-    expect(getFormattedTooltips(obj)).toEqual(["April, 2016", "2"]);
+    expect(getFormattedTooltips(obj)).toEqual(["April 2016", "2"]);
   });
 
   it("should show the correct tooltip for months", () => {
@@ -78,7 +78,7 @@ describe("getClickHoverObject", () => {
 
     const obj = getClickHoverObject(d, otherArgs);
 
-    expect(getFormattedTooltips(obj)).toEqual(["April, 2016", "2"]);
+    expect(getFormattedTooltips(obj)).toEqual(["April 2016", "2"]);
   });
 
   describe("event/element target", () => {

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -581,7 +581,7 @@ describe("formatting", () => {
       ["hour", "Wed, April 27, 2022, 6:00 AM"],
       ["day", "Wed, April 27, 2022"],
       ["week", "Wed, April 27, 2022"],
-      ["month", "April, 2022"],
+      ["month", "April 2022"],
       ["year", "2022"],
     ])(
       "should include weekday when date unit is smaller or equal whan a week",


### PR DESCRIPTION
Fixes date format consistency issues when fixing https://github.com/metabase/metabase/issues/12496

✅ [Approved by design team on slack](https://metaboat.slack.com/archives/C02H619CJ8K/p1689699865302799)

### Description

This uses a more standard and simpler date format when displaying months and quarters:
* e.g. `January, 2020` → `January 2020`  ([source](https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Dates_and_numbers#Dates,_months,_and_years))
* e.g. `Q1, 2020` → `Q1 2020` ([source](https://www.instructionalsolutions.com/blog/format-for-quarters))
* e.g. `Q1 - 2020` → `Q1 2020`

### Rationale

We’re standardizing date formats so that they’re consistent when used in new date range formats added by  https://github.com/metabase/metabase/pull/32490.  

### How to verify

These date formats are used everywhere on the frontend.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
