### PR TITLE
Tune MySQL and Postgres CSV uploads to use less memory

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -804,12 +804,14 @@
                                      :columns     (map keyword column-names)
                                      ::from-stdin "''"}
                                     :quoted true
-                                    :dialect (sql.qp/quote-style driver))
-           tsvs         (->> values
-                             (map row->tsv)
-                             (str/join "\n")
-                             (StringReader.))]
-       (.copyIn copy-manager ^String sql tsvs)))))
+                                    :dialect (sql.qp/quote-style driver))]
+       ;; There's nothing magic about 100, but it felt good in testing. There could well be a better number.
+       (doseq [slice-of-values (partition-all 100 values)]
+         (let [tsvs (->> slice-of-values
+                         (map row->tsv)
+                         (str/join "\n")
+                         (StringReader.))]
+           (.copyIn copy-manager ^String sql tsvs)))))))
 
 ;;; ------------------------------------------------- User Impersonation --------------------------------------------------
 


### PR DESCRIPTION
1. Keep the seq of values-to-insert lazy until it's time to send it to the database. This lets us operate line-by-line instead of putting the whole thing into memory.
2. We gotta realize them somewhere. For MySQL this is great—it reads from a file, so we can dump the values into a temp file line by line.
3. For Postgres it's a bit fiddlier since it needs a string representation of the values in memory. I opted for batching it in groups of 100, which seemed good on my machine, but this is something to keep an eye on in Stats to see what happens.

[Fixes #31949]