### PR TITLE
[E2E] Content verification

### DIFF
--- a/e2e/test/scenarios/organization/content-verification.cy.spec.js
+++ b/e2e/test/scenarios/organization/content-verification.cy.spec.js
@@ -35,7 +35,7 @@ describeEE("scenarios > premium > content verification", () => {
         },
       }).then(({ body, status, statusText }) => {
         expect(body).to.eq(
-          "This API endpoint is only enabled if you have a premium token with the :content-verification feature.",
+          "Content verification is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/",
         );
         expect(status).to.eq(402);
         expect(statusText).to.eq("Payment Required");

--- a/e2e/test/scenarios/organization/content-verification.cy.spec.js
+++ b/e2e/test/scenarios/organization/content-verification.cy.spec.js
@@ -144,7 +144,7 @@ describeEE("scenarios > premium > content verification", () => {
       });
     });
 
-    describe("as a non-admin user", () => {
+    describe("non-admin user", () => {
       beforeEach(() => {
         cy.createModerationReview({
           status: "verified",
@@ -155,22 +155,39 @@ describeEE("scenarios > premium > content verification", () => {
         cy.signInAsNormalUser();
       });
 
-      it("should be able to see that a question has been verified", () => {
+      it("should be able to see that a question has been verified but can't moderate the question themselves", () => {
         visitQuestion(ORDERS_COUNT_QUESTION_ID);
 
-        cy.icon("verified");
+        cy.findByTestId("qb-header").within(() => {
+          cy.findByText("Orders, Count");
+          cy.icon("verified");
+        });
+
+        cy.log("Non-admin users cannot change question verification status.");
+        openQuestionActions();
+        popover()
+          .should("contain", "Add to dashboard")
+          .and("not.contain", "Remove verification");
 
         questionInfoButton().click();
-        cy.findAllByText(`${adminFullName} verified this`);
+        cy.findByTestId("sidebar-right")
+          .findAllByText(`${adminFullName} verified this`)
+          .should("have.length", 2);
 
         cy.findByPlaceholderText("Search…").type("orders{enter}");
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText("Orders, Count").parent().icon("verified");
+        cy.log("Verified content should show up higher in search results");
+        cy.findAllByTestId("search-result-item")
+          .first()
+          .within(() => {
+            cy.findByText("Orders, Count");
+            cy.icon("verified");
+          });
 
         cy.visit("/collection/root");
-
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText("Orders, Count").closest("td").icon("verified");
+        cy.findByRole("table")
+          .findByText("Orders, Count")
+          .closest("td")
+          .icon("verified");
       });
     });
   });

--- a/e2e/test/scenarios/organization/content-verification.cy.spec.js
+++ b/e2e/test/scenarios/organization/content-verification.cy.spec.js
@@ -191,6 +191,45 @@ describeEE("scenarios > premium > content verification", () => {
       });
     });
   });
+
+  context("token expired or removed", () => {
+    beforeEach(() => {
+      setTokenFeatures("all");
+      cy.createModerationReview({
+        status: "verified",
+        moderated_item_type: "card",
+        moderated_item_id: ORDERS_COUNT_QUESTION_ID,
+      });
+
+      setTokenFeatures("none");
+    });
+
+    it("should not treat the question as verified anymore", () => {
+      visitQuestion(ORDERS_COUNT_QUESTION_ID);
+
+      cy.findByTestId("qb-header").within(() => {
+        cy.findByText("Orders, Count");
+        cy.icon("verified").should("not.exist");
+      });
+
+      questionInfoButton().click();
+      cy.findByTestId("sidebar-right").within(() => {
+        cy.contains(/created this./);
+        cy.contains(/verified this/).should("not.exist");
+      });
+
+      cy.findByPlaceholderText("Search…").type("orders{enter}");
+      cy.log(
+        "The question lost the verification status and does not appear high in search results anymore",
+      );
+      cy.findAllByTestId("search-result-item")
+        .as("searchResults")
+        .first()
+        .should("not.contain", "Orders, Count");
+      cy.log("Verified icon should not appear at all in search results");
+      cy.get("@searchResults").icon("verified").should("not.exist");
+    });
+  });
 });
 
 function verifyQuestion() {

--- a/e2e/test/scenarios/organization/content-verification.cy.spec.js
+++ b/e2e/test/scenarios/organization/content-verification.cy.spec.js
@@ -67,7 +67,7 @@ describeEE("scenarios > premium > content verification", () => {
   context("premium token with paid features", () => {
     beforeEach(() => setTokenFeatures("all"));
 
-    describe("as an admin", () => {
+    describe("an admin", () => {
       it("should be able to verify and unverify a saved question", () => {
         visitQuestion(ORDERS_COUNT_QUESTION_ID);
 

--- a/e2e/test/scenarios/organization/content-verification.cy.spec.js
+++ b/e2e/test/scenarios/organization/content-verification.cy.spec.js
@@ -15,7 +15,7 @@ import { ORDERS_COUNT_QUESTION_ID } from "e2e/support/cypress_sample_instance_da
 const { admin } = USERS;
 const adminFullName = getFullName(admin);
 
-describeEE("scenarios > saved question moderation", () => {
+describeEE("scenarios > premium > content verification", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/organization/content-verification.cy.spec.js
+++ b/e2e/test/scenarios/organization/content-verification.cy.spec.js
@@ -74,15 +74,19 @@ describeEE("scenarios > premium > content verification", () => {
         verifyQuestion();
 
         // 1. Question title
-        cy.findByTestId("qb-header-left-side").find(".Icon-verified");
+        cy.findByTestId("qb-header").within(() => {
+          cy.findByText("Orders, Count");
+          cy.icon("verified");
+        });
 
         // 2. Question's history
         questionInfoButton().click();
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText("History");
-        cy.findAllByText("You verified this")
-          .should("have.length", 2)
-          .and("be.visible");
+        cy.findByTestId("sidebar-right").within(() => {
+          cy.findByText("History");
+          cy.findAllByText("You verified this")
+            .should("have.length", 2)
+            .and("be.visible");
+        });
 
         // 3. Recently viewed list
         cy.findByPlaceholderText("Search…").click();
@@ -98,10 +102,12 @@ describeEE("scenarios > premium > content verification", () => {
 
         // 5. Question's collection
         cy.visit("/collection/root");
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText("Orders, Count").closest("a").find(".Icon-verified");
+        cy.findByRole("table")
+          .findByText("Orders, Count")
+          .closest("td")
+          .icon("verified");
 
-        // Let's go back to the question and remove the verification
+        cy.log("Go back to the question and remove the verification");
         visitQuestion(ORDERS_COUNT_QUESTION_ID);
 
         removeQuestionVerification();
@@ -113,12 +119,11 @@ describeEE("scenarios > premium > content verification", () => {
 
         // 2. Question's history
         questionInfoButton().click();
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText("History");
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText("You removed verification");
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText("You verified this"); // Implicit assertion - there can be only one :)
+        cy.findByTestId("sidebar-right").within(() => {
+          cy.findByText("History");
+          cy.findByText("You removed verification");
+          cy.findByText("You verified this"); // Implicit assertion - there can be only one :)
+        });
 
         // 3. Recently viewed list
         cy.findByPlaceholderText("Search…").click();
@@ -136,10 +141,10 @@ describeEE("scenarios > premium > content verification", () => {
 
         // 5. Question's collection
         cy.visit("/collection/root");
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText("Orders, Count")
-          .closest("a")
-          .find(".Icon-verified")
+        cy.findByRole("table")
+          .findByText("Orders, Count")
+          .closest("td")
+          .icon("verified")
           .should("not.exist");
       });
     });


### PR DESCRIPTION
Expand and refactor E2E tests for the `content-verification` feature flag.

There should be no more eslint warnings.