### PR TITLE
Dont crash with bad fieldValues options

### DIFF
--- a/e2e/test/scenarios/filters/filter-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter-reproductions.cy.spec.js
@@ -1,0 +1,44 @@
+import { restore, popover } from "e2e/support/helpers";
+
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+
+const { REVIEWS, PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
+
+describe("filter bug reproductions", () => {
+  const questionDetails = {
+    database: SAMPLE_DB_ID,
+    query: {
+      "source-table": PEOPLE_ID,
+    },
+    type: "query",
+  };
+
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should not crash when searching large field values sets in filters popover (metabase#32985)", () => {
+    // we need to mess with the field metadata to make the field values crazy
+    cy.request("PUT", `/api/field/${REVIEWS.REVIEWER}`, {
+      semantic_type: "type/PK",
+    });
+    cy.request("PUT", `/api/field/${PEOPLE.EMAIL}`, {
+      semantic_type: "type/FK",
+    });
+    cy.request("PUT", `/api/field/${PEOPLE.EMAIL}`, {
+      fk_target_field_id: REVIEWS.REVIEWER,
+    });
+
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+
+    cy.findByTestId("TableInteractive-root").findByText("Email").click();
+
+    popover().within(() => {
+      cy.findByText("Filter by this column").click();
+      cy.findByPlaceholderText("Search by Email").type("foo");
+      cy.findByText(/no matching/i);
+    });
+  });
+});

--- a/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.tsx
+++ b/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.tsx
@@ -4,6 +4,7 @@ import { useMount, useUnmount } from "react-use";
 import { connect } from "react-redux";
 import { jt, t } from "ttag";
 import _ from "underscore";
+import ErrorBoundary from "metabase/ErrorBoundary";
 
 import TokenField, {
   parseNumberValue,
@@ -448,71 +449,73 @@ export function FieldValuesWidgetInner({
   };
 
   return (
-    <div
-      data-testid="field-values-widget"
-      style={{
-        width: expand ? maxWidth : undefined,
-        minWidth: minWidth,
-        maxWidth: maxWidth,
-      }}
-    >
-      {isListMode && isLoading ? (
-        <LoadingState />
-      ) : isListMode && hasListValues && multi ? (
-        <ListField
-          isDashboardFilter={!!parameter}
-          placeholder={tokenFieldPlaceholder}
-          value={value?.filter((v: string) => v != null)}
-          onChange={onChange}
-          options={options}
-          optionRenderer={optionRenderer}
-          checkedColor={checkedColor}
-        />
-      ) : isListMode && hasListValues && !multi ? (
-        <SingleSelectListField
-          isDashboardFilter={!!parameter}
-          placeholder={tokenFieldPlaceholder}
-          value={value.filter(v => v != null)}
-          onChange={onChange}
-          options={options}
-          optionRenderer={optionRenderer}
-          checkedColor={checkedColor}
-        />
-      ) : (
-        <TokenField
-          prefix={prefix}
-          value={value.filter(v => v != null)}
-          onChange={onChange}
-          placeholder={tokenFieldPlaceholder}
-          updateOnInputChange
-          // forwarded props
-          multi={multi}
-          autoFocus={autoFocus}
-          color={color}
-          style={{ ...style, minWidth: "inherit" }}
-          className={className}
-          optionsStyle={
-            !parameter && !showOptionsInPopover ? { maxHeight: "none" } : {}
-          }
-          // end forwarded props
-          options={options}
-          valueKey="0"
-          valueRenderer={valueRenderer}
-          optionRenderer={optionRenderer}
-          layoutRenderer={layoutRenderer}
-          filterOption={(option, filterString) => {
-            const lowerCaseFilterString = filterString.toLowerCase();
-            return option.some(
-              value =>
-                value != null &&
-                String(value).toLowerCase().includes(lowerCaseFilterString),
-            );
-          }}
-          onInputChange={onInputChange}
-          parseFreeformValue={parseFreeformValue}
-        />
-      )}
-    </div>
+    <ErrorBoundary>
+      <div
+        data-testid="field-values-widget"
+        style={{
+          width: expand ? maxWidth : undefined,
+          minWidth: minWidth,
+          maxWidth: maxWidth,
+        }}
+      >
+        {isListMode && isLoading ? (
+          <LoadingState />
+        ) : isListMode && hasListValues && multi ? (
+          <ListField
+            isDashboardFilter={!!parameter}
+            placeholder={tokenFieldPlaceholder}
+            value={value?.filter((v: string) => v != null)}
+            onChange={onChange}
+            options={options}
+            optionRenderer={optionRenderer}
+            checkedColor={checkedColor}
+          />
+        ) : isListMode && hasListValues && !multi ? (
+          <SingleSelectListField
+            isDashboardFilter={!!parameter}
+            placeholder={tokenFieldPlaceholder}
+            value={value.filter(v => v != null)}
+            onChange={onChange}
+            options={options}
+            optionRenderer={optionRenderer}
+            checkedColor={checkedColor}
+          />
+        ) : (
+          <TokenField
+            prefix={prefix}
+            value={value.filter(v => v != null)}
+            onChange={onChange}
+            placeholder={tokenFieldPlaceholder}
+            updateOnInputChange
+            // forwarded props
+            multi={multi}
+            autoFocus={autoFocus}
+            color={color}
+            style={{ ...style, minWidth: "inherit" }}
+            className={className}
+            optionsStyle={
+              !parameter && !showOptionsInPopover ? { maxHeight: "none" } : {}
+            }
+            // end forwarded props
+            options={options}
+            valueKey="0"
+            valueRenderer={valueRenderer}
+            optionRenderer={optionRenderer}
+            layoutRenderer={layoutRenderer}
+            filterOption={(option, filterString) => {
+              const lowerCaseFilterString = filterString.toLowerCase();
+              return option?.some?.(
+                value =>
+                  value != null &&
+                  String(value).toLowerCase().includes(lowerCaseFilterString),
+              );
+            }}
+            onInputChange={onInputChange}
+            parseFreeformValue={parseFreeformValue}
+          />
+        )}
+      </div>
+    </ErrorBoundary>
   );
 }
 


### PR DESCRIPTION
related to  https://github.com/metabase/metabase/issues/32985

### Description

There's a backend error that produces invalid results when we search for field values sometimes.  @qnkhuat is working on investigating the backend issue, but in any event, we shouldn't crash the frontend if we get unexpected field values options.

Before | After
--- | ---
![badFilter](https://github.com/metabase/metabase/assets/30528226/b141654e-5742-4695-a3a6-91061d82bdd7) | ![goodfilter](https://github.com/metabase/metabase/assets/30528226/676baa30-e673-4294-8033-7e105f8ab38b)

This fixes the crash in the FieldValues widget by
- null chaining the `options.some` call so that even if we get a non-array value from the backend, it'll still be ok
- adding an error boundary to FieldValuesWidget so any future unexpected problems we have inside it will only crash the one component instead of the whole component tree.
- 
### How to verify

Steps to reproduce locally:

1. Admin -> Table Metadata -> Sample Dataset -> Accounts -> Email -> Change Field Type to Entity Key
1. Feedback -> Email -> Gear Icon -> Change Field Type to FK and link to Account.Email
1. Also change the "Filtering on this field" to Search Box
1. New question -> Feedback -> Filter by Email column
1. Type in anything and you will see the error page

- on master, the app will crash
- on this branch you'll simply see no field values results and the app will behave properly
- even if you remove the null chain on this branch, the error boundary will catch the error in the FieldValuesWidget component and will keep the app alive

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
