### PR TITLE
[Manual backport] Remove references to missing expressions when converting to pMBQL (#32685)

### DIFF
--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -43,7 +43,7 @@
 (def ^:private stage-keys
   #{:aggregation :breakout :expressions :fields :filters :order-by :joins})
 
-(defn- clean-stage [almost-stage]
+(defn- clean-stage-schema-errors [almost-stage]
   (loop [almost-stage almost-stage
          removals []]
     (if-let [[error-type error-location] (->> (mc/explain ::lib.schema/stage.mbql almost-stage)
@@ -63,6 +63,17 @@
           almost-stage
           (recur new-stage (conj removals [error-type error-location]))))
       almost-stage)))
+
+(defn- clean-stage-ref-errors [almost-stage]
+  (reduce (fn [almost-stage [loc _]]
+              (clean-location almost-stage ::lib.schema/invalid-ref loc))
+          almost-stage
+          (lib.schema/ref-errors-for-stage almost-stage)))
+
+(defn- clean-stage [almost-stage]
+  (-> almost-stage
+      clean-stage-schema-errors
+      clean-stage-ref-errors))
 
 (defn- clean [almost-query]
   (loop [almost-query almost-query

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -562,4 +562,16 @@
                                  :fields [[:xfield 2 nil]]}]
                         :source-table 4}}
                lib.convert/->pMBQL
-               (get-in [:stages 0 :joins 0 :fields]))))))
+               (get-in [:stages 0 :joins 0 :fields]))))
+    (testing "references to missing expressions are removed (#32625)"
+      (let [query {:database 2762
+                   :type     :query
+                   :query    {:aggregation [[:sum [:case [[[:< [:field 139657 nil] 2] [:field 139657 nil]]] {:default 0}]]]
+                              :expressions {"custom" [:+ 1 1]}
+                              :breakout    [[:expression "expr1" nil] [:expression "expr2" nil]]
+                              :order-by    [[:expression "expr2" nil]]
+                              :limit       4
+                              :source-table 33674}}
+            converted (lib.convert/->pMBQL query)]
+        (is (empty? (get-in converted [:stages 0 :breakout])))
+        (is (empty? (get-in converted [:stages 0 :group-by])))))))


### PR DESCRIPTION
#32685
