### PR TITLE
[POC] Faster E2E tests in CI

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -141,7 +141,7 @@ jobs:
     if: |
       !cancelled() &&
       (needs.download_uberjar.result == 'success' || needs.build.result == 'success')
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     name: e2e-tests-${{ matrix.folder }}${{ matrix.context }}-${{ matrix.edition }}
     env:
@@ -159,6 +159,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        runner: [ubuntu-22.04]
         java-version: [11]
         edition: [ee]
         folder:
@@ -185,8 +186,13 @@ jobs:
           - "visualizations"
         include:
           - edition: oss
-            context: grep
+            runner: ubuntu-22.04
+            context: oss-subset
             java-version: 11
+          - edition: ee
+            java-version: 11
+            context: slow
+            runner: buildjet-2vcpu-ubuntu-2204
     services:
       maildev:
         image: maildev/maildev:2.0.5
@@ -294,17 +300,27 @@ jobs:
         if: matrix.edition == 'oss' && github.event_name != 'schedule'
         run: |
           yarn run test-cypress-run \
-          --env grepTags=@OSS \
+          --env grepTags=@OSS,grepOmitFiltered=true \
+          --spec './e2e/test/scenarios/**/*.cy.spec.js' \
+          --browser ${{ steps.setup-chrome.outputs.chrome-path }}
+        env:
+          TERM: xterm
+
+      - name: Run slow and resource-intensive Cypress tests
+        if: matrix.context == 'slow' && github.event_name != 'schedule'
+        run: |
+          yarn run test-cypress-run \
+          --env grepTags="@slow",grepOmitFiltered=true \
           --spec './e2e/test/scenarios/**/*.cy.spec.js' \
           --browser ${{ steps.setup-chrome.outputs.chrome-path }}
         env:
           TERM: xterm
 
       - name: Run EE Cypress tests on ${{ matrix.folder }}
-        if: matrix.edition == 'ee' && github.event_name != 'schedule'
+        if: matrix.edition == 'ee' && github.event_name != 'schedule' && matrix.context != 'slow'
         run: |
           yarn run test-cypress-run \
-          --env grepTags="-@quarantine" \
+          --env grepTags="-@slow --@quarantine",grepOmitFiltered=true \
           --folder ${{ matrix.folder }} \
           --browser ${{ steps.setup-chrome.outputs.chrome-path }}
         env:
@@ -319,7 +335,7 @@ jobs:
         if: matrix.edition == 'oss' && github.event_name == 'schedule'
         run: |
           yarn run test-cypress-run \
-          --env grepTags=@OSS \
+          --env grepTags=@OSS,grepOmitFiltered=true \
           --spec './e2e/test/scenarios/**/*.cy.spec.js' \
           --browser "replay-chromium"
         env:
@@ -329,10 +345,10 @@ jobs:
           RECORD_REPLAY_METADATA_TEST_RUN_ID: ${{ needs.test-run-id.outputs.testRunId }}
 
       - name: Run EE Cypress tests on ${{ matrix.folder }} using Replay.io browser
-        if: matrix.edition == 'ee' && github.event_name == 'schedule'
+        if: matrix.edition == 'ee' && github.event_name == 'schedule' && matrix.context != 'slow'
         run: |
           yarn run test-cypress-run \
-          --env grepTags="-@quarantine" \
+          --env grepTags="-@slow --@quarantine,grepOmitFiltered=true \
           --folder ${{ matrix.folder }} \
           --browser "replay-chromium"
         env:
@@ -398,6 +414,10 @@ jobs:
           - edition: oss
             context: grep
             java-version: 11
+          - edition: ee
+            java-version: 11
+            context: grep
+            runner: buildjet-2vcpu-ubuntu-2204
     steps:
       - run: |
           echo "Didn't run due to conditional filtering"

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
@@ -57,484 +57,215 @@ const TOAST_TIMEOUT = 20000;
 const TOAST_MESSAGE =
   "You can make this dashboard snappier by turning off auto-applying filters.";
 
-describe("scenarios > dashboards > filters > auto apply", () => {
-  beforeEach(() => {
-    restore();
-    cy.signInAsNormalUser();
-    cy.intercept(
-      "PUT",
-      "/api/dashboard/*",
-      cy.spy().as("updateDashboardSpy"),
-    ).as("updateDashboard");
-    cy.intercept(
-      "PUT",
-      "/api/dashboard/*/cards",
-      cy.spy().as("updateDashboardCardsSpy"),
-    );
-  });
-
-  describe("modifying only dashboard", () => {
-    it("should handle toggling auto applying filters on and off", () => {
-      createDashboard();
-      openDashboard();
-      cy.wait("@cardQuery");
-
-      cy.log(
-        "changing parameter values by default should reload affected questions",
-      );
-      filterWidget().findByText(FILTER.name).click();
-      popover().within(() => {
-        cy.findByText("Gadget").click();
-        cy.button("Add filter").click();
-        cy.wait("@cardQuery");
-      });
-      getDashboardCard().findByText("Rows 1-5 of 53").should("be.visible");
-
-      cy.log(
-        "parameter values should be preserved when disabling auto applying filters",
-      );
-      toggleDashboardInfoSidebar();
-      rightSidebar().within(() => {
-        cy.findByLabelText("Auto-apply filters").click();
-        cy.wait("@updateDashboard");
-        cy.findByLabelText("Auto-apply filters").should("not.be.checked");
-      });
-      filterWidget().findByText("Gadget").should("be.visible");
-      getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
-
-      cy.log("draft parameter values should be applied manually");
-      filterWidget().findByText("Gadget").click();
-      popover().within(() => {
-        cy.findByText("Widget").click();
-        cy.button("Update filter").click();
-      });
-      getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
-      dashboardParametersContainer().within(() => {
-        cy.button("Apply").click();
-        cy.wait("@cardQuery");
-      });
-      getDashboardCard().findByText("Rows 1-4 of 107").should("be.visible");
-      cy.get("@cardQuery.all").should("have.length", 3);
-
-      cy.log(
-        "draft parameter values should be applied when enabling auto-applying filters",
-      );
-      filterWidget().findByText("2 selections").click();
-      popover().within(() => {
-        cy.findByText("Gadget").click();
-        cy.button("Update filter").click();
-      });
-      filterWidget().findByText("Widget").should("be.visible");
-      dashboardParametersContainer().button("Apply").should("be.visible");
-      rightSidebar().within(() => {
-        cy.findByLabelText("Auto-apply filters").click();
-        cy.wait("@updateDashboard");
-        cy.findByLabelText("Auto-apply filters").should("be.checked");
-      });
-      filterWidget().findByText("Widget").should("be.visible");
-      getDashboardCard().findByText("Rows 1-4 of 54").should("be.visible");
-      cy.get("@cardQuery.all").should("have.length", 4);
-
-      cy.log(
-        "last applied parameter values should be used when disabling auto applying filters, even if previously there were draft parameter values",
-      );
-      filterWidget().findByText("Widget").click();
-      popover().within(() => {
-        cy.findByText("Gadget").click();
-        cy.button("Update filter").click();
-      });
-      rightSidebar().within(() => {
-        cy.findByLabelText("Auto-apply filters").click();
-        cy.wait("@updateDashboard");
-        cy.findByLabelText("Auto-apply filters").should("not.be.checked");
-      });
-      filterWidget().findByText("2 selections").should("be.visible");
-      cy.get("@cardQuery.all").should("have.length", 5);
-
-      cy.log("should not call unnecessary API requests (metabase#31721)");
-      cy.get("@updateDashboardSpy").should("have.callCount", 3);
-      cy.get("@updateDashboardCardsSpy").should("not.have.been.called");
-    });
-  });
-
-  describe("modifying dashboard and dashboard cards", () => {
-    it("should not preserve draft parameter values when editing the dashboard", () => {
-      createDashboard({ dashboardDetails: { auto_apply_filters: false } });
-      openDashboard();
-
-      filterWidget().findByText(FILTER.name).click();
-      popover().within(() => {
-        cy.findByText("Gadget").click();
-        cy.button("Add filter").click();
-      });
-      dashboardParametersContainer().button("Apply").should("be.visible");
-
-      editDashboard();
-      dashboardHeader().icon("filter").click();
-      popover().within(() => {
-        cy.findByText("Text or Category").click();
-        cy.findByText("Is").click();
-      });
-      sidebar().findByDisplayValue("Text").clear().type("Vendor");
-      getDashboardCard().findByText("Select…").click();
-      popover().findByText("Vendor").click();
-      saveDashboard();
-
-      dashboardParametersContainer().within(() => {
-        cy.findByText("Category").should("be.visible");
-        cy.findByText("Vendor").should("be.visible");
-        cy.findByText("Gadget").should("not.exist");
-        cy.button("Apply").should("not.exist");
-      });
-
-      cy.log("should not call unnecessary API requests (metabase#31721)");
-      cy.get("@updateDashboardSpy").should("have.callCount", 1);
-      cy.get("@updateDashboardCardsSpy").should("have.callCount", 1);
-    });
-  });
-
-  describe("modify nothing", () => {
-    it("should preserve draft parameter values when editing of the dashboard was cancelled", () => {
-      createDashboard({ dashboardDetails: { auto_apply_filters: false } });
-      openDashboard();
-
-      filterWidget().findByText(FILTER.name).click();
-      popover().within(() => {
-        cy.findByText("Gadget").click();
-        cy.button("Add filter").click();
-      });
-      dashboardParametersContainer().button("Apply").should("be.visible");
-
-      editDashboard();
-      cy.findByTestId("edit-bar").button("Cancel").click();
-      filterWidget().findByText("Gadget").should("be.visible");
-      dashboardParametersContainer().button("Apply").should("be.visible");
-    });
-  });
-
-  describe("parameter with default values", () => {
+describe(
+  "scenarios > dashboards > filters > auto apply",
+  { tags: "@slow" },
+  () => {
     beforeEach(() => {
-      createDashboard({ parameter: FILTER_WITH_DEFAULT_VALUE });
-    });
-
-    it("should handle toggling auto applying filters on and off", () => {
-      openDashboard();
-      toggleDashboardInfoSidebar();
-
-      getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
-
-      cy.log(
-        "parameter with default value should still be applied after turning auto-apply filter off",
+      restore();
+      cy.signInAsNormalUser();
+      cy.intercept(
+        "PUT",
+        "/api/dashboard/*",
+        cy.spy().as("updateDashboardSpy"),
+      ).as("updateDashboard");
+      cy.intercept(
+        "PUT",
+        "/api/dashboard/*/cards",
+        cy.spy().as("updateDashboardCardsSpy"),
       );
-      rightSidebar().within(() => {
-        cy.findByLabelText("Auto-apply filters").should("be.checked").click();
-        cy.wait("@updateDashboard");
-        cy.findByLabelText("Auto-apply filters").should("not.be.checked");
-      });
-
-      getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
-
-      cy.log(
-        "card result should be updated after manually updating the filter",
-      );
-      filterWidget().icon("close").click();
-      dashboardParametersContainer()
-        .button("Apply")
-        .should("be.visible")
-        .click();
-
-      getDashboardCard().findByText("Rows 1-4 of 200").should("be.visible");
-
-      cy.log(
-        "should not use the default parameter after turning auto-apply filter on again since the parameter was manually updated",
-      );
-      rightSidebar().within(() => {
-        cy.findByLabelText("Auto-apply filters")
-          .should("not.be.checked")
-          .click();
-        cy.wait("@updateDashboard");
-        cy.findByLabelText("Auto-apply filters").should("be.checked");
-      });
-
-      getDashboardCard().findByText("Rows 1-4 of 200").should("be.visible");
     });
 
-    it("should display a toast when a dashboard takes longer than 15s to load even without parameter values (but has parameters with default values)", () => {
-      cy.clock();
-      openSlowDashboard();
-
-      cy.tick(TOAST_TIMEOUT);
-      cy.wait("@cardQuery");
-      undoToast().within(() => {
-        cy.findByText(TOAST_MESSAGE).should("be.visible");
-        cy.button("Turn off").click();
-        cy.wait("@updateDashboard");
-      });
-
-      toggleDashboardInfoSidebar();
-      rightSidebar()
-        .findByLabelText("Auto-apply filters")
-        .should("not.be.checked");
-      // Gadget
-      const filterDefaultValue = FILTER_WITH_DEFAULT_VALUE.default[0];
-      filterWidget().findByText(filterDefaultValue).should("be.visible");
-      getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
-    });
-
-    it("should not display the toast when we clear out parameter default value", () => {
-      cy.clock();
-      openSlowDashboard({ [FILTER_WITH_DEFAULT_VALUE.slug]: null });
-
-      cy.tick(TOAST_TIMEOUT);
-      cy.wait("@cardQuery");
-      undoToast().should("not.exist");
-      getDashboardCard().findByText("Rows 1-5 of 200").should("be.visible");
-    });
-  });
-
-  describe("auto-apply filter toast", () => {
-    it("should display a toast when a dashboard takes longer than 15s to load", () => {
-      cy.clock();
-      createDashboard();
-      openSlowDashboard({ [FILTER.slug]: "Gadget" });
-
-      cy.tick(TOAST_TIMEOUT);
-      cy.wait("@cardQuery");
-      undoToast().within(() => {
-        cy.findByText(TOAST_MESSAGE).should("be.visible");
-        cy.button("Turn off").click();
-        cy.wait("@updateDashboard");
-      });
-
-      toggleDashboardInfoSidebar();
-      rightSidebar()
-        .findByLabelText("Auto-apply filters")
-        .should("not.be.checked");
-      filterWidget().findByText("Gadget").should("be.visible");
-      getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
-    });
-
-    it("should display the toast indefinitely unless dismissing manually", () => {
-      cy.clock();
-      createDashboard();
-      openSlowDashboard({ [FILTER.slug]: "Gadget" });
-
-      cy.tick(TOAST_TIMEOUT);
-      cy.wait("@cardQuery");
-      undoToast().findByText(TOAST_MESSAGE).should("be.visible");
-
-      cy.tick(100 * TOAST_TIMEOUT);
-      undoToast().findByText(TOAST_MESSAGE).should("be.visible");
-
-      undoToast().icon("close").click();
-      undoToast().should("not.exist");
-    });
-
-    it("should not display the toast when auto applying filters is disabled", () => {
-      cy.clock();
-      createDashboard({ dashboardDetails: { auto_apply_filters: false } });
-      openSlowDashboard({ [FILTER.slug]: "Gadget" });
-
-      cy.tick(TOAST_TIMEOUT);
-      cy.wait("@cardQuery");
-      undoToast().should("not.exist");
-      filterWidget().findByText("Gadget").should("be.visible");
-      getDashboardCard().findByText("Rows 1-5 of 53").should("be.visible");
-    });
-
-    it("should not display the toast if there are no parameter values", () => {
-      cy.clock();
-      createDashboard();
-      openSlowDashboard();
-
-      cy.tick(TOAST_TIMEOUT);
-      cy.wait("@cardQuery");
-      undoToast().should("not.exist");
-    });
-
-    it("should not display the same toast twice for a dashboard", () => {
-      cy.clock();
-      createDashboard();
-      openSlowDashboard({ [FILTER.slug]: "Gadget" });
-
-      cy.tick(TOAST_TIMEOUT);
-      cy.wait("@cardQuery");
-      undoToast().within(() => {
-        cy.button("Turn off").should("be.visible");
-        cy.icon("close").click();
-      });
-      filterWidget().findByText("Gadget").click();
-      popover().within(() => {
-        cy.findByText("Widget").click();
-        cy.findByText("Update filter").click();
-      });
-
-      cy.tick(TOAST_TIMEOUT);
-      cy.wait("@cardQuery");
-      undoToast().should("not.exist");
-    });
-  });
-
-  describe("no collection curate permission", () => {
-    beforeEach(() => {
-      createDashboard();
-      cy.signIn("readonly");
-    });
-
-    it("should not be able to toggle auto-apply filters toggle", () => {
-      openDashboard();
-      cy.wait("@cardQuery");
-
-      toggleDashboardInfoSidebar();
-      rightSidebar()
-        .findByLabelText("Auto-apply filters")
-        .should("be.disabled");
-    });
-
-    it("should not display a toast even when a dashboard takes longer than 15s to load", () => {
-      cy.clock();
-      openSlowDashboard({ [FILTER.slug]: "Gadget" });
-
-      cy.tick(TOAST_TIMEOUT);
-      cy.wait("@cardQuery");
-      undoToast().should("not.exist");
-    });
-  });
-
-  describe("embeddings", () => {
-    beforeEach(() => {
-      cy.signInAsAdmin();
-    });
-
-    describe("public embeds", () => {
-      it("should apply filters after clicking the apply button when auto-apply filters is turned off", () => {
-        createDashboard({ dashboardDetails: { auto_apply_filters: false } });
-        cy.get("@dashboardId").then(dashboardId => {
-          visitPublicDashboard(dashboardId);
-        });
-
-        dashboardParametersContainer().button("Apply").should("not.exist");
-        filterWidget().findByText("Category").click();
-        popover().within(() => {
-          cy.findByText("Widget").click();
-          cy.button("Add filter").click();
-        });
-        getDashboardCard().findByText("Rows 1-5 of 200").should("be.visible");
-        dashboardParametersContainer()
-          .button("Apply")
-          .should("be.visible")
-          .click();
-        getDashboardCard().findByText("Rows 1-5 of 54").should("be.visible");
-      });
-
-      it("should not show toast", () => {
+    describe("modifying only dashboard", () => {
+      it("should handle toggling auto applying filters on and off", () => {
         createDashboard();
-        cy.clock();
-        openSlowPublicDashboard({ [FILTER.slug]: "Gadget" });
-        filterWidget().findByText("Gadget").should("be.visible");
-
-        cy.tick(TOAST_TIMEOUT);
+        openDashboard();
         cy.wait("@cardQuery");
-        undoToast().should("not.exist");
-      });
-    });
 
-    describe("signed embeds", () => {
-      it("should apply filters after clicking the apply button when auto-apply filters is turned off", () => {
-        createDashboard({
-          dashboardDetails: {
-            auto_apply_filters: false,
-            enable_embedding: true,
-            embedding_params: {
-              [FILTER.slug]: "enabled",
-            },
-          },
-        });
-        cy.get("@dashboardId").then(dashboardId => {
-          const embeddingPayload = {
-            resource: { dashboard: dashboardId },
-            params: {},
-          };
-          visitEmbeddedPage(embeddingPayload);
-        });
-
-        dashboardParametersContainer().button("Apply").should("not.exist");
-        filterWidget().findByText("Category").click();
-        popover().within(() => {
-          cy.findByText("Widget").click();
-          cy.button("Add filter").click();
-        });
-        getDashboardCard().findByText("Rows 1-5 of 200").should("be.visible");
-        dashboardParametersContainer()
-          .button("Apply")
-          .should("be.visible")
-          .click();
-        getDashboardCard().findByText("Rows 1-5 of 54").should("be.visible");
-      });
-
-      it("should not show toast", () => {
-        createDashboard({
-          dashboardDetails: {
-            enable_embedding: true,
-            embedding_params: {
-              [FILTER.slug]: "enabled",
-            },
-          },
-        });
-
-        cy.clock();
-        openSlowEmbeddingDashboard({ [FILTER.slug]: "Gadget" });
-        filterWidget().findByText("Gadget").should("be.visible");
-
-        cy.tick(TOAST_TIMEOUT);
-        cy.wait("@cardQuery");
-        undoToast().should("not.exist");
-      });
-    });
-
-    describe("full-app embeddings", () => {
-      beforeEach(() => {
-        cy.signInAsNormalUser();
-      });
-
-      it("should apply filters after clicking the apply button when auto-apply filters is turned off", () => {
-        createDashboard({
-          dashboardDetails: {
-            name: "Full-app embedding dashboard",
-            auto_apply_filters: false,
-          },
-        });
-        cy.get("@dashboardId").then(dashboardId => {
-          visitFullAppEmbeddingUrl({
-            url: `/dashboard/${dashboardId}`,
-            qs: { side_nav: false, logo: false },
-          });
-        });
-        cy.findByDisplayValue("Full-app embedding dashboard").should(
-          "be.visible",
+        cy.log(
+          "changing parameter values by default should reload affected questions",
         );
-        // Ensure that we're viewing the dashboard in full-app embedding mode, since `logo` is a full-app embedding parameter.
-        cy.findByTestId("main-logo").should("not.exist");
+        filterWidget().findByText(FILTER.name).click();
+        popover().within(() => {
+          cy.findByText("Gadget").click();
+          cy.button("Add filter").click();
+          cy.wait("@cardQuery");
+        });
+        getDashboardCard().findByText("Rows 1-5 of 53").should("be.visible");
 
-        dashboardParametersContainer().button("Apply").should("not.exist");
-        filterWidget().findByText("Category").click();
+        cy.log(
+          "parameter values should be preserved when disabling auto applying filters",
+        );
+        toggleDashboardInfoSidebar();
+        rightSidebar().within(() => {
+          cy.findByLabelText("Auto-apply filters").click();
+          cy.wait("@updateDashboard");
+          cy.findByLabelText("Auto-apply filters").should("not.be.checked");
+        });
+        filterWidget().findByText("Gadget").should("be.visible");
+        getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
+
+        cy.log("draft parameter values should be applied manually");
+        filterWidget().findByText("Gadget").click();
         popover().within(() => {
           cy.findByText("Widget").click();
+          cy.button("Update filter").click();
+        });
+        getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
+        dashboardParametersContainer().within(() => {
+          cy.button("Apply").click();
+          cy.wait("@cardQuery");
+        });
+        getDashboardCard().findByText("Rows 1-4 of 107").should("be.visible");
+        cy.get("@cardQuery.all").should("have.length", 3);
+
+        cy.log(
+          "draft parameter values should be applied when enabling auto-applying filters",
+        );
+        filterWidget().findByText("2 selections").click();
+        popover().within(() => {
+          cy.findByText("Gadget").click();
+          cy.button("Update filter").click();
+        });
+        filterWidget().findByText("Widget").should("be.visible");
+        dashboardParametersContainer().button("Apply").should("be.visible");
+        rightSidebar().within(() => {
+          cy.findByLabelText("Auto-apply filters").click();
+          cy.wait("@updateDashboard");
+          cy.findByLabelText("Auto-apply filters").should("be.checked");
+        });
+        filterWidget().findByText("Widget").should("be.visible");
+        getDashboardCard().findByText("Rows 1-4 of 54").should("be.visible");
+        cy.get("@cardQuery.all").should("have.length", 4);
+
+        cy.log(
+          "last applied parameter values should be used when disabling auto applying filters, even if previously there were draft parameter values",
+        );
+        filterWidget().findByText("Widget").click();
+        popover().within(() => {
+          cy.findByText("Gadget").click();
+          cy.button("Update filter").click();
+        });
+        rightSidebar().within(() => {
+          cy.findByLabelText("Auto-apply filters").click();
+          cy.wait("@updateDashboard");
+          cy.findByLabelText("Auto-apply filters").should("not.be.checked");
+        });
+        filterWidget().findByText("2 selections").should("be.visible");
+        cy.get("@cardQuery.all").should("have.length", 5);
+
+        cy.log("should not call unnecessary API requests (metabase#31721)");
+        cy.get("@updateDashboardSpy").should("have.callCount", 3);
+        cy.get("@updateDashboardCardsSpy").should("not.have.been.called");
+      });
+    });
+
+    describe("modifying dashboard and dashboard cards", () => {
+      it("should not preserve draft parameter values when editing the dashboard", () => {
+        createDashboard({ dashboardDetails: { auto_apply_filters: false } });
+        openDashboard();
+
+        filterWidget().findByText(FILTER.name).click();
+        popover().within(() => {
+          cy.findByText("Gadget").click();
           cy.button("Add filter").click();
         });
-        getDashboardCard().findByText("Rows 1-5 of 200").should("be.visible");
+        dashboardParametersContainer().button("Apply").should("be.visible");
+
+        editDashboard();
+        dashboardHeader().icon("filter").click();
+        popover().within(() => {
+          cy.findByText("Text or Category").click();
+          cy.findByText("Is").click();
+        });
+        sidebar().findByDisplayValue("Text").clear().type("Vendor");
+        getDashboardCard().findByText("Select…").click();
+        popover().findByText("Vendor").click();
+        saveDashboard();
+
+        dashboardParametersContainer().within(() => {
+          cy.findByText("Category").should("be.visible");
+          cy.findByText("Vendor").should("be.visible");
+          cy.findByText("Gadget").should("not.exist");
+          cy.button("Apply").should("not.exist");
+        });
+
+        cy.log("should not call unnecessary API requests (metabase#31721)");
+        cy.get("@updateDashboardSpy").should("have.callCount", 1);
+        cy.get("@updateDashboardCardsSpy").should("have.callCount", 1);
+      });
+    });
+
+    describe("modify nothing", () => {
+      it("should preserve draft parameter values when editing of the dashboard was cancelled", () => {
+        createDashboard({ dashboardDetails: { auto_apply_filters: false } });
+        openDashboard();
+
+        filterWidget().findByText(FILTER.name).click();
+        popover().within(() => {
+          cy.findByText("Gadget").click();
+          cy.button("Add filter").click();
+        });
+        dashboardParametersContainer().button("Apply").should("be.visible");
+
+        editDashboard();
+        cy.findByTestId("edit-bar").button("Cancel").click();
+        filterWidget().findByText("Gadget").should("be.visible");
+        dashboardParametersContainer().button("Apply").should("be.visible");
+      });
+    });
+
+    describe("parameter with default values", () => {
+      beforeEach(() => {
+        createDashboard({ parameter: FILTER_WITH_DEFAULT_VALUE });
+      });
+
+      it("should handle toggling auto applying filters on and off", () => {
+        openDashboard();
+        toggleDashboardInfoSidebar();
+
+        getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
+
+        cy.log(
+          "parameter with default value should still be applied after turning auto-apply filter off",
+        );
+        rightSidebar().within(() => {
+          cy.findByLabelText("Auto-apply filters").should("be.checked").click();
+          cy.wait("@updateDashboard");
+          cy.findByLabelText("Auto-apply filters").should("not.be.checked");
+        });
+
+        getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
+
+        cy.log(
+          "card result should be updated after manually updating the filter",
+        );
+        filterWidget().icon("close").click();
         dashboardParametersContainer()
           .button("Apply")
           .should("be.visible")
           .click();
-        getDashboardCard().findByText("Rows 1-5 of 54").should("be.visible");
+
+        getDashboardCard().findByText("Rows 1-4 of 200").should("be.visible");
+
+        cy.log(
+          "should not use the default parameter after turning auto-apply filter on again since the parameter was manually updated",
+        );
+        rightSidebar().within(() => {
+          cy.findByLabelText("Auto-apply filters")
+            .should("not.be.checked")
+            .click();
+          cy.wait("@updateDashboard");
+          cy.findByLabelText("Auto-apply filters").should("be.checked");
+        });
+
+        getDashboardCard().findByText("Rows 1-4 of 200").should("be.visible");
       });
 
-      it("should display a toast when a dashboard takes longer than 15s to load", () => {
-        createDashboard();
-        // Not sure why I need to pass a date in this case, but it doesn't work without it.
-        cy.clock(Date.now());
-        openSlowFullAppEmbeddingDashboard({ [FILTER.slug]: "Gadget" });
+      it("should display a toast when a dashboard takes longer than 15s to load even without parameter values (but has parameters with default values)", () => {
+        cy.clock();
+        openSlowDashboard();
+
         cy.tick(TOAST_TIMEOUT);
         cy.wait("@cardQuery");
         undoToast().within(() => {
@@ -543,61 +274,334 @@ describe("scenarios > dashboards > filters > auto apply", () => {
           cy.wait("@updateDashboard");
         });
 
-        // In embedding we'll load bookmark after the dashboard is loaded, it's the opposite in normal app because bookmark is cached from somewhere else.
-        // And somehow, dashboard card query will be completed before the dashboard even start to load, and in entity loader it uses `setTimeout`,
-        // so to make sure callback in `setTimeout` is called, we need to advance the clock using cy.tick().
-        cy.tick();
+        toggleDashboardInfoSidebar();
+        rightSidebar()
+          .findByLabelText("Auto-apply filters")
+          .should("not.be.checked");
+        // Gadget
+        const filterDefaultValue = FILTER_WITH_DEFAULT_VALUE.default[0];
+        filterWidget().findByText(filterDefaultValue).should("be.visible");
+        getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
+      });
+
+      it("should not display the toast when we clear out parameter default value", () => {
+        cy.clock();
+        openSlowDashboard({ [FILTER_WITH_DEFAULT_VALUE.slug]: null });
+
+        cy.tick(TOAST_TIMEOUT);
+        cy.wait("@cardQuery");
+        undoToast().should("not.exist");
+        getDashboardCard().findByText("Rows 1-5 of 200").should("be.visible");
+      });
+    });
+
+    describe("auto-apply filter toast", () => {
+      it("should display a toast when a dashboard takes longer than 15s to load", () => {
+        cy.clock();
+        createDashboard();
+        openSlowDashboard({ [FILTER.slug]: "Gadget" });
+
+        cy.tick(TOAST_TIMEOUT);
+        cy.wait("@cardQuery");
+        undoToast().within(() => {
+          cy.findByText(TOAST_MESSAGE).should("be.visible");
+          cy.button("Turn off").click();
+          cy.wait("@updateDashboard");
+        });
 
         toggleDashboardInfoSidebar();
         rightSidebar()
           .findByLabelText("Auto-apply filters")
           .should("not.be.checked");
         filterWidget().findByText("Gadget").should("be.visible");
-
-        // Card height isn't updated because we're mocking clock, this is because
-        // dashcard visualizations are wrapped within `ExplicitSize` HoC which uses
-        // either `setTimeout` or `setInterval` under the hood.
-        // That's why this dashcard is only showing 1 result per page.
-        getDashboardCard().findByText("Rows 1-1 of 53").should("be.visible");
-
-        // Card result should be updated after manually updating the filter
-        filterWidget().icon("close").click();
-        dashboardParametersContainer()
-          .button("Apply")
-          .should("be.visible")
-          .click();
-
-        // Card height isn't updated because we're mocking clock, this is because
-        // dashcard visualizations are wrapped within `ExplicitSize` HoC which uses
-        // either `setTimeout` or `setInterval` under the hood.
-        // That's why this dashcard is only showing 1 result per page.
-        getDashboardCard().findByText("Rows 1-1 of 200").should("be.visible");
+        getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
       });
 
-      it("should not display a toast when a dashboard takes longer than 15s to load if users have no write access to a dashboard", () => {
+      it("should display the toast indefinitely unless dismissing manually", () => {
+        cy.clock();
         createDashboard();
-        cy.signIn("readonly");
-        // Not sure why I need to pass a date in this case, but it doesn't work without it.
-        cy.clock(Date.now());
-        openSlowFullAppEmbeddingDashboard({ [FILTER.slug]: "Gadget" });
+        openSlowDashboard({ [FILTER.slug]: "Gadget" });
+
+        cy.tick(TOAST_TIMEOUT);
+        cy.wait("@cardQuery");
+        undoToast().findByText(TOAST_MESSAGE).should("be.visible");
+
+        cy.tick(100 * TOAST_TIMEOUT);
+        undoToast().findByText(TOAST_MESSAGE).should("be.visible");
+
+        undoToast().icon("close").click();
+        undoToast().should("not.exist");
+      });
+
+      it("should not display the toast when auto applying filters is disabled", () => {
+        cy.clock();
+        createDashboard({ dashboardDetails: { auto_apply_filters: false } });
+        openSlowDashboard({ [FILTER.slug]: "Gadget" });
+
         cy.tick(TOAST_TIMEOUT);
         cy.wait("@cardQuery");
         undoToast().should("not.exist");
+        filterWidget().findByText("Gadget").should("be.visible");
+        getDashboardCard().findByText("Rows 1-5 of 53").should("be.visible");
+      });
 
-        // In embedding we'll load bookmark after the dashboard is loaded, it's the opposite in normal app because bookmark is cached from somewhere else.
-        // And somehow, dashboard card query will be completed before the dashboard even start to load, and in entity loader it uses `setTimeout`,
-        // so to make sure callback in `setTimeout` is called, we need to advance the clock using cy.tick().
-        cy.tick();
+      it("should not display the toast if there are no parameter values", () => {
+        cy.clock();
+        createDashboard();
+        openSlowDashboard();
 
-        // Card height isn't updated because we're mocking clock, this is because
-        // dashcard visualizations are wrapped within `ExplicitSize` HoC which uses
-        // either `setTimeout` or `setInterval` under the hood.
-        // That's why this dashcard is only showing 1 result per page.
-        getDashboardCard().findByText("Rows 1-1 of 53").should("be.visible");
+        cy.tick(TOAST_TIMEOUT);
+        cy.wait("@cardQuery");
+        undoToast().should("not.exist");
+      });
+
+      it("should not display the same toast twice for a dashboard", () => {
+        cy.clock();
+        createDashboard();
+        openSlowDashboard({ [FILTER.slug]: "Gadget" });
+
+        cy.tick(TOAST_TIMEOUT);
+        cy.wait("@cardQuery");
+        undoToast().within(() => {
+          cy.button("Turn off").should("be.visible");
+          cy.icon("close").click();
+        });
+        filterWidget().findByText("Gadget").click();
+        popover().within(() => {
+          cy.findByText("Widget").click();
+          cy.findByText("Update filter").click();
+        });
+
+        cy.tick(TOAST_TIMEOUT);
+        cy.wait("@cardQuery");
+        undoToast().should("not.exist");
       });
     });
-  });
-});
+
+    describe("no collection curate permission", () => {
+      beforeEach(() => {
+        createDashboard();
+        cy.signIn("readonly");
+      });
+
+      it("should not be able to toggle auto-apply filters toggle", () => {
+        openDashboard();
+        cy.wait("@cardQuery");
+
+        toggleDashboardInfoSidebar();
+        rightSidebar()
+          .findByLabelText("Auto-apply filters")
+          .should("be.disabled");
+      });
+
+      it("should not display a toast even when a dashboard takes longer than 15s to load", () => {
+        cy.clock();
+        openSlowDashboard({ [FILTER.slug]: "Gadget" });
+
+        cy.tick(TOAST_TIMEOUT);
+        cy.wait("@cardQuery");
+        undoToast().should("not.exist");
+      });
+    });
+
+    describe("embeddings", () => {
+      beforeEach(() => {
+        cy.signInAsAdmin();
+      });
+
+      describe("public embeds", () => {
+        it("should apply filters after clicking the apply button when auto-apply filters is turned off", () => {
+          createDashboard({ dashboardDetails: { auto_apply_filters: false } });
+          cy.get("@dashboardId").then(dashboardId => {
+            visitPublicDashboard(dashboardId);
+          });
+
+          dashboardParametersContainer().button("Apply").should("not.exist");
+          filterWidget().findByText("Category").click();
+          popover().within(() => {
+            cy.findByText("Widget").click();
+            cy.button("Add filter").click();
+          });
+          getDashboardCard().findByText("Rows 1-5 of 200").should("be.visible");
+          dashboardParametersContainer()
+            .button("Apply")
+            .should("be.visible")
+            .click();
+          getDashboardCard().findByText("Rows 1-5 of 54").should("be.visible");
+        });
+
+        it("should not show toast", () => {
+          createDashboard();
+          cy.clock();
+          openSlowPublicDashboard({ [FILTER.slug]: "Gadget" });
+          filterWidget().findByText("Gadget").should("be.visible");
+
+          cy.tick(TOAST_TIMEOUT);
+          cy.wait("@cardQuery");
+          undoToast().should("not.exist");
+        });
+      });
+
+      describe("signed embeds", () => {
+        it("should apply filters after clicking the apply button when auto-apply filters is turned off", () => {
+          createDashboard({
+            dashboardDetails: {
+              auto_apply_filters: false,
+              enable_embedding: true,
+              embedding_params: {
+                [FILTER.slug]: "enabled",
+              },
+            },
+          });
+          cy.get("@dashboardId").then(dashboardId => {
+            const embeddingPayload = {
+              resource: { dashboard: dashboardId },
+              params: {},
+            };
+            visitEmbeddedPage(embeddingPayload);
+          });
+
+          dashboardParametersContainer().button("Apply").should("not.exist");
+          filterWidget().findByText("Category").click();
+          popover().within(() => {
+            cy.findByText("Widget").click();
+            cy.button("Add filter").click();
+          });
+          getDashboardCard().findByText("Rows 1-5 of 200").should("be.visible");
+          dashboardParametersContainer()
+            .button("Apply")
+            .should("be.visible")
+            .click();
+          getDashboardCard().findByText("Rows 1-5 of 54").should("be.visible");
+        });
+
+        it("should not show toast", () => {
+          createDashboard({
+            dashboardDetails: {
+              enable_embedding: true,
+              embedding_params: {
+                [FILTER.slug]: "enabled",
+              },
+            },
+          });
+
+          cy.clock();
+          openSlowEmbeddingDashboard({ [FILTER.slug]: "Gadget" });
+          filterWidget().findByText("Gadget").should("be.visible");
+
+          cy.tick(TOAST_TIMEOUT);
+          cy.wait("@cardQuery");
+          undoToast().should("not.exist");
+        });
+      });
+
+      describe("full-app embeddings", () => {
+        beforeEach(() => {
+          cy.signInAsNormalUser();
+        });
+
+        it("should apply filters after clicking the apply button when auto-apply filters is turned off", () => {
+          createDashboard({
+            dashboardDetails: {
+              name: "Full-app embedding dashboard",
+              auto_apply_filters: false,
+            },
+          });
+          cy.get("@dashboardId").then(dashboardId => {
+            visitFullAppEmbeddingUrl({
+              url: `/dashboard/${dashboardId}`,
+              qs: { side_nav: false, logo: false },
+            });
+          });
+          cy.findByDisplayValue("Full-app embedding dashboard").should(
+            "be.visible",
+          );
+          // Ensure that we're viewing the dashboard in full-app embedding mode, since `logo` is a full-app embedding parameter.
+          cy.findByTestId("main-logo").should("not.exist");
+
+          dashboardParametersContainer().button("Apply").should("not.exist");
+          filterWidget().findByText("Category").click();
+          popover().within(() => {
+            cy.findByText("Widget").click();
+            cy.button("Add filter").click();
+          });
+          getDashboardCard().findByText("Rows 1-5 of 200").should("be.visible");
+          dashboardParametersContainer()
+            .button("Apply")
+            .should("be.visible")
+            .click();
+          getDashboardCard().findByText("Rows 1-5 of 54").should("be.visible");
+        });
+
+        it("should display a toast when a dashboard takes longer than 15s to load", () => {
+          createDashboard();
+          // Not sure why I need to pass a date in this case, but it doesn't work without it.
+          cy.clock(Date.now());
+          openSlowFullAppEmbeddingDashboard({ [FILTER.slug]: "Gadget" });
+          cy.tick(TOAST_TIMEOUT);
+          cy.wait("@cardQuery");
+          undoToast().within(() => {
+            cy.findByText(TOAST_MESSAGE).should("be.visible");
+            cy.button("Turn off").click();
+            cy.wait("@updateDashboard");
+          });
+
+          // In embedding we'll load bookmark after the dashboard is loaded, it's the opposite in normal app because bookmark is cached from somewhere else.
+          // And somehow, dashboard card query will be completed before the dashboard even start to load, and in entity loader it uses `setTimeout`,
+          // so to make sure callback in `setTimeout` is called, we need to advance the clock using cy.tick().
+          cy.tick();
+
+          toggleDashboardInfoSidebar();
+          rightSidebar()
+            .findByLabelText("Auto-apply filters")
+            .should("not.be.checked");
+          filterWidget().findByText("Gadget").should("be.visible");
+
+          // Card height isn't updated because we're mocking clock, this is because
+          // dashcard visualizations are wrapped within `ExplicitSize` HoC which uses
+          // either `setTimeout` or `setInterval` under the hood.
+          // That's why this dashcard is only showing 1 result per page.
+          getDashboardCard().findByText("Rows 1-1 of 53").should("be.visible");
+
+          // Card result should be updated after manually updating the filter
+          filterWidget().icon("close").click();
+          dashboardParametersContainer()
+            .button("Apply")
+            .should("be.visible")
+            .click();
+
+          // Card height isn't updated because we're mocking clock, this is because
+          // dashcard visualizations are wrapped within `ExplicitSize` HoC which uses
+          // either `setTimeout` or `setInterval` under the hood.
+          // That's why this dashcard is only showing 1 result per page.
+          getDashboardCard().findByText("Rows 1-1 of 200").should("be.visible");
+        });
+
+        it("should not display a toast when a dashboard takes longer than 15s to load if users have no write access to a dashboard", () => {
+          createDashboard();
+          cy.signIn("readonly");
+          // Not sure why I need to pass a date in this case, but it doesn't work without it.
+          cy.clock(Date.now());
+          openSlowFullAppEmbeddingDashboard({ [FILTER.slug]: "Gadget" });
+          cy.tick(TOAST_TIMEOUT);
+          cy.wait("@cardQuery");
+          undoToast().should("not.exist");
+
+          // In embedding we'll load bookmark after the dashboard is loaded, it's the opposite in normal app because bookmark is cached from somewhere else.
+          // And somehow, dashboard card query will be completed before the dashboard even start to load, and in entity loader it uses `setTimeout`,
+          // so to make sure callback in `setTimeout` is called, we need to advance the clock using cy.tick().
+          cy.tick();
+
+          // Card height isn't updated because we're mocking clock, this is because
+          // dashcard visualizations are wrapped within `ExplicitSize` HoC which uses
+          // either `setTimeout` or `setInterval` under the hood.
+          // That's why this dashcard is only showing 1 result per page.
+          getDashboardCard().findByText("Rows 1-1 of 53").should("be.visible");
+        });
+      });
+    });
+  },
+);
 
 describeWithSnowplow("scenarios > dashboards > filters > auto apply", () => {
   const NUMBERS_OF_GOOD_SNOWPLOW_EVENTS_BEFORE_DISABLING_AUTO_APPLY_FILTERS = 2;

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-source.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-source.cy.spec.js
@@ -52,7 +52,7 @@ const targetQuestion = {
   },
 };
 
-describe("scenarios > dashboard > filters", () => {
+describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
@@ -95,42 +95,50 @@ describe("scenarios > dashboard > dashboard back navigation", () => {
     cy.findByTestId("native-query-editor").should("not.be.visible");
   });
 
-  it("should display a back to the dashboard button in table x-ray dashboards", () => {
-    const cardTitle = "Sales per state";
-    cy.visit(`/auto/dashboard/table/${ORDERS_ID}`);
-    cy.wait("@dataset");
+  it(
+    "should display a back to the dashboard button in table x-ray dashboards",
+    { tags: "@slow" },
+    () => {
+      const cardTitle = "Sales per state";
+      cy.visit(`/auto/dashboard/table/${ORDERS_ID}`);
+      cy.wait("@dataset");
 
-    getDashboardCards()
-      .filter(`:contains("${cardTitle}")`)
-      .findByText(cardTitle)
-      .click();
-    cy.wait("@dataset");
+      getDashboardCards()
+        .filter(`:contains("${cardTitle}")`)
+        .findByText(cardTitle)
+        .click();
+      cy.wait("@dataset");
 
-    queryBuilderHeader()
-      .findByLabelText(/Back to .*Orders.*/)
-      .click();
+      queryBuilderHeader()
+        .findByLabelText(/Back to .*Orders.*/)
+        .click();
 
-    getDashboardCards().filter(`:contains("${cardTitle}")`).should("exist");
-  });
+      getDashboardCards().filter(`:contains("${cardTitle}")`).should("exist");
+    },
+  );
 
-  it("should display a back to the dashboard button in model x-ray dashboards", () => {
-    const cardTitle = "Orders by Subtotal";
-    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { dataset: true });
-    cy.visit("/auto/dashboard/model/1");
-    cy.wait("@dataset");
+  it(
+    "should display a back to the dashboard button in model x-ray dashboards",
+    { tags: "@slow" },
+    () => {
+      const cardTitle = "Orders by Subtotal";
+      cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { dataset: true });
+      cy.visit("/auto/dashboard/model/1");
+      cy.wait("@dataset");
 
-    getDashboardCards()
-      .filter(`:contains("${cardTitle}")`)
-      .findByText(cardTitle)
-      .click();
-    cy.wait("@dataset");
+      getDashboardCards()
+        .filter(`:contains("${cardTitle}")`)
+        .findByText(cardTitle)
+        .click();
+      cy.wait("@dataset");
 
-    queryBuilderHeader()
-      .findByLabelText(/Back to .*Orders.*/)
-      .click();
+      queryBuilderHeader()
+        .findByLabelText(/Back to .*Orders.*/)
+        .click();
 
-    getDashboardCards().filter(`:contains("${cardTitle}")`).should("exist");
-  });
+      getDashboardCards().filter(`:contains("${cardTitle}")`).should("exist");
+    },
+  );
 
   it("should preserve query results when navigating between the dashboard and the query builder", () => {
     createDashboardWithCards();

--- a/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
@@ -18,7 +18,7 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, PEOPLE, PEOPLE_ID } =
   SAMPLE_DATABASE;
 
-describe("scenarios > x-rays", () => {
+describe("scenarios > x-rays", { tags: "@slow" }, () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -23,7 +23,7 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 const { ORDERS, ORDERS_ID, PEOPLE, PEOPLE_ID, PRODUCTS, PRODUCTS_ID } =
   SAMPLE_DATABASE;
 
-describe("scenarios > question > notebook", () => {
+describe("scenarios > question > notebook", { tags: "@slow" }, () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -30,338 +30,350 @@ const PERMISSIONS = {
   no: ["nocollection", "nosql", "none"],
 };
 
-describe("managing question from the question's details sidebar", () => {
-  beforeEach(() => {
-    restore();
-  });
+describe(
+  "managing question from the question's details sidebar",
+  { tags: "@slow" },
+  () => {
+    beforeEach(() => {
+      restore();
+    });
 
-  Object.entries(PERMISSIONS).forEach(([permission, userGroup]) => {
-    context(`${permission} access`, () => {
-      userGroup.forEach(user => {
-        onlyOn(permission === "curate", () => {
-          describe(`${user} user`, () => {
-            beforeEach(() => {
-              cy.intercept("PUT", `/api/card/${ORDERS_QUESTION_ID}`).as(
-                "updateQuestion",
-              );
-
-              cy.signIn(user);
-              visitQuestion(ORDERS_QUESTION_ID);
-            });
-
-            it("should be able to edit question details (metabase#11719-1)", () => {
-              cy.findByTestId("saved-question-header-title")
-                .click()
-                .type("1")
-                .blur();
-              assertOnRequest("updateQuestion");
-              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-              cy.findByText("Orders1");
-            });
-
-            it("should be able to edit a question's description", () => {
-              questionInfoButton().click();
-
-              cy.findByPlaceholderText("Add description")
-                .type("foo", { delay: 0 })
-                .blur();
-
-              assertOnRequest("updateQuestion");
-
-              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-              cy.findByText("foo");
-            });
-
-            describe("move", () => {
-              it("should be able to move the question (metabase#11719-2)", () => {
-                openNavigationSidebar();
-                navigationSidebar().within(() => {
-                  // Highlight "Our analytics"
-                  cy.findByText("Our analytics")
-                    .parents("li")
-                    .should("have.attr", "aria-selected", "true");
-                  cy.findByText("Your personal collection")
-                    .parents("li")
-                    .should("have.attr", "aria-selected", "false");
-                });
-
-                openQuestionActions();
-                cy.findByTestId("move-button").click();
-                // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-                cy.findByText("My personal collection").click();
-                clickButton("Move");
-                assertOnRequest("updateQuestion");
-                // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-                cy.contains("37.65");
-
-                // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-                cy.contains(
-                  `Question moved to ${getPersonalCollectionName(USERS[user])}`,
+    Object.entries(PERMISSIONS).forEach(([permission, userGroup]) => {
+      context(`${permission} access`, () => {
+        userGroup.forEach(user => {
+          onlyOn(permission === "curate", () => {
+            describe(`${user} user`, () => {
+              beforeEach(() => {
+                cy.intercept("PUT", `/api/card/${ORDERS_QUESTION_ID}`).as(
+                  "updateQuestion",
                 );
 
-                navigationSidebar().within(() => {
-                  // Highlight "Your personal collection" after move
-                  cy.findByText("Our analytics")
-                    .parents("li")
-                    .should("have.attr", "aria-selected", "false");
-                  cy.findByText("Your personal collection")
-                    .parents("li")
-                    .should("have.attr", "aria-selected", "true");
-                });
+                cy.signIn(user);
+                visitQuestion(ORDERS_QUESTION_ID);
               });
 
-              it("should be able to move the question to a collection created on the go", () => {
-                openQuestionActions();
-                cy.findByTestId("move-button").click();
-                const NEW_COLLECTION = "Foo";
-                modal().within(() => {
-                  cy.findByText("New collection").click();
-                  cy.findByLabelText("Name").type(NEW_COLLECTION, { delay: 0 });
-                  cy.findByText("Create").click();
-                });
-                cy.get("header").findByText(NEW_COLLECTION);
-              });
-
-              it("should be able to move models", () => {
-                // TODO: Currently nodata users can't turn a question into a model
-                cy.skipOn(user === "nodata");
-
-                turnIntoModel();
-
-                openNavigationSidebar();
-                navigationSidebar().within(() => {
-                  // Highlight "Our analytics"
-                  cy.findByText("Our analytics")
-                    .parents("li")
-                    .should("have.attr", "aria-selected", "true");
-                  cy.findByText("Your personal collection")
-                    .parents("li")
-                    .should("have.attr", "aria-selected", "false");
-                });
-
-                openQuestionActions();
-                cy.findByTestId("move-button").click();
-                // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-                cy.findByText("My personal collection").click();
-                clickButton("Move");
+              it("should be able to edit question details (metabase#11719-1)", () => {
+                cy.findByTestId("saved-question-header-title")
+                  .click()
+                  .type("1")
+                  .blur();
                 assertOnRequest("updateQuestion");
                 // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-                cy.contains("37.65");
+                cy.findByText("Orders1");
+              });
+
+              it("should be able to edit a question's description", () => {
+                questionInfoButton().click();
+
+                cy.findByPlaceholderText("Add description")
+                  .type("foo", { delay: 0 })
+                  .blur();
+
+                assertOnRequest("updateQuestion");
 
                 // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-                cy.contains(
-                  `Model moved to ${getPersonalCollectionName(USERS[user])}`,
+                cy.findByText("foo");
+              });
+
+              describe("move", () => {
+                it("should be able to move the question (metabase#11719-2)", () => {
+                  openNavigationSidebar();
+                  navigationSidebar().within(() => {
+                    // Highlight "Our analytics"
+                    cy.findByText("Our analytics")
+                      .parents("li")
+                      .should("have.attr", "aria-selected", "true");
+                    cy.findByText("Your personal collection")
+                      .parents("li")
+                      .should("have.attr", "aria-selected", "false");
+                  });
+
+                  openQuestionActions();
+                  cy.findByTestId("move-button").click();
+                  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+                  cy.findByText("My personal collection").click();
+                  clickButton("Move");
+                  assertOnRequest("updateQuestion");
+                  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+                  cy.contains("37.65");
+
+                  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+                  cy.contains(
+                    `Question moved to ${getPersonalCollectionName(
+                      USERS[user],
+                    )}`,
+                  );
+
+                  navigationSidebar().within(() => {
+                    // Highlight "Your personal collection" after move
+                    cy.findByText("Our analytics")
+                      .parents("li")
+                      .should("have.attr", "aria-selected", "false");
+                    cy.findByText("Your personal collection")
+                      .parents("li")
+                      .should("have.attr", "aria-selected", "true");
+                  });
+                });
+
+                it("should be able to move the question to a collection created on the go", () => {
+                  openQuestionActions();
+                  cy.findByTestId("move-button").click();
+                  const NEW_COLLECTION = "Foo";
+                  modal().within(() => {
+                    cy.findByText("New collection").click();
+                    cy.findByLabelText("Name").type(NEW_COLLECTION, {
+                      delay: 0,
+                    });
+                    cy.findByText("Create").click();
+                  });
+                  cy.get("header").findByText(NEW_COLLECTION);
+                });
+
+                it("should be able to move models", () => {
+                  // TODO: Currently nodata users can't turn a question into a model
+                  cy.skipOn(user === "nodata");
+
+                  turnIntoModel();
+
+                  openNavigationSidebar();
+                  navigationSidebar().within(() => {
+                    // Highlight "Our analytics"
+                    cy.findByText("Our analytics")
+                      .parents("li")
+                      .should("have.attr", "aria-selected", "true");
+                    cy.findByText("Your personal collection")
+                      .parents("li")
+                      .should("have.attr", "aria-selected", "false");
+                  });
+
+                  openQuestionActions();
+                  cy.findByTestId("move-button").click();
+                  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+                  cy.findByText("My personal collection").click();
+                  clickButton("Move");
+                  assertOnRequest("updateQuestion");
+                  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+                  cy.contains("37.65");
+
+                  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+                  cy.contains(
+                    `Model moved to ${getPersonalCollectionName(USERS[user])}`,
+                  );
+
+                  navigationSidebar().within(() => {
+                    // Highlight "Your personal collection" after move
+                    cy.findByText("Our analytics")
+                      .parents("li")
+                      .should("have.attr", "aria-selected", "false");
+                    cy.findByText("Your personal collection")
+                      .parents("li")
+                      .should("have.attr", "aria-selected", "true");
+                  });
+                });
+              });
+
+              it("should be able to archive the question (metabase#11719-3, metabase#16512, metabase#20133)", () => {
+                cy.intercept("GET", "/api/collection/root/items**").as(
+                  "getItems",
                 );
-
-                navigationSidebar().within(() => {
-                  // Highlight "Your personal collection" after move
-                  cy.findByText("Our analytics")
-                    .parents("li")
-                    .should("have.attr", "aria-selected", "false");
-                  cy.findByText("Your personal collection")
-                    .parents("li")
-                    .should("have.attr", "aria-selected", "true");
-                });
-              });
-            });
-
-            it("should be able to archive the question (metabase#11719-3, metabase#16512, metabase#20133)", () => {
-              cy.intercept("GET", "/api/collection/root/items**").as(
-                "getItems",
-              );
-              openQuestionActions();
-              cy.findByTestId("archive-button").click();
-              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-              cy.findByText(
-                "It will also be removed from the filter that uses it to populate values.",
-              ).should("not.exist");
-              clickButton("Archive");
-              assertOnRequest("updateQuestion");
-              cy.wait("@getItems"); // pinned items
-              cy.wait("@getItems"); // unpinned items
-              cy.location("pathname").should("eq", "/collection/root");
-              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-              cy.findByText("Orders").should("not.exist");
-
-              cy.findByPlaceholderText("Search…").click();
-              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-              cy.findByText("Recently viewed");
-              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-              cy.findByText("Nothing here");
-
-              // Check page for archived questions
-              cy.visit("/question/" + ORDERS_QUESTION_ID);
-              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-              cy.findByText("This question has been archived");
-            });
-
-            describe("Add to Dashboard", () => {
-              it("should be able to add question to dashboard", () => {
                 openQuestionActions();
-                cy.findByTestId("add-to-dashboard-button").click();
+                cy.findByTestId("archive-button").click();
+                // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+                cy.findByText(
+                  "It will also be removed from the filter that uses it to populate values.",
+                ).should("not.exist");
+                clickButton("Archive");
+                assertOnRequest("updateQuestion");
+                cy.wait("@getItems"); // pinned items
+                cy.wait("@getItems"); // unpinned items
+                cy.location("pathname").should("eq", "/collection/root");
+                // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+                cy.findByText("Orders").should("not.exist");
 
-                modal().as("modal").findByText("Orders in a dashboard").click();
+                cy.findByPlaceholderText("Search…").click();
+                // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+                cy.findByText("Recently viewed");
+                // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+                cy.findByText("Nothing here");
 
-                cy.get("@modal").should("not.exist");
-                // By default, the dashboard contains one question
-                // After we add a new one, we check there are two questions now
-                cy.get(".DashCard").should("have.length", 2);
+                // Check page for archived questions
+                cy.visit("/question/" + ORDERS_QUESTION_ID);
+                // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+                cy.findByText("This question has been archived");
               });
 
-              onlyOn(user === "normal", () => {
-                it("should preselect the most recently visited dashboard", () => {
+              describe("Add to Dashboard", () => {
+                it("should be able to add question to dashboard", () => {
                   openQuestionActions();
                   cy.findByTestId("add-to-dashboard-button").click();
 
-                  findSelectedItem().should("not.exist");
+                  modal()
+                    .as("modal")
+                    .findByText("Orders in a dashboard")
+                    .click();
 
-                  // before visiting the dashboard, we don't have any history
-                  visitDashboard(ORDERS_DASHBOARD_ID);
-
-                  visitQuestion(ORDERS_QUESTION_ID);
-
-                  openQuestionActions();
-                  cy.findByTestId("add-to-dashboard-button").click();
-
-                  findSelectedItem().should(
-                    "have.text",
-                    "Orders in a dashboard",
-                  );
+                  cy.get("@modal").should("not.exist");
+                  // By default, the dashboard contains one question
+                  // After we add a new one, we check there are two questions now
+                  cy.get(".DashCard").should("have.length", 2);
                 });
 
-                it("should handle lost access", () => {
-                  cy.intercept(
-                    "GET",
-                    "/api/activity/most_recently_viewed_dashboard",
-                  ).as("mostRecentlyViewedDashboard");
+                onlyOn(user === "normal", () => {
+                  it("should preselect the most recently visited dashboard", () => {
+                    openQuestionActions();
+                    cy.findByTestId("add-to-dashboard-button").click();
 
-                  openQuestionActions();
-                  cy.findByTestId("add-to-dashboard-button").click();
+                    findSelectedItem().should("not.exist");
 
-                  cy.wait("@mostRecentlyViewedDashboard");
+                    // before visiting the dashboard, we don't have any history
+                    visitDashboard(ORDERS_DASHBOARD_ID);
 
-                  findSelectedItem().should("not.exist");
+                    visitQuestion(ORDERS_QUESTION_ID);
 
-                  // before visiting the dashboard, we don't have any history
-                  visitDashboard(ORDERS_DASHBOARD_ID);
-                  visitQuestion(ORDERS_QUESTION_ID);
+                    openQuestionActions();
+                    cy.findByTestId("add-to-dashboard-button").click();
 
-                  openQuestionActions();
-                  cy.findByTestId("add-to-dashboard-button").click();
-
-                  cy.wait("@mostRecentlyViewedDashboard");
-
-                  findSelectedItem().should(
-                    "have.text",
-                    "Orders in a dashboard",
-                  );
-
-                  cy.findByRole("dialog").within(() => {
-                    cy.icon("close").click();
+                    findSelectedItem().should(
+                      "have.text",
+                      "Orders in a dashboard",
+                    );
                   });
 
-                  cy.signInAsAdmin();
+                  it("should handle lost access", () => {
+                    cy.intercept(
+                      "GET",
+                      "/api/activity/most_recently_viewed_dashboard",
+                    ).as("mostRecentlyViewedDashboard");
 
-                  // Let's revoke access to "Our analytics"
-                  cy.updateCollectionGraph({
-                    [USER_GROUPS.COLLECTION_GROUP]: { root: "none" },
+                    openQuestionActions();
+                    cy.findByTestId("add-to-dashboard-button").click();
+
+                    cy.wait("@mostRecentlyViewedDashboard");
+
+                    findSelectedItem().should("not.exist");
+
+                    // before visiting the dashboard, we don't have any history
+                    visitDashboard(ORDERS_DASHBOARD_ID);
+                    visitQuestion(ORDERS_QUESTION_ID);
+
+                    openQuestionActions();
+                    cy.findByTestId("add-to-dashboard-button").click();
+
+                    cy.wait("@mostRecentlyViewedDashboard");
+
+                    findSelectedItem().should(
+                      "have.text",
+                      "Orders in a dashboard",
+                    );
+
+                    cy.findByRole("dialog").within(() => {
+                      cy.icon("close").click();
+                    });
+
+                    cy.signInAsAdmin();
+
+                    // Let's revoke access to "Our analytics"
+                    cy.updateCollectionGraph({
+                      [USER_GROUPS.COLLECTION_GROUP]: { root: "none" },
+                    });
+
+                    cy.signIn(user);
+
+                    openQuestionActions();
+                    cy.findByTestId("add-to-dashboard-button").click();
+
+                    cy.wait("@mostRecentlyViewedDashboard");
+
+                    // no access - no dashboard
+                    findSelectedItem().should("not.exist");
                   });
-
-                  cy.signIn(user);
-
-                  openQuestionActions();
-                  cy.findByTestId("add-to-dashboard-button").click();
-
-                  cy.wait("@mostRecentlyViewedDashboard");
-
-                  // no access - no dashboard
-                  findSelectedItem().should("not.exist");
                 });
               });
             });
           });
-        });
 
-        onlyOn(permission === "view", () => {
-          describe(`${user} user`, () => {
-            beforeEach(() => {
-              cy.signIn(user);
-              visitQuestion(ORDERS_QUESTION_ID);
-            });
+          onlyOn(permission === "view", () => {
+            describe(`${user} user`, () => {
+              beforeEach(() => {
+                cy.signIn(user);
+                visitQuestion(ORDERS_QUESTION_ID);
+              });
 
-            it("should not be offered to add question to dashboard inside a collection they have `read` access to", () => {
-              openQuestionActions();
-              cy.findByTestId("add-to-dashboard-button").click();
+              it("should not be offered to add question to dashboard inside a collection they have `read` access to", () => {
+                openQuestionActions();
+                cy.findByTestId("add-to-dashboard-button").click();
 
-              cy.get(".Modal").within(() => {
-                cy.findByText("Orders in a dashboard").should("not.exist");
-                cy.icon("search").click();
-                cy.findByPlaceholderText("Search").type(
-                  "Orders in a dashboard{Enter}",
-                  { delay: 0 },
+                cy.get(".Modal").within(() => {
+                  cy.findByText("Orders in a dashboard").should("not.exist");
+                  cy.icon("search").click();
+                  cy.findByPlaceholderText("Search").type(
+                    "Orders in a dashboard{Enter}",
+                    { delay: 0 },
+                  );
+                  cy.findByText("Orders in a dashboard").should("not.exist");
+                });
+              });
+
+              it("should offer personal collection as a save destination for a new dashboard", () => {
+                const { first_name, last_name } = USERS[user];
+                const personalCollection = `${first_name} ${last_name}'s Personal Collection`;
+                openQuestionActions();
+                cy.findByTestId("add-to-dashboard-button").click();
+
+                cy.get(".Modal").within(() => {
+                  cy.findByText("Create a new dashboard").click();
+                  cy.findByTestId("select-button").findByText(
+                    personalCollection,
+                  );
+                  cy.findByLabelText("Name").type("Foo", { delay: 0 });
+                  cy.button("Create").click();
+                });
+                cy.url().should("match", /\/dashboard\/\d+-foo$/);
+                saveDashboard();
+                cy.get("header").findByText(personalCollection);
+              });
+
+              it("should not offer a user the ability to update or clone the question", () => {
+                cy.findByTestId("edit-details-button").should("not.exist");
+                cy.findByRole("button", { name: "Add a description" }).should(
+                  "not.exist",
                 );
-                cy.findByText("Orders in a dashboard").should("not.exist");
-              });
-            });
 
-            it("should offer personal collection as a save destination for a new dashboard", () => {
-              const { first_name, last_name } = USERS[user];
-              const personalCollection = `${first_name} ${last_name}'s Personal Collection`;
-              openQuestionActions();
-              cy.findByTestId("add-to-dashboard-button").click();
+                openQuestionActions();
 
-              cy.get(".Modal").within(() => {
-                cy.findByText("Create a new dashboard").click();
-                cy.findByTestId("select-button").findByText(personalCollection);
-                cy.findByLabelText("Name").type("Foo", { delay: 0 });
-                cy.button("Create").click();
-              });
-              cy.url().should("match", /\/dashboard\/\d+-foo$/);
-              saveDashboard();
-              cy.get("header").findByText(personalCollection);
-            });
+                popover().within(() => {
+                  cy.findByTestId("move-button").should("not.exist");
+                  cy.findByTestId("clone-button").should("not.exist");
+                  cy.findByTestId("archive-button").should("not.exist");
+                });
 
-            it("should not offer a user the ability to update or clone the question", () => {
-              cy.findByTestId("edit-details-button").should("not.exist");
-              cy.findByRole("button", { name: "Add a description" }).should(
-                "not.exist",
-              );
-
-              openQuestionActions();
-
-              popover().within(() => {
-                cy.findByTestId("move-button").should("not.exist");
-                cy.findByTestId("clone-button").should("not.exist");
-                cy.findByTestId("archive-button").should("not.exist");
+                // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+                cy.findByText("Revert").should("not.exist");
               });
 
-              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-              cy.findByText("Revert").should("not.exist");
-            });
+              it("should not preselect the most recently visited dashboard", () => {
+                openQuestionActions();
+                cy.findByTestId("add-to-dashboard-button").click();
 
-            it("should not preselect the most recently visited dashboard", () => {
-              openQuestionActions();
-              cy.findByTestId("add-to-dashboard-button").click();
+                findSelectedItem().should("not.exist");
 
-              findSelectedItem().should("not.exist");
+                // before visiting the dashboard, we don't have any history
+                visitDashboard(ORDERS_DASHBOARD_ID);
+                visitQuestion(ORDERS_QUESTION_ID);
 
-              // before visiting the dashboard, we don't have any history
-              visitDashboard(ORDERS_DASHBOARD_ID);
+                openQuestionActions();
+                cy.findByTestId("add-to-dashboard-button").click();
 
-              visitQuestion(ORDERS_QUESTION_ID);
-
-              openQuestionActions();
-              cy.findByTestId("add-to-dashboard-button").click();
-
-              // still no data
-              findSelectedItem().should("not.exist");
+                // still no data
+                findSelectedItem().should("not.exist");
+              });
             });
           });
         });
       });
     });
-  });
-});
+  },
+);
 
 describeWithSnowplow("send snowplow question events", () => {
   const NUMBERS_OF_GOOD_SNOWPLOW_EVENTS_BEFORE_MODEL_CONVERSION = 2;

--- a/e2e/test/scenarios/visualizations/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/object_detail.cy.spec.js
@@ -41,7 +41,7 @@ const TEST_PEOPLE_QUESTION = {
   },
 };
 
-describe("scenarios > question > object details", () => {
+describe("scenarios > question > object details", { tags: "@slow" }, () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -31,7 +31,7 @@ const TEST_CASES = [
   { case: "dashboard", subject: DASHBOARD_NAME },
 ];
 
-describe("scenarios > visualizations > pivot tables", () => {
+describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
We have some extremely long and slow tests in our E2E test suite.
The longest one takes around eight minutes on regular GitHub hosted runners.

I've identified specs that take more than 2 - 3 minutes on GH free hosted runners and have tagged them with `@slow`. Cypress allows a custom config as a second parameter for each test `it` and for each block `describe`.
```js
describe("very long set of slow tests", { ...config } , ()=> {
  // testing logic...
})
```

We're utilizing the power of Cypress grep plugin to tag slow tests without having to physically move them.
See the documentation for the reference: https://github.com/cypress-io/cypress/tree/develop/npm/grep

We're then utilizing [the `include` option](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations) in GitHub `matrix` creation to add a new runner that will run only these specific tests.

**The beauty of this approach is that you can use ANY custom runner**.

The main idea is illustrated here
1. Identify slow specs
```
E2E group A (takes 35 minutes total)
   - foo1 spec
   - foo2 spec (takes 5+ minutes)
   - foo3 spec (takes 3 minutes)
   - ...fooN spec
E2E group B (takes 23 minutes total)
   - bar1 spec
   - bar2 spec (takes 7 minutes)
   - ...barN spec
```
2. tag slow specs with `@slow`
3. Run them using a beefy runner which would create a virtual group we can call `group S`
4. Exclude them from the main group `group A` without moving them physically

The result:
- `group A` now takes 27 minutes (35 - 5 - 3)
- `group B` now takes 16 minutes (23 - 7)
- `group S` **should** take less than the sum of the specs we isolated because we run them on faster and more powerful machine
    - total time on the default runners for all tagged specs combined was ~15 min
    - total time on beefier runner **should** be `f * 15 min` where `f < 1`; the actual fraction `f` depends on how much more powerful the runner is