### PR TITLE
Hide read-only items in the archive page

### DIFF
--- a/frontend/src/metabase/archive/containers/ArchiveApp.jsx
+++ b/frontend/src/metabase/archive/containers/ArchiveApp.jsx
@@ -45,30 +45,51 @@ class ArchiveApp extends Component {
   constructor(props) {
     super(props);
     this.mainElement = getMainElement();
+    this.state = {
+      writableList: [],
+    };
   }
 
   componentDidMount() {
     if (!isSmallScreen()) {
       this.props.openNavbar();
     }
+
+    this.setWritableItems();
+  }
+
+  componentDidUpdate(prevProps) {
+    this.setWritableItems({ prevList: prevProps.list });
+  }
+
+  setWritableItems({ prevList } = { prevList: [] }) {
+    const { isAdmin, list, collectionsById } = this.props;
+
+    if (_.isEqual(prevList, list)) {
+      return;
+    }
+
+    const newWritableList = isAdmin
+      ? list
+      : list.filter(
+          item => collectionsById?.[item.getCollection().id]?.can_write,
+        );
+
+    this.setState({
+      writableList: newWritableList,
+    });
   }
 
   render() {
     const {
       isAdmin,
       isNavbarOpen,
-      list,
-      collectionsById,
       reload,
       selected,
       selection,
       onToggleSelected,
     } = this.props;
-    const writableList = isAdmin
-      ? list
-      : list.filter(
-          item => collectionsById?.[item.getCollection().id]?.can_write,
-        );
+    const { writableList } = this.state;
 
     return (
       <ArchiveRoot>

--- a/frontend/src/metabase/archive/containers/ArchiveApp.jsx
+++ b/frontend/src/metabase/archive/containers/ArchiveApp.jsx
@@ -55,14 +55,14 @@ class ArchiveApp extends Component {
       this.props.openNavbar();
     }
 
-    this.setWritableItems();
+    this.setWritableList();
   }
 
   componentDidUpdate(prevProps) {
-    this.setWritableItems({ prevList: prevProps.list });
+    this.setWritableList({ prevList: prevProps.list });
   }
 
-  setWritableItems({ prevList } = { prevList: [] }) {
+  setWritableList({ prevList } = { prevList: [] }) {
     const { isAdmin, list, collectionsById } = this.props;
 
     if (_.isEqual(prevList, list)) {

--- a/frontend/src/metabase/archive/containers/ArchiveApp.jsx
+++ b/frontend/src/metabase/archive/containers/ArchiveApp.jsx
@@ -16,6 +16,7 @@ import listSelect from "metabase/hoc/ListSelect";
 
 import { getIsNavbarOpen, openNavbar } from "metabase/redux/app";
 import { getUserIsAdmin } from "metabase/selectors/user";
+import { getCollectionsById } from "metabase/selectors/collection";
 import { isSmallScreen, getMainElement } from "metabase/lib/dom";
 import ArchivedItem from "../../components/ArchivedItem";
 
@@ -31,6 +32,7 @@ import {
 const mapStateToProps = (state, props) => ({
   isNavbarOpen: getIsNavbarOpen(state),
   isAdmin: getUserIsAdmin(state, props),
+  collectionsById: getCollectionsById(state),
 });
 
 const mapDispatchToProps = {
@@ -56,12 +58,18 @@ class ArchiveApp extends Component {
       isAdmin,
       isNavbarOpen,
       list,
+      collectionsById,
       reload,
-
       selected,
       selection,
       onToggleSelected,
     } = this.props;
+    const writableList = isAdmin
+      ? list
+      : list.filter(
+          item => collectionsById?.[item.getCollection().id]?.can_write,
+        );
+
     return (
       <ArchiveRoot>
         <ArchiveHeader>
@@ -70,13 +78,16 @@ class ArchiveApp extends Component {
         <ArchiveBody>
           <Card
             style={{
-              height: list.length > 0 ? ROW_HEIGHT * list.length : "auto",
+              height:
+                writableList.length > 0
+                  ? ROW_HEIGHT * writableList.length
+                  : "auto",
             }}
           >
-            {list.length > 0 ? (
+            {writableList.length > 0 ? (
               <VirtualizedList
                 scrollElement={this.mainElement}
-                items={list}
+                items={writableList}
                 rowHeight={ROW_HEIGHT}
                 renderItem={({ item }) => (
                   <ArchivedItem

--- a/frontend/src/metabase/selectors/collection.ts
+++ b/frontend/src/metabase/selectors/collection.ts
@@ -1,0 +1,10 @@
+import { createSelector } from "@reduxjs/toolkit";
+
+import type { State } from "metabase-types/store";
+
+export const getEntities = (state: State) => state.entities;
+
+export const getCollectionsById = createSelector(
+  [getEntities],
+  entities => entities.collections,
+);


### PR DESCRIPTION
**Problem:** When users navigate to the archive page, it shows them items for which they have read-only permissions (items that they are not permitted to un-archive or delete)
- Context: https://github.com/metabase/metabase/issues/24018

---
**Desired Behavior**/**Acceptance Criteria**

_Tests_


---
**How to Verify**
