### PR TITLE
Fix - Flaky test - table popover should not be scrollable horizontally

### DIFF
--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -759,7 +759,7 @@ class TableInteractive extends Component {
         }}
       >
         <HeaderCell
-          data-testid="header-cell"
+          data-testid={isVirtual ? undefined : "header-cell"}
           ref={e => (this.headerRefs[columnIndex] = e)}
           style={{
             ...style,


### PR DESCRIPTION
Closes #32590

### Description

[`TableInteractive` has a hack](https://github.com/metabase/metabase/blob/77fbb58/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx#L673-L680) which causes columns to be rendered twice in the DOM for a short while. This causes extra elements with `data-testid="header-cell"` to appear. 

This PR removes `data-testid` attributes from those extra temporary elements.

### How to verify

E2E Stress Test Flake Fix run: https://github.com/metabase/metabase/actions/runs/5653532856

The test has 48% flake rate. Running it several times should be a good indication it's fixed.

