### PR TITLE
Fully prevent open redirects during JWT/SAML auth

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -114,7 +114,7 @@
 
 (defn- has-host? [url]
   (try
-    (some? (.getHost (new URI url)))
+    (-> uri URI. .getHost some?)
     (catch MalformedURLException _ false)))
 
 (defmethod sso.i/sso-get :saml

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -38,7 +38,7 @@
    [saml20-clj.core :as saml]
    [schema.core :as s])
   (:import
-   (java.net MalformedURLException URL)
+   (java.net MalformedURLException URI)
    (java.util Base64 UUID)))
 
 (set! *warn-on-reflection* true)
@@ -114,7 +114,7 @@
 
 (defn- has-host? [url]
   (try
-    (some? (.getHost (new URL url)))
+    (some? (.getHost (new URI url)))
     (catch MalformedURLException _ false)))
 
 (defmethod sso.i/sso-get :saml

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -112,7 +112,7 @@
   (api/check (sso-settings/saml-enabled)
     [400 (tru "SAML has not been enabled and/or configured")]))
 
-(defn- has-host? [url]
+(defn- has-host? [uri]
   (try
     (-> uri URI. .getHost some?)
     (catch MalformedURLException _ false)))

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
@@ -13,7 +13,7 @@
    [schema.core :as s]
    [toucan2.core :as t2])
   (:import
-   (java.net URI URL URLDecoder)))
+   (java.net URI URLDecoder)))
 
 (set! *warn-on-reflection* true)
 

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
@@ -13,7 +13,7 @@
    [schema.core :as s]
    [toucan2.core :as t2])
   (:import
-   (java.net MalformedURLException URL URLDecoder)))
+   (java.net URI URL URLDecoder)))
 
 (set! *warn-on-reflection* true)
 
@@ -55,12 +55,7 @@
   "Check if open redirect is being exploited in SSO, blurts out a 400 if so"
   [redirect-url]
   (let [decoded-url (some-> redirect-url (URLDecoder/decode))
-                    ;; In this case, this just means that we don't have a specified host in redirect,
-                    ;; meaning it can't be an open redirect
-        no-host     (or (nil? decoded-url) (= (first decoded-url) \/))
-        host        (try
-                      (.getHost (new URL decoded-url))
-                      (catch MalformedURLException _ ""))
-        our-host    (some-> (public-settings/site-url) (URL.) (.getHost))]
-   (api/check (or no-host (= host our-host))
-     [400 (tru "SSO is trying to do an open redirect to an untrusted site")])))
+        host        (some-> decoded-url (URI.) (.getHost))
+        our-host    (some-> (public-settings/site-url) (URI.) (.getHost))]
+    (api/check (or (nil? decoded-url) (= host our-host))
+               [400 (tru "SSO is trying to do an open redirect to an untrusted site")])))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -140,18 +140,20 @@
                  (t2/select-one-fn :login_attributes User :email "rasta@metabase.com"))))))))
 
 (deftest no-open-redirect-test
-  (testing "Check a JWT with bad (open redirect)"
+  (testing "Check that we prevent open redirects to untrusted sites"
     (with-jwt-default-setup
-      (is (= "SSO is trying to do an open redirect to an untrusted site"
-             (saml-test/client
-               :get 400 "/auth/sso" {:request-options {:redirect-strategy :none}}
-               :return_to "https://evilsite.com"
-               :jwt (jwt/sign {:email      "rasta@metabase.com"
-                               :first_name "Rasta"
-                               :last_name  "Toucan"
-                               :extra      "keypairs"
-                               :are        "also present"}
-                              default-jwt-secret)))))))
+      (doseq [redirect-uri ["https://badsite.com"
+                            "//badsite.com"]]
+        (is (= "SSO is trying to do an open redirect to an untrusted site"
+               (saml-test/client
+                 :get 400 "/auth/sso" {:request-options {:redirect-strategy :none}}
+                 :return_to redirect-uri
+                 :jwt (jwt/sign {:email      "rasta@metabase.com"
+                                 :first_name "Rasta"
+                                 :last_name  "Toucan"
+                                 :extra      "keypairs"
+                                 :are        "also present"}
+                                default-jwt-secret))))))))
 
 (deftest expired-jwt-test
   (testing "Check an expired JWT"

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -413,7 +413,8 @@
                          ""
                          "   "
                          "/"
-                         "https://badsite.com"]]
+                         "https://badsite.com"
+                         "//badsite.com"]]
       (testing (format "\nRelayState = %s" (pr-str relay-state))
         (with-saml-default-setup
           (do-with-some-validators-disabled
@@ -425,8 +426,10 @@
                        (get-in response [:headers "Location"])))
                 (is (= (some-saml-attributes "rasta")
                        (saml-login-attributes "rasta@metabase.com"))))))))))
+
   (testing "if the RelayState leads us to the wrong host, avoid the open redirect (boat#160)"
-    (let [redirect-url "https://badsite.com"]
+    (doseq [redirect-url ["https://badsite.com"
+                          "//badsite.com"]]
       (with-saml-default-setup
         (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
           (do-with-some-validators-disabled


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/32816

Essentially this was a bug in the previous logic. It used `(= (first decoded-url) \/)` to detect whether a redirect URI has a host, assuming that if it begins with a `/` it must be a relative path. But a redirect URI like `//example.com` should still be considered as having a host.

I've removed this logic and changed usages of `java.net.URL` to `java.net.URI` which is more flexible, and will properly detect the host from a URI like `//example.com` which isn't a full URL (since it doesn't have a protocol).