### PR TITLE
Reproduce failed breakout detection in multistage queries

### DIFF
--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -297,6 +297,120 @@ describe("scenarios > question > settings", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("₿ 6.10");
     });
+
+    it("should allow hiding and showing aggregated columns with a post-aggregation custom column (metabase#22563)", () => {
+      // products joined to orders with breakouts on 3 product columns followed by a custom column
+      cy.createQuestion(
+        {
+          name: "repro 22563",
+          query: {
+            "source-query": {
+              "source-table": ORDERS_ID,
+              joins: [
+                {
+                  alias: "Products",
+                  condition: [
+                    "=",
+                    ["field", ORDERS.PRODUCT_ID, null],
+                    [
+                      "field",
+                      PRODUCTS.ID,
+                      {
+                        "join-alias": "Products",
+                      },
+                    ],
+                  ],
+                  "source-table": PRODUCTS_ID,
+                },
+              ],
+              aggregation: [["count"]],
+              breakout: [
+                [
+                  "field",
+                  PRODUCTS.CATEGORY,
+                  {
+                    "base-type": "type/Text",
+                    "join-alias": "Products",
+                  },
+                ],
+                [
+                  "field",
+                  PRODUCTS.TITLE,
+                  {
+                    "base-type": "type/Text",
+                    "join-alias": "Products",
+                  },
+                ],
+                [
+                  "field",
+                  PRODUCTS.VENDOR,
+                  {
+                    "base-type": "type/Text",
+                    "join-alias": "Products",
+                  },
+                ],
+              ],
+            },
+            expressions: {
+              two: ["+", 1, 1],
+            },
+          },
+        },
+        { visitQuestion: true },
+      );
+
+      const columnNames = [
+        "Products → Category",
+        "Products → Title",
+        "Products → Vendor",
+        "Count",
+        "two",
+      ];
+
+      cy.findByTestId("TableInteractive-root").within(() => {
+        columnNames.forEach(text => cy.findByText(text).should("be.visible"));
+      });
+
+      cy.findByTestId("viz-settings-button").click();
+
+      cy.findByTestId("chartsettings-sidebar").within(() => {
+        columnNames.forEach(text => cy.findByText(text).should("be.visible"));
+        cy.findByText("More Columns").should("not.exist");
+
+        cy.icon("eye_outline").first().click();
+
+        cy.findByText("More columns").should("be.visible");
+
+        // disable the first column
+        cy.findByTestId("disabled-columns")
+          .findByText("Products → Category")
+          .should("be.visible");
+        cy.findByTestId("visible-columns")
+          .findByText("Products → Category")
+          .should("not.exist");
+      });
+
+      cy.findByTestId("TableInteractive-root").within(() => {
+        // the query should not have changed
+        cy.icon("play").should("not.exist");
+        cy.findByText("Products → Category").should("not.exist");
+      });
+
+      cy.findByTestId("chartsettings-sidebar").within(() => {
+        cy.icon("add").click();
+        // re-enable the first column
+        cy.findByText("More columns").should("not.exist");
+        cy.findByTestId("visible-columns")
+          .findByText("Products → Category")
+          .should("be.visible");
+      });
+
+      cy.findByTestId("TableInteractive-root").within(() => {
+        // the query should not have changed
+        cy.icon("play").should("not.exist");
+        cy.findByText("Products → Category").should("be.visible");
+      });
+    });
   });
 
   describe("resetting state", () => {

--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -298,7 +298,7 @@ describe("scenarios > question > settings", () => {
       cy.findByText("₿ 6.10");
     });
 
-    it("should allow hiding and showing aggregated columns with a post-aggregation custom column (metabase#22563)", () => {
+    it.skip("should allow hiding and showing aggregated columns with a post-aggregation custom column (metabase#22563)", () => {
       // products joined to orders with breakouts on 3 product columns followed by a custom column
       cy.createQuestion(
         {


### PR DESCRIPTION
reproduces https://github.com/metabase/metabase/issues/22563

### Problem

The reproduction is complex in the issue, but the essence of this bug is that when you have custom columns after aggregations in a query, the query becomes multistage and the calls to `columnDimensions()` in `/metabase-lib/queries/utils/dataset.js` don't treat the query as having aggregations because it only checks the last stage.  

*(you can check this by following the repro, but put the custom column before the aggregation and see that everything works fine)*

This creates two problems: 
- First, we show `additionalOptions` in the column settings, which are nonsensical for aggregated queries.
- Second, we get `columnDimensions` that don't follow the correct logic path because we ignore the aggregations, which causes `syncTableColumnsToQuery()` in `/metabase-lib/utils/dataset.js` to get inconsistent results from `columnDimensions` and it thinks it needs to add a fieldsClause to the query, which is what messes up the columns to create this bug.

## Solution

Wait for MLv2 to save us with its better handling of query stages. Commiting the reproduction for now.


~~The fix I found was to check not just the top level query for breakouts, but all stages of the query both in producing `fieldOptions()` and `columnDimensions()`)~~

Before | After
--- | ---
![beforebreakoutsfix](https://github.com/metabase/metabase/assets/30528226/57eb739d-59e0-4a87-8d54-8871555f5e35) | ![afteraggfix](https://github.com/metabase/metabase/assets/30528226/d695179a-d7b8-42e4-89f2-b5e98492026d)

~~This is accomplished by adding a new `hasAnyBreakouts()` function to the StructuredQuery class that checks all query stages for breakouts, and using that in `fieldOptions()` and `columnDimensions()`. ~~

~~This certainly solves this issue, but what is less clear is whether these changes to `columnDimensions` could have side effects elsewhere. 🤔  It is only called in `dataset.js`, but that affects nearly every query we send to the backend.~~

### How to verify

Follow Flamber's repro steps, or run the e2e test.

