### PR TITLE
Revert running E2E tests on Electron

### DIFF
--- a/e2e/runner/cypress-runner-generate-snapshots.js
+++ b/e2e/runner/cypress-runner-generate-snapshots.js
@@ -4,6 +4,7 @@ const { parseArguments, args } = require("./cypress-runner-utils");
 
 const getConfig = baseUrl => {
   return {
+    browser: "chrome",
     configFile: "e2e/support/cypress-snapshots.config.js",
     config: {
       baseUrl,

--- a/e2e/runner/cypress-runner-run-tests.js
+++ b/e2e/runner/cypress-runner-run-tests.js
@@ -22,6 +22,7 @@ const runCypress = async (baseUrl, exitFunction) => {
   });
 
   const defaultConfig = {
+    browser: "chrome",
     configFile: "e2e/support/cypress.config.js",
     config: {
       baseUrl,


### PR DESCRIPTION
#32734 introduced a commit that removed "Chrome" as a predefined browser that Cypress runs on.
This was needed due to frequent failures that were interfering with the release process.

Even if we decide to switch to Electron, let's do it in a dedicated commit for easier git blame.
We'll forget in a month already why a commit called "Disallow new H2 connections" switched E2E tests to Electron.