### PR TITLE
Fix official collections feature flag error msg

### DIFF
--- a/e2e/test/scenarios/organization/official-collections.cy.spec.js
+++ b/e2e/test/scenarios/organization/official-collections.cy.spec.js
@@ -44,7 +44,7 @@ describeEE("official collections", () => {
         },
       }).then(({ body, status, statusText }) => {
         expect(body).to.eq(
-          "Official collections is an Enterprise feature. Please upgrade to a paid plan to use this feature.",
+          "Official Collections is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/",
         );
         expect(status).to.eq(402);
         expect(statusText).to.eq("Payment Required");


### PR DESCRIPTION
This fixes a failing test on the feature-flags-integration branch (PR https://github.com/metabase/metabase/pull/32432).

The error message was updated here, but the test wasn't https://github.com/metabase/metabase/issues/32113