### PR TITLE
Do not run query if dashboard filter is not connected to the card

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/reproductions/8030-32444-reload-card-without-change.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/8030-32444-reload-card-without-change.cy.spec.js
@@ -82,7 +82,7 @@ describe("issue 32444", () => {
     cy.signInAsAdmin();
   });
 
-  it("should not reload dashboard cards with filter not connected to a filter (metabase#32444)", () => {
+  it("should not reload dashboard cards not connected to a filter (metabase#32444)", () => {
     cy.createDashboardWithQuestions({
       dashboardName: "Dashboard with a card and filter",
       questions: [questionWithFilter],

--- a/e2e/test/scenarios/dashboard-filters/reproductions/8030-32444-reload-card-without-change.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/8030-32444-reload-card-without-change.cy.spec.js
@@ -101,7 +101,7 @@ describe("issue 32444", () => {
       cy.wait("@getCardQuery");
       cy.get("@getCardQuery.all").should("have.length", 1);
 
-      addFilterValue();
+      addFilterValue(5);
 
       cy.get("@getCardQuery.all").should("have.length", 1);
     });
@@ -172,8 +172,8 @@ const interceptRequests = ({ dashboard_id, card1_id, card2_id }) => {
   ).as("getCardQuery2");
 };
 
-function addFilterValue() {
+function addFilterValue(value) {
   filterWidget().click();
-  cy.findByPlaceholderText("Enter some text").type("5{enter}");
+  cy.findByPlaceholderText("Enter some text").type(`${value}{enter}`);
   cy.button("Add filter").click();
 }

--- a/frontend/src/metabase-lib/queries/utils/filter.js
+++ b/frontend/src/metabase-lib/queries/utils/filter.js
@@ -22,7 +22,7 @@ export function getFilters(filter) {
 }
 
 // turns a list of Filters into the canonical FilterClause, either `undefined`, `filter`, or `["and", filter...]`
-function getFilterClause(filters) {
+export function getFilterClause(filters) {
   if (filters.length === 0) {
     return undefined;
   } else if (filters.length === 1) {

--- a/frontend/src/metabase-lib/queries/utils/index.js
+++ b/frontend/src/metabase-lib/queries/utils/index.js
@@ -70,7 +70,7 @@ export function cleanQuery(query) {
     _.all(filter, a => a != null),
   );
   if (filters.length > 0) {
-    query.filter = ["and", ...filters];
+    query.filter = QUERY.getFilterClause(filters);
   } else {
     delete query.filter;
   }

--- a/frontend/src/metabase-lib/queries/utils/query.js
+++ b/frontend/src/metabase-lib/queries/utils/query.js
@@ -52,6 +52,8 @@ export const clearSegments = query =>
 
 export const canAddFilter = query => F.canAddFilter(query.filter);
 
+export { getFilterClause } from "./filter";
+
 // JOIN
 
 export const getJoins = query => J.getJoins(query.joins);


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/32444

### Description

it's a MBQLv1 bug of query normalization. In this PR we replaced the old (wrong) logic of building filter with new (correct).

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Go to Question -> Sample DB -> Orders -> Filter by Total is not Empty...
2. Add it to a Dashboard
3. Add any type of Filter but don't link it to anything

### Demo

https://www.loom.com/share/d88157488c6745ff8ecb23861ff17991

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
