### PR TITLE
[E2E] Embedding helpers improvements

### DIFF
--- a/e2e/support/helpers/e2e-embedding-helpers.js
+++ b/e2e/support/helpers/e2e-embedding-helpers.js
@@ -1,7 +1,5 @@
 import { METABASE_SECRET_KEY } from "e2e/support/cypress_data";
 
-const jwtSignLocation = "e2e/support/external/e2e-jwt-sign.js";
-
 /**
  * Programatically generate token and visit the embedded page for question or dashboard
  *
@@ -21,6 +19,7 @@ export function visitEmbeddedPage(
   payload,
   { setFilters = "", hideFilters = "" } = {},
 ) {
+  const jwtSignLocation = "e2e/support/external/e2e-jwt-sign.js";
   const payloadWithExpiration = {
     ...payload,
     exp: Math.round(Date.now() / 1000) + 10 * 60, // 10 minute expiration
@@ -46,36 +45,36 @@ export function visitEmbeddedPage(
 
     cy.visit(embeddableUrl);
   });
-}
 
-/**
- * Construct the string that sets value to certain filters
- *
- * @param {string} filters
- * @returns string
- */
-function getFilterValues(filters) {
-  return filters && "?" + filters;
-}
+  /**
+   * Construct the string that sets value to certain filters
+   *
+   * @param {string} filters
+   * @returns string
+   */
+  function getFilterValues(filters) {
+    return filters && "?" + filters;
+  }
 
-/**
- * Construct the string that hides certain filters
- *
- * @param {string} filters
- * @returns string
- */
-function getHiddenFilters(filters) {
-  return filters && "&hide_parameters=" + filters;
-}
+  /**
+   * Construct the string that hides certain filters
+   *
+   * @param {string} filters
+   * @returns string
+   */
+  function getHiddenFilters(filters) {
+    return filters && "&hide_parameters=" + filters;
+  }
 
-/**
- * Extract the embeddable object type from the payload
- *
- * @param {object} payload
- * @returns ("question"|"dashboard")
- */
-function getEmbeddableObject(payload) {
-  return Object.keys(payload.resource)[0];
+  /**
+   * Extract the embeddable object type from the payload
+   *
+   * @param {object} payload
+   * @returns ("question"|"dashboard")
+   */
+  function getEmbeddableObject(payload) {
+    return Object.keys(payload.resource)[0];
+  }
 }
 
 /**

--- a/e2e/support/helpers/e2e-embedding-helpers.js
+++ b/e2e/support/helpers/e2e-embedding-helpers.js
@@ -29,16 +29,15 @@ export function visitEmbeddedPage(
 
   const embeddableObject = getEmbeddableObject(payload);
 
-  const urlRoot = `/embed/${embeddableObject}/`;
   const filters = getFilterValues(setFilters);
   const hiddenFilters = getHiddenFilters(hideFilters);
   // Style is hard coded for now because we're not concerned with testing its properties
   const style = "#bordered=true&titled=true";
+  const signTransaction = `node  ${jwtSignLocation} '${stringifiedPayload}' ${METABASE_SECRET_KEY}`;
 
-  cy.exec(
-    `node  ${jwtSignLocation} '${stringifiedPayload}' ${METABASE_SECRET_KEY}`,
-  ).then(({ stdout: token }) => {
-    const embeddableUrl = urlRoot + token + filters + style + hiddenFilters;
+  cy.exec(signTransaction).then(({ stdout: tokenizedQuery }) => {
+    const urlRoot = `/embed/${embeddableObject}/${tokenizedQuery}`;
+    const embeddableUrl = urlRoot + filters + style + hiddenFilters;
 
     // Always visit embedded page logged out
     cy.signOut();

--- a/e2e/support/helpers/e2e-embedding-helpers.js
+++ b/e2e/support/helpers/e2e-embedding-helpers.js
@@ -1,14 +1,36 @@
 import { METABASE_SECRET_KEY } from "e2e/support/cypress_data";
 
 /**
- * Programatically generate token and visit the embedded page for a question or a dashboard
+ * @typedef {object} QuestionResource
+ * @property {number} question - ID of a question we are embedding
  *
- * @param {object} payload
- * @param {{setFilters: object, setStyle: object, hideFilters: string[]}}
+ * @typedef {object} DashboardResource
+ * @property {number} dashboard - ID of a dashboard we are embedding
+ *
+ * @typedef {object} EmbedPayload
+ * @property {(QuestionResource|DashboardResource)} resource
+ * {@link QuestionResource} or {@link DashboardResource}
+ * @property {object} params
+ *
+ * @typedef {object} HiddenFilters
+ * @property {string} hide_parameters
+ *
+ * @typedef {object} PageStyle
+ * @property {boolean} bordered
+ * @property {boolean} titled
+ * @property {boolean} hide_download_button - EE/PRO only feature to disable downloads
+ */
+
+/**
+ * Programmatically generate token and visit the embedded page for a question or a dashboard
+ *
+ * @param {EmbedPayload} payload - The {@link EmbedPayload} we pass to this function
+ * @param {{setFilters: object, pageStyle: PageStyle, hideFilters: string[]}} options
  *
  * @example
  * visitEmbeddedPage(payload, {
  *   setFilters: {id: 92, source: "Organic"},
+ *   pageStyle: {titled: true},
  *   hideFilters: ["id", "source"]
  * });
  */
@@ -47,19 +69,21 @@ export function visitEmbeddedPage(
   });
 
   /**
-   * Construct the string that hides certain filters
+   * Construct a hidden filters object from the list of filters we want to hide
    *
    * @param {string[]} filters
-   * @returns object
+   * @returns {HiddenFilters}
    */
   function getHiddenFilters(filters) {
-    return filters.length > 0 ? { hide_parameters: filters.join(",") } : {};
+    const params = filters.join(",");
+    return filters.length > 0 ? { hide_parameters: params } : {};
   }
 
   /**
+   * Get the URL hash from the page style and/or hidden filters parameters
    *
-   * @param {object} pageStyle
-   * @param {object} hiddenFilters
+   * @param {PageStyle} pageStyle
+   * @param {HiddenFilters} hiddenFilters
    *
    * @returns string
    */
@@ -70,7 +94,7 @@ export function visitEmbeddedPage(
   /**
    * Extract the embeddable object type from the payload
    *
-   * @param {object} payload
+   * @param {EmbedPayload} payload - See {@link EmbedPayload}
    * @returns ("question"|"dashboard")
    */
   function getEmbeddableObject(payload) {
@@ -79,7 +103,7 @@ export function visitEmbeddedPage(
 }
 
 /**
- * Grab iframe `src` via UI and open it,
+ * Grab an iframe `src` via UI and open it,
  * but make sure user is signed out.
  */
 export function visitIframe() {

--- a/e2e/support/helpers/e2e-embedding-helpers.js
+++ b/e2e/support/helpers/e2e-embedding-helpers.js
@@ -26,16 +26,14 @@ export function visitEmbeddedPage(
   };
 
   const stringifiedPayload = JSON.stringify(payloadWithExpiration);
-
-  const embeddableObject = getEmbeddableObject(payload);
-
-  const filters = getFilterValues(setFilters);
-  const hiddenFilters = getHiddenFilters(hideFilters);
-  // Style is hard coded for now because we're not concerned with testing its properties
-  const style = "#bordered=true&titled=true";
   const signTransaction = `node  ${jwtSignLocation} '${stringifiedPayload}' ${METABASE_SECRET_KEY}`;
 
   cy.exec(signTransaction).then(({ stdout: tokenizedQuery }) => {
+    const embeddableObject = getEmbeddableObject(payload);
+    const filters = getFilterValues(setFilters);
+    const hiddenFilters = getHiddenFilters(hideFilters);
+    // Style is hard coded for now because we're not concerned with testing its properties
+    const style = "#bordered=true&titled=true";
     const urlRoot = `/embed/${embeddableObject}/${tokenizedQuery}`;
     const embeddableUrl = urlRoot + filters + style + hiddenFilters;
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
@@ -726,7 +726,7 @@ const openSlowEmbeddingDashboard = (params = {}) => {
       params: {},
     };
     visitEmbeddedPage(embeddingPayload, {
-      setFilters: new URLSearchParams(params).toString(),
+      setFilters: params,
     });
   });
 

--- a/e2e/test/scenarios/dashboard-filters/reproductions/29347-remapped-field-values.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/29347-remapped-field-values.cy.spec.js
@@ -130,7 +130,7 @@ describe("issues 29347, 29346", () => {
             params: {},
           },
           {
-            setFilters: `${filterDetails.slug}=${filterValue}`,
+            setFilters: { [filterDetails.slug]: filterValue },
           },
         );
       });

--- a/e2e/test/scenarios/embedding/embedding-linked-filters.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-linked-filters.cy.spec.js
@@ -192,7 +192,7 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
         };
 
         visitEmbeddedPage(payload, {
-          setFilters: "state=AK",
+          setFilters: { state: "AK" },
         });
       });
 
@@ -235,7 +235,7 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
         };
 
         visitEmbeddedPage(payload, {
-          setFilters: "state=AK",
+          setFilters: { state: "AK" },
           hideFilters: "state",
         });
       });
@@ -384,9 +384,10 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
           .and("contain", "Doohickey");
 
         cy.log("Make sure we can set multiple values");
-        visitEmbeddedPage(payload, {
-          setFilters: "id_filter=4&id_filter=29&category=Widget",
-        });
+        cy.window().then(
+          win =>
+            (win.location.search = "?id_filter=4&id_filter=29&category=Widget"),
+        );
 
         filterWidget()
           .should("have.length", 2)

--- a/e2e/test/scenarios/embedding/embedding-linked-filters.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-linked-filters.cy.spec.js
@@ -236,7 +236,7 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
 
         visitEmbeddedPage(payload, {
           setFilters: { state: "AK" },
-          hideFilters: "state",
+          hideFilters: ["state"],
         });
       });
 
@@ -362,7 +362,7 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
         };
 
         cy.log("Make sure we can override the default value");
-        visitEmbeddedPage(payload, { setFilters: "id_filter=4" });
+        visitEmbeddedPage(payload, { setFilters: { id_filter: 4 } });
 
         cy.location("search").should("eq", "?id_filter=4");
 
@@ -436,7 +436,7 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
         };
 
         visitEmbeddedPage(payload, {
-          hideFilters: "id_filter",
+          hideFilters: ["id_filter"],
         });
       });
 

--- a/e2e/test/scenarios/embedding/embedding-native.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-native.cy.spec.js
@@ -157,7 +157,7 @@ describe("scenarios > embedding > native questions", () => {
         // It should be possible to both set the filter value and hide it at the same time.
         // That's the synonymous to the locked filter.
         visitEmbeddedPage(payload, {
-          setFilters: "id=92",
+          setFilters: { id: 92 },
           hideFilters: "id,product_id,state,created_at,total",
         });
 
@@ -186,7 +186,7 @@ describe("scenarios > embedding > native questions", () => {
         };
 
         visitEmbeddedPage(payload, {
-          setFilters: "created_at=Q2-2025&source=Organic&state=OR",
+          setFilters: { created_at: "Q2-2025", source: "Organic", state: "OR" },
         });
 
         filterWidget()
@@ -204,7 +204,7 @@ describe("scenarios > embedding > native questions", () => {
 
         // OTOH, we should also be able to override the default filter value by eplixitly setting it
         visitEmbeddedPage(payload, {
-          setFilters: "total=80",
+          setFilters: { total: 80 },
         });
 
         cy.get("legend").contains("Total").parent("fieldset").contains("80");

--- a/e2e/test/scenarios/embedding/embedding-native.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-native.cy.spec.js
@@ -158,7 +158,7 @@ describe("scenarios > embedding > native questions", () => {
         // That's the synonymous to the locked filter.
         visitEmbeddedPage(payload, {
           setFilters: { id: 92 },
-          hideFilters: "id,product_id,state,created_at,total",
+          hideFilters: ["id", "product_id", "state", "created_at", "total"],
         });
 
         cy.findByTestId("table-row").should("have.length", 1);


### PR DESCRIPTION
We've had a fairly naive `visitEmbedPage` helper implementation for a while now.
It required a literal string params like `#bordered=true&titled=true`, or literal string representation of query search params.

This PR updates the helper and all related tests to use actual `URLSearchParams` and URL hash where possible.
It also documents needed types in more detail.

I started working on this when I realized how silly it is to try to guess whether or not the style (in the url hash) is present when wanting to add `hide_download_button`. If `hide_download_button` was the only thing in the hash, then it needed to start with `#`. OTOH, if it was supposed to be concatenated to the existing style, then it needed to start with `&`.

It was cumbersome and naive to try to maintain such implementation so I re-wrote the logic, which now relies on URL API to construct these strings for us.