### PR TITLE
Run E2E tests using Electron by default

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -176,17 +176,6 @@ jobs:
       - name: Run Snowplow micro
         uses: ./.github/actions/run-snowplow-micro
 
-      - name: Install Chrome v114
-        uses: browser-actions/setup-chrome@v1
-        with:
-          # https://chromium.cypress.io/linux/stable/114.0.5735.133
-          # https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2F1135580%2Fchrome-linux.zip
-          chrome-version: 1135580
-        id: setup-chrome
-      - run: |
-          echo Installed chromium version: ${{ steps.setup-chrome.outputs.chrome-version }}
-          ${{ steps.setup-chrome.outputs.chrome-path }} --version
-
       - uses: actions/download-artifact@v3
         name: Retrieve uberjar artifact for ${{ matrix.edition }}
         with:
@@ -201,8 +190,7 @@ jobs:
         run: |
           yarn run test-cypress-run \
           --env grepTags=@OSS \
-          --spec './e2e/test/scenarios/**/*.cy.spec.js' \
-          --browser ${{ steps.setup-chrome.outputs.chrome-path }}
+          --spec './e2e/test/scenarios/**/*.cy.spec.js'
         env:
           TERM: xterm
 
@@ -211,8 +199,7 @@ jobs:
         run: |
           yarn run test-cypress-run \
           --env grepTags="-@quarantine" \
-          --folder ${{ matrix.folder }} \
-          --browser ${{ steps.setup-chrome.outputs.chrome-path }}
+          --folder ${{ matrix.folder }}
         env:
           TERM: xterm
 

--- a/e2e/runner/cypress-runner-generate-snapshots.js
+++ b/e2e/runner/cypress-runner-generate-snapshots.js
@@ -4,7 +4,6 @@ const { parseArguments, args } = require("./cypress-runner-utils");
 
 const getConfig = baseUrl => {
   return {
-    browser: "chrome",
     configFile: "e2e/support/cypress-snapshots.config.js",
     config: {
       baseUrl,

--- a/e2e/runner/cypress-runner-run-tests.js
+++ b/e2e/runner/cypress-runner-run-tests.js
@@ -22,7 +22,6 @@ const runCypress = async (baseUrl, exitFunction) => {
   });
 
   const defaultConfig = {
-    browser: "chrome",
     configFile: "e2e/support/cypress.config.js",
     config: {
       baseUrl,


### PR DESCRIPTION
Opened https://github.com/metabase/metabase/pull/32740 directly against the release branch instead of waiting for it to get merged into `master` and then backporting.