### PR TITLE
Extract styled components from `NativeQueryEditor`

### DIFF
--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -45,7 +45,7 @@ export function openNativeEditor({
  */
 export function runNativeQuery({ wait = true } = {}) {
   cy.intercept("POST", "api/dataset").as("dataset");
-  cy.get(".NativeQueryEditor .Icon-play").click();
+  cy.findByTestId("native-query-editor-container").icon("play").click();
 
   if (wait) {
     cy.wait("@dataset");

--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -548,7 +548,7 @@ describe("scenarios > models", () => {
       openNativeEditor().type("select * from {{#1}}", {
         parseSpecialCharSequences: false,
       });
-      cy.get(".NativeQueryEditor .Icon-play").click();
+      cy.findByTestId("native-query-editor-container").icon("play").click();
       cy.wait("@query");
       cy.findByTestId("TableInteractive-root").within(() => {
         cy.findByText("USER_ID");

--- a/e2e/test/scenarios/models/reproductions/22517-add-remove-column-drops-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/22517-add-remove-column-drops-metadata.cy.spec.js
@@ -43,7 +43,7 @@ describe("issue 22517", () => {
         ", case when quantity > 4 then 'large' else 'small' end size ",
     );
 
-    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.findByTestId("native-query-editor-container").icon("play").click();
     cy.wait("@dataset");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/native-filters/helpers/e2e-sql-filter-helpers.js
+++ b/e2e/test/scenarios/native-filters/helpers/e2e-sql-filter-helpers.js
@@ -73,7 +73,7 @@ export function toggleRequired() {
  * @param {string} [xhrAlias ="dataset"]
  */
 export function runQuery(xhrAlias = "dataset") {
-  cy.get(".NativeQueryEditor .Icon-play").click();
+  cy.findByTestId("native-query-editor-container").icon("play").click();
   cy.wait("@" + xhrAlias);
   cy.icon("play").should("not.exist");
 }

--- a/e2e/test/scenarios/native-filters/reproductions/14145.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/reproductions/14145.cy.spec.js
@@ -56,7 +56,7 @@ describe.skip("issue 14145", () => {
       .contains("Category");
 
     // Rerun the query and assert on the dimension (field-id) that didn't change
-    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.findByTestId("native-query-editor-container").icon("play").click();
 
     cy.wait("@dataset").then(xhr => {
       const { dimension } =

--- a/e2e/test/scenarios/native/native-mongo.cy.spec.js
+++ b/e2e/test/scenarios/native/native-mongo.cy.spec.js
@@ -31,7 +31,7 @@ describe("scenarios > question > native > mongo", { tags: "@external" }, () => {
       .type(`[ { $count: "Total" } ]`, {
         parseSpecialCharSequences: false,
       });
-    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.findByTestId("native-query-editor-container").icon("play").click();
 
     cy.wait("@dataset");
 

--- a/e2e/test/scenarios/native/native-mysql.cy.spec.js
+++ b/e2e/test/scenarios/native/native-mysql.cy.spec.js
@@ -19,7 +19,7 @@ describe("scenatios > question > native > mysql", { tags: "@external" }, () => {
         parseSpecialCharSequences: false,
       },
     );
-    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.findByTestId("native-query-editor-container").icon("play").click();
 
     cy.wait("@dataset");
 
@@ -30,7 +30,7 @@ describe("scenatios > question > native > mysql", { tags: "@external" }, () => {
     // Filter by Product ID = 1 (its category is Gizmo)
     cy.findByPlaceholderText(/Id/i).click().type("1");
 
-    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.findByTestId("native-query-editor-container").icon("play").click();
 
     cy.get("@queryPreview").contains("Widget").should("not.exist");
 
@@ -41,7 +41,7 @@ describe("scenatios > question > native > mysql", { tags: "@external" }, () => {
     openNativeEditor({ databaseName: MYSQL_DB_NAME }).type(
       `SELECT * FROM ORDERS`,
     );
-    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.findByTestId("native-query-editor-container").icon("play").click();
 
     cy.wait("@dataset");
     cy.findByTextEnsureVisible("SUBTOTAL");

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -188,7 +188,11 @@ describe("scenarios > question > native", () => {
 
   it("should be able to add new columns after hiding some (metabase#15393)", () => {
     openNativeEditor().type("select 1 as visible, 2 as hidden");
-    cy.get(".NativeQueryEditor .Icon-play").as("runQuery").click();
+    cy.findByTestId("native-query-editor-container")
+      .icon("play")
+      .as("runQuery")
+      .click();
+
     cy.findByTestId("viz-settings-button").click();
     cy.findByTestId("sidebar-left")
       .as("sidebar")

--- a/e2e/test/scenarios/native/reproductions/16886.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/16886.cy.spec.js
@@ -20,7 +20,7 @@ describe("issue 16886", () => {
       { delay: 50 },
     );
 
-    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.findByTestId("native-query-editor-container").icon("play").click();
 
     cy.get(".ScalarValue").invoke("text").should("eq", "1");
 

--- a/e2e/test/scenarios/native/reproductions/21597-query-build-card-save-modal.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/21597-query-build-card-save-modal.cy.spec.js
@@ -46,19 +46,19 @@ describe("issue 21597", { tags: "@external" }, () => {
       cy.findByText("Category").click();
     });
 
-    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.findByTestId("native-query-editor-container").icon("play").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("200");
 
     // Change DB
     // and re-run the native query
-    cy.get(".NativeQueryEditor .GuiBuilder-section")
+    cy.findByTestId("native-query-editor-container")
       .findByText("Sample Database")
       .click();
     popover().within(() => {
       cy.findByText(databaseCopyName).click();
     });
-    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.findByTestId("native-query-editor-container").icon("play").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains(
       `Failed to fetch Field ${PRODUCTS.CATEGORY}: Field does not exist, or belongs to a different Database.`,

--- a/e2e/test/scenarios/native/reproductions/32121-sql-source-query-can-explore-results.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/32121-sql-source-query-can-explore-results.cy.spec.js
@@ -21,7 +21,7 @@ describe("issue 32121", () => {
 
       // Run the query.
       cy.intercept("POST", "/api/dataset").as("dataset");
-      cy.get(".NativeQueryEditor .Icon-play").click();
+      cy.findByTestId("native-query-editor-container").icon("play").click();
       cy.wait("@dataset");
       cy.findByTestId("question-row-count").contains(
         "Showing first 2,000 rows",
@@ -58,7 +58,7 @@ describe("issue 32121", () => {
       cy.get(".Modal").should("not.exist");
 
       cy.intercept("POST", "/api/dataset").as("dataset");
-      cy.get(".NativeQueryEditor .Icon-play").click();
+      cy.findByTestId("native-query-editor-container").icon("play").click();
       cy.wait("@dataset");
 
       saveQuestion("all Orders");

--- a/e2e/test/scenarios/native/snippets/snippets.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets/snippets.cy.spec.js
@@ -36,7 +36,7 @@ describe("scenarios > question > snippets", () => {
     cy.get("@editor").contains("select {{snippet: stuff-snippet}}");
 
     // Run the query and check the value
-    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.findByTestId("native-query-editor-container").icon("play").click();
     cy.get(".ScalarValue").contains("stuff");
   });
 
@@ -77,7 +77,7 @@ describe("scenarios > question > snippets", () => {
     cy.get("@editor").contains("select {{snippet: Math}}");
 
     // Run the query and check the new value
-    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.findByTestId("native-query-editor-container").icon("play").click();
     cy.get(".ScalarValue").contains("2");
   });
 
@@ -139,7 +139,7 @@ describe("scenarios > question > snippets", () => {
       /^select \* from {{snippet: Table: Reviews}} limit 1$/,
     );
     // Rerun the query
-    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.findByTestId("native-query-editor-container").icon("play").click();
     cy.get("@results").contains(/christ/i);
   });
 });

--- a/e2e/test/scenarios/question/reproductions/9027-new-questions-not-in-saved-questions-immediately.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/9027-new-questions-not-in-saved-questions-immediately.cy.spec.js
@@ -25,7 +25,7 @@ describe("issue 9027", () => {
     openNativeEditor({ fromCurrentPage: true });
 
     cy.get(".ace_content").type("select 0");
-    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.findByTestId("native-query-editor-container").icon("play").click();
 
     saveQuestion(QUESTION_NAME);
   });

--- a/e2e/test/scenarios/visualizations/maps.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/maps.cy.spec.js
@@ -22,7 +22,7 @@ describe("scenarios > visualizations > maps", () => {
     openNativeEditor().type(
       "select -80 as lng, 40 as lat union all select -120 as lng, 40 as lat",
     );
-    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.findByTestId("native-query-editor-container").icon("play").click();
 
     // switch to a pin map visualization
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/visualizations/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/table.cy.spec.js
@@ -50,7 +50,7 @@ describe("scenarios > visualizations > table", () => {
 
   it("should allow you to reorder columns in the table header", () => {
     openNativeEditor().type("select * from orders LIMIT 2");
-    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.findByTestId("native-query-editor-container").icon("play").click();
 
     cy.findByTestId("viz-settings-button").click();
 
@@ -241,7 +241,7 @@ describe("scenarios > visualizations > table", () => {
 
   it("should show field metadata popovers for native query tables", () => {
     openNativeEditor().type("select * from products");
-    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.findByTestId("native-query-editor-container").icon("play").click();
 
     cy.get(".cellData").contains("CATEGORY").trigger("mouseenter");
     popover().within(() => {

--- a/e2e/test/scenarios/visualizations/waterfall.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/waterfall.cy.spec.js
@@ -47,7 +47,7 @@ describe("scenarios > visualizations > waterfall", () => {
     openNativeEditor().type(
       "select 'A' as product, 10 as profit union select 'B' as product, -4 as profit",
     );
-    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.findByTestId("native-query-editor-container").icon("play").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Visualization").click();
     cy.icon("waterfall").click();
@@ -60,7 +60,7 @@ describe("scenarios > visualizations > waterfall", () => {
       "select 1 as X, 20 as Y union select 2 as X, -10 as Y",
     );
 
-    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.findByTestId("native-query-editor-container").icon("play").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Visualization").click();
     switchToWaterfallDisplay();
@@ -87,7 +87,7 @@ describe("scenarios > visualizations > waterfall", () => {
     openNativeEditor().type(
       "select 1 as X, 10 as Y union select 2 as X, -2 as Y",
     );
-    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.findByTestId("native-query-editor-container").icon("play").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Visualization").click();
     switchToWaterfallDisplay();
@@ -278,7 +278,7 @@ describe("scenarios > visualizations > waterfall", () => {
       cy.signInAsNormalUser();
 
       openNativeEditor().type("select 'A' as X, -4.56 as Y");
-      cy.get(".NativeQueryEditor .Icon-play").click();
+      cy.findByTestId("native-query-editor-container").icon("play").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Visualization").click();
       switchToWaterfallDisplay();

--- a/frontend/src/metabase/css/query_builder.css
+++ b/frontend/src/metabase/css/query_builder.css
@@ -375,12 +375,6 @@
   top: -0.8rem;
 }
 
-/* NATIVE */
-
-.NativeQueryEditor .GuiBuilder-data {
-  border-right: none;
-}
-
 /* VISUALIZATION SETTINGS */
 
 .VisualizationSettings .GuiBuilder-section {

--- a/frontend/src/metabase/css/query_builder.css
+++ b/frontend/src/metabase/css/query_builder.css
@@ -381,24 +381,6 @@
   border-right: none;
 }
 
-.NativeQueryEditorDragHandleWrapper {
-  position: absolute;
-  height: 8px;
-  width: 100%;
-  bottom: -4px;
-  cursor: row-resize;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-.NativeQueryEditorDragHandle {
-  background: color-mod(var(--color-border) blackness(3%));
-  width: 100px;
-  height: 5px;
-  border-radius: 4px;
-}
-
 /* VISUALIZATION SETTINGS */
 
 .VisualizationSettings .GuiBuilder-section {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.css
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.css
@@ -1,9 +1,9 @@
 .ace_editor.ace_autocomplete {
   border: none;
-  box-shadow: 0 2px 3px 2px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 2px 3px 2px var(--color-shadow);
   border-radius: 4px;
-  background-color: white;
-  color: #4c5773;
+  background-color: var(--color-white);
+  color: var(--color-text-dark);
   width: 520px;
 }
 

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.css
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.css
@@ -1,3 +1,9 @@
+/*
+  Ace autocompletion styles are hard to migrate to CSS-in-JS
+  because the popover is rendered at the top level of the DOM,
+  outside of the NativeQueryEditor component.
+*/
+
 .ace_editor.ace_autocomplete {
   border: none;
   box-shadow: 0 2px 3px 2px var(--color-shadow);

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.jsx
@@ -587,7 +587,7 @@ export class NativeQueryEditor extends Component {
 
     return (
       <NativeQueryEditorRoot
-        className="NativeQueryEditor bg-light full"
+        className="NativeQueryEditor"
         data-testid="native-query-editor-container"
       >
         {hasTopBar && (

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.jsx
@@ -2,9 +2,7 @@
 /* eslint-disable react/prop-types */
 import { t } from "ttag";
 import { createRef, Component } from "react";
-import { ResizableBox } from "react-resizable";
 import { connect } from "react-redux";
-import cx from "classnames";
 import _ from "underscore";
 import slugg from "slugg";
 
@@ -23,6 +21,7 @@ import "ace/snippets/pgsql";
 import "ace/snippets/sqlserver";
 import "ace/snippets/json";
 
+import { Flex } from "metabase/ui";
 import ExplicitSize from "metabase/components/ExplicitSize";
 import Modal from "metabase/components/Modal";
 
@@ -59,9 +58,11 @@ import DataSourceSelectors from "./DataSourceSelectors";
 import NativeQueryEditorPrompt from "./NativeQueryEditorPrompt";
 
 import {
-  NativeQueryEditorRoot,
   DragHandleContainer,
   DragHandle,
+  EditorRoot,
+  NativeQueryEditorRoot,
+  StyledResizableBox,
 } from "./NativeQueryEditor.styled";
 import "./NativeQueryEditor.css";
 
@@ -591,7 +592,7 @@ export class NativeQueryEditor extends Component {
         data-testid="native-query-editor-container"
       >
         {hasTopBar && (
-          <div className="flex align-center" data-testid="native-query-top-bar">
+          <Flex align="center" data-testid="native-query-top-bar">
             {canChangeDatabase && (
               <div className={!isNativeEditorOpen ? "hide sm-show" : ""}>
                 <DataSourceSelectors
@@ -620,7 +621,7 @@ export class NativeQueryEditor extends Component {
                 toggleEditor={this.toggleEditor}
               />
             )}
-          </div>
+          </Flex>
         )}
         {isPromptInputVisible && (
           <NativeQueryEditorPrompt
@@ -629,9 +630,9 @@ export class NativeQueryEditor extends Component {
             onClose={this.togglePromptVisibility}
           />
         )}
-        <ResizableBox
+        <StyledResizableBox
           ref={this.resizeBox}
-          className={cx("border-top flex ", { hide: !isNativeEditorOpen })}
+          isOpen={isNativeEditorOpen}
           height={this.state.initialHeight}
           minConstraints={[Infinity, getEditorLineHeight(MIN_HEIGHT_LINES)]}
           axis="y"
@@ -647,10 +648,9 @@ export class NativeQueryEditor extends Component {
           }}
         >
           <>
-            <div
-              className="flex-full"
-              data-testid="native-query-editor"
+            <EditorRoot
               id={ACE_ELEMENT_ID}
+              data-testid="native-query-editor"
               ref={this.editor}
             />
 
@@ -689,7 +689,7 @@ export class NativeQueryEditor extends Component {
               />
             )}
           </>
-        </ResizableBox>
+        </StyledResizableBox>
       </NativeQueryEditorRoot>
     );
   }

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.jsx
@@ -587,10 +587,7 @@ export class NativeQueryEditor extends Component {
     );
 
     return (
-      <NativeQueryEditorRoot
-        className="NativeQueryEditor"
-        data-testid="native-query-editor-container"
-      >
+      <NativeQueryEditorRoot data-testid="native-query-editor-container">
         {hasTopBar && (
           <Flex align="center" data-testid="native-query-top-bar">
             {canChangeDatabase && (

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.jsx
@@ -58,7 +58,11 @@ import DataSourceSelectors from "./DataSourceSelectors";
 
 import NativeQueryEditorPrompt from "./NativeQueryEditorPrompt";
 
-import { NativeQueryEditorRoot } from "./NativeQueryEditor.styled";
+import {
+  NativeQueryEditorRoot,
+  DragHandleContainer,
+  DragHandle,
+} from "./NativeQueryEditor.styled";
 import "./NativeQueryEditor.css";
 
 const AUTOCOMPLETE_DEBOUNCE_DURATION = 700;
@@ -572,9 +576,9 @@ export class NativeQueryEditor extends Component {
     const parameters = query.question().parameters();
 
     const dragHandle = resizable ? (
-      <div className="NativeQueryEditorDragHandleWrapper">
-        <div className="NativeQueryEditorDragHandle" />
-      </div>
+      <DragHandleContainer>
+        <DragHandle />
+      </DragHandleContainer>
     ) : null;
 
     const canSaveSnippets = snippetCollections.some(

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.jsx
@@ -594,16 +594,14 @@ export class NativeQueryEditor extends Component {
         {hasTopBar && (
           <Flex align="center" data-testid="native-query-top-bar">
             {canChangeDatabase && (
-              <div className={!isNativeEditorOpen ? "hide sm-show" : ""}>
-                <DataSourceSelectors
-                  isNativeEditorOpen={isNativeEditorOpen}
-                  query={query}
-                  readOnly={readOnly}
-                  setDatabaseId={this.setDatabaseId}
-                  setTableId={this.setTableId}
-                  editorContext={editorContext}
-                />
-              </div>
+              <DataSourceSelectors
+                isNativeEditorOpen={isNativeEditorOpen}
+                query={query}
+                readOnly={readOnly}
+                setDatabaseId={this.setDatabaseId}
+                setTableId={this.setTableId}
+                editorContext={editorContext}
+              />
             )}
             {hasParametersList && (
               <ResponsiveParametersList
@@ -615,7 +613,6 @@ export class NativeQueryEditor extends Component {
             )}
             {query.hasWritePermission() && this.props.setIsNativeEditorOpen && (
               <VisibilityToggler
-                className={!isNativeEditorOpen ? "hide sm-show" : ""}
                 isOpen={isNativeEditorOpen}
                 readOnly={!!readOnly}
                 toggleEditor={this.toggleEditor}

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.styled.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
-import { color } from "metabase/lib/colors";
+import { color, darken } from "metabase/lib/colors";
 
 const aceEditorStyle = css`
   .ace_editor {
@@ -94,4 +94,25 @@ const aceEditorStyle = css`
 
 export const NativeQueryEditorRoot = styled.div`
   ${aceEditorStyle}
+`;
+
+export const DragHandleContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  height: 8px;
+
+  position: absolute;
+  bottom: -4px;
+
+  cursor: row-resize;
+`;
+
+export const DragHandle = styled.div`
+  width: 100px;
+  height: 5px;
+  background-color: ${darken("border", 0.03)};
+  border-radius: 4px;
 `;

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.styled.tsx
@@ -93,7 +93,14 @@ const aceEditorStyle = css`
 `;
 
 export const NativeQueryEditorRoot = styled.div`
+  width: 100%;
+  background-color: ${color("bg-light")};
+
   ${aceEditorStyle}
+
+  .GuiBuilder-data {
+    border-right: none;
+  }
 `;
 
 export const DragHandleContainer = styled.div`

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.styled.tsx
@@ -1,3 +1,4 @@
+import { ResizableBox } from "react-resizable";
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import { color, darken } from "metabase/lib/colors";
@@ -122,4 +123,15 @@ export const DragHandle = styled.div`
   height: 5px;
   background-color: ${darken("border", 0.03)};
   border-radius: 4px;
+`;
+
+export const EditorRoot = styled.div`
+  flex: 1 0 auto;
+`;
+
+export const StyledResizableBox = styled(ResizableBox)<{
+  isOpen: boolean;
+}>`
+  display: ${props => (props.isOpen ? "flex" : "none")};
+  border-top: 1px solid ${color("border")};
 `;

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.styled.tsx
@@ -1,7 +1,8 @@
 import styled from "@emotion/styled";
+import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
 
-export const NativeQueryEditorRoot = styled.div`
+const aceEditorStyle = css`
   .ace_editor {
     height: 100%;
     background-color: ${color("bg-light")};
@@ -89,4 +90,8 @@ export const NativeQueryEditorRoot = styled.div`
   .ace_editor .ace_gutter {
     background-color: ${color("bg-light")};
   }
+`;
+
+export const NativeQueryEditorRoot = styled.div`
+  ${aceEditorStyle}
 `;


### PR DESCRIPTION
Migrates CSS classes to emotion components wherever possible in the `NativeQueryEditor`. No functional or visual changes expected