### PR TITLE
Add getListMetadata to useEntityListQuery calls

### DIFF
--- a/frontend/src/metabase-types/api/mocks/search.ts
+++ b/frontend/src/metabase-types/api/mocks/search.ts
@@ -1,4 +1,5 @@
-import { SearchResult, SearchScore } from "metabase-types/api";
+import _ from "underscore";
+import { SearchResult, SearchResults, SearchScore } from "metabase-types/api";
 import { createMockCollection } from "./collection";
 
 export const createMockSearchResult = (
@@ -42,3 +43,24 @@ export const createMockSearchScore = (
   name: "text-total-occurrences",
   ...options,
 });
+
+export const createMockSearchResults = ({
+  items = [createMockSearchResult()],
+  options = {},
+}: {
+  items?: SearchResult[];
+  options?: Partial<SearchResults>;
+}): SearchResults => {
+  const uniqueModels = _.uniq(items.map(item => item.model));
+
+  return {
+    available_models: uniqueModels,
+    data: items,
+    limit: 10,
+    models: uniqueModels,
+    offset: 0,
+    table_db_id: null,
+    total: items.length,
+    ...options,
+  };
+};

--- a/frontend/src/metabase/common/hooks/use-collection-list-query/use-collection-list-query.ts
+++ b/frontend/src/metabase/common/hooks/use-collection-list-query/use-collection-list-query.ts
@@ -16,5 +16,6 @@ export const useCollectionListQuery = (
     getList: Collections.selectors.getList,
     getLoaded: Collections.selectors.getLoaded,
     getLoading: Collections.selectors.getLoading,
+    getListMetadata: Collections.selectors.getListMetadata,
   });
 };

--- a/frontend/src/metabase/common/hooks/use-collection-list-query/use-collection-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-collection-list-query/use-collection-list-query.unit.spec.tsx
@@ -27,15 +27,7 @@ const TestComponent = () => {
         <div key={collection.id}>{collection.name}</div>
       ))}
       <div data-testid="metadata">
-        {metadata && Object.keys(metadata).length > 0
-          ? Object.entries(metadata).map(([key, value]) => (
-              <div key={key}>
-                <div>
-                  {key}: {value}
-                </div>
-              </div>
-            ))
-          : "No metadata"}
+        {(!metadata || Object.keys(metadata).length === 0) && "No metadata"}
       </div>
     </div>
   );
@@ -76,7 +68,7 @@ describe("useCollectionListQuery", () => {
     expect(screen.getByText(TEST_COLLECTION.name)).toBeInTheDocument();
   });
 
-  it("should show metadata from the response", async () => {
+  it("should not have any metadata in the response", async () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(

--- a/frontend/src/metabase/common/hooks/use-collection-list-query/use-collection-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-collection-list-query/use-collection-list-query.unit.spec.tsx
@@ -6,6 +6,7 @@ import {
   renderWithProviders,
   screen,
   waitForElementToBeRemoved,
+  within,
 } from "__support__/ui";
 import { createMockCollection } from "metabase-types/api/mocks";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
@@ -14,7 +15,7 @@ import { useCollectionListQuery } from "./use-collection-list-query";
 const TEST_COLLECTION = createMockCollection();
 
 const TestComponent = () => {
-  const { data = [], isLoading, error } = useCollectionListQuery();
+  const { data = [], metadata, isLoading, error } = useCollectionListQuery();
 
   if (isLoading || error) {
     return <LoadingAndErrorWrapper loading={isLoading} error={error} />;
@@ -25,6 +26,17 @@ const TestComponent = () => {
       {data.map(collection => (
         <div key={collection.id}>{collection.name}</div>
       ))}
+      <div data-testid="metadata">
+        {metadata && Object.keys(metadata).length > 0
+          ? Object.entries(metadata).map(([key, value]) => (
+              <div key={key}>
+                <div>
+                  {key}: {value}
+                </div>
+              </div>
+            ))
+          : "No metadata"}
+      </div>
     </div>
   );
 };
@@ -62,5 +74,13 @@ describe("useCollectionListQuery", () => {
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
 
     expect(screen.getByText(TEST_COLLECTION.name)).toBeInTheDocument();
+  });
+
+  it("should show metadata from the response", async () => {
+    setup();
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
+    expect(
+      within(screen.getByTestId("metadata")).getByText("No metadata"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/common/hooks/use-database-candidate-list-query/use-database-candidate-list-query.ts
+++ b/frontend/src/metabase/common/hooks/use-database-candidate-list-query/use-database-candidate-list-query.ts
@@ -18,5 +18,6 @@ export const useDatabaseCandidateListQuery = (
     getLoading: DatabaseCandidates.selectors.getLoading,
     getLoaded: DatabaseCandidates.selectors.getLoaded,
     getError: DatabaseCandidates.selectors.getError,
+    getListMetadata: DatabaseCandidates.selectors.getListMetadata,
   });
 };

--- a/frontend/src/metabase/common/hooks/use-database-candidate-list-query/use-database-candidate-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-database-candidate-list-query/use-database-candidate-list-query.unit.spec.tsx
@@ -5,6 +5,7 @@ import {
   renderWithProviders,
   screen,
   waitForElementToBeRemoved,
+  within,
 } from "__support__/ui";
 import { useDatabaseCandidateListQuery } from "./use-database-candidate-list-query";
 
@@ -14,6 +15,7 @@ const TEST_DB_CANDIDATE = createMockDatabaseCandidate();
 const TestComponent = () => {
   const {
     data = [],
+    metadata,
     isLoading,
     error,
   } = useDatabaseCandidateListQuery({
@@ -29,6 +31,18 @@ const TestComponent = () => {
       {data.map((item, index) => (
         <div key={index}>{item.schema}</div>
       ))}
+
+      <div data-testid="metadata">
+        {metadata && Object.keys(metadata).length > 0
+          ? Object.entries(metadata).map(([key, value]) => (
+              <div key={key}>
+                <div>
+                  {key}: {value}
+                </div>
+              </div>
+            ))
+          : "No metadata"}
+      </div>
     </div>
   );
 };
@@ -48,5 +62,13 @@ describe("useDatabaseCandidateListQuery", () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(screen.getByText(TEST_DB_CANDIDATE.schema)).toBeInTheDocument();
+  });
+
+  it("should show metadata from the response", async () => {
+    setup();
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
+    expect(
+      within(screen.getByTestId("metadata")).getByText("No metadata"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/common/hooks/use-database-candidate-list-query/use-database-candidate-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-database-candidate-list-query/use-database-candidate-list-query.unit.spec.tsx
@@ -5,7 +5,6 @@ import {
   renderWithProviders,
   screen,
   waitForElementToBeRemoved,
-  within,
 } from "__support__/ui";
 import { useDatabaseCandidateListQuery } from "./use-database-candidate-list-query";
 
@@ -15,7 +14,6 @@ const TEST_DB_CANDIDATE = createMockDatabaseCandidate();
 const TestComponent = () => {
   const {
     data = [],
-    metadata,
     isLoading,
     error,
   } = useDatabaseCandidateListQuery({
@@ -31,18 +29,6 @@ const TestComponent = () => {
       {data.map((item, index) => (
         <div key={index}>{item.schema}</div>
       ))}
-
-      <div data-testid="metadata">
-        {metadata && Object.keys(metadata).length > 0
-          ? Object.entries(metadata).map(([key, value]) => (
-              <div key={key}>
-                <div>
-                  {key}: {value}
-                </div>
-              </div>
-            ))
-          : "No metadata"}
-      </div>
     </div>
   );
 };
@@ -62,13 +48,5 @@ describe("useDatabaseCandidateListQuery", () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(screen.getByText(TEST_DB_CANDIDATE.schema)).toBeInTheDocument();
-  });
-
-  it("should show metadata from the response", async () => {
-    setup();
-    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
-    expect(
-      within(screen.getByTestId("metadata")).getByText("No metadata"),
-    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/common/hooks/use-database-list-query/use-database-list-query.ts
+++ b/frontend/src/metabase/common/hooks/use-database-list-query/use-database-list-query.ts
@@ -16,5 +16,6 @@ export const useDatabaseListQuery = (
     getLoading: Databases.selectors.getLoading,
     getLoaded: Databases.selectors.getLoaded,
     getError: Databases.selectors.getError,
+    getListMetadata: Databases.selectors.getListMetadata,
   });
 };

--- a/frontend/src/metabase/common/hooks/use-database-list-query/use-database-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-database-list-query/use-database-list-query.unit.spec.tsx
@@ -5,13 +5,14 @@ import {
   renderWithProviders,
   screen,
   waitForElementToBeRemoved,
+  within,
 } from "__support__/ui";
 import { useDatabaseListQuery } from "./use-database-list-query";
 
 const TEST_DB = createMockDatabase();
 
 const TestComponent = () => {
-  const { data = [], isLoading, error } = useDatabaseListQuery();
+  const { data = [], metadata, isLoading, error } = useDatabaseListQuery();
 
   if (isLoading || error) {
     return <LoadingAndErrorWrapper loading={isLoading} error={error} />;
@@ -22,6 +23,18 @@ const TestComponent = () => {
       {data.map(database => (
         <div key={database.id}>{database.name}</div>
       ))}
+
+      <div data-testid="metadata">
+        {metadata && Object.keys(metadata).length > 0
+          ? Object.entries(metadata).map(([key, value]) => (
+              <div key={key}>
+                <div>
+                  {key}: {value}
+                </div>
+              </div>
+            ))
+          : "No metadata"}
+      </div>
     </div>
   );
 };
@@ -41,5 +54,13 @@ describe("useDatabaseListQuery", () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(screen.getByText(TEST_DB.name)).toBeInTheDocument();
+  });
+
+  it("should show metadata from the response", async () => {
+    setup();
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
+    expect(
+      within(screen.getByTestId("metadata")).getByText("No metadata"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/common/hooks/use-database-list-query/use-database-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-database-list-query/use-database-list-query.unit.spec.tsx
@@ -25,15 +25,7 @@ const TestComponent = () => {
       ))}
 
       <div data-testid="metadata">
-        {metadata && Object.keys(metadata).length > 0
-          ? Object.entries(metadata).map(([key, value]) => (
-              <div key={key}>
-                <div>
-                  {key}: {value}
-                </div>
-              </div>
-            ))
-          : "No metadata"}
+        {(!metadata || Object.keys(metadata).length === 0) && "No metadata"}
       </div>
     </div>
   );
@@ -56,7 +48,7 @@ describe("useDatabaseListQuery", () => {
     expect(screen.getByText(TEST_DB.name)).toBeInTheDocument();
   });
 
-  it("should show metadata from the response", async () => {
+  it("should not have any metadata in the response", async () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(

--- a/frontend/src/metabase/common/hooks/use-entity-list-query/use-entity-list-query.ts
+++ b/frontend/src/metabase/common/hooks/use-entity-list-query/use-entity-list-query.ts
@@ -26,6 +26,10 @@ export interface UseEntityListOwnProps<TItem, TQuery = never> {
     options: EntityQueryOptions<TQuery>,
   ) => boolean | undefined;
   getError: (state: State, options: EntityQueryOptions<TQuery>) => unknown;
+  getListMetadata: (
+    state: State,
+    options: EntityQueryOptions<TQuery>,
+  ) => unknown;
 }
 
 export interface UseEntityListQueryProps<TQuery = never> {
@@ -36,6 +40,7 @@ export interface UseEntityListQueryProps<TQuery = never> {
 
 export interface UseEntityListQueryResult<TItem> {
   data?: TItem[];
+  metadata?: unknown;
   isLoading: boolean;
   error: unknown;
 }
@@ -52,10 +57,12 @@ export const useEntityListQuery = <TItem, TQuery = never>(
     getLoading,
     getLoaded,
     getError,
+    getListMetadata,
   }: UseEntityListOwnProps<TItem, TQuery>,
 ): UseEntityListQueryResult<TItem> => {
   const options = { entityQuery };
   const data = useSelector(state => getList(state, options));
+  const metadata = useSelector(state => getListMetadata(state, options));
   const error = useSelector(state => getError(state, options));
   const isLoading = useSelector(state => getLoading(state, options));
   const isLoadingOrDefault = isLoading ?? enabled;
@@ -78,5 +85,5 @@ export const useEntityListQuery = <TItem, TQuery = never>(
     }
   }, [dispatch, fetchList, entityQuery, reload, enabled, isInvalidated]);
 
-  return { data, isLoading: isLoadingOrDefault, error };
+  return { data, metadata, isLoading: isLoadingOrDefault, error };
 };

--- a/frontend/src/metabase/common/hooks/use-entity-list-query/use-entity-list-query.ts
+++ b/frontend/src/metabase/common/hooks/use-entity-list-query/use-entity-list-query.ts
@@ -11,7 +11,11 @@ export interface EntityQueryOptions<TQuery = never> {
   entityQuery?: TQuery;
 }
 
-export interface UseEntityListOwnProps<TItem, TQuery = never> {
+export interface UseEntityListOwnProps<
+  TItem,
+  TQuery = never,
+  TMetadata = never,
+> {
   fetchList: (query?: TQuery, options?: EntityFetchOptions) => Action;
   getList: (
     state: State,
@@ -29,7 +33,7 @@ export interface UseEntityListOwnProps<TItem, TQuery = never> {
   getListMetadata: (
     state: State,
     options: EntityQueryOptions<TQuery>,
-  ) => unknown;
+  ) => TMetadata | undefined;
 }
 
 export interface UseEntityListQueryProps<TQuery = never> {
@@ -38,14 +42,14 @@ export interface UseEntityListQueryProps<TQuery = never> {
   enabled?: boolean;
 }
 
-export interface UseEntityListQueryResult<TItem> {
+export interface UseEntityListQueryResult<TItem, TMetadata = never> {
   data?: TItem[];
-  metadata?: unknown;
+  metadata?: TMetadata;
   isLoading: boolean;
   error: unknown;
 }
 
-export const useEntityListQuery = <TItem, TQuery = never>(
+export const useEntityListQuery = <TItem, TQuery = never, TMetadata = never>(
   {
     query: entityQuery,
     reload = false,
@@ -58,8 +62,8 @@ export const useEntityListQuery = <TItem, TQuery = never>(
     getLoaded,
     getError,
     getListMetadata,
-  }: UseEntityListOwnProps<TItem, TQuery>,
-): UseEntityListQueryResult<TItem> => {
+  }: UseEntityListOwnProps<TItem, TQuery, TMetadata>,
+): UseEntityListQueryResult<TItem, TMetadata> => {
   const options = { entityQuery };
   const data = useSelector(state => getList(state, options));
   const metadata = useSelector(state => getListMetadata(state, options));

--- a/frontend/src/metabase/common/hooks/use-entity-list-query/use-entity-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-entity-list-query/use-entity-list-query.unit.spec.tsx
@@ -36,6 +36,7 @@ const TestComponent = () => {
       getLoading: Databases.selectors.getLoading,
       getLoaded: Databases.selectors.getLoaded,
       getError: Databases.selectors.getError,
+      getListMetadata: Databases.selectors.getListMetadata,
     },
   );
 
@@ -72,6 +73,7 @@ const TestInnerComponent = () => {
       getLoading: Tables.selectors.getLoading,
       getLoaded: Tables.selectors.getLoaded,
       getError: Tables.selectors.getError,
+      getListMetadata: Tables.selectors.getListMetadata,
     },
   );
 

--- a/frontend/src/metabase/common/hooks/use-metric-list-query/use-metric-list-query.ts
+++ b/frontend/src/metabase/common/hooks/use-metric-list-query/use-metric-list-query.ts
@@ -15,5 +15,6 @@ export const useMetricListQuery = (
     getLoading: Metrics.selectors.getLoading,
     getLoaded: Metrics.selectors.getLoaded,
     getError: Metrics.selectors.getError,
+    getListMetadata: Metrics.selectors.getListMetadata,
   });
 };

--- a/frontend/src/metabase/common/hooks/use-metric-list-query/use-metric-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-metric-list-query/use-metric-list-query.unit.spec.tsx
@@ -25,15 +25,7 @@ const TestComponent = () => {
       ))}
 
       <div data-testid="metadata">
-        {metadata && Object.keys(metadata).length > 0
-          ? Object.entries(metadata).map(([key, value]) => (
-              <div key={key}>
-                <div>
-                  {key}: {value}
-                </div>
-              </div>
-            ))
-          : "No metadata"}
+        {(!metadata || Object.keys(metadata).length === 0) && "No metadata"}
       </div>
     </div>
   );
@@ -56,7 +48,7 @@ describe("useMetricListQuery", () => {
     expect(screen.getByText(TEST_METRIC.name)).toBeInTheDocument();
   });
 
-  it("should show metadata from the response", async () => {
+  it("should not have any metadata in the response", async () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(

--- a/frontend/src/metabase/common/hooks/use-metric-list-query/use-metric-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-metric-list-query/use-metric-list-query.unit.spec.tsx
@@ -5,13 +5,14 @@ import {
   renderWithProviders,
   screen,
   waitForElementToBeRemoved,
+  within,
 } from "__support__/ui";
 import { useMetricListQuery } from "./use-metric-list-query";
 
 const TEST_METRIC = createMockMetric();
 
 const TestComponent = () => {
-  const { data = [], isLoading, error } = useMetricListQuery();
+  const { data = [], metadata, isLoading, error } = useMetricListQuery();
 
   if (isLoading || error) {
     return <LoadingAndErrorWrapper loading={isLoading} error={error} />;
@@ -22,6 +23,18 @@ const TestComponent = () => {
       {data.map(metric => (
         <div key={metric.id}>{metric.name}</div>
       ))}
+
+      <div data-testid="metadata">
+        {metadata && Object.keys(metadata).length > 0
+          ? Object.entries(metadata).map(([key, value]) => (
+              <div key={key}>
+                <div>
+                  {key}: {value}
+                </div>
+              </div>
+            ))
+          : "No metadata"}
+      </div>
     </div>
   );
 };
@@ -41,5 +54,13 @@ describe("useMetricListQuery", () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(screen.getByText(TEST_METRIC.name)).toBeInTheDocument();
+  });
+
+  it("should show metadata from the response", async () => {
+    setup();
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
+    expect(
+      within(screen.getByTestId("metadata")).getByText("No metadata"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/common/hooks/use-popular-item-list-query/use-popular-item-list-query.ts
+++ b/frontend/src/metabase/common/hooks/use-popular-item-list-query/use-popular-item-list-query.ts
@@ -15,5 +15,6 @@ export const usePopularItemListQuery = (
     getLoading: PopularItems.selectors.getLoading,
     getLoaded: PopularItems.selectors.getLoaded,
     getError: PopularItems.selectors.getError,
+    getListMetadata: PopularItems.selectors.getListMetadata,
   });
 };

--- a/frontend/src/metabase/common/hooks/use-popular-item-list-query/use-popular-item-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-popular-item-list-query/use-popular-item-list-query.unit.spec.tsx
@@ -5,13 +5,14 @@ import {
   renderWithProviders,
   screen,
   waitForElementToBeRemoved,
+  within,
 } from "__support__/ui";
 import { usePopularItemListQuery } from "./use-popular-item-list-query";
 
 const TEST_ITEM = createMockPopularItem();
 
 const TestComponent = () => {
-  const { data = [], isLoading, error } = usePopularItemListQuery();
+  const { data = [], metadata, isLoading, error } = usePopularItemListQuery();
 
   if (isLoading || error) {
     return <LoadingAndErrorWrapper loading={isLoading} error={error} />;
@@ -22,6 +23,18 @@ const TestComponent = () => {
       {data.map((item, index) => (
         <div key={index}>{item.model_object.name}</div>
       ))}
+
+      <div data-testid="metadata">
+        {metadata && Object.keys(metadata).length > 0
+          ? Object.entries(metadata).map(([key, value]) => (
+              <div key={key}>
+                <div>
+                  {key}: {value}
+                </div>
+              </div>
+            ))
+          : "No metadata"}
+      </div>
     </div>
   );
 };
@@ -41,5 +54,12 @@ describe("usePopularItemListQuery", () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(screen.getByText(TEST_ITEM.model_object.name)).toBeInTheDocument();
+  });
+  it("should show metadata from the response", async () => {
+    setup();
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
+    expect(
+      within(screen.getByTestId("metadata")).getByText("No metadata"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/common/hooks/use-popular-item-list-query/use-popular-item-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-popular-item-list-query/use-popular-item-list-query.unit.spec.tsx
@@ -25,15 +25,7 @@ const TestComponent = () => {
       ))}
 
       <div data-testid="metadata">
-        {metadata && Object.keys(metadata).length > 0
-          ? Object.entries(metadata).map(([key, value]) => (
-              <div key={key}>
-                <div>
-                  {key}: {value}
-                </div>
-              </div>
-            ))
-          : "No metadata"}
+        {(!metadata || Object.keys(metadata).length === 0) && "No metadata"}
       </div>
     </div>
   );
@@ -55,7 +47,7 @@ describe("usePopularItemListQuery", () => {
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(screen.getByText(TEST_ITEM.model_object.name)).toBeInTheDocument();
   });
-  it("should show metadata from the response", async () => {
+  it("should not have any metadata in the response", async () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(

--- a/frontend/src/metabase/common/hooks/use-question-list-query/use-question-list-query.ts
+++ b/frontend/src/metabase/common/hooks/use-question-list-query/use-question-list-query.ts
@@ -16,5 +16,6 @@ export const useQuestionListQuery = (
     getLoading: Questions.selectors.getLoading,
     getLoaded: Questions.selectors.getLoaded,
     getError: Questions.selectors.getError,
+    getListMetadata: Questions.selectors.getListMetadata,
   });
 };

--- a/frontend/src/metabase/common/hooks/use-question-list-query/use-question-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-question-list-query/use-question-list-query.unit.spec.tsx
@@ -25,15 +25,7 @@ const TestComponent = () => {
       ))}
 
       <div data-testid="metadata">
-        {metadata && Object.keys(metadata).length > 0
-          ? Object.entries(metadata).map(([key, value]) => (
-              <div key={key}>
-                <div>
-                  {key}: {value}
-                </div>
-              </div>
-            ))
-          : "No metadata"}
+        {(!metadata || Object.keys(metadata).length === 0) && "No metadata"}
       </div>
     </div>
   );
@@ -56,7 +48,7 @@ describe("useQuestionListQuery", () => {
     expect(screen.getByText(TEST_CARD.name)).toBeInTheDocument();
   });
 
-  it("should show metadata from the response", async () => {
+  it("should not have any metadata in the response", async () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(

--- a/frontend/src/metabase/common/hooks/use-question-list-query/use-question-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-question-list-query/use-question-list-query.unit.spec.tsx
@@ -5,13 +5,14 @@ import {
   renderWithProviders,
   screen,
   waitForElementToBeRemoved,
+  within,
 } from "__support__/ui";
 import { useQuestionListQuery } from "./use-question-list-query";
 
 const TEST_CARD = createMockCard();
 
 const TestComponent = () => {
-  const { data = [], isLoading, error } = useQuestionListQuery();
+  const { data = [], metadata, isLoading, error } = useQuestionListQuery();
 
   if (isLoading || error) {
     return <LoadingAndErrorWrapper loading={isLoading} error={error} />;
@@ -22,6 +23,18 @@ const TestComponent = () => {
       {data.map(question => (
         <div key={question.id()}>{question.displayName()}</div>
       ))}
+
+      <div data-testid="metadata">
+        {metadata && Object.keys(metadata).length > 0
+          ? Object.entries(metadata).map(([key, value]) => (
+              <div key={key}>
+                <div>
+                  {key}: {value}
+                </div>
+              </div>
+            ))
+          : "No metadata"}
+      </div>
     </div>
   );
 };
@@ -41,5 +54,13 @@ describe("useQuestionListQuery", () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(screen.getByText(TEST_CARD.name)).toBeInTheDocument();
+  });
+
+  it("should show metadata from the response", async () => {
+    setup();
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
+    expect(
+      within(screen.getByTestId("metadata")).getByText("No metadata"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/common/hooks/use-recent-item-list-query/use-recent-item-list-query.ts
+++ b/frontend/src/metabase/common/hooks/use-recent-item-list-query/use-recent-item-list-query.ts
@@ -15,5 +15,6 @@ export const useRecentItemListQuery = (
     getLoading: RecentItems.selectors.getLoading,
     getLoaded: RecentItems.selectors.getLoaded,
     getError: RecentItems.selectors.getError,
+    getListMetadata: RecentItems.selectors.getListMetadata,
   });
 };

--- a/frontend/src/metabase/common/hooks/use-recent-item-list-query/use-recent-item-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-recent-item-list-query/use-recent-item-list-query.unit.spec.tsx
@@ -5,13 +5,14 @@ import {
   renderWithProviders,
   screen,
   waitForElementToBeRemoved,
+  within,
 } from "__support__/ui";
 import { useRecentItemListQuery } from "./use-recent-item-list-query";
 
 const TEST_ITEM = createMockRecentItem();
 
 const TestComponent = () => {
-  const { data = [], isLoading, error } = useRecentItemListQuery();
+  const { data = [], metadata, isLoading, error } = useRecentItemListQuery();
 
   if (isLoading || error) {
     return <LoadingAndErrorWrapper loading={isLoading} error={error} />;
@@ -22,6 +23,18 @@ const TestComponent = () => {
       {data.map((item, index) => (
         <div key={index}>{item.model_object.name}</div>
       ))}
+
+      <div data-testid="metadata">
+        {metadata && Object.keys(metadata).length > 0
+          ? Object.entries(metadata).map(([key, value]) => (
+              <div key={key}>
+                <div>
+                  {key}: {value}
+                </div>
+              </div>
+            ))
+          : "No metadata"}
+      </div>
     </div>
   );
 };
@@ -41,5 +54,13 @@ describe("useRecentItemListQuery", () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(screen.getByText(TEST_ITEM.model_object.name)).toBeInTheDocument();
+  });
+
+  it("should show metadata from the response", async () => {
+    setup();
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
+    expect(
+      within(screen.getByTestId("metadata")).getByText("No metadata"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/common/hooks/use-recent-item-list-query/use-recent-item-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-recent-item-list-query/use-recent-item-list-query.unit.spec.tsx
@@ -25,15 +25,7 @@ const TestComponent = () => {
       ))}
 
       <div data-testid="metadata">
-        {metadata && Object.keys(metadata).length > 0
-          ? Object.entries(metadata).map(([key, value]) => (
-              <div key={key}>
-                <div>
-                  {key}: {value}
-                </div>
-              </div>
-            ))
-          : "No metadata"}
+        {(!metadata || Object.keys(metadata).length === 0) && "No metadata"}
       </div>
     </div>
   );
@@ -56,7 +48,7 @@ describe("useRecentItemListQuery", () => {
     expect(screen.getByText(TEST_ITEM.model_object.name)).toBeInTheDocument();
   });
 
-  it("should show metadata from the response", async () => {
+  it("should not have any metadata in the response", async () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(

--- a/frontend/src/metabase/common/hooks/use-revision-list-query/use-revision-list-query.ts
+++ b/frontend/src/metabase/common/hooks/use-revision-list-query/use-revision-list-query.ts
@@ -15,5 +15,6 @@ export const useRevisionListQuery = (
     getLoading: RevisionEntity.selectors.getLoading,
     getLoaded: RevisionEntity.selectors.getLoaded,
     getError: RevisionEntity.selectors.getError,
+    getListMetadata: RevisionEntity.selectors.getListMetadata,
   });
 };

--- a/frontend/src/metabase/common/hooks/use-revision-list-query/use-revision-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-revision-list-query/use-revision-list-query.unit.spec.tsx
@@ -3,6 +3,7 @@ import {
   renderWithProviders,
   screen,
   waitForElementToBeRemoved,
+  within,
 } from "__support__/ui";
 import { createMockRevision } from "metabase-types/api/mocks/revision";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper/LoadingAndErrorWrapper";
@@ -12,7 +13,7 @@ import { useRevisionListQuery } from "./use-revision-list-query";
 const TEST_REVISION = createMockRevision();
 
 function TestComponent() {
-  const { data = [], isLoading, error } = useRevisionListQuery();
+  const { data = [], metadata, isLoading, error } = useRevisionListQuery();
 
   if (isLoading || error) {
     return <LoadingAndErrorWrapper loading={isLoading} error={error} />;
@@ -23,6 +24,18 @@ function TestComponent() {
       {data.map(revision => (
         <div key={revision.id}>{revision.description}</div>
       ))}
+
+      <div data-testid="metadata">
+        {metadata && Object.keys(metadata).length > 0
+          ? Object.entries(metadata).map(([key, value]) => (
+              <div key={key}>
+                <div>
+                  {key}: {value}
+                </div>
+              </div>
+            ))
+          : "No metadata"}
+      </div>
     </div>
   );
 }
@@ -42,5 +55,13 @@ describe("useRevisionListQuery", () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(screen.getByText(TEST_REVISION.description)).toBeInTheDocument();
+  });
+
+  it("should show metadata from the response", async () => {
+    setup();
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
+    expect(
+      within(screen.getByTestId("metadata")).getByText("No metadata"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/common/hooks/use-revision-list-query/use-revision-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-revision-list-query/use-revision-list-query.unit.spec.tsx
@@ -26,15 +26,7 @@ function TestComponent() {
       ))}
 
       <div data-testid="metadata">
-        {metadata && Object.keys(metadata).length > 0
-          ? Object.entries(metadata).map(([key, value]) => (
-              <div key={key}>
-                <div>
-                  {key}: {value}
-                </div>
-              </div>
-            ))
-          : "No metadata"}
+        {(!metadata || Object.keys(metadata).length === 0) && "No metadata"}
       </div>
     </div>
   );
@@ -57,7 +49,7 @@ describe("useRevisionListQuery", () => {
     expect(screen.getByText(TEST_REVISION.description)).toBeInTheDocument();
   });
 
-  it("should show metadata from the response", async () => {
+  it("should not have any metadata in the response", async () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(

--- a/frontend/src/metabase/common/hooks/use-schema-list-query/use-schema-list-query.ts
+++ b/frontend/src/metabase/common/hooks/use-schema-list-query/use-schema-list-query.ts
@@ -16,5 +16,6 @@ export const useSchemaListQuery = (
     getLoading: Schemas.selectors.getLoading,
     getLoaded: Schemas.selectors.getLoaded,
     getError: Schemas.selectors.getError,
+    getListMetadata: Schemas.selectors.getListMetadata,
   });
 };

--- a/frontend/src/metabase/common/hooks/use-schema-list-query/use-schema-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-schema-list-query/use-schema-list-query.unit.spec.tsx
@@ -40,15 +40,7 @@ const TestComponent = () => {
       ))}
 
       <div data-testid="metadata">
-        {metadata && Object.keys(metadata).length > 0
-          ? Object.entries(metadata).map(([key, value]) => (
-              <div key={key}>
-                <div>
-                  {key}: {value}
-                </div>
-              </div>
-            ))
-          : "No metadata"}
+        {(!metadata || Object.keys(metadata).length === 0) && "No metadata"}
       </div>
     </div>
   );
@@ -86,7 +78,7 @@ describe("useSchemaListQuery", () => {
     expect(screen.getByText(PERMISSION_ERROR)).toBeInTheDocument();
   });
 
-  it("should show metadata from the response", async () => {
+  it("should not have any metadata in the response", async () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(

--- a/frontend/src/metabase/common/hooks/use-schema-list-query/use-schema-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-schema-list-query/use-schema-list-query.unit.spec.tsx
@@ -9,6 +9,7 @@ import {
   renderWithProviders,
   screen,
   waitForElementToBeRemoved,
+  within,
 } from "__support__/ui";
 import { useSchemaListQuery } from "./use-schema-list-query";
 
@@ -21,6 +22,7 @@ const TEST_DATABASE = createMockDatabase({
 const TestComponent = () => {
   const {
     data = [],
+    metadata,
     isLoading,
     error,
   } = useSchemaListQuery({
@@ -36,6 +38,18 @@ const TestComponent = () => {
       {data.map(schema => (
         <div key={schema.id}>{schema.name}</div>
       ))}
+
+      <div data-testid="metadata">
+        {metadata && Object.keys(metadata).length > 0
+          ? Object.entries(metadata).map(([key, value]) => (
+              <div key={key}>
+                <div>
+                  {key}: {value}
+                </div>
+              </div>
+            ))
+          : "No metadata"}
+      </div>
     </div>
   );
 };
@@ -70,5 +84,13 @@ describe("useSchemaListQuery", () => {
     setup({ hasDataAccess: false });
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(screen.getByText(PERMISSION_ERROR)).toBeInTheDocument();
+  });
+
+  it("should show metadata from the response", async () => {
+    setup();
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
+    expect(
+      within(screen.getByTestId("metadata")).getByText("No metadata"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/common/hooks/use-search-list-query/use-search-list-query.ts
+++ b/frontend/src/metabase/common/hooks/use-search-list-query/use-search-list-query.ts
@@ -15,5 +15,6 @@ export const useSearchListQuery = (
     getLoading: Search.selectors.getLoading,
     getLoaded: Search.selectors.getLoaded,
     getError: Search.selectors.getError,
+    getListMetadata: Search.selectors.getListMetadata,
   });
 };

--- a/frontend/src/metabase/common/hooks/use-search-list-query/use-search-list-query.ts
+++ b/frontend/src/metabase/common/hooks/use-search-list-query/use-search-list-query.ts
@@ -1,5 +1,9 @@
 import Search from "metabase/entities/search";
-import { CollectionItem, SearchListQuery } from "metabase-types/api";
+import {
+  CollectionItem,
+  SearchListQuery,
+  SearchResults,
+} from "metabase-types/api";
 import {
   useEntityListQuery,
   UseEntityListQueryProps,
@@ -8,7 +12,7 @@ import {
 
 export const useSearchListQuery = (
   props: UseEntityListQueryProps<SearchListQuery> = {},
-): UseEntityListQueryResult<CollectionItem> => {
+): UseEntityListQueryResult<CollectionItem, Omit<SearchResults, "data">> => {
   return useEntityListQuery(props, {
     fetchList: Search.actions.fetchList,
     getList: Search.selectors.getList,

--- a/frontend/src/metabase/common/hooks/use-search-list-query/use-search-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-search-list-query/use-search-list-query.unit.spec.tsx
@@ -17,10 +17,12 @@ import { useSearchListQuery } from "./use-search-list-query";
 const TEST_ITEM = createMockCollectionItem();
 
 const TEST_TABLE_DB_ID = 1;
-const TEST_SEARCH_METADATA = createMockSearchResults({
+const TEST_SEARCH_RESULTS = createMockSearchResults({
   items: [createMockSearchResult({ collection: TEST_ITEM })],
   options: { table_db_id: TEST_TABLE_DB_ID },
 });
+
+const TEST_SEARCH_METADATA = _.omit(TEST_SEARCH_RESULTS, "data");
 
 const TestComponent = () => {
   const {
@@ -80,9 +82,7 @@ describe("useSearchListQuery", () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
 
-    const searchResultMetdata = _.omit(TEST_SEARCH_METADATA, "data");
-
-    for (const [key, value] of Object.entries(searchResultMetdata)) {
+    for (const [key, value] of Object.entries(TEST_SEARCH_METADATA)) {
       expect(
         within(screen.getByTestId("metadata")).getByText(`${key}: ${value}`),
       ).toBeInTheDocument();

--- a/frontend/src/metabase/common/hooks/use-search-list-query/use-search-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-search-list-query/use-search-list-query.unit.spec.tsx
@@ -52,16 +52,14 @@ const TestComponent = () => {
       <div data-testid="metadata">
         {metadata && (
           <>
-            <div data-testid="metadata-available-models">
+            <div data-testid="available-models">
               {(metadata.available_models || []).join(", ")}
             </div>
-            <div data-testid="metadata-limit">{metadata.limit}</div>
-            <div data-testid="metadata-models">
-              {(metadata.models || []).join(", ")}
-            </div>
-            <div data-testid="metadata-offset">{metadata.offset}</div>
-            <div data-testid="metadata-table-db-id">{metadata.table_db_id}</div>
-            <div data-testid="metadata-total">{metadata.total}</div>
+            <div data-testid="limit">{metadata.limit}</div>
+            <div data-testid="models">{(metadata.models || []).join(", ")}</div>
+            <div data-testid="offset">{metadata.offset}</div>
+            <div data-testid="table-db-id">{metadata.table_db_id}</div>
+            <div data-testid="total">{metadata.total}</div>
           </>
         )}
       </div>
@@ -100,22 +98,20 @@ describe("useSearchListQuery", () => {
       ", ",
     );
 
-    expect(metadata.getByTestId("metadata-available-models")).toHaveTextContent(
+    expect(metadata.getByTestId("available-models")).toHaveTextContent(
       availableModelTextContent,
     );
-    expect(metadata.getByTestId("metadata-limit")).toHaveTextContent(
+    expect(metadata.getByTestId("limit")).toHaveTextContent(
       String(TEST_SEARCH_METADATA.limit),
     );
-    expect(metadata.getByTestId("metadata-models")).toHaveTextContent(
-      modelsTextContent,
-    );
-    expect(metadata.getByTestId("metadata-offset")).toHaveTextContent(
+    expect(metadata.getByTestId("models")).toHaveTextContent(modelsTextContent);
+    expect(metadata.getByTestId("offset")).toHaveTextContent(
       String(TEST_SEARCH_METADATA.offset),
     );
-    expect(metadata.getByTestId("metadata-table-db-id")).toHaveTextContent(
+    expect(metadata.getByTestId("table-db-id")).toHaveTextContent(
       String(TEST_SEARCH_METADATA.table_db_id),
     );
-    expect(metadata.getByTestId("metadata-total")).toHaveTextContent(
+    expect(metadata.getByTestId("total")).toHaveTextContent(
       String(TEST_SEARCH_METADATA.total),
     );
   });

--- a/frontend/src/metabase/common/hooks/use-search-list-query/use-search-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-search-list-query/use-search-list-query.unit.spec.tsx
@@ -12,6 +12,7 @@ import {
   screen,
   waitForElementToBeRemoved,
 } from "__support__/ui";
+import { checkNotNull } from "metabase/core/utils/types";
 import { useSearchListQuery } from "./use-search-list-query";
 
 const TEST_ITEM = createMockCollectionItem();
@@ -49,13 +50,20 @@ const TestComponent = () => {
         <div key={item.id}>{item.name}</div>
       ))}
       <div data-testid="metadata">
-        {metadata && Object.keys(metadata).length > 0
-          ? Object.entries(metadata).map(([key, value]) => (
-              <div key={key}>
-                {key}: {value}
-              </div>
-            ))
-          : "No metadata"}
+        {metadata && (
+          <>
+            <div data-testid="metadata-available-models">
+              {(metadata.available_models || []).join(", ")}
+            </div>
+            <div data-testid="metadata-limit">{metadata.limit}</div>
+            <div data-testid="metadata-models">
+              {(metadata.models || []).join(", ")}
+            </div>
+            <div data-testid="metadata-offset">{metadata.offset}</div>
+            <div data-testid="metadata-table-db-id">{metadata.table_db_id}</div>
+            <div data-testid="metadata-total">{metadata.total}</div>
+          </>
+        )}
       </div>
     </div>
   );
@@ -82,10 +90,33 @@ describe("useSearchListQuery", () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
 
-    for (const [key, value] of Object.entries(TEST_SEARCH_METADATA)) {
-      expect(
-        within(screen.getByTestId("metadata")).getByText(`${key}: ${value}`),
-      ).toBeInTheDocument();
-    }
+    const metadata = within(screen.getByTestId("metadata"));
+
+    const availableModelTextContent = checkNotNull(
+      TEST_SEARCH_METADATA.available_models,
+    ).join(", ");
+
+    const modelsTextContent = checkNotNull(TEST_SEARCH_METADATA.models).join(
+      ", ",
+    );
+
+    expect(metadata.getByTestId("metadata-available-models")).toHaveTextContent(
+      availableModelTextContent,
+    );
+    expect(metadata.getByTestId("metadata-limit")).toHaveTextContent(
+      String(TEST_SEARCH_METADATA.limit),
+    );
+    expect(metadata.getByTestId("metadata-models")).toHaveTextContent(
+      modelsTextContent,
+    );
+    expect(metadata.getByTestId("metadata-offset")).toHaveTextContent(
+      String(TEST_SEARCH_METADATA.offset),
+    );
+    expect(metadata.getByTestId("metadata-table-db-id")).toHaveTextContent(
+      String(TEST_SEARCH_METADATA.table_db_id),
+    );
+    expect(metadata.getByTestId("metadata-total")).toHaveTextContent(
+      String(TEST_SEARCH_METADATA.total),
+    );
   });
 });

--- a/frontend/src/metabase/common/hooks/use-search-list-query/use-search-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-search-list-query/use-search-list-query.unit.spec.tsx
@@ -1,5 +1,11 @@
+import _ from "underscore";
+import { within } from "@testing-library/react";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
-import { createMockCollectionItem } from "metabase-types/api/mocks";
+import {
+  createMockCollectionItem,
+  createMockSearchResult,
+  createMockSearchResults,
+} from "metabase-types/api/mocks";
 import { setupSearchEndpoints } from "__support__/server-mocks";
 import {
   renderWithProviders,
@@ -10,13 +16,25 @@ import { useSearchListQuery } from "./use-search-list-query";
 
 const TEST_ITEM = createMockCollectionItem();
 
+const TEST_TABLE_DB_ID = 1;
+const TEST_SEARCH_METADATA = createMockSearchResults({
+  items: [createMockSearchResult({ collection: TEST_ITEM })],
+  options: { table_db_id: TEST_TABLE_DB_ID },
+});
+
 const TestComponent = () => {
   const {
     data = [],
+    metadata,
     isLoading,
     error,
   } = useSearchListQuery({
-    query: { models: TEST_ITEM.model },
+    query: {
+      models: TEST_ITEM.model,
+      limit: TEST_SEARCH_METADATA.limit,
+      offset: TEST_SEARCH_METADATA.offset,
+      table_db_id: TEST_TABLE_DB_ID,
+    },
   });
 
   if (isLoading || error) {
@@ -28,6 +46,15 @@ const TestComponent = () => {
       {data.map(item => (
         <div key={item.id}>{item.name}</div>
       ))}
+      <div data-testid="metadata">
+        {metadata && Object.keys(metadata).length > 0
+          ? Object.entries(metadata).map(([key, value]) => (
+              <div key={key}>
+                {key}: {value}
+              </div>
+            ))
+          : "No metadata"}
+      </div>
     </div>
   );
 };
@@ -47,5 +74,18 @@ describe("useSearchListQuery", () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(screen.getByText(TEST_ITEM.name)).toBeInTheDocument();
+  });
+
+  it("should show metadata from the response", async () => {
+    setup();
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
+
+    const searchResultMetdata = _.omit(TEST_SEARCH_METADATA, "data");
+
+    for (const [key, value] of Object.entries(searchResultMetdata)) {
+      expect(
+        within(screen.getByTestId("metadata")).getByText(`${key}: ${value}`),
+      ).toBeInTheDocument();
+    }
   });
 });

--- a/frontend/src/metabase/common/hooks/use-segment-list-query/use-segment-list-query.ts
+++ b/frontend/src/metabase/common/hooks/use-segment-list-query/use-segment-list-query.ts
@@ -15,5 +15,6 @@ export const useSegmentListQuery = (
     getLoading: Segments.selectors.getLoading,
     getLoaded: Segments.selectors.getLoaded,
     getError: Segments.selectors.getError,
+    getListMetadata: Segments.selectors.getListMetadata,
   });
 };

--- a/frontend/src/metabase/common/hooks/use-segment-list-query/use-segment-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-segment-list-query/use-segment-list-query.unit.spec.tsx
@@ -25,15 +25,7 @@ const TestComponent = () => {
       ))}
 
       <div data-testid="metadata">
-        {metadata && Object.keys(metadata).length > 0
-          ? Object.entries(metadata).map(([key, value]) => (
-              <div key={key}>
-                <div>
-                  {key}: {value}
-                </div>
-              </div>
-            ))
-          : "No metadata"}
+        {(!metadata || Object.keys(metadata).length === 0) && "No metadata"}
       </div>
     </div>
   );
@@ -56,7 +48,7 @@ describe("useSegmentListQuery", () => {
     expect(screen.getByText(TEST_SEGMENT.name)).toBeInTheDocument();
   });
 
-  it("should show metadata from the response", async () => {
+  it("should not have any metadata in the response", async () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(

--- a/frontend/src/metabase/common/hooks/use-segment-list-query/use-segment-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-segment-list-query/use-segment-list-query.unit.spec.tsx
@@ -5,13 +5,14 @@ import {
   renderWithProviders,
   screen,
   waitForElementToBeRemoved,
+  within,
 } from "__support__/ui";
 import { useSegmentListQuery } from "./use-segment-list-query";
 
 const TEST_SEGMENT = createMockSegment();
 
 const TestComponent = () => {
-  const { data = [], isLoading, error } = useSegmentListQuery();
+  const { data = [], metadata, isLoading, error } = useSegmentListQuery();
 
   if (isLoading || error) {
     return <LoadingAndErrorWrapper loading={isLoading} error={error} />;
@@ -22,6 +23,18 @@ const TestComponent = () => {
       {data.map(segment => (
         <div key={segment.id}>{segment.name}</div>
       ))}
+
+      <div data-testid="metadata">
+        {metadata && Object.keys(metadata).length > 0
+          ? Object.entries(metadata).map(([key, value]) => (
+              <div key={key}>
+                <div>
+                  {key}: {value}
+                </div>
+              </div>
+            ))
+          : "No metadata"}
+      </div>
     </div>
   );
 };
@@ -41,5 +54,13 @@ describe("useSegmentListQuery", () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(screen.getByText(TEST_SEGMENT.name)).toBeInTheDocument();
+  });
+
+  it("should show metadata from the response", async () => {
+    setup();
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
+    expect(
+      within(screen.getByTestId("metadata")).getByText("No metadata"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/common/hooks/use-table-list-query/use-table-list-query.ts
+++ b/frontend/src/metabase/common/hooks/use-table-list-query/use-table-list-query.ts
@@ -16,5 +16,6 @@ export const useTableListQuery = (
     getLoading: Tables.selectors.getLoading,
     getLoaded: Tables.selectors.getLoaded,
     getError: Tables.selectors.getError,
+    getListMetadata: Tables.selectors.getListMetadata,
   });
 };

--- a/frontend/src/metabase/common/hooks/use-table-list-query/use-table-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-table-list-query/use-table-list-query.unit.spec.tsx
@@ -5,13 +5,14 @@ import {
   renderWithProviders,
   screen,
   waitForElementToBeRemoved,
+  within,
 } from "__support__/ui";
 import { useTableListQuery } from "./use-table-list-query";
 
 const TEST_TABLE = createMockTable();
 
 const TestComponent = () => {
-  const { data = [], isLoading, error } = useTableListQuery();
+  const { data = [], metadata, isLoading, error } = useTableListQuery();
 
   if (isLoading || error) {
     return <LoadingAndErrorWrapper loading={isLoading} error={error} />;
@@ -22,6 +23,18 @@ const TestComponent = () => {
       {data.map(table => (
         <div key={table.id}>{table.name}</div>
       ))}
+
+      <div data-testid="metadata">
+        {metadata && Object.keys(metadata).length > 0
+          ? Object.entries(metadata).map(([key, value]) => (
+              <div key={key}>
+                <div>
+                  {key}: {value}
+                </div>
+              </div>
+            ))
+          : "No metadata"}
+      </div>
     </div>
   );
 };
@@ -41,5 +54,13 @@ describe("useTableListQuery", () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(screen.getByText(TEST_TABLE.name)).toBeInTheDocument();
+  });
+
+  it("should show metadata from the response", async () => {
+    setup();
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
+    expect(
+      within(screen.getByTestId("metadata")).getByText("No metadata"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/common/hooks/use-table-list-query/use-table-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-table-list-query/use-table-list-query.unit.spec.tsx
@@ -25,15 +25,7 @@ const TestComponent = () => {
       ))}
 
       <div data-testid="metadata">
-        {metadata && Object.keys(metadata).length > 0
-          ? Object.entries(metadata).map(([key, value]) => (
-              <div key={key}>
-                <div>
-                  {key}: {value}
-                </div>
-              </div>
-            ))
-          : "No metadata"}
+        {(!metadata || Object.keys(metadata).length === 0) && "No metadata"}
       </div>
     </div>
   );
@@ -56,7 +48,7 @@ describe("useTableListQuery", () => {
     expect(screen.getByText(TEST_TABLE.name)).toBeInTheDocument();
   });
 
-  it("should show metadata from the response", async () => {
+  it("should not have any metadata in the response", async () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(

--- a/frontend/src/metabase/common/hooks/use-user-list-query/use-user-list-query.ts
+++ b/frontend/src/metabase/common/hooks/use-user-list-query/use-user-list-query.ts
@@ -15,5 +15,6 @@ export const useUserListQuery = (
     getLoading: Users.selectors.getLoading,
     getLoaded: Users.selectors.getLoaded,
     getError: Users.selectors.getError,
+    getListMetadata: Users.selectors.getListMetadata,
   });
 };

--- a/frontend/src/metabase/common/hooks/use-user-list-query/use-user-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-user-list-query/use-user-list-query.unit.spec.tsx
@@ -3,6 +3,7 @@ import {
   renderWithProviders,
   screen,
   waitForElementToBeRemoved,
+  within,
 } from "__support__/ui";
 import { createMockUserInfo } from "metabase-types/api/mocks";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper/LoadingAndErrorWrapper";
@@ -12,7 +13,7 @@ import { useUserListQuery } from "./use-user-list-query";
 const TEST_USER = createMockUserInfo();
 
 function TestComponent() {
-  const { data = [], isLoading, error } = useUserListQuery();
+  const { data = [], metadata, isLoading, error } = useUserListQuery();
 
   if (isLoading || error) {
     return <LoadingAndErrorWrapper loading={isLoading} error={error} />;
@@ -23,6 +24,18 @@ function TestComponent() {
       {data.map(user => (
         <div key={user.id}>{user.common_name}</div>
       ))}
+
+      <div data-testid="metadata">
+        {metadata && Object.keys(metadata).length > 0
+          ? Object.entries(metadata).map(([key, value]) => (
+              <div key={key}>
+                <div>
+                  {key}: {value}
+                </div>
+              </div>
+            ))
+          : "No metadata"}
+      </div>
     </div>
   );
 }
@@ -42,5 +55,13 @@ describe("useUserListQuery", () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(screen.getByText("Testy Tableton")).toBeInTheDocument();
+  });
+
+  it("should show metadata from the response", async () => {
+    setup();
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
+    expect(
+      within(screen.getByTestId("metadata")).getByText("No metadata"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/common/hooks/use-user-list-query/use-user-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-user-list-query/use-user-list-query.unit.spec.tsx
@@ -26,15 +26,7 @@ function TestComponent() {
       ))}
 
       <div data-testid="metadata">
-        {metadata && Object.keys(metadata).length > 0
-          ? Object.entries(metadata).map(([key, value]) => (
-              <div key={key}>
-                <div>
-                  {key}: {value}
-                </div>
-              </div>
-            ))
-          : "No metadata"}
+        {(!metadata || Object.keys(metadata).length === 0) && "No metadata"}
       </div>
     </div>
   );
@@ -57,7 +49,7 @@ describe("useUserListQuery", () => {
     expect(screen.getByText("Testy Tableton")).toBeInTheDocument();
   });
 
-  it("should show metadata from the response", async () => {
+  it("should not have any metadata in the response", async () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(

--- a/frontend/test/__support__/server-mocks/search.ts
+++ b/frontend/test/__support__/server-mocks/search.ts
@@ -7,6 +7,9 @@ export function setupSearchEndpoints(items: CollectionItem[]) {
   fetchMock.get("path:/api/search", uri => {
     const url = new URL(uri);
     const models = url.searchParams.getAll("models");
+    const limit = Number(url.searchParams.get("limit"));
+    const offset = Number(url.searchParams.get("offset"));
+    const table_db_id = url.searchParams.get("table_db_id") || null;
     const matchedItems = items.filter(({ model }) => models.includes(model));
 
     return {
@@ -14,9 +17,9 @@ export function setupSearchEndpoints(items: CollectionItem[]) {
       total: matchedItems.length,
       models, // this should reflect what is in the query param
       available_models: availableModels,
-      limit: null,
-      offset: null,
-      table_db_id: null,
+      limit,
+      offset,
+      table_db_id,
     };
   });
 }


### PR DESCRIPTION
### Description

Add getListMetadata to useEntityListQuery calls. This allows devs to access the metadata of an API call. For example, in `useSearchListQuery`, we can now access data such as `available_models`, or `total` from `useDatabaseListQuery`.

This change should not affect current code.