### PR TITLE
DRAFT - DO NOT SUBMIT - experimental fieldable-columns-with-joins

### DIFF
--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -140,7 +140,8 @@
   [lib.field
    fields
    with-fields
-   fieldable-columns]
+   fieldable-columns
+   fieldable-columns-with-joins]
   [lib.filter
    filter
    filters

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -408,8 +408,8 @@
   (-> column
       lib.core/ref
       convert/->legacy-MBQL
-      (update 2 update-keys u/->camelCaseEn)
-      (clj->js :keyword-fn u/qualified-name)))
+      (update 2 update-vals u/qualified-name)
+      clj->js))
 
 (defn ^:export join-strategy
   "Get the strategy (type) of a given join as an opaque JoinStrategy object."

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -402,6 +402,15 @@
   [a-query stage-number]
   (to-array (lib.core/fieldable-columns-with-joins a-query stage-number)))
 
+(defn ^:export legacy-field-ref
+  "Given a column metadata from eg. [[fieldable-columns]], return it as a legacy JSON field ref."
+  [column]
+  (-> column
+      lib.core/ref
+      convert/->legacy-MBQL
+      (update 2 update-keys u/->camelCaseEn)
+      (clj->js :keyword-fn u/qualified-name)))
+
 (defn ^:export join-strategy
   "Get the strategy (type) of a given join as an opaque JoinStrategy object."
   [a-join]

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -396,6 +396,12 @@
   [a-query stage-number]
   (to-array (lib.core/fieldable-columns a-query stage-number)))
 
+(defn ^:export fieldable-columns-with-joins
+  "Return a sequence of column metadatas for columns that you can specify in the `:fields` of a query, including fields
+  which are expressions or explicitly joined in."
+  [a-query stage-number]
+  (to-array (lib.core/fieldable-columns-with-joins a-query stage-number)))
+
 (defn ^:export join-strategy
   "Get the strategy (type) of a given join as an opaque JoinStrategy object."
   [a-join]


### PR DESCRIPTION
Experimental new function `fieldable-columns-with-joins` that include explicitly joined and custom expression fields,
which `fieldable-columns` excludes (perhaps wrongly?)
