### PR TITLE
Refactor viz auto-selection: merge switchTableScalar into maybeResetDisplay

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -337,14 +337,14 @@ class QuestionInner {
 
     if (isSensible && defaultDisplay === "table") {
       // any sensible display is better than the default table display
-      return question;
+      return this;
     }
 
-    if (shouldUnlock && question.displayIsLocked()) {
-      return question.setDisplayIsLocked(false).setDefaultDisplay();
+    if (shouldUnlock && this.displayIsLocked()) {
+      return this.setDisplayIsLocked(false).setDefaultDisplay();
     }
 
-    return question.setDefaultDisplay();
+    return this.setDefaultDisplay();
   }
 
   setDefaultDisplay(): Question {

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -335,12 +335,12 @@ class QuestionInner {
       return this.setDisplayIsLocked(false).setDefaultDisplay();
     }
 
-    return this.setDefaultDisplay().switchTableScalar(data);
+    return this.setDefaultDisplay()._switchTableScalar(data);
   }
 
   // Switches display based on data shape. For 1x1 data, we show a scalar. If
   // our display was a 1x1 type, but the data isn't 1x1, we show a table.
-  switchTableScalar({ rows, cols }): Question {
+  private _switchTableScalar({ rows, cols }): Question {
     // For 1x1 data, we show a scalar. If our display was a 1x1 type, but the data
     // isn't 1x1, we show a table.
     const isScalar = ["scalar", "progress", "gauge"].includes(this.display());

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -319,7 +319,14 @@ class QuestionInner {
     sensibleDisplays: [string],
     previousSensibleDisplays: [string] | null,
   ): Question {
-    const question = this._maybeSwitchToScalar(data);
+    // For 1x1 data, we show a scalar. If our display was a 1x1 type, but the data
+    // isn't 1x1, we show a table.
+    const isScalar = ["scalar", "progress", "gauge"].includes(this.display());
+    const isOneByOne = data.rows.length === 1 && data.cols.length === 1;
+    // if we have a 1x1 data result then this should always be viewed as a scalar
+    if (!isScalar && isOneByOne && !this.displayIsLocked()) {
+      return this.setDisplay("scalar");
+    }
 
     const wasSensible =
       previousSensibleDisplays == null ||
@@ -338,20 +345,6 @@ class QuestionInner {
     }
 
     return question.setDefaultDisplay();
-  }
-
-  // Switches display based on data shape. For 1x1 data, we show a scalar. If
-  // our display was a 1x1 type, but the data isn't 1x1, we show a table.
-  private _maybeSwitchToScalar({ rows, cols }): Question {
-    // For 1x1 data, we show a scalar. If our display was a 1x1 type, but the data
-    // isn't 1x1, we show a table.
-    const isScalar = ["scalar", "progress", "gauge"].includes(this.display());
-    const isOneByOne = rows.length === 1 && cols.length === 1;
-    // if we have a 1x1 data result then this should always be viewed as a scalar
-    if (!isScalar && isOneByOne && !this.displayIsLocked()) {
-      return this.setDisplay("scalar");
-    }
-    return this;
   }
 
   setDefaultDisplay(): Question {

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -335,12 +335,12 @@ class QuestionInner {
       return this.setDisplayIsLocked(false).setDefaultDisplay();
     }
 
-    return this.setDefaultDisplay()._switchTableScalar(data);
+    return this.setDefaultDisplay()._maybeSwitchToScalar(data);
   }
 
   // Switches display based on data shape. For 1x1 data, we show a scalar. If
   // our display was a 1x1 type, but the data isn't 1x1, we show a table.
-  private _switchTableScalar({ rows, cols }): Question {
+  private _maybeSwitchToScalar({ rows, cols }): Question {
     // For 1x1 data, we show a scalar. If our display was a 1x1 type, but the data
     // isn't 1x1, we show a table.
     const isScalar = ["scalar", "progress", "gauge"].includes(this.display());

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -316,8 +316,8 @@ class QuestionInner {
 
   maybeResetDisplay(
     data: DatasetData,
-    sensibleDisplays: [string],
-    previousSensibleDisplays: [string] | null,
+    sensibleDisplays: string[],
+    previousSensibleDisplays: string[] | undefined,
   ): Question {
     const wasSensible =
       previousSensibleDisplays == null ||

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -319,6 +319,8 @@ class QuestionInner {
     sensibleDisplays: [string],
     previousSensibleDisplays: [string] | null,
   ): Question {
+    const question = this._maybeSwitchToScalar(data);
+
     const wasSensible =
       previousSensibleDisplays == null ||
       previousSensibleDisplays.includes(this.display());
@@ -328,14 +330,14 @@ class QuestionInner {
 
     if (isSensible && defaultDisplay === "table") {
       // any sensible display is better than the default table display
-      return this;
+      return question;
     }
 
-    if (shouldUnlock && this.displayIsLocked()) {
-      return this.setDisplayIsLocked(false).setDefaultDisplay();
+    if (shouldUnlock && question.displayIsLocked()) {
+      return question.setDisplayIsLocked(false).setDefaultDisplay();
     }
 
-    return this.setDefaultDisplay()._maybeSwitchToScalar(data);
+    return question.setDefaultDisplay();
   }
 
   // Switches display based on data shape. For 1x1 data, we show a scalar. If

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -339,14 +339,10 @@ class QuestionInner {
     return question._maybeSwitchToScalar(data);
   }
 
-  // Switches display based on data shape. For 1x1 data, we show a scalar. If
-  // our display was a 1x1 type, but the data isn't 1x1, we show a table.
+  // Switches display to scalar if the data is 1 row x 1 column
   private _maybeSwitchToScalar({ rows, cols }): Question {
-    // For 1x1 data, we show a scalar. If our display was a 1x1 type, but the data
-    // isn't 1x1, we show a table.
     const isScalar = ["scalar", "progress", "gauge"].includes(this.display());
     const isOneByOne = rows.length === 1 && cols.length === 1;
-    // if we have a 1x1 data result then this should always be viewed as a scalar
     if (!isScalar && isOneByOne && !this.displayIsLocked()) {
       return this.setDisplay("scalar");
     }

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -313,13 +313,26 @@ class QuestionInner {
     return this._card && this._card.displayIsLocked;
   }
 
-  maybeResetDisplay(sensibleDisplays, previousSensibleDisplays): Question {
+  maybeResetDisplay(
+    data,
+    sensibleDisplays,
+    previousSensibleDisplays,
+  ): Question {
     const wasSensible =
       previousSensibleDisplays == null ||
       previousSensibleDisplays.includes(this.display());
     const isSensible = sensibleDisplays.includes(this.display());
     const shouldUnlock = wasSensible && !isSensible;
     const defaultDisplay = this.setDefaultDisplay().display();
+
+    // For 1x1 data, we show a scalar. If our display was a 1x1 type, but the data
+    // isn't 1x1, we show a table.
+    const isScalar = ["scalar", "progress", "gauge"].includes(this.display());
+    const isOneByOne = data.rows.length === 1 && data.cols.length === 1;
+    // if we have a 1x1 data result then this should always be viewed as a scalar
+    if (!isScalar && isOneByOne && !this.displayIsLocked()) {
+      return this.setDisplay("scalar");
+    }
 
     if (isSensible && defaultDisplay === "table") {
       // any sensible display is better than the default table display
@@ -330,26 +343,10 @@ class QuestionInner {
       return this.setDisplayIsLocked(false).setDefaultDisplay();
     }
 
-    return this.setDefaultDisplay();
-  }
-
-  // Switches display based on data shape. For 1x1 data, we show a scalar. If
-  // our display was a 1x1 type, but the data isn't 1x1, we show a table.
-  switchTableScalar({ rows = [], cols }): Question {
     if (this.displayIsLocked()) {
       return this;
     }
-
-    const display = this.display();
-    const isScalar = ["scalar", "progress", "gauge"].includes(display);
-    const isOneByOne = rows.length === 1 && cols.length === 1;
-    const newDisplay =
-      !isScalar && isOneByOne // if we have a 1x1 data result then this should always be viewed as a scalar
-        ? "scalar"
-        : isScalar && !isOneByOne // any time we were a scalar and now have more than 1x1 data switch to table view
-        ? "table" // otherwise leave the display unchanged
-        : display;
-    return this.setDisplay(newDisplay);
+    return this.setDefaultDisplay();
   }
 
   setDefaultDisplay(): Question {

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -343,9 +343,6 @@ class QuestionInner {
       return this.setDisplayIsLocked(false).setDefaultDisplay();
     }
 
-    if (this.displayIsLocked()) {
-      return this;
-    }
     return this.setDefaultDisplay();
   }
 

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -189,12 +189,11 @@ export const queryCompleted = (question, queryResults) => {
         );
       }
 
-      question = question
-        .maybeResetDisplay(
-          getSensibleDisplays(data),
-          prevData && getSensibleDisplays(prevData),
-        )
-        .switchTableScalar(data);
+      question = question.maybeResetDisplay(
+        data,
+        getSensibleDisplays(data),
+        prevData && getSensibleDisplays(prevData),
+      );
     }
 
     const card = question.card();

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -2,7 +2,11 @@ import { assoc, dissoc, assocIn } from "icepick";
 import { parse } from "url";
 import { createMockMetadata } from "__support__/metadata";
 import { deserializeCardFromUrl } from "metabase/lib/card";
-import { createMockMetric } from "metabase-types/api/mocks";
+import {
+  createMockColumn,
+  createMockDatasetData,
+  createMockMetric,
+} from "metabase-types/api/mocks";
 import {
   createOrdersTable,
   createPeopleTable,
@@ -139,6 +143,29 @@ const orders_count_card = {
   },
 };
 const orders_count_question = new Question(orders_count_card, metadata);
+const ordersCountData = createMockDatasetData({
+  cols: [
+    createMockColumn({
+      name: "count",
+      display_name: "Count",
+      base_type: "type/BigInteger",
+      semantic_type: "type/Quantity",
+      effective_type: "type/BigInteger",
+    }),
+  ],
+  rows: [[1]],
+});
+
+const multipleRowsData = createMockDatasetData({
+  cols: [
+    createMockColumn({ display_name: "foo" }),
+    createMockColumn({ display_name: "bar" }),
+  ],
+  rows: [
+    [10, 20],
+    [100, 200],
+  ],
+});
 
 const orders_count_where_card = {
   id: 2,
@@ -445,11 +472,35 @@ describe("Question", () => {
         expect(question.display()).toBe("scalar");
       });
 
-      it("should not set the display to scalar if table was selected", () => {
+      it("should not set the display to scalar if table was selected and display is locked", () => {
         const question = orders_count_question
           .setDisplay("table")
           .lockDisplay()
-          .maybeResetDisplay(["table", "scalar"]);
+          .maybeResetDisplay(ordersCountData, ["table", "scalar"]);
+
+        expect(question.display()).toBe("table");
+      });
+
+      it("should set the display to scalar if a non-scalar was selected and display is locked", () => {
+        const question = base_question
+          .setDisplay("table")
+          .maybeResetDisplay(ordersCountData, ["table", "scalar"]);
+
+        expect(question.display()).toBe("scalar");
+      });
+
+      it("should not set the display to scalar if another scalar display was selected and display is locked", () => {
+        const question = base_question
+          .setDisplay("gauge")
+          .maybeResetDisplay(ordersCountData, ["table", "scalar", "gauge"]);
+
+        expect(question.display()).toBe("gauge");
+      });
+
+      it("switch to table view if we had a scalar and now have more than 1x1 data", () => {
+        const question = base_question
+          .setDisplay("scalar")
+          .maybeResetDisplay(multipleRowsData, ["table"]);
 
         expect(question.display()).toBe("table");
       });
@@ -458,7 +509,7 @@ describe("Question", () => {
         const question = orders_count_question
           .setDisplay("funnel")
           .lockDisplay()
-          .maybeResetDisplay(["table", "scalar"]);
+          .maybeResetDisplay(ordersCountData, ["table", "scalar"]);
 
         expect(question.display()).toBe("scalar");
       });
@@ -471,7 +522,11 @@ describe("Question", () => {
         const question = new Question(orders_count_card, metadata)
           .setDisplay("scalar")
           .lockDisplay()
-          .maybeResetDisplay(sensibleDisplays, previousSensibleDisplays);
+          .maybeResetDisplay(
+            ordersCountData,
+            sensibleDisplays,
+            previousSensibleDisplays,
+          );
 
         expect(question.displayIsLocked()).toBe(true);
         expect(question.display()).toBe("scalar");
@@ -483,7 +538,11 @@ describe("Question", () => {
         const question = new Question(orders_count_card, metadata)
           .setDisplay("funnel")
           .lockDisplay()
-          .maybeResetDisplay(sensibleDisplays, previousSensibleDisplays);
+          .maybeResetDisplay(
+            ordersCountData,
+            sensibleDisplays,
+            previousSensibleDisplays,
+          );
 
         expect(question.displayIsLocked()).toBe(true);
         expect(question.display()).toBe("funnel");
@@ -493,7 +552,11 @@ describe("Question", () => {
         const sensibleDisplays = ["table", "scalar"];
         const question = base_question
           .setDisplay("funnel")
-          .maybeResetDisplay(sensibleDisplays, sensibleDisplays);
+          .maybeResetDisplay(
+            multipleRowsData,
+            sensibleDisplays,
+            sensibleDisplays,
+          );
 
         expect(question.display()).not.toBe("funnel");
         expect(question.display()).toBe("table");
@@ -505,7 +568,11 @@ describe("Question", () => {
         const question = orders_count_question
           .setDisplay("funnel")
           .lockDisplay()
-          .maybeResetDisplay(sensibleDisplays, previousSensibleDisplays);
+          .maybeResetDisplay(
+            ordersCountData,
+            sensibleDisplays,
+            previousSensibleDisplays,
+          );
 
         expect(question.displayIsLocked()).toBe(false);
         expect(question.display()).not.toBe("funnel");
@@ -517,7 +584,7 @@ describe("Question", () => {
         const question = base_question
           .setDisplay("scalar")
           .lockDisplay()
-          .maybeResetDisplay(sensibleDisplays);
+          .maybeResetDisplay(multipleRowsData, sensibleDisplays);
 
         expect(question.display()).not.toBe("table");
         expect(question.display()).toBe("scalar");
@@ -527,7 +594,17 @@ describe("Question", () => {
         const sensibleDisplays = ["table", "scalar"];
         const question = base_question
           .setDisplay("scalar")
-          .maybeResetDisplay(sensibleDisplays);
+          .maybeResetDisplay(multipleRowsData, sensibleDisplays);
+
+        expect(question.display()).not.toBe("table");
+        expect(question.display()).toBe("scalar");
+      });
+
+      it("should switch to scalar display for 1x1 data", () => {
+        const sensibleDisplays = ["table", "scalar"];
+        const question = orders_count_question
+          .setDisplay("table")
+          .maybeResetDisplay(ordersCountData, sensibleDisplays);
 
         expect(question.display()).not.toBe("table");
         expect(question.display()).toBe("scalar");


### PR DESCRIPTION
This PR is part of an effort to clean up viz auto-selection code https://github.com/metabase/metabase/pull/31891

There should be no behaviour change here. This simply moves the `switchTableScalar` method into the `maybeResetDisplay` method and removes redundancies, and adds unit tests to cover the new logic in `maybeResetDisplay`. This behaviour was previously not unit tested since no unit tests exist for `switchTableScalar`.

