### PR TITLE
Fix long running queries possibly piling up via auto-refresh

### DIFF
--- a/e2e/test/scenarios/dashboard/reproductions/12578-prevent-fetching-slow-cards-more-than-one-at-a-time-when-auto-refreshing.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/12578-prevent-fetching-slow-cards-more-than-one-at-a-time-when-auto-refreshing.cy.spec.js
@@ -1,0 +1,44 @@
+const { SAMPLE_DATABASE } = require("e2e/support/cypress_sample_database");
+const { restore, visitDashboard, popover } = require("e2e/support/helpers");
+
+const { ORDERS_ID } = SAMPLE_DATABASE;
+
+const ORDERS_QUESTION = {
+  name: "Orders question",
+  query: {
+    "source-table": ORDERS_ID,
+  },
+};
+
+describe("issue 12578", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should not fetch cards that are still loading when refreshing", () => {
+    console.log("clock");
+    cy.clock(Date.now());
+    cy.createQuestionAndDashboard({ questionDetails: ORDERS_QUESTION }).then(
+      ({ body: { dashboard_id } }) => {
+        visitDashboard(dashboard_id);
+      },
+    );
+
+    // Without tick the dashboard header will not load
+    cy.tick();
+    cy.findByLabelText("Auto Refresh").click();
+    popover().findByText("1 minute").click();
+
+    // Mock slow card request
+    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query", req => {
+      req.on("response", res => {
+        res.setDelay(99999);
+      });
+    }).as("dashcardQuery");
+    cy.tick(61 * 1000);
+    cy.tick(61 * 1000);
+
+    cy.get("@dashcardQuery.all").should("have.length", 1);
+  });
+});

--- a/frontend/src/metabase-types/store/dashboard.ts
+++ b/frontend/src/metabase-types/store/dashboard.ts
@@ -56,7 +56,6 @@ export interface DashboardState {
   parameterValues: Record<ParameterId, ParameterValueOrArray>;
 
   loadingDashCards: {
-    dashcardIds: DashCardId[];
     loadingIds: DashCardId[];
     loadingStatus: "idle" | "running" | "complete";
     startTime: number | null;

--- a/frontend/src/metabase-types/store/dashboard.ts
+++ b/frontend/src/metabase-types/store/dashboard.ts
@@ -56,6 +56,7 @@ export interface DashboardState {
   parameterValues: Record<ParameterId, ParameterValueOrArray>;
 
   loadingDashCards: {
+    dashboardId: number | null;
     loadingIds: DashCardId[];
     loadingStatus: "idle" | "running" | "complete";
     startTime: number | null;

--- a/frontend/src/metabase-types/store/dashboard.ts
+++ b/frontend/src/metabase-types/store/dashboard.ts
@@ -56,7 +56,6 @@ export interface DashboardState {
   parameterValues: Record<ParameterId, ParameterValueOrArray>;
 
   loadingDashCards: {
-    dashboardId: number | null;
     loadingIds: DashCardId[];
     loadingStatus: "idle" | "running" | "complete";
     startTime: number | null;

--- a/frontend/src/metabase-types/store/mocks/dashboard.ts
+++ b/frontend/src/metabase-types/store/mocks/dashboard.ts
@@ -9,7 +9,6 @@ export const createMockDashboardState = (
   dashcardData: {},
   parameterValues: {},
   loadingDashCards: {
-    dashcardIds: [],
     loadingIds: [],
     loadingStatus: "idle",
     startTime: null,

--- a/frontend/src/metabase/dashboard/actions/data-fetching.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.js
@@ -444,7 +444,7 @@ export const fetchDashboardCardData = options => (dispatch, getState) => {
 
   dispatch(setDocumentTitle(t`0/${promises.length} loaded`));
 
-  // XXX: There is a race condition here, when refreshing a dashboard before
+  // TODO: There is a race condition here, when refreshing a dashboard before
   // the previous API calls finished.
   Promise.all(promises).then(() => {
     dispatch(loadingComplete());

--- a/frontend/src/metabase/dashboard/actions/data-fetching.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.js
@@ -446,6 +446,7 @@ export const fetchDashboardCardData =
       payload: {
         currentTime: performance.now(),
         loadingIds: newLoadingIds,
+        dashboardId: dashboard.id,
       },
     });
 

--- a/frontend/src/metabase/dashboard/actions/data-fetching.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.js
@@ -419,7 +419,7 @@ export const fetchCardData = createThunkAction(
 );
 
 export const fetchDashboardCardData =
-  ({ skipOngoingDashcardRequests, ...options }) =>
+  ({ isRefreshing, ...options }) =>
   (dispatch, getState) => {
     const dashboard = getDashboardComplete(getState());
     const selectedTabId = getSelectedTabId(getState());
@@ -430,7 +430,7 @@ export const fetchDashboardCardData =
     )
       .filter(({ dashcard }) => !isVirtualDashCard(dashcard))
       .filter(({ dashcard }) => {
-        if (skipOngoingDashcardRequests) {
+        if (isRefreshing) {
           const loadingIds = getLoadingDashCards(getState()).loadingIds;
           return !loadingIds.includes(dashcard.id);
         }

--- a/frontend/src/metabase/dashboard/actions/data-fetching.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.js
@@ -419,7 +419,7 @@ export const fetchCardData = createThunkAction(
 );
 
 export const fetchDashboardCardData =
-  ({ isRefreshing, ...options }) =>
+  ({ isRefreshing, ...options } = {}) =>
   (dispatch, getState) => {
     const dashboard = getDashboardComplete(getState());
     const selectedTabId = getSelectedTabId(getState());

--- a/frontend/src/metabase/dashboard/actions/data-fetching.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.js
@@ -418,8 +418,6 @@ export const fetchCardData = createThunkAction(
   },
 );
 
-const fetchDashboardCardDataSync = createAction(FETCH_DASHBOARD_CARD_DATA);
-
 export const fetchDashboardCardData =
   ({ skipOngoingDashcardRequests, ...options }) =>
   (dispatch, getState) => {
@@ -443,12 +441,13 @@ export const fetchDashboardCardData =
     const newLoadingIds = nonVirtualDashcardsToFetch.map(({ dashcard }) => {
       return dashcard.id;
     });
-    dispatch(
-      fetchDashboardCardDataSync({
+    dispatch({
+      type: FETCH_DASHBOARD_CARD_DATA,
+      payload: {
         currentTime: performance.now(),
         loadingIds: newLoadingIds,
-      }),
-    );
+      },
+    });
 
     const promises = nonVirtualDashcardsToFetch.map(({ card, dashcard }) => {
       return dispatch(fetchCardData(card, dashcard, options)).then(() => {

--- a/frontend/src/metabase/dashboard/components/RefreshWidget.jsx
+++ b/frontend/src/metabase/dashboard/components/RefreshWidget.jsx
@@ -59,7 +59,10 @@ export default class RefreshWidget extends Component {
         triggerElement={
           elapsed == null ? (
             <Tooltip tooltip={t`Auto-refresh`}>
-              <DashboardHeaderButton icon="clock" />
+              <DashboardHeaderButton
+                icon="clock"
+                aria-label={t`Auto Refresh`}
+              />
             </Tooltip>
           ) : (
             <Tooltip
@@ -80,6 +83,7 @@ export default class RefreshWidget extends Component {
                     percent={Math.min(0.95, (period - elapsed) / period)}
                   />
                 }
+                aria-label={t`Auto Refresh`}
               />
             </Tooltip>
           )
@@ -117,7 +121,6 @@ const RefreshOption = ({ name, period, selected, onClick }) => (
     onClick={onClick}
   >
     <RefreshOptionIcon name="check" />
-    <span>{name.split(" ")[0]}</span>
-    <span>{name.split(" ")[1]}</span>
+    <span>{name}</span>
   </RefreshOptionItem>
 );

--- a/frontend/src/metabase/dashboard/constants.ts
+++ b/frontend/src/metabase/dashboard/constants.ts
@@ -19,7 +19,6 @@ export const INITIAL_DASHBOARD_STATE: DashboardState = {
   dashcardData: {},
   parameterValues: {},
   loadingDashCards: {
-    dashcardIds: [],
     loadingIds: [],
     loadingStatus: "idle" as const,
     startTime: null,

--- a/frontend/src/metabase/dashboard/constants.ts
+++ b/frontend/src/metabase/dashboard/constants.ts
@@ -19,7 +19,6 @@ export const INITIAL_DASHBOARD_STATE: DashboardState = {
   dashcardData: {},
   parameterValues: {},
   loadingDashCards: {
-    dashboardId: null,
     loadingIds: [],
     loadingStatus: "idle" as const,
     startTime: null,

--- a/frontend/src/metabase/dashboard/constants.ts
+++ b/frontend/src/metabase/dashboard/constants.ts
@@ -19,6 +19,7 @@ export const INITIAL_DASHBOARD_STATE: DashboardState = {
   dashcardData: {},
   parameterValues: {},
   loadingDashCards: {
+    dashboardId: null,
     loadingIds: [],
     loadingStatus: "idle" as const,
     startTime: null,

--- a/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
+++ b/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
@@ -174,6 +174,7 @@ export default ComposedComponent =>
             { preserveParameters: true },
           );
           this.props.fetchDashboardCardData({
+            skipOngoingDashcardRequests: true,
             reload: true,
             clearCache: false,
           });

--- a/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
+++ b/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
@@ -174,7 +174,7 @@ export default ComposedComponent =>
             { preserveParameters: true },
           );
           this.props.fetchDashboardCardData({
-            skipOngoingDashcardRequests: true,
+            isRefreshing: true,
             reload: true,
             clearCache: false,
           });

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -375,8 +375,6 @@ const loadingDashCards = handleActions(
         const newLoadingIds = state.loadingIds.concat(loadingIds);
         return {
           ...state,
-          // used for updating documents title. It's used for the number of total request loaded.
-          // dashcardIds: loadingIds,
           loadingIds: newLoadingIds,
           loadingStatus: newLoadingIds.length > 0 ? "running" : "idle",
           startTime: loadingIds.length > 0 ? currentTime : null,

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -378,7 +378,7 @@ const loadingDashCards = handleActions(
           ...state,
           // used for updating documents title. It's used for the number of total request loaded.
           // dashcardIds: loadingIds,
-          loadingIds,
+          loadingIds: state.loadingIds.concat(loadingIds),
           loadingStatus: loadingIds.length > 0 ? "running" : "idle",
           startTime: loadingIds.length > 0 ? currentTime : null,
         };

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -371,24 +371,37 @@ const loadingDashCards = handleActions(
       }),
     },
     [FETCH_DASHBOARD_CARD_DATA]: {
-      next: (state, { payload: { currentTime, loadingIds } }) => {
+      next: (state, { payload: { currentTime, loadingIds, dashboardId } }) => {
+        // Loading a new dahsboard e.g. when navigating to a new dashboard
+        if (dashboardId !== state.dashboardId) {
+          return {
+            ...state,
+            dashboardId,
+            loadingIds,
+            loadingStatus: loadingIds.length > 0 ? "running" : "idle",
+            startTime: loadingIds.length > 0 ? currentTime : null,
+          };
+        }
+
+        // When auto-refreshing we could load a different dashcard while other dashcards are still loading
         const newLoadingIds = state.loadingIds.concat(loadingIds);
-        const startFetching =
-          state.loadingIds.length === 0 && loadingIds.length > 0;
-        const hasNothingToFetch =
-          state.loadingIds.length === 0 && loadingIds.length === 0;
+
         let startTime;
-        if (startFetching) {
+        const notFinishLoadingDashcards = state.loadingIds.length > 0;
+        if (notFinishLoadingDashcards) {
+          startTime = state.startTime;
+        } else if (loadingIds.length > 0) {
           startTime = currentTime;
-        } else if (hasNothingToFetch) {
+        } else {
           startTime = null;
         }
 
         return {
           ...state,
+          dashboardId,
           loadingIds: newLoadingIds,
           loadingStatus: newLoadingIds.length > 0 ? "running" : "idle",
-          ...(startTime !== undefined ? { startTime } : {}),
+          startTime,
         };
       },
     },

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -373,11 +373,22 @@ const loadingDashCards = handleActions(
     [FETCH_DASHBOARD_CARD_DATA]: {
       next: (state, { payload: { currentTime, loadingIds } }) => {
         const newLoadingIds = state.loadingIds.concat(loadingIds);
+        const startFetching =
+          state.loadingIds.length === 0 && loadingIds.length > 0;
+        const hasNothingToFetch =
+          state.loadingIds.length === 0 && loadingIds.length === 0;
+        let startTime;
+        if (startFetching) {
+          startTime = currentTime;
+        } else if (hasNothingToFetch) {
+          startTime = null;
+        }
+
         return {
           ...state,
           loadingIds: newLoadingIds,
           loadingStatus: newLoadingIds.length > 0 ? "running" : "idle",
-          startTime: loadingIds.length > 0 ? currentTime : null,
+          ...(startTime !== undefined ? { startTime } : {}),
         };
       },
     },

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -43,7 +43,6 @@ import {
   UNDO_REMOVE_CARD_FROM_DASH,
   SHOW_AUTO_APPLY_FILTERS_TOAST,
   tabsReducer,
-  SET_LOADING_DASHCARDS_COMPLETE,
 } from "./actions";
 import { syncParametersAndEmbeddingParams } from "./utils";
 import { INITIAL_DASHBOARD_STATE } from "./constants";
@@ -373,11 +372,12 @@ const loadingDashCards = handleActions(
     },
     [FETCH_DASHBOARD_CARD_DATA]: {
       next: (state, { payload: { currentTime, dashcardIds } }) => {
-        const loadingIds = Array.isArray(dashcardIds) ? dashcardIds : [];
+        const loadingIds = dashcardIds;
 
         return {
           ...state,
-          dashcardIds: loadingIds,
+          // used for updating documents title. It's used for the number of total request loaded.
+          // dashcardIds: loadingIds,
           loadingIds,
           loadingStatus: loadingIds.length > 0 ? "running" : "idle",
           startTime: loadingIds.length > 0 ? currentTime : null,
@@ -406,15 +406,7 @@ const loadingDashCards = handleActions(
         };
       },
     },
-    [SET_LOADING_DASHCARDS_COMPLETE]: {
-      next: state => {
-        return {
-          ...state,
-          loadingIds: [],
-          loadingStatus: "complete",
-        };
-      },
-    },
+
     [RESET]: {
       next: state => ({
         ...state,

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -371,37 +371,12 @@ const loadingDashCards = handleActions(
       }),
     },
     [FETCH_DASHBOARD_CARD_DATA]: {
-      next: (state, { payload: { currentTime, loadingIds, dashboardId } }) => {
-        // Loading a new dahsboard e.g. when navigating to a new dashboard
-        if (dashboardId !== state.dashboardId) {
-          return {
-            ...state,
-            dashboardId,
-            loadingIds,
-            loadingStatus: loadingIds.length > 0 ? "running" : "idle",
-            startTime: loadingIds.length > 0 ? currentTime : null,
-          };
-        }
-
-        // When auto-refreshing we could load a different dashcard while other dashcards are still loading
-        const newLoadingIds = state.loadingIds.concat(loadingIds);
-
-        let startTime;
-        const notFinishLoadingDashcards = state.loadingIds.length > 0;
-        if (notFinishLoadingDashcards) {
-          startTime = state.startTime;
-        } else if (loadingIds.length > 0) {
-          startTime = currentTime;
-        } else {
-          startTime = null;
-        }
-
+      next: (state, { payload: { currentTime, loadingIds } }) => {
         return {
           ...state,
-          dashboardId,
-          loadingIds: newLoadingIds,
-          loadingStatus: newLoadingIds.length > 0 ? "running" : "idle",
-          startTime,
+          loadingIds,
+          loadingStatus: loadingIds.length > 0 ? "running" : "idle",
+          startTime: loadingIds.length > 0 ? currentTime : null,
         };
       },
     },

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -371,15 +371,14 @@ const loadingDashCards = handleActions(
       }),
     },
     [FETCH_DASHBOARD_CARD_DATA]: {
-      next: (state, { payload: { currentTime, dashcardIds } }) => {
-        const loadingIds = dashcardIds;
-
+      next: (state, { payload: { currentTime, loadingIds } }) => {
+        const newLoadingIds = state.loadingIds.concat(loadingIds);
         return {
           ...state,
           // used for updating documents title. It's used for the number of total request loaded.
           // dashcardIds: loadingIds,
-          loadingIds: state.loadingIds.concat(loadingIds),
-          loadingStatus: loadingIds.length > 0 ? "running" : "idle",
+          loadingIds: newLoadingIds,
+          loadingStatus: newLoadingIds.length > 0 ? "running" : "idle",
           startTime: loadingIds.length > 0 ? currentTime : null,
         };
       },
@@ -406,7 +405,6 @@ const loadingDashCards = handleActions(
         };
       },
     },
-
     [RESET]: {
       next: state => ({
         ...state,

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.js
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.js
@@ -27,7 +27,6 @@ describe("dashboard reducers", () => {
       isNavigatingBackToDashboard: false,
       isEditing: null,
       loadingDashCards: {
-        dashcardIds: [],
         loadingIds: [],
         startTime: null,
         endTime: null,
@@ -234,7 +233,6 @@ describe("dashboard reducers", () => {
     it("should change to running when loading cards", () => {
       const dashcardIds = [1, 2, 3];
       const loadingMatch = {
-        dashcardIds: dashcardIds,
         loadingIds: dashcardIds,
         loadingStatus: "running",
         startTime: expect.any(Number),
@@ -245,13 +243,12 @@ describe("dashboard reducers", () => {
           {
             ...initState,
             loadingDashCards: {
-              dashcardIds: dashcardIds,
               loadingIds: dashcardIds,
             },
           },
           {
             type: FETCH_DASHBOARD_CARD_DATA,
-            payload: { currentTime: 100, dashcardIds },
+            payload: { currentTime: 100 },
           },
         ),
       ).toMatchObject({
@@ -269,7 +266,6 @@ describe("dashboard reducers", () => {
       ).toEqual({
         ...initState,
         loadingDashCards: {
-          dashcardIds: [],
           loadingIds: [],
           loadingStatus: "idle",
           startTime: null,
@@ -284,7 +280,6 @@ describe("dashboard reducers", () => {
           {
             ...initState,
             loadingDashCards: {
-              dashcardIds: [1, 2, 3],
               loadingIds: [3],
               loadingStatus: "running",
               startTime: 100,
@@ -303,7 +298,6 @@ describe("dashboard reducers", () => {
       ).toEqual({
         ...initState,
         loadingDashCards: {
-          dashcardIds: [1, 2, 3],
           loadingIds: [],
           loadingStatus: "complete",
           startTime: 100,

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.js
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.js
@@ -248,7 +248,7 @@ describe("dashboard reducers", () => {
           },
           {
             type: FETCH_DASHBOARD_CARD_DATA,
-            payload: { currentTime: 100 },
+            payload: { currentTime: 100, loadingIds: dashcardIds },
           },
         ),
       ).toMatchObject({
@@ -261,7 +261,7 @@ describe("dashboard reducers", () => {
       expect(
         reducer(initState, {
           type: FETCH_DASHBOARD_CARD_DATA,
-          payload: {},
+          payload: { currentTime: 100, loadingIds: [] },
         }),
       ).toEqual({
         ...initState,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/12578

### Description

Avoid fetching new dashcard when the current dashcard request is still on going

### How to verify

For now follow the repro steps in https://github.com/metabase/metabase/issues/12578


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
