### PR TITLE
[E2E] Downloads in embedded questions

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-downloads-questions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-downloads-questions.cy.spec.js
@@ -1,0 +1,102 @@
+import {
+  restore,
+  describeEE,
+  visitQuestion,
+  visitEmbeddedPage,
+  popover,
+} from "e2e/support/helpers";
+
+const questionDetails = {
+  name: "Simple SQL Query for Embedding",
+  native: {
+    query: "select {{text}} as WYSIWYG",
+    "template-tags": {
+      text: {
+        id: "fake-uuid",
+        name: "text",
+        "display-name": "Text",
+        type: "text",
+        default: null,
+      },
+    },
+  },
+};
+
+describeEE("scenarios > embedding > questions > downloads", () => {
+  beforeEach(() => {
+    cy.intercept("PUT", "/api/card/*").as("publishChanges");
+    cy.intercept("GET", "/api/embed/card/**/query").as("dl");
+
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createNativeQuestion(questionDetails, {
+      wrapId: true,
+    });
+  });
+
+  context("without token", () => {
+    it("should not be possible to disable downloads", () => {
+      cy.get("@questionId").then(questionId => {
+        visitQuestion(questionId);
+        openEmbeddingSettingsPage();
+
+        cy.log(
+          "Embedding settings page should not show option to disable downloads",
+        );
+        cy.get("section")
+          .should("have.length", 2)
+          .and("not.contain", "Download data")
+          .and("not.contain", "Enable users to download data from this embed?");
+
+        cy.log('Use API to "publish" this question and to enable its filter');
+        cy.request("PUT", `/api/card/${questionId}`, {
+          enable_embedding: true,
+          embedding_params: {
+            text: "enabled",
+          },
+        });
+
+        const payload = {
+          resource: { question: questionId },
+          params: {},
+        };
+
+        cy.log(
+          "Visit embedded question and set its filter through query parameters",
+        );
+        visitEmbeddedPage(payload, {
+          setFilters: { text: "Foo" },
+        });
+
+        cy.get(".cellData").should("have.text", "Foo");
+        cy.findByRole("contentinfo").icon("download").click();
+
+        popover().within(() => {
+          cy.findByText("Download full results");
+          cy.findByText(".csv");
+          cy.findByText(".xlsx");
+          cy.findByText(".json");
+        });
+
+        cy.log(
+          "Trying to prevent downloads via query params doesn't have any effect",
+        );
+        cy.url().then(url => {
+          cy.visit(url + "&hide_download_button=true");
+        });
+
+        cy.get(".cellData").should("have.text", "Foo");
+        cy.findByRole("contentinfo").icon("download");
+      });
+    });
+  });
+});
+
+function openEmbeddingSettingsPage() {
+  cy.intercept("GET", "/api/session/properties").as("sessionProperties");
+
+  cy.icon("share").click();
+  cy.findByText("Embed in your application").click();
+  cy.wait("@sessionProperties");
+}


### PR DESCRIPTION
This PR adds E2E tests that cover "downloading from an embedded question" scenarios.

NOTE:
This is still not actually downloading and asserting on the contents of downloaded formats. That'll be the scope of a separate PR.