### PR TITLE
Convert `TagEditorSidebar` to TypeScript

### DIFF
--- a/frontend/src/metabase/parameters/utils/formatting.ts
+++ b/frontend/src/metabase/parameters/utils/formatting.ts
@@ -51,7 +51,7 @@ export function formatParameterValue(
     }
 
     // format using the parameter's first targeted field
-    if (parameter.fields.length > 0) {
+    if (parameter.fields?.length > 0) {
       const [firstField] = parameter.fields;
       // when a parameter targets multiple fields we won't know
       // which parameter the value is associated with, meaning we

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -14,7 +14,7 @@ import Confirm from "metabase/components/Confirm";
 import QueryVisualization from "metabase/query_builder/components/QueryVisualization";
 import ViewSidebar from "metabase/query_builder/components/view/ViewSidebar";
 import DataReference from "metabase/query_builder/components/dataref/DataReference";
-import TagEditorSidebar from "metabase/query_builder/components/template_tags/TagEditorSidebar";
+import { TagEditorSidebar } from "metabase/query_builder/components/template_tags/TagEditorSidebar";
 import { SnippetSidebar } from "metabase/query_builder/components/template_tags/SnippetSidebar/SnippetSidebar";
 import { calcInitialEditorHeight } from "metabase/query_builder/components/NativeQueryEditor/utils";
 

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.tsx
@@ -4,11 +4,8 @@ import Button from "metabase/core/components/Button";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import MetabaseSettings from "metabase/lib/settings";
 import Utils from "metabase/lib/utils";
-import type {
-  Database,
-  DatabaseId,
-  NativeDatasetQuery,
-} from "metabase-types/api";
+import type { DatabaseId, NativeDatasetQuery } from "metabase-types/api";
+import type Database from "metabase-lib/metadata/Database";
 
 const SQL_EXAMPLES: Record<string, NativeDatasetQuery> = {
   variable: {
@@ -221,7 +218,7 @@ const TagExample = ({ datasetQuery, setDatasetQuery }: TagExampleProps) => (
 );
 
 interface TagEditorHelpProps {
-  database: Database;
+  database?: Database | null;
   sampleDatabaseId: DatabaseId;
   setDatasetQuery: (datasetQuery: NativeDatasetQuery, run?: boolean) => void;
   switchToSettings: () => void;
@@ -233,9 +230,9 @@ export const TagEditorHelp = ({
   setDatasetQuery,
   switchToSettings,
 }: TagEditorHelpProps) => {
-  const driver = database && database.engine;
-  const examples = driver === "mongo" ? MONGO_EXAMPLES : SQL_EXAMPLES;
-  const datasetId = driver === "mongo" ? database.id : sampleDatabaseId;
+  const engine = database?.engine;
+  const examples = engine === "mongo" ? MONGO_EXAMPLES : SQL_EXAMPLES;
+  const datasetId = engine === "mongo" ? database?.id : sampleDatabaseId;
 
   let setQueryWithDatasetId;
 

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.tsx
@@ -1,12 +1,16 @@
-/* eslint-disable react/prop-types */
 import { t, jt } from "ttag";
 import Code from "metabase/components/Code";
 import Button from "metabase/core/components/Button";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import MetabaseSettings from "metabase/lib/settings";
 import Utils from "metabase/lib/utils";
+import type {
+  Database,
+  DatabaseId,
+  NativeDatasetQuery,
+} from "metabase-types/api";
 
-const SQL_EXAMPLES = {
+const SQL_EXAMPLES: Record<string, NativeDatasetQuery> = {
   variable: {
     database: null,
     type: "native",
@@ -16,7 +20,7 @@ const SQL_EXAMPLES = {
         category: {
           id: Utils.uuid(),
           name: "category",
-          display_name: "Category",
+          "display-name": "Category",
           type: "text",
           required: true,
           default: "Widget",
@@ -33,9 +37,8 @@ const SQL_EXAMPLES = {
         created_at: {
           id: Utils.uuid(),
           name: "created_at",
-          display_name: "Created At",
+          "display-name": "Created At",
           type: "dimension",
-          dimension: null,
           required: false,
         },
       },
@@ -51,7 +54,7 @@ const SQL_EXAMPLES = {
         category: {
           id: Utils.uuid(),
           name: "category",
-          display_name: "Category",
+          "display-name": "Category",
           type: "text",
           required: false,
         },
@@ -68,14 +71,14 @@ const SQL_EXAMPLES = {
         id: {
           id: Utils.uuid(),
           name: "id",
-          display_name: "ID",
+          "display-name": "ID",
           type: "number",
           required: false,
         },
         category: {
           id: Utils.uuid(),
           name: "category",
-          display_name: "Category",
+          "display-name": "Category",
           type: "text",
           required: false,
         },
@@ -92,9 +95,8 @@ const SQL_EXAMPLES = {
         category: {
           id: Utils.uuid(),
           name: "category",
-          display_name: "Category",
+          "display-name": "Category",
           type: "dimension",
-          dimension: null,
           required: false,
         },
       },
@@ -102,7 +104,7 @@ const SQL_EXAMPLES = {
   },
 };
 
-const MONGO_EXAMPLES = {
+const MONGO_EXAMPLES: Record<string, NativeDatasetQuery> = {
   variable: {
     database: null,
     type: "native",
@@ -112,7 +114,7 @@ const MONGO_EXAMPLES = {
         category: {
           id: Utils.uuid(),
           name: "price",
-          display_name: "Price",
+          "display-name": "Price",
           type: "number",
           required: true,
           default: "2",
@@ -129,9 +131,8 @@ const MONGO_EXAMPLES = {
         created_at: {
           id: Utils.uuid(),
           name: "created_at",
-          display_name: "Created At",
+          "display-name": "Created At",
           type: "dimension",
-          dimension: null,
           required: false,
         },
       },
@@ -146,7 +147,7 @@ const MONGO_EXAMPLES = {
         category: {
           id: Utils.uuid(),
           name: "id",
-          display_name: "ID",
+          "display-name": "ID",
           type: "text",
           required: false,
         },
@@ -163,14 +164,14 @@ const MONGO_EXAMPLES = {
         id: {
           id: Utils.uuid(),
           name: "id",
-          display_name: "ID",
+          "display-name": "ID",
           type: "number",
           required: false,
         },
         category: {
           id: Utils.uuid(),
           name: "category",
-          display_name: "Category",
+          "display-name": "Category",
           type: "text",
           required: false,
         },
@@ -186,9 +187,8 @@ const MONGO_EXAMPLES = {
         category: {
           id: Utils.uuid(),
           name: "category",
-          display_name: "Category",
+          "display-name": "Category",
           type: "dimension",
-          dimension: null,
           required: false,
         },
       },
@@ -196,7 +196,12 @@ const MONGO_EXAMPLES = {
   },
 };
 
-const TagExample = ({ datasetQuery, setDatasetQuery }) => (
+interface TagExampleProps {
+  datasetQuery: NativeDatasetQuery;
+  setDatasetQuery?: (datasetQuery: NativeDatasetQuery, run?: boolean) => void;
+}
+
+const TagExample = ({ datasetQuery, setDatasetQuery }: TagExampleProps) => (
   <div>
     <h5>{t`Example:`}</h5>
     <p>
@@ -215,19 +220,30 @@ const TagExample = ({ datasetQuery, setDatasetQuery }) => (
   </div>
 );
 
-const TagEditorHelp = ({
+interface TagEditorHelpProps {
+  database: Database;
+  sampleDatabaseId: DatabaseId;
+  setDatasetQuery: (datasetQuery: NativeDatasetQuery, run?: boolean) => void;
+  switchToSettings: () => void;
+}
+
+export const TagEditorHelp = ({
   database,
-  setDatasetQuery,
   sampleDatabaseId,
+  setDatasetQuery,
   switchToSettings,
-}) => {
+}: TagEditorHelpProps) => {
   const driver = database && database.engine;
   const examples = driver === "mongo" ? MONGO_EXAMPLES : SQL_EXAMPLES;
   const datasetId = driver === "mongo" ? database.id : sampleDatabaseId;
 
-  let setQueryWithDatasetId = null;
+  let setQueryWithDatasetId;
+
   if (datasetId != null) {
-    setQueryWithDatasetId = (dataset_query, run) => {
+    setQueryWithDatasetId = (
+      dataset_query: NativeDatasetQuery,
+      run?: boolean,
+    ) => {
       setDatasetQuery(
         {
           ...dataset_query,
@@ -306,5 +322,3 @@ const TagEditorHelp = ({
     </div>
   );
 };
-
-export default TagEditorHelp;

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
@@ -56,8 +56,9 @@ import {
 interface Props {
   tag: TemplateTag;
   parameter: Parameter;
-  database: Database;
+  database?: Database | null;
   databases: Database[];
+  databaseFields?: Field[];
   metadata: Metadata;
   setTemplateTag: (tag: TemplateTag) => void;
   setTemplateTagConfig: (tag: TemplateTag, config: Parameter) => void;

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.unit.spec.tsx
@@ -1,4 +1,5 @@
 import userEvent from "@testing-library/user-event";
+import { checkNotNull } from "metabase/core/utils/types";
 import { getMetadata } from "metabase/selectors/metadata";
 import {
   setupDatabasesEndpoints,
@@ -10,6 +11,7 @@ import { TemplateTag } from "metabase-types/api";
 import {
   createMockCard,
   createMockNativeDatasetQuery,
+  createMockParameter,
   createMockTemplateTag,
 } from "metabase-types/api/mocks";
 import {
@@ -21,7 +23,7 @@ import {
   createMockQueryBuilderState,
   createMockState,
 } from "metabase-types/store/mocks";
-import TagEditorParam from "./TagEditorParam";
+import { TagEditorParam } from "./TagEditorParam";
 
 interface SetupOpts {
   tag?: TemplateTag;
@@ -39,7 +41,10 @@ const setup = ({ tag = createMockTemplateTag() }: SetupOpts = {}) => {
       databases: [database],
     }),
   });
+
   const metadata = getMetadata(state);
+
+  const databaseMetadata = checkNotNull(metadata.database(database.id));
 
   setupDatabasesEndpoints([database]);
   setupSearchEndpoints([]);
@@ -51,8 +56,9 @@ const setup = ({ tag = createMockTemplateTag() }: SetupOpts = {}) => {
   renderWithProviders(
     <TagEditorParam
       tag={tag}
-      database={metadata.database(database.id)}
+      database={databaseMetadata}
       databases={metadata.databasesList()}
+      parameter={createMockParameter()}
       setTemplateTag={setTemplateTag}
       setTemplateTagConfig={setTemplateTagConfig}
       setParameterValue={setParameterValue}

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
@@ -10,7 +10,7 @@ import SidebarContent from "metabase/query_builder/components/SidebarContent";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import NativeQuery from "metabase-lib/queries/NativeQuery";
 import TagEditorParam from "./TagEditorParam";
-import TagEditorHelp from "./TagEditorHelp";
+import { TagEditorHelp } from "./TagEditorHelp";
 
 export default class TagEditorSidebar extends Component {
   state = {

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
@@ -9,7 +9,7 @@ import _ from "underscore";
 import SidebarContent from "metabase/query_builder/components/SidebarContent";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import NativeQuery from "metabase-lib/queries/NativeQuery";
-import TagEditorParam from "./TagEditorParam";
+import { TagEditorParam } from "./TagEditorParam";
 import { TagEditorHelp } from "./TagEditorHelp";
 
 export default class TagEditorSidebar extends Component {

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.tsx
@@ -1,19 +1,49 @@
-/* eslint-disable react/prop-types */
 import { Component } from "react";
 import PropTypes from "prop-types";
-
 import { t } from "ttag";
 import cx from "classnames";
 import _ from "underscore";
 
 import SidebarContent from "metabase/query_builder/components/SidebarContent";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
-import NativeQuery from "metabase-lib/queries/NativeQuery";
+
+import type {
+  Card,
+  DatabaseId,
+  NativeDatasetQuery,
+  Parameter,
+  ParameterId,
+  RowValue,
+  TemplateTag,
+  TemplateTagId,
+} from "metabase-types/api";
+import type NativeQuery from "metabase-lib/queries/NativeQuery";
+import type Database from "metabase-lib/metadata/Database";
+import type Field from "metabase-lib/metadata/Field";
+
 import { TagEditorParam } from "./TagEditorParam";
 import { TagEditorHelp } from "./TagEditorHelp";
 
-export default class TagEditorSidebar extends Component {
-  state = {
+interface TagEditorSidebarProps {
+  card: Card;
+  query: NativeQuery;
+  databases: Database[];
+  databaseFields: Field[];
+  sampleDatabaseId: DatabaseId;
+  setDatasetQuery: (query: NativeDatasetQuery) => void;
+  setTemplateTag: (tag: TemplateTag) => void;
+  setTemplateTagConfig: (tag: TemplateTag, config: Parameter) => void;
+  setParameterValue: (tagId: TemplateTagId, value: RowValue) => void;
+  onClose: () => void;
+}
+
+interface TagEditorSidebarState {
+  section: "settings" | "help";
+}
+
+// eslint-disable-next-line import/no-default-export
+export default class TagEditorSidebar extends Component<TagEditorSidebarProps> {
+  state: TagEditorSidebarState = {
     section: "settings",
   };
 
@@ -28,8 +58,8 @@ export default class TagEditorSidebar extends Component {
     setParameterValue: PropTypes.func.isRequired,
   };
 
-  setSection(section) {
-    this.setState({ section: section });
+  setSection(section: "settings" | "help") {
+    this.setState({ section });
     MetabaseAnalytics.trackStructEvent(
       "QueryBuilder",
       "Template Tag Editor Section Change",
@@ -104,6 +134,17 @@ export default class TagEditorSidebar extends Component {
   }
 }
 
+interface SettingsPaneProps {
+  tags: TemplateTag[];
+  database?: Database | null;
+  databases: Database[];
+  databaseFields: Field[];
+  parametersById: Record<ParameterId, Parameter>;
+  setTemplateTag: (tag: TemplateTag) => void;
+  setTemplateTagConfig: (tag: TemplateTag, config: Parameter) => void;
+  setParameterValue: (tagId: TemplateTagId, value: RowValue) => void;
+}
+
 const SettingsPane = ({
   tags,
   parametersById,
@@ -113,13 +154,13 @@ const SettingsPane = ({
   setTemplateTag,
   setTemplateTagConfig,
   setParameterValue,
-}) => (
+}: SettingsPaneProps) => (
   <div>
     {tags.map(tag => (
-      <div key={tags.name}>
+      <div key={tag.name}>
         <TagEditorParam
           tag={tag}
-          key={tags.name}
+          key={tag.name}
           parameter={parametersById[tag.id]}
           databaseFields={databaseFields}
           database={database}
@@ -132,12 +173,3 @@ const SettingsPane = ({
     ))}
   </div>
 );
-
-SettingsPane.propTypes = {
-  tags: PropTypes.array.isRequired,
-  query: NativeQuery,
-  databaseFields: PropTypes.array,
-  setDatasetQuery: PropTypes.func.isRequired,
-  setTemplateTag: PropTypes.func.isRequired,
-  setParameterValue: PropTypes.func.isRequired,
-};

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.tsx
@@ -41,8 +41,7 @@ interface TagEditorSidebarState {
   section: "settings" | "help";
 }
 
-// eslint-disable-next-line import/no-default-export
-export default class TagEditorSidebar extends Component<TagEditorSidebarProps> {
+export class TagEditorSidebar extends Component<TagEditorSidebarProps> {
   state: TagEditorSidebarState = {
     section: "settings",
   };

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -21,7 +21,7 @@ import DatasetEditor from "../DatasetEditor";
 import NativeQueryEditor from "../NativeQueryEditor";
 import QueryVisualization from "../QueryVisualization";
 import DataReference from "../dataref/DataReference";
-import TagEditorSidebar from "../template_tags/TagEditorSidebar";
+import { TagEditorSidebar } from "../template_tags/TagEditorSidebar";
 import { SnippetSidebar } from "../template_tags/SnippetSidebar";
 import SavedQuestionIntroModal from "../SavedQuestionIntroModal";
 import QueryModals from "../QueryModals";


### PR DESCRIPTION
Followup to #33102

Converts the `TagEditorSidebar` component to TypeScript for better type safety
No changes in functionality are expected

### To Verify

CI should be green