### PR TITLE
MLv2 Joins 3 — Fields

### DIFF
--- a/frontend/src/metabase-lib/comparison.ts
+++ b/frontend/src/metabase-lib/comparison.ts
@@ -1,5 +1,7 @@
 import * as ML from "cljs/metabase.lib.js";
 import type { DatasetQuery } from "metabase-types/api";
+import type { ColumnMetadata, Query } from "./types";
+import { displayInfo } from "./metadata";
 
 export function areLegacyQueriesEqual(
   query1: DatasetQuery,
@@ -7,4 +9,15 @@ export function areLegacyQueriesEqual(
   fieldIds?: number[],
 ): boolean {
   return ML.query_EQ_(query1, query2, fieldIds);
+}
+
+export function isSameColumn(
+  query: Query,
+  stageIndex: number,
+  column1: ColumnMetadata,
+  column2: ColumnMetadata,
+): boolean {
+  const info1 = displayInfo(query, stageIndex, column1);
+  const info2 = displayInfo(query, stageIndex, column2);
+  return info1.name === info2.name && info1?.table?.name === info2?.table?.name;
 }

--- a/frontend/src/metabase-lib/comparison.ts
+++ b/frontend/src/metabase-lib/comparison.ts
@@ -1,7 +1,5 @@
 import * as ML from "cljs/metabase.lib.js";
 import type { DatasetQuery } from "metabase-types/api";
-import type { ColumnMetadata, Query } from "./types";
-import { displayInfo } from "./metadata";
 
 export function areLegacyQueriesEqual(
   query1: DatasetQuery,
@@ -9,15 +7,4 @@ export function areLegacyQueriesEqual(
   fieldIds?: number[],
 ): boolean {
   return ML.query_EQ_(query1, query2, fieldIds);
-}
-
-export function isSameColumn(
-  query: Query,
-  stageIndex: number,
-  column1: ColumnMetadata,
-  column2: ColumnMetadata,
-): boolean {
-  const info1 = displayInfo(query, stageIndex, column1);
-  const info2 = displayInfo(query, stageIndex, column2);
-  return info1.name === info2.name && info1?.table?.name === info2?.table?.name;
 }

--- a/frontend/src/metabase-lib/join.ts
+++ b/frontend/src/metabase-lib/join.ts
@@ -159,7 +159,7 @@ export function suggestedJoinCondition(
   return ML.suggested_join_condition(query, stageIndex, joinable);
 }
 
-type JoinFields = ColumnMetadata[] | "all" | "none";
+export type JoinFields = ColumnMetadata[] | "all" | "none";
 
 export function joinFields(join: Join): JoinFields {
   return ML.join_fields(join);

--- a/frontend/src/metabase/common/components/FieldPicker/FieldPicker.tsx
+++ b/frontend/src/metabase/common/components/FieldPicker/FieldPicker.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { t } from "ttag";
 import CheckBox from "metabase/core/components/CheckBox";
 import StackedCheckBox from "metabase/components/StackedCheckBox";
@@ -5,24 +6,49 @@ import * as Lib from "metabase-lib";
 import { ToggleItem, ColumnItem } from "./FieldPicker.styled";
 
 interface FieldPickerProps {
-  columnsInfo: Lib.ColumnDisplayInfo[];
-  isAll: boolean;
-  isNone: boolean;
-  isDisabledDeselection?: boolean;
+  query: Lib.Query;
+  stageIndex: number;
+  columns: Lib.ColumnMetadata[];
+  isColumnSelected?: (column: Lib.ColumnMetadata) => boolean;
   onToggle: (columnIndex: number, isSelected: boolean) => void;
   onSelectAll: () => void;
   onSelectNone: () => void;
 }
 
 export const FieldPicker = ({
-  columnsInfo,
-  isAll,
-  isNone,
-  isDisabledDeselection,
+  query,
+  stageIndex,
+  columns,
   onToggle,
   onSelectAll,
   onSelectNone,
+  isColumnSelected = (column: Lib.ColumnMetadata) =>
+    !!Lib.displayInfo(query, stageIndex, column).selected,
 }: FieldPickerProps) => {
+  const items = useMemo(
+    () =>
+      columns.map(column => ({
+        ...Lib.displayInfo(query, stageIndex, column),
+        column,
+      })),
+    [query, stageIndex, columns],
+  );
+
+  const isAll = useMemo(
+    () => columns.every(isColumnSelected),
+    [columns, isColumnSelected],
+  );
+
+  const isNone = useMemo(
+    () => columns.every(column => !isColumnSelected(column)),
+    [columns, isColumnSelected],
+  );
+
+  const isDisabledDeselection = useMemo(
+    () => columns.filter(isColumnSelected).length <= 1,
+    [columns, isColumnSelected],
+  );
+
   const handleLabelToggle = () => {
     if (isAll) {
       onSelectNone();
@@ -42,13 +68,13 @@ export const FieldPicker = ({
           onChange={handleLabelToggle}
         />
       </ToggleItem>
-      {columnsInfo.map((columnInfo, columnIndex) => (
-        <ColumnItem key={columnIndex}>
+      {items.map((item, index) => (
+        <ColumnItem key={item.longDisplayName}>
           <CheckBox
-            checked={columnInfo.selected}
-            label={columnInfo.displayName}
-            disabled={columnInfo.selected && isDisabledDeselection}
-            onChange={event => onToggle(columnIndex, event.target.checked)}
+            checked={isColumnSelected(item.column)}
+            label={item.displayName}
+            disabled={isColumnSelected(item.column) && isDisabledDeselection}
+            onChange={event => onToggle(index, event.target.checked)}
           />
         </ColumnItem>
       ))}

--- a/frontend/src/metabase/common/components/FieldPicker/FieldPicker.tsx
+++ b/frontend/src/metabase/common/components/FieldPicker/FieldPicker.tsx
@@ -9,6 +9,7 @@ interface FieldPickerProps {
   query: Lib.Query;
   stageIndex: number;
   columns: Lib.ColumnMetadata[];
+  "data-testid"?: string;
   isColumnSelected?: (column: Lib.ColumnMetadata) => boolean;
   onToggle: (columnIndex: number, isSelected: boolean) => void;
   onSelectAll: () => void;
@@ -24,6 +25,7 @@ export const FieldPicker = ({
   onSelectNone,
   isColumnSelected = (column: Lib.ColumnMetadata) =>
     !!Lib.displayInfo(query, stageIndex, column).selected,
+  ...props
 }: FieldPickerProps) => {
   const items = useMemo(
     () =>
@@ -58,7 +60,7 @@ export const FieldPicker = ({
   };
 
   return (
-    <ul>
+    <ul data-testid={props["data-testid"]}>
       <ToggleItem>
         <StackedCheckBox
           className=""

--- a/frontend/src/metabase/common/components/FieldPicker/FieldPicker.tsx
+++ b/frontend/src/metabase/common/components/FieldPicker/FieldPicker.tsx
@@ -10,7 +10,7 @@ interface FieldPickerProps {
   stageIndex: number;
   columns: Lib.ColumnMetadata[];
   "data-testid"?: string;
-  isColumnSelected?: (column: Lib.ColumnMetadata) => boolean;
+  isColumnSelected: (column: Lib.ColumnMetadata) => boolean;
   onToggle: (columnIndex: number, isSelected: boolean) => void;
   onSelectAll: () => void;
   onSelectNone: () => void;
@@ -23,8 +23,7 @@ export const FieldPicker = ({
   onToggle,
   onSelectAll,
   onSelectNone,
-  isColumnSelected = (column: Lib.ColumnMetadata) =>
-    !!Lib.displayInfo(query, stageIndex, column).selected,
+  isColumnSelected,
   ...props
 }: FieldPickerProps) => {
   const items = useMemo(

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
@@ -72,7 +72,7 @@ interface DataFieldsPickerProps {
   updateQuery: (query: Lib.Query) => Promise<void>;
 }
 
-const DataFieldsPicker = ({
+export const DataFieldsPicker = ({
   query,
   stageIndex,
   updateQuery,
@@ -82,32 +82,14 @@ const DataFieldsPicker = ({
     [query, stageIndex],
   );
 
-  const columnsInfo = useMemo(
-    () => columns.map(column => Lib.displayInfo(query, stageIndex, column)),
-    [query, stageIndex, columns],
-  );
-
-  const isAll = useMemo(
-    () => columnsInfo.every(columnInfo => columnInfo.selected),
-    [columnsInfo],
-  );
-
-  const isNone = useMemo(
-    () => columnsInfo.every(columnInfo => !columnInfo.selected),
-    [columnsInfo],
-  );
-
-  const isDisabledDeselection = useMemo(
-    () => columnsInfo.filter(columnInfo => columnInfo.selected).length <= 1,
-    [columnsInfo],
-  );
-
   const handleToggle = (changedIndex: number, isSelected: boolean) => {
-    const nextColumns = columns.filter((_, currentIndex) =>
-      currentIndex === changedIndex
-        ? isSelected
-        : columnsInfo[currentIndex].selected,
-    );
+    const nextColumns = columns.filter((_, currentIndex) => {
+      if (currentIndex === changedIndex) {
+        return isSelected;
+      }
+      const column = columns[currentIndex];
+      return Lib.displayInfo(query, stageIndex, column).selected;
+    });
     const nextQuery = Lib.withFields(query, stageIndex, nextColumns);
     updateQuery(nextQuery);
   };
@@ -128,10 +110,9 @@ const DataFieldsPicker = ({
       triggerElement={FieldsPickerIcon}
     >
       <FieldPicker
-        columnsInfo={columnsInfo}
-        isAll={isAll}
-        isNone={isNone}
-        isDisabledDeselection={isDisabledDeselection}
+        query={query}
+        stageIndex={stageIndex}
+        columns={columns}
         onToggle={handleToggle}
         onSelectAll={handleSelectAll}
         onSelectNone={handleSelectNone}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
@@ -94,6 +94,9 @@ export const DataFieldsPicker = ({
     updateQuery(nextQuery);
   };
 
+  const checkColumnSelected = (column: Lib.ColumnMetadata) =>
+    !!Lib.displayInfo(query, stageIndex, column).selected;
+
   const handleSelectAll = () => {
     const nextQuery = Lib.withFields(query, stageIndex, []);
     updateQuery(nextQuery);
@@ -113,6 +116,7 @@ export const DataFieldsPicker = ({
         query={query}
         stageIndex={stageIndex}
         columns={columns}
+        isColumnSelected={checkColumnSelected}
         onToggle={handleToggle}
         onSelectAll={handleSelectAll}
         onSelectNone={handleSelectNone}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
@@ -1,6 +1,5 @@
 import { useRef, useState } from "react";
 import { t } from "ttag";
-import _ from "underscore";
 
 import { Box, Flex, Text } from "metabase/ui";
 
@@ -37,11 +36,14 @@ export function JoinStep({
   const {
     strategy,
     table,
+    columns,
     conditions,
     setStrategy,
     setTable,
     addCondition,
     updateCondition,
+    isColumnSelected,
+    setSelectedColumns,
   } = useJoin(query, stageIndex, join);
 
   const [isAddingNewCondition, setIsAddingNewCondition] = useState(false);
@@ -79,6 +81,13 @@ export function JoinStep({
       updateQuery(nextQuery);
     } else {
       setIsAddingNewCondition(true);
+    }
+  };
+
+  const handleSelectedColumnsChange = (nextColumns: Lib.JoinFields) => {
+    const nextQuery = setSelectedColumns(nextColumns);
+    if (nextQuery) {
+      updateQuery(nextQuery);
     }
   };
 
@@ -150,11 +159,13 @@ export function JoinStep({
             query={query}
             stageIndex={stageIndex}
             table={table}
+            columns={columns}
             color={color}
             isStartedFromModel={isStartedFromModel}
             readOnly={readOnly}
+            isColumnSelected={isColumnSelected}
             onChangeTable={handleTableChange}
-            onChangeFields={_.noop}
+            onChangeFields={handleSelectedColumnsChange}
           />
         </Flex>
       </NotebookCell>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -419,9 +419,78 @@ describe("Notebook Editor > Join Step", () => {
       });
     });
 
-    it.todo("should select a few columns when adding a join");
+    it("should select a few columns when adding a join", async () => {
+      const { getRecentJoin } = setup();
 
-    it.todo("should be able to select no columns when adding a new join");
+      const popover = screen.getByTestId("popover");
+      userEvent.click(await within(popover).findByText("Reviews"));
+
+      userEvent.click(await screen.findByLabelText("Pick columns"));
+      const joinColumnsPicker = await screen.findByTestId(
+        "join-columns-picker",
+      );
+
+      // Excluding a few columns
+      userEvent.click(within(joinColumnsPicker).getByText("Product ID"));
+      userEvent.click(within(joinColumnsPicker).getByText("Created At"));
+
+      userEvent.click(screen.getByLabelText("Left column"));
+      const lhsColumnPicker = await screen.findByLabelText("grid");
+      userEvent.click(within(lhsColumnPicker).getByText("Product ID"));
+      await waitFor(() =>
+        expect(screen.getByLabelText("Left column")).toHaveTextContent(
+          "Product ID",
+        ),
+      );
+
+      userEvent.click(screen.getByLabelText("Right column"));
+      await screen.findByLabelText("grid");
+      const [, rhsColumnPicker] = screen.getAllByLabelText("grid");
+      userEvent.click(within(rhsColumnPicker).getByText("Rating"));
+
+      const { query, fields } = getRecentJoin();
+      const columns = fields as Lib.ColumnMetadata[];
+      const category = columns.find(
+        column => Lib.displayInfo(query, 0, column).name === "PRODUCT_ID",
+      );
+      const price = columns.find(
+        column => Lib.displayInfo(query, 0, column).name === "CREATED_AT",
+      );
+      expect(columns).not.toHaveLength(0);
+      expect(category).toBeUndefined();
+      expect(price).toBeUndefined();
+    });
+
+    it("should be able to select no columns when adding a new join", async () => {
+      const { getRecentJoin } = setup();
+
+      const popover = screen.getByTestId("popover");
+      userEvent.click(await within(popover).findByText("Reviews"));
+
+      userEvent.click(await screen.findByLabelText("Pick columns"));
+      const joinColumnsPicker = await screen.findByTestId(
+        "join-columns-picker",
+      );
+
+      userEvent.click(within(joinColumnsPicker).getByText("Select none"));
+
+      userEvent.click(screen.getByLabelText("Left column"));
+      const lhsColumnPicker = await screen.findByLabelText("grid");
+      userEvent.click(within(lhsColumnPicker).getByText("Product ID"));
+      await waitFor(() =>
+        expect(screen.getByLabelText("Left column")).toHaveTextContent(
+          "Product ID",
+        ),
+      );
+
+      userEvent.click(screen.getByLabelText("Right column"));
+      await screen.findByLabelText("grid");
+      const [, rhsColumnPicker] = screen.getAllByLabelText("grid");
+      userEvent.click(within(rhsColumnPicker).getByText("Rating"));
+
+      const { fields } = getRecentJoin();
+      expect(fields).toHaveLength(0);
+    });
 
     it("should select a few columns for an existing join", async () => {
       const { getRecentJoin } = setup(

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -431,8 +431,12 @@ describe("Notebook Editor > Join Step", () => {
       );
 
       // Excluding a few columns
+      userEvent.click(within(joinColumnsPicker).getByText("Reviewer"));
       userEvent.click(within(joinColumnsPicker).getByText("Product ID"));
       userEvent.click(within(joinColumnsPicker).getByText("Created At"));
+
+      // Bring Reviewer column back
+      userEvent.click(within(joinColumnsPicker).getByText("Reviewer"));
 
       userEvent.click(screen.getByLabelText("Left column"));
       const lhsColumnPicker = await screen.findByLabelText("grid");
@@ -450,6 +454,9 @@ describe("Notebook Editor > Join Step", () => {
 
       const { query, fields } = getRecentJoin();
       const columns = fields as Lib.ColumnMetadata[];
+      const reviewer = columns.find(
+        column => Lib.displayInfo(query, 0, column).name === "REVIEWER",
+      );
       const category = columns.find(
         column => Lib.displayInfo(query, 0, column).name === "PRODUCT_ID",
       );
@@ -457,6 +464,7 @@ describe("Notebook Editor > Join Step", () => {
         column => Lib.displayInfo(query, 0, column).name === "CREATED_AT",
       );
       expect(columns).not.toHaveLength(0);
+      expect(reviewer).not.toBeUndefined();
       expect(category).toBeUndefined();
       expect(price).toBeUndefined();
     });
@@ -501,11 +509,18 @@ describe("Notebook Editor > Join Step", () => {
       const picker = await screen.findByTestId("join-columns-picker");
 
       // Excluding a few columns
-      userEvent.click(within(picker).getByText("Category"));
+      userEvent.click(within(picker).getByText("Vendor"));
       userEvent.click(within(picker).getByText("Price"));
+      userEvent.click(within(picker).getByText("Category"));
+
+      // Bring Vendors column back
+      userEvent.click(within(picker).getByText("Vendor"));
 
       const { query, fields } = getRecentJoin();
       const columns = fields as Lib.ColumnMetadata[];
+      const vendor = columns.find(
+        column => Lib.displayInfo(query, 0, column).name === "VENDOR",
+      );
       const category = columns.find(
         column => Lib.displayInfo(query, 0, column).name === "CATEGORY",
       );
@@ -513,6 +528,7 @@ describe("Notebook Editor > Join Step", () => {
         column => Lib.displayInfo(query, 0, column).name === "PRICE",
       );
       expect(columns).not.toHaveLength(0);
+      expect(vendor).not.toBeUndefined();
       expect(category).toBeUndefined();
       expect(price).toBeUndefined();
     });

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -447,9 +447,7 @@ describe("Notebook Editor > Join Step", () => {
         ),
       );
 
-      userEvent.click(screen.getByLabelText("Right column"));
-      await screen.findByLabelText("grid");
-      const [, rhsColumnPicker] = screen.getAllByLabelText("grid");
+      const [, rhsColumnPicker] = await screen.findAllByLabelText("grid");
       userEvent.click(within(rhsColumnPicker).getByText("Rating"));
 
       const { query, fields } = getRecentJoin();
@@ -491,9 +489,7 @@ describe("Notebook Editor > Join Step", () => {
         ),
       );
 
-      userEvent.click(screen.getByLabelText("Right column"));
-      await screen.findByLabelText("grid");
-      const [, rhsColumnPicker] = screen.getAllByLabelText("grid");
+      const [, rhsColumnPicker] = await screen.findAllByLabelText("grid");
       userEvent.click(within(rhsColumnPicker).getByText("Rating"));
 
       const { fields } = getRecentJoin();

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -531,6 +531,5 @@ describe("Notebook Editor > Join Step", () => {
     });
   });
 
-  it.todo("field selection");
   it.todo("multiple conditions");
 });

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -268,18 +268,18 @@ describe("Notebook Editor > Join Step", () => {
     const popover = screen.getByTestId("popover");
     userEvent.click(await within(popover).findByText("Products"));
 
+    expect(await screen.findByLabelText("Left column")).toHaveTextContent(
+      "Product ID",
+    );
+    expect(screen.getByLabelText("Right column")).toHaveTextContent("ID");
+    expect(screen.getByLabelText("Change operator")).toHaveTextContent("=");
+
     const { conditions } = getRecentJoin();
     const [condition] = conditions;
     expect(conditions).toHaveLength(1);
     expect(condition.operator).toBe("=");
     expect(condition.lhsColumn.longDisplayName).toBe("Product ID");
     expect(condition.rhsColumn.longDisplayName).toBe("Products → ID");
-
-    expect(await screen.findByLabelText("Left column")).toHaveTextContent(
-      "Product ID",
-    );
-    expect(screen.getByLabelText("Right column")).toHaveTextContent("ID");
-    expect(screen.getByLabelText("Change operator")).toHaveTextContent("=");
   });
 
   it("should change LHS column", async () => {
@@ -413,8 +413,10 @@ describe("Notebook Editor > Join Step", () => {
       const popover = screen.getByTestId("popover");
       userEvent.click(await within(popover).findByText("Products"));
 
-      const { fields } = getRecentJoin();
-      expect(fields).toBe("all");
+      await waitFor(() => {
+        const { fields } = getRecentJoin();
+        expect(fields).toBe("all");
+      });
     });
 
     it.todo("should select a few columns when adding a join");

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.styled.tsx
@@ -1,7 +1,16 @@
 import styled from "@emotion/styled";
+import IconButtonWrapper from "metabase/components/IconButtonWrapper/IconButtonWrapper";
+import { color } from "metabase/lib/colors";
+import { NotebookCell } from "../../../NotebookCell";
 
 export const PickerButton = styled.button`
   color: inherit;
   font-weight: inherit;
   cursor: pointer;
+`;
+
+export const ColumnPickerButton = styled(IconButtonWrapper)`
+  padding: ${NotebookCell.CONTAINER_PADDING};
+  opacity: 0.5;
+  color: ${color("white")};
 `;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
@@ -8,8 +8,11 @@ import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/Tipp
 import { DataSourceSelector } from "metabase/query_builder/components/DataSelector";
 import { DATA_BUCKET } from "metabase/containers/DataPicker";
 
+import Tables from "metabase/entities/tables";
 import { getMetadata } from "metabase/selectors/metadata";
-import { useSelector } from "metabase/lib/redux";
+import { useDispatch, useSelector } from "metabase/lib/redux";
+
+import type { TableId } from "metabase-types/api";
 import * as Lib from "metabase-lib";
 import type Table from "metabase-lib/metadata/Table";
 
@@ -42,6 +45,7 @@ export function JoinTablePicker({
   onChangeTable,
   onChangeFields,
 }: JoinTablePickerProps) {
+  const dispatch = useDispatch();
   const metadata = useSelector(getMetadata);
 
   const tableInfo = table ? Lib.displayInfo(query, stageIndex, table) : null;
@@ -65,8 +69,10 @@ export function JoinTablePicker({
     return undefined;
   }, [tableId, isStartedFromModel]);
 
-  const handleTableChange = (tableId: number | string) =>
+  const handleTableChange = async (tableId: TableId) => {
+    await dispatch(Tables.actions.fetchMetadata({ id: tableId }));
     onChangeTable(Lib.tableOrCardMetadata(query, tableId));
+  };
 
   const tableFilter = (table: Table) => !tableId || table.db_id === databaseId;
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
@@ -1,6 +1,10 @@
 import { useMemo } from "react";
 import { t } from "ttag";
 
+import { Icon } from "metabase/core/components/Icon";
+import Tooltip from "metabase/core/components/Tooltip";
+import { FieldPicker } from "metabase/common/components/FieldPicker";
+import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import { DataSourceSelector } from "metabase/query_builder/components/DataSelector";
 import { DATA_BUCKET } from "metabase/containers/DataPicker";
 
@@ -10,27 +14,33 @@ import * as Lib from "metabase-lib";
 import type Table from "metabase-lib/metadata/Table";
 
 import { NotebookCellItem } from "../../../NotebookCell";
-import { PickerButton } from "./JoinTablePicker.styled";
+import { FIELDS_PICKER_STYLES } from "../../../FieldsPickerIcon";
+import { PickerButton, ColumnPickerButton } from "./JoinTablePicker.styled";
 
 interface JoinTablePickerProps {
   query: Lib.Query;
   stageIndex: number;
+  columns?: Lib.ColumnMetadata[];
   table?: Lib.CardMetadata | Lib.TableMetadata;
   isStartedFromModel?: boolean;
   readOnly?: boolean;
   color: string;
+  isColumnSelected: (column: Lib.ColumnMetadata) => boolean;
   onChangeTable: (joinable: Lib.Joinable) => void;
-  onChangeFields: () => void;
+  onChangeFields: (columns: Lib.JoinFields) => void;
 }
 
 export function JoinTablePicker({
   query,
   stageIndex,
+  columns = [],
   table,
   isStartedFromModel,
   readOnly = false,
   color,
+  isColumnSelected,
   onChangeTable,
+  onChangeFields,
 }: JoinTablePickerProps) {
   const metadata = useSelector(getMetadata);
 
@@ -66,6 +76,18 @@ export function JoinTablePicker({
       readOnly={readOnly}
       color={color}
       aria-label={t`Right table`}
+      right={
+        table ? (
+          <JoinTableColumnsPicker
+            query={query}
+            stageIndex={stageIndex}
+            columns={columns}
+            isColumnSelected={isColumnSelected}
+            onChange={onChangeFields}
+          />
+        ) : null
+      }
+      rightContainerStyle={FIELDS_PICKER_STYLES.notebookRightItemContainer}
     >
       <DataSourceSelector
         hasTableSearch
@@ -82,5 +104,68 @@ export function JoinTablePicker({
         }
       />
     </NotebookCellItem>
+  );
+}
+
+interface JoinTableColumnsPickerProps {
+  query: Lib.Query;
+  stageIndex: number;
+  columns: Lib.ColumnMetadata[];
+  isColumnSelected: (column: Lib.ColumnMetadata) => boolean;
+  onChange: (columns: Lib.JoinFields) => void;
+}
+
+function JoinTableColumnsPicker({
+  query,
+  stageIndex,
+  columns,
+  isColumnSelected,
+  onChange,
+}: JoinTableColumnsPickerProps) {
+  const handleToggle = (changedIndex: number, isSelected: boolean) => {
+    const nextColumns = columns.filter((_, currentIndex) =>
+      currentIndex === changedIndex
+        ? isSelected
+        : isColumnSelected(columns[currentIndex]),
+    );
+    onChange(nextColumns);
+  };
+
+  const handleSelectAll = () => {
+    onChange("all");
+  };
+
+  const handleSelectNone = () => {
+    onChange("none");
+  };
+
+  return (
+    <TippyPopoverWithTrigger
+      popoverContent={
+        <FieldPicker
+          query={query}
+          stageIndex={stageIndex}
+          columns={columns}
+          isColumnSelected={isColumnSelected}
+          onToggle={handleToggle}
+          onSelectAll={handleSelectAll}
+          onSelectNone={handleSelectNone}
+          data-testid="join-columns-picker"
+        />
+      }
+      renderTrigger={({ onClick }) => (
+        <div>
+          <Tooltip tooltip={t`Pick columns`}>
+            <ColumnPickerButton
+              onClick={onClick}
+              aria-label={t`Pick columns`}
+              data-testid="fields-picker"
+            >
+              <Icon name="chevrondown" />
+            </ColumnPickerButton>
+          </Tooltip>
+        </div>
+      )}
+    />
   );
 }


### PR DESCRIPTION
Part of #31070, epic #30514

Implements RHS table columns selection for joins (`fields` in a join query object)

> **Warning**
> This PR targets a feature branch and doesn't migrate `JoinStep` features 1:1
> This branch is expected to have failing tests because parts of functionality are simply missing
> You can monitor the migration health with the last branch in the chain — #32912

**Previous PRs**

- #32903
- #32904

**Next PRs**

- #32906
- #32907
- #32908
- #32911
- #32912