### PR TITLE
Fix dynamic message id in translations

### DIFF
--- a/e2e/test/scenarios/question/reproductions/33079-drill-underlying-records.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/33079-drill-underlying-records.cy.spec.js
@@ -24,11 +24,11 @@ describe("issue 33079", () => {
 
   it("underlying records drill should work in a non-English locale (metabase#33079)", () => {
     cy.createQuestion(questionDetails, { visitQuestion: true });
-    cy.get(".dot").eq(0).click({ force: true });
+    cy.get(".dot").eq(1).click({ force: true });
     popover()
       .findByText(/Order/) // See these Orders
       .click();
     cy.wait("@dataset");
-    cy.findByTestId("question-row-count").should("contain", "1");
+    cy.findByTestId("question-row-count").should("contain", "19");
   });
 });

--- a/e2e/test/scenarios/question/reproductions/33079-drill-underlying-records.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/33079-drill-underlying-records.cy.spec.js
@@ -1,0 +1,34 @@
+import { popover, restore } from "e2e/support/helpers";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  display: "line",
+  query: {
+    "source-table": ORDERS_ID,
+    aggregation: [["count"]],
+    breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }]],
+  },
+};
+
+describe("issue 33079", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.request("GET", "/api/user/current").then(({ body: user }) => {
+      cy.request("PUT", `/api/user/${user.id}`, { locale: "de" });
+    });
+  });
+
+  it("underlying records drill should work in a non-English locale (metabase#33079)", () => {
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+    cy.get(".dot").eq(0).click({ force: true });
+    popover()
+      .findByText(/Order/) // See these Orders
+      .click();
+    cy.wait("@dataset");
+    cy.findByTestId("question-row-count").should("contain", "1");
+  });
+});

--- a/frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.ts
+++ b/frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.ts
@@ -1,4 +1,4 @@
-import { msgid, ngettext } from "ttag";
+import { t, msgid, ngettext } from "ttag";
 import { inflect } from "metabase/lib/formatting/strings";
 import type { Drill } from "metabase/modes/types";
 import {
@@ -21,11 +21,8 @@ export const UnderlyingRecordsDrill: Drill = ({ question, clicked }) => {
       ? inflect(tableName, rowCount)
       : ngettext(msgid`record`, `records`, rowCount);
 
-  const actionTitle = ngettext(
-    msgid`See this ${tableTitle}`,
-    `See these ${tableTitle}`,
-    rowCount,
-  );
+  const actionTitle =
+    rowCount === 1 ? t`See this ${tableTitle}` : t`See these ${tableTitle}`;
 
   return [
     {

--- a/frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.ts
+++ b/frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.ts
@@ -1,4 +1,4 @@
-import { t, msgid, ngettext } from "ttag";
+import { msgid, ngettext } from "ttag";
 import { inflect } from "metabase/lib/formatting/strings";
 import type { Drill } from "metabase/modes/types";
 import {
@@ -21,8 +21,12 @@ export const UnderlyingRecordsDrill: Drill = ({ question, clicked }) => {
       ? inflect(tableName, rowCount)
       : ngettext(msgid`record`, `records`, rowCount);
 
-  const actionTitle =
-    rowCount === 1 ? t`See this ${tableTitle}` : t`See these ${tableTitle}`;
+  const actionTitle = ngettext(
+    // extra argument is required to avoid a collision with a singular form (metabase#33079)
+    msgid`See this ${tableTitle}${""}`,
+    `See these ${tableTitle}`,
+    rowCount,
+  );
 
   return [
     {

--- a/frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.ts
+++ b/frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.ts
@@ -22,7 +22,7 @@ export const UnderlyingRecordsDrill: Drill = ({ question, clicked }) => {
       : ngettext(msgid`record`, `records`, rowCount);
 
   const actionTitle = ngettext(
-    // extra argument is required to avoid a collision with a singular form (metabase#33079)
+    // extra argument is required to avoid a collision with a singular form translation (metabase#33079)
     msgid`See this ${tableTitle}${""}`,
     `See these ${tableTitle}`,
     rowCount,


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/33079

Passing dynamic `msgid` doesn't work with `ttag`. This PR fixes the issue by adding a check for the row count manually.

<img width="1330" alt="Screenshot 2023-08-11 at 13 26 46" src="https://github.com/metabase/metabase/assets/8542534/e425357e-6a8f-449a-8521-f9a378822e5d">
