### PR TITLE
Fix can't remove click behavior on structured question hidden columns

### DIFF
--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TableClickBehaviorView/TableClickBehaviorView.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TableClickBehaviorView/TableClickBehaviorView.tsx
@@ -34,6 +34,7 @@ function explainClickBehaviorType(
 
 interface Props {
   columns: DatasetColumn[];
+  disabledStructuredQuestionColumns: DatasetColumn[];
   dashcard: DashboardOrderedCard;
   getClickBehaviorForColumn: (
     column: DatasetColumn,
@@ -43,12 +44,18 @@ interface Props {
 
 function TableClickBehaviorView({
   columns,
+  disabledStructuredQuestionColumns,
   dashcard,
   getClickBehaviorForColumn,
   onColumnClick,
 }: Props) {
   const groupedColumns = useMemo(() => {
-    const withClickBehaviors = columns.map(column => ({
+    const disabledColumnsWithClickColumns =
+      disabledStructuredQuestionColumns.filter(column =>
+        getClickBehaviorForColumn(column),
+      );
+    const visibleColumns = columns.concat(disabledColumnsWithClickColumns);
+    const withClickBehaviors = visibleColumns.map(column => ({
       column,
       clickBehavior: getClickBehaviorForColumn(column),
     }));
@@ -63,7 +70,7 @@ function TableClickBehaviorView({
     return _.sortBy(pairs, ([type]) =>
       COLUMN_SORTING_ORDER_BY_CLICK_BEHAVIOR_TYPE.indexOf(type),
     );
-  }, [columns, getClickBehaviorForColumn]);
+  }, [columns, disabledStructuredQuestionColumns, getClickBehaviorForColumn]);
 
   const renderColumn = useCallback(
     ({ column, clickBehavior }, index) => {


### PR DESCRIPTION
> **Note**
> Awaiting engineering discussion

Closes https://github.com/metabase/metabase/issues/18298

### Description

For a start, only non-native questions (structured questions) have this problem. Since we show all columns when configuring native question click behaviors.

This fix uses the same logic presented in `ChartSettingOrderedColumns.jsx`
https://github.com/metabase/metabase/blob/bb00748b09aeb9fa219d08ea5bcff058ab223756/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx#L36-L43

Which is used to render hidden columns on table settings
![Screenshot 2023-08-17 at 8 11 22 PM](https://github.com/metabase/metabase/assets/1937582/67054e76-5e69-4780-9319-a9e3c4870c13)


If we found disabled columns with click behavior configured, we will show the option so users can choose to remove the click behavior, once removed, the columns won't be visible again in the click behavior sidebar unless users unhide those columns.

Though I'm not sure if the fix is desirable considering the work behind migrating to MLv2 since this fix uses MLv1, so feedback is appreciated.


### How to verify

1) Build a dashboard and add a table visualization
2) add click behaviour to that table on any column, save the dashboard
3) go to the question and hide a column from the table visualization settings
4) return to the dashboard and check the click behaviour setting, you won't see the column anymore, although the card will say that there is 1 column with click behaviour

### Demo
![Screenshot 2023-08-17 at 8 06 32 PM](https://github.com/metabase/metabase/assets/1937582/5014c200-d4aa-4b4c-9fab-28797f293d81)


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
