### PR TITLE
docs - add Latvian to list of languages

### DIFF
--- a/docs/configuring-metabase/localization.md
+++ b/docs/configuring-metabase/localization.md
@@ -34,6 +34,7 @@ The languages you can currently pick from are:
 - Italian
 - Japanese
 - Korean
+- Latvian
 - Norwegian Bokmål
 - Polish
 - Portuguese


### PR DESCRIPTION
Adds Latvian to our list of supported languages.