### PR TITLE
Introduce stylelint for css files

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -12,7 +12,6 @@
     "selector-id-pattern": null,
     "color-function-notation": null,
     "declaration-block-no-redundant-longhand-properties": null,
-    "rule-empty-line-before": null,
     "media-feature-range-notation": null,
     "selector-no-vendor-prefix": null,
     "alpha-value-notation": null,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -15,7 +15,6 @@
     "selector-no-vendor-prefix": null,
     "alpha-value-notation": null,
     "property-no-vendor-prefix": null,
-    "import-notation": null,
-    "declaration-block-no-shorthand-property-overrides": null
+    "import-notation": null
   }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -14,7 +14,6 @@
     "declaration-block-no-redundant-longhand-properties": null,
     "rule-empty-line-before": null,
     "no-duplicate-selectors": null,
-    "declaration-empty-line-before": null,
     "comment-empty-line-before": null,
     "media-feature-range-notation": null,
     "selector-no-vendor-prefix": null,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -16,7 +16,6 @@
     "comment-empty-line-before": null,
     "media-feature-range-notation": null,
     "selector-no-vendor-prefix": null,
-    "declaration-block-no-duplicate-properties": null,
     "custom-property-empty-line-before": null,
     "alpha-value-notation": null,
     "property-no-vendor-prefix": null,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -27,7 +27,6 @@
     "property-no-vendor-prefix": null,
     "shorthand-property-no-redundant-values": null,
     "import-notation": null,
-    "font-family-name-quotes": null,
     "at-rule-empty-line-before": null,
     "media-query-no-invalid": null,
     "declaration-block-no-shorthand-property-overrides": null

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -16,7 +16,6 @@
     "comment-empty-line-before": null,
     "media-feature-range-notation": null,
     "selector-no-vendor-prefix": null,
-    "custom-property-empty-line-before": null,
     "alpha-value-notation": null,
     "property-no-vendor-prefix": null,
     "import-notation": null,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -22,7 +22,6 @@
     "custom-property-empty-line-before": null,
     "alpha-value-notation": null,
     "property-no-vendor-prefix": null,
-    "shorthand-property-no-redundant-values": null,
     "import-notation": null,
     "at-rule-empty-line-before": null,
     "media-query-no-invalid": null,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -11,7 +11,6 @@
     "custom-property-pattern": null,
     "selector-id-pattern": null,
     "color-function-notation": null,
-    "declaration-block-no-redundant-longhand-properties": null,
     "media-feature-range-notation": "prefix",
     "selector-no-vendor-prefix": null,
     "alpha-value-notation": null,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -23,7 +23,6 @@
     "declaration-block-no-duplicate-properties": null,
     "custom-property-empty-line-before": null,
     "alpha-value-notation": null,
-    "length-zero-no-unit": null,
     "property-no-vendor-prefix": null,
     "shorthand-property-no-redundant-values": null,
     "import-notation": null,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -13,7 +13,6 @@
     "color-function-notation": null,
     "declaration-block-no-redundant-longhand-properties": null,
     "rule-empty-line-before": null,
-    "no-duplicate-selectors": null,
     "comment-empty-line-before": null,
     "media-feature-range-notation": null,
     "selector-no-vendor-prefix": null,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": [
+    "stylelint-config-standard",
+    "stylelint-config-css-modules"
+  ],
+  "rules": {
+    "selector-class-pattern": null,
+    "function-no-unknown": [true, {"ignoreFunctions": ["color-mod", "alpha", "blackness"]}],
+    "value-keyword-case": null,
+    "no-descending-specificity": null,
+    "custom-property-pattern": null,
+    "selector-id-pattern": null,
+    "color-function-notation": null,
+    "selector-pseudo-element-colon-notation": null,
+    "declaration-block-no-redundant-longhand-properties": null,
+    "rule-empty-line-before": null,
+    "no-duplicate-selectors": null,
+    "declaration-empty-line-before": null,
+    "comment-whitespace-inside": null,
+    "comment-empty-line-before": null,
+    "media-feature-range-notation": null,
+    "selector-no-vendor-prefix": null,
+    "declaration-block-no-duplicate-properties": null,
+    "custom-property-empty-line-before": null,
+    "alpha-value-notation": null,
+    "length-zero-no-unit": null,
+    "property-no-vendor-prefix": null,
+    "shorthand-property-no-redundant-values": null,
+    "import-notation": null,
+    "font-family-name-quotes": null,
+    "at-rule-empty-line-before": null,
+    "media-query-no-invalid": null,
+    "color-hex-length": null,
+    "declaration-block-no-shorthand-property-overrides": null
+  }
+}

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -4,17 +4,17 @@
     "stylelint-config-css-modules"
   ],
   "rules": {
-    "selector-class-pattern": null,
-    "function-no-unknown": [true, {"ignoreFunctions": ["color-mod", "alpha", "blackness"]}],
-    "value-keyword-case": null,
-    "no-descending-specificity": null,
-    "custom-property-pattern": null,
-    "selector-id-pattern": null,
-    "color-function-notation": null,
-    "media-feature-range-notation": "prefix",
-    "selector-no-vendor-prefix": null,
     "alpha-value-notation": null,
+    "color-function-notation": null,
+    "custom-property-pattern": null,
+    "function-no-unknown": [true, {"ignoreFunctions": ["color-mod", "alpha", "blackness"]}],
+    "import-notation": null,
+    "media-feature-range-notation": "prefix",
+    "no-descending-specificity": null,
     "property-no-vendor-prefix": null,
-    "import-notation": null
+    "selector-id-pattern": null,
+    "selector-class-pattern": null,
+    "selector-no-vendor-prefix": null,
+    "value-keyword-case": null
   }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -13,7 +13,6 @@
     "color-function-notation": null,
     "declaration-block-no-redundant-longhand-properties": null,
     "rule-empty-line-before": null,
-    "comment-empty-line-before": null,
     "media-feature-range-notation": null,
     "selector-no-vendor-prefix": null,
     "alpha-value-notation": null,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -20,7 +20,6 @@
     "alpha-value-notation": null,
     "property-no-vendor-prefix": null,
     "import-notation": null,
-    "at-rule-empty-line-before": null,
     "media-query-no-invalid": null,
     "declaration-block-no-shorthand-property-overrides": null
   }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -11,7 +11,6 @@
     "custom-property-pattern": null,
     "selector-id-pattern": null,
     "color-function-notation": null,
-    "selector-pseudo-element-colon-notation": null,
     "declaration-block-no-redundant-longhand-properties": null,
     "rule-empty-line-before": null,
     "no-duplicate-selectors": null,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -17,7 +17,6 @@
     "alpha-value-notation": null,
     "property-no-vendor-prefix": null,
     "import-notation": null,
-    "media-query-no-invalid": null,
     "declaration-block-no-shorthand-property-overrides": null
   }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -16,7 +16,6 @@
     "rule-empty-line-before": null,
     "no-duplicate-selectors": null,
     "declaration-empty-line-before": null,
-    "comment-whitespace-inside": null,
     "comment-empty-line-before": null,
     "media-feature-range-notation": null,
     "selector-no-vendor-prefix": null,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -30,7 +30,6 @@
     "font-family-name-quotes": null,
     "at-rule-empty-line-before": null,
     "media-query-no-invalid": null,
-    "color-hex-length": null,
     "declaration-block-no-shorthand-property-overrides": null
   }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -12,7 +12,7 @@
     "selector-id-pattern": null,
     "color-function-notation": null,
     "declaration-block-no-redundant-longhand-properties": null,
-    "media-feature-range-notation": null,
+    "media-feature-range-notation": "prefix",
     "selector-no-vendor-prefix": null,
     "alpha-value-notation": null,
     "property-no-vendor-prefix": null,

--- a/frontend/src/metabase/components/Breadcrumbs/Breadcrumbs.css
+++ b/frontend/src/metabase/components/Breadcrumbs/Breadcrumbs.css
@@ -2,6 +2,7 @@
   --breadcrumbs-color: var(--color-text-light);
   --breadcrumb-page-color: var(--color-text-dark);
   --breadcrumb-divider-spacing: 0.75em;
+
   /* taken from Sidebar.css, should probably factor them out into variables */
   --sidebar-breadcrumbs-color: var(--color-text-medium);
   --sidebar-breadcrumb-page-color: var(--color-brand);

--- a/frontend/src/metabase/components/Calendar/Calendar.css
+++ b/frontend/src/metabase/components/Calendar/Calendar.css
@@ -21,12 +21,8 @@
   opacity: 0.12;
 }
 
-.Calendar-day,
-.Calendar-day-name {
-  flex: 1;
-}
-
 .Calendar-day {
+  flex: 1;
   color: var(--color-text-light);
   position: relative;
   border-radius: 99px;
@@ -37,15 +33,13 @@
 }
 
 .Calendar-day-name {
+  flex: 1;
   cursor: inherit;
+  color: inherit !important;
 }
 
 .Calendar-day--this-month {
   color: currentcolor;
-}
-
-.Calendar-day-name {
-  color: inherit !important;
 }
 
 .Calendar--range .Calendar-day--selected {

--- a/frontend/src/metabase/components/List/List.css
+++ b/frontend/src/metabase/components/List/List.css
@@ -86,13 +86,16 @@
 :local(.icons) {
   composes: flex flex-row align-center from "style";
 }
+
 :local(.leftIcons) {
   composes: flex-no-shrink flex align-self-start mr2 from "style";
   composes: icons;
 }
+
 :local(.rightIcons) {
   composes: icons;
 }
+
 :local(.itemIcons) {
   composes: leftIcons;
   padding-top: 4px;
@@ -119,9 +122,11 @@
 :local(.item) :local(.icon) {
   visibility: hidden;
 }
+
 :local(.item):hover :local(.icon) {
   visibility: visible;
 }
+
 :local(.icon):hover {
   color: var(--color-brand);
 }
@@ -133,10 +138,12 @@
   visibility: visible !important;
   margin-left: 10px;
 }
+
 :local(.item):hover :local(.itemCheckbox),
 :local(.item.selected) :local(.itemCheckbox) {
   display: inline;
 }
+
 :local(.item.selected) :local(.itemCheckbox) {
   color: var(--color-brand);
 }
@@ -146,6 +153,7 @@
   visibility: visible !important;
   composes: relative from "style";
 }
+
 :local(.item):hover :local(.itemIcon),
 :local(.item.selected) :local(.itemIcon) {
   display: none;

--- a/frontend/src/metabase/components/List/List.css
+++ b/frontend/src/metabase/components/List/List.css
@@ -143,7 +143,6 @@
 
 /* ITEM ICON */
 :local(.itemIcon) {
-  composes: icon;
   visibility: visible !important;
   composes: relative from "style";
 }
@@ -154,7 +153,6 @@
 
 /* CHART ICON */
 :local(.chartIcon) {
-  composes: icon;
   visibility: visible !important;
   composes: relative from "style";
 }

--- a/frontend/src/metabase/components/Popover/Popover.css
+++ b/frontend/src/metabase/components/Popover/Popover.css
@@ -87,8 +87,8 @@
 }
 
 /* shared arrow styles */
-.PopoverBody--withArrow:before,
-.PopoverBody--withArrow:after {
+.PopoverBody--withArrow::before,
+.PopoverBody--withArrow::after {
   position: absolute;
   content: "";
   display: block;
@@ -144,8 +144,8 @@
   margin-right: 8px;
 }
 
-.PopoverHeader-item--withArrow:before,
-.PopoverHeader-item--withArrow:after {
+.PopoverHeader-item--withArrow::before,
+.PopoverHeader-item--withArrow::after {
   position: absolute;
   content: "";
   display: block;
@@ -158,13 +158,13 @@
 }
 
 /* create a slightly larger arrow on the right for border purposes */
-.PopoverHeader-item--withArrow:before {
+.PopoverHeader-item--withArrow::before {
   right: -16px;
   border-left-color: var(--color-border);
 }
 
 /* create a smaller inset arrow on the right */
-.PopoverHeader-item--withArrow:after {
+.PopoverHeader-item--withArrow::after {
   right: -15px;
   border-left-color: var(--color-bg-white);
 }
@@ -196,61 +196,61 @@
 }
 
 /* create a slightly larger arrow on the top for border purposes */
-.tether-element-attached-top .PopoverBody--withArrow:before {
+.tether-element-attached-top .PopoverBody--withArrow::before {
   top: -20px;
   border-bottom-color: var(--color-border);
 }
-.tether-element-attached-top .PopoverBody--tooltip:before {
+.tether-element-attached-top .PopoverBody--tooltip::before {
   border-bottom: none;
 }
 
 /* create a smaller inset arrow on the top */
-.tether-element-attached-top .PopoverBody--withArrow:after {
+.tether-element-attached-top .PopoverBody--withArrow::after {
   top: -18px;
   border-bottom-color: var(--color-bg-white);
 }
-.tether-element-attached-top .PopoverBody--tooltip:after {
+.tether-element-attached-top .PopoverBody--tooltip::after {
   border-bottom-color: var(--color-bg-black);
 }
 
 /* create a slightly larger arrow on the bottom for border purposes */
-.tether-element-attached-bottom .PopoverBody--withArrow:before {
+.tether-element-attached-bottom .PopoverBody--withArrow::before {
   bottom: -20px;
   border-top-color: var(--color-border);
 }
-.tether-element-attached-bottom .PopoverBody--tooltip:before {
+.tether-element-attached-bottom .PopoverBody--tooltip::before {
   border-top: none;
 }
 
 /* create a smaller inset arrow on the bottom */
-.tether-element-attached-bottom .PopoverBody--withArrow:after {
+.tether-element-attached-bottom .PopoverBody--withArrow::after {
   bottom: -18px;
   border-top-color: var(--color-bg-white);
 }
-.tether-element-attached-bottom .PopoverBody--tooltip:after {
+.tether-element-attached-bottom .PopoverBody--tooltip::after {
   border-top-color: var(--color-bg-black);
 }
 
 /* if the tether element is attached right, move our arrows right */
-.tether-target-attached-right .PopoverBody--withArrow:before,
-.tether-target-attached-right .PopoverBody--withArrow:after {
+.tether-target-attached-right .PopoverBody--withArrow::before,
+.tether-target-attached-right .PopoverBody--withArrow::after {
   right: 12px;
 }
 
 /* if the tether element is attached center, move our arrows to the center */
-.tether-element-attached-center .PopoverBody--withArrow:before,
-.tether-element-attached-center .PopoverBody--withArrow:after {
+.tether-element-attached-center .PopoverBody--withArrow::before,
+.tether-element-attached-center .PopoverBody--withArrow::after {
   margin-left: 50%;
   left: -10px;
 }
 
-.tether-element-attached-right .PopoverBody--withArrow:before,
-.tether-element-attached-right .PopoverBody--withArrow:after {
+.tether-element-attached-right .PopoverBody--withArrow::before,
+.tether-element-attached-right .PopoverBody--withArrow::after {
   right: 12px;
 }
 
-.tether-element-attached-left .PopoverBody--withArrow:before,
-.tether-element-attached-left .PopoverBody--withArrow:after {
+.tether-element-attached-left .PopoverBody--withArrow::before,
+.tether-element-attached-left .PopoverBody--withArrow::after {
   left: 12px;
 }
 

--- a/frontend/src/metabase/components/Popover/Popover.css
+++ b/frontend/src/metabase/components/Popover/Popover.css
@@ -81,6 +81,7 @@
   line-height: 1.26;
   padding: 10px 12px;
 }
+
 .PopoverBody.PopoverBody--tooltip.PopoverBody--tooltipConstrainedWidth {
   font-size: 12px;
   max-width: 200px;
@@ -200,6 +201,7 @@
   top: -20px;
   border-bottom-color: var(--color-border);
 }
+
 .tether-element-attached-top .PopoverBody--tooltip::before {
   border-bottom: none;
 }
@@ -209,6 +211,7 @@
   top: -18px;
   border-bottom-color: var(--color-bg-white);
 }
+
 .tether-element-attached-top .PopoverBody--tooltip::after {
   border-bottom-color: var(--color-bg-black);
 }
@@ -218,6 +221,7 @@
   bottom: -20px;
   border-top-color: var(--color-border);
 }
+
 .tether-element-attached-bottom .PopoverBody--tooltip::before {
   border-top: none;
 }
@@ -227,6 +231,7 @@
   bottom: -18px;
   border-top-color: var(--color-bg-white);
 }
+
 .tether-element-attached-bottom .PopoverBody--tooltip::after {
   border-top-color: var(--color-bg-black);
 }

--- a/frontend/src/metabase/components/Popover/Popover.css
+++ b/frontend/src/metabase/components/Popover/Popover.css
@@ -51,7 +51,6 @@
 
 .tippy-box[data-theme~="popover"] {
   font-size: inherit;
-  background-color: var(--color-bg-white);
   color: var(--color-text-default);
   border: 1px solid var(--color-border);
   box-shadow: 0 4px 10px var(--color-shadow);

--- a/frontend/src/metabase/components/Popover/Popover.css
+++ b/frontend/src/metabase/components/Popover/Popover.css
@@ -9,6 +9,7 @@
   min-width: 1em; /* ewwwwwwww */
   display: flex;
   flex-direction: column;
+
   /* add a max-width so that long strings don't cause the popover to expand
    * see metabase#4930 */
   max-width: 500px;
@@ -176,6 +177,7 @@
   border-bottom-left-radius: 6px;
   padding-top: 8px;
   width: 100%;
+
   /* Without z-index; calendar days, if selected, scroll above this component */
   z-index: 1;
 }

--- a/frontend/src/metabase/components/Popover/Popover.css
+++ b/frontend/src/metabase/components/Popover/Popover.css
@@ -127,7 +127,6 @@
   top: 1px; /* to overlap bottom border */
   text-align: center;
   padding: 1em;
-
   text-transform: uppercase;
   font-size: 0.8em;
   font-weight: 700;

--- a/frontend/src/metabase/components/Sidebar.css
+++ b/frontend/src/metabase/components/Sidebar.css
@@ -43,6 +43,7 @@
 :local(.sectionTitle.selected) {
   color: var(--color-brand);
 }
+
 :local(.item.selected),
 :local(.sectionTitle.selected) {
   background-color: rgba(80, 158, 227, 0.15);

--- a/frontend/src/metabase/containers/SaveQuestionModal.css
+++ b/frontend/src/metabase/containers/SaveQuestionModal.css
@@ -5,14 +5,17 @@
 .saveQuestionModalFields-enter {
   max-height: 0;
 }
+
 .saveQuestionModalFields-enter.saveQuestionModalFields-enter-active {
   /* using 100% max-height breaks the transition */
   max-height: 300px;
   transition: max-height 500ms ease-out;
 }
+
 .saveQuestionModalFields-exit {
   max-height: 300px;
 }
+
 .saveQuestionModalFields-exit.saveQuestionModalFields-exit-active {
   max-height: 0;
   transition: max-height 500ms ease-out;

--- a/frontend/src/metabase/containers/SaveQuestionModal.css
+++ b/frontend/src/metabase/containers/SaveQuestionModal.css
@@ -3,7 +3,7 @@
 }
 
 .saveQuestionModalFields-enter {
-  max-height: 0px;
+  max-height: 0;
 }
 .saveQuestionModalFields-enter.saveQuestionModalFields-enter-active {
   /* using 100% max-height breaks the transition */
@@ -14,6 +14,6 @@
   max-height: 300px;
 }
 .saveQuestionModalFields-exit.saveQuestionModalFields-exit-active {
-  max-height: 0px;
+  max-height: 0;
   transition: max-height 500ms ease-out;
 }

--- a/frontend/src/metabase/css/admin.css
+++ b/frontend/src/metabase/css/admin.css
@@ -199,7 +199,7 @@
 }
 
 .TableEditor-field-visibility {
-  /*color: var(--color-warning);*/
+  /* color: var(--color-warning); */
 }
 
 .TableEditor-field-visibility .ColumnarSelector-row:hover {

--- a/frontend/src/metabase/css/admin.css
+++ b/frontend/src/metabase/css/admin.css
@@ -95,7 +95,7 @@
 }
 
 .AdminList-item {
-  padding: 0.75em 1em 0.75em 1em;
+  padding: 0.75em 1em;
   border: var(--border-size) var(--border-style) transparent;
   border-radius: var(--default-border-radius);
   margin-bottom: 0.25em;
@@ -118,7 +118,7 @@
 
 .AdminList-section {
   margin-top: 1em;
-  padding: 0.5em 1em 0.5em 1em;
+  padding: 0.5em 1em;
   text-transform: uppercase;
   color: var(--color-text-light);
   font-weight: 700;

--- a/frontend/src/metabase/css/admin.css
+++ b/frontend/src/metabase/css/admin.css
@@ -75,12 +75,9 @@
 
 .AdminList-search .Icon {
   position: absolute;
-  margin-top: auto;
-  margin-bottom: auto;
+  margin: auto auto auto 1em;
   top: 0;
   bottom: 0;
-  margin: auto;
-  margin-left: 1em;
   color: var(--color-text-light);
 }
 

--- a/frontend/src/metabase/css/admin.css
+++ b/frontend/src/metabase/css/admin.css
@@ -132,6 +132,7 @@
   background-color: var(--color-bg-light);
   border: 1px solid transparent;
 }
+
 .AdminInput:focus {
   border-color: var(--color-brand);
   box-shadow: none;
@@ -162,9 +163,11 @@
 .AdminSelect--borderless {
   border: none !important;
 }
+
 .AdminSelect--borderless .AdminSelect-content {
   margin-left: auto;
 }
+
 .AdminSelect--borderless .AdminSelect-chevron {
   margin-left: 0;
 }

--- a/frontend/src/metabase/css/card.css
+++ b/frontend/src/metabase/css/card.css
@@ -2,7 +2,6 @@
   --card-border-color: var(--color-border);
   --card-text-color: var(--color-text-medium);
   --card-border-radius: 4px;
-
   --card-scalar-text-lg: 2.4em;
   --card-scalar-text-xl: 3.4em;
 }

--- a/frontend/src/metabase/css/components/buttons.css
+++ b/frontend/src/metabase/css/components/buttons.css
@@ -99,6 +99,7 @@
   background: transparent;
   color: var(--color-text-medium);
 }
+
 .Button--borderless:hover {
   border-color: transparent;
   color: var(--color-text-medium);
@@ -194,6 +195,7 @@
   border-color: var(--color-success);
   color: var(--color-text-white);
 }
+
 .Button--success:hover {
   background-color: var(--color-success);
   border-color: var(--color-success);

--- a/frontend/src/metabase/css/components/buttons.css
+++ b/frontend/src/metabase/css/components/buttons.css
@@ -5,7 +5,6 @@
 .Button {
   display: inline-block;
   box-sizing: border-box;
-  text-decoration: none;
   padding: 0.5rem 0.75rem;
   background: transparent;
   border: 1px solid color-mod(var(--color-border) blackness(5%));

--- a/frontend/src/metabase/css/components/form.css
+++ b/frontend/src/metabase/css/components/form.css
@@ -2,12 +2,15 @@
   --form-field-border-color: var(--color-border);
   --input-border-radius: 8px;
 }
+
 ::-webkit-input-placeholder {
   color: var(--color-text-light);
 }
+
 :-moz-placeholder {
   color: var(--color-text-light);
 }
+
 :-ms-input-placeholder {
   color: var(--color-text-light);
 }

--- a/frontend/src/metabase/css/components/grabber.css
+++ b/frontend/src/metabase/css/components/grabber.css
@@ -17,6 +17,7 @@
 .grabbing {
   cursor: grabbing;
 }
+
 .grabbing * {
   cursor: grabbing;
 }

--- a/frontend/src/metabase/css/components/list.css
+++ b/frontend/src/metabase/css/components/list.css
@@ -18,6 +18,7 @@
 .List-section-header {
   color: var(--color-text-dark);
   border: 2px solid transparent;
+
   /* so that spacing matches .List-item */
 }
 

--- a/frontend/src/metabase/css/components/modal.css
+++ b/frontend/src/metabase/css/components/modal.css
@@ -31,6 +31,7 @@
 .Modal.Modal--medium {
   width: 65%;
 }
+
 .Modal.Modal--wide {
   width: 85%;
 }

--- a/frontend/src/metabase/css/components/modal.css
+++ b/frontend/src/metabase/css/components/modal.css
@@ -48,10 +48,7 @@
 .Modal--full {
   background-color: white;
   position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  inset: 0;
   z-index: 3;
 }
 

--- a/frontend/src/metabase/css/components/table.css
+++ b/frontend/src/metabase/css/components/table.css
@@ -19,9 +19,7 @@ th {
   /* standard table reset */
   border-collapse: collapse;
   border-spacing: 0;
-
   width: 100%;
-
   font-family: "Helvetica Neue", Helvetica, sans-serif;
   font-size: 0.76rem;
   line-height: 0.76rem;

--- a/frontend/src/metabase/css/components/table.css
+++ b/frontend/src/metabase/css/components/table.css
@@ -1,7 +1,6 @@
 :root {
   --table-border-color: color-mod(var(--color-border) alpha(-70%));
   --table-alt-bg-color: color-mod(var(--color-bg-black) alpha(-98%));
-
   --entity-image-small-size: 24px;
   --entity-image-large-size: 64px;
 }

--- a/frontend/src/metabase/css/components/table.css
+++ b/frontend/src/metabase/css/components/table.css
@@ -22,7 +22,7 @@ th {
 
   width: 100%;
 
-  font-family: "Helvetica Neue", "Helvetica", sans-serif;
+  font-family: "Helvetica Neue", Helvetica, sans-serif;
   font-size: 0.76rem;
   line-height: 0.76rem;
   text-align: left;

--- a/frontend/src/metabase/css/containers/entity_search.css
+++ b/frontend/src/metabase/css/containers/entity_search.css
@@ -16,13 +16,16 @@
     display: flex;
     align-items: center;
   }
+
   .Entity-search-grouping-options > h3 {
     margin-bottom: 0;
     margin-right: 20px;
   }
+
   .Entity-search-grouping-options > ul {
     display: flex;
   }
+
   .Entity-search-grouping-options > ul > li {
     margin-right: 10px;
   }

--- a/frontend/src/metabase/css/core/animation.css
+++ b/frontend/src/metabase/css/core/animation.css
@@ -3,6 +3,7 @@
   from {
     transform: translate3d(0, 0, 0, 0);
   }
+
   to {
     transform: translate3d(1000px, 0, 0);
   }

--- a/frontend/src/metabase/css/core/arrow.css
+++ b/frontend/src/metabase/css/core/arrow.css
@@ -6,8 +6,8 @@
 }
 
 /* shared arrow styles */
-.arrow-right:before,
-.arrow-right:after {
+.arrow-right::before,
+.arrow-right::after {
   position: absolute;
   content: "";
   display: block;
@@ -18,20 +18,20 @@
 }
 
 /* create a slightly larger arrow on the right for border purposes */
-.arrow-right:before {
+.arrow-right::before {
   right: -20px;
   border-left-color: var(--color-border);
 }
 
 /* create a smaller inset arrow on the right */
-.arrow-right:after {
+.arrow-right::after {
   right: -19px;
   border-left-color: var(--color-white);
 }
 
 /* move our arrows to the center */
-.arrow-right:before,
-.arrow-right:after {
+.arrow-right::before,
+.arrow-right::after {
   top: 50%;
   margin-top: -10px;
 }

--- a/frontend/src/metabase/css/core/arrow.css
+++ b/frontend/src/metabase/css/core/arrow.css
@@ -15,6 +15,9 @@
   border-right: 10px solid transparent;
   border-top: 10px solid transparent;
   border-bottom: 10px solid transparent;
+  /* move our arrows to the center */
+  top: 50%;
+  margin-top: -10px;
 }
 
 /* create a slightly larger arrow on the right for border purposes */
@@ -27,11 +30,4 @@
 .arrow-right::after {
   right: -19px;
   border-left-color: var(--color-white);
-}
-
-/* move our arrows to the center */
-.arrow-right::before,
-.arrow-right::after {
-  top: 50%;
-  margin-top: -10px;
 }

--- a/frontend/src/metabase/css/core/arrow.css
+++ b/frontend/src/metabase/css/core/arrow.css
@@ -1,4 +1,5 @@
 /* TODO: based on popover.css, combine them? */
+
 /* TODO: other arrow directions */
 
 .arrow-right {
@@ -15,6 +16,7 @@
   border-right: 10px solid transparent;
   border-top: 10px solid transparent;
   border-bottom: 10px solid transparent;
+
   /* move our arrows to the center */
   top: 50%;
   margin-top: -10px;

--- a/frontend/src/metabase/css/core/base.css
+++ b/frontend/src/metabase/css/core/base.css
@@ -90,6 +90,7 @@ textarea {
 :local(.faded) {
   opacity: 0.4;
 }
+
 .fade-in-hover:hover {
   opacity: 1;
   transition: opacity 0.3s;

--- a/frontend/src/metabase/css/core/base.css
+++ b/frontend/src/metabase/css/core/base.css
@@ -31,7 +31,6 @@ body {
   display: flex;
   flex-direction: column;
   background-color: var(--color-bg-light);
-
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/frontend/src/metabase/css/core/base.css
+++ b/frontend/src/metabase/css/core/base.css
@@ -14,6 +14,7 @@ html {
     width: 8.5in;
   }
 }
+
 @media print and (orientation: landscape) {
   html {
     width: 11in;

--- a/frontend/src/metabase/css/core/bordered.css
+++ b/frontend/src/metabase/css/core/bordered.css
@@ -89,7 +89,9 @@
 }
 
 /* BORDERLESS IS THE DEFAULT */
+
 /* ONLY USE IF needing to override an existing border! */
+
 /* ensure there is no border via important */
 .borderless,
 :local(.borderless) {

--- a/frontend/src/metabase/css/core/breakpoints.css
+++ b/frontend/src/metabase/css/core/breakpoints.css
@@ -5,7 +5,6 @@
 @custom-media --breakpoint-min-md (min-width: 60em);
 @custom-media --breakpoint-min-lg (min-width: 80em);
 @custom-media --breakpoint-min-xl (min-width: 120em);
-
 @custom-media --breakpoint-max-xs (max-width: 23em);
 @custom-media --breakpoint-max-sm (max-width: 40em);
 @custom-media --breakpoint-max-md (max-width: 60em);

--- a/frontend/src/metabase/css/core/clearfix.css
+++ b/frontend/src/metabase/css/core/clearfix.css
@@ -1,5 +1,6 @@
 /* Nicolas Gallaghers Clearfix solution
    Ref: http://nicolasgallagher.com/micro-clearfix-hack/ */
+
 /**
  * For modern browsers
  * 1. The space content is one way to avoid an Opera bug when the

--- a/frontend/src/metabase/css/core/clearfix.css
+++ b/frontend/src/metabase/css/core/clearfix.css
@@ -9,13 +9,13 @@
  * 2. The use of `table` rather than `block` is only necessary if using
  *    `:before` to contain the top-margins of child elements.
  */
-.clearfix:before,
-.clearfix:after {
+.clearfix::before,
+.clearfix::after {
   content: " "; /* 1 */
   display: table; /* 2 */
 }
 
-.clearfix:after {
+.clearfix::after {
   clear: both;
 }
 

--- a/frontend/src/metabase/css/core/colors.css
+++ b/frontend/src/metabase/css/core/colors.css
@@ -5,7 +5,7 @@
   --color-brand: #509ee3;
   --color-brand-light: #ddecfa;
   --color-admin-navbar: #7172ad;
-  --color-white: #ffffff;
+  --color-white: #fff;
   --color-black: #2e353b;
   --color-success: #84bb4c;
   --color-error: #ed6e6e;
@@ -13,12 +13,12 @@
   --color-text-dark: #4c5773;
   --color-text-medium: #696e7b;
   --color-text-light: #949aab;
-  --color-text-white: #ffffff;
+  --color-text-white: #fff;
   --color-bg-black: #2e353b;
   --color-bg-dark: #93a1ab;
   --color-bg-medium: #edf2f5;
   --color-bg-light: #f9fbfc;
-  --color-bg-white: #ffffff;
+  --color-bg-white: #fff;
   --color-bg-yellow: #fffcf2;
   --color-focus: #cbe2f7;
   --color-shadow: rgba(0, 0, 0, 0.13);

--- a/frontend/src/metabase/css/core/colors.css
+++ b/frontend/src/metabase/css/core/colors.css
@@ -67,6 +67,7 @@
 .text-success {
   color: var(--color-success);
 }
+
 .bg-success {
   background-color: var(--color-success);
 }
@@ -83,6 +84,7 @@
 .bg-error-hover:hover {
   background-color: var(--color-error);
 }
+
 .bg-error-input {
   background-color: var(--color-bg-white);
 }
@@ -95,9 +97,11 @@
 .text-slate {
   color: var(--color-text-medium);
 }
+
 .text-slate-light {
   color: var(--color-text-light);
 }
+
 .text-slate-extra-light {
   background-color: var(--color-bg-light);
 }
@@ -164,6 +168,7 @@
   color: var(--color-text-white);
   background-color: var(--color-brand);
 }
+
 .brand-hover:hover * {
   color: var(--color-text-white);
 }
@@ -195,6 +200,7 @@
 .bg-question {
   background-color: var(--color-bg-dark);
 }
+
 .text-question {
   color: var(--color-text-medium);
 }
@@ -202,9 +208,11 @@
 .text-light {
   color: var(--color-text-light);
 }
+
 .text-medium {
   color: var(--color-text-medium);
 }
+
 .text-dark {
   color: var(--color-text-dark);
 }

--- a/frontend/src/metabase/css/core/colors.css
+++ b/frontend/src/metabase/css/core/colors.css
@@ -185,9 +185,6 @@
 .text-light-blue-hover:hover {
   color: var(--color-text-light);
 }
-.text-slate {
-  color: var(--color-text-medium);
-}
 
 .bg-transparent {
   background-color: transparent;

--- a/frontend/src/metabase/css/core/float.css
+++ b/frontend/src/metabase/css/core/float.css
@@ -2,6 +2,7 @@
 :local(.float-left) {
   float: left;
 }
+
 .float-right,
 :local(.float-right) {
   float: right;

--- a/frontend/src/metabase/css/core/fonts.css
+++ b/frontend/src/metabase/css/core/fonts.css
@@ -33,6 +33,7 @@
     /* Safari, Android, iOS */ url("~fonts/Lato/lato-v16-latin-700.svg#Lato")
       format("svg"); /* Legacy iOS */
 }
+
 /* lato-900 - latin */
 @font-face {
   font-family: Lato;

--- a/frontend/src/metabase/css/core/fonts.css
+++ b/frontend/src/metabase/css/core/fonts.css
@@ -50,7 +50,7 @@
       format("svg"); /* Legacy iOS */
 }
 
-/*PT Serif 400 */
+/* PT Serif 400 */
 @font-face {
   font-family: "PT Serif";
   src: local("PT Serif"), local("PTSerif-Regular"),
@@ -60,7 +60,7 @@
   font-display: swap;
 }
 
-/*PT Serif 700 */
+/* PT Serif 700 */
 @font-face {
   font-family: "PT Serif";
   src: local("PT Serif Bold"), local("PTSerif-Bold"),

--- a/frontend/src/metabase/css/core/fonts.css
+++ b/frontend/src/metabase/css/core/fonts.css
@@ -1,6 +1,6 @@
 /* lato-regular - latin */
 @font-face {
-  font-family: "Lato";
+  font-family: Lato;
   font-style: normal;
   font-weight: 400;
   src: url("~fonts/Lato/lato-v16-latin-regular.eot"); /* IE9 Compat Modes */
@@ -19,7 +19,7 @@
 
 /* lato-700 - latin */
 @font-face {
-  font-family: "Lato";
+  font-family: Lato;
   font-style: normal;
   font-weight: 700;
   src: url("~fonts/Lato/lato-v16-latin-700.eot"); /* IE9 Compat Modes */
@@ -35,7 +35,7 @@
 }
 /* lato-900 - latin */
 @font-face {
-  font-family: "Lato";
+  font-family: Lato;
   font-style: normal;
   font-weight: 900;
   src: url("~fonts/Lato/lato-v16-latin-900.eot"); /* IE9 Compat Modes */
@@ -72,7 +72,7 @@
 
 /* Merriweather-400 */
 @font-face {
-  font-family: "Merriweather";
+  font-family: Merriweather;
   src: local("Merriweather Regular"), local("Merriweather-Regular"),
     url("~fonts/Merriweather/Merriweather-Regular.woff2") format("woff2");
   font-weight: 400;
@@ -82,7 +82,7 @@
 
 /* Merriweather-700 */
 @font-face {
-  font-family: "Merriweather";
+  font-family: Merriweather;
   src: local("Merriweather Bold"), local("Merriweather-Bold"),
     url("~fonts/Merriweather/Merriweather-Bold.woff2") format("woff2");
   font-weight: 700;
@@ -92,7 +92,7 @@
 
 /* Merriweather-400 */
 @font-face {
-  font-family: "Merriweather";
+  font-family: Merriweather;
   src: local("Merriweather Black"), local("Merriweather-Black"),
     url("~fonts/Merriweather/Merriweather-Black.woff2") format("woff2");
   font-weight: 900;
@@ -101,7 +101,7 @@
 }
 
 @font-face {
-  font-family: "Montserrat";
+  font-family: Montserrat;
   src: local("Montserrat Regular"), local("Montserrat-Regular"),
     url("~fonts/Montserrat/Montserrat-Regular.woff2") format("woff2");
   font-weight: normal;
@@ -110,7 +110,7 @@
 }
 
 @font-face {
-  font-family: "Montserrat";
+  font-family: Montserrat;
   src: local("Montserrat Bold"), local("Montserrat-Bold"),
     url("~fonts/Montserrat/Montserrat-Bold.woff2") format("woff2");
   font-weight: bold;
@@ -119,7 +119,7 @@
 }
 
 @font-face {
-  font-family: "Montserrat";
+  font-family: Montserrat;
   src: local("Montserrat Black"), local("Montserrat-Black"),
     url("~fonts/Montserrat/Montserrat-Black.woff2") format("woff2");
   font-weight: 900;
@@ -146,7 +146,7 @@
 }
 
 @font-face {
-  font-family: "Oswald";
+  font-family: Oswald;
   src: local("Oswald Bold"), local("Oswald-Bold"),
     url("~fonts/Oswald/Oswald-Bold.woff2") format("woff2");
   font-weight: bold;
@@ -155,7 +155,7 @@
 }
 
 @font-face {
-  font-family: "Oswald";
+  font-family: Oswald;
   src: local("Oswald Regular"), local("Oswald-Regular"),
     url("~fonts/Oswald/Oswald-Regular.woff2") format("woff2");
   font-weight: normal;
@@ -164,7 +164,7 @@
 }
 
 @font-face {
-  font-family: "Raleway";
+  font-family: Raleway;
   src: local("Raleway Bold"), local("Raleway-Bold"),
     url("~fonts/Raleway/Raleway-Bold.woff2") format("woff2");
   font-weight: bold;
@@ -173,7 +173,7 @@
 }
 
 @font-face {
-  font-family: "Raleway";
+  font-family: Raleway;
   src: local("Raleway Regular"), local("Raleway-Regular"),
     url("~fonts/Raleway/Raleway-Regular.woff2") format("woff2");
   font-weight: normal;
@@ -182,7 +182,7 @@
 }
 
 @font-face {
-  font-family: "Raleway";
+  font-family: Raleway;
   src: local("Raleway Black"), local("Raleway-Black"),
     url("~fonts/Raleway/Raleway-Black.woff2") format("woff2");
   font-weight: 900;
@@ -191,7 +191,7 @@
 }
 
 @font-face {
-  font-family: "Roboto";
+  font-family: Roboto;
   src: local("Roboto Black"), local("Roboto-Black"),
     url("~fonts/Roboto/Roboto-Black.woff2") format("woff2");
   font-weight: 900;
@@ -200,7 +200,7 @@
 }
 
 @font-face {
-  font-family: "Roboto";
+  font-family: Roboto;
   src: local("Roboto Bold"), local("Roboto-Bold"),
     url("~fonts/Roboto/Roboto-Bold.woff2") format("woff2");
   font-weight: bold;
@@ -209,7 +209,7 @@
 }
 
 @font-face {
-  font-family: "Roboto";
+  font-family: Roboto;
   src: local("Roboto"), local("Roboto-Regular"),
     url("~fonts/Roboto/Roboto-Regular.woff2") format("woff2");
   font-weight: normal;
@@ -272,7 +272,7 @@
 }
 
 @font-face {
-  font-family: "Lora";
+  font-family: Lora;
   src: local("Lora Bold"), local("Lora-Bold"),
     url("~fonts/Lora/Lora-Bold.woff2") format("woff2");
   font-weight: bold;
@@ -281,7 +281,7 @@
 }
 
 @font-face {
-  font-family: "Lora";
+  font-family: Lora;
   src: local("Lora Regular"), local("Lora-Regular"),
     url("~fonts/Lora/Lora-Regular.woff2") format("woff2");
   font-weight: normal;
@@ -344,7 +344,7 @@
 }
 
 @font-face {
-  font-family: "Poppins";
+  font-family: Poppins;
   src: local("Poppins Bold"), local("Poppins-Bold"),
     url("~fonts/Poppins/Poppins-Bold.woff2") format("woff2");
   font-weight: bold;
@@ -353,7 +353,7 @@
 }
 
 @font-face {
-  font-family: "Poppins";
+  font-family: Poppins;
   src: local("Poppins Regular"), local("Poppins-Regular"),
     url("~fonts/Poppins/Poppins-Regular.woff2") format("woff2");
   font-weight: normal;
@@ -362,7 +362,7 @@
 }
 
 @font-face {
-  font-family: "Poppins";
+  font-family: Poppins;
   src: local("Poppins Black"), local("Poppins-Black"),
     url("~fonts/Poppins/Poppins-Black.woff2") format("woff2");
   font-weight: 900;
@@ -434,7 +434,7 @@
 }
 
 @font-face {
-  font-family: "Ubuntu";
+  font-family: Ubuntu;
   src: local("Ubuntu Bold"), local("Ubuntu-Bold"),
     url("~fonts/Ubuntu/Ubuntu-Bold.woff2") format("woff2");
   font-weight: bold;
@@ -443,7 +443,7 @@
 }
 
 @font-face {
-  font-family: "Ubuntu";
+  font-family: Ubuntu;
   src: local("Ubuntu Regular"), local("Ubuntu-Regular"),
     url("~fonts/Ubuntu/Ubuntu-Regular.woff2") format("woff2");
   font-weight: normal;
@@ -452,7 +452,7 @@
 }
 
 @font-face {
-  font-family: "Inter";
+  font-family: Inter;
   src: local("Inter Regular"), local("Inter-Regular"),
     url("~fonts/Inter/Inter-Regular.woff2") format("woff2");
   font-weight: normal;
@@ -461,7 +461,7 @@
 }
 
 @font-face {
-  font-family: "Inter";
+  font-family: Inter;
   src: local("Inter Bold"), local("Inter-Bold"),
     url("~fonts/Inter/Inter-Bold.woff2") format("woff2");
   font-weight: bold;
@@ -470,7 +470,7 @@
 }
 
 @font-face {
-  font-family: "Inter";
+  font-family: Inter;
   src: local("Inter Black"), local("Inter-Black"),
     url("~fonts/Inter/Inter-Black.woff2") format("woff2");
   font-weight: 900;

--- a/frontend/src/metabase/css/core/grid.css
+++ b/frontend/src/metabase/css/core/grid.css
@@ -71,15 +71,19 @@
   .small-Grid--fit > .Grid-cell {
     flex: 1;
   }
+
   .small-Grid--full > .Grid-cell {
     flex: 0 0 100%;
   }
+
   .small-Grid--1of2 > .Grid-cell {
     flex: 0 0 50%;
   }
+
   .small-Grid--1of3 > .Grid-cell {
     flex: 0 0 33.3333%;
   }
+
   .small-Grid--1of4 > .Grid-cell {
     flex: 0 0 25%;
   }
@@ -89,15 +93,19 @@
   .md-Grid--fit > .Grid-cell {
     flex: 1;
   }
+
   .md-Grid--full > .Grid-cell {
     flex: 0 0 100%;
   }
+
   .md-Grid--1of2 > .Grid-cell {
     flex: 0 0 50%;
   }
+
   .md-Grid--1of3 > .Grid-cell {
     flex: 0 0 33.3333%;
   }
+
   .md-Grid--1of4 > .Grid-cell {
     flex: 0 0 25%;
   }
@@ -107,15 +115,19 @@
   .large-Grid--fit > .Grid-cell {
     flex: 1;
   }
+
   .large-Grid--full > .Grid-cell {
     flex: 0 0 100%;
   }
+
   .large-Grid--1of2 > .Grid-cell {
     flex: 0 0 50%;
   }
+
   .large-Grid--1of3 > .Grid-cell {
     flex: 0 0 33.3333%;
   }
+
   .large-Grid--1of4 > .Grid-cell {
     flex: 0 0 25%;
   }
@@ -124,6 +136,7 @@
 .Grid--gutters {
   margin: -1em 0 1em -1em;
 }
+
 .Grid--gutters > .Grid-cell {
   padding: 1em 0 0 1em;
 }
@@ -131,6 +144,7 @@
 .Grid--guttersLg {
   margin: -1.5em 0 1.5em -1.5em;
 }
+
 .Grid--guttersLg > .Grid-cell {
   padding: 1.5em 0 0 1.5em;
 }
@@ -138,6 +152,7 @@
 .Grid--guttersXl {
   margin: -2em 0 2em -2em;
 }
+
 .Grid--guttersXl > .Grid-cell {
   padding: 2em 0 0 2em;
 }
@@ -145,6 +160,7 @@
 .Grid--guttersXXl {
   margin: -5em 0 5em -5em;
 }
+
 .Grid--guttersXXl > .Grid-cell {
   padding: 5em 0 0 5em;
 }
@@ -153,27 +169,35 @@
   .small-Grid--gutters {
     margin: -1em 0 1em -1em;
   }
+
   .small-Grid--gutters > .Grid-cell {
     padding: 1em 0 0 1em;
   }
+
   .small-Grid--guttersLg {
     margin: -1.5em 0 1.5em -1.5em;
   }
+
   .small-Grid--guttersLg > .Grid-cell {
     padding: 1.5em 0 0 1.5em;
   }
+
   .small-Grid--guttersXl {
     margin: -2em 0 2em -2em;
   }
+
   .small-Grid--guttersXl > .Grid-cell {
     padding: 2em 0 0 2em;
   }
+
   .small-Grid--guttersXXl {
     margin: -5em 0 5em -5em;
   }
+
   .small-Grid--guttersXXl > .Grid-cell {
     padding: 5em 0 0 5em;
   }
+
   .sm-Grid--normal > .Grid-cell {
     flex: 1;
   }
@@ -183,27 +207,35 @@
   .md-Grid--gutters {
     margin: -1em 0 1em -1em;
   }
+
   .md-Grid--gutters > .Grid-cell {
     padding: 1em 0 0 1em;
   }
+
   .md-Grid--guttersLg {
     margin: -1.5em 0 1.5em -1.5em;
   }
+
   .md-Grid--guttersLg > .Grid-cell {
     padding: 1.5em 0 0 1.5em;
   }
+
   .md-Grid--guttersXl {
     margin: -2em 0 2em -2em;
   }
+
   .md-Grid--guttersXl > .Grid-cell {
     padding: 2em 0 0 2em;
   }
+
   .md-Grid--guttersXXl {
     margin: -5em 0 5em -5em;
   }
+
   .md-Grid--guttersXXl > .Grid-cell {
     padding: 5em 0 0 5em;
   }
+
   .md-Grid--normal > .Grid-cell {
     flex: 1;
   }
@@ -213,27 +245,35 @@
   .large-Grid--gutters {
     margin: -1em 0 1em -1em;
   }
+
   .large-Grid--gutters > .Grid-cell {
     padding: 1em 0 0 1em;
   }
+
   .large-Grid--guttersLg {
     margin: -1.5em 0 1.5em -1.5em;
   }
+
   .large-Grid--guttersLg > .Grid-cell {
     padding: 1.5em 0 0 1.5em;
   }
+
   .large-Grid--guttersXl {
     margin: -2em 0 2em -2em;
   }
+
   .large-Grid--guttersXl > .Grid-cell {
     padding: 2em 0 0 2em;
   }
+
   .large-Grid--guttersXXl {
     margin: -5em 0 5em -5em;
   }
+
   .large-Grid--guttersXXl > .Grid-cell {
     padding: 5em 0 0 5em;
   }
+
   .large-Grid--normal > .Grid-cell {
     flex: 1;
   }

--- a/frontend/src/metabase/css/core/headings.css
+++ b/frontend/src/metabase/css/core/headings.css
@@ -31,18 +31,23 @@ h1 {
 .h1 {
   font-size: 2em;
 }
+
 .h2 {
   font-size: 1.5em;
 }
+
 .h3 {
   font-size: 1.17em;
 }
+
 .h4 {
   font-size: 1.12em;
 }
+
 .h5 {
   font-size: 0.83em;
 }
+
 .h6 {
   font-size: 0.75em;
 }
@@ -51,18 +56,23 @@ h1 {
   .sm-h1 {
     font-size: 2em;
   }
+
   .sm-h2 {
     font-size: 1.5em;
   }
+
   .sm-h3 {
     font-size: 1.17em;
   }
+
   .sm-h4 {
     font-size: 1.12em;
   }
+
   .sm-h5 {
     font-size: 0.83em;
   }
+
   .sm-h6 {
     font-size: 0.75em;
   }
@@ -72,18 +82,23 @@ h1 {
   .md-h1 {
     font-size: 2em;
   }
+
   .md-h2 {
     font-size: 1.5em;
   }
+
   .md-h3 {
     font-size: 1.17em;
   }
+
   .md-h4 {
     font-size: 1.12em;
   }
+
   .md-h5 {
     font-size: 0.83em;
   }
+
   .md-h6 {
     font-size: 0.75em;
   }
@@ -93,18 +108,23 @@ h1 {
   .lg-h1 {
     font-size: 2em;
   }
+
   .lg-h2 {
     font-size: 1.5em;
   }
+
   .lg-h3 {
     font-size: 1.17em;
   }
+
   .lg-h4 {
     font-size: 1.12em;
   }
+
   .lg-h5 {
     font-size: 0.83em;
   }
+
   .lg-h6 {
     font-size: 0.75em;
   }

--- a/frontend/src/metabase/css/core/hide.css
+++ b/frontend/src/metabase/css/core/hide.css
@@ -1,6 +1,7 @@
 .hide {
   display: none !important;
 }
+
 .show {
   display: inherit;
 }

--- a/frontend/src/metabase/css/core/hide.css
+++ b/frontend/src/metabase/css/core/hide.css
@@ -74,7 +74,7 @@
 }
 
 /* xl */
-@media screen and (--breakpoint-min-xl) h {
+@media screen and (--breakpoint-min-xl) {
   .xl-hide {
     display: none !important;
   }

--- a/frontend/src/metabase/css/core/hide.css
+++ b/frontend/src/metabase/css/core/hide.css
@@ -23,6 +23,7 @@
     display: none !important;
   }
 }
+
 @media screen and (--breakpoint-min-xs) {
   .xs-show {
     display: inherit !important;
@@ -36,6 +37,7 @@
     display: none !important;
   }
 }
+
 @media screen and (--breakpoint-min-sm) {
   .sm-show {
     display: inherit !important;
@@ -49,6 +51,7 @@
     display: none !important;
   }
 }
+
 @media screen and (--breakpoint-min-md) {
   .md-show {
     display: inherit !important;
@@ -61,6 +64,7 @@
     display: none !important;
   }
 }
+
 @media screen and (--breakpoint-min-lg) {
   .lg-show {
     display: inherit !important;
@@ -73,6 +77,7 @@
     display: none !important;
   }
 }
+
 @media screen and (--breakpoint-min-xl) {
   .xl-show {
     display: inherit !important;

--- a/frontend/src/metabase/css/core/hide.css
+++ b/frontend/src/metabase/css/core/hide.css
@@ -57,6 +57,7 @@
     display: inherit !important;
   }
 }
+
 /* large */
 
 @media screen and (--breakpoint-min-lg) {

--- a/frontend/src/metabase/css/core/inputs.css
+++ b/frontend/src/metabase/css/core/inputs.css
@@ -8,7 +8,7 @@
 :local(.input) {
   color: var(--color-text-dark);
   font-size: 1.12em;
-  padding: 0.75rem 0.75rem;
+  padding: 0.75rem;
   border: 1px solid var(--input-border-color);
   border-radius: var(--input-border-radius);
   transition: border 0.3s linear;

--- a/frontend/src/metabase/css/core/layout.css
+++ b/frontend/src/metabase/css/core/layout.css
@@ -4,6 +4,7 @@
   --lg-width: 1140px;
   --xl-width: 1540px;
 }
+
 /* When converting to styled components, use FullWidthContainer */
 .wrapper,
 :local(.wrapper) {

--- a/frontend/src/metabase/css/core/layout.css
+++ b/frontend/src/metabase/css/core/layout.css
@@ -150,10 +150,7 @@
 .spread,
 :local(.spread) {
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  inset: 0;
 }
 
 /* force a stacking context for adding z-index to children */

--- a/frontend/src/metabase/css/core/layout.css
+++ b/frontend/src/metabase/css/core/layout.css
@@ -73,6 +73,7 @@
 :local(.full-width) {
   width: 100%;
 }
+
 .half {
   width: 50%;
 }
@@ -87,6 +88,7 @@
 :local(.relative) {
   position: relative;
 }
+
 .absolute,
 :local(.absolute) {
   position: absolute;
@@ -102,14 +104,17 @@
 :local(.top) {
   top: 0;
 }
+
 .right,
 :local(.right) {
   right: 0;
 }
+
 .bottom,
 :local(.bottom) {
   bottom: 0;
 }
+
 .left,
 :local(.left) {
   left: 0;

--- a/frontend/src/metabase/css/core/scroll.css
+++ b/frontend/src/metabase/css/core/scroll.css
@@ -2,6 +2,7 @@
 :local(.scroll-y) {
   overflow-y: auto;
 }
+
 .scroll-x {
   overflow-x: auto;
 }
@@ -14,6 +15,7 @@
 .scroll-show--hover::-webkit-scrollbar {
   display: none;
 }
+
 .scroll-show--hover:hover::-webkit-scrollbar {
   display: inherit;
 }
@@ -30,6 +32,7 @@
   height: 0;
   display: none;
 }
+
 .scroll-show::-webkit-scrollbar-corner {
   background-color: transparent;
 }
@@ -37,10 +40,12 @@
 .scroll-show:hover::-webkit-scrollbar-thumb {
   background-color: var(--color-bg-dark);
 }
+
 .scroll-show::-webkit-scrollbar-thumb:horizontal:hover,
 .scroll-show::-webkit-scrollbar-thumb:vertical:hover {
   background-color: var(--color-bg-dark);
 }
+
 .scroll-show::-webkit-scrollbar-thumb:horizontal:active,
 .scroll-show::-webkit-scrollbar-thumb:vertical:active {
   background-color: var(--color-bg-dark);
@@ -63,6 +68,7 @@
   -ms-overflow-style: none; /* IE 10+ */
   overflow: -moz-scrollbars-none; /* Firefox */
 }
+
 .scroll-hide::-webkit-scrollbar {
   display: none; /* Safari and Chrome */
 }
@@ -73,6 +79,7 @@
   overflow: -moz-scrollbars-none; /* Firefox */
   scrollbar-width: none; /* Firefox */
 }
+
 .scroll-hide-all::-webkit-scrollbar,
 .scroll-hide-all *::-webkit-scrollbar {
   display: none; /* Safari and Chrome */

--- a/frontend/src/metabase/css/core/shadow.css
+++ b/frontend/src/metabase/css/core/shadow.css
@@ -2,6 +2,7 @@
   --shadow-color: var(--color-shadow);
   --shadow-hover-color: var(--color-shadow);
 }
+
 .shadowed,
 :local(.shadowed) {
   box-shadow: 0 2px 2px var(--color-shadow);

--- a/frontend/src/metabase/css/core/spacing.css
+++ b/frontend/src/metabase/css/core/spacing.css
@@ -3,7 +3,6 @@
   --padding-2: 1rem;
   --padding-3: 1.5rem;
   --padding-4: 2rem;
-
   --margin-1: 0.5rem;
   --margin-2: 1rem;
   --margin-3: 1.5rem;

--- a/frontend/src/metabase/css/core/spacing.css
+++ b/frontend/src/metabase/css/core/spacing.css
@@ -13,10 +13,12 @@
 :local(.ml-auto) {
   margin-left: auto;
 }
+
 .mr-auto,
 :local(.mr-auto) {
   margin-right: auto;
 }
+
 .mt-auto {
   margin-top: auto;
 }
@@ -32,18 +34,22 @@
 :local(.p0) {
   padding: 0;
 }
+
 .pt0,
 :local(.pt0) {
   padding-top: 0;
 }
+
 .pb0,
 :local(.pb0) {
   padding-bottom: 0;
 }
+
 .pl0,
 :local(.pl0) {
   padding-left: 0;
 }
+
 .pr0,
 :local(.pr0) {
   padding-right: 0;
@@ -71,14 +77,17 @@
 :local(.pt1) {
   padding-top: var(--padding-1);
 }
+
 .pb1,
 :local(.pb1) {
   padding-bottom: var(--padding-1);
 }
+
 .pl1,
 :local(.pl1) {
   padding-left: var(--padding-1);
 }
+
 .pr1,
 :local(.pr1) {
   padding-right: var(--padding-1);
@@ -107,14 +116,17 @@
 :local(.pt2) {
   padding-top: var(--padding-2);
 }
+
 .pb2,
 :local(.pb2) {
   padding-bottom: var(--padding-2);
 }
+
 .pl2,
 :local(.pl2) {
   padding-left: var(--padding-2);
 }
+
 .pr2,
 :local(.pr2) {
   padding-right: var(--padding-2);
@@ -143,14 +155,17 @@
 :local(.pt3) {
   padding-top: var(--padding-3);
 }
+
 .pb3,
 :local(.pb3) {
   padding-bottom: var(--padding-3);
 }
+
 .pl3,
 :local(.pl3) {
   padding-left: var(--padding-3);
 }
+
 .pr3,
 :local(.pr3) {
   padding-right: var(--padding-3);
@@ -179,14 +194,17 @@
 :local(.pt4) {
   padding-top: var(--padding-4);
 }
+
 .pb4,
 :local(.pb4) {
   padding-bottom: var(--padding-4);
 }
+
 .pl4,
 :local(.pl4) {
   padding-left: var(--padding-4);
 }
+
 .pr4,
 :local(.pr4) {
   padding-right: var(--padding-4);
@@ -199,18 +217,22 @@
 :local(.m0) {
   margin: 0;
 }
+
 .mt0,
 :local(.mt0) {
   margin-top: 0;
 }
+
 .mb0,
 :local(.mb0) {
   margin-bottom: 0;
 }
+
 .ml0,
 :local(.ml0) {
   margin-left: 0;
 }
+
 .mr0,
 :local(.mr0) {
   margin-right: 0;
@@ -238,14 +260,17 @@
 :local(.mt1) {
   margin-top: var(--margin-1);
 }
+
 .mb1,
 :local(.mb1) {
   margin-bottom: var(--margin-1);
 }
+
 .ml1,
 :local(.ml1) {
   margin-left: var(--margin-1);
 }
+
 .mr1,
 :local(.mr1) {
   margin-right: var(--margin-1);
@@ -274,14 +299,17 @@
 :local(.mt2) {
   margin-top: var(--margin-2);
 }
+
 .mb2,
 :local(.mb2) {
   margin-bottom: var(--margin-2);
 }
+
 .ml2,
 :local(.ml2) {
   margin-left: var(--margin-2);
 }
+
 .mr2,
 :local(.mr2) {
   margin-right: var(--margin-2);
@@ -310,14 +338,17 @@
 :local(.mt3) {
   margin-top: var(--margin-3);
 }
+
 .mb3,
 :local(.mb3) {
   margin-bottom: var(--margin-3);
 }
+
 .ml3,
 :local(.ml3) {
   margin-left: var(--margin-3);
 }
+
 .mr3,
 :local(.mr3) {
   margin-right: var(--margin-3);
@@ -346,14 +377,17 @@
 :local(.mt4) {
   margin-top: var(--margin-4);
 }
+
 .mb4,
 :local(.mb4) {
   margin-bottom: var(--margin-4);
 }
+
 .ml4,
 :local(.ml4) {
   margin-left: var(--margin-4);
 }
+
 .mr4,
 :local(.mr4) {
   margin-right: var(--margin-4);
@@ -363,12 +397,15 @@
 .mln1 {
   margin-left: calc(-1 * var(--margin-1));
 }
+
 .mln2 {
   margin-left: calc(-1 * var(--margin-2));
 }
+
 .mln3 {
   margin-left: calc(-1 * var(--margin-3));
 }
+
 .mln4 {
   margin-left: calc(-1 * var(--margin-4));
 }
@@ -376,12 +413,15 @@
 .mbn1 {
   margin-bottom: calc(-1 * var(--margin-1));
 }
+
 .mbn2 {
   margin-bottom: calc(-1 * var(--margin-2));
 }
+
 .mbn3 {
   margin-bottom: calc(-1 * var(--margin-3));
 }
+
 .mbn4 {
   margin-bottom: calc(-1 * var(--margin-4));
 }
@@ -395,15 +435,19 @@
   .sm-p0 {
     padding: 0;
   }
+
   .sm-pt0 {
     padding-top: 0;
   }
+
   .sm-pb0 {
     padding-bottom: 0;
   }
+
   .sm-pl0 {
     padding-left: 0;
   }
+
   .sm-pr0 {
     padding-right: 0;
   }
@@ -426,12 +470,15 @@
   .sm-pt1 {
     padding-top: var(--padding-1);
   }
+
   .sm-pb1 {
     padding-bottom: var(--padding-1);
   }
+
   .sm-pl1 {
     padding-left: var(--padding-1);
   }
+
   .sm-pr1 {
     padding-right: var(--padding-1);
   }
@@ -455,12 +502,15 @@
   .sm-pt2 {
     padding-top: var(--padding-2);
   }
+
   .sm-pb2 {
     padding-bottom: var(--padding-2);
   }
+
   .sm-pl2 {
     padding-left: var(--padding-2);
   }
+
   .sm-pr2 {
     padding-right: var(--padding-2);
   }
@@ -484,12 +534,15 @@
   .sm-pt3 {
     padding-top: var(--padding-3);
   }
+
   .sm-pb3 {
     padding-bottom: var(--padding-3);
   }
+
   .sm-pl3 {
     padding-left: var(--padding-3);
   }
+
   .sm-pr3 {
     padding-right: var(--padding-3);
   }
@@ -513,12 +566,15 @@
   .sm-pt4 {
     padding-top: var(--padding-4);
   }
+
   .sm-pb4 {
     padding-bottom: var(--padding-4);
   }
+
   .sm-pl4 {
     padding-left: var(--padding-4);
   }
+
   .sm-pr4 {
     padding-right: var(--padding-4);
   }
@@ -529,15 +585,19 @@
   .sm-m0 {
     margin: 0;
   }
+
   .sm-mt0 {
     margin-top: 0;
   }
+
   .sm-mb0 {
     margin-bottom: 0;
   }
+
   .sm-ml0 {
     margin-left: 0;
   }
+
   .sm-mr0 {
     margin-right: 0;
   }
@@ -560,12 +620,15 @@
   .sm-mt1 {
     margin-top: var(--margin-1);
   }
+
   .sm-mb1 {
     margin-bottom: var(--margin-1);
   }
+
   .sm-ml1 {
     margin-left: var(--margin-1);
   }
+
   .sm-mr1 {
     margin-right: var(--margin-1);
   }
@@ -589,12 +652,15 @@
   .sm-mt2 {
     margin-top: var(--margin-2);
   }
+
   .sm-mb2 {
     margin-bottom: var(--margin-2);
   }
+
   .sm-ml2 {
     margin-left: var(--margin-2);
   }
+
   .sm-mr2 {
     margin-right: var(--margin-2);
   }
@@ -618,12 +684,15 @@
   .sm-mt3 {
     margin-top: var(--margin-3);
   }
+
   .sm-mb3 {
     margin-bottom: var(--margin-3);
   }
+
   .sm-ml3 {
     margin-left: var(--margin-3);
   }
+
   .sm-mr3 {
     margin-right: var(--margin-3);
   }
@@ -647,12 +716,15 @@
   .sm-mt4 {
     margin-top: var(--margin-4);
   }
+
   .sm-mb4 {
     margin-bottom: var(--margin-4);
   }
+
   .sm-ml4 {
     margin-left: var(--margin-4);
   }
+
   .sm-mr4 {
     margin-right: var(--margin-4);
   }
@@ -665,15 +737,19 @@
   .md-p0 {
     padding: 0;
   }
+
   .md-pt0 {
     padding-top: 0;
   }
+
   .md-pb0 {
     padding-bottom: 0;
   }
+
   .md-pl0 {
     padding-left: 0;
   }
+
   .md-pr0 {
     padding-right: 0;
   }
@@ -696,12 +772,15 @@
   .md-pt1 {
     padding-top: var(--padding-1);
   }
+
   .md-pb1 {
     padding-bottom: var(--padding-1);
   }
+
   .md-pl1 {
     padding-left: var(--padding-1);
   }
+
   .md-pr1 {
     padding-right: var(--padding-1);
   }
@@ -725,12 +804,15 @@
   .md-pt2 {
     padding-top: var(--padding-2);
   }
+
   .md-pb2 {
     padding-bottom: var(--padding-2);
   }
+
   .md-pl2 {
     padding-left: var(--padding-2);
   }
+
   .md-pr2 {
     padding-right: var(--padding-2);
   }
@@ -754,12 +836,15 @@
   .md-pt3 {
     padding-top: var(--padding-3);
   }
+
   .md-pb3 {
     padding-bottom: var(--padding-3);
   }
+
   .md-pl3 {
     padding-left: var(--padding-3);
   }
+
   .md-pr3 {
     padding-right: var(--padding-3);
   }
@@ -783,12 +868,15 @@
   .md-pt4 {
     padding-top: var(--padding-4);
   }
+
   .md-pb4 {
     padding-bottom: var(--padding-4);
   }
+
   .md-pl4 {
     padding-left: var(--padding-4);
   }
+
   .md-pr4 {
     padding-right: var(--padding-4);
   }
@@ -799,15 +887,19 @@
   .md-m0 {
     margin: 0;
   }
+
   .md-mt0 {
     margin-top: 0;
   }
+
   .md-mb0 {
     margin-bottom: 0;
   }
+
   .md-ml0 {
     margin-left: 0;
   }
+
   .md-mr0 {
     margin-right: 0;
   }
@@ -830,12 +922,15 @@
   .md-mt1 {
     margin-top: var(--margin-1);
   }
+
   .md-mb1 {
     margin-bottom: var(--margin-1);
   }
+
   .md-ml1 {
     margin-left: var(--margin-1);
   }
+
   .md-mr1 {
     margin-right: var(--margin-1);
   }
@@ -859,12 +954,15 @@
   .md-mt2 {
     margin-top: var(--margin-2);
   }
+
   .md-mb2 {
     margin-bottom: var(--margin-2);
   }
+
   .md-ml2 {
     margin-left: var(--margin-2);
   }
+
   .md-mr2 {
     margin-right: var(--margin-2);
   }
@@ -888,12 +986,15 @@
   .md-mt3 {
     margin-top: var(--margin-3);
   }
+
   .md-mb3 {
     margin-bottom: var(--margin-3);
   }
+
   .md-ml3 {
     margin-left: var(--margin-3);
   }
+
   .md-mr3 {
     margin-right: var(--margin-3);
   }
@@ -917,12 +1018,15 @@
   .md-mt4 {
     margin-top: var(--margin-4);
   }
+
   .md-mb4 {
     margin-bottom: var(--margin-4);
   }
+
   .md-ml4 {
     margin-left: var(--margin-4);
   }
+
   .md-mr4 {
     margin-right: var(--margin-4);
   }
@@ -935,15 +1039,19 @@
   .lg-p0 {
     padding: 0;
   }
+
   .lg-pt0 {
     padding-top: 0;
   }
+
   .lg-pb0 {
     padding-bottom: 0;
   }
+
   .lg-pl0 {
     padding-left: 0;
   }
+
   .lg-pr0 {
     padding-right: 0;
   }
@@ -966,12 +1074,15 @@
   .lg-pt1 {
     padding-top: var(--padding-1);
   }
+
   .lg-pb1 {
     padding-bottom: var(--padding-1);
   }
+
   .lg-pl1 {
     padding-left: var(--padding-1);
   }
+
   .lg-pr1 {
     padding-right: var(--padding-1);
   }
@@ -995,12 +1106,15 @@
   .lg-pt2 {
     padding-top: var(--padding-2);
   }
+
   .lg-pb2 {
     padding-bottom: var(--padding-2);
   }
+
   .lg-pl2 {
     padding-left: var(--padding-2);
   }
+
   .lg-pr2 {
     padding-right: var(--padding-2);
   }
@@ -1024,12 +1138,15 @@
   .lg-pt3 {
     padding-top: var(--padding-3);
   }
+
   .lg-pb3 {
     padding-bottom: var(--padding-3);
   }
+
   .lg-pl3 {
     padding-left: var(--padding-3);
   }
+
   .lg-pr3 {
     padding-right: var(--padding-3);
   }
@@ -1053,12 +1170,15 @@
   .lg-pt4 {
     padding-top: var(--padding-4);
   }
+
   .lg-pb4 {
     padding-bottom: var(--padding-4);
   }
+
   .lg-pl4 {
     padding-left: var(--padding-4);
   }
+
   .lg-pr4 {
     padding-right: var(--padding-4);
   }
@@ -1069,15 +1189,19 @@
   .lg-m0 {
     margin: 0;
   }
+
   .lg-mt0 {
     margin-top: 0;
   }
+
   .lg-mb0 {
     margin-bottom: 0;
   }
+
   .lg-ml0 {
     margin-left: 0;
   }
+
   .lg-mr0 {
     margin-right: 0;
   }
@@ -1100,12 +1224,15 @@
   .lg-mt1 {
     margin-top: var(--margin-1);
   }
+
   .lg-mb1 {
     margin-bottom: var(--margin-1);
   }
+
   .lg-ml1 {
     margin-left: var(--margin-1);
   }
+
   .lg-mr1 {
     margin-right: var(--margin-1);
   }
@@ -1129,12 +1256,15 @@
   .lg-mt2 {
     margin-top: var(--margin-2);
   }
+
   .lg-mb2 {
     margin-bottom: var(--margin-2);
   }
+
   .lg-ml2 {
     margin-left: var(--margin-2);
   }
+
   .lg-mr2 {
     margin-right: var(--margin-2);
   }
@@ -1158,12 +1288,15 @@
   .lg-mt3 {
     margin-top: var(--margin-3);
   }
+
   .lg-mb3 {
     margin-bottom: var(--margin-3);
   }
+
   .lg-ml3 {
     margin-left: var(--margin-3);
   }
+
   .lg-mr3 {
     margin-right: var(--margin-3);
   }
@@ -1187,12 +1320,15 @@
   .lg-mt4 {
     margin-top: var(--margin-4);
   }
+
   .lg-mb4 {
     margin-bottom: var(--margin-4);
   }
+
   .lg-ml4 {
     margin-left: var(--margin-4);
   }
+
   .lg-mr4 {
     margin-right: var(--margin-4);
   }
@@ -1205,15 +1341,19 @@
   .xl-p0 {
     padding: 0;
   }
+
   .xl-pt0 {
     padding-top: 0;
   }
+
   .xl-pb0 {
     padding-bottom: 0;
   }
+
   .xl-pl0 {
     padding-left: 0;
   }
+
   .xl-pr0 {
     padding-right: 0;
   }
@@ -1236,12 +1376,15 @@
   .xl-pt1 {
     padding-top: var(--padding-1);
   }
+
   .xl-pb1 {
     padding-bottom: var(--padding-1);
   }
+
   .xl-pl1 {
     padding-left: var(--padding-1);
   }
+
   .xl-pr1 {
     padding-right: var(--padding-1);
   }
@@ -1265,12 +1408,15 @@
   .xl-pt2 {
     padding-top: var(--padding-2);
   }
+
   .xl-pb2 {
     padding-bottom: var(--padding-2);
   }
+
   .xl-pl2 {
     padding-left: var(--padding-2);
   }
+
   .xl-pr2 {
     padding-right: var(--padding-2);
   }
@@ -1294,12 +1440,15 @@
   .xl-pt3 {
     padding-top: var(--padding-3);
   }
+
   .xl-pb3 {
     padding-bottom: var(--padding-3);
   }
+
   .xl-pl3 {
     padding-left: var(--padding-3);
   }
+
   .xl-pr3 {
     padding-right: var(--padding-3);
   }
@@ -1323,12 +1472,15 @@
   .xl-pt4 {
     padding-top: var(--padding-4);
   }
+
   .xl-pb4 {
     padding-bottom: var(--padding-4);
   }
+
   .xl-pl4 {
     padding-left: var(--padding-4);
   }
+
   .xl-pr4 {
     padding-right: var(--padding-4);
   }
@@ -1339,15 +1491,19 @@
   .xl-m0 {
     margin: 0;
   }
+
   .xl-mt0 {
     margin-top: 0;
   }
+
   .xl-mb0 {
     margin-bottom: 0;
   }
+
   .xl-ml0 {
     margin-left: 0;
   }
+
   .xl-mr0 {
     margin-right: 0;
   }
@@ -1370,12 +1526,15 @@
   .xl-mt1 {
     margin-top: var(--margin-1);
   }
+
   .xl-mb1 {
     margin-bottom: var(--margin-1);
   }
+
   .xl-ml1 {
     margin-left: var(--margin-1);
   }
+
   .xl-mr1 {
     margin-right: var(--margin-1);
   }
@@ -1399,12 +1558,15 @@
   .xl-mt2 {
     margin-top: var(--margin-2);
   }
+
   .xl-mb2 {
     margin-bottom: var(--margin-2);
   }
+
   .xl-ml2 {
     margin-left: var(--margin-2);
   }
+
   .xl-mr2 {
     margin-right: var(--margin-2);
   }
@@ -1428,12 +1590,15 @@
   .xl-mt3 {
     margin-top: var(--margin-3);
   }
+
   .xl-mb3 {
     margin-bottom: var(--margin-3);
   }
+
   .xl-ml3 {
     margin-left: var(--margin-3);
   }
+
   .xl-mr3 {
     margin-right: var(--margin-3);
   }
@@ -1457,12 +1622,15 @@
   .xl-mt4 {
     margin-top: var(--margin-4);
   }
+
   .xl-mb4 {
     margin-bottom: var(--margin-4);
   }
+
   .xl-ml4 {
     margin-left: var(--margin-4);
   }
+
   .xl-mr4 {
     margin-right: var(--margin-4);
   }

--- a/frontend/src/metabase/css/core/text.css
+++ b/frontend/src/metabase/css/core/text.css
@@ -113,6 +113,7 @@
 }
 
 /* text weight */
+
 /* NOTE: .text-light removed since it conflicted with text-light in colors.css */
 .text-normal {
   font-weight: 400;

--- a/frontend/src/metabase/css/core/text.css
+++ b/frontend/src/metabase/css/core/text.css
@@ -100,6 +100,7 @@
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }
+
 .text-lowercase {
   text-transform: lowercase;
 }
@@ -118,6 +119,7 @@
 .text-normal {
   font-weight: 400;
 }
+
 .text-bold,
 :local(.text-bold) {
   font-weight: 700;
@@ -204,6 +206,7 @@
   line-height: 1.4em;
   white-space: pre-wrap;
 }
+
 .text-code-plain {
   font-family: monospace;
   color: var(--color-text-dark);

--- a/frontend/src/metabase/css/core/transitions.css
+++ b/frontend/src/metabase/css/core/transitions.css
@@ -2,13 +2,16 @@
 :local(.transition-color) {
   transition: color 0.3s linear;
 }
+
 .transition-background,
 :local(.transition-background) {
   transition: background 0.2s linear;
 }
+
 .transition-shadow {
   transition: box-shadow 0.2s linear;
 }
+
 .transition-all {
   transition: all 0.2s linear;
 }

--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -122,7 +122,7 @@
   box-shadow: 3px 3px 8px var(--color-shadow);
 }
 
-.BrandColorResizeHandle .react-resizable-handle:after {
+.BrandColorResizeHandle .react-resizable-handle::after {
   border-color: var(--color-brand) !important;
 }
 
@@ -164,7 +164,7 @@
   background: none; /* hide default RGL's resize handle */
 }
 
-.Dash--editing .DashCard .react-resizable-handle:after {
+.Dash--editing .DashCard .react-resizable-handle::after {
   content: "";
   position: absolute;
   width: 8px;
@@ -178,18 +178,20 @@
   opacity: 0.01;
 }
 
-.Dash--editing .DashCard .react-resizable-handle:hover:after {
+.Dash--editing .DashCard .react-resizable-handle:hover::after {
   border-color: var(--color-border);
 }
 
-.Dash--editing .DashCard:hover .react-resizable-handle:after {
+.Dash--editing .DashCard:hover .react-resizable-handle::after {
   opacity: 1;
 }
 
-.Dash--editing .DashCard.react-draggable-dragging .react-resizable-handle:after,
+.Dash--editing
+  .DashCard.react-draggable-dragging
+  .react-resizable-handle::after,
 .Dash--editing
   .DashCard.react-resizable-resizing
-  .react-resizable-handle:after {
+  .react-resizable-handle::after {
   opacity: 0.01;
 }
 

--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -218,6 +218,7 @@
   nav {
     display: none;
   }
+
   /* improve label contrast */
   .dc-chart .axis .tick text,
   .dc-chart .x-axis-label,

--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -142,6 +142,7 @@
   right: -2px;
   top: -2px;
 }
+
 .Dash--editing .DashCard:hover .Visualization-slow-spinner {
   opacity: 0;
   transition: opacity 0.15s linear;

--- a/frontend/src/metabase/css/home.css
+++ b/frontend/src/metabase/css/home.css
@@ -32,6 +32,7 @@
   background-color: var(--color-bg-light);
   border-left: 2px solid var(--color-border);
 }
+
 .Layout-mainColumn {
   max-width: 700px;
   margin-left: auto;

--- a/frontend/src/metabase/css/index.css
+++ b/frontend/src/metabase/css/index.css
@@ -1,5 +1,4 @@
 @import "./vendor.css";
-
 @import "./components/buttons.css";
 @import "./components/form.css";
 @import "./components/header.css";
@@ -9,9 +8,7 @@
 @import "./components/table.css";
 @import "./components/tippy.css";
 @import "./components/grabber.css";
-
 @import "./containers/entity_search.css";
-
 @import "./admin.css";
 @import "./card.css";
 @import "./dashboard.css";

--- a/frontend/src/metabase/css/query_builder.css
+++ b/frontend/src/metabase/css/query_builder.css
@@ -253,7 +253,6 @@
   background-color: white;
   padding-left: var(--padding-1);
   padding-right: var(--padding-1);
-
   position: absolute;
   top: -0.75em;
   left: 50%;
@@ -285,7 +284,6 @@
   font-size: 0.9em;
   z-index: 2;
   background-color: var(--color-bg-white);
-
   border: 1px solid var(--color-border);
 }
 
@@ -512,11 +510,9 @@
   width: 20px;
   height: 20px;
   display: flex;
-
   align-items: center;
   justify-content: center;
   opacity: 0.7;
-
   cursor: pointer;
 }
 

--- a/frontend/src/metabase/css/query_builder.css
+++ b/frontend/src/metabase/css/query_builder.css
@@ -245,7 +245,7 @@
   padding: var(--padding-1) var(--padding-4) var(--padding-1) var(--padding-4);
 }
 
-.QueryError-adminEmail:before {
+.QueryError-adminEmail::before {
   content: "Admin Email";
   font-size: 10px;
   text-align: center;
@@ -520,7 +520,7 @@
   cursor: pointer;
 }
 
-.QuestionTooltipTarget:after {
+.QuestionTooltipTarget::after {
   content: "?";
   font-size: 13px;
   font-weight: bold;

--- a/frontend/src/metabase/css/query_builder.css
+++ b/frontend/src/metabase/css/query_builder.css
@@ -366,7 +366,7 @@
 /* SORT/LIMIT SECTION */
 
 .GuiBuilder-sort-limit {
-  min-width: 0px;
+  min-width: 0;
 }
 
 .EllipsisButton {

--- a/frontend/src/metabase/css/query_builder.css
+++ b/frontend/src/metabase/css/query_builder.css
@@ -301,9 +301,6 @@
 .GuiBuilder-row:last-child {
   border-bottom-color: transparent;
 }
-.GuiBuilder-data {
-  border-right: 1px solid var(--color-border);
-}
 .GuiBuilder-filtered-by {
   border-right: 1px solid transparent;
 }
@@ -312,6 +309,7 @@
 }
 .GuiBuilder-sort-limit {
   border-left: 1px solid var(--color-border);
+  min-width: 0;
 }
 
 /* expanded */
@@ -351,6 +349,7 @@
 /* DATA SECTION */
 
 .GuiBuilder-data {
+  border-right: 1px solid var(--color-border);
   z-index: 1; /* moved the arrow thingy above the filter outline */
 }
 
@@ -362,10 +361,6 @@
 }
 
 /* SORT/LIMIT SECTION */
-
-.GuiBuilder-sort-limit {
-  min-width: 0;
-}
 
 .EllipsisButton {
   font-size: 3em;

--- a/frontend/src/metabase/css/query_builder.css
+++ b/frontend/src/metabase/css/query_builder.css
@@ -183,13 +183,16 @@
   background-color: color-mod(var(--color-bg-white) alpha(-28%));
   transition: opacity 0.5s;
 }
+
 .Loading.Loading--hidden {
   background-color: transparent;
 }
+
 .Dirty {
   background-color: color-mod(var(--color-bg-white) alpha(-28%));
   transition: opacity 0.5s;
 }
+
 .Dirty.Loading--hidden {
   background-color: transparent;
 }
@@ -298,15 +301,19 @@
 .GuiBuilder-row {
   border-bottom: 1px solid var(--color-border);
 }
+
 .GuiBuilder-row:last-child {
   border-bottom-color: transparent;
 }
+
 .GuiBuilder-filtered-by {
   border-right: 1px solid transparent;
 }
+
 .GuiBuilder-view {
   border-right: 1px solid var(--color-border);
 }
+
 .GuiBuilder-sort-limit {
   border-left: 1px solid var(--color-border);
   min-width: 0;
@@ -316,10 +323,12 @@
 .GuiBuilder.GuiBuilder--expand {
   flex-direction: row;
 }
+
 .GuiBuilder.GuiBuilder--expand .GuiBuilder-row:last-child {
   border-right-color: transparent;
   border-bottom-color: var(--color-border);
 }
+
 .GuiBuilder.GuiBuilder--expand .GuiBuilder-filtered-by {
   border-right-color: var(--color-border);
 }

--- a/frontend/src/metabase/css/query_builder.css
+++ b/frontend/src/metabase/css/query_builder.css
@@ -499,7 +499,6 @@
 
 .QuestionTooltipTarget {
   color: var(--color-text-light);
-  display: inline-block;
   border: 2px solid currentColor;
   border-radius: 99px;
   width: 20px;

--- a/frontend/src/metabase/css/vendor.css
+++ b/frontend/src/metabase/css/vendor.css
@@ -3,5 +3,4 @@
 
 /* z-index utils */
 @import "z-index/z-index.css";
-
 @import "tippy.js/dist/tippy.css";

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.css
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.css
@@ -20,9 +20,11 @@
   margin-right: 0;
   margin-left: 0;
 }
+
 :local(.fullscreen .name) {
   font-size: 14px;
 }
+
 :local(.fullscreen .parameter) {
   min-width: 0;
   min-height: 0;
@@ -59,15 +61,19 @@
   color: var(--color-text-dark);
   width: 142px;
 }
+
 :local(.parameter.noPopover) input::-webkit-input-placeholder {
   color: var(--color-text-medium);
 }
+
 :local(.parameter.noPopover) input:-moz-placeholder {
   color: var(--color-text-medium);
 }
+
 :local(.parameter.noPopover) input::-moz-placeholder {
   color: var(--color-text-medium);
 }
+
 :local(.parameter.noPopover) input:-ms-input-placeholder {
   color: var(--color-text-medium);
 }

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.css
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.css
@@ -11,7 +11,6 @@
   min-height: 30px;
   min-width: 150px;
   color: var(--color-text-medium);
-  border: none;
   font-size: 1em;
   font-weight: 600;
   border: none;

--- a/frontend/src/metabase/reference/Reference.css
+++ b/frontend/src/metabase/reference/Reference.css
@@ -53,8 +53,8 @@
 }
 
 :local(.guideLeftPadded)::before {
-  /*FIXME: not sure how to share this with other components
-     because we can't use composes here apparently. any workarounds?*/
+  /* FIXME: not sure how to share this with other components
+     because we can't use composes here apparently. any workarounds? */
   content: "";
   display: block;
   flex: 0.3;

--- a/frontend/src/metabase/reference/components/Formula.css
+++ b/frontend/src/metabase/reference/components/Formula.css
@@ -24,14 +24,17 @@
 .formulaDefinition-enter {
   max-height: 0;
 }
+
 .formulaDefinition-enter.formulaDefinition-enter-active {
   /* using 100% max-height breaks the transition */
   max-height: 150px;
   transition: max-height 300ms ease-out;
 }
+
 .formulaDefinition-exit {
   max-height: 150px;
 }
+
 .formulaDefinition-exit.formulaDefinition-exit-active {
   max-height: 0;
   transition: max-height 300ms ease-out;

--- a/frontend/src/metabase/reference/components/Formula.css
+++ b/frontend/src/metabase/reference/components/Formula.css
@@ -22,7 +22,7 @@
 }
 
 .formulaDefinition-enter {
-  max-height: 0px;
+  max-height: 0;
 }
 .formulaDefinition-enter.formulaDefinition-enter-active {
   /* using 100% max-height breaks the transition */
@@ -33,6 +33,6 @@
   max-height: 150px;
 }
 .formulaDefinition-exit.formulaDefinition-exit-active {
-  max-height: 0px;
+  max-height: 0;
   transition: max-height 300ms ease-out;
 }

--- a/frontend/src/metabase/visualizations/components/ChartWithLegend.css
+++ b/frontend/src/metabase/visualizations/components/ChartWithLegend.css
@@ -41,6 +41,7 @@
 :local .ChartWithLegend.small .Legend {
   display: none;
 }
+
 :local .ChartWithLegend.small .Chart {
   flex: 1;
 }
@@ -49,17 +50,21 @@
 :local .ChartWithLegend.vertical {
   flex-direction: column-reverse;
 }
+
 :local .ChartWithLegend.vertical .Legend {
   flex-shrink: 1;
   overflow: hidden;
 }
+
 :local .ChartWithLegend.vertical .LegendWrapper {
   flex-direction: column;
 }
+
 :local .ChartWithLegend.vertical.flexChart .Legend {
   flex-grow: 0;
   flex-shrink: 0;
 }
+
 :local .ChartWithLegend.vertical.flexChart .Chart {
   flex-grow: 1;
   flex-shrink: 1;
@@ -70,18 +75,22 @@
 :local .ChartWithLegend.horizontal {
   flex-direction: row;
 }
+
 :local .ChartWithLegend.horizontal .Legend {
   flex-grow: 0;
   flex-shrink: 1;
   overflow: hidden;
 }
+
 :local .ChartWithLegend.horizontal .LegendWrapper {
   flex-direction: row;
 }
+
 :local .ChartWithLegend.horizontal.flexChart .Legend {
   flex-grow: 0;
   flex-shrink: 0;
 }
+
 :local .ChartWithLegend.horizontal.flexChart .Chart {
   flex-grow: 1;
   flex-shrink: 1;

--- a/frontend/src/metabase/visualizations/components/ChartWithLegend.css
+++ b/frontend/src/metabase/visualizations/components/ChartWithLegend.css
@@ -15,6 +15,7 @@
 :local .ChartWithLegend .LegendWrapper {
   flex-basis: auto;
   flex-grow: 1;
+
   /* allow legend and spacer to shrink */
   min-width: 0;
   min-height: 0;
@@ -88,6 +89,7 @@
 }
 
 /* DEBUG */
+
 /*
 :local .ChartWithLegend .Legend {
   background-color: color-mod(var(--color-bg-black) alpha(-90%));

--- a/frontend/src/metabase/visualizations/components/Legend.css
+++ b/frontend/src/metabase/visualizations/components/Legend.css
@@ -30,7 +30,6 @@ fullscreen dashboard mode
 
 :local .Legend.horizontal {
   display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
+  flex-flow: row wrap;
   margin-top: 1em;
 }

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
@@ -1,8 +1,5 @@
 .LineAreaBarChart .renderer {
-  margin-top: -5px;
-  margin-left: -0.5em;
-  margin-right: -0.5em;
-  margin-bottom: -0.5em;
+  margin: -5px -0.5em -0.5em;
   overflow: hidden;
 }
 

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
@@ -179,10 +179,6 @@
   transition: opacity 0.25s linear;
 }
 
-.LineAreaBarChart .dc-chart .event-line {
-  transition: stroke 0.15s linear;
-}
-
 /* .mute-* selectors dynamically generated in LineAreaBarChart.js */
 
 .LineAreaBarChart.mute-yl .dc-chart .axis.y,
@@ -230,9 +226,6 @@
 
 text.value-label {
   pointer-events: none;
-}
-
-text.value-label {
   fill: var(--color-text-dark);
   font-size: 12px;
   font-weight: 800;
@@ -277,6 +270,7 @@ text.value-label-white {
 }
 
 .LineAreaBarChart .dc-chart .event-line {
+  transition: stroke 0.15s linear;
   stroke: color-mod(var(--color-text-medium) alpha(-80%));
   stroke-width: 2;
   pointer-events: none;

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
@@ -34,6 +34,7 @@
   fill: var(--color-text-medium);
   font-weight: 900;
 }
+
 .LineAreaBarChart .dc-chart g.row text.inside {
   fill: white;
   font-weight: bold;
@@ -123,6 +124,7 @@
 .LineAreaBarChart .dc-chart .line {
   stroke-width: 2px;
 }
+
 .LineAreaBarChart .dc-chart .dc-tooltip .dot {
   r: 3px !important;
   stroke-width: 2px;
@@ -132,6 +134,7 @@
 .LineAreaBarChart .dc-chart .line--medium .line {
   stroke-width: 3px;
 }
+
 .LineAreaBarChart .dc-chart .line--medium .dc-tooltip .dot {
   r: 3px !important;
   stroke-width: 2px;
@@ -141,6 +144,7 @@
 .LineAreaBarChart .dc-chart .line--heavy .line {
   stroke-width: 4px;
 }
+
 .LineAreaBarChart .dc-chart .line--heavy .dc-tooltip .dot {
   r: 3.5px !important;
   stroke-width: 3px;
@@ -159,6 +163,7 @@
 .LineAreaBarChart .dc-chart .dc-tooltip .dot.deselected {
   opacity: 0;
 }
+
 .LineAreaBarChart .dc-chart .line.deselected {
   color: var(--color-text-light);
 }

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
@@ -183,7 +183,7 @@
   transition: stroke 0.15s linear;
 }
 
-/* .mute-* selectors dynamically generated in LineAreaBarChart.js*/
+/* .mute-* selectors dynamically generated in LineAreaBarChart.js */
 
 .LineAreaBarChart.mute-yl .dc-chart .axis.y,
 .LineAreaBarChart.mute-yl .dc-chart .y-axis-label.y-label {
@@ -206,7 +206,7 @@
 /* we put the brush behind everything so this isn't necessary
 /*.LineAreaBarChart .dc-chart .brush {
   pointer-events: none;
-}*/
+} */
 
 /* grid lines aren't clickable, and get in the way of the brush */
 .LineAreaBarChart .dc-chart .grid-line {

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.css
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.css
@@ -32,7 +32,7 @@
   transition: opacity 0.3s linear;
 }
 
-/* if the column is the one that is being sorted*/
+/* if the column is the one that is being sorted */
 .TableInteractive-headerCellData--sorted {
   color: var(--color-brand);
 }

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.css
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.css
@@ -46,7 +46,6 @@
   overflow: hidden;
   display: flex;
   align-items: center;
-
   border-top: 1px solid transparent;
   border-left: 1px solid transparent;
   border-right: 1px solid transparent;

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.css
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.css
@@ -32,11 +32,6 @@
   transition: opacity 0.3s linear;
 }
 
-/* if the column is the one that is being sorted */
-.TableInteractive-headerCellData--sorted {
-  color: var(--color-brand);
-}
-
 .TableInteractive-header {
   box-sizing: border-box;
   border-bottom: 1px solid var(--color-border);
@@ -58,12 +53,7 @@
 
 .TableInteractive .TableInteractive-header,
 .TableInteractive .TableInteractive-header .TableInteractive-cellWrapper {
-  background-color: var(--color-bg-white);
   background-image: none;
-}
-
-.TableInteractive .TableInteractive-header,
-.TableInteractive .TableInteractive-header .TableInteractive-cellWrapper {
   background-color: var(--color-bg-white);
 }
 

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.css
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.css
@@ -1,10 +1,7 @@
 :local .Chart,
 :local .Detail {
   position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
+  inset: 0;
 }
 
 :local .Chart {

--- a/package.json
+++ b/package.json
@@ -271,6 +271,9 @@
     "shadow-cljs": "2.24.0",
     "source-map-loader": "^4.0.1",
     "style-loader": "3.3.1",
+    "stylelint": "^15.10.2",
+    "stylelint-config-css-modules": "^4.3.0",
+    "stylelint-config-standard": "^34.0.0",
     "terser-webpack-plugin": "^5.3.9",
     "typescript": "^4.7.2",
     "webpack": "^5.85.0",
@@ -360,6 +363,7 @@
   },
   "lint-staged": {
     "+(enterprise|frontend)/**/*.css": [
+      "stylelint --fix",
       "prettier --write"
     ],
     "+(enterprise|frontend)/**/*.{js,jsx,ts,tsx}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3919,6 +3919,26 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@csstools/css-parser-algorithms@^2.3.0":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.3.1.tgz#ec4fc764ba45d2bb7ee2774667e056aa95003f3a"
+  integrity sha512-xrvsmVUtefWMWQsGgFffqWSK03pZ1vfDki4IVIIUxxDKnGBzqNgv0A7SB1oXtVNEkcVO8xi1ZrTL29HhSu5kGA==
+
+"@csstools/css-tokenizer@^2.1.1":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-2.2.0.tgz#9d70e6dcbe94e44c7400a2929928db35c4de32b5"
+  integrity sha512-wErmsWCbsmig8sQKkM6pFhr/oPha1bHfvxsUY5CYSQxwyhA9Ulrs8EqCgClhg4Tgg2XapVstGqSVcz0xOYizZA==
+
+"@csstools/media-query-list-parser@^2.1.2":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.4.tgz#0017f99945f6c16dd81a7aacf6821770933c3a5c"
+  integrity sha512-V/OUXYX91tAC1CDsiY+HotIcJR+vPtzrX8pCplCpT++i8ThZZsq5F5dzZh/bDM3WUOjrvC1ljed1oSJxMfjqhw==
+
+"@csstools/selector-specificity@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-3.0.0.tgz#798622546b63847e82389e473fd67f2707d82247"
+  integrity sha512-hBI9tfBtuPIi885ZsZ32IMEU/5nlZH/KOVYJCOh7gyMxaVLGmLedYqFN6Ui1LXkI8JlC8IsuC0rF0btcRZKd5g==
+
 "@cypress/commit-info@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@cypress/commit-info/-/commit-info-2.2.0.tgz#6086d478975edb7ac7c9ffdd5cfd5be2b9fe44f2"
@@ -7520,6 +7540,11 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
+"@types/minimist@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
+  integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
+
 "@types/mockdate@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/mockdate/-/mockdate-3.0.0.tgz#ed140c46c4542964621e553d181faf62cadc973a"
@@ -9423,6 +9448,11 @@ array.prototype.tosorted@^1.1.1:
     es-shim-unscopables "^1.0.0"
     get-intrinsic "^1.1.3"
 
+arrify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+  integrity sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==
+
 arrify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
@@ -9916,6 +9946,11 @@ balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+balanced-match@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-2.0.0.tgz#dc70f920d78db8b858535795867bf48f820633d9"
+  integrity sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==
 
 base64-arraybuffer@^1.0.2:
   version "1.0.2"
@@ -10477,6 +10512,16 @@ camelcase-keys@^2.0.0:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
 
+camelcase-keys@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-7.0.2.tgz#d048d8c69448745bb0de6fc4c1c52a30dfbe7252"
+  integrity sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==
+  dependencies:
+    camelcase "^6.3.0"
+    map-obj "^4.1.0"
+    quick-lru "^5.1.1"
+    type-fest "^1.2.1"
+
 camelcase@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
@@ -10491,6 +10536,11 @@ camelcase@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
+
+camelcase@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
+  integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001274, caniuse-lite@^1.0.30001280, caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001489:
   version "1.0.30001505"
@@ -10979,6 +11029,11 @@ color@^3.0.0:
     color-convert "^1.9.1"
     color-string "^1.5.4"
 
+colord@^2.9.3:
+  version "2.9.3"
+  resolved "https://registry.yarnpkg.com/colord/-/colord-2.9.3.tgz#4f8ce919de456f1d5c1c368c307fe20f3e59fb43"
+  integrity sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==
+
 colorette@2.0.19, colorette@^2.0.19:
   version "2.0.19"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
@@ -11372,6 +11427,16 @@ cosmiconfig@^8.1.3:
     parse-json "^5.0.0"
     path-type "^4.0.0"
 
+cosmiconfig@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.2.0.tgz#f7d17c56a590856cd1e7cee98734dca272b0d8fd"
+  integrity sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==
+  dependencies:
+    import-fresh "^3.2.1"
+    js-yaml "^4.1.0"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+
 cp-file@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/cp-file/-/cp-file-7.0.0.tgz#b9454cfd07fe3b974ab9ea0e5f29655791a9b8cd"
@@ -11545,6 +11610,11 @@ css-box-model@^1.2.0:
   dependencies:
     tiny-invariant "^1.0.6"
 
+css-functions-list@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/css-functions-list/-/css-functions-list-3.2.0.tgz#8290b7d064bf483f48d6559c10e98dc4d1ad19ee"
+  integrity sha512-d/jBMPyYybkkLVypgtGv12R+pIFw4/f/IHtCTxWpZc8ofTYOPigIgmA6vu5rMHartZC+WuXhBUHfnyNUIQSYrg==
+
 css-has-pseudo@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/css-has-pseudo/-/css-has-pseudo-0.10.0.tgz#3c642ab34ca242c59c41a125df9105841f6966ee"
@@ -11675,7 +11745,7 @@ css-tree@^1.1.2:
     mdn-data "2.0.14"
     source-map "^0.6.1"
 
-css-tree@^2.2.1:
+css-tree@^2.2.1, css-tree@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-2.3.1.tgz#10264ce1e5442e8572fc82fbe490644ff54b5c20"
   integrity sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==
@@ -12063,10 +12133,23 @@ debug@^4.3.3:
   dependencies:
     ms "2.1.2"
 
-decamelize@^1.1.2, decamelize@^1.2.0:
+decamelize-keys@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.1.tgz#04a2d523b2f18d80d0158a43b895d56dff8d19d8"
+  integrity sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==
+  dependencies:
+    decamelize "^1.1.0"
+    map-obj "^1.0.0"
+
+decamelize@^1.1.0, decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
+
+decamelize@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-5.0.1.tgz#db11a92e58c741ef339fb0a2868d8a06a9a7b1e9"
+  integrity sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==
 
 decimal.js@^10.4.3:
   version "10.4.3"
@@ -13780,6 +13863,17 @@ fast-glob@^3.2.11, fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
+fast-glob@^3.3.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.1.tgz#784b4e897340f3dbbef17413b3f11acf03c874c4"
+  integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-json-parse@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/fast-json-parse/-/fast-json-parse-1.0.3.tgz#43e5c61ee4efa9265633046b770fb682a7577c4d"
@@ -13821,6 +13915,11 @@ fastest-levenshtein@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
   integrity sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==
+
+fastest-levenshtein@^1.0.16:
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz#210e61b6ff181de91ea9b3d1b84fdedd47e034e5"
+  integrity sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==
 
 fastest-stable-stringify@^2.0.2:
   version "2.0.2"
@@ -14679,6 +14778,22 @@ global-dirs@^3.0.0:
   dependencies:
     ini "2.0.0"
 
+global-modules@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-2.0.0.tgz#997605ad2345f27f51539bea26574421215c7780"
+  integrity sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==
+  dependencies:
+    global-prefix "^3.0.0"
+
+global-prefix@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-3.0.0.tgz#fc85f73064df69f50421f47f883fe5b913ba9b97"
+  integrity sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==
+  dependencies:
+    ini "^1.3.5"
+    kind-of "^6.0.2"
+    which "^1.3.1"
+
 global@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/global/-/global-4.4.0.tgz#3e7b105179006a323ed71aafca3e9c57a5cc6406"
@@ -14751,6 +14866,11 @@ globby@^9.2.0:
     pify "^4.0.1"
     slash "^2.0.0"
 
+globjoin@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/globjoin/-/globjoin-0.1.4.tgz#2f4494ac8919e3767c5cbb691e9f463324285d43"
+  integrity sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==
+
 gopd@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
@@ -14816,6 +14936,11 @@ handlebars@^4.7.7:
     wordwrap "^1.0.0"
   optionalDependencies:
     uglify-js "^3.1.4"
+
+hard-rejection@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/hard-rejection/-/hard-rejection-2.1.0.tgz#1c6eda5c1685c63942766d79bb40ae773cecd883"
+  integrity sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -15077,6 +15202,13 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
   integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
 
+hosted-git-info@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-4.1.0.tgz#827b82867e9ff1c8d0c4d9d53880397d2c86d224"
+  integrity sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==
+  dependencies:
+    lru-cache "^6.0.0"
+
 hpack.js@^2.1.6:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/hpack.js/-/hpack.js-2.1.6.tgz#87774c0949e513f42e84575b3c45681fade2a0b2"
@@ -15141,6 +15273,11 @@ html-tags@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.1.0.tgz#7b5e6f7e665e9fb41f30007ed9e0d41e97fb2140"
   integrity sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==
+
+html-tags@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.3.1.tgz#a04026a18c882e4bba8a01a3d39cfe465d40b5ce"
+  integrity sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==
 
 html-void-elements@^1.0.0:
   version "1.0.5"
@@ -15449,6 +15586,11 @@ ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
+ignore@^5.2.4:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
+  integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
+
 image-size@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-1.0.0.tgz#58b31fe4743b1cec0a0ac26f5c914d3c5b2f0750"
@@ -15482,6 +15624,11 @@ import-lazy@^2.1.0:
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
   integrity sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=
 
+import-lazy@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"
+  integrity sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==
+
 import-local@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-3.0.2.tgz#a8cfd0431d1de4a2199703d003e3e62364fa6db6"
@@ -15506,6 +15653,11 @@ indent-string@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
+indent-string@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-5.0.0.tgz#4fd2980fccaf8622d14c64d694f4cf33c81951a5"
+  integrity sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==
 
 indexes-of@^1.0.1:
   version "1.0.1"
@@ -15550,7 +15702,7 @@ ini@2.0.0, ini@^2.0.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
   integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
 
-ini@~1.3.0:
+ini@^1.3.5, ini@~1.3.0:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
@@ -15792,6 +15944,13 @@ is-core-module@^2.2.0:
   dependencies:
     has "^1.0.3"
 
+is-core-module@^2.5.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.0.tgz#bb52aa6e2cbd49a30c2ba68c42bf3435ba6072db"
+  integrity sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==
+  dependencies:
+    has "^1.0.3"
+
 is-core-module@^2.9.0:
   version "2.12.1"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.12.1.tgz#0c0b6885b6f80011c71541ce15c8d66cf5a4f9fd"
@@ -16005,6 +16164,11 @@ is-path-inside@^3.0.2:
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
+is-plain-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
+  integrity sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==
+
 is-plain-obj@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
@@ -16027,7 +16191,7 @@ is-plain-object@2.0.4, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
-is-plain-object@5.0.0:
+is-plain-object@5.0.0, is-plain-object@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
   integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
@@ -17218,7 +17382,7 @@ kind-of@^5.0.0:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
   integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
 
-kind-of@^6.0.0, kind-of@^6.0.2:
+kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
@@ -17264,6 +17428,11 @@ knex@^2.4.2:
     resolve-from "^5.0.0"
     tarn "^3.0.2"
     tildify "2.0.0"
+
+known-css-properties@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.27.0.tgz#82a9358dda5fe7f7bd12b5e7142c0a205393c0c5"
+  integrity sha512-uMCj6+hZYDoffuvAJjFAPz56E9uoowFHmTkqRtRq5WyC5Q6Cu/fTZKNQpX/RbzChBYLLl3lo8CjFZBAZXq9qFg==
 
 latest-version@^5.1.0:
   version "5.1.0"
@@ -17754,6 +17923,11 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
   integrity sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==
 
+map-obj@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
+  integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
+
 map-or-similar@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/map-or-similar/-/map-or-similar-1.5.0.tgz#6de2653174adfb5d9edc33c69d3e92a1b76faf08"
@@ -17824,6 +17998,11 @@ math-expression-evaluator@^1.2.14:
   version "1.2.22"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.22.tgz#c14dcb3d8b4d150e5dcea9c68c8dad80309b0d5e"
   integrity sha512-L0j0tFVZBQQLeEjmWOvDLoRciIY8gQGWahvkztXUal8jH8R5Rlqo9GCvgqvXcy9LQhEWdQCVvzqAbxgYNt4blQ==
+
+mathml-tag-names@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz#4ddadd67308e780cf16a47685878ee27b736a0a3"
+  integrity sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -18061,6 +18240,24 @@ memory-fs@^0.5.0:
   dependencies:
     errno "^0.1.3"
     readable-stream "^2.0.1"
+
+meow@^10.1.5:
+  version "10.1.5"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-10.1.5.tgz#be52a1d87b5f5698602b0f32875ee5940904aa7f"
+  integrity sha512-/d+PQ4GKmGvM9Bee/DPa8z3mXs/pkvJE2KEThngVNOqtmljC6K7NMPxtc2JeZYTmpWb9k/TmxjeL18ez3h7vCw==
+  dependencies:
+    "@types/minimist" "^1.2.2"
+    camelcase-keys "^7.0.0"
+    decamelize "^5.0.0"
+    decamelize-keys "^1.1.0"
+    hard-rejection "^2.1.0"
+    minimist-options "4.1.0"
+    normalize-package-data "^3.0.2"
+    read-pkg-up "^8.0.0"
+    redent "^4.0.0"
+    trim-newlines "^4.0.2"
+    type-fest "^1.2.2"
+    yargs-parser "^20.2.9"
 
 meow@^3.1.0:
   version "3.7.0"
@@ -18484,7 +18681,7 @@ min-document@^2.19.0:
   dependencies:
     dom-walk "^0.1.0"
 
-min-indent@^1.0.0:
+min-indent@^1.0.0, min-indent@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
@@ -18533,6 +18730,15 @@ minimatch@^5.1.1:
   integrity sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==
   dependencies:
     brace-expansion "^2.0.1"
+
+minimist-options@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-4.1.0.tgz#c0655713c53a8a2ebd77ffa247d342c40f010619"
+  integrity sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==
+  dependencies:
+    arrify "^1.0.1"
+    is-plain-obj "^1.1.0"
+    kind-of "^6.0.3"
 
 minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
@@ -18793,6 +18999,11 @@ nanoid@^3.3.1, nanoid@^3.3.4:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
   integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
 
+nanoid@^3.3.6:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
+  integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -19023,6 +19234,16 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-
     hosted-git-info "^2.1.4"
     resolve "^1.10.0"
     semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
+
+normalize-package-data@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-3.0.3.tgz#dbcc3e2da59509a0983422884cd172eefdfa525e"
+  integrity sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==
+  dependencies:
+    hosted-git-info "^4.0.1"
+    is-core-module "^2.5.0"
+    semver "^7.3.4"
     validate-npm-package-license "^3.0.1"
 
 normalize-path@^2.1.1:
@@ -20210,6 +20431,11 @@ postcss-media-minmax@^4.0.0:
   dependencies:
     postcss "^7.0.2"
 
+postcss-media-query-parser@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz#27b39c6f4d94f81b1a73b8f76351c609e5cef244"
+  integrity sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==
+
 postcss-modules-extract-imports@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz#dc87e34148ec7eab5f791f7cd5849833375b741a"
@@ -20389,6 +20615,16 @@ postcss-replace-overflow-wrap@^3.0.0:
   dependencies:
     postcss "^7.0.2"
 
+postcss-resolve-nested-selector@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz#29ccbc7c37dedfac304e9fff0bf1596b3f6a0e4e"
+  integrity sha512-HvExULSwLqHLgUy1rl3ANIqCsvMS0WHss2UOsXhXnQaZ9VCc2oBvIpXrl00IUFT5ZDITME0o6oiXeiHr2SAIfw==
+
+postcss-safe-parser@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz#bb4c29894171a94bc5c996b9a30317ef402adaa1"
+  integrity sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==
+
 postcss-selector-matches@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/postcss-selector-matches/-/postcss-selector-matches-4.0.0.tgz#71c8248f917ba2cc93037c9637ee09c64436fcff"
@@ -20422,6 +20658,14 @@ postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2, postcss-selector
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
+postcss-selector-parser@^6.0.13:
+  version "6.0.13"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz#d05d8d76b1e8e173257ef9d60b706a8e5e99bf1b"
+  integrity sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
+
 postcss-url@^10.1.3:
   version "10.1.3"
   resolved "https://registry.yarnpkg.com/postcss-url/-/postcss-url-10.1.3.tgz#54120cc910309e2475ec05c2cfa8f8a2deafdf1e"
@@ -20441,6 +20685,11 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
+
+postcss-value-parser@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
+  integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
 postcss-values-parser@^2.0.0, postcss-values-parser@^2.0.1:
   version "2.0.1"
@@ -20485,6 +20734,15 @@ postcss@^8.2.15:
     nanoid "^3.1.30"
     picocolors "^1.0.0"
     source-map-js "^0.6.2"
+
+postcss@^8.4.25:
+  version "8.4.27"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.27.tgz#234d7e4b72e34ba5a92c29636734349e0d9c3057"
+  integrity sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==
+  dependencies:
+    nanoid "^3.3.6"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
 
 postgres-array@~2.0.0:
   version "2.0.0"
@@ -20913,6 +21171,11 @@ queue@6.0.2:
   integrity sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==
   dependencies:
     inherits "~2.0.3"
+
+quick-lru@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
+  integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
 raf-schd@^4.0.2:
   version "4.0.3"
@@ -21485,6 +21748,15 @@ read-pkg-up@^7.0.1:
     read-pkg "^5.2.0"
     type-fest "^0.8.1"
 
+read-pkg-up@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-8.0.0.tgz#72f595b65e66110f43b052dd9af4de6b10534670"
+  integrity sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==
+  dependencies:
+    find-up "^5.0.0"
+    read-pkg "^6.0.0"
+    type-fest "^1.0.1"
+
 read-pkg@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
@@ -21512,6 +21784,16 @@ read-pkg@^5.2.0:
     normalize-package-data "^2.5.0"
     parse-json "^5.0.0"
     type-fest "^0.6.0"
+
+read-pkg@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-6.0.0.tgz#a67a7d6a1c2b0c3cd6aa2ea521f40c458a4a504c"
+  integrity sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==
+  dependencies:
+    "@types/normalize-package-data" "^2.4.0"
+    normalize-package-data "^3.0.2"
+    parse-json "^5.2.0"
+    type-fest "^1.0.1"
 
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
@@ -21608,6 +21890,14 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+redent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-4.0.0.tgz#0c0ba7caabb24257ab3bb7a4fd95dd1d5c5681f9"
+  integrity sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==
+  dependencies:
+    indent-string "^5.0.0"
+    strip-indent "^4.0.0"
 
 reduce-css-calc@^1.3.0:
   version "1.3.0"
@@ -22746,6 +23036,11 @@ signal-exit@^3.0.2, signal-exit@^3.0.3:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
+signal-exit@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
 simple-bin-help@^1.7.7:
   version "1.7.7"
   resolved "https://registry.yarnpkg.com/simple-bin-help/-/simple-bin-help-1.7.7.tgz#3202946a9414152fba6fa61a9c154015750c684e"
@@ -23503,6 +23798,13 @@ strip-indent@^3.0.0:
   dependencies:
     min-indent "^1.0.0"
 
+strip-indent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-4.0.0.tgz#b41379433dd06f5eae805e21d631e07ee670d853"
+  integrity sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==
+  dependencies:
+    min-indent "^1.0.1"
+
 strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
@@ -23539,12 +23841,92 @@ style-loader@^2.0.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
+style-search@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
+  integrity sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==
+
 style-to-object@0.3.0, style-to-object@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-0.3.0.tgz#b1b790d205991cc783801967214979ee19a76e46"
   integrity sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==
   dependencies:
     inline-style-parser "0.1.1"
+
+stylelint-config-css-modules@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-css-modules/-/stylelint-config-css-modules-4.3.0.tgz#aa2a861f9cf30c31676013db5412c15048ca97c3"
+  integrity sha512-KvIvhzzjpcjHKkGSPkQCueoZJHrb6sZ6GCtrQb/J45HQTBVwJAeNYXaSZZK6ZQOC7NxJ4v5kLxpQLDiCK6zzgw==
+  optionalDependencies:
+    stylelint-scss "^5.0.0 || ^6.0.0"
+
+stylelint-config-recommended@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-13.0.0.tgz#c48a358cc46b629ea01f22db60b351f703e00597"
+  integrity sha512-EH+yRj6h3GAe/fRiyaoO2F9l9Tgg50AOFhaszyfov9v6ayXJ1IkSHwTxd7lB48FmOeSGDPLjatjO11fJpmarkQ==
+
+stylelint-config-standard@^34.0.0:
+  version "34.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-34.0.0.tgz#309f3c48118a02aae262230c174282e40e766cf4"
+  integrity sha512-u0VSZnVyW9VSryBG2LSO+OQTjN7zF9XJaAJRX/4EwkmU0R2jYwmBSN10acqZisDitS0CLiEiGjX7+Hrq8TAhfQ==
+  dependencies:
+    stylelint-config-recommended "^13.0.0"
+
+"stylelint-scss@^5.0.0 || ^6.0.0":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-5.0.1.tgz#b33a6580b5734eace083cfc2cc3021225e28547f"
+  integrity sha512-n87iCRZrr2J7//I/QFsDXxFLnHKw633U4qvWZ+mOW6KDAp/HLj06H+6+f9zOuTYy+MdGdTuCSDROCpQIhw5fvQ==
+  dependencies:
+    postcss-media-query-parser "^0.2.3"
+    postcss-resolve-nested-selector "^0.1.1"
+    postcss-selector-parser "^6.0.13"
+    postcss-value-parser "^4.2.0"
+
+stylelint@^15.10.2:
+  version "15.10.2"
+  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-15.10.2.tgz#0ee5a8371d3a2e1ff27fefd48309d3ddef7c3405"
+  integrity sha512-UxqSb3hB74g4DTO45QhUHkJMjKKU//lNUAOWyvPBVPZbCknJ5HjOWWZo+UDuhHa9FLeVdHBZXxu43eXkjyIPWg==
+  dependencies:
+    "@csstools/css-parser-algorithms" "^2.3.0"
+    "@csstools/css-tokenizer" "^2.1.1"
+    "@csstools/media-query-list-parser" "^2.1.2"
+    "@csstools/selector-specificity" "^3.0.0"
+    balanced-match "^2.0.0"
+    colord "^2.9.3"
+    cosmiconfig "^8.2.0"
+    css-functions-list "^3.2.0"
+    css-tree "^2.3.1"
+    debug "^4.3.4"
+    fast-glob "^3.3.0"
+    fastest-levenshtein "^1.0.16"
+    file-entry-cache "^6.0.1"
+    global-modules "^2.0.0"
+    globby "^11.1.0"
+    globjoin "^0.1.4"
+    html-tags "^3.3.1"
+    ignore "^5.2.4"
+    import-lazy "^4.0.0"
+    imurmurhash "^0.1.4"
+    is-plain-object "^5.0.0"
+    known-css-properties "^0.27.0"
+    mathml-tag-names "^2.1.3"
+    meow "^10.1.5"
+    micromatch "^4.0.5"
+    normalize-path "^3.0.0"
+    picocolors "^1.0.0"
+    postcss "^8.4.25"
+    postcss-resolve-nested-selector "^0.1.1"
+    postcss-safe-parser "^6.0.0"
+    postcss-selector-parser "^6.0.13"
+    postcss-value-parser "^4.2.0"
+    resolve-from "^5.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
+    style-search "^0.1.0"
+    supports-hyperlinks "^3.0.0"
+    svg-tags "^1.0.0"
+    table "^6.8.1"
+    write-file-atomic "^5.0.1"
 
 stylis@4.0.13:
   version "4.0.13"
@@ -23587,6 +23969,14 @@ supports-color@^8.0.0, supports-color@^8.1.0, supports-color@^8.1.1:
   dependencies:
     has-flag "^4.0.0"
 
+supports-hyperlinks@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz#c711352a5c89070779b4dad54c05a2f14b15c94b"
+  integrity sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==
+  dependencies:
+    has-flag "^4.0.0"
+    supports-color "^7.0.0"
+
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
@@ -23601,6 +23991,11 @@ svg-pathdata@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/svg-pathdata/-/svg-pathdata-6.0.3.tgz#80b0e0283b652ccbafb69ad4f8f73e8d3fbf2cac"
   integrity sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==
+
+svg-tags@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"
+  integrity sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==
 
 svgo@^3.0.2:
   version "3.0.2"
@@ -23648,6 +24043,17 @@ table@^6.0.9:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/table/-/table-6.8.0.tgz#87e28f14fa4321c3377ba286f07b79b281a3b3ca"
   integrity sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==
+  dependencies:
+    ajv "^8.0.1"
+    lodash.truncate "^4.4.2"
+    slice-ansi "^4.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
+
+table@^6.8.1:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.8.1.tgz#ea2b71359fe03b017a5fbc296204471158080bdf"
+  integrity sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==
   dependencies:
     ajv "^8.0.1"
     lodash.truncate "^4.4.2"
@@ -24094,6 +24500,11 @@ trim-newlines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
   integrity sha512-Nm4cF79FhSTzrLKGDMi3I4utBtFv8qKy4sq1enftf2gMdpqI8oVQTAfySkTz5r49giVzDj88SVZXP4CeYQwjaw==
 
+trim-newlines@^4.0.2:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-4.1.1.tgz#28c88deb50ed10c7ba6dc2474421904a00139125"
+  integrity sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==
+
 trim-trailing-lines@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz#bd4abbec7cc880462f10b2c8b5ce1d8d1ec7c2c0"
@@ -24239,6 +24650,11 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^1.0.1, type-fest@^1.2.1, type-fest@^1.2.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
+  integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
 type-fest@^2.14.0, type-fest@^2.19.0:
   version "2.19.0"
@@ -25514,6 +25930,14 @@ write-file-atomic@^4.0.1, write-file-atomic@^4.0.2:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
+write-file-atomic@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-5.0.1.tgz#68df4717c55c6fa4281a7860b4c2ba0a6d2b11e7"
+  integrity sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==
+  dependencies:
+    imurmurhash "^0.1.4"
+    signal-exit "^4.0.1"
+
 ws@^7.2.0, ws@^7.4.6, ws@^7.5.0:
   version "7.5.9"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
@@ -25639,7 +26063,7 @@ yargs-parser@^18.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^20.2.2, yargs-parser@^20.2.7:
+yargs-parser@^20.2.2, yargs-parser@^20.2.7, yargs-parser@^20.2.9:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==


### PR DESCRIPTION
# How to test

```
yarn && yarn stylelint "(enterprise|frontend)/**/*.css"
```

# Description

We rely on standard config from stylelint mostly.
Stylelint check is added as a pre-commit hook, so if you touch `.css` files and break it, you'll notice.

- Add stylelint for css
- Enable rule 'color-hex-length'
- Enable rule 'font-family-name-quotes'
- Enable rule 'length-zero-no-unit'
- Enable rule 'comment-whitespace-inside'
- Enable rule 'selector-pseudo-element-colon-notation'
- Enable rule 'shorthand-property-no-redundant-values'
- Enable rule 'declaration-empty-line-before'
- Enable rule 'no-duplicate-selectors'
- Enable rule 'declaration-block-no-duplicate-properties'
- Enable rule 'at-rule-empty-line-before'
- Enable rule 'custom-property-empty-line-before'
- Enable rule 'comment-empty-line-before'
- Enable rule 'rule-empty-line-before'
- Enable rule 'media-query-no-invalid'
- Enable rule 'media-feature-range-notation'
- Enable rule 'declaration-block-no-redundant-longhand-properties'
- Enable rule 'declaration-block-no-redundant-longhand-properties'