### PR TITLE
Allow workflow to be cancelled via UI or by concurrent job

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -67,7 +67,7 @@ jobs:
   e2e-tests:
     needs: [build, files-changed, test-run-id]
     if: |
-      always() &&
+      !cancelled() &&
       needs.files-changed.outputs.e2e_all == 'true' &&
       needs.build.result == 'success'
     runs-on: ubuntu-22.04
@@ -246,7 +246,7 @@ jobs:
           RECORD_REPLAY_METADATA_TEST_RUN_ID: ${{ needs.test-run-id.outputs.testRunId }}
 
       - name: Upload Replay.io recordings
-        if: github.event_name == 'schedule' && always()
+        if: github.event_name == 'schedule' && !cancelled()
         uses: replayio/action-upload@v0.4.7
         with:
           api-key: rwk_gXbvYctIcR6RZyEzUvby3gtkO4esrB2L321lkY8FSuQ
@@ -265,7 +265,7 @@ jobs:
   e2e-tests-skipped-stub:
     needs: [build, files-changed]
     if: |
-      always() &&
+      !cancelled() &&
       needs.files-changed.outputs.e2e_all == 'false' &&
       needs.build.result == 'skipped'
     runs-on: ubuntu-22.04


### PR DESCRIPTION
### Description

Based on https://github.com/orgs/community/discussions/26303 and my experience, workflows with `always()` will not cancel even if a new run of the same workflow appears with concurrency and cancel-in-progress:true. Official documentation suggests using `!cancelled()` instead https://docs.github.com/en/actions/learn-github-actions/expressions#always

> Warning: Avoid using always for any task that could suffer from a critical failure, for example: getting sources, otherwise the workflow may hang until it times out. If you want to run a job or step regardless of its success or failure, use the recommended alternative: if: ${{ !cancelled() }}


### How to verify

click "cancel" on any `e2e-tests-*` running job in this PR - it will be cancelled. It will not on any other PR
