### PR TITLE
docs - update release list

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -15,11 +15,15 @@ See docs on [upgrading Metabase](./installation-and-operation/upgrading-metabase
 
 ## Metabase Enterprise Edition releases
 
+- [v1.46.6.1](https://github.com/metabase/metabase/releases/tag/v1.46.6.1)
+- [v1.46.6](https://github.com/metabase/metabase/releases/tag/v1.46.6)
+- [v1.46.5](https://github.com/metabase/metabase/releases/tag/v1.46.5)
 - [v1.46.4](https://github.com/metabase/metabase/releases/tag/v1.46.4)
 - [v1.46.3](https://github.com/metabase/metabase/releases/tag/v1.46.3)
 - [v1.46.2](https://github.com/metabase/metabase/releases/tag/v1.46.2)
 - [v1.46.1](https://github.com/metabase/metabase/releases/tag/v1.46.1)
 - [v1.46.0](https://github.com/metabase/metabase/releases/tag/v1.46.0)
+- [v1.45.4.1](https://github.com/metabase/metabase/releases/tag/v1.45.4.1)
 - [v1.45.4](https://github.com/metabase/metabase/releases/tag/v1.45.4)
 - [v1.45.3.1](https://github.com/metabase/metabase/releases/tag/v1.45.3.1)
 - [v1.45.3](https://github.com/metabase/metabase/releases/tag/v1.45.3)
@@ -27,6 +31,7 @@ See docs on [upgrading Metabase](./installation-and-operation/upgrading-metabase
 - [v1.45.2](https://github.com/metabase/metabase/releases/tag/v1.45.2)
 - [v1.45.1](https://github.com/metabase/metabase/releases/tag/v1.45.1)
 - [v1.45.0](https://github.com/metabase/metabase/releases/tag/v1.45.0)
+- [v1.44.7.1](https://github.com/metabase/metabase/releases/tag/v1.44.7.1)
 - [v1.44.7](https://github.com/metabase/metabase/releases/tag/v1.44.7)
 - [v1.44.6.1](https://github.com/metabase/metabase/releases/tag/v1.44.6.1)
 - [v1.44.6](https://github.com/metabase/metabase/releases/tag/v1.44.6)
@@ -36,6 +41,7 @@ See docs on [upgrading Metabase](./installation-and-operation/upgrading-metabase
 - [v1.44.2](https://github.com/metabase/metabase/releases/tag/v1.44.2)
 - [v1.44.1](https://github.com/metabase/metabase/releases/tag/v1.44.1)
 - [v1.44.0](https://github.com/metabase/metabase/releases/tag/v1.44.0)
+- [v1.43.7.2](https://github.com/metabase/metabase/releases/tag/v1.43.7.2)
 - [v1.43.7.1](https://github.com/metabase/metabase/releases/tag/v1.43.7.1)
 - [v1.43.7](https://github.com/metabase/metabase/releases/tag/v1.43.7)
 - [v1.43.5](https://github.com/metabase/metabase/releases/tag/v1.43.5)
@@ -105,11 +111,15 @@ See docs on [upgrading Metabase](./installation-and-operation/upgrading-metabase
 
 ## Metabase Open Source Edition releases
 
+- [v0.46.6.1](https://github.com/metabase/metabase/releases/tag/v0.46.6.1)
+- [v0.46.6](https://github.com/metabase/metabase/releases/tag/v0.46.6)
+- [v0.46.5](https://github.com/metabase/metabase/releases/tag/v0.46.5)
 - [v0.46.4](https://github.com/metabase/metabase/releases/tag/v0.46.4)
 - [v0.46.3](https://github.com/metabase/metabase/releases/tag/v0.46.3)
 - [v0.46.2](https://github.com/metabase/metabase/releases/tag/v0.46.2)
 - [v0.46.1](https://github.com/metabase/metabase/releases/tag/v0.46.1)
 - [v0.46.0](https://github.com/metabase/metabase/releases/tag/v0.46.0)
+- [v0.45.4.1](https://github.com/metabase/metabase/releases/tag/v0.45.4.1)
 - [v0.45.4](https://github.com/metabase/metabase/releases/tag/v0.45.4)
 - [v0.45.3.1](https://github.com/metabase/metabase/releases/tag/v0.45.3.1)
 - [v0.45.3](https://github.com/metabase/metabase/releases/tag/v0.45.3)
@@ -117,6 +127,7 @@ See docs on [upgrading Metabase](./installation-and-operation/upgrading-metabase
 - [v0.45.2](https://github.com/metabase/metabase/releases/tag/v0.45.2)
 - [v0.45.1](https://github.com/metabase/metabase/releases/tag/v0.45.1)
 - [v0.45.0](https://github.com/metabase/metabase/releases/tag/v0.45.0)
+- [v0.44.7.1](https://github.com/metabase/metabase/releases/tag/v0.44.7.1)
 - [v0.44.7](https://github.com/metabase/metabase/releases/tag/v0.44.7)
 - [v0.44.6.1](https://github.com/metabase/metabase/releases/tag/v0.44.6.1)
 - [v0.44.6](https://github.com/metabase/metabase/releases/tag/v0.44.6)
@@ -126,6 +137,7 @@ See docs on [upgrading Metabase](./installation-and-operation/upgrading-metabase
 - [v0.44.2](https://github.com/metabase/metabase/releases/tag/v0.44.2)
 - [v0.44.1](https://github.com/metabase/metabase/releases/tag/v0.44.1)
 - [v0.44.0](https://github.com/metabase/metabase/releases/tag/v0.44.0)
+- [v0.43.7.2](https://github.com/metabase/metabase/releases/tag/v0.43.7.2)
 - [v0.43.7.1](https://github.com/metabase/metabase/releases/tag/v0.43.7.1)
 - [v0.43.7](https://github.com/metabase/metabase/releases/tag/v0.43.7)
 - [v0.43.5](https://github.com/metabase/metabase/releases/tag/v0.43.5)


### PR DESCRIPTION
Backport to 46 branch of https://github.com/metabase/metabase/pull/32559.