### PR TITLE
additional feature flag checks for `whitelabel`

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/index.js
@@ -107,8 +107,8 @@ if (hasPremiumFeature("whitelabel")) {
 
   PLUGIN_LOGO_ICON_COMPONENTS.push(LogoIcon);
   PLUGIN_SELECTORS.canWhitelabel = () => true;
-}
 
-// these selectors control whitelabeling UI
-PLUGIN_SELECTORS.getLoadingMessage = getLoadingMessage;
-PLUGIN_SELECTORS.getIsWhiteLabeling = getIsWhiteLabeling;
+  // these selectors control whitelabeling UI
+  PLUGIN_SELECTORS.getLoadingMessage = getLoadingMessage;
+  PLUGIN_SELECTORS.getIsWhiteLabeling = getIsWhiteLabeling;
+}

--- a/frontend/src/metabase/metabot/components/MetabotQueryBuilder/MetabotQueryBuilder.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotQueryBuilder/MetabotQueryBuilder.tsx
@@ -1,6 +1,7 @@
 import { connect } from "react-redux";
 import { t } from "ttag";
-import { PLUGIN_SELECTORS } from "metabase/plugins";
+
+import { getWhiteLabeledLoadingMessage } from "metabase/selectors/whitelabel";
 import { getResponseErrorMessage } from "metabase/core/utils/errors";
 import { Dataset } from "metabase-types/api";
 import { MetabotQueryStatus, State } from "metabase-types/store";
@@ -35,7 +36,7 @@ interface StateProps {
 type MetabotQueryBuilderProps = StateProps;
 
 const mapStateToProps = (state: State): StateProps => ({
-  loadingMessage: PLUGIN_SELECTORS.getLoadingMessage(state),
+  loadingMessage: getWhiteLabeledLoadingMessage(state),
   queryStatus: getQueryStatus(state),
   queryResults: getQueryResults(state),
   queryError: getQueryError(state),

--- a/frontend/src/metabase/nav/hooks.ts
+++ b/frontend/src/metabase/nav/hooks.ts
@@ -1,13 +1,13 @@
 import { useDatabaseListQuery } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
-import { PLUGIN_SELECTORS } from "metabase/plugins";
 import { getIsPaidPlan } from "metabase/selectors/settings";
 import { getUserIsAdmin } from "metabase/selectors/user";
+import { getIsWhiteLabeling } from "metabase/selectors/whitelabel";
 
 export function useShouldShowDatabasePromptBanner(): boolean | undefined {
   const isAdmin = useSelector(getUserIsAdmin);
   const isPaidPlan = useSelector(getIsPaidPlan);
-  const isWhiteLabeling = useSelector(PLUGIN_SELECTORS.getIsWhiteLabeling);
+  const isWhiteLabeling = useSelector(getIsWhiteLabeling);
   const isEligibleForDatabasePromptBanner =
     isAdmin && isPaidPlan && !isWhiteLabeling;
 

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -1,7 +1,6 @@
 import { t } from "ttag";
 import { createAction } from "redux-actions";
 
-import { PLUGIN_SELECTORS } from "metabase/plugins";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { startTimer } from "metabase/lib/performance";
 import { defer } from "metabase/lib/promise";
@@ -10,6 +9,7 @@ import { runQuestionQuery as apiRunQuestionQuery } from "metabase/services";
 
 import { getMetadata } from "metabase/selectors/metadata";
 import { getSensibleDisplays } from "metabase/visualizations";
+import { getWhiteLabeledLoadingMessage } from "metabase/selectors/whitelabel";
 import { isSameField } from "metabase-lib/queries/utils/field-ref";
 
 import Question from "metabase-lib/Question";
@@ -150,7 +150,7 @@ export const runQuestionQuery = ({
 const loadStartUIControls = createThunkAction(
   LOAD_START_UI_CONTROLS,
   () => (dispatch, getState) => {
-    const loadingMessage = PLUGIN_SELECTORS.getLoadingMessage(getState());
+    const loadingMessage = getWhiteLabeledLoadingMessage(getState());
     const title = {
       onceQueryIsRun: loadingMessage,
       ifQueryTakesLong: t`Still Here...`,

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -6,7 +6,6 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { useMount, useUnmount, usePrevious } from "react-use";
-import { PLUGIN_SELECTORS } from "metabase/plugins";
 import Bookmark from "metabase/entities/bookmarks";
 import Collections from "metabase/entities/collections";
 import Timelines from "metabase/entities/timelines";
@@ -31,6 +30,8 @@ import favicon from "metabase/hoc/Favicon";
 
 import useBeforeUnload from "metabase/hooks/use-before-unload";
 import { useSelector } from "metabase/lib/redux";
+import { getWhiteLabeledLoadingMessage } from "metabase/selectors/whitelabel";
+
 import View from "../components/view/View";
 
 import {
@@ -176,7 +177,7 @@ const mapStateToProps = (state, props) => {
     documentTitle: getDocumentTitle(state),
     pageFavicon: getPageFavicon(state),
     isLoadingComplete: getIsLoadingComplete(state),
-    loadingMessage: PLUGIN_SELECTORS.getLoadingMessage(state),
+    loadingMessage: getWhiteLabeledLoadingMessage(state),
 
     reportTimezone: getSetting(state, "report-timezone-long"),
   };

--- a/frontend/src/metabase/selectors/whitelabel/index.ts
+++ b/frontend/src/metabase/selectors/whitelabel/index.ts
@@ -4,3 +4,7 @@ import { PLUGIN_SELECTORS } from "metabase/plugins";
 export function getWhiteLabeledLoadingMessage(state: State) {
   return PLUGIN_SELECTORS.getLoadingMessage(state);
 }
+
+export function getIsWhiteLabeling(state: State) {
+  return PLUGIN_SELECTORS.getIsWhiteLabeling(state);
+}

--- a/frontend/src/metabase/selectors/whitelabel/index.ts
+++ b/frontend/src/metabase/selectors/whitelabel/index.ts
@@ -1,0 +1,6 @@
+import { State } from "metabase-types/store";
+import { PLUGIN_SELECTORS } from "metabase/plugins";
+
+export function getWhiteLabeledLoadingMessage(state: State) {
+  return PLUGIN_SELECTORS.getLoadingMessage(state);
+}

--- a/frontend/src/metabase/selectors/whitelabel/tests/common.unit.spec.ts
+++ b/frontend/src/metabase/selectors/whitelabel/tests/common.unit.spec.ts
@@ -1,0 +1,22 @@
+import { getWhiteLabeledLoadingMessage } from "..";
+import { setup } from "./setup";
+
+describe("getWhiteLabeledLoadingMessage (OSS)", () => {
+  it("should return 'Doing science...' when loading-message is set to 'doing-science'", () => {
+    const { getState } = setup({ loadingMessage: "doing-science" });
+
+    expect(getWhiteLabeledLoadingMessage(getState())).toBe("Doing science...");
+  });
+
+  it("should return 'Doing science...' when loading-message is set to 'loading-results'", () => {
+    const { getState } = setup({ loadingMessage: "loading-results" });
+
+    expect(getWhiteLabeledLoadingMessage(getState())).toBe("Doing science...");
+  });
+
+  it("should return 'Doing science...' when loading-message is set to 'running-query'", () => {
+    const { getState } = setup({ loadingMessage: "running-query" });
+
+    expect(getWhiteLabeledLoadingMessage(getState())).toBe("Doing science...");
+  });
+});

--- a/frontend/src/metabase/selectors/whitelabel/tests/common.unit.spec.ts
+++ b/frontend/src/metabase/selectors/whitelabel/tests/common.unit.spec.ts
@@ -1,4 +1,4 @@
-import { getWhiteLabeledLoadingMessage } from "..";
+import { getIsWhiteLabeling, getWhiteLabeledLoadingMessage } from "..";
 import { setup } from "./setup";
 
 describe("getWhiteLabeledLoadingMessage (OSS)", () => {
@@ -18,5 +18,19 @@ describe("getWhiteLabeledLoadingMessage (OSS)", () => {
     const { getState } = setup({ loadingMessage: "running-query" });
 
     expect(getWhiteLabeledLoadingMessage(getState())).toBe("Doing science...");
+  });
+});
+
+describe("getIsWhiteLabeling (OSS)", () => {
+  it("should return false when application-name is unchanged", () => {
+    const { getState } = setup();
+
+    expect(getIsWhiteLabeling(getState())).toBe(false);
+  });
+
+  it("should return false when application-name is changed", () => {
+    const { getState } = setup({ applicationName: "something else" });
+
+    expect(getIsWhiteLabeling(getState())).toBe(false);
   });
 });

--- a/frontend/src/metabase/selectors/whitelabel/tests/enterprise.unit.spec.ts
+++ b/frontend/src/metabase/selectors/whitelabel/tests/enterprise.unit.spec.ts
@@ -1,0 +1,26 @@
+import { getWhiteLabeledLoadingMessage } from "..";
+import { SetupOpts, setup as baseSetup } from "./setup";
+
+function setup(opts: SetupOpts = {}) {
+  return baseSetup({ hasEnterprisePlugins: true, ...opts });
+}
+
+describe("getWhiteLabeledLoadingMessage (EE without token)", () => {
+  it("should return 'Doing science...' when loading-message is set to 'doing-science'", () => {
+    const { getState } = setup({ loadingMessage: "doing-science" });
+
+    expect(getWhiteLabeledLoadingMessage(getState())).toBe("Doing science...");
+  });
+
+  it("should return 'Doing science...' when loading-message is set to 'loading-results'", () => {
+    const { getState } = setup({ loadingMessage: "loading-results" });
+
+    expect(getWhiteLabeledLoadingMessage(getState())).toBe("Doing science...");
+  });
+
+  it("should return 'Doing science...' when loading-message is set to 'running-query'", () => {
+    const { getState } = setup({ loadingMessage: "running-query" });
+
+    expect(getWhiteLabeledLoadingMessage(getState())).toBe("Doing science...");
+  });
+});

--- a/frontend/src/metabase/selectors/whitelabel/tests/enterprise.unit.spec.ts
+++ b/frontend/src/metabase/selectors/whitelabel/tests/enterprise.unit.spec.ts
@@ -1,4 +1,4 @@
-import { getWhiteLabeledLoadingMessage } from "..";
+import { getIsWhiteLabeling, getWhiteLabeledLoadingMessage } from "..";
 import { SetupOpts, setup as baseSetup } from "./setup";
 
 function setup(opts: SetupOpts = {}) {
@@ -22,5 +22,19 @@ describe("getWhiteLabeledLoadingMessage (EE without token)", () => {
     const { getState } = setup({ loadingMessage: "running-query" });
 
     expect(getWhiteLabeledLoadingMessage(getState())).toBe("Doing science...");
+  });
+});
+
+describe("getIsWhiteLabeling (EE without token)", () => {
+  it("should return false when application-name is unchanged", () => {
+    const { getState } = setup();
+
+    expect(getIsWhiteLabeling(getState())).toBe(false);
+  });
+
+  it("should return false when application-name is changed", () => {
+    const { getState } = setup({ applicationName: "something else" });
+
+    expect(getIsWhiteLabeling(getState())).toBe(false);
   });
 });

--- a/frontend/src/metabase/selectors/whitelabel/tests/premium.unit.spec.ts
+++ b/frontend/src/metabase/selectors/whitelabel/tests/premium.unit.spec.ts
@@ -1,0 +1,32 @@
+import { getWhiteLabeledLoadingMessage } from "..";
+import { SetupOpts, setup as baseSetup } from "./setup";
+
+function setup(opts: SetupOpts = {}) {
+  return baseSetup({
+    hasEnterprisePlugins: true,
+    tokenFeatures: { whitelabel: true },
+    ...opts,
+  });
+}
+
+describe("getWhiteLabeledLoadingMessage (EE with token)", () => {
+  it("should return 'Doing science...' when loading-message is set to 'doing-science'", () => {
+    const { getState } = setup({ loadingMessage: "doing-science" });
+
+    expect(getWhiteLabeledLoadingMessage(getState())).toBe("Doing science...");
+  });
+
+  it("should return 'Loading results...' when loading-message is set to 'loading-results'", () => {
+    const { getState } = setup({ loadingMessage: "loading-results" });
+
+    expect(getWhiteLabeledLoadingMessage(getState())).toBe(
+      "Loading results...",
+    );
+  });
+
+  it("should return 'Running query...' when loading-message is set to 'running-query'", () => {
+    const { getState } = setup({ loadingMessage: "running-query" });
+
+    expect(getWhiteLabeledLoadingMessage(getState())).toBe("Running query...");
+  });
+});

--- a/frontend/src/metabase/selectors/whitelabel/tests/premium.unit.spec.ts
+++ b/frontend/src/metabase/selectors/whitelabel/tests/premium.unit.spec.ts
@@ -1,4 +1,4 @@
-import { getWhiteLabeledLoadingMessage } from "..";
+import { getIsWhiteLabeling, getWhiteLabeledLoadingMessage } from "..";
 import { SetupOpts, setup as baseSetup } from "./setup";
 
 function setup(opts: SetupOpts = {}) {
@@ -28,5 +28,19 @@ describe("getWhiteLabeledLoadingMessage (EE with token)", () => {
     const { getState } = setup({ loadingMessage: "running-query" });
 
     expect(getWhiteLabeledLoadingMessage(getState())).toBe("Running query...");
+  });
+});
+
+describe("getIsWhiteLabeling (EE with token)", () => {
+  it("should return false when application-name is unchanged", () => {
+    const { getState } = setup();
+
+    expect(getIsWhiteLabeling(getState())).toBe(false);
+  });
+
+  it("should return true when application-name is changed", () => {
+    const { getState } = setup({ applicationName: "something else" });
+
+    expect(getIsWhiteLabeling(getState())).toBe(true);
   });
 });

--- a/frontend/src/metabase/selectors/whitelabel/tests/setup.tsx
+++ b/frontend/src/metabase/selectors/whitelabel/tests/setup.tsx
@@ -9,18 +9,21 @@ import type { LoadingMessage, TokenFeatures } from "metabase-types/api";
 
 export interface SetupOpts {
   loadingMessage?: LoadingMessage;
+  applicationName?: string;
   tokenFeatures?: Partial<TokenFeatures>;
   hasEnterprisePlugins?: boolean;
 }
 
 export function setup({
   loadingMessage = "doing-science",
+  applicationName = "Metabase",
   tokenFeatures = {},
   hasEnterprisePlugins = false,
 }: SetupOpts = {}) {
   const state = createMockState({
     settings: mockSettings({
       "loading-message": loadingMessage,
+      "application-name": applicationName,
       "token-features": createMockTokenFeatures(tokenFeatures),
     }),
   });

--- a/frontend/src/metabase/selectors/whitelabel/tests/setup.tsx
+++ b/frontend/src/metabase/selectors/whitelabel/tests/setup.tsx
@@ -7,15 +7,17 @@ import { createMockTokenFeatures } from "metabase-types/api/mocks";
 import { createMockState } from "metabase-types/store/mocks";
 import type { LoadingMessage, TokenFeatures } from "metabase-types/api";
 
+export interface SetupOpts {
+  loadingMessage?: LoadingMessage;
+  tokenFeatures?: Partial<TokenFeatures>;
+  hasEnterprisePlugins?: boolean;
+}
+
 export function setup({
   loadingMessage = "doing-science",
   tokenFeatures = {},
   hasEnterprisePlugins = false,
-}: {
-  loadingMessage?: LoadingMessage;
-  tokenFeatures?: Partial<TokenFeatures>;
-  hasEnterprisePlugins?: boolean;
-} = {}) {
+}: SetupOpts = {}) {
   const state = createMockState({
     settings: mockSettings({
       "loading-message": loadingMessage,

--- a/frontend/src/metabase/selectors/whitelabel/tests/setup.tsx
+++ b/frontend/src/metabase/selectors/whitelabel/tests/setup.tsx
@@ -1,0 +1,35 @@
+/* istanbul ignore file */
+
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders } from "__support__/ui";
+import { createMockTokenFeatures } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+import type { LoadingMessage, TokenFeatures } from "metabase-types/api";
+
+export function setup({
+  loadingMessage = "doing-science",
+  tokenFeatures = {},
+  hasEnterprisePlugins = false,
+}: {
+  loadingMessage?: LoadingMessage;
+  tokenFeatures?: Partial<TokenFeatures>;
+  hasEnterprisePlugins?: boolean;
+} = {}) {
+  const state = createMockState({
+    settings: mockSettings({
+      "loading-message": loadingMessage,
+      "token-features": createMockTokenFeatures(tokenFeatures),
+    }),
+  });
+
+  if (hasEnterprisePlugins) {
+    setupEnterprisePlugins();
+  }
+
+  const {
+    store: { getState },
+  } = renderWithProviders(<></>, { storeInitialState: state });
+
+  return { getState };
+}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase-private/issues/133

### Description

Adding additional checks for the `whitelabel` flag ([slack](https://metaboat.slack.com/archives/C05EWA11Z1V/p1690266769260069)).

### How to verify

Describe the steps to verify that the changes are working as expected.

Loading message
1. `yarn dev-ee`
2. Add token
3. In appearance settings, change loading message
4. Create a new question, verify the loading message changed
5. Remove token
6. Create a new question, verify the loading message went back to `Doing science`

Database connection banner
1. `yarn dev-ee`
2. Add token
3. Confirm banner appeared
4. In appearance settings, change app name to anything other than `Metabase`
5. Confirm banner disappears
6. Change name back to `Metabase`
7. Confirm banner reappears
8. Remove token
9. Confirm banner disappears


### Demo

Loading message with token

https://github.com/metabase/metabase/assets/37751258/0299e1e0-48a8-4f7c-b3b8-8780197994a8

Loading message after removing token

https://github.com/metabase/metabase/assets/37751258/c39f6a3f-9f4b-464d-848c-7be8600404d4

Banner with token

https://github.com/metabase/metabase/assets/37751258/18fb3647-8d94-4c8b-927a-26ec384a3442

Banner after removing token

https://github.com/metabase/metabase/assets/37751258/20e4a6e7-f8d2-4e39-a2b1-ae2eee9c6cc8

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
