### PR TITLE
fixing onFieldUpdate and unskipping tests

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/field.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/field.cy.spec.js
@@ -17,8 +17,9 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 // [quarantine] - intermittently failing, possibly due to a "flickering" element (re-rendering)
-describe.skip("scenarios > admin > datamodel > field", () => {
+describe("scenarios > admin > datamodel > field", () => {
   beforeEach(() => {
+    restore();
     cy.signInAsAdmin();
 
     ["CREATED_AT", "PRODUCT_ID", "QUANTITY"].forEach(name => {
@@ -60,6 +61,19 @@ describe.skip("scenarios > admin > datamodel > field", () => {
       cy.reload();
       cy.get("@display_name").should("have.value", "new display_name");
       cy.get("@description").should("have.value", "new description");
+    });
+  });
+
+  describe("Formatting", () => {
+    it("should allow you to change field formatting", () => {
+      visitAlias("@ORDERS_QUANTITY_URL");
+      cy.findByRole("link", { name: "Formatting" }).click();
+      cy.findByLabelText("Style").click();
+      popover().findByText("Percent").click();
+      cy.wait("@fieldUpdate");
+      cy.findByRole("list", { name: "undo-list" })
+        .findByText("Updated Quantity")
+        .should("exist");
     });
   });
 

--- a/frontend/src/metabase/admin/datamodel/metadata/components/FieldFormattingSettings/FieldFormattingSettings.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/FieldFormattingSettings/FieldFormattingSettings.tsx
@@ -18,7 +18,7 @@ interface DispatchProps {
 type FieldFormattingSettingsProps = OwnProps & DispatchProps;
 
 const mapDispatchToProps: DispatchProps = {
-  onUpdateField: Fields.updateField,
+  onUpdateField: Fields.actions.updateField,
 };
 
 const FieldFormattingSettings = ({

--- a/frontend/src/metabase/containers/UndoListing.jsx
+++ b/frontend/src/metabase/containers/UndoListing.jsx
@@ -91,7 +91,7 @@ function UndoListingInner() {
   const undos = useSelector(state => state.undo);
 
   return (
-    <UndoList data-testid="undo-list">
+    <UndoList data-testid="undo-list" aria-label="undo-list">
       {undos.map(undo => (
         <UndoToast
           key={undo._domId}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/32345

### Description
This PR does 2 things. It assigns the correct action to the `onFieldUpdate` dispatchToActions map, as well as unskipps the `fields.cy.spec.js` tests, as they have been skipped for about 3 years now. 

### How to verify

1. Go to Admin -> Table Metadata
2. Pick a table, then press the gear icon for one of the columns
3. On the left hand sidepanel, select formatting and try to change a setting. You should see a toast confirming the that setting has changed, and refreshing the page should persist your changes.

### Demo
![chrome_kzaXBwCSGo](https://github.com/metabase/metabase/assets/1328979/5ba9c975-4a2a-4438-a251-cf3ee78b173c)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
