### PR TITLE
MLv2 Joins 2 — Suggested condition

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
@@ -71,8 +71,15 @@ export function JoinStep({
   };
 
   const handleTableChange = (nextTable: Lib.Joinable) => {
-    setTable(nextTable);
-    setIsAddingNewCondition(true);
+    const nextQuery = setTable(nextTable);
+
+    // If setTable returns a query,
+    // it means it was possible to automatically set the condition via FKs
+    if (nextQuery) {
+      updateQuery(nextQuery);
+    } else {
+      setIsAddingNewCondition(true);
+    }
   };
 
   const handleAddCondition = (condition: Lib.JoinConditionClause) => {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -404,6 +404,5 @@ describe("Notebook Editor > Join Step", () => {
   });
 
   it.todo("field selection");
-  it.todo("default condition");
   it.todo("multiple conditions");
 });

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -259,6 +259,26 @@ describe("Notebook Editor > Join Step", () => {
     );
   });
 
+  it("should apply a suggested condition when table is selected", async () => {
+    const { getRecentJoin } = setup();
+
+    const popover = screen.getByTestId("popover");
+    userEvent.click(await within(popover).findByText("Products"));
+
+    const { conditions } = getRecentJoin();
+    const [condition] = conditions;
+    expect(conditions).toHaveLength(1);
+    expect(condition.operator).toBe("=");
+    expect(condition.lhsColumn.longDisplayName).toBe("Product ID");
+    expect(condition.rhsColumn.longDisplayName).toBe("Products → ID");
+
+    expect(screen.getByLabelText("Left column")).toHaveTextContent(
+      "Product ID",
+    );
+    expect(screen.getByLabelText("Right column")).toHaveTextContent("ID");
+    expect(screen.getByLabelText("Change operator")).toHaveTextContent("=");
+  });
+
   it("should change LHS column", async () => {
     const query = getJoinedQuery();
     const { getRecentJoin } = setup(

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/use-join.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/use-join.ts
@@ -47,10 +47,28 @@ export function useJoin(query: Lib.Query, stageIndex: number, join?: Lib.Join) {
     [query, stageIndex, join],
   );
 
-  const setTable = useCallback((nextTable: Lib.Joinable) => {
-    _setTable(nextTable);
-    _setConditions([]);
-  }, []);
+  const setTable = useCallback(
+    (nextTable: Lib.Joinable) => {
+      _setTable(nextTable);
+      const suggestedCondition = Lib.suggestedJoinCondition(
+        query,
+        stageIndex,
+        nextTable,
+      );
+
+      if (suggestedCondition) {
+        const nextConditions = [suggestedCondition];
+        _setConditions(nextConditions);
+        let nextJoin = Lib.joinClause(nextTable, nextConditions);
+        nextJoin = Lib.withJoinFields(nextJoin, "all");
+        nextJoin = Lib.withJoinStrategy(nextJoin, strategy);
+        return Lib.join(query, stageIndex, nextJoin);
+      } else {
+        _setConditions([]);
+      }
+    },
+    [query, stageIndex, strategy],
+  );
 
   const addCondition = useCallback(
     (condition: Lib.JoinConditionClause) => {


### PR DESCRIPTION
Part of #31070, epic #30514

Integrates MLv2's `suggested-condition` method. When constructing a new join and picking the RHS table, `suggested-condition` will check if there's a relation between LHS and RHS tables and, if there is one, would return a join condition object

> **Warning**
> This PR targets a feature branch and doesn't migrate `JoinStep` features 1:1
> This branch is expected to have failing tests because parts of functionality are simply missing
> You can monitor the migration health with the last branch in the chain — #32912

**Previous PRs**

- #32903

**Next PRs**

- #32905
- #32906
- #32907
- #32908
- #32911
- #32912