### PR TITLE
Get rid of backfill query for user-recent-views

### DIFF
--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -2,13 +2,10 @@
   (:require
    [clojure.core.async :as a]
    [java-time :as t]
-   [metabase.api.common :as api]
-   [metabase.db.connection :as mdb.connection]
    [metabase.events :as events]
    [metabase.models.setting :as setting :refer [defsetting]]
    [metabase.models.view-log :refer [ViewLog]]
    [metabase.server.middleware.session :as mw.session]
-   [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :as i18n :refer [deferred-tru]]
    [metabase.util.log :as log]
    [toucan2.core :as t2]))

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -28,82 +28,10 @@
 
 ;;; ## ---------------------------------------- PER-USER VIEWS ----------------------------------------
 
-(defn- bookmarks-query
-  [user-id]
-  (let [as-null (when (= (mdb.connection/db-type) :postgres) (h2x/->integer nil))]
-    {:select [[:type :model] [:item_id :model_id]]
-     :from   [[{:union-all [{:select [:card_id
-                                      [as-null :dashboard_id]
-                                      [as-null :collection_id]
-                                      [:card_id :item_id]
-                                      [(h2x/literal "card") :type]
-                                      :created_at]
-                             :from   [:card_bookmark]
-                             :where  [:= :user_id [:inline user-id]]}
-                            {:select [[as-null :card_id]
-                                      :dashboard_id
-                                      [as-null :collection_id]
-                                      [:dashboard_id :item_id]
-                                      [(h2x/literal "dashboard") :type]
-                                      :created_at]
-                             :from   [:dashboard_bookmark]
-                             :where  [:= :user_id [:inline user-id]]}]}
-               :bookmarks]]}))
-
-(defn- recent-views-from-view-log
-  [user-id]
-  (let [bookmarks (bookmarks-query user-id)
-        qe        {:select [[(h2x/literal "qe") :source]
-                            [:executor_id :user_id]
-                            :context
-                            [:started_at :timestamp]
-                            [(h2x/literal "card") :model]
-                            [:card_id :model_id]
-                            [false :dataset]]
-                   :from   :query_execution}
-        vl        {:select    [[(h2x/literal "vl") :source]
-                               :user_id
-                               [(h2x/literal "question") :context]
-                               :timestamp
-                               :model
-                               :model_id
-                               [:report_card.dataset :dataset]]
-                   :from      [:view_log]
-                   :left-join [:report_card
-                               [:and
-                                [:= :view_log.model (h2x/literal "card")]
-                                [:= :view_log.model_id :report_card.id]]]}
-        views     {:union-all [qe vl]}]
-    (t2/query
-     {:select   [[[:max :timestamp] :timestamp]
-                 :model
-                 :model_id]
-      :from     [[views :views]]
-      :where    [[:and
-                  [:= :user_id [:inline user-id]]
-                  [:>= :timestamp (t/minus (t/offset-date-time) (t/days 30))]
-                  [:not= :context (h2x/literal "pulse")]
-                  [:not= :context (h2x/literal "collection")]
-                  [:not= :context (h2x/literal "ad-hoc")]
-                  [:not= [:composite :context :model] [:composite (h2x/literal "dashboard") (h2x/literal "card")]]
-                  [:not= [:composite :source :model :dataset] [:composite (h2x/literal "vl") (h2x/literal "card") [:inline false]]]
-                  [:not-in [:composite :model :model_id] bookmarks]]]
-      :group-by [:model :model_id]
-      :order-by [[:timestamp :desc]]
-      :limit    [:inline 8]})))
-
 (defsetting user-recent-views
   (deferred-tru "List of the 10 most recently viewed items for the user.")
   :user-local :only
-  :type :json
-  :getter (fn []
-            (let [value (setting/get-value-of-type :json :user-recent-views)]
-              (if value
-                (vec value)
-                (let [views (mapv #(select-keys % [:model :model_id])
-                                  (recent-views-from-view-log api/*current-user-id*))]
-                  (setting/set-value-of-type! :json :user-recent-views views)
-                  views)))))
+  :type :json)
 
 (defsetting dismissed-custom-dashboard-toast
   (deferred-tru "Toggle which is true after a user has dismissed the custom dashboard toast.")


### PR DESCRIPTION
This giant query is only being used to backfill recent views for users who don't have any data stored in the user-local setting, but it's still causing issues. We can remove it entirely with only very minor consequences (see https://metaboat.slack.com/archives/C056QEW4KNF/p1691001916669419 for more context). 

Resolves https://github.com/metabase/metabase/issues/32737

I'll look into migrating the user-local setting into a standalone table in another PR