### PR TITLE
DB Connection Test flake

### DIFF
--- a/e2e/test/scenarios/admin/databases/add-new-database.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/add-new-database.cy.spec.js
@@ -16,6 +16,7 @@ describe("admin > database > add", () => {
     cy.signInAsAdmin();
 
     cy.intercept("POST", "/api/database").as("createDatabase");
+    cy.intercept("GET", "/api/database").as("getDatabases");
 
     cy.visit("/admin/databases/create");
     // should display a setup help card
@@ -58,38 +59,35 @@ describe("admin > database > add", () => {
         }
       });
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("PostgreSQL").click({ force: true });
+      popover().contains("PostgreSQL").click({ force: true });
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Show advanced options").click();
+      cy.findByTestId("database-form").within(() => {
+        cy.findByText("Show advanced options").click();
+        cy.findByLabelText("Rerun queries for simple explorations").should(
+          "have.attr",
+          "aria-checked",
+          "true",
+        );
+        // Reproduces (metabase#14334)
+        cy.findByText("Additional JDBC connection string options");
+        // Reproduces (metabase#17450)
+        cy.findByLabelText("Choose when syncs and scans happen")
+          .click()
+          .should("have.attr", "aria-checked", "true");
+        cy.findByLabelText("Never, I'll do this manually if I need to").should(
+          "have.attr",
+          "aria-selected",
+          "true",
+        );
 
-      // Reproduces (metabase#14334)
-      cy.findByLabelText("Rerun queries for simple explorations").should(
-        "have.attr",
-        "aria-checked",
-        "true",
-      );
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("Additional JDBC connection string options");
-      // Reproduces (metabase#17450)
-      cy.findByLabelText("Choose when syncs and scans happen")
-        .click()
-        .should("have.attr", "aria-checked", "true");
-
-      cy.findByLabelText("Never, I'll do this manually if I need to").should(
-        "have.attr",
-        "aria-selected",
-        "true",
-      );
-
-      // make sure fields needed to connect to the database are properly trimmed (metabase#12972)
-      typeAndBlurUsingLabel("Display name", "QA Postgres12");
-      typeAndBlurUsingLabel("Host", "localhost");
-      typeAndBlurUsingLabel("Port", QA_POSTGRES_PORT);
-      typeAndBlurUsingLabel("Database name", "sample");
-      typeAndBlurUsingLabel("Username", "metabase");
-      typeAndBlurUsingLabel("Password", "metasample123");
+        // make sure fields needed to connect to the database are properly trimmed (metabase#12972)
+        typeAndBlurUsingLabel("Display name", "QA Postgres12");
+        typeAndBlurUsingLabel("Host", "localhost");
+        typeAndBlurUsingLabel("Port", QA_POSTGRES_PORT);
+        typeAndBlurUsingLabel("Database name", "sample");
+        typeAndBlurUsingLabel("Username", "metabase");
+        typeAndBlurUsingLabel("Password", "metasample123");
+      });
 
       const confirmSSLFields = (visible, hidden) => {
         visible.forEach(field => cy.findByText(field));
@@ -148,12 +146,15 @@ describe("admin > database > add", () => {
 
       cy.url().should("match", /\/admin\/databases\?created=true$/);
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("We're taking a look at your database!");
-      cy.findByLabelText("close icon").click();
+      waitForDbSync();
+
+      cy.findByRole("dialog").within(() => {
+        cy.findByText("We're taking a look at your database!");
+        cy.findByLabelText("close icon").click();
+      });
 
       cy.findByRole("status").within(() => {
-        cy.findByText("Syncing…");
+        cy.findByText(/syncing/i);
         cy.findByText("Done!");
       });
 
@@ -367,4 +368,16 @@ function mockSuccessfulDatabaseSave() {
 
   cy.button("Save").click();
   return cy.wait("@createDatabase");
+}
+
+// we need to check for an indefinite number of these requests because we don't know how many polls it's going to take
+function waitForDbSync(maxRetries = 10) {
+  if (maxRetries === 0) {
+    throw new Error("Timed out waiting for database sync");
+  }
+  cy.wait("@getDatabases").then(({ response }) => {
+    if (response.body.data.some(db => db.initial_sync_status !== "complete")) {
+      waitForDbSync(maxRetries - 1);
+    }
+  });
 }

--- a/e2e/test/scenarios/admin/databases/add-new-database.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/add-new-database.cy.spec.js
@@ -175,7 +175,7 @@ describe("admin > database > add", () => {
       );
     });
 
-    it("should add Mongo database and redirect to listing", () => {
+    it.skip("should add Mongo database and redirect to listing", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("MongoDB").click({ force: true });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -213,7 +213,7 @@ describe("admin > database > add", () => {
       });
     });
 
-    it("should add Mongo database via the connection string", () => {
+    it.skip("should add Mongo database via the connection string", () => {
       const connectionString = `mongodb://metabase:metasample123@localhost:${QA_MONGO_PORT}/sample?authSource=admin`;
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -251,7 +251,7 @@ describe("admin > database > add", () => {
       });
     });
 
-    it("should add MySQL database and redirect to listing", () => {
+    it.skip("should add MySQL database and redirect to listing", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("MySQL").click({ force: true });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -296,7 +296,7 @@ describe("admin > database > add", () => {
     });
   });
 
-  describe("Google service account JSON upload", () => {
+  describe.skip("Google service account JSON upload", () => {
     const serviceAccountJSON = '{"foo": 123}';
 
     it("should work for BigQuery", () => {

--- a/e2e/test/scenarios/admin/databases/add-new-database.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/add-new-database.cy.spec.js
@@ -154,7 +154,6 @@ describe("admin > database > add", () => {
       });
 
       cy.findByRole("status").within(() => {
-        cy.findByText(/syncing/i);
         cy.findByText("Done!");
       });
 

--- a/e2e/test/scenarios/admin/databases/add-new-database.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/add-new-database.cy.spec.js
@@ -174,7 +174,7 @@ describe("admin > database > add", () => {
       );
     });
 
-    it.skip("should add Mongo database and redirect to listing", () => {
+    it("should add Mongo database and redirect to listing", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("MongoDB").click({ force: true });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -212,7 +212,7 @@ describe("admin > database > add", () => {
       });
     });
 
-    it.skip("should add Mongo database via the connection string", () => {
+    it("should add Mongo database via the connection string", () => {
       const connectionString = `mongodb://metabase:metasample123@localhost:${QA_MONGO_PORT}/sample?authSource=admin`;
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -250,7 +250,7 @@ describe("admin > database > add", () => {
       });
     });
 
-    it.skip("should add MySQL database and redirect to listing", () => {
+    it("should add MySQL database and redirect to listing", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("MySQL").click({ force: true });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -295,7 +295,7 @@ describe("admin > database > add", () => {
     });
   });
 
-  describe.skip("Google service account JSON upload", () => {
+  describe("Google service account JSON upload", () => {
     const serviceAccountJSON = '{"foo": 123}';
 
     it("should work for BigQuery", () => {

--- a/e2e/test/scenarios/admin/databases/add-new-database.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/add-new-database.cy.spec.js
@@ -150,7 +150,7 @@ describe("admin > database > add", () => {
 
       cy.findByRole("dialog").within(() => {
         cy.findByText("We're taking a look at your database!");
-        cy.findByLabelText("close icon").click();
+        cy.icon("close").click();
       });
 
       cy.findByRole("status").within(() => {

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
@@ -134,7 +134,7 @@ const DatabaseFormBody = ({
   }, [engine, values, isAdvanced]);
 
   return (
-    <Form>
+    <Form data-testid="database-form">
       <DatabaseEngineField
         engineKey={engineKey}
         engines={engines}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/33171

![Screen Shot 2023-08-14 at 10 50 42 AM](https://github.com/metabase/metabase/assets/30528226/9baa2e8d-ac72-4100-a69b-b36ec73b1d54)


### Flake Cause

This is currently our flakiest test. When we connect a new DB for the first time, we show a nice little informational modal:

![Screen Shot 2023-08-14 at 12 57 45 PM](https://github.com/metabase/metabase/assets/30528226/44c418fb-a6bc-4f63-b995-0a79b583d902)

As you can see in this screenshot, the db status is "Syncing..." while this modal is open. Sometimes, the sync happens so fast that the next render after closing the modal shows the sync as complete (note the click indicator, we're still on the mouseUp event):

![Screen Shot 2023-08-14 at 1 18 35 PM](https://github.com/metabase/metabase/assets/30528226/79a7b2bd-54db-45ba-b601-cddf192657be)

Sometimes though, the db is stilly syncing when the modal is closed

![Screen Shot 2023-08-14 at 1 17 16 PM](https://github.com/metabase/metabase/assets/30528226/3c0f1108-7066-4aec-b069-05ea66b726dd)

The problem here is that we don't know exactly how long the db will take to sync. The frontend just continually polls the `/api/database` endpoint to check that the sync has finished, so we don't even know how many API requests to wait for.

## Solution

We should rely on the api requests, not just the UI to determine whether the db has synced. We can predict the exact state of the UI if we wait until we get a successful response from `/api/database`. This adds a recursive `waitForDbSync()` function that keeps waiting on these sync requests until it gets one with the success payload.