### PR TITLE
Change log level for api.field/search-values to error

### DIFF
--- a/src/metabase/api/field.clj
+++ b/src/metabase/api/field.clj
@@ -423,9 +423,8 @@
            limit   (or maybe-limit default-max-field-search-limit)
            results (qp/process-query (search-values-query field search-field value limit))]
        (get-in results [:data :rows]))
-     ;; this Exception is usually one that can be ignored which is why I gave it log level debug
      (catch Throwable e
-       (log/debug e (trs "Error searching field values"))
+       (log/error e (trs "Error searching field values"))
        nil))))
 
 (api/defendpoint GET "/:id/search/:search-id"


### PR DESCRIPTION
We have a regression on stats ([thread](https://metaboat.slack.com/archives/C505ZNNH4/p1691429382920669)) but it's very hard to debug because the error is set to debug currently...

Changing it to error to make it easy to debug. We should have it as error anyway

Related https://github.com/metabase/metabase/issues/32985