### PR TITLE
[WIP] Allow some e2e Tests to run only nightly

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -211,7 +211,7 @@ jobs:
         if: matrix.edition == 'ee' && github.event_name != 'schedule'
         run: |
           yarn run test-cypress-run \
-          --env grepTags="-@quarantine -@nightly" \
+          --env grepTags="-@quarantine+-@nightly" \
           --folder ${{ matrix.folder }} \
           --browser ${{ steps.setup-chrome.outputs.chrome-path }}
         env:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,7 +3,8 @@ name: E2E Tests
 on:
   # We'll record runs using Replay.io and their browser on a schedule as an experiment
   schedule:
-    - cron: '0 22 * * 0'
+    - cron: '0 22 * * 0' # weekly
+    - cron: '0 19 * * *' # daily
   push:
     branches:
       - "master"
@@ -210,7 +211,17 @@ jobs:
         if: matrix.edition == 'ee' && github.event_name != 'schedule'
         run: |
           yarn run test-cypress-run \
-          --env grepTags="-@quarantine" \
+          --env grepTags="-@quarantine -@nightly" \
+          --folder ${{ matrix.folder }} \
+          --browser ${{ steps.setup-chrome.outputs.chrome-path }}
+        env:
+          TERM: xterm
+
+      - name: Run Nightly EE Cypress tests on ${{ matrix.folder }}
+        if: matrix.edition == 'ee' && (github.event.schedule == '0 19 * * *' || contains(github.event.pull_request.labels.*.name, 'run-nightly-tests'))
+        run: |
+          yarn run test-cypress-run \
+          --env grepTags="@nightly" \
           --folder ${{ matrix.folder }} \
           --browser ${{ steps.setup-chrome.outputs.chrome-path }}
         env:
@@ -218,11 +229,11 @@ jobs:
 
       # REPLAY.IO specific jobs
       - name: Install Replay.io browser
-        if: ${{ github.event_name == 'schedule' }}
+        if: github.event.schedule == '0 22 * * 0'
         run: npx @replayio/cypress install
 
       - name: Run OSS-specific Cypress tests using Replay.io browser
-        if: matrix.edition == 'oss' && github.event_name == 'schedule'
+        if: matrix.edition == 'oss' && github.event.schedule == '0 22 * * 0'
         run: |
           yarn run test-cypress-run \
           --env grepTags=@OSS \
@@ -235,7 +246,7 @@ jobs:
           RECORD_REPLAY_METADATA_TEST_RUN_ID: ${{ needs.test-run-id.outputs.testRunId }}
 
       - name: Run EE Cypress tests on ${{ matrix.folder }} using Replay.io browser
-        if: matrix.edition == 'ee' && github.event_name == 'schedule'
+        if: matrix.edition == 'ee' && github.event.schedule == '0 22 * * 0'
         run: |
           yarn run test-cypress-run \
           --env grepTags="-@quarantine" \
@@ -248,7 +259,7 @@ jobs:
           RECORD_REPLAY_METADATA_TEST_RUN_ID: ${{ needs.test-run-id.outputs.testRunId }}
 
       - name: Upload Replay.io recordings
-        if: github.event_name == 'schedule' && always()
+        if: github.event.schedule == '0 22 * * 0' && always()
         uses: replayio/action-upload@v0.4.7
         with:
           api-key: rwk_gXbvYctIcR6RZyEzUvby3gtkO4esrB2L321lkY8FSuQ

--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -10,8 +10,8 @@ jobs:
   rerun-on-failure:
     name: 'Re-run ''${{ github.event.workflow_run.name }}'' workflow'
     runs-on: ubuntu-22.04
-    # Do not re-run scheduled workflow runs. That's only Replay.io E2E tests for now.
-    if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event != 'schedule'
+    # Do not re-run Replay.io scheduled E2E tests
+    if: github.event.workflow_run.conclusion == 'failure' && github.event.schedule != '0 22 * * 0'
     steps:
       - name: Generate job summary
         run: |
@@ -35,6 +35,8 @@ jobs:
             const FAILED_RUN_NAME = "${{ github.event.workflow_run.name }}";
             const AUTHOR = "${{ github.event.workflow_run.head_commit.author.name }}";
             const BREAKING_COMMIT = "${{ github.event.workflow_run.head_sha }}";
+
+            const isNightly = "${{ github.event.schedule }}" === "0 19 * * *";
 
             if (ATTEMPT <= MAX_ATTEMPTS) {
               github.rest.actions.reRunWorkflowFailedJobs({
@@ -66,7 +68,7 @@ jobs:
                       "type": "section",
                       "text": {
                         "type": "mrkdwn",
-                        "text": `Commit <https://github.com/metabase/metabase/commit/${BREAKING_COMMIT}|${BREAKING_COMMIT.slice(0,7)}> by ${AUTHOR} has failing <${FAILED_RUN_URL}|${FAILED_RUN_NAME}> tests on the \`${BRANCH}\` branch . :sad-panda:\nPlease fix ASAP. \n\nEmoji this message when it's fixed.`
+                        "text": `Commit <https://github.com/metabase/metabase/commit/${BREAKING_COMMIT}|${BREAKING_COMMIT.slice(0,7)}> by ${AUTHOR} has failing <${FAILED_RUN_URL}|${FAILED_RUN_NAME}> ${isNightly ? "nightly " : ""}tests on the \`${BRANCH}\` branch . :sad-panda:\nPlease fix ASAP. \n\nEmoji this message when it's fixed.`
                       }
                     },
                     {

--- a/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
@@ -38,7 +38,7 @@ const MODEL_NAME = "Test Action Model";
 ["mysql", "postgres"].forEach(dialect => {
   describe(
     `Write Actions on Dashboards (${dialect})`,
-    { tags: ["@external", "@actions"] },
+    { tags: ["@external", "@actions", "@nightly"] },
     () => {
       beforeEach(() => {
         cy.intercept("GET", /\/api\/card\/\d+/).as("getModel");

--- a/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
@@ -963,7 +963,7 @@ const MODEL_NAME = "Test Action Model";
 
 describe(
   "Action Parameters Mapping",
-  { tags: ["@external", "@actions"] },
+  { tags: ["@external", "@actions", "@nightly"] },
   () => {
     beforeEach(() => {
       cy.intercept("GET", /\/api\/card\/\d+/).as("getModel");
@@ -987,7 +987,7 @@ describe(
         });
       });
 
-      it("should reflect to updated action on mapping form", () => {
+      it("should reflect updated action on mapping form", () => {
         const ACTION_NAME = "Update Score";
 
         cy.get("@modelId").then(id => {

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -89,7 +89,7 @@ const SAMPLE_WRITABLE_QUERY_ACTION = assocIn(
 
 describe(
   "scenarios > models > actions",
-  { tags: ["@external", "@actions"] },
+  { tags: ["@external", "@actions", "@nightly"] },
   () => {
     beforeEach(() => {
       restore("postgres-12");

--- a/e2e/test/scenarios/dashboard/dashboard-card-resizing.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-card-resizing.cy.spec.js
@@ -197,7 +197,7 @@ const viewports = [
   [1440, 800],
 ];
 
-describe("scenarios > dashboard card resizing", () => {
+describe("scenarios > dashboard card resizing", { tags: ["@nightly"] }, () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/dashboard/reproductions/31628-responsive-scalars.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/31628-responsive-scalars.cy.spec.js
@@ -89,7 +89,7 @@ const SMART_SCALAR_QUESTION_CARDS = [
  * Every block with JSDoc within "it" callbacks should ideally be a separate "it" call.
  * @see https://github.com/metabase/metabase/pull/31722#discussion_r1246165418
  */
-describe("issue 31628", () => {
+describe("responsive scalars Metbase#31628", { tags: ["@nightly"] }, () => {
   describe("display: scalar", () => {
     const descendantsSelector = [
       "[data-testid='scalar-container']",

--- a/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
@@ -17,7 +17,7 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, PEOPLE, PEOPLE_ID } =
   SAMPLE_DATABASE;
 
-describe("scenarios > x-rays", () => {
+describe("scenarios > x-rays", { tags: "@nightly" }, () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/onboarding/setup/user_settings.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/setup/user_settings.cy.spec.js
@@ -134,23 +134,27 @@ describe("user > settings", () => {
     cy.icon("gear").should("exist");
   });
 
-  it("should be able to open the app with every locale from the available locales (metabase#22192)", () => {
-    cy.request("GET", "/api/user/current").then(({ body: user }) => {
-      cy.intercept("GET", "/api/user/current").as("getUser");
+  it(
+    "should be able to open the app with every locale from the available locales (metabase#22192)",
+    { tags: "@nightly" },
+    () => {
+      cy.request("GET", "/api/user/current").then(({ body: user }) => {
+        cy.intercept("GET", "/api/user/current").as("getUser");
 
-      cy.request("GET", "/api/session/properties").then(
-        ({ body: settings }) => {
-          cy.wrap(settings["available-locales"]).each(([locale]) => {
-            cy.log(`Using ${locale} locale`);
-            cy.request("PUT", `/api/user/${user.id}`, { locale });
-            cy.visit("/");
-            cy.wait("@getUser");
-            cy.icon("gear").should("exist");
-          });
-        },
-      );
-    });
-  });
+        cy.request("GET", "/api/session/properties").then(
+          ({ body: settings }) => {
+            cy.wrap(settings["available-locales"]).each(([locale]) => {
+              cy.log(`Using ${locale} locale`);
+              cy.request("PUT", `/api/user/${user.id}`, { locale });
+              cy.visit("/");
+              cy.wait("@getUser");
+              cy.icon("gear").should("exist");
+            });
+          },
+        );
+      });
+    },
+  );
 
   describe("when user is authenticated via ldap", () => {
     beforeEach(() => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31299

### Description

We have a lot of e2e tests and they take ages to run. Many of these tests cover rarely-touched areas of the product, or take a long time to run. We don't want to lose the coverage of these tests, but the value of running them on every pull request and commit to master is dubious.

Some tests are fine if we just run them nightly.

- [x] allow e2e tests with `@nightly` tag to only run once per day on a schedule, or if the PR has a `run-nightly-tests` tag on it
- [x] identify slow or rarely-used tests and add `@nightly` tag
- [x] set up a slack notification to alert of failed nightly tests

### How to verify

- see that the nightly flagged tests did not run on this PR

