### PR TITLE
Global search refactor

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -386,7 +386,9 @@
     metabase.query-processor.timezone                               qp.timezone
     metabase.query-processor.util                                   qp.util
     metabase.related                                                related
+    metabase.search.config                                          search.config
     metabase.search.filter                                          search.filter
+    metabase.search.util                                            search.util
     metabase.search.scoring                                         scoring
     metabase.server.middleware.auth                                 mw.auth
     metabase.server.middleware.browser-cookie                       mw.browser-cookie

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -293,7 +293,7 @@
 (defn order-clause
   "CASE expression that lets the results be ordered by whether they're an exact (non-fuzzy) match or not"
   [query]
-  (let [match             (search.util/wildcard-match (search-util/normalize query))
+  (let [match             (search.util/wildcard-match (search.util/normalize query))
         columns-to-search (->> all-search-columns
                                (filter (fn [[_k v]] (= v :text)))
                                (map first)

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -233,8 +233,6 @@
 
 (defmethod search-query-for-model "database"
   [model search-ctx]
-  (def model model)
-  (def search-ctx search-ctx)
   (base-query-for-model model search-ctx))
 
 (defmethod search-query-for-model "dashboard"

--- a/src/metabase/models/params/custom_values.clj
+++ b/src/metabase/models/params/custom_values.clj
@@ -11,7 +11,7 @@
    [metabase.models.interface :as mi]
    [metabase.query-processor :as qp]
    [metabase.query-processor.util :as qp.util]
-   [metabase.search.util :as search]
+   [metabase.search.util :as search.util]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]
@@ -26,11 +26,11 @@
   - [value1, value2]
   - [[value1, label1], [value2, label2]] - we search using label in this case"
   [query values]
-  (let [normalized-query (search/normalize query)]
-    (filter #(str/includes? (search/normalize (if (string? %)
-                                                %
-                                                ;; search by label
-                                                (second %)))
+  (let [normalized-query (search.util/normalize query)]
+    (filter #(str/includes? (search.util/normalize (if (string? %)
+                                                     %
+                                                     ;; search by label
+                                                     (second %)))
                             normalized-query) values)))
 
 (defn- static-list-values

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -89,10 +89,10 @@
      [:archived?                           :boolean]
      [:models                              [:set SearchableModel]]
      [:current-user-perms                  [:set perms/PathMalliSchema]]
-     [:created-by         {:optional true} [:maybe ms/PositiveInt]]
-     [:table-db-id        {:optional true} [:maybe ms/PositiveInt]]
-     [:limit-int          {:optional true} [:maybe ms/Int]]
-     [:offset-int         {:optional true} [:maybe ms/Int]]]))
+     [:created-by         {:optional true} ms/PositiveInt]
+     [:table-db-id        {:optional true} ms/PositiveInt]
+     [:limit-int          {:optional true} ms/Int]
+     [:offset-int         {:optional true} ms/Int]]))
 
 (def ^:const displayed-columns
   "All of the result components that by default are displayed by the frontend."

--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -25,7 +25,7 @@
 ;;                                         Required Filters                                         ;
 ;; ------------------------------------------------------------------------------------------------;;
 
-(defmulti archived-clause
+(defmulti ^:private archived-clause
   "Clause to filter by the archived status of the entity."
   {:arglists '([model archived?])}
   (fn [model _] model))

--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -81,14 +81,14 @@
 ;;                                         Optional filters                                        ;;
 ;; ------------------------------------------------------------------------------------------------;;
 
-(defmulti ^:private optional-filter-query
-  "Clause for optional filters.
+(defmulti ^:private build-optional-filter-query
+  "Build the query to filter by `filter`.
   Dispath with an array of [filter model-name]."
   {:arglists '([model fitler query filter-value])}
   (fn [filter model _query _filter-value]
     [filter model]))
 
-(defmethod optional-filter-query :default
+(defmethod build-optional-filter-query :default
   [filter model _query _creator-id]
   (throw (ex-info (format "%s filter for %s is not supported" filter model) {:filter filter :model model})))
 
@@ -97,19 +97,19 @@
   [model creator-id]
   [:= (search.config/column-with-model-alias model :creator_id) creator-id])
 
-(defmethod optional-filter-query [:created-by "card"]
+(defmethod build-optional-filter-query [:created-by "card"]
   [_filter model query creator-id]
   (sql.helpers/where query (default-created-by-fitler-clause model creator-id)))
 
-(defmethod optional-filter-query [:created-by "dataset"]
+(defmethod build-optional-filter-query [:created-by "dataset"]
   [_filter model query creator-id]
   (sql.helpers/where query (default-created-by-fitler-clause model creator-id)))
 
-(defmethod optional-filter-query [:created-by "dashboard"]
+(defmethod build-optional-filter-query [:created-by "dashboard"]
   [_filter model query creator-id]
   (sql.helpers/where query (default-created-by-fitler-clause model creator-id)))
 
-(defmethod optional-filter-query [:created-by "action"]
+(defmethod build-optional-filter-query [:created-by "action"]
   [_filter model query creator-id]
   (sql.helpers/where query (default-created-by-fitler-clause model creator-id)))
 
@@ -120,7 +120,7 @@
 
   This is function instead of a def so that optional-filter-clause can be defined anywhere in the codebase."
   []
-  (->> (dissoc (methods optional-filter-query) :default)
+  (->> (dissoc (methods build-optional-filter-query) :default)
        keys
        (reduce (fn [acc [filter model]]
                  (update acc filter set/union #{model}))
@@ -155,4 +155,4 @@
 
       ;; build optional filters
       (int? created-by)
-      (#(optional-filter-query :created-by model % created-by)))))
+      (#(build-optional-filter-query :created-by model % created-by)))))

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -4,7 +4,7 @@
    [java-time :as t]
    [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.search.config :as search.config]
-   [metabase.search.util :as search-util]
+   [metabase.search.util :as search.util]
    [metabase.util :as u]))
 
 (defn- matches?
@@ -53,7 +53,7 @@
                      :let        [matched-text (-> search-result
                                                    (get column)
                                                    (search.config/column->string (:model search-result) column))
-                                  match-tokens (some-> matched-text search-util/normalize search-util/tokenize)
+                                  match-tokens (some-> matched-text search.util/normalize search.util/tokenize)
                                   raw-score (scorer query-tokens match-tokens)]
                      :when       (and matched-text (pos? raw-score))]
                  {:score               raw-score
@@ -68,7 +68,7 @@
 
 (defn- consecutivity-scorer
   [query-tokens match-tokens]
-  (/ (search-util/largest-common-subseq-length
+  (/ (search.util/largest-common-subseq-length
       matches?
       ;; See comment on largest-common-subseq-length re. its cache. This is a little conservative, but better to under- than over-estimate
       (take 30 query-tokens)
@@ -148,7 +148,7 @@
   [raw-search-string result]
   (if (seq raw-search-string)
     (text-scores-with match-based-scorers
-                      (search-util/tokenize (search-util/normalize raw-search-string))
+                      (search.util/tokenize (search.util/normalize raw-search-string))
                       result)
     [{:score 0 :weight 0}]))
 

--- a/src/metabase/search/util.clj
+++ b/src/metabase/search/util.clj
@@ -5,6 +5,11 @@
    [metabase.util :as u]
    [metabase.util.malli :as mu]))
 
+(defn wildcard-match
+  "Returns a string pattern to match a wildcard search term."
+  [s]
+  (str "%" s "%"))
+
 (mu/defn normalize :- :string
   "Normalize a `query` to lower-case."
   [query :- :string]

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -11,7 +11,7 @@
    [metabase.driver :as driver]
    [metabase.mbql.util :as mbql.u]
    [metabase.public-settings :as public-settings]
-   [metabase.search.util :as search-util]
+   [metabase.search.util :as search.util]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]])
   (:import
@@ -137,7 +137,7 @@
 
 (defn- row->types
   [row]
-  (map (comp value->type search-util/normalize) row))
+  (map (comp value->type search.util/normalize) row))
 
 (defn- lowest-common-member [[x & xs :as all-xs] ys]
   (cond

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -512,21 +512,7 @@
                                  :model_id      (:id model)
                                  :model_name    (:name model)}}
                       (into {} (comp relevant (map (juxt :name normalize)))
-                            (search! "rom"))))))))))
-
-  #_(testing "Sandboxing inhibits searching indexes"
-      (binding [api/*current-user-id* (mt/user->id :rasta)]
-        (is (= [:or [:like [:lower :model-index-value.name] "%foo%"]]
-               (#'api.search/base-where-clause-for-model "indexed-entity" {:archived? false
-                                                                           :search-string "foo"
-                                                                           :models             search-config/all-models
-                                                                           :current-user-perms #{"/"}})))
-        (with-redefs [premium-features/sandboxed-or-impersonated-user? (constantly true)]
-          (is (= [:or [:= 0 1]]
-                 (#'api.search/base-where-clause-for-model "indexed-entity" {:archived? false
-                                                                             :search-string "foo"
-                                                                             :models             search-config/all-models
-                                                                             :current-user-perms #{"/"}})))))))
+                            (search! "rom")))))))))))
 
 (deftest archived-results-test
   (testing "Should return unarchived results by default"

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -517,15 +517,13 @@
 
   (testing "Sandboxing inhibits searching indexes"
     (binding [api/*current-user-id* (mt/user->id :rasta)]
-      (is (= [:and
-              [:or [:like [:lower :model-index-value.name] "%foo%"]]
-              [:inline [:= 1 1]]]
+      (is (= [:or [:like [:lower :model-index-value.name] "%foo%"]]
              (#'api.search/base-where-clause-for-model "indexed-entity" {:archived? false
                                                                          :search-string "foo"
                                                                          :models             search-config/all-models
                                                                          :current-user-perms #{"/"}})))
       (with-redefs [premium-features/sandboxed-or-impersonated-user? (constantly true)]
-        (is (= [:and [:or [:= 0 1]] [:inline [:= 1 1]]]
+        (is (= [:or [:= 0 1]]
                (#'api.search/base-where-clause-for-model "indexed-entity" {:archived? false
                                                                            :search-string "foo"
                                                                            :models             search-config/all-models

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -218,13 +218,13 @@
                     :group_ids              #{(u/the-id (perms-group/all-users))}
                     :personal_collection_id true
                     :common_name            "Rasta Toucan"}
-                  {:email                  "trashbird@metabase.com"
-                    :first_name             "Trash"
-                    :last_name              "Bird"
-                    :is_active              false
-                    :group_ids              #{(u/the-id (perms-group/all-users))}
-                    :personal_collection_id true
-                    :common_name            "Trash Bird"}]
+                   {:email                  "trashbird@metabase.com"
+                     :first_name             "Trash"
+                     :last_name              "Bird"
+                     :is_active              false
+                     :group_ids              #{(u/the-id (perms-group/all-users))}
+                     :personal_collection_id true
+                     :common_name            "Trash Bird"}]
                   (map (partial merge @user-defaults))
                   (map #(dissoc % :is_qbnewb :last_login)))
              (->> ((mt/user-http-request :crowberto :get 200 "user", :include_deactivated true) :data)

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -106,4 +106,3 @@
                       base-search-query
                       "indexed-entity"
                       (merge default-search-ctx {:search-string "foo"}))))))))
-

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -1,26 +1,26 @@
 (ns ^:mb/once metabase.search.filter-test
   (:require
    [clojure.test :refer :all]
-   [metabase.search.config :as search-config]
+   [metabase.search.config :as search.config]
    [metabase.search.filter :as search.filter]))
 
 (def ^:private default-search-ctx
   {:search-string       "a string"
    :archived?           false
-   :models             search-config/all-models
+   :models             search.config/all-models
    :current-user-perms #{"/"}})
 
 (deftest ^:parallel search-context->applicable-models-test
   (testing "without optional filters"
     (testing "return :models as is"
-      (is (= search-config/all-models
+      (is (= search.config/all-models
              (search.filter/search-context->applicable-models default-search-ctx)))
       (is (= #{}
              (search.filter/search-context->applicable-models
               (merge default-search-ctx
                      {:models #{}}))))
 
-      (is (= search-config/all-models
+      (is (= search.config/all-models
              (search.filter/search-context->applicable-models
               (merge default-search-ctx
                      {:archived? true}))))))
@@ -38,21 +38,41 @@
                      {:models #{"dashboard" "dataset" "table"}
                       :created-by 1})))))))
 
+(def ^:private base-search-query
+  {:select [:*]
+   :from   [:table]})
+
 (deftest ^:parallel build-filters-test
   (testing "no optional filters"
-    (is (= [[:= :card.archived false]]
-           (search.filter/build-filters "card" default-search-ctx))))
+    (is (= [:and [:or
+                  [:like [:lower :card.name] "%a%"]
+                  [:like [:lower :card.name] "%string%"]
+                  [:like [:lower :card.description] "%a%"]
+                  [:like [:lower :card.description] "%string%"]]
+            [:= :card.archived false]]
+           (:where (search.filter/build-filters base-search-query "card" default-search-ctx)))))
 
   (testing "optional filters"
     (testing "created-by"
-      (is (= [[:= :card.creator_id 1] [:= :card.archived false]]
-             (search.filter/build-filters "card"
-                                          (merge default-search-ctx
-                                                 {:created-by 1}))))
+      (is (= [:and
+              [:or
+               [:like [:lower :card.name] "%a%"]
+               [:like [:lower :card.name] "%string%"]
+               [:like [:lower :card.description] "%a%"]
+               [:like [:lower :card.description] "%string%"]]
+              [:= :card.archived false]
+              [:= :card.creator_id 1]]
+             (:where (search.filter/build-filters
+                       base-search-query
+                       "card"
+                       (merge default-search-ctx
+                              {:created-by 1})))))
       (testing "throw error for unsupport models"
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
              #":created-by filter for database is not supported"
-             (search.filter/build-filters "database"
-                                          (merge default-search-ctx
-                                                 {:created-by 1}))))))))
+             (search.filter/build-filters
+              base-search-query
+              "database"
+              (merge default-search-ctx
+                     {:created-by 1}))))))))

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -1,11 +1,12 @@
 (ns ^:mb/once metabase.search.filter-test
   (:require
    [clojure.test :refer :all]
+   [metabase.public-settings.premium-features :as premium-features]
    [metabase.search.config :as search.config]
    [metabase.search.filter :as search.filter]))
 
 (def ^:private default-search-ctx
-  {:search-string       "a string"
+  {:search-string       nil
    :archived?           false
    :models             search.config/all-models
    :current-user-perms #{"/"}})
@@ -43,36 +44,66 @@
    :from   [:table]})
 
 (deftest ^:parallel build-filters-test
-  (testing "no optional filters"
-    (is (= [:and [:or
-                  [:like [:lower :card.name] "%a%"]
-                  [:like [:lower :card.name] "%string%"]
-                  [:like [:lower :card.description] "%a%"]
-                  [:like [:lower :card.description] "%string%"]]
+  (doseq [[[model search-ctx] expected-where]
+          [;; -- card models
+           [["card" default-search-ctx]
             [:= :card.archived false]]
-           (:where (search.filter/build-filters base-search-query "card" default-search-ctx)))))
 
-  (testing "optional filters"
-    (testing "created-by"
+           [["card" (merge default-search-ctx {:archived? true})]
+            [:= :card.archived true]]
+
+
+           ;; with search string
+           [["card" (merge default-search-ctx {:search-string "a string"})]
+            [:and
+             [:or
+              [:like [:lower :card.name] "%a%"]
+              [:like [:lower :card.name] "%string%"]
+              [:like [:lower :card.description] "%a%"]
+              [:like [:lower :card.description] "%string%"]]
+             [:= :card.archived false]]]
+
+           ;; created by filters
+           [["card" (merge default-search-ctx {:created-by 1})]
+            [:and [:= :card.archived false] [:= :card.creator_id 1]]]
+
+
+           ;; -- table models
+           [["table" (merge default-search-ctx {:archived? false})]
+            [:and [:= :table.active true] [:= :table.visibility_type nil]]]]]
+
+    (testing (format "filter for model %s with context %s" model search-ctx)
+      (is (= expected-where
+             (:where (search.filter/build-filters base-search-query model search-ctx))))))
+
+  (testing "throw error for filtering with unsupport models"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #":created-by filter for database is not supported"
+         (search.filter/build-filters
+          base-search-query
+          "database"
+          (merge default-search-ctx
+                 {:created-by 1}))))))
+
+(deftest build-filters-indexed-entity-test
+  (testing "users that are not sandboxed or impersonated can search for indexed entity"
+    (with-redefs [premium-features/sandboxed-or-impersonated-user? (constantly false)]
       (is (= [:and
-              [:or
-               [:like [:lower :card.name] "%a%"]
-               [:like [:lower :card.name] "%string%"]
-               [:like [:lower :card.description] "%a%"]
-               [:like [:lower :card.description] "%string%"]]
-              [:= :card.archived false]
-              [:= :card.creator_id 1]]
+              [:or [:like [:lower :model-index-value.name] "%foo%"]]
+              [:inline [:= 1 1]]]
              (:where (search.filter/build-filters
-                       base-search-query
-                       "card"
-                       (merge default-search-ctx
-                              {:created-by 1})))))
-      (testing "throw error for unsupport models"
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo
-             #":created-by filter for database is not supported"
-             (search.filter/build-filters
-              base-search-query
-              "database"
-              (merge default-search-ctx
-                     {:created-by 1}))))))))
+                      base-search-query
+                      "indexed-entity"
+                      (merge default-search-ctx {:search-string "foo"})))))))
+
+  (testing "otherwise search result is empty"
+    (with-redefs [premium-features/sandboxed-or-impersonated-user? (constantly true)]
+      (is (= [:and
+              [:or [:= 0 1]]
+              [:inline [:= 1 1]]]
+             (:where (search.filter/build-filters
+                      base-search-query
+                      "indexed-entity"
+                      (merge default-search-ctx {:search-string "foo"}))))))))
+

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [java-time :as t]
-   [metabase.search.config :as search-config]
+   [metabase.search.config :as search.config]
    [metabase.search.scoring :as scoring]))
 
 (defn- result-row
@@ -136,7 +136,7 @@
         (is (= (map :result items)
                (scoring/top-results items large xf)))))
     (testing "a full queue only saves the top items"
-      (let [sorted-items (->> (+ small search-config/max-filtered-results)
+      (let [sorted-items (->> (+ small search.config/max-filtered-results)
                               range
                               reverse ;; descending order
                               (map (fn [i]
@@ -217,7 +217,7 @@
                   reverse
                   (map :id)))))
     (testing "it treats stale items as being equally old"
-      (let [stale search-config/stale-time-in-days]
+      (let [stale search.config/stale-time-in-days]
         (is (= [1 2 3 4]
                (->> [(item 1 (days-ago (+ stale 1)))
                      (item 2 (days-ago (+ stale 50)))

--- a/test/metabase/search/util_test.clj
+++ b/test/metabase/search/util_test.clj
@@ -1,23 +1,23 @@
 (ns metabase.search.util-test
   (:require
    [clojure.test :refer :all]
-   [metabase.search.util :as search-util]))
+   [metabase.search.util :as search.util]))
 
 (deftest ^:parallel tokenize-test
   (testing "basic tokenization"
     (is (= ["Rasta" "the" "Toucan's" "search"]
-           (search-util/tokenize "Rasta the Toucan's search")))
+           (search.util/tokenize "Rasta the Toucan's search")))
     (is (= ["Rasta" "the" "Toucan"]
-           (search-util/tokenize "                Rasta\tthe    \tToucan     ")))
+           (search.util/tokenize "                Rasta\tthe    \tToucan     ")))
     (is (= []
-           (search-util/tokenize " \t\n\t ")))
+           (search.util/tokenize " \t\n\t ")))
     (is (= []
-           (search-util/tokenize "")))
+           (search.util/tokenize "")))
     (is (thrown-with-msg? Exception #"should be a string"
-                          (search-util/tokenize nil)))))
+                          (search.util/tokenize nil)))))
 
 (deftest ^:parallel test-largest-common-subseq-length
-  (let [subseq-length (partial search-util/largest-common-subseq-length =)]
+  (let [subseq-length (partial search.util/largest-common-subseq-length =)]
     (testing "greedy choice can't be taken"
       (is (= 3
              (subseq-length ["garden" "path" "this" "is" "not" "a" "garden" "path"]


### PR DESCRIPTION
Some refactoring with how search filter is generated, this will make implementing verified filter easier([PR](https://github.com/metabase/metabase/pull/32662))

Summary of the changes:
- move the rest of search logic in `api.search` to `search.filter`, this ns will handle all filters logic from now on
- the `build-filters` now will receive the whole query and its filter methods will operate on the query, not just a single clause.
  - we need this because in order to implement `verified` filter we need to join tables
- change namespace from `search-config, search-util` to `search.config, search.util` to matches the general convention


Part of milestone 2 of https://github.com/metabase/metabase/issues/27982