### PR TITLE
adding Index route to people modal routes

### DIFF
--- a/e2e/test/scenarios/admin/people/people.cy.spec.js
+++ b/e2e/test/scenarios/admin/people/people.cy.spec.js
@@ -131,6 +131,7 @@ describe("scenarios > admin > people", () => {
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(FULL_NAME);
+      cy.location().should(loc => expect(loc.pathname).to.eq("/admin/people"));
     });
 
     it("should allow admin to create new users without first name or last name (metabase#22754)", () => {
@@ -198,6 +199,9 @@ describe("scenarios > admin > people", () => {
         cy.findByText("Deactivate user").click();
         clickButton("Deactivate");
         cy.findByText(FULL_NAME).should("not.exist");
+        cy.location().should(loc =>
+          expect(loc.pathname).to.eq("/admin/people"),
+        );
 
         cy.log("It should load inactive users");
         cy.findByText("Deactivated").click();
@@ -205,6 +209,9 @@ describe("scenarios > admin > people", () => {
         cy.icon("refresh").click();
         cy.findByText(`Reactivate ${FULL_NAME}?`);
         clickButton("Reactivate");
+        cy.location().should(loc =>
+          expect(loc.pathname).to.eq("/admin/people"),
+        );
       });
     });
 
@@ -221,6 +228,7 @@ describe("scenarios > admin > people", () => {
       clickButton("Update");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(NEW_FULL_NAME);
+      cy.location().should(loc => expect(loc.pathname).to.eq("/admin/people"));
     });
 
     it("should reset user password without SMTP set up", () => {
@@ -236,6 +244,7 @@ describe("scenarios > admin > people", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/^temporary password$/i);
       clickButton("Done");
+      cy.location().should(loc => expect(loc.pathname).to.eq("/admin/people"));
     });
 
     it(

--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -134,6 +134,7 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => (
           </Route>
 
           <Route path=":userId" component={PeopleListingApp}>
+            <IndexRedirect to="/admin/people" />
             <ModalRoute path="edit" modal={EditUserModal} />
             <ModalRoute path="success" modal={UserSuccessModal} />
             <ModalRoute path="reset" modal={UserPasswordResetModal} />


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/30197

### Description
The modal route definition has an "onClose" handler that navigates the user up to the parent route when the modal is closed. However, in the case of the modals in the People page, that will leave the userId in the URL. This change adds an `<IndexRedirect />` to automatically forward people from `/admin/people/:userId` to `/admin/people`. Assertions were added to existing e2e tests to confirm that the user ID was removed from the url.

### How to verify
1. Go to Admin Settings -> people
2. Open the edit user modal, but close the modal (or actually edit the user)
3. Examine the URL after the modal is closed. It should no longer include the UserID

This should be the case for any of the modals on this page.

### Demo
![chrome_MQ5wQJWPai](https://github.com/metabase/metabase/assets/1328979/37505b65-7f81-4d28-8b7c-02e75f357f6c)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
