### PR TITLE
Fix nils in subscriptions for values in series

### DIFF
--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -452,9 +452,17 @@
                             (table-fn some-entries)])
                          (split-at (/ (count legend-entries) 2) legend-entries)))])))
 
+(defn- replace-nils [rows]
+  (mapv (fn [row]
+          (if (nil? (first row))
+            (assoc row 0 "(empty)")
+            row))
+        rows))
+
 (s/defmethod render :categorical/donut :- common/RenderedPulseCard
   [_ render-type timezone-id :- (s/maybe s/Str) card dashcard {:keys [rows cols viz-settings] :as data}]
-  (let [viz-settings                (merge viz-settings (:visualization_settings dashcard))
+  (let [rows                        (replace-nils rows)
+        viz-settings                (merge viz-settings (:visualization_settings dashcard))
         [x-axis-rowfn y-axis-rowfn] (common/graphing-column-row-fns card data)
         rows                        (map (juxt (comp str x-axis-rowfn) y-axis-rowfn)
                                          (common/row-preprocess x-axis-rowfn y-axis-rowfn rows))
@@ -786,13 +794,6 @@
         settings          (->ts-viz x-col y-col labels viz-settings)
         series-seqs       (map card-result->series (cons {:card card :result {:data data}} multi-res))]
     (attach-image-bundle (image-bundle/make-image-bundle render-type (js-svg/combo-chart series-seqs settings)))))
-
-(defn- replace-nils [rows]
-  (mapv (fn [row]
-          (if (nil? (first row))
-            (assoc row 0 "(empty)")
-            row))
-        rows))
 
 (defn- lab-image-bundle
   "Generate an image-bundle for a Line Area Bar chart (LAB)

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -787,12 +787,20 @@
         series-seqs       (map card-result->series (cons {:card card :result {:data data}} multi-res))]
     (attach-image-bundle (image-bundle/make-image-bundle render-type (js-svg/combo-chart series-seqs settings)))))
 
+(defn- replace-nils [rows]
+  (mapv (fn [row]
+          (if (nil? (first row))
+            (assoc row 0 "(empty)")
+            row))
+        rows))
+
 (defn- lab-image-bundle
   "Generate an image-bundle for a Line Area Bar chart (LAB)
 
   Use the combo charts for every chart-type in line area bar because we get multiple chart series for cheaper this way."
   [chart-type render-type _timezone-id card dashcard {:keys [cols rows viz-settings] :as data}]
-  (let [viz-settings    (merge viz-settings (:visualization_settings dashcard))
+  (let [rows            (replace-nils rows)
+        viz-settings    (merge viz-settings (:visualization_settings dashcard))
         x-axis-rowfn    (or (ui-logic/mult-x-axis-rowfn card data) #(vector (first %)))
         y-axis-rowfn    (or (ui-logic/mult-y-axis-rowfn card data) #(vector (second %)))
         x-rows          (filter some? (map x-axis-rowfn rows))

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -421,11 +421,15 @@
          (render-bar-graph {:cols         default-columns
                             :rows         [[10.0 1] [5.0 10] [2.50 20] [1.25 nil]]
                             :viz-settings {:graph.metrics ["NumPurchased"]}}))))
-  (testing "Check to make sure we allow nil values for the y-axis"
-    (is (has-inline-image?
-         (render-bar-graph {:cols         default-columns
-                            :rows         [[10.0 1] [5.0 10] [2.50 20] [nil 30]]
-                            :viz-settings {:graph.metrics ["NumPurchased"]}}))))
+  (testing "Check to make sure we allow nil values for the x-axis"
+    (let [graph (render-bar-graph {:cols         default-columns
+                                   :rows         [[10.0 1] [5.0 10] [2.50 20] [nil 30]]
+                                   :viz-settings {:graph.metrics ["NumPurchased"]}})]
+      (is (has-inline-image? graph))
+      (is (= graph
+             (render-bar-graph {:cols         default-columns
+                                :rows         [[10.0 1] [5.0 10] [2.50 20] ["(empty)" 30]]
+                                :viz-settings {:graph.metrics ["NumPurchased"]}})))))
   (testing "Check to make sure we allow nil values for both x and y on different rows"
     (is (has-inline-image?
          (render-bar-graph {:cols         default-columns
@@ -576,15 +580,16 @@
                                     x))
                                 html-tree))]
     (testing "Renders without error"
-      (let [rendered-info (render [["Doohickey" 75] ["Widget" 25]] {:show_values true})]
+      (let [rendered-info (render [[nil 10] ["Doohickey" 65] ["Widget" 25]] {:show_values true})]
         (is (has-inline-image? rendered-info))))
     (testing "Includes percentages"
       (is (= [:div
               [:img]
               [:table
-               [:tr [:td [:span "•"]] [:td "Doohickey"] [:td "75%"]]
+               [:tr [:td [:span "•"]] [:td "(empty)"] [:td "10%"]]
+               [:tr [:td [:span "•"]] [:td "Doohickey"] [:td "65%"]]
                [:tr [:td [:span "•"]] [:td "Widget"] [:td "25%"]]]]
-             (prune (:content (render [["Doohickey" 75] ["Widget" 25]]))))))))
+             (prune (:content (render [[nil 10] ["Doohickey" 65] ["Widget" 25]]))))))))
 
 (deftest render-progress
   (let [col [{:name          "NumPurchased",


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31704

### Description

`x-axis-rowfn` doesn't deal with nils correctly, so replace nils before that with `(empty)`


### Demo

Before
<img width="660" alt="image" src="https://github.com/metabase/metabase/assets/34140255/40e17cf8-8285-4ce2-8be9-c4bbe6c52f63">
<img width="596" alt="image" src="https://github.com/metabase/metabase/assets/34140255/463fb55a-7dbb-4ae0-b9bd-ece89a840972">

After
<img width="575" alt="image" src="https://github.com/metabase/metabase/assets/34140255/635876e6-8d0e-4065-80ca-37491e5f6ae5">
<img width="662" alt="image" src="https://github.com/metabase/metabase/assets/34140255/2c3d102a-cded-4018-9b2e-f5008717537f">
