### PR TITLE
check for enable-password-login

### DIFF
--- a/e2e/test/scenarios/admin/people/people.cy.spec.js
+++ b/e2e/test/scenarios/admin/people/people.cy.spec.js
@@ -247,6 +247,21 @@ describe("scenarios > admin > people", () => {
       cy.location().should(loc => expect(loc.pathname).to.eq("/admin/people"));
     });
 
+    it("should not offer to reset passwords when password login is disabled", () => {
+      cy.request("PUT", "/api/google/settings", {
+        "google-auth-auto-create-accounts-domain": null,
+        "google-auth-client-id": "example1.apps.googleusercontent.com",
+        "google-auth-enabled": true,
+      });
+
+      cy.request("PUT", "/api/setting", {
+        "enable-password-login": false,
+      });
+      cy.visit("/admin/people");
+      showUserOptions(normalUserName);
+      popover().findByText("Reset password").should("not.exist");
+    });
+
     it(
       "should reset user password with SMTP set up",
       { tags: "@external" },

--- a/frontend/src/metabase/admin/people/components/PeopleListRow.jsx
+++ b/frontend/src/metabase/admin/people/components/PeopleListRow.jsx
@@ -1,12 +1,13 @@
 /* eslint-disable react/prop-types */
 import { Fragment, useMemo } from "react";
 import { t } from "ttag";
+
 import moment from "moment-timezone";
 
 import { color } from "metabase/lib/colors";
 import { getFullName } from "metabase/lib/user";
 import * as Urls from "metabase/lib/urls";
-
+import { useSelector } from "metabase/lib/redux";
 import EntityMenu from "metabase/components/EntityMenu";
 import { Icon } from "metabase/core/components/Icon";
 import Link from "metabase/core/components/Link";
@@ -14,7 +15,10 @@ import Tooltip from "metabase/core/components/Tooltip";
 import UserAvatar from "metabase/components/UserAvatar";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 import { PLUGIN_ADMIN_USER_MENU_ITEMS } from "metabase/plugins";
+import { getSetting } from "metabase/selectors/settings";
 import MembershipSelect from "./MembershipSelect";
+
+const enablePasswordLoginKey = "enable-password-login";
 
 const PeopleListRow = ({
   user,
@@ -37,6 +41,10 @@ const PeopleListRow = ({
   );
 
   const isLoadingGroups = !groups;
+
+  const isPasswordLoginEnabled = useSelector(state =>
+    getSetting(state, enablePasswordLoginKey),
+  );
 
   return (
     <tr key={user.id}>
@@ -106,7 +114,7 @@ const PeopleListRow = ({
                     title: t`Edit user`,
                     link: Urls.editUser(user.id),
                   },
-                  {
+                  isPasswordLoginEnabled && {
                     title: t`Reset password`,
                     link: Urls.resetPassword(user.id),
                   },


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/25054

### Description
Small check to see if the `enable-password-login` flag is enabled before rendering the "reset password" option in the edit people screen.

### How to verify

1. Go to Admin -> Authentication
2. Under Google, click setup
3. Enter a Client ID (for example, `example1.apps.googleusercontent.com`), then go back to the Authentication page
4. Scroll down and disable "Enable Password Authenticaiton"
5. Go to the people page, and open the menu for a user
6. "Reset Password" should not be visible

### Demo
![chrome_J0Rnj7rDaJ](https://github.com/metabase/metabase/assets/1328979/21fbc88d-607f-4496-a8fb-9841f6edd1c5)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
