### PR TITLE
available_models should not take models into account

### DIFF
--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -336,7 +336,8 @@
 (mu/defn query-model-set :- [:set SearchableModel]
   "Queries all models with respect to query for one result to see if we get a result or not"
   [search-ctx :- SearchContext]
-  (let [model-queries (for [model (search.filter/search-context->applicable-models search.config/all-models search-ctx)]
+  (let [model-queries (for [model (search.filter/search-context->applicable-models
+                                   (assoc search-ctx :models search.config/all-models))]
                         {:nest (sql.helpers/limit (search-query-for-model model search-ctx) 1)})
         query         (when (pos-int? (count model-queries))
                         {:select [:*]
@@ -438,7 +439,7 @@
                  (some? limit)       (assoc :limit-int limit)
                  (some? offset)      (assoc :offset-int offset)
                  (some? verified)    (assoc :verified verified))]
-    (assoc ctx :models (search.filter/search-context->applicable-models models ctx))))
+    (assoc ctx :models (search.filter/search-context->applicable-models ctx))))
 
 (api/defendpoint GET "/models"
   "Get the set of models that a search query will return"

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -336,7 +336,7 @@
 (mu/defn query-model-set :- [:set SearchableModel]
   "Queries all models with respect to query for one result to see if we get a result or not"
   [search-ctx :- SearchContext]
-  (let [model-queries (for [model (:models search-ctx)]
+  (let [model-queries (for [model (search.filter/->applicable-models search.config/all-models search-ctx)]
                         {:nest (sql.helpers/limit (search-query-for-model model search-ctx) 1)})
         query         (when (pos-int? (count model-queries))
                         {:select [:*]
@@ -438,7 +438,7 @@
                  (some? limit)       (assoc :limit-int limit)
                  (some? offset)      (assoc :offset-int offset)
                  (some? verified)    (assoc :verified verified))]
-    (assoc ctx :models (search.filter/search-context->applicable-models ctx))))
+    (assoc ctx :models (search.filter/->applicable-models models ctx))))
 
 (api/defendpoint GET "/models"
   "Get the set of models that a search query will return"

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -336,7 +336,7 @@
 (mu/defn query-model-set :- [:set SearchableModel]
   "Queries all models with respect to query for one result to see if we get a result or not"
   [search-ctx :- SearchContext]
-  (let [model-queries (for [model (search.filter/->applicable-models search.config/all-models search-ctx)]
+  (let [model-queries (for [model (search.filter/search-context->applicable-models search.config/all-models search-ctx)]
                         {:nest (sql.helpers/limit (search-query-for-model model search-ctx) 1)})
         query         (when (pos-int? (count model-queries))
                         {:select [:*]
@@ -438,7 +438,7 @@
                  (some? limit)       (assoc :limit-int limit)
                  (some? offset)      (assoc :offset-int offset)
                  (some? verified)    (assoc :verified verified))]
-    (assoc ctx :models (search.filter/->applicable-models models ctx))))
+    (assoc ctx :models (search.filter/search-context->applicable-models models ctx))))
 
 (api/defendpoint GET "/models"
   "Get the set of models that a search query will return"

--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -156,8 +156,9 @@
   "Returns a set of models that are applicable given the search context.
 
   If the context has optional filters, the models will be restricted for the set of supported models only."
-  [models :- [:set SearchableModel] search-context :- SearchContext]
+  [search-context :- SearchContext]
   (let [{:keys [created-by
+                models
                 verified]} search-context]
     (cond-> models
       (some? created-by) (set/intersection (:created-by (feature->supported-models)))

--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -152,8 +152,8 @@
 ;;                                        Public functions                                         ;;
 ;; ------------------------------------------------------------------------------------------------;;
 
-(mu/defn ->applicable-models :- [:set SearchableModel]
-  "Returns a set of models that are applicable for the search context.
+(mu/defn search-context->applicable-models :- [:set SearchableModel]
+  "Returns a set of models that are applicable given the search context.
 
   If the context has optional filters, the models will be restricted for the set of supported models only."
   [models :- [:set SearchableModel] search-context :- SearchContext]

--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -152,13 +152,12 @@
 ;;                                        Public functions                                         ;;
 ;; ------------------------------------------------------------------------------------------------;;
 
-(mu/defn search-context->applicable-models :- [:set SearchableModel]
-  "Given a search-context, retuns the list of models that can be applied to it.
+(mu/defn ->applicable-models :- [:set SearchableModel]
+  "Returns a set of models that are applicable for the search context.
 
   If the context has optional filters, the models will be restricted for the set of supported models only."
-  [search-context :- SearchContext]
+  [models :- [:set SearchableModel] search-context :- SearchContext]
   (let [{:keys [created-by
-                models
                 verified]} search-context]
     (cond-> models
       (some? created-by) (set/intersection (:created-by (feature->supported-models)))

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -37,7 +37,6 @@
 
       (is (= #{"dashboard" "dataset"}
              (search.filter/search-context->applicable-models
-
               (merge default-search-ctx
                      {:models #{"dashboard" "dataset" "table"}
                       :created-by 1})))))
@@ -50,9 +49,8 @@
 
       (is (= #{"card"}
              (search.filter/search-context->applicable-models
-
               (merge default-search-ctx
-                     {:models  #{"card" "dashboard" "dataset" "table"}
+                     {:models   #{"card" "dashboard" "dataset" "table"}
                       :verified true})))))))
 
 (def ^:private base-search-query

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -17,55 +17,43 @@
     (testing "return :models as is"
       (is (= search.config/all-models
              (search.filter/search-context->applicable-models
-              search.config/all-models
               default-search-ctx)))
 
       (is (= #{}
              (search.filter/search-context->applicable-models
-              #{}
-              default-search-ctx)))
+              (assoc default-search-ctx :models #{}))))
 
       (is (= search.config/all-models
              (search.filter/search-context->applicable-models
-              search.config/all-models
               (merge default-search-ctx
                      {:archived? true}))))))
-
-  (testing "ignores :modess from search-context"
-    (is (= search.config/all-models
-             (search.filter/search-context->applicable-models
-              search.config/all-models
-              (merge default-search-ctx
-                     {:models   #{"card"}
-                      :archived? true})))))
 
   (testing "optional filters will return intersection of support models and provided models\n"
     (testing "created by"
       (is (= #{"dashboard" "dataset" "action" "card"}
              (search.filter/search-context->applicable-models
-              search.config/all-models
               (merge default-search-ctx
                      {:created-by 1}))))
 
       (is (= #{"dashboard" "dataset"}
              (search.filter/search-context->applicable-models
-              #{"dashboard" "dataset" "table"}
+
               (merge default-search-ctx
-                     {:created-by 1})))))
+                     {:models #{"dashboard" "dataset" "table"}
+                      :created-by 1})))))
 
     (testing "verified"
       (is (= #{"card" "collection"}
              (search.filter/search-context->applicable-models
-              search.config/all-models
               (merge default-search-ctx
                      {:verified true}))))
 
-
       (is (= #{"card"}
              (search.filter/search-context->applicable-models
-              #{"card" "dashboard" "dataset" "table"}
+
               (merge default-search-ctx
-                     {:verified true})))))))
+                     {:models  #{"card" "dashboard" "dataset" "table"}
+                      :verified true})))))))
 
 (def ^:private base-search-query
   {:select [:*]

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -12,45 +12,60 @@
    :models             search.config/all-models
    :current-user-perms #{"/"}})
 
-(deftest ^:parallel search-context->applicable-models-test
+(deftest ^:parallel ->applicable-models-test
   (testing "without optional filters"
     (testing "return :models as is"
       (is (= search.config/all-models
-             (search.filter/search-context->applicable-models default-search-ctx)))
+             (search.filter/->applicable-models
+              search.config/all-models
+              default-search-ctx)))
+
       (is (= #{}
-             (search.filter/search-context->applicable-models
-              (merge default-search-ctx
-                     {:models #{}}))))
+             (search.filter/->applicable-models
+              #{}
+              default-search-ctx)))
 
       (is (= search.config/all-models
-             (search.filter/search-context->applicable-models
+             (search.filter/->applicable-models
+              search.config/all-models
               (merge default-search-ctx
                      {:archived? true}))))))
+
+  (testing "ignores :modess from search-context"
+    (is (= search.config/all-models
+             (search.filter/->applicable-models
+              search.config/all-models
+              (merge default-search-ctx
+                     {:models   #{"card"}
+                      :archived? true})))))
 
   (testing "optional filters will return intersection of support models and provided models\n"
     (testing "created by"
       (is (= #{"dashboard" "dataset" "action" "card"}
-             (search.filter/search-context->applicable-models
+             (search.filter/->applicable-models
+              search.config/all-models
               (merge default-search-ctx
                      {:created-by 1}))))
 
       (is (= #{"dashboard" "dataset"}
-             (search.filter/search-context->applicable-models
+             (search.filter/->applicable-models
+              #{"dashboard" "dataset" "table"}
               (merge default-search-ctx
-                     {:models #{"dashboard" "dataset" "table"}
-                      :created-by 1})))))
+                     {:created-by 1})))))
 
     (testing "verified"
       (is (= #{"card" "collection"}
-             (search.filter/search-context->applicable-models
+             (search.filter/->applicable-models
+              search.config/all-models
               (merge default-search-ctx
                      {:verified true}))))
 
+
       (is (= #{"card"}
-             (search.filter/search-context->applicable-models
+             (search.filter/->applicable-models
+              #{"card" "dashboard" "dataset" "table"}
               (merge default-search-ctx
-                     {:models #{"card" "dashboard" "dataset" "table"}
-                      :verified true})))))))
+                     {:verified true})))))))
 
 (def ^:private base-search-query
   {:select [:*]

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -16,24 +16,24 @@
   (testing "without optional filters"
     (testing "return :models as is"
       (is (= search.config/all-models
-             (search.filter/->applicable-models
+             (search.filter/search-context->applicable-models
               search.config/all-models
               default-search-ctx)))
 
       (is (= #{}
-             (search.filter/->applicable-models
+             (search.filter/search-context->applicable-models
               #{}
               default-search-ctx)))
 
       (is (= search.config/all-models
-             (search.filter/->applicable-models
+             (search.filter/search-context->applicable-models
               search.config/all-models
               (merge default-search-ctx
                      {:archived? true}))))))
 
   (testing "ignores :modess from search-context"
     (is (= search.config/all-models
-             (search.filter/->applicable-models
+             (search.filter/search-context->applicable-models
               search.config/all-models
               (merge default-search-ctx
                      {:models   #{"card"}
@@ -42,27 +42,27 @@
   (testing "optional filters will return intersection of support models and provided models\n"
     (testing "created by"
       (is (= #{"dashboard" "dataset" "action" "card"}
-             (search.filter/->applicable-models
+             (search.filter/search-context->applicable-models
               search.config/all-models
               (merge default-search-ctx
                      {:created-by 1}))))
 
       (is (= #{"dashboard" "dataset"}
-             (search.filter/->applicable-models
+             (search.filter/search-context->applicable-models
               #{"dashboard" "dataset" "table"}
               (merge default-search-ctx
                      {:created-by 1})))))
 
     (testing "verified"
       (is (= #{"card" "collection"}
-             (search.filter/->applicable-models
+             (search.filter/search-context->applicable-models
               search.config/all-models
               (merge default-search-ctx
                      {:verified true}))))
 
 
       (is (= #{"card"}
-             (search.filter/->applicable-models
+             (search.filter/search-context->applicable-models
               #{"card" "dashboard" "dataset" "table"}
               (merge default-search-ctx
                      {:verified true})))))))


### PR DESCRIPTION
Discussed with @oisincoveney and he thinks that for search APIs, when we provide a list of `models`, the `available_models` from the response should be generated such that `models` from the param were not taken into account.

So this PR makes that happens.

Part of https://github.com/metabase/metabase/pull/32624