### PR TITLE
Show form-field-specific errors coming from execute action endpoints

### DIFF
--- a/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
@@ -29,7 +29,9 @@ describe(
   { tags: ["@external", "@actions"] },
   () => {
     beforeEach(() => {
+      cy.intercept("GET", "/api/card/*").as("getModel");
       cy.intercept("GET", "/api/action?model-id=*").as("getModelActions");
+      cy.intercept("POST", "/api/action/*/execute").as("executeAction");
       cy.intercept("GET", "/api/action/*/execute?parameters=*").as(
         "prefetchValues",
       );
@@ -185,6 +187,38 @@ describe(
         });
       },
     );
+
+    it("should show detailed form errors for constraint violations when executing model actions", () => {
+      const actionName = "Update";
+
+      cy.signInAsAdmin();
+
+      cy.get("@modelId").then(modelId => {
+        cy.visit(`/model/${modelId}/detail`);
+        cy.wait("@getModel");
+        createImplicitActions({ modelId });
+        visitObjectDetail(modelId, FIRST_SCORE_ROW_ID);
+        openUpdateObjectModal();
+      });
+
+      actionExecuteModal().within(() => {
+        cy.wait("@prefetchValues");
+
+        actionForm().within(() => {
+          cy.findByLabelText("Team Name").clear().type("Dusty Ducks");
+          cy.findByText(actionName).click();
+        });
+
+        cy.wait("@executeAction");
+
+        cy.findByLabelText("Team Name").should("not.exist");
+        cy.findByLabelText(
+          "Team Name: This Team_name value already exists.",
+        ).should("exist");
+
+        cy.findByText("Team_name already exists.").should("exist");
+      });
+    });
   },
 );
 

--- a/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
@@ -29,7 +29,6 @@ describe(
   { tags: ["@external", "@actions"] },
   () => {
     beforeEach(() => {
-      cy.intercept("GET", "/api/card/*").as("getModel");
       cy.intercept("GET", "/api/action?model-id=*").as("getModelActions");
       cy.intercept("POST", "/api/action/*/execute").as("executeAction");
       cy.intercept("GET", "/api/action/*/execute?parameters=*").as(

--- a/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
@@ -194,8 +194,6 @@ describe(
       cy.signInAsAdmin();
 
       cy.get("@modelId").then(modelId => {
-        cy.visit(`/model/${modelId}/detail`);
-        cy.wait("@getModel");
         createImplicitActions({ modelId });
         visitObjectDetail(modelId, FIRST_SCORE_ROW_ID);
         openUpdateObjectModal();

--- a/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
@@ -52,10 +52,10 @@ const MODEL_NAME = "Test Action Model";
         cy.intercept(
           "GET",
           "/api/dashboard/*/dashcard/*/execute?parameters=*",
-        ).as("executePrefetch");
+        ).as("prefetchValues");
 
         cy.intercept("POST", "/api/dashboard/*/dashcard/*/execute").as(
-          "executeAPI",
+          "executeAction",
         );
       });
 
@@ -137,7 +137,7 @@ const MODEL_NAME = "Test Action Model";
             cy.button(ACTION_NAME).click();
           });
 
-          cy.wait("@executeAPI");
+          cy.wait("@executeAction");
 
           queryWritableDB(
             `SELECT * FROM ${TEST_TABLE} WHERE id = 1`,
@@ -173,7 +173,7 @@ const MODEL_NAME = "Test Action Model";
             cy.button("Save").click();
           });
 
-          cy.wait("@executeAPI");
+          cy.wait("@executeAction");
 
           queryWritableDB(
             `SELECT * FROM ${TEST_TABLE} WHERE team_name = 'Zany Zebras'`,
@@ -209,7 +209,7 @@ const MODEL_NAME = "Test Action Model";
 
           cy.findByRole("button", { name: actionName }).click();
 
-          cy.wait("@executePrefetch");
+          cy.wait("@prefetchValues");
           // let's check that the existing values are pre-filled correctly
           modal().within(() => {
             cy.findByPlaceholderText("Team Name")
@@ -225,7 +225,7 @@ const MODEL_NAME = "Test Action Model";
             cy.button("Update").click();
           });
 
-          cy.wait("@executeAPI");
+          cy.wait("@executeAction");
 
           queryWritableDB(
             `SELECT * FROM ${TEST_TABLE} WHERE team_name = 'Emotional Elephants'`,
@@ -268,7 +268,7 @@ const MODEL_NAME = "Test Action Model";
             cy.button("Delete").click();
           });
 
-          cy.wait("@executeAPI");
+          cy.wait("@executeAction");
 
           queryWritableDB(
             `SELECT * FROM ${TEST_TABLE} WHERE team_name = 'Cuddly Cats'`,
@@ -302,7 +302,7 @@ const MODEL_NAME = "Test Action Model";
               cy.button("Save").click();
             });
 
-            cy.wait("@executeAPI");
+            cy.wait("@executeAction");
 
             queryWritableDB(
               `SELECT * FROM ${TEST_TABLE} WHERE team_name = 'Zany Zebras'`,
@@ -390,7 +390,7 @@ const MODEL_NAME = "Test Action Model";
               cy.button(ACTION_NAME).click();
             });
 
-            cy.wait("@executeAPI");
+            cy.wait("@executeAction");
 
             queryWritableDB(
               `SELECT * FROM ${TEST_TABLE} WHERE id = 1`,
@@ -449,7 +449,7 @@ const MODEL_NAME = "Test Action Model";
               cy.button(ACTION_NAME).click();
             });
 
-            cy.wait("@executeAPI");
+            cy.wait("@executeAction");
 
             queryWritableDB(
               `SELECT * FROM ${TEST_TABLE} WHERE id = 1`,
@@ -495,7 +495,7 @@ const MODEL_NAME = "Test Action Model";
 
           cy.findByRole("button", { name: "Update" }).click();
 
-          cy.wait("@executePrefetch");
+          cy.wait("@prefetchValues");
 
           const oldRow = many_data_types_rows[0];
 
@@ -547,7 +547,7 @@ const MODEL_NAME = "Test Action Model";
             cy.button("Update").click();
           });
 
-          cy.wait("@executeAPI");
+          cy.wait("@executeAction");
 
           queryWritableDB(
             `SELECT * FROM ${TEST_COLUMNS_TABLE} WHERE id = 1`,
@@ -618,7 +618,7 @@ const MODEL_NAME = "Test Action Model";
             cy.button("Save").click();
           });
 
-          cy.wait("@executeAPI");
+          cy.wait("@executeAction");
 
           queryWritableDB(
             `SELECT * FROM ${TEST_COLUMNS_TABLE} WHERE string = 'Zany Zebras'`,
@@ -704,7 +704,7 @@ const MODEL_NAME = "Test Action Model";
 
           cy.findByRole("button", { name: "Update" }).click();
 
-          cy.wait("@executePrefetch");
+          cy.wait("@prefetchValues");
 
           const oldRow = many_data_types_rows[0];
           const newTime = "2020-01-10T01:35:55";
@@ -774,7 +774,7 @@ const MODEL_NAME = "Test Action Model";
             cy.button("Update").click();
           });
 
-          cy.wait("@executeAPI");
+          cy.wait("@executeAction");
 
           queryWritableDB(
             `SELECT * FROM ${TEST_COLUMNS_TABLE} WHERE id = 1`,
@@ -944,7 +944,7 @@ const MODEL_NAME = "Test Action Model";
             cy.button(SAMPLE_QUERY_ACTION.name).click();
           });
 
-          cy.wait("@executeAPI").then(interception => {
+          cy.wait("@executeAction").then(interception => {
             expect(
               Object.values(interception.request.body.parameters)
                 .sort()
@@ -974,10 +974,10 @@ describe("action error handling", { tags: ["@external", "@actions"] }, () => {
 
     cy.intercept("GET", "/api/action").as("getActions");
     cy.intercept("GET", "/api/dashboard/*/dashcard/*/execute?parameters=*").as(
-      "executePrefetch",
+      "prefetchValues",
     );
     cy.intercept("POST", "/api/dashboard/*/dashcard/*/execute").as(
-      "executeAPI",
+      "executeAction",
     );
   });
 
@@ -994,12 +994,12 @@ describe("action error handling", { tags: ["@external", "@actions"] }, () => {
     addWidgetStringFilter("5");
     cy.button(actionName).click();
 
-    cy.wait("@executePrefetch");
+    cy.wait("@prefetchValues");
 
     modal().within(() => {
       cy.findByLabelText("Team Name").clear().type("Kind Koalas");
       cy.button(actionName).click();
-      cy.wait("@executeAPI");
+      cy.wait("@executeAction");
 
       cy.findByLabelText("Team Name").should("not.exist");
       cy.findByLabelText(

--- a/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
@@ -961,7 +961,7 @@ const MODEL_NAME = "Test Action Model";
   );
 });
 
-describe("action error handling", () => {
+describe("action error handling", { tags: ["@external", "@actions"] }, () => {
   beforeEach(() => {
     resetTestTable({ type: "postgres", table: TEST_TABLE });
     restore("postgres-writable");

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -350,20 +350,20 @@ describe(
 
       modal().within(() => {
         cy.findByLabelText("ID").type("1");
-        // cy.findByLabelText("Product ID").type("999999");
         cy.findByLabelText("User ID").type("999999");
+        // cy.findByLabelText("Product ID").type("999999");
         cy.findByRole("button", { name: "Update" }).click();
         cy.wait("@executeAction");
-
-        // cy.findByLabelText("Product ID").should("not.exist");
-        // cy.findByLabelText("Product ID: This Product_id does not exist.").should(
-        //   "exist",
-        // );
 
         cy.findByLabelText("User ID").should("not.exist");
         cy.findByLabelText("User ID: This User_id does not exist.").should(
           "exist",
         );
+
+        // cy.findByLabelText("Product ID").should("not.exist");
+        // cy.findByLabelText("Product ID: This Product_id does not exist.").should(
+        //   "exist",
+        // );
 
         cy.findByText("Unable to update the record.").should("exist");
       });

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -107,45 +107,6 @@ describe(
       cy.intercept("POST", "/api/action").as("createAction");
     });
 
-    it("should show detailed form errors for constraint violations when executing model actions", () => {
-      cy.get("@modelId").then(modelId => {
-        cy.visit(`/model/${modelId}/detail`);
-        cy.wait("@getModel");
-      });
-
-      cy.findByRole("tablist").within(() => {
-        cy.findByText("Actions").click();
-      });
-
-      createBasicActions();
-
-      cy.findByLabelText("Action list").within(() => {
-        cy.get("li").eq(1).findByText("Update").should("be.visible");
-      });
-
-      runActionFor("Update");
-
-      modal().within(() => {
-        cy.findByLabelText("ID").type("1");
-        // cy.findByLabelText("Product ID").type("999999");
-        cy.findByLabelText("User ID").type("999999");
-        cy.findByRole("button", { name: "Update" }).click();
-        cy.wait("@executeAction");
-
-        // cy.findByLabelText("Product ID").should("not.exist");
-        // cy.findByLabelText("Product ID: This Product_id does not exist.").should(
-        //   "exist",
-        // );
-
-        cy.findByLabelText("User ID").should("not.exist");
-        cy.findByLabelText("User ID: This User_id does not exist.").should(
-          "exist",
-        );
-
-        cy.findByText("Unable to update the record.").should("exist");
-      });
-    });
-
     it("should allow CRUD operations on model actions", () => {
       cy.get("@modelId").then(id => {
         cy.visit(`/model/${id}/detail`);
@@ -367,6 +328,45 @@ describe(
       cy.findByLabelText("#1-orders-model").should("not.exist");
       cy.findByLabelText("101").should("not.exist");
       cy.findByLabelText("ID").should("be.visible");
+    });
+
+    it("should show detailed form errors for constraint violations when executing model actions", () => {
+      cy.get("@modelId").then(modelId => {
+        cy.visit(`/model/${modelId}/detail`);
+        cy.wait("@getModel");
+      });
+
+      cy.findByRole("tablist").within(() => {
+        cy.findByText("Actions").click();
+      });
+
+      createBasicActions();
+
+      cy.findByLabelText("Action list").within(() => {
+        cy.get("li").eq(1).findByText("Update").should("be.visible");
+      });
+
+      runActionFor("Update");
+
+      modal().within(() => {
+        cy.findByLabelText("ID").type("1");
+        // cy.findByLabelText("Product ID").type("999999");
+        cy.findByLabelText("User ID").type("999999");
+        cy.findByRole("button", { name: "Update" }).click();
+        cy.wait("@executeAction");
+
+        // cy.findByLabelText("Product ID").should("not.exist");
+        // cy.findByLabelText("Product ID: This Product_id does not exist.").should(
+        //   "exist",
+        // );
+
+        cy.findByLabelText("User ID").should("not.exist");
+        cy.findByLabelText("User ID: This User_id does not exist.").should(
+          "exist",
+        );
+
+        cy.findByText("Unable to update the record.").should("exist");
+      });
     });
   },
 );

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -1,17 +1,17 @@
 import { assocIn } from "icepick";
 import {
-  createAction,
-  createModelFromTableName,
-  fillActionQuery,
+  setActionsEnabledForDB,
   modal,
+  popover,
+  restore,
+  fillActionQuery,
+  createAction,
   navigationSidebar,
   openNavigationSidebar,
-  popover,
-  queryWritableDB,
   resetTestTable,
-  restore,
   resyncDatabase,
-  setActionsEnabledForDB,
+  createModelFromTableName,
+  queryWritableDB,
   setTokenFeatures,
 } from "e2e/support/helpers";
 

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -367,7 +367,6 @@ describe(
       modal().within(() => {
         cy.findByLabelText("ID").type("1");
         cy.findByLabelText("User ID").type("999999");
-        cy.findByLabelText("Product ID").type("999999");
         cy.button(actionName).click();
         cy.wait("@executeAction");
 
@@ -375,17 +374,6 @@ describe(
         cy.findByLabelText("User ID: This User_id does not exist.").should(
           "exist",
         );
-
-        /**
-         * Even though we violate 2 FK constraints with this request, the JDBC gives
-         * us only the information about 1 FK violation at a time.
-         *
-         * @see https://github.com/metabase/metabase/pull/32935#discussion_r1297054339
-         */
-        cy.findByLabelText("Product ID").should("exist");
-        cy.findByLabelText(
-          "Product ID: This Product_id does not exist.",
-        ).should("not.exist");
 
         cy.findByText("Unable to update the record.").should("exist");
       });

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -21,8 +21,8 @@ import {
   WRITABLE_DB_ID,
 } from "e2e/support/cypress_data";
 
-import { getCreatePostgresRoleIfNotExistSql } from "e2e/support/test_roles";
 import { createMockActionParameter } from "metabase-types/api/mocks";
+import { getCreatePostgresRoleIfNotExistSql } from "e2e/support/test_roles";
 
 const PG_DB_ID = 2;
 const PG_ORDERS_TABLE_ID = 9;

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -353,7 +353,7 @@ describe(
       modal().within(() => {
         cy.findByLabelText("ID").type("1");
         cy.findByLabelText("User ID").type("999999");
-        // cy.findByLabelText("Product ID").type("999999");
+        cy.findByLabelText("Product ID").type("999999");
         cy.button(actionName).click();
         cy.wait("@executeAction");
 
@@ -362,10 +362,16 @@ describe(
           "exist",
         );
 
-        // cy.findByLabelText("Product ID").should("not.exist");
-        // cy.findByLabelText("Product ID: This Product_id does not exist.").should(
-        //   "exist",
-        // );
+        /**
+         * Even though we violate 2 FK constraints with this request, the JDBC gives
+         * us only the information about 1 FK violation at a time.
+         *
+         * @see https://github.com/metabase/metabase/pull/32935#discussion_r1297054339
+         */
+        cy.findByLabelText("Product ID").should("exist");
+        cy.findByLabelText(
+          "Product ID: This Product_id does not exist.",
+        ).should("not.exist");
 
         cy.findByText("Unable to update the record.").should("exist");
       });

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -1,5 +1,6 @@
 import { assocIn } from "icepick";
 import {
+  createImplicitActions,
   setActionsEnabledForDB,
   modal,
   popover,
@@ -338,25 +339,13 @@ describe(
       const actionName = "Update";
 
       cy.get("@modelId").then(modelId => {
+        createImplicitActions({ modelId });
+
         cy.visit(`/model/${modelId}/detail`);
         cy.wait("@getModel");
       });
 
       cy.findByRole("tablist").findByText("Actions").click();
-
-      cy.wait([
-        "@fetchMetadata",
-        "@fetchMetadata",
-        "@fetchMetadata",
-        "@getModelAction",
-        "@getSearchResults",
-      ]);
-
-      createBasicActions();
-
-      cy.findByLabelText("Action list").within(() => {
-        cy.get("li").eq(1).findByText(actionName).should("be.visible");
-      });
 
       runActionFor(actionName);
 

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -331,6 +331,8 @@ describe(
     });
 
     it("should show detailed form errors for constraint violations when executing model actions", () => {
+      const actionName = "Update";
+
       cy.get("@modelId").then(modelId => {
         cy.visit(`/model/${modelId}/detail`);
         cy.wait("@getModel");
@@ -343,16 +345,16 @@ describe(
       createBasicActions();
 
       cy.findByLabelText("Action list").within(() => {
-        cy.get("li").eq(1).findByText("Update").should("be.visible");
+        cy.get("li").eq(1).findByText(actionName).should("be.visible");
       });
 
-      runActionFor("Update");
+      runActionFor(actionName);
 
       modal().within(() => {
         cy.findByLabelText("ID").type("1");
         cy.findByLabelText("User ID").type("999999");
         // cy.findByLabelText("Product ID").type("999999");
-        cy.findByRole("button", { name: "Update" }).click();
+        cy.button(actionName).click();
         cy.wait("@executeAction");
 
         cy.findByLabelText("User ID").should("not.exist");

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -342,9 +342,7 @@ describe(
         cy.wait("@getModel");
       });
 
-      cy.findByRole("tablist").within(() => {
-        cy.findByText("Actions").click();
-      });
+      cy.findByRole("tablist").findByText("Actions").click();
 
       cy.wait([
         "@fetchMetadata",

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -102,9 +102,13 @@ describe(
       });
 
       cy.intercept("GET", "/api/card/*").as("getModel");
+      cy.intercept("GET", "/api/action/*").as("getAction");
+      cy.intercept("GET", "/api/action?model-id=*").as("getModelAction");
       cy.intercept("PUT", "/api/action/*").as("updateAction");
       cy.intercept("POST", "/api/action/*/execute").as("executeAction");
       cy.intercept("POST", "/api/action").as("createAction");
+      cy.intercept("GET", "/api/table/*/query_metadata*").as("fetchMetadata");
+      cy.intercept("GET", "/api/search?*").as("getSearchResults");
     });
 
     it("should allow CRUD operations on model actions", () => {
@@ -342,6 +346,14 @@ describe(
         cy.findByText("Actions").click();
       });
 
+      cy.wait([
+        "@fetchMetadata",
+        "@fetchMetadata",
+        "@fetchMetadata",
+        "@getModelAction",
+        "@getSearchResults",
+      ]);
+
       createBasicActions();
 
       cy.findByLabelText("Action list").within(() => {
@@ -349,6 +361,8 @@ describe(
       });
 
       runActionFor(actionName);
+
+      cy.wait("@getAction");
 
       modal().within(() => {
         cy.findByLabelText("ID").type("1");

--- a/frontend/src/metabase-types/api/actions.ts
+++ b/frontend/src/metabase-types/api/actions.ts
@@ -86,7 +86,7 @@ export type ActionFormInitialValues = ParametersForActionExecution;
 export interface ActionFormSubmitResult {
   success: boolean;
   message?: string;
-  error?: string;
+  error?: unknown;
 }
 
 export type OnSubmitActionForm = (

--- a/frontend/src/metabase/actions/actions.ts
+++ b/frontend/src/metabase/actions/actions.ts
@@ -27,6 +27,6 @@ export const executeAction =
       return { success: true, message };
     } catch (error) {
       const message = getActionErrorMessage(error);
-      return { success: false, error: message, message };
+      return { success: false, error, message };
     }
   };

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.tsx
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.tsx
@@ -51,7 +51,7 @@ function ActionParametersInputForm({
         actions.setErrors({});
         onSubmitSuccess?.(actions);
       } else {
-        throw new Error(error);
+        throw error;
       }
     },
     [onSubmit, onSubmitSuccess],

--- a/frontend/src/metabase/dashboard/actions/actions.ts
+++ b/frontend/src/metabase/dashboard/actions/actions.ts
@@ -98,7 +98,7 @@ export const executeRowAction = async ({
       );
     }
 
-    return { success: false, error: message, message };
+    return { success: false, error, message };
   }
 };
 


### PR DESCRIPTION
Closes #33238

Based on #32935.
But it can be merged to `master` before #32935 if we `.skip()` the e2e tests.

### Description

There are 3 tests, 1 for each place where we can run actions from:
- dashboard
- object detail modal
- model detail page (actions tab)

### How to verify

1. Create a model based on Invoices table from Sample DB
2. Enable basic actions in that model
3. Run the update action for an invoice with "Account ID" that does not exist (e.g. `99999`)
    - from dashboard (add ID filter, then add action button and connect it to the action and use ID filter as ID parameter for the action)
    - from object detail modal (browse model, click on an object id)
    - from model detail page (actions tab)
4. An error should be shown for "Account ID" form input field.



### Demo

[before](https://github.com/metabase/metabase/assets/6830683/b9c5b94e-f217-4668-974d-3aeb66229947) & [after](https://github.com/metabase/metabase/assets/6830683/0febab4e-7199-434e-a3fd-721790a04739)
