### PR TITLE
MLv2 Joins 7 — Fix notebook editor lifecycle issue

### DIFF
--- a/frontend/src/metabase-lib/comparison.ts
+++ b/frontend/src/metabase-lib/comparison.ts
@@ -1,7 +1,5 @@
 import * as ML from "cljs/metabase.lib.js";
 import type { DatasetQuery } from "metabase-types/api";
-import type { Query } from "./types";
-import { toLegacyQuery } from "./query";
 
 export function areLegacyQueriesEqual(
   query1: DatasetQuery,
@@ -9,16 +7,4 @@ export function areLegacyQueriesEqual(
   fieldIds?: number[],
 ): boolean {
   return ML.query_EQ_(query1, query2, fieldIds);
-}
-
-export function areQueriesEqual(
-  query1: Query,
-  query2: Query,
-  fieldIds?: number[],
-): boolean {
-  return areLegacyQueriesEqual(
-    toLegacyQuery(query1),
-    toLegacyQuery(query2),
-    fieldIds,
-  );
 }

--- a/frontend/src/metabase-lib/comparison.ts
+++ b/frontend/src/metabase-lib/comparison.ts
@@ -1,5 +1,7 @@
 import * as ML from "cljs/metabase.lib.js";
 import type { DatasetQuery } from "metabase-types/api";
+import type { Query } from "./types";
+import { toLegacyQuery } from "./query";
 
 export function areLegacyQueriesEqual(
   query1: DatasetQuery,
@@ -7,4 +9,16 @@ export function areLegacyQueriesEqual(
   fieldIds?: number[],
 ): boolean {
   return ML.query_EQ_(query1, query2, fieldIds);
+}
+
+export function areQueriesEqual(
+  query1: Query,
+  query2: Query,
+  fieldIds?: number[],
+): boolean {
+  return areLegacyQueriesEqual(
+    toLegacyQuery(query1),
+    toLegacyQuery(query2),
+    fieldIds,
+  );
 }

--- a/frontend/src/metabase-lib/queries/structured/Join.ts
+++ b/frontend/src/metabase-lib/queries/structured/Join.ts
@@ -17,7 +17,6 @@ import type {
 import {
   getDatetimeUnit,
   isDateTimeField,
-  isFieldLiteral,
 } from "metabase-lib/queries/utils/field-ref";
 import DimensionOptions from "metabase-lib/DimensionOptions";
 import Dimension, { FieldDimension } from "metabase-lib/Dimension";
@@ -653,24 +652,8 @@ export default class Join extends MBQLObjectClause {
   }
 
   isValid() {
-    if (!this.condition || !this.joinedTable() || this.hasGaps()) {
-      return false;
-    }
-
-    const dimensionOptions = this.parent().dimensionOptions();
-    const dimensions = [...this.parentDimensions(), ...this.joinDimensions()];
-    return dimensions.every(
-      dimension =>
-        dimensionOptions.hasDimension(dimension) ||
-        dimensionOptions.hasDimension(dimension.getMLv1CompatibleDimension()) ||
-        // For some GUI queries created in earlier versions of Metabase,
-        // some dimensions are described as field literals
-        // Usually it's [ "field", field_numeric_id, null|object ]
-        // And field literals look like [ "field", "PRODUCT_ID", {'base-type': 'type/Integer' } ]
-        // These literals are not present in dimension options, but still work
-        // As a workaround, we just skip field literals if they're not present in dimension options
-        isFieldLiteral(dimension.mbql()),
-    );
+    // MLv2 should ensure there's a valid condition, etc.
+    return !!this.parentTable() && !!this.joinedTable();
   }
 
   clean() {

--- a/frontend/src/metabase-lib/queries/utils/field-ref.js
+++ b/frontend/src/metabase-lib/queries/utils/field-ref.js
@@ -52,14 +52,6 @@ export function getFieldTargetId(field) {
   console.warn("Unknown field type:", field);
 }
 
-export function isFieldLiteral(fieldClause) {
-  return (
-    isValidField(fieldClause) &&
-    isLocalField(fieldClause) &&
-    typeof fieldClause[1] === "string"
-  );
-}
-
 export function getDatetimeUnit(fieldClause) {
   if (isLocalField(fieldClause)) {
     const dimension = FieldDimension.parseMBQLOrWarn(fieldClause);

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookSteps/NotebookSteps.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookSteps/NotebookSteps.tsx
@@ -36,8 +36,7 @@ function getInitialOpenSteps(question: Question, readOnly: boolean): OpenSteps {
 
   // We need to keep join steps open at all time for MLv1-MLv2 compat
   // This should be reworked once all notebook clauses are using MLv2
-  // Learn more: ...
-  // TODO add PR link
+  // Learn more: https://github.com/metabase/metabase/pull/32911
 
   const steps = getQuestionSteps(question, {});
   const joinSteps = steps.filter(step => step.type === "join");

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookSteps/NotebookSteps.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookSteps/NotebookSteps.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
+import { useEffectOnce } from "react-use";
 
 import * as Lib from "metabase-lib";
 import StructuredQuery from "metabase-lib/queries/StructuredQuery";
@@ -53,6 +54,20 @@ function NotebookSteps({
     }
     return getQuestionSteps(question, openSteps);
   }, [question, openSteps]);
+
+  // TODO Reimplement in getInitialOpenSteps
+  useEffectOnce(() => {
+    if (steps.length > 0) {
+      const joinStepIds = steps
+        .filter(step => step.type === "join")
+        .map(step => step.id);
+      const openStepsEntries = joinStepIds.map(id => [id, true]);
+      setOpenSteps(openSteps => ({
+        ...openSteps,
+        ...Object.fromEntries(openStepsEntries),
+      }));
+    }
+  });
 
   const handleStepOpen = useCallback((id: string) => {
     setOpenSteps(openSteps => ({ ...openSteps, [id]: true }));

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookSteps/NotebookSteps.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookSteps/NotebookSteps.tsx
@@ -6,7 +6,11 @@ import StructuredQuery from "metabase-lib/queries/StructuredQuery";
 import type { Query } from "metabase-lib/types";
 import type Question from "metabase-lib/Question";
 
-import type { NotebookStep as INotebookStep, OpenSteps } from "../types";
+import type {
+  NotebookStep as INotebookStep,
+  OpenSteps,
+  UpdateQueryOpts,
+} from "../types";
 import { getQuestionSteps } from "../lib/steps";
 import NotebookStep from "../NotebookStep";
 import { Container } from "./NotebookSteps.styled";
@@ -63,7 +67,11 @@ function NotebookSteps({
   }, []);
 
   const handleQueryChange = useCallback(
-    async (step: INotebookStep, query: StructuredQuery | Query) => {
+    async (
+      step: INotebookStep,
+      query: StructuredQuery | Query,
+      { closeStep = true }: UpdateQueryOpts = {},
+    ) => {
       // Performs a query update with either metabase-lib v1 or v2
       // The StructuredQuery block is temporary and will be removed
       // once all the notebook steps are using metabase-lib v2
@@ -79,9 +87,11 @@ function NotebookSteps({
         await updateQuestion(cleanQuestion);
       }
 
-      // mark the step as "closed" since we can assume
-      // it's been added or removed by the updateQuery
-      handleStepClose(step.id);
+      if (closeStep) {
+        // mark the step as "closed" since we can assume
+        // it's been added or removed by the updateQuery
+        handleStepClose(step.id);
+      }
     },
     [question, updateQuestion, handleStepClose],
   );
@@ -95,8 +105,10 @@ function NotebookSteps({
       {steps.map((step, index) => {
         const isLast = index === steps.length - 1;
         const isLastOpened = lastOpenedStep === step.id;
-        const onChange = (query: StructuredQuery | Query) =>
-          handleQueryChange(step, query);
+        const onChange = (
+          query: StructuredQuery | Query,
+          opts?: UpdateQueryOpts,
+        ) => handleQueryChange(step, query, opts);
 
         return (
           <NotebookStep

--- a/frontend/src/metabase/query_builder/components/notebook/lib/steps.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/lib/steps.ts
@@ -54,6 +54,9 @@ const STEPS: NotebookStepDef[] = [
         return legacyQuery;
       }
       const join = Lib.joins(topLevelQuery, stageIndex)[index];
+      if (!join) {
+        return legacyQuery;
+      }
       const nextQuery = Lib.removeClause(topLevelQuery, stageIndex, join);
       return convertStageQueryToLegacyStageQuery(
         nextQuery,

--- a/frontend/src/metabase/query_builder/components/notebook/lib/steps.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/lib/steps.ts
@@ -16,7 +16,7 @@ import { NotebookStep, NotebookStepFn, OpenSteps } from "../types";
 type NotebookStepDef = Pick<NotebookStep, "type" | "clean" | "revert"> & {
   valid: NotebookStepFn<boolean>;
   active: NotebookStepFn<boolean>;
-  subSteps?: (query: StructuredQuery) => number;
+  subSteps?: (query: Lib.Query, stageIndex: number) => number;
 };
 
 function convertStageQueryToLegacyStageQuery(
@@ -44,21 +44,24 @@ const STEPS: NotebookStepDef[] = [
       const database = query.database();
       return query.hasData() && database != null && database.hasFeature("join");
     },
-    subSteps: query => query.joins().length,
-    active: (query, index) =>
-      typeof index === "number" && query.joins().length > index,
-    revert: (query, index) => query.removeJoin(index),
-    clean: (query, index) => {
-      const join = typeof index === "number" ? query.joins()[index] : null;
-      if (!join || join.isValid() || join.hasGaps()) {
-        return query;
+    subSteps: (topLevelQuery, stageIndex) =>
+      Lib.joins(topLevelQuery, stageIndex).length,
+    active: (legacyQuery, index, topLevelQuery, stageIndex) =>
+      typeof index === "number" &&
+      Lib.joins(topLevelQuery, stageIndex).length > index,
+    revert: (legacyQuery, index, topLevelQuery, stageIndex) => {
+      if (typeof index !== "number") {
+        return legacyQuery;
       }
-      const cleanJoin = join.clean();
-      if (cleanJoin.isValid()) {
-        return query.updateJoin(index, cleanJoin);
-      }
-      return query.removeJoin(index);
+      const join = Lib.joins(topLevelQuery, stageIndex)[index];
+      const nextQuery = Lib.removeClause(topLevelQuery, stageIndex, join);
+      return convertStageQueryToLegacyStageQuery(
+        nextQuery,
+        legacyQuery,
+        stageIndex,
+      );
     },
+    clean: query => query,
   },
   {
     type: "expression",
@@ -265,7 +268,10 @@ function getStageSteps(
     STEPS.map(STEP => {
       if (STEP.subSteps) {
         // add 1 for the initial or next action button
-        const itemIndexes = _.range(0, STEP.subSteps(stageQuery) + 1);
+        const itemIndexes = _.range(
+          0,
+          STEP.subSteps(topLevelQuery, stageIndex) + 1,
+        );
         return itemIndexes.map(itemIndex => getStep(STEP, itemIndex));
       } else {
         return [getStep(STEP)];

--- a/frontend/src/metabase/query_builder/components/notebook/lib/steps.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/lib/steps.ts
@@ -16,7 +16,7 @@ import { NotebookStep, NotebookStepFn, OpenSteps } from "../types";
 type NotebookStepDef = Pick<NotebookStep, "type" | "clean" | "revert"> & {
   valid: NotebookStepFn<boolean>;
   active: NotebookStepFn<boolean>;
-  subSteps?: (query: Lib.Query, stageIndex: number) => number;
+  subSteps?: (query: StructuredQuery) => number;
 };
 
 function convertStageQueryToLegacyStageQuery(
@@ -44,24 +44,21 @@ const STEPS: NotebookStepDef[] = [
       const database = query.database();
       return query.hasData() && database != null && database.hasFeature("join");
     },
-    subSteps: (topLevelQuery, stageIndex) =>
-      Lib.joins(topLevelQuery, stageIndex).length,
-    active: (legacyQuery, index, topLevelQuery, stageIndex) =>
-      typeof index === "number" &&
-      Lib.joins(topLevelQuery, stageIndex).length > index,
-    revert: (legacyQuery, index, topLevelQuery, stageIndex) => {
-      if (typeof index !== "number") {
-        return legacyQuery;
+    subSteps: query => query.joins().length,
+    active: (query, index) =>
+      typeof index === "number" && query.joins().length > index,
+    revert: (query, index) => query.removeJoin(index),
+    clean: (query, index) => {
+      const join = typeof index === "number" ? query.joins()[index] : null;
+      if (!join || join.isValid() || join.hasGaps()) {
+        return query;
       }
-      const join = Lib.joins(topLevelQuery, stageIndex)[index];
-      const nextQuery = Lib.removeClause(topLevelQuery, stageIndex, join);
-      return convertStageQueryToLegacyStageQuery(
-        nextQuery,
-        legacyQuery,
-        stageIndex,
-      );
+      const cleanJoin = join.clean();
+      if (cleanJoin.isValid()) {
+        return query.updateJoin(index, cleanJoin);
+      }
+      return query.removeJoin(index);
     },
-    clean: query => query,
   },
   {
     type: "expression",
@@ -268,10 +265,7 @@ function getStageSteps(
     STEPS.map(STEP => {
       if (STEP.subSteps) {
         // add 1 for the initial or next action button
-        const itemIndexes = _.range(
-          0,
-          STEP.subSteps(topLevelQuery, stageIndex) + 1,
-        );
+        const itemIndexes = _.range(0, STEP.subSteps(stageQuery) + 1);
         return itemIndexes.map(itemIndex => getStep(STEP, itemIndex));
       } else {
         return [getStep(STEP)];

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
@@ -86,13 +86,12 @@ export function JoinStep({
   };
 
   const handleTableChange = (nextTable: Lib.Joinable) => {
-    const nextQuery = setTable(nextTable);
-
-    // If setTable returns a query,
-    // it means it was possible to automatically set the condition via FKs
+    setIsAddingNewCondition(false);
+    const { nextQuery, hasConditions } = setTable(nextTable);
     if (nextQuery) {
       updateQuery(nextQuery);
-    } else {
+    }
+    if (!hasConditions) {
       setIsAddingNewCondition(true);
     }
   };

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { t } from "ttag";
 
 import { Box, Flex, Text } from "metabase/ui";
@@ -33,12 +33,17 @@ export function JoinStep({
   color,
   readOnly,
   sourceQuestion,
-  updateQuery,
+  updateQuery: _updateQuery,
 }: NotebookStepUiComponentProps) {
   const { stageIndex, itemIndex } = step;
 
   const joins = Lib.joins(query, stageIndex);
   const join = typeof itemIndex === "number" ? joins[itemIndex] : undefined;
+
+  const updateQuery = useCallback(
+    (nextQuery: Lib.Query) => _updateQuery(nextQuery, { closeStep: false }),
+    [_updateQuery],
+  );
 
   const {
     strategy,

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/use-join.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/use-join.ts
@@ -35,13 +35,7 @@ export function useJoin(query: Lib.Query, stageIndex: number, join?: Lib.Join) {
   }, [query, stageIndex, join, table]);
 
   useEffect(() => {
-    if (
-      join &&
-      previousJoin !== join &&
-      previousQuery &&
-      // This prevents updates when only metadata is updated
-      !Lib.areQueriesEqual(query, previousQuery)
-    ) {
+    if (join && previousJoin !== join) {
       _setStrategy(Lib.joinStrategy(join));
       _setTable(Lib.joinedThing(query, join));
       _setConditions(Lib.joinConditions(join));

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/use-join.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/use-join.ts
@@ -3,6 +3,7 @@ import { usePrevious } from "react-use";
 import * as Lib from "metabase-lib";
 
 export function useJoin(query: Lib.Query, stageIndex: number, join?: Lib.Join) {
+  const previousQuery = usePrevious(query);
   const previousJoin = usePrevious(join);
 
   const [strategy, _setStrategy] = useState<Lib.JoinStrategy>(
@@ -34,7 +35,13 @@ export function useJoin(query: Lib.Query, stageIndex: number, join?: Lib.Join) {
   }, [query, stageIndex, join, table]);
 
   useEffect(() => {
-    if (join && previousJoin !== join) {
+    if (
+      join &&
+      previousJoin !== join &&
+      previousQuery &&
+      // This prevents updates when only metadata is updated
+      !Lib.areQueriesEqual(query, previousQuery)
+    ) {
       _setStrategy(Lib.joinStrategy(join));
       _setTable(Lib.joinedThing(query, join));
       _setConditions(Lib.joinConditions(join));
@@ -45,7 +52,7 @@ export function useJoin(query: Lib.Query, stageIndex: number, join?: Lib.Join) {
     if (!previousJoin && join) {
       _setSelectedColumns([]);
     }
-  }, [query, stageIndex, join, previousJoin]);
+  }, [query, previousQuery, stageIndex, join, previousJoin]);
 
   const isColumnSelected = (column: Lib.ColumnMetadata) => {
     if (join) {
@@ -101,17 +108,32 @@ export function useJoin(query: Lib.Query, stageIndex: number, join?: Lib.Join) {
       if (suggestedCondition) {
         const nextConditions = [suggestedCondition];
         _setConditions(nextConditions);
+
         let nextJoin = Lib.joinClause(nextTable, nextConditions);
         nextJoin = Lib.withJoinFields(nextJoin, "all");
         nextJoin = Lib.withJoinStrategy(nextJoin, strategy);
-        return Lib.join(query, stageIndex, nextJoin);
-      } else {
-        _setTable(nextTable);
-        _setSelectedColumns("all");
-        _setConditions([]);
+
+        const nextQuery = join
+          ? Lib.replaceClause(query, stageIndex, join, nextJoin)
+          : Lib.join(query, stageIndex, nextJoin);
+
+        return { nextQuery, hasConditions: true };
       }
+
+      _setTable(nextTable);
+      _setSelectedColumns("all");
+      _setConditions([]);
+
+      // With a new table and no suggested condition,
+      // the existing join in no longer valid, so we remove it
+      if (join) {
+        const nextQuery = Lib.removeClause(query, stageIndex, join);
+        return { nextQuery, hasConditions: false };
+      }
+
+      return { nextQuery: null, hasConditions: false };
     },
-    [query, stageIndex, strategy],
+    [query, stageIndex, join, strategy],
   );
 
   const addCondition = useCallback(

--- a/frontend/src/metabase/query_builder/components/notebook/types.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/types.ts
@@ -49,6 +49,10 @@ export interface NotebookStepAction {
   }) => void;
 }
 
+export type UpdateQueryOpts = {
+  closeStep?: boolean;
+};
+
 export interface NotebookStepUiComponentProps {
   step: NotebookStep;
   topLevelQuery: Query;
@@ -58,7 +62,10 @@ export interface NotebookStepUiComponentProps {
   isLastOpened: boolean;
   reportTimezone: string;
   readOnly?: boolean;
-  updateQuery: (query: StructuredQuery | Query) => Promise<void>;
+  updateQuery: (
+    query: StructuredQuery | Query,
+    opts?: UpdateQueryOpts,
+  ) => Promise<void>;
 }
 
 export type OpenSteps = Record<NotebookStep["id"], boolean>;

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-clean.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-clean.unit.spec.js
@@ -73,27 +73,6 @@ describe("StructuredQuery", () => {
           joins: [{ ...join, condition: VALID_CONDITION }],
         });
       });
-
-      it("should remove join without any condition", () => {
-        const q = ordersTable.query().join(getJoin({ condition: null }));
-        expect(q.clean().query()).toEqual({ "source-table": ORDERS_ID });
-      });
-
-      it("should remove join referencing invalid source field", () => {
-        const q = ordersTable
-          .query()
-          .join(getJoin({ condition: ["=", null, PRODUCT_ID_FIELD_REF] }));
-        expect(q.clean().query()).toEqual({ "source-table": ORDERS_ID });
-      });
-
-      it("should remove join referencing invalid join field", () => {
-        const q = ordersTable
-          .query()
-          .join(
-            getJoin({ condition: ["=", ORDERS_PRODUCT_ID_FIELD_REF, null] }),
-          );
-        expect(q.clean().query()).toEqual({ "source-table": ORDERS_ID });
-      });
     });
 
     describe("filters", () => {

--- a/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
@@ -775,63 +775,6 @@ describe("Join", () => {
     });
   });
 
-  describe("isValid", () => {
-    it("should return 'true' for complete one-fields pair join", () => {
-      const join = getJoin({
-        query: getOrdersJoinQuery({
-          condition: ORDERS_PRODUCT_JOIN_CONDITION,
-        }),
-      });
-      expect(join.isValid()).toBe(true);
-    });
-
-    it("should return 'true' for complete multi-fields join", () => {
-      const join = getJoin({
-        query: getOrdersJoinQuery({
-          condition: ORDERS_PRODUCT_MULTI_FIELD_JOIN_CONDITION,
-        }),
-      });
-      expect(join.isValid()).toBe(true);
-    });
-
-    it("should return 'false' if references unavailable field", () => {
-      const join = getJoin({
-        query: getOrdersJoinQuery({
-          condition: [
-            "and",
-            ORDERS_PRODUCT_JOIN_CONDITION,
-            ["=", ["field", 111222333444, null], PRODUCTS_CREATED_AT_FIELD_REF],
-          ],
-        }),
-      });
-
-      expect(join.isValid()).toBe(false);
-    });
-
-    it("should ignore field literals not present in dimension options for backward compatibility", () => {
-      const join = getJoin({
-        query: getOrdersJoinQuery({
-          condition: [
-            "=",
-            ORDERS_PRODUCT_ID_FIELD_REF,
-            ["field", "USER_ID", { "base-type": "type/Integer" }],
-          ],
-        }),
-      });
-
-      expect(join.isValid()).toBe(true);
-    });
-
-    invalidTestCases.forEach(([invalidReason, queryOpts]) => {
-      it(`should return 'false' when ${invalidReason}`, () => {
-        const join = getJoin({
-          query: getOrdersJoinQuery(queryOpts),
-        });
-        expect(join.isValid()).toBe(false);
-      });
-    });
-  });
-
   describe("clean", () => {
     describe("for single dimensions pair join", () => {
       it("does nothing if valid", () => {


### PR DESCRIPTION
Part of #31070, epic #30514

Fixes a set of problems around joins editing in the notebook editor. The notebook is built around MLv1 principles and the new join step component doesn't fit into it really well.

### Root cause

Quoting #32903:

> MLv1 is fine with partially incomplete queries and the join step used to be built around this principle. It'd instantiate an empty Join class instance and add parts to it step-by-step (like RHS table, conditions, etc.). OTOH, MLv2's idea is to ensure every function produces a valid query, so we can't give it an incomplete or partially complete join object. So instead, we'd keep different parts of the join in the local state and create a join the moment we have everything needed.

This difference in behavior made some join editing flows pretty non-trivial. Example:

1. Let's say we have a query started from the sample Orders table and joining the Products table on Orders.PRODUCT_ID = Products.ID
2. We want to change the join, and actually change the Reviews table instead of Products. So we click the Products table cell in the join step and select Reviews instead
3. Our Orders.PRODUCT_ID = Products.ID condition is obviously irrelevant now, so we remove it. So we end up with an incomplete join on the UI

We should remember it's still possible to click the "Visualize" button at this point. Here's how it used to work with MLv1:

1. We have a query object with a Products table join
2. When we change the RHS table to Reviews, we'd update join's `source-table` and clean-up its `conditions`
3. We click the Visualize button
4. We'd call `question.query().clean()` before running a query. It'd see we have an incomplete join (no conditions) and remove it
5. If you open the notebook again, you'd see that the join step is gone

Since MLv2 intentionally doesn't allow having partially complete joins, we need to rework that flow. Essentially we need to remove the join the moment it becomes invalid, and keep the join step component in place.

This appeared to be problematic because of how the notebook works with the steps:

- the notebook inspects a query and builds a list of steps to render ([here](https://github.com/metabase/metabase/blob/0f897c1d28e89445471c21a4d2fba85018b4b558/frontend/src/metabase/query_builder/components/notebook/NotebookSteps/NotebookSteps.tsx#L50))
- a regular step always has a backing clause in the query
- when we need to add a new clause, we'd "open a step" [here](https://github.com/metabase/metabase/blob/0f897c1d28e89445471c21a4d2fba85018b4b558/frontend/src/metabase/query_builder/components/notebook/NotebookSteps/NotebookSteps.tsx#L53) (which practically means "create a new step")
- when we add a new clause from scratch or completely remove a step, we'd "close" it [here](https://github.com/metabase/metabase/blob/0f897c1d28e89445471c21a4d2fba85018b4b558/frontend/src/metabase/query_builder/components/notebook/NotebookSteps/NotebookSteps.tsx#L84)

So if we just remove a join the moment it becomes invalid, the notebook deals with it the same way as if you clicked the "close" icon on the entire step to remove the join. 

### Solution

The fix is based on two thoughts:

1. We need to remove the join the moment it becomes invalid, so there're no surprises when you click "Visualize" at any given moment
2. We need to ensure the join step remains "open" in notebook terms

What the PR is doing:

1. Removes a join once it becomes invalid
2. Ensures its join step won't be "closed" once the join is removed
3. Marks all the join steps as open when we open the notebook editor. Otherwise, step 2 won't work if the join step isn't marked as open beforehand

> **Warning**
> This PR targets a feature branch and doesn't migrate `JoinStep` features 1:1
> This branch is expected to have failing tests because parts of functionality are simply missing
> You can monitor the migration health with the last branch in the chain — #32912

**Previous PRs**

- #32903
- #32904
- #32905
- #32906
- #32907
- #32908

**Next PRs**

- #32912