### PR TITLE
When embedded, force showing side nav when top nav is hidden

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -165,10 +165,12 @@ describeEE("scenarios > embedding > full app", () => {
         qs: { additional_info: false },
       });
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Our analytics").should("be.visible");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText(/Edited/).should("not.exist");
+      cy.findByTestId("app-bar")
+        .findByText("Our analytics")
+        .should("be.visible");
+      cy.findByTestId("qb-header")
+        .findByText(/Edited/)
+        .should("not.exist");
     });
 
     it("should hide the question's action buttons by a param", () => {
@@ -282,12 +284,15 @@ describeEE("scenarios > embedding > full app", () => {
         qs: { additional_info: false },
       });
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Orders in a dashboard").should("be.visible");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText(/Edited/).should("not.exist");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Our analytics").should("be.visible");
+      cy.findByTestId("dashboard-header")
+        .findByText("Orders in a dashboard")
+        .should("be.visible");
+      cy.findByTestId("dashboard-header")
+        .findByText(/Edited/)
+        .should("not.exist");
+      cy.findByTestId("app-bar")
+        .findByText("Our analytics")
+        .should("be.visible");
     });
 
     it("should preserve embedding options with click behavior (metabase#24756)", () => {

--- a/frontend/src/metabase/redux/app.js
+++ b/frontend/src/metabase/redux/app.js
@@ -1,4 +1,5 @@
 import { push, LOCATION_CHANGE } from "react-router-redux";
+import { createSelector } from "@reduxjs/toolkit";
 
 import {
   combineReducers,
@@ -10,6 +11,8 @@ import {
   openInBlankWindow,
   shouldOpenInBlankWindow,
 } from "metabase/lib/dom";
+
+import { getEmbedOptions, getIsEmbedded } from "metabase/selectors/embed";
 
 export const SET_ERROR_PAGE = "metabase/app/SET_ERROR_PAGE";
 export function setErrorPage(error) {
@@ -60,9 +63,22 @@ export const openNavbar = createAction(OPEN_NAVBAR);
 export const closeNavbar = createAction(CLOSE_NAVBAR);
 export const toggleNavbar = createAction(TOGGLE_NAVBAR);
 
-export function getIsNavbarOpen(state) {
-  return state.app.isNavbarOpen;
-}
+export const getIsNavbarOpen = createSelector(
+  [getIsEmbedded, getEmbedOptions, state => state.app.isNavbarOpen],
+  (isEmbedded, embedOptions, isNavbarOpen) => {
+    // in an embedded instance, when the app bar is hidden, but the nav bar is not
+    // we need to force the sidebar to be open or else it will be totally inaccessible
+    if (
+      isEmbedded &&
+      embedOptions.side_nav === true &&
+      embedOptions.top_nav === false
+    ) {
+      return true;
+    }
+
+    return isNavbarOpen;
+  },
+);
 
 const isNavbarOpen = handleActions(
   {

--- a/frontend/src/metabase/redux/app.js
+++ b/frontend/src/metabase/redux/app.js
@@ -13,6 +13,7 @@ import {
 } from "metabase/lib/dom";
 
 import { getEmbedOptions, getIsEmbedded } from "metabase/selectors/embed";
+import { getIsAppBarVisible } from "metabase/selectors/app";
 
 export const SET_ERROR_PAGE = "metabase/app/SET_ERROR_PAGE";
 export function setErrorPage(error) {
@@ -64,15 +65,16 @@ export const closeNavbar = createAction(CLOSE_NAVBAR);
 export const toggleNavbar = createAction(TOGGLE_NAVBAR);
 
 export const getIsNavbarOpen = createSelector(
-  [getIsEmbedded, getEmbedOptions, state => state.app.isNavbarOpen],
-  (isEmbedded, embedOptions, isNavbarOpen) => {
+  [
+    getIsEmbedded,
+    getEmbedOptions,
+    getIsAppBarVisible,
+    state => state.app.isNavbarOpen,
+  ],
+  (isEmbedded, embedOptions, isAppBarVisible, isNavbarOpen) => {
     // in an embedded instance, when the app bar is hidden, but the nav bar is not
     // we need to force the sidebar to be open or else it will be totally inaccessible
-    if (
-      isEmbedded &&
-      embedOptions.side_nav === true &&
-      embedOptions.top_nav === false
-    ) {
+    if (isEmbedded && embedOptions.side_nav === true && !isAppBarVisible) {
       return true;
     }
 

--- a/frontend/src/metabase/redux/app.ts
+++ b/frontend/src/metabase/redux/app.ts
@@ -1,5 +1,6 @@
 import { push, LOCATION_CHANGE } from "react-router-redux";
 import { createSelector } from "@reduxjs/toolkit";
+import type { Selector } from "@reduxjs/toolkit";
 
 import {
   combineReducers,
@@ -14,9 +15,10 @@ import {
 
 import { getEmbedOptions, getIsEmbedded } from "metabase/selectors/embed";
 import { getIsAppBarVisible } from "metabase/selectors/app";
+import type { State, Dispatch } from "metabase-types/store";
 
 export const SET_ERROR_PAGE = "metabase/app/SET_ERROR_PAGE";
-export function setErrorPage(error) {
+export function setErrorPage(error: any) {
   console.error("Error:", error);
   return {
     type: SET_ERROR_PAGE,
@@ -24,13 +26,21 @@ export function setErrorPage(error) {
   };
 }
 
-export const openUrl = (url, options) => dispatch => {
-  if (shouldOpenInBlankWindow(url, options)) {
-    openInBlankWindow(url);
-  } else {
-    dispatch(push(url));
-  }
-};
+interface IOpenUrlOptions {
+  blank?: boolean;
+  event?: Event;
+  blankOnMetaOrCtrlKey?: boolean;
+  blankOnDifferentOrigin?: boolean;
+}
+
+export const openUrl =
+  (url: string, options: IOpenUrlOptions) => (dispatch: Dispatch) => {
+    if (shouldOpenInBlankWindow(url, options)) {
+      openInBlankWindow(url);
+    } else {
+      dispatch(push(url));
+    }
+  };
 
 const errorPage = handleActions(
   {
@@ -64,7 +74,7 @@ export const openNavbar = createAction(OPEN_NAVBAR);
 export const closeNavbar = createAction(CLOSE_NAVBAR);
 export const toggleNavbar = createAction(TOGGLE_NAVBAR);
 
-export const getIsNavbarOpen = createSelector(
+export const getIsNavbarOpen: Selector<State> = createSelector(
   [
     getIsEmbedded,
     getEmbedOptions,
@@ -91,6 +101,7 @@ const isNavbarOpen = handleActions(
   checkIsSidebarInitiallyOpen(),
 );
 
+// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default combineReducers({
   errorPage,
   isNavbarOpen,

--- a/frontend/src/metabase/selectors/app.ts
+++ b/frontend/src/metabase/selectors/app.ts
@@ -17,7 +17,6 @@ export interface RouterProps {
   location: Location;
 }
 
-const HOMEPAGE_PATH = /^\/$/;
 const PATHS_WITHOUT_NAVBAR = [
   /^\/auth/,
   /\/model\/.*\/query/,
@@ -25,11 +24,7 @@ const PATHS_WITHOUT_NAVBAR = [
   /\/model\/query/,
   /\/model\/metadata/,
 ];
-const EMBEDDED_PATHS_WITH_NAVBAR = [
-  HOMEPAGE_PATH,
-  /^\/collection\/.*/,
-  /^\/archive/,
-];
+
 const PATHS_WITH_COLLECTION_BREADCRUMBS = [
   /\/question\//,
   /\/model\//,
@@ -38,11 +33,11 @@ const PATHS_WITH_COLLECTION_BREADCRUMBS = [
 const PATHS_WITH_QUESTION_LINEAGE = [/\/question/, /\/model/];
 
 export const getRouterPath = (state: State, props: RouterProps) => {
-  return props.location.pathname;
+  return props?.location?.pathname ?? window.location.pathname;
 };
 
 export const getRouterHash = (state: State, props: RouterProps) => {
-  return props.location.hash;
+  return props?.location?.hash ?? window.location.hash;
 };
 
 export const getIsAdminApp = createSelector([getRouterPath], path => {
@@ -85,9 +80,7 @@ export const getIsNavBarEnabled = createSelector(
     if (isEmbedded && !embedOptions.side_nav) {
       return false;
     }
-    if (isEmbedded && embedOptions.side_nav === "default") {
-      return EMBEDDED_PATHS_WITH_NAVBAR.some(pattern => pattern.test(path));
-    }
+
     return !PATHS_WITHOUT_NAVBAR.some(pattern => pattern.test(path));
   },
 );


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/32542

### Description

In full-app embedding, when users set `?top_nav=false&side_nav=true` side nav would be invisible if they navigated directly to a question, model, or dashboard because on those pages, we hide the side nav by default. However, with top_nav hidden, users are totally unable to open the side nav (unless they happen to know the keyboard shortcut).

This forces the side nav open when it is explicitly set to `true` only when the top nav is hidden.

![Screen Shot 2023-07-24 at 3 29 57 PM](https://github.com/metabase/metabase/assets/30528226/e6d24d17-43a1-4202-bfd5-5095236f83a3)

. | side_nav=true | side_nav=false | side_nav=default
 --|---------------|----------------|----------------- 
 top_nav=true | side nav hidden by default on questions/dashboards/models, can toggle | never show side nav | side nav hidden by default on questions/dashboards/models, can toggle
 top_nav=false | always show side nav | never show side nav | side nav hidden on questions/dashboards/models

### How to verify

- you can easily simulate full-app-embedding locally by editing `frontend/src/metabase/lib/dom.js` to make the `isWithinIframe()` function always return `true` see [this guide](https://www.notion.so/metabase/Embedding-9d327a4178a14d24a18c8e7d5e4c2d78)
- navigate to a specific question or dashboard with these embedding params: `/question/1?top_nav=false&side_nav=true`
- see that you get the side nav to show up by default on every page in the app

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
