### PR TITLE
Fix flaky reproduction for 15891

### DIFF
--- a/e2e/test/scenarios/custom-column/cc-help-text.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-help-text.cy.spec.js
@@ -2,7 +2,6 @@ import {
   enterCustomColumnDetails,
   restore,
   openProductsTable,
-  popover,
 } from "e2e/support/helpers";
 
 describe("scenarios > question > custom column > help text", () => {
@@ -34,24 +33,26 @@ describe("scenarios > question > custom column > help text", () => {
   });
 
   it("should not appear when formula field is not in focus (metabase#15891)", () => {
-    enterCustomColumnDetails({ formula: "rou{enter}1.5" });
+    enterCustomColumnDetails({ formula: "rou{enter}1.5){leftArrow}" });
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("round([Temperature])");
+    cy.findByTestId("expression-helper-popover").findByText(
+      "round([Temperature])",
+    );
 
-    // Click outside of formula field instead of blur
-    popover().first().click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("round([Temperature])").should("not.exist");
+    cy.log("Blur event should remove the expression helper popover");
+    cy.get("@formula").blur();
+    cy.findByTestId("expression-helper-popover").should("not.exist");
 
-    // Should also work with escape key
     cy.get("@formula").focus();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("round([Temperature])");
+    cy.findByTestId("expression-helper-popover").findByText(
+      "round([Temperature])",
+    );
 
+    cy.log(
+      "Pressing `escape` key should also remove the expression helper popover",
+    );
     cy.get("@formula").type("{esc}");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("round([Temperature])").should("not.exist");
+    cy.findByTestId("expression-helper-popover").should("not.exist");
   });
 
   it("should not disappear when clicked on (metabase#17548)", () => {


### PR DESCRIPTION
The failure happens on faster runners, including locally.
Example of a failed run when using 8 cores: https://www.deploysentinel.com/ci/runs/64d6914e732006fc0f42406d

The test was trying to click on the popover, rather than relying on the `blur` event. It then failed to click because the popover is being covered by another element (help text popover)
![image](https://github.com/metabase/metabase/assets/31325167/0f1e0ce3-a01a-4169-9c5b-18c15eebcabe)

Not sure exactly why, but I suspect this was the workaround for the original issue.
So not only does this PR fix the flake, but it actually fixes a wrong test implementation.

After the fix:
![image](https://github.com/metabase/metabase/assets/31325167/67a7b49c-c756-4033-93e3-8805ec56567c)
