### PR TITLE
Customize and style Cypress `log` command

### DIFF
--- a/e2e/support/commands/overwrites/log.js
+++ b/e2e/support/commands/overwrites/log.js
@@ -1,10 +1,12 @@
-Cypress.Commands.overwrite("log", (originalFn, message) => {
-  Cypress.log({
-    displayName: `--- ${window.logCalls}. ${message} ---`,
-    name: `--- ${window.logCalls}. ${message} ---`,
+Cypress.Commands.overwrite("log", (originalFn, text) => {
+  const logConfig = {
+    displayName: `=== ${window.logCalls}. ${text}`,
+    name: "log",
     message: "",
-  });
+  };
 
+  appendStyleIfItDoesntExists(logConfig);
+  Cypress.log(logConfig);
   window.logCalls++;
 });
 
@@ -12,3 +14,27 @@ Cypress.Commands.overwrite("log", (originalFn, message) => {
 beforeEach(() => {
   window.logCalls = 1;
 });
+
+function appendStyleIfItDoesntExists(logConfig) {
+  const headHTML = Cypress.$(window.top.document.head);
+  const allStyles = Array.from(Cypress.$(window.top.document.styleSheets));
+
+  const getCustomStyle = allStyles.filter(s => s.ownerNode.dataset.customLog);
+  const customStyleExists = getCustomStyle.length > 0;
+
+  if (!customStyleExists) {
+    const style = document.createElement("style");
+
+    style.textContent = `
+      .command-name-${logConfig.name} .command-pin-target{
+        color: #ffffff !important;
+        background-color: darkorchid !important;;
+        font-weight: bold !important;
+      }
+    `;
+    style.type = "text/css";
+    style.dataset.customLog = true;
+
+    headHTML.append(style);
+  }
+}

--- a/e2e/support/commands/overwrites/log.js
+++ b/e2e/support/commands/overwrites/log.js
@@ -5,7 +5,7 @@ Cypress.Commands.overwrite("log", (originalFn, text) => {
     message: "",
   };
 
-  appendStyleIfItDoesntExists(logConfig);
+  appendStyleIfNotExists(logConfig);
   Cypress.log(logConfig);
   window.logCalls++;
 });
@@ -15,7 +15,7 @@ beforeEach(() => {
   window.logCalls = 1;
 });
 
-function appendStyleIfItDoesntExists(logConfig) {
+function appendStyleIfNotExists(logConfig) {
   const headHTML = Cypress.$(window.top.document.head);
   const allStyles = Array.from(Cypress.$(window.top.document.styleSheets));
 

--- a/e2e/support/commands/overwrites/log.js
+++ b/e2e/support/commands/overwrites/log.js
@@ -18,7 +18,8 @@ beforeEach(() => {
 function appendStyleIfNotExists(logConfig) {
   const doc = window.top.document;
   const headHTML = doc.head;
-  const customStyle = doc.getElementById("customLogStyle");
+  const styleId = "customLogStyle";
+  const customStyle = doc.getElementById(styleId);
   const bgColor = "#7f43c9";
 
   if (!customStyle) {
@@ -32,7 +33,7 @@ function appendStyleIfNotExists(logConfig) {
     }
     `;
     style.type = "text/css";
-    style.id = "customLogStyle";
+    style.id = styleId;
 
     headHTML.append(style);
   }

--- a/e2e/support/commands/overwrites/log.js
+++ b/e2e/support/commands/overwrites/log.js
@@ -1,6 +1,6 @@
 Cypress.Commands.overwrite("log", (originalFn, text) => {
   const logConfig = {
-    displayName: `=== ${window.logCalls}. ${text}`,
+    displayName: `${window.logCalls}. ${text}`,
     name: "log",
     message: "",
   };

--- a/e2e/support/commands/overwrites/log.js
+++ b/e2e/support/commands/overwrites/log.js
@@ -16,24 +16,23 @@ beforeEach(() => {
 });
 
 function appendStyleIfNotExists(logConfig) {
-  const headHTML = Cypress.$(window.top.document.head);
-  const allStyles = Array.from(Cypress.$(window.top.document.styleSheets));
+  const doc = window.top.document;
+  const headHTML = doc.head;
+  const customStyle = doc.getElementById("customLogStyle");
+  const bgColor = "#7f43c9";
 
-  const getCustomStyle = allStyles.filter(s => s.ownerNode.dataset.customLog);
-  const customStyleExists = getCustomStyle.length > 0;
-
-  if (!customStyleExists) {
+  if (!customStyle) {
     const style = document.createElement("style");
 
     style.textContent = `
-      .command-name-${logConfig.name} .command-pin-target{
-        color: #ffffff !important;
-        background-color: #7f43c9 !important;
-        font-weight: bold !important;
-      }
+    .command-name-${logConfig.name} .command-pin-target{
+      color: #ffffff !important;
+      background-color: ${bgColor} !important;
+      font-weight: bold !important;
+    }
     `;
     style.type = "text/css";
-    style.dataset.customLog = true;
+    style.id = "customLogStyle";
 
     headHTML.append(style);
   }

--- a/e2e/support/commands/overwrites/log.js
+++ b/e2e/support/commands/overwrites/log.js
@@ -28,7 +28,7 @@ function appendStyleIfItDoesntExists(logConfig) {
     style.textContent = `
       .command-name-${logConfig.name} .command-pin-target{
         color: #ffffff !important;
-        background-color: darkorchid !important;;
+        background-color: #7f43c9 !important;
         font-weight: bold !important;
       }
     `;


### PR DESCRIPTION
This PR will add a background color to the Cypress log command, in order to make it stand out. This should help with reviewing Cypress recorded runs and with the general E2E tests debugging experience.

**The name of the color is semi-arbitrary for now and NOT configurable.**
If we want to go down the path of configuring color or the style for each individual `cy.log()` we can, but it might lead to chaos.

Visual example:
![image](https://github.com/metabase/metabase/assets/31325167/fdb178ff-8a51-4053-9ab9-7af4f89429f0)
