### PR TITLE
fix breakout autoselection

### DIFF
--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -8,6 +8,7 @@ import cx from "classnames";
 
 import "./LineAreaBarChart.css";
 
+import { NULL_DISPLAY_VALUE } from "metabase/lib/constants";
 import { getFriendlyName, MAX_SERIES } from "metabase/visualizations/lib/utils";
 import { addCSSRule } from "metabase/lib/dom";
 import { formatValue } from "metabase/lib/formatting";
@@ -428,7 +429,8 @@ function transformSingleSeries(s, series, seriesIndex) {
           // show series title if it's multiseries
           series.length > 1 && card.name,
           // always show grouping value
-          formatValue(breakoutValue, { column: cols[seriesColumnIndex] }),
+          formatValue(breakoutValue, { column: cols[seriesColumnIndex] }) ??
+            NULL_DISPLAY_VALUE,
         ]
           .filter(n => n)
           .join(": "),

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedSimple.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedSimple.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 
 import type { Series } from "metabase-types/api";
 
+import { NULL_DISPLAY_VALUE } from "metabase/lib/constants";
 import { ChartSettingOrderedItems } from "./ChartSettingOrderedItems";
 import {
   ChartSettingMessage,
@@ -53,7 +54,7 @@ export const ChartSettingOrderedSimple = ({
   };
 
   const getItemTitle = (item: SortableItem) => {
-    return item.name || "Unknown";
+    return item.name ?? NULL_DISPLAY_VALUE;
   };
 
   const handleOnEdit = (item: SortableItem, ref: HTMLElement | undefined) => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/32107

### Description

Smart automatic breakout suggestion did not take into account cases when a breakout column has 1 unique value so as a result there is still one series like without the breakout but a legend on chart appears.

### How to verify

Query to reproduce
```
select 'a' x, null x1, 1 y
union all select 'b', null, 2
union all select 'c', null, 3
```

1. New native query -> paste the sql above
2. Switch viz type to Line
3. Ensure it did not select `x1` as a breakout column automatically

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
