### PR TITLE
Changing source for member count on group detail screen

### DIFF
--- a/e2e/test/scenarios/admin/people/people.cy.spec.js
+++ b/e2e/test/scenarios/admin/people/people.cy.spec.js
@@ -95,10 +95,24 @@ describe("scenarios > admin > people", () => {
 
       // should load the members when navigating to the group directly
       cy.visit(`/admin/people/groups/${DATA_GROUP}`);
+
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("2 members");
 
-      removeUserFromGroup(noCollectionUserName);
+      cy.findByRole("list", { name: "admin-list-items" })
+        .findByRole("link", { name: /people/i })
+        .click();
+
+      showUserOptions(noCollectionUserName);
+
+      popover().findByText("Deactivate user").click();
+
+      clickButton("Deactivate");
+
+      cy.findByRole("link", { name: /group/i }).click();
+
+      cy.findByRole("table").findByRole("link", { name: /data/i }).click();
+
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("1 member");
 

--- a/frontend/src/metabase/admin/people/components/GroupDetail.jsx
+++ b/frontend/src/metabase/admin/people/components/GroupDetail.jsx
@@ -160,9 +160,9 @@ const GroupDetail = ({
           {getGroupNameLocalized(group ?? {})}
           <span className="text-light ml1">
             {ngettext(
-              msgid`${groupMemberships.length} member`,
-              `${groupMemberships.length} members`,
-              groupMemberships.length,
+              msgid`${group.members.length} member`,
+              `${group.members.length} members`,
+              group.members.length,
             )}
           </span>
         </Fragment>

--- a/frontend/src/metabase/admin/people/components/GroupMembersTable/GroupMembersTable.tsx
+++ b/frontend/src/metabase/admin/people/components/GroupMembersTable/GroupMembersTable.tsx
@@ -61,7 +61,7 @@ function GroupMembersTable({
   const canRemove = (user: IUser) =>
     !isDefaultGroup(group) && !(isAdminGroup(group) && isCurrentUser(user));
 
-  const hasMembers = groupMemberships.length > 0;
+  const hasMembers = group.members.length > 0;
 
   const handleAddUser: GroupMembersTableProps["onAddUserDone"] =
     async userIds => {

--- a/frontend/src/metabase/admin/people/containers/GroupDetailApp.jsx
+++ b/frontend/src/metabase/admin/people/containers/GroupDetailApp.jsx
@@ -14,5 +14,5 @@ class GroupDetailApp extends Component {
 
 export default _.compose(
   User.loadList(),
-  Group.load({ id: (_state, props) => props.params.groupId }),
+  Group.load({ id: (_state, props) => props.params.groupId, reload: true }),
 )(GroupDetailApp);

--- a/frontend/src/metabase/admin/people/people.js
+++ b/frontend/src/metabase/admin/people/people.js
@@ -2,6 +2,7 @@ import _ from "underscore";
 import { assoc, dissoc } from "icepick";
 import {
   createAction,
+  createThunkAction,
   handleActions,
   combineReducers,
 } from "metabase/lib/redux";
@@ -19,6 +20,8 @@ import {
   UPDATE_MEMBERSHIP,
   CLEAR_TEMPORARY_PASSWORD,
 } from "./events";
+
+import { getMemberships } from "./selectors";
 
 // ACTION CREATORS
 
@@ -47,12 +50,14 @@ export const createMembership = createAction(
     };
   },
 );
-export const deleteMembership = createAction(
+export const deleteMembership = createThunkAction(
   DELETE_MEMBERSHIP,
-  async membershipId => {
+  membershipId => async (_dispatch, getState) => {
+    const memberships = getMemberships(getState());
+    const membership = memberships[membershipId];
     await PermissionsApi.deleteMembership({ id: membershipId });
     MetabaseAnalytics.trackStructEvent("People Groups", "Membership Deleted");
-    return { membershipId };
+    return { membershipId, groupId: membership.group_id };
   },
 );
 

--- a/frontend/src/metabase/components/LeftNavPane/LeftNavPane.jsx
+++ b/frontend/src/metabase/components/LeftNavPane/LeftNavPane.jsx
@@ -47,7 +47,9 @@ export function LeftNavPane({ children, fullHeight = true }) {
         "full-height": fullHeight,
       })}
     >
-      <ul className="AdminList-items pt1">{children}</ul>
+      <ul className="AdminList-items pt1" aria-label="admin-list-items">
+        {children}
+      </ul>
     </div>
   );
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/28091

### Description
Previously, the count of members was driven by the number of memberships a group had. However, because deactivated users could still technically be part of groups we were including them in the count of users despite not showing them on the group details page. Getting `/api/permissions/group/:groupId` returns an object with a list of members that are active, so we are now driving the count from that

### How to verify
1. Go to admin -> people
2. Add a user to a group
3. Deactivate that user
4. Go to group details page and confirm that member count is correct
5. Remove a user from the group and ensure that the member count updates correctly

### Demo
![chrome_tKZh7sV68q](https://github.com/metabase/metabase/assets/1328979/91e7a7e0-3afa-4ba7-be14-eb00fea276ca)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
