### PR TITLE
Allow custom fonts in mantine components

### DIFF
--- a/frontend/src/metabase/ui/theme.ts
+++ b/frontend/src/metabase/ui/theme.ts
@@ -40,7 +40,7 @@ export const getThemeOverrides = (): MantineThemeOverride => ({
     lg: "17px",
     xl: "21px",
   },
-  fontFamily: 'Lato, "Helvetica Neue", Helvetica, sans-serif',
+  fontFamily: "var(--default-font-family)",
   fontFamilyMonospace: "Monaco, monospace",
   components: {
     ...getAccordionOverrides(),


### PR DESCRIPTION
Simple fix for the custom font files, for now

How to verify:
- `yarn storybook`
- Make sure `Lato` is still the default font

<img width="1728" alt="Screenshot 2023-08-17 at 14 08 42" src="https://github.com/metabase/metabase/assets/8542534/7e5220e2-91b1-49f5-82d0-bf4b7a903272">
