### PR TITLE
Creating a collection when saving a question/dashboard should return to the question/dashboard save modal with the new collection selected

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -771,6 +771,9 @@ describe("scenarios > dashboard", () => {
     modal().within(() => {
       cy.findByLabelText("Name").type(NEW_COLLECTION);
       cy.findByText("Create").click();
+      cy.findByText("New dashboard");
+      cy.findByTestId("select-button").should("have.text", NEW_COLLECTION);
+      cy.findByText("Create").click();
     });
     saveDashboard();
     closeNavigationSidebar();

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -301,6 +301,9 @@ describe("scenarios > question > new", () => {
     modal().within(() => {
       cy.findByLabelText("Name").type(NEW_COLLECTION);
       cy.findByText("Create").click();
+      cy.findByText("Save new question");
+      cy.findByTestId("select-button").should("have.text", NEW_COLLECTION);
+      cy.findByText("Save").click();
     });
     cy.get("header").findByText(NEW_COLLECTION);
   });

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.styled.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.styled.tsx
@@ -1,7 +1,6 @@
 import styled from "@emotion/styled";
 
 import ItemPicker from "metabase/containers/ItemPicker";
-import Button from "metabase/core/components/Button";
 
 export const MIN_POPOVER_WIDTH = 300;
 
@@ -9,8 +8,4 @@ export const PopoverItemPicker = styled(ItemPicker)<{ width: number }>`
   width: ${({ width = MIN_POPOVER_WIDTH }) => width}px;
   padding: 1rem;
   overflow: auto;
-`;
-
-export const NewButton = styled(Button)`
-  margin-top: 0.5rem;
 `;

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.styled.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.styled.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 
 import ItemPicker from "metabase/containers/ItemPicker";
-import Button from "metabase/core/components/Button/Button";
+import Button from "metabase/core/components/Button";
 
 export const MIN_POPOVER_WIDTH = 300;
 

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.styled.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.styled.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 
 import ItemPicker from "metabase/containers/ItemPicker";
+import Button from "metabase/core/components/Button/Button";
 
 export const MIN_POPOVER_WIDTH = 300;
 
@@ -8,4 +9,7 @@ export const PopoverItemPicker = styled(ItemPicker)<{ width: number }>`
   width: ${({ width = MIN_POPOVER_WIDTH }) => width}px;
   padding: 1rem;
   overflow: auto;
+`;
+export const NewCollectionButton = styled(Button)`
+  margin-top: 0.5rem;
 `;

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -38,6 +38,7 @@ export interface FormCollectionPickerProps
   title?: string;
   placeholder?: string;
   type?: "collections" | "snippet-collections";
+  canCreateNew?: boolean;
   initialOpenCollectionId?: CollectionId;
   onOpenCollectionChange?: (collectionId: CollectionId) => void;
 }
@@ -79,6 +80,7 @@ function FormCollectionPicker({
   title,
   placeholder = t`Select a collection`,
   type = "collections",
+  canCreateNew = false,
   initialOpenCollectionId,
   onOpenCollectionChange,
   children,
@@ -125,7 +127,7 @@ function FormCollectionPicker({
 
       const entity = type === "collections" ? Collections : SnippetCollections;
 
-      // TODO: if CreateCollectionOnTheGoModal context is available
+      // TODO: if canCreateNew
       //    add onOpenCollectionChange to send to context state
       //    replace `children` below with CreateCollectionOnTheGoButton
       return (

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -102,7 +102,7 @@ function FormCollectionPicker({
     [id, value, type, title, placeholder, error, touched, className, style],
   );
 
-  const formik = useFormikContext();
+  const { values } = useFormikContext();
   const [openCollectionId, setOpenCollectionId] = useState<
     CollectionId | undefined
   >(undefined);
@@ -136,7 +136,7 @@ function FormCollectionPicker({
         >
           {canCreateNew && (
             <CreateCollectionOnTheGoButton
-              resumedValues={formik.values}
+              resumedValues={values}
               openCollectionId={openCollectionId}
             />
           )}
@@ -150,7 +150,7 @@ function FormCollectionPicker({
       setValue,
       initialOpenCollectionId,
       openCollectionId,
-      formik.values,
+      values,
       onOpenCollectionChange,
       canCreateNew,
       CreateCollectionOnTheGoButton,

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -16,7 +16,10 @@ import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/Tipp
 
 import CollectionName from "metabase/containers/CollectionName";
 import SnippetCollectionName from "metabase/containers/SnippetCollectionName";
-import type { OnClickNewCollection } from "metabase/containers/CreateCollectionOnTheGo";
+import type {
+  OnClickNewCollection,
+  Values,
+} from "metabase/containers/CreateCollectionOnTheGo";
 
 import Collections from "metabase/entities/collections";
 import SnippetCollections from "metabase/entities/snippet-collections";
@@ -104,7 +107,7 @@ function FormCollectionPicker({
     [id, value, type, title, placeholder, error, touched, className, style],
   );
 
-  const { values } = useFormikContext();
+  const { values } = useFormikContext<Values>();
   const [openCollectionId, setOpenCollectionId] =
     useState<CollectionId>("root");
 

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -26,12 +26,9 @@ import { isValidCollectionId } from "metabase/collections/utils";
 
 import type { CollectionId } from "metabase-types/api";
 
-import { ButtonProps } from "metabase/core/components/Button";
-import Tooltip from "metabase/core/components/Tooltip";
 import {
   PopoverItemPicker,
   MIN_POPOVER_WIDTH,
-  NewButton,
 } from "./FormCollectionPicker.styled";
 
 export interface FormCollectionPickerProps
@@ -58,22 +55,6 @@ function ItemName({
     <CollectionName id={id} />
   );
 }
-
-export const NewCollectionButton = (props: ButtonProps) => {
-  const button = (
-    <NewButton light icon="add" {...props}>
-      {t`New collection`}
-    </NewButton>
-  );
-  // button has to be wrapped in a span when disabled or the tooltip doesn’t show
-  return props.disabled === true ? (
-    <Tooltip tooltip={t`You must first fix the required fields above.`}>
-      <span>{button}</span>
-    </Tooltip>
-  ) : (
-    button
-  );
-};
 
 function FormCollectionPicker({
   className,

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -121,10 +121,10 @@ function FormCollectionPicker({
     [id, value, type, title, placeholder, error, touched, className, style],
   );
 
-  const [openCollectionId, setOpenCollectionId] = useState<CollectionId | null>(
-    null,
-  );
   const formik = useFormikContext();
+  const [openCollectionId, setOpenCollectionId] = useState<
+    CollectionId | undefined
+  >(undefined);
   const CreateCollectionOnTheGoButton = useContext(
     CreateCollectionOnTheGoButtonContext,
   );
@@ -155,8 +155,8 @@ function FormCollectionPicker({
         >
           {canCreateNew && (
             <CreateCollectionOnTheGoButton
-              openCollectionId={openCollectionId}
               resumedValues={formik.values}
+              openCollectionId={openCollectionId}
             />
           )}
         </PopoverItemPicker>
@@ -168,7 +168,11 @@ function FormCollectionPicker({
       width,
       setValue,
       initialOpenCollectionId,
+      openCollectionId,
+      formik.values,
       onOpenCollectionChange,
+      canCreateNew,
+      CreateCollectionOnTheGoButton,
     ],
   );
 

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -125,6 +125,9 @@ function FormCollectionPicker({
 
       const entity = type === "collections" ? Collections : SnippetCollections;
 
+      // TODO: if CreateCollectionOnTheGoModal context is available
+      //    add onOpenCollectionChange to send to context state
+      //    replace `children` below with CreateCollectionOnTheGoButton
       return (
         <PopoverItemPicker
           value={{ id: value, model: "collection" }}

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -128,7 +128,6 @@ function FormCollectionPicker({
       const entity = type === "collections" ? Collections : SnippetCollections;
 
       // TODO: if canCreateNew
-      //    add onOpenCollectionChange to send to context state
       //    replace `children` below with CreateCollectionOnTheGoButton
       return (
         <PopoverItemPicker

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -4,7 +4,6 @@ import {
   useState,
   useRef,
   HTMLAttributes,
-  useContext,
 } from "react";
 import { t } from "ttag";
 import { useField, useFormikContext } from "formik";
@@ -17,7 +16,7 @@ import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/Tipp
 
 import CollectionName from "metabase/containers/CollectionName";
 import SnippetCollectionName from "metabase/containers/SnippetCollectionName";
-import { CreateCollectionOnTheGoButtonContext } from "metabase/containers/CreateCollectionOnTheGo";
+import type { OnClickNewCollection } from "metabase/containers/CreateCollectionOnTheGo";
 
 import Collections from "metabase/entities/collections";
 import SnippetCollections from "metabase/entities/snippet-collections";
@@ -29,6 +28,7 @@ import type { CollectionId } from "metabase-types/api";
 import {
   PopoverItemPicker,
   MIN_POPOVER_WIDTH,
+  NewCollectionButton,
 } from "./FormCollectionPicker.styled";
 
 export interface FormCollectionPickerProps
@@ -40,6 +40,7 @@ export interface FormCollectionPickerProps
   canCreateNew?: boolean;
   initialOpenCollectionId?: CollectionId;
   onOpenCollectionChange?: (collectionId: CollectionId) => void;
+  onClickNewCollection?: OnClickNewCollection;
 }
 
 function ItemName({
@@ -66,6 +67,7 @@ function FormCollectionPicker({
   canCreateNew = false,
   initialOpenCollectionId,
   onOpenCollectionChange,
+  onClickNewCollection,
 }: FormCollectionPickerProps) {
   const id = useUniqueId();
   const [{ value }, { error, touched }, { setValue }] = useField(name);
@@ -103,12 +105,8 @@ function FormCollectionPicker({
   );
 
   const { values } = useFormikContext();
-  const [openCollectionId, setOpenCollectionId] = useState<
-    CollectionId | undefined
-  >(undefined);
-  const CreateCollectionOnTheGoButton = useContext(
-    CreateCollectionOnTheGoButtonContext,
-  );
+  const [openCollectionId, setOpenCollectionId] =
+    useState<CollectionId>("root");
 
   const renderContent = useCallback(
     ({ closePopover }) => {
@@ -135,10 +133,13 @@ function FormCollectionPicker({
           }}
         >
           {canCreateNew && (
-            <CreateCollectionOnTheGoButton
-              resumedValues={values}
-              openCollectionId={openCollectionId}
-            />
+            <NewCollectionButton
+              light
+              icon="add"
+              onClick={() => onClickNewCollection?.(values, openCollectionId)}
+            >
+              {t`New collection`}
+            </NewCollectionButton>
           )}
         </PopoverItemPicker>
       );
@@ -153,7 +154,7 @@ function FormCollectionPicker({
       values,
       onOpenCollectionChange,
       canCreateNew,
-      CreateCollectionOnTheGoButton,
+      onClickNewCollection,
     ],
   );
 

--- a/frontend/src/metabase/containers/CreateCollectionOnTheGo.styled.tsx
+++ b/frontend/src/metabase/containers/CreateCollectionOnTheGo.styled.tsx
@@ -1,0 +1,6 @@
+import styled from "@emotion/styled";
+import Button from "metabase/core/components/Button/Button";
+
+export const NewCollectionButton = styled(Button)`
+  margin-top: 0.5rem;
+`;

--- a/frontend/src/metabase/containers/CreateCollectionOnTheGo.styled.tsx
+++ b/frontend/src/metabase/containers/CreateCollectionOnTheGo.styled.tsx
@@ -1,6 +1,0 @@
-import styled from "@emotion/styled";
-import Button from "metabase/core/components/Button/Button";
-
-export const NewCollectionButton = styled(Button)`
-  margin-top: 0.5rem;
-`;

--- a/frontend/src/metabase/containers/CreateCollectionOnTheGo.tsx
+++ b/frontend/src/metabase/containers/CreateCollectionOnTheGo.tsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import { useFormikContext } from "formik";
+import { Collection, CollectionId } from "metabase-types/api";
+import CreateCollectionModal from "metabase/collections/containers/CreateCollectionModal";
+import { NewCollectionButton } from "metabase/collections/containers/FormCollectionPicker/FormCollectionPicker";
+
+export function CreateCollectionOnTheGoModal(props) {
+  const [enabled, setEnabled] = useState(false);
+  const [resumedValues, setResumedValues] = useState(null);
+
+  // TODO: use in FormCollectionPicker via context
+  const [openCollectionId, setOpenCollectionId] = useState<CollectionId>();
+
+  // TODO: use in CreateCollectionOnTheGoButton via context
+  const openNewCollModal = _resumedValues => {
+    setResumedValues(_resumedValues);
+    setEnabled(true);
+  };
+
+  if (enabled) {
+    return (
+      <CreateCollectionModal
+        collectionId={openCollectionId}
+        onClose={() => setEnabled(false)}
+        onCreate={(collection: Collection) => {
+          setResumedValues({
+            ...resumedValues,
+            collection_id: collection.id,
+          });
+          setEnabled(false);
+        }}
+      />
+    );
+  }
+
+  // TODO: ensure that this props.children[0] is a function
+  return props.children[0](resumedValues);
+}
+
+export function CreateCollectionOnTheGoButton(props) {
+  // TODO: use context to get CreateCollectionOnTheGoModal’s openNewCollModal function
+  const { values } = useFormikContext();
+  return <NewCollectionButton onClick={() => openNewCollModal(values)} />;
+}

--- a/frontend/src/metabase/containers/CreateCollectionOnTheGo.tsx
+++ b/frontend/src/metabase/containers/CreateCollectionOnTheGo.tsx
@@ -1,7 +1,8 @@
 import { useState, createContext, useCallback, ReactElement } from "react";
+import { t } from "ttag";
 import { Collection, CollectionId } from "metabase-types/api";
 import CreateCollectionModal from "metabase/collections/containers/CreateCollectionModal";
-import { NewCollectionButton } from "metabase/collections/containers/FormCollectionPicker/FormCollectionPicker";
+import { NewCollectionButton } from "./CreateCollectionOnTheGo.styled";
 
 interface State {
   enabled: boolean;
@@ -30,11 +31,15 @@ export function CreateCollectionOnTheGo({ children }: Props) {
   });
   const { enabled, openCollectionId, resumedValues } = state;
 
-  const EnablingButton = useCallback(
+  const CreateCollectionOnTheGoButton = useCallback(
     (buttonProps: ButtonProps) => (
       <NewCollectionButton
+        light
+        icon="add"
         onClick={() => setState({ ...state, ...buttonProps, enabled: true })}
-      />
+      >
+        {t`New collection`}
+      </NewCollectionButton>
     ),
     [state, setState],
   );
@@ -52,7 +57,9 @@ export function CreateCollectionOnTheGo({ children }: Props) {
       }}
     />
   ) : (
-    <CreateCollectionOnTheGoButtonContext.Provider value={EnablingButton}>
+    <CreateCollectionOnTheGoButtonContext.Provider
+      value={CreateCollectionOnTheGoButton}
+    >
       {children(resumedValues)}
     </CreateCollectionOnTheGoButtonContext.Provider>
   );

--- a/frontend/src/metabase/containers/CreateCollectionOnTheGo.tsx
+++ b/frontend/src/metabase/containers/CreateCollectionOnTheGo.tsx
@@ -1,19 +1,21 @@
-import { useState } from "react";
+import { useState, createContext, useContext, Children } from "react";
 import { useFormikContext } from "formik";
 import { Collection, CollectionId } from "metabase-types/api";
 import CreateCollectionModal from "metabase/collections/containers/CreateCollectionModal";
 import { NewCollectionButton } from "metabase/collections/containers/FormCollectionPicker/FormCollectionPicker";
 
-export function CreateCollectionOnTheGoModal(props) {
-  const [enabled, setEnabled] = useState(false);
-  const [resumedValues, setResumedValues] = useState(null);
+const CreateCollectionContext = createContext<any>({
+  openModal: null,
+});
 
-  // TODO: use in FormCollectionPicker via context
+export function CreateCollectionOnTheGo(props: any) {
+  const [enabled, setEnabled] = useState(false);
+  const [resumedValues, setResumedValues] = useState<any>(null);
   const [openCollectionId, setOpenCollectionId] = useState<CollectionId>();
 
-  // TODO: use in CreateCollectionOnTheGoButton via context
-  const openNewCollModal = _resumedValues => {
+  const openModal = (_resumedValues: any, _openCollectionId) => {
     setResumedValues(_resumedValues);
+    setOpenCollectionId(_openCollectionId);
     setEnabled(true);
   };
 
@@ -33,12 +35,18 @@ export function CreateCollectionOnTheGoModal(props) {
     );
   }
 
-  // TODO: ensure that this props.children[0] is a function
-  return props.children[0](resumedValues);
+  const child = Children.only(props.children);
+  const context = { setOpenCollectionId, openModal };
+  return (
+    <CreateCollectionContext.Provider value={context}>
+      {child(resumedValues)}
+    </CreateCollectionContext.Provider>
+  );
 }
 
-export function CreateCollectionOnTheGoButton(props) {
-  // TODO: use context to get CreateCollectionOnTheGoModal’s openNewCollModal function
+export function CreateCollectionOnTheGoButton(props: any) {
+  const { openModal } = useContext(CreateCollectionContext);
   const { values } = useFormikContext();
-  return <NewCollectionButton onClick={() => openNewCollModal(values)} />;
+  // TODO: figure out how to have FormCollectionPicker and CollectionPicker share current open collection, probably with prop
+  return <NewCollectionButton onClick={() => openModal(values)} />;
 }

--- a/frontend/src/metabase/containers/CreateCollectionOnTheGo.tsx
+++ b/frontend/src/metabase/containers/CreateCollectionOnTheGo.tsx
@@ -1,8 +1,6 @@
-import { useState, createContext, useCallback, ReactElement } from "react";
-import { t } from "ttag";
+import { useState, useCallback, ReactElement } from "react";
 import { Collection, CollectionId } from "metabase-types/api";
 import CreateCollectionModal from "metabase/collections/containers/CreateCollectionModal";
-import { NewCollectionButton } from "./CreateCollectionOnTheGo.styled";
 
 interface State {
   enabled: boolean;
@@ -10,19 +8,17 @@ interface State {
   openCollectionId?: CollectionId;
 }
 
+export type OnClickNewCollection = (
+  resumedValues: any,
+  openCollectionId: CollectionId,
+) => void;
+
 interface Props {
-  children: (resumedValues: any) => ReactElement;
+  children: (
+    resumedValues: any,
+    onClickNewCollection: OnClickNewCollection,
+  ) => ReactElement;
 }
-
-interface ButtonProps {
-  resumedValues: any;
-  openCollectionId?: CollectionId;
-}
-
-type ButtonType = (buttonProps: ButtonProps) => ReactElement;
-export const CreateCollectionOnTheGoButtonContext = createContext<ButtonType>(
-  (buttonProps: ButtonProps) => <div />,
-);
 
 export function CreateCollectionOnTheGo({ children }: Props) {
   const [state, setState] = useState<State>({
@@ -31,16 +27,9 @@ export function CreateCollectionOnTheGo({ children }: Props) {
   });
   const { enabled, openCollectionId, resumedValues } = state;
 
-  const CreateCollectionOnTheGoButton = useCallback(
-    (buttonProps: ButtonProps) => (
-      <NewCollectionButton
-        light
-        icon="add"
-        onClick={() => setState({ ...state, ...buttonProps, enabled: true })}
-      >
-        {t`New collection`}
-      </NewCollectionButton>
-    ),
+  const onClickNewCollection = useCallback<OnClickNewCollection>(
+    (resumedValues: any, openCollectionId: CollectionId) =>
+      setState({ ...state, enabled: true, resumedValues, openCollectionId }),
     [state, setState],
   );
 
@@ -57,10 +46,6 @@ export function CreateCollectionOnTheGo({ children }: Props) {
       }}
     />
   ) : (
-    <CreateCollectionOnTheGoButtonContext.Provider
-      value={CreateCollectionOnTheGoButton}
-    >
-      {children(resumedValues)}
-    </CreateCollectionOnTheGoButtonContext.Provider>
+    children(resumedValues, onClickNewCollection)
   );
 }

--- a/frontend/src/metabase/containers/CreateCollectionOnTheGo.tsx
+++ b/frontend/src/metabase/containers/CreateCollectionOnTheGo.tsx
@@ -1,34 +1,40 @@
 import { useState, useCallback, ReactElement } from "react";
+import type { FormikValues } from "formik";
 import { Collection, CollectionId } from "metabase-types/api";
 import CreateCollectionModal from "metabase/collections/containers/CreateCollectionModal";
 
+export interface Values extends FormikValues {
+  collection_id: CollectionId;
+}
+
 interface State {
   enabled: boolean;
-  resumedValues: any;
+  resumedValues?: Values;
   openCollectionId?: CollectionId;
 }
 
 export type OnClickNewCollection = (
-  resumedValues: any,
+  resumedValues: Values,
   openCollectionId: CollectionId,
 ) => void;
 
-interface Props {
-  children: (
-    resumedValues: any,
-    onClickNewCollection: OnClickNewCollection,
-  ) => ReactElement;
-}
+type RenderChildFn = (
+  resumedValues: Values | undefined,
+  onClickNewCollection: OnClickNewCollection,
+) => ReactElement;
 
-export function CreateCollectionOnTheGo({ children }: Props) {
+export function CreateCollectionOnTheGo({
+  children,
+}: {
+  children: RenderChildFn;
+}) {
   const [state, setState] = useState<State>({
     enabled: false,
-    resumedValues: {},
   });
   const { enabled, openCollectionId, resumedValues } = state;
 
   const onClickNewCollection = useCallback<OnClickNewCollection>(
-    (resumedValues: any, openCollectionId: CollectionId) =>
+    (resumedValues, openCollectionId) =>
       setState({ ...state, enabled: true, resumedValues, openCollectionId }),
     [state, setState],
   );

--- a/frontend/src/metabase/containers/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.tsx
@@ -181,7 +181,8 @@ export const SaveQuestionModal = ({
         collectionId={openCollectionId}
         onClose={() => setCreatingNewCollection(false)}
         onCreate={(collection: Collection) => {
-          handleSubmit({ ...stagedValues, collection_id: collection.id });
+          setCreatingNewCollection(false);
+          setStagedValues({ ...stagedValues, collection_id: collection.id });
         }}
       />
     );
@@ -238,7 +239,6 @@ export const SaveQuestionModal = ({
                       title={t`Which collection should this go in?`}
                     >
                       <NewCollectionButton
-                        disabled={!isValid}
                         onClick={() => {
                           setCreatingNewCollection(true);
                           setStagedValues(values);

--- a/frontend/src/metabase/containers/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.tsx
@@ -6,7 +6,7 @@ import * as Yup from "yup";
 import ModalContent from "metabase/components/ModalContent";
 import FormProvider from "metabase/core/components/FormProvider/FormProvider";
 import FormCollectionPicker from "metabase/collections/containers/FormCollectionPicker/FormCollectionPicker";
-import { CreateCollectionOnTheGoModal } from "metabase/containers/CreateCollectionOnTheGo";
+import { CreateCollectionOnTheGo } from "metabase/containers/CreateCollectionOnTheGo";
 import Form from "metabase/core/components/Form";
 import FormInput from "metabase/core/components/FormInput";
 import FormFooter from "metabase/core/components/FormFooter";
@@ -169,7 +169,7 @@ export const SaveQuestionModal = ({
       : t`What is the name of your model?`;
 
   return (
-    <CreateCollectionOnTheGoModal>
+    <CreateCollectionOnTheGo>
       {resumedValues => (
         <ModalContent id="SaveQuestionModal" title={title} onClose={onClose}>
           <FormProvider
@@ -234,6 +234,6 @@ export const SaveQuestionModal = ({
           </FormProvider>
         </ModalContent>
       )}
-    </CreateCollectionOnTheGoModal>
+    </CreateCollectionOnTheGo>
   );
 };

--- a/frontend/src/metabase/containers/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.tsx
@@ -175,7 +175,7 @@ export const SaveQuestionModal = ({
 
   return (
     <CreateCollectionOnTheGo>
-      {(resumedValues: any, onClickNewCollection: OnClickNewCollection) => (
+      {(resumedValues, onClickNewCollection) => (
         <ModalContent id="SaveQuestionModal" title={title} onClose={onClose}>
           <FormProvider
             initialValues={{ ...initialValues, ...resumedValues }}

--- a/frontend/src/metabase/containers/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.tsx
@@ -218,6 +218,7 @@ export const SaveQuestionModal = ({
                         <FormCollectionPicker
                           name="collection_id"
                           title={t`Which collection should this go in?`}
+                          canCreateNew={true}
                         />
                       </div>
                     </CSSTransition>

--- a/frontend/src/metabase/containers/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.tsx
@@ -1,14 +1,12 @@
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 import { t } from "ttag";
 import * as Yup from "yup";
 
 import ModalContent from "metabase/components/ModalContent";
 import FormProvider from "metabase/core/components/FormProvider/FormProvider";
-import FormCollectionPicker, {
-  NewCollectionButton,
-} from "metabase/collections/containers/FormCollectionPicker/FormCollectionPicker";
-import CreateCollectionModal from "metabase/collections/containers/CreateCollectionModal";
+import FormCollectionPicker from "metabase/collections/containers/FormCollectionPicker/FormCollectionPicker";
+import { CreateCollectionOnTheGoModal } from "metabase/containers/CreateCollectionOnTheGo";
 import Form from "metabase/core/components/Form";
 import FormInput from "metabase/core/components/FormInput";
 import FormFooter from "metabase/core/components/FormFooter";
@@ -18,7 +16,7 @@ import Button from "metabase/core/components/Button";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import FormRadio from "metabase/core/components/FormRadio";
 import { canonicalCollectionId } from "metabase/collections/utils";
-import { Collection, CollectionId } from "metabase-types/api";
+import { CollectionId } from "metabase-types/api";
 import * as Errors from "metabase/core/utils/errors";
 import { getIsSavedQuestionChanged } from "metabase/query_builder/selectors";
 import { useSelector } from "metabase/lib/redux";
@@ -131,10 +129,6 @@ export const SaveQuestionModal = ({
     [originalQuestion, handleOverwrite, handleCreate],
   );
 
-  const [creatingNewCollection, setCreatingNewCollection] = useState(false);
-  const [openCollectionId, setOpenCollectionId] = useState<CollectionId>();
-  const [stagedValues, setStagedValues] = useState<FormValues | null>(null);
-
   const isReadonly = originalQuestion != null && !originalQuestion.canWrite();
 
   const initialValues: FormValues = {
@@ -150,7 +144,6 @@ export const SaveQuestionModal = ({
       originalQuestion.canWrite()
         ? "overwrite"
         : "create",
-    ...stagedValues,
   };
 
   const questionType = question.isDataset() ? "model" : "question";
@@ -175,88 +168,71 @@ export const SaveQuestionModal = ({
       ? t`What is the name of your question?`
       : t`What is the name of your model?`;
 
-  if (creatingNewCollection && stagedValues) {
-    return (
-      <CreateCollectionModal
-        collectionId={openCollectionId}
-        onClose={() => setCreatingNewCollection(false)}
-        onCreate={(collection: Collection) => {
-          setCreatingNewCollection(false);
-          setStagedValues({ ...stagedValues, collection_id: collection.id });
-        }}
-      />
-    );
-  }
-
   return (
-    <ModalContent id="SaveQuestionModal" title={title} onClose={onClose}>
-      <FormProvider
-        initialValues={initialValues}
-        onSubmit={handleSubmit}
-        validationSchema={SAVE_QUESTION_SCHEMA}
-        enableReinitialize
-      >
-        {({ values, isValid }) => (
-          <Form>
-            {showSaveType && (
-              <FormRadio
-                name="saveType"
-                title={t`Replace or save as new?`}
-                options={[
-                  {
-                    name: t`Replace original question, "${originalQuestion?.displayName()}"`,
-                    value: "overwrite",
-                  },
-                  { name: t`Save as new question`, value: "create" },
-                ]}
-                vertical
-              />
-            )}
-            <TransitionGroup>
-              {values.saveType === "create" && (
-                <CSSTransition
-                  classNames="saveQuestionModalFields"
-                  timeout={{
-                    enter: 500,
-                    exit: 500,
-                  }}
-                >
-                  <div className="saveQuestionModalFields">
-                    <FormInput
-                      autoFocus
-                      name="name"
-                      title={t`Name`}
-                      placeholder={nameInputPlaceholder}
-                    />
-                    <FormTextArea
-                      name="description"
-                      title={t`Description`}
-                      placeholder={t`It's optional but oh, so helpful`}
-                    />
-                    <FormCollectionPicker
-                      onOpenCollectionChange={setOpenCollectionId}
-                      name="collection_id"
-                      title={t`Which collection should this go in?`}
+    <CreateCollectionOnTheGoModal>
+      {resumedValues => (
+        <ModalContent id="SaveQuestionModal" title={title} onClose={onClose}>
+          <FormProvider
+            initialValues={{ ...initialValues, resumedValues }}
+            onSubmit={handleSubmit}
+            validationSchema={SAVE_QUESTION_SCHEMA}
+            enableReinitialize
+          >
+            {({ values }) => (
+              <Form>
+                {showSaveType && (
+                  <FormRadio
+                    name="saveType"
+                    title={t`Replace or save as new?`}
+                    options={[
+                      {
+                        name: t`Replace original question, "${originalQuestion?.displayName()}"`,
+                        value: "overwrite",
+                      },
+                      { name: t`Save as new question`, value: "create" },
+                    ]}
+                    vertical
+                  />
+                )}
+                <TransitionGroup>
+                  {values.saveType === "create" && (
+                    <CSSTransition
+                      classNames="saveQuestionModalFields"
+                      timeout={{
+                        enter: 500,
+                        exit: 500,
+                      }}
                     >
-                      <NewCollectionButton
-                        onClick={() => {
-                          setCreatingNewCollection(true);
-                          setStagedValues(values);
-                        }}
-                      />
-                    </FormCollectionPicker>
-                  </div>
-                </CSSTransition>
-              )}
-            </TransitionGroup>
-            <FormFooter>
-              <FormErrorMessage inline />
-              <Button type="button" onClick={onClose}>{t`Cancel`}</Button>
-              <FormSubmitButton title={t`Save`} primary />
-            </FormFooter>
-          </Form>
-        )}
-      </FormProvider>
-    </ModalContent>
+                      <div className="saveQuestionModalFields">
+                        <FormInput
+                          autoFocus
+                          name="name"
+                          title={t`Name`}
+                          placeholder={nameInputPlaceholder}
+                        />
+                        <FormTextArea
+                          name="description"
+                          title={t`Description`}
+                          placeholder={t`It's optional but oh, so helpful`}
+                        />
+                        <FormCollectionPicker
+                          name="collection_id"
+                          title={t`Which collection should this go in?`}
+                        />
+                      </div>
+                    </CSSTransition>
+                  )}
+                </TransitionGroup>
+                <FormFooter>
+                  <FormErrorMessage inline />
+                  <Button type="button" onClick={onClose}>{t`Cancel`}</Button>
+                  <FormSubmitButton title={t`Save`} primary />
+                </FormFooter>
+              </Form>
+            )}
+          </FormProvider>
+        </ModalContent>
+      )}
+    </CreateCollectionOnTheGoModal>
   );
 };

--- a/frontend/src/metabase/containers/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.tsx
@@ -170,10 +170,10 @@ export const SaveQuestionModal = ({
 
   return (
     <CreateCollectionOnTheGo>
-      {resumedValues => (
+      {(resumedValues: any) => (
         <ModalContent id="SaveQuestionModal" title={title} onClose={onClose}>
           <FormProvider
-            initialValues={{ ...initialValues, resumedValues }}
+            initialValues={{ ...initialValues, ...resumedValues }}
             onSubmit={handleSubmit}
             validationSchema={SAVE_QUESTION_SCHEMA}
             enableReinitialize

--- a/frontend/src/metabase/containers/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.tsx
@@ -6,7 +6,10 @@ import * as Yup from "yup";
 import ModalContent from "metabase/components/ModalContent";
 import FormProvider from "metabase/core/components/FormProvider/FormProvider";
 import FormCollectionPicker from "metabase/collections/containers/FormCollectionPicker/FormCollectionPicker";
-import { CreateCollectionOnTheGo } from "metabase/containers/CreateCollectionOnTheGo";
+import {
+  CreateCollectionOnTheGo,
+  OnClickNewCollection,
+} from "metabase/containers/CreateCollectionOnTheGo";
 import Form from "metabase/core/components/Form";
 import FormInput from "metabase/core/components/FormInput";
 import FormFooter from "metabase/core/components/FormFooter";
@@ -53,6 +56,7 @@ interface SaveQuestionModalProps {
   onClose: () => void;
   multiStep?: boolean;
   initialCollectionId?: number;
+  onClickNewCollection?: OnClickNewCollection;
 }
 
 interface FormValues {
@@ -77,6 +81,7 @@ export const SaveQuestionModal = ({
   onClose,
   multiStep,
   initialCollectionId,
+  onClickNewCollection,
 }: SaveQuestionModalProps) => {
   const handleOverwrite = useCallback(
     async (originalQuestion: Question, details: FormValues) => {
@@ -170,7 +175,7 @@ export const SaveQuestionModal = ({
 
   return (
     <CreateCollectionOnTheGo>
-      {(resumedValues: any) => (
+      {(resumedValues: any, onClickNewCollection: OnClickNewCollection) => (
         <ModalContent id="SaveQuestionModal" title={title} onClose={onClose}>
           <FormProvider
             initialValues={{ ...initialValues, ...resumedValues }}
@@ -219,6 +224,7 @@ export const SaveQuestionModal = ({
                           name="collection_id"
                           title={t`Which collection should this go in?`}
                           canCreateNew={true}
+                          onClickNewCollection={onClickNewCollection}
                         />
                       </div>
                     </CSSTransition>

--- a/frontend/src/metabase/containers/SaveQuestionModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.unit.spec.tsx
@@ -666,7 +666,6 @@ describe("SaveQuestionModal", () => {
   });
 
   describe("new collection modal", () => {
-    const nameField = () => screen.getByRole("textbox", { name: /name/i });
     const collDropdown = () => screen.getByTestId("select-button");
     const newCollBtn = () =>
       screen.getByRole("button", {
@@ -683,16 +682,10 @@ describe("SaveQuestionModal", () => {
       userEvent.click(collDropdown());
       await waitFor(() => expect(newCollBtn()).toBeInTheDocument());
     });
-    it("should not be accessible if the dashboard form is invalid", async () => {
-      await setup(getQuestion());
-      userEvent.clear(nameField());
-      userEvent.click(collDropdown());
-      await waitFor(() => expect(newCollBtn()).toBeDisabled());
-    });
     it("should open new collection modal and return to dashboard modal when clicking close", async () => {
       await setup(getQuestion());
       userEvent.click(collDropdown());
-      await waitFor(() => expect(newCollBtn()).toBeEnabled());
+      await waitFor(() => expect(newCollBtn()).toBeInTheDocument());
       userEvent.click(newCollBtn());
       await waitFor(() => expect(collModalTitle()).toBeInTheDocument());
       userEvent.click(cancelBtn());

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 import * as Yup from "yup";
@@ -19,9 +19,7 @@ import * as Errors from "metabase/core/utils/errors";
 import Collections from "metabase/entities/collections";
 import Dashboards from "metabase/entities/dashboards";
 
-import FormCollectionPicker, {
-  NewCollectionButton,
-} from "metabase/collections/containers/FormCollectionPicker/FormCollectionPicker";
+import FormCollectionPicker from "metabase/collections/containers/FormCollectionPicker/FormCollectionPicker";
 
 import type { CollectionId, Dashboard } from "metabase-types/api";
 import type { State } from "metabase-types/store";
@@ -41,17 +39,10 @@ export interface CreateDashboardProperties {
   collection_id: CollectionId;
 }
 
-export interface StagedDashboard {
-  values: CreateDashboardProperties;
-  handleCreate: (values: CreateDashboardProperties) => void;
-  openCollectionId: CollectionId | undefined;
-}
-
 export interface CreateDashboardFormOwnProps {
   collectionId?: CollectionId | null; // can be used by `getInitialCollectionId`
   onCreate?: (dashboard: Dashboard) => void;
   onCancel?: () => void;
-  saveToNewCollection?: (stagedDash: StagedDashboard) => void;
   initialValues?: CreateDashboardProperties | null;
 }
 
@@ -87,7 +78,6 @@ function CreateDashboardForm({
   handleCreateDashboard,
   onCreate,
   onCancel,
-  saveToNewCollection,
   initialValues,
 }: Props) {
   const computedInitialValues = useMemo(
@@ -108,15 +98,13 @@ function CreateDashboardForm({
     [handleCreateDashboard, onCreate],
   );
 
-  const [openCollectionId, setOpenCollectionId] = useState<CollectionId>();
-
   return (
     <FormProvider
       initialValues={computedInitialValues}
       validationSchema={DASHBOARD_SCHEMA}
       onSubmit={handleCreate}
     >
-      {({ dirty, isValid, values }) => (
+      {({ dirty, values }) => (
         <Form>
           <FormInput
             name="name"
@@ -131,21 +119,9 @@ function CreateDashboardForm({
             nullable
           />
           <FormCollectionPicker
-            onOpenCollectionChange={setOpenCollectionId}
             name="collection_id"
             title={t`Which collection should this go in?`}
-          >
-            <NewCollectionButton
-              disabled={!isValid}
-              onClick={() =>
-                saveToNewCollection?.({
-                  values,
-                  handleCreate,
-                  openCollectionId,
-                })
-              }
-            />
-          </FormCollectionPicker>
+          />
           <FormFooter>
             <FormErrorMessage inline />
             {!!onCancel && (

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
@@ -121,6 +121,7 @@ function CreateDashboardForm({
           <FormCollectionPicker
             name="collection_id"
             title={t`Which collection should this go in?`}
+            canCreateNew={true}
           />
           <FormFooter>
             <FormErrorMessage inline />

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
@@ -14,6 +14,8 @@ import FormTextArea from "metabase/core/components/FormTextArea";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import FormErrorMessage from "metabase/core/components/FormErrorMessage";
 
+import { OnClickNewCollection } from "metabase/containers/CreateCollectionOnTheGo";
+
 import * as Errors from "metabase/core/utils/errors";
 
 import Collections from "metabase/entities/collections";
@@ -43,6 +45,7 @@ export interface CreateDashboardFormOwnProps {
   collectionId?: CollectionId | null; // can be used by `getInitialCollectionId`
   onCreate?: (dashboard: Dashboard) => void;
   onCancel?: () => void;
+  onClickNewCollection?: OnClickNewCollection;
   initialValues?: CreateDashboardProperties | null;
 }
 
@@ -78,6 +81,7 @@ function CreateDashboardForm({
   handleCreateDashboard,
   onCreate,
   onCancel,
+  onClickNewCollection,
   initialValues,
 }: Props) {
   const computedInitialValues = useMemo(
@@ -122,6 +126,7 @@ function CreateDashboardForm({
             name="collection_id"
             title={t`Which collection should this go in?`}
             canCreateNew={true}
+            onClickNewCollection={onClickNewCollection}
           />
           <FormFooter>
             <FormErrorMessage inline />

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
@@ -104,7 +104,7 @@ function CreateDashboardForm({
       validationSchema={DASHBOARD_SCHEMA}
       onSubmit={handleCreate}
     >
-      {({ dirty, values }) => (
+      {() => (
         <Form>
           <FormInput
             name="name"
@@ -128,7 +128,7 @@ function CreateDashboardForm({
             {!!onCancel && (
               <Button type="button" onClick={onCancel}>{t`Cancel`}</Button>
             )}
-            <FormSubmitButton title={t`Create`} disabled={!dirty} primary />
+            <FormSubmitButton title={t`Create`} primary />
           </FormFooter>
         </Form>
       )}

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
@@ -4,10 +4,7 @@ import { connect } from "react-redux";
 import { push } from "react-router-redux";
 import type { LocationDescriptor } from "history";
 
-import {
-  CreateCollectionOnTheGo,
-  OnClickNewCollection,
-} from "metabase/containers/CreateCollectionOnTheGo";
+import { CreateCollectionOnTheGo } from "metabase/containers/CreateCollectionOnTheGo";
 import ModalContent from "metabase/components/ModalContent";
 
 import * as Urls from "metabase/lib/urls";
@@ -54,7 +51,7 @@ function CreateDashboardModal({
 
   return (
     <CreateCollectionOnTheGo>
-      {(resumedValues: any, onClickNewCollection: OnClickNewCollection) => (
+      {(resumedValues, onClickNewCollection) => (
         <ModalContent title={t`New dashboard`} onClose={onClose}>
           <CreateDashboardForm
             {...props}

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
@@ -4,7 +4,7 @@ import { connect } from "react-redux";
 import { push } from "react-router-redux";
 import type { LocationDescriptor } from "history";
 
-import { CreateCollectionOnTheGoModal } from "metabase/containers/CreateCollectionOnTheGo";
+import { CreateCollectionOnTheGo } from "metabase/containers/CreateCollectionOnTheGo";
 import ModalContent from "metabase/components/ModalContent";
 
 import * as Urls from "metabase/lib/urls";
@@ -50,7 +50,7 @@ function CreateDashboardModal({
   );
 
   return (
-    <CreateCollectionOnTheGoModal>
+    <CreateCollectionOnTheGo>
       {resumedValues => (
         <ModalContent title={t`New dashboard`} onClose={onClose}>
           <CreateDashboardForm
@@ -61,7 +61,7 @@ function CreateDashboardModal({
           />
         </ModalContent>
       )}
-    </CreateCollectionOnTheGoModal>
+    </CreateCollectionOnTheGo>
   );
 }
 

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
@@ -51,7 +51,7 @@ function CreateDashboardModal({
 
   return (
     <CreateCollectionOnTheGo>
-      {resumedValues => (
+      {(resumedValues: any) => (
         <ModalContent title={t`New dashboard`} onClose={onClose}>
           <CreateDashboardForm
             {...props}

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
@@ -1,20 +1,19 @@
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import { t } from "ttag";
 import { connect } from "react-redux";
 import { push } from "react-router-redux";
 import type { LocationDescriptor } from "history";
 
+import { CreateCollectionOnTheGoModal } from "metabase/containers/CreateCollectionOnTheGo";
 import ModalContent from "metabase/components/ModalContent";
 
 import * as Urls from "metabase/lib/urls";
 
-import type { Dashboard, Collection, CollectionId } from "metabase-types/api";
+import type { Dashboard } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
-import CreateCollectionModal from "metabase/collections/containers/CreateCollectionModal";
 import CreateDashboardForm, {
   CreateDashboardFormOwnProps,
-  StagedDashboard,
 } from "./CreateDashboardForm";
 
 interface CreateDashboardModalOwnProps
@@ -50,39 +49,19 @@ function CreateDashboardModal({
     [onCreate, onChangeLocation, onClose],
   );
 
-  const [creatingNewCollection, setCreatingNewCollection] = useState(false);
-  const [openCollectionId, setOpenCollectionId] = useState<CollectionId>();
-  const [stagedDashboard, setStagedDashboard] =
-    useState<StagedDashboard | null>(null);
-  const saveToNewCollection = (s: StagedDashboard) => {
-    setCreatingNewCollection(true);
-    setOpenCollectionId(s.openCollectionId);
-    setStagedDashboard(s);
-  };
-
-  if (creatingNewCollection && stagedDashboard) {
-    return (
-      <CreateCollectionModal
-        collectionId={openCollectionId}
-        onClose={() => setCreatingNewCollection(false)}
-        onCreate={(collection: Collection) => {
-          const { values, handleCreate } = stagedDashboard;
-          handleCreate({ ...values, collection_id: collection.id });
-        }}
-      />
-    );
-  }
-
   return (
-    <ModalContent title={t`New dashboard`} onClose={onClose}>
-      <CreateDashboardForm
-        {...props}
-        onCreate={handleCreate}
-        onCancel={onClose}
-        saveToNewCollection={saveToNewCollection}
-        initialValues={stagedDashboard?.values}
-      />
-    </ModalContent>
+    <CreateCollectionOnTheGoModal>
+      {resumedValues => (
+        <ModalContent title={t`New dashboard`} onClose={onClose}>
+          <CreateDashboardForm
+            {...props}
+            onCreate={handleCreate}
+            onCancel={onClose}
+            initialValues={resumedValues}
+          />
+        </ModalContent>
+      )}
+    </CreateCollectionOnTheGoModal>
   );
 }
 

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
@@ -4,7 +4,10 @@ import { connect } from "react-redux";
 import { push } from "react-router-redux";
 import type { LocationDescriptor } from "history";
 
-import { CreateCollectionOnTheGo } from "metabase/containers/CreateCollectionOnTheGo";
+import {
+  CreateCollectionOnTheGo,
+  OnClickNewCollection,
+} from "metabase/containers/CreateCollectionOnTheGo";
 import ModalContent from "metabase/components/ModalContent";
 
 import * as Urls from "metabase/lib/urls";
@@ -51,12 +54,13 @@ function CreateDashboardModal({
 
   return (
     <CreateCollectionOnTheGo>
-      {(resumedValues: any) => (
+      {(resumedValues: any, onClickNewCollection: OnClickNewCollection) => (
         <ModalContent title={t`New dashboard`} onClose={onClose}>
           <CreateDashboardForm
             {...props}
             onCreate={handleCreate}
             onCancel={onClose}
+            onClickNewCollection={onClickNewCollection}
             initialValues={resumedValues}
           />
         </ModalContent>

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
@@ -138,17 +138,12 @@ describe("CreateDashboardModal", () => {
       userEvent.click(collDropdown());
       await waitFor(() => expect(newCollBtn()).toBeInTheDocument());
     });
-    it("should not be accessible if the dashboard form is invalid", async () => {
-      setup();
-      userEvent.click(collDropdown());
-      await waitFor(() => expect(newCollBtn()).toBeDisabled());
-    });
     it("should open new collection modal and return to dashboard modal when clicking close", async () => {
       setup();
       const name = "my dashboard";
       userEvent.type(nameField(), name);
       userEvent.click(collDropdown());
-      await waitFor(() => expect(newCollBtn()).toBeEnabled());
+      await waitFor(() => expect(newCollBtn()).toBeInTheDocument());
       userEvent.click(newCollBtn());
       await waitFor(() => expect(collModalTitle()).toBeInTheDocument());
       userEvent.click(cancelBtn());


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/32600

Part 2 of https://github.com/metabase/metabase/pull/31747

### Description

Any modal that contains a collection picker can now be wrapped in a `CreateCollectionOnTheGo` component, allowing the modal to be suspended while creating a new collection, then resumed with that collection selected.

Previously, this was implemented differently between `SaveQuestionModal` and `CreateDashboardModal`, but I unified their implementation to fix the linked issue in one place.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. From the modal for saving a question or creating a dashboard:
2. Open the collection picker
3. Click New Collection
4. Create a new collection
5. Verify that the question/dashboard modal is resumed, but with the newly created collection selected.

### Review notes

Hide whitespace diffs by clicking the gear icon.

### Demo

https://github.com/metabase/metabase/assets/116838/da1acf8d-eeda-4b19-b517-35a9cfdd6812


### Checklist

- [X] Tests have been added/updated to cover changes in this PR
