### PR TITLE
Make sure filter button only appears when search bar is open

### DIFF
--- a/frontend/src/metabase/nav/components/SearchBar.tsx
+++ b/frontend/src/metabase/nav/components/SearchBar.tsx
@@ -194,16 +194,19 @@ function SearchBarView({ location, onSearchActive, onSearchInactive }: Props) {
           onKeyPress={handleInputKeyPress}
           ref={searchInput}
         />
-        <SearchFunnelButton
-          icon="filter"
-          data-is-filtered={isFiltered}
-          data-testid="search-bar-filter-button"
-          isFiltered={isFiltered}
-          onClick={e => {
-            e.stopPropagation();
-            setIsFilterModalOpen(true);
-          }}
-        />
+
+        {(!isSmallScreen() || isActive) && (
+          <SearchFunnelButton
+            icon="filter"
+            data-is-filtered={isFiltered}
+            data-testid="search-bar-filter-button"
+            isFiltered={isFiltered}
+            onClick={e => {
+              e.stopPropagation();
+              setIsFilterModalOpen(true);
+            }}
+          />
+        )}
         {isSmallScreen() && isActive && (
           <CloseSearchButton onClick={handleClickOnClose}>
             <Icon name="close" />

--- a/frontend/src/metabase/nav/components/SearchBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/SearchBar.unit.spec.tsx
@@ -17,6 +17,7 @@ import {
 import { CollectionItem, RecentItem } from "metabase-types/api";
 import SearchBar from "metabase/nav/components/SearchBar";
 import { checkNotNull } from "metabase/core/utils/types";
+import * as domUtils from "metabase/lib/dom";
 
 const TEST_SEARCH_RESULTS: CollectionItem[] = [
   "Card ABC",
@@ -94,6 +95,34 @@ describe("SearchBar", () => {
       );
 
       expect(screen.getByText("Didn't find anything")).toBeInTheDocument();
+    });
+  });
+
+  describe("rendering filter button with screen size", () => {
+    it("should not render filter button on small screens", () => {
+      const isSmallScreenMock = jest.spyOn(domUtils, "isSmallScreen");
+      isSmallScreenMock.mockReturnValue(true);
+
+      setup();
+
+      expect(
+        screen.queryByTestId("search-bar-filter-button"),
+      ).not.toBeInTheDocument();
+
+      isSmallScreenMock.mockRestore();
+    });
+
+    it("should render filter button on large screens", () => {
+      const isSmallScreenMock = jest.spyOn(domUtils, "isSmallScreen");
+      isSmallScreenMock.mockReturnValue(false);
+
+      setup();
+
+      expect(
+        screen.getByTestId("search-bar-filter-button"),
+      ).toBeInTheDocument();
+
+      isSmallScreenMock.mockRestore();
     });
   });
 


### PR DESCRIPTION
Quick bug fix for #32742 

### Description

In Stats the filter button is covering the search button, so you can't search on a small screen.
<img width="505" alt="image" src="https://github.com/metabase/metabase/assets/25306947/779ea3c8-9bfc-48e0-9f4f-c60d791b2a88">

After the fix
<img width="419" alt="image" src="https://github.com/metabase/metabase/assets/25306947/e6b1040b-d4a1-4462-a8f5-6a53f564aa6f">


### How to verify

Check stats to verify that the filter button is covering the search icon. Then check this PR to show that it's fixed.