### PR TITLE
Wrap long column names in chart settings sidebar

### DIFF
--- a/e2e/test/scenarios/question/reproductions/32964-long-column-name-in-visualization-settings.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/32964-long-column-name-in-visualization-settings.cy.spec.js
@@ -1,0 +1,49 @@
+import { restore, visitQuestionAdhoc } from "e2e/support/helpers";
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+const { ORDERS_ID } = SAMPLE_DATABASE;
+
+const LONG_NAME = "A very long column name that will cause text overflow";
+
+const QUESTION = {
+  dataset_query: {
+    type: "query",
+    database: SAMPLE_DB_ID,
+    query: {
+      "source-table": ORDERS_ID,
+      expressions: {
+        LONG_NAME: ["*", ["field", SAMPLE_DATABASE.ORDERS.SUBTOTAL, null], 2],
+      },
+      aggregation: [["sum", ["expression", LONG_NAME]]],
+      breakout: [
+        [
+          "field",
+          SAMPLE_DATABASE.ORDERS.CREATED_AT,
+          {
+            "base-type": "type/DateTime",
+            "temporal-unit": "week",
+          },
+        ],
+      ],
+    },
+  },
+};
+
+describe("issue 32964", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should not overflow chart settings sidebar with long column name (metabase#32964)", () => {
+    visitQuestionAdhoc(QUESTION);
+    cy.findByTestId("viz-settings-button").click();
+
+    const sidebarLeft = cy.findByTestId("sidebar-left");
+    const longName = sidebarLeft.findByText(LONG_NAME);
+
+    expect(longName.getBoundingClientRect().right).toBeLessThan(
+      sidebarLeft.getBoundingClientRect().right,
+    );
+  });
+});

--- a/e2e/test/scenarios/question/reproductions/32964-long-column-name-in-visualization-settings.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/32964-long-column-name-in-visualization-settings.cy.spec.js
@@ -12,7 +12,7 @@ const QUESTION = {
     query: {
       "source-table": ORDERS_ID,
       expressions: {
-        LONG_NAME: ["*", ["field", SAMPLE_DATABASE.ORDERS.SUBTOTAL, null], 2],
+        [LONG_NAME]: ["*", ["field", SAMPLE_DATABASE.ORDERS.SUBTOTAL, null], 2],
       },
       aggregation: [["sum", ["expression", LONG_NAME]]],
       breakout: [
@@ -38,12 +38,12 @@ describe("issue 32964", () => {
   it("should not overflow chart settings sidebar with long column name (metabase#32964)", () => {
     visitQuestionAdhoc(QUESTION);
     cy.findByTestId("viz-settings-button").click();
-
-    const sidebarLeft = cy.findByTestId("sidebar-left");
-    const longName = sidebarLeft.findByText(LONG_NAME);
-
-    expect(longName.getBoundingClientRect().right).toBeLessThan(
-      sidebarLeft.getBoundingClientRect().right,
-    );
+    cy.findByTestId("sidebar-left").within(([sidebar]) => {
+      const maxX = sidebar.getBoundingClientRect().right;
+      cy.findByText(`Sum of ${LONG_NAME}`).then(([el]) => {
+        const x = el.getBoundingClientRect().right;
+        expect(x).to.be.lessThan(maxX);
+      });
+    });
   });
 });

--- a/frontend/src/metabase/visualizations/components/ChartSettings.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.styled.tsx
@@ -51,6 +51,7 @@ export const ChartSettingsMenu = styled.div`
   flex: 1 0 0;
   display: flex;
   flex-direction: column;
+  width: 100%;
 `;
 
 export const ChartSettingsListContainer = styled.div`

--- a/frontend/src/metabase/visualizations/components/ChartSettings.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.styled.tsx
@@ -51,7 +51,6 @@ export const ChartSettingsMenu = styled.div`
   flex: 1 0 0;
   display: flex;
   flex-direction: column;
-  width: 100%;
 `;
 
 export const ChartSettingsListContainer = styled.div`

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
@@ -43,7 +43,8 @@ export const ChartSettingFieldPickerRoot = styled.div<ChartSettingFieldPickerRoo
     margin-right: 0.25rem;
     text-overflow: ellipsis;
     max-width: 100%;
-    white-space: nowrap;
+    overflow-wrap: anywhere;
+    text-align: left;
     overflow: hidden;
     color: ${color("text-dark")};
   }

--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem.styled.tsx
@@ -74,6 +74,7 @@ export const ColumnItemIcon = styled(Button)`
 
 export const ColumnItemDragHandle = styled(Icon)`
   color: ${color("text-medium")};
+  flex-shrink: 0;
 `;
 
 export const ColumnItemColorPicker = styled(ChartSettingColorPicker)`


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/32964

### Description

Fix the ChartSettingField width to wrap the column name to multiple lines. 

<table>
<tr><td>before</td><td>after</td></tr>
<tr><td valign="top"><img width="380" src="https://github.com/metabase/metabase/assets/116838/f84edc2c-4853-4236-85ff-a90de018460d"></td><td><img width="356" alt="CleanShot 2023-08-09 at 14 28 17@2x" src="https://github.com/metabase/metabase/assets/116838/63a37ed6-3b37-4051-aaf8-ae2ba843c459"></td></tr>
</table>



### How to verify

Describe the steps to verify that the changes are working as expected.

1. Open this question: http://localhost:3000/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoxLCJ0eXBlIjoicXVlcnkiLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjIsImV4cHJlc3Npb25zIjp7IkEgdmVyeSBsb25nIGNvbHVtbiBuYW1lIHRoYXQgd2lsbCBjYXVzZSB0ZXh0IG92ZXJmbG93IjpbIioiLFsiZmllbGQiLDE3LG51bGxdLDJdfSwiYWdncmVnYXRpb24iOltbInN1bSIsWyJleHByZXNzaW9uIiwiQSB2ZXJ5IGxvbmcgY29sdW1uIG5hbWUgdGhhdCB3aWxsIGNhdXNlIHRleHQgb3ZlcmZsb3ciXV1dLCJicmVha291dCI6W1siZmllbGQiLDE0LHsiYmFzZS10eXBlIjoidHlwZS9EYXRlVGltZSIsInRlbXBvcmFsLXVuaXQiOiJ3ZWVrIn1dXX19LCJkaXNwbGF5IjoibGluZSIsInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9fQ==
4. Click the gear icon for visualization settings
5. Verify that the column name is wrapped to multiple lines.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
