### PR TITLE
additional feature flag checks for `snippet-collections` 

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/snippets/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/index.js
@@ -29,50 +29,48 @@ if (hasPremiumFeature("snippet_collections")) {
         },
       }),
   }));
-}
 
-PLUGIN_SNIPPET_SIDEBAR_MODALS.push(
-  snippetSidebar =>
-    snippetSidebar.state.modalSnippetCollection && (
-      <Modal
-        onClose={() =>
-          snippetSidebar.setState({ modalSnippetCollection: null })
-        }
-      >
-        <SnippetCollectionFormModal
-          collection={snippetSidebar.state.modalSnippetCollection}
+  PLUGIN_SNIPPET_SIDEBAR_MODALS.push(
+    snippetSidebar =>
+      snippetSidebar.state.modalSnippetCollection && (
+        <Modal
           onClose={() =>
             snippetSidebar.setState({ modalSnippetCollection: null })
           }
-          onSaved={() => {
-            snippetSidebar.setState({ modalSnippetCollection: null });
-          }}
-        />
-      </Modal>
-    ),
-  snippetSidebar =>
-    snippetSidebar.state.permissionsModalCollectionId != null && (
-      <Modal
-        onClose={() =>
-          snippetSidebar.setState({ permissionsModalCollectionId: null })
-        }
-      >
-        <CollectionPermissionsModal
-          params={{
-            slug: snippetSidebar.state.permissionsModalCollectionId,
-          }}
+        >
+          <SnippetCollectionFormModal
+            collection={snippetSidebar.state.modalSnippetCollection}
+            onClose={() =>
+              snippetSidebar.setState({ modalSnippetCollection: null })
+            }
+            onSaved={() => {
+              snippetSidebar.setState({ modalSnippetCollection: null });
+            }}
+          />
+        </Modal>
+      ),
+    snippetSidebar =>
+      snippetSidebar.state.permissionsModalCollectionId != null && (
+        <Modal
           onClose={() =>
             snippetSidebar.setState({ permissionsModalCollectionId: null })
           }
-          namespace="snippets"
-        />
-      </Modal>
-    ),
-);
+        >
+          <CollectionPermissionsModal
+            params={{
+              slug: snippetSidebar.state.permissionsModalCollectionId,
+            }}
+            onClose={() =>
+              snippetSidebar.setState({ permissionsModalCollectionId: null })
+            }
+            namespace="snippets"
+          />
+        </Modal>
+      ),
+  );
 
-PLUGIN_SNIPPET_SIDEBAR_ROW_RENDERERS.collection = CollectionRow;
+  PLUGIN_SNIPPET_SIDEBAR_ROW_RENDERERS.collection = CollectionRow;
 
-if (hasPremiumFeature("snippet_collections")) {
   PLUGIN_SNIPPET_SIDEBAR_HEADER_BUTTONS.push((snippetSidebar, props) => {
     const collection = snippetSidebar.props.snippetCollection;
     return (


### PR DESCRIPTION
Closes https://github.com/metabase/metabase-private/issues/132

### Description

Adding additional checks for the `snippet-collections` flag ([slack](https://metaboat.slack.com/archives/C05EWA11Z1V/p1690266731100319)).

### How to verify

Describe the steps to verify that the changes are working as expected.

OSS
1. `yarn dev`
2. Create sql question, open snippet sidebar
3. Permissions and collections should not be visible

EE
1. `yarn dev-ee`
2. Set token in admin settings
3. Create sql question, open snippet sidebar
4. Permissions and collections should be visible
5. Confirm that all related models work

### Demo

OSS

https://github.com/metabase/metabase/assets/37751258/de052241-0cc8-40c8-9701-d4638af2479e

EE

https://github.com/metabase/metabase/assets/37751258/31b47fb2-fb1b-414f-bfcc-f81e8d820b22

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

_Not applicable, since user facing functionality is still exactly the same._
