### PR TITLE
[46] Fix load-from-h2 bugs with H2 databases

### DIFF
--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -1,9 +1,11 @@
 (ns metabase.cmd.copy
-  "Shared lower-level implementation of the `dump-to-h2` and `load-from-h2` commands. The `copy!` function implemented
-  here supports loading data from an application database to any empty application database for all combinations of
-  supported application database types."
+  "Shared lower-level implementation of the [[metabase.cmd.dump-to-h2/dump-to-h2!]]
+  and [[metabase.cmd.load-from-h2/load-from-h2!]] commands. The [[copy!]] function implemented here supports loading
+  data from an application database to any empty application database for all combinations of supported application
+  database types."
   (:require
    [clojure.java.jdbc :as jdbc]
+   [honey.sql :as sql]
    [metabase.db.connection :as mdb.connection]
    [metabase.db.data-migrations :refer [DataMigrations]]
    [metabase.db.setup :as mdb.setup]
@@ -163,36 +165,51 @@
       (log/error (with-out-str (jdbc/print-sql-exception-chain e)))
       (throw e))))
 
-(def ^:dynamic *allow-loading-h2-databases*
-  "Whether `load-from-h2` should allow loading H2 databases. Normally disabled for security reasons. This is only here
-  so we can disable this check for tests."
+(def ^:dynamic *copy-h2-database-details*
+  "Whether [[copy-data!]] (and thus [[metabase.cmd.load-from-h2/load-from-h2!]]) should copy connection details for H2
+  Databases from the source application database. Normally disabled for security reasons. This is only here so we can
+  disable this check for tests."
   false)
 
-(defn- table-select-fragment [table-name]
-  (cond
-    ;; ensure ID order to ensure that parent fields are inserted before children
-    (= table-name (name (t2/table-name Field)))
-    "ORDER BY id ASC"
+(defn- model-select-fragment
+  [model]
+  (condp = model
+    Field {:order-by [[:id :asc]]}
+    nil))
 
-    ;; don't copy H2 Databases, since we don't allow people to create them for security reasons.
-    (when-not *allow-loading-h2-databases*
-      (= table-name (name (t2/table-name Database))))
-    "WHERE engine <> 'h2'"))
+(defn- sql-for-selecting-instances-from-source-db [model]
+  (first
+   (sql/format
+    (merge {:select [[:*]]
+            :from   [[(t2/table-name model)]]}
+           (model-select-fragment model))
+    {:quoted false})))
 
-(defn- sql-for-selecting-instances-from-source-db [table-name]
-  (let [fragment (table-select-fragment (u/lower-case-en (name table-name)))]
-    (str "SELECT * FROM "
-         (name table-name)
-         (when fragment (str " " fragment)))))
+(defn- model-results-xform [model]
+  (condp = model
+    Database
+    ;; For security purposes, do NOT copy connection details for H2 Databases by default; replace them with an empty map.
+    ;; Why? Because this is a potential pathway to injecting sneaky H2 connection parameters that cause RCEs. For the
+    ;; Sample Database, the correct details are reset automatically on every
+    ;; launch (see [[metabase.sample-data/update-sample-database-if-needed!]]), and we don't support connecting other H2
+    ;; Databases in prod anyway, so this ultimately shouldn't cause anyone any problems.
+    (if *copy-h2-database-details*
+      identity
+      (map (fn [database]
+             (cond-> database
+               (= (:engine database) "h2") (assoc :details "{}")))))
+    ;; else
+    identity))
 
 (defn- copy-data! [^javax.sql.DataSource source-data-source target-db-type target-db-conn-spec]
   (with-open [source-conn (.getConnection source-data-source)]
-    (doseq [entity entities
-            :let   [table-name (t2/table-name entity)
-                    sql        (sql-for-selecting-instances-from-source-db table-name)
-                    results    (jdbc/reducible-query {:connection source-conn} sql)]]
+    (doseq [model entities
+            :let  [table-name (t2/table-name model)
+                   sql        (sql-for-selecting-instances-from-source-db model)
+                   results    (jdbc/reducible-query {:connection source-conn} sql)]]
       (transduce
-       (partition-all chunk-size)
+       (comp (model-results-xform model)
+             (partition-all chunk-size))
        ;; cnt    = the total number we've inserted so far
        ;; chunkk = current chunk to insert
        (fn
@@ -202,12 +219,12 @@
          ([cnt chunkk]
           (when (seq chunkk)
             (when (zero? cnt)
-              (log/info (u/colorize 'blue (trs "Copying instances of {0}..." (name entity)))))
+              (log/info (u/colorize 'blue (trs "Copying instances of {0}..." (name model)))))
             (try
               (insert-chunk! target-db-type target-db-conn-spec table-name chunkk)
               (catch Throwable e
-                (throw (ex-info (trs "Error copying instances of {0}" (name entity))
-                                {:entity (name entity)}
+                (throw (ex-info (trs "Error copying instances of {0}" (name model))
+                                {:model (name model)}
                                 e)))))
           (+ cnt (count chunkk))))
        0
@@ -217,7 +234,7 @@
   "Make sure [target] application DB is empty before we start copying data."
   [data-source]
   ;; check that there are no Users yet
-  (let [[{:keys [cnt]}] (jdbc/query {:datasource data-source} "SELECT count(*) AS \"cnt\" FROM core_user;")]
+  (let [[{:keys [cnt]}] (jdbc/query {:datasource data-source} "SELECT count(*) AS cnt FROM core_user;")]
     (assert (integer? cnt))
     (when (pos? cnt)
       (throw (ex-info (trs "Target DB is already populated!")

--- a/test/metabase/cmd/copy_test.clj
+++ b/test/metabase/cmd/copy_test.clj
@@ -2,30 +2,26 @@
   (:require
    [clojure.test :refer :all]
    [metabase.cmd.copy :as copy]
-   [metabase.models :refer [Database]]
+   [metabase.models :refer [Database Field]]
    [metabase.plugins.classloader :as classloader]
-   [metabase.test :as mt]
    [metabase.util :as u]
-   [toucan.models :as models]
-   [toucan2.core :as t2]))
+   [toucan.models :as models]))
 
 (deftest ^:parallel sql-for-selecting-instances-from-source-db-test
-  (are [table-name] (re-find #"(?i)SELECT \* FROM METABASE_DATABASE WHERE engine <> 'h2'"
-                             (#'copy/sql-for-selecting-instances-from-source-db table-name))
-    (t2/table-name Database)
-    :METABASE_DATABASE
-    "metabase_database")
-  ;; make sure the H2 `test-data` DB is loaded
-  (mt/db)
-  (let [sql              (#'copy/sql-for-selecting-instances-from-source-db (t2/table-name Database))
-        selected-drivers (t2/select-fn-set :engine Database sql)]
-    (is (not (contains? selected-drivers :h2)))))
+  (is (= "SELECT * FROM metabase_field ORDER BY id ASC"
+         (#'copy/sql-for-selecting-instances-from-source-db Field))))
 
-(deftest ^:parallel allow-loading-h2-databases-test
-  (testing `copy/*allow-loading-h2-databases*
-    (binding [copy/*allow-loading-h2-databases* true]
-      (is (= "SELECT * FROM metabase_database"
-             (#'copy/sql-for-selecting-instances-from-source-db (t2/table-name Database)))))))
+(deftest ^:parallel copy-h2-database-details-test
+  (doseq [copy-h2-database-details? [true false]]
+    (testing (str `copy/*copy-h2-database-details* " = " copy-h2-database-details?)
+      (binding [copy/*copy-h2-database-details* copy-h2-database-details?]
+        (is (= [{:id 1, :engine "h2", :details (if copy-h2-database-details? "{:db \"metabase.db\"}" "{}")}
+                {:id 2, :engine "postgres", :details "{:db \"metabase\"}"}]
+               (into
+                []
+                (#'copy/model-results-xform Database)
+                [{:id 1, :engine "h2", :details "{:db \"metabase.db\"}"}
+                 {:id 2, :engine "postgres", :details "{:db \"metabase\"}"}])))))))
 
 (deftest ^:paralell all-models-accounted-for-test
   ;; This fetches the `metabase.cmd.load-from-h2/entities` and compares it all existing entities

--- a/test/metabase/cmd/dump_to_h2_test.clj
+++ b/test/metabase/cmd/dump_to_h2_test.clj
@@ -78,7 +78,7 @@
                                                        (persistent-data-source driver/*driver* db-name))]
               (when-not (= driver/*driver* :h2)
                 (tx/create-db! driver/*driver* {:database-name db-name}))
-              (binding [copy/*allow-loading-h2-databases* true]
+              (binding [copy/*copy-h2-database-details* true]
                 (load-from-h2/load-from-h2! h2-fixture-db-file)
                 (encryption-test/with-secret-key "89ulvIGoiYw6mNELuOoEZphQafnF/zYe+3vT+v70D1A="
                   (db/insert! Setting {:key "my-site-admin", :value "baz"})

--- a/test/metabase/cmd/load_and_dump_test.clj
+++ b/test/metabase/cmd/load_and_dump_test.clj
@@ -42,7 +42,7 @@
             (with-redefs [i18n.impl/site-locale-from-setting-fn (atom (constantly false))]
               (when-not (= driver/*driver* :h2)
                 (tx/create-db! driver/*driver* {:database-name db-name}))
-              (binding [copy/*allow-loading-h2-databases* true]
+              (binding [copy/*copy-h2-database-details* true]
                 (load-from-h2/load-from-h2! h2-fixture-db-file)
                 (dump-to-h2/dump-to-h2! h2-file))
               (is (not (compare-h2-dbs/different-contents?

--- a/test/metabase/cmd/load_from_h2_test.clj
+++ b/test/metabase/cmd/load_from_h2_test.clj
@@ -8,15 +8,17 @@
    [metabase.db.test-util :as mdb.test-util]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
-   [metabase.models :refer [Table]]
+   [metabase.models :refer [Database Table]]
    [metabase.test :as mt]
    [metabase.test.data.interface :as tx]
-   [toucan.db :as db]))
+   [toucan2.core :as t2]))
 
-(deftest load-from-h2-test
+(defn- load-from-h2-test* [db-name thunk]
   ;; enable this test in the REPL with something like (mt/set-test-drivers! #{:postgres})
   (mt/test-drivers #{:postgres :mysql}
-    (let [db-def             {:database-name "dump-test"}
+    ;; create a Postgres/MySQL database named `dump-test` (destroying it if it already exists first) and then copy
+    ;; things from the [[metabase.cmd.test-util/fixture-db-file-path]] H2 database.
+    (let [db-def             {:database-name db-name}
           h2-filename        @cmd.test-util/fixture-db-file-path
           target-db-type     driver/*driver*
           target-data-source (mdb.test-util/->ClojureJDBCSpecDataSource
@@ -24,9 +26,25 @@
                                target-db-type
                                (tx/dbdef->connection-details target-db-type :db db-def)))]
       (tx/create-db! target-db-type db-def)
-      (binding [mdb.connection/*application-db*   (mdb.connection/application-db target-db-type target-data-source)
-                copy/*allow-loading-h2-databases* true]
+      (binding [mdb.connection/*application-db* (mdb.connection/application-db target-db-type target-data-source)]
         (load-from-h2/load-from-h2! h2-filename)
         (is (= 4
-               (db/count Table)))))))
-        ;; TODO -- better/more complete validation
+               (t2/count Table)))
+        (thunk)))))
+
+(deftest ^:parallel load-from-h2-test
+  (load-from-h2-test*
+   "dump-test"
+   (fn []
+     (testing "H2 connection details should not have been copied"
+       (is (= {}
+              (t2/select-one-fn :details Database :engine :h2)))))))
+
+(deftest ^:parallel load-from-h2-copy-details-enabled-test
+  (binding [copy/*copy-h2-database-details* true]
+    (load-from-h2-test*
+     "dump-test-2"
+     (fn []
+       (testing "H2 connection details SHOULD have been copied"
+         (is (=? {:db string?}
+                (t2/select-one-fn :details Database :engine :h2))))))))

--- a/test/metabase/cmd/rotate_encryption_key_test.clj
+++ b/test/metabase/cmd/rotate_encryption_key_test.clj
@@ -96,7 +96,7 @@
                       mdb.connection/*application-db* (mdb.connection/application-db driver/*driver* data-source)]
               (when-not (= driver/*driver* :h2)
                 (tx/create-db! driver/*driver* {:database-name db-name}))
-              (binding [copy/*allow-loading-h2-databases* true]
+              (binding [copy/*copy-h2-database-details* true]
                 (load-from-h2/load-from-h2! h2-fixture-db-file))
               (db/insert! Setting {:key "nocrypt", :value "unencrypted value"})
               (db/insert! Setting {:key "settings-last-updated", :value original-timestamp})


### PR DESCRIPTION
This is #32960 manually backported to 46.x since it needs to ship with both 46 and 47