### PR TITLE
Install `terser-webpack-plugin`

### DIFF
--- a/package.json
+++ b/package.json
@@ -271,6 +271,7 @@
     "shadow-cljs": "2.24.0",
     "source-map-loader": "^4.0.1",
     "style-loader": "3.3.1",
+    "terser-webpack-plugin": "^5.3.9",
     "typescript": "^4.7.2",
     "webpack": "^5.85.0",
     "webpack-cli": "^5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4881,6 +4881,14 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@jridgewell/source-map@^0.3.3":
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.5.tgz#a3bb4d5c6825aab0d281268f47f6ad5853431e91"
+  integrity sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.0"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
 "@jridgewell/sourcemap-codec@1.4.14":
   version "1.4.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
@@ -8956,6 +8964,11 @@ acorn@^8.7.1, acorn@^8.8.0:
   version "8.8.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.1.tgz#0a3f9cbecc4ec3bea6f0a80b66ae8dd2da250b73"
   integrity sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==
+
+acorn@^8.8.2:
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
+  integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
 
 address@^1.0.1:
   version "1.1.2"
@@ -23778,6 +23791,17 @@ terser-webpack-plugin@^5.3.7:
     serialize-javascript "^6.0.1"
     terser "^5.16.5"
 
+terser-webpack-plugin@^5.3.9:
+  version "5.3.9"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz#832536999c51b46d468067f9e37662a3b96adfe1"
+  integrity sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.17"
+    jest-worker "^27.4.5"
+    schema-utils "^3.1.1"
+    serialize-javascript "^6.0.1"
+    terser "^5.16.8"
+
 terser@^4.1.2, terser@^4.6.3:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
@@ -23803,6 +23827,16 @@ terser@^5.16.5:
   dependencies:
     "@jridgewell/source-map" "^0.3.2"
     acorn "^8.5.0"
+    commander "^2.20.0"
+    source-map-support "~0.5.20"
+
+terser@^5.16.8:
+  version "5.19.2"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.19.2.tgz#bdb8017a9a4a8de4663a7983f45c506534f9234e"
+  integrity sha512-qC5+dmecKJA4cpYxRa5aVkKehYsQKc+AHeKl0Oe62aYjBL8ZA33tTljktDHJSaxxMnbI5ZYw+o/S2DxxLu8OfA==
+  dependencies:
+    "@jridgewell/source-map" "^0.3.3"
+    acorn "^8.8.2"
     commander "^2.20.0"
     source-map-support "~0.5.20"
 


### PR DESCRIPTION
This PR should resolve #29265

If you do what the error message says and add `--trace-deprecation` to `NODE_OPTIONS`, you'll see that it leads to `terser-webpack-plugin`

```
(node:95526) [DEP_WEBPACK_MAIN_TEMPLATE_HASH_FOR_CHUNK] DeprecationWarning: MainTemplate.hooks.hashForChunk is deprecated (use JavascriptModulesPlugin.getCompilationHooks().chunkHash instead)
    at /Users/metabase/code/metabase-org/metabase/node_modules/terser-webpack-plugin/dist/index.js:552:39
    at Hook.eval [as call] (eval at create (/Users/metabase/code/metabase-org/metabase/node_modules/tapable/lib/HookCodeFactory.js:19:10), <anonymous>:110:1)
    at Hook.CALL_DELEGATE [as _call] (/Users/metabase/code/metabase-org/metabase/node_modules/tapable/lib/Hook.js:14:14)
    at Compiler.newCompilation (/Users/metabase/code/metabase-org/metabase/node_modules/webpack/lib/Compiler.js:1125:26)
    at /Users/metabase/code/metabase-org/metabase/node_modules/webpack/lib/Compiler.js:1169:29
    at Hook.eval [as callAsync] (eval at create (/Users/metabase/code/metabase-org/metabase/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
    at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/Users/metabase/code/metabase-org/metabase/node_modules/tapable/lib/Hook.js:18:14)
    at Compiler.compile (/Users/metabase/code/metabase-org/metabase/node_modules/webpack/lib/Compiler.js:1164:28)
    at /Users/metabase/code/metabase-org/metabase/node_modules/webpack/lib/Compiler.js:524:12
    at Compiler.readRecords (/Users/metabase/code/metabase-org/metabase/node_modules/webpack/lib/Compiler.js:989:5)
    at /Users/metabase/code/metabase-org/metabase/node_modules/webpack/lib/Compiler.js:521:11
    at Hook.eval [as callAsync] (eval at create (/Users/metabase/code/metabase-org/metabase/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:15:1)
    at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/Users/metabase/code/metabase-org/metabase/node_modules/tapable/lib/Hook.js:18:14)
    at /Users/metabase/code/metabase-org/metabase/node_modules/webpack/lib/Compiler.js:518:20
    at Hook.eval [as callAsync] (eval at create (/Users/metabase/code/metabase-org/metabase/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:15:1)
    at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/Users/metabase/code/metabase-org/metabase/node_modules/tapable/lib/Hook.js:18:14)
```

## Solution
[Terser Webpack Plugin](https://www.npmjs.com/package/terser-webpack-plugin) readme says:

> Webpack v5 comes with the latest terser-webpack-plugin out of the box. **If you are using Webpack v5 or above and wish to customize the options, you will still need to install terser-webpack-plugin**.

We were relying on the "out-of-the-box" solution, but we do indeed have some customizations in our [`webpack.config.js`](https://github.com/metabase/metabase/blob/master/webpack.config.js#L353)

## Potential Benefits:
It also locally reduced the build time for me locally (~20s) but I'm not sure if this is a reliable result.

**Before**
```
webpack 5.85.0 compiled with 2 warnings in 74462 ms
✨  Done in 104.25s.
```

**After**
```
webpack 5.85.0 compiled with 2 warnings in 55663 ms
✨  Done in 85.01s.
```

## How to test?
1. run `yarn build-release`
2. you shouldn't see deprecation warnings anymore

If you want to check before and after, edit this line:
`"build-release:js": "yarn && WEBPACK_BUNDLE=production NODE_OPTIONS=\"--max-old-space-size=8196 --trace-deprecation\" webpack --bail",`
