### PR TITLE
Update H2 tests

### DIFF
--- a/e2e/test/scenarios/admin/databases/add-new-database.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/add-new-database.cy.spec.js
@@ -26,29 +26,6 @@ describe("admin > database > add", () => {
     cy.findByLabelText("Database type").click();
   });
 
-  it.skip("should add a new database", () => {
-    typeAndBlurUsingLabel("Display name", "Test");
-    typeAndBlurUsingLabel("Connection String", "invalid");
-
-    // should surface an error if the connection string is invalid
-    cy.button("Save").click();
-    cy.wait("@createDatabase");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(": check your connection string");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Implicitly relative file paths are not allowed.");
-
-    // should be able to recover from an error and add database with the correct connection string
-    cy.findByDisplayValue("invalid")
-      .clear()
-      .type(
-        "zip:./target/uberjar/metabase.jar!/sample-database.db;USER=GUEST;PASSWORD=guest",
-        { delay: 0 },
-      );
-    cy.button("Save", { timeout: 10000 }).click();
-    cy.wait("@createDatabase");
-  });
-
   describe("external databases", { tags: "@external" }, () => {
     it("should add Postgres database and redirect to listing (metabase#12972, metabase#14334, metabase#17450)", () => {
       popover().within(() => {

--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.js
@@ -7,7 +7,7 @@ import {
   restore,
 } from "e2e/support/helpers";
 
-import { USERS } from "e2e/support/cypress_data";
+import { USERS, QA_DB_CONFIG } from "e2e/support/cypress_data";
 
 const { admin } = USERS;
 
@@ -18,212 +18,193 @@ describe("scenarios > setup", () => {
   locales.forEach(locale => {
     beforeEach(() => restore("blank"));
 
-    it(`should allow you to sign up using "${locale}" browser locale`, () => {
-      // intial redirection and welcome page
-      cy.visit("/", {
-        // set the browser language as per:
-        // https://glebbahmutov.com/blog/cypress-tips-and-tricks/index.html#control-navigatorlanguage
-        onBeforeLoad(win) {
-          Object.defineProperty(win.navigator, "language", {
-            value: locale,
-          });
-        },
-      });
-      cy.location("pathname").should("eq", "/setup");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Welcome to Metabase");
-      cy.findByTextEnsureVisible("Let's get started").click();
+    it(
+      `should allow you to sign up using "${locale}" browser locale`,
+      { tags: ["@external"] },
+      () => {
+        // intial redirection and welcome page
+        cy.visit("/", {
+          // set the browser language as per:
+          // https://glebbahmutov.com/blog/cypress-tips-and-tricks/index.html#control-navigatorlanguage
+          onBeforeLoad(win) {
+            Object.defineProperty(win.navigator, "language", {
+              value: locale,
+            });
+          },
+        });
+        cy.location("pathname").should("eq", "/setup");
 
-      // ========
-      // Language
-      // ========
+        cy.findByTestId("welcome-page").within(() => {
+          cy.findByText("Welcome to Metabase");
+          cy.findByTextEnsureVisible("Let's get started").click();
+        });
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("What's your preferred language?");
-      cy.findByLabelText("English");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Next").click();
+        cy.findByTestId("setup-forms").within(() => {
+          // ========
+          // Language
+          // ========
+          cy.findByText("What's your preferred language?");
+          cy.findByLabelText("English");
+          cy.findByText("Next").click();
 
-      // ====
-      // User
-      // ====
+          // ====
+          // User
+          // ====
 
-      // "Next" should be disabled on the blank form
-      // NOTE: unclear why cy.findByText("Next", { selector: "button" }) doesn't work
-      // alternative: cy.contains("Next").should("be.disabled");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Next").closest("button").should("be.disabled");
+          // "Next" should be disabled on the blank form
+          // NOTE: unclear why cy.findByText("Next", { selector: "button" }) doesn't work
+          // alternative: cy.contains("Next").should("be.disabled");
+          cy.findByText("Next").closest("button").should("be.disabled");
+          cy.findByLabelText("First name").type("Testy");
+          cy.findByLabelText("Last name").type("McTestface");
+          cy.findByLabelText("Email").type("testy@metabase.test");
+          cy.findByLabelText("Company or team name").type("Epic Team");
 
-      cy.findByLabelText("First name").type("Testy");
-      cy.findByLabelText("Last name").type("McTestface");
-      cy.findByLabelText("Email").type("testy@metabase.test");
-      cy.findByLabelText("Company or team name").type("Epic Team");
+          // test first with a weak password
+          cy.findByLabelText("Create a password").type("password");
+          cy.findByLabelText("Confirm your password").type("password");
 
-      // test first with a weak password
-      cy.findByLabelText("Create a password").type("password");
-      cy.findByLabelText("Confirm your password").type("password");
+          // the form shouldn't be valid yet and we should display an error
+          cy.findByText("must include one number", { exact: false });
+          cy.findByText("Next").closest("button").should("be.disabled");
 
-      // the form shouldn't be valid yet and we should display an error
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("must include one number", { exact: false });
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Next").closest("button").should("be.disabled");
+          // now try a strong password that doesn't match
+          const strongPassword = "QJbHYJN3tPW[";
+          cy.findByLabelText(/^Create a password/)
+            .clear()
+            .type(strongPassword);
+          cy.findByLabelText(/^Confirm your password/)
+            .clear()
+            .type(strongPassword + "foobar")
+            .blur();
 
-      // now try a strong password that doesn't match
-      const strongPassword = "QJbHYJN3tPW[";
-      cy.findByLabelText(/^Create a password/)
-        .clear()
-        .type(strongPassword);
-      cy.findByLabelText(/^Confirm your password/)
-        .clear()
-        .type(strongPassword + "foobar")
-        .blur();
+          // tell the user about the mismatch after clicking "Next"
+          cy.findByText("Next").closest("button").should("be.disabled");
+          cy.findByText("passwords do not match", { exact: false });
 
-      // tell the user about the mismatch after clicking "Next"
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Next").closest("button").should("be.disabled");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("passwords do not match", { exact: false });
+          // fix that mismatch
+          cy.findByLabelText(/^Confirm your password/)
+            .clear()
+            .type(strongPassword);
 
-      // fix that mismatch
-      cy.findByLabelText(/^Confirm your password/)
-        .clear()
-        .type(strongPassword);
+          // Submit the first section
+          cy.findByText("Next").click();
 
-      // Submit the first section
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Next").click();
+          // ========
+          // Database
+          // ========
 
-      // ========
-      // Database
-      // ========
+          // The database step should be open
+          cy.findByText("Add your data");
 
-      // The database step should be open
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Add your data");
+          // test database setup help card is NOT displayed before DB is selected
+          cy.findByText("Need help connecting?").should("not.be.visible");
 
-      // test database setup help card is NOT displayed before DB is selected
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Need help connecting?").should("not.be.visible");
+          // test that you can return to user settings if you want
+          cy.findByText("Hi, Testy. Nice to meet you!").click();
+          cy.findByLabelText("Email").should(
+            "have.value",
+            "testy@metabase.test",
+          );
 
-      // test that you can return to user settings if you want
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Hi, Testy. Nice to meet you!").click();
-      cy.findByLabelText("Email").should("have.value", "testy@metabase.test");
+          // test database setup help card is NOT displayed on other steps
+          cy.findByText("Need help connecting?").should("not.be.visible");
 
-      // test database setup help card is NOT displayed on other steps
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Need help connecting?").should("not.be.visible");
+          // now back to database setting
+          cy.findByText("Next").click();
 
-      // now back to database setting
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Next").click();
+          // check database setup card is visible
+          cy.findByText("MySQL").click();
+          cy.findByText("Need help connecting?").should("be.visible");
+          cy.findByLabelText("Remove database").click();
+          cy.findByPlaceholderText("Search for a database…").type("SQL");
+          cy.findByText("SQLite").click();
+          cy.findByText("Need help connecting?");
 
-      // check database setup card is visible
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("MySQL").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Need help connecting?").should("be.visible");
+          // remove sqlite database
+          cy.findByLabelText("Remove database").click();
+          cy.findByText("I'll add my data later").click();
 
-      cy.findByLabelText("Remove database").click();
-      cy.findByPlaceholderText("Search for a database…").type("SQL");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("SQLite").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Need help connecting?");
+          // test database setup help card is hidden on the next step
+          cy.findByText("Need help connecting?").should("not.be.visible");
 
-      // remove database
-      cy.findByLabelText("Remove database").click();
+          // ================
+          // Data Preferences
+          // ================
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("I'll add my data later").click();
+          // collection defaults to on and describes data collection
+          cy.findByText("All collection is completely anonymous.");
+          // turn collection off, which hides data collection description
+          cy.findByLabelText(
+            "Allow Metabase to anonymously collect usage events",
+          ).click();
 
-      // test database setup help card is hidden on the next step
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Need help connecting?").should("not.be.visible");
+          cy.findByText("All collection is completely anonymous.").should(
+            "not.exist",
+          );
 
-      // ================
-      // Data Preferences
-      // ================
+          cy.findByText("Finish").click();
 
-      // collection defaults to on and describes data collection
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("All collection is completely anonymous.");
-      // turn collection off, which hides data collection description
-      cy.findByLabelText(
-        "Allow Metabase to anonymously collect usage events",
-      ).click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("All collection is completely anonymous.").should(
-        "not.exist",
-      );
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Finish").click();
+          // ==================
+          // Finish & Subscribe
+          // ==================
+          cy.findByText("You're all set up!");
 
-      // ==================
-      // Finish & Subscribe
-      // ==================
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("You're all set up!");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText(
-        "Get infrequent emails about new releases and feature updates.",
-      );
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Take me to Metabase").click();
-      cy.location("pathname").should("eq", "/");
-    });
+          cy.findByText(
+            "Get infrequent emails about new releases and feature updates.",
+          );
+
+          cy.findByText("Take me to Metabase").click();
+        });
+
+        cy.location("pathname").should("eq", "/");
+      },
+    );
   });
 
   it("should set up Metabase without first name and last name (metabase#22754)", () => {
     // This is a simplified version of the "scenarios > setup" test
     cy.visit("/");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Welcome to Metabase");
+
     cy.location("pathname").should("eq", "/setup");
-    cy.findByTextEnsureVisible("Let's get started").click();
+    cy.findByTestId("welcome-page").within(() => {
+      cy.findByText("Welcome to Metabase");
+      cy.findByTextEnsureVisible("Let's get started").click();
+    });
 
-    // Language
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("What's your preferred language?");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("English").click();
-    cy.button("Next").click();
+    cy.findByTestId("setup-forms").within(() => {
+      // Language
+      cy.findByText("What's your preferred language?");
+      cy.findByText("English").click();
+      cy.button("Next").click();
 
-    // User
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("What should we call you?");
+      // User
+      cy.findByText("What should we call you?");
+      cy.findByLabelText("Email").type(admin.email);
+      cy.findByLabelText("Company or team name").type("Epic Team");
+      cy.findByLabelText("Create a password").type(admin.password);
+      cy.findByLabelText("Confirm your password").type(admin.password);
+      cy.button("Next").click();
 
-    cy.findByLabelText("Email").type(admin.email);
-    cy.findByLabelText("Company or team name").type("Epic Team");
+      cy.findByText("Hi. Nice to meet you!");
 
-    cy.findByLabelText("Create a password").type(admin.password);
-    cy.findByLabelText("Confirm your password").type(admin.password);
-    cy.button("Next").click();
+      // Database
+      cy.findByText("Add your data");
+      cy.findByText("I'll add my data later").click();
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Hi. Nice to meet you!");
+      // Turns off anonymous data collection
+      cy.findByLabelText(
+        "Allow Metabase to anonymously collect usage events",
+      ).click();
 
-    // Database
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Add your data");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("I'll add my data later").click();
+      cy.findByText("All collection is completely anonymous.").should(
+        "not.exist",
+      );
+      cy.button("Finish").click();
 
-    // Turns off anonymous data collection
-    cy.findByLabelText(
-      "Allow Metabase to anonymously collect usage events",
-    ).click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("All collection is completely anonymous.").should(
-      "not.exist",
-    );
-    cy.button("Finish").click();
-
-    // Finish & Subscribe
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Take me to Metabase").click();
+      // Finish & Subscribe
+      cy.findByText("Take me to Metabase").click();
+    });
     cy.location("pathname").should("eq", "/");
   });
 
@@ -232,23 +213,90 @@ describe("scenarios > setup", () => {
   it("should allow pre-filling user details", () => {
     cy.visit(`/setup#123456`);
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Welcome to Metabase");
-    cy.findByTextEnsureVisible("Let's get started").click();
+    cy.findByTestId("welcome-page").within(() => {
+      cy.findByText("Welcome to Metabase");
+      cy.findByTextEnsureVisible("Let's get started").click();
+    });
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("What's your preferred language?");
-    cy.findByLabelText("English");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Next").click();
+    cy.findByTestId("setup-forms").within(() => {
+      cy.findByText("What's your preferred language?");
+      cy.findByLabelText("English");
 
-    cy.findByLabelText("First name").should("have.value", "Testy");
-    cy.findByLabelText("Last name").should("have.value", "McTestface");
-    cy.findByLabelText("Email").should("have.value", "testy@metabase.test");
-    cy.findByLabelText("Company or team name").should(
-      "have.value",
-      "Epic Team",
-    );
+      cy.findByText("Next").click();
+
+      cy.findByLabelText("First name").should("have.value", "Testy");
+      cy.findByLabelText("Last name").should("have.value", "McTestface");
+      cy.findByLabelText("Email").should("have.value", "testy@metabase.test");
+      cy.findByLabelText("Company or team name").should(
+        "have.value",
+        "Epic Team",
+      );
+    });
+  });
+
+  ["postgres", "mysql"].forEach(engine => {
+    it(`should allow you to connect a ${engine} db during setup`, () => {
+      cy.intercept("GET", "api/collection/root").as("getRootCollection");
+      cy.intercept("GET", "api/database").as("getDatabases");
+
+      cy.visit(`/setup#123456`);
+
+      cy.findByTestId("welcome-page").within(() => {
+        cy.findByText("Welcome to Metabase");
+        cy.findByTextEnsureVisible("Let's get started").click();
+      });
+
+      cy.findByTestId("setup-forms").within(() => {
+        cy.findByText("What's your preferred language?");
+        cy.findByLabelText("English");
+
+        cy.findByText("Next").click();
+
+        const strongPassword = "QJbHYJN3tPW[";
+        cy.findByLabelText(/^Create a password/)
+          .clear()
+          .type(strongPassword);
+        cy.findByLabelText(/^Confirm your password/)
+          .clear()
+          .type(strongPassword)
+          .blur();
+
+        cy.findByText("Next").click();
+
+        cy.findByText(new RegExp(engine, "i")).click();
+
+        cy.findByLabelText("Display name").type(`QA ${engine} db`);
+        cy.findByLabelText("Host").type("localhost");
+        cy.findByLabelText("Port").type(QA_DB_CONFIG[engine].connection.port);
+        cy.findByLabelText("Database name").type(
+          QA_DB_CONFIG[engine].connection.database,
+        );
+        cy.findByLabelText("Username").type(
+          QA_DB_CONFIG[engine].connection.user,
+        );
+        cy.findByLabelText("Password").type(
+          QA_DB_CONFIG[engine].connection.password,
+        );
+
+        cy.button("Connect database").click();
+
+        // usage data
+        cy.findByRole("switch").click();
+        cy.button("Finish").click();
+
+        // done
+        cy.findByText("Take me to Metabase").click();
+      });
+
+      // in app
+      cy.location("pathname").should("eq", "/");
+      cy.wait(["@getRootCollection", "@getDatabases"]);
+
+      cy.findByTestId("main-navbar-root").findByText("Browse data").click();
+      cy.location("pathname").should("eq", "/browse");
+
+      cy.findByTestId("database-browser").findByText(`QA ${engine} db`);
+    });
   });
 });
 
@@ -268,13 +316,15 @@ describeWithSnowplow("scenarios > setup", () => {
     cy.visit(`/setup`);
 
     // 3 - setup/step_seen
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Welcome to Metabase");
-    cy.button("Let's get started").click();
+    cy.findByTestId("welcome-page").within(() => {
+      cy.findByText("Welcome to Metabase");
+      cy.findByTextEnsureVisible("Let's get started").click();
+    });
 
     // 4 - setup/step_seen
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("What's your preferred language?");
+    cy.findByTestId("setup-forms").findByText(
+      "What's your preferred language?",
+    );
 
     expectGoodSnowplowEvents(4);
   });
@@ -282,10 +332,10 @@ describeWithSnowplow("scenarios > setup", () => {
   it("should ignore snowplow failures and work as normal", () => {
     blockSnowplow();
     cy.visit(`/setup`);
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Welcome to Metabase");
-    cy.button("Let's get started").click();
+    cy.findByTestId("welcome-page").within(() => {
+      cy.findByText("Welcome to Metabase");
+      cy.findByTextEnsureVisible("Let's get started").click();
+    });
 
     expectGoodSnowplowEvents(1);
   });

--- a/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.tsx
@@ -11,7 +11,7 @@ import { PageBody, PageHeader } from "./SettingsPage.styled";
 
 export const SettingsPage = (): JSX.Element => {
   return (
-    <div>
+    <div data-testid="setup-forms">
       <PageHeader>
         <LogoIcon height={51} />
       </PageHeader>

--- a/frontend/src/metabase/setup/components/WelcomePage/WelcomePage.tsx
+++ b/frontend/src/metabase/setup/components/WelcomePage/WelcomePage.tsx
@@ -33,7 +33,7 @@ export const WelcomePage = (): JSX.Element | null => {
   }
 
   return (
-    <PageRoot>
+    <PageRoot data-testid="welcome-page">
       <PageMain>
         <LogoIcon height={118} />
         <PageTitle>{t`Welcome to Metabase`}</PageTitle>


### PR DESCRIPTION
relates to https://github.com/metabase/metabase-private/issues/160

### Description

- [x] Remove h2 database connection test from `add-new-database` e2e spec (because we no longer support it)
- [x] Update `setup` spec to separately test the ability to connect mysql and postgres DBs during setup
- [x] updates mongodb connection tests to check for bad connection string errors

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
> **Note**
> Need to backport, in some form, all the way back to v43
