### PR TITLE
Do not load clojure.core/inc in metabase.analytics.prometheus

### DIFF
--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -5,6 +5,7 @@
 
   Api is quite simple: [[setup!]] and [[shutdown!]]. After that you can retrieve metrics from
   http://localhost:<prometheus-server-port>/metrics."
+  (:refer-clojure :exclude [inc])
   (:require
    [clojure.java.jmx :as jmx]
    [iapetos.collector :as collector]
@@ -251,7 +252,6 @@
              (catch Exception e
                (log/warn e (trs "Error stopping prometheus web-server"))))))))
 
-#_{:clj-kondo/ignore [:redefined-var]}
 (defn inc
   "Call iapetos.core/inc on the metric in the global registry,
    if it has already been initialized and the metric is registered."


### PR DESCRIPTION
Instead of silencing the linter, do not load the var.

Suggested-by: @camsaul
References: https://metaboat.slack.com/archives/CKZEMT1MJ/p1689785862424079
