### PR TITLE
Modify `SearchApp` for integration branch

### DIFF
--- a/frontend/src/metabase/search/components/SearchFilterModal/SearchFilterModal.tsx
+++ b/frontend/src/metabase/search/components/SearchFilterModal/SearchFilterModal.tsx
@@ -5,11 +5,11 @@ import { SearchFilterModalFooter } from "metabase/search/components/SearchFilter
 import {
   FilterTypeKeys,
   SearchFilterComponent,
-  SearchFilterKeys,
   SearchFilters,
 } from "metabase/search/types";
 import Button from "metabase/core/components/Button";
 import { Title, Flex } from "metabase/ui";
+import { SearchFilterKeys } from "metabase/search/constants";
 import { TypeFilter } from "./filters/TypeFilter";
 import { SearchFilterWrapper } from "./SearchFilterModal.styled";
 

--- a/frontend/src/metabase/search/components/SearchResult.tsx
+++ b/frontend/src/metabase/search/components/SearchResult.tsx
@@ -151,6 +151,8 @@ export function SearchResult({
           <Score scores={result.scores} />
         </div>
         {loading && (
+          // SearchApp also uses `loading-spinner`, using a different test ID
+          // to not confuse unit tests waiting for loading-spinner to disappear
           <ResultSpinner
             data-testid="search-result-loading-spinner"
             size={24}

--- a/frontend/src/metabase/search/components/SearchResult.tsx
+++ b/frontend/src/metabase/search/components/SearchResult.tsx
@@ -150,7 +150,13 @@ export function SearchResult({
           )}
           <Score scores={result.scores} />
         </div>
-        {loading && <ResultSpinner size={24} borderWidth={3} />}
+        {loading && (
+          <ResultSpinner
+            data-testid="search-result-loading-spinner"
+            size={24}
+            borderWidth={3}
+          />
+        )}
       </ResultLinkContent>
       {compact || <Context context={result.context} />}
     </ResultContainer>

--- a/frontend/src/metabase/search/components/TypeSearchSidebar/TypeSearchSidebar.tsx
+++ b/frontend/src/metabase/search/components/TypeSearchSidebar/TypeSearchSidebar.tsx
@@ -67,7 +67,7 @@ export const TypeSearchSidebar = ({
 }) => {
   const searchModels = [
     {
-      name: t`All items`,
+      name: t`All results`,
       icon: "search",
       filter: null,
     },

--- a/frontend/src/metabase/search/components/TypeSearchSidebar/TypeSearchSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/TypeSearchSidebar/TypeSearchSidebar.unit.spec.tsx
@@ -57,7 +57,7 @@ const TEST_TYPES: {
 ];
 
 const TEST_ALL_ITEMS_TYPE = {
-  name: "All items",
+  name: "All results",
   filter: null,
   icon: "search",
 };

--- a/frontend/src/metabase/search/components/TypeSearchSidebar/index.ts
+++ b/frontend/src/metabase/search/components/TypeSearchSidebar/index.ts
@@ -1,0 +1,1 @@
+export * from "./TypeSearchSidebar";

--- a/frontend/src/metabase/search/constants.ts
+++ b/frontend/src/metabase/search/constants.ts
@@ -1,0 +1,3 @@
+export const SearchFilterKeys = {
+  Type: "type",
+} as const;

--- a/frontend/src/metabase/search/containers/SearchApp.jsx
+++ b/frontend/src/metabase/search/containers/SearchApp.jsx
@@ -1,21 +1,26 @@
-import { Fragment, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import PropTypes from "prop-types";
-import cx from "classnames";
 
 import { jt, t } from "ttag";
-import Link from "metabase/core/components/Link";
 
+import _ from "underscore";
 import Search from "metabase/entities/search";
 
 import Card from "metabase/components/Card";
 import EmptyState from "metabase/components/EmptyState";
-import { SearchResult } from "metabase/search/components/SearchResult";
 import Subhead from "metabase/components/type/Subhead";
 
-import { Icon } from "metabase/core/components/Icon";
 import NoResults from "assets/img/no_results.svg";
 import PaginationControls from "metabase/components/PaginationControls";
 import { usePagination } from "metabase/hooks/use-pagination";
+import {
+  getFiltersFromLocation,
+  getSearchTextFromLocation,
+} from "metabase/search/utils";
+import { TypeSearchSidebar } from "metabase/search/components/TypeSearchSidebar/TypeSearchSidebar";
+import { PAGE_SIZE } from "metabase/search/containers/constants";
+import { SearchFilterKeys } from "metabase/search/types";
+import { SearchResult } from "metabase/search/components/SearchResult";
 import {
   SearchBody,
   SearchControls,
@@ -25,172 +30,90 @@ import {
   SearchRoot,
 } from "./SearchApp.styled";
 
-const PAGE_SIZE = 50;
-
-const SEARCH_FILTERS = [
-  {
-    name: t`Apps`,
-    filter: "app",
-    icon: "star",
-  },
-  {
-    name: t`Dashboards`,
-    filter: "dashboard",
-    icon: "dashboard",
-  },
-  {
-    name: t`Collections`,
-    filter: "collection",
-    icon: "folder",
-  },
-  {
-    name: t`Databases`,
-    filter: "database",
-    icon: "database",
-  },
-  {
-    name: t`Models`,
-    filter: "dataset",
-    icon: "model",
-  },
-  {
-    name: t`Raw Tables`,
-    filter: "table",
-    icon: "table",
-  },
-  {
-    name: t`Questions`,
-    filter: "card",
-    icon: "bar",
-  },
-  {
-    name: t`Pulses`,
-    filter: "pulse",
-    icon: "pulse",
-  },
-  {
-    name: t`Metrics`,
-    filter: "metric",
-    icon: "sum",
-  },
-  {
-    name: t`Segments`,
-    filter: "segment",
-    icon: "segment",
-  },
-];
-
 export default function SearchApp({ location }) {
   const { handleNextPage, handlePreviousPage, setPage, page } = usePagination();
-  const [filter, setFilter] = useState(location.query.type);
 
-  const handleFilterChange = filterItem => {
-    setFilter(filterItem && filterItem.filter);
+  const searchText = useMemo(
+    () => getSearchTextFromLocation(location),
+    [location],
+  );
+
+  const searchFilters = useMemo(() => {
+    return getFiltersFromLocation(location);
+  }, [location]);
+
+  const [selectedSidebarType, setSelectedSidebarType] = useState(null);
+
+  useEffect(() => {
+    setSelectedSidebarType(null);
+  }, [searchText, searchFilters]);
+
+  const query = useMemo(
+    () => ({
+      q: searchText,
+      ..._.omit(searchFilters, SearchFilterKeys.Type),
+      models: selectedSidebarType ?? searchFilters[SearchFilterKeys.Type],
+      limit: PAGE_SIZE,
+      offset: PAGE_SIZE * page,
+    }),
+    [searchText, searchFilters, selectedSidebarType, page],
+  );
+
+  const onChangeSelectedType = filter => {
+    setSelectedSidebarType(filter);
     setPage(0);
   };
 
-  const query = {
-    q: location.query.q,
-    limit: PAGE_SIZE,
-    offset: PAGE_SIZE * page,
-  };
-
-  if (filter) {
-    query.models = filter;
-  }
-
   return (
-    <SearchRoot>
-      {location.query.q && (
+    <SearchRoot data-testid="search-app">
+      {searchText && (
         <SearchHeader>
-          <Subhead>{jt`Results for "${location.query.q}"`}</Subhead>
+          <Subhead>{jt`Results for "${searchText}"`}</Subhead>
         </SearchHeader>
       )}
-      <div>
-        <Search.ListLoader query={query} wrapped>
-          {({ list, metadata }) => {
-            if (list.length === 0) {
-              return (
-                <SearchEmptyState>
-                  <Card>
-                    <EmptyState
-                      title={t`Didn't find anything`}
-                      message={t`There weren't any results for your search.`}
-                      illustrationElement={<img src={NoResults} />}
-                    />
-                  </Card>
-                </SearchEmptyState>
-              );
-            }
-
-            const availableModels = metadata.available_models || [];
-
-            const filters = SEARCH_FILTERS.filter(f =>
-              availableModels.includes(f.filter),
-            );
-
-            return (
-              <SearchBody>
-                <SearchMain>
-                  <Fragment>
-                    <SearchResultSection items={list} />
-                    <div className="flex justify-end my2">
-                      <PaginationControls
-                        showTotal
-                        pageSize={PAGE_SIZE}
-                        page={page}
-                        itemsLength={list.length}
-                        total={metadata.total}
-                        onNextPage={handleNextPage}
-                        onPreviousPage={handlePreviousPage}
-                      />
-                    </div>
-                  </Fragment>
-                </SearchMain>
+      <Search.ListLoader query={query} wrapped>
+        {({ list, metadata }) =>
+          list && list.length > 0 ? (
+            <SearchBody>
+              <SearchMain>
+                <SearchResultSection items={list} />
+                <PaginationControls
+                  showTotal
+                  pageSize={PAGE_SIZE}
+                  page={page}
+                  itemsLength={list.length}
+                  total={metadata.total}
+                  onNextPage={handleNextPage}
+                  onPreviousPage={handlePreviousPage}
+                />
+              </SearchMain>
+              {searchFilters?.type || metadata.available_models ? (
                 <SearchControls>
-                  {filters.length > 0 ? (
-                    <Link
-                      className={cx("flex align-center mb3", {
-                        "text-brand": filter == null,
-                        "text-inherit": filter != null,
-                      })}
-                      onClick={() => handleFilterChange(null)}
-                      to={{
-                        pathname: location.pathname,
-                        query: { ...location.query, type: undefined },
-                      }}
-                    >
-                      <Icon name="search" className="mr1" />
-                      <h4>{t`All results`}</h4>
-                    </Link>
-                  ) : null}
-                  {filters.map(f => {
-                    const isActive = filter === f.filter;
-
-                    return (
-                      <Link
-                        key={f.filter}
-                        className={cx("mb3 flex align-center", {
-                          "text-brand": isActive,
-                          "text-medium": !isActive,
-                        })}
-                        onClick={() => handleFilterChange(f)}
-                        to={{
-                          pathname: location.pathname,
-                          query: { ...location.query, type: f.filter },
-                        }}
-                      >
-                        <Icon className="mr1" name={f.icon} size={16} />
-                        <h4>{f.name}</h4>
-                      </Link>
-                    );
-                  })}
+                  <TypeSearchSidebar
+                    availableModels={metadata.available_models.filter(
+                      filter =>
+                        !searchFilters?.type ||
+                        searchFilters.type.includes(filter),
+                    )}
+                    selectedType={selectedSidebarType}
+                    onSelectType={onChangeSelectedType}
+                  />
                 </SearchControls>
-              </SearchBody>
-            );
-          }}
-        </Search.ListLoader>
-      </div>
+              ) : null}
+            </SearchBody>
+          ) : (
+            <SearchEmptyState>
+              <Card>
+                <EmptyState
+                  title={t`Didn't find anything`}
+                  message={t`There weren't any results for your search.`}
+                  illustrationElement={<img src={NoResults} />}
+                />
+              </Card>
+            </SearchEmptyState>
+          )
+        }
+      </Search.ListLoader>
     </SearchRoot>
   );
 }

--- a/frontend/src/metabase/search/containers/SearchApp.jsx
+++ b/frontend/src/metabase/search/containers/SearchApp.jsx
@@ -46,8 +46,10 @@ export default function SearchApp({ location }) {
   const [selectedSidebarType, setSelectedSidebarType] = useState(null);
 
   useEffect(() => {
-    setSelectedSidebarType(null);
-  }, [searchText, searchFilters]);
+    if (location.search) {
+      setSelectedSidebarType(null);
+    }
+  }, [location.search]);
 
   const query = {
     q: searchText,

--- a/frontend/src/metabase/search/containers/SearchApp.unit.spec.tsx
+++ b/frontend/src/metabase/search/containers/SearchApp.unit.spec.tsx
@@ -15,6 +15,7 @@ import {
 import { SearchResult } from "metabase-types/api";
 
 import { SearchFilters } from "metabase/search/types";
+import { checkNotNull } from "metabase/core/utils/types";
 
 // Mock PAGE_SIZE so we don't have to generate a ton of elements for the pagination test
 jest.mock("metabase/search/containers/constants", () => ({
@@ -92,7 +93,7 @@ const setup = async ({
   });
 
   return {
-    history,
+    history: checkNotNull(history),
   };
 };
 
@@ -164,7 +165,7 @@ describe("SearchApp", () => {
           searchText: "Test",
         });
 
-        let url = history?.getCurrentLocation();
+        let url = history.getCurrentLocation();
         const { pathname: prevPathname, search: prevSearch } = url ?? {};
 
         const sidebarItems = screen.getAllByTestId("type-sidebar-item");
@@ -173,7 +174,7 @@ describe("SearchApp", () => {
 
         const sidebarItem = screen.getByText(SIDEBAR_NAMES[model]);
         userEvent.click(sidebarItem);
-        url = history?.getCurrentLocation();
+        url = history.getCurrentLocation();
         const { pathname, search } = url ?? {};
         expect(pathname).toEqual(prevPathname);
         expect(search).toEqual(prevSearch);

--- a/frontend/src/metabase/search/containers/SearchApp.unit.spec.tsx
+++ b/frontend/src/metabase/search/containers/SearchApp.unit.spec.tsx
@@ -13,7 +13,7 @@ import {
 } from "metabase-types/api/mocks";
 import { SearchResult } from "metabase-types/api";
 
-import { SearchFilters } from "metabase/search/util/filter-types";
+import { SearchFilters } from "metabase/search/types";
 
 // Mock PAGE_SIZE so we don't have to generate a ton of elements for the pagination test
 jest.mock("metabase/search/containers/constants", () => ({

--- a/frontend/src/metabase/search/containers/SearchApp.unit.spec.tsx
+++ b/frontend/src/metabase/search/containers/SearchApp.unit.spec.tsx
@@ -1,4 +1,3 @@
-import querystring from "querystring";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import SearchApp from "metabase/search/containers/SearchApp";
@@ -6,10 +5,12 @@ import { Route } from "metabase/hoc/Title";
 import {
   setupDatabasesEndpoints,
   setupSearchEndpoints,
+  setupTableEndpoints,
 } from "__support__/server-mocks";
 import {
   createMockDatabase,
   createMockSearchResult,
+  createMockTable,
 } from "metabase-types/api/mocks";
 import { SearchResult } from "metabase-types/api";
 
@@ -20,8 +21,9 @@ jest.mock("metabase/search/containers/constants", () => ({
   PAGE_SIZE: 3,
 }));
 
-const TRANSLATED_SIDEBAR_NAMES: Record<string, string> = {
-  "All results": "All results",
+const ALL_RESULTS_SIDEBAR_NAME = "All results";
+
+const SIDEBAR_NAMES: Record<string, string> = {
   collection: "Collections",
   dashboard: "Dashboards",
   database: "Databases",
@@ -34,15 +36,15 @@ const TRANSLATED_SIDEBAR_NAMES: Record<string, string> = {
 };
 
 const TEST_ITEMS: Partial<SearchResult>[] = [
-  { name: "Card", model: "card" },
-  { name: "Collection", model: "collection" },
-  { name: "Dashboard", model: "dashboard" },
-  { name: "Database", model: "database" },
-  { name: "Dataset", model: "dataset" },
-  { name: "Table", model: "table" },
-  { name: "Pulse", model: "pulse" },
-  { name: "Segment", model: "segment" },
-  { name: "Metric", model: "metric" },
+  { name: "Test Card", model: "card" },
+  { name: "Test Collection", model: "collection" },
+  { name: "Test Dashboard", model: "dashboard" },
+  { name: "Test Database", model: "database" },
+  { name: "Test Dataset", model: "dataset" },
+  { name: "Test Table", model: "table" },
+  { name: "Test Pulse", model: "pulse" },
+  { name: "Test Segment", model: "segment" },
+  { name: "Test Metric", model: "metric" },
 ];
 
 const TEST_SEARCH_RESULTS: SearchResult[] = TEST_ITEMS.map((metadata, index) =>
@@ -50,25 +52,31 @@ const TEST_SEARCH_RESULTS: SearchResult[] = TEST_ITEMS.map((metadata, index) =>
 );
 
 const TEST_DATABASE = createMockDatabase();
+const TEST_TABLE = createMockTable();
 
 const setup = async ({
   searchText,
   searchFilters = {},
   searchItems = TEST_SEARCH_RESULTS,
 }: {
-  searchText?: string;
+  searchText: string;
   searchFilters?: SearchFilters;
   searchItems?: SearchResult[];
 }) => {
   setupDatabasesEndpoints([TEST_DATABASE]);
   setupSearchEndpoints(searchItems);
+  setupTableEndpoints(TEST_TABLE);
 
   // for testing the hydration of search text and filters on page load
   const params = {
     ...searchFilters,
     q: searchText,
   };
-  const searchParams = querystring.stringify(params);
+
+  const searchParams = new URLSearchParams(
+    params as unknown as Record<string, string>,
+  ).toString();
+
   const initialRoute = searchParams ? `/search?${searchParams}` : `/search`;
 
   const { history } = renderWithProviders(
@@ -151,35 +159,30 @@ describe("SearchApp", () => {
   describe("filtering search results with the sidebar", () => {
     it("should reload with filtered searches when a type on the right sidebar is clicked without changing URL", async () => {
       const { history } = await setup({
-        searchText: "Card",
+        searchText: "Test",
       });
 
       let url = history?.getCurrentLocation();
       const { pathname: prevPathname, search: prevSearch } = url ?? {};
 
-      expect(screen.getAllByTestId("type-sidebar-item")).toHaveLength(2);
+      const sidebarItems = screen.getAllByTestId("type-sidebar-item");
+      expect(sidebarItems).toHaveLength(10);
+      expect(sidebarItems[0]).toHaveTextContent(ALL_RESULTS_SIDEBAR_NAME);
 
-      const expectedSidebarLabels = ["All items", "Questions"];
-      screen.getAllByTestId("type-sidebar-item").forEach(item => {
-        expect(expectedSidebarLabels).toContain(item.textContent);
-      });
+      for (const { model, name } of TEST_SEARCH_RESULTS) {
+        const sidebarItem = screen.getByText(SIDEBAR_NAMES[model]);
+        userEvent.click(sidebarItem);
+        url = history?.getCurrentLocation();
+        const { pathname, search } = url ?? {};
+        expect(pathname).toEqual(prevPathname);
+        expect(search).toEqual(prevSearch);
 
-      userEvent.click(screen.getByText("Questions"));
-
-      await waitFor(() => {
-        expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
-      });
-
-      expect(screen.getByText('Results for "Card"')).toBeInTheDocument();
-      expect(screen.getByTestId("search-result-item")).toBeInTheDocument();
-      expect(screen.getByTestId("search-result-item-name")).toHaveTextContent(
-        "Card",
-      );
-
-      url = history?.getCurrentLocation();
-      const { pathname, search } = url ?? {};
-      expect(pathname).toEqual(prevPathname);
-      expect(search).toEqual(prevSearch);
+        const searchResultItem = await screen.findByTestId(
+          "search-result-item",
+        );
+        expect(searchResultItem).toBeInTheDocument();
+        expect(searchResultItem).toHaveTextContent(name);
+      }
     });
   });
 
@@ -199,13 +202,12 @@ describe("SearchApp", () => {
         expect(screen.getByTestId("search-result-item-name")).toHaveTextContent(
           name,
         );
-        expect(screen.getAllByTestId("type-sidebar-item")).toHaveLength(2);
-        expect(screen.getByTestId("type-sidebar")).toHaveTextContent(
-          "All items",
-        );
-        expect(screen.getByTestId("type-sidebar")).toHaveTextContent(
-          TRANSLATED_SIDEBAR_NAMES[model],
-        );
+
+        const sidebarItems = screen.getAllByTestId("type-sidebar-item");
+
+        expect(sidebarItems).toHaveLength(2);
+        expect(sidebarItems[0]).toHaveTextContent(ALL_RESULTS_SIDEBAR_NAME);
+        expect(sidebarItems[1]).toHaveTextContent(SIDEBAR_NAMES[model]);
       },
     );
   });

--- a/frontend/src/metabase/search/containers/SearchApp.unit.spec.tsx
+++ b/frontend/src/metabase/search/containers/SearchApp.unit.spec.tsx
@@ -157,19 +157,20 @@ describe("SearchApp", () => {
   });
 
   describe("filtering search results with the sidebar", () => {
-    it("should reload with filtered searches when a type on the right sidebar is clicked without changing URL", async () => {
-      const { history } = await setup({
-        searchText: "Test",
-      });
+    it.each(TEST_SEARCH_RESULTS)(
+      "should reload with filtered searches when type=$model on the right sidebar is clicked without changing URL",
+      async ({ model, name }) => {
+        const { history } = await setup({
+          searchText: "Test",
+        });
 
-      let url = history?.getCurrentLocation();
-      const { pathname: prevPathname, search: prevSearch } = url ?? {};
+        let url = history?.getCurrentLocation();
+        const { pathname: prevPathname, search: prevSearch } = url ?? {};
 
-      const sidebarItems = screen.getAllByTestId("type-sidebar-item");
-      expect(sidebarItems).toHaveLength(10);
-      expect(sidebarItems[0]).toHaveTextContent(ALL_RESULTS_SIDEBAR_NAME);
+        const sidebarItems = screen.getAllByTestId("type-sidebar-item");
+        expect(sidebarItems).toHaveLength(10);
+        expect(sidebarItems[0]).toHaveTextContent(ALL_RESULTS_SIDEBAR_NAME);
 
-      for (const { model, name } of TEST_SEARCH_RESULTS) {
         const sidebarItem = screen.getByText(SIDEBAR_NAMES[model]);
         userEvent.click(sidebarItem);
         url = history?.getCurrentLocation();
@@ -182,8 +183,8 @@ describe("SearchApp", () => {
         );
         expect(searchResultItem).toBeInTheDocument();
         expect(searchResultItem).toHaveTextContent(name);
-      }
-    });
+      },
+    );
   });
 
   describe("hydrating search filters from URL", () => {

--- a/frontend/src/metabase/search/containers/SearchApp.unit.spec.tsx
+++ b/frontend/src/metabase/search/containers/SearchApp.unit.spec.tsx
@@ -1,0 +1,212 @@
+import querystring from "querystring";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import SearchApp from "metabase/search/containers/SearchApp";
+import { Route } from "metabase/hoc/Title";
+import {
+  setupDatabasesEndpoints,
+  setupSearchEndpoints,
+} from "__support__/server-mocks";
+import {
+  createMockDatabase,
+  createMockSearchResult,
+} from "metabase-types/api/mocks";
+import { SearchResult } from "metabase-types/api";
+
+import { SearchFilters } from "metabase/search/util/filter-types";
+
+// Mock PAGE_SIZE so we don't have to generate a ton of elements for the pagination test
+jest.mock("metabase/search/containers/constants", () => ({
+  PAGE_SIZE: 3,
+}));
+
+const TRANSLATED_SIDEBAR_NAMES: Record<string, string> = {
+  "All results": "All results",
+  collection: "Collections",
+  dashboard: "Dashboards",
+  database: "Databases",
+  dataset: "Models",
+  metric: "Metrics",
+  pulse: "Pulses",
+  segment: "Segments",
+  table: "Raw Tables",
+  card: "Questions",
+};
+
+const TEST_ITEMS: Partial<SearchResult>[] = [
+  { name: "Card", model: "card" },
+  { name: "Collection", model: "collection" },
+  { name: "Dashboard", model: "dashboard" },
+  { name: "Database", model: "database" },
+  { name: "Dataset", model: "dataset" },
+  { name: "Table", model: "table" },
+  { name: "Pulse", model: "pulse" },
+  { name: "Segment", model: "segment" },
+  { name: "Metric", model: "metric" },
+];
+
+const TEST_SEARCH_RESULTS: SearchResult[] = TEST_ITEMS.map((metadata, index) =>
+  createMockSearchResult({ ...metadata, id: index + 1 }),
+);
+
+const TEST_DATABASE = createMockDatabase();
+
+const setup = async ({
+  searchText,
+  searchFilters = {},
+  searchItems = TEST_SEARCH_RESULTS,
+}: {
+  searchText?: string;
+  searchFilters?: SearchFilters;
+  searchItems?: SearchResult[];
+}) => {
+  setupDatabasesEndpoints([TEST_DATABASE]);
+  setupSearchEndpoints(searchItems);
+
+  // for testing the hydration of search text and filters on page load
+  const params = {
+    ...searchFilters,
+    q: searchText,
+  };
+  const searchParams = querystring.stringify(params);
+  const initialRoute = searchParams ? `/search?${searchParams}` : `/search`;
+
+  const { history } = renderWithProviders(
+    <Route path="search" component={SearchApp} />,
+    {
+      withRouter: true,
+      initialRoute,
+    },
+  );
+
+  await waitFor(() => {
+    expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
+  });
+
+  return {
+    history,
+  };
+};
+
+describe("SearchApp", () => {
+  describe("rendering search results and pagination", () => {
+    it("renders empty state when there are no search results", async () => {
+      // let's pick some text that doesn't ever match anything
+      await setup({ searchText: "oisin" });
+
+      expect(screen.getByText('Results for "oisin"')).toBeInTheDocument();
+      expect(
+        screen.getByText("There weren't any results for your search."),
+      ).toBeInTheDocument();
+      expect(screen.queryByLabelText("pagination")).not.toBeInTheDocument();
+    });
+
+    it("renders search results when there is at least one result", async () => {
+      await setup({ searchText: "Card" });
+
+      const searchResultsHeader = screen.getByText('Results for "Card"');
+      expect(searchResultsHeader).toBeInTheDocument();
+
+      const searchResults = screen.getAllByTestId("search-result-item");
+      expect(searchResults.length).toEqual(1);
+      expect(screen.queryByLabelText("pagination")).not.toBeInTheDocument();
+    });
+
+    it("renders search results and pagination when there is more than PAGE_SIZE results", async () => {
+      await setup({ searchText: "a" });
+      const getPaginationTotal = () => screen.getByTestId("pagination-total");
+      const getPagination = () => screen.getByLabelText("pagination");
+      const getNextPageButton = () => screen.getByTestId("next-page-btn");
+      const getPreviousPageButton = () =>
+        screen.getByTestId("previous-page-btn");
+
+      expect(getPaginationTotal()).toHaveTextContent("5");
+      expect(getPreviousPageButton()).toBeDisabled();
+      expect(getNextPageButton()).toBeEnabled();
+      expect(getPagination()).toHaveTextContent("1 - 3");
+
+      // test next page button
+      userEvent.click(getNextPageButton());
+      await waitFor(() => {
+        expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
+      });
+      expect(getPaginationTotal()).toHaveTextContent("5");
+      expect(getPreviousPageButton()).toBeEnabled();
+      expect(getNextPageButton()).toBeDisabled();
+
+      expect(getPagination()).toHaveTextContent("4 - 5");
+
+      // test previous page button
+      userEvent.click(getPreviousPageButton());
+      await waitFor(() => {
+        expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
+      });
+      expect(getPaginationTotal()).toHaveTextContent("5");
+      expect(getPreviousPageButton()).toBeDisabled();
+      expect(getNextPageButton()).toBeEnabled();
+      expect(getPagination()).toHaveTextContent("1 - 3");
+    });
+  });
+
+  describe("filtering search results with the sidebar", () => {
+    it("should reload with filtered searches when a type on the right sidebar is clicked without changing URL", async () => {
+      const { history } = await setup({
+        searchText: "Card",
+      });
+
+      let url = history?.getCurrentLocation();
+      const { pathname: prevPathname, search: prevSearch } = url ?? {};
+
+      expect(screen.getAllByTestId("type-sidebar-item")).toHaveLength(2);
+
+      const expectedSidebarLabels = ["All items", "Questions"];
+      screen.getAllByTestId("type-sidebar-item").forEach(item => {
+        expect(expectedSidebarLabels).toContain(item.textContent);
+      });
+
+      userEvent.click(screen.getByText("Questions"));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Results for "Card"')).toBeInTheDocument();
+      expect(screen.getByTestId("search-result-item")).toBeInTheDocument();
+      expect(screen.getByTestId("search-result-item-name")).toHaveTextContent(
+        "Card",
+      );
+
+      url = history?.getCurrentLocation();
+      const { pathname, search } = url ?? {};
+      expect(pathname).toEqual(prevPathname);
+      expect(search).toEqual(prevSearch);
+    });
+  });
+
+  describe("hydrating search filters from URL", () => {
+    // TODO: Add tests for other filters as they come
+
+    it.each(TEST_SEARCH_RESULTS)(
+      "should filter by type = $name",
+      async ({ name, model }) => {
+        await setup({
+          searchText: name,
+          searchFilters: { type: [model] },
+        });
+
+        expect(screen.getByText(`Results for "${name}"`)).toBeInTheDocument();
+        expect(screen.getByTestId("search-result-item")).toBeInTheDocument();
+        expect(screen.getByTestId("search-result-item-name")).toHaveTextContent(
+          name,
+        );
+        expect(screen.getAllByTestId("type-sidebar-item")).toHaveLength(2);
+        expect(screen.getByTestId("type-sidebar")).toHaveTextContent(
+          "All items",
+        );
+        expect(screen.getByTestId("type-sidebar")).toHaveTextContent(
+          TRANSLATED_SIDEBAR_NAMES[model],
+        );
+      },
+    );
+  });
+});

--- a/frontend/src/metabase/search/containers/constants.ts
+++ b/frontend/src/metabase/search/containers/constants.ts
@@ -1,0 +1,1 @@
+export const PAGE_SIZE = 50;

--- a/frontend/src/metabase/search/types.ts
+++ b/frontend/src/metabase/search/types.ts
@@ -2,6 +2,7 @@ import { Location } from "history";
 import { FC } from "react";
 import { Collection, SearchModelType, SearchResult } from "metabase-types/api";
 import { IconName } from "metabase/core/components/Icon";
+import { SearchFilterKeys } from "metabase/search/constants";
 
 export interface WrappedResult extends SearchResult {
   getUrl: () => string;
@@ -13,10 +14,6 @@ export interface WrappedResult extends SearchResult {
   };
   getCollection: () => Partial<Collection>;
 }
-
-export const SearchFilterKeys = {
-  Type: "type",
-} as const;
 
 export type TypeFilterProps = SearchModelType[];
 

--- a/frontend/src/metabase/search/utils/search-location/search-location.ts
+++ b/frontend/src/metabase/search/utils/search-location/search-location.ts
@@ -1,10 +1,7 @@
 import _ from "underscore";
 
-import {
-  SearchAwareLocation,
-  SearchFilterKeys,
-  SearchFilters,
-} from "metabase/search/types";
+import { SearchAwareLocation, SearchFilters } from "metabase/search/types";
+import { SearchFilterKeys } from "metabase/search/constants";
 
 export function isSearchPageLocation(location: SearchAwareLocation): boolean {
   const components = location.pathname.split("/");

--- a/frontend/src/metabase/search/utils/search-location/search-location.unit.spec.ts
+++ b/frontend/src/metabase/search/utils/search-location/search-location.unit.spec.ts
@@ -4,7 +4,8 @@ import {
   isSearchPageLocation,
 } from "metabase/search/utils";
 
-import { SearchAwareLocation, SearchFilterKeys } from "metabase/search/types";
+import { SearchAwareLocation } from "metabase/search/types";
+import { SearchFilterKeys } from "metabase/search/constants";
 
 describe("isSearchPageLocation", () => {
   it('should return true when the last component of pathname is "search"', () => {


### PR DESCRIPTION
### Description

Adds changes to #32742 - Search Filter Integration Branch:

- Changes to **`SearchApp`**:
	- Extracts search text as well as the new filters extracted from the provided `location` prop.
	- Extracts the **`TypeSearchSidebar`** for filtering, and doesn't change the URL based on the changes in the sidebar anymore.

These files will later be used in the `Search Filter for Types` Milestone (#32392). I've put these files in separate PRs to break up the technical feedback process and make sure that nothing gets missed in review or in the testing strategy.

### How to verify

For now, all tests should pass. For now, don't worry about UI/UX, since I've already confirmed the expected behavior with the PD/PM through prototypes, so we will convene in the final review process for this.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
