### PR TITLE
Run Cypress using Chromium `111.0.5563.146`

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -160,6 +160,15 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
+      - name: Install Chrome v111
+        uses: browser-actions/setup-chrome@v1
+        with:
+          # https://chromium.cypress.io/linux/stable/114.0.5735.133
+          chrome-version: 1135580
+        id: setup-chrome
+      - run: |
+          echo Installed chromium version: ${{ steps.setup-chrome.outputs.chrome-version }}
+          ${{ steps.setup-chrome.outputs.chrome-path }} --version
       - name: Record runs using Deploysentinel except for the release branch
         if: ${{ github.ref == 'refs/heads/master' || !(startsWith(github.event.pull_request.base.ref, 'release')) }}
         run: |
@@ -175,17 +184,6 @@ jobs:
         uses: ./.github/actions/prepare-cypress
       - name: Run Snowplow micro
         uses: ./.github/actions/run-snowplow-micro
-
-      - name: Install Chrome v114
-        uses: browser-actions/setup-chrome@v1
-        with:
-          # https://chromium.cypress.io/linux/stable/114.0.5735.133
-          # https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2F1135580%2Fchrome-linux.zip
-          chrome-version: 1135580
-        id: setup-chrome
-      - run: |
-          echo Installed chromium version: ${{ steps.setup-chrome.outputs.chrome-version }}
-          ${{ steps.setup-chrome.outputs.chrome-path }} --version
 
       - uses: actions/download-artifact@v3
         name: Retrieve uberjar artifact for ${{ matrix.edition }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -163,8 +163,8 @@ jobs:
       - name: Install Chrome v111
         uses: browser-actions/setup-chrome@v1
         with:
-          # https://chromium.cypress.io/linux/stable/114.0.5735.133
-          chrome-version: 1135580
+          # https://chromium.cypress.io/linux/stable/111.0.5563.146
+          chrome-version: 1097615
         id: setup-chrome
       - run: |
           echo Installed chromium version: ${{ steps.setup-chrome.outputs.chrome-version }}


### PR DESCRIPTION
Ever since we switched to a custom Chrome version in https://github.com/metabase/metabase/pull/32688, we have been seeing a lot of timeouts due to Cypress failing to connect to DevTools.

It's been almost two weeks of trial and error, with many people involved.
This particular older Chromium version is the one that seems to be working. We should run our E2E tests on `Chromium 111.0.5563.146` for the forseeable future, rather than relying on whichever version comes baked with the hosted GitHub runner.