### PR TITLE
Add `TypeSearchSidebar` to integration branch

### DIFF
--- a/frontend/src/metabase/search/components/TypeSearchSidebar/TypeSearchSidebar.styled.tsx
+++ b/frontend/src/metabase/search/components/TypeSearchSidebar/TypeSearchSidebar.styled.tsx
@@ -1,0 +1,8 @@
+import styled from "@emotion/styled";
+import Button from "metabase/core/components/Button";
+import { color } from "metabase/lib/colors";
+
+export const TypeSidebarButton = styled(Button)<{ isActive: boolean }>`
+  color: ${props => (props.isActive ? color("brand") : color("text-medium"))};
+  border: none;
+`;

--- a/frontend/src/metabase/search/components/TypeSearchSidebar/TypeSearchSidebar.tsx
+++ b/frontend/src/metabase/search/components/TypeSearchSidebar/TypeSearchSidebar.tsx
@@ -10,11 +10,6 @@ const SEARCH_FILTERS: {
   filter: SearchModelType;
 }[] = [
   {
-    name: t`Apps`,
-    filter: "app",
-    icon: "star",
-  },
-  {
     name: t`Dashboards`,
     filter: "dashboard",
     icon: "dashboard",

--- a/frontend/src/metabase/search/components/TypeSearchSidebar/TypeSearchSidebar.tsx
+++ b/frontend/src/metabase/search/components/TypeSearchSidebar/TypeSearchSidebar.tsx
@@ -1,0 +1,106 @@
+import { t } from "ttag";
+import { Flex } from "@mantine/core";
+import { IconName } from "metabase/core/components/Icon";
+import { TypeSidebarButton } from "metabase/search/components/TypeSearchSidebar/TypeSearchSidebar.styled";
+import { SearchModelType } from "metabase-types/api";
+
+const SEARCH_FILTERS: {
+  name: string;
+  icon: IconName;
+  filter: SearchModelType;
+}[] = [
+  {
+    name: t`Apps`,
+    filter: "app",
+    icon: "star",
+  },
+  {
+    name: t`Dashboards`,
+    filter: "dashboard",
+    icon: "dashboard",
+  },
+  {
+    name: t`Collections`,
+    filter: "collection",
+    icon: "folder",
+  },
+  {
+    name: t`Databases`,
+    filter: "database",
+    icon: "database",
+  },
+  {
+    name: t`Models`,
+    filter: "dataset",
+    icon: "model",
+  },
+  {
+    name: t`Raw Tables`,
+    filter: "table",
+    icon: "table",
+  },
+  {
+    name: t`Questions`,
+    filter: "card",
+    icon: "bar",
+  },
+  {
+    name: t`Pulses`,
+    filter: "pulse",
+    icon: "pulse",
+  },
+  {
+    name: t`Metrics`,
+    filter: "metric",
+    icon: "sum",
+  },
+  {
+    name: t`Segments`,
+    filter: "segment",
+    icon: "segment",
+  },
+];
+
+export const TypeSearchSidebar = ({
+  availableModels,
+  selectedType = null,
+  onSelectType,
+}: {
+  availableModels: SearchModelType[];
+  selectedType: SearchModelType | null;
+  onSelectType: (type: SearchModelType | null) => void;
+}) => {
+  const searchModels = [
+    {
+      name: t`All items`,
+      icon: "search",
+      filter: null,
+    },
+    ...SEARCH_FILTERS.filter(({ filter }) => availableModels.includes(filter)),
+  ];
+
+  return (
+    <Flex
+      data-testid="type-sidebar"
+      gap={"sm"}
+      align={"flex-start"}
+      justify={"center"}
+      direction={"column"}
+    >
+      {searchModels.map(({ name, icon, filter }) => {
+        return (
+          <TypeSidebarButton
+            data-testid="type-sidebar-item"
+            key={name}
+            onClick={() => onSelectType(filter)}
+            icon={icon}
+            iconSize={16}
+            isActive={filter === selectedType}
+          >
+            <h4>{name}</h4>
+          </TypeSidebarButton>
+        );
+      })}
+    </Flex>
+  );
+};

--- a/frontend/src/metabase/search/components/TypeSearchSidebar/TypeSearchSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/TypeSearchSidebar/TypeSearchSidebar.unit.spec.tsx
@@ -98,7 +98,7 @@ const setup = ({ initSelectedType = null } = {}) => {
 describe("TypeSearchSidebar", () => {
   it("display all available models with the correct text and icon for each type", () => {
     setup();
-    const sidebar = within(screen.getByTestId("sidebar"));
+    const sidebar = within(screen.getByTestId("type-sidebar"));
     TEST_ALL_TYPES.forEach(({ name, icon }) => {
       expect(sidebar.getByText(name)).toBeInTheDocument();
       expect(sidebar.getByLabelText(`${icon} icon`)).toBeInTheDocument();
@@ -107,7 +107,7 @@ describe("TypeSearchSidebar", () => {
 
   it("should select the correct type when clicking on it", () => {
     const { onChange } = setup();
-    const sidebar = within(screen.getByTestId("sidebar"));
+    const sidebar = within(screen.getByTestId("type-sidebar"));
     TEST_TYPES.forEach(({ name, filter }) => {
       sidebar.getByText(name).click();
       expect(onChange).toHaveBeenCalledWith(filter);

--- a/frontend/src/metabase/search/components/TypeSearchSidebar/TypeSearchSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/TypeSearchSidebar/TypeSearchSidebar.unit.spec.tsx
@@ -10,11 +10,6 @@ const TEST_TYPES: {
   filter: SearchModelType;
 }[] = [
   {
-    name: "Apps",
-    filter: "app",
-    icon: "star",
-  },
-  {
     name: "Dashboards",
     filter: "dashboard",
     icon: "dashboard",

--- a/frontend/src/metabase/search/components/TypeSearchSidebar/TypeSearchSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/TypeSearchSidebar/TypeSearchSidebar.unit.spec.tsx
@@ -1,0 +1,124 @@
+import { useState } from "react";
+import { IconName } from "metabase/core/components/Icon";
+import { TypeSearchSidebar } from "metabase/search/components/TypeSearchSidebar/TypeSearchSidebar";
+import { screen, render, within } from "__support__/ui";
+import { SearchModelType } from "metabase-types/api";
+
+const TEST_TYPES: {
+  name: string;
+  icon: IconName;
+  filter: SearchModelType;
+}[] = [
+  {
+    name: "Apps",
+    filter: "app",
+    icon: "star",
+  },
+  {
+    name: "Dashboards",
+    filter: "dashboard",
+    icon: "dashboard",
+  },
+  {
+    name: "Collections",
+    filter: "collection",
+    icon: "folder",
+  },
+  {
+    name: "Databases",
+    filter: "database",
+    icon: "database",
+  },
+  {
+    name: "Models",
+    filter: "dataset",
+    icon: "model",
+  },
+  {
+    name: "Raw Tables",
+    filter: "table",
+    icon: "table",
+  },
+  {
+    name: "Questions",
+    filter: "card",
+    icon: "bar",
+  },
+  {
+    name: "Pulses",
+    filter: "pulse",
+    icon: "pulse",
+  },
+  {
+    name: "Metrics",
+    filter: "metric",
+    icon: "sum",
+  },
+  {
+    name: "Segments",
+    filter: "segment",
+    icon: "segment",
+  },
+];
+
+const TEST_ALL_ITEMS_TYPE = {
+  name: "All items",
+  filter: null,
+  icon: "search",
+};
+
+const TEST_ALL_TYPES = [TEST_ALL_ITEMS_TYPE, ...TEST_TYPES];
+
+const TestTypeSearchSidebarComponent = ({
+  initSelectedType = null,
+  onChange,
+}: {
+  initSelectedType: SearchModelType | null;
+  onChange: jest.Mock;
+}) => {
+  const [selectedType, onSelectType] = useState(initSelectedType);
+  onChange.mockImplementation(onSelectType);
+
+  return (
+    <TypeSearchSidebar
+      availableModels={TEST_TYPES.map(({ filter }) => filter)}
+      onSelectType={onChange}
+      selectedType={selectedType}
+    />
+  );
+};
+
+const setup = ({ initSelectedType = null } = {}) => {
+  const onChange = jest.fn();
+  render(
+    <TestTypeSearchSidebarComponent
+      initSelectedType={initSelectedType}
+      onChange={onChange}
+    />,
+  );
+
+  return { onChange };
+};
+
+describe("TypeSearchSidebar", () => {
+  it("display all available models with the correct text and icon for each type", () => {
+    setup();
+    const sidebar = within(screen.getByTestId("sidebar"));
+    TEST_ALL_TYPES.forEach(({ name, icon }) => {
+      expect(sidebar.getByText(name)).toBeInTheDocument();
+      expect(sidebar.getByLabelText(`${icon} icon`)).toBeInTheDocument();
+    });
+  });
+
+  it("should select the correct type when clicking on it", () => {
+    const { onChange } = setup();
+    const sidebar = within(screen.getByTestId("sidebar"));
+    TEST_TYPES.forEach(({ name, filter }) => {
+      sidebar.getByText(name).click();
+      expect(onChange).toHaveBeenCalledWith(filter);
+    });
+
+    sidebar.getByText(TEST_ALL_ITEMS_TYPE.name).click();
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+});


### PR DESCRIPTION
### Description

Adds to #32742 - Search Filter Integration Branch:

- **`TypeSearchSidebar`** - Splits out the sidebar component in the full page search to handle displaying an icon and label for each possible search type, as well as handling the `onClick` method for the icons, rather than keeping it in the `SearchApp` component

<img width="216" alt="image" src="https://github.com/metabase/metabase/assets/25306947/6e02ce73-b3c2-4c72-ae6f-2b274f1df700">


These files will later be used in the `Search Filter for Types` Milestone (#32392). I've put these files in separate PRs to break up the technical feedback process and make sure that nothing gets missed in review or in the testing strategy.

### How to verify

For now, all tests should pass. For now, don't worry about UI/UX, since I've already confirmed the expected behavior with the PD/PM through prototypes, so we will convene in the final review process for this.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR