### PR TITLE
Tests for various number of PKs in a model

### DIFF
--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.unit.spec.tsx
@@ -494,7 +494,7 @@ describe("Object Detail", () => {
     expect(actionsMenu).toBeUndefined();
   });
 
-  it("should not render actions menu when model does not have a PK", async () => {
+  it("should not render actions menu when model's source table does not have a primary key", async () => {
     setupDatabasesEndpoints([databaseWithActionsEnabled]);
     setupActionsEndpoints(actions);
     setup({ question: mockDatasetNoPk });
@@ -503,7 +503,7 @@ describe("Object Detail", () => {
     expect(actionsMenu).toBeUndefined();
   });
 
-  it("should not render actions menu when model has more than 1 PK", async () => {
+  it("should not render actions menu when model's source table has multiple primary keys", async () => {
     setupDatabasesEndpoints([databaseWithActionsEnabled]);
     setupActionsEndpoints(actions);
     setup({ question: mockDatasetMultplePk });

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.unit.spec.tsx
@@ -46,7 +46,7 @@ const mockTableNoPk = createMockTable({
   fields: [],
 });
 
-const mockTableMultiplePk = createMockTable({
+const mockTableMultiplePks = createMockTable({
   id: getNextId(),
   fields: [
     createMockField({ semantic_type: "type/PK" }),
@@ -88,14 +88,14 @@ const mockDatasetNoPkCard = createMockCard({
   },
 });
 
-const mockDatasetMultiplePkCard = createMockCard({
+const mockDatasetMultiplePksCard = createMockCard({
   id: getNextId(),
   dataset: true,
   dataset_query: {
     type: "query",
     database: databaseWithActionsEnabled.id,
     query: {
-      "source-table": mockTableMultiplePk.id,
+      "source-table": mockTableMultiplePks.id,
     },
   },
 });
@@ -138,12 +138,12 @@ const metadata = createMockMetadata({
       settings: { "database-enable-actions": true },
     }),
   ],
-  tables: [mockTable, mockTableMultiplePk, mockTableNoPk],
+  tables: [mockTable, mockTableMultiplePks, mockTableNoPk],
   questions: [
     mockCard,
     mockDatasetCard,
     mockDatasetNoPkCard,
-    mockDatasetMultiplePkCard,
+    mockDatasetMultiplePksCard,
     mockDatasetWithClausesCard,
     mockDatasetNoWritePermissionCard,
   ],
@@ -155,8 +155,8 @@ const mockDataset = checkNotNull(metadata.question(mockDatasetCard.id));
 
 const mockDatasetNoPk = checkNotNull(metadata.question(mockDatasetNoPkCard.id));
 
-const mockDatasetMultiplePk = checkNotNull(
-  metadata.question(mockDatasetMultiplePkCard.id),
+const mockDatasetMultiplePks = checkNotNull(
+  metadata.question(mockDatasetMultiplePksCard.id),
 );
 
 const mockDatasetWithClauses = checkNotNull(
@@ -506,7 +506,7 @@ describe("Object Detail", () => {
   it("should not render actions menu when model's source table has multiple primary keys", async () => {
     setupDatabasesEndpoints([databaseWithActionsEnabled]);
     setupActionsEndpoints(actions);
-    setup({ question: mockDatasetMultiplePk });
+    setup({ question: mockDatasetMultiplePks });
 
     const actionsMenu = await findActionsMenu();
     expect(actionsMenu).toBeUndefined();

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.unit.spec.tsx
@@ -155,7 +155,7 @@ const mockDataset = checkNotNull(metadata.question(mockDatasetCard.id));
 
 const mockDatasetNoPk = checkNotNull(metadata.question(mockDatasetNoPkCard.id));
 
-const mockDatasetMultplePk = checkNotNull(
+const mockDatasetMultiplePk = checkNotNull(
   metadata.question(mockDatasetMultiplePkCard.id),
 );
 
@@ -506,7 +506,7 @@ describe("Object Detail", () => {
   it("should not render actions menu when model's source table has multiple primary keys", async () => {
     setupDatabasesEndpoints([databaseWithActionsEnabled]);
     setupActionsEndpoints(actions);
-    setup({ question: mockDatasetMultplePk });
+    setup({ question: mockDatasetMultiplePk });
 
     const actionsMenu = await findActionsMenu();
     expect(actionsMenu).toBeUndefined();

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.unit.spec.tsx
@@ -42,6 +42,11 @@ const mockTable = createMockTable({
   display_name: "Product",
 });
 
+const mockTableNoPk = createMockTable({
+  id: getNextId(),
+  fields: [],
+});
+
 const databaseWithActionsEnabled = createMockDatabase({
   id: getNextId(),
   settings: { "database-enable-actions": true },
@@ -61,6 +66,19 @@ const mockDatasetCard = createMockCard({
     database: databaseWithActionsEnabled.id,
     query: {
       "source-table": PEOPLE_ID,
+    },
+  },
+});
+
+const mockDatasetNoPkCard = createMockCard({
+  id: getNextId(),
+  name: "Product",
+  dataset: true,
+  dataset_query: {
+    type: "query",
+    database: databaseWithActionsEnabled.id,
+    query: {
+      "source-table": mockTableNoPk.id,
     },
   },
 });
@@ -109,6 +127,7 @@ const metadata = createMockMetadata({
   questions: [
     mockCard,
     mockDatasetCard,
+    mockDatasetNoPkCard,
     mockDatasetWithClausesCard,
     mockDatasetNoWritePermissionCard,
   ],
@@ -117,6 +136,7 @@ const metadata = createMockMetadata({
 const mockQuestion = checkNotNull(metadata.question(mockCard.id));
 
 const mockDataset = checkNotNull(metadata.question(mockDatasetCard.id));
+const mockDatasetNoPk = checkNotNull(metadata.question(mockDatasetNoPkCard.id));
 
 const mockDatasetWithClauses = checkNotNull(
   metadata.question(mockDatasetWithClausesCard.id),
@@ -448,6 +468,15 @@ describe("Object Detail", () => {
     setupDatabasesEndpoints([databaseWithActionsEnabled]);
     setupActionsEndpoints(actions);
     setup({ question: mockDatasetWithClauses });
+
+    const actionsMenu = await findActionsMenu();
+    expect(actionsMenu).toBeUndefined();
+  });
+
+  it("should not render actions menu when model does not have a PK", async () => {
+    setupDatabasesEndpoints([databaseWithActionsEnabled]);
+    setupActionsEndpoints(actions);
+    setup({ question: mockDatasetNoPk });
 
     const actionsMenu = await findActionsMenu();
     expect(actionsMenu).toBeUndefined();


### PR DESCRIPTION
Closes #32783

### Description

Improves #32350.

Covering extra cases with tests as [suggested in Slack](https://metaboat.slack.com/archives/C057T1QTB3L/p1690875617860239?thread_ts=1690814414.882049&cid=C057T1QTB3L):
- when model's source table has 0 PKs
- when model's source table has more than 1 PK

### How to verify

Tests are all green.
