### PR TITLE
[AuditV2] Allow loading instance analytics into h2

### DIFF
--- a/src/metabase/db/env.clj
+++ b/src/metabase/db/env.clj
@@ -72,7 +72,9 @@
    ;; Tell H2 to defrag when Metabase is shut down -- can reduce DB size by multiple GIGABYTES -- see #6510
    :DEFRAG_ALWAYS  true
    ;; LOCK_TIMEOUT=60000 = wait up to one minute to acquire table lock instead of default of 1 second
-   :LOCK_TIMEOUT   60000})
+   :LOCK_TIMEOUT   60000
+   ;; Tell H2 to handle identifiers in a similar way to postgres. `select id from table` will find TABLE and ID.
+   :CASE_INSENSITIVE_IDENTIFIERS true})
 
 (defn- broken-out-details
   "Connection details that can be used when pretending the Metabase DB is itself a `Database` (e.g., to use the Generic


### PR DESCRIPTION
Part of #31632

This is an interesting run around the problem of h2 normally treating identifiers as case sensitive. H2 v 2 introduced `CASE_INSENSITIVE_IDENTIFIERS` https://www.h2database.com/javadoc/org/h2/engine/DbSettings.html

Normally, when you `create table foobar` in H2, that table will be created with uppercase identifiers `FOOBAR` however, when you `select from foobar` the table will not be found as identifiers need to match the case in which they are stored during queries by default. This setting allows unquoted identifiers in queries to match table and column names in a case insensitive way.

What this means, is that we can serialize from a postgres db and restore in an h2 db. Table and field `name`s will be loaded as lowercase, and the queries will be built with lowercase identifiers but still match the created uppercase tables and field names. This is good because it should allow native queries to be portable.

Unfortunately, the setting does not work for schema identifiers. So before and after loading we have to update the schema names to lower then upper case.

