### PR TITLE
Ensure that entity links aren't opened in new tab

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
@@ -14,7 +14,6 @@ import type {
 
 import { useToggle } from "metabase/hooks/use-toggle";
 import Search from "metabase/entities/search";
-import { isWithinIframe } from "metabase/lib/dom";
 
 import { isRestrictedLinkEntity } from "metabase-types/guards/dashboard";
 import {
@@ -127,14 +126,11 @@ function LinkVizInner({
       );
     }
 
-    const target = isWithinIframe() ? undefined : "_self";
-
     return (
       <DisplayLinkCardWrapper>
         <CardLink
           data-testid="entity-view-display-link"
           to={wrappedEntity.getUrl()}
-          target={target}
           rel="noreferrer"
           role="link"
         >

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
@@ -127,7 +127,7 @@ function LinkVizInner({
       );
     }
 
-    const target = isWithinIframe() ? undefined : "_blank";
+    const target = isWithinIframe() ? undefined : "_self";
 
     return (
       <DisplayLinkCardWrapper>

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.unit.spec.tsx
@@ -220,7 +220,7 @@ describe("LinkViz", () => {
           tableLinkDashcard.visualization_settings as LinkCardVizSettings,
       });
 
-      expect(screen.getByRole("link")).toHaveAttribute("target", "_blank");
+      expect(screen.getByRole("link")).not.toHaveAttribute("target");
     });
 
     it("sets embedded entity links to not open in new tabs", () => {
@@ -331,17 +331,6 @@ describe("LinkViz", () => {
 
       expect(getIcon("key")).toBeInTheDocument();
       expect(screen.getByText(/don't have permission/i)).toBeInTheDocument();
-    });
-
-    it("should have a link that loads the URL in the same page", () => {
-      setup({
-        isEditing: false,
-        dashcard: tableLinkDashcard,
-        settings:
-          tableLinkDashcard.visualization_settings as LinkCardVizSettings,
-      });
-      expect(screen.getByText("Table Uno")).toBeInTheDocument();
-      expect(screen.getByRole("link")).not.toHaveAttribute("target");
     });
   });
 });

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.unit.spec.tsx
@@ -178,6 +178,13 @@ describe("LinkViz", () => {
 
       expect(screen.getByText("Choose a link")).toBeInTheDocument();
     });
+
+    it("should have a link that loads the URL in a new page", () => {
+      setup({ isEditing: false });
+
+      expect(screen.getByText("https://example23.com")).toBeInTheDocument();
+      expect(screen.getByRole("link")).toHaveAttribute("target", "_blank");
+    });
   });
 
   describe("entity links", () => {
@@ -324,6 +331,17 @@ describe("LinkViz", () => {
 
       expect(getIcon("key")).toBeInTheDocument();
       expect(screen.getByText(/don't have permission/i)).toBeInTheDocument();
+    });
+
+    it("should have a link that loads the URL in the same page", () => {
+      setup({
+        isEditing: false,
+        dashcard: tableLinkDashcard,
+        settings:
+          tableLinkDashcard.visualization_settings as LinkCardVizSettings,
+      });
+      expect(screen.getByText("Table Uno")).toBeInTheDocument();
+      expect(screen.getByRole("link")).not.toHaveAttribute("target");
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/33218

### Description

Ensures that entity links are opened in the same window, not in a new tab.

### How to verify

1. Add a Link to a dashboard
2. Pick an item to link to
3. Save
4. Click the Link card
5. See that it opens in a new tab no matter how nicely you ask it not to.

Do the same thing with an external link, and see that it still opens in a new tab as well.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
