### PR TITLE
fix: cancel ongoing query when removing card from dashboard

### DIFF
--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -155,6 +155,8 @@ export function visitModel(id, { hasDataAccess = true } = {}) {
  * Visit a dashboard and wait for the related queries to load.
  *
  * @param {number} dashboard_id
+ * @param {Object} options
+ * @param {boolean} should_wait - if cypress should wait for the cards to load, defaults to true
  */
 export function visitDashboard(
   dashboard_id,

--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -156,7 +156,10 @@ export function visitModel(id, { hasDataAccess = true } = {}) {
  *
  * @param {number} dashboard_id
  */
-export function visitDashboard(dashboard_id, { params = {} } = {}) {
+export function visitDashboard(
+  dashboard_id,
+  { params = {}, should_wait } = {},
+) {
   // Some users will not have permissions for this request
   cy.request({
     method: "GET",
@@ -201,8 +204,9 @@ export function visitDashboard(dashboard_id, { params = {} } = {}) {
         url: `/dashboard/${dashboard_id}`,
         qs: params,
       });
-
-      cy.wait(aliases);
+      if (should_wait !== false) {
+        cy.wait(aliases);
+      }
     } else {
       // For a dashboard:
       //  - without questions (can be empty or markdown only) or

--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -155,13 +155,8 @@ export function visitModel(id, { hasDataAccess = true } = {}) {
  * Visit a dashboard and wait for the related queries to load.
  *
  * @param {number} dashboard_id
- * @param {Object} options
- * @param {boolean} should_wait - if cypress should wait for the cards to load, defaults to true
  */
-export function visitDashboard(
-  dashboard_id,
-  { params = {}, should_wait } = {},
-) {
+export function visitDashboard(dashboard_id, { params = {} } = {}) {
   // Some users will not have permissions for this request
   cy.request({
     method: "GET",
@@ -206,9 +201,8 @@ export function visitDashboard(
         url: `/dashboard/${dashboard_id}`,
         qs: params,
       });
-      if (should_wait !== false) {
-        cy.wait(aliases);
-      }
+
+      cy.wait(aliases);
     } else {
       // For a dashboard:
       //  - without questions (can be empty or markdown only) or

--- a/e2e/test/scenarios/dashboard/reproductions/12926-editing-dashboards-doesnt-cancel-running-queries.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/12926-editing-dashboards-doesnt-cancel-running-queries.cy.spec.js
@@ -16,7 +16,7 @@ describe("issue 12926", () => {
     cy.signInAsAdmin();
   });
 
-  describe("field source", () => {
+  describe("card removal while query is in progress", () => {
     it("should stop the ongoing query when removing a card from a dashboard", () => {
       slowDownQuery();
 

--- a/e2e/test/scenarios/dashboard/reproductions/12926-editing-dashboards-doesnt-cancel-running-queries.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/12926-editing-dashboards-doesnt-cancel-running-queries.cy.spec.js
@@ -65,6 +65,7 @@ function slowDownQuery() {
 
 function restoreQuery() {
   cy.intercept("POST", "api/dashboard/*/dashcard/*/card/*/query", req => {
+    // calling req.continue() will make cypress skip all previously added intercepts
     req.continue();
   }).as("cardQueryRestored");
 }

--- a/e2e/test/scenarios/dashboard/reproductions/12926-editing-dashboards-doesnt-cancel-running-queries.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/12926-editing-dashboards-doesnt-cancel-running-queries.cy.spec.js
@@ -2,6 +2,7 @@ import {
   editDashboard,
   restore,
   showDashboardCardActions,
+  undo,
   visitDashboard,
 } from "e2e/support/helpers";
 
@@ -31,15 +32,39 @@ describe("issue 12926", { tags: "@external" }, () => {
         cy.stub(win.XMLHttpRequest.prototype, "abort").as("xhrAbort");
       });
 
-      editDashboard();
-
-      showDashboardCardActions();
-
-      cy.findByTestId("dashboardcard-actions-panel").within(() => {
-        cy.findByLabelText("close icon").click();
-      });
+      removeCard();
 
       cy.get("@xhrAbort").should("have.been.calledOnce");
     });
+
+    it("should re-fetch the query when doing undo on the removal", () => {
+      cy.createNativeQuestionAndDashboard({
+        questionDetails,
+      }).then(({ body: { dashboard_id } }) => {
+        visitDashboard(dashboard_id, { should_wait: false });
+      });
+
+      removeCard();
+
+      // stub the response so that the we can wait the request to see if it has been made
+      // without the stub it would go in timeout as the query is longer than the default timeout
+      cy.intercept("POST", "api/dashboard/*/dashcard/*/card/*/query", req => {
+        req.reply({});
+      }).as("cardQuery");
+
+      undo();
+
+      cy.wait("@cardQuery");
+    });
   });
 });
+
+function removeCard() {
+  editDashboard();
+
+  showDashboardCardActions();
+
+  cy.findByTestId("dashboardcard-actions-panel").within(() => {
+    cy.findByLabelText("close icon").click();
+  });
+}

--- a/e2e/test/scenarios/dashboard/reproductions/12926-editing-dashboards-doesnt-cancel-running-queries.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/12926-editing-dashboards-doesnt-cancel-running-queries.cy.spec.js
@@ -1,0 +1,45 @@
+import {
+  editDashboard,
+  restore,
+  showDashboardCardActions,
+  visitDashboard,
+} from "e2e/support/helpers";
+
+const PG_DB_ID = 2;
+
+const questionDetails = {
+  name: "Q1",
+  native: { query: "SELECT 1, pg_sleep(600)" },
+  database: PG_DB_ID,
+};
+
+describe("issue 12926", { tags: "@external" }, () => {
+  beforeEach(() => {
+    restore("postgres-12");
+    cy.signInAsAdmin();
+  });
+
+  describe("field source", () => {
+    it("should stop the ongoing query when removing a card from a dashboard", () => {
+      cy.createNativeQuestionAndDashboard({
+        questionDetails,
+      }).then(({ body: { dashboard_id } }) => {
+        visitDashboard(dashboard_id, { should_wait: false });
+      });
+
+      cy.window().then(win => {
+        cy.stub(win.XMLHttpRequest.prototype, "abort").as("xhrAbort");
+      });
+
+      editDashboard();
+
+      showDashboardCardActions();
+
+      cy.findByTestId("dashboardcard-actions-panel").within(() => {
+        cy.findByLabelText("close icon").click();
+      });
+
+      cy.get("@xhrAbort").should("have.been.calledOnce");
+    });
+  });
+});

--- a/e2e/test/scenarios/dashboard/reproductions/12926-editing-dashboards-doesnt-cancel-running-queries.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/12926-editing-dashboards-doesnt-cancel-running-queries.cy.spec.js
@@ -15,13 +15,12 @@ const questionDetails = {
 
 describe("issue 12926", { tags: "@external" }, () => {
   beforeEach(() => {
-    cy.intercept("POST", "/api/dashboard/*/card/*/query").as("query");
     restore("postgres-12");
     cy.signInAsAdmin();
   });
 
   describe("field source", () => {
-    it("should stop the ongoing query when removing a card from a dashboard", done => {
+    it("should stop the ongoing query when removing a card from a dashboard", () => {
       cy.createNativeQuestionAndDashboard({
         questionDetails,
       }).then(({ body: { dashboard_id } }) => {
@@ -40,20 +39,7 @@ describe("issue 12926", { tags: "@external" }, () => {
         cy.findByLabelText("close icon").click();
       });
 
-      cy.on("fail", err => {
-        if (
-          err.name === "CypressError" &&
-          err.message.includes("query") &&
-          err.message.includes("Timed out")
-        ) {
-          done();
-          return true;
-        }
-        throw err;
-      });
-      cy.wait("@query", { timeout: 2000 }).then(() => {
-        throw new Error("Request wasn't cancelled");
-      });
+      cy.get("@xhrAbort").should("have.been.calledOnce");
     });
   });
 });

--- a/e2e/test/scenarios/dashboard/reproductions/12926-editing-dashboards-doesnt-cancel-running-queries.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/12926-editing-dashboards-doesnt-cancel-running-queries.cy.spec.js
@@ -1,5 +1,6 @@
 import {
   editDashboard,
+  getDashboardCard,
   restore,
   showDashboardCardActions,
   undo,
@@ -7,7 +8,7 @@ import {
 
 const questionDetails = {
   name: "Q1",
-  native: { query: "SELECT 1" },
+  native: { query: "SELECT  '42' as ANSWER" },
 };
 
 describe("issue 12926", () => {
@@ -51,6 +52,8 @@ describe("issue 12926", () => {
       undo();
 
       cy.wait("@cardQueryRestored");
+
+      getDashboardCard().findByText("42");
     });
   });
 });

--- a/e2e/test/scenarios/dashboard/reproductions/12926-editing-dashboards-doesnt-cancel-running-queries.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/12926-editing-dashboards-doesnt-cancel-running-queries.cy.spec.js
@@ -50,7 +50,7 @@ describe("issue 12926", () => {
 
       undo();
 
-      cy.wait("@cardQueryRestored").then(a => console.log("aa", a));
+      cy.wait("@cardQueryRestored");
     });
   });
 });

--- a/e2e/test/scenarios/dashboard/reproductions/12926-editing-dashboards-doesnt-cancel-running-queries.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/12926-editing-dashboards-doesnt-cancel-running-queries.cy.spec.js
@@ -3,20 +3,16 @@ import {
   restore,
   showDashboardCardActions,
   undo,
-  visitDashboard,
 } from "e2e/support/helpers";
-
-const PG_DB_ID = 2;
 
 const questionDetails = {
   name: "Q1",
-  native: { query: "SELECT 1, pg_sleep(600)" },
-  database: PG_DB_ID,
+  native: { query: "SELECT 1" },
 };
 
-describe("issue 12926", { tags: "@external" }, () => {
+describe("issue 12926", () => {
   beforeEach(() => {
-    restore("postgres-12");
+    restore();
     cy.signInAsAdmin();
   });
 
@@ -25,7 +21,7 @@ describe("issue 12926", { tags: "@external" }, () => {
       cy.createNativeQuestionAndDashboard({
         questionDetails,
       }).then(({ body: { dashboard_id } }) => {
-        visitDashboard(dashboard_id, { should_wait: false });
+        cy.visit(`/dashboard/${dashboard_id}`);
       });
 
       cy.window().then(win => {
@@ -41,7 +37,7 @@ describe("issue 12926", { tags: "@external" }, () => {
       cy.createNativeQuestionAndDashboard({
         questionDetails,
       }).then(({ body: { dashboard_id } }) => {
-        visitDashboard(dashboard_id, { should_wait: false });
+        cy.visit(`/dashboard/${dashboard_id}`);
       });
 
       removeCard();

--- a/e2e/test/scenarios/dashboard/reproductions/12926-editing-dashboards-doesnt-cancel-running-queries.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/12926-editing-dashboards-doesnt-cancel-running-queries.cy.spec.js
@@ -74,7 +74,7 @@ function removeCard() {
 
   showDashboardCardActions();
 
-  cy.findByTestId("dashboardcard-actions-panel").within(() => {
-    cy.findByLabelText("close icon").click();
-  });
+  cy.findByTestId("dashboardcard-actions-panel")
+    .findByLabelText("close icon")
+    .click();
 }

--- a/frontend/src/metabase/dashboard/actions/cards.js
+++ b/frontend/src/metabase/dashboard/actions/cards.js
@@ -12,7 +12,7 @@ import { createCard } from "metabase/lib/card";
 
 import { getVisualizationRaw } from "metabase/visualizations";
 import { trackCardCreated } from "../analytics";
-import { getDashCardById } from "../selectors";
+import { getDashCardById, getSingleDashCardData } from "../selectors";
 import {
   ADD_CARD_TO_DASH,
   REMOVE_CARD_FROM_DASH,
@@ -92,7 +92,13 @@ export const undoRemoveCardFromDashboard = createThunkAction(
       const dashcard = getDashCardById(getState(), dashcardId);
       const card = dashcard.card;
 
-      dispatch(fetchCardData(card, dashcard));
+      const cardAlreadyLoaded = Boolean(
+        getSingleDashCardData(getState(), dashcardId),
+      );
+
+      if (!cardAlreadyLoaded) {
+        dispatch(fetchCardData(card, dashcard));
+      }
       return { dashcardId };
     },
 );

--- a/frontend/src/metabase/dashboard/actions/cards.js
+++ b/frontend/src/metabase/dashboard/actions/cards.js
@@ -12,7 +12,7 @@ import { createCard } from "metabase/lib/card";
 
 import { getVisualizationRaw } from "metabase/visualizations";
 import { trackCardCreated } from "../analytics";
-import { getDashCardById, getSingleDashCardData } from "../selectors";
+import { getDashCardById } from "../selectors";
 import {
   ADD_CARD_TO_DASH,
   REMOVE_CARD_FROM_DASH,
@@ -81,7 +81,7 @@ export const removeCardFromDashboard = createThunkAction(
   ({ dashcardId, cardId }) =>
     (dispatch, _getState) => {
       dispatch(cancelFetchCardData(cardId, dashcardId));
-      return { dashcardId, cardId };
+      return { dashcardId };
     },
 );
 
@@ -92,13 +92,8 @@ export const undoRemoveCardFromDashboard = createThunkAction(
       const dashcard = getDashCardById(getState(), dashcardId);
       const card = dashcard.card;
 
-      const cardAlreadyLoaded = Boolean(
-        getSingleDashCardData(getState(), dashcardId),
-      );
+      dispatch(fetchCardData(card, dashcard));
 
-      if (!cardAlreadyLoaded) {
-        dispatch(fetchCardData(card, dashcard));
-      }
       return { dashcardId };
     },
 );

--- a/frontend/src/metabase/dashboard/actions/cards.js
+++ b/frontend/src/metabase/dashboard/actions/cards.js
@@ -12,7 +12,12 @@ import { createCard } from "metabase/lib/card";
 
 import { getVisualizationRaw } from "metabase/visualizations";
 import { trackCardCreated } from "../analytics";
-import { ADD_CARD_TO_DASH, REMOVE_CARD_FROM_DASH } from "./core";
+import { getDashCardById } from "../selectors";
+import {
+  ADD_CARD_TO_DASH,
+  REMOVE_CARD_FROM_DASH,
+  UNDO_REMOVE_CARD_FROM_DASH,
+} from "./core";
 import { cancelFetchCardData, fetchCardData } from "./data-fetching";
 import { loadMetadataForDashboard } from "./metadata";
 
@@ -76,6 +81,18 @@ export const removeCardFromDashboard = createThunkAction(
   ({ dashcardId, cardId }) =>
     (dispatch, _getState) => {
       dispatch(cancelFetchCardData(cardId, dashcardId));
+      return { dashcardId, cardId };
+    },
+);
+
+export const undoRemoveCardFromDashboard = createThunkAction(
+  UNDO_REMOVE_CARD_FROM_DASH,
+  ({ dashcardId, cardId }) =>
+    (dispatch, getState) => {
+      const dashcard = getDashCardById(getState(), dashcardId);
+      const card = dashcard.card;
+
+      dispatch(fetchCardData(card, dashcard));
       return { dashcardId, cardId };
     },
 );

--- a/frontend/src/metabase/dashboard/actions/cards.js
+++ b/frontend/src/metabase/dashboard/actions/cards.js
@@ -87,13 +87,13 @@ export const removeCardFromDashboard = createThunkAction(
 
 export const undoRemoveCardFromDashboard = createThunkAction(
   UNDO_REMOVE_CARD_FROM_DASH,
-  ({ dashcardId, cardId }) =>
+  ({ dashcardId }) =>
     (dispatch, getState) => {
       const dashcard = getDashCardById(getState(), dashcardId);
       const card = dashcard.card;
 
       dispatch(fetchCardData(card, dashcard));
-      return { dashcardId, cardId };
+      return { dashcardId };
     },
 );
 

--- a/frontend/src/metabase/dashboard/actions/cards.js
+++ b/frontend/src/metabase/dashboard/actions/cards.js
@@ -1,6 +1,6 @@
 import _ from "underscore";
 import { t } from "ttag";
-import { createAction } from "metabase/lib/redux";
+import { createAction, createThunkAction } from "metabase/lib/redux";
 
 import Questions from "metabase/entities/questions";
 
@@ -12,8 +12,8 @@ import { createCard } from "metabase/lib/card";
 
 import { getVisualizationRaw } from "metabase/visualizations";
 import { trackCardCreated } from "../analytics";
-import { ADD_CARD_TO_DASH } from "./core";
-import { fetchCardData } from "./data-fetching";
+import { ADD_CARD_TO_DASH, REMOVE_CARD_FROM_DASH } from "./core";
+import { cancelFetchCardData, fetchCardData } from "./data-fetching";
 import { loadMetadataForDashboard } from "./metadata";
 
 export const MARK_NEW_CARD_SEEN = "metabase/dashboard/MARK_NEW_CARD_SEEN";
@@ -70,6 +70,15 @@ export const addCardToDashboard =
 
     dispatch(loadMetadataForDashboard([dashcard]));
   };
+
+export const removeCardFromDashboard = createThunkAction(
+  REMOVE_CARD_FROM_DASH,
+  ({ dashcardId, cardId }) =>
+    (dispatch, _getState) => {
+      dispatch(cancelFetchCardData(cardId, dashcardId));
+      return { dashcardId, cardId };
+    },
+);
 
 export const addDashCardToDashboard = function ({
   dashId,

--- a/frontend/src/metabase/dashboard/actions/core.js
+++ b/frontend/src/metabase/dashboard/actions/core.js
@@ -26,7 +26,6 @@ export const setMultipleDashCardAttributes = createAction(
 export const ADD_CARD_TO_DASH = "metabase/dashboard/ADD_CARD_TO_DASH";
 
 export const REMOVE_CARD_FROM_DASH = "metabase/dashboard/REMOVE_CARD_FROM_DASH";
-export const removeCardFromDashboard = createAction(REMOVE_CARD_FROM_DASH);
 
 export const UNDO_REMOVE_CARD_FROM_DASH =
   "metabase/dashboard/UNDO_REMOVE_CARD_FROM_DASH";

--- a/frontend/src/metabase/dashboard/actions/core.js
+++ b/frontend/src/metabase/dashboard/actions/core.js
@@ -29,9 +29,6 @@ export const REMOVE_CARD_FROM_DASH = "metabase/dashboard/REMOVE_CARD_FROM_DASH";
 
 export const UNDO_REMOVE_CARD_FROM_DASH =
   "metabase/dashboard/UNDO_REMOVE_CARD_FROM_DASH";
-export const undoRemoveCardFromDashboard = createAction(
-  UNDO_REMOVE_CARD_FROM_DASH,
-);
 
 export const UPDATE_DASHCARD_VISUALIZATION_SETTINGS =
   "metabase/dashboard/UPDATE_DASHCARD_VISUALIZATION_SETTINGS";

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -32,7 +32,6 @@ import {
   MOBILE_DEFAULT_CARD_HEIGHT,
 } from "metabase/visualizations/shared/utils/sizes";
 
-import { cancelFetchCardData } from "../actions/data-fetching";
 import { DashboardCard } from "./DashboardGrid.styled";
 
 import GridLayout from "./grid/GridLayout";
@@ -41,7 +40,7 @@ import { generateMobileLayout } from "./grid/utils";
 import AddSeriesModal from "./AddSeriesModal/AddSeriesModal";
 import DashCard from "./DashCard";
 
-const mapDispatchToProps = { addUndo, cancelFetchCardData };
+const mapDispatchToProps = { addUndo };
 
 class DashboardGrid extends Component {
   static contextType = ContentViewportContext;
@@ -295,9 +294,9 @@ class DashboardGrid extends Component {
   };
 
   onDashCardRemove(dc) {
-    this.props.cancelFetchCardData(dc.card_id, dc.id);
     this.props.removeCardFromDashboard({
       dashcardId: dc.id,
+      cardId: dc.card_id,
     });
     this.props.addUndo({
       message: t`Removed card`,

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -32,6 +32,7 @@ import {
   MOBILE_DEFAULT_CARD_HEIGHT,
 } from "metabase/visualizations/shared/utils/sizes";
 
+import { cancelFetchCardData } from "../actions/data-fetching";
 import { DashboardCard } from "./DashboardGrid.styled";
 
 import GridLayout from "./grid/GridLayout";
@@ -40,7 +41,7 @@ import { generateMobileLayout } from "./grid/utils";
 import AddSeriesModal from "./AddSeriesModal/AddSeriesModal";
 import DashCard from "./DashCard";
 
-const mapDispatchToProps = { addUndo };
+const mapDispatchToProps = { addUndo, cancelFetchCardData };
 
 class DashboardGrid extends Component {
   static contextType = ContentViewportContext;
@@ -294,6 +295,7 @@ class DashboardGrid extends Component {
   };
 
   onDashCardRemove(dc) {
+    this.props.cancelFetchCardData(dc.card_id, dc.id);
     this.props.removeCardFromDashboard({
       dashcardId: dc.id,
     });


### PR DESCRIPTION
This addresses part of https://github.com/metabase/metabase/issues/12926, specifically queries not being cancelled when removing cards from dashboards.

How to reproduce:
- add a long running query to a dashboard (for example `SELECT 1, pg_sleep(600)`)
- remove the card from the dashboard, without this PR the query will still be pending, with this PR it should be cancelled

I also had to make the "undo" work again by re-fetching the query when undoing the removal.



https://github.com/metabase/metabase/assets/1914270/08a4c72e-ef00-4914-9691-2c20065d5ef2


