### PR TITLE
Fix styling of ParametersWidgetContainer

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.tsx
@@ -112,7 +112,8 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)<{
   flex-direction: row;
   padding-top: ${space(2)};
   padding-bottom: ${space(1)};
-  z-index: 3;
+  /* z-index should be higher than in dashcards */
+  z-index: 4;
   position: sticky;
   top: 0;
   left: 0;


### PR DESCRIPTION
Before
<img width="1514" alt="Screenshot 2023-08-09 at 18 07 51" src="https://github.com/metabase/metabase/assets/125459446/caf1564f-bcbf-4df8-9f87-714dfc5aa6ce">

After
<img width="1535" alt="Screenshot 2023-08-09 at 18 07 08" src="https://github.com/metabase/metabase/assets/125459446/0d09628e-4b1d-49bc-b331-f26f9aeffc75">
