### PR TITLE
Global search: filter by verified

### DIFF
--- a/src/metabase/moderation.clj
+++ b/src/metabase/moderation.clj
@@ -8,14 +8,12 @@
 
 (def moderated-item-types
   "Schema enum of the acceptable values for the `moderated_item_type` column"
-  (s/enum "card" "dashboard" :card :dashboard))
+  (s/enum "card" :card))
 
 (def moderated-item-type->model
   "Maps DB name of the moderated item type to the model symbol (used for t2/select and such)"
-  {"card"      'Card
-   :card       'Card
-   "dashboard" 'Dashboard
-   :dashboard  'Dashboard})
+  {"card" 'Card
+   :card  'Card})
 
 (defn- object->type
   "Convert a moderated item instance to the keyword stored in the database"

--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -254,13 +254,19 @@
 
 (mu/defn assert-has-feature
   "Check if an token with `feature` is present. If not, throw an error with a message using `feature-name`.
-   `feature-name` should be a localized string unless used in a CLI context.
-
+  `feature-name` should be a localized string unless used in a CLI context.
   (assert-has-feature :sandboxes (tru \"Sandboxing\"))
   => throws an error with a message using \"Sandboxing\" as the feature name."
   [feature-flag :- keyword?
    feature-name :- [:or string? mu/localized-string-schema]]
   (when-not (has-feature? feature-flag)
+    (throw (ee-feature-error feature-name))))
+
+(mu/defn assert-has-any-features
+  "Check if has at least one of feature in `features`. Throw an error if none of the features are available."
+  [feature-flag :- [:sequential keyword?]
+   feature-name :- [:or string? mu/localized-string-schema]]
+  (when-not (some has-feature? feature-flag)
     (throw (ee-feature-error feature-name))))
 
 (defn- default-premium-feature-getter [feature]

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -84,15 +84,18 @@
 (def SearchContext
   "Map with the various allowed search parameters, used to construct the SQL query."
   (mc/schema
-    [:map {:closed true}
-     [:search-string                       [:maybe ms/NonBlankString]]
-     [:archived?                           :boolean]
-     [:models                              [:set SearchableModel]]
-     [:current-user-perms                  [:set perms/PathMalliSchema]]
-     [:created-by         {:optional true} ms/PositiveInt]
-     [:table-db-id        {:optional true} ms/PositiveInt]
-     [:limit-int          {:optional true} ms/Int]
-     [:offset-int         {:optional true} ms/Int]]))
+   [:map {:closed true}
+    [:search-string                       [:maybe ms/NonBlankString]]
+    [:archived?                           :boolean]
+    [:models                              [:set SearchableModel]]
+    [:current-user-perms                  [:set perms/PathMalliSchema]]
+    [:created-by         {:optional true} ms/PositiveInt]
+    [:table-db-id        {:optional true} ms/PositiveInt]
+    [:limit-int          {:optional true} ms/Int]
+    [:offset-int         {:optional true} ms/Int]
+    ;; true to search for verified items only,
+    ;; nil will return all items
+    [:verified           {:optional true} [:maybe true?]]]))
 
 (def ^:const displayed-columns
   "All of the result components that by default are displayed by the frontend."

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -244,7 +244,8 @@
   with-temp-vals-in-db
   with-temporary-setting-values
   with-temporary-raw-setting-values
-  with-user-in-groups]
+  with-user-in-groups
+  with-verified-cards]
 
  [tu.async
   wait-for-result

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -34,6 +34,7 @@
             User]]
    [metabase.models.collection :as collection]
    [metabase.models.interface :as mi]
+   [metabase.models.moderation-review :as moderation-review]
    [metabase.models.permissions :as perms]
    [metabase.models.permissions-group :as perms-group]
    [metabase.models.setting :as setting]
@@ -531,6 +532,8 @@
        ~@body)))
 
 
+
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                   SCHEDULER                                                    |
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -679,6 +682,49 @@
           (testing "Shouldn't delete other Cards"
             (is (pos? (t2/count Card)))))))))
 
+(defn do-with-verified-cards
+  "Impl for [[with-verified-cards]]."
+  [card-or-ids thunk]
+  (with-model-cleanup [:model/ModerationReview]
+    (doseq [card-or-id card-or-ids]
+      (doseq [status ["verified" nil "verified"]]
+        ;; create multiple moderation review for a card, but the end result is it's still verified
+        (moderation-review/create-review!
+         {:moderated_item_id   (u/the-id card-or-id)
+          :moderated_item_type "card"
+          :moderator_id        ((requiring-resolve 'metabase.test.data.users/user->id) :rasta)
+          :status              status}))
+      (thunk))))
+
+(defmacro with-verified-cards
+  "Execute the body with all `card-or-ids` verified."
+  [card-or-ids & body]
+  `(do-with-verified-cards ~card-or-ids (fn [] ~@body)))
+
+(deftest with-verified-cards-test
+  (t2.with-temp/with-temp
+    [:model/Card {card-id :id} {}]
+    (with-verified-cards [card-id]
+      (is (=? #{{:moderated_item_id   card-id
+                 :moderated_item_type :card
+                 :most_recent         true
+                 :status              "verified"}
+                {:moderated_item_id   card-id
+                 :moderated_item_type :card
+                 :most_recent         false
+                 :status              nil}
+                {:moderated_item_id   card-id
+                 :moderated_item_type :card
+                 :most_recent         false
+                 :status              "verified"}}
+              (t2/select-fn-set #(select-keys % [:moderated_item_id :moderated_item_type :most_recent :status])
+                                :model/ModerationReview
+                                :moderated_item_id card-id
+                                :moderated_item_type "card"))))
+    (testing "everything is cleaned up after the macro"
+      (is (= 0 (t2/count :model/ModerationReview
+                         :moderated_item_id card-id
+                         :moderated_item_type "card"))))))
 
 ;; TODO - not 100% sure I understand
 (defn call-with-paused-query


### PR DESCRIPTION
Adding `verified` filter to search api

Part of milestone 2 of https://github.com/metabase/metabase/issues/27982