### PR TITLE
Add `SearchFunnelButton` and `SearchBar` to integration branch

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -311,7 +311,7 @@ describeEE("scenarios > embedding > full app", () => {
       // will force the cursor to move away from the app bar, if
       // the cursor is still on the app bar, the logo will not be
       // be visible, since we'll only see the side bar toggle button.
-      cy.findByRole("button", { name: /Filter/i }).realHover();
+      cy.findByTestId("question-filter-header").realHover();
 
       cy.findByTestId("main-logo").should("be.visible");
     });

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -66,7 +66,9 @@ describe("scenarios > question > notebook", () => {
     popover().within(() => {
       cy.contains("User ID").click();
     });
-    cy.icon("filter").click();
+    cy.findByTestId("step-summarize-0-0").within(() => {
+      cy.icon("filter").click();
+    });
     popover().within(() => {
       cy.icon("int").click();
       cy.get("input").type("46");

--- a/frontend/src/metabase/nav/components/DatabasePromptBanner/DatabasePromptBanner.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/DatabasePromptBanner/DatabasePromptBanner.unit.spec.tsx
@@ -5,10 +5,9 @@ import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import { createMockState } from "metabase-types/store/mocks";
 import {
   createMockDatabase,
-  createMockTokenFeatures,
+  createMockTokenStatus,
   createMockUser,
 } from "metabase-types/api/mocks";
-import type { TokenFeatures } from "metabase-types/api";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
 import { setupDatabasesEndpoints } from "__support__/server-mocks";
@@ -44,9 +43,7 @@ async function setup({
   const state = createMockState({
     currentUser: createMockUser({ is_superuser: isAdmin }),
     settings: mockSettings({
-      "token-features": createMockTokenFeatures(
-        isPaidPlan ? randomizePaidPlanFeatures() : {},
-      ),
+      "token-status": createMockTokenStatus({ valid: isPaidPlan }),
       "application-name": isWhiteLabeling ? "Acme Corp." : "Metabase",
     }),
   });
@@ -251,14 +248,3 @@ describe("DatabasePromptBanner", () => {
     });
   });
 });
-
-function randomizePaidPlanFeatures(): Partial<TokenFeatures> {
-  const features: Partial<TokenFeatures> = {};
-  if (Math.random() > 0.5) {
-    features.sso = true;
-  } else {
-    features.hosting = true;
-  }
-
-  return features;
-}

--- a/frontend/src/metabase/nav/components/DatabasePromptBanner/DatabasePromptBanner.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/DatabasePromptBanner/DatabasePromptBanner.unit.spec.tsx
@@ -5,9 +5,10 @@ import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import { createMockState } from "metabase-types/store/mocks";
 import {
   createMockDatabase,
-  createMockTokenStatus,
+  createMockTokenFeatures,
   createMockUser,
 } from "metabase-types/api/mocks";
+import type { TokenFeatures } from "metabase-types/api";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
 import { setupDatabasesEndpoints } from "__support__/server-mocks";
@@ -43,7 +44,9 @@ async function setup({
   const state = createMockState({
     currentUser: createMockUser({ is_superuser: isAdmin }),
     settings: mockSettings({
-      "token-status": createMockTokenStatus({ valid: isPaidPlan }),
+      "token-features": createMockTokenFeatures(
+        isPaidPlan ? randomizePaidPlanFeatures() : {},
+      ),
       "application-name": isWhiteLabeling ? "Acme Corp." : "Metabase",
     }),
   });
@@ -248,3 +251,14 @@ describe("DatabasePromptBanner", () => {
     });
   });
 });
+
+function randomizePaidPlanFeatures(): Partial<TokenFeatures> {
+  const features: Partial<TokenFeatures> = {};
+  if (Math.random() > 0.5) {
+    features.sso = true;
+  } else {
+    features.hosting = true;
+  }
+
+  return features;
+}

--- a/frontend/src/metabase/nav/components/SearchBar.styled.tsx
+++ b/frontend/src/metabase/nav/components/SearchBar.styled.tsx
@@ -11,6 +11,7 @@ import {
   breakpointMaxSmall,
   breakpointMinSmall,
 } from "metabase/styled-components/theme";
+import Button from "metabase/core/components/Button";
 
 const activeInputCSS = css`
   border-radius: 6px;
@@ -175,5 +176,15 @@ export const SearchResultsContainer = styled.div`
     border: 1px solid ${color("border")};
     border-radius: 6px;
     box-shadow: 0 7px 20px ${color("shadow")};
+  }
+`;
+
+export const SearchFunnelButton = styled(Button)<{ isFiltered?: boolean }>`
+  margin-right: 0.25rem;
+  border: none;
+
+  ${({ isFiltered }) => isFiltered && `color: ${color("brand")};`}
+  &:hover {
+    background: transparent;
   }
 `;

--- a/frontend/src/metabase/nav/components/SearchBar.tsx
+++ b/frontend/src/metabase/nav/components/SearchBar.tsx
@@ -21,6 +21,11 @@ import SearchResults from "metabase/nav/components/SearchResults";
 
 import { SearchAwareLocation } from "metabase/search/types";
 import {
+  getFiltersFromLocation,
+  getSearchTextFromLocation,
+  isSearchPageLocation,
+} from "metabase/search/utils";
+import {
   SearchInputContainer,
   SearchIcon,
   CloseSearchButton,
@@ -30,11 +35,6 @@ import {
   SearchBarRoot,
   SearchFunnelButton,
 } from "./SearchBar.styled";
-import {
-  getFiltersFromLocation,
-  getSearchTextFromLocation,
-  isSearchPageLocation,
-} from "metabase/search/utils";
 
 const ALLOWED_SEARCH_FOCUS_ELEMENTS = new Set(["BODY", "A"]);
 

--- a/frontend/src/metabase/nav/components/SearchBar.tsx
+++ b/frontend/src/metabase/nav/components/SearchBar.tsx
@@ -196,11 +196,8 @@ function SearchBarView({ location, onSearchActive, onSearchInactive }: Props) {
         />
         <SearchFunnelButton
           icon="filter"
-          data-testid={
-            isFiltered
-              ? "highlighted-search-bar-filter-button"
-              : "search-bar-filter-button"
-          }
+          data-is-filtered={isFiltered}
+          data-testid="search-bar-filter-button"
           isFiltered={isFiltered}
           onClick={e => {
             e.stopPropagation();

--- a/frontend/src/metabase/nav/components/SearchBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/SearchBar.unit.spec.tsx
@@ -1,0 +1,182 @@
+import { Route } from "react-router";
+import userEvent from "@testing-library/user-event";
+import { waitFor, renderWithProviders, screen, within } from "__support__/ui";
+import {
+  setupRecentViewsEndpoints,
+  setupSearchEndpoints,
+} from "__support__/server-mocks";
+import {
+  createMockCollectionItem,
+  createMockModelObject,
+  createMockRecentItem,
+} from "metabase-types/api/mocks";
+import {
+  createMockSettingsState,
+  createMockState,
+} from "metabase-types/store/mocks";
+import { CollectionItem, RecentItem } from "metabase-types/api";
+import SearchBar from "metabase/nav/components/SearchBar";
+
+const TEST_SEARCH_RESULTS: CollectionItem[] = [
+  "Card ABC",
+  "Card BCD",
+  "Card DEF",
+  "Card EFG",
+].map((name, index) =>
+  createMockCollectionItem({
+    name,
+    id: index + 1,
+    getUrl: () => "/",
+  }),
+);
+
+const TEST_RECENT_VIEWS_RESULTS: RecentItem[] = [
+  "Recents ABC",
+  "Recents BCD",
+  "Recents CDE",
+  "Recents DEF",
+].map((name, index) =>
+  createMockRecentItem({
+    model_object: createMockModelObject({ name }),
+    model_id: index,
+  }),
+);
+
+const setup = ({
+  initialRoute = "/",
+  searchResultItems = TEST_SEARCH_RESULTS,
+  recentViewsItems = TEST_RECENT_VIEWS_RESULTS,
+} = {}) => {
+  const state = createMockState({
+    settings: createMockSettingsState({
+      "search-typeahead-enabled": true,
+    }),
+  });
+
+  setupSearchEndpoints(searchResultItems);
+  setupRecentViewsEndpoints(recentViewsItems);
+
+  const { history } = renderWithProviders(
+    <Route path="*" component={SearchBar} />,
+    {
+      withRouter: true,
+      initialRoute,
+      storeInitialState: state,
+    },
+  );
+
+  return { history };
+};
+
+const getSearchBar = () => {
+  return screen.getByPlaceholderText("Search…");
+};
+
+describe("SearchBar", () => {
+  describe("typing a search query", () => {
+    it("should change URL when user types a query and hits `Enter`", async () => {
+      const { history } = setup();
+
+      userEvent.type(getSearchBar(), "BC{enter}");
+
+      const location = history?.getCurrentLocation();
+      expect(location?.pathname).toEqual("search");
+      expect(location?.search).toEqual("?q=BC");
+    });
+    it("should render 'No Results Found' when the query has no results", async () => {
+      setup({ searchResultItems: [] });
+      const searchBar = getSearchBar();
+      userEvent.click(searchBar);
+      userEvent.type(searchBar, "XXXXX");
+      await waitFor(() =>
+        expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument(),
+      );
+
+      expect(
+        within(screen.getByTestId("search-bar-results-container")).getByText(
+          "Didn't find anything",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+  describe("focusing on search bar", () => {
+    it("should render `Recent Searches` list when clicking the search bar", async () => {
+      setup();
+      getSearchBar().click();
+      expect(await screen.findByText("Recents ABC")).toBeInTheDocument();
+    });
+
+    it("should render `Nothing here` and a folder icon if there are no recently viewed items", async () => {
+      setup({ recentViewsItems: [] });
+      getSearchBar().click();
+      expect(await screen.findByText("Nothing here")).toBeInTheDocument();
+    });
+  });
+  describe("keyboard navigation", () => {
+    it("should focus on the filter bar when the user tabs from the search bar", () => {
+      setup();
+      getSearchBar().click();
+      userEvent.tab();
+      expect(screen.getByTestId("search-bar-filter-button")).toHaveFocus();
+    });
+    it("should allow navigation through the search results with the keyboard", async () => {
+      setup();
+      getSearchBar().click();
+      userEvent.type(getSearchBar(), "BC");
+
+      await waitFor(() =>
+        expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument(),
+      );
+
+      const resultItems = await screen.findAllByTestId("search-result-item");
+      expect(resultItems.length).toBe(2);
+
+      // tab over the filter button
+      userEvent.tab();
+
+      // There are two search results, each with a link to `Our analytics`,
+      // so we want to navigate to the search result, then the collection link.
+      for (const substring of ["Card ABC", "Card BCD"]) {
+        userEvent.tab();
+
+        const filteredElement = resultItems.find(element =>
+          element.textContent?.includes(substring),
+        );
+
+        expect(filteredElement).not.toBeUndefined();
+        expect(filteredElement).toHaveFocus();
+
+        userEvent.tab();
+
+        expect(
+          within(filteredElement as HTMLElement).getByText("Our analytics"),
+        ).toHaveFocus();
+      }
+    });
+  });
+  describe("populating existing query", () => {
+    it("should populate text and highlight filter button when a query is in the search bar", () => {
+      setup({
+        initialRoute: "/search?q=foo&type=card",
+      });
+
+      expect(getSearchBar()).toHaveValue("foo");
+
+      expect(
+        screen.getByTestId("highlighted-search-bar-filter-button"),
+      ).toBeInTheDocument();
+    });
+
+    it("should not populate text or highlight filter button on non-search pages", () => {
+      setup({
+        initialRoute: "/collection/root?q=foo&type=card&type=dashboard",
+      });
+
+      expect(getSearchBar()).toHaveValue("");
+
+      expect(
+        screen.getByTestId("search-bar-filter-button"),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/metabase/nav/components/SearchBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/SearchBar.unit.spec.tsx
@@ -16,12 +16,13 @@ import {
 } from "metabase-types/store/mocks";
 import { CollectionItem, RecentItem } from "metabase-types/api";
 import SearchBar from "metabase/nav/components/SearchBar";
+import { checkNotNull } from "metabase/core/utils/types";
 
 const TEST_SEARCH_RESULTS: CollectionItem[] = [
   "Card ABC",
   "Card BCD",
+  "Card CDE",
   "Card DEF",
-  "Card EFG",
 ].map((name, index) =>
   createMockCollectionItem({
     name,
@@ -38,7 +39,7 @@ const TEST_RECENT_VIEWS_RESULTS: RecentItem[] = [
 ].map((name, index) =>
   createMockRecentItem({
     model_object: createMockModelObject({ name }),
-    model_id: index,
+    model_id: index + 1,
   }),
 );
 
@@ -65,7 +66,7 @@ const setup = ({
     },
   );
 
-  return { history };
+  return { history: checkNotNull(history) };
 };
 
 const getSearchBar = () => {
@@ -79,54 +80,49 @@ describe("SearchBar", () => {
 
       userEvent.type(getSearchBar(), "BC{enter}");
 
-      const location = history?.getCurrentLocation();
-      expect(location?.pathname).toEqual("search");
-      expect(location?.search).toEqual("?q=BC");
+      const location = history.getCurrentLocation();
+      expect(location.pathname).toEqual("search");
+      expect(location.search).toEqual("?q=BC");
     });
+
     it("should render 'No Results Found' when the query has no results", async () => {
       setup({ searchResultItems: [] });
       const searchBar = getSearchBar();
-      userEvent.click(searchBar);
       userEvent.type(searchBar, "XXXXX");
       await waitFor(() =>
         expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument(),
       );
 
-      expect(
-        within(screen.getByTestId("search-bar-results-container")).getByText(
-          "Didn't find anything",
-        ),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Didn't find anything")).toBeInTheDocument();
     });
   });
+
   describe("focusing on search bar", () => {
     it("should render `Recent Searches` list when clicking the search bar", async () => {
       setup();
-      getSearchBar().click();
+      userEvent.click(getSearchBar());
       expect(await screen.findByText("Recents ABC")).toBeInTheDocument();
     });
 
     it("should render `Nothing here` and a folder icon if there are no recently viewed items", async () => {
       setup({ recentViewsItems: [] });
-      getSearchBar().click();
+      userEvent.click(getSearchBar());
       expect(await screen.findByText("Nothing here")).toBeInTheDocument();
     });
   });
+
   describe("keyboard navigation", () => {
     it("should focus on the filter bar when the user tabs from the search bar", () => {
       setup();
-      getSearchBar().click();
+      userEvent.click(getSearchBar());
       userEvent.tab();
       expect(screen.getByTestId("search-bar-filter-button")).toHaveFocus();
     });
+
     it("should allow navigation through the search results with the keyboard", async () => {
       setup();
-      getSearchBar().click();
+      userEvent.click(getSearchBar());
       userEvent.type(getSearchBar(), "BC");
-
-      await waitFor(() =>
-        expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument(),
-      );
 
       const resultItems = await screen.findAllByTestId("search-result-item");
       expect(resultItems.length).toBe(2);
@@ -136,11 +132,11 @@ describe("SearchBar", () => {
 
       // There are two search results, each with a link to `Our analytics`,
       // so we want to navigate to the search result, then the collection link.
-      for (const substring of ["Card ABC", "Card BCD"]) {
+      for (const cardName of ["Card ABC", "Card BCD"]) {
         userEvent.tab();
 
         const filteredElement = resultItems.find(element =>
-          element.textContent?.includes(substring),
+          element.textContent?.includes(cardName),
         );
 
         expect(filteredElement).not.toBeUndefined();
@@ -154,6 +150,7 @@ describe("SearchBar", () => {
       }
     });
   });
+
   describe("populating existing query", () => {
     it("should populate text and highlight filter button when a query is in the search bar", () => {
       setup({
@@ -162,9 +159,10 @@ describe("SearchBar", () => {
 
       expect(getSearchBar()).toHaveValue("foo");
 
-      expect(
-        screen.getByTestId("highlighted-search-bar-filter-button"),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("search-bar-filter-button")).toHaveAttribute(
+        "data-is-filtered",
+        "true",
+      );
     });
 
     it("should not populate text or highlight filter button on non-search pages", () => {
@@ -174,9 +172,10 @@ describe("SearchBar", () => {
 
       expect(getSearchBar()).toHaveValue("");
 
-      expect(
-        screen.getByTestId("search-bar-filter-button"),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("search-bar-filter-button")).toHaveAttribute(
+        "data-is-filtered",
+        "false",
+      );
     });
   });
 });

--- a/frontend/src/metabase/nav/components/SearchResults.jsx
+++ b/frontend/src/metabase/nav/components/SearchResults.jsx
@@ -82,11 +82,14 @@ export default _.compose(
     wrapped: true,
     reload: true,
     debounced: true,
-    query: (_state, props) => ({
-      q: props.searchText,
-      limit: DEFAULT_SEARCH_LIMIT,
-      ...props.searchFilters,
-      models: props.searchFilters.type,
-    }),
+    query: (_state, props) => {
+      const searchFilters = props.searchFilters || {};
+      return {
+        q: props.searchText,
+        limit: DEFAULT_SEARCH_LIMIT,
+        ...searchFilters,
+        models: searchFilters.type,
+      };
+    },
   }),
 )(SearchResults);

--- a/frontend/src/metabase/nav/components/SearchResults.jsx
+++ b/frontend/src/metabase/nav/components/SearchResults.jsx
@@ -18,6 +18,7 @@ const propTypes = {
   onEntitySelect: PropTypes.func,
   forceEntitySelect: PropTypes.bool,
   searchText: PropTypes.string,
+  searchFilters: PropTypes.object,
 };
 
 const SearchResults = ({
@@ -84,7 +85,8 @@ export default _.compose(
     query: (_state, props) => ({
       q: props.searchText,
       limit: DEFAULT_SEARCH_LIMIT,
-      models: props.models,
+      ...props.searchFilters,
+      models: props.searchFilters.type,
     }),
   }),
 )(SearchResults);

--- a/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
@@ -159,6 +159,7 @@ export function QuestionFilterWidget({ onOpenModal, className }) {
       onClick={() => onOpenModal(MODAL_TYPES.FILTERS)}
       aria-label={t`Show more filters`}
       data-metabase-event="View Mode; Open Filter Modal"
+      data-testid="question-filter-header"
     >
       {t`Filter`}
     </HeaderButton>


### PR DESCRIPTION
### Description

Adds changes to #32742 - Search Filter Integration Branch:

- **`SearchBar`**
	- Hydrates the search bar and search filters from the URL, and sends the search text and filters into the `/search` URL when the user presses `Enter`
	- Contains the `SearchFunnelButton` which opens the `SearchFilterModal`
	- Displays recently viewed items when there's nothing in the search bar, and shows search results (based on the filters, if any) when something is typed in

Overall, this code sets up a search bar component that listens to user input, displays search results, and handles search navigation based on user interactions. It relies on several React hooks and Redux functionalities for state management and router integration.

### How to verify

For now, all tests should pass. For now, don't worry about UI/UX, since I've already confirmed the expected behavior with the PD/PM through prototypes, so we will convene in the final review process for this.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
