### PR TITLE
docs - remove optional field

### DIFF
--- a/docs/actions/custom.md
+++ b/docs/actions/custom.md
@@ -118,37 +118,6 @@ VALUES (
 {% endraw %}
 ```
 
-### `INSERT` statement with optional fields
-
-Though if you want to make a field optional in an `INSERT` statement, you need to get a little fancy. Metabase will only run an optional statement if a value is supplied to a variable in that optional statement, so the trick here is to use a SQL comment to sneak a variable into the optional column.
-
-```
-{% raw %}
-  [[,expected_invoice -- {{ expected_invoice}}]]
-{% endraw %}
-```
-
-So a full `INSERT` statement with an optional variable would look like so (note that the optional clauses for the `{% raw %}{{ expected_invoice}}{{% endraw %}` variable are in both the column and values lists):
-
-```
-{% raw %}
-INSERT INTO invoices (
-  account_id
-  ,payment
-  [[,expected_invoice -- {{expected_invoice}}]]
-  ,plan
-  ,date_received
-)
-VALUES (
-  {{ account_id }}
-  ,{{ payment }}
-  [[,{{ expected_invoice }}]]
-  ,{{ plan }}
-  ,({{ date_received }}
-);
-{% endraw %}
-```
-
 ### Casting field values in actions
 
 If you get a type error when you submit a form, you may need to `CAST` the data type in the query so it matches the data type of the target field in the database. Here we're casting a value to a `boolean`:


### PR DESCRIPTION
Removes mention of optional values in `INSERT` actions.

See https://github.com/metabase/metabase/issues/32936.