### PR TITLE
Increase pre-release sanity check timeout

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -151,7 +151,7 @@ jobs:
 
   run-sanity-check:
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 30
     needs: check-uberjar-health
     strategy:
       matrix:


### PR DESCRIPTION
At 15 min, this has consistently been timing out.

![Screen Shot 2023-08-10 at 1 36 04 PM](https://github.com/metabase/metabase/assets/30528226/e9911e7d-ec7a-4de0-9ef7-746c6a7000ec)
