### PR TITLE
[MLv2] Add TypeScript wrappers for MLv2 expression methods

### DIFF
--- a/frontend/src/metabase-lib/expression.ts
+++ b/frontend/src/metabase-lib/expression.ts
@@ -1,0 +1,25 @@
+import * as ML from "cljs/metabase.lib.js";
+import type { ColumnMetadata, ExpressionClause, Query } from "./types";
+
+export function expression(
+  query: Query,
+  stageIndex: number,
+  clause: ExpressionClause,
+): Query {
+  return ML.expression(query, stageIndex, clause);
+}
+
+export function expressions(
+  query: Query,
+  stageIndex: number,
+): ExpressionClause[] {
+  return ML.expressions(query, stageIndex);
+}
+
+export function expressionableColumns(
+  query: Query,
+  stageIndex: number,
+  expressionPosition: number,
+): ColumnMetadata[] {
+  return ML.expressionable_columns(query, stageIndex, expressionPosition);
+}

--- a/frontend/src/metabase-lib/expression.ts
+++ b/frontend/src/metabase-lib/expression.ts
@@ -4,9 +4,10 @@ import type { ColumnMetadata, ExpressionClause, Query } from "./types";
 export function expression(
   query: Query,
   stageIndex: number,
+  expressionName: string,
   clause: ExpressionClause,
 ): Query {
-  return ML.expression(query, stageIndex, clause);
+  return ML.expression(query, stageIndex, expressionName, clause);
 }
 
 export function expressions(

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -30,6 +30,9 @@ export type AggregationOperator = unknown & {
 declare const BreakoutClause: unique symbol;
 export type BreakoutClause = unknown & { _opaque: typeof BreakoutClause };
 
+declare const ExpressionClause: unique symbol;
+export type ExpressionClause = unknown & { _opaque: typeof ExpressionClause };
+
 declare const OrderByClause: unique symbol;
 export type OrderByClause = unknown & { _opaque: typeof OrderByClause };
 
@@ -41,6 +44,7 @@ export type FilterClause = unknown & { _opaque: typeof FilterClause };
 export type Clause =
   | AggregationClause
   | BreakoutClause
+  | ExpressionClause
   | FilterClause
   | OrderByClause;
 

--- a/frontend/src/metabase-lib/v2.ts
+++ b/frontend/src/metabase-lib/v2.ts
@@ -9,6 +9,7 @@ export * from "./column_types";
 export * from "./common";
 export * from "./comparison";
 export * from "./database";
+export * from "./expression";
 export * from "./fields";
 export * from "./filter";
 export * from "./join";


### PR DESCRIPTION
Epic #30513

Adds TypeScript wrapper for existing expression methods:

* `expression` — adds a new expression to a query
* `expressions` — returns a list of expressions in a query
* `expressionableColumns` — returns a list of columns that can be used in an expression