### PR TITLE
Embiggen chart selection icons

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.tsx
@@ -188,7 +188,7 @@ const ChartTypeOption = ({
       data-is-sensible={isSensible}
       data-testid={`${visualization.uiName}-button`}
     >
-      <Icon name={visualization.iconName} />
+      <Icon name={visualization.iconName} size={20} />
       {isSelected && (
         <SettingsButton
           onlyIcon


### PR DESCRIPTION
We got feedback from Bruno that the size of the new icons in this context felt too squint-inducing, so I zapped them with the 20px laser.

| Before | After |
| -------|------|
| <img width="354" alt="image" src="https://github.com/metabase/metabase/assets/2223916/df1fdbb9-e61b-4e0c-9c95-a384769f2709"> | <img width="357" alt="image" src="https://github.com/metabase/metabase/assets/2223916/b45c7514-0ab2-4611-8060-7956dc85821f">
|



