### PR TITLE
Bump org.apache.sshd/sshd-core to fix security alert

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -111,7 +111,7 @@
   org.apache.poi/poi-ooxml                  {:mvn/version "5.2.3"
                                              :exclusions  [org.bouncycastle/bcpkix-jdk15on
                                                            org.bouncycastle/bcprov-jdk15on]}
-  org.apache.sshd/sshd-core                 {:mvn/version "2.9.2"}              ; ssh tunneling and test server
+  org.apache.sshd/sshd-core                 {:mvn/version "2.10.0"}             ; ssh tunneling and test server
   org.apache.xmlgraphics/batik-all          {:mvn/version "1.16"}               ; SVG -> image
   org.clojars.pntblnk/clj-ldap              {:mvn/version "0.0.17"}             ; LDAP client
   org.bouncycastle/bcpkix-jdk15on           {:mvn/version "1.70"}               ; Bouncy Castle crypto library -- explicit version of BC specified to resolve illegal reflective access errors


### PR DESCRIPTION
This is a conservative change that leaves the inclusion of version `1.7.32` of `org.slf4j/jcl-over-slf4j` unmodified.

I'm not sure `jcl-over-slf4j` is really used. If it is, it should be at the same version as `org.slf4j/slf4j-api` (`2.0.6` at the moment). What is happening now is not good, but this is how things have been for a while now.

I've opened #32766 too to see what happens if we exclude the `org.slf4j/jcl-over-slf4j` dependency.