### PR TITLE
Round small y-axis values to zero with no min/max difference on the Y scale

### DIFF
--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -493,7 +493,8 @@ export function getYValueFormatter(chart, series, yExtent) {
     const metricColumn = series[seriesIndex].data.cols[1];
     const columnSettings = chart.settings.column(metricColumn);
     const columnExtent = options.extent ?? yExtent;
-    const roundedValue = maybeRoundValueToZero(value, columnExtent);
+    const roundedValue =
+      value === null ? "" : maybeRoundValueToZero(value, columnExtent);
     return formatValue(roundedValue, { ...columnSettings, ...options });
   };
 }

--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -352,7 +352,10 @@ export function applyChartOrdinalXAxis(
 // The tolerance is arbitrarily set to one millionth of the yExtent.
 const TOLERANCE_TO_Y_EXTENT = 1e6;
 export function maybeRoundValueToZero(value, [yMin, yMax]) {
-  const tolerance = Math.abs(yMax - yMin) / TOLERANCE_TO_Y_EXTENT;
+  const tolerance =
+    yMin !== yMax
+      ? Math.abs(yMax - yMin) / TOLERANCE_TO_Y_EXTENT
+      : 1 / TOLERANCE_TO_Y_EXTENT;
   return Math.abs(value) < tolerance ? 0 : value;
 }
 

--- a/frontend/src/metabase/visualizations/lib/apply_axis.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.unit.spec.js
@@ -61,5 +61,11 @@ describe("visualization.lib.apply_axis", () => {
 
       expect(value).toBe(0.0000000000018);
     });
+
+    it("should work on single-value charts (where minExtent === maxExtent)", () => {
+      const value = maybeRoundValueToZero(0.0000000000018, [0.00001, 0.00001]);
+
+      expect(value).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/32815

### Problem

This bug manifested only on charts where there was a single value. In those cases, there was an edge case where our existing round-to-zero logic would get bypassed.

On master, a bar chart with a single value shows the error, but multiple values do not:

<table>
<thead>
<tr><td>query</td><td>chart</td></tr>
</thead>
<tbody>

<tr>
  <td>
<pre>
SELECT 'a' as label, -0.0094 AS val
UNION ALL 
SELECT 'b' as label, -0.0094 AS val
</pre>
</td>
<td>
  <img src="https://github.com/metabase/metabase/assets/30528226/66c277df-e56b-4cbe-bb79-c0f1ca5fef1c">
</td>
</tr>
<tr>
  <td>
<pre>
SELECT 'a' as label, -0.0094 AS val
UNION ALL 
SELECT 'b' as label, -0.0095 AS val
</pre>
</td>
<td>
  <img src="https://github.com/metabase/metabase/assets/30528226/46eca941-845e-4764-9d75-1809eb4f6f55">
</td>
</tr>
</tbody>
</table>


### Solution

If a chart has no difference between the min and max values, for rounding purposes, we treat it as if the min/max difference is 1.

![Screen Shot 2023-08-14 at 2 47 19 PM](https://github.com/metabase/metabase/assets/30528226/d53e2758-ba44-42c9-b719-099995d7a153)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
