### PR TITLE
Make it easier to configure `QueryColumnPicker` color

### DIFF
--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.styled.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.styled.tsx
@@ -1,5 +1,10 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
+import type { ColorName } from "metabase/lib/colors/types";
+
+export const Root = styled.div<{ color: ColorName }>`
+  color: ${props => color(props.color)};
+`;
 
 export const ColumnPickerContainer = styled.div`
   min-width: 300px;

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -20,6 +20,7 @@ import type StructuredQuery from "metabase-lib/queries/StructuredQuery";
 
 import QueryColumnPicker from "../QueryColumnPicker";
 import {
+  Root,
   ColumnPickerContainer,
   ColumnPickerHeaderContainer,
   ColumnPickerHeaderTitleContainer,
@@ -241,6 +242,7 @@ export function AggregationPicker({
           columnGroups={columnGroups}
           hasTemporalBucketing
           maxHeight={maxHeight}
+          color="summarize"
           checkIsColumnSelected={checkColumnSelected}
           onSelect={handleColumnSelect}
           onClose={onClose}
@@ -250,18 +252,19 @@ export function AggregationPicker({
   }
 
   return (
-    <AccordionList
-      className={className}
-      sections={sections}
-      maxHeight={maxHeight}
-      alwaysExpanded={false}
-      onChange={handleChange}
-      onChangeSection={handleSectionChange}
-      itemIsSelected={checkIsItemSelected}
-      renderItemName={renderItemName}
-      renderItemDescription={omitItemDescription}
-      renderItemExtra={renderItemExtra}
-    />
+    <Root className={className} color="summarize">
+      <AccordionList
+        sections={sections}
+        maxHeight={maxHeight}
+        alwaysExpanded={false}
+        onChange={handleChange}
+        onChangeSection={handleSectionChange}
+        itemIsSelected={checkIsItemSelected}
+        renderItemName={renderItemName}
+        renderItemDescription={omitItemDescription}
+        renderItemExtra={renderItemExtra}
+      />
+    </Root>
   );
 }
 

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.styled.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.styled.tsx
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 import { Icon } from "metabase/core/components/Icon";
 import BaseSelectList from "metabase/components/SelectList";
 import { alpha, color } from "metabase/lib/colors";
+import type { ColorName } from "metabase/lib/colors/types";
 
 export const TriggerIcon = styled(Icon)`
   color: ${color("white")} !important;
@@ -23,16 +24,18 @@ export const TriggerButton = styled.button`
   }
 `;
 
-export const SelectListItem = styled(BaseSelectList.Item)`
+export const SelectListItem = styled(BaseSelectList.Item)<{
+  activeColor: ColorName;
+}>`
   padding: 0.5rem 1rem;
   font-weight: 400;
 
   &[aria-selected="true"] {
-    background-color: ${color("summarize")};
+    background-color: ${props => color(props.activeColor)};
   }
 
   &:hover {
-    background-color: ${color("summarize")};
+    background-color: ${props => color(props.activeColor)};
   }
 `;
 

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
+import type { ColorName } from "metabase/lib/colors/types";
 import * as Lib from "metabase-lib";
 import {
   TriggerButton,
@@ -22,6 +23,7 @@ export interface BaseBucketPickerPopoverProps {
   isEditing: boolean;
   triggerLabel?: string;
   hasArrowIcon?: boolean;
+  color?: ColorName;
   checkBucketIsSelected: (item: BucketListItem) => boolean;
   renderTriggerContent: (bucket?: Lib.BucketDisplayInfo) => void;
   onSelect: (column: Lib.Bucket | NoBucket) => void;
@@ -35,6 +37,7 @@ function _BaseBucketPickerPopover({
   isEditing,
   triggerLabel,
   hasArrowIcon = true,
+  color = "brand",
   checkBucketIsSelected,
   renderTriggerContent,
   onSelect,
@@ -73,6 +76,7 @@ function _BaseBucketPickerPopover({
               id={item.displayName}
               key={item.displayName}
               name={item.displayName}
+              activeColor={color}
               isSelected={checkBucketIsSelected(item)}
               onSelect={() => {
                 onSelect(item.bucket);

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/types.ts
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/types.ts
@@ -3,7 +3,7 @@ import type { BaseBucketPickerPopoverProps } from "./BaseBucketPickerPopover";
 
 type CommonProps = Pick<
   BaseBucketPickerPopoverProps,
-  "query" | "stageIndex" | "isEditing" | "hasArrowIcon"
+  "query" | "stageIndex" | "isEditing" | "color" | "hasArrowIcon"
 >;
 
 export interface CommonBucketPickerProps extends CommonProps {

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.styled.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.styled.tsx
@@ -1,7 +1,8 @@
 import styled from "@emotion/styled";
+import AccordionList from "metabase/core/components/AccordionList";
 import { color } from "metabase/lib/colors";
 import type { ColorName } from "metabase/lib/colors/types";
 
-export const Root = styled.div<{ color: ColorName }>`
+export const StyledAccordionList = styled(AccordionList)<{ color: ColorName }>`
   color: ${props => color(props.color)};
 `;

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.styled.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.styled.tsx
@@ -1,0 +1,7 @@
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+import type { ColorName } from "metabase/lib/colors/types";
+
+export const Root = styled.div<{ color: ColorName }>`
+  color: ${props => color(props.color)};
+`;

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useMemo } from "react";
 
-import AccordionList from "metabase/core/components/AccordionList";
 import { getColumnIcon } from "metabase/common/utils/columns";
 import { Icon, IconName } from "metabase/core/components/Icon";
 import { singularize } from "metabase/lib/formatting";
@@ -9,7 +8,7 @@ import type { ColorName } from "metabase/lib/colors/types";
 import * as Lib from "metabase-lib";
 
 import { BucketPickerPopover } from "./BucketPickerPopover";
-import { Root } from "./QueryColumnPicker.styled";
+import { StyledAccordionList } from "./QueryColumnPicker.styled";
 
 const DEFAULT_MAX_HEIGHT = 610;
 
@@ -143,22 +142,22 @@ function QueryColumnPicker({
   );
 
   return (
-    <Root className={className} color={color}>
-      <AccordionList
-        sections={sections}
-        maxHeight={maxHeight}
-        alwaysExpanded={false}
-        onChange={handleSelectColumn}
-        itemIsSelected={checkIsColumnSelected}
-        renderItemName={renderItemName}
-        renderItemDescription={omitItemDescription}
-        renderItemIcon={renderItemIcon}
-        renderItemExtra={renderItemExtra}
-        // Compat with E2E tests around MLv1-based components
-        // Prefer using a11y role selectors
-        itemTestId="dimension-list-item"
-      />
-    </Root>
+    <StyledAccordionList
+      className={className}
+      sections={sections}
+      maxHeight={maxHeight}
+      alwaysExpanded={false}
+      onChange={handleSelectColumn}
+      itemIsSelected={checkIsColumnSelected}
+      renderItemName={renderItemName}
+      renderItemDescription={omitItemDescription}
+      renderItemIcon={renderItemIcon}
+      renderItemExtra={renderItemExtra}
+      color={color}
+      // Compat with E2E tests around MLv1-based components
+      // Prefer using a11y role selectors
+      itemTestId="dimension-list-item"
+    />
   );
 }
 

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -4,10 +4,12 @@ import AccordionList from "metabase/core/components/AccordionList";
 import { getColumnIcon } from "metabase/common/utils/columns";
 import { Icon, IconName } from "metabase/core/components/Icon";
 import { singularize } from "metabase/lib/formatting";
+import type { ColorName } from "metabase/lib/colors/types";
 
 import * as Lib from "metabase-lib";
 
 import { BucketPickerPopover } from "./BucketPickerPopover";
+import { Root } from "./QueryColumnPicker.styled";
 
 const DEFAULT_MAX_HEIGHT = 610;
 
@@ -23,6 +25,7 @@ export interface QueryColumnPickerProps {
   hasBinning?: boolean;
   hasTemporalBucketing?: boolean;
   maxHeight?: number;
+  color?: ColorName;
   checkIsColumnSelected: (item: ColumnListItem) => boolean;
   onSelect: (column: Lib.ColumnMetadata) => void;
   onClose?: () => void;
@@ -42,6 +45,7 @@ function QueryColumnPicker({
   hasBinning = false,
   hasTemporalBucketing = false,
   maxHeight = DEFAULT_MAX_HEIGHT,
+  color = "brand",
   checkIsColumnSelected,
   onSelect,
   onClose,
@@ -123,6 +127,7 @@ function QueryColumnPicker({
           isEditing={checkIsColumnSelected(item)}
           hasBinning={hasBinning}
           hasTemporalBucketing={hasTemporalBucketing}
+          color={color}
           onSelect={handleSelect}
         />
       ) : null,
@@ -131,27 +136,29 @@ function QueryColumnPicker({
       stageIndex,
       hasBinning,
       hasTemporalBucketing,
+      color,
       checkIsColumnSelected,
       handleSelect,
     ],
   );
 
   return (
-    <AccordionList
-      className={className}
-      sections={sections}
-      maxHeight={maxHeight}
-      alwaysExpanded={false}
-      onChange={handleSelectColumn}
-      itemIsSelected={checkIsColumnSelected}
-      renderItemName={renderItemName}
-      renderItemDescription={omitItemDescription}
-      renderItemIcon={renderItemIcon}
-      renderItemExtra={renderItemExtra}
-      // Compat with E2E tests around MLv1-based components
-      // Prefer using a11y role selectors
-      itemTestId="dimension-list-item"
-    />
+    <Root className={className} color={color}>
+      <AccordionList
+        sections={sections}
+        maxHeight={maxHeight}
+        alwaysExpanded={false}
+        onChange={handleSelectColumn}
+        itemIsSelected={checkIsColumnSelected}
+        renderItemName={renderItemName}
+        renderItemDescription={omitItemDescription}
+        renderItemIcon={renderItemIcon}
+        renderItemExtra={renderItemExtra}
+        // Compat with E2E tests around MLv1-based components
+        // Prefer using a11y role selectors
+        itemTestId="dimension-list-item"
+      />
+    </Root>
   );
 }
 

--- a/frontend/src/metabase/lib/colors/types.ts
+++ b/frontend/src/metabase/lib/colors/types.ts
@@ -2,6 +2,8 @@ import { colors } from "./palette";
 
 export type ColorPalette = Partial<Record<keyof typeof colors, string>>;
 
+export type ColorName = keyof ColorPalette;
+
 export interface AccentColorOptions {
   main?: boolean;
   light?: boolean;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.styled.tsx
@@ -1,7 +1,0 @@
-import styled from "@emotion/styled";
-import { AggregationPicker as BaseAggregationPicker } from "metabase/common/components/AggregationPicker";
-import { color } from "metabase/lib/colors";
-
-export const AggregationPicker = styled(BaseAggregationPicker)`
-  color: ${color("summarize")};
-`;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
@@ -1,12 +1,12 @@
 import { t } from "ttag";
 
+import { AggregationPicker } from "metabase/common/components/AggregationPicker";
+
 import * as Lib from "metabase-lib";
 import type StructuredQuery from "metabase-lib/queries/StructuredQuery";
 
 import type { NotebookStepUiComponentProps } from "../../types";
 import ClauseStep from "../ClauseStep";
-
-import { AggregationPicker } from "./AggregateStep.styled";
 
 const aggTetherOptions = {
   attachment: "top left",

--- a/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.styled.tsx
@@ -1,7 +1,0 @@
-import styled from "@emotion/styled";
-import QueryColumnPicker from "metabase/common/components/QueryColumnPicker";
-import { color } from "metabase/lib/colors";
-
-export const BreakoutColumnPicker = styled(QueryColumnPicker)`
-  color: ${color("summarize")};
-`;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.tsx
@@ -1,10 +1,10 @@
 import { t } from "ttag";
 
+import QueryColumnPicker from "metabase/common/components/QueryColumnPicker";
 import * as Lib from "metabase-lib";
 
 import type { NotebookStepUiComponentProps } from "../../types";
 import ClauseStep from "../ClauseStep";
-import { BreakoutColumnPicker } from "./BreakoutStep.styled";
 
 const breakoutTetherOptions = {
   attachment: "top left",
@@ -91,12 +91,13 @@ function BreakoutStep({
       tetherOptions={breakoutTetherOptions}
       renderName={renderBreakoutName}
       renderPopover={(breakout, breakoutIndex) => (
-        <BreakoutColumnPicker
+        <QueryColumnPicker
           query={topLevelQuery}
           stageIndex={stageIndex}
           columnGroups={getColumnGroups(breakoutIndex)}
           hasBinning
           hasTemporalBucketing
+          color="summarize"
           checkIsColumnSelected={item =>
             checkColumnSelected(item, breakoutIndex)
           }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.tsx
@@ -92,6 +92,7 @@ function SortStep({
           query={topLevelQuery}
           stageIndex={stageIndex}
           columnGroups={getColumnGroups(orderByIndex)}
+          color="text-dark"
           checkIsColumnSelected={item =>
             checkColumnSelected(item, orderByIndex)
           }

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnListItem/BreakoutColumnListItem.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnListItem/BreakoutColumnListItem.styled.tsx
@@ -17,6 +17,8 @@ export const BucketPickerPopover = styled(BaseBucketPickerPopover)`
   }
 `;
 
+BucketPickerPopover.defaultProps = { color: "summarize" };
+
 export const Content = styled.div`
   display: flex;
   flex: auto;


### PR DESCRIPTION
Preparation for joins MLv2 migration: it's possible to specify a temporal unit for join condition columns. We want the temporal unit picker to use the "brand" color, but now it's hardcoded to "summarize" and isn't easy to change.

The PR introduces an optional `color` prop ("brand" by default) to the `QueryColumnPicker` and `BucketPickerPopover` components. Also updates how they're used across the codebase:

* `AggregationPicker` (notebook, summarize sidebar) 
* `AggregationStep` (notebook)
* `BreakoutStep` (notebook)
* `SortStep` (notebook)

### To Verify

1. New > Question > Pick any table
2. Ensure aggregation, breakout, and sort column pickers use expected colors
3. Exit the notebook
4. Click "Summarize", and ensure the sidebar uses the expected "summarize" color