### PR TITLE
Ldap group mapping slash issue

### DIFF
--- a/src/metabase/integrations/ldap.clj
+++ b/src/metabase/integrations/ldap.clj
@@ -20,7 +20,7 @@
 ;; Load the EE namespace up front so that the extra Settings it defines are available immediately.
 ;; Otherwise, this would only happen the first time `find-user` or `fetch-or-create-user!` is called.
 (when config/ee-available?
- (classloader/require 'metabase-enterprise.enhancements.integrations.ldap))
+  (classloader/require 'metabase-enterprise.enhancements.integrations.ldap))
 
 (defsetting ldap-host
   (deferred-tru "Server hostname."))
@@ -92,7 +92,7 @@
 
                (map? new-value)
                (do (doseq [k (keys new-value)]
-                     (when-not (DN/isValidDN (name k))
+                     (when-not (DN/isValidDN (metabase.util/qualified-name k))
                        (throw (IllegalArgumentException. (tru "{0} is not a valid DN." (name k))))))
                    (setting/set-value-of-type! :json :ldap-group-mappings new-value)))))
 
@@ -200,7 +200,7 @@
   "Tests the connection to an LDAP server using the currently set settings."
   []
   (let [settings (into {} (for [[k v] mb-settings->ldap-details]
-                             [v (setting/get k)]))]
+                            [v (setting/get k)]))]
     (test-ldap-connection settings)))
 
 (defn verify-password

--- a/src/metabase/integrations/ldap.clj
+++ b/src/metabase/integrations/ldap.clj
@@ -92,8 +92,8 @@
 
                (map? new-value)
                (do (doseq [k (keys new-value)]
-                     (when-not (DN/isValidDN (metabase.util/qualified-name k))
-                       (throw (IllegalArgumentException. (tru "{0} is not a valid DN." (name k))))))
+                     (when-not (DN/isValidDN (u/qualified-name k))
+                       (throw (IllegalArgumentException. (tru "{0} is not a valid DN." (u/qualified-name k))))))
                    (setting/set-value-of-type! :json :ldap-group-mappings new-value)))))
 
 (defsetting ldap-configured?

--- a/test/metabase/integrations/ldap_test.clj
+++ b/test/metabase/integrations/ldap_test.clj
@@ -10,7 +10,7 @@
    [metabase.test.integrations.ldap :as ldap.test]
    [toucan2.core :as t2])
   (:import
-   (com.unboundid.ldap.sdk LDAPConnectionPool)))
+   (com.unboundid.ldap.sdk DN LDAPConnectionPool)))
 
 (set! *warn-on-reflection* true)
 
@@ -171,6 +171,14 @@
               ["CN=Accounting,OU=Groups,DC=metabase,DC=com"
                "CN=Shipping,OU=Groups,DC=metabase,DC=com"]
               {:group-mappings (ldap/ldap-group-mappings)}))))))
+
+(deftest valid-group-mapping
+  (testing "Validating that the LDAP keyword can contain a forward slash (#29629)"
+    (mt/with-temporary-setting-values
+      [ldap-group-mappings nil]
+      (ldap/ldap-group-mappings! {(keyword "CN=People,OU=Security/Distribution Groups,DC=metabase,DC=com") []})
+      (is (= {(DN. "CN=People,OU=Security/Distribution Groups,DC=metabase,DC=com") []}
+             (ldap/ldap-group-mappings))))))
 
 ;; For hosts that do not support IPv6, the connection code will return an error
 ;; This isn't a failure of the code, it's a failure of the host.

--- a/test/metabase/integrations/ldap_test.clj
+++ b/test/metabase/integrations/ldap_test.clj
@@ -173,7 +173,7 @@
               {:group-mappings (ldap/ldap-group-mappings)}))))))
 
 (deftest valid-group-mapping
-  (testing "Validating that the LDAP keyword can contain a forward slash (#29629)"
+  (testing "Validating that a group mapping DN can contain a forward slash when set as a keyword (#29629)"
     (mt/with-temporary-setting-values
       [ldap-group-mappings nil]
       (ldap/ldap-group-mappings! {(keyword "CN=People,OU=Security/Distribution Groups,DC=metabase,DC=com") []})


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/29629

### Description

Use the custom qualified-name function to not strip out the slash in the LDAP group name

