### PR TITLE
Remove question error logs flag

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/api/session_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/api/session_test.clj
@@ -9,7 +9,6 @@
 
 (deftest properties-token-features-test
   (premium-features-test/with-premium-features #{:dashboard-subscription-filters
-                                                 :question-error-logs
                                                  :disable-password-login
                                                  :audit-app
                                                  :snippet-collections
@@ -45,7 +44,6 @@
                   :email_allow_list               true
                   :email_restrict_recipients      true
                   :embedding                      true
-                  :question_error_logs            true
                   :hosting                        true
                   :official_collections           true
                   :sandboxes                      true

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -564,7 +564,6 @@
                       :embedding                      (premium-features/hide-embed-branding?)
                       :hosting                        (premium-features/is-hosted?)
                       :official_collections           (premium-features/enable-official-collections?)
-                      :question_error_logs            (premium-features/enable-question-error-logs?)
                       :sandboxes                      (premium-features/enable-sandboxes?)
                       :session_timeout_config         (premium-features/enable-session-timeout-config?)
                       :snippet_collections            (premium-features/enable-snippet-collections?)

--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -373,10 +373,6 @@
   "Should we enable official collections (and more in the future, like workflows, forking, etc.)?"
   :content-management)
 
-(define-premium-feature ^{:added "0.41.0"} enable-question-error-logs?
-  "Should we enable viewing question error logs?"
-  :question-error-logs)
-
 (define-premium-feature ^{:added "0.41.0"} enable-official-collections?
   "Should we enable Official Collections?"
   :official-collections)


### PR DESCRIPTION
BE for https://github.com/metabase/metabase-private/issues/125
Removing the feature flag `question-error-logs` since it uses `audit-app` feature flag instead