### PR TITLE
Add an E2E test to click behavior not working on non-numeric ID fields

### DIFF
--- a/e2e/support/helpers/e2e-qa-databases-helpers.js
+++ b/e2e/support/helpers/e2e-qa-databases-helpers.js
@@ -228,19 +228,28 @@ export function waitForSyncToFinish({
 
   cy.request("GET", `/api/database/${dbId}/metadata`).then(({ body }) => {
     if (!body.tables.length) {
-      return waitForSyncToFinish({ iteration: ++iteration, dbId, tableName });
+      return waitForSyncToFinish({
+        iteration: ++iteration,
+        dbId,
+        tableName,
+        tableAlias,
+      });
     } else if (tableName) {
       const table = body.tables.find(
         table =>
           table.name === tableName && table.initial_sync_status === "complete",
       );
-      console.log({ table, body, tableAlias });
+
       if (!table) {
-        return waitForSyncToFinish({ iteration: ++iteration, dbId, tableName });
+        return waitForSyncToFinish({
+          iteration: ++iteration,
+          dbId,
+          tableName,
+          tableAlias,
+        });
       }
 
       if (tableAlias) {
-        console.log("setting table alias");
         cy.wrap(table).as(tableAlias);
       }
 

--- a/e2e/support/helpers/e2e-qa-databases-helpers.js
+++ b/e2e/support/helpers/e2e-qa-databases-helpers.js
@@ -228,19 +228,21 @@ export function waitForSyncToFinish({
 
   cy.request("GET", `/api/database/${dbId}/metadata`).then(({ body }) => {
     if (!body.tables.length) {
-      waitForSyncToFinish({ iteration: ++iteration, dbId, tableName });
+      return waitForSyncToFinish({ iteration: ++iteration, dbId, tableName });
     } else if (tableName) {
       const table = body.tables.find(
         table =>
           table.name === tableName && table.initial_sync_status === "complete",
       );
       if (!table) {
-        waitForSyncToFinish({ iteration: ++iteration, dbId, tableName });
+        return waitForSyncToFinish({ iteration: ++iteration, dbId, tableName });
       }
 
       if (tableAlias) {
         cy.wrap(table).as(tableAlias);
       }
+
+      return null;
     }
   });
 }

--- a/e2e/support/helpers/e2e-qa-databases-helpers.js
+++ b/e2e/support/helpers/e2e-qa-databases-helpers.js
@@ -234,11 +234,13 @@ export function waitForSyncToFinish({
         table =>
           table.name === tableName && table.initial_sync_status === "complete",
       );
+      console.log({ table, body, tableAlias });
       if (!table) {
         return waitForSyncToFinish({ iteration: ++iteration, dbId, tableName });
       }
 
       if (tableAlias) {
+        console.log("setting table alias");
         cy.wrap(table).as(tableAlias);
       }
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/15170

### Description

The issue stated that non-numeric ID fields don't show up in click behavior options, but that's already fixed in https://github.com/metabase/metabase/pull/24222 Specifically here.
https://github.com/metabase/metabase/blob/69939cd3579dc3b968c34796ba87fa34c8c19585/frontend/src/metabase/lib/click-behavior.js#L188

This PR adds a test to cover https://github.com/metabase/metabase/issues/15170.

I unskipped the current test and modify the test to suit the actual cause of the issue. [We use `base_type`](https://github.com/metabase/metabase/blob/d239393ef393236fdd8908ce83d3e61ad4e84d59/frontend/src/metabase-lib/parameters/utils/click-behavior.js#L166) to determine whether we want to show field options when mapping dashboard parameters to fields, we can't just follow the repro steps from https://github.com/metabase/metabase/issues/15170#issuecomment-799603856 since modifying field type in Table Metadata only changes their `semantic_type` not `base_type`. 

### How to verify
> **Note**
> use `yarn test-cypress-open-qa` to test this since it requires a different database than the sample database since it contains UUID field

1. Run this E2E suite `e2e/test/scenarios/dashboard-filters/dashboard-chained-filters.cy.spec.js` and all tests should pass.
2. Remove `TYPE.UUID` from here
    https://github.com/metabase/metabase/blob/35653d30968c1fbe132666ed64194b3992e893ad/frontend/src/metabase-lib/parameters/utils/click-behavior.js#L185
    And the unskipped test should fail

### Demo
![Screenshot 2023-08-17 at 1 32 31 PM](https://github.com/metabase/metabase/assets/1937582/1016261a-c34e-48bc-86c1-9b16bcca7990)



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
