### PR TITLE
Add `SearchFilterModal` to integration branch

### DIFF
--- a/frontend/src/metabase/search/components/SearchFilterModal/SearchFilterModal.styled.tsx
+++ b/frontend/src/metabase/search/components/SearchFilterModal/SearchFilterModal.styled.tsx
@@ -1,0 +1,10 @@
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+
+export const SearchFilterWrapper = styled.div`
+  & > * {
+    border-bottom: 1px solid ${color("border")};
+    padding: 1.5rem 2rem;
+    margin: 0;
+  }
+`;

--- a/frontend/src/metabase/search/components/SearchFilterModal/SearchFilterModal.tsx
+++ b/frontend/src/metabase/search/components/SearchFilterModal/SearchFilterModal.tsx
@@ -1,0 +1,89 @@
+import { t } from "ttag";
+import { useEffect, useMemo, useState } from "react";
+import Modal from "metabase/components/Modal";
+import { SearchFilterModalFooter } from "metabase/search/components/SearchFilterModal/SearchFilterModalFooter";
+import {
+  FilterTypeKeys,
+  SearchFilterComponent,
+  SearchFilterKeys,
+  SearchFilters,
+} from "metabase/search/types";
+import Button from "metabase/core/components/Button";
+import { Title, Flex } from "metabase/ui";
+import { TypeFilter } from "./filters/TypeFilter";
+import { SearchFilterWrapper } from "./SearchFilterModal.styled";
+
+const filterMap: Record<FilterTypeKeys, SearchFilterComponent> = {
+  [SearchFilterKeys.Type]: TypeFilter,
+};
+
+export const SearchFilterModal = ({
+  isOpen,
+  setIsOpen,
+  value,
+  onChangeFilters,
+}: {
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+  value: SearchFilters;
+  onChangeFilters: (filters: SearchFilters) => void;
+}) => {
+  const [output, setOutput] = useState<SearchFilters>(value);
+
+  useEffect(() => {
+    setOutput(value);
+  }, [value]);
+
+  const closeModal = () => {
+    setIsOpen(false);
+  };
+
+  const clearFilters = () => {
+    onChangeFilters({});
+    setIsOpen(false);
+  };
+
+  const applyFilters = () => {
+    onChangeFilters(output);
+    setIsOpen(false);
+  };
+
+  // we can use this field to control which filters are available
+  // - we can enable the 'verified' filter here
+  const availableFilters: FilterTypeKeys[] = useMemo(() => {
+    return [SearchFilterKeys.Type];
+  }, []);
+
+  return isOpen ? (
+    <Modal isOpen={isOpen} onClose={closeModal}>
+      <SearchFilterWrapper data-testid="search-filter-modal-container">
+        <Flex direction="row" justify="space-between" align="center">
+          <Title order={4}>{t`Filter by`}</Title>
+          <Button onlyIcon onClick={() => setIsOpen(false)} icon="close" />
+        </Flex>
+        {availableFilters.map(key => {
+          const Filter = filterMap[key];
+          return (
+            <Filter
+              key={key}
+              data-testid={`${key}-search-filter`}
+              value={output[key]}
+              onChange={val =>
+                setOutput({
+                  ...output,
+                  [key]: val,
+                })
+              }
+            />
+          );
+        })}
+
+        <SearchFilterModalFooter
+          onApply={applyFilters}
+          onCancel={closeModal}
+          onClear={clearFilters}
+        />
+      </SearchFilterWrapper>
+    </Modal>
+  ) : null;
+};

--- a/frontend/src/metabase/search/components/SearchFilterModal/SearchFilterModal.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/SearchFilterModal/SearchFilterModal.unit.spec.tsx
@@ -1,0 +1,111 @@
+import { useState } from "react";
+import userEvent from "@testing-library/user-event";
+import { waitFor, within, renderWithProviders, screen } from "__support__/ui";
+import { setupSearchEndpoints } from "__support__/server-mocks";
+import { createMockSearchResult } from "metabase-types/api/mocks";
+import { SearchFilterModal } from "metabase/search/components/SearchFilterModal/SearchFilterModal";
+import { SearchModelType } from "metabase-types/api";
+import { SearchFilters } from "metabase/search/types";
+
+const TestSearchFilterModal = ({
+  initialFilters = {},
+  onChangeFilters,
+}: {
+  initialFilters?: SearchFilters;
+  onChangeFilters: jest.Mock;
+}) => {
+  const [filters, setFilters] = useState(initialFilters);
+
+  onChangeFilters.mockImplementation(newFilters => setFilters(newFilters));
+
+  return (
+    <SearchFilterModal
+      isOpen={true}
+      setIsOpen={jest.fn()}
+      value={filters}
+      onChangeFilters={onChangeFilters}
+    />
+  );
+};
+
+const TEST_TYPES: Array<SearchModelType> = [
+  "action",
+  "card",
+  "collection",
+  "dashboard",
+  "database",
+  "dataset",
+  "metric",
+  "pulse",
+  "segment",
+  "table",
+];
+
+const TEST_INITIAL_FILTERS: SearchFilters = {
+  type: TEST_TYPES,
+};
+
+const setup = async ({
+  initialFilters = {},
+  availableModelTypes = TEST_TYPES,
+} = {}) => {
+  const onChangeFilters = jest.fn();
+
+  setupSearchEndpoints(
+    availableModelTypes.map((type, index) =>
+      createMockSearchResult({ model: type, id: index + 1 }),
+    ),
+  );
+
+  renderWithProviders(
+    <TestSearchFilterModal
+      initialFilters={initialFilters}
+      onChangeFilters={onChangeFilters}
+    />,
+  );
+  await waitFor(() => {
+    expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
+  });
+
+  return {
+    onChangeFilters,
+  };
+};
+
+describe("SearchFilterModal", () => {
+  it("should populate selected filters when `value` is passed in", async () => {
+    await setup({
+      initialFilters: TEST_INITIAL_FILTERS,
+    });
+
+    const typeFilter = screen.getByTestId("type-search-filter");
+    within(typeFilter)
+      .getAllByRole("checkbox")
+      .forEach(checkbox => {
+        expect(checkbox).toBeChecked();
+      });
+  });
+
+  it("should return all selected filters when `Apply all filters` is clicked", async () => {
+    const { onChangeFilters } = await setup({
+      initialFilters: TEST_INITIAL_FILTERS,
+    });
+
+    userEvent.click(screen.getByText("Apply all filters"));
+    expect(onChangeFilters).toHaveBeenCalledWith(TEST_INITIAL_FILTERS);
+  });
+
+  it("should clear all selections when `Clear all filters` is clicked", async () => {
+    const { onChangeFilters } = await setup();
+
+    userEvent.click(screen.getByText("Clear all filters"));
+    expect(onChangeFilters).toHaveBeenCalledWith({});
+  });
+
+  it("should not change filters when `Cancel` is clicked", async () => {
+    const { onChangeFilters } = await setup();
+
+    userEvent.click(screen.getByText("Cancel"));
+    expect(onChangeFilters).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/metabase/search/components/SearchFilterModal/SearchFilterModalFooter.styled.tsx
+++ b/frontend/src/metabase/search/components/SearchFilterModal/SearchFilterModalFooter.styled.tsx
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+import Button from "metabase/core/components/Button";
+
+export const CloseAllFiltersButton = styled(Button)`
+  border: none;
+  padding-left: 0;
+  padding-right: 0;
+  background: none;
+
+  &:hover {
+    background: none;
+  }
+`;

--- a/frontend/src/metabase/search/components/SearchFilterModal/SearchFilterModalFooter.tsx
+++ b/frontend/src/metabase/search/components/SearchFilterModal/SearchFilterModalFooter.tsx
@@ -1,0 +1,28 @@
+import { t } from "ttag";
+import Button from "metabase/core/components/Button";
+import { Flex, Group } from "metabase/ui";
+import { CloseAllFiltersButton } from "metabase/search/components/SearchFilterModal/SearchFilterModalFooter.styled";
+
+type SearchFilterModalFooterProps = {
+  onApply: () => void;
+  onCancel: () => void;
+  onClear: () => void;
+};
+
+export const SearchFilterModalFooter = ({
+  onApply,
+  onCancel,
+  onClear,
+}: SearchFilterModalFooterProps) => {
+  return (
+    <Flex direction={"row"} justify={"space-between"} align={"center"}>
+      <CloseAllFiltersButton
+        onClick={onClear}
+      >{t`Clear all filters`}</CloseAllFiltersButton>
+      <Group>
+        <Button onClick={onCancel}>{t`Cancel`}</Button>
+        <Button primary onClick={onApply}>{t`Apply all filters`}</Button>
+      </Group>
+    </Flex>
+  );
+};


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/27982
### Description

Adds to #32742 - Search Filter Integration Branch:

- **`SearchFilterModal`**:
	- Displays available filter options (currently, just the `TypeFilter` component), with a future ability to filter the keys based on whatever booleans we decide to put in the future (i.e. for Verified filter)
	- Contains the state for all filters for the search, which is initially populated from the URL when a user accesses a search page
- **`SearchFilterModalFooter`**
	- Breaks out the buttons of the modal into a different component where we can handle the styling and layout separately from the actual functionality of the filters within `SearchFilterModal`

These files will later be used in the `Search Filter for Types` Milestone (#32392). I've put these files in separate PRs to break up the technical feedback process and make sure that nothing gets missed in review or in the testing strategy.

### How to verify

For now, all tests should pass. For now, don't worry about UI/UX, since I've already confirmed the expected behavior with the PD/PM through prototypes, so we will convene in the final review process for this.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
