### PR TITLE
Rename embedding - manual backport

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-premium-token.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-premium-token.cy.spec.js
@@ -32,11 +32,11 @@ describe(
 
       cy.visit(embeddingPage);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Full-app embedding").click();
+      cy.findByText("Interactive embedding").click();
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains(
-        "With some of our paid plans, you can embed the full Metabase app and enable your users to drill-through to charts, browse collections, and use the graphical query builder. You can also get priority support, more tools to help you share your insights with your teams and powerful options to help you create seamless, interactive data experiences for your customers.",
+        "With some of our paid plans, you can embed the full Metabase app to allow people to drill-through to charts, browse collections, and use the graphical query builder. You can also get priority support, more tools to help you share your insights with your teams and powerful options to help you create seamless, interactive data experiences for your customers.",
       );
       assertLinkMatchesUrl("some of our paid plans,", upgradeUrl);
 

--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -100,15 +100,15 @@ describe("scenarios > embedding > smoke tests", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("No questions have been embedded yet.");
 
-      // Full app embedding section (available only for EE version and in PRO hosted plans)
+      // Interactive embedding section (available only for EE version and in PRO hosted plans)
       if (isEE) {
         sidebar().within(() => {
           cy.findByText("Embedding").click();
         });
-        cy.findByText("Full-app embedding").click();
+        cy.findByText("Interactive embedding").click();
         cy.findByText(/Embedding the entire Metabase app/i);
         cy.contains(
-          "With some of our paid plans, you can embed the full Metabase app and enable your users to drill-through to charts, browse collections, and use the graphical query builder. You can also get priority support, more tools to help you share your insights with your teams and powerful options to help you create seamless, interactive data experiences for your customers.",
+          "With some of our paid plans, you can embed the full Metabase app to allow people to drill-through to charts, browse collections, and use the graphical query builder. You can also get priority support, more tools to help you share your insights with your teams and powerful options to help you create seamless, interactive data experiences for your customers.",
         );
         cy.contains(
           "Enter the origins for the websites or web apps where you want to allow embedding, separated by a space. Here are the exact specifications for what can be entered.",

--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -69,7 +69,7 @@ describe("scenarios > embedding > smoke tests", () => {
       cy.findByText("Enabled");
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Standalone embeds").click();
+      cy.findByText("Static embedding").click();
       if (isOSS) {
         cy.contains(
           "In order to remove the Metabase logo from embeds, you can always upgrade to one of our paid plans.",
@@ -191,7 +191,7 @@ describe("scenarios > embedding > smoke tests", () => {
 
         cy.visit(embeddingPage);
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText("Standalone embeds").click();
+        cy.findByText("Static embedding").click();
         cy.wait("@currentlyEmbeddedObject");
 
         const sectionName = new RegExp(`Embedded ${object}s`, "i");
@@ -223,7 +223,7 @@ describe("scenarios > embedding > smoke tests", () => {
 
         cy.visit(embeddingPage);
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText("Standalone embeds").click();
+        cy.findByText("Static embedding").click();
         cy.wait("@currentlyEmbeddedObject");
 
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/embedding/embedding-standalone.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-standalone.cy.spec.js
@@ -1,0 +1,24 @@
+import { restore, modal } from "e2e/support/helpers";
+const embeddingPage = "/admin/settings/embedding-in-other-applications";
+
+describe("scenarios > embedding > static embedding", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should allow you to set and regenerate an embedding token", () => {
+    cy.visit(embeddingPage);
+    cy.findByTestId("-static-embedding-setting")
+      .findByText("Static embedding")
+      .click();
+    cy.findByRole("button", { name: "Regenerate key" }).click();
+
+    modal().within(() => {
+      cy.findByText("Regenerate embedding key?").should("exist");
+      cy.findByText(
+        "This will cause existing embeds to stop working until they are updated with the new key.",
+      ).should("exist");
+    });
+  });
+});

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/common.unit.spec.tsx
@@ -9,14 +9,14 @@ import { setup, FULL_APP_EMBEDDING_URL, EMAIL_URL } from "./setup";
 
 describe("SettingsEditor", () => {
   describe("full-app embedding", () => {
-    it("should show info about full app embedding", async () => {
+    it("should show info about interactive embedding", async () => {
       await setup({
         settings: [createMockSettingDefinition({ key: "enable-embedding" })],
         settingValues: createMockSettings({ "enable-embedding": true }),
       });
 
       userEvent.click(screen.getByText("Embedding"));
-      userEvent.click(screen.getByText("Full-app embedding"));
+      userEvent.click(screen.getByText("Interactive embedding"));
       expect(screen.getByText(/some of our paid plans/)).toBeInTheDocument();
       expect(screen.queryByText("Authorized origins")).not.toBeInTheDocument();
     });
@@ -31,7 +31,9 @@ describe("SettingsEditor", () => {
       expect(
         screen.getByText(/Embed dashboards, questions/),
       ).toBeInTheDocument();
-      expect(screen.queryByText("Full-app embedding")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Interactive embedding"),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding.unit.spec.tsx
@@ -18,7 +18,7 @@ const setupEmbedding = async (opts?: SetupOpts) => {
 };
 
 describe("SettingsEditor", () => {
-  it("should allow to configure the origin for full-app embedding", async () => {
+  it("should allow to configure the origin for interactive embedding", async () => {
     await setupEmbedding({
       settings: [
         createMockSettingDefinition({ key: "enable-embedding" }),
@@ -30,8 +30,8 @@ describe("SettingsEditor", () => {
     });
 
     userEvent.click(screen.getByText("Embedding"));
-    userEvent.click(screen.getByText("Full-app embedding"));
-    expect(screen.getByText("Full-app embedding")).toBeInTheDocument();
+    userEvent.click(screen.getByText("Interactive embedding"));
+    expect(screen.getByText("Interactive embedding")).toBeInTheDocument();
     expect(screen.getByText("Authorized origins")).toBeInTheDocument();
     expect(
       screen.queryByText(/some of our paid plans/),

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/enterprise.unit.spec.tsx
@@ -14,7 +14,7 @@ const setupEnterprise = async (opts?: SetupOpts) => {
 };
 
 describe("SettingsEditor", () => {
-  it("should not allow to configure the origin for full-app embedding", async () => {
+  it("should not allow to configure the origin for interactive embedding", async () => {
     await setupEnterprise({
       settings: [
         createMockSettingDefinition({ key: "enable-embedding" }),
@@ -24,7 +24,7 @@ describe("SettingsEditor", () => {
     });
 
     userEvent.click(screen.getByText("Embedding"));
-    userEvent.click(screen.getByText("Full-app embedding"));
+    userEvent.click(screen.getByText("Interactive embedding"));
     expect(screen.getByText(/some of our paid plans/)).toBeInTheDocument();
     expect(screen.queryByText("Authorized origins")).not.toBeInTheDocument();
   });

--- a/frontend/src/metabase/admin/settings/components/widgets/FullAppEmbeddingLinkWidget/FullAppEmbeddingLinkWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/FullAppEmbeddingLinkWidget/FullAppEmbeddingLinkWidget.tsx
@@ -15,7 +15,7 @@ export const FullAppEmbeddingLinkWidget = () => {
       <ExternalLink key="upgrade-link" href={upgradeUrl}>
         {t`some of our paid plans,`}
       </ExternalLink>
-    )} you can embed the full Metabase app and enable your users to drill-through to charts, browse collections, and use the graphical query builder. You can also get priority support, more tools to help you share your insights with your teams and powerful options to help you create seamless, interactive data experiences for your customers.`,
+    )} you can embed the full Metabase app to allow people to drill-through to charts, browse collections, and use the graphical query builder. You can also get priority support, more tools to help you share your insights with your teams and powerful options to help you create seamless, interactive data experiences for your customers.`,
   };
 
   return <SettingHeader id="embedding-customization-info" setting={setting} />;

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -470,17 +470,19 @@ export const ADMIN_SETTINGS_SECTIONS = {
         getHidden: (_, derivedSettings) => !derivedSettings["enable-embedding"],
       },
       {
+        key: "-static-embedding",
         widget: EmbeddingOption,
         getHidden: (_, derivedSettings) => !derivedSettings["enable-embedding"],
-        embedName: t`Standalone embeds`,
-        embedDescription: t`Securely embed individual questions and dashboards within other applications.`,
+        embedName: t`Static embedding`,
+        embedDescription: t`Embed dashboards, charts, and questions on your app or website with basic filters for insights with limited discovery.`,
         embedType: "standalone",
       },
       {
+        key: "-interactive-embedding",
         widget: EmbeddingOption,
         getHidden: (_, derivedSettings) => !derivedSettings["enable-embedding"],
-        embedName: t`Full-app embedding`,
-        embedDescription: t`With this Pro/Enterprise feature you can embed the full Metabase app. Enable your users to drill-through to charts, browse collections, and use the graphical query builder.`,
+        embedName: t`Interactive embedding`,
+        embedDescription: t`With this Pro/Enterprise feature, you can let your customers query, visualize, and drill-down on their data with the full functionality of Metabase in your app or website, complete with your branding. Set permissions with SSO, down to the row- or column-level, so people only see what they need to.`,
         embedType: "full-app",
       },
     ],
@@ -497,7 +499,7 @@ export const ADMIN_SETTINGS_SECTIONS = {
                   t`Embedding`,
                   "/admin/settings/embedding-in-other-applications",
                 ],
-                [t`Standalone embeds`],
+                [t`Static embedding`],
               ]}
             />
           );
@@ -547,7 +549,7 @@ export const ADMIN_SETTINGS_SECTIONS = {
                   t`Embedding`,
                   "/admin/settings/embedding-in-other-applications",
                 ],
-                [t`Full-app embedding`],
+                [t`Interactive embedding`],
               ]}
             />
           );


### PR DESCRIPTION
Cherry-picked backport of https://github.com/metabase/metabase/pull/32774. The tests differed significantly, so I defaulted to updating the tests in the release banch with the update embedding names.