### PR TITLE
Quick fix for UI glitches caused by changing z-index at dashboards

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.tsx
@@ -113,7 +113,7 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)<{
   padding-top: ${space(2)};
   padding-bottom: ${space(1)};
   /* z-index should be higher than in dashcards */
-  z-index: 4;
+  z-index: 3;
   position: sticky;
   top: 0;
   left: 0;

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.styled.tsx
@@ -7,7 +7,7 @@ interface DashboardCardProps {
 
 export const DashboardCard = styled.div<DashboardCardProps>`
   position: relative;
-  z-index: 2;
+  z-index: 1;
 
   /**
   * Dashcards are positioned absolutely so each one forms a new stacking context.
@@ -18,7 +18,7 @@ export const DashboardCard = styled.div<DashboardCardProps>`
   */
   &:hover,
   &:focus-within {
-    z-index: 3;
+    z-index: 2;
   }
 
   .Card {


### PR DESCRIPTION
### 🚧 A note for reviewers

Please pay attention on dashboard in edit mode. It's better to check if initial problem with stacking dashcard actions with different order is fixed.

(steps to reproduce and demo is in PR description https://github.com/metabase/metabase/pull/32796)

### Description

It's a quick fix for UI glitches. As we encountered problems with z-index in different areas to put out the fire at https://github.com/metabase/metabase/pull/33011
https://github.com/metabase/metabase/pull/32796

the proper fix will be to have a generalized list of z indices and I'll address it in different PR, but to unblock everyone, let's merge this simple increase of z-index

### How to verify

Go to dashboard add a filter, click on search, hover over some element with popover (e.g. more info with `i` icon), text shouldn't be clipped 

### Demo

<img width="619" alt="image" src="https://github.com/metabase/metabase/assets/125459446/16368881-ee3d-45d0-b6fc-2f7ed638022b">
<img width="720" alt="image" src="https://github.com/metabase/metabase/assets/125459446/eb3609bc-da89-43d6-846f-93ed2d640df3">


### Checklist

- no tests
