### PR TITLE
Update mock Search API to reflect current response state

### DIFF
--- a/frontend/test/__support__/server-mocks/search.ts
+++ b/frontend/test/__support__/server-mocks/search.ts
@@ -2,10 +2,11 @@ import fetchMock from "fetch-mock";
 import type { CollectionItem, SearchResult } from "metabase-types/api";
 
 export function setupSearchEndpoints(items: (CollectionItem | SearchResult)[]) {
+  console.log(items);
   fetchMock.get("path:/api/search", uri => {
     const url = new URL(uri);
     const models = url.searchParams.getAll("models");
-    const limit = Number(url.searchParams.get("limit"));
+    const limit = Number(url.searchParams.get("limit")) || 50;
     const offset = Number(url.searchParams.get("offset"));
     const table_db_id = url.searchParams.get("table_db_id") || null;
     const queryText = url.searchParams.get("q")?.toLowerCase();
@@ -22,6 +23,16 @@ export function setupSearchEndpoints(items: (CollectionItem | SearchResult)[]) {
     matchedItems = matchedItems.filter(
       ({ model }) => !models.length || models.includes(model),
     );
+
+    console.log(matchedItems, {
+      data: matchedItems.slice(offset, offset + limit),
+      total: matchedItems.length,
+      models,
+      available_models: availableModels,
+      limit,
+      offset,
+      table_db_id,
+    });
 
     return {
       data: matchedItems.slice(offset, offset + limit),

--- a/frontend/test/__support__/server-mocks/search.ts
+++ b/frontend/test/__support__/server-mocks/search.ts
@@ -1,21 +1,43 @@
 import fetchMock from "fetch-mock";
-import type { CollectionItem } from "metabase-types/api";
+import type { CollectionItem, SearchResult } from "metabase-types/api";
 
-export function setupSearchEndpoints(items: CollectionItem[]) {
-  const availableModels = items.map(({ model }) => model);
-
+export function setupSearchEndpoints(items: (CollectionItem | SearchResult)[]) {
   fetchMock.get("path:/api/search", uri => {
     const url = new URL(uri);
-    const models = url.searchParams.getAll("models");
+    const urlModels = [...new Set(url.searchParams.getAll("models"))];
     const limit = Number(url.searchParams.get("limit"));
     const offset = Number(url.searchParams.get("offset"));
     const table_db_id = url.searchParams.get("table_db_id") || null;
-    const matchedItems = items.filter(({ model }) => models.includes(model));
+    const queryText = url.searchParams.get("q");
+
+    let availableModelItems = items;
+    if (queryText) {
+      const searchString = queryText.toLowerCase();
+
+      availableModelItems = availableModelItems.filter(({ name }) =>
+        name.toLowerCase().includes(searchString),
+      );
+    }
+
+    let matchedItems = [...availableModelItems];
+    if (urlModels && urlModels.length > 0) {
+      matchedItems = matchedItems.filter(({ model }) =>
+        urlModels.includes(model),
+      );
+    }
+
+    // available_models: all possible types in a user's database (or in this case, the test data), AFTER the text query filter
+    const availableModels = [
+      ...new Set(availableModelItems.map(({ model }) => model)),
+    ];
+
+    // models: the types that are actually present in the data
+    const models = [...new Set(matchedItems.map(({ model }) => model))];
 
     return {
-      data: matchedItems,
+      data: matchedItems.slice(offset, offset + limit),
       total: matchedItems.length,
-      models, // this should reflect what is in the query param
+      models,
       available_models: availableModels,
       limit,
       offset,

--- a/frontend/test/__support__/server-mocks/search.ts
+++ b/frontend/test/__support__/server-mocks/search.ts
@@ -4,29 +4,24 @@ import type { CollectionItem, SearchResult } from "metabase-types/api";
 export function setupSearchEndpoints(items: (CollectionItem | SearchResult)[]) {
   fetchMock.get("path:/api/search", uri => {
     const url = new URL(uri);
-    const models = [...new Set(url.searchParams.getAll("models"))];
+    const models = url.searchParams.getAll("models");
     const limit = Number(url.searchParams.get("limit"));
     const offset = Number(url.searchParams.get("offset"));
     const table_db_id = url.searchParams.get("table_db_id") || null;
-    const queryText = url.searchParams.get("q");
+    const queryText = url.searchParams.get("q")?.toLowerCase();
 
-    let matchedItems = items;
-    if (queryText) {
-      const searchString = queryText.toLowerCase();
+    let matchedItems = items.filter(
+      ({ name }) =>
+        !queryText || name.toLowerCase().includes(queryText.toLowerCase()),
+    );
 
-      matchedItems = matchedItems.filter(({ name }) =>
-        name.toLowerCase().includes(searchString),
-      );
-    }
-
-    // available_models: all possible types in a user's database (or in this case, the test data), AFTER the text query filter
     const availableModels = [
       ...new Set(matchedItems.map(({ model }) => model)),
     ];
 
-    if (models && models.length > 0) {
-      matchedItems = matchedItems.filter(({ model }) => models.includes(model));
-    }
+    matchedItems = matchedItems.filter(
+      ({ model }) => !models.length || models.includes(model),
+    );
 
     return {
       data: matchedItems.slice(offset, offset + limit),

--- a/frontend/test/__support__/server-mocks/search.ts
+++ b/frontend/test/__support__/server-mocks/search.ts
@@ -4,35 +4,29 @@ import type { CollectionItem, SearchResult } from "metabase-types/api";
 export function setupSearchEndpoints(items: (CollectionItem | SearchResult)[]) {
   fetchMock.get("path:/api/search", uri => {
     const url = new URL(uri);
-    const urlModels = [...new Set(url.searchParams.getAll("models"))];
+    const models = [...new Set(url.searchParams.getAll("models"))];
     const limit = Number(url.searchParams.get("limit"));
     const offset = Number(url.searchParams.get("offset"));
     const table_db_id = url.searchParams.get("table_db_id") || null;
     const queryText = url.searchParams.get("q");
 
-    let availableModelItems = items;
+    let matchedItems = items;
     if (queryText) {
       const searchString = queryText.toLowerCase();
 
-      availableModelItems = availableModelItems.filter(({ name }) =>
+      matchedItems = matchedItems.filter(({ name }) =>
         name.toLowerCase().includes(searchString),
       );
     }
 
-    let matchedItems = [...availableModelItems];
-    if (urlModels && urlModels.length > 0) {
-      matchedItems = matchedItems.filter(({ model }) =>
-        urlModels.includes(model),
-      );
-    }
-
-    // available_models: all possible entity types within the test data after the text query filter
+    // available_models: all possible types in a user's database (or in this case, the test data), AFTER the text query filter
     const availableModels = [
-      ...new Set(availableModelItems.map(({ model }) => model)),
+      ...new Set(matchedItems.map(({ model }) => model)),
     ];
 
-    // models: the types that are actually present in the search response
-    const models = [...new Set(matchedItems.map(({ model }) => model))];
+    if (models && models.length > 0) {
+      matchedItems = matchedItems.filter(({ model }) => models.includes(model));
+    }
 
     return {
       data: matchedItems.slice(offset, offset + limit),

--- a/frontend/test/__support__/server-mocks/search.ts
+++ b/frontend/test/__support__/server-mocks/search.ts
@@ -26,12 +26,12 @@ export function setupSearchEndpoints(items: (CollectionItem | SearchResult)[]) {
       );
     }
 
-    // available_models: all possible types in a user's database (or in this case, the test data), AFTER the text query filter
+    // available_models: all possible entity types within the test data after the text query filter
     const availableModels = [
       ...new Set(availableModelItems.map(({ model }) => model)),
     ];
 
-    // models: the types that are actually present in the data
+    // models: the types that are actually present in the search response
     const models = [...new Set(matchedItems.map(({ model }) => model))];
 
     return {


### PR DESCRIPTION
Previously, the mock API only supported basic text queries for searching data items. Now, users can include additional model parameters in their search queries to filter the results by specific data types. These changes reflect the current state of the search API.

#### An example from a local environment:

When there's only a search query (e.g., `/api/search?q=e&limit=50&offset=0`) and no type filter, the response should include all available items that match the query, and the `available_models` field will include all data models found in the search results after applying the text query filter. 
![image](https://github.com/metabase/metabase/assets/25306947/9588eb92-9022-4be4-b654-48fea65296c3)

When there's a search query _and_ a type filter in the query (e.g., `/api/search?q=e&limit=50&offset=0&models=dataset&models=card`), the response will include only the data items that match the search query and belong to the specified data models, but the `available_models` field will still show all the available data models that match the search query, _regardless of the applied filters_:
![image](https://github.com/metabase/metabase/assets/25306947/5736e1e7-8c7a-4906-a09a-4bd135710a02)

The mock API should now reflect these changes. They should not affect any existing tests, and will be used in the `SearchBar`, `SearchApp`, and `SearchAppSidebar` tests to test behavior for pagination, displaying the correct models, and hydrating filters from the URL.


### How to verify

All existing tests should pass. `available_models` and `models` will be used in the tests for #32392 to test pagination, filter hydration, and displaying types for `SearchBar`, `SearchApp`, and `SearchAppSidebar` tests