### PR TITLE
46.x: fix `metabase.cmd.load-from-h2-test/load-from-h2-test`

### DIFF
--- a/test/metabase/cmd/load_from_h2_test.clj
+++ b/test/metabase/cmd/load_from_h2_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.cmd.load-from-h2-test
   (:require
    [clojure.test :refer :all]
+   [metabase.cmd.copy :as copy]
    [metabase.cmd.load-from-h2 :as load-from-h2]
    [metabase.cmd.test-util :as cmd.test-util]
    [metabase.db.connection :as mdb.connection]
@@ -23,7 +24,8 @@
                                target-db-type
                                (tx/dbdef->connection-details target-db-type :db db-def)))]
       (tx/create-db! target-db-type db-def)
-      (binding [mdb.connection/*application-db* (mdb.connection/application-db target-db-type target-data-source)]
+      (binding [mdb.connection/*application-db*   (mdb.connection/application-db target-db-type target-data-source)
+                copy/*allow-loading-h2-databases* true]
         (load-from-h2/load-from-h2! h2-filename)
         (is (= 4
                (db/count Table)))))))


### PR DESCRIPTION
The test needed to be setting `copy/*allow-loading-h2-databases*` but wasn't