### PR TITLE
Fix: Don't offer to create new items on read only collections

### DIFF
--- a/e2e/test/scenarios/collections/permissions.cy.spec.js
+++ b/e2e/test/scenarios/collections/permissions.cy.spec.js
@@ -353,6 +353,29 @@ describe("collection permissions", () => {
               cy.signIn(user);
             });
 
+            it("should not show write access options on an empty, read-only collection", () => {
+              cy.request("GET", "/api/collection").then(xhr => {
+                // We need to obtain the ID programatically
+                const { id: THIRD_COLLECTION_ID } = xhr.body.find(
+                  collection => collection.slug === "third_collection",
+                );
+
+                // read-only, empty collection
+                cy.visit(`/collection/${THIRD_COLLECTION_ID}`);
+                cy.findByTestId("collection-empty-state")
+                  .findByText("Create a new…")
+                  .should("not.exist");
+              });
+
+              // writable, empty collection
+              cy.findByTestId("main-navbar-root")
+                .findByText("Your personal collection")
+                .click();
+              cy.findByTestId("collection-empty-state")
+                .findByText("Create a new…")
+                .should("exist");
+            });
+
             it("should not show pins or a helper text (metabase#20043)", () => {
               cy.visit("/collection/root");
 

--- a/e2e/test/scenarios/collections/permissions.cy.spec.js
+++ b/e2e/test/scenarios/collections/permissions.cy.spec.js
@@ -353,29 +353,6 @@ describe("collection permissions", () => {
               cy.signIn(user);
             });
 
-            it("should not show write access options on an empty, read-only collection", () => {
-              cy.request("GET", "/api/collection").then(xhr => {
-                // We need to obtain the ID programatically
-                const { id: THIRD_COLLECTION_ID } = xhr.body.find(
-                  collection => collection.slug === "third_collection",
-                );
-
-                // read-only, empty collection
-                cy.visit(`/collection/${THIRD_COLLECTION_ID}`);
-                cy.findByTestId("collection-empty-state")
-                  .findByText("Create a new…")
-                  .should("not.exist");
-              });
-
-              // writable, empty collection
-              cy.findByTestId("main-navbar-root")
-                .findByText("Your personal collection")
-                .click();
-              cy.findByTestId("collection-empty-state")
-                .findByText("Create a new…")
-                .should("exist");
-            });
-
             it("should not show pins or a helper text (metabase#20043)", () => {
               cy.visit("/collection/root");
 

--- a/frontend/src/metabase/collections/components/CollectionEmptyState/CollectionEmptyState.tsx
+++ b/frontend/src/metabase/collections/components/CollectionEmptyState/CollectionEmptyState.tsx
@@ -18,7 +18,7 @@ export interface CollectionEmptyStateProps {
 const CollectionEmptyState = ({
   collection,
 }: CollectionEmptyStateProps): JSX.Element => {
-  const canWrite = collection?.can_write ?? false;
+  const canWrite = !!collection?.can_write;
 
   return (
     <EmptyStateRoot data-testid="collection-empty-state">

--- a/frontend/src/metabase/collections/components/CollectionEmptyState/CollectionEmptyState.tsx
+++ b/frontend/src/metabase/collections/components/CollectionEmptyState/CollectionEmptyState.tsx
@@ -2,7 +2,7 @@ import { t } from "ttag";
 import Button from "metabase/core/components/Button";
 import NewItemMenu from "metabase/containers/NewItemMenu";
 import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
-import { CollectionId } from "metabase-types/api";
+import { Collection } from "metabase-types/api";
 import {
   EmptyStateDescription,
   EmptyStateIconBackground,
@@ -12,22 +12,26 @@ import {
 } from "./CollectionEmptyState.styled";
 
 export interface CollectionEmptyStateProps {
-  collectionId?: CollectionId;
+  collection?: Collection;
 }
 
 const CollectionEmptyState = ({
-  collectionId,
+  collection,
 }: CollectionEmptyStateProps): JSX.Element => {
+  const canWrite = collection?.can_write ?? false;
+
   return (
     <EmptyStateRoot data-testid="collection-empty-state">
       <CollectionEmptyIcon />
       <EmptyStateTitle>{t`This collection is empty`}</EmptyStateTitle>
       <EmptyStateDescription>{t`Use collections to organize and group dashboards and questions for your team or yourself`}</EmptyStateDescription>
-      <NewItemMenu
-        trigger={<Button icon="add">{t`Create a new…`}</Button>}
-        collectionId={collectionId}
-        analyticsContext={ANALYTICS_CONTEXT}
-      />
+      {canWrite && (
+        <NewItemMenu
+          trigger={<Button icon="add">{t`Create a new…`}</Button>}
+          collectionId={collection?.id}
+          analyticsContext={ANALYTICS_CONTEXT}
+        />
+      )}
     </EmptyStateRoot>
   );
 };

--- a/frontend/src/metabase/collections/components/CollectionEmptyState/CollectionEmptyState.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionEmptyState/CollectionEmptyState.unit.spec.tsx
@@ -1,12 +1,35 @@
 import { screen, renderWithProviders } from "__support__/ui";
 import type { Collection } from "metabase-types/api";
-import { createMockCollection } from "metabase-types/api/mocks";
+import {
+  createMockCollection,
+  createMockCollectionItem,
+  createMockDatabase,
+} from "metabase-types/api/mocks";
+import {
+  setupDatabasesEndpoints,
+  setupSearchEndpoints,
+} from "__support__/server-mocks";
+
 import CollectionEmptyState from "metabase/collections/components/CollectionEmptyState";
+
+console.warn = jest.fn();
+console.error = jest.fn();
+
+const TEST_DATABASE = createMockDatabase();
+
+const TEST_COLLECTION = createMockCollection();
+const TEST_COLLECTION_ITEM = createMockCollectionItem({
+  collection: TEST_COLLECTION,
+  model: "dataset",
+});
 
 async function setup({
   collection,
 }: { collection?: Partial<Collection> } = {}) {
   const mockCollection = createMockCollection(collection);
+
+  setupDatabasesEndpoints([TEST_DATABASE]);
+  setupSearchEndpoints([TEST_COLLECTION_ITEM]);
 
   renderWithProviders(<CollectionEmptyState collection={mockCollection} />);
 }

--- a/frontend/src/metabase/collections/components/CollectionEmptyState/CollectionEmptyState.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionEmptyState/CollectionEmptyState.unit.spec.tsx
@@ -1,0 +1,26 @@
+import { screen, renderWithProviders } from "__support__/ui";
+import type { Collection } from "metabase-types/api";
+import { createMockCollection } from "metabase-types/api/mocks";
+import CollectionEmptyState from "metabase/collections/components/CollectionEmptyState";
+
+async function setup({
+  collection,
+}: { collection?: Partial<Collection> } = {}) {
+  const mockCollection = createMockCollection(collection);
+
+  renderWithProviders(<CollectionEmptyState collection={mockCollection} />);
+}
+
+describe("empty collection", () => {
+  it("should show the 'create a new' button if the user has write access", async () => {
+    await setup();
+
+    expect(screen.getByText("Create a new…")).toBeInTheDocument();
+  });
+
+  it("should not show the 'create a new' button if the user lacks write access", async () => {
+    await setup({ collection: { can_write: false } });
+
+    expect(screen.queryByText("Create a new…")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -303,7 +303,7 @@ function CollectionContent({
                     if (isEmpty && !loadingUnpinnedItems) {
                       return (
                         <CollectionEmptyContent>
-                          <CollectionEmptyState collectionId={collectionId} />
+                          <CollectionEmptyState collection={collection} />
                         </CollectionEmptyContent>
                       );
                     }


### PR DESCRIPTION
**Problem:** Users with read-only access on empty collections still see an option to "Create a new..."

Context: https://github.com/metabase/metabase/issues/32224

---
**Desired Behavior**/**Acceptance Criteria**

_Writable, empty collection_

![image](https://github.com/metabase/metabase/assets/22608765/9301b1db-e6b7-42fa-ba05-77cfa093535a)

- [ ] Should **show** "Create a new..." button for writable, empty collections

_Read-only, empty collection_

![image](https://github.com/metabase/metabase/assets/22608765/50552ab1-f31f-4d32-9745-50b186da5a02)

- [ ] Should **not show** "Create a new..." button for read-only, empty collections

_Tests_

- [ ] **Writable:** Validated behavior for writable, empty collections
- [ ] **Read-only:** Validated behavior for read-only, empty collections