### PR TITLE
Run E2E tests on Chrome v114

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -176,6 +176,17 @@ jobs:
       - name: Run Snowplow micro
         uses: ./.github/actions/run-snowplow-micro
 
+      - name: Install Chrome v114
+        uses: browser-actions/setup-chrome@v1
+        with:
+          # https://chromium.cypress.io/linux/stable/114.0.5735.133
+          # https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2F1135580%2Fchrome-linux.zip
+          chrome-version: 1135580
+        id: setup-chrome
+      - run: |
+          echo Installed chromium version: ${{ steps.setup-chrome.outputs.chrome-version }}
+          ${{ steps.setup-chrome.outputs.chrome-path }} --version
+
       - uses: actions/download-artifact@v3
         name: Retrieve uberjar artifact for ${{ matrix.edition }}
         with:
@@ -190,7 +201,8 @@ jobs:
         run: |
           yarn run test-cypress-run \
           --env grepTags=@OSS \
-          --spec './e2e/test/scenarios/**/*.cy.spec.js'
+          --spec './e2e/test/scenarios/**/*.cy.spec.js' \
+          --browser ${{ steps.setup-chrome.outputs.chrome-path }}
         env:
           TERM: xterm
 
@@ -199,7 +211,8 @@ jobs:
         run: |
           yarn run test-cypress-run \
           --env grepTags="-@quarantine" \
-          --folder ${{ matrix.folder }}
+          --folder ${{ matrix.folder }} \
+          --browser ${{ steps.setup-chrome.outputs.chrome-path }}
         env:
           TERM: xterm
 


### PR DESCRIPTION
As of two days ago we started seeing Chrome crashing in E2E tests.
An example of the failed run: https://github.com/metabase/metabase/actions/runs/5665970958/job/15354475344

```
We detected that the Chromium Renderer process just crashed.

This is the equivalent to seeing the 'sad face' when Chrome dies.

This can happen for a number of different reasons:

- You wrote an endless loop and you must fix your own code
- You are running Docker (there is an easy fix for this: see link below)
- You are running lots of tests on a memory intense application.
    - Try enabling experimentalMemoryManagement in your config file.
    - Try lowering numTestsKeptInMemory in your config file.
- You are running in a memory starved VM environment.
    - Try enabling experimentalMemoryManagement in your config file.
    - Try lowering numTestsKeptInMemory in your config file.
- There are problems with your GPU / GPU drivers
- There are browser bugs in Chromium
```

I'm not quite sure whether this is a bug in Chrome v115 or some interplay between Cypress and this particular Chrome version, but running all tests on older Chrome version `v114` seems to be working just fine.
https://github.com/metabase/metabase/actions/runs/5677579526?pr=32688

## Proposal
Let's merge this ASAP as a hotfix to unblock everyone, and then we'll follow-up when there's a clear resolution of this problem (most likely upstream).