### PR TITLE
Allow creating a collection on the go when duplicating items

### DIFF
--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -147,6 +147,43 @@ describe("scenarios > question > saved", () => {
     });
   });
 
+  it("should duplicate a saved question to a collection created on the go", () => {
+    cy.intercept("POST", "/api/card").as("cardCreate");
+
+    visitQuestion(ORDERS_QUESTION_ID);
+
+    openQuestionActions();
+    popover().within(() => {
+      cy.findByText("Duplicate").click();
+    });
+
+    modal().within(() => {
+      cy.findByLabelText("Name").should("have.value", "Orders - Duplicate");
+      cy.findByTestId("select-button").click();
+    });
+    popover().findByText("New collection").click();
+
+    const NEW_COLLECTION = "Foo";
+    modal().within(() => {
+      cy.findByLabelText("Name").type(NEW_COLLECTION);
+      cy.findByText("Create").click();
+      cy.findByLabelText("Name").should("have.value", "Orders - Duplicate");
+      cy.findByTestId("select-button").should("have.text", NEW_COLLECTION);
+      cy.findByText("Duplicate").click();
+      cy.wait("@cardCreate");
+    });
+
+    modal().within(() => {
+      cy.findByText("Not now").click();
+    });
+
+    cy.findByTestId("qb-header-left-side").within(() => {
+      cy.findByDisplayValue("Orders - Duplicate");
+    });
+
+    cy.get("header").findByText(NEW_COLLECTION);
+  });
+
   it("should revert a saved question to a previous version", () => {
     cy.intercept("PUT", "/api/card/**").as("updateQuestion");
 

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.styled.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.styled.tsx
@@ -1,7 +1,6 @@
 import styled from "@emotion/styled";
 
 import ItemPicker from "metabase/containers/ItemPicker";
-import Button from "metabase/core/components/Button";
 
 export const MIN_POPOVER_WIDTH = 300;
 
@@ -9,7 +8,4 @@ export const PopoverItemPicker = styled(ItemPicker)<{ width: number }>`
   width: ${({ width = MIN_POPOVER_WIDTH }) => width}px;
   padding: 1rem;
   overflow: auto;
-`;
-export const NewCollectionButton = styled(Button)`
-  margin-top: 0.5rem;
 `;

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -6,7 +6,7 @@ import {
   HTMLAttributes,
 } from "react";
 import { t } from "ttag";
-import { useField, useFormikContext } from "formik";
+import { useField } from "formik";
 
 import { useUniqueId } from "metabase/hooks/use-unique-id";
 
@@ -16,10 +16,7 @@ import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/Tipp
 
 import CollectionName from "metabase/containers/CollectionName";
 import SnippetCollectionName from "metabase/containers/SnippetCollectionName";
-import type {
-  OnClickNewCollection,
-  Values,
-} from "metabase/containers/CreateCollectionOnTheGo";
+import { CreateCollectionOnTheGoButton } from "metabase/containers/CreateCollectionOnTheGo";
 
 import Collections from "metabase/entities/collections";
 import SnippetCollections from "metabase/entities/snippet-collections";
@@ -31,7 +28,6 @@ import type { CollectionId } from "metabase-types/api";
 import {
   PopoverItemPicker,
   MIN_POPOVER_WIDTH,
-  NewCollectionButton,
 } from "./FormCollectionPicker.styled";
 
 export interface FormCollectionPickerProps
@@ -40,10 +36,8 @@ export interface FormCollectionPickerProps
   title?: string;
   placeholder?: string;
   type?: "collections" | "snippet-collections";
-  canCreateNew?: boolean;
   initialOpenCollectionId?: CollectionId;
   onOpenCollectionChange?: (collectionId: CollectionId) => void;
-  onClickNewCollection?: OnClickNewCollection;
 }
 
 function ItemName({
@@ -67,10 +61,8 @@ function FormCollectionPicker({
   title,
   placeholder = t`Select a collection`,
   type = "collections",
-  canCreateNew = false,
   initialOpenCollectionId,
   onOpenCollectionChange,
-  onClickNewCollection,
 }: FormCollectionPickerProps) {
   const id = useUniqueId();
   const [{ value }, { error, touched }, { setValue }] = useField(name);
@@ -107,7 +99,6 @@ function FormCollectionPicker({
     [id, value, type, title, placeholder, error, touched, className, style],
   );
 
-  const { values } = useFormikContext<Values>();
   const [openCollectionId, setOpenCollectionId] =
     useState<CollectionId>("root");
 
@@ -135,15 +126,7 @@ function FormCollectionPicker({
             setOpenCollectionId(id);
           }}
         >
-          {canCreateNew && (
-            <NewCollectionButton
-              light
-              icon="add"
-              onClick={() => onClickNewCollection?.(values, openCollectionId)}
-            >
-              {t`New collection`}
-            </NewCollectionButton>
-          )}
+          <CreateCollectionOnTheGoButton openCollectionId={openCollectionId} />
         </PopoverItemPicker>
       );
     },
@@ -154,10 +137,7 @@ function FormCollectionPicker({
       setValue,
       initialOpenCollectionId,
       openCollectionId,
-      values,
       onOpenCollectionChange,
-      canCreateNew,
-      onClickNewCollection,
     ],
   );
 

--- a/frontend/src/metabase/containers/CollectionPicker.jsx
+++ b/frontend/src/metabase/containers/CollectionPicker.jsx
@@ -1,15 +1,26 @@
+import { useState } from "react";
 import PropTypes from "prop-types";
+
+import { CreateCollectionOnTheGoButton } from "metabase/containers/CreateCollectionOnTheGo";
 
 import ItemPicker from "./ItemPicker";
 
-const CollectionPicker = ({ value, onChange, ...props }) => (
-  <ItemPicker
-    {...props}
-    value={value === undefined ? undefined : { model: "collection", id: value }}
-    onChange={collection => onChange(collection ? collection.id : undefined)}
-    models={["collection"]}
-  />
-);
+const CollectionPicker = ({ value, onChange, ...props }) => {
+  const [openCollectionId, setOpenCollectionId] = useState("root");
+  return (
+    <ItemPicker
+      {...props}
+      value={
+        value === undefined ? undefined : { model: "collection", id: value }
+      }
+      onChange={collection => onChange(collection ? collection.id : undefined)}
+      models={["collection"]}
+      onOpenCollectionChange={id => setOpenCollectionId(id)}
+    >
+      <CreateCollectionOnTheGoButton openCollectionId={openCollectionId} />
+    </ItemPicker>
+  );
+};
 
 CollectionPicker.propTypes = {
   // a collection ID or null (for "root" collection), or undefined if none selected

--- a/frontend/src/metabase/containers/CreateCollectionOnTheGo.styled.tsx
+++ b/frontend/src/metabase/containers/CreateCollectionOnTheGo.styled.tsx
@@ -1,0 +1,6 @@
+import styled from "@emotion/styled";
+import Button from "metabase/core/components/Button";
+
+export const NewCollectionButton = styled(Button)`
+  margin-top: 0.5rem;
+`;

--- a/frontend/src/metabase/containers/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.tsx
@@ -6,10 +6,7 @@ import * as Yup from "yup";
 import ModalContent from "metabase/components/ModalContent";
 import FormProvider from "metabase/core/components/FormProvider/FormProvider";
 import FormCollectionPicker from "metabase/collections/containers/FormCollectionPicker/FormCollectionPicker";
-import {
-  CreateCollectionOnTheGo,
-  OnClickNewCollection,
-} from "metabase/containers/CreateCollectionOnTheGo";
+import { CreateCollectionOnTheGo } from "metabase/containers/CreateCollectionOnTheGo";
 import Form from "metabase/core/components/Form";
 import FormInput from "metabase/core/components/FormInput";
 import FormFooter from "metabase/core/components/FormFooter";
@@ -56,7 +53,6 @@ interface SaveQuestionModalProps {
   onClose: () => void;
   multiStep?: boolean;
   initialCollectionId?: number;
-  onClickNewCollection?: OnClickNewCollection;
 }
 
 interface FormValues {
@@ -81,7 +77,6 @@ export const SaveQuestionModal = ({
   onClose,
   multiStep,
   initialCollectionId,
-  onClickNewCollection,
 }: SaveQuestionModalProps) => {
   const handleOverwrite = useCallback(
     async (originalQuestion: Question, details: FormValues) => {
@@ -172,10 +167,9 @@ export const SaveQuestionModal = ({
     questionType === "question"
       ? t`What is the name of your question?`
       : t`What is the name of your model?`;
-
   return (
     <CreateCollectionOnTheGo>
-      {(resumedValues, onClickNewCollection) => (
+      {({ resumedValues }) => (
         <ModalContent id="SaveQuestionModal" title={title} onClose={onClose}>
           <FormProvider
             initialValues={{ ...initialValues, ...resumedValues }}
@@ -223,8 +217,6 @@ export const SaveQuestionModal = ({
                         <FormCollectionPicker
                           name="collection_id"
                           title={t`Which collection should this go in?`}
-                          canCreateNew={true}
-                          onClickNewCollection={onClickNewCollection}
                         />
                       </div>
                     </CSSTransition>

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
@@ -14,8 +14,6 @@ import FormTextArea from "metabase/core/components/FormTextArea";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import FormErrorMessage from "metabase/core/components/FormErrorMessage";
 
-import { OnClickNewCollection } from "metabase/containers/CreateCollectionOnTheGo";
-
 import * as Errors from "metabase/core/utils/errors";
 
 import Collections from "metabase/entities/collections";
@@ -45,7 +43,6 @@ export interface CreateDashboardFormOwnProps {
   collectionId?: CollectionId | null; // can be used by `getInitialCollectionId`
   onCreate?: (dashboard: Dashboard) => void;
   onCancel?: () => void;
-  onClickNewCollection?: OnClickNewCollection;
   initialValues?: CreateDashboardProperties | null;
 }
 
@@ -81,7 +78,6 @@ function CreateDashboardForm({
   handleCreateDashboard,
   onCreate,
   onCancel,
-  onClickNewCollection,
   initialValues,
 }: Props) {
   const computedInitialValues = useMemo(
@@ -125,8 +121,6 @@ function CreateDashboardForm({
           <FormCollectionPicker
             name="collection_id"
             title={t`Which collection should this go in?`}
-            canCreateNew={true}
-            onClickNewCollection={onClickNewCollection}
           />
           <FormFooter>
             <FormErrorMessage inline />

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
@@ -51,13 +51,12 @@ function CreateDashboardModal({
 
   return (
     <CreateCollectionOnTheGo>
-      {(resumedValues, onClickNewCollection) => (
+      {({ resumedValues }) => (
         <ModalContent title={t`New dashboard`} onClose={onClose}>
           <CreateDashboardForm
             {...props}
             onCreate={handleCreate}
             onCancel={onClose}
-            onClickNewCollection={onClickNewCollection}
             initialValues={resumedValues}
           />
         </ModalContent>

--- a/frontend/src/metabase/entities/containers/EntityCopyModal.tsx
+++ b/frontend/src/metabase/entities/containers/EntityCopyModal.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 
 import EntityForm from "metabase/entities/containers/EntityForm";
 import ModalContent from "metabase/components/ModalContent";
+import { CreateCollectionOnTheGo } from "metabase/containers/CreateCollectionOnTheGo";
 
 interface EntityCopyModalProps {
   entityType: string;
@@ -22,23 +23,28 @@ const EntityCopyModal = ({
   onSaved,
   ...props
 }: EntityCopyModalProps) => (
-  <ModalContent
-    title={title || t`Duplicate "${entityObject.name}"`}
-    onClose={onClose}
-  >
-    <EntityForm
-      entityType={entityType}
-      entityObject={{
-        ...dissoc(entityObject, "id"),
-        name: entityObject.name + " - " + t`Duplicate`,
-      }}
-      onSubmit={copy}
-      onClose={onClose}
-      onSaved={onSaved}
-      submitTitle={t`Duplicate`}
-      {...props}
-    />
-  </ModalContent>
+  <CreateCollectionOnTheGo>
+    {({ resumedValues }) => (
+      <ModalContent
+        title={title || t`Duplicate "${entityObject.name}"`}
+        onClose={onClose}
+      >
+        <EntityForm
+          resumedValues={resumedValues}
+          entityType={entityType}
+          entityObject={{
+            ...dissoc(entityObject, "id"),
+            name: entityObject.name + " - " + t`Duplicate`,
+          }}
+          onSubmit={copy}
+          onClose={onClose}
+          onSaved={onSaved}
+          submitTitle={t`Duplicate`}
+          {...props}
+        />
+      </ModalContent>
+    )}
+  </CreateCollectionOnTheGo>
 );
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage

--- a/frontend/src/metabase/entities/containers/EntityForm.jsx
+++ b/frontend/src/metabase/entities/containers/EntityForm.jsx
@@ -21,17 +21,18 @@ const EForm = ({
   create,
   onSubmit = object => (object.id ? update(object) : create(object)),
   onSaved,
+  resumedValues,
   ...props
 }) => {
+  const initialValues =
+    typeof entityObject?.getPlainObject === "function"
+      ? entityObject.getPlainObject()
+      : entityObject;
   return (
     <Form
       {...props}
       form={form}
-      initialValues={
-        typeof entityObject?.getPlainObject === "function"
-          ? entityObject.getPlainObject()
-          : entityObject
-      }
+      initialValues={{ ...initialValues, ...resumedValues }}
       onSubmit={onSubmit}
       onSubmitSuccess={action => onSaved && onSaved(action.payload.object)}
     />


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/32638

### Description

Last piece of “creating a collection on the go”.

* **Why React Context?**  [We prefer prop-drilling over context](https://github.com/metabase/metabase/pull/32778#discussion_r1286469079), but prop-drilling `EntityCopyForm` now would be excessive.  Also, I wasn’t able to puzzle out how to pass custom props to `CollectionPicker`, since it seems to be dynamically inserted by deprecated code.  Using context solved both problems.
* **Context is private though.** The context is hidden inside a normally exported button component.  This allows the button to update the state of the create-collection flow from any level of the tree.

### How to verify

Duplicate a dashboard or a question.  Save it to a newly created collection.

### How to review

Hide whitespace.  Commit by commit.

### Checklist

- [X] E2E specs