### PR TITLE
[MLv2] Expose field_id mlv2 function

### DIFF
--- a/frontend/src/metabase-lib/fields.ts
+++ b/frontend/src/metabase-lib/fields.ts
@@ -19,3 +19,14 @@ export function fieldableColumns(
 ): ColumnMetadata[] {
   return ML.fieldable_columns(query, stageIndex);
 }
+
+/**
+ * This should only be used to get field IDs when it is necessary, like interacting with backend API parameters.
+ * For most purposes, you should be use columnMetadata objects and not access field ids directly
+ *
+ * @param {ColumnMetadata} column
+ * @returns { number } field id
+ */
+export function _fieldId(column: ColumnMetadata): number {
+  return ML.field_id(column);
+}

--- a/frontend/src/metabase-lib/fields.ts
+++ b/frontend/src/metabase-lib/fields.ts
@@ -25,8 +25,8 @@ export function fieldableColumns(
  * For most purposes, you should be use columnMetadata objects and not access field ids directly
  *
  * @param {ColumnMetadata} column
- * @returns { number } field id
+ * @returns {number|null} field id
  */
-export function _fieldId(column: ColumnMetadata): number {
+export function _fieldId(column: ColumnMetadata): number | null {
   return ML.field_id(column);
 }


### PR DESCRIPTION
follow-up to https://github.com/metabase/metabase/pull/32537

discussion: https://metaboat.slack.com/archives/C04CYTEL9N2/p1691513939715319

### Description

exposes `ML.field_id()` as `Lib._fieldId()`

### How to verify

In your browser console with metabase-lib (`Lib`) and a query (`q`) exposed on the window object:

```ts
const col = Lib.filterableColumns(q, -1)[0];

const id = Lib._fieldId(col); 
```
