### PR TITLE
Display trend line for Stack-100% bar charts

### DIFF
--- a/e2e/test/visual/visualizations/bar.cy.spec.js
+++ b/e2e/test/visual/visualizations/bar.cy.spec.js
@@ -3,7 +3,11 @@ import {
   visitQuestionAdhoc,
   ensureDcChartVisibility,
 } from "e2e/support/helpers";
+
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describe("visual tests > visualizations > bar", () => {
   beforeEach(() => {
@@ -29,6 +33,32 @@ describe("visual tests > visualizations > bar", () => {
         "graph.dimensions": ["X"],
         "graph.metrics": ["A", "B", "C"],
         "stackable.stack_type": "stacked",
+      },
+    });
+
+    ensureDcChartVisibility();
+    cy.createPercySnapshot();
+  });
+
+  it("with stack-100% series and showing trend line", () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        type: "query",
+        query: {
+          "source-table": PRODUCTS_ID,
+          aggregation: [["count"], ["avg", ["field", PRODUCTS.PRICE, null]]],
+          breakout: [
+            ["field", PRODUCTS.CREATED_AT, { "temporal-unit": "year" }],
+          ],
+        },
+        database: SAMPLE_DB_ID,
+      },
+      display: "bar",
+      visualization_settings: {
+        "graph.show_trendline": true,
+        "graph.dimensions": ["CREATED_AT"],
+        "graph.metrics": ["avg", "count"],
+        "stackable.stack_type": "normalized",
       },
     });
 

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -154,6 +154,7 @@ function getDimensionsAndGroupsAndUpdateSeriesDisplayNamesForStackedChart(
   warn,
 ) {
   const dataset = crossfilter();
+  const { _raw } = props.series;
 
   const normalized = isNormalized(props.settings, datas);
   // get the sum of the metric for each dimension value in order to scale
@@ -166,6 +167,7 @@ function getDimensionsAndGroupsAndUpdateSeriesDisplayNamesForStackedChart(
     }
 
     props.series = addPercentSignsToDisplayNames(props.series);
+    props.series._raw = _raw;
 
     const normalizedValues = datas.flatMap(data =>
       data.map(([d, m]) => m / scaleFactors[d]),
@@ -175,6 +177,7 @@ function getDimensionsAndGroupsAndUpdateSeriesDisplayNamesForStackedChart(
       maximumSignificantDigits: 2,
     });
     props.series = addDecimalsToPercentColumn(props.series, decimals);
+    props.series._raw = _raw;
   }
 
   datas.map((data, i) =>
@@ -683,6 +686,11 @@ function addTrendlineChart(
 
   const rawSeries = series._raw || series;
   const insights = rawSeries[0].data.insights || [];
+
+  // TODO: If isStacked(settings) && isNormalized(settings),
+  //    precompute getTrendDataPointsFromInsight for each insight i,
+  //    then divide each y coord by the total of all y-coords for that x.
+  //    This should give us a percentage trend line.
 
   for (const insight of insights) {
     const index = findSeriesIndexForColumnName(series, insight.col);

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -701,7 +701,12 @@ function addTrendlineChart(
   }
 
   const rawSeries = series._raw || series;
-  const insights = rawSeries[0].data.insights || [];
+  const insights = (rawSeries[0].data.insights || []).filter(insight => {
+    const index = findSeriesIndexForColumnName(series, insight.col);
+    const shouldShowSeries = index !== -1;
+    const hasTrendLineData = insight.slope != null && insight.offset != null;
+    return shouldShowSeries && hasTrendLineData;
+  });
 
   const trendDatas = getTrendDatasFromInsights(insights, {
     xDomain,
@@ -711,14 +716,6 @@ function addTrendlineChart(
 
   for (const [insight, trendData] of _.zip(insights, trendDatas)) {
     const index = findSeriesIndexForColumnName(series, insight.col);
-
-    const shouldShowSeries = index !== -1;
-    const hasTrendLineData = insight.slope != null && insight.offset != null;
-
-    if (!shouldShowSeries || !hasTrendLineData) {
-      continue;
-    }
-
     const seriesSettings = settings.series(series[index]);
     const color = lighten(seriesSettings.color, 0.25);
 

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -30,7 +30,10 @@ import {
 } from "./apply_axis";
 
 import { setupTooltips } from "./apply_tooltips";
-import { getTrendDataPointsFromInsight } from "./trends";
+import {
+  getNormalizedStackedTrendDatas,
+  getTrendDataPointsFromInsight,
+} from "./trends";
 
 import fillMissingValuesInDatas from "./fill_data";
 import { NULL_DIMENSION_WARNING, unaggregatedDataWarning } from "./warnings";
@@ -673,19 +676,13 @@ function findSeriesIndexForColumnName(series, colName) {
 const TREND_LINE_POINT_SPACING = 25;
 
 function getTrendDatasFromInsights(insights, { xDomain, settings, parent }) {
-  const numPoints = Math.round(parent.width() / TREND_LINE_POINT_SPACING);
+  const xCount = Math.round(parent.width() / TREND_LINE_POINT_SPACING);
   const trendDatas = insights.map(insight =>
-    getTrendDataPointsFromInsight(insight, xDomain, numPoints),
+    getTrendDataPointsFromInsight(insight, xDomain, xCount),
   );
-  if (!isNormalized(settings)) {
-    return trendDatas;
-  }
-  const sums = _.range(numPoints).map(i =>
-    trendDatas.reduce((sum, trendData) => sum + trendData[i][1], 0),
-  );
-  return trendDatas.map(trendData =>
-    trendData.map(([x, y], i) => [x, y / sums[i]]),
-  );
+  return !isNormalized(settings)
+    ? trendDatas
+    : getNormalizedStackedTrendDatas(trendDatas);
 }
 
 function addTrendlineChart(

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -154,7 +154,6 @@ function getDimensionsAndGroupsAndUpdateSeriesDisplayNamesForStackedChart(
   warn,
 ) {
   const dataset = crossfilter();
-  const { _raw } = props.series;
 
   const normalized = isNormalized(props.settings, datas);
   // get the sum of the metric for each dimension value in order to scale
@@ -166,8 +165,8 @@ function getDimensionsAndGroupsAndUpdateSeriesDisplayNamesForStackedChart(
       }
     }
 
+    const { _raw } = props.series;
     props.series = addPercentSignsToDisplayNames(props.series);
-    props.series._raw = _raw;
 
     const normalizedValues = datas.flatMap(data =>
       data.map(([d, m]) => m / scaleFactors[d]),

--- a/frontend/src/metabase/visualizations/lib/trends.js
+++ b/frontend/src/metabase/visualizations/lib/trends.js
@@ -35,6 +35,16 @@ export function compileExpression(node) {
 
 const msToDays = ms => ms / (24 * 60 * 60 * 1000);
 
+export function getNormalizedStackedTrendDatas(trendDatas) {
+  const count = trendDatas[0].length;
+  const sums = _.range(count).map(i =>
+    trendDatas.reduce((sum, trendData) => sum + trendData[i][1], 0),
+  );
+  return trendDatas.map(trendData =>
+    trendData.map(([x, y], i) => [x, y / sums[i]]),
+  );
+}
+
 export function getTrendDataPointsFromInsight(insight, xDomain, count = 10) {
   const isTimeseries = moment.isMoment(xDomain[0]);
 

--- a/frontend/src/metabase/visualizations/lib/trends.js
+++ b/frontend/src/metabase/visualizations/lib/trends.js
@@ -57,5 +57,5 @@ export function getTrendDataPointsFromInsight(insight, xDomain, count = 10) {
 
 function getValuesInRange(start, end, count) {
   const delta = (end - start) / (count - 1);
-  return _.range(start, end, delta).concat([end]);
+  return _.range(count).map(i => start + delta * i);
 }

--- a/frontend/src/metabase/visualizations/lib/trends.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/trends.unit.spec.js
@@ -1,0 +1,39 @@
+import { getNormalizedStackedTrendDatas } from "./trends";
+
+describe("getNormalizedStackedTrendDatas", () => {
+  const mockTrendData = ys => ys.map((y, i) => [i, y]); // use index as x
+
+  it("should return correct normalized trend data", () => {
+    const a = [5, 10, 8, 12];
+    const b = [6, 3, 7, 15];
+    const c = [12, 13, 18, 20];
+    const sums = [23, 26, 33, 47];
+
+    expect(
+      getNormalizedStackedTrendDatas([
+        mockTrendData(a),
+        mockTrendData(b),
+        mockTrendData(c),
+      ]),
+    ).toEqual([
+      mockTrendData([
+        a[0] / sums[0],
+        a[1] / sums[1],
+        a[2] / sums[2],
+        a[3] / sums[3],
+      ]),
+      mockTrendData([
+        b[0] / sums[0],
+        b[1] / sums[1],
+        b[2] / sums[2],
+        b[3] / sums[3],
+      ]),
+      mockTrendData([
+        c[0] / sums[0],
+        c[1] / sums[1],
+        c[2] / sums[2],
+        c[3] / sums[3],
+      ]),
+    ]);
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/25614

### Description

To show trend lines for normalized stacked bar charts, we have to:

1. Ensure that the `_raw` property (needed for computing the trend line) remains attached to the `series` array after a series transformation is performed for normalized bar charts.
2. Normalize the trend line points so that they all total 100% for a given x.

### How to verify

Follow the repro steps in the issue above to verify that the trend line is now visible (for both stacked Bar and Area charts):

Stack | Stack 100% (This PR)
---|---
![CleanShot 2023-07-24 at 23 03 52@2x](https://github.com/metabase/metabase/assets/116838/e694645a-6286-400d-8b47-6a0b77434fe8) | ![CleanShot 2023-07-24 at 23 04 04@2x](https://github.com/metabase/metabase/assets/116838/51b4a8f8-1864-4d47-9325-01a08e2a08b9)
![CleanShot 2023-07-24 at 23 24 03@2x](https://github.com/metabase/metabase/assets/116838/43a13863-47ef-418b-92a1-2413a76c10cc) | ![CleanShot 2023-07-24 at 23 24 17@2x](https://github.com/metabase/metabase/assets/116838/becfd950-658b-442c-805c-07d0a3308fff)




### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
