### PR TITLE
Reset heading size and adjust line-height for h1 inside aside

### DIFF
--- a/frontend/src/metabase/css/core/headings.css
+++ b/frontend/src/metabase/css/core/headings.css
@@ -22,7 +22,7 @@ h6,
 /**
  * Correct the font size on `h1` elements within `section` and
  * `article` contexts in Chrome, Firefox, and Safari.
- * https://github.com/necolas/normalize.css/blob/master/normalize.css#L40
+ * https://github.com/necolas/normalize.css/blob/fc091cc/normalize.css#L40
  */
 h1 {
   font-size: 2em;

--- a/frontend/src/metabase/css/core/headings.css
+++ b/frontend/src/metabase/css/core/headings.css
@@ -19,6 +19,15 @@ h6,
   margin-bottom: var(--default-header-margin);
 }
 
+/**
+ * Correct the font size on `h1` elements within `section` and
+ * `article` contexts in Chrome, Firefox, and Safari.
+ * https://github.com/necolas/normalize.css/blob/master/normalize.css#L40
+ */
+h1 {
+  font-size: 2em;
+}
+
 .h1 {
   font-size: 2em;
 }

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.styled.tsx
@@ -45,6 +45,10 @@ export const ContentSection = styled.div`
     font-size: 1rem;
     line-height: 1.4rem;
     margin-left: -0.3rem;
+
+    h1 {
+      line-height: 1em;
+    }
   }
 
   ${FormField.Root}:last-child {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.styled.tsx
@@ -35,6 +35,10 @@ export const ContentSection = styled.div<ContentSectionProps>`
     font-size: 1rem;
     line-height: 1.4rem;
     margin-left: -0.3rem;
+
+    h1 {
+      line-height: 1em;
+    }
   }
 `;
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31327

### Description

Reset css for h1 inside aside. It turned out `h1` has a reduced size inside some html tags, normalize.css solves this problem, but we don't use it at the moment. https://github.com/necolas/normalize.css/blob/master/normalize.css#L35-L43

### How to verify


1. open any question -> click on `i` button on the right hand, find "about section", type there 
```
# Heading 1

## Heading 2
```
2. click outside the textarea - text should be formatted as h1 and h2
3. verify that h1 is actually bigger than h2 and looks great
4. repeat for dashboard instead of question

### Demo

<img width="391" alt="image" src="https://github.com/metabase/metabase/assets/125459446/52a6611d-6f66-4a91-b6b7-c76f8ecd9860">
<img width="385" alt="image" src="https://github.com/metabase/metabase/assets/125459446/6c2fa5b7-5af6-4520-893c-8eb0a31e7bb4">


### Checklist

~- [ ] Tests have been added/updated to cover changes in this PR~
