### PR TITLE
MLv2 Joins 5 — Update condition UI

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.styled.tsx
@@ -4,16 +4,15 @@ import QueryColumnPicker from "metabase/common/components/QueryColumnPicker/Quer
 import { color, darken } from "metabase/lib/colors";
 
 const noColumnStyle = css`
-  height: 34px;
+  min-height: 34px;
   padding: 8px 20px;
   border: 1px solid rgba(255, 255, 255, 0.51);
   border-radius: 4px;
 `;
 
 const hasColumnStyle = css`
-  height: 39px;
-  padding-right: 16px;
-  padding-left: 10px;
+  min-height: 39px;
+  padding: 6px 16px 6px 10px;
   border-radius: 6px;
 `;
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.styled.tsx
@@ -1,12 +1,43 @@
 import styled from "@emotion/styled";
+import { css } from "@emotion/react";
+import { Flex } from "metabase/ui";
 import QueryColumnPicker from "metabase/common/components/QueryColumnPicker/QueryColumnPicker";
-import { color } from "metabase/lib/colors";
-import { NotebookCellItem } from "../../../NotebookCell";
+import { color, darken } from "metabase/lib/colors";
 
-export const JoinConditionCellItem = styled(NotebookCellItem)<{
+const noColumnStyle = css`
+  height: 34px;
+  padding: 8px 20px;
+  border: 1px solid rgba(255, 255, 255, 0.51);
+  border-radius: 4px;
+`;
+
+const hasColumnStyle = css`
+  height: 39px;
+  padding-right: 16px;
+  padding-left: 10px;
+  border-radius: 6px;
+`;
+
+export const JoinConditionCellItem = styled(Flex)<{
+  hasColumnSelected: boolean;
+  isOpen?: boolean;
   readOnly?: boolean;
 }>`
+  flex-direction: column;
+  justify-content: center;
+  gap: 2px;
+
+  ${props => (props.hasColumnSelected ? hasColumnStyle : noColumnStyle)};
+
   cursor: ${props => (props.readOnly ? "default" : "pointer")};
+  transition: background 300ms linear;
+
+  background: ${props =>
+    props.isOpen ? darken("brand", 0.15) : "transparent"};
+
+  &:hover {
+    background: ${darken("brand", 0.15)};
+  }
 `;
 
 export const StyledQueryColumnPicker = styled(QueryColumnPicker)`

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.styled.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
-import { Flex } from "metabase/ui";
 import QueryColumnPicker from "metabase/common/components/QueryColumnPicker/QueryColumnPicker";
 import { color, darken } from "metabase/lib/colors";
 
@@ -18,11 +17,12 @@ const hasColumnStyle = css`
   border-radius: 6px;
 `;
 
-export const JoinConditionCellItem = styled(Flex)<{
+export const JoinConditionCellItem = styled.button<{
   hasColumnSelected: boolean;
   isOpen?: boolean;
   readOnly?: boolean;
 }>`
+  display: flex;
   flex-direction: column;
   justify-content: center;
   gap: 2px;
@@ -35,7 +35,8 @@ export const JoinConditionCellItem = styled(Flex)<{
   background: ${props =>
     props.isOpen ? darken("brand", 0.15) : "transparent"};
 
-  &:hover {
+  &:hover,
+  &:focus {
     background: ${darken("brand", 0.15)};
   }
 `;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.styled.tsx
@@ -1,19 +1,32 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import QueryColumnPicker from "metabase/common/components/QueryColumnPicker/QueryColumnPicker";
-import { alpha, color, darken } from "metabase/lib/colors";
+import { alpha, color, lighten } from "metabase/lib/colors";
 
-const noColumnStyle = css`
+const noColumnStyle = (isOpen = false) => css`
   min-height: 34px;
   padding: 8px 20px;
-  border: 1px solid ${alpha(color("white"), 0.5)};
+  color: ${alpha("brand", 0.45)};
+  border: 2px solid ${isOpen ? color("brand") : alpha("brand", 0.45)};
   border-radius: 4px;
+
+  &:hover,
+  &:focus {
+    border-color: ${color("brand")};
+  }
 `;
 
-const hasColumnStyle = css`
+const hasColumnStyle = (isOpen = false) => css`
   min-height: 39px;
   padding: 6px 16px 6px 10px;
   border-radius: 6px;
+
+  background-color: ${isOpen ? lighten("brand", 0.1) : color("brand")};
+
+  &:hover,
+  &:focus {
+    background-color: ${lighten("brand", 0.1)};
+  }
 `;
 
 export const JoinConditionCellItem = styled.button<{
@@ -26,18 +39,13 @@ export const JoinConditionCellItem = styled.button<{
   justify-content: center;
   gap: 2px;
 
-  ${props => (props.hasColumnSelected ? hasColumnStyle : noColumnStyle)};
+  ${props =>
+    props.hasColumnSelected
+      ? hasColumnStyle(props.isOpen)
+      : noColumnStyle(props.isOpen)};
 
   cursor: ${props => (props.readOnly ? "default" : "pointer")};
-  transition: background 300ms linear;
-
-  background: ${props =>
-    props.isOpen ? darken("brand", 0.15) : "transparent"};
-
-  &:hover,
-  &:focus {
-    background: ${darken("brand", 0.15)};
-  }
+  transition: background 300ms linear, border 300ms linear, color 300ms linear;
 `;
 
 export const StyledQueryColumnPicker = styled(QueryColumnPicker)`

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.styled.tsx
@@ -1,12 +1,12 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import QueryColumnPicker from "metabase/common/components/QueryColumnPicker/QueryColumnPicker";
-import { color, darken } from "metabase/lib/colors";
+import { alpha, color, darken } from "metabase/lib/colors";
 
 const noColumnStyle = css`
   min-height: 34px;
   padding: 8px 20px;
-  border: 1px solid rgba(255, 255, 255, 0.51);
+  border: 1px solid ${alpha(color("white"), 0.5)};
   border-radius: 4px;
 `;
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.tsx
@@ -100,13 +100,21 @@ const ColumnNotebookCellItem = forwardRef<
       ref={ref}
     >
       {hasTableLabel && (
-        <Text display="block" size={11} lh={1} color="white" weight={400}>
+        <Text
+          display="block"
+          size={11}
+          lh={1}
+          color="white"
+          align="left"
+          weight={400}
+        >
           {tableName || t`Previous results`}
         </Text>
       )}
       <Text
         display="block"
         color="white"
+        align="left"
         weight={hasColumnSelected ? 600 : 400}
         lh={1}
       >

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, RefObject } from "react";
 import { t } from "ttag";
 
-import { Flex, Text } from "metabase/ui";
+import { Text } from "metabase/ui";
 import TippyPopoverWithTrigger, {
   TippyPopoverWithTriggerRef,
 } from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
@@ -23,7 +23,6 @@ interface JoinConditionColumnPickerProps
   label?: string;
   isInitiallyVisible?: boolean;
   readOnly?: boolean;
-  color: string;
   popoverRef?: RefObject<TippyPopoverWithTriggerRef>;
 }
 
@@ -40,7 +39,6 @@ export function JoinConditionColumnPicker({
   label,
   isInitiallyVisible = false,
   readOnly = false,
-  color,
   popoverRef,
   ...props
 }: JoinConditionColumnPickerProps) {
@@ -49,14 +47,13 @@ export function JoinConditionColumnPicker({
   return (
     <TippyPopoverWithTrigger
       isInitiallyVisible={isInitiallyVisible}
-      renderTrigger={({ onClick }) => (
+      renderTrigger={({ visible, onClick }) => (
         <ColumnNotebookCellItem
+          isOpen={visible}
           tableName={columnInfo?.table?.displayName}
           columnName={columnInfo?.displayName}
-          aria-label={label}
-          inactive={!column}
+          label={label}
           readOnly={readOnly}
-          color={color}
           onClick={onClick}
         />
       )}
@@ -78,8 +75,8 @@ export function JoinConditionColumnPicker({
 interface ColumnNotebookCellItemProps {
   tableName?: string;
   columnName?: string;
-  color: string;
-  inactive: boolean;
+  label?: string;
+  isOpen?: boolean;
   readOnly?: boolean;
   onClick: () => void;
 }
@@ -87,19 +84,34 @@ interface ColumnNotebookCellItemProps {
 const ColumnNotebookCellItem = forwardRef<
   HTMLDivElement,
   ColumnNotebookCellItemProps
->(function ColumnNotebookCellItem({ tableName, columnName, ...props }, ref) {
+>(function ColumnNotebookCellItem(
+  { tableName, columnName, label, isOpen, readOnly, onClick },
+  ref,
+) {
+  const hasColumnSelected = !!columnName;
+  const hasTableLabel = !!tableName || hasColumnSelected;
   return (
-    <JoinConditionCellItem {...props} ref={ref}>
-      <Flex direction="column" gap="2px">
-        {Boolean(tableName || columnName) && (
-          <Text display="block" size={11} lh={1} color="white" opacity={0.65}>
-            {tableName || t`Previous results`}
-          </Text>
-        )}
-        <Text display="block" lh={1}>
-          {columnName || t`Pick a column…`}
+    <JoinConditionCellItem
+      isOpen={isOpen}
+      hasColumnSelected={hasColumnSelected}
+      aria-label={label}
+      readOnly={readOnly}
+      onClick={onClick}
+      ref={ref}
+    >
+      {hasTableLabel && (
+        <Text display="block" size={11} lh={1} color="white" weight={400}>
+          {tableName || t`Previous results`}
         </Text>
-      </Flex>
+      )}
+      <Text
+        display="block"
+        color="white"
+        weight={hasColumnSelected ? 600 : 400}
+        lh={1}
+      >
+        {columnName || t`Pick a column…`}
+      </Text>
     </JoinConditionCellItem>
   );
 });

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.tsx
@@ -82,7 +82,7 @@ interface ColumnNotebookCellItemProps {
 }
 
 const ColumnNotebookCellItem = forwardRef<
-  HTMLDivElement,
+  HTMLButtonElement,
   ColumnNotebookCellItemProps
 >(function ColumnNotebookCellItem(
   { tableName, columnName, label, isOpen, readOnly, onClick },

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.tsx
@@ -113,9 +113,9 @@ const ColumnNotebookCellItem = forwardRef<
       )}
       <Text
         display="block"
-        color="white"
+        color={columnName ? "white" : "brand"}
         align="left"
-        weight={hasColumnSelected ? 600 : 400}
+        weight={700}
         lh={1}
       >
         {columnName || t`Pick a column…`}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionOperatorPicker/JoinConditionOperatorPicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionOperatorPicker/JoinConditionOperatorPicker.styled.tsx
@@ -15,7 +15,8 @@ export const OperatorPickerButton = styled.button<{ isOpen?: boolean }>`
 
   transition: background 300ms linear;
 
-  &:hover {
+  &:hover,
+  &:focus {
     background: ${darken("brand", 0.15)};
   }
 `;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionOperatorPicker/JoinConditionOperatorPicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionOperatorPicker/JoinConditionOperatorPicker.styled.tsx
@@ -1,24 +1,43 @@
 import styled from "@emotion/styled";
+import { css } from "@emotion/react";
 import SelectList from "metabase/components/SelectList";
-import { color, darken } from "metabase/lib/colors";
+import { color, lighten } from "metabase/lib/colors";
 
-export const OperatorPickerButton = styled.button<{ isOpen?: boolean }>`
-  background-color: ${props =>
-    props.isOpen ? darken("brand", 0.15) : "transparent"};
+const completeConditionStyle = (isOpen = false) => css`
   color: ${color("white")};
-  font-size: 16px;
+  background-color: ${isOpen ? lighten("brand", 0.1) : "transparent"};
 
+  &:hover,
+  &:focus {
+    background-color: ${lighten("brand", 0.1)};
+  }
+`;
+
+const incompleteConditionStyle = (isOpen = false) => css`
+  color: ${color("brand")};
+  border: 2px solid ${isOpen ? color("brand") : "transparent"};
+
+  &:hover,
+  &:focus {
+    border: 2px solid ${color("brand")};
+  }
+`;
+
+export const OperatorPickerButton = styled.button<{
+  isOpen?: boolean;
+  isConditionComplete: boolean;
+}>`
+  ${props =>
+    props.isConditionComplete
+      ? completeConditionStyle(props.isOpen)
+      : incompleteConditionStyle(props.isOpen)}
+
+  font-size: 16px;
   padding: 4px 8px;
   border-radius: 4px;
 
   cursor: ${props => (props.disabled ? "default" : "pointer")};
-
-  transition: background 300ms linear;
-
-  &:hover,
-  &:focus {
-    background: ${darken("brand", 0.15)};
-  }
+  transition: background 300ms linear, border 300ms linear, color 300ms linear;
 `;
 
 export const OperatorList = styled(SelectList)`

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionOperatorPicker/JoinConditionOperatorPicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionOperatorPicker/JoinConditionOperatorPicker.styled.tsx
@@ -1,15 +1,24 @@
 import styled from "@emotion/styled";
-import Button from "metabase/core/components/Button";
 import SelectList from "metabase/components/SelectList";
+import { color, darken } from "metabase/lib/colors";
 
-export const OperatorPickerButton = styled(Button)`
-  width: 36px;
-  height: 36px;
+export const OperatorPickerButton = styled.button<{ isOpen?: boolean }>`
+  background-color: ${props =>
+    props.isOpen ? darken("brand", 0.15) : "transparent"};
+  color: ${color("white")};
   font-size: 16px;
-  padding: 0;
-`;
 
-OperatorPickerButton.defaultProps = { primary: true };
+  padding: 4px 8px;
+  border-radius: 4px;
+
+  cursor: ${props => (props.disabled ? "default" : "pointer")};
+
+  transition: background 300ms linear;
+
+  &:hover {
+    background: ${darken("brand", 0.15)};
+  }
+`;
 
 export const OperatorList = styled(SelectList)`
   width: 80px;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionOperatorPicker/JoinConditionOperatorPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionOperatorPicker/JoinConditionOperatorPicker.tsx
@@ -12,6 +12,7 @@ interface JoinConditionOperatorPickerProps {
   stageIndex: number;
   operator?: Lib.FilterOperator;
   operators: Lib.FilterOperator[];
+  disabled?: boolean;
   onChange: (operator: Lib.FilterOperator) => void;
 }
 
@@ -20,6 +21,7 @@ export function JoinConditionOperatorPicker({
   stageIndex,
   operator: selectedOperator,
   operators,
+  disabled,
   onChange,
 }: JoinConditionOperatorPickerProps) {
   const selectedOperatorInfo = selectedOperator
@@ -28,8 +30,13 @@ export function JoinConditionOperatorPicker({
 
   return (
     <TippyPopoverWithTrigger
-      renderTrigger={({ onClick }) => (
-        <OperatorPickerButton onClick={onClick} aria-label={t`Change operator`}>
+      renderTrigger={({ visible, onClick }) => (
+        <OperatorPickerButton
+          isOpen={visible}
+          onClick={onClick}
+          disabled={disabled}
+          aria-label={t`Change operator`}
+        >
           {selectedOperatorInfo?.shortName}
         </OperatorPickerButton>
       )}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionOperatorPicker/JoinConditionOperatorPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionOperatorPicker/JoinConditionOperatorPicker.tsx
@@ -13,6 +13,7 @@ interface JoinConditionOperatorPickerProps {
   operator?: Lib.FilterOperator;
   operators: Lib.FilterOperator[];
   disabled?: boolean;
+  isConditionComplete: boolean;
   onChange: (operator: Lib.FilterOperator) => void;
 }
 
@@ -22,6 +23,7 @@ export function JoinConditionOperatorPicker({
   operator: selectedOperator,
   operators,
   disabled,
+  isConditionComplete,
   onChange,
 }: JoinConditionOperatorPickerProps) {
   const selectedOperatorInfo = selectedOperator
@@ -36,6 +38,7 @@ export function JoinConditionOperatorPicker({
           onClick={onClick}
           disabled={disabled}
           aria-label={t`Change operator`}
+          isConditionComplete={isConditionComplete}
         >
           {selectedOperatorInfo?.shortName}
         </OperatorPickerButton>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.styled.tsx
@@ -46,7 +46,8 @@ export const RemoveConditionButton = styled.button`
 
   transition: background-color 300ms linear;
 
-  &:hover {
+  &:hover,
+  &:focus {
     background-color: ${darken("brand", 0.15)};
   }
 `;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.styled.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { alpha, color, darken } from "metabase/lib/colors";
+import { alpha, color, lighten } from "metabase/lib/colors";
 import { Flex } from "metabase/ui";
 import { NotebookCell } from "../../NotebookCell";
 
@@ -8,9 +8,12 @@ export const TablesNotebookCell = styled(NotebookCell)`
   align-self: start;
 `;
 
-export const ConditionContainer = styled(Flex)`
-  background-color: ${color("brand")};
+export const ConditionContainer = styled(Flex)<{ isComplete: boolean }>`
   border-radius: 8px;
+  transition: background-color 300ms linear;
+
+  background-color: ${props =>
+    props.isComplete ? color("brand") : alpha("brand", 0.15)};
 `;
 
 export const ConditionNotebookCell = styled(NotebookCell)`
@@ -29,7 +32,9 @@ export const ConditionUnionLabel = styled.span`
   color: ${color("text-dark")};
 `;
 
-export const RemoveConditionButton = styled.button`
+export const RemoveConditionButton = styled.button<{
+  isConditionComplete: boolean;
+}>`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -46,8 +51,12 @@ export const RemoveConditionButton = styled.button`
 
   transition: background-color 300ms linear;
 
+  color: ${props =>
+    props.isConditionComplete ? color("white") : color("brand")};
+
   &:hover,
   &:focus {
-    background-color: ${darken("brand", 0.15)};
+    background-color: ${props =>
+      props.isConditionComplete ? lighten("brand", 0.1) : alpha("brand", 0.2)};
   }
 `;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.styled.tsx
@@ -1,11 +1,16 @@
 import styled from "@emotion/styled";
-import { color } from "metabase/lib/colors";
-import IconButtonWrapper from "metabase/components/IconButtonWrapper/IconButtonWrapper";
+import { alpha, color, darken } from "metabase/lib/colors";
+import { Flex } from "metabase/ui";
 import { NotebookCell } from "../../NotebookCell";
 
 export const TablesNotebookCell = styled(NotebookCell)`
   flex: 1;
   align-self: start;
+`;
+
+export const ConditionContainer = styled(Flex)`
+  background-color: ${color("brand")};
+  border-radius: 8px;
 `;
 
 export const ConditionNotebookCell = styled(NotebookCell)`
@@ -20,17 +25,28 @@ export const ConditionNotebookCell = styled(NotebookCell)`
 
 export const ConditionUnionLabel = styled.span`
   display: block;
-  color: ${color("text-medium")};
-  font-weight: bold;
-  margin-left: 4px;
+  font-weight: 400;
+  color: ${color("text-dark")};
 `;
 
-export const RemoveConditionButton = styled(IconButtonWrapper)`
-  margin-left: 8px;
+export const RemoveConditionButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
 
-  color: ${color("text-light")};
+  cursor: pointer;
+
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
+
+  border-left: 1px solid ${alpha(color("white"), 0.25)};
+
+  transition: background-color 300ms linear;
 
   &:hover {
-    color: ${color("text-medium")};
+    background-color: ${darken("brand", 0.15)};
   }
 `;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
@@ -297,6 +297,8 @@ function JoinCondition({
   const lhsColumnGroup = Lib.groupColumns(lhsColumns);
   const rhsColumnGroup = Lib.groupColumns(rhsColumns);
 
+  const isComplete = Boolean(lhsColumn && rhsColumn && operator);
+
   const handleOperatorChange = (operator: Lib.FilterOperator) => {
     const nextCondition = setOperator(operator);
     if (nextCondition) {
@@ -322,7 +324,7 @@ function JoinCondition({
   };
 
   return (
-    <ConditionContainer>
+    <ConditionContainer isComplete={isComplete}>
       <Flex align="center" gap="4px" mih="47px" p="4px">
         <Box ml={!lhsColumn ? "4px" : undefined}>
           <JoinConditionColumnPicker
@@ -343,6 +345,7 @@ function JoinCondition({
           operator={operator}
           operators={operators}
           disabled={readOnly}
+          isConditionComplete={isComplete}
           onChange={handleOperatorChange}
         />
         <Box mr={!rhsColumn ? "4px" : undefined}>
@@ -362,9 +365,10 @@ function JoinCondition({
       {!readOnly && canRemove && (
         <RemoveConditionButton
           onClick={onRemove}
+          isConditionComplete={isComplete}
           aria-label={t`Remove condition`}
         >
-          <Icon name="close" size={16} color="white" />
+          <Icon name="close" size={16} />
         </RemoveConditionButton>
       )}
     </ConditionContainer>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
@@ -323,7 +323,7 @@ function JoinCondition({
 
   return (
     <ConditionContainer>
-      <Flex align="center" gap="4px" h="47px" px="4px">
+      <Flex align="center" gap="4px" mih="47px" p="4px">
         <Box ml={!lhsColumn ? "4px" : undefined}>
           <JoinConditionColumnPicker
             query={query}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
@@ -22,6 +22,7 @@ import { JoinTablePicker } from "./JoinTablePicker";
 import {
   ConditionNotebookCell,
   ConditionUnionLabel,
+  ConditionContainer,
   TablesNotebookCell,
   RemoveConditionButton,
 } from "./JoinStep.styled";
@@ -48,6 +49,7 @@ export function JoinStep({
     setTable,
     addCondition,
     updateCondition,
+    removeCondition,
     isColumnSelected,
     setSelectedColumns,
   } = useJoin(query, stageIndex, join);
@@ -115,6 +117,13 @@ export function JoinStep({
     }
   };
 
+  const handleRemoveCondition = (condition: Lib.JoinConditionClause) => {
+    const nextQuery = removeCondition(condition);
+    if (nextQuery) {
+      updateQuery(nextQuery);
+    }
+  };
+
   const handleNewConditionClick = () => setIsAddingNewCondition(true);
 
   const renderJoinCondition = (
@@ -128,20 +137,23 @@ export function JoinStep({
     const isComplete = !!condition && typeof index === "number";
     const key = isComplete ? `join-condition-${index}` : "new-join-condition";
 
+    const isSingleCondition = isComplete
+      ? conditions.length === 1
+      : conditions.length === 0;
     const isLast = isAddingNewCondition
       ? !isComplete
       : index === conditions.length - 1;
 
     return (
-      <Flex key={key} mr="6px" align="center" data-testid={key}>
+      <Flex key={key} mr="6px" align="center" gap="8px" data-testid={key}>
         <JoinCondition
           query={query}
           stageIndex={stageIndex}
           condition={condition}
           join={join}
           table={table}
-          color={color}
           readOnly={readOnly}
+          canRemove={!isSingleCondition}
           onChange={nextCondition => {
             if (isComplete) {
               handleUpdateCondition(index, nextCondition);
@@ -150,6 +162,13 @@ export function JoinStep({
             }
           }}
           onChangeLHSColumn={setSelectedLHSColumn}
+          onRemove={() => {
+            if (isComplete) {
+              handleRemoveCondition(condition);
+            } else {
+              setIsAddingNewCondition(false);
+            }
+          }}
         />
         <JoinConditionRightPart
           isComplete={isComplete}
@@ -157,7 +176,6 @@ export function JoinStep({
           color={color}
           readOnly={readOnly}
           onNewCondition={handleNewConditionClick}
-          onRemove={() => setIsAddingNewCondition(false)}
         />
       </Flex>
     );
@@ -211,7 +229,6 @@ interface JoinConditionRightPartProps {
   color: string;
   readOnly?: boolean;
   onNewCondition: () => void;
-  onRemove: () => void;
 }
 
 function JoinConditionRightPart({
@@ -220,17 +237,12 @@ function JoinConditionRightPart({
   color,
   readOnly,
   onNewCondition,
-  onRemove,
 }: JoinConditionRightPartProps) {
   if (!isLast) {
     return <ConditionUnionLabel>{t`and`}</ConditionUnionLabel>;
   }
 
-  if (readOnly) {
-    return null;
-  }
-
-  if (isComplete) {
+  if (!readOnly && isComplete) {
     return (
       <NotebookCellAdd
         color={color}
@@ -240,11 +252,7 @@ function JoinConditionRightPart({
     );
   }
 
-  return (
-    <RemoveConditionButton onClick={onRemove} aria-label={t`Remove condition`}>
-      <Icon name="close" size={12} />
-    </RemoveConditionButton>
-  );
+  return null;
 }
 
 interface JoinConditionProps {
@@ -254,9 +262,10 @@ interface JoinConditionProps {
   join?: Lib.Join;
   table: Lib.Joinable;
   readOnly?: boolean;
-  color: string;
+  canRemove: boolean;
   onChange: (condition: Lib.JoinConditionClause) => void;
   onChangeLHSColumn: (column: Lib.ColumnMetadata) => void;
+  onRemove: () => void;
 }
 
 function JoinCondition({
@@ -266,9 +275,10 @@ function JoinCondition({
   join,
   table,
   readOnly,
-  color,
+  canRemove,
   onChange,
   onChangeLHSColumn,
+  onRemove,
 }: JoinConditionProps) {
   const {
     lhsColumn,
@@ -312,38 +322,51 @@ function JoinCondition({
   };
 
   return (
-    <Flex gap="6px" align="center">
-      <JoinConditionColumnPicker
-        query={query}
-        stageIndex={stageIndex}
-        column={lhsColumn}
-        columnGroups={lhsColumnGroup}
-        label={t`Left column`}
-        isInitiallyVisible={!condition}
-        withDefaultBucketing={!rhsColumn}
-        readOnly={readOnly}
-        color={color}
-        onSelect={handleLHSColumnChange}
-      />
-      <JoinConditionOperatorPicker
-        query={query}
-        stageIndex={stageIndex}
-        operator={operator}
-        operators={operators}
-        onChange={handleOperatorChange}
-      />
-      <JoinConditionColumnPicker
-        query={query}
-        stageIndex={stageIndex}
-        column={rhsColumn}
-        columnGroups={rhsColumnGroup}
-        label={t`Right column`}
-        withDefaultBucketing={!lhsColumn}
-        readOnly={readOnly}
-        color={color}
-        popoverRef={rhsColumnPicker}
-        onSelect={handleRHSColumnChange}
-      />
-    </Flex>
+    <ConditionContainer>
+      <Flex align="center" gap="4px" h="47px" px="4px">
+        <Box ml={!lhsColumn ? "4px" : undefined}>
+          <JoinConditionColumnPicker
+            query={query}
+            stageIndex={stageIndex}
+            column={lhsColumn}
+            columnGroups={lhsColumnGroup}
+            label={t`Left column`}
+            isInitiallyVisible={!condition}
+            withDefaultBucketing={!rhsColumn}
+            readOnly={readOnly}
+            onSelect={handleLHSColumnChange}
+          />
+        </Box>
+        <JoinConditionOperatorPicker
+          query={query}
+          stageIndex={stageIndex}
+          operator={operator}
+          operators={operators}
+          disabled={readOnly}
+          onChange={handleOperatorChange}
+        />
+        <Box mr={!rhsColumn ? "4px" : undefined}>
+          <JoinConditionColumnPicker
+            query={query}
+            stageIndex={stageIndex}
+            column={rhsColumn}
+            columnGroups={rhsColumnGroup}
+            label={t`Right column`}
+            withDefaultBucketing={!lhsColumn}
+            readOnly={readOnly}
+            popoverRef={rhsColumnPicker}
+            onSelect={handleRHSColumnChange}
+          />
+        </Box>
+      </Flex>
+      {!readOnly && canRemove && (
+        <RemoveConditionButton
+          onClick={onRemove}
+          aria-label={t`Remove condition`}
+        >
+          <Icon name="close" size={16} color="white" />
+        </RemoveConditionButton>
+      )}
+    </ConditionContainer>
   );
 }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/use-join.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/use-join.ts
@@ -148,6 +148,17 @@ export function useJoin(query: Lib.Query, stageIndex: number, join?: Lib.Join) {
     [query, stageIndex, conditions],
   );
 
+  const removeCondition = useCallback(
+    (condition: Lib.JoinConditionClause) => {
+      const nextConditions = conditions.filter(
+        _condition => _condition !== condition,
+      );
+      _setConditions(nextConditions);
+      return Lib.removeClause(query, stageIndex, condition);
+    },
+    [query, stageIndex, conditions],
+  );
+
   return {
     strategy,
     table,
@@ -157,6 +168,7 @@ export function useJoin(query: Lib.Query, stageIndex: number, join?: Lib.Join) {
     setTable,
     addCondition,
     updateCondition,
+    removeCondition,
     isColumnSelected,
     setSelectedColumns,
   };


### PR DESCRIPTION
Part of #31070, epic #30514

Updates the join condition looks and makes it possible to remove any condition as opposed to the last one only as it is now. OTOH, it's not possible to remove the condition if it's the only condition in a join, it's expected to remove the whole join instead. Also, removes the ability to "clear" a column on an existing condition, now it's only possible to either change a column or remove the entire condition. More context on [this Slack thread](https://metaboat.slack.com/archives/C01LQQ2UW03/p1690473893073989).

> **Warning**
> This PR targets a feature branch and doesn't migrate `JoinStep` features 1:1
> This branch is expected to have failing tests because parts of functionality are simply missing
> You can monitor the migration health with the last branch in the chain — #32912

**Previous PRs**

- #32903
- #32904
- #32905
- #32906

**Next PRs**

- #32908
- #32911
- #32912
