### PR TITLE
Update snowplow schema to include new feature flags

### DIFF
--- a/snowplow/iglu-client-embedded/schemas/com.metabase/instance/jsonschema/1-1-2
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/instance/jsonschema/1-1-2
@@ -60,10 +60,6 @@
           "description": "Should we enable data sandboxes (row-level permissions)?",
           "type": "boolean"
         },
-        "sso": {
-          "description": "Should we enable advanced SSO features (SAML and JWT authentication; role and group mapping)?",
-          "type": "boolean"
-        },
         "email_allow_list": {
           "description": "Should we enable restrict email domains for subscription recipients?",
           "type": "boolean"
@@ -122,10 +118,6 @@
         },
         "advanced_permissions": {
           "description": "Should we enable extra knobs around permissions (block access, and in the future, moderator roles, feature-level permissions, etc.)?",
-          "type": "boolean"
-        },
-        "content_management": {
-          "description": "Should we enable official Collections, Question verifications (and more in the future, like workflows, forking, etc.)?",
           "type": "boolean"
         },
         "hosting": {

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/instance/jsonschema/1-1-2
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/instance/jsonschema/1-1-2
@@ -80,6 +80,10 @@
           "description": "Should we enable initialization on launch from a config file?",
           "type": "boolean"
         },
+        "sso": {
+          "description": "DEPRECATED: Should we enable advanced SSO features (SAML and JWT authentication; role and group mapping)?",
+          "type": "boolean"
+        },
         "sso_jwt":  {
           "description": "Should we enable JWT-based authentication?",
           "type": "boolean"
@@ -94,6 +98,14 @@
         },
         "sso_google":  {
           "description": "Should we enable advanced configuration for Google Sign-In authentication?",
+          "type": "boolean"
+        },
+        "advanced_config": {
+          "description": "DEPRECATED: Should we enable knobs and levers for more complex orgs (granular caching controls, allow-lists email domains for notifications, more in the future)?",
+          "type": "boolean"
+        },
+        "content_management": {
+          "description": "DEPRECATED: Should we enable official Collections, Question verifications (and more in the future, like workflows, forking, etc.)?",
           "type": "boolean"
         },
         "disable_password_login":  {

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/instance/jsonschema/1-1-2
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/instance/jsonschema/1-1-2
@@ -5,7 +5,7 @@
     "vendor": "com.metabase",
     "name": "instance",
     "format": "jsonschema",
-    "version": "1-1-1"
+    "version": "1-1-2"
   },
   "type": "object",
   "properties": {

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/instance/jsonschema/1-1-2
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/instance/jsonschema/1-1-2
@@ -1,0 +1,162 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Metabase instance",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "instance",
+    "format": "jsonschema",
+    "version": "1-1-1"
+  },
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "Instance ID",
+      "type": "string",
+      "maxLength": 1024
+    },
+    "version": {
+      "description": "Instance version",
+      "type": "object",
+      "properties": {
+        "tag": {
+          "description": "Instance version tag",
+          "type": "string",
+          "maxLength": 1024
+        }
+      },
+      "required": [
+        "tag"
+      ]
+    },
+    "created_at": {
+      "description": "The date the instance was created",
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time",
+      "maxLength": 1024
+    },
+    "token_features": {
+      "description": "Premium token features",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "embedding": {
+          "description": "Should we hide the 'Powered by Metabase' attribution on the embedding pages?",
+          "type": "boolean"
+        },
+        "whitelabel": {
+          "description": "Should we allow full whitelabel embedding (reskinning the entire interface?)",
+          "type": "boolean"
+        },
+        "audit_app": {
+          "description": "Should we enable the Audit Logs interface in the Admin UI?",
+          "type": "boolean"
+        },
+        "sandboxes": {
+          "description": "Should we enable data sandboxes (row-level permissions)?",
+          "type": "boolean"
+        },
+        "sso": {
+          "description": "Should we enable advanced SSO features (SAML and JWT authentication; role and group mapping)?",
+          "type": "boolean"
+        },
+        "email_allow_list": {
+          "description": "Should we enable restrict email domains for subscription recipients?",
+          "type": "boolean"
+        },
+        "email_restrict_recipients": {
+          "description": "Shoudl we enable restrict email subscription recipients?",
+          "type": "boolean"
+        },
+        "cache_granular_controls": {
+          "description": "Should we enable granular controls for cache TTL at the database, dashboard, and card level?",
+          "type": "boolean"
+        },
+        "dashboard_subscription_filters":  {
+          "description": "Should we enable filters for dashboard subscriptions?",
+          "type": "boolean"
+        },
+        "config_text_file":  {
+          "description": "Should we enable initialization on launch from a config file?",
+          "type": "boolean"
+        },
+        "sso_jwt":  {
+          "description": "Should we enable JWT-based authentication?",
+          "type": "boolean"
+        },
+        "sso_saml":  {
+          "description": "Should we enable SAML-based authentication?",
+          "type": "boolean"
+        },
+        "sso_ldap":  {
+          "description": "Should we enable advanced configuration for LDAP authentication?",
+          "type": "boolean"
+        },
+        "sso_google":  {
+          "description": "Should we enable advanced configuration for Google Sign-In authentication?",
+          "type": "boolean"
+        },
+        "disable_password_login":  {
+          "description": "Can we disable login by password?",
+          "type": "boolean"
+        },
+        "session_timeout_config":  {
+          "description": "Should we enable configuring session timeouts?",
+          "type": "boolean"
+        },
+        "content_verification":  {
+          "description": "Should we enable verified content, like verified questions and models (and more in the future, like actions)?",
+          "type": "boolean"
+        },
+        "official_collections":  {
+          "description": "Should we enable Official Collections?",
+          "type": "boolean"
+        },
+        "snippet_collections":  {
+          "description": "Should we enable SQL snippet folders?",
+          "type": "boolean"
+        },
+        "advanced_permissions": {
+          "description": "Should we enable extra knobs around permissions (block access, and in the future, moderator roles, feature-level permissions, etc.)?",
+          "type": "boolean"
+        },
+        "content_management": {
+          "description": "Should we enable official Collections, Question verifications (and more in the future, like workflows, forking, etc.)?",
+          "type": "boolean"
+        },
+        "hosting": {
+          "description": "Is the Metabase instance running in the cloud?",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
+    },
+    "application_database": {
+      "description": "Application database type",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "application_database_version": {
+      "description": "Application database version",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    }
+  },
+  "required": [
+    "id",
+    "version"
+  ],
+  "additionalProperties": true
+}

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -140,7 +140,7 @@
    ::csvupload    "1-0-0"
    ::dashboard    "1-1-0"
    ::database     "1-0-0"
-   ::instance     "1-1-1"
+   ::instance     "1-1-2"
    ::metabot      "1-0-1"
    ::search       "1-0-0"
    ::model        "1-0-0"

--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -304,7 +304,7 @@
   :audit-app)
 
 (define-premium-feature ^{:added "0.41.0"} enable-email-allow-list?
-  "Should we enable allow-lists for email domains?"
+  "Should we enable restrict email domains for subscription recipients?"
   :email-allow-list)
 
 (define-premium-feature ^{:added "0.41.0"} enable-cache-granular-controls?
@@ -348,7 +348,7 @@
   :session-timeout-config)
 
 (define-premium-feature can-disable-password-login?
-  "Can we password login?"
+  "Can we disable login by password?"
   :disable-password-login)
 
 ;; TODO: remove this once all its uses have been switched to new granular features

--- a/test/metabase/analytics/snowplow_test.clj
+++ b/test/metabase/analytics/snowplow_test.clj
@@ -96,7 +96,7 @@
            and creation timestamp"
     (with-fake-snowplow-collector
       (snowplow/track-event! ::snowplow/new-instance-created)
-      (is (= {:schema "iglu:com.metabase/instance/jsonschema/1-1-1",
+      (is (= {:schema "iglu:com.metabase/instance/jsonschema/1-1-2",
               :data {:id                           (snowplow/analytics-uuid)
                      :version                      {:tag (:tag (public-settings/version))},
                      :token_features               (public-settings/token-features)


### PR DESCRIPTION
Add a new instance schema for snowplow that is fired [here](https://github.com/metabase/metabase/blob/772425358681c29b35165b3c352af6df7d7ae18b/src/metabase/analytics/snowplow.clj#L171) . In this PR we add some new keys to instance schema.
  - cache_granular_controls
  - config_text_file
  - content_verification
  - dashboard_subscription_filters
  - disable_password_login
  - email_allow_list
  - email_restrict_recipients
  - official_collections
  - session_timeout_config
  - snippet_collections
  - sso_google
  - sso_jwt
  - sso_ldap
  - sso_saml

The old keys are not removed to keep backward compatibility


Completeness check: the new schema has to include all the keys that `(public-settings/token-features)` returned, and it's 20 flags after https://github.com/metabase/metabase/pull/32618 is merged.


```clojure
(clojure.set/subset? 
 (->> (metabase.public-settings/token-features)
      keys
      (map name)
      set)
 (-> (slurp "/Users/earther/metabase/metabase/snowplow/iglu-client-embedded/schemas/com.metabase/instance/jsonschema/1-1-2")
     cheshire.core/parse-string
     (get-in ["properties" "token_features" "properties"])
     keys
     set))
   
;; => true
```