### PR TITLE
MLv2: Hide differences of temporal-unit and binning when matching refs

### DIFF
--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -120,6 +120,8 @@
                                        update-options-remove-namespaced-keys
                                        ;; ignore type info
                                        #(lib.options/update-options % dissoc :base-type :effective-type)
+                                       ;; ignore binning and bucketing
+                                       #(lib.options/update-options % dissoc :binning :temporal-unit)
                                        ;; ignore join alias
                                        #(lib.options/update-options % dissoc :join-alias)]]
      (or (let [a-ref (xform a-ref)]

--- a/test/metabase/lib/equality_test.cljc
+++ b/test/metabase/lib/equality_test.cljc
@@ -215,7 +215,32 @@
     [:field {} 1]
     [[:field {:join-alias "J"} 1]
      [:field {:join-alias "J"} 2]]
-    [:field {:join-alias "J"} 1]))
+    [:field {:join-alias "J"} 1]
+
+    ;; prefer matching binning settings
+    [:field {:binning {:strategy :bin-width :bin-width 1.0}} 1]
+    [[:field {:binning {:strategy :bin-width :bin-width 1.0}} 1]
+     [:field {} 1]]
+    [:field {:binning {:strategy :bin-width :bin-width 1.0}} 1]
+
+    ;; but ignore binning settings if necessary
+    [:field {:binning {:strategy :bin-width :bin-width 1.0}} 1]
+    [[:field {:binning {:strategy :bin-width :bin-width 1.0}} 2]
+     [:field {} 1]]
+    [:field {} 1]
+
+    ;; prefer matching temporal-unit
+    [:field {:temporal-unit :month} 1]
+    [[:field {:temporal-unit :month} 1]
+     [:field {:temporal-unit :week} 1]
+     [:field {} 1]]
+    [:field {:temporal-unit :month} 1]
+
+    ;; but ignore temporal-unit if necessary
+    [:field {:temporal-unit :month} 1]
+    [[:field {:temporal-unit :month} 2]
+     [:field {} 1]]
+    [:field {} 1]))
 
 (deftest ^:parallel find-closest-matching-ref-3-arity-test
   (is (= [:field {} "CATEGORY"]


### PR DESCRIPTION
Fixes #32920
