### PR TITLE
Run Cloverage job only on merge to `master`

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -33,7 +33,7 @@ jobs:
 
   be-linter-cloverage:
     needs: files-changed
-    if: github.ref == 'refs/heads/master' && needs.files-changed.outputs.backend_all == 'true'
+    if: github.ref_name == 'master' && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     steps:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -33,7 +33,7 @@ jobs:
 
   be-linter-cloverage:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: github.ref == 'refs/heads/master' && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     steps:


### PR DESCRIPTION
Should be self-explanatory.

We're currently running this very slow job on every single commit.
It should be safe enough to run it only when a PR lands into `master`.