### PR TITLE
improve actions-on-dashboards e2e tests

### DIFF
--- a/e2e/support/helpers/e2e-qa-databases-helpers.js
+++ b/e2e/support/helpers/e2e-qa-databases-helpers.js
@@ -229,7 +229,10 @@ export function waitForSyncToFinish({
     if (!body.tables.length) {
       waitForSyncToFinish({ iteration: ++iteration, dbId, tableName });
     } else if (tableName) {
-      const hasTable = body.tables.some(table => table.name === tableName);
+      const hasTable = body.tables.some(
+        table =>
+          table.name === tableName && table.initial_sync_status === "complete",
+      );
       if (!hasTable) {
         waitForSyncToFinish({ iteration: ++iteration, dbId, tableName });
       }

--- a/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
@@ -1033,7 +1033,7 @@ describe(
           cy.button("Pick an action").click();
         });
 
-        cy.wait("@getActions");
+        waitForValidActions();
 
         cy.findByRole("dialog").within(() => {
           cy.findByText(MODEL_NAME).click();
@@ -1095,7 +1095,7 @@ function createDashboardWithActionButton({
     cy.button("Pick an action").click();
   });
 
-  cy.wait("@getActions");
+  waitForValidActions();
 
   cy.findByRole("dialog").within(() => {
     cy.findByText(modelName).click();
@@ -1181,4 +1181,14 @@ function actionEditorModal() {
 
 function getActionParametersInputModal() {
   return cy.findByTestId("action-parameters-input-modal");
+}
+
+function waitForValidActions() {
+  cy.wait("@getActions").then(({ response }) => {
+    const { body: actions } = response;
+
+    actions.forEach(action => {
+      expect(action.parameters).to.have.length.gt(0);
+    });
+  });
 }


### PR DESCRIPTION
maybe closes https://github.com/metabase/metabase/issues/31201

### Description

actions-on-dashboard tests have been flaking a lot

![Screen Shot 2023-07-26 at 5 05 28 PM](https://github.com/metabase/metabase/assets/30528226/d0b31c97-9c50-42c6-9850-ccd21f7ec440)
![Screen Shot 2023-07-26 at 5 05 23 PM](https://github.com/metabase/metabase/assets/30528226/6fde50ca-0ea1-469a-9c9d-69493663e918)
![Screen Shot 2023-07-26 at 5 05 17 PM](https://github.com/metabase/metabase/assets/30528226/b7ee3f34-65a0-4df9-9609-4323cdc4285e)

many of the flakes involve trying to use implicit actions with empty parameters.

![Screen Shot 2023-07-26 at 4 42 12 PM](https://github.com/metabase/metabase/assets/30528226/f668dee6-d894-42fa-95e3-539f1debcb4b) 
![Screen Shot 2023-07-26 at 5 09 35 PM](https://github.com/metabase/metabase/assets/30528226/287f6076-babd-41bb-be29-2632cf2cb479)


hypothesis: these actions have empty parameters because the table isn't fully synced so metabase can't auto-generate the parameters from the table metadata.


