### PR TITLE
additional feature flag checks for `disable-password-login`

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/auth/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/auth/index.js
@@ -236,6 +236,7 @@ PLUGIN_AUTH_PROVIDERS.push(providers => {
     providers = [SSO_PROVIDER, ...providers];
   }
   if (
+    hasPremiumFeature("disable_password_login") &&
     !MetabaseSettings.isPasswordLoginEnabled() &&
     !MetabaseSettings.isLdapEnabled()
   ) {

--- a/enterprise/frontend/src/metabase-enterprise/auth/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/auth/index.js
@@ -245,12 +245,14 @@ PLUGIN_AUTH_PROVIDERS.push(providers => {
   return providers;
 });
 
-PLUGIN_IS_PASSWORD_USER.push(
-  user =>
-    !user.google_auth &&
-    !user.ldap_auth &&
-    MetabaseSettings.isPasswordLoginEnabled(),
-);
+if (hasPremiumFeature("disable_password_login")) {
+  PLUGIN_IS_PASSWORD_USER.push(
+    user =>
+      !user.google_auth &&
+      !user.ldap_auth &&
+      MetabaseSettings.isPasswordLoginEnabled(),
+  );
+}
 
 if (hasPremiumFeature("sso_ldap")) {
   PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections =>

--- a/frontend/src/metabase/account/profile/containers/UserProfileApp/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/account/profile/containers/UserProfileApp/tests/common.unit.spec.tsx
@@ -1,0 +1,14 @@
+import { screen } from "__support__/ui";
+
+import { setup } from "./setup";
+
+describe("UserProfileApp (OSS)", () => {
+  it("should show all form fields, even when password login is disabled", () => {
+    setup({ isPasswordLoginEnabled: false });
+
+    expect(screen.getByText(/first name/i)).toBeInTheDocument();
+    expect(screen.getByText(/last name/i)).toBeInTheDocument();
+    expect(screen.getByText(/email/i)).toBeInTheDocument();
+    expect(screen.getByText(/language/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/account/profile/containers/UserProfileApp/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/account/profile/containers/UserProfileApp/tests/enterprise.unit.spec.tsx
@@ -1,0 +1,14 @@
+import { screen } from "__support__/ui";
+
+import { setup } from "./setup";
+
+describe("UserProfileApp (EE)", () => {
+  it("should show all form fields, even when password login is disabled", () => {
+    setup({ isPasswordLoginEnabled: false, hasEnterprisePlugins: true });
+
+    expect(screen.getByText(/first name/i)).toBeInTheDocument();
+    expect(screen.getByText(/last name/i)).toBeInTheDocument();
+    expect(screen.getByText(/email/i)).toBeInTheDocument();
+    expect(screen.getByText(/language/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/account/profile/containers/UserProfileApp/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/account/profile/containers/UserProfileApp/tests/premium.unit.spec.tsx
@@ -1,0 +1,18 @@
+import { screen } from "__support__/ui";
+
+import { setup } from "./setup";
+
+describe("UserProfileApp (EE with token)", () => {
+  it("should show only show language field for an SSO user", () => {
+    setup({
+      isPasswordLoginEnabled: false,
+      hasEnterprisePlugins: true,
+      tokenFeatures: { disable_password_login: true },
+    });
+
+    expect(screen.queryByText(/first name/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/last name/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/email/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/language/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/account/profile/containers/UserProfileApp/tests/setup.tsx
+++ b/frontend/src/metabase/account/profile/containers/UserProfileApp/tests/setup.tsx
@@ -1,0 +1,32 @@
+import { renderWithProviders } from "__support__/ui";
+
+import { TokenFeatures } from "metabase-types/api";
+import { createMockTokenFeatures } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+import { mockSettings } from "__support__/settings";
+import { setupEnterprisePlugins } from "__support__/enterprise";
+
+import UserProfileApp from "../UserProfileApp";
+
+export function setup({
+  isPasswordLoginEnabled = true,
+  hasEnterprisePlugins = false,
+  tokenFeatures = {},
+}: {
+  isPasswordLoginEnabled?: boolean;
+  hasEnterprisePlugins?: boolean;
+  tokenFeatures?: Partial<TokenFeatures>;
+} = {}) {
+  const state = createMockState({
+    settings: mockSettings({
+      "enable-password-login": isPasswordLoginEnabled,
+      "token-features": createMockTokenFeatures(tokenFeatures),
+    }),
+  });
+
+  if (hasEnterprisePlugins) {
+    setupEnterprisePlugins();
+  }
+
+  renderWithProviders(<UserProfileApp />, { storeInitialState: state });
+}

--- a/frontend/src/metabase/auth/components/Login/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/auth/components/Login/tests/common.unit.spec.tsx
@@ -1,12 +1,8 @@
 import { screen } from "__support__/ui";
 
-import { setup, cleanUp } from "./setup";
+import { setup } from "./setup";
 
 describe("Login", () => {
-  afterEach(() => {
-    cleanUp();
-  });
-
   it("should render a list of auth providers", () => {
     setup({ isPasswordLoginEnabled: true, isGoogleAuthEnabled: true });
 

--- a/frontend/src/metabase/auth/components/Login/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/auth/components/Login/tests/common.unit.spec.tsx
@@ -1,0 +1,40 @@
+import { screen } from "__support__/ui";
+
+import { setup, cleanUp } from "./setup";
+
+describe("Login", () => {
+  afterEach(() => {
+    cleanUp();
+  });
+
+  it("should render a list of auth providers", () => {
+    setup({ isPasswordLoginEnabled: true, isGoogleAuthEnabled: true });
+
+    expect(screen.getAllByRole("link")).toHaveLength(2);
+  });
+
+  it("should render the panel of the selected provider", () => {
+    setup({
+      initialRoute: "/auth/login/password",
+      isPasswordLoginEnabled: true,
+      isGoogleAuthEnabled: true,
+    });
+
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("should implicitly select the only provider with a panel", () => {
+    setup({
+      isPasswordLoginEnabled: true,
+      isGoogleAuthEnabled: false,
+    });
+
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("should not disable password login for OSS", () => {
+    setup({ isPasswordLoginEnabled: false, isGoogleAuthEnabled: true });
+
+    expect(screen.getByText("Sign in with email")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/auth/components/Login/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/auth/components/Login/tests/enterprise.unit.spec.tsx
@@ -1,0 +1,15 @@
+import { screen } from "__support__/ui";
+
+import { setup } from "./setup";
+
+describe("Login", () => {
+  it("should not disable password login without the 'disable_password_login' token feature", () => {
+    setup({
+      isPasswordLoginEnabled: false,
+      isGoogleAuthEnabled: true,
+      hasEnterprisePlugins: true,
+    });
+
+    expect(screen.getByText("Sign in with email")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/auth/components/Login/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/auth/components/Login/tests/premium.unit.spec.tsx
@@ -1,0 +1,16 @@
+import { screen } from "__support__/ui";
+
+import { setup } from "./setup";
+
+describe("Login", () => {
+  it("should disable password login with the 'disable_password_login' token feature", () => {
+    setup({
+      isPasswordLoginEnabled: false,
+      isGoogleAuthEnabled: true,
+      hasEnterprisePlugins: true,
+      tokenFeatures: { disable_password_login: true },
+    });
+
+    expect(screen.queryByText("Sign in with email")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/auth/components/Login/tests/setup.tsx
+++ b/frontend/src/metabase/auth/components/Login/tests/setup.tsx
@@ -1,11 +1,13 @@
 import { Route } from "react-router";
+
 import MetabaseSettings from "metabase/lib/settings";
 import {
   createMockSettingsState,
   createMockState,
 } from "metabase-types/store/mocks";
-import { renderWithProviders, screen } from "__support__/ui";
-import { Login } from "./Login";
+import { renderWithProviders } from "__support__/ui";
+
+import { Login } from "../Login";
 
 interface SetupOpts {
   initialRoute?: string;
@@ -13,7 +15,7 @@ interface SetupOpts {
   isGoogleAuthEnabled?: boolean;
 }
 
-const setup = ({
+export const setup = ({
   initialRoute = "/auth/login",
   isPasswordLoginEnabled = true,
   isGoogleAuthEnabled = false,
@@ -37,38 +39,7 @@ const setup = ({
   );
 };
 
-const cleanUp = () => {
+export const cleanUp = () => {
   MetabaseSettings.set("enable-password-login", true);
   MetabaseSettings.set("google-auth-enabled", false);
 };
-
-describe("Login", () => {
-  afterEach(() => {
-    cleanUp();
-  });
-
-  it("should render a list of auth providers", () => {
-    setup({ isPasswordLoginEnabled: true, isGoogleAuthEnabled: true });
-
-    expect(screen.getAllByRole("link")).toHaveLength(2);
-  });
-
-  it("should render the panel of the selected provider", () => {
-    setup({
-      initialRoute: "/auth/login/password",
-      isPasswordLoginEnabled: true,
-      isGoogleAuthEnabled: true,
-    });
-
-    expect(screen.getByRole("button")).toBeInTheDocument();
-  });
-
-  it("should implicitly select the only provider with a panel", () => {
-    setup({
-      isPasswordLoginEnabled: true,
-      isGoogleAuthEnabled: false,
-    });
-
-    expect(screen.getByRole("button")).toBeInTheDocument();
-  });
-});

--- a/frontend/src/metabase/auth/components/Login/tests/setup.tsx
+++ b/frontend/src/metabase/auth/components/Login/tests/setup.tsx
@@ -1,11 +1,11 @@
 import { Route } from "react-router";
 
-import MetabaseSettings from "metabase/lib/settings";
-import {
-  createMockSettingsState,
-  createMockState,
-} from "metabase-types/store/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+import type { TokenFeatures } from "metabase-types/api";
+import { createMockTokenFeatures } from "metabase-types/api/mocks";
 import { renderWithProviders } from "__support__/ui";
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import { mockSettings } from "__support__/settings";
 
 import { Login } from "../Login";
 
@@ -13,22 +13,28 @@ interface SetupOpts {
   initialRoute?: string;
   isPasswordLoginEnabled?: boolean;
   isGoogleAuthEnabled?: boolean;
+  hasEnterprisePlugins?: boolean;
+  tokenFeatures?: Partial<TokenFeatures>;
 }
 
 export const setup = ({
   initialRoute = "/auth/login",
   isPasswordLoginEnabled = true,
   isGoogleAuthEnabled = false,
+  hasEnterprisePlugins = false,
+  tokenFeatures = {},
 }: SetupOpts = {}) => {
   const state = createMockState({
-    settings: createMockSettingsState({
+    settings: mockSettings({
       "enable-password-login": isPasswordLoginEnabled,
       "google-auth-enabled": isGoogleAuthEnabled,
+      "token-features": createMockTokenFeatures(tokenFeatures),
     }),
   });
 
-  MetabaseSettings.set("enable-password-login", isPasswordLoginEnabled);
-  MetabaseSettings.set("google-auth-enabled", isGoogleAuthEnabled);
+  if (hasEnterprisePlugins) {
+    setupEnterprisePlugins();
+  }
 
   renderWithProviders(
     <>
@@ -37,9 +43,4 @@ export const setup = ({
     </>,
     { storeInitialState: state, withRouter: true, initialRoute },
   );
-};
-
-export const cleanUp = () => {
-  MetabaseSettings.set("enable-password-login", true);
-  MetabaseSettings.set("google-auth-enabled", false);
 };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase-private/issues/131

### Description

Adding additional checks for the `disable-password-login` flag ([slack](https://metaboat.slack.com/archives/C05EWA11Z1V/p1690266548838039)).

### How to verify

1. `yarn dev-ee`
2. Add token
3. In auth settings tab, enable google auth and disable password logins
4. On login screen, should only see google option
5. Remove token
6. On login screen, should see both google and email options

### Demo

Without token

<img width="561" alt="Screenshot 2023-07-25 at 1 00 03 PM" src="https://github.com/metabase/metabase/assets/37751258/08719792-00c3-42c3-bcf9-1949893bc0a5">

With token

<img width="598" alt="Screenshot 2023-07-25 at 1 00 29 PM" src="https://github.com/metabase/metabase/assets/37751258/dca1f895-cbde-4f2d-9356-d6b5f908018d">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
