### PR TITLE
[MLv2] Add `lib.field/add-field` and `remove-field`

### DIFF
--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -142,10 +142,12 @@
    upper
    lower]
   [lib.field
+   add-field
    field-id
+   fieldable-columns
    fields
-   with-fields
-   fieldable-columns]
+   remove-field
+   with-fields]
   [lib.filter
    filter
    filters

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -585,7 +585,7 @@
                                            [column]
                                            (conj join-fields column)))))))
 
-(def ^:private native-query-fields-edit-error
+(defn- native-query-fields-edit-error []
   (i18n/tru "Fields cannot be adjusted on native queries. Either edit the native query, or save this question and edit the fields in a GUI question based on this one."))
 
 (mu/defn add-field :- ::lib.schema/query
@@ -610,7 +610,7 @@
                                     (contains? stage :fields) (include-field stage-number column))
       :source/joins               (add-field-to-join query stage-number column)
       :source/implicitly-joinable (include-field query stage-number column)
-      :source/native              (throw (ex-info native-query-fields-edit-error {:query query :stage stage-number}))
+      :source/native              (throw (ex-info (native-query-fields-edit-error) {:query query :stage stage-number}))
       ;; Default case - for columns from a native query or a custom expression - these are always returned and cannot be
       ;; selected off and on.
       query)))
@@ -683,6 +683,6 @@
                                                   {:query      query
                                                    :stage      stage-number
                                                    :expression column}))
-      :source/native              (throw (ex-info native-query-fields-edit-error {:query query :stage stage-number}))
+      :source/native              (throw (ex-info (native-query-fields-edit-error) {:query query :stage stage-number}))
       ;; Default case: do nothing and return the query unchaged.
       query)))

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -644,8 +644,8 @@
                           join-fields)
             removed     (remove #(lib.equality/find-closest-matching-ref query field-ref [%]) join-fields)]
         (cond-> query
-          ;; Return the query unchanged if we didn't find anything.
-          (= (count join-fields) (count removed))
+          ;; If we actually removed a field, replace the join. Otherwise return the query unchanged.
+          (< (count removed) (count join-fields))
           (lib.remove-replace/replace-join stage-number join (lib.join/with-join-fields join removed)))))))
 
 (mu/defn remove-field :- ::lib.schema/query

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -404,7 +404,8 @@
 (defn ^:export add-field
   "Adds a given field (`ColumnMetadata`, as returned from eg. [[visible-columns]]) to the fields returned by the query.
   Exactly what this means depends on the source of the field:
-  - Source table/card: add it to the `:fields` list
+  - Source table/card, previous stage of the query, aggregation or breakout:
+      - Add it to the `:fields` list
       - If `:fields` is missing, it's implicitly `:all`, so do nothing.
   - Implicit join: add it to the `:fields` list; query processor will do the right thing with it.
   - Explicit join: add it to that join's `:fields` list.
@@ -415,11 +416,14 @@
 (defn ^:export remove-field
   "Removes the field (a `ColumnMetadata`, as returned from eg. [[visible-columns]]) from those fields returned by the
   query. Exactly what this means depends on the source of the field:
-  - Source table/card: remove it to the `:fields` list
-      - If `:fields` is missing, it's implicitly `:all` - populate it with all the columns except the given one.
+  - Source table/card, previous stage, aggregations or breakouts:
+      - If `:fields` is missing, it's implicitly `:all` - populate it with all the columns except the removed one.
+      - Remove the target column from the `:fields` list
   - Implicit join: remove it from the `:fields` list; do nothing if it's not there.
+      - (An implicit join only exists in the `:fields` clause, so if it's not there then it's not anywhere.)
   - Explicit join: remove it from that join's `:fields` list (handle `:fields :all` like for source tables).
-  - Custom expression: Throw - the custom expression should itself be removed."
+  - Custom expression: Throw! Custom expressions are always returned. To remove a custom expression, the expression
+    itself should be removed from the query."
   [a-query stage-number column]
   (lib.core/remove-field a-query stage-number column))
 

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -401,6 +401,28 @@
   [a-query stage-number]
   (to-array (lib.core/fieldable-columns a-query stage-number)))
 
+(defn ^:export add-field
+  "Adds a given field (`ColumnMetadata`, as returned from eg. [[visible-columns]]) to the fields returned by the query.
+  Exactly what this means depends on the source of the field:
+  - Source table/card: add it to the `:fields` list
+      - If `:fields` is missing, it's implicitly `:all`, so do nothing.
+  - Implicit join: add it to the `:fields` list; query processor will do the right thing with it.
+  - Explicit join: add it to that join's `:fields` list.
+  - Custom expression: Do nothing - expressions are always included."
+  [a-query stage-number column]
+  (lib.core/add-field a-query stage-number column))
+
+(defn ^:export remove-field
+  "Removes the field (a `ColumnMetadata`, as returned from eg. [[visible-columns]]) from those fields returned by the
+  query. Exactly what this means depends on the source of the field:
+  - Source table/card: remove it to the `:fields` list
+      - If `:fields` is missing, it's implicitly `:all` - populate it with all the columns except the given one.
+  - Implicit join: remove it from the `:fields` list; do nothing if it's not there.
+  - Explicit join: remove it from that join's `:fields` list (handle `:fields :all` like for source tables).
+  - Custom expression: Throw - the custom expression should itself be removed."
+  [a-query stage-number column]
+  (lib.core/remove-field a-query stage-number column))
+
 (defn ^:export join-strategy
   "Get the strategy (type) of a given join as an opaque JoinStrategy object."
   [a-join]

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -4,14 +4,17 @@
    [medley.core :as m]
    [metabase.lib.binning :as lib.binning]
    [metabase.lib.core :as lib]
+   [metabase.lib.field :as lib.field]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.metadata.composed-provider
     :as lib.metadata.composed-provider]
+   [metabase.lib.options :as lib.options]
    [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.lib.temporal-bucket :as lib.temporal-bucket]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
+   [metabase.lib.util :as lib.util]
    [metabase.util :as u]
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))))
 
@@ -747,3 +750,360 @@
     (is (=? {"foo" nil
              "ID" venues-id}
            (into {} (map (juxt :lib/desired-column-alias lib/field-id)) cols)))))
+
+(defn- sorted-fields [fields]
+  (sort-by (comp str last) fields))
+
+(defn- fields-of
+  ([query] (fields-of query -1))
+  ([query stage-number]
+   (sorted-fields (lib/fields query stage-number))))
+
+(deftest ^:parallel populate-fields-for-stage-test
+  (testing "simple table query"
+    (is (=? [[:field {} (meta/id :orders :id)]
+             [:field {} (meta/id :orders :subtotal)]
+             [:field {} (meta/id :orders :total)]
+             [:field {} (meta/id :orders :tax)]
+             [:field {} (meta/id :orders :discount)]
+             [:field {} (meta/id :orders :quantity)]
+             [:field {} (meta/id :orders :created-at)]
+             [:field {} (meta/id :orders :product-id)]
+             [:field {} (meta/id :orders :user-id)]]
+            (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                (#'lib.field/populate-fields-for-stage -1)
+                fields-of))))
+  (testing "aggregated"
+    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                    (lib/aggregate -1 (lib/count)))]
+      (is (=? [[:aggregation {} (-> query lib/aggregations first lib.options/uuid)]]
+              (-> query
+                  (#'lib.field/populate-fields-for-stage -1)
+                  fields-of)))))
+  (testing "aggregated with breakout"
+    (let [query        (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                           (lib/aggregate -1 (lib/count)))
+          breakoutable (lib/breakoutable-columns query -1)
+          created-at   (first (filter #(= (:name %) "CREATED_AT") breakoutable))
+          query        (lib/breakout query -1 (lib/with-temporal-bucket created-at :month))]
+      (is (=? (sorted-fields [[:field {:temporal-unit :month} (meta/id :orders :created-at)]
+                              [:aggregation {} (-> query lib/aggregations first lib.options/uuid)]])
+              (-> query
+                  (#'lib.field/populate-fields-for-stage -1)
+                  fields-of)))))
+
+  (testing "explicit join fields are *not* included"
+    (let [query  (as-> (meta/table-metadata :orders) <>
+                   (lib/query meta/metadata-provider <>)
+                   (lib/join <> -1 (->> (meta/table-metadata :people)
+                                        (lib/suggested-join-condition <> -1)
+                                        vector
+                                        (lib/join-clause (meta/table-metadata :people)))))
+          fields [[:field {} (meta/id :orders :id)]
+                  [:field {} (meta/id :orders :subtotal)]
+                  [:field {} (meta/id :orders :total)]
+                  [:field {} (meta/id :orders :tax)]
+                  [:field {} (meta/id :orders :discount)]
+                  [:field {} (meta/id :orders :quantity)]
+                  [:field {} (meta/id :orders :created-at)]
+                  [:field {} (meta/id :orders :product-id)]
+                  [:field {} (meta/id :orders :user-id)]]]
+      (testing "when set to :all"
+        (is (=? fields
+                (-> query
+                    (#'lib.field/populate-fields-for-stage -1)
+                    fields-of))))
+      (testing "when given as a list"
+        (is (=? fields
+                (let [returned (lib.metadata.calculation/returned-columns query -1 (first (lib/joins query -1)))]
+                  (-> query
+                      (lib.util/update-query-stage -1 update-in [:joins 0] lib/with-join-fields (take 3 returned))
+                      (#'lib.field/populate-fields-for-stage -1)
+                      fields-of))))))))
+
+(deftest ^:parallel add-field-tests
+  (testing "simple table query"
+    (let [query       (lib/query meta/metadata-provider (meta/table-metadata :orders))
+          fieldable   (lib/fieldable-columns query -1)
+          own-columns (filter #(= (:lib/source %) :source/table-defaults) fieldable)
+          created-at  (first (filter #(= (:name %) "CREATED_AT") own-columns))
+          subset      (map lib/ref (take 4 own-columns))
+          field-query (lib/with-fields query -1 subset)]
+      (testing "does nothing with implicit :all"
+        (is (nil? (-> query
+                      (lib/add-field -1 created-at)
+                      (lib/fields -1)))))
+      ;; sanity check that the query is constructed properly.
+      (is (=? (sorted-fields subset)
+              (fields-of field-query)))
+      (testing "adds the column to the :fields list if missing"
+        (is (=? (sorted-fields (conj subset [:field {} (:id created-at)]))
+                (-> field-query
+                    (lib/add-field -1 created-at)
+                    fields-of))))
+      (testing "doesn't duplicate the column if it already exists"
+        (let [extended-subset (conj subset (lib/ref created-at))]
+          (is (=? (sorted-fields extended-subset)
+                  (-> field-query
+                      (lib/with-fields -1 extended-subset)
+                      (lib/add-field -1 created-at)
+                      fields-of)))))))
+  (testing "custom expressions are ignored"
+    (let [query       (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                          (lib/expression "custom" (lib/* 3 2)))
+          expr-column (->> (lib.metadata.calculation/returned-columns query)
+                           (remove :id)
+                           first)
+          own-columns (filter #(= (:lib/source %) :source/table-defaults)
+                              (lib/fieldable-columns query -1))
+          subset      (map lib/ref (take 4 own-columns))
+          field-query (lib/with-fields query -1 subset)]
+      (testing "with missing :fields list"
+        (is (=? query
+                (lib/add-field query -1 expr-column))))
+      (testing "with explicit :fields list"
+        (is (=? field-query
+                (lib/add-field field-query -1 expr-column))))))
+  (testing "single join"
+    (let [query  (as-> (meta/table-metadata :orders) <>
+                   (lib/query meta/metadata-provider <>)
+                   (lib/join <> -1 (->> (meta/table-metadata :people)
+                                        (lib/suggested-join-condition <> -1)
+                                        vector
+                                        (lib/join-clause (meta/table-metadata :people)))))
+          all-columns   (lib.metadata.calculation/returned-columns query)
+          table-columns (lib/fieldable-columns query -1)
+          join-columns  (filter #(= (:lib/source %) :source/joins) all-columns)]
+      ;; Orders has 9 columns, People has 13, for 22 total.
+      (is (= 22 (count all-columns)))
+      (is (= 9  (count table-columns)))
+      (is (= 13 (count join-columns)))
+      (testing "adding an already included field from the main table does nothing"
+        (is (= query (lib/add-field query -1 (nth table-columns 6)))))
+      (testing "adding an already included field from an :all join does nothing"
+        (is (= query (lib/add-field query -1 (nth join-columns 6)))))
+      (testing "top-level :fields with only some included"
+        (let [field-query (->> table-columns
+                               (take 4)
+                               (lib/with-fields query -1))]
+          (testing "returns those plus all the joined fields"
+            (is (=? (->> (concat (take 4 table-columns)
+                                 join-columns)
+                         (map lib/ref)
+                         (map #(lib.options/update-options % dissoc :lib/uuid))
+                         sorted-fields)
+                    (->> (lib.metadata.calculation/returned-columns field-query)
+                         (map lib/ref)
+                         sorted-fields))))
+          (testing "properly adds a top-level field"
+            (is (=? (->> (concat (take 4 table-columns)
+                                 join-columns
+                                 [(nth table-columns 6)])
+                         (map lib/ref)
+                         (map #(lib.options/update-options % dissoc :lib/uuid))
+                         sorted-fields)
+                    (->> (lib/add-field field-query -1 (nth table-columns 6))
+                         lib.metadata.calculation/returned-columns
+                         (map lib/ref)
+                         sorted-fields))))))
+
+      (testing "join :fields list"
+        (let [join-fields-query (lib.util/update-query-stage
+                                  query -1
+                                  update-in [:joins 0]
+                                  lib/with-join-fields (map lib/ref (take 4 join-columns)))]
+          (testing "returns those plus all the main table fields"
+            (is (=? (->> (concat table-columns
+                                 (take 4 join-columns))
+                         (map lib/ref)
+                         (map #(lib.options/update-options % dissoc :lib/uuid))
+                         sorted-fields)
+                    (->> (lib.metadata.calculation/returned-columns join-fields-query)
+                         (map lib/ref)
+                         sorted-fields))))
+          (testing "properly adds a join field"
+              (is (=? (->> (concat table-columns
+                                   (take 4 join-columns)
+                                   [(nth join-columns 6)])
+                           (map lib/ref)
+                           (map #(lib.options/update-options % dissoc :lib/uuid))
+                           sorted-fields)
+                      (->> (lib/add-field join-fields-query -1 (nth join-columns 6))
+                           lib.metadata.calculation/returned-columns
+                           (map lib/ref)
+                           sorted-fields))))
+          (testing "does nothing if the join field is already selected"
+              (is (=? join-fields-query
+                      (lib/add-field join-fields-query -1 (nth join-columns 3)))))))))
+
+  (testing "adding implicit join fields"
+    (let [query            (lib/query meta/metadata-provider (meta/table-metadata :orders))
+          viz-columns      (lib.metadata.calculation/visible-columns query)
+          table-columns    (lib/fieldable-columns query -1)
+          implicit-columns (filter #(= (:lib/source %) :source/implicitly-joinable) viz-columns)]
+      (is (= (map #(dissoc % :selected?) table-columns)
+             (lib.metadata.calculation/returned-columns query)))
+      (testing "with no :fields set"
+        (testing "populates the table's fields plus the implicitly joined field"
+          (is (=? (->> (concat table-columns
+                               [(nth implicit-columns 6)])
+                       (map lib/ref)
+                       (map #(lib.options/update-options % dissoc :lib/uuid))
+                       sorted-fields)
+                  (-> query
+                      (lib/add-field -1 (nth implicit-columns 6))
+                      fields-of)))))
+
+      (testing "with explicit :fields list"
+        (let [field-query (->> table-columns
+                               (take 4)
+                               (map lib/ref)
+                               (lib/with-fields query -1))]
+          (testing "properly adds the implicitly joined field"
+            (is (=? (->> (concat (take 4 table-columns)
+                                 [(nth implicit-columns 6)])
+                         (map lib/ref)
+                         (map #(lib.options/update-options % dissoc :lib/uuid))
+                         sorted-fields)
+                    (-> field-query
+                        (lib/add-field -1 (nth implicit-columns 6))
+                        fields-of))))
+          (testing "does nothing if this field is already selected"
+            (let [implied-query (lib/add-field field-query -1 (nth implicit-columns 6))]
+              (is (=? implied-query
+                      (lib/add-field implied-query -1 (nth implicit-columns 6)))))))))))
+
+(deftest ^:parallel remove-field-tests
+  (testing "simple table query"
+    (let [query       (lib/query meta/metadata-provider (meta/table-metadata :orders))
+          fieldable   (lib/fieldable-columns query -1)
+          own-columns (filter #(= (:lib/source %) :source/table-defaults) fieldable)
+          id          (first (filter #(= (:name %) "ID") own-columns))
+          created-at  (first (filter #(= (:name %) "CREATED_AT") own-columns))
+          subset      (->> own-columns
+                           (take 4)
+                           (map lib/ref))
+          field-query (lib/with-fields query -1 subset)]
+      (testing "populates :fields if missing, and removes the field"
+        (is (=? (->> own-columns
+                     (remove #(= (:id %) (:id created-at)))
+                     (map lib/ref)
+                     (map #(lib.options/update-options % dissoc :lib/uuid))
+                     sorted-fields)
+                (-> query
+                    (lib/remove-field -1 created-at)
+                    fields-of))))
+      ;; sanity check that the query is constructed properly.
+      (is (=? (sorted-fields subset)
+              (fields-of field-query)))
+      (testing "removes the column from the :fields list if present"
+        (is (=? (->> subset
+                     (remove (comp #{(meta/id :orders :id)} last))
+                     (map #(lib.options/update-options % assoc :lib/uuid string?))
+                     sorted-fields)
+                (-> field-query
+                    (lib/remove-field -1 id)
+                    fields-of))))
+      (testing "does nothing if the column is already not selected"
+        (is (=? (->> subset
+                     (map #(lib.options/update-options % assoc :lib/uuid string?))
+                     sorted-fields)
+                (-> field-query
+                    (lib/remove-field -1 created-at)
+                    fields-of))))))
+  (testing "custom expressions throw an exception"
+    (let [query       (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                          (lib/expression "custom" (lib/* 3 2)))
+          expr-column (->> (lib.metadata.calculation/returned-columns query)
+                           (remove :id)
+                           first)]
+      (is (thrown-with-msg? #?(:cljs :default :clj Exception) #"Custom expressions cannot be de-selected."
+                              (lib/remove-field query -1 expr-column)))))
+  (testing "single join"
+    (let [query  (as-> (meta/table-metadata :orders) <>
+                   (lib/query meta/metadata-provider <>)
+                   (lib/join <> -1 (->> (meta/table-metadata :people)
+                                        (lib/suggested-join-condition <> -1)
+                                        vector
+                                        (lib/join-clause (meta/table-metadata :people)))))
+          all-columns   (lib.metadata.calculation/returned-columns query)
+          table-columns (lib/fieldable-columns query -1)
+          join-columns  (filter #(= (:lib/source %) :source/joins) all-columns)]
+      ;; Orders has 9 columns, People has 13, for 22 total.
+      (is (= 22 (count all-columns)))
+      (is (= 9  (count table-columns)))
+      (is (= 13 (count join-columns)))
+      (testing "top-level :fields with only some included"
+        (let [field-query (->> table-columns
+                               (take 4)
+                               (lib/with-fields query -1))]
+          (testing "properly removes a top-level field"
+            (is (=? (->> (concat (rest (take 4 table-columns))
+                                 join-columns)
+                         (map lib/ref)
+                         (map #(lib.options/update-options % dissoc :lib/uuid))
+                         sorted-fields)
+                    (->> (lib/remove-field field-query -1 (first table-columns))
+                         lib.metadata.calculation/returned-columns
+                         (map lib/ref)
+                         sorted-fields))))
+          (testing "does nothing if field not listed"
+            (is (=? field-query
+                    (lib/remove-field field-query -1 (nth table-columns 6)))))))
+
+      (testing "join with :fields :all"
+        (let [created-at (first (filter (comp #{"CREATED_AT"} :name) join-columns))]
+          (testing "fills in the :fields list and removes the field"
+            (is (=? (->> (concat table-columns
+                                 join-columns)
+                         (remove (comp #{(meta/id :people :created-at)} :id))
+                         (map lib/ref)
+                         (map #(lib.options/update-options % dissoc :lib/uuid))
+                         sorted-fields)
+                    (->> (lib/remove-field query -1 created-at)
+                         lib.metadata.calculation/returned-columns
+                         (map lib/ref)
+                         sorted-fields))))))
+
+      (testing "join with :fields list"
+        (let [join-fields-query (lib.util/update-query-stage
+                                  query -1
+                                  update-in [:joins 0]
+                                  lib/with-join-fields (map lib/ref (take 4 join-columns)))]
+          (testing ":all fills in the :fields list and removes the field"
+            (is (=? (->> (concat table-columns
+                                 (rest (take 4 join-columns)))
+                         (map lib/ref)
+                         (map #(lib.options/update-options % dissoc :lib/uuid))
+                         sorted-fields)
+                    (->> (lib/remove-field join-fields-query -1 (first join-columns))
+                         lib.metadata.calculation/returned-columns
+                         (map lib/ref)
+                         sorted-fields))))
+          (testing ":does nothing if the join field is already selected"
+            (is (=? join-fields-query
+                    (lib/remove-field join-fields-query -1 (nth join-columns 6)))))))))
+
+  (testing "removing implicit join fields"
+    (let [query            (lib/query meta/metadata-provider (meta/table-metadata :orders))
+          viz-columns      (lib.metadata.calculation/visible-columns query)
+          table-columns    (lib/fieldable-columns query -1)
+          implicit-columns (filter #(= (:lib/source %) :source/implicitly-joinable) viz-columns)
+          implied-query    (lib/add-field query -1 (first implicit-columns))]
+      (is (= (map #(dissoc % :selected?) table-columns)
+             (lib.metadata.calculation/returned-columns query)))
+      (testing "with no :fields set does nothing"
+        (is (=? query
+                (lib/remove-field query -1 (first implicit-columns)))))
+
+      (testing "with explicit :fields list"
+        (is (=? (->> table-columns
+                     (map lib/ref)
+                     (map #(lib.options/update-options % dissoc :lib/uuid))
+                     sorted-fields)
+                (-> implied-query
+                    (lib/remove-field -1 (first implicit-columns))
+                    fields-of))))
+      (is (not= query
+                (lib/remove-field implied-query -1 (first implicit-columns)))
+          "even though the :fields list is now the default again, it's still an explicit list"))))

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -1064,7 +1064,7 @@
             (is (=? field-query
                     (lib/remove-field field-query -1 (nth table-columns 6)))))))
 
-      (testing "join with :fields :all"
+      (testing "with :fields :all"
         (let [created-at (first (filter (comp #{"CREATED_AT"} :name) join-columns))]
           (testing "fills in the :fields list and removes the field"
             (is (=? (->> (concat table-columns
@@ -1078,7 +1078,7 @@
                          (map lib/ref)
                          sorted-fields))))))
 
-      (testing "join with :fields list"
+      (testing "with :fields list"
         (let [join-fields-query (lib.util/update-query-stage
                                  query -1
                                  update-in [:joins 0]
@@ -1093,7 +1093,7 @@
                          lib.metadata.calculation/returned-columns
                          (map lib/ref)
                          sorted-fields))))
-          (testing ":does nothing if the join field is already selected"
+          (testing "does nothing if the join field is already selected"
             (is (=? join-fields-query
                     (lib/remove-field join-fields-query -1 (nth join-columns 6)))))))))
 


### PR DESCRIPTION
These are "porcelain" APIs to make FE management of the set of selected
columns for a query much easier.

`add-field` and `remove-field` will handle regular table fields,
explicit join fields, and custom expressions correctly.

One known quirk: if the set of `:fields` on a stage happens to match the
default set, this is *not* noticed or fixed. Once an explicit list is
set on a stage, it will forever have a list.