### PR TITLE
Fix a question suffix created when deep copying a dashboard with question

### DIFF
--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -277,7 +277,7 @@
                           (api.card/create-card!
                            (cond-> (assoc card :collection_id dest-coll-id)
                              same-collection?
-                             (update :name #(str % " -- " (tru "Duplicate"))))
+                             (update :name #(str % " - " (tru "Duplicate"))))
                            ;; creating cards from a transaction. wait until tx complete to signal event
                            true))))
             {:copied {}

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1123,10 +1123,10 @@
               ;; original 3 plust 3 duplicates
               (is (= 6 (count cards-in-coll)) "Not all cards were copied")
               (is (= (into #{} (comp (map :name)
-                                     (mapcat (fn [n] [n (str n " -- Duplicate")])))
+                                     (mapcat (fn [n] [n (str n " - Duplicate")])))
                            [total-card avg-card card])
                      (set (map :name cards-in-coll)))
-                  "Cards should have \"-- Duplicate\" appended"))))))))
+                  "Cards should have \"- Duplicate\" appended"))))))))
 
 (defn- ordered-cards-by-position
   "Returns dashcards for a dashboard ordered by their position instead of creation like [[dashboard/ordered-cards]] does."


### PR DESCRIPTION
Fixes #33080

### Description

This was unintentionally introduced in #25530.
Prior to fixing it, I checked with @dpsutton who confirmed that this wasn't a desired/specced behavior.

### How to verify

Follow the repro steps from the original issue and make sure duplicated questions have the following format:
`Original Name - Duplicate`

### Demo

**Before**
![image](https://github.com/metabase/metabase/assets/31325167/59cc88d9-a221-4b15-a1ac-33ae8066cc4f)

**After**
![image](https://github.com/metabase/metabase/assets/31325167/25d866af-3916-42d1-bc46-65bfc1ebbc2f)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
