### PR TITLE
Normalize Formatted strings on \space char.

### DIFF
--- a/shared/test/metabase/shared/formatting/time_test.cljc
+++ b/shared/test/metabase/shared/formatting/time_test.cljc
@@ -1,10 +1,14 @@
 (ns metabase.shared.formatting.time-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [are deftest]]
    [metabase.shared.formatting.time :as time]))
 
 (deftest format-time-test
-  (are [exp input] (= exp (time/format-time input))
+  ;; some JVMs use non-breaking space (nbsp) in their formatted strings
+  ;; which can cause confusing looking test failures.
+  ;; A string replace normalizes on the ascii space char
+  (are [exp input] (= exp (str/replace (time/format-time input) #" " " "))
     "1:02 AM"  "01:02:03.456+07:00"
     "1:02 AM"  "01:02"
     "10:29 PM" "22:29:59.26816+01:00"

--- a/shared/test/metabase/shared/formatting/time_test.cljc
+++ b/shared/test/metabase/shared/formatting/time_test.cljc
@@ -8,7 +8,7 @@
   ;; some JVMs use non-breaking space (nbsp) in their formatted strings
   ;; which can cause confusing looking test failures.
   ;; A string replace normalizes on the ascii space char
-  (are [exp input] (= exp (str/replace (time/format-time input) #" " " "))
+  (are [exp input] (= exp (str/replace (time/format-time input) \u202f \space))
     "1:02 AM"  "01:02:03.456+07:00"
     "1:02 AM"  "01:02"
     "10:29 PM" "22:29:59.26816+01:00"

--- a/test/metabase/util/date_2_test.clj
+++ b/test/metabase/util/date_2_test.clj
@@ -197,7 +197,7 @@
           [locale expected] expected]
     (mt/with-user-locale locale
       (testing (format "%s %s" (.getCanonicalName (class t)) (pr-str t))
-        (let [actual (str/replace (u.date/format-human-readable t) #" " " ")]
+        (let [actual (str/replace (u.date/format-human-readable t) \u202f \space)]
           (if (set? expected)
             (is (contains? expected actual))
             (is (= expected actual))))))))

--- a/test/metabase/util/date_2_test.clj
+++ b/test/metabase/util/date_2_test.clj
@@ -197,7 +197,7 @@
           [locale expected] expected]
     (mt/with-user-locale locale
       (testing (format "%s %s" (.getCanonicalName (class t)) (pr-str t))
-        (let [actual (u.date/format-human-readable t)]
+        (let [actual (str/replace (u.date/format-human-readable t) #" " " ")]
           (if (set? expected)
             (is (contains? expected actual))
             (is (= expected actual))))))))


### PR DESCRIPTION
Some JVMs use nbsp chars in their formatted strings. I noticed weird test failures that printed the same because of this and it was confusing. So I propose a simple string replace to normalize on one type of space char only.

<img width="607" alt="image" src="https://github.com/metabase/metabase/assets/21064735/6bed71ba-fb98-4d1e-9ce6-db95a6303dff">
