### PR TITLE
Reduce number of tests stored in memory

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -118,6 +118,7 @@ const mainConfig = {
   ...defaultConfig,
   viewportHeight: 800,
   viewportWidth: 1280,
+  numTestsKeptInMemory: 1,
   reporter: "mochawesome",
   reporterOptions: {
     reportDir: "cypress/reports/mochareports",


### PR DESCRIPTION
This PR should help free up some memory during E2E test runs.

From the Cypress docs
https://docs.cypress.io/guides/references/configuration#Global

> The number of tests for which snapshots and command data are kept in memory. Reduce this number if you are experiencing high memory consumption in your browser during a test run.

The default value is 50.
We're dialing it down to 1.