### PR TITLE
Fix the failing E2E test in questions/settings

### DIFF
--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -345,9 +345,7 @@ function getSidebarColumns() {
 }
 
 function getVisibleSidebarColumns() {
-  return cy
-    .findByRole("group", { name: /visible-columns/ })
-    .findAllByRole("listitem");
+  return cy.findByTestId("visible-columns").findAllByRole("listitem");
 }
 
 function hideColumn(name) {


### PR DESCRIPTION
Breaking change was introduced in https://github.com/metabase/metabase/pull/32791 with [this line](https://github.com/metabase/metabase/pull/32791/files#diff-e597b8ddb83a0b8a92d0d3ec1d043abda80a7892308e7f06e968a684605de58bL126).


Stress-testing the fix passes 10/10
```
      ✓ should preserve correct order of columns after column removal via sidebar (metabase#13455): burning 1 of 10 (20694ms)
      ✓ should preserve correct order of columns after column removal via sidebar (metabase#13455): burning 2 of 10 (22829ms)
      ✓ should preserve correct order of columns after column removal via sidebar (metabase#13455): burning 3 of 10 (22791ms)
      ✓ should preserve correct order of columns after column removal via sidebar (metabase#13455): burning 4 of 10 (21178ms)
      ✓ should preserve correct order of columns after column removal via sidebar (metabase#13455): burning 5 of 10 (22530ms)
      ✓ should preserve correct order of columns after column removal via sidebar (metabase#13455): burning 6 of 10 (22846ms)
      ✓ should preserve correct order of columns after column removal via sidebar (metabase#13455): burning 7 of 10 (24092ms)
      ✓ should preserve correct order of columns after column removal via sidebar (metabase#13455): burning 8 of 10 (21085ms)
      ✓ should preserve correct order of columns after column removal via sidebar (metabase#13455): burning 9 of 10 (21922ms)
      ✓ should preserve correct order of columns after column removal via sidebar (metabase#13455): burning 10 of 10 (22700ms)
```
