### PR TITLE
[wip]Update maxWorkers for jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -302,7 +302,7 @@
     "lint-yaml": "yamllint **/*.{yaml,yml} --ignore=node_modules/**/*.{yaml,yml}",
     "test": "yarn test-unit && yarn test-timezones && yarn test-cypress",
     "test-debug": "yarn build:cljs && node --inspect-brk node_modules/.bin/jest --runInBand --detectOpenHandles --config jest.unit.conf.json",
-    "test-unit": "yarn build:cljs && jest --config jest.unit.conf.json",
+    "test-unit": "yarn build:cljs && jest --maxWorkers=50% --config jest.unit.conf.json",
     "test-unit-keep-cljs": "jest --maxWorkers=2 --config jest.unit.conf.json",
     "test-unit-watch": "yarn test-unit --watch",
     "test-unit-watch:cljs": "yarn concurrently -n 'cljs,tests' 'yarn build-watch:cljs' 'yarn test-unit-keep-cljs --watch'",

--- a/package.json
+++ b/package.json
@@ -302,7 +302,7 @@
     "lint-yaml": "yamllint **/*.{yaml,yml} --ignore=node_modules/**/*.{yaml,yml}",
     "test": "yarn test-unit && yarn test-timezones && yarn test-cypress",
     "test-debug": "yarn build:cljs && node --inspect-brk node_modules/.bin/jest --runInBand --detectOpenHandles --config jest.unit.conf.json",
-    "test-unit": "yarn build:cljs && jest --maxWorkers=2 --config jest.unit.conf.json",
+    "test-unit": "yarn build:cljs && jest --config jest.unit.conf.json",
     "test-unit-keep-cljs": "jest --maxWorkers=2 --config jest.unit.conf.json",
     "test-unit-watch": "yarn test-unit --watch",
     "test-unit-watch:cljs": "yarn concurrently -n 'cljs,tests' 'yarn build-watch:cljs' 'yarn test-unit-keep-cljs --watch'",


### PR DESCRIPTION
Reverts https://github.com/metabase/metabase/pull/13524

### Description

[By default](https://jestjs.io/docs/cli#:~:text=%2D%2DmaxWorkers%3D%7C%20%E2%80%8B&text=In%20single%20run%20mode%2C%20this,your%20machine%20to%20a%20halt) Jest uses the full number of cores on the machine to run unit tests in single-run mode and half the cores for watch mode. This seems like better behavior than limiting them to 2 cores.

- should see much better performance by default locally
- should see identical performance on default CI runners
- will seamlessly get better performance out of CI runners with more core.

## Benchmarks

https://metaboat.slack.com/archives/C505ZNNH4/p1668619712356539
https://metaboat.slack.com/archives/C505ZNNH4/p1685647139767959

