### PR TITLE
Remove obsolete CLI flags for `export`; fix collection specification

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -203,15 +203,14 @@
 
 (defn v2-dump
   "Exports Metabase app data to directory at path"
-  [path {:keys [user-email collection-ids] :as opts}]
+  [path {:keys [collection-ids] :as opts}]
   (log/info (trs "Exporting Metabase to {0}" path) (u/emoji "🏭 🚛💨"))
   (mdb/setup-db!)
   (check-premium-token!)
   (t2/select User) ;; TODO -- why??? [editor's note: this comment originally from Cam]
   (serdes/with-cache
     (-> (cond-> opts
-          (seq collection-ids) (assoc :targets (v2.extract/make-targets-of-type "Collection" collection-ids))
-          user-email        (assoc :user-id (t2/select-one-pk User :email user-email :is_superuser true)))
+          (seq collection-ids) (assoc :targets (v2.extract/make-targets-of-type "Collection" collection-ids)))
         v2.extract/extract
         (v2.storage/store! path)))
   (log/info (trs "Export to {0} complete!" path) (u/emoji "🚛💨 📦"))

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -206,15 +206,11 @@
 
 (defn ^:command export
   {:doc "Serialize Metabase instance into directory at `path`."
-   :arg-spec [["-u" "--user EMAIL"               "Include collections owned by the specified user"
-               :id :user-email]
-              ["-c" "--collection ID"            "Export only specified ID; may occur multiple times."
-               :id        :collections
+   :arg-spec [["-c" "--collection ID"            "Export only specified ID; may occur multiple times."
+               :id        :collection-ids
                :multi     true
                :parse-fn  #(Integer/parseInt %)
                :update-fn (fnil conj [])]
-              [nil "--collections ID_LIST"       "(Legacy-style) Export collections in comma-separated list of IDs, e.g. '123,456'."
-               :parse-fn  (fn [s] (map #(Integer/parseInt %) (str/split s #"\s*,\s*")))]
               ["-C" "--no-collections"           "Do not export any content in collections."]
               ["-S" "--no-settings"              "Do not export settings.yaml"]
               ["-D" "--no-data-model"            "Do not export any data model entities; useful for subsequent exports."]

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -206,11 +206,9 @@
 
 (defn ^:command export
   {:doc "Serialize Metabase instance into directory at `path`."
-   :arg-spec [["-c" "--collection ID"            "Export only specified ID; may occur multiple times."
+   :arg-spec [["-c" "--collection ID"            "Export only specified ID(s). Use commas to separate multiple IDs."
                :id        :collection-ids
-               :multi     true
-               :parse-fn  #(Integer/parseInt %)
-               :update-fn (fnil conj [])]
+               :parse-fn  (fn [raw-string] (map parse-long (str/split raw-string #"\s*,\s*")))]
               ["-C" "--no-collections"           "Do not export any content in collections."]
               ["-S" "--no-settings"              "Do not export settings.yaml"]
               ["-D" "--no-data-model"            "Do not export any data model entities; useful for subsequent exports."]

--- a/test/metabase/cmd_test.clj
+++ b/test/metabase/cmd_test.clj
@@ -47,10 +47,10 @@
     {}
 
     ["--collection" "123"]
-    {:collections [123]}
+    {:collection-ids [123]}
 
     ["-c" "123" "-c" "456"]
-    {:collections [123 456]}
+    {:collection-ids [123 456]}
 
     ["--include-field-values"]
     {:include-field-values true}

--- a/test/metabase/cmd_test.clj
+++ b/test/metabase/cmd_test.clj
@@ -49,8 +49,12 @@
     ["--collection" "123"]
     {:collection-ids [123]}
 
-    ["-c" "123" "-c" "456"]
+    ["-c" "123, 456"]
     {:collection-ids [123 456]}
+
+    ["-c" "123,456,789"]
+    {:collection-ids [123 456 789]}
+
 
     ["--include-field-values"]
     {:include-field-values true}


### PR DESCRIPTION
[Fixes #33168]

Key thing to note is that the dump expects `collection-ids` (which seems like a better name than `collections`):

```
;; /enterprise/.../serialization/cmd.clj
(defn v2-dump
  "Exports Metabase app data to directory at path"
  [path {:keys [collection-ids] :as opts}]
```