### PR TITLE
Restrict graph to not return permissions for non-active tables

### DIFF
--- a/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.tsx
@@ -57,6 +57,7 @@ function DataPermissionsPage({
         Tables.actions.fetchList({
           dbId,
           include_hidden: true,
+          remove_inactive: true,
         }),
       ),
     [dispatch],

--- a/frontend/src/metabase/admin/permissions/permissions.js
+++ b/frontend/src/metabase/admin/permissions/permissions.js
@@ -106,6 +106,7 @@ export const updateDataPermission = createThunkAction(
           Tables.actions.fetchList({
             dbId: entityId.databaseId,
             include_hidden: true,
+            remove_inactive: true,
           }),
         );
       }

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -423,7 +423,7 @@
   []
   (saved-cards-virtual-db-metadata :card :include-tables? true, :include-fields? true))
 
-(defn- db-metadata [id include-hidden? include-editable-data-model?]
+(defn- db-metadata [id include-hidden? include-editable-data-model? remove_inactive?]
   (let [db (-> (if include-editable-data-model?
                  (api/check-404 (t2/select-one Database :id id))
                  (api/read-check Database id))
@@ -450,7 +450,11 @@
                           (for [table tables]
                             (-> table
                                 (update :segments (partial filter mi/can-read?))
-                                (update :metrics  (partial filter mi/can-read?)))))))))
+                                (update :metrics  (partial filter mi/can-read?))))))
+        (update :tables (if remove_inactive?
+                          (fn [tables]
+                            (filter :active tables))
+                          identity)))))
 
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema GET "/:id/metadata"
@@ -461,12 +465,14 @@
   permissions, if Enterprise Edition code is available and a token with the advanced-permissions feature is present.
   In addition, if the user has no data access for the DB (aka block permissions), it will return only the DB name, ID
   and tables, with no additional metadata."
-  [id include_hidden include_editable_data_model]
+  [id include_hidden include_editable_data_model remove_inactive]
   {include_hidden              (s/maybe su/BooleanString)
-   include_editable_data_model (s/maybe su/BooleanString)}
+   include_editable_data_model (s/maybe su/BooleanString)
+   remove_inactive             (s/maybe su/BooleanString)}
   (db-metadata id
                (Boolean/parseBoolean include_hidden)
-               (Boolean/parseBoolean include_editable_data_model)))
+               (Boolean/parseBoolean include_editable_data_model)
+               (Boolean/parseBoolean remove_inactive)))
 
 
 ;;; --------------------------------- GET /api/database/:id/autocomplete_suggestions ---------------------------------

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -475,6 +475,14 @@
                         (map :name)
                         (some (partial = "PRICE"))))))))))
 
+(deftest fetch-database-metadata-remove-inactive-test
+  (mt/with-temp* [Database [{db-id :id}]
+                  Table    [_ {:db_id db-id, :active false}]]
+    (testing "GET /api/database/:id/metadata?include_hidden=true"
+        (let [tables (->> (mt/user-http-request :rasta :get 200 (format "database/%d/metadata?remove_inactive=true" db-id))
+                          :tables)]
+          (is (= () tables))))))
+
 (deftest autocomplete-suggestions-test
   (let [prefix-fn (fn [db-id prefix]
                     (mt/user-http-request :rasta :get 200


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31585

### Description

Fix before `/api/database/:id/metadata` gets deprecated.

### How to verify

1. go to settings->admin->permissions
2. do granular permissions (e.g. no self service on people)
3. check the graph
4. now delete reviews
5. sync
6. go again to the permissions, you'll see that the table id is still not there


### Demo
Not all tables show up
<img width="1012" alt="image" src="https://github.com/metabase/metabase/assets/34140255/76f34e7b-61bf-4320-be53-5d5207216aa4">
