### PR TITLE
Fix viz icons color

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.styled.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { color, tint, isDark, lighten } from "metabase/lib/colors";
+import { alpha, color } from "metabase/lib/colors";
 import Button from "metabase/core/components/Button";
 
 export interface OptionRootProps {
@@ -9,8 +9,6 @@ export interface OptionRootProps {
 const getOptionIconColor = ({ isSelected }: OptionIconContainerProps) => {
   if (isSelected) {
     return color("white");
-  } else if (isDark("brand")) {
-    return tint("brand", 0.5);
   } else {
     return color("brand");
   }
@@ -25,7 +23,7 @@ export const OptionRoot = styled.div<OptionRootProps>`
     props.isSelected &&
     `
     ${OptionIconContainer} {
-      &, &:hover { 
+      &, &:hover {
       background-color: ${color("brand")};
       color: ${getOptionIconColor(props)};
       border: 1px solid transparent;
@@ -75,7 +73,7 @@ export const OptionIconContainer = styled.div<OptionIconContainerProps>`
   padding: 0.875rem;
   &:hover {
     color: ${color("brand")};
-    background-color: ${lighten("brand", 0.55)};
+    background-color: ${alpha("brand", 0.15)};
     border: 1px solid transparent;
 
     ${SettingsButton} {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/33222

Our brand color:
<img width="355" alt="Screenshot 2023-08-16 at 14 29 06" src="https://github.com/metabase/metabase/assets/8542534/41789e00-a999-449a-9306-819c8c2fc6ca">

Black:
<img width="360" alt="Screenshot 2023-08-16 at 14 29 34" src="https://github.com/metabase/metabase/assets/8542534/a5599b62-3b7e-43e3-8683-070a421f4b72">

The color from the ticket:
<img width="360" alt="Screenshot 2023-08-16 at 14 30 08" src="https://github.com/metabase/metabase/assets/8542534/42bd7c34-8b91-406e-b0f6-1260afe97c3e">

Very light brand color:
<img width="550" alt="Screenshot 2023-08-16 at 14 35 41" src="https://github.com/metabase/metabase/assets/8542534/7610e1e5-7b3e-404d-b4ae-d44d5332fe32">
