### PR TITLE
Allow `w` and `h` props usage in eslint for Mantine

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -57,7 +57,7 @@
         ]
       }
     ],
-    "no-console": [2, {"allow": ["warn", "error"]}],
+    "no-console": [2, { "allow": ["warn", "error"] }],
     "react/no-is-mounted": 2,
     "react/prefer-es6-class": 2,
     "react/display-name": 1,
@@ -79,7 +79,25 @@
     "no-useless-escape": 0,
     "no-only-tests/no-only-tests": [
       "error",
-      {"block": ["describe", "it", "context", "test", "tape", "fixture", "serial", "Feature", "Scenario", "Given", "And", "When", "Then", "describeWithSnowplow", "describeEE"]}
+      {
+        "block": [
+          "describe",
+          "it",
+          "context",
+          "test",
+          "tape",
+          "fixture",
+          "serial",
+          "Feature",
+          "Scenario",
+          "Given",
+          "And",
+          "When",
+          "Then",
+          "describeWithSnowplow",
+          "describeEE"
+        ]
+      }
     ],
     "complexity": ["error", { "max": 54 }]
   },

--- a/.eslintrc
+++ b/.eslintrc
@@ -70,7 +70,7 @@
     "react/no-unescaped-entities": 2,
     "react/jsx-no-target-blank": 2,
     "react/jsx-key": 2,
-    "react/forbid-component-props": [2, { "forbid": ["w", "h", "sx"] }],
+    "react/forbid-component-props": [2, { "forbid": ["sx"] }],
     "react-hooks/exhaustive-deps": [
       "warn",
       { "additionalHooks": "(useSyncedQueryString|useSafeAsyncFunction)" }


### PR DESCRIPTION
#17656 restricted `w` and `h` props usage for `styled-system`. `styled-system` is removed, but `w` and `h` are perfectly valid props in Mantine. This PR removes them from eslint's `react/forbid-component-props` rule. Also prettier did some formatting to the file