### PR TITLE
Do not count empty lines and duplicates in action option editor

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.tsx
@@ -16,7 +16,7 @@ import {
 } from "./OptionEditor.styled";
 
 const optionsToText = (options: FieldValueOptions) => options.join("\n");
-const textToOptions = (text: string): FieldValueOptions => {
+export const textToOptions = (text: string): FieldValueOptions => {
   const options = text
     .trim()
     .split("\n")

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.tsx
@@ -16,22 +16,36 @@ import {
 } from "./OptionEditor.styled";
 
 const optionsToText = (options: FieldValueOptions) => options.join("\n");
-const textToOptions = (text: string): FieldValueOptions =>
-  text.split("\n").map(option => option.trim());
+const textToOptions = (text: string): FieldValueOptions => {
+  const options = text
+    .trim()
+    .split("\n")
+    .map(option => option.trim())
+    .filter(Boolean);
+  const uniqueOptions = [...new Set(options)];
 
-function cleanOptions(options: FieldValueOptions, fieldType: FieldType) {
+  return uniqueOptions;
+};
+
+function transformOptionsIfNeeded(
+  options: FieldValueOptions,
+  fieldType: FieldType,
+) {
   if (fieldType === "number") {
     return options.map(option => Number(option));
   }
+
   return options;
 }
 
 function getValidationError(options: FieldValueOptions, fieldType: FieldType) {
-  if (fieldType === "number") {
-    const isValid = options.every(option => !Number.isNaN(option));
-    return isValid ? undefined : t`Invalid number format`;
+  if (fieldType !== "number") {
+    return;
   }
-  return;
+
+  const isValid = options.every(option => !Number.isNaN(option));
+
+  return isValid ? undefined : t`Invalid number format`;
 }
 
 export interface OptionEditorProps {
@@ -72,8 +86,13 @@ export const OptionPopover = ({
 
   const handleSave = (closePopover: () => void) => {
     setError(null);
-    const nextOptions = cleanOptions(textToOptions(text), fieldType);
+
+    const nextOptions = transformOptionsIfNeeded(
+      textToOptions(text),
+      fieldType,
+    );
     const error = getValidationError(nextOptions, fieldType);
+
     if (error) {
       setError(error);
     } else {

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.unit.spec.tsx
@@ -2,7 +2,11 @@ import { useState } from "react";
 import userEvent from "@testing-library/user-event";
 import { render, screen, getIcon } from "__support__/ui";
 import type { FieldType, FieldValueOptions } from "metabase-types/api";
-import { OptionPopover, OptionEditorProps } from "./OptionEditor";
+import {
+  OptionPopover,
+  OptionEditorProps,
+  textToOptions,
+} from "./OptionEditor";
 
 async function baseSetup({
   fieldType = "string",
@@ -129,5 +133,19 @@ describe("OptionEditor", () => {
         expect(onChange).toHaveBeenCalledWith(["1", "2"]);
       });
     });
+  });
+});
+
+describe("textToOptions", () => {
+  it("should filter duplicates", () => {
+    const input = "1\n2\n1\n1\n2";
+
+    expect(textToOptions(input)).toEqual(["1", "2"]);
+  });
+
+  it("should filter empty values and trim empty space", () => {
+    const input = " \n  1\n2 \n\n\n  ";
+
+    expect(textToOptions(input)).toEqual(["1", "2"]);
   });
 });

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.unit.spec.tsx
@@ -98,10 +98,36 @@ describe("OptionEditor", () => {
         screen.queryByText("Invalid number format"),
       ).not.toBeInTheDocument();
 
-      userEvent.type(input, "1\n2");
+      userEvent.type(input, "1\n2\n\n2\n\n\n1");
       userEvent.click(saveButton);
 
       expect(onChange).toHaveBeenCalledWith([1, 2]);
+    });
+
+    it("should omit empty lines and duplicates", async () => {
+      const { input, saveButton, onChange } = await baseSetup({
+        fieldType: "number",
+        options: [],
+      });
+
+      userEvent.type(input, "1\n2\n\n2\n\n1\n\n");
+      userEvent.click(saveButton);
+
+      expect(onChange).toHaveBeenCalledWith([1, 2]);
+    });
+
+    describe("given string field type", () => {
+      it("should omit empty lines and duplicates", async () => {
+        const { input, saveButton, onChange } = await baseSetup({
+          fieldType: "string",
+          options: [],
+        });
+
+        userEvent.type(input, "1\n2\n\n2\n\n1\n\n");
+        userEvent.click(saveButton);
+
+        expect(onChange).toHaveBeenCalledWith(["1", "2"]);
+      });
     });
   });
 });

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.unit.spec.tsx
@@ -98,7 +98,7 @@ describe("OptionEditor", () => {
         screen.queryByText("Invalid number format"),
       ).not.toBeInTheDocument();
 
-      userEvent.type(input, "1\n2\n\n2\n\n\n1");
+      userEvent.type(input, "1\n2");
       userEvent.click(saveButton);
 
       expect(onChange).toHaveBeenCalledWith([1, 2]);


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/29652

### Description

Option editor filters out duplicates and empty lines now.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New model -> actions -> create new action
2. put a code like `select * from products where order_id == {{param}};`
3. on the right hand you have Action Parameter, find `param` there, click cog icon, choose `dropdown`
4. save -> click on the icon left to cog. paste there values with duplicates and empty lines
e.g

```
premium
basic
business

premium

```

after clicking "save", you should be able co click on input below "appearance" section and see only `premium, basic, business` values

### Demo

TBA

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
