### PR TITLE
indicate orphan dashboard parameters

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
@@ -160,6 +160,19 @@ export function DashCardCardParameterMapper({
             />
           ),
         };
+      } else if (target != null) {
+        return {
+          buttonVariant: "invalid",
+          buttonText: t`Unknown Field`,
+          buttonIcon: (
+            <CloseIconButton
+              onClick={e => {
+                handleChangeTarget(null);
+                e.stopPropagation();
+              }}
+            />
+          ),
+        };
       } else {
         return {
           buttonVariant: "default",
@@ -172,6 +185,7 @@ export function DashCardCardParameterMapper({
       hasPermissionsToMap,
       isDisabled,
       selectedMappingOption,
+      target,
       handleChangeTarget,
       isVirtual,
     ]);

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.styled.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 
 import { space } from "metabase/styled-components/theme";
-import { color, lighten } from "metabase/lib/colors";
+import { alpha, color } from "metabase/lib/colors";
 import { Icon } from "metabase/core/components/Icon";
 import Button from "metabase/core/components/Button";
 import ExternalLink from "metabase/core/components/ExternalLink";
@@ -107,6 +107,14 @@ export const TargetButton = styled.div<{ variant: string }>`
       background-color: ${color("bg-light")};
       color: ${color("text-medium")};
     `}
+
+  ${({ variant }) =>
+    variant === "invalid" &&
+    css`
+      border-color: ${color("error")};
+      background-color: ${color("error")};
+      color: ${color("white")};
+    `}
 `;
 
 TargetButton.defaultProps = {
@@ -128,7 +136,7 @@ export const CloseIconButton = styled(Button)<{ icon: string; size: number }>`
 
   &:hover {
     color: ${color("white")};
-    background-color: ${lighten("brand", 0.2)};
+    background-color: ${alpha("white", 0.2)};
   }
 `;
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
@@ -107,6 +107,27 @@ describe("DashCardParameterMapper", () => {
     expect(screen.getByText(/Variable to map to/i)).toBeInTheDocument();
   });
 
+  it("should render an error state when a field is not present in the list of options", () => {
+    const card = createMockCard({
+      dataset_query: createMockStructuredDatasetQuery({
+        query: {
+          "source-table": 1,
+        },
+      }),
+      display: "scalar",
+    });
+    setup({
+      card,
+      dashcard: createMockDashboardOrderedCard({
+        card,
+      }),
+      mappingOptions: [["dimension", ["field", 1]]],
+      target: ["dimension", ["field", 2]],
+      isMobile: true,
+    });
+    expect(screen.getByText(/unknown field/i)).toBeInTheDocument();
+  });
+
   it("should show header content when card is more than 2 units high", () => {
     const numberCard = createMockCard({
       dataset_query: createMockStructuredDatasetQuery({}),


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/32573

### Description

We leave invalid orphan dashboard parameters when a card source model removes columns that were used for the parameters.

### How to verify

Describe the steps to verify that the changes are working as expected.

- Sample Dataset -> Orders -> Save as a model M1
- Create Q1 from M1
- Add Q1 on a dashboard D1
- Add an ID filter, connect it to Q1: Orders.Id and set any default value
- Edit model definition of M1 and in the notebook editor simply remove Id column from it
- Go to the D1 dashboard, ensure the chart is broken
- Edit -> open the filter settings and ensure the card shows its parameter has an Unknown Field

### Demo

#### Before: no sign there is anything wrong with the parameters
<img width="709" alt="Screen Shot 2023-07-27 at 9 29 36 PM" src="https://github.com/metabase/metabase/assets/14301985/7f35b9a0-fae3-4a8a-a5ae-ca5446737218">

#### After
<img width="710" alt="Screen Shot 2023-07-27 at 9 29 14 PM" src="https://github.com/metabase/metabase/assets/14301985/36062664-94c1-4826-bbf3-a96f477dc06d">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
