### PR TITLE
Prefer current-join-alias to directly pulling the alias from options

### DIFF
--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -483,8 +483,8 @@
     ;; so we break ties by looking at the poisition of the field reference.
     (mbql.u.match/replace condition
       [op op-opts (lhs :guard lib.util/field-clause?) (rhs :guard lib.util/field-clause?)]
-      (let [lhs-alias (:join-alias (lib.options/options lhs))
-            rhs-alias (:join-alias (lib.options/options rhs))]
+      (let [lhs-alias (current-join-alias lhs)
+            rhs-alias (current-join-alias rhs)]
         (cond
           ;; no sides obviously belong to joined
           (not (or lhs-alias rhs-alias))


### PR DESCRIPTION
This is fixing a missed review comment from #32987.