### PR TITLE
Migrate addCssRule to emotion

### DIFF
--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -53,7 +53,7 @@ import TasksApp from "metabase/admin/tasks/containers/TasksApp";
 import TaskModal from "metabase/admin/tasks/containers/TaskModal";
 import JobInfoApp from "metabase/admin/tasks/containers/JobInfoApp";
 import JobTriggersModal from "metabase/admin/tasks/containers/JobTriggersModal";
-import Logs from "metabase/admin/tasks/containers/Logs";
+import { Logs } from "metabase/admin/tasks/components/Logs";
 import { Help } from "metabase/admin/tasks/components/Help";
 
 // People

--- a/frontend/src/metabase/admin/tasks/components/Logs/Logs.jsx
+++ b/frontend/src/metabase/admin/tasks/components/Logs/Logs.jsx
@@ -12,23 +12,8 @@ import { UtilApi } from "metabase/services";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
 import Select, { Option } from "metabase/core/components/Select";
-import { addCSSRule } from "metabase/lib/dom";
-import { color } from "metabase/lib/colors";
+import { LogsContainer } from "./Logs.styled";
 
-const ANSI_COLORS = {
-  black: color("text-dark"),
-  white: color("text-white"),
-  gray: color("text-medium"),
-  red: color("saturated-red"),
-  green: color("saturated-green"),
-  yellow: color("saturated-yellow"),
-  blue: color("saturated-blue"),
-  magenta: color("saturated-purple"),
-  cyan: "cyan",
-};
-for (const [name, color] of Object.entries(ANSI_COLORS)) {
-  addCSSRule(`.react-ansi-style-${name}`, `color: ${color} !important`);
-}
 const MAX_LOGS = 50000;
 
 function logEventKey(ev) {
@@ -149,18 +134,9 @@ export class Logs extends Component {
           loading={!filteredLogs || filteredLogs.length === 0}
         >
           {() => (
-            <div
-              className="rounded bordered bg-light"
-              style={{
-                fontFamily: '"Lucida Console", Monaco, monospace',
-                fontSize: "14px",
-                whiteSpace: "pre",
-                padding: "1em",
-                overflowX: "scroll",
-              }}
-            >
+            <LogsContainer>
               {reactAnsiStyle(React, renderedLogs.join("\n"))}
-            </div>
+            </LogsContainer>
           )}
         </LoadingAndErrorWrapper>
       </div>

--- a/frontend/src/metabase/admin/tasks/components/Logs/Logs.jsx
+++ b/frontend/src/metabase/admin/tasks/components/Logs/Logs.jsx
@@ -46,7 +46,7 @@ function mergeLogs(...logArrays) {
     .value();
 }
 
-export default class Logs extends Component {
+export class Logs extends Component {
   constructor() {
     super();
     this.state = {

--- a/frontend/src/metabase/admin/tasks/components/Logs/Logs.styled.tsx
+++ b/frontend/src/metabase/admin/tasks/components/Logs/Logs.styled.tsx
@@ -1,0 +1,33 @@
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+
+const ANSI_COLORS = {
+  black: color("text-dark"),
+  white: color("text-white"),
+  gray: color("text-medium"),
+  red: color("saturated-red"),
+  green: color("saturated-green"),
+  yellow: color("saturated-yellow"),
+  blue: color("saturated-blue"),
+  magenta: color("saturated-purple"),
+  cyan: "cyan",
+};
+
+const getColorRule = (name: string, color: string) => {
+  return `.react-ansi-style-${name} { color: ${color} !important }`;
+};
+
+export const LogsContainer = styled.div`
+  border: 1px solid ${color("border")};
+  border-radius: 0.5rem;
+  background-color: ${color("bg-light")};
+  font-family: "Lucida Console", Monaco, monospace;
+  font-size: 14px;
+  white-space: pre;
+  padding: 1em;
+  overflow-x: scroll;
+
+  ${Object.entries(ANSI_COLORS)
+    .map(([name, color]) => getColorRule(name, color))
+    .join(" ")}
+`;

--- a/frontend/src/metabase/admin/tasks/components/Logs/Logs.unit.spec.js
+++ b/frontend/src/metabase/admin/tasks/components/Logs/Logs.unit.spec.js
@@ -1,8 +1,7 @@
 import fetchMock from "fetch-mock";
 import { render, screen } from "@testing-library/react";
-import Logs from "metabase/admin/tasks/containers/Logs";
-
 import { UtilApi } from "metabase/services";
+import { Logs } from "./Logs";
 
 describe("Logs", () => {
   describe("log fetching", () => {

--- a/frontend/src/metabase/admin/tasks/components/Logs/index.ts
+++ b/frontend/src/metabase/admin/tasks/components/Logs/index.ts
@@ -1,0 +1,1 @@
+export * from "./Logs";

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -194,10 +194,6 @@ function getTextNodeAtPosition(root, index) {
   };
 }
 
-export function addCSSRule(selector, rules, index = 0) {
-  // noop to test emotion changes
-}
-
 export function constrainToScreen(element, direction, padding) {
   if (!element) {
     return false;

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -9,7 +9,6 @@ import cx from "classnames";
 import "./LineAreaBarChart.css";
 
 import { getFriendlyName, MAX_SERIES } from "metabase/visualizations/lib/utils";
-import { addCSSRule } from "metabase/lib/dom";
 import { formatValue } from "metabase/lib/formatting";
 
 import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
@@ -30,46 +29,6 @@ import {
 } from "./LineAreaBarChart.styled";
 import LegendLayout from "./legend/LegendLayout";
 import CardRenderer from "./CardRenderer";
-
-const MUTE_STYLE = "opacity: 0.25;";
-for (let i = 0; i < MAX_SERIES; i++) {
-  addCSSRule(
-    `.LineAreaBarChart.mute-${i} svg.stacked .stack._${i} .area`,
-    MUTE_STYLE,
-  );
-  addCSSRule(
-    `.LineAreaBarChart.mute-${i} svg.stacked .stack._${i} .line`,
-    MUTE_STYLE,
-  );
-  addCSSRule(
-    `.LineAreaBarChart.mute-${i} svg.stacked .stack._${i} .bar`,
-    MUTE_STYLE,
-  );
-  addCSSRule(
-    `.LineAreaBarChart.mute-${i} svg.stacked .dc-tooltip._${i} .dot`,
-    MUTE_STYLE,
-  );
-
-  addCSSRule(
-    `.LineAreaBarChart.mute-${i} svg:not(.stacked) .sub._${i} .bar`,
-    MUTE_STYLE,
-  );
-  addCSSRule(
-    `.LineAreaBarChart.mute-${i} svg:not(.stacked) .sub._${i} .line`,
-    MUTE_STYLE,
-  );
-  addCSSRule(
-    `.LineAreaBarChart.mute-${i} svg:not(.stacked) .sub._${i} .dot`,
-    MUTE_STYLE,
-  );
-  addCSSRule(
-    `.LineAreaBarChart.mute-${i} svg:not(.stacked) .sub._${i} .bubble`,
-    MUTE_STYLE,
-  );
-
-  // row charts don't support multiseries
-  addCSSRule(`.LineAreaBarChart.mute-${i} svg:not(.stacked) .row`, MUTE_STYLE);
-}
 
 export default class LineAreaBarChart extends Component {
   static noHeader = true;

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.styled.tsx
@@ -1,5 +1,23 @@
 import styled from "@emotion/styled";
+import _ from "underscore";
+import { MAX_SERIES } from "metabase/visualizations/lib/utils";
 import LegendCaption from "./legend/LegendCaption";
+
+const getMuteSeriesClass = (i: number) => [
+  `&.mute-${i} svg.stacked .stack._${i} .area`,
+  `&.mute-${i} svg.stacked .stack._${i} .line`,
+  `&.mute-${i} svg.stacked .stack._${i} .bar`,
+  `&.mute-${i} svg.stacked .dc-tooltip._${i} .dot`,
+  `&.mute-${i} svg:not(.stacked) .sub._${i} .bar`,
+  `&.mute-${i} svg:not(.stacked) .sub._${i} .line`,
+  `&.mute-${i} svg:not(.stacked) .sub._${i} .dot`,
+  `&.mute-${i} svg:not(.stacked) .sub._${i} .bubble`,
+  `&.mute-${i} svg:not(.stacked) .row`,
+];
+
+const getMuteSeriesSelector = () => {
+  return _.range(MAX_SERIES).flatMap(getMuteSeriesClass).join(",");
+};
 
 export const LineAreaBarChartRoot = styled.div<{ isQueryBuilder: boolean }>`
   display: flex;
@@ -7,6 +25,10 @@ export const LineAreaBarChartRoot = styled.div<{ isQueryBuilder: boolean }>`
   padding: ${({ isQueryBuilder }) =>
     isQueryBuilder ? "1rem 1rem 1rem 2rem" : "0.5rem 1rem"};
   overflow: hidden;
+
+  ${getMuteSeriesSelector()} {
+    opacity: 0.25;
+  }
 `;
 
 export const ChartLegendCaption = styled(LegendCaption)`


### PR DESCRIPTION
Related to https://github.com/metabase/metabase-private/issues/73

Migrate `LineAreaBarChart` and `Logs` to use emotion for styles instead of `addCssRule`.

How to verify `LineAreaBarChart` changes:
- New -> Question -> Orders -> Summarize by Count, Group by Created At and Source
- Hover over legend items - it should highlight the selected series

<img width="1728" alt="Screenshot 2023-07-19 at 18 14 24" src="https://github.com/metabase/metabase/assets/8542534/8e27b099-a595-4dba-906c-8b2d9993319b">

How to verify `Logs` changes:
- Admin -> Troubleshooting -> Logs
- Logs should be colored using the same colors as before

<img width="1400" alt="Screenshot 2023-07-19 at 18 13 26" src="https://github.com/metabase/metabase/assets/8542534/3c2e6fe0-6b69-47bc-821b-3bf91dd5f3a2">
