### PR TITLE
Address dashboard visual glitches caused by css refactoring

### DIFF
--- a/e2e/test/scenarios/dashboard/reproductions/31274-dashcard-actions-overlap.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/31274-dashcard-actions-overlap.cy.spec.js
@@ -44,57 +44,53 @@ describe("issue 31274", () => {
   });
 
   // cypress automatically scrolls to the element, but we don't need it in this test
-  it(
-    "should not clip dashcard actions (mestabase#31274)",
-    { scrollBehavior: false },
-    () => {
-      cy.createDashboard().then(({ body: dashboard }) => {
-        const cards = createTextCards(3);
-        cy.request("PUT", `/api/dashboard/${dashboard.id}/cards`, {
-          cards,
-        });
-
-        visitDashboard(dashboard.id);
-        editDashboard(dashboard.id);
-
-        secondTextCard().realHover();
-
-        visibleActionsPanel().should("have.length", 1);
-
-        cy.log(
-          "Make sure cypress can click the element, which means it is not covered by another",
-        );
-
-        visibleActionsPanel().within(() => {
-          cy.icon("close").click({
-            position: "top",
-          });
-        });
-      });
-    },
-  );
-
-  it(
-    "renders cross icon on the link card without clipping",
-    { scrollBehavior: false },
-    () => {
-      cy.createDashboard().then(({ body: dashboard }) => {
-        visitDashboard(dashboard.id);
-        editDashboard(dashboard.id);
+  it("should not clip dashcard actions (metabase#31274)", () => {
+    cy.createDashboard().then(({ body: dashboard }) => {
+      const cards = createTextCards(3);
+      cy.request("PUT", `/api/dashboard/${dashboard.id}/cards`, {
+        cards,
       });
 
-      createLinkCard();
-      cy.findByPlaceholderText("https://example.com").realHover();
+      visitDashboard(dashboard.id);
+      editDashboard(dashboard.id);
+
+      secondTextCard().realHover();
+
+      visibleActionsPanel().should("have.length", 1);
 
       cy.log(
         "Make sure cypress can click the element, which means it is not covered by another",
       );
 
-      cy.findByTestId("dashboardcard-actions-panel").within(() => {
-        cy.icon("close").click({ position: "bottom" });
+      visibleActionsPanel().within(() => {
+        cy.icon("close").click({
+          position: "top",
+        });
       });
-    },
-  );
+
+      cy.findAllByTestId("dashcard").should("have.length", 2);
+    });
+  });
+
+  it("renders cross icon on the link card without clipping", () => {
+    cy.createDashboard().then(({ body: dashboard }) => {
+      visitDashboard(dashboard.id);
+      editDashboard(dashboard.id);
+    });
+
+    createLinkCard();
+    cy.findByPlaceholderText("https://example.com").realHover();
+
+    cy.log(
+      "Make sure cypress can click the element, which means it is not covered by another",
+    );
+
+    cy.findByTestId("dashboardcard-actions-panel").within(() => {
+      cy.icon("close").click({ position: "bottom" });
+    });
+
+    cy.findByTestId("dashcard").should("not.exist");
+  });
 });
 
 function visibleActionsPanel() {

--- a/e2e/test/scenarios/dashboard/reproductions/31274-dashcard-actions-overlap.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/31274-dashcard-actions-overlap.cy.spec.js
@@ -1,4 +1,9 @@
-import { editDashboard, restore, visitDashboard } from "e2e/support/helpers";
+import {
+  editDashboard,
+  restore,
+  visitDashboard,
+  createLinkCard,
+} from "e2e/support/helpers";
 
 const baseTextDashcardDetails = {
   col: 0,
@@ -57,7 +62,7 @@ describe("issue 31274", () => {
         visibleActionsPanel().should("have.length", 1);
 
         cy.log(
-          "Make sure cypress can click, so element is not covered by another",
+          "Make sure cypress can click the element, which means it is not covered by another",
         );
 
         visibleActionsPanel().within(() => {
@@ -65,6 +70,28 @@ describe("issue 31274", () => {
             position: "top",
           });
         });
+      });
+    },
+  );
+
+  it(
+    "renders cross icon on the link card without clipping",
+    { scrollBehavior: false },
+    () => {
+      cy.createDashboard().then(({ body: dashboard }) => {
+        visitDashboard(dashboard.id);
+        editDashboard(dashboard.id);
+      });
+
+      createLinkCard();
+      cy.findByPlaceholderText("https://example.com").realHover();
+
+      cy.log(
+        "Make sure cypress can click the element, which means it is not covered by another",
+      );
+
+      cy.findByTestId("dashboardcard-actions-panel").within(() => {
+        cy.icon("close").click({ position: "bottom" });
       });
     },
   );

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
@@ -54,6 +54,8 @@ export const DashboardCardActionsPanel = styled.div`
   transition: opacity 200ms;
   opacity: 0;
   pointer-events: none;
+  // react-resizable covers panel, we have to override it
+  z-index: 2;
 
   .Card:hover &,
   .Card:focus-within & {

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.styled.tsx
@@ -16,7 +16,8 @@ export const DashboardCard = styled.div<DashboardCardProps>`
   *
   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context
   */
-  &:hover {
+  &:hover,
+  &:focus-within {
     z-index: 3;
   }
 
@@ -27,7 +28,7 @@ export const DashboardCard = styled.div<DashboardCardProps>`
     bottom: 0;
     right: 0;
     border-radius: 8px;
-    box-shadow: 0px 1px 3px var(--color-shadow);
+    box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.13);
   }
 
   ${props =>


### PR DESCRIPTION
### Description

After https://github.com/metabase/metabase/pull/32796/ several bugs were introduced:
- missed shadow at dashcards
- partial visibility of the cross icon ad link cards during editing

So this PR addresses those issues and adds a test to verify cross icon is still visible.

### How to verify

- add a link card to the dashboard, hover over it and verify cross icon is visible

<img width="345" alt="image" src="https://github.com/metabase/metabase/assets/125459446/fd09d6d3-fe9e-4e6d-b47e-b4a27ef15932">


- add a couple of questions to the dashboard, verify that shadow is there

<img width="528" alt="image" src="https://github.com/metabase/metabase/assets/125459446/07fbcab9-0d4e-4614-be61-5bb28364b775">


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
