### PR TITLE
Add test for metabase.lib.js.metadata/parse-objects

### DIFF
--- a/src/metabase/lib/js/metadata.cljs
+++ b/src/metabase/lib/js/metadata.cljs
@@ -23,10 +23,6 @@
 ;;;
 ;;; where keys are a map of String ID => metadata
 
-(defn- object-get [obj k]
-  (when obj
-    (gobject/get obj k)))
-
 (defn- obj->clj
   "Convert a JS object of *any* class to a ClojureScript object."
   ([xform obj]
@@ -37,7 +33,7 @@
      (into {} xform obj)
      ;; has a plain-JavaScript `_plainObject` attached: apply `xform` to it and call it a day
      (if-let [plain-object (when use-plain-object?
-                             (some-> (object-get obj "_plainObject")
+                             (some-> (gobject/get obj "_plainObject")
                                      js->clj
                                      not-empty))]
        (into {} xform plain-object)
@@ -46,7 +42,7 @@
        (into {}
              (comp
               (map (fn [k]
-                     [k (object-get obj k)]))
+                     [k (gobject/get obj k)]))
               ;; ignore values that are functions
               (remove (fn [[_k v]]
                         (= (goog/typeOf v) "function")))
@@ -131,7 +127,7 @@
   (let [parse-object (parse-object-fn object-type)]
     (obj->clj (map (fn [[k v]]
                      [(parse-long k) (delay (parse-object v))]))
-              (object-get metadata (parse-objects-default-key object-type)))))
+              (gobject/get metadata (parse-objects-default-key object-type)))))
 
 (defmethod lib-type :database
   [_object-type]
@@ -179,7 +175,7 @@
                               (str/starts-with? k "card__")))
                     (map (fn [[k v]]
                            [(parse-long k) (delay (parse-table v))])))
-              (object-get metadata "tables"))))
+              (gobject/get metadata "tables"))))
 
 (defmethod lib-type :field
   [_object-type]
@@ -221,7 +217,7 @@
 (defmethod parse-objects :field
   [object-type metadata]
   (let [parse-object (parse-object-fn object-type)
-        unparsed-fields (object-get metadata "fields")]
+        unparsed-fields (gobject/get metadata "fields")]
     (obj->clj (keep (fn [[k v]]
                       ;; Sometimes fields coming from saved questions are only present with their ID
                       ;; prefixed with "card__<card-id>:". For such keys we parse the field ID from
@@ -230,7 +226,7 @@
                       ;; same but the one under the plain key is to be preferred.)
                       (when-let [field-id (or (parse-long k)
                                               (when-let [[_ id-str] (re-matches #"card__\d+:(\d+)" k)]
-                                                (and (nil? (object-get unparsed-fields id-str))
+                                                (and (nil? (gobject/get unparsed-fields id-str))
                                                      (parse-long id-str))))]
                         [field-id (delay (parse-object v))])))
               unparsed-fields)))
@@ -274,7 +270,7 @@
   "Sometimes a card is stored in the metadata as some sort of weird object where the thing we actually want is under the
   key `_card` (not sure why), but if it is just unwrap it and then parse it normally."
   [obj]
-  (or (object-get obj "_card")
+  (or (gobject/get obj "_card")
       obj))
 
 (defn- assemble-card
@@ -285,16 +281,16 @@
     ;; in from the table matadata.
     (merge
      (-> metadata
-         (object-get "tables")
-         (object-get (str "card__" id))
+         (gobject/get "tables")
+         (gobject/get (str "card__" id))
          ;; _plainObject can contain field names in the field property
          ;; instead of the field objects themselves.  Ignoring this
          ;; property makes sure we parse the real fields.
          parse-card-ignoring-plain-object
          (assoc :id id))
      (-> metadata
-         (object-get "questions")
-         (object-get (str id))
+         (gobject/get "questions")
+         (gobject/get (str id))
          unwrap-card
          parse-card))))
 
@@ -305,9 +301,9 @@
                [id (delay (assemble-card metadata id))]))
         (-> #{}
             (into (keep lib.util/legacy-string-table-id->card-id)
-                  (gobject/getKeys (object-get metadata "tables")))
+                  (gobject/getKeys (gobject/get metadata "tables")))
             (into (map parse-long)
-                  (gobject/getKeys (object-get metadata "questions"))))))
+                  (gobject/getKeys (gobject/get metadata "questions"))))))
 
 (defmethod lib-type :metric
   [_object-type]

--- a/test/metabase/lib/js/metadata_test.cljs
+++ b/test/metabase/lib/js/metadata_test.cljs
@@ -1,0 +1,16 @@
+(ns metabase.lib.js.metadata-test
+  (:require
+   [clojure.test :refer [deftest is]]
+   [metabase.lib.js.metadata :as lib.js.metadata]))
+
+(deftest ^:parallel parse-fields-test
+  (let [metadata-fragment #js {:fields #js {"card__1234:5678" #js {:id 0}
+                                            "5678" #js {:id 1}
+                                            "8765" #js {:id 2}
+                                            "card__1234:4321" #js {:id 3}}}
+        parsed-fragment (lib.js.metadata/parse-objects :field metadata-fragment)]
+    (is (every? delay? (vals parsed-fragment)))
+    (is (= {4321 {:lib/type :metadata/column, :id 3}
+            5678 {:lib/type :metadata/column, :id 1}
+            8765 {:lib/type :metadata/column, :id 2}}
+           (update-vals parsed-fragment deref)))))


### PR DESCRIPTION
Besides adding the test, I've removed `object-get` because it seems to be just a renamed version of `gobject/get`.