### PR TITLE
Removed placeholder, added issuer props to list of saml settings

### DIFF
--- a/e2e/test/scenarios/admin/settings/sso/saml.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/sso/saml.cy.spec.js
@@ -76,6 +76,31 @@ describeEE("scenarios > admin > settings > SSO > SAML", () => {
     getSamlCard().findByText("Set up").should("exist");
   });
 
+  it("should display a message when using env variable values", () => {
+    cy.intercept("GET", "/api/setting", req => {
+      req.continue(res => {
+        const { body } = res;
+
+        Object.assign(
+          body.find(setting => setting.key === "saml-identity-provider-uri"),
+          {
+            is_env_setting: true,
+            default: "Using value of env var $MB_SAML_IDENTITY_PROVIDER_URI",
+          },
+        );
+
+        res.send(body);
+      });
+    });
+
+    cy.visit("/admin/settings/authentication/saml");
+
+    cy.findByLabelText("SAML Identity Provider URL").should(
+      "have.value",
+      "Using value of env var $MB_SAML_IDENTITY_PROVIDER_URI",
+    );
+  });
+
   describe("Group Mappings Widget", () => {
     beforeEach(() => {
       cy.intercept("GET", "/api/setting").as("getSettings");

--- a/e2e/test/scenarios/admin/settings/sso/saml.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/sso/saml.cy.spec.js
@@ -76,31 +76,6 @@ describeEE("scenarios > admin > settings > SSO > SAML", () => {
     getSamlCard().findByText("Set up").should("exist");
   });
 
-  it("should display a message when using env variable values", () => {
-    cy.intercept("GET", "/api/setting", req => {
-      req.continue(res => {
-        const { body } = res;
-
-        Object.assign(
-          body.find(setting => setting.key === "saml-identity-provider-uri"),
-          {
-            is_env_setting: true,
-            default: "Using value of env var $MB_SAML_IDENTITY_PROVIDER_URI",
-          },
-        );
-
-        res.send(body);
-      });
-    });
-
-    cy.visit("/admin/settings/authentication/saml");
-
-    cy.findByLabelText("SAML Identity Provider URL").should(
-      "have.value",
-      "Using value of env var $MB_SAML_IDENTITY_PROVIDER_URI",
-    );
-  });
-
   describe("Group Mappings Widget", () => {
     beforeEach(() => {
       cy.intercept("GET", "/api/setting").as("getSettings");

--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm/SettingsSAMLForm.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm/SettingsSAMLForm.jsx
@@ -194,6 +194,10 @@ const SAML_ATTRS = [
   "saml-attribute-email",
   "saml-attribute-firstname",
   "saml-attribute-lastname",
+  "saml-identity-provider-uri",
+  "saml-identity-provider-issuer",
+  "saml-identity-provider-certificate",
+  "saml-application-name",
 ];
 
 const getAttributeValues = (values, defaults) => {

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -175,6 +175,7 @@ export interface SettingDefinition {
   env_name?: string;
   is_env_setting: boolean;
   value?: unknown;
+  default?: unknown;
 }
 
 export interface OpenAiModel {

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/sso-saml.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/sso-saml.unit.spec.tsx
@@ -1,6 +1,7 @@
 import { screen } from "__support__/ui";
 import {
   createMockGroup,
+  createMockSettingDefinition,
   createMockSettings,
   createMockTokenFeatures,
 } from "metabase-types/api/mocks";
@@ -54,5 +55,22 @@ describe("SettingsEditorApp", () => {
     expect(
       await screen.findByText("Notify admins of new SSO users"),
     ).toBeInTheDocument();
+  });
+
+  it("shows proper message when using environment variables for settings", async () => {
+    setupPremium({
+      initialRoute: "/admin/settings/authentication/saml",
+      settings: [
+        createMockSettingDefinition({
+          key: "saml-identity-provider-uri",
+          is_env_setting: true,
+          default: "Using value of env var $MB_SAML_IDENTITY_PROVIDER_URI",
+        }),
+      ],
+    });
+
+    expect(
+      await screen.findByLabelText("SAML Identity Provider URL"),
+    ).toHaveValue("Using value of env var $MB_SAML_IDENTITY_PROVIDER_URI");
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/21677

### Description
Added the SAML Issuer props to the list of SAML Settings so that the proper text is pulled for the fields: `Using value of env var $MB_SOMETHING`. This also changes the text from looking like a placeholver to looking like the value, implying that nothing needs to be added to the input.

Unfortunately, I'm not totally sure how to test this out as it involves setting env variables before starting the test. I'll ask around.

### How to verify
Set the `MB_SAML_IDENTITY_PROVIDER_URI` env variable to something, and start metabase. In the admin section under Authentication SAML, you should see that we're using the env variable. You can do the same with these variables as well:
- MB_SAML_APPLICATION_NAME
- MB_SAML_IDENTITY_PROVIDER_CERTIFICATE
- MB_SAML_IDENTITY_PROVIDER_ISSUER

### Demo
![image](https://github.com/metabase/metabase/assets/1328979/5fa36096-4eb7-486e-8c62-4a50dec50fe2)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
