### PR TITLE
Fixes for MLv2 types

### DIFF
--- a/frontend/src/metabase-lib/filter.ts
+++ b/frontend/src/metabase-lib/filter.ts
@@ -27,7 +27,7 @@ export function filterClause(
   filterOperator: FilterOperator,
   column: ColumnMetadata,
   ...args: ExpressionArg[]
-): ExternalOp {
+): FilterClause {
   return ML.filter_clause(filterOperator, column, ...args);
 }
 

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -17,6 +17,8 @@ import type {
   ColumnDisplayInfo,
   ColumnGroup,
   ColumnMetadata,
+  FilterOperator,
+  FilterOperatorDisplayInfo,
   JoinStrategy,
   JoinStrategyDisplayInfo,
   MetadataProvider,
@@ -90,6 +92,11 @@ declare function DisplayInfoFn(
   stageIndex: number,
   joinStrategy: JoinStrategy,
 ): JoinStrategyDisplayInfo;
+declare function DisplayInfoFn(
+  query: Query,
+  stageIndex: number,
+  filterOperator: FilterOperator,
+): FilterOperatorDisplayInfo;
 
 // x can be any sort of opaque object, e.g. a clause or metadata map. Values returned depend on what you pass in, but it
 // should always have display_name... see :metabase.lib.metadata.calculation/display-info schema

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -150,10 +150,7 @@ export type ExpressionArg =
   | ColumnMetadata
   | Clause;
 
-// ExternalOp is a JS-friendly representation of a filter clause or aggregation clause.
-declare const ExternalOp: unique symbol;
 export type ExternalOp = {
-  _opaque: typeof ExternalOp;
   operator: string;
   options: Record<string, unknown>;
   args: ExpressionArg[];

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -136,6 +136,12 @@ export type OrderByClauseDisplayInfo = ClauseDisplayInfo & {
 declare const FilterOperator: unique symbol;
 export type FilterOperator = unknown & { _opaque: typeof FilterOperator };
 
+export type FilterOperatorDisplayInfo = {
+  displayName: string;
+  shortName: string;
+  default?: boolean;
+};
+
 export type ExpressionArg =
   | null
   | boolean

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -57,7 +57,7 @@ declare const ColumnMetadata: unique symbol;
 export type ColumnMetadata = unknown & { _opaque: typeof ColumnMetadata };
 
 declare const ColumnWithOperators: unique symbol;
-export type ColumnWithOperators = unknown & {
+export type ColumnWithOperators = ColumnMetadata & {
   _opaque: typeof ColumnWithOperators;
 };
 

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -153,7 +153,7 @@ export type ExpressionArg =
 export type ExternalOp = {
   operator: string;
   options: Record<string, unknown>;
-  args: ExpressionArg[];
+  args: [ColumnMetadata, ...ExpressionArg[]];
 };
 
 declare const Join: unique symbol;


### PR DESCRIPTION
Fixes a few things around MLv2 types, leaving more context in code comments below.
Backporting to avoid potential merge conflicts later. The PR only changes types, so no changes in behavior are expected.