### PR TITLE
remove broken width prop, wrap with an ErrorBoundary

### DIFF
--- a/frontend/src/metabase/auth/components/GoogleButton/GoogleButton.tsx
+++ b/frontend/src/metabase/auth/components/GoogleButton/GoogleButton.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 import { getIn } from "icepick";
 import { GoogleOAuthProvider, GoogleLogin } from "@react-oauth/google";
 import { useDispatch, useSelector } from "metabase/lib/redux";
+import ErrorBoundary from "metabase/ErrorBoundary";
 import * as Urls from "metabase/lib/urls";
 import { loginGoogle } from "../../actions";
 import { getGoogleClientId, getSiteLocale } from "../../selectors";
@@ -49,15 +50,16 @@ export const GoogleButton = ({ redirectUrl, isCard }: GoogleButtonProps) => {
   return (
     <GoogleButtonRoot>
       {isCard && clientId ? (
-        <GoogleOAuthProvider clientId={clientId}>
-          <GoogleLogin
-            useOneTap
-            onSuccess={handleLogin}
-            onError={handleError}
-            locale={locale}
-            width="300"
-          />
-        </GoogleOAuthProvider>
+        <ErrorBoundary>
+          <GoogleOAuthProvider clientId={clientId}>
+            <GoogleLogin
+              useOneTap
+              onSuccess={handleLogin}
+              onError={handleError}
+              locale={locale}
+            />
+          </GoogleOAuthProvider>
+        </ErrorBoundary>
       ) : (
         <TextLink to={Urls.login(redirectUrl)}>
           {t`Sign in with Google`}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/32602
Task to fix it properly: https://github.com/metabase/metabase/issues/32614

### Description

Ports Google SSO patch from https://github.com/metabase/metabase-private/pull/127 which have already been released.

Removes `width` property entirely to avoid any potential issues if Google updates it the other way around. Adds an ErrorBoundary to at least keep other login options working if Google SSO breaks

### How to verify

1. Configure Google SSO
2. Enable VPN from Brazil or Uruguay or Argentina
3. Logout and try login using Google SSO
4. Ensure the login page works

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
