### PR TITLE
Download previously saved uberjar for E2E workflow

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -80,7 +80,6 @@ e2e_specs: &e2e_specs
 e2e_all:
   - *default
   - *ci
-  - *e2e_specs
   - *sources
 
 snowplow:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -38,9 +38,85 @@ jobs:
           token: ${{ github.token }}
           filters: .github/file-paths.yaml
 
-  build:
+  download_uberjar:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.e2e_all == 'true'
+    if: |
+      !cancelled() &&
+      github.event.pull_request.draft == false &&
+      needs.files-changed.outputs.e2e_specs == 'true'
+    strategy:
+      matrix:
+        edition: [oss, ee]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Artifact zip URL
+        run: |
+          get_parent () {
+            parent_commit=$(git rev-parse $1^)
+            echo $parent_commit
+          }
+
+          main () {
+            parent_commit=$(get_parent $1)
+            echo $parent_commit
+
+            current_page=${2:-1}
+
+            artifacts=$(curl -sL \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/metabase/metabase/actions/artifacts?name=metabase-${{ matrix.edition }}-uberjar&per_page=100&page=$current_page")
+
+
+            zip=$(echo $artifacts | jq '[.artifacts[] | {url: .url, dl: .archive_download_url, run: .workflow_run}]' \
+            | jq -c --arg COMMIT "$parent_commit" '[.[] | select(.run.head_sha | contains($COMMIT))'.dl] | jq '.[0] | select (.!=null)')
+
+            if [[ $zip ]]; then
+                echo "Found metabase-${{ matrix.edition }} uberjar for '$parent_commit'!"
+                echo "download_link=$(echo $zip)" >> $GITHUB_OUTPUT
+            elif [[ $current_page -le 5 ]]; then
+                echo "Didn't find the artifact for '$parent_commit' on the page: $current_page."
+                current_page=$((++current_page))
+                main $parent_commit $current_page
+            else
+              parent_commit=$(get_parent $parent_commit)
+              echo "Switching to a new parent $parent_commit"
+              main $parent_commit
+            fi
+          }
+
+          main "HEAD"
+        id: saved_artifact
+        shell: bash
+
+      - name: Download Metabase uberjar from a previously stored artifact
+        run: |
+          curl -sL \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            ${{ steps.saved_artifact.outputs.download_link }} \
+            -o mb.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+
+      - name: Unzip Metabase artifact containing an uberjar
+        run: unzip mb.zip
+      - name: Prepare uberjar artifact
+        uses: ./.github/actions/prepare-uberjar-artifact
+
+  build:
+    needs: [download_uberjar, files-changed]
+    if: |
+      !cancelled() &&
+      github.event.pull_request.draft == false &&
+      needs.download_uberjar.result == 'skipped' &&
+      needs.files-changed.outputs.e2e_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 25
     strategy:
@@ -264,11 +340,12 @@ jobs:
           if-no-files-found: ignore
 
   e2e-tests-skipped-stub:
-    needs: [build, files-changed]
+    needs: [build, files-changed, download_uberjar]
     if: |
       !cancelled() &&
       needs.files-changed.outputs.e2e_all == 'false' &&
-      needs.build.result == 'skipped'
+      needs.build.result == 'skipped' &&
+      needs.download_uberjar.result == 'skipped'
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     name: e2e-tests-${{ matrix.folder }}${{ matrix.context }}-${{ matrix.edition }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -60,15 +60,15 @@ jobs:
       - name: Artifact zip URL
         id: zip_url
         run: |
+          current_commit="HEAD"
+
           get_parent () {
             parent_commit=$(git rev-parse $1^)
             echo $parent_commit
           }
 
-          main () {
+          get_download_link () {
             parent_commit=$(get_parent $1)
-            echo $parent_commit
-
             current_page=${2:-1}
 
             artifacts=$(curl -sL \
@@ -91,15 +91,15 @@ jobs:
             elif [[ $current_page -le 5 ]]; then
                 echo "Didn't find the artifact for '$parent_commit' on the page: $current_page."
                 current_page=$((++current_page))
-                main $parent_commit $current_page
+                get_download_link $current_commit $current_page
             else
-              parent_commit=$(get_parent $parent_commit)
-              echo "Switching to a new parent $parent_commit"
-              main $parent_commit
+              current_commit=$parent_commit
+              echo "Switching to a new parent"
+              get_download_link $current_commit
             fi
           }
 
-          main "HEAD"
+          get_download_link $current_commit
         shell: bash
 
   build:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -73,6 +73,7 @@ jobs:
 
             artifacts=$(curl -sL \
             -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/metabase/metabase/actions/artifacts?name=metabase-${{ matrix.edition }}-uberjar&per_page=100&page=$current_page")
 
@@ -88,7 +89,7 @@ jobs:
                 else
                   echo "oss_dl=$(echo $zip)" >> $GITHUB_OUTPUT
                 fi
-            elif [[ $current_page -le 5 ]]; then
+            elif [[ $current_page -le 3 ]]; then
                 echo "Didn't find the artifact for '$parent_commit' on the page: $current_page."
                 current_page=$((++current_page))
                 get_download_link $current_commit $current_page
@@ -101,6 +102,8 @@ jobs:
 
           get_download_link $current_commit
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build:
     needs: [download_uberjar, files-changed]

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -78,7 +78,12 @@ jobs:
 
             if [[ $zip ]]; then
                 echo "Found metabase-${{ matrix.edition }} uberjar for '$parent_commit'!"
-                echo "download_link_${{ matrix.edition }}=$(echo $zip)" >> $GITHUB_OUTPUT
+
+                if [[ "${{ matrix.edition }}" == "ee" ]]; then
+                  echo "enterprise_download_link=$(echo $zip)" >> $GITHUB_OUTPUT
+                else
+                  echo "oss_download_link=$(echo $zip)" >> $GITHUB_OUTPUT
+                fi
             elif [[ $current_page -le 5 ]]; then
                 echo "Didn't find the artifact for '$parent_commit' on the page: $current_page."
                 current_page=$((++current_page))
@@ -248,11 +253,17 @@ jobs:
       - name: Download Metabase uberjar from a previously stored artifact
         if: needs.download_uberjar.result == 'success'
         run: |
+          if [[ "${{ matrix.edition }}" == "ee" ]]; then
+            DOWNLOAD_LINK="${{ steps.saved_artifact.outputs.enterprise_download_link }}"
+          else
+            DOWNLOAD_LINK="${{ steps.saved_artifact.outputs.oss_download_link }}"
+          fi
+
           curl -sL \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            ${{ steps.saved_artifact.outputs.download_link_${{ matrix.edition }} }} \
+            $DOWNLOAD_LINK \
             -o mb.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -146,7 +146,7 @@ jobs:
     if: |
       !cancelled() &&
       needs.files-changed.outputs.e2e_all == 'true' &&
-      needs.build.result == 'success'
+      (needs.build.result == 'success' || needs.build.result == 'skipped')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     name: e2e-tests-${{ matrix.folder }}${{ matrix.context }}-${{ matrix.edition }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -401,8 +401,11 @@ jobs:
   visual-regression-tests:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
-    needs: build
-    if: ${{ github.event_name != 'schedule' }}
+    needs: [build, download_uberjar]
+    if: |
+      !cancelled() &&
+      (needs.download_uberjar.result == 'success' || needs.build.result == 'success') &&
+      github.event_name != 'schedule'
     name: percy-visual-regression-tests
     env:
       MB_EDITION: ${{ matrix.edition }}
@@ -417,6 +420,36 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
+
+      - name: Download Metabase uberjar from a previously stored artifact
+        if: needs.download_uberjar.result == 'success'
+        run: |
+          DOWNLOAD_LINK="$(echo ${{ needs.download_uberjar.outputs.enterprise_download_link }})"
+
+          curl -sL \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            $DOWNLOAD_LINK \
+            -o mb.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+      - name: Unzip Metabase artifact containing an uberjar
+        if: needs.download_uberjar.result == 'success'
+        run: unzip mb.zip
+
+      - uses: actions/download-artifact@v3
+        if: needs.build.result == 'success'
+        name: Retrieve uberjar artifact for ee
+        with:
+          name: metabase-ee-uberjar
+
+      - name: Get the version info
+        run: |
+          jar xf target/uberjar/metabase.jar version.properties
+          mv version.properties resources/
+
       - name: Enable Percy recording on master only
         if: github.ref == 'refs/heads/master'
         run: |
@@ -431,14 +464,6 @@ jobs:
       - name: Prepare Cypress environment
         uses: ./.github/actions/prepare-cypress
 
-      - uses: actions/download-artifact@v3
-        name: Retrieve uberjar artifact for ee
-        with:
-          name: metabase-ee-uberjar
-      - name: Get the version info
-        run: |
-          jar xf target/uberjar/metabase.jar version.properties
-          mv version.properties resources/
       - name: Percy Test
         run: yarn run test-visual-run
         env:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -50,11 +50,15 @@ jobs:
     strategy:
       matrix:
         edition: [oss, ee]
+    outputs:
+      enterprise_download_link: ${{ steps.zip_url.outputs.ee_dl }}
+      oss_download_link: ${{ steps.zip_url.outputs.oss_dl }}
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Artifact zip URL
+        id: zip_url
         run: |
           get_parent () {
             parent_commit=$(git rev-parse $1^)
@@ -80,9 +84,9 @@ jobs:
                 echo "Found metabase-${{ matrix.edition }} uberjar for '$parent_commit'!"
 
                 if [[ "${{ matrix.edition }}" == "ee" ]]; then
-                  echo "enterprise_download_link=$(echo $zip)" >> $GITHUB_OUTPUT
+                  echo "ee_dl=$(echo $zip)" >> $GITHUB_OUTPUT
                 else
-                  echo "oss_download_link=$(echo $zip)" >> $GITHUB_OUTPUT
+                  echo "oss_dl=$(echo $zip)" >> $GITHUB_OUTPUT
                 fi
             elif [[ $current_page -le 5 ]]; then
                 echo "Didn't find the artifact for '$parent_commit' on the page: $current_page."
@@ -96,7 +100,6 @@ jobs:
           }
 
           main "HEAD"
-        id: saved_artifact
         shell: bash
 
   build:
@@ -229,9 +232,9 @@ jobs:
         if: needs.download_uberjar.result == 'success'
         run: |
           if [[ "${{ matrix.edition }}" == "ee" ]]; then
-            DOWNLOAD_LINK="${{ steps.saved_artifact.outputs.enterprise_download_link }}"
+            DOWNLOAD_LINK="$(echo ${{ needs.download_uberjar.outputs.enterprise_download_link }})"
           else
-            DOWNLOAD_LINK="${{ steps.saved_artifact.outputs.oss_download_link }}"
+            DOWNLOAD_LINK="$(echo ${{ needs.download_uberjar.outputs.oss_download_link }})"
           fi
 
           curl -sL \

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -78,7 +78,7 @@ jobs:
 
             if [[ $zip ]]; then
                 echo "Found metabase-${{ matrix.edition }} uberjar for '$parent_commit'!"
-                echo "download_link=$(echo $zip)" >> $GITHUB_OUTPUT
+                echo "download_link_${{ matrix.edition }}=$(echo $zip)" >> $GITHUB_OUTPUT
             elif [[ $current_page -le 5 ]]; then
                 echo "Didn't find the artifact for '$parent_commit' on the page: $current_page."
                 current_page=$((++current_page))
@@ -93,23 +93,6 @@ jobs:
           main "HEAD"
         id: saved_artifact
         shell: bash
-
-      - name: Download Metabase uberjar from a previously stored artifact
-        run: |
-          curl -sL \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $GITHUB_TOKEN" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            ${{ steps.saved_artifact.outputs.download_link }} \
-            -o mb.zip
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-
-      - name: Unzip Metabase artifact containing an uberjar
-        run: unzip mb.zip
-      - name: Prepare uberjar artifact
-        uses: ./.github/actions/prepare-uberjar-artifact
 
   build:
     needs: [download_uberjar, files-changed]
@@ -262,10 +245,28 @@ jobs:
       - name: Run Snowplow micro
         uses: ./.github/actions/run-snowplow-micro
 
+      - name: Download Metabase uberjar from a previously stored artifact
+        if: needs.download_uberjar.result == 'success'
+        run: |
+          curl -sL \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            ${{ steps.saved_artifact.outputs.download_link_${{ matrix.edition }} }} \
+            -o mb.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+      - name: Unzip Metabase artifact containing an uberjar
+        if: needs.download_uberjar.result == 'success'
+        run: unzip mb.zip
+
       - uses: actions/download-artifact@v3
+        if: needs.build.result == 'success'
         name: Retrieve uberjar artifact for ${{ matrix.edition }}
         with:
           name: metabase-${{ matrix.edition }}-uberjar
+
       - name: Get the version info
         run: |
           jar xf target/uberjar/metabase.jar version.properties

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -225,31 +225,6 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
-      - name: Install Chrome v111
-        uses: browser-actions/setup-chrome@v1
-        with:
-          # https://chromium.cypress.io/linux/stable/111.0.5563.146
-          chrome-version: 1097615
-        id: setup-chrome
-      - run: |
-          echo Installed chromium version: ${{ steps.setup-chrome.outputs.chrome-version }}
-          ${{ steps.setup-chrome.outputs.chrome-path }} --version
-      - name: Record runs using Deploysentinel except for the release branch
-        if: ${{ github.ref == 'refs/heads/master' || !(startsWith(github.event.pull_request.base.ref, 'release')) }}
-        run: |
-          echo "CYPRESS_DEPLOYSENTINEL_KEY=${{ secrets.CYPRESS_DEPLOYSENTINEL_KEY }}" >> $GITHUB_ENV
-      - name: Prepare front-end environment
-        uses: ./.github/actions/prepare-frontend
-      - name: Prepare JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ matrix.java-version }}
-          distribution: "temurin"
-      - name: Prepare Cypress environment
-        uses: ./.github/actions/prepare-cypress
-      - name: Run Snowplow micro
-        uses: ./.github/actions/run-snowplow-micro
-
       - name: Download Metabase uberjar from a previously stored artifact
         if: needs.download_uberjar.result == 'success'
         run: |
@@ -282,6 +257,31 @@ jobs:
         run: |
           jar xf target/uberjar/metabase.jar version.properties
           mv version.properties resources/
+
+      - name: Install Chrome v111
+        uses: browser-actions/setup-chrome@v1
+        with:
+          # https://chromium.cypress.io/linux/stable/111.0.5563.146
+          chrome-version: 1097615
+        id: setup-chrome
+      - run: |
+          echo Installed chromium version: ${{ steps.setup-chrome.outputs.chrome-version }}
+          ${{ steps.setup-chrome.outputs.chrome-path }} --version
+      - name: Record runs using Deploysentinel except for the release branch
+        if: ${{ github.ref == 'refs/heads/master' || !(startsWith(github.event.pull_request.base.ref, 'release')) }}
+        run: |
+          echo "CYPRESS_DEPLOYSENTINEL_KEY=${{ secrets.CYPRESS_DEPLOYSENTINEL_KEY }}" >> $GITHUB_ENV
+      - name: Prepare front-end environment
+        uses: ./.github/actions/prepare-frontend
+      - name: Prepare JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: "temurin"
+      - name: Prepare Cypress environment
+        uses: ./.github/actions/prepare-cypress
+      - name: Run Snowplow micro
+        uses: ./.github/actions/run-snowplow-micro
 
       - name: Run OSS-specific Cypress tests
         if: matrix.edition == 'oss' && github.event_name != 'schedule'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,6 +28,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 3
     outputs:
+      e2e_specs: ${{ steps.changes.outputs.e2e_specs }}
       e2e_all: ${{ steps.changes.outputs.e2e_all }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -142,11 +142,10 @@ jobs:
         uses: ./.github/actions/prepare-uberjar-artifact
 
   e2e-tests:
-    needs: [build, files-changed, test-run-id]
+    needs: [build, files-changed, test-run-id, download_uberjar]
     if: |
       !cancelled() &&
-      needs.files-changed.outputs.e2e_all == 'true' &&
-      (needs.build.result == 'success' || needs.build.result == 'skipped')
+      (needs.download_uberjar.result == 'success' || needs.build.result == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     name: e2e-tests-${{ matrix.folder }}${{ matrix.context }}-${{ matrix.edition }}


### PR DESCRIPTION
E2E tests require a full-fledged Metabase artifact in order to run.
We've been **always** building it from scratch so far, even when there were no source code changes in a PR! This is wasteful and slow.

This PR introduces a new logic that will find the previously saved uberjar by traversing the current commit parents and searching for the matching uberjar.

If it finds it, the build will be skipped and E2E tests will download and will use that uberjar directly.
If it cannot find the uberjar or it fails, `build` job will take over as a fallback mechanism and it's business as usual.

## Download Logic Explained
GitHub API allows to list all artifacts across all workflows in a repo.
https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28#list-artifacts-for-a-repository

If you try this endpoint, you'll realize just how many artifacts we store
```json
{
	"total_count": 30242,
        "artifacts":[{...}, {...}, ...{}]
}
```

Lucky for us, it accepts a few query parameters that will help us in this quest.
- `name`: we know we're searching for either "metabase-oss-uberjar" or `metabase-ee-uberjar"
- `page`: Page number of the results to fetch.
- `per_page`: How many results do we want to fetch per page to increase our chance of finding the right artifact (max is 100)

The individual artifact has the following shape:
```json
{
  "id": 861710849,
  "node_id": "MDg6QXJ0aWZhY3Q4NjE3MTA4NDk=",
  "name": "metabase-ee-uberjar",
  "size_in_bytes": 335089591,
  "url": "https://api.github.com/repos/metabase/metabase/actions/artifacts/861710849",
  "archive_download_url": "https://api.github.com/repos/metabase/metabase/actions/artifacts/861710849/zip",
  "expired": false,
  "created_at": "2023-08-14T18:47:16Z",
  "updated_at": "2023-08-14T18:47:19Z",
  "expires_at": "2023-09-13T18:17:04Z",
  "workflow_run": {
    "id": 5858087729,
    "repository_id": 30203935,
    "head_repository_id": 30203935,
    "head_branch": "mblib-column-settings-round-trip",
    "head_sha": "4ba2debf861132965d30fa69b8493c86a36ba9d0"
  }
}
```

In order to get the `archive_download_url` we will match the `head_sha` to the parent commit SHA1. I.e. we filter the list of all possible artifacts by the artifact name and the parent's SHA1.

Once we know the `archive_download_url`, the only thing left to do is to download and store it using `curl`.

To save some time, we're mapping `download_uberjar` job outputs[^1] to:
1. `enterprise_download_link`
2. `oss_download_link`

which we later use in the`e2e-tests` job to download, store and unzip the uberjar directly where it's needed.

## How to test?
### tl;dr
- if changed files include [source files](https://github.com/metabase/metabase/blob/a0eb1e8bf69c0b7a8a1bce4f89c0b98dc1ade5a6/.github/file-paths.yaml#L80)
    - download should be skipped
    - build should run as it did before
- if changed files include [only E2E specs and helpers](https://github.com/metabase/metabase/blob/a0eb1e8bf69c0b7a8a1bce4f89c0b98dc1ade5a6/.github/file-paths.yaml#L74)
    - download should find previously built uberjar
    - build should be skipped


### Detailed
For this I created a separate PR that:
1. only changes an E2E spec
2. merges into this one (so that the diff shows only that one spec)

https://github.com/metabase/metabase/pull/33202

Let's examine what happened:
- It tried to find the matching uberjar that matches its parent commit SHA1
    - It searched recursively for 3 pages, listing 100 artifacts per page
- Since it couldn't find it, it moved to the next parent, and so on
- And then it repeated the process until it reached f9d328cb8f597e078594da9e374d01ed3cb2df4d, which was the commit previously merged into `master`
    - This commit triggered workflows that built Metabase uberjar

If we take a look at [the job logs](https://github.com/metabase/metabase/actions/runs/5902919492/job/16011822942?pr=33202#step:3:95), we'll see exactly what happened:
```
Didn't find the artifact for 'a0eb1e8bf69c0b7a8a1bce4f89c0b98dc1ade5a6' on the page: 1.
Didn't find the artifact for 'a0eb1e8bf69c0b7a8a1bce4f89c0b98dc1ade5a6' on the page: 2.
Didn't find the artifact for 'a0eb1e8bf69c0b7a8a1bce4f89c0b98dc1ade5a6' on the page: 3.
Switching to a new parent
Didn't find the artifact for 'c9a7b4617a330da87fd7aeefc50b3cb0bd6bcc30' on the page: 1.
Didn't find the artifact for 'c9a7b4617a330da87fd7aeefc50b3cb0bd6bcc30' on the page: 2.
Didn't find the artifact for 'c9a7b4617a330da87fd7aeefc50b3cb0bd6bcc30' on the page: 3.
Switching to a new parent
Didn't find the artifact for '54e18f6a[47](https://github.com/metabase/metabase/actions/runs/5902919492/job/16011822942?pr=33202#step:3:48)38472c53aff46210d286ce5fbccc28' on the page: 1.
Didn't find the artifact for '54e18f6a4738472c53aff46210d286ce5fbccc28' on the page: 2.
Didn't find the artifact for '54e18f6a4738472c53aff46210d286ce5fbccc28' on the page: 3.
Switching to a new parent
Didn't find the artifact for '0fde8ca31cf39823592a95dad35bdbac7e6e6126' on the page: 1.
Didn't find the artifact for '0fde8ca31cf39823592a95dad35bdbac7e6e6126' on the page: 2.
Didn't find the artifact for '0fde8ca31cf39823592a95dad35bdbac7e6e6126' on the page: 3.
Switching to a new parent
Didn't find the artifact for '[48](https://github.com/metabase/metabase/actions/runs/5902919492/job/16011822942?pr=33202#step:3:49)97a17e385ca23e[49](https://github.com/metabase/metabase/actions/runs/5902919492/job/16011822942?pr=33202#step:3:50)f3d1691dba7d47081d2ece' on the page: 1.
Didn't find the artifact for '4897a17e385ca23e49f3d1691dba7d47081d2ece' on the page: 2.
Didn't find the artifact for '4897a17e385ca23e49f3d1691dba7d47081d2ece' on the page: 3.
Switching to a new parent
Didn't find the artifact for '4a14108d3a76a1e176e7b997ba7cee28a00e[51](https://github.com/metabase/metabase/actions/runs/5902919492/job/16011822942?pr=33202#step:3:52)a9' on the page: 1.
Didn't find the artifact for '4a14108d3a76a1e176e7b997ba7cee28a00e51a9' on the page: 2.
Didn't find the artifact for '4a14108d3a76a1e176e7b997ba7cee28a00e51a9' on the page: 3.
Switching to a new parent
Didn't find the artifact for 'ca1eeb167242e339a23c0cd0202b9e0ca262ab23' on the page: 1.
Didn't find the artifact for 'ca1eeb167242e339a23c0cd0202b9e0ca262ab23' on the page: 2.
Didn't find the artifact for 'ca1eeb167242e339a23c0cd0202b9e0ca262ab23' on the page: 3.
Switching to a new parent
Didn't find the artifact for '205bd67705ad1f06f798057d34c456cea355ca[52](https://github.com/metabase/metabase/actions/runs/5902919492/job/16011822942?pr=33202#step:3:53)' on the page: 1.
Didn't find the artifact for '205bd67705ad1f06f798057d34c456cea355ca52' on the page: 2.
Didn't find the artifact for '205bd67705ad1f06f798057d34c456cea355ca52' on the page: 3.
Switching to a new parent
Didn't find the artifact for '18eb09bed831faabbd45e6d2[53](https://github.com/metabase/metabase/actions/runs/5902919492/job/16011822942?pr=33202#step:3:54)88c7ded463c998' on the page: 1.
Didn't find the artifact for '18eb09bed831faabbd45e6d25388c7ded463c998' on the page: 2.
Didn't find the artifact for '18eb09bed831faabbd45e6d25388c7ded463c998' on the page: 3.
Switching to a new parent
Didn't find the artifact for '9da4fe4bda31641080bb0[54](https://github.com/metabase/metabase/actions/runs/5902919492/job/16011822942?pr=33202#step:3:55)2ae82ad743e8f6c1a' on the page: 1.
Didn't find the artifact for '9da4fe4bda31641080bb0542ae82ad743e8f6c1a' on the page: 2.
Didn't find the artifact for '9da4fe4bda31641080bb0542ae82ad743e8f6c1a' on the page: 3.
Switching to a new parent
Didn't find the artifact for 'ff1590dc7d61a3caad7f029[57](https://github.com/metabase/metabase/actions/runs/5902919492/job/16011822942?pr=33202#step:3:58)98c4f8a901f605d' on the page: 1.
Didn't find the artifact for 'ff1590dc7d61a3caad7f0295798c4f8a901f605d' on the page: 2.
Didn't find the artifact for 'ff1590dc7d61a3caad7f0295798c4f8a901f605d' on the page: 3.
Switching to a new parent
Didn't find the artifact for '6ced4c9e662da3a126bbda[59](https://github.com/metabase/metabase/actions/runs/5902919492/job/16011822942?pr=33202#step:3:60)14ed78089be51f0c' on the page: 1.
Didn't find the artifact for '6ced4c9e662da3a126bbda5914ed78089be51f0c' on the page: 2.
Didn't find the artifact for '6ced4c9e662da3a126bbda5914ed78089be51f0c' on the page: 3.
Switching to a new parent
Found metabase-ee uberjar for 'f9d328cb8f597e078594da9e3[74](https://github.com/metabase/metabase/actions/runs/5902919492/job/16011822942?pr=33202#step:3:75)d01ed3cb2df4d'!
```

[^1]: https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs