### PR TITLE
fix resetting to default dashcard visualization settings

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -118,8 +118,11 @@ class ChartSettings extends Component {
   handleResetSettings = () => {
     MetabaseAnalytics.trackStructEvent("Chart Settings", "Reset Settings");
 
-    const settings = getClickBehaviorSettings(this._getSettings());
-    this.props.onChange(settings);
+    const originalCardSettings =
+      this.props.dashcard.card.visualization_settings;
+    const clickBehaviorSettings = getClickBehaviorSettings(this._getSettings());
+
+    this.props.onChange({ ...originalCardSettings, ...clickBehaviorSettings });
   };
 
   handleChangeSettings = changedSettings => {

--- a/frontend/src/metabase/visualizations/components/ChartSettings.unit.spec.js
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.unit.spec.js
@@ -1,4 +1,10 @@
+import userEvent from "@testing-library/user-event";
 import { renderWithProviders, fireEvent, screen } from "__support__/ui";
+import {
+  createMockCard,
+  createMockDashboardOrderedCard,
+  createMockVisualizationSettings,
+} from "metabase-types/api/mocks";
 
 import ChartSettings from "metabase/visualizations/components/ChartSettings";
 
@@ -114,5 +120,43 @@ describe("ChartSettings", () => {
     });
 
     expect(screen.queryByText("Foo")).not.toBeInTheDocument();
+  });
+
+  it("reset settings should revert to the original card settings with click behavior", () => {
+    const onChange = jest.fn();
+
+    const originalVizSettings = createMockVisualizationSettings({
+      "graph.goal_value": 100,
+      "graph.show_goal": true,
+      "graph.goal_label": "foo",
+    });
+
+    const modifiedSettings = createMockVisualizationSettings({
+      "graph.show_goal": false,
+      "graph.goal_label": "bar",
+      click_behavior: {
+        type: "link",
+        linkType: "url",
+      },
+    });
+
+    setup({
+      dashcard: createMockDashboardOrderedCard({
+        card: createMockCard({ visualization_settings: originalVizSettings }),
+      }),
+      settings: modifiedSettings,
+      widgets: [],
+      onChange,
+    });
+
+    userEvent.click(screen.getByText("Reset to defaults"));
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...originalVizSettings,
+      click_behavior: {
+        type: "link",
+        linkType: "url",
+      },
+    });
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/13248

### Description

Fixes the "Reset to defaults" button behavior on the visualization settings modal of a dashcard. It cleared even card's own visualization settings which is incorrect.

### How to verify

1. New question -> Orders: count by "Created At" with a breakout by Product.Category
2. Hide any series in visualization settings
3. Add the card on a dashboard
4. Open dashcard visualization settings, change anything and press "Reset to defaults"
5. Ensure it does not show series you've hidden on a card

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
