### PR TITLE
Centralize EE endpoints error message

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/api/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/api/routes.clj
@@ -14,7 +14,8 @@
    [metabase-enterprise.content-verification.api.routes
     :as content-verification]
    [metabase-enterprise.sandbox.api.routes :as sandbox]
-   [metabase-enterprise.serialization.api.routes :as serialization]))
+   [metabase-enterprise.serialization.api.routes :as serialization]
+   [metabase.util.i18n :refer [deferred-tru]]))
 
 (compojure/defroutes ^{:doc "API routes only available when running Metabase® Enterprise Edition™."} routes
   ;; The following routes are NAUGHTY and do not follow the naming convention (i.e., they do not start with
@@ -29,13 +30,13 @@
    "/ee" []
    (compojure/context
     "/audit-app" []
-    (ee.api.common/+require-premium-feature :audit-app audit-app/routes))
+    (ee.api.common/+require-premium-feature :audit-app (deferred-tru "Audit app") audit-app/routes))
    (compojure/context
     "/advanced-permissions" []
-    (ee.api.common/+require-premium-feature :advanced-permissions advanced-permissions/routes))
+    (ee.api.common/+require-premium-feature :advanced-permissions (deferred-tru "Advanced Permissions") advanced-permissions/routes))
    (compojure/context
     "/logs" []
-    (ee.api.common/+require-premium-feature :advanced-config logs/routes))
+    (ee.api.common/+require-premium-feature :advanced-config (deferred-tru "Advanced Config") logs/routes))
    (compojure/context
     "/serialization" []
-    (ee.api.common/+require-premium-feature :serialization serialization/routes))))
+    (ee.api.common/+require-premium-feature :serialization (deferred-tru "Serialization") serialization/routes))))

--- a/enterprise/backend/src/metabase_enterprise/api/routes/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/api/routes/common.clj
@@ -2,26 +2,23 @@
   "Shared stuff used by various EE-only API routes."
   (:require
    [metabase.public-settings.premium-features :as premium-features]
-   [metabase.util.i18n :refer [tru]]))
+   [metabase.util.i18n :as i18n]))
 
 (defn +require-premium-feature
   "Wraps Ring `handler`. Check that we have a premium token with `feature` (a keyword; see [[metabase.public-settings.premium-features]] for a
   current known features) or return a 401 if it is not.
 
-    (context \"/whatever\" [] (+require-premium-feature :sandboxes whatever/routes))
+    (context \"/whatever\" [] (+require-premium-feature :sandboxes (tru \"Sandboxes\") whatever/routes))
 
   Very important! Make sure you only wrap handlers inside [[compojure.core/context]] forms with this middleware (as in
   example above). Otherwise it can end up causing requests the handler would not have handled anyway to fail.
   Use [[when-premium-feature]] instead if you want the handler to apply if we have the premium feature but pass-thru
   if we do not."
-  [feature handler]
+  [feature feature-name handler]
+  (assert (i18n/localized-string? feature-name), (format "`feature-name` %s must be i18ned" feature-name))
   (fn [request respond raise]
-    (if-not (premium-features/has-feature? feature)
-      (respond {:body   (tru "This API endpoint is only enabled if you have a premium token with the {0} feature."
-                             feature)
-                ;; 402 Payment Required
-                :status 402})
-      (handler request respond raise))))
+    (premium-features/assert-has-feature feature feature-name)
+    (handler request respond raise)))
 
 (defn ^:deprecated +when-premium-feature
   "Wraps Ring `handler`. Only applies handler if we have a premium token with `feature`; if not, passes thru to the next

--- a/enterprise/backend/src/metabase_enterprise/api/routes/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/api/routes/common.clj
@@ -8,7 +8,7 @@
   "Wraps Ring `handler`. Check that we have a premium token with `feature` (a keyword; see [[metabase.public-settings.premium-features]] for a
   current known features) or return a 401 if it is not.
 
-    (context \"/whatever\" [] (+require-premium-feature :sandboxes (tru \"Sandboxes\") whatever/routes))
+    (context \"/whatever\" [] (+require-premium-feature :sandboxes (deferred-tru \"Sandboxes\") whatever/routes))
 
   Very important! Make sure you only wrap handlers inside [[compojure.core/context]] forms with this middleware (as in
   example above). Otherwise it can end up causing requests the handler would not have handled anyway to fail.

--- a/enterprise/backend/src/metabase_enterprise/api/routes/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/api/routes/common.clj
@@ -15,7 +15,7 @@
   Use [[when-premium-feature]] instead if you want the handler to apply if we have the premium feature but pass-thru
   if we do not."
   [feature feature-name handler]
-  (assert (i18n/localized-string? feature-name), (format "`feature-name` %s must be i18ned" feature-name))
+  (assert (i18n/localized-string? feature-name), "`feature-name` must be i18ned")
   (fn [request respond raise]
     (premium-features/assert-has-feature feature feature-name)
     (handler request respond raise)))

--- a/enterprise/backend/src/metabase_enterprise/content_verification/api/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_verification/api/routes.clj
@@ -3,10 +3,11 @@
    [compojure.core :as compojure :refer [context]]
    [metabase-enterprise.api.routes.common :as ee.api.common]
    [metabase-enterprise.content-verification.api.review :as review]
-   [metabase.api.routes.common :refer [+auth]]))
+   [metabase.api.routes.common :refer [+auth]]
+   [metabase.util.i18n :refer [deferred-tru]]))
 
 (defn- +require-content-verification [handler]
-  (ee.api.common/+require-premium-feature :content-verification handler))
+  (ee.api.common/+require-premium-feature :content-verification (deferred-tru "Content verification") handler))
 
 (compojure/defroutes ^{:doc "API routes only available if we have a premium token with the `:content-verification` feature."}
   routes

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/routes.clj
@@ -6,7 +6,8 @@
    [metabase-enterprise.sandbox.api.gtap :as gtap]
    [metabase-enterprise.sandbox.api.table :as table]
    [metabase-enterprise.sandbox.api.user :as user]
-   [metabase.api.routes.common :refer [+auth]]))
+   [metabase.api.routes.common :refer [+auth]]
+   [metabase.util.i18n :refer [deferred-tru]]))
 
 (compojure/defroutes ^{:doc "Ring routes for mt API endpoints."} routes
   ;; EE-only sandboxing routes live under `/mt` for historical reasons. `/mt` is for multi-tenant.
@@ -16,6 +17,7 @@
    "/mt" []
    (ee.api.common/+require-premium-feature
     :sandboxes
+    (deferred-tru "Sandboxes")
     (compojure/routes
      (compojure/context "/gtap" [] (+auth gtap/routes))
      (compojure/context "/user" [] (+auth user/routes)))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/api/logs_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/api/logs_test.clj
@@ -51,5 +51,5 @@
                  (mt/user-http-request :rasta :get 403 "ee/logs/query_execution/2023-02")))))
       (testing "only works when `:advanced-config` feature is available."
         (premium-features.test/with-premium-features #{}
-          (is (= "This API endpoint is only enabled if you have a premium token with the :advanced-config feature."
+          (is (= "Advanced Config is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
                  (mt/user-http-request :crowberto :get 402 "ee/logs/query_execution/2023-02"))))))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/application_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/application_test.clj
@@ -12,7 +12,7 @@
     (testing "GET /api/ee/advanced-permissions/application/graph"
       (premium-features-test/with-premium-features #{}
         (testing "Should require a token with `:advanced-permissions`"
-          (is (= "This API endpoint is only enabled if you have a premium token with the :advanced-permissions feature."
+          (is (= "Advanced Permissions is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
                  (mt/user-http-request :crowberto :get 402 "ee/advanced-permissions/application/graph")))))
 
       (premium-features-test/with-premium-features #{:advanced-permissions}
@@ -43,7 +43,7 @@
 
         (premium-features-test/with-premium-features #{}
           (testing "Should require a token with `:advanced-permissions`"
-            (is (= "This API endpoint is only enabled if you have a premium token with the :advanced-permissions feature."
+            (is (= "Advanced Permissions is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
                    (mt/user-http-request :crowberto :put 402 "ee/advanced-permissions/application/graph" new-graph)))))
 
         (premium-features-test/with-premium-features #{:advanced-permissions}

--- a/enterprise/backend/test/metabase_enterprise/audit_app/api/user_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/api/user_test.clj
@@ -12,7 +12,7 @@
     (testing "Should require a token with `:audit-app`"
       (premium-features-test/with-premium-features #{}
         (t2.with-temp/with-temp [User {user-id :id}]
-          (is (= "This API endpoint is only enabled if you have a premium token with the :audit-app feature."
+          (is (= "Audit app is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
                  (mt/user-http-request user-id
                                        :delete 402
                                        (format "ee/audit-app/user/%d/subscriptions" user-id)))))))

--- a/enterprise/backend/test/metabase_enterprise/content_management/api/collection_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_management/api/collection_test.clj
@@ -110,12 +110,12 @@
      :model/Card {model-id :id} {:name "A question" :dataset true}]
     (testing "can't use verified questions/models if has :official-collections feature"
       (premium-features-test/with-premium-features #{:official-collections}
-        (is (= "This API endpoint is only enabled if you have a premium token with the :content-verification feature."
+        (is (= "Content verification is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
                (mt/user-http-request :crowberto :post 402 "moderation-review"
                                      {:moderated_item_id   card-id
                                       :moderated_item_type :card
                                       :status              :verified})))
-        (is (= "This API endpoint is only enabled if you have a premium token with the :content-verification feature."
+        (is (= "Content verification is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
                (mt/user-http-request :crowberto :post 402 "moderation-review"
                                      {:moderated_item_id   model-id
                                       :moderated_item_type :card

--- a/enterprise/backend/test/metabase_enterprise/content_verification/api/review_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_verification/api/review_test.clj
@@ -16,7 +16,7 @@
   (testing "POST /api/moderation-review"
     (testing "Should require a token with `:content-verification`"
       (premium-features-test/with-premium-features #{}
-        (is (= "This API endpoint is only enabled if you have a premium token with the :content-verification feature."
+        (is (= "Content verification is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
                (mt/user-http-request :rasta :post 402 "moderation-review"
                                      {:text                "review"
                                       :status              "verified"

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
@@ -51,7 +51,7 @@
           (mt/with-temp* [Table            [{table-id :id}]
                           PermissionsGroup [{group-id :id}]
                           Card             [{card-id :id}]]
-            (is (= "This API endpoint is only enabled if you have a premium token with the :sandboxes feature."
+            (is (= "Sandboxes is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
                    (mt/user-http-request :crowberto :post 402 "mt/gtap"
                                          {:table_id             table-id
                                           :group_id             group-id

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/user_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/user_test.clj
@@ -47,7 +47,7 @@
 
 (deftest get-user-attributes-test
   (testing "requires sandbox enabled"
-    (is (= "This API endpoint is only enabled if you have a premium token with the :sandboxes feature."
+    (is (= "Sandboxes is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
            (mt/user-http-request :crowberto :get 402 "mt/user/attributes"))))
 
   (premium-features-test/with-premium-features #{:sandboxes}
@@ -66,7 +66,7 @@
 
 (deftest update-user-attributes-test
   (testing "requires sandbox enabled"
-    (is (= "This API endpoint is only enabled if you have a premium token with the :sandboxes feature."
+    (is (= "Sandboxes is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
            (mt/user-http-request :crowberto :put 402 (format "mt/user/%d/attributes" (mt/user->id :crowberto)) {}))))
 
   (premium-features-test/with-premium-features #{:sandboxes}

--- a/enterprise/backend/test/metabase_enterprise/serialization/api/serialize_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api/serialize_test.clj
@@ -76,7 +76,7 @@
                                                 request))]
        (testing "Require a EE token with the `:serialization` feature"
          (premium-features-test/with-premium-features #{}
-           (is (= "This API endpoint is only enabled if you have a premium token with the :serialization feature."
+           (is (= "Serialization is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
                   (serialize! :expected-status-code 402)))))
        (testing "Require current user to be a superuser"
          (is (= "You don't have permissions to do that."


### PR DESCRIPTION
Change the error message for ee endpoints from 
`This API endpoint is only enabled if you have a premium token with the :advanced-config feature.` 
to
 `Advanced Config is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/`

Context: https://metaboat.slack.com/archives/C05EWA11Z1V/p1689776384483649

Epic: https://github.com/metabase/metabase-private/issues/80