### PR TITLE
Fix `value` propTypes for `ParameterFieldWidget` component

### DIFF
--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/ParameterFieldWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/ParameterFieldWidget.jsx
@@ -26,7 +26,7 @@ const propTypes = {
   parameters: PropTypes.array.isRequired,
   placeholder: PropTypes.string.isRequired,
   setValue: PropTypes.func.isRequired,
-  value: PropTypes.string,
+  value: PropTypes.arrayOf(PropTypes.string),
   question: PropTypes.object,
   dashboard: PropTypes.object,
 };

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/ParameterFieldWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/ParameterFieldWidget.jsx
@@ -26,7 +26,10 @@ const propTypes = {
   parameters: PropTypes.array.isRequired,
   placeholder: PropTypes.string.isRequired,
   setValue: PropTypes.func.isRequired,
-  value: PropTypes.arrayOf(PropTypes.string),
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+  ]),
   question: PropTypes.object,
   dashboard: PropTypes.object,
 };


### PR DESCRIPTION
There was a warning in the console about mismatched prop types for this component.

It seems that the component always expects an array of strings for its value, but the propTypes for it was set to string.

### How to test?
1. Open any dashboard with the text/category filter
2. Click on the filter and observe the console

There should be no errors related to failed prop type for the `value`.

Before the fix:
```
react-jsx-runtime.development.js:124 Warning: Failed prop type: Invalid prop `value` of type `array` supplied to `ParameterFieldWidget`, expected `string`.
    in ParameterFieldWidget (created by Widget)
    in Widget (created by ParameterValueWidget)
    in div (created by Popover)
    in OnClickOutsideWrapper (created by Popover)
    in span (created by Popover)
    in Popover (created by Triggerable[Popover])
    in Triggerable[Popover] (created by ParameterValueWidget)
    in ParameterValueWidget (created by ParameterWidget)
    in div (created by FieldSet)
    in fieldset (created by FieldSet)
```