### PR TITLE
Ignore H2 databases in load-from-h2

### DIFF
--- a/test/metabase/cmd/copy_test.clj
+++ b/test/metabase/cmd/copy_test.clj
@@ -3,10 +3,31 @@
    [clojure.test :refer :all]
    [metabase.cmd.copy :as copy]
    [metabase.db.util :as mdb.u]
+   [metabase.models :refer [Database]]
    [metabase.plugins.classloader :as classloader]
-   [metabase.util :as u]))
+   [metabase.test :as mt]
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
 
-(deftest all-models-accounted-for-test
+(deftest ^:parallel sql-for-selecting-instances-from-source-db-test
+  (are [table-name] (re-find #"(?i)SELECT \* FROM METABASE_DATABASE WHERE engine <> 'h2'"
+                             (#'copy/sql-for-selecting-instances-from-source-db table-name))
+    (t2/table-name Database)
+    :METABASE_DATABASE
+    "metabase_database")
+  ;; make sure the H2 `test-data` DB is loaded
+  (mt/db)
+  (let [sql              (#'copy/sql-for-selecting-instances-from-source-db (t2/table-name Database))
+        selected-drivers (t2/select-fn-set :engine Database sql)]
+    (is (not (contains? selected-drivers :h2)))))
+
+(deftest ^:parallel allow-loading-h2-databases-test
+  (testing `copy/*allow-loading-h2-databases*
+    (binding [copy/*allow-loading-h2-databases* true]
+      (is (= "SELECT * FROM metabase_database"
+             (#'copy/sql-for-selecting-instances-from-source-db (t2/table-name Database)))))))
+
+(deftest ^:paralell all-models-accounted-for-test
   ;; This fetches the `metabase.cmd.load-from-h2/entities` and compares it all existing entities
   (let [migrated-model-names (set (map :name copy/entities))
         ;; Models that should *not* be migrated in `load-from-h2`.

--- a/test/metabase/cmd/dump_to_h2_test.clj
+++ b/test/metabase/cmd/dump_to_h2_test.clj
@@ -78,13 +78,14 @@
                                                        (persistent-data-source driver/*driver* db-name))]
               (when-not (= driver/*driver* :h2)
                 (tx/create-db! driver/*driver* {:database-name db-name}))
-              (load-from-h2/load-from-h2! h2-fixture-db-file)
-              (encryption-test/with-secret-key "89ulvIGoiYw6mNELuOoEZphQafnF/zYe+3vT+v70D1A="
-                (t2/insert! Setting {:key "my-site-admin", :value "baz"})
-                (t2/update! Database 1 {:details {:db "/tmp/test.db"}})
-                (dump-to-h2/dump-to-h2! h2-file-plaintext {:dump-plaintext? true})
-                (dump-to-h2/dump-to-h2! h2-file-enc {:dump-plaintext? false})
-                (dump-to-h2/dump-to-h2! h2-file-default-enc))
+              (binding [copy/*allow-loading-h2-databases* true]
+                (load-from-h2/load-from-h2! h2-fixture-db-file)
+                (encryption-test/with-secret-key "89ulvIGoiYw6mNELuOoEZphQafnF/zYe+3vT+v70D1A="
+                  (t2/insert! Setting {:key "my-site-admin", :value "baz"})
+                  (t2/update! Database 1 {:details {:db "/tmp/test.db"}})
+                  (dump-to-h2/dump-to-h2! h2-file-plaintext {:dump-plaintext? true})
+                  (dump-to-h2/dump-to-h2! h2-file-enc {:dump-plaintext? false})
+                  (dump-to-h2/dump-to-h2! h2-file-default-enc)))
 
               (testing "decodes settings and dashboard.details"
                 (with-open [target-conn (.getConnection (copy.h2/h2-data-source h2-file-plaintext))]

--- a/test/metabase/cmd/load_and_dump_test.clj
+++ b/test/metabase/cmd/load_and_dump_test.clj
@@ -3,6 +3,7 @@
    [clojure.java.io :as io]
    [clojure.test :refer :all]
    [metabase.cmd.compare-h2-dbs :as compare-h2-dbs]
+   [metabase.cmd.copy :as copy]
    [metabase.cmd.copy.h2 :as copy.h2]
    [metabase.cmd.dump-to-h2 :as dump-to-h2]
    [metabase.cmd.load-from-h2 :as load-from-h2]
@@ -41,8 +42,9 @@
             (with-redefs [i18n.impl/site-locale-from-setting (constantly nil)]
               (when-not (= driver/*driver* :h2)
                 (tx/create-db! driver/*driver* {:database-name db-name}))
-              (load-from-h2/load-from-h2! h2-fixture-db-file)
-              (dump-to-h2/dump-to-h2! h2-file)
+              (binding [copy/*allow-loading-h2-databases* true]
+                (load-from-h2/load-from-h2! h2-fixture-db-file)
+                (dump-to-h2/dump-to-h2! h2-file))
               (is (not (compare-h2-dbs/different-contents?
                         h2-file
                         h2-fixture-db-file))))))))))

--- a/test/metabase/cmd/load_from_h2_test.clj
+++ b/test/metabase/cmd/load_from_h2_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.cmd.load-from-h2-test
   (:require
    [clojure.test :refer :all]
+   [metabase.cmd.copy :as copy]
    [metabase.cmd.load-from-h2 :as load-from-h2]
    [metabase.cmd.test-util :as cmd.test-util]
    [metabase.db.connection :as mdb.connection]
@@ -23,7 +24,8 @@
                                target-db-type
                                (tx/dbdef->connection-details target-db-type :db db-def)))]
       (tx/create-db! target-db-type db-def)
-      (binding [mdb.connection/*application-db* (mdb.connection/application-db target-db-type target-data-source)]
+      (binding [mdb.connection/*application-db*   (mdb.connection/application-db target-db-type target-data-source)
+                copy/*allow-loading-h2-databases* true]
         (load-from-h2/load-from-h2! h2-filename)
         (is (= 4
                (t2/count Table)))))))

--- a/test/metabase/cmd/rotate_encryption_key_test.clj
+++ b/test/metabase/cmd/rotate_encryption_key_test.clj
@@ -3,6 +3,7 @@
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]
    [metabase.cmd :as cmd]
+   [metabase.cmd.copy :as copy]
    [metabase.cmd.dump-to-h2-test :as dump-to-h2-test]
    [metabase.cmd.load-from-h2 :as load-from-h2]
    [metabase.cmd.rotate-encryption-key :refer [rotate-encryption-key!]]
@@ -78,7 +79,8 @@
                       mdb.connection/*application-db* (mdb.connection/application-db driver/*driver* data-source)]
               (when-not (= driver/*driver* :h2)
                 (tx/create-db! driver/*driver* {:database-name db-name}))
-              (load-from-h2/load-from-h2! h2-fixture-db-file)
+              (binding [copy/*allow-loading-h2-databases* true]
+                (load-from-h2/load-from-h2! h2-fixture-db-file))
               (t2/insert! Setting {:key "nocrypt", :value "unencrypted value"})
               (t2/insert! Setting {:key "settings-last-updated", :value original-timestamp})
               (let [u (first (t2/insert-returning-instances! User {:email        "nobody@nowhere.com"
@@ -87,6 +89,7 @@
                                                                    :password     "nopassword"
                                                                    :is_active    true
                                                                    :is_superuser false}))]
+
                 (reset! user-id (u/the-id u)))
               (let [secret (first (t2/insert-returning-instances! Secret {:name       "My Secret (plaintext)"
                                                                           :kind       "password"


### PR DESCRIPTION
This is already live in the release branch, this PR is just to add it to `master`. 