### PR TITLE
SecretKeyWidget accepts confirmation header and dialogs

### DIFF
--- a/e2e/test/scenarios/admin/settings/sso/jwt.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/sso/jwt.cy.spec.js
@@ -64,7 +64,13 @@ describeEE("scenarios > admin > settings > SSO > JWT", () => {
     cy.visit("/admin/settings/authentication/jwt");
 
     cy.button("Regenerate key").click();
-    modal().button("Yes").click();
+    modal().within(() => {
+      cy.findByText("Regenerate JWT signing key?").should("exist");
+      cy.findByText(
+        "This will cause existing tokens to stop working until the identity provider is updated with the new key.",
+      ).should("exist");
+      cy.button("Yes").click();
+    });
     cy.button("Save changes").click();
     cy.wait("@updateSettings");
 

--- a/e2e/test/scenarios/embedding/embedding-standalone.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-standalone.cy.spec.js
@@ -1,0 +1,24 @@
+import { restore, modal } from "e2e/support/helpers";
+const embeddingPage = "/admin/settings/embedding-in-other-applications";
+
+describe("scenarios > embedding > standalone embedding", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should allow you to set and regenerate an embedding token", () => {
+    cy.visit(embeddingPage);
+    cy.findByTestId("-standalone-embeds-setting")
+      .findByText("Standalone embeds")
+      .click();
+    cy.findByRole("button", { name: "Regenerate key" }).click();
+
+    modal().within(() => {
+      cy.findByText("Regenerate embedding key?").should("exist");
+      cy.findByText(
+        "This will cause existing embeds to stop working until they are updated with the new key.",
+      ).should("exist");
+    });
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/auth/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/auth/index.js
@@ -181,6 +181,12 @@ PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections => ({
         required: true,
         widget: SecretKeyWidget,
         getHidden: settings => !settings["jwt-enabled"],
+        props: {
+          confirmation: {
+            header: t`Regenerate JWT signing key?`,
+            dialog: t`This will cause existing tokens to stop working until the identity provider is updated with the new key.`,
+          },
+        },
       },
       {
         key: "jwt-attribute-email",

--- a/frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget/SecretKeyWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget/SecretKeyWidget.tsx
@@ -7,11 +7,19 @@ import { GenerateButton, SecretKeyWidgetRoot } from "./SecretKeyWidget.styled";
 interface SecretKeyWidgetProps {
   onChange: (token: string) => void;
   setting: any;
+  confirmation?: {
+    header: string;
+    dialog: string;
+  };
 }
 
 const SecretKeyWidget = ({
   onChange,
   setting,
+  confirmation = {
+    header: t`Regenerate embedding key?`,
+    dialog: t`This will cause existing embeds to stop working until they are updated with the new key.`,
+  },
   ...rest
 }: SecretKeyWidgetProps) => {
   const generateToken = async () => {
@@ -25,8 +33,8 @@ const SecretKeyWidget = ({
       {setting.value ? (
         <Confirm
           triggerClasses="full-height"
-          title={t`Regenerate embedding key?`}
-          content={t`This will cause existing embeds to stop working until they are updated with the new key.`}
+          title={confirmation.header}
+          content={confirmation.dialog}
           action={generateToken}
         >
           <GenerateButton primary>{t`Regenerate key`}</GenerateButton>

--- a/frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget/SecretKeyWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget/SecretKeyWidget.tsx
@@ -7,7 +7,7 @@ import { GenerateButton, SecretKeyWidgetRoot } from "./SecretKeyWidget.styled";
 interface SecretKeyWidgetProps {
   onChange: (token: string) => void;
   setting: any;
-  confirmation?: {
+  confirmation: {
     header: string;
     dialog: string;
   };
@@ -16,10 +16,7 @@ interface SecretKeyWidgetProps {
 const SecretKeyWidget = ({
   onChange,
   setting,
-  confirmation = {
-    header: t`Regenerate embedding key?`,
-    dialog: t`This will cause existing embeds to stop working until they are updated with the new key.`,
-  },
+  confirmation,
   ...rest
 }: SecretKeyWidgetProps) => {
   const generateToken = async () => {

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -515,6 +515,12 @@ const SECTIONS = {
         description: t`Standalone Embed Secret Key used to sign JSON Web Tokens for requests to /api/embed endpoints. This lets you create a secure environment limited to specific users or organizations.`,
         widget: SecretKeyWidget,
         getHidden: (_, derivedSettings) => !derivedSettings["enable-embedding"],
+        props: {
+          confirmation: {
+            header: t`Regenerate embedding key?`,
+            dialog: t`This will cause existing embeds to stop working until they are updated with the new key.`,
+          },
+        },
       },
       {
         key: "-embedded-dashboards",


### PR DESCRIPTION
Closes: https://github.com/metabase/metabase/issues/28644

### Description
Updating the `SecretKeyWidget` component to accept an override for the confirmation and dialog text, and passed in updated values for the JWT token

### How to verify

1. Run Enterprise Edition of Metabase
2. Go to Admin -> Authentication -> Setup JWT
3. Click "Generate Key", then click "Regenerate key".
4. The header and Dialog should be updated as per the issue.
5. Now go to Settings -> Embedding and enable embedding
6. Under standalone, click "Regenerate key". The dialog copy should be related to embedding key 


### Demo
![image](https://github.com/metabase/metabase/assets/1328979/adf7235e-8e60-4aab-842a-ea3e6582bd37)
![image](https://github.com/metabase/metabase/assets/1328979/c82bd8ca-cc96-43b3-87c1-ddbbab6ec463)


### Acceptance Criteria

- [x] JWT key re-generate dialog is updated and displayed according to design
- [x] Embedding key re-generate dialog is the same as before
- [x] Tests have been added/updated to cover changes in this PR
