### PR TITLE
BE: Clean up old feature flags

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/search/scoring.clj
@@ -1,7 +1,7 @@
 (ns metabase-enterprise.search.scoring
   ;; TODO -- move to `metabase-enterprise.<feature>.*`
   (:require
-   [metabase.public-settings.premium-features :refer [defenterprise]]
+   [metabase.public-settings.premium-features :as premium-features :refer [defenterprise]]
    [metabase.search.scoring :as scoring]))
 
 (defn- official-collection-score
@@ -20,12 +20,14 @@
 
 (defenterprise score-result
   "Scoring implementation that adds score for items in official collections."
-  :feature :content-management
+  :feature :none
   [result]
-  (conj (scoring/weights-and-scores result)
-        {:weight 2
-         :score  (official-collection-score result)
-         :name   "official collection score"}
-        {:weight 2
-         :score  (verified-score result)
-         :name   "verified"}))
+  (cond-> (scoring/weights-and-scores result)
+    (premium-features/has-feature? :official-collections)
+    (conj {:weight 2
+            :score  (official-collection-score result)
+            :name   "official collection score"})
+    (premium-features/has-feature? :content-verification)
+    (conj {:weight 2
+           :score  (verified-score result)
+           :name   "verified"})))

--- a/enterprise/backend/src/metabase_enterprise/snippet_collections/api/native_query_snippet.clj
+++ b/enterprise/backend/src/metabase_enterprise/snippet_collections/api/native_query_snippet.clj
@@ -5,7 +5,7 @@
 
 (defenterprise snippets-collection-filter-clause
   "Clause to filter out snippet collections from the collection query on OSS instances, and instances without the
-  snippet collections feature flag. EE implementation returns `nil`, so as to not filter out snippet collections."
+  snippet-collections feature flag. EE implementation returns `nil`, so as to not filter out snippet collections."
   :feature :snippet-collections
   [])
 

--- a/enterprise/backend/src/metabase_enterprise/snippet_collections/api/native_query_snippet.clj
+++ b/enterprise/backend/src/metabase_enterprise/snippet_collections/api/native_query_snippet.clj
@@ -5,7 +5,7 @@
 
 (defenterprise snippets-collection-filter-clause
   "Clause to filter out snippet collections from the collection query on OSS instances, and instances without the
-  content-management feature flag. EE implementation returns `nil`, so as to not filter out snippet collections."
+  snippet collections feature flag. EE implementation returns `nil`, so as to not filter out snippet collections."
   :feature :snippet-collections
   [])
 

--- a/enterprise/backend/test/metabase_enterprise/api/session_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/api/session_test.clj
@@ -17,11 +17,9 @@
                                                  :official-collections
                                                  :whitelabel
                                                  :no-upsell
-                                                 :advanced-config
                                                  :cache-granular-controls
                                                  :content-verification
                                                  :serialization
-                                                 :content-management
                                                  :config-text-file
                                                  :email-allow-list
                                                  :hosting
@@ -32,12 +30,10 @@
                                                  :sso-jwt
                                                  :sso-ldap
                                                  :sso-saml}
-          (is (= {:advanced_config                true
-                  :advanced_permissions           true
+          (is (= {:advanced_permissions           true
                   :audit_app                      true
                   :cache_granular_controls        true
                   :config_text_file               true
-                  :content_management             true
                   :content_verification           true
                   :dashboard_subscription_filters true
                   :disable_password_login         true

--- a/enterprise/backend/test/metabase_enterprise/content_management/api/collection_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_management/api/collection_test.clj
@@ -33,13 +33,6 @@
         (is (= "Official Collections is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
                (mt/user-http-request :crowberto :post 402 "collection" {:name            "An official collection"
                                                                         :color           "#000000"
-                                                                        :authority_level "official"})))))
-
-    (testing "fails to add an official collection if has :content-management feature"
-      (premium-features-test/with-premium-features #{:content-management}
-        (is (= "Official Collections is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
-               (mt/user-http-request :crowberto :post 402 "collection" {:name            "An official collection"
-                                                                        :color           "#000000"
                                                                         :authority_level "official"})))))))
 
 (deftest update-collection-authority-happy-path-test
@@ -75,13 +68,6 @@
 
     (testing "fails to update if doesn't have any premium features"
       (premium-features-test/with-premium-features #{}
-        (t2.with-temp/with-temp
-          [:model/Collection {id :id} {:authority_level nil}]
-          (is (= "Official Collections is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
-                 (mt/user-http-request :crowberto :put 402 (format "collection/%d" id) {:authority_level "official"}))))))
-
-    (testing "fails to update if has :content-management feature"
-      (premium-features-test/with-premium-features #{:content-management}
         (t2.with-temp/with-temp
           [:model/Collection {id :id} {:authority_level nil}]
           (is (= "Official Collections is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"

--- a/enterprise/backend/test/metabase_enterprise/content_management/api/collection_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_management/api/collection_test.clj
@@ -90,7 +90,7 @@
           (mt/user-http-request :crowberto :put 200 (format "collection/%d" id) {:authority_level nil :name "New name"})
           (is (= "New name" (t2/select-one-fn :name :model/Collection id))))))))
 
-(deftest content-management-legacy-does-not-work-for-official-questions-test
+(deftest moderation-review-test
   (t2.with-temp/with-temp
     [:model/Card {card-id :id} {:name "A question"}
      :model/Card {model-id :id} {:name "A question" :dataset true}]

--- a/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
@@ -2,12 +2,12 @@
   (:require
    [cheshire.core :as json]
    [clojure.math.combinatorics :as math.combo]
+   [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [java-time :as t]
    [metabase-enterprise.search.scoring :as ee-scoring]
-   [metabase.public-settings.premium-features-test
-    :as premium-features-test]
+   [metabase.public-settings.premium-features-test :as premium-features-test]
    [metabase.search.scoring :as scoring]))
 
 (deftest ^:parallel verified-score-test
@@ -24,7 +24,7 @@
 
 (defn- ee-score
   [search-string item]
-  (premium-features-test/with-premium-features #{:content-management}
+  (premium-features-test/with-premium-features #{:official-collections :content-verification}
     (-> (scoring/score-and-result search-string item) :score)))
 
 (defn- oss-score
@@ -129,3 +129,23 @@
   (test-corups ["foo" "bar"])
   (test-corups ["foo" "bar" "baz"])
   (test-corups ["foo" "bar" "baz" "quux"]))
+
+(deftest score-result-test
+  (let [score-result-names (fn [] (set (map :name (scoring/score-result {}))))]
+    (testing "does not include scores for official collection or verified if features are disabled"
+      (premium-features-test/with-premium-features #{}
+        (is (= #{}
+               (set/intersection #{"official collection score" "verified"}
+                                 (score-result-names))))))
+
+    (testing "includes official collection score if :official-collections is enabled"
+      (premium-features-test/with-premium-features #{:official-collections}
+        (is (set/subset? #{"official collection score"} (score-result-names)))))
+
+    (testing "includes verified if :content-verification is enabled"
+      (premium-features-test/with-premium-features #{:content-verification}
+        (is (set/subset? #{"verified"} (score-result-names)))))
+
+    (testing "includes both if has both features"
+      (premium-features-test/with-premium-features #{:official-collections :content-verification}
+        (is (set/subset? #{"official collection score" "verified"} (score-result-names)))))))

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -740,7 +740,7 @@
   (when cache_ttl
     (api/check (premium-features/enable-cache-granular-controls?)
                [402 (tru (str "The cache TTL database setting is only enabled if you have a premium token with the "
-                              "advanced-config feature."))]))
+                              "cache granular controls feature."))]))
   (let [is-full-sync?    (or (nil? is_full_sync)
                              (boolean is_full_sync))
         details-or-error (test-connection-details engine details)

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -170,7 +170,6 @@
      custom-formatting
      custom-geojson
      custom-geojson-enabled
-     enable-content-management?
      enable-embedding
      enable-nested-queries
      enable-sandboxes?

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -550,12 +550,10 @@
   "Features registered for this instance's token"
   :visibility :public
   :setter     :none
-  :getter     (fn [] {:advanced_config                (premium-features/enable-advanced-config?)
-                      :advanced_permissions           (premium-features/enable-advanced-permissions?)
+  :getter     (fn [] {:advanced_permissions           (premium-features/enable-advanced-permissions?)
                       :audit_app                      (premium-features/enable-audit-app?)
                       :cache_granular_controls        (premium-features/enable-cache-granular-controls?)
                       :config_text_file               (premium-features/enable-config-text-file?)
-                      :content_management             (premium-features/enable-content-management?)
                       :content_verification           (premium-features/enable-content-verification?)
                       :dashboard_subscription_filters (premium-features/enable-dashboard-subscription-filters?)
                       :disable_password_login         (premium-features/can-disable-password-login?)

--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -351,11 +351,6 @@
   "Can we password login?"
   :disable-password-login)
 
-;; TODO: remove this once all its uses have been switched to new granular features
-(define-premium-feature ^{:added "0.41.0"} enable-advanced-config?
-  "Should we enable knobs and levers for more complex orgs?"
-  :advanced-config)
-
 (define-premium-feature ^{:added "0.41.0"} enable-dashboard-subscription-filters?
   "Should we enable filters for dashboard subscriptions?"
   :dashboard-subscription-filters)
@@ -368,10 +363,6 @@
 (define-premium-feature ^{:added "0.41.0"} enable-content-verification?
   "Should we enable verified content, like verified questions and models (and more in the future, like actions)?"
   :content-verification)
-
-(define-premium-feature ^{:added "0.41.0"} enable-content-management?
-  "Should we enable official collections (and more in the future, like workflows, forking, etc.)?"
-  :content-management)
 
 (define-premium-feature ^{:added "0.41.0"} enable-official-collections?
   "Should we enable Official Collections?"

--- a/test/metabase/public_settings/premium_features_test.clj
+++ b/test/metabase/public_settings/premium_features_test.clj
@@ -110,8 +110,6 @@
                                     #'premium-features/enable-whitelabeling?
                                     #'premium-features/enable-audit-app?
                                     #'premium-features/enable-sandboxes?
-                                    #'premium-features/enable-advanced-config?
-                                    #'premium-features/enable-content-management?
                                     #'premium-features/enable-serialization?]]
                 (testing (format "\n%s is false" (:name (meta has-feature?)))
                   (is (not (has-feature?)))))


### PR DESCRIPTION
Remove all the old feature flags from BE, the list of removed flags are :
- :content-management
- :advanced-config