### PR TITLE
MLv2 Joins 6 — Read-only mode

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.tsx
@@ -46,6 +46,7 @@ export function JoinConditionColumnPicker({
 
   return (
     <TippyPopoverWithTrigger
+      disabled={readOnly}
       isInitiallyVisible={isInitiallyVisible}
       renderTrigger={({ visible, onClick }) => (
         <ColumnNotebookCellItem
@@ -95,6 +96,7 @@ const ColumnNotebookCellItem = forwardRef<
       isOpen={isOpen}
       hasColumnSelected={hasColumnSelected}
       aria-label={label}
+      disabled={readOnly}
       readOnly={readOnly}
       onClick={onClick}
       ref={ref}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
@@ -192,6 +192,7 @@ export function JoinStep({
             query={query}
             stageIndex={stageIndex}
             strategy={strategy}
+            readOnly={readOnly}
             onChange={handleStrategyChange}
           />
           <JoinTablePicker

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -751,4 +751,58 @@ describe("Notebook Editor > Join Step", () => {
       ).not.toBeInTheDocument();
     });
   });
+
+  describe("read-only", () => {
+    it("shouldn't allow changing the join type", () => {
+      setup(createMockNotebookStep({ topLevelQuery: getJoinedQuery() }), {
+        readOnly: true,
+      });
+
+      expect(screen.getByLabelText("Change join type")).toBeDisabled();
+    });
+
+    it("shouldn't allow changing the operator", () => {
+      setup(createMockNotebookStep({ topLevelQuery: getJoinedQuery() }), {
+        readOnly: true,
+      });
+
+      expect(screen.getByLabelText("Change operator")).toBeDisabled();
+    });
+
+    it("shouldn't allow changing the join fields", () => {
+      setup(createMockNotebookStep({ topLevelQuery: getJoinedQuery() }), {
+        readOnly: true,
+      });
+
+      expect(screen.queryByLabelText("Pick columns")).not.toBeInTheDocument();
+    });
+
+    it("shouldn't allow changing columns", () => {
+      setup(createMockNotebookStep({ topLevelQuery: getJoinedQuery() }), {
+        readOnly: true,
+      });
+
+      expect(screen.getByLabelText("Left column")).toBeDisabled();
+      expect(screen.getByLabelText("Right column")).toBeDisabled();
+    });
+
+    it("shouldn't allow adding a new condition", () => {
+      setup(createMockNotebookStep({ topLevelQuery: getJoinedQuery() }), {
+        readOnly: true,
+      });
+
+      expect(screen.queryByLabelText("Add condition")).not.toBeInTheDocument();
+    });
+
+    it("shouldn't allow removing a condition", async () => {
+      const query = getJoinedQueryWithMultipleConditions();
+      setup(createMockNotebookStep({ topLevelQuery: query }), {
+        readOnly: true,
+      });
+
+      expect(
+        screen.queryByLabelText("Remove condition"),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStrategyPicker/JoinStrategyPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStrategyPicker/JoinStrategyPicker.tsx
@@ -14,6 +14,7 @@ interface JoinStrategyPickerProps {
   query: Lib.Query;
   stageIndex: number;
   strategy: Lib.JoinStrategy;
+  readOnly?: boolean;
   onChange: (strategy: Lib.JoinStrategy) => void;
 }
 
@@ -21,6 +22,7 @@ export function JoinStrategyPicker({
   query,
   stageIndex,
   strategy: currentStrategy,
+  readOnly = false,
   onChange,
 }: JoinStrategyPickerProps) {
   const items = useMemo(
@@ -41,8 +43,13 @@ export function JoinStrategyPicker({
 
   return (
     <TippyPopoverWithTrigger
+      disabled={readOnly}
       renderTrigger={({ onClick }) => (
-        <IconButtonWrapper onClick={onClick} aria-label={t`Change join type`}>
+        <IconButtonWrapper
+          onClick={onClick}
+          disabled={readOnly}
+          aria-label={t`Change join type`}
+        >
           <JoinStrategyIcon
             name={currentStrategyIcon}
             tooltip={t`Change join type`}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
@@ -83,7 +83,7 @@ export function JoinTablePicker({
       color={color}
       aria-label={t`Right table`}
       right={
-        table ? (
+        table && !readOnly ? (
           <JoinTableColumnsPicker
             query={query}
             stageIndex={stageIndex}
@@ -106,7 +106,9 @@ export function JoinTablePicker({
         selectedTableId={tableId}
         setSourceTableFn={handleTableChange}
         triggerElement={
-          <PickerButton>{tableInfo?.displayName || t`Pick data…`}</PickerButton>
+          <PickerButton disabled={readOnly}>
+            {tableInfo?.displayName || t`Pick data…`}
+          </PickerButton>
         }
       />
     </NotebookCellItem>


### PR DESCRIPTION
Part of #31070, epic #30514

Adds proper support for notebook step's `readOnly` prop. If a join step receives a `readOnly: true` prop, it would:

* disable RHS table picker
* disable join strategy picker
* disable join condition operator picker
* disable LHS/RHS column pickers
* hide "add condition" button
* hide "remove condition" buttons

> **Warning**
> This PR targets a feature branch and doesn't migrate `JoinStep` features 1:1
> This branch is expected to have failing tests because parts of functionality are simply missing
> You can monitor the migration health with the last branch in the chain — #32912

**Previous PRs**

- #32903
- #32904
- #32905
- #32906
- #32907

**Next PRs**

- #32911
- #32912
