### PR TITLE
Improve actions-in-object-detail test

### DIFF
--- a/e2e/support/helpers/e2e-action-helpers.js
+++ b/e2e/support/helpers/e2e-action-helpers.js
@@ -44,7 +44,7 @@ export function createImplicitAction({ model_id, kind }) {
  * @param {number} actionParams.model_id
  */
 export function createImplicitActions({ modelId }) {
-  createImplicitAction({ modelId, kind: "create" });
-  createImplicitAction({ modelId, kind: "update" });
-  createImplicitAction({ modelId, kind: "delete" });
+  createImplicitAction({ model_id: modelId, kind: "create" });
+  createImplicitAction({ model_id: modelId, kind: "update" });
+  createImplicitAction({ model_id: modelId, kind: "delete" });
 }

--- a/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
@@ -85,101 +85,106 @@ describe(
       });
     });
 
-    describe("in modal", { viewportHeight: 1200 }, () => {
-      const permissionLevels = [
-        {
-          name: "admin",
-          permissionFn: asAdmin,
-        },
-        {
-          name: "normal",
-          permissionFn: asNormalUser,
-        },
-      ];
+    describe(
+      "in modal",
+      // These tests time out frequently in CI on `POST /api/dataset`
+      { viewportHeight: 1200, requestTimeout: 10000 },
+      () => {
+        const permissionLevels = [
+          {
+            name: "admin",
+            permissionFn: asAdmin,
+          },
+          {
+            name: "normal",
+            permissionFn: asNormalUser,
+          },
+        ];
 
-      permissionLevels.forEach(({ name, permissionFn }) => {
-        it(`should be able to run update and delete actions when enabled for a ${name} user`, () => {
-          cy.get("@modelId").then(modelId => {
-            permissionFn(() => {
-              cy.log(
-                `As ${name} user: verify there are no model actions to run`,
-              );
-              visitObjectDetail(modelId, FIRST_SCORE_ROW_ID);
-              objectDetailModal().within(() => {
-                assertActionsDropdownNotExists();
-              });
-            });
-
-            asAdmin(() => {
-              createImplicitActions({ modelId });
-            });
-
-            permissionFn(() => {
-              cy.log(
-                `As ${name} user: verify there are model actions to run (1)`,
-              );
-              visitObjectDetail(modelId, FIRST_SCORE_ROW_ID);
-              objectDetailModal().within(() => {
-                assertActionsDropdownExists();
-              });
-
-              cy.log(`As ${name} user: verify update form gets prefilled`);
-              openUpdateObjectModal();
-              actionExecuteModal().within(() => {
-                cy.wait("@prefetchValues").then(request => {
-                  const firstScoreRow = request.response.body;
-
-                  actionForm().within(() => {
-                    assertScoreFormPrefilled(firstScoreRow);
-                  });
-                });
-
-                cy.icon("close").click();
-              });
-              objectDetailModal().icon("close").click();
-
-              cy.log(
-                `As ${name} user: verify there are model actions to run (2)`,
-              );
-              openObjectDetailModal(SECOND_SCORE_ROW_ID);
-              objectDetailModal().within(() => {
-                assertActionsDropdownExists();
-              });
-
-              cy.log(
-                `As ${name} user: verify form gets prefilled with values for another entity and run update action`,
-              );
-              openUpdateObjectModal();
-              actionExecuteModal().within(() => {
-                cy.wait("@prefetchValues").then(request => {
-                  const secondScoreRow = request.response.body;
-
-                  actionForm().within(() => {
-                    assertScoreFormPrefilled(secondScoreRow);
-
-                    cy.findByLabelText("Score").clear().type(UPDATED_SCORE);
-                    cy.findByText("Update").click();
-                  });
+        permissionLevels.forEach(({ name, permissionFn }) => {
+          it(`should be able to run update and delete actions when enabled for a ${name} user`, () => {
+            cy.get("@modelId").then(modelId => {
+              permissionFn(() => {
+                cy.log(
+                  `As ${name} user: verify there are no model actions to run`,
+                );
+                visitObjectDetail(modelId, FIRST_SCORE_ROW_ID);
+                objectDetailModal().within(() => {
+                  assertActionsDropdownNotExists();
                 });
               });
-              objectDetailModal().icon("close").click();
-              assertSuccessfullUpdateToast();
-              assertUpdatedScoreInTable();
 
-              cy.log(`As ${name} user: run delete action`);
-              openObjectDetailModal(SECOND_SCORE_ROW_ID);
-              objectDetailModal().within(() => {
-                assertActionsDropdownExists();
+              asAdmin(() => {
+                createImplicitActions({ modelId });
               });
-              openDeleteObjectModal();
-              deleteObjectModal().findByText("Delete forever").click();
-              assertSuccessfullDeleteToast();
-              assertUpdatedScoreNotInTable();
+
+              permissionFn(() => {
+                cy.log(
+                  `As ${name} user: verify there are model actions to run (1)`,
+                );
+                visitObjectDetail(modelId, FIRST_SCORE_ROW_ID);
+                objectDetailModal().within(() => {
+                  assertActionsDropdownExists();
+                });
+
+                cy.log(`As ${name} user: verify update form gets prefilled`);
+                openUpdateObjectModal();
+                actionExecuteModal().within(() => {
+                  cy.wait("@prefetchValues").then(request => {
+                    const firstScoreRow = request.response.body;
+
+                    actionForm().within(() => {
+                      assertScoreFormPrefilled(firstScoreRow);
+                    });
+                  });
+
+                  cy.icon("close").click();
+                });
+                objectDetailModal().icon("close").click();
+
+                cy.log(
+                  `As ${name} user: verify there are model actions to run (2)`,
+                );
+                openObjectDetailModal(SECOND_SCORE_ROW_ID);
+                objectDetailModal().within(() => {
+                  assertActionsDropdownExists();
+                });
+
+                cy.log(
+                  `As ${name} user: verify form gets prefilled with values for another entity and run update action`,
+                );
+                openUpdateObjectModal();
+                actionExecuteModal().within(() => {
+                  cy.wait("@prefetchValues").then(request => {
+                    const secondScoreRow = request.response.body;
+
+                    actionForm().within(() => {
+                      assertScoreFormPrefilled(secondScoreRow);
+
+                      cy.findByLabelText("Score").clear().type(UPDATED_SCORE);
+                      cy.findByText("Update").click();
+                    });
+                  });
+                });
+                objectDetailModal().icon("close").click();
+                assertSuccessfullUpdateToast();
+                assertUpdatedScoreInTable();
+
+                cy.log(`As ${name} user: run delete action`);
+                openObjectDetailModal(SECOND_SCORE_ROW_ID);
+                objectDetailModal().within(() => {
+                  assertActionsDropdownExists();
+                });
+                openDeleteObjectModal();
+                deleteObjectModal().findByText("Delete forever").click();
+                assertSuccessfullDeleteToast();
+                assertUpdatedScoreNotInTable();
+              });
             });
           });
         });
-      });
-    });
+      },
+    );
   },
 );
 

--- a/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
@@ -10,29 +10,18 @@ import {
   undoToast,
   visitDashboard,
   visitModel,
+  createModelFromTableName,
 } from "e2e/support/helpers";
 
-const PG_DB_ID = 2;
-const PG_SCOREBOARD_TABLE_ID = 9;
 const WRITABLE_TEST_TABLE = "scoreboard_actions";
 const FIRST_SCORE_ROW_ID = 11;
 const SECOND_SCORE_ROW_ID = 12;
 const UPDATED_SCORE = 987654321;
 const UPDATED_SCORE_FORMATTED = "987,654,321";
 
-const SCORES_MODEL = {
-  name: "Scores model",
-  dataset: true,
-  display: "table",
-  database: PG_DB_ID,
-  query: {
-    "source-table": PG_SCOREBOARD_TABLE_ID,
-  },
-};
-
 const DASHBOARD = {
   name: "Test dashboard",
-  database: PG_DB_ID,
+  database: WRITABLE_DB_ID,
 };
 
 describe("scenarios > actions > actions-in-object-detail-view", () => {
@@ -45,18 +34,22 @@ describe("scenarios > actions > actions-in-object-detail-view", () => {
 
     resetTestTable({ type: "postgres", table: WRITABLE_TEST_TABLE });
     restore("postgres-writable");
+    asAdmin(() => {
+      resyncDatabase({
+        dbId: WRITABLE_DB_ID,
+        tableName: WRITABLE_TEST_TABLE,
+      });
+
+      createModelFromTableName({
+        tableName: WRITABLE_TEST_TABLE,
+        idAlias: "modelId",
+      });
+    });
   });
 
   describe("in dashboard", () => {
     beforeEach(() => {
       asAdmin(() => {
-        resyncDatabase({
-          dbId: WRITABLE_DB_ID,
-          tableName: WRITABLE_TEST_TABLE,
-        });
-
-        cy.createQuestion(SCORES_MODEL, { wrapId: true, idAlias: "modelId" });
-
         cy.get("@modelId").then(modelId => {
           createBasicModelActions(modelId);
 
@@ -64,7 +57,7 @@ describe("scenarios > actions > actions-in-object-detail-view", () => {
             questionDetails: {
               name: "Score detail",
               display: "object",
-              database: PG_DB_ID,
+              database: WRITABLE_DB_ID,
               query: {
                 "source-table": `card__${modelId}`,
               },
@@ -92,16 +85,6 @@ describe("scenarios > actions > actions-in-object-detail-view", () => {
   });
 
   describe("in modal", () => {
-    beforeEach(() => {
-      asAdmin(() => {
-        resyncDatabase({
-          dbId: WRITABLE_DB_ID,
-          tableName: WRITABLE_TEST_TABLE,
-        });
-        cy.createQuestion(SCORES_MODEL, { wrapId: true, idAlias: "modelId" });
-      });
-    });
-
     it("should be able to run update and delete actions when enabled", () => {
       cy.get("@modelId").then(modelId => {
         asNormalUser(() => {

--- a/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
@@ -82,7 +82,7 @@ describe("scenarios > actions > actions-in-object-detail-view", () => {
     });
   });
 
-  describe("in modal", () => {
+  describe("in modal", { viewportHeight: 1200 }, () => {
     const permissionLevels = [
       {
         name: "admin",

--- a/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
@@ -201,12 +201,12 @@ function openObjectDetailModal(objectId) {
 
 function openUpdateObjectModal() {
   cy.findByTestId("actions-menu").click();
-  popover().findByText("Update").click();
+  popover().findByText("Update").should("be.visible").click();
 }
 
 function openDeleteObjectModal() {
   cy.findByTestId("actions-menu").click();
-  popover().findByText("Delete").click();
+  popover().findByText("Delete").should("be.visible").click();
 }
 
 function assertActionsDropdownExists() {

--- a/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
@@ -26,7 +26,6 @@ const DASHBOARD = {
 
 describe("scenarios > actions > actions-in-object-detail-view", () => {
   beforeEach(() => {
-    cy.intercept("GET", "/api/card/*").as("getCard");
     cy.intercept("GET", "/api/action?model-id=*").as("getModelActions");
     cy.intercept("GET", "/api/action/*/execute?parameters=*").as(
       "prefetchValues",
@@ -192,7 +191,6 @@ function asNormalUser(callback) {
 
 function visitObjectDetail(modelId, objectId) {
   visitModel(modelId);
-  cy.wait("@getCard");
   cy.get("main").findByText("Loading...").should("not.exist");
   cy.findByTestId("TableInteractive-root").findByText(objectId).click();
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/32889

### Description

## Problem 1: Hard-coded table IDs

Metabase's sync logic is non-deterministic, so for any created tables, we cannot rely on having consistent table or field IDs in tests. We have various utilitites that make handling this easier.

This test hardcoded the Table ID for a test table, which was only correct about 30% of the time.  We have a utility in `e2e-qa-databases-helpers.js` called `getTableId` that queries the api for a table ID by the table's name.  

This test actually doesn't need it though because we have another handy helper in the same file: `createModelFromTableName()` which is actually what we want to do here. Under the hood it looks up the table id before creating the model.

## Problem 2: Test Too Big For Potato

While we try to make our e2e tests pretty big rather than lots of little ones, this is a bit too big. even my local machine was running out of memory and crashing, and it looks like the mini CI runners were simply getting bogged down sometimes.

I simplified the test a bit to focus on testing the actions behavior in modals, and stripped out a lot of page views and UI interactions on the model detail page that we can simply do via API calls. All the enabling/disabling tests are handled elsewhere.

![Screen Shot 2023-08-03 at 1 09 39 PM](https://github.com/metabase/metabase/assets/30528226/fd9b820f-9af5-4b80-888d-39ac0ca53d87)


### How to verify

Test should pass consistently now.

