### PR TITLE
Fix stacking of dashcards

### DIFF
--- a/e2e/test/scenarios/dashboard/reproductions/31274-dashcard-actions-overlap.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/31274-dashcard-actions-overlap.cy.spec.js
@@ -1,0 +1,79 @@
+import { editDashboard, restore, visitDashboard } from "e2e/support/helpers";
+
+const baseTextDashcardDetails = {
+  col: 0,
+  row: 0,
+  size_x: 2,
+  size_y: 2,
+  visualization_settings: {
+    virtual_card: {
+      name: null,
+      display: "text",
+      visualization_settings: {},
+      dataset_query: {},
+      archived: false,
+    },
+    text: "Text card",
+  },
+};
+
+const createTextCards = length => {
+  return Array.from({ length }).map((_, index) => {
+    return {
+      ...baseTextDashcardDetails,
+      id: index + 1,
+      // reversed order of appearing
+      row: (length - index - 1) * 2,
+      visualization_settings: {
+        ...baseTextDashcardDetails.visualization_settings,
+        text: `Text card ${index + 1}`,
+      },
+    };
+  });
+};
+
+describe("issue 31274", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  // cypress automatically scrolls to the element, but we don't need it in this test
+  it(
+    "should not clip dashcard actions (mestabase#31274)",
+    { scrollBehavior: false },
+    () => {
+      cy.createDashboard().then(({ body: dashboard }) => {
+        const cards = createTextCards(3);
+        cy.request("PUT", `/api/dashboard/${dashboard.id}/cards`, {
+          cards,
+        });
+
+        visitDashboard(dashboard.id);
+        editDashboard(dashboard.id);
+
+        secondTextCard().realHover();
+
+        visibleActionsPanel().should("have.length", 1);
+
+        cy.log(
+          "Make sure cypress can click, so element is not covered by another",
+        );
+
+        visibleActionsPanel().within(() => {
+          cy.icon("close").click({
+            position: "top",
+          });
+        });
+      });
+    },
+  );
+});
+
+function visibleActionsPanel() {
+  return cy.findAllByTestId("dashboardcard-actions-panel").filter(":visible");
+}
+
+function secondTextCard() {
+  return cy.findAllByTestId("editing-dashboard-text-preview").eq(1).parent();
+}

--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -101,6 +101,10 @@
   z-index: 2;
 }
 
+.DashCard:hover {
+  z-index: 3;
+}
+
 .DashCard .Card {
   position: absolute;
   top: 0;

--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -101,10 +101,13 @@
   z-index: 2;
 }
 
-/* dashcards use positioned absolutely,
-   so children calculate z-index inside a container, not globally,
-   that's why we have to override parent's z-index
-*/
+/**
+ * Dashcards are positioned absolutely so each one forms a new stacking context.
+ * The dashcard user is currently interacting with needs to be positioned above other dashcards
+ * to make sure it's not covered by absolutely positioned children of neighboring dashcards.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context
+ */
 .DashCard:hover {
   z-index: 3;
 }

--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -101,6 +101,10 @@
   z-index: 2;
 }
 
+/* dashcards use positioned absolutely,
+   so children calculate z-index inside a container, not globally,
+   that's why we have to override parent's z-index
+*/
 .DashCard:hover {
   z-index: 3;
 }

--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -96,30 +96,6 @@
   margin-top: 1.5em;
 }
 
-.DashCard {
-  position: relative;
-  z-index: 2;
-}
-
-/**
- * Dashcards are positioned absolutely so each one forms a new stacking context.
- * The dashcard user is currently interacting with needs to be positioned above other dashcards
- * to make sure it's not covered by absolutely positioned children of neighboring dashcards.
- *
- * @see https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context
- */
-.DashCard:hover {
-  z-index: 3;
-}
-
-.DashCard .Card {
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
-}
-
 .Dash--editing .DashCard .Card {
   transition: border 0.3s, background-color 0.3s;
 }
@@ -132,21 +108,6 @@
   z-index: 2;
 }
 
-/* Google Maps widgets */
-.DashCard .gm-style-mtc,
-.DashCard .gm-bundled-control,
-.DashCard .PinMapUpdateButton,
-.leaflet-container .leaflet-control-container {
-  opacity: 0.01;
-  transition: opacity 0.3s linear;
-}
-.DashCard:hover .gm-style-mtc,
-.DashCard:hover .gm-bundled-control,
-.DashCard:hover .PinMapUpdateButton,
-.leaflet-container:hover .leaflet-control-container {
-  opacity: 1;
-}
-
 .Dash--editing .PinMap {
   /* allow map to pan. need to stopPropagation in PinMap to prevent weird dragging interaction */
   pointer-events: all;
@@ -155,18 +116,6 @@
 .PinMapUpdateButton--disabled {
   pointer-events: none;
   color: var(--color-text-light);
-}
-
-.DashCard .Card {
-  border-radius: 8px;
-  box-shadow: 0px 1px 3px var(--color-shadow);
-}
-
-@media (prefers-reduced-motion) {
-  /* short duration (instead of none) to still trigger transition events */
-  .DashCard {
-    transition-duration: 10ms !important;
-  }
 }
 
 .Dash--editing .DashCard.react-draggable-dragging .Card {

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
@@ -50,7 +50,6 @@ export const DashboardCardActionsPanel = styled.div`
   right: 20px;
   border-radius: 8px;
   box-shadow: 0px 1px 3px rgb(0 0 0 / 13%);
-  z-index: 3;
   cursor: default;
   transition: opacity 200ms;
   opacity: 0;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
@@ -55,7 +55,8 @@ export const DashboardCardActionsPanel = styled.div`
   opacity: 0;
   pointer-events: none;
 
-  .Card:hover & {
+  .Card:hover,
+  .Card:focus-within & {
     opacity: 1;
     pointer-events: all;
   }

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
@@ -55,7 +55,7 @@ export const DashboardCardActionsPanel = styled.div`
   opacity: 0;
   pointer-events: none;
 
-  .Card:hover,
+  .Card:hover &,
   .Card:focus-within & {
     opacity: 1;
     pointer-events: all;

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.styled.tsx
@@ -6,10 +6,55 @@ interface DashboardCardProps {
 }
 
 export const DashboardCard = styled.div<DashboardCardProps>`
+  position: relative;
+  z-index: 2;
+
+  /**
+  * Dashcards are positioned absolutely so each one forms a new stacking context.
+  * The dashcard user is currently interacting with needs to be positioned above other dashcards
+  * to make sure it's not covered by absolutely positioned children of neighboring dashcards.
+  *
+  * @see https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context
+  */
+  &:hover {
+    z-index: 3;
+  }
+
+  .Card {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    border-radius: 8px;
+    box-shadow: 0px 1px 3px var(--color-shadow);
+  }
+
   ${props =>
     props.isAnimationDisabled
       ? css`
           transition: none;
         `
       : null};
+
+  @media (prefers-reduced-motion) {
+    /* short duration (instead of none) to still trigger transition events */
+    transition-duration: 10ms !important;
+  }
+
+  /* Google Maps widgets */
+  .gm-style-mtc,
+  .gm-bundled-control,
+  .PinMapUpdateButton,
+  .leaflet-container .leaflet-control-container {
+    opacity: 0.01;
+    transition: opacity 0.3s linear;
+  }
+
+  &:hover .gm-style-mtc,
+  &:hover .gm-bundled-control,
+  &:hover .PinMapUpdateButton,
+  .leaflet-container:hover .leaflet-control-container {
+    opacity: 1;
+  }
 `;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31274, resolves #32827

### Description

This change actually fixes stacking cards on a dashboard. 
Includes refactoring of the dashcard css: some styles were moved from .css to emotion

### How to verify

1. Go to dashboard edit mode or create a new one, add three cards on it, change their order, hover over card to see the action buttons -> make sure they are not cut

Added e2e test which relies on the ability of cypress to click on not covered elements only.

### Demo

https://www.loom.com/share/d8306edc254246cdb69a3bb874c9b1f5

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
