### PR TITLE
Misc kondo linter improvements & code cleanup

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -462,7 +462,10 @@
     ring.adapter.jetty9.servlet                                     servlet
     saml20-clj.core                                                 saml
     toucan.db                                                       db
-    toucan.models                                                   models}}}
+    toucan.models                                                   models}}
+
+  :metabase/validate-deftest                   {:level :warning}
+  :metabase/missing-test-expr-requires-in-cljs {:level :warning}}
 
  :lint-as
  {clojure.core.logic/defne                                                             clj-kondo.lint-as/def-catch-all
@@ -528,7 +531,10 @@
 
  :hooks
  {:analyze-call
-  {clojure.test/deftest                                                                                                      hooks.clojure.test/deftest
+  {cljs.test/deftest                                                                                                         hooks.clojure.test/deftest
+   cljs.test/is                                                                                                              hooks.clojure.test/is
+   clojure.test/deftest                                                                                                      hooks.clojure.test/deftest
+   clojure.test/is                                                                                                           hooks.clojure.test/is
    metabase-enterprise.advanced-permissions.models.permissions.application-permissions-test/with-new-group-and-current-graph hooks.common/with-two-top-level-bindings
    metabase-enterprise.audit-app.pages-test/with-temp-objects                                                                hooks.common/with-one-binding
    metabase-enterprise.serialization.test-util/with-temp-dpc                                                                 hooks.toucan.util.test/with-temp*
@@ -703,8 +709,8 @@
   source-namespaces
   {:linters
    {:discouraged-var
-    {clojure.core/with-redefs {:message "Don't use with-redefs"}
-     clojure.core/eval        {:message "Don't use eval"}}}}
+    {clojure.core/with-redefs {:message "Don't use with-redefs outside of tests"}
+     clojure.core/eval        {:message "Don't use eval outside of tests"}}}}
 
   printable-namespaces
   {:linters

--- a/.clj-kondo/hooks/clojure/test.clj
+++ b/.clj-kondo/hooks/clojure/test.clj
@@ -7,10 +7,10 @@
      metabase.test/with-temporary-setting-values
      mt/with-temporary-setting-values})
 
-(defn warn-about-disallowed-parallel-forms [form]
+(defn- warn-about-disallowed-parallel-forms [form]
   (letfn [(f [form]
-            (when-let [sexpr (and (hooks/token-node? form)
-                                  (hooks/sexpr form))]
+            (when-let [sexpr (when (hooks/token-node? form)
+                               (hooks/sexpr form))]
               (when (disallowed-parallel-forms sexpr)
                 (hooks/reg-finding! (assoc (meta form)
                                            :message (format "%s is not allowed inside a ^:parallel test" sexpr)
@@ -21,7 +21,10 @@
               (walk child)))]
     (walk form)))
 
-(defn deftest [{{[_ test-name & body] :children, :as node} :node}]
+(defn- deftest-check-parallel
+  "1. Check if test is marked ^:parallel / ^:synchronized correctly
+   2. Make sure disallowed forms are not used in ^:parallel tests"
+  [{[_ test-name & body] :children, :as _node}]
   (let [test-metadata     (:meta test-name)
         metadata-sexprs   (map hooks/sexpr test-metadata)
         combined-metadata (transduce
@@ -48,5 +51,51 @@
               :type :metabase/deftest-not-marked-parallel-or-synchronized)))
     (when parallel?
       (doseq [form body]
-        (warn-about-disallowed-parallel-forms form))))
+        (warn-about-disallowed-parallel-forms form)))))
+
+(defn deftest [{:keys [node cljc lang]}]
+  ;; run [[deftest-check-parallel]] only once... if this is a `.cljc` file only run it for the `:clj` analysis, no point
+  ;; in running it twice.
+  (when (or (not cljc)
+            (= lang :clj))
+    (deftest-check-parallel node))
+  {:node node})
+
+;;; this is a hacky way to determine whether these namespaces are required in the `ns` form or not... basically `:ns`
+;;; will come back as `nil` if they are not.
+(defn- approximately-equal-ns-required? []
+  (= (:ns (hooks/resolve {:name 'metabase.test-runner.assert-exprs.approximately-equal/=?-report}))
+     'metabase.test-runner.assert-exprs.approximately-equal))
+
+(defn- malli-equals-ns-required? []
+  (= (:ns (hooks/resolve {:name 'metabase.test-runner.assert-exprs.malli-equals/malli=-report}))
+     'metabase.test-runner.assert-exprs.malli-equals))
+
+(defn- warn-about-missing-test-expr-requires-in-cljs [{:keys [children], :as _is-node}]
+  (let [[_is assertion-node] children]
+    (when (hooks/list-node? assertion-node)
+      (let [[assertion-symb-node] (:children assertion-node)]
+        (when (hooks/token-node? assertion-symb-node)
+          (let [assertion-symb-token (hooks/sexpr assertion-symb-node)
+                warn!                (fn [ns-to-require]
+                                       (hooks/reg-finding!
+                                        (assoc (meta assertion-symb-node)
+                                               :message (format "You must require %s to use %s in ClojureScript"
+                                                                ns-to-require
+                                                                assertion-symb-token)
+                                               :type :metabase/missing-test-expr-requires-in-cljs)))]
+            (condp = assertion-symb-token
+              '=?
+              (when-not (approximately-equal-ns-required?)
+                (warn! 'metabase.test-runner.assert-exprs.approximately-equal))
+
+              'malli=
+              (when-not (malli-equals-ns-required?)
+                (warn! 'metabase.test-runner.assert-exprs.malli-equals))
+
+              nil)))))))
+
+(defn is [{:keys [node lang]}]
+  (when (= lang :cljs)
+    (warn-about-missing-test-expr-requires-in-cljs node))
   {:node node})

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CLJ_KONDO_VERSION: "2023.04.14"
+  CLJ_KONDO_VERSION: "2023.07.13"
 
 jobs:
   files-changed:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CLJ_KONDO_VERSION: "2023.07.13"
+  CLJ_KONDO_VERSION: "2023.04.14"
 
 jobs:
   files-changed:

--- a/deps.edn
+++ b/deps.edn
@@ -204,7 +204,7 @@
   {:extra-deps
    {clj-http-fake/clj-http-fake  {:mvn/version "1.0.3"
                                   :exclusions  [slingshot/slingshot]}
-    clj-kondo/clj-kondo          {:mvn/version "2023.02.17"}                ; this is not for RUNNING kondo, but so we can hack on custom hooks code from the REPL.
+    clj-kondo/clj-kondo          {:mvn/version "2023.07.13"}                ; this is not for RUNNING kondo, but so we can hack on custom hooks code from the REPL.
     cloverage/cloverage          {:mvn/version "1.2.4"}
     com.gfredericks/test.chuck   {:mvn/version "0.2.14"}                    ; generating strings from regexes (useful with malli)
     djblue/portal                {:mvn/version "0.40.0"}                    ; ui for inspecting values

--- a/test/metabase/lib/breakout_test.cljc
+++ b/test/metabase/lib/breakout_test.cljc
@@ -36,7 +36,7 @@
             (lib/breakouts query)))))
 
 (deftest ^:parallel breakout-should-drop-invalid-parts
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/with-fields [(meta/field-metadata :venues :price)])
                   (lib/order-by (meta/field-metadata :venues :price))
                   (lib/join (-> (lib/join-clause (meta/table-metadata :categories)
@@ -55,7 +55,7 @@
     (is (= 1 (count (lib/joins query 0))))
     (is (not (contains? first-join :fields))))
   (testing "Already summarized query should be left alone"
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (let [query (-> lib.tu/venues-query
                     (lib/breakout (meta/field-metadata :venues :category-id))
                     (lib/order-by (meta/field-metadata :venues :category-id))
                     (lib/append-stage)
@@ -65,7 +65,7 @@
       (is (contains? first-stage :order-by)))))
 
 (deftest ^:parallel breakoutable-columns-test
-  (let [query (lib/query meta/metadata-provider (meta/table-metadata :venues))]
+  (let [query lib.tu/venues-query]
     (testing (lib.util/format "Query =\n%s" (u/pprint-to-str query))
       (is (=? [{:lib/type                 :metadata/column
                 :name                     "ID"
@@ -134,7 +134,7 @@
 
 (deftest ^:parallel breakoutable-expressions-test
   (testing "orderable-columns should include expressions"
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (let [query (-> lib.tu/venues-query
                     (lib/expression "Category ID + 1"  (lib/+ (meta/field-metadata :venues :category-id) 1)))]
       (testing (lib.util/format "Query =\n%s" (u/pprint-to-str query))
         (is (=? [{:id (meta/id :venues :id) :name "ID"}
@@ -154,7 +154,7 @@
 
 (deftest ^:parallel binned-breakouts-test
   (testing "binned breakout columns should have a position (#31437)"
-    (let [base-query (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (let [base-query lib.tu/venues-query
           breakoutables (lib/breakoutable-columns base-query)
           price-col (m/find-first #(= (:name %) "PRICE") breakoutables)
           latitude-col (m/find-first #(= (:name %) "LATITUDE") breakoutables)
@@ -175,7 +175,7 @@
 
 (deftest ^:parallel breakoutable-explicit-joins-test
   (testing "breakoutable-columns should include columns from explicit joins"
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (let [query (-> lib.tu/venues-query
                     (lib/join (-> (lib/join-clause
                                    (meta/table-metadata :categories)
                                    [(lib/=
@@ -244,7 +244,7 @@
 
 (deftest ^:parallel breakoutable-columns-e2e-test
   (testing "Use the metadata returned by `breakoutable-columns` to add a new breakout to a query."
-    (let [query (lib/query meta/metadata-provider (meta/table-metadata :venues))]
+    (let [query lib.tu/venues-query]
       (is (=? {:lib/type :mbql/query
                :database (meta/id)
                :stages   [{:lib/type     :mbql.stage/mbql
@@ -265,7 +265,7 @@
 
 (deftest ^:parallel breakoutable-columns-own-and-implicitly-joinable-columns-e2e-test
   (testing "An implicitly joinable column can be broken out by."
-    (let [query (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (let [query lib.tu/venues-query
           cat-name-col (m/find-first #(= (:id %) (meta/id :categories :name))
                                      (lib/breakoutable-columns query))
           ven-price-col (m/find-first #(= (:id %) (meta/id :venues :price))
@@ -390,7 +390,7 @@
                      (lib/display-name query' breakout))))))))))
 
 (deftest ^:parallel breakoutable-columns-expression-e2e-test
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/expression "expr" (lib/absolute-datetime "2020" :month))
                   (lib/with-fields [(meta/field-metadata :venues :id)]))]
     (is (=? [{:id (meta/id :venues :id),          :name "ID",          :display-name "ID",          :lib/source :source/table-defaults}
@@ -416,7 +416,7 @@
                  (lib/describe-query query'))))))))
 
 (deftest ^:parallel breakoutable-columns-new-stage-e2e-test
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/expression "expr" (lib/absolute-datetime "2020" :month))
                   (as-> <> (lib/with-fields <> [(meta/field-metadata :venues :id)
                                                 (lib/expression-ref <> "expr")]))
@@ -448,7 +448,7 @@
             "Categories__ID" ; this column is not projected, but should still be returned.
             "Categories__NAME"]
            (map :lib/desired-column-alias
-                (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                (-> lib.tu/venues-query
                     (lib/join (-> (lib/join-clause
                                    (meta/table-metadata :categories)
                                    [(lib/=
@@ -469,7 +469,7 @@
                                  "busted ref"
                                  [:field {:lib/uuid (str (random-uuid))} (meta/id :categories :name)]}]
       (testing (str \newline message " ref = " (pr-str field-ref))
-        (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+        (let [query (-> lib.tu/venues-query
                         (lib/join (-> (lib/join-clause
                                        (meta/table-metadata :categories)
                                        [(lib/=

--- a/test/metabase/lib/column_group_test.cljc
+++ b/test/metabase/lib/column_group_test.cljc
@@ -11,7 +11,7 @@
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
 (deftest ^:parallel basic-test
-  (let [query   (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query   lib.tu/venues-query
         columns (lib/orderable-columns query)
         groups  (lib/group-columns columns)]
     (is (not (mc/explain [:sequential @#'lib.column-group/ColumnGroup] groups)))
@@ -45,7 +45,7 @@
              (mapcat lib/columns-group-columns groups))))))
 
 (deftest ^:parallel aggregation-and-breakout-test
-  (let [query   (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query   (-> lib.tu/venues-query
                     (lib/aggregate (lib/sum (meta/field-metadata :venues :id)))
                     (lib/breakout (meta/field-metadata :venues :name)))
         columns (lib/orderable-columns query)
@@ -66,7 +66,7 @@
              (mapcat lib/columns-group-columns groups))))))
 
 (deftest ^:parallel multi-stage-test
-  (let [query   (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query   (-> lib.tu/venues-query
                     (lib/aggregate (lib/sum (meta/field-metadata :venues :id)))
                     (lib/breakout (meta/field-metadata :venues :name))
                     (lib/append-stage))

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -23,7 +23,7 @@
                      :expressions [[:+ {:lib/uuid string? :lib/expression-name "myadd"}
                                     1
                                     [:field {:base-type :type/Integer, :lib/uuid string?} (meta/id :venues :category-id)]]]}]}
-          (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+          (-> lib.tu/venues-query
               (lib/expression "myadd" (lib/+ 1 (meta/field-metadata :venues :category-id)))
               (dissoc :lib/metadata)))))
 
@@ -76,7 +76,7 @@
                           (lib/upper string-field) :type/Text
                           (lib/lower string-field) :type/Text])]
       (testing (str "expression: " (pr-str expr))
-        (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+        (let [query (-> lib.tu/venues-query
                         (lib/expression "myexpr" expr))
               resolved (lib.expression/resolve-expression query 0 "myexpr")]
           (testing (pr-str resolved)
@@ -240,7 +240,7 @@
   (testing "expressions should include the original expression name"
     (is (=? [{:name         "expr"
               :display-name "expr"}]
-            (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+            (-> lib.tu/venues-query
                 (lib/expression "expr" (lib/absolute-datetime "2020" :month))
                 lib/expressions-metadata))))
   (testing "collisions with other column names are detected and rejected"
@@ -263,15 +263,15 @@
             :name "expr",
             :display-name "expr",
             :lib/source :source/expressions}]
-          (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+          (-> lib.tu/venues-query
               (lib/expression "expr" 100)
               (lib/expressions-metadata))))
   (is (=? [[:value {:lib/expression-name "expr" :effective-type :type/Integer} 100]]
-          (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+          (-> lib.tu/venues-query
               (lib/expression "expr" 100)
               (lib/expressions))))
   (is (=? [[:value {:lib/expression-name "expr" :effective-type :type/Text} "value"]]
-          (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+          (-> lib.tu/venues-query
               (lib/expression "expr" "value")
               (lib/expressions)))))
 

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -417,7 +417,7 @@
 
 (deftest ^:parallel available-binning-strategies-expressions-test
   (testing "There should be no binning strategies for expressions as they are not supported (#31367)"
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (let [query (-> lib.tu/venues-query
                     (lib/expression "myadd" (lib/+ 1 (meta/field-metadata :venues :category-id))))]
       (is (empty? (->> (lib.metadata.calculation/returned-columns query)
                        (m/find-first (comp #{"myadd"} :name))
@@ -488,7 +488,7 @@
 
 (deftest ^:parallel implicitly-joinable-field-display-name-test
   (testing "Should be able to calculate a display name for an implicitly joinable Field"
-    (let [query           (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (let [query           lib.tu/venues-query
           categories-name (m/find-first #(= (:id %) (meta/id :categories :name))
                                         (lib/orderable-columns query))]
       (are [style expected] (= expected
@@ -582,7 +582,7 @@
               (lib.metadata.calculation/returned-columns query))))))
 
 (deftest ^:parallel with-fields-test
-  (let [query           (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query           (-> lib.tu/venues-query
                             (lib/expression "myadd" (lib/+ 1 (meta/field-metadata :venues :category-id)))
                             (lib/with-fields [(meta/field-metadata :venues :id) (meta/field-metadata :venues :name)]))
         fields-metadata (fn [query]
@@ -612,7 +612,7 @@
               (is (not (has-fields? query'))))))))))
 
 (deftest ^:parallel with-fields-plus-expression-test
-  (let [query           (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query           (-> lib.tu/venues-query
                             (lib/with-fields [(meta/field-metadata :venues :id)])
                             (lib/expression "myadd" (lib/+ 1 (meta/field-metadata :venues :category-id))))
         fields-metadata (fn [query]
@@ -632,7 +632,7 @@
              {:lib/desired-column-alias "LATITUDE", :selected? true}
              {:lib/desired-column-alias "LONGITUDE", :selected? true}
              {:lib/desired-column-alias "PRICE", :selected? true}]
-            (lib/fieldable-columns (lib/query meta/metadata-provider (meta/table-metadata :venues)))))))
+            (lib/fieldable-columns lib.tu/venues-query)))))
 
 (deftest ^:parallel fieldable-columns-query-with-fields-test
   (testing "query with :fields"
@@ -642,7 +642,7 @@
              {:lib/desired-column-alias "LATITUDE", :selected? false}
              {:lib/desired-column-alias "LONGITUDE", :selected? false}
              {:lib/desired-column-alias "PRICE", :selected? false}]
-            (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+            (-> lib.tu/venues-query
                 (lib/with-fields [(meta/field-metadata :venues :id)
                                   (meta/field-metadata :venues :name)])
                 lib/fieldable-columns)))))
@@ -690,7 +690,7 @@
               [:field {:lib/uuid "aa0e13af-29b3-4c27-a880-a10c33e55a3e", :base-type :type/Text} 4]))))))
 
 (deftest ^:parallel ref-to-joined-column-from-previous-stage-test
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/join (-> (lib/join-clause
                                  (meta/table-metadata :categories)
                                  [(lib/=

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -285,7 +285,7 @@
                 (lib/filter new-filter)
                 lib/filters))))
   (testing "standalone clause"
-    (let [query (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (let [query lib.tu/venues-query
           [id-col] (lib/filterable-columns query)
           [eq-op] (lib/filterable-column-operators id-col)
           filter-clause (lib/filter-clause eq-op id-col 123)]

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -600,10 +600,10 @@
                       query
                       (meta/table-metadata :categories)))
       ;; plain query
-      (lib/query meta/metadata-provider (meta/table-metadata :venues))
+      lib.tu/venues-query
 
       ;; query with an aggregation (FK column is not exported, but is still "visible")
-      (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+      (-> lib.tu/venues-query
           (lib/aggregate (lib/count))))))
 
 (deftest ^:parallel suggested-join-condition-pk->fk-test

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -4,7 +4,7 @@
    [metabase.lib.js :as lib.js]
    [metabase.lib.test-util :as lib.tu]))
 
-(deftest query=-test
+(deftest ^:parallel query=-test
   (doseq [q1 [nil js/undefined]
           q2 [nil js/undefined]]
     (is (lib.js/query= q1 q2)))
@@ -51,7 +51,7 @@
   Object
   (raw [_this] guts))
 
-(deftest query=-unwrapping-test
+(deftest ^:parallel query=-unwrapping-test
   (testing "JS wrapper types like Join get unwrapped"
     ;; This doesn't use the real Join classes, just pretends it has one.
     (let [join         #js {"alias" "Products"
@@ -66,7 +66,7 @@
       (is (not= (js->clj join) (js->clj join-class)))
       (is (lib.js/query= basic-query classy-query)))))
 
-(deftest available-join-strategies-test
+(deftest ^:parallel available-join-strategies-test
   (testing "available-join-strategies returns an array of opaque strategy objects (#32089)"
     (let [strategies (lib.js/available-join-strategies lib.tu/query-with-join -1)]
       (is (array? strategies))

--- a/test/metabase/lib/limit_test.cljc
+++ b/test/metabase/lib/limit_test.cljc
@@ -2,12 +2,16 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [metabase.lib.core :as lib]
-   [metabase.lib.test-metadata :as meta]))
+   [metabase.lib.test-metadata :as meta]
+   [metabase.lib.test-util :as lib.tu]
+   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))))
+
+#?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
 (deftest ^:parallel limit-test
   (letfn [(limit [query]
             (get-in query [:stages 0 :limit] ::not-found))]
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (let [query (-> lib.tu/venues-query
                     (lib/limit 100))]
       (is (= 100
              (limit query)))
@@ -21,7 +25,7 @@
 
 (deftest ^:parallel current-limit-test
   (testing "Last stage"
-    (let [query (lib/query meta/metadata-provider (meta/table-metadata :venues))]
+    (let [query lib.tu/venues-query]
       (is (nil? (lib/current-limit query)))
       (is (nil? (lib/current-limit query -1)))
       (is (= 100 (lib/current-limit (lib/limit query 100))))

--- a/test/metabase/lib/metadata/calculation_test.cljc
+++ b/test/metabase/lib/metadata/calculation_test.cljc
@@ -3,11 +3,12 @@
    [clojure.test :refer [deftest is testing]]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
-   [metabase.lib.test-metadata :as meta]))
+   [metabase.lib.test-metadata :as meta]
+   [metabase.lib.test-util :as lib.tu]))
 
 (deftest ^:parallel calculate-names-even-without-metadata-test
   (testing "Even if metadata is missing, we should still be able to calculate reasonable display names"
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (let [query (-> lib.tu/venues-query
                     (lib/order-by [:field
                                    {:lib/uuid  (str (random-uuid))
                                     :base-type :type/Text}
@@ -16,7 +17,7 @@
              (lib.metadata.calculation/suggested-name query))))))
 
 (deftest ^:parallel long-display-name-test
-  (let [query (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query lib.tu/venues-query
         results (->> query
                      lib.metadata.calculation/visible-columns
                      (map (comp :long-display-name #(lib/display-info query 0 %))))]
@@ -70,7 +71,7 @@
             "Categories__ID"            ; this column is not projected, but should still be returned.
             "Categories__NAME"]
            (map :lib/desired-column-alias
-                (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                (-> lib.tu/venues-query
                     (lib/join (-> (lib/join-clause
                                    (meta/table-metadata :categories)
                                    [(lib/=
@@ -79,5 +80,5 @@
                                   (lib/with-join-fields [(lib/with-join-alias (meta/field-metadata :categories :name) "Categories")])))
                     lib.metadata.calculation/visible-columns)))))
   (testing "nil has no visible columns (#31366)"
-    (is (empty? (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (is (empty? (-> lib.tu/venues-query
                     (lib.metadata.calculation/visible-columns nil))))))

--- a/test/metabase/lib/metric_test.cljc
+++ b/test/metabase/lib/metric_test.cljc
@@ -146,7 +146,7 @@
 
 (deftest ^:parallel ga-metric-metadata-test
   (testing "Make sure we can calculate metadata for FAKE Google Analytics metric clauses"
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (let [query (-> lib.tu/venues-query
                     (lib/aggregate [:metric {:lib/uuid (str (random-uuid))} "ga:totalEvents"]))]
       (is (=? [{:base-type                :type/*
                 :display-name             "[Unknown Metric]"

--- a/test/metabase/lib/native_test.cljc
+++ b/test/metabase/lib/native_test.cljc
@@ -8,6 +8,7 @@
    [metabase.lib.native :as lib.native]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-metadata.graph-provider :as meta.graph-provider]
+   [metabase.lib.test-util :as lib.tu]
    [metabase.util.humanization :as u.humanization]))
 
 (deftest ^:parallel variable-tag-test
@@ -203,7 +204,7 @@
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs :default)
           #"Must be a native query"
-          (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+          (-> lib.tu/venues-query
               (lib/with-native-query "foobar"))))))
 
 (deftest ^:parallel with-template-tags-test
@@ -227,7 +228,7 @@
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs :default)
           #"Must be a native query"
-          (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+          (-> lib.tu/venues-query
               (lib/with-template-tags {"myid" (assoc (get original-tags "myid") :display-name "My ID")}))))))
 
 (defn ^:private metadata-provider-requiring-collection []
@@ -268,7 +269,7 @@
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs :default)
           #"Must be a native query"
-          (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+          (-> lib.tu/venues-query
               (lib/with-different-database meta/metadata-provider))))))
 
 (deftest ^:parallel with-native-collection-test

--- a/test/metabase/lib/order_by_test.cljc
+++ b/test/metabase/lib/order_by_test.cljc
@@ -22,7 +22,7 @@
                        :order-by     [[:asc
                                        {:lib/uuid string?}
                                        [:field {:lib/uuid string?} (meta/id :venues :id)]]]}]}
-          (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+          (-> lib.tu/venues-query
               (lib/order-by (meta/field-metadata :venues :id))))))
 
 (deftest ^:parallel threading-test
@@ -32,7 +32,7 @@
                        :order-by     [[:asc
                                        {:lib/uuid string?}
                                        [:field {:lib/uuid string?} (meta/id :venues :id)]]]}]}
-          (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+          (-> lib.tu/venues-query
               (lib/order-by (meta/field-metadata :venues :id))
               (dissoc :lib/metadata)))))
 
@@ -43,7 +43,7 @@
                        :order-by     [[:desc
                                        {:lib/uuid string?}
                                        [:field {:lib/uuid string?} (meta/id :venues :id)]]]}]}
-          (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+          (-> lib.tu/venues-query
               (lib/order-by (meta/field-metadata :venues :id) :desc)
               (dissoc :lib/metadata)))))
 
@@ -90,7 +90,7 @@
   (is (=? [[:asc
             {:lib/uuid string?}
             [:field {:lib/uuid string?} (meta/id :venues :id)]]]
-          (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+          (-> lib.tu/venues-query
               (lib/order-by (meta/field-metadata :venues :id))
               lib/order-bys))))
 
@@ -121,7 +121,7 @@
 
 (deftest ^:parallel orderable-columns-breakouts-test
   (testing "If query has aggregations and/or breakouts you can only order by those."
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (let [query (-> lib.tu/venues-query
                     (lib/aggregate (lib/sum (meta/field-metadata :venues :price)))
                     (lib/aggregate (lib/avg (lib/+ (meta/field-metadata :venues :price) 1)))
                     (lib/breakout (meta/field-metadata :venues :category-id)))]
@@ -152,7 +152,7 @@
 
 (deftest ^:parallel orderable-columns-breakouts-with-expression-test
   (testing "If query has aggregations and/or breakouts you can only order by those (with an expression)"
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (let [query (-> lib.tu/venues-query
                     (lib/expression "Category ID + 1"  (lib/+ (meta/field-metadata :venues :category-id) 1))
                     (lib/breakout [:expression {:lib/uuid (str (random-uuid))} "Category ID + 1"]))]
       (testing (lib.util/format "Query =\n%s" (u/pprint-to-str query))
@@ -164,7 +164,7 @@
                 (lib/orderable-columns query)))))))
 
 (deftest ^:parallel orderable-columns-test
-  (let [query (lib/query meta/metadata-provider (meta/table-metadata :venues))]
+  (let [query lib.tu/venues-query]
     (testing (lib.util/format "Query =\n%s" (u/pprint-to-str query))
       (is (=? [{:lib/type                 :metadata/column
                 :name                     "ID"
@@ -233,7 +233,7 @@
 
 (deftest ^:parallel orderable-expressions-test
   (testing "orderable-columns should include expressions"
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (let [query (-> lib.tu/venues-query
                     (lib/expression "Category ID + 1"  (lib/+ (meta/field-metadata :venues :category-id) 1)))]
       (testing (lib.util/format "Query =\n%s" (u/pprint-to-str query))
         (is (=? [{:id (meta/id :venues :id) :name "ID"}
@@ -253,7 +253,7 @@
 
 (deftest ^:parallel orderable-expressions-exclude-boolean-expressions-test
   (testing "orderable-columns should filter out boolean expressions."
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (let [query (-> lib.tu/venues-query
                     (lib/expression "Name is empty?"  (lib/is-empty (meta/field-metadata :venues :name))))]
       (testing (lib.util/format "Query =\n%s" (u/pprint-to-str query))
         (is (=? [{:id (meta/id :venues :id) :name "ID"}
@@ -268,7 +268,7 @@
 
 (deftest ^:parallel orderable-explicit-joins-test
   (testing "orderable-columns should include columns from explicit joins"
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (let [query (-> lib.tu/venues-query
                     (lib/join (-> (lib/join-clause
                                    (meta/table-metadata :categories)
                                    [(lib/=
@@ -331,7 +331,7 @@
 
 (deftest ^:parallel orderable-columns-e2e-test
   (testing "Use the metadata returned by `orderable-columns` to add a new order-by to a query."
-    (let [query (lib/query meta/metadata-provider (meta/table-metadata :venues))]
+    (let [query lib.tu/venues-query]
       (is (=? {:lib/type :mbql/query
                :database (meta/id)
                :stages   [{:lib/type     :mbql.stage/mbql
@@ -409,7 +409,7 @@
             :lib/source-column-alias  "NAME"
             :lib/desired-column-alias "Cat__NAME"
             :lib/source               :source/joins}]
-          (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+          (-> lib.tu/venues-query
               (lib/join (-> (lib/join-clause
                              (meta/table-metadata :categories)
                              [(lib/=
@@ -453,7 +453,7 @@
               :table-id                 (meta/id :categories)
               :lib/source-column-alias  "Cat__NAME"
               :lib/desired-column-alias "Cat__NAME"}]
-            (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+            (-> lib.tu/venues-query
                 (lib/join (-> (lib/join-clause
                                (meta/table-metadata :categories)
                                [(lib/=
@@ -468,7 +468,7 @@
 
 (deftest ^:parallel orderable-columns-exclude-already-sorted-columns-test
   (testing "orderable-columns should return position for normal Fields already included in :order-by (#30568)"
-    (let [query (lib/query meta/metadata-provider (meta/table-metadata :venues))]
+    (let [query lib.tu/venues-query]
       (is (=? [{:display-name "ID",          :lib/source :source/table-defaults}
                {:display-name "Name",        :lib/source :source/table-defaults}
                {:display-name "Category ID", :lib/source :source/table-defaults}
@@ -511,7 +511,7 @@
 
 (deftest ^:parallel orderable-columns-exclude-already-sorted-aggregation-test
   (testing "orderable-columns should return position for aggregation refs that are already in :order-by (#30568)"
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (let [query (-> lib.tu/venues-query
                     (lib/aggregate (lib/sum (meta/field-metadata :venues :price)))
                     (lib/aggregate (lib/sum (meta/field-metadata :venues :id))))]
       (let [orderable-columns (lib/orderable-columns query)]
@@ -528,7 +528,7 @@
 
 (deftest ^:parallel orderable-columns-exclude-already-sorted-joined-columns-test
   (testing "orderable-columns should return position for joined columns that are already in :order-by (#30568)"
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (let [query (-> lib.tu/venues-query
                     (lib/join (-> (lib/join-clause (meta/table-metadata :categories))
                                   (lib/with-join-alias "Cat")
                                   (lib/with-join-fields :all)
@@ -569,7 +569,7 @@
 
 (deftest ^:parallel orderable-columns-exclude-already-sorted-implicitly-joinable-columns-test
   (testing "orderable-columns should return position implicitly joinable columns that are already in :order-by (#30568)"
-    (let [query (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (let [query lib.tu/venues-query
           query (-> query
                     (lib/order-by (m/find-first #(= (:id %) (meta/id :categories :name))
                                    (lib/orderable-columns query))))]
@@ -591,7 +591,7 @@
 
 (deftest ^:parallel orderable-columns-exclude-already-sorted-expression-test
   (testing "orderable-columns should return position for expressions that are already in :order-by (#30568)"
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (let [query (-> lib.tu/venues-query
                     (lib/expression "My Expression" (lib/+ 2 3)))]
       (is (=? [{:display-name "ID",            :lib/source :source/table-defaults}
                {:display-name "Name",          :lib/source :source/table-defaults}
@@ -627,7 +627,7 @@
             "Categories__ID" ; this column is not projected, but should still be returned.
             "Categories__NAME"]
            (map :lib/desired-column-alias
-                (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                (-> lib.tu/venues-query
                     (lib/join (-> (lib/join-clause
                                    (meta/table-metadata :categories)
                                    [(lib/=
@@ -638,7 +638,7 @@
 
 (deftest ^:parallel order-by-aggregation-test
   (testing "Should be able to order by an aggregation (#30089)"
-    (let [query             (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (let [query             (-> lib.tu/venues-query
                                 (lib/aggregate (lib/avg (lib/+ (meta/field-metadata :venues :price) 1))))
           {ag-uuid :lib/source-uuid} (first (lib/aggregations-metadata query))
           orderable-columns (lib/orderable-columns query)]
@@ -674,7 +674,7 @@
                    (lib/describe-query query'')))))))))
 
 (deftest ^:parallel order-by-expression-test
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/expression "expr" (lib/absolute-datetime "2020" :month))
                   (lib/with-fields [(meta/field-metadata :venues :id)]))]
     (is (=? [{:id (meta/id :venues :id),          :name "ID",          :display-name "ID",          :lib/source :source/table-defaults}
@@ -700,7 +700,7 @@
                  (lib/describe-query updated-query))))))))
 
 (deftest ^:parallel orderable-columns-display-info-test
-  (let [query (lib/query meta/metadata-provider (meta/table-metadata :venues))]
+  (let [query lib.tu/venues-query]
     (is (=? [{:semantic-type          :type/PK
               :is-calculated          false
               :table                  {:name "VENUES", :display-name "Venues" :is-source-table true}
@@ -728,7 +728,7 @@
               (lib/display-info query col))))))
 
 (deftest ^:parallel order-bys-display-info-test
-  (let [query             (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query             lib.tu/venues-query
         orderable-columns (lib/orderable-columns query)
         col               (m/find-first #(= (:id %) (meta/id :venues :name)) orderable-columns)
         _                 (is (some? col))
@@ -754,7 +754,7 @@
 
 (deftest ^:parallel change-direction-test
   (doseq [[dir opposite] {:asc :desc, :desc :asc}]
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (let [query (-> lib.tu/venues-query
                     (lib/order-by (meta/field-metadata :venues :id) dir))
           current-order-by (first (lib/order-bys query))
           new-query (lib/change-direction query current-order-by)

--- a/test/metabase/lib/query_test.cljc
+++ b/test/metabase/lib/query_test.cljc
@@ -4,14 +4,15 @@
    [clojure.test :refer [deftest is]]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
-   [metabase.lib.test-metadata :as meta]))
+   [metabase.lib.test-metadata :as meta]
+   [metabase.lib.test-util :as lib.tu]))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
 (comment lib/keep-me)
 
 (deftest ^:parallel describe-query-test
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/aggregate (lib/sum (meta/field-metadata :venues :price))))
         ;; wrong arity: there's a bug in our Kondo config, see https://metaboat.slack.com/archives/C04DN5VRQM6/p1679022185079739?thread_ts=1679022025.317059&cid=C04DN5VRQM6
         query (-> #_{:clj-kondo/ignore [:invalid-arity]}

--- a/test/metabase/lib/remove_replace_test.cljc
+++ b/test/metabase/lib/remove_replace_test.cljc
@@ -11,7 +11,7 @@
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
 (deftest ^:parallel remove-clause-order-bys-test
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/order-by (meta/field-metadata :venues :name))
                   (lib/order-by (meta/field-metadata :venues :name)))
         order-bys (lib/order-bys query)]
@@ -26,7 +26,7 @@
                   (lib/order-bys))))))
 
 (deftest ^:parallel remove-clause-filters-test
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/filter (lib/= (meta/field-metadata :venues :price) 4))
                   (lib/filter (lib/= (meta/field-metadata :venues :name) "x")))
         filters (lib/filters query)]
@@ -41,7 +41,7 @@
                   (lib/filters))))))
 
 (deftest ^:parallel remove-clause-join-conditions-test
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/join (lib/join-clause (lib/query meta/metadata-provider (meta/table-metadata :categories))
                                              [(lib/= (meta/field-metadata :venues :price) 4)
                                               (lib/= (meta/field-metadata :venues :name) "x")])))
@@ -61,7 +61,7 @@
               (lib/remove-clause (second conditions)))))))
 
 (deftest ^:parallel remove-clause-breakout-test
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/breakout (meta/field-metadata :venues :id))
                   (lib/breakout (meta/field-metadata :venues :name)))
         breakouts (lib/breakouts query)]
@@ -97,7 +97,7 @@
                     (lib/breakouts 0)))))))
 
 (deftest ^:parallel remove-clause-fields-test
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/expression "myadd" (lib/+ 1 (meta/field-metadata :venues :category-id)))
                   (lib/with-fields [(meta/field-metadata :venues :id) (meta/field-metadata :venues :name)]))
         fields (lib/fields query)]
@@ -134,7 +134,7 @@
 
 (deftest ^:parallel remove-clause-join-fields-test
   (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :categories))
-                  (lib/join (-> (lib/join-clause (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                  (lib/join (-> (lib/join-clause lib.tu/venues-query
                                                  [(lib/= (meta/field-metadata :venues :price) 4)])
                                 (lib/with-join-fields [(meta/field-metadata :venues :price)
                                                        (meta/field-metadata :venues :id)]))))
@@ -171,7 +171,7 @@
     (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :categories))
                     (lib/breakout (meta/field-metadata :categories :id))
                     (lib/aggregate (lib/sum (meta/field-metadata :categories :id)))
-                    (lib/join (-> (lib/join-clause (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                    (lib/join (-> (lib/join-clause lib.tu/venues-query
                                                    [(lib/= (meta/field-metadata :venues :category-id)
                                                            (meta/field-metadata :categories :id))])
                                   (lib/with-join-fields :all))))
@@ -195,7 +195,7 @@
                                   (lib/avg (lib/length (meta/field-metadata :categories :name)))))))))
 
 (deftest ^:parallel remove-clause-aggregation-test
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/aggregate (lib/sum (meta/field-metadata :venues :id)))
                   (lib/aggregate (lib/sum (meta/field-metadata :venues :price))))
         aggregations (lib/aggregations query)]
@@ -218,7 +218,7 @@
                   (lib/remove-clause 0 (first aggregations))))))))
 
 (deftest ^:parallel remove-clause-expression-test
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/expression "a" (meta/field-metadata :venues :id))
                   (lib/expression "b" (meta/field-metadata :venues :price)))
         [expr-a expr-b :as expressions] (lib/expressions query)]
@@ -241,7 +241,7 @@
                   (lib/remove-clause 0 expr-a)))))))
 
 (deftest ^:parallel replace-clause-order-by-test
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/filter (lib/= "myvenue" (meta/field-metadata :venues :name)))
                   (lib/order-by (meta/field-metadata :venues :name))
                   (lib/order-by (meta/field-metadata :venues :name)))
@@ -257,7 +257,7 @@
       (is (= (second order-bys) (second replaced-order-bys))))))
 
 (deftest ^:parallel replace-clause-filters-test
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/filter (lib/= (meta/field-metadata :venues :name) "myvenue"))
                   (lib/filter (lib/= (meta/field-metadata :venues :price) 2)))
         filters (lib/filters query)]
@@ -272,7 +272,7 @@
       (is (= (second filters) (second replaced-filters))))))
 
 (deftest ^:parallel replace-clause-join-conditions-test
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/join (lib/join-clause (lib/query meta/metadata-provider (meta/table-metadata :categories))
                                              [(lib/= (meta/field-metadata :venues :price) 4)])))
         conditions (lib/join-conditions (first (lib/joins query)))]
@@ -287,7 +287,7 @@
       (is (= (second conditions) (second replaced-conditions))))))
 
 (deftest ^:parallel replace-clause-join-fields-test
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/join
                     (-> (lib/join-clause (lib/query meta/metadata-provider (meta/table-metadata :categories))
                                          [(lib/= (meta/field-metadata :venues :price) 4)])
@@ -305,7 +305,7 @@
       (is (= 1 (count replaced-fields))))))
 
 (deftest ^:parallel replace-clause-breakout-test
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/breakout (meta/field-metadata :venues :id))
                   (lib/breakout (meta/field-metadata :venues :name)))
         breakouts (lib/breakouts query)
@@ -332,7 +332,7 @@
                               (lib/breakouts 0)))))))
 
 (deftest ^:parallel replace-clause-fields-test
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/with-fields [(meta/field-metadata :venues :id) (meta/field-metadata :venues :name)]))
         fields (lib/fields query)
         replaced (-> query
@@ -358,7 +358,7 @@
                            (lib/fields 0)))))))
 
 (deftest ^:parallel replace-clause-aggregation-test
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/aggregate (lib/sum (meta/field-metadata :venues :id)))
                   (lib/aggregate (lib/distinct (meta/field-metadata :venues :name))))
         aggregations (lib/aggregations query)
@@ -408,7 +408,7 @@
                   (as-> $q (lib/replace-clause $q (first (lib/aggregations $q)) (lib/count)))))))))
 
 (deftest ^:parallel replace-clause-expression-test
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/expression "a" (meta/field-metadata :venues :id))
                   (lib/expression "b" (meta/field-metadata :venues :name)))
         [expr-a expr-b :as expressions] (lib/expressions query)
@@ -461,7 +461,7 @@
         (is (= :day (:temporal-unit (second (last (first (lib/order-bys q3)))))))
         (is (= :month (:temporal-unit (second (last (first (lib/order-bys q4)))))))))
     (testing "Binning should keep in order-by in sync"
-      (let [query (lib/query meta/metadata-provider (meta/table-metadata :venues))
+      (let [query lib.tu/venues-query
             breakout-col (->> (lib/breakoutable-columns query)
                               (m/find-first (comp #{"PRICE"} :name)))
             ten (->> (lib/available-binning-strategies query breakout-col)
@@ -480,7 +480,7 @@
         (is (= 100 (:num-bins (:binning (second (last (first (lib/order-bys q3))))))))
         (is (= 10 (:num-bins (:binning (second (last (first (lib/order-bys q4))))))))))
     (testing "Replace the correct order-by bin when there are multiple"
-      (let [query (lib/query meta/metadata-provider (meta/table-metadata :venues))
+      (let [query lib.tu/venues-query
             breakout-col (->> (lib/breakoutable-columns query)
                               (m/find-first (comp #{"PRICE"} :name)))
             ten (->> (lib/available-binning-strategies query breakout-col)
@@ -517,7 +517,7 @@
                          (lib/replace-clause ten-breakout fiddy)
                          lib/order-bys))))))
     (testing "Replacing with a new field should remove the order by"
-      (let [query (lib/query meta/metadata-provider (meta/table-metadata :venues))
+      (let [query lib.tu/venues-query
             breakout-col (->> (lib/breakoutable-columns query)
                               (m/find-first (comp #{"PRICE"} :name)))
             new-breakout-col (->> (lib/breakoutable-columns query)
@@ -536,7 +536,7 @@
                   (lib/replace-clause ten-breakout new-breakout-col)
                   lib/order-bys)))))
     (testing "Removing a breakout should remove the order by"
-      (let [query (lib/query meta/metadata-provider (meta/table-metadata :venues))
+      (let [query lib.tu/venues-query
             breakout-col (->> (lib/breakoutable-columns query)
                               (m/find-first (comp #{"PRICE"} :name)))
             q2 (-> query

--- a/test/metabase/lib/stage_test.cljc
+++ b/test/metabase/lib/stage_test.cljc
@@ -16,7 +16,7 @@
    (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
 (deftest ^:parallel ensure-previous-stages-have-metadata-test
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/with-fields [(meta/field-metadata :venues :id) (meta/field-metadata :venues :name)])
                   lib/append-stage
                   lib/append-stage)]
@@ -75,7 +75,7 @@
            (lib.metadata.calculation/display-name query)))))
 
 (deftest ^:parallel adding-and-removing-stages
-  (let [query                (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query                lib.tu/venues-query
         query-with-new-stage (-> query
                                  lib/append-stage
                                  (lib/order-by 1 (meta/field-metadata :venues :name) :asc))]
@@ -89,7 +89,7 @@
       (is (thrown-with-msg? #?(:cljs :default :clj Exception) #"Cannot drop the only stage" (-> query (lib/drop-stage)))))))
 
 (defn- query-with-expressions []
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/expression "ID + 1" (lib/+ (meta/field-metadata :venues :id) 1))
                   (lib/expression "ID + 2" (lib/+ (meta/field-metadata :venues :id) 2)))]
     (is (=? {:stages [{:expressions [[:+ {:lib/expression-name "ID + 1"} [:field {} (meta/id :venues :id)] 1]
@@ -201,7 +201,7 @@
             (map lib/ref cols)))))
 
 (deftest ^:parallel fields-should-not-hide-joined-fields
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/with-fields [(meta/field-metadata :venues :id)
                                     (meta/field-metadata :venues :name)])
                   (lib/join (-> (lib/join-clause (meta/table-metadata :categories))

--- a/test/metabase/lib/table_test.cljc
+++ b/test/metabase/lib/table_test.cljc
@@ -5,11 +5,15 @@
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.metadata.protocols :as metadata.protocols]
    [metabase.lib.test-metadata :as meta]
-   [metabase.util.malli :as mu]))
+   [metabase.lib.test-util :as lib.tu]
+   [metabase.util.malli :as mu]
+   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))))
+
+#?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
 (deftest ^:parallel join-table-metadata-test
   (testing "You should be able to pass :metadata/table to lib/join INDIRECTLY VIA join-clause"
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (let [query (-> lib.tu/venues-query
                     (lib/join (-> (lib/join-clause (meta/table-metadata :categories))
                                   (lib/with-join-alias "Cat")
                                   (lib/with-join-fields :all)

--- a/test/metabase/lib/temporal_bucket_test.cljc
+++ b/test/metabase/lib/temporal_bucket_test.cljc
@@ -5,7 +5,8 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.temporal-bucket :as lib.temporal-bucket]
-   [metabase.lib.test-metadata :as meta]))
+   [metabase.lib.test-metadata :as meta]
+   [metabase.lib.test-util :as lib.tu]))
 
 (deftest ^:parallel describe-temporal-interval-test
   (doseq [unit [:day nil]]
@@ -157,7 +158,7 @@
 
 (deftest ^:parallel temporal-bucketing-options-expressions-test
   (testing "There should be no bucketing options for expressions as they are not supported (#31367)"
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+    (let [query (-> lib.tu/venues-query
                     (lib/expression "myadd" (lib/+ 1 (meta/field-metadata :venues :category-id))))]
       (is (empty? (->> (lib.metadata.calculation/returned-columns query)
                        (m/find-first (comp #{"myadd"} :name))

--- a/test/metabase/lib/types/isa_test.cljc
+++ b/test/metabase/lib/types/isa_test.cljc
@@ -1,10 +1,14 @@
 (ns metabase.lib.types.isa-test
   (:require
-   [clojure.test :refer [deftest is are testing]]
+   [clojure.test :refer [are deftest is testing]]
    [metabase.lib.core :as lib]
    [metabase.lib.test-metadata :as meta]
+   [metabase.lib.test-util :as lib.tu]
    [metabase.lib.types.constants :as lib.types.constants]
-   [metabase.lib.types.isa :as lib.types.isa]))
+   [metabase.lib.types.isa :as lib.types.isa]
+   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))))
+
+#?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
 (deftest ^:parallel basic-isa-test
   (testing "nil doesn't belong to any type"
@@ -28,7 +32,7 @@
               :type/Text)))))
 
 (deftest ^:parallel column-isa-test
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+  (let [query (-> lib.tu/venues-query
                   (lib/expression "myadd" (lib/+ 1 (meta/field-metadata :venues :category-id))))
         orderable-columns (lib/orderable-columns query)
         columns-of-type (fn [typ] (filter #(lib.types.isa/isa? % typ)


### PR DESCRIPTION
- Enable our `:metabase/validate-deftest` linter which I wrote but forgot to enable. Adds warning if you try to use `with-redefs` in a `^:parallel` test, etc.
- Do Kondo analysis for `deftest` and `is` in Cljs (previously only done for Clojure, even in Cljc/Cljs files)
- Add `:metabase/missing-test-expr-requires-in-cljs` linter that will warn if you try to use `=?` or `malli=` in Cljc/Cljs without requiring the namespaces you need to require
   - Fix the warnings
- Update things to use `lib.tu/venues-query` instead of constructing the same query from scratch 100 times