### PR TITLE
`with-join-conditions` should add `:join-alias` to RHSes

### DIFF
--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -33,6 +33,7 @@ export function metadataProvider(
   databaseId: DatabaseId,
   metadata: Metadata,
 ): MetadataProvider {
+  // eslint-disable-next-line no-console
   console.log("Initializing new metadata provider for metadata", metadata);
   return ML.metadataProvider(databaseId, metadata);
 }

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -33,6 +33,7 @@ export function metadataProvider(
   databaseId: DatabaseId,
   metadata: Metadata,
 ): MetadataProvider {
+  console.log("Initializing new metadata provider for metadata", metadata);
   return ML.metadataProvider(databaseId, metadata);
 }
 

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -71,25 +71,68 @@
                                                (with-join-alias field-ref new-alias))
                                              fields))))))
 
-(defn- with-join-alias-update-join-conditions
+(mu/defn ^:private standard-join-condition? :- :boolean
+  "Whether this join condition is a binary condition with two `:field` references (a LHS and a RHS), as you'd produce
+  in the frontend using functions like [[join-condition-operators]], [[join-condition-lhs-columns]],
+  and [[join-condition-rhs-columns]]."
+  [condition  :- ::lib.schema.expression/boolean]
+  (mbql.u.match/match-one condition
+    [(_operator :guard keyword?)
+     _opts
+     [:field _lhs-opts _lhs-id-or-name]
+     [:field _rhs-opts _rhs-id-or-name]]
+    true
+    _
+    false))
+
+(defn- standard-join-condition-rhs
+  "If `condition` is a [[standard-join-condition?]], return the RHS."
+  [condition]
+  (when (standard-join-condition? condition)
+    (let [[_operator _opts _lhs rhs] condition]
+      rhs)))
+
+(defn- standard-join-condition-update-rhs
+  "If `condition` is a [[standard-join-condition?]], update the RHS with `f` like
+
+    (apply f rhs args)"
+  [condition f & args]
+  (if-not (standard-join-condition? condition)
+    condition
+    (let [[operator opts lhs rhs] condition]
+      [operator opts lhs (apply f rhs args)])))
+
+(mu/defn ^:private with-join-alias-update-join-conditions :- PartialJoin
   "Impl for [[with-join-alias]] for a join: recursively update the `:join-alias` for inside the `:conditions` of the
   join.
 
-  Only updates things that already had a join alias of `old-alias`; does not add alias to things that did not already
-  have one (such as the RHS of a 'typical' join condition). I went back and forth on this behavior, but eventually
-  decided NOT to assume that every join condition is the shape
+  If `old-alias` is specified, uses [[metabase.mbql.util.match]] to update all the `:field` references using the old
+  alias.
 
-    [<operator> <lhs-column-from-source> <rhs-column-from-join>]
-
-  This is currently true of normal FE usage, but may not be true everywhere in the future; we don't want to make MLv2
-  impossible to use if you're doing something different like swapping the order of the columns or some sort of more
-  complex condition."
-  [join old-alias new-alias]
-  (if-not old-alias
+  If `old-alias` is `nil`, updates the RHS of all 'normal' conditions (binary filter clauses with two `:field` refs as
+  args, e.g. the kind you'd get if you were using [[join-condition-operators]] and the like to create them). This
+  currently doesn't handle more complex filter clauses that were created without the 'normal' MLv2 functions used by
+  the frontend; we can add this in the future if we need it."
+  [join      :- PartialJoin
+   old-alias :- [:maybe ::lib.schema.common/non-blank-string]
+   new-alias :- [:maybe ::lib.schema.common/non-blank-string]]
+  (cond
+    (empty? (:conditions join))
     join
+
+    ;; if we've specified `old-alias`, then update ANY `:field` clause using it to `new-alias` instead.
+    old-alias
     (mbql.u.match/replace-in join [:conditions]
       [:field {:join-alias old-alias} _id-or-name]
-      (with-join-alias &match new-alias))))
+      (with-join-alias &match new-alias))
+
+    ;; otherwise if `old-alias` is `nil`, then add (or remove!) `new-alias` to the RHS of any binary
+    ;; filter clauses that don't already have a `:join-alias`.
+    :else
+    (update join :conditions (fn [conditions]
+                               (mapv (fn [condition]
+                                       (standard-join-condition-update-rhs condition with-join-alias new-alias))
+                                     conditions)))))
 
 (defn- with-join-alias-update-join
   "Impl for [[with-join-alias]] for a join."
@@ -278,12 +321,27 @@
        :stages   [mbql-stage]}
       lib.options/ensure-uuid))
 
+(defn- with-join-conditions-add-alias-to-rhses
+  "Add `join-alias` to the RHS of all [[standard-join-condition?]] `conditions` that don't already have a `:join-alias`.
+  If an RHS already has a `:join-alias`, don't second guess what was already explicitly specified."
+  [conditions join-alias]
+  (if-not join-alias
+    conditions
+    (mapv (fn [condition]
+            (or (when-let [rhs (standard-join-condition-rhs condition)]
+                  (when-not (current-join-alias rhs)
+                    (standard-join-condition-update-rhs condition with-join-alias join-alias)))
+                condition))
+          conditions)))
+
 (mu/defn with-join-conditions :- PartialJoin
   "Update the `:conditions` (filters) for a Join clause."
   {:style/indent [:form]}
   [a-join     :- PartialJoin
    conditions :- [:maybe [:sequential [:or ::lib.schema.expression/boolean ::lib.schema.common/external-op]]]]
-  (u/assoc-dissoc a-join :conditions (not-empty (mapv lib.common/->op-arg conditions))))
+  (let [conditions (-> (mapv lib.common/->op-arg conditions)
+                       (with-join-conditions-add-alias-to-rhses (current-join-alias a-join)))]
+    (u/assoc-dissoc a-join :conditions (not-empty conditions))))
 
 (mu/defn join-clause :- PartialJoin
   "Create an MBQL join map from something that can conceptually be joined against. A `Table`? An MBQL or native query? A
@@ -472,15 +530,15 @@
    source-field-id-name :- ::lib.schema.common/non-blank-string]
   (lib.util/format "%s__via__%s" table-name source-field-id-name))
 
-(mu/defn join-conditions :- ::lib.schema.join/conditions
+(mu/defn join-conditions :- [:maybe ::lib.schema.join/conditions]
   "Get all join conditions for the given join"
-  [j :- ::lib.schema.join/join]
-  (:conditions j))
+  [a-join :- PartialJoin]
+  (:conditions a-join))
 
 (mu/defn join-fields :- [:maybe ::lib.schema.join/fields]
   "Get all join conditions for the given join"
-  [j :- ::lib.schema.join/join]
-  (:fields j))
+  [a-join :- PartialJoin]
+  (:fields a-join))
 
 (defn- raw-join-strategy->strategy-option [raw-strategy]
   (merge
@@ -492,13 +550,13 @@
 (mu/defn raw-join-strategy :- ::lib.schema.join/strategy
   "Get the raw keyword strategy (type) of a given join, e.g. `:left-join` or `:right-join`. This is either the value
   of the optional `:strategy` key or the default, `:left-join`, if `:strategy` is not specified."
-  [a-join :- ::lib.schema.join/join]
+  [a-join :- PartialJoin]
   (get a-join :strategy :left-join))
 
 (mu/defn join-strategy :- ::lib.schema.join/strategy.option
   "Get the strategy (type) of a given join, as a `:option/join.strategy` map. If `:stategy` is unspecified, returns
   the default, left join."
-  [a-join :- ::lib.schema.join/join]
+  [a-join :- PartialJoin]
   (raw-join-strategy->strategy-option (raw-join-strategy a-join)))
 
 (mu/defn with-join-strategy :- PartialJoin

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -109,7 +109,7 @@
   If `old-alias` is specified, uses [[metabase.mbql.util.match]] to update all the `:field` references using the old
   alias.
 
-  If `old-alias` is `nil`, updates the RHS of all 'normal' conditions (binary filter clauses with two `:field` refs as
+  If `old-alias` is `nil`, updates the RHS of all 'standard' conditions (binary filter clauses with two `:field` refs as
   args, e.g. the kind you'd get if you were using [[join-condition-operators]] and the like to create them). This
   currently doesn't handle more complex filter clauses that were created without the 'normal' MLv2 functions used by
   the frontend; we can add this in the future if we need it."

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -424,6 +424,28 @@
                  :alias      "New Alias"}
                 join'))))))
 
+(deftest ^:parallel with-join-alias-update-condition-rhs-set-alias-for-first-time-test
+  (testing "with-join-alias should set the alias of the RHS column(s) when setting the alias for the first time"
+    (let [query  lib.tu/query-with-join
+          [join] (lib/joins query)
+          join   (-> join
+                     (dissoc :alias)
+                     (update :conditions (fn [conditions]
+                                           (mapv (fn [[operator opts lhs rhs :as _condition]]
+                                                   [operator opts lhs (lib/with-join-alias rhs nil)])
+                                                 conditions))))]
+      (is (=? {:conditions [[:= {}
+                             [:field {} (meta/id :venues :category-id)]
+                             [:field {:join-alias (symbol "nil #_\"key is not present.\"")} (meta/id :categories :id)]]]
+               :alias      (symbol "nil #_\"key is not present.\"")}
+              join))
+      (let [join' (lib/with-join-alias join "New Alias")]
+        (is (=? {:conditions [[:= {}
+                               [:field {} (meta/id :venues :category-id)]
+                               [:field {:join-alias "New Alias"} (meta/id :categories :id)]]]
+                 :alias      "New Alias"}
+                join'))))))
+
 (deftest ^:parallel with-join-conditions-empty-test
   (let [query  lib.tu/query-with-join
         [join] (lib/joins query)]

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -79,17 +79,17 @@
                                                       {:lib/uuid string?}
                                                       [:field
                                                        {:lib/uuid string?
-                                                        :join-alias "Venues"}
-                                                       (meta/id :venues :category-id)]
+                                                        :join-alias (symbol "nil #_\"key is not present.\"")}
+                                                       (meta/id :categories :id)]
                                                       [:field
                                                        {:lib/uuid string?
-                                                        :join-alias (symbol "nil #_\"key is not present.\"")}
-                                                       (meta/id :categories :id)]]]}]}]}
+                                                        :join-alias "Venues"}
+                                                       (meta/id :venues :category-id)]]]}]}]}
           (-> (lib/query meta/metadata-provider (meta/table-metadata :categories))
               (lib/join (lib/join-clause
                          (lib/saved-question-query meta/metadata-provider meta/saved-question)
-                         [(lib/= (meta/field-metadata :venues :category-id)
-                                 (meta/field-metadata :categories :id))]))
+                         [(lib/= (meta/field-metadata :categories :id)
+                                 (meta/field-metadata :venues :category-id))]))
               (dissoc :lib/metadata)))))
 
 (deftest ^:parallel join-condition-field-metadata-test
@@ -423,6 +423,114 @@
                                [:field {:join-alias "New Alias"} (meta/id :categories :id)]]]
                  :alias      "New Alias"}
                 join'))))))
+
+(deftest ^:parallel with-join-conditions-empty-test
+  (let [query  lib.tu/query-with-join
+        [join] (lib/joins query)]
+    (are [new-conditions] (nil? (lib/join-conditions (lib/with-join-conditions join new-conditions)))
+      nil
+      [])))
+
+(deftest ^:parallel with-join-conditions-add-alias-test
+  (testing "with-join-conditions should add join alias to RHS of conditions (#32558)"
+    (let [query      lib.tu/query-with-join
+          [join]     (lib/joins query)
+          conditions (lib/join-conditions join)]
+      (is (=? [[:= {}
+                [:field {} (meta/id :venues :category-id)]
+                [:field {:join-alias "Cat"} (meta/id :categories :id)]]]
+              conditions))
+      (testing "Replace conditions; should add join alias"
+        (let [new-conditions [(lib/=
+                               (meta/field-metadata :venues :id)
+                               (meta/field-metadata :categories :id))
+                              (lib/=
+                               (meta/field-metadata :venues :category-id)
+                               (meta/field-metadata :categories :id))]]
+          ;; test with both one new condition and with multiple new conditions.
+          (doseq [new-conditions [(take 1 new-conditions)
+                                  new-conditions]
+                  ;; test with both normal MBQL clauses and with external-op representations.
+                  new-conditions [new-conditions
+                                  (mapv lib/external-op new-conditions)]]
+            (testing (str "\nconditions =\n" (u/pprint-to-str new-conditions))
+              (is (=? (concat
+                       [[:= {}
+                         [:field {} (meta/id :venues :id)]
+                         [:field {:join-alias "Cat"} (meta/id :categories :id)]]]
+                       (when (= (count new-conditions) 2)
+                         [[:= {}
+                           [:field {} (meta/id :venues :category-id)]
+                           [:field {:join-alias "Cat"} (meta/id :categories :id)]]]))
+                      (lib/join-conditions (lib/with-join-conditions join new-conditions)))))))))))
+
+(deftest ^:parallel with-join-conditions-do-not-add-alias-when-already-present-test
+  (testing "with-join-conditions should not replace an existing join alias (don't second guess explicit aliases)"
+    (let [query  lib.tu/query-with-join
+          [join] (lib/joins query)]
+      (let [new-conditions [(lib/=
+                             (meta/field-metadata :venues :id)
+                             (-> (meta/field-metadata :categories :id)
+                                 (lib/with-join-alias "My Join")))]]
+        (is (=? [[:= {}
+                  [:field {} (meta/id :venues :id)]
+                  [:field {:join-alias "My Join"} (meta/id :categories :id)]]]
+                (lib/join-conditions (lib/with-join-conditions join new-conditions))))))))
+
+(deftest ^:parallel with-join-conditions-join-has-no-alias-yet-test
+  (testing "with-join-conditions should work if join doesn't yet have an alias"
+    (let [query  lib.tu/query-with-join
+          [join] (lib/joins query)
+          join   (lib/with-join-alias join nil)]
+      (is (nil? (lib.join/current-join-alias join)))
+      (let [new-conditions [(lib/=
+                             (meta/field-metadata :venues :id)
+                             (meta/field-metadata :categories :id))]
+            join' (lib/with-join-conditions join new-conditions)]
+        (is (=? [[:= {}
+                  [:field {} (meta/id :venues :id)]
+                  [:field {:join-alias (symbol "nil #_\"key is not present.\"")} (meta/id :categories :id)]]]
+                (lib/join-conditions join')))
+        (testing "Adding an alias later with lib/with-join-alias should update conditions that are missing aliases"
+          (let [join'' (lib/with-join-alias join' "New Alias")]
+            (is (=? [[:= {}
+                      [:field {} (meta/id :venues :id)]
+                      [:field {:join-alias "New Alias"} (meta/id :categories :id)]]]
+                    (lib/join-conditions join'')))))))))
+
+(deftest ^:parallel with-join-conditions-do-not-add-alias-to-complex-conditions
+  (testing "with-join-conditions should not add aliases to non-binary filter clauses"
+    (let [query  lib.tu/query-with-join
+          [join] (lib/joins query)]
+      (testing :between
+        (let [new-conditions [(lib/between
+                               (meta/field-metadata :venues :id)
+                               (meta/field-metadata :categories :id)
+                               1)]
+              conditions' (lib/join-conditions (lib/with-join-conditions join new-conditions))]
+          (is (=? [[:between {}
+                    [:field {} (meta/id :venues :id)]
+                    [:field {:join-alias (symbol "nil #_\"key is not present.\"")}
+                     (meta/id :categories :id)]
+                    1]]
+                  conditions'))))
+      (testing :and
+        (let [new-conditions [(lib/and
+                               (lib/=
+                                (meta/field-metadata :venues :id)
+                                (meta/field-metadata :categories :id))
+                               (lib/=
+                                (meta/field-metadata :venues :category-id)
+                                (meta/field-metadata :categories :id)))]
+              conditions' (lib/join-conditions (lib/with-join-conditions join new-conditions))]
+          (is (=? [[:and {}
+                    [:= {}
+                     [:field {} (meta/id :venues :id)]
+                     [:field {:join-alias (symbol "nil #_\"key is not present.\"")} (meta/id :categories :id)]]
+                    [:= {}
+                     [:field {} (meta/id :venues :category-id)]
+                     [:field {:join-alias (symbol "nil #_\"key is not present.\"")} (meta/id :categories :id)]]]]
+                  conditions')))))))
 
 (defn- test-with-join-fields [input expected]
   (testing (pr-str (list 'with-join-fields 'query input))


### PR DESCRIPTION
Resolves #32558

* `with-join-conditions` will now set the `:join-alias` for the RHS for all *standard join conditions*, which I'm using to mean any join condition similar to the ones the FE would create (binary filter clauses with two `:field` refs). 
   * This will not stomp on any join aliases you have explicitly specified. 
   * Only applied when you call `with-join-conditions` with a join that already has an `:alias`, which may not be true if we're in the process of building it still
* I updated `with-join-alias` to set the alias for RHSes when adding an alias to a join we're in the process of building that did not yet have an alias. This covers cases where you called `with-join-conditions` before the join had an alias