### PR TITLE
Bump google-cloud-bigquery to fix trivy alert

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -3,6 +3,6 @@
 
  :deps
  ;; TODO: figure out how to be able to leave off this version string and use the version from the BOM
- {com.google.cloud/google-cloud-bigquery      {:mvn/version "2.23.2"}
+ {com.google.cloud/google-cloud-bigquery      {:mvn/version "2.31.0"}
   com.google.code.gson/gson                   {:mvn/version "2.10.1"}
   com.google.oauth-client/google-oauth-client {:mvn/version "1.34.1"}}}


### PR DESCRIPTION
Updated version uses patched version of guava to resolve https://github.com/metabase/metabase/security/code-scanning/107