### PR TITLE
Fix errors when removing custom columns used by other clauses

### DIFF
--- a/e2e/test/scenarios/question/reproductions/32625-removing-dependent-clauses.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/32625-removing-dependent-clauses.cy.spec.js
@@ -1,0 +1,61 @@
+import {
+  main,
+  getNotebookStep,
+  restore,
+  visitQuestionAdhoc,
+  visualize,
+} from "e2e/support/helpers";
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { ORDERS_ID } = SAMPLE_DATABASE;
+
+const CC_NAME = "Is Promotion";
+
+const QUESTION = {
+  dataset_query: {
+    type: "query",
+    database: SAMPLE_DB_ID,
+    query: {
+      "source-table": ORDERS_ID,
+      aggregation: ["distinct", ["field", 13, { "base-type": "type/Integer" }]],
+      breakout: ["expression", CC_NAME],
+      expressions: {
+        [CC_NAME]: [
+          "case",
+          [[[">", ["field", 9, null], 0], 1]],
+          { default: 0 },
+        ],
+      },
+    },
+  },
+};
+
+describe("issue 32625, issue 31635", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should remove dependent clauses when a clause is removed (metabase#32625, metabase#31635)", () => {
+    visitQuestionAdhoc(QUESTION, { mode: "notebook" });
+
+    getNotebookStep("expression")
+      .findAllByTestId("notebook-cell-item")
+      .first()
+      .icon("close")
+      .click();
+
+    getNotebookStep("expression").should("not.exist");
+    getNotebookStep("summarize").findByText(CC_NAME).should("not.exist");
+
+    visualize();
+
+    main().within(() => {
+      cy.findByTestId("scalar-value").should("have.text", "200");
+      cy.findByText("There was a problem with your question").should(
+        "not.exist",
+      );
+    });
+  });
+});

--- a/e2e/test/scenarios/question/reproductions/32625-removing-dependent-clauses.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/32625-removing-dependent-clauses.cy.spec.js
@@ -1,5 +1,4 @@
 import {
-  main,
   getNotebookStep,
   restore,
   visitQuestionAdhoc,
@@ -51,7 +50,7 @@ describe("issue 32625, issue 31635", () => {
 
     visualize();
 
-    main().within(() => {
+    cy.findByTestId("query-builder-main").within(() => {
       cy.findByTestId("scalar-value").should("have.text", "200");
       cy.findByText("There was a problem with your question").should(
         "not.exist",

--- a/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
@@ -51,6 +51,10 @@ const Notebook = ({ className, ...props }: NotebookProps) => {
       Lib.toLegacyQuery(question._getMLv2Query()),
     );
 
+    // MLv2 doesn't clean up redundant stages, so we do it with MLv1 for now
+    const query = cleanQuestion.query() as StructuredQuery;
+    cleanQuestion = cleanQuestion.setQuery(query.cleanEmpty());
+
     if (cleanQuestion.display() === "table") {
       cleanQuestion = cleanQuestion.setDefaultDisplay();
     }

--- a/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
@@ -53,7 +53,7 @@ const Notebook = ({ className, ...props }: NotebookProps) => {
 
     // MLv2 doesn't clean up redundant stages, so we do it with MLv1 for now
     const query = cleanQuestion.query() as StructuredQuery;
-    cleanQuestion = cleanQuestion.setQuery(query.cleanEmpty());
+    cleanQuestion = cleanQuestion.setQuery(query.clean());
 
     if (cleanQuestion.display() === "table") {
       cleanQuestion = cleanQuestion.setDefaultDisplay();

--- a/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
@@ -3,6 +3,7 @@ import _ from "underscore";
 import Button from "metabase/core/components/Button";
 import Questions from "metabase/entities/questions";
 import { State } from "metabase-types/store";
+import * as Lib from "metabase-lib";
 import Question from "metabase-lib/Question";
 import StructuredQuery from "metabase-lib/queries/StructuredQuery";
 import {
@@ -44,10 +45,12 @@ const Notebook = ({ className, ...props }: NotebookProps) => {
     setQueryBuilderMode,
   } = props;
 
-  // When switching out of the notebook editor, cleanupQuestion accounts for
-  // post aggregation filters and otherwise nested queries with duplicate column names.
   async function cleanupQuestion() {
-    let cleanQuestion = question.setQuery(question.query().clean());
+    // Converting a query to MLv2 and back performs a clean-up
+    let cleanQuestion = question.setDatasetQuery(
+      Lib.toLegacyQuery(question._getMLv2Query()),
+    );
+
     if (cleanQuestion.display() === "table") {
       cleanQuestion = cleanQuestion.setDefaultDisplay();
     }


### PR DESCRIPTION
Reproduces #32625, fixes #32625, fixes #31635

Followup FE fix for #32625 and #31635 (which are essentially the same issue)

#32685 has a BE fix. On the FE, we need to convert a query to MLv2 and back to MLv1 before running it from the notebook. That'd ensure we drop hanging clauses or references in the query. Overall there shouldn't be a need for that in MLv2, but since CCs are not yet ported, they're still removed by the MLv1 mechanism that doesn't perform that kind of cleanup anymore.

> **Warning**
> #31635 is technically solved, but you'd run into another issue if you try to reproduce it (#32845)

### To Verify

1. New > Question > Raw Data > Sample Database > Orders
2. Add a custom column called "Is Promotion", with a formula being `case([Discount] > 0, 1, 0)`
3. Summarize count by "Is Promotion"
4. Click "Visualize"
5. You should see a table
6. Go back to the notebook editor and remove the "Is Promotion" column
7. Ensure the breakout on "Is Promotion" disappeared
8. Click "Visualize" again
9. You should see a number (from aggregation) and no errors

### Demo

**Before**

https://github.com/metabase/metabase/assets/17258145/f043bac4-73ca-4de5-a5b8-a247d32f9e7a

**After**

https://github.com/metabase/metabase/assets/17258145/cba18942-9896-49fa-ba5e-37bb426ab137
