### PR TITLE
Migrate `NativeQueryEditor` to TypeScript

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -594,19 +594,25 @@ export class NativeQueryEditor extends Component<
   };
 
   _updateSize() {
-    const doc = this._editor.getSession().getDocument();
+    const { viewHeight } = this.props;
+
+    const doc = this._editor?.getSession().getDocument();
     const element = this.resizeBox.current;
-    // set the newHeight based on the line count, but ensure it's within
-    // [MIN_HEIGHT_LINES, getMaxAutoSizeLines()]
+
+    if (!doc || !element) {
+      return;
+    }
+
     const newHeight = getEditorLineHeight(
       Math.max(
-        Math.min(doc.getLength(), getMaxAutoSizeLines()),
+        Math.min(doc.getLength(), getMaxAutoSizeLines(viewHeight)),
         MIN_HEIGHT_LINES,
       ),
     );
+
     if (newHeight > element.offsetHeight) {
-      element.style.height = newHeight + "px";
-      this._editor.resize();
+      element.style.height = `${newHeight}px`;
+      this._editor?.resize();
     }
   }
 

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -37,6 +37,7 @@ import Questions from "metabase/entities/questions";
 
 import { getSetting } from "metabase/selectors/settings";
 
+import { checkNotNull } from "metabase/core/utils/types";
 import { isEventOverElement } from "metabase/lib/dom";
 import { getEngineNativeAceMode } from "metabase/lib/engine";
 import { SQLBehaviour } from "metabase/lib/ace/sql_behaviour";
@@ -405,14 +406,15 @@ export class NativeQueryEditor extends Component<
       return;
     }
 
-    this._editor = ace.edit(editorElement) as Ace.Editor;
+    const editor = checkNotNull<Ace.Editor>(ace.edit(editorElement));
+    this._editor = editor;
 
     // listen to onChange events
-    this._editor.getSession().on("change", this.onChange);
-    this._editor.getSelection().on("changeCursor", this.handleCursorChange);
+    editor.getSession().on("change", this.onChange);
+    editor.getSelection().on("changeCursor", this.handleCursorChange);
 
     const minLineNumberWidth = 20;
-    this._editor.getSession().gutterRenderer = {
+    editor.getSession().gutterRenderer = {
       getWidth: (session, lastLineNumber, config) =>
         Math.max(
           minLineNumberWidth,
@@ -423,15 +425,15 @@ export class NativeQueryEditor extends Component<
 
     // initialize the content
     this.handleQueryUpdate(query?.queryText() ?? "");
-    this._editor.renderer.setScrollMargin(SCROLL_MARGIN, SCROLL_MARGIN, 0, 0);
+    editor.renderer.setScrollMargin(SCROLL_MARGIN, SCROLL_MARGIN, 0, 0);
 
     // hmmm, this could be dangerous
     if (!this.props.readOnly) {
-      this._editor.focus();
+      editor.focus();
     }
 
     const aceLanguageTools = ace.require("ace/ext/language_tools");
-    this._editor.setOptions({
+    editor.setOptions({
       enableBasicAutocompletion: true,
       enableSnippets: false,
       enableLiveAutocompletion: true,

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -321,12 +321,21 @@ export class NativeQueryEditor extends Component<
   }
 
   cardTagIdAtCursor = ({ row, column }: Ace.Position) => {
+    if (!this._editor) {
+      return null;
+    }
     const line = this._editor.getValue().split("\n")[row];
     const matches = Array.from(line.matchAll(CARD_TAG_REGEX));
+
     const match = matches.find(
-      m => column > m.index && column < m.index + m[0].length,
+      m =>
+        typeof m.index === "number" &&
+        column > m.index &&
+        column < m.index + m[0].length,
     );
-    return parseInt(match?.[2]) || null;
+    const idStr = match?.[2];
+
+    return (idStr && parseInt(idStr)) || null;
   };
 
   handleCursorChange = _.debounce(

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -408,12 +408,7 @@ export class NativeQueryEditor extends Component<
 
     // initialize the content
     this.handleQueryUpdate(query?.queryText() ?? "");
-    this._editor.renderer.setScrollMargin(
-      SCROLL_MARGIN,
-      SCROLL_MARGIN,
-      SCROLL_MARGIN,
-      SCROLL_MARGIN,
-    );
+    this._editor.renderer.setScrollMargin(SCROLL_MARGIN, SCROLL_MARGIN, 0, 0);
 
     // hmmm, this could be dangerous
     if (!this.props.readOnly) {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -547,13 +547,19 @@ export class NativeQueryEditor extends Component<
     callback,
   ) => {
     const name = this.getSnippetNameAtCursor(pos);
+
+    if (!name) {
+      callback(null, []);
+      return;
+    }
+
     const snippets = (this.props.snippets || []).filter(snippet =>
       snippet.name.toLowerCase().includes(name.toLowerCase()),
     );
 
     callback(
       null,
-      snippets.map(({ name, description, content }) => ({
+      snippets.map(({ name }) => ({
         name,
         value: name,
       })),

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -345,7 +345,7 @@ export class NativeQueryEditor extends Component<
     100,
   );
 
-  handleKeyDown = e => {
+  handleKeyDown = (e: KeyboardEvent) => {
     const { isRunning, cancelQuery, enableRun } = this.props;
 
     if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
@@ -461,7 +461,7 @@ export class NativeQueryEditor extends Component<
 
             // Get columns from referenced questions that match the prefix
             const lowerCasePrefix = prefix.toLowerCase();
-            const isMatchForPrefix = name =>
+            const isMatchForPrefix = (name: string) =>
               name.toLowerCase().includes(lowerCasePrefix);
             const questionColumns = referencedQuestions
               .filter(Boolean)

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -573,8 +573,9 @@ export class NativeQueryEditor extends Component<
     //   - {{#123-foo|}} will fetch completions for the word "123-foo"
     //   - {{#123 foo|}} will not fetch completions because the word "foo" is not the first word in the tag.
     // Note we need to drop the leading `#` from the card tag name because the prefix only includes alphanumerics
-    if (prefix !== this.getCardTagNameAtCursor(pos).substring(1)) {
-      callback(null, null);
+    const tagNameAtCursor = this.getCardTagNameAtCursor(pos);
+    if (prefix !== tagNameAtCursor?.substring?.(1)) {
+      callback(null, []);
     }
     const apiResults = await this.props.cardAutocompleteResultsFn(prefix);
     const resultsForAce = apiResults.map(

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -484,13 +484,14 @@ export class NativeQueryEditor extends Component<
             const questionColumns = referencedQuestions
               .filter(Boolean)
               .flatMap(question =>
-                question.result_metadata
+                question
+                  .getResultMetadata()
                   .filter(columnMetadata =>
                     isMatchForPrefix(columnMetadata.name),
                   )
                   .map(columnMetadata => [
                     columnMetadata.name,
-                    `${question.name} :${columnMetadata.base_type}`,
+                    `${question.displayName()} :${columnMetadata.base_type}`,
                   ]),
               );
 

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -386,7 +386,7 @@ export class NativeQueryEditor extends Component<
       return;
     }
 
-    this._editor = ace.edit(editorElement);
+    this._editor = ace.edit(editorElement) as Ace.Editor;
 
     // listen to onChange events
     this._editor.getSession().on("change", this.onChange);

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -678,7 +678,7 @@ export class NativeQueryEditor extends Component<
   setTableId = (tableId: TableId) => {
     const { query, setDatasetQuery } = this.props;
     const table = query.metadata().table(tableId);
-    if (table && table?.name !== query.collection()) {
+    if (table && table.name !== query.collection()) {
       setDatasetQuery(query.setCollectionName(table.name));
     }
   };

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -186,10 +186,10 @@ export class NativeQueryEditor extends Component<
 
   _editor: Ace.Editor | null = null;
   _lastAutoComplete: {
-    timestamp?: number;
-    prefix?: string | null;
-    results?: AutocompleteItem[];
-  } = {};
+    timestamp: number;
+    prefix: string | null;
+    results: AutocompleteItem[];
+  } = { timestamp: 0, prefix: null, results: [] };
   _localUpdate = false;
 
   constructor(props: Props) {
@@ -458,7 +458,6 @@ export class NativeQueryEditor extends Component<
         try {
           let { results, timestamp } = this._lastAutoComplete;
           const cacheHit =
-            typeof timestamp === "number" &&
             Date.now() - timestamp < AUTOCOMPLETE_CACHE_DURATION &&
             this._lastAutoComplete.prefix === prefix;
           if (!cacheHit) {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -721,7 +721,6 @@ export class NativeQueryEditor extends Component<
       readOnly,
       isNativeEditorOpen,
       openSnippetModalWithSelectedText,
-      width,
       hasParametersList = true,
       hasTopBar = true,
       hasEditingSidebar = true,
@@ -786,10 +785,10 @@ export class NativeQueryEditor extends Component<
             onClose={this.togglePromptVisibility}
           />
         )}
+        {/* @ts-expect-error — error in resizable box types  */}
         <StyledResizableBox
           ref={this.resizeBox}
           isOpen={isNativeEditorOpen}
-          width={width}
           height={this.state.initialHeight}
           minConstraints={[Infinity, getEditorLineHeight(MIN_HEIGHT_LINES)]}
           axis="y"

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -649,10 +649,9 @@ export class NativeQueryEditor extends Component<
   };
 
   setTableId = (tableId: TableId) => {
-    // TODO: push more of this into metabase-lib?
     const { query, setDatasetQuery } = this.props;
     const table = query.metadata().table(tableId);
-    if (table?.name !== query.collection()) {
+    if (table && table?.name !== query.collection()) {
       setDatasetQuery(query.setCollectionName(table.name));
     }
   };

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -155,18 +155,7 @@ interface NativeQueryEditorState {
   isPromptInputVisible: boolean;
 }
 
-type AceCompletionsGetterCallback = (
-  _: unknown,
-  completions: Ace.Completion[] | null,
-) => void;
-
-type AceCompletionsGetter = (
-  editor: Ace.Editor,
-  session: Ace.EditSession,
-  pos: Ace.Position,
-  prefix: string,
-  callback: AceCompletionsGetterCallback,
-) => void;
+type AceCompletionsGetter = Ace.Completer["getCompletions"];
 
 export class NativeQueryEditor extends Component<
   Props,
@@ -448,7 +437,7 @@ export class NativeQueryEditor extends Component<
         _session: Ace.EditSession,
         _pos: Ace.Position,
         prefix: string,
-        callback: AceCompletionsGetterCallback,
+        callback: Ace.CompleterCallback,
       ) => {
         if (!this.props.autocompleteResultsFn) {
           return callback(null, []);

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -340,12 +340,16 @@ export class NativeQueryEditor extends Component<
 
   handleCursorChange = _.debounce(
     (e: Event, { cursor }: { cursor: Ace.Position }) => {
-      this._editor.completers = this.nextCompleters(cursor);
-      if (this.props.setNativeEditorSelectedRange) {
+      if (this._editor && this.nextCompleters) {
+        this._editor.completers = this.nextCompleters(cursor);
+      }
+
+      if (this._editor && this.props.setNativeEditorSelectedRange) {
         this.props.setNativeEditorSelectedRange(
           this._editor.getSelectionRange(),
         );
       }
+
       const cardTagId = this.cardTagIdAtCursor(cursor);
       if (cardTagId) {
         this.props.openDataReferenceAtQuestion(cardTagId);

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -358,7 +358,7 @@ export class NativeQueryEditor extends Component<
   };
 
   runQuery = () => {
-    this.props.cancelQuery();
+    this.props.cancelQuery?.();
     const { query, runQuestionQuery } = this.props;
 
     // if any text is selected, just run that
@@ -619,7 +619,7 @@ export class NativeQueryEditor extends Component<
   }
 
   toggleEditor = () => {
-    this.props.setIsNativeEditorOpen(!this.props.isNativeEditorOpen);
+    this.props.setIsNativeEditorOpen?.(!this.props.isNativeEditorOpen);
   };
 
   /// Change the Database we're currently editing a query for.

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -342,7 +342,7 @@ export class NativeQueryEditor extends Component<
     );
     const idStr = match?.[2];
 
-    return (idStr && parseInt(idStr)) || null;
+    return (idStr && parseInt(idStr, 10)) || null;
   };
 
   handleCursorChange = _.debounce(

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -102,13 +102,8 @@ interface OwnProps {
   query: NativeQuery;
 
   nativeEditorSelectedText?: string;
-
-  snippets?: NativeQuerySnippet[];
   modalSnippet?: NativeQuerySnippet;
-  snippetCollections?: Collection[];
-
   viewHeight: number;
-  width: number;
 
   isOpen?: boolean;
   isInitiallyOpen?: boolean;
@@ -118,7 +113,6 @@ interface OwnProps {
   readOnly?: boolean;
   enableRun?: boolean;
   canChangeDatabase?: boolean;
-  canUsePromptInput?: boolean;
   cancelQueryOnLeave?: boolean;
   hasTopBar?: boolean;
   hasParametersList?: boolean;
@@ -133,7 +127,6 @@ interface OwnProps {
   autocompleteResultsFn: (prefix: string) => Promise<AutocompleteItem[]>;
   cardAutocompleteResultsFn: (prefix: string) => Promise<CardCompletionItem[]>;
   setDatasetQuery: (query: NativeQuery) => Promise<Question>;
-  fetchQuestion: (cardId: CardId) => Promise<Card>;
   runQuestionQuery: (opts?: {
     overrideWithCard?: Card;
     shouldUpdateUrl?: boolean;
@@ -148,7 +141,29 @@ interface OwnProps {
   closeSnippetModal: () => void;
 }
 
-type Props = OwnProps;
+interface StateProps {
+  canUsePromptInput: boolean;
+}
+
+interface DispatchProps {
+  fetchQuestion: (cardId: CardId) => Promise<Card>;
+}
+
+interface ExplicitSizeProps {
+  width: number;
+  height: number;
+}
+
+interface EntityLoaderProps {
+  snippets?: NativeQuerySnippet[];
+  snippetCollections?: Collection[];
+}
+
+type Props = OwnProps &
+  StateProps &
+  DispatchProps &
+  ExplicitSizeProps &
+  EntityLoaderProps;
 
 interface NativeQueryEditorState {
   initialHeight: number;

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -629,7 +629,7 @@ export class NativeQueryEditor extends Component<
       setDatasetQuery(query.setDatabaseId(databaseId).setDefaultCollection());
       if (this._editor && !this.props.readOnly) {
         // HACK: the cursor doesn't blink without this intended small delay
-        setTimeout(() => this._editor.focus(), 50);
+        setTimeout(() => this._editor?.focus(), 50);
       }
     }
   };
@@ -661,13 +661,13 @@ export class NativeQueryEditor extends Component<
   };
 
   handleQueryUpdate = (queryText: string) => {
-    this._editor.setValue(queryText);
-    this._editor.clearSelection();
+    this._editor?.setValue(queryText);
+    this._editor?.clearSelection();
   };
 
   handleQueryGenerated = (queryText: string) => {
     this.handleQueryUpdate(queryText);
-    this._editor.focus();
+    this._editor?.focus();
   };
 
   isPromptInputVisible = () => {
@@ -772,7 +772,7 @@ export class NativeQueryEditor extends Component<
             if (typeof resizableBoxProps?.onResizeStop === "function") {
               resizableBoxProps.onResizeStop(e, data);
             }
-            this._editor.resize();
+            this._editor?.resize();
           }}
         >
           <>

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -417,7 +417,12 @@ export class NativeQueryEditor extends Component<
 
     // initialize the content
     this.handleQueryUpdate(query?.queryText() ?? "");
-    this._editor.renderer.setScrollMargin(SCROLL_MARGIN, SCROLL_MARGIN);
+    this._editor.renderer.setScrollMargin(
+      SCROLL_MARGIN,
+      SCROLL_MARGIN,
+      SCROLL_MARGIN,
+      SCROLL_MARGIN,
+    );
 
     // hmmm, this could be dangerous
     if (!this.props.readOnly) {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -657,7 +657,7 @@ export class NativeQueryEditor extends Component<
     const { query, setDatasetQuery } = this.props;
     if (query.databaseId() !== databaseId) {
       setDatasetQuery(query.setDatabaseId(databaseId).setDefaultCollection());
-      if (this._editor && !this.props.readOnly) {
+      if (!this.props.readOnly) {
         // HACK: the cursor doesn't blink without this intended small delay
         setTimeout(() => this._editor?.focus(), 50);
       }

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -133,7 +133,7 @@ interface OwnProps {
   autocompleteResultsFn: (prefix: string) => Promise<AutocompleteItem[]>;
   cardAutocompleteResultsFn: (prefix: string) => Promise<CardCompletionItem[]>;
   setDatasetQuery: (query: NativeQuery) => Promise<Question>;
-  fetchQuestion: (questionId: CardId) => Question;
+  fetchQuestion: (questionId: CardId) => Promise<Question>;
   runQuestionQuery: (opts?: {
     overrideWithCard?: Card;
     shouldUpdateUrl?: boolean;

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -133,7 +133,7 @@ interface OwnProps {
   autocompleteResultsFn: (prefix: string) => Promise<AutocompleteItem[]>;
   cardAutocompleteResultsFn: (prefix: string) => Promise<CardCompletionItem[]>;
   setDatasetQuery: (query: NativeQuery) => Promise<Question>;
-  fetchQuestion: (questionId: CardId) => Promise<Question>;
+  fetchQuestion: (cardId: CardId) => Promise<Card>;
   runQuestionQuery: (opts?: {
     overrideWithCard?: Card;
     shouldUpdateUrl?: boolean;
@@ -460,7 +460,7 @@ export class NativeQueryEditor extends Component<
             const referencedQuestionIds =
               this.props.query.referencedQuestionIds();
             // The results of the API call are cached by ID
-            const referencedQuestions = await Promise.all(
+            const referencedCards = await Promise.all(
               referencedQuestionIds.map(id => this.props.fetchQuestion(id)),
             );
 
@@ -468,11 +468,10 @@ export class NativeQueryEditor extends Component<
             const lowerCasePrefix = prefix.toLowerCase();
             const isMatchForPrefix = (name: string) =>
               name.toLowerCase().includes(lowerCasePrefix);
-            const questionColumns: AutocompleteItem[] = referencedQuestions
+            const questionColumns: AutocompleteItem[] = referencedCards
               .filter(Boolean)
-              .flatMap(question =>
-                question
-                  .getResultMetadata()
+              .flatMap(card =>
+                card.result_metadata
                   .filter(columnMetadata =>
                     isMatchForPrefix(columnMetadata.name),
                   )
@@ -480,9 +479,7 @@ export class NativeQueryEditor extends Component<
                     columnMetadata =>
                       [
                         columnMetadata.name,
-                        `${question.displayName()} :${
-                          columnMetadata.base_type
-                        }`,
+                        `${card.name} :${columnMetadata.base_type}`,
                       ] as AutocompleteItem,
                   ),
               );

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -278,10 +278,10 @@ export class NativeQueryEditor extends Component<
 
     if (query.hasWritePermission() && !readOnly) {
       this._editor.setReadOnly(false);
-      editorElement.classList.remove("read-only");
+      editorElement?.classList.remove("read-only");
     } else {
       this._editor.setReadOnly(true);
-      editorElement.classList.add("read-only");
+      editorElement?.classList.add("read-only");
     }
 
     const aceMode = getEngineNativeAceMode(query.engine());
@@ -788,7 +788,9 @@ export class NativeQueryEditor extends Component<
                 openSnippetModalWithSelectedText
               }
               runQuery={this.runQuery}
-              target={() => this.editor.current.querySelector(".ace_selection")}
+              target={() =>
+                this.editor.current?.querySelector(".ace_selection")
+              }
               canSaveSnippets={canSaveSnippets}
             />
 

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -520,6 +520,9 @@ export class NativeQueryEditor extends Component<
   }
 
   getSnippetNameAtCursor = ({ row, column }: Ace.Position) => {
+    if (!this._editor) {
+      return null;
+    }
     const lines = this._editor.getValue().split("\n");
     const linePrefix = lines[row].slice(0, column);
     const match = linePrefix.match(/\{\{\s*snippet:\s*([^\}]*)$/);
@@ -527,6 +530,9 @@ export class NativeQueryEditor extends Component<
   };
 
   getCardTagNameAtCursor = ({ row, column }: Ace.Position) => {
+    if (!this._editor) {
+      return null;
+    }
     const lines = this._editor.getValue().split("\n");
     const linePrefix = lines[row].slice(0, column);
     const match = linePrefix.match(/\{\{\s*(#[^\}]*)$/);
@@ -605,7 +611,7 @@ export class NativeQueryEditor extends Component<
   }
 
   _retriggerAutocomplete = _.debounce(() => {
-    if (this._editor.completer?.popup?.isOpen) {
+    if (this._editor?.completer?.popup?.isOpen) {
       this._editor.execCommand("startAutocomplete");
     }
   }, AUTOCOMPLETE_DEBOUNCE_DURATION);

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorPrompt/NativeQueryEditorPrompt.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorPrompt/NativeQueryEditorPrompt.tsx
@@ -23,7 +23,7 @@ import {
 } from "./NativeQueryEditorPrompt.styled";
 
 interface NativeQueryEditorPromptProps {
-  databaseId: DatabaseId;
+  databaseId?: DatabaseId | null;
   onQueryGenerated: (queryText: string) => void;
   onClose: () => void;
 }

--- a/frontend/src/types/ace-builds.d.ts
+++ b/frontend/src/types/ace-builds.d.ts
@@ -31,7 +31,7 @@ declare module "ace-builds" {
       };
 
       bgTokenizer: Tokenizer & {
-        start: (number: index) => void;
+        start: (index: number) => void;
         setTokenizer: (tokenizer: Tokenizer) => void;
       };
 

--- a/frontend/src/types/ace-builds.d.ts
+++ b/frontend/src/types/ace-builds.d.ts
@@ -9,5 +9,40 @@ declare module "ace-builds" {
     interface TextInput {
       getElement(): HTMLTextAreaElement;
     }
+    interface Editor {
+      completer?: {
+        popup?: {
+          isOpen: boolean;
+        };
+      };
+    }
+    interface EditSession {
+      $modeId: string;
+      $mode: {
+        $behaviour: unknown;
+        $highlightRules: {
+          $rules: {
+            start: { token: string; regex: string; onMatch: null }[];
+          };
+        };
+        $tokenizer?: unknown;
+
+        getTokenizer: () => Tokenizer;
+      };
+
+      bgTokenizer: Tokenizer & {
+        start: (number: index) => void;
+        setTokenizer: (tokenizer: Tokenizer) => void;
+      };
+
+      gutterRenderer: {
+        getWidth(
+          session: Ace.EditSession,
+          lastLineNumber: number,
+          config: { characterWidth: number },
+        ): number;
+        getText: (session: Ace.EditSession, row: number) => number;
+      };
+    }
   }
 }


### PR DESCRIPTION
Migrates `NativeQueryEditor` to TypeScript trying to avoid any significant code changes. TypeScript should become an additional safety net while refactoring the editor (it's _very_ hard to unit test because of the ace editor).

* had to extend `ace-builds.d.ts`. Not sure, but seems like we're using a lot of private stuff 😢 
* a lot of changes are null checks for ace editor ref and resizable box ref