### PR TITLE
Debounce link Viz input blur

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -811,7 +811,18 @@ describeWithSnowplow("scenarios > dashboard", () => {
     cy.wait("@recentViews");
     cy.findByTestId("custom-edit-text-link").click().type("Orders");
 
+    popover().within(() => {
+      cy.findByText(/Loading/i).should("not.exist");
+      cy.findByText("Orders in a dashboard").click();
+    });
+
+    cy.findByTestId("entity-edit-display-link").findByText(
+      /orders in a dashboard/i,
+    );
+
     saveDashboard();
+
+    cy.findByTestId("entity-view-display-link").findByText(/orders in/i);
 
     expectGoodSnowplowEvent({
       event: "new_link_card_created",

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -822,7 +822,9 @@ describeWithSnowplow("scenarios > dashboard", () => {
 
     saveDashboard();
 
-    cy.findByTestId("entity-view-display-link").findByText(/orders in/i);
+    cy.findByTestId("entity-view-display-link").findByText(
+      /orders in a dashboard/i,
+    );
 
     expectGoodSnowplowEvent({
       event: "new_link_card_created",

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { usePrevious } from "react-use";
+import _ from "underscore";
 
 import Input from "metabase/core/components/Input";
 import SearchResults from "metabase/nav/components/SearchResults";
@@ -170,7 +171,8 @@ function LinkViz({
             placeholder={"https://example.com"}
             onChange={e => handleLinkChange(e.target.value)}
             onFocus={onFocusInput}
-            onBlur={onBlurInput}
+            // we need to debounce this or it may close the popover before the click event can fire
+            onBlur={_.debounce(onBlurInput, 10)}
             // the dashcard really wants to turn all mouse events into drag events
             onMouseDown={e => e.stopPropagation()}
           />

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
@@ -172,7 +172,7 @@ function LinkViz({
             onChange={e => handleLinkChange(e.target.value)}
             onFocus={onFocusInput}
             // we need to debounce this or it may close the popover before the click event can fire
-            onBlur={_.debounce(onBlurInput, 10)}
+            onBlur={_.debounce(onBlurInput, 100)}
             // the dashcard really wants to turn all mouse events into drag events
             onMouseDown={e => e.stopPropagation()}
           />


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/32603

### Description

This was a tricky one. I checked all the way back to the initial relase of this feature in 46.0, and it was always there. I wasn't able to consistently reproduce this manually, but I was able to repro in cypress consistently.

What was happening is that *sometimes*, the onblur handler was firing before the onClick handler on search results, so the whole search results component was being destroyed before the click event even registered. Simply debouncing the onBlur slightly fixed the issue.

![linkViz-working](https://github.com/metabase/metabase/assets/30528226/d6a22b06-4d38-46ba-912f-1d45fafb1a83)

### How to verify

a) run the test, or
b) add a link card that links to an entity

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
