### PR TITLE
Fix issue with JSON aliases

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -466,6 +466,9 @@
       (= (:database_type stored-field) "money")
       (pg-conversion identifier :numeric)
 
+      (= ::add/source (::add/source-table opts))
+      (keyword (::add/source-alias opts))
+
       (field/json-field? stored-field)
       (if (::sql.qp/forced-alias opts)
         (keyword (::add/source-alias opts))


### PR DESCRIPTION
I definitely do not understand the compiler well enough to feel
confident in this change, but I thought it was worth submitting a PR as
documentation of the issue.

I ran into this when trying to visualize a table with a JSON field - I
got an error back:

```
Error executing query: ERROR: column source.json_field does not exist
```

Looking at the query that was being run, it was something like this:

```
SELECT (source.json_field # >> array [ ? ] :: text [ ]) :: text AS "json_field → some_json_key"
FROM (
    SELECT
        (
        public.some_table."some_json_field" # >> array [ ? ] :: text [ ]"
        ) :: text AS "some_json_field → some_json_key"
    FROM some_table
    ) AS source
LIMIT 2000
```

We're selecting `some_table.some_json_field.some_json_value` in the
subselect, but then trying to access
`source.some_json_field.some_json_value` in the main select - which
doesn't work, because `source` does not have a `some_json_field`
attribute, just a `"some_json_field -> some_json_key` field!

I wrote a quick test to reproduce this in
`metabase.driver.postgres-test/json-aliases-test`. The original code
results in the following compiled query:

```
 SELECT (source.jsonfield#>> array[?]::text[])::integer AS foo
 FROM (
   SELECT (
     silly_table.jsonfield#>> array[?]::text[]
   )::integer AS foo
   FROM silly_table
 ) AS source
 LIMIT 1048575"
```

My change (which again, I'm not at all confident that this is the
correct way to go about!) results in the following compiled query:

```
 SELECT foo AS foo
 FROM (
   SELECT (
     silly_table.jsonfield#>> array[?]::text[]
   )::integer AS foo
   FROM silly_table
 ) AS source
 LIMIT 1048575"
```

It uses the aliased row from the source table, rather than trying to
dive into the JSON again.

I suspect there's a better way to go about this - maybe using the
`forced-alias` machinery? - but figured the test case would at least
make for useful documentation.

(I'm also happy to create an issue for this, if that would be better.)