### PR TITLE
temporarily fix for the broken database endpoint

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -229,9 +229,6 @@
   [db]
   (driver/database-supports? (driver.u/database->driver db) :uploads db))
 
-(defn to-map
-       [x]
-       (into {} x))
 (defn- dbs-list
   [& {:keys [include-tables?
              include-saved-questions-db?
@@ -287,8 +284,7 @@
                                                               :exclude-uneditable-details?     only-editable?
                                                               :include-analytics?              include_analytics
                                                               :include-only-uploadable?        include_only_uploadable))
-                                            [])
-        db-list-res                     (map #(into {} %) db-list-res)]
+                                            [])]
    {:data  db-list-res
     :total (count db-list-res)}))
 

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -248,7 +248,7 @@
       filter-by-data-access?       (#(filter mi/can-read? %))
       include-saved-questions-db?  (add-saved-questions-virtual-database :include-tables? include-saved-questions-tables?)
       ;; Perms checks for uploadable DBs are handled by exclude-uneditable-details? (see below)
-     include-only-uploadable?     (#(filter uploadable-db? %)))))
+      include-only-uploadable?     (#(filter uploadable-db? %)))))
 
 (api/defendpoint GET "/"
   "Fetch all `Databases`.
@@ -277,13 +277,13 @@
   (let [include-tables?                 (= include "tables")
         include-saved-questions-tables? (and saved include-tables?)
         only-editable?                  (or include_only_uploadable exclude_uneditable_details)
-        db-list-res                     (or (into [] (dbs-list :include-tables?                 include-tables?
-                                                              :include-saved-questions-db?     saved
-                                                              :include-saved-questions-tables? include-saved-questions-tables?
-                                                              :include-editable-data-model?    include_editable_data_model
-                                                              :exclude-uneditable-details?     only-editable?
-                                                              :include-analytics?              include_analytics
-                                                              :include-only-uploadable?        include_only_uploadable))
+        db-list-res                     (or (dbs-list :include-tables?                 include-tables?
+                                                      :include-saved-questions-db?     saved
+                                                      :include-saved-questions-tables? include-saved-questions-tables?
+                                                      :include-editable-data-model?    include_editable_data_model
+                                                      :exclude-uneditable-details?     only-editable?
+                                                      :include-analytics?              include_analytics
+                                                      :include-only-uploadable?        include_only_uploadable)
                                             [])]
    {:data  db-list-res
     :total (count db-list-res)}))

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -229,6 +229,9 @@
   [db]
   (driver/database-supports? (driver.u/database->driver db) :uploads db))
 
+(defn to-map
+       [x]
+       (into {} x))
 (defn- dbs-list
   [& {:keys [include-tables?
              include-saved-questions-db?
@@ -248,7 +251,7 @@
       filter-by-data-access?       (#(filter mi/can-read? %))
       include-saved-questions-db?  (add-saved-questions-virtual-database :include-tables? include-saved-questions-tables?)
       ;; Perms checks for uploadable DBs are handled by exclude-uneditable-details? (see below)
-      include-only-uploadable?     (#(filter uploadable-db? %)))))
+     include-only-uploadable?     (#(filter uploadable-db? %)))))
 
 (api/defendpoint GET "/"
   "Fetch all `Databases`.
@@ -277,17 +280,17 @@
   (let [include-tables?                 (= include "tables")
         include-saved-questions-tables? (and saved include-tables?)
         only-editable?                  (or include_only_uploadable exclude_uneditable_details)
-        db-list-res                     (or (dbs-list :include-tables?                 include-tables?
-                                                      :include-saved-questions-db?     saved
-                                                      :include-saved-questions-tables? include-saved-questions-tables?
-                                                      :include-editable-data-model?    include_editable_data_model
-                                                      :exclude-uneditable-details?     only-editable?
-                                                      :include-analytics?  include_analytics
-                                                      :include-only-uploadable?        include_only_uploadable)
-                                            [])]
-    {:data  db-list-res
-     :total (count db-list-res)}))
-
+        db-list-res                     (or (into [] (dbs-list :include-tables?                 include-tables?
+                                                              :include-saved-questions-db?     saved
+                                                              :include-saved-questions-tables? include-saved-questions-tables?
+                                                              :include-editable-data-model?    include_editable_data_model
+                                                              :exclude-uneditable-details?     only-editable?
+                                                              :include-analytics?              include_analytics
+                                                              :include-only-uploadable?        include_only_uploadable))
+                                            [])
+        db-list-res                     (map #(into {} %) db-list-res)]
+   {:data  db-list-res
+    :total (count db-list-res)}))
 
 ;;; --------------------------------------------- GET /api/database/:id ----------------------------------------------
 

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -299,12 +299,16 @@
                                      details
                                      (sensitive-fields-for-db db)))))]
      (update db :settings (fn [settings]
-                            (when settings
+                            (when (map? settings)
                               (into {}
                                     (filter (fn [[setting-name _v]]
-                                              (setting/can-read-setting? setting-name
-                                                                         (setting/current-user-readable-visibilities))))
-                                    settings)))))
+                                              (try
+                                               (setting/can-read-setting? setting-name
+                                                                          (setting/current-user-readable-visibilities))
+                                               (catch Throwable _e
+                                                 true)))
+                                            settings))))))
+
    json-generator))
 
 ;;; ------------------------------------------------ Serialization ----------------------------------------------------


### PR DESCRIPTION
Fix `GET /api/database` returns empty list on stats

See https://metaboat.slack.com/archives/CKZEMT1MJ/p1690901134194209 for how to reproduce.

See comments on the cause.

It's late at my time so I'll fix this temporarily, I'll put up a proper fix tmr by define a settings for `:persist-models-enabled`.

---
Edit by @nemanjaglumac for more context: 
The bug was introduced in #31755