### PR TITLE
Fix load-from-h2 bugs with H2 databases 

### DIFF
--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -1,9 +1,11 @@
 (ns metabase.cmd.copy
-  "Shared lower-level implementation of the `dump-to-h2` and `load-from-h2` commands. The `copy!` function implemented
-  here supports loading data from an application database to any empty application database for all combinations of
-  supported application database types."
+  "Shared lower-level implementation of the [[metabase.cmd.dump-to-h2/dump-to-h2!]]
+  and [[metabase.cmd.load-from-h2/load-from-h2!]] commands. The [[copy!]] function implemented here supports loading
+  data from an application database to any empty application database for all combinations of supported application
+  database types."
   (:require
    [clojure.java.jdbc :as jdbc]
+   [honey.sql :as sql]
    [metabase.db.connection :as mdb.connection]
    #_{:clj-kondo/ignore [:deprecated-namespace]}
    [metabase.db.data-migrations :refer [DataMigrations]]
@@ -164,36 +166,51 @@
       (log/error (with-out-str (jdbc/print-sql-exception-chain e)))
       (throw e))))
 
-(def ^:dynamic *allow-loading-h2-databases*
-  "Whether `load-from-h2` should allow loading H2 databases. Normally disabled for security reasons. This is only here
-  so we can disable this check for tests."
+(def ^:dynamic *copy-h2-database-details*
+  "Whether [[copy-data!]] (and thus [[metabase.cmd.load-from-h2/load-from-h2!]]) should copy connection details for H2
+  Databases from the source application database. Normally disabled for security reasons. This is only here so we can
+  disable this check for tests."
   false)
 
-(defn- table-select-fragment [table-name]
-  (cond
-    ;; ensure ID order to ensure that parent fields are inserted before children
-    (= table-name (name (t2/table-name Field)))
-    "ORDER BY id ASC"
+(defn- model-select-fragment
+  [model]
+  (case model
+    :model/Field {:order-by [[:id :asc]]}
+    nil))
 
-    ;; don't copy H2 Databases, since we don't allow people to create them for security reasons.
-    (when-not *allow-loading-h2-databases*
-      (= table-name (name (t2/table-name Database))))
-    "WHERE engine <> 'h2'"))
+(defn- sql-for-selecting-instances-from-source-db [model]
+  (first
+   (sql/format
+    (merge {:select [[:*]]
+            :from   [[(t2/table-name model)]]}
+           (model-select-fragment model))
+    {:quoted false})))
 
-(defn- sql-for-selecting-instances-from-source-db [table-name]
-  (let [fragment (table-select-fragment (u/lower-case-en (name table-name)))]
-    (str "SELECT * FROM "
-         (name table-name)
-         (when fragment (str " " fragment)))))
+(defn- model-results-xform [model]
+  (case model
+    :model/Database
+    ;; For security purposes, do NOT copy connection details for H2 Databases by default; replace them with an empty map.
+    ;; Why? Because this is a potential pathway to injecting sneaky H2 connection parameters that cause RCEs. For the
+    ;; Sample Database, the correct details are reset automatically on every
+    ;; launch (see [[metabase.sample-data/update-sample-database-if-needed!]]), and we don't support connecting other H2
+    ;; Databases in prod anyway, so this ultimately shouldn't cause anyone any problems.
+    (if *copy-h2-database-details*
+      identity
+      (map (fn [database]
+             (cond-> database
+               (= (:engine database) "h2") (assoc :details "{}")))))
+    ;; else
+    identity))
 
 (defn- copy-data! [^javax.sql.DataSource source-data-source target-db-type target-db-conn-spec]
   (with-open [source-conn (.getConnection source-data-source)]
-    (doseq [entity entities
-            :let   [table-name (t2/table-name entity)
-                    sql        (sql-for-selecting-instances-from-source-db table-name)
-                    results    (jdbc/reducible-query {:connection source-conn} sql)]]
+    (doseq [model entities
+            :let  [table-name (t2/table-name model)
+                   sql        (sql-for-selecting-instances-from-source-db model)
+                   results    (jdbc/reducible-query {:connection source-conn} sql)]]
       (transduce
-       (partition-all chunk-size)
+       (comp (model-results-xform model)
+             (partition-all chunk-size))
        ;; cnt    = the total number we've inserted so far
        ;; chunkk = current chunk to insert
        (fn
@@ -203,12 +220,12 @@
          ([cnt chunkk]
           (when (seq chunkk)
             (when (zero? cnt)
-              (log/info (u/colorize 'blue (trs "Copying instances of {0}..." (name entity)))))
+              (log/info (u/colorize 'blue (trs "Copying instances of {0}..." (name model)))))
             (try
               (insert-chunk! target-db-type target-db-conn-spec table-name chunkk)
               (catch Throwable e
-                (throw (ex-info (trs "Error copying instances of {0}" (name entity))
-                                {:entity (name entity)}
+                (throw (ex-info (trs "Error copying instances of {0}" (name model))
+                                {:model (name model)}
                                 e)))))
           (+ cnt (count chunkk))))
        0
@@ -218,7 +235,7 @@
   "Make sure [target] application DB is empty before we start copying data."
   [data-source]
   ;; check that there are no Users yet
-  (let [[{:keys [cnt]}] (jdbc/query {:datasource data-source} "SELECT count(*) AS \"cnt\" FROM core_user;")]
+  (let [[{:keys [cnt]}] (jdbc/query {:datasource data-source} "SELECT count(*) AS cnt FROM core_user;")]
     (assert (integer? cnt))
     (when (pos? cnt)
       (throw (ex-info (trs "Target DB is already populated!")

--- a/test/metabase/cmd/dump_to_h2_test.clj
+++ b/test/metabase/cmd/dump_to_h2_test.clj
@@ -78,7 +78,7 @@
                                                        (persistent-data-source driver/*driver* db-name))]
               (when-not (= driver/*driver* :h2)
                 (tx/create-db! driver/*driver* {:database-name db-name}))
-              (binding [copy/*allow-loading-h2-databases* true]
+              (binding [copy/*copy-h2-database-details* true]
                 (load-from-h2/load-from-h2! h2-fixture-db-file)
                 (encryption-test/with-secret-key "89ulvIGoiYw6mNELuOoEZphQafnF/zYe+3vT+v70D1A="
                   (t2/insert! Setting {:key "my-site-admin", :value "baz"})

--- a/test/metabase/cmd/load_and_dump_test.clj
+++ b/test/metabase/cmd/load_and_dump_test.clj
@@ -42,7 +42,7 @@
             (with-redefs [i18n.impl/site-locale-from-setting (constantly nil)]
               (when-not (= driver/*driver* :h2)
                 (tx/create-db! driver/*driver* {:database-name db-name}))
-              (binding [copy/*allow-loading-h2-databases* true]
+              (binding [copy/*copy-h2-database-details* true]
                 (load-from-h2/load-from-h2! h2-fixture-db-file)
                 (dump-to-h2/dump-to-h2! h2-file))
               (is (not (compare-h2-dbs/different-contents?

--- a/test/metabase/cmd/load_from_h2_test.clj
+++ b/test/metabase/cmd/load_from_h2_test.clj
@@ -13,10 +13,12 @@
    [metabase.test.data.interface :as tx]
    [toucan2.core :as t2]))
 
-(deftest load-from-h2-test
+(defn- load-from-h2-test* [db-name thunk]
   ;; enable this test in the REPL with something like (mt/set-test-drivers! #{:postgres})
   (mt/test-drivers #{:postgres :mysql}
-    (let [db-def             {:database-name "dump-test"}
+    ;; create a Postgres/MySQL database named `dump-test` (destroying it if it already exists first) and then copy
+    ;; things from the [[metabase.cmd.test-util/fixture-db-file-path]] H2 database.
+    (let [db-def             {:database-name db-name}
           h2-filename        @cmd.test-util/fixture-db-file-path
           target-db-type     driver/*driver*
           target-data-source (mdb.test-util/->ClojureJDBCSpecDataSource
@@ -24,9 +26,25 @@
                                target-db-type
                                (tx/dbdef->connection-details target-db-type :db db-def)))]
       (tx/create-db! target-db-type db-def)
-      (binding [mdb.connection/*application-db*   (mdb.connection/application-db target-db-type target-data-source)
-                copy/*allow-loading-h2-databases* true]
+      (binding [mdb.connection/*application-db* (mdb.connection/application-db target-db-type target-data-source)]
         (load-from-h2/load-from-h2! h2-filename)
         (is (= 4
-               (t2/count Table)))))))
-        ;; TODO -- better/more complete validation
+               (t2/count Table)))
+        (thunk)))))
+
+(deftest ^:parallel load-from-h2-test
+  (load-from-h2-test*
+   "dump-test"
+   (fn []
+     (testing "H2 connection details should not have been copied"
+       (is (= {}
+              (t2/select-one-fn :details :model/Database :engine :h2)))))))
+
+(deftest ^:parallel load-from-h2-copy-details-enabled-test
+  (binding [copy/*copy-h2-database-details* true]
+    (load-from-h2-test*
+     "dump-test-2"
+     (fn []
+       (testing "H2 connection details SHOULD have been copied"
+         (is (=? {:db string?}
+                (t2/select-one-fn :details :model/Database :engine :h2))))))))

--- a/test/metabase/cmd/rotate_encryption_key_test.clj
+++ b/test/metabase/cmd/rotate_encryption_key_test.clj
@@ -79,7 +79,7 @@
                       mdb.connection/*application-db* (mdb.connection/application-db driver/*driver* data-source)]
               (when-not (= driver/*driver* :h2)
                 (tx/create-db! driver/*driver* {:database-name db-name}))
-              (binding [copy/*allow-loading-h2-databases* true]
+              (binding [copy/*copy-h2-database-details* true]
                 (load-from-h2/load-from-h2! h2-fixture-db-file))
               (t2/insert! Setting {:key "nocrypt", :value "unencrypted value"})
               (t2/insert! Setting {:key "settings-last-updated", :value original-timestamp})


### PR DESCRIPTION
Fixes #32837

For security purposes we stopped copying H2 databases with the `load-from-h2` command (see https://github.com/metabase/metabase/commit/d495caabcd640d97425ce41cc10861956ecf5427, https://github.com/metabase/metabase/pull/32925, and #32735) since it was a potential way to inject malicious H2 connection strings. 

This ended up breaking the `load-from-h2` command for people who had H2 databases (such as the Sample Database) -- see #32837 -- since it did not also filter out Tables and Fields and other related things for those excluded H2 databases.

This PR replaces that approach with a better one: instead of skipping H2 databases entirely, we now just copy them with their details replaced by an empty map (`{}`). This still eliminates the attack vector, but fixes problems with broken FK references.

For the Sample Database, we automatically set the correct details on launch; we don't allow adding other H2 database connections in production anyway, so ultimately this security measure should be entirely transparent to people.

Please review https://github.com/metabase/metabase/pull/32961 at the same time as this, it's the same PR but manually backported to 46.