### PR TITLE
Fix outdated advanced_config flag

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/model_persistence/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/model_persistence/index.ts
@@ -8,7 +8,7 @@ import ModelCacheControl, {
   toggleModelPersistence,
 } from "./components/ModelCacheControl";
 
-if (hasPremiumFeature("advanced_config")) {
+if (hasPremiumFeature("cache_granular_controls")) {
   PLUGIN_MODEL_PERSISTENCE.isModelLevelPersistenceEnabled = () => true;
 
   PLUGIN_MODEL_PERSISTENCE.ModelCacheControl = ModelCacheControl;

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -98,7 +98,6 @@ export const createMockTokenStatus = (
 export const createMockTokenFeatures = (
   opts?: Partial<TokenFeatures>,
 ): TokenFeatures => ({
-  advanced_config: false,
   advanced_permissions: false,
   audit_app: false,
   cache_granular_controls: false,

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -141,7 +141,6 @@ export type DayOfWeekId =
   | "saturday";
 
 export const tokenFeatures = [
-  "advanced_config",
   "advanced_permissions",
   "audit_app",
   "cache_granular_controls",

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.js
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.js
@@ -44,7 +44,9 @@ async function setup({ cachingEnabled = false, databaseIdParam = "" } = {}) {
 
   const settings = mockSettings({
     engines: ENGINES_MOCK,
-    "token-features": createMockTokenFeatures({ advanced_config: true }),
+    "token-features": createMockTokenFeatures({
+      cache_granular_controls: true,
+    }),
     "enable-query-caching": cachingEnabled,
   });
 


### PR DESCRIPTION
Uses `cache_granular_controls` instead of `advanced_config` for model persistence (caching).