### PR TITLE
Introduce a backport reminder CI workflow

### DIFF
--- a/.github/workflows/backport-reminder.yml
+++ b/.github/workflows/backport-reminder.yml
@@ -1,0 +1,15 @@
+name: Backport Reminder
+
+on:
+  pull_request:
+    types: [auto_merge_enabled, review_requested, unlabeled]
+
+jobs:
+  backport-reminder:
+    name: Remind the author to decide whether to backport or not
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          valid-labels: 'backport, no-backport'

--- a/.github/workflows/backport-reminder.yml
+++ b/.github/workflows/backport-reminder.yml
@@ -15,3 +15,4 @@ jobs:
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           valid-labels: 'backport, no-backport'
+          disable-reviews: true

--- a/.github/workflows/backport-reminder.yml
+++ b/.github/workflows/backport-reminder.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   backport-reminder:
-    name: Remind the author to decide whether to backport or not
+    name: Decide whether to backport or not
     runs-on: ubuntu-22.04
     steps:
       - uses: jesusvasquez333/verify-pr-label-action@v1.4.0

--- a/.github/workflows/backport-reminder.yml
+++ b/.github/workflows/backport-reminder.yml
@@ -2,7 +2,7 @@ name: Backport Reminder
 
 on:
   pull_request:
-    types: [auto_merge_enabled, review_requested, unlabeled]
+    types: [auto_merge_enabled, review_requested, labeled, unlabeled]
     branches:
       - "master"
 

--- a/.github/workflows/backport-reminder.yml
+++ b/.github/workflows/backport-reminder.yml
@@ -3,6 +3,8 @@ name: Backport Reminder
 on:
   pull_request:
     types: [auto_merge_enabled, review_requested, unlabeled]
+    branches:
+      - "master"
 
 jobs:
   backport-reminder:


### PR DESCRIPTION
Making a decision whether or not to backport a certain change to the latest release branch is hard. Which (ironically) makes it so easy to forget.

At the same time, forgetting to backport a change means we will not ship a particular change in the current release. If it lives in `master` only, it will go out with the next major release.

This workflow relies on the (non-)existence of these two labels:
1. `backport`
2. `no-backport`

At the very least, the PR author should make a conscious decision about this, manifested by adding one of the aforementioned labels. This makes it easier to keep an inventory of labeled PRs and to keep an eye on them. E.g. sometimes backports fail due to merge conflicts.

