### PR TITLE
Add emotion.d.ts

### DIFF
--- a/frontend/src/metabase/search/components/SearchFilterModal/SearchFilterModal.styled.tsx
+++ b/frontend/src/metabase/search/components/SearchFilterModal/SearchFilterModal.styled.tsx
@@ -1,9 +1,8 @@
 import styled from "@emotion/styled";
-import { color } from "metabase/lib/colors";
 
 export const SearchFilterWrapper = styled.div`
   & > * {
-    border-bottom: 1px solid ${color("border")};
+    border-bottom: 1px solid ${({ theme }) => theme.fn.primaryColor()};
     padding: 1.5rem 2rem;
     margin: 0;
   }

--- a/frontend/src/metabase/search/components/SearchFilterModal/SearchFilterModal.styled.tsx
+++ b/frontend/src/metabase/search/components/SearchFilterModal/SearchFilterModal.styled.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 
 export const SearchFilterWrapper = styled.div`
   & > * {
-    border-bottom: 1px solid ${({ theme }) => theme.fn.primaryColor()};
+    border-bottom: 1px solid ${({ theme }) => theme.colors.border[0]};
     padding: 1.5rem 2rem;
     margin: 0;
   }

--- a/frontend/src/types/emotion.d.ts
+++ b/frontend/src/types/emotion.d.ts
@@ -1,0 +1,48 @@
+import "ace-builds";
+
+declare module "ace-builds" {
+  namespace Ace {
+    interface CommandManager {
+      // "commandKeyBinding" is not typed, but used in the code, and it works. So, adding an explicit typing here
+      commandKeyBinding: Ace.CommandMap;
+    }
+    interface TextInput {
+      getElement(): HTMLTextAreaElement;
+    }
+    interface Editor {
+      completer?: {
+        popup?: {
+          isOpen: boolean;
+        };
+      };
+    }
+    interface EditSession {
+      $modeId: string;
+      $mode: {
+        $behaviour: unknown;
+        $highlightRules: {
+          $rules: {
+            start: { token: string; regex: string; onMatch: null }[];
+          };
+        };
+        $tokenizer?: unknown;
+
+        getTokenizer: () => Tokenizer;
+      };
+
+      bgTokenizer: Tokenizer & {
+        start: (index: number) => void;
+        setTokenizer: (tokenizer: Tokenizer) => void;
+      };
+
+      gutterRenderer: {
+        getWidth(
+          session: Ace.EditSession,
+          lastLineNumber: number,
+          config: { characterWidth: number },
+        ): number;
+        getText: (session: Ace.EditSession, row: number) => number;
+      };
+    }
+  }
+}

--- a/frontend/src/types/emotion.d.ts
+++ b/frontend/src/types/emotion.d.ts
@@ -1,48 +1,7 @@
-import "ace-builds";
+import "@emotion/react";
+import type { MantineTheme } from "@mantine/core";
 
-declare module "ace-builds" {
-  namespace Ace {
-    interface CommandManager {
-      // "commandKeyBinding" is not typed, but used in the code, and it works. So, adding an explicit typing here
-      commandKeyBinding: Ace.CommandMap;
-    }
-    interface TextInput {
-      getElement(): HTMLTextAreaElement;
-    }
-    interface Editor {
-      completer?: {
-        popup?: {
-          isOpen: boolean;
-        };
-      };
-    }
-    interface EditSession {
-      $modeId: string;
-      $mode: {
-        $behaviour: unknown;
-        $highlightRules: {
-          $rules: {
-            start: { token: string; regex: string; onMatch: null }[];
-          };
-        };
-        $tokenizer?: unknown;
-
-        getTokenizer: () => Tokenizer;
-      };
-
-      bgTokenizer: Tokenizer & {
-        start: (index: number) => void;
-        setTokenizer: (tokenizer: Tokenizer) => void;
-      };
-
-      gutterRenderer: {
-        getWidth(
-          session: Ace.EditSession,
-          lastLineNumber: number,
-          config: { characterWidth: number },
-        ): number;
-        getText: (session: Ace.EditSession, row: number) => number;
-      };
-    }
-  }
+declare module "@emotion/react" {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface Theme extends MantineTheme {}
 }


### PR DESCRIPTION
### Description

Adds `emotion.d.ts` so we can use Mantine's `theme` object within styled components. I've added an example in `SearchFilterModal.styled.tsx` that uses `theme.fn.primaryColor()`.

The reference for this code is here:
[https://mantine.dev/styles/styled/#typescript](https://mantine.dev/styles/styled/#typescript)

### How to verify

As an example, you can check the `SearchFilterModal` and see that the border color between the sections hasn't been changed.