### PR TITLE
Add column rename via popover test

### DIFF
--- a/e2e/test/scenarios/visualizations/table-column-settings.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/table-column-settings.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "e2e/support/helpers";
+import { popover, restore } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS_ID, ORDERS, PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
@@ -169,6 +169,26 @@ describe("scenarios > visualizations > table column settings", () => {
       additionalColumns().findByText("Tax").should("not.exist");
       scrollVisualization();
       visualization().findByText("Tax").should("exist");
+    });
+
+    it("should be able to rename table columns via popover", () => {
+      cy.createQuestion(tableQuestion, { visitQuestion: true });
+
+      cy.findByTestId("TableInteractive-root").within(() => {
+        cy.findByText("Product ID").click();
+      });
+
+      popover().within(() => {
+        cy.icon("gear").click();
+        cy.findByDisplayValue("Product ID").clear().type("prod_id");
+      });
+
+      // clicking outside of the popover to close it
+      cy.findByTestId("app-bar").click();
+
+      cy.findByTestId("TableInteractive-root").within(() => {
+        cy.findByText("prod_id");
+      });
     });
 
     it("should be able to show and hide table fields with in a join", () => {


### PR DESCRIPTION
relates to #14401 

### Description

Adding a repro for column renaming  popover behavior. It was reported as broken previously, but seems to be working now. I couldn't find any test coverage for it, so am just adding the test for this here..

### How to verify

- in table visualization, rename any column from he column header
- click outside the popover to save it
- see that the column actually renames

### Demo

![save_click_outside](https://github.com/metabase/metabase/assets/30528226/81a36926-6f28-4960-a23a-e17833367572)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
