### PR TITLE
fix `ChartSettingInputNumeric` not accepting decimals on safari

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/CharSettingInputNumeric.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/CharSettingInputNumeric.unit.spec.tsx
@@ -1,0 +1,4 @@
+// TODO
+// allow int
+// allow decimal
+// don't allow non-alphanumeric

--- a/frontend/src/metabase/visualizations/components/settings/CharSettingInputNumeric.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/CharSettingInputNumeric.unit.spec.tsx
@@ -1,4 +1,0 @@
-// TODO
-// allow int
-// allow decimal
-// don't allow non-alphanumeric

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.tsx
@@ -3,8 +3,10 @@ import * as React from "react";
 import _ from "underscore";
 import { ChartSettingNumericInput } from "./ChartSettingInputNumeric.styled";
 
+const ALLOWED_CHARS = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "."];
+
 interface ChartSettingInputProps {
-  value: number;
+  value: number | undefined;
   onChange: (value: number | undefined) => void;
   onChangeSettings: () => void;
 }
@@ -14,20 +16,25 @@ const ChartSettingInputNumeric = ({
   value,
   ...props
 }: ChartSettingInputProps) => {
-  const [internalValue, setInternalValue] = useState(value);
+  const [internalValue, setInternalValue] = useState(value?.toString() ?? "");
 
   return (
     <ChartSettingNumericInput
-      type="number"
+      type="text"
       {..._.omit(props, "onChangeSettings")}
-      error={!!internalValue && isNaN(internalValue)}
+      error={internalValue !== "" && isNaN(Number(internalValue))}
       value={internalValue}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-        const num = parseFloat(e.target.value);
-        setInternalValue(num);
+        const everyCharValid = e.target.value
+          .split("")
+          .every(char => ALLOWED_CHARS.includes(char));
+
+        if (everyCharValid) {
+          setInternalValue(e.target.value);
+        }
       }}
       onBlur={(e: React.ChangeEvent<HTMLInputElement>) => {
-        const num = parseFloat(e.target.value);
+        const num = e.target.value !== "" ? Number(e.target.value) : Number.NaN;
         if (isNaN(num)) {
           onChange(undefined);
         } else {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.tsx
@@ -3,7 +3,20 @@ import * as React from "react";
 import _ from "underscore";
 import { ChartSettingNumericInput } from "./ChartSettingInputNumeric.styled";
 
-const ALLOWED_CHARS = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "."];
+const ALLOWED_CHARS = [
+  "0",
+  "1",
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+  ".",
+  "-",
+];
 
 interface ChartSettingInputProps {
   value: number | undefined;
@@ -11,7 +24,7 @@ interface ChartSettingInputProps {
   onChangeSettings: () => void;
 }
 
-const ChartSettingInputNumeric = ({
+export const ChartSettingInputNumeric = ({
   onChange,
   value,
   ...props
@@ -44,6 +57,3 @@ const ChartSettingInputNumeric = ({
     />
   );
 };
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default ChartSettingInputNumeric;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.unit.spec.tsx
@@ -1,0 +1,76 @@
+import userEvent from "@testing-library/user-event";
+
+import { fireEvent, renderWithProviders, screen } from "__support__/ui";
+import { ChartSettingInputNumeric } from "./ChartSettingInputNumeric";
+
+function setup({
+  value,
+}: {
+  value?: number;
+} = {}) {
+  const onChange = jest.fn();
+
+  renderWithProviders(
+    <ChartSettingInputNumeric
+      value={value}
+      onChange={onChange}
+      onChangeSettings={() => null}
+    />,
+  );
+
+  const input = screen.getByRole("textbox");
+
+  return { input, onChange };
+}
+
+function type({ input, value }: { input: HTMLElement; value: string }) {
+  userEvent.clear(input);
+  userEvent.type(input, value);
+  fireEvent.blur(input);
+}
+
+describe("ChartSettingInputNumber", () => {
+  it("allows integer values", () => {
+    const { input, onChange } = setup();
+
+    type({ input, value: "123" });
+    expect(input).toHaveDisplayValue("123");
+    expect(onChange).toHaveBeenCalledWith(123);
+
+    type({ input, value: "-456" });
+    expect(input).toHaveDisplayValue("-456");
+    expect(onChange).toHaveBeenCalledWith(-456);
+  });
+
+  it("allows decimal values", () => {
+    const { input, onChange } = setup();
+
+    type({ input, value: "1.23" });
+    expect(input).toHaveDisplayValue("1.23");
+    expect(onChange).toHaveBeenCalledWith(1.23);
+
+    type({ input, value: "-4.56" });
+    expect(input).toHaveDisplayValue("-4.56");
+    expect(onChange).toHaveBeenCalledWith(-4.56);
+
+    // multiple decimal places should call onChange with
+    // undefined since it's an invalid value
+    type({ input, value: "1.2.3" });
+    expect(input).toHaveDisplayValue("1.2.3");
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it("does not allow non-alphanumeric values", () => {
+    const { input, onChange } = setup();
+
+    type({ input, value: "asdf" });
+    expect(input).toHaveDisplayValue("");
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it("renders the `value` prop on load", () => {
+    const { input } = setup({ value: 123 });
+
+    expect(input).toHaveDisplayValue("123");
+  });
+});

--- a/frontend/src/metabase/visualizations/lib/settings.js
+++ b/frontend/src/metabase/visualizations/lib/settings.js
@@ -3,7 +3,7 @@ import { getIn } from "icepick";
 import _ from "underscore";
 import ChartSettingInput from "metabase/visualizations/components/settings/ChartSettingInput";
 import ChartSettingInputGroup from "metabase/visualizations/components/settings/ChartSettingInputGroup";
-import ChartSettingInputNumeric from "metabase/visualizations/components/settings/ChartSettingInputNumeric";
+import { ChartSettingInputNumeric } from "metabase/visualizations/components/settings/ChartSettingInputNumeric";
 import ChartSettingRadio from "metabase/visualizations/components/settings/ChartSettingRadio";
 import ChartSettingSelect from "metabase/visualizations/components/settings/ChartSettingSelect";
 import ChartSettingToggle from "metabase/visualizations/components/settings/ChartSettingToggle";


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/28402

### Description

Decimals were not being accepted on numeric inputs for column settings in Safari. Safari handles typing a `.` character into a input with `type="number"` differently than Firefox and Chrome. The latter two will trigger the change event on the next digit input after the `.` with the correct value. Safari will instead trigger the input with an empty string as the value.

<img width="407" alt="image" src="https://github.com/metabase/metabase/assets/37751258/a0634d41-e12d-418f-809e-dadd000cd6bf">
<img width="345" alt="image" src="https://github.com/metabase/metabase/assets/37751258/aea220db-36a7-4201-8c6f-16d4421342b0">


To fix this issue, we made this input of `type="text"` instead, and adding the correct parsing and validation to accommodate this change.

### How to verify

1. New question -> Orders
2. Click on a column settings for a numeric field like tax
3. Go the "multiply by a number" field, and confirm it can accept a decimal on Safari.

### Demo

https://github.com/metabase/metabase/assets/37751258/9aced495-1154-494c-a4f3-9160da9a98bd

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
