### PR TITLE
Adding Model to Cypress Snapshot

### DIFF
--- a/e2e/snapshot-creators/default.cy.snap.js
+++ b/e2e/snapshot-creators/default.cy.snap.js
@@ -206,6 +206,13 @@ describe("snapshots", () => {
       },
       display: "line",
     });
+
+    // Model 1
+    cy.createQuestion({
+      name: "Orders Model",
+      query: { "source-table": ORDERS_ID },
+      dataset: true,
+    });
   }
 
   function ensureTableIdsAreCorrect({

--- a/e2e/snapshot-creators/default.cy.snap.js
+++ b/e2e/snapshot-creators/default.cy.snap.js
@@ -41,6 +41,8 @@ describe("snapshots", () => {
         ensureTableIdsAreCorrect(SAMPLE_DATABASE);
         hideNewSampleTables(SAMPLE_DATABASE);
         createQuestionsAndDashboards(SAMPLE_DATABASE);
+        snapshot("without-models");
+        createModels(SAMPLE_DATABASE);
         cy.writeFile(
           "e2e/support/cypress_sample_database.json",
           SAMPLE_DATABASE,
@@ -206,7 +208,9 @@ describe("snapshots", () => {
       },
       display: "line",
     });
+  }
 
+  function createModels({ ORDERS_ID }) {
     // Model 1
     cy.createQuestion({
       name: "Orders Model",

--- a/e2e/support/commands/api/dashboard.js
+++ b/e2e/support/commands/api/dashboard.js
@@ -1,18 +1,23 @@
 Cypress.Commands.add(
   "createDashboard",
-  ({
-    name = "Test Dashboard",
-    enable_embedding,
-    embedding_params,
-    auto_apply_filters,
-    ...dashboardDetails
-  } = {}) => {
+  (
+    {
+      name = "Test Dashboard",
+      enable_embedding,
+      embedding_params,
+      auto_apply_filters,
+      ...dashboardDetails
+    } = {},
+    { wrapId = false, idAlias = "dashboardId" } = {},
+  ) => {
     cy.log(`Create a dashboard: ${name}`);
 
     // For all the possible keys, refer to `src/metabase/api/dashboard.clj`
-    return cy
-      .request("POST", "/api/dashboard", { name, ...dashboardDetails })
-      .then(({ body }) => {
+    cy.request("POST", "/api/dashboard", { name, ...dashboardDetails }).then(
+      ({ body }) => {
+        if (wrapId) {
+          cy.wrap(body.id).as(idAlias);
+        }
         if (enable_embedding != null || auto_apply_filters != null) {
           cy.request("PUT", `/api/dashboard/${body.id}`, {
             enable_embedding,

--- a/e2e/support/helpers/e2e-ad-hoc-question-helpers.js
+++ b/e2e/support/helpers/e2e-ad-hoc-question-helpers.js
@@ -78,7 +78,9 @@ export function visitQuestionAdhoc(
 
   runQueryIfNeeded(question, autorun);
 
-  cy.wait("@" + alias).then(xhr => callback && callback(xhr));
+  if (mode !== "notebook") {
+    cy.wait("@" + alias).then(xhr => callback && callback(xhr));
+  }
 }
 
 /**

--- a/e2e/support/helpers/e2e-notebook-helpers.js
+++ b/e2e/support/helpers/e2e-notebook-helpers.js
@@ -86,6 +86,7 @@ export function selectSavedQuestionsToJoin(
 
   popover().within(() => {
     cy.findByTextEnsureVisible("Sample Database").click();
+    cy.findByTextEnsureVisible("Raw Data").click();
     cy.findByTextEnsureVisible("Saved Questions").click();
     cy.findByText(secondQuestionName).click();
   });

--- a/e2e/test/scenarios/admin-2/auditing/auditing.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/auditing/auditing.cy.spec.js
@@ -238,7 +238,7 @@ describeEE("audit > auditing", () => {
       // All questions tab
       cy.visit("/admin/audit/questions/all");
       cy.findByPlaceholderText("Question name");
-      cy.findAllByText("Sample Database").should("have.length", 5);
+      cy.findAllByText("Sample Database").should("have.length", 6);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(NORMAL_QUESTION);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/admin-2/auditing/questions-audit.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/auditing/questions-audit.cy.spec.js
@@ -24,6 +24,7 @@ describeEE("audit > auditing > questions", () => {
         "Orders, Count, Grouped by Created At (year)",
         "Orders, Count",
         "Orders",
+        "Orders Model",
       ];
 
       const QUERY_RUNS_ASC_ORDER = [...QUERY_RUNS_DESC_ORDER].reverse();

--- a/e2e/test/scenarios/admin-2/auditing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/auditing/subscriptions.cy.spec.js
@@ -81,7 +81,6 @@ describeEE("audit > auditing > subscriptions", () => {
           questionDetails: getQuestionDetails(),
         }).then(({ body: { card_id, dashboard_id } }) => {
           cy.wrap(dashboard_id).as("dashboardId");
-
           cy.createPulse(
             getSubscriptionsDetails({ card_id, dashboard_id, user_id }),
           );
@@ -131,6 +130,7 @@ describeEE("audit > auditing > subscriptions", () => {
       cy.getCurrentUser().then(({ body: { id: user_id } }) => {
         cy.createQuestion(getQuestionDetails()).then(
           ({ body: { id: card_id } }) => {
+            cy.wrap(card_id).as("questionId");
             cy.createAlert(getAlertDetails({ card_id, user_id }));
           },
         );
@@ -152,7 +152,12 @@ describeEE("audit > auditing > subscriptions", () => {
     it("opens a question audit page when question title clicked", () => {
       cy.get("tbody").within(() => {
         cy.findByText("Test Question").click();
-        cy.url().should("include", "/admin/audit/question/4/activity");
+        cy.get("@questionId").then(questionId => {
+          cy.url().should(
+            "include",
+            `/admin/audit/question/${questionId}/activity`,
+          );
+        });
       });
     });
 

--- a/e2e/test/scenarios/admin/databases/default-sample-database.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/default-sample-database.cy.spec.js
@@ -260,6 +260,7 @@ describe("scenarios > admin > databases > sample database", () => {
     cy.wait("@loadDatabaseUsageInfo");
     modal().within(() => {
       cy.findByLabelText(/Delete \d+ saved questions?/).click();
+      cy.findByLabelText(/Delete \d+ model?/).click();
       cy.findByTestId("database-name-confirmation-input").type(
         "Sample Database",
       );

--- a/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
@@ -7,6 +7,7 @@ import {
   restore,
   startNewQuestion,
   setTokenFeatures,
+  openTable,
 } from "e2e/support/helpers";
 import {
   SAMPLE_DB_ID,
@@ -53,7 +54,7 @@ describe("scenarios > admin > datamodel > editor", () => {
 
       startNewQuestion();
       popover().within(() => {
-        cy.findByText("Sample Database").click();
+        cy.findByText("Raw Data").click();
         cy.findByText("People").should("be.visible");
         cy.findByText("New orders").should("be.visible");
       });
@@ -100,7 +101,7 @@ describe("scenarios > admin > datamodel > editor", () => {
 
       startNewQuestion();
       popover().within(() => {
-        cy.findByText("Sample Database").click();
+        cy.findByText("Raw Data").click();
         cy.findByText("People").should("be.visible");
         cy.findByText("Orders").should("not.exist");
       });
@@ -114,7 +115,7 @@ describe("scenarios > admin > datamodel > editor", () => {
 
       startNewQuestion();
       popover().within(() => {
-        cy.findByText("Sample Database").click();
+        cy.findByText("Raw Data").click();
         cy.findByText("People").should("be.visible");
         cy.findByText("Orders").should("be.visible");
       });
@@ -223,11 +224,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated User ID").should("be.visible");
 
-      startNewQuestion();
-      popover().within(() => {
-        cy.findByText("Sample Database").click();
-        cy.findByText("Orders").click();
-      });
+      openTable({ database: SAMPLE_DB_ID, table: ORDERS_ID, mode: "notebook" });
       cy.icon("join_left_outer").click();
       popover().within(() => {
         cy.findByText("Products").click();
@@ -406,11 +403,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated User ID").should("be.visible");
 
-      startNewQuestion();
-      popover().within(() => {
-        cy.findByText("Sample Database").click();
-        cy.findByText("Orders").click();
-      });
+      openTable({ database: SAMPLE_DB_ID, table: ORDERS_ID, mode: "notebook" });
       cy.icon("join_left_outer").click();
       popover().within(() => {
         cy.findByText("Products").click();
@@ -442,7 +435,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       cy.signInAsNormalUser();
       startNewQuestion();
       popover().within(() => {
-        cy.findByText("Sample Database").click();
+        cy.findByText("Raw Data").click();
         cy.findByText("People").should("be.visible");
         cy.findByText("New orders").should("be.visible");
       });
@@ -508,11 +501,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       cy.findByText("Updated User ID").should("be.visible");
 
       cy.signInAsNormalUser();
-      startNewQuestion();
-      popover().within(() => {
-        cy.findByText("Sample Database").click();
-        cy.findByText("Orders").click();
-      });
+      openTable({ database: SAMPLE_DB_ID, table: ORDERS_ID, mode: "notebook" });
       cy.icon("join_left_outer").click();
       popover().within(() => {
         cy.findByText("Products").click();

--- a/e2e/test/scenarios/admin/datamodel/hide_tables.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/hide_tables.cy.spec.js
@@ -33,7 +33,7 @@ describe("scenarios > admin > datamodel > hidden tables (metabase#9759)", () => 
     // It shouldn't show in a new question data picker
     startNewQuestion();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("Sample Database").click();
+    cy.contains("Raw Data").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Products");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
@@ -143,6 +143,7 @@ describe("binning related reproductions", () => {
 
     popover().within(() => {
       cy.findByTextEnsureVisible("Sample Database").click();
+      cy.findByTextEnsureVisible("Raw Data").click();
       cy.findByTextEnsureVisible("Saved Questions").click();
       cy.findByText("18646").click();
     });
@@ -171,7 +172,7 @@ describe("binning related reproductions", () => {
       cy.findByRole("option", { name: "CREATED_AT" }).click();
     });
 
-    getNotebookStep("summarize").findByText("Question 4 → Created At: Month");
+    getNotebookStep("summarize").findByText("Question 5 → Created At: Month");
 
     visualize();
     cy.get("circle");

--- a/e2e/test/scenarios/collections/collection-items-listing.cy.spec.js
+++ b/e2e/test/scenarios/collections/collection-items-listing.cy.spec.js
@@ -34,15 +34,7 @@ describe("scenarios > collection items listing", () => {
     beforeEach(() => {
       // Removes questions and dashboards included in the default database,
       // so the test won't fail if we change the default database
-      cy.request("GET", "/api/collection/root/items").then(response => {
-        response.body.data.forEach(({ model, id }) => {
-          if (model !== "collection") {
-            cy.request("PUT", `/api/${model}/${id}`, {
-              archived: true,
-            });
-          }
-        });
-      });
+      archiveAll();
 
       _.times(ADDED_DASHBOARDS, i =>
         cy.createDashboard({ name: `dashboard ${i}` }),
@@ -91,15 +83,7 @@ describe("scenarios > collection items listing", () => {
     beforeEach(() => {
       // Removes questions and dashboards included in a default dataset,
       // so it's easier to test sorting
-      cy.request("GET", "/api/collection/root/items").then(response => {
-        response.body.data.forEach(({ model, id }) => {
-          if (model !== "collection") {
-            cy.request("PUT", `/api/${model}/${id}`, {
-              archived: true,
-            });
-          }
-        });
-      });
+      archiveAll();
     });
 
     it("should allow to sort unpinned items by columns asc and desc", () => {
@@ -261,4 +245,20 @@ function getAllCollectionItemNames() {
 function visitRootCollection() {
   cy.visit("/collection/root");
   cy.wait(["@getCollectionItems", "@getCollectionItems"]);
+}
+
+function archiveAll() {
+  cy.request("GET", "/api/collection/root/items").then(response => {
+    response.body.data.forEach(({ model, id }) => {
+      if (model !== "collection") {
+        cy.request(
+          "PUT",
+          `/api/${model === "dataset" ? "card" : model}/${id}`,
+          {
+            archived: true,
+          },
+        );
+      }
+    });
+  });
 }

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -467,7 +467,7 @@ describe("scenarios > collection defaults", () => {
           cy.findByLabelText("Select all items").click();
           cy.icon("dash").should("not.exist");
           // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-          cy.findByText("4 items selected");
+          cy.findByText("5 items selected");
 
           // Deselect all
           cy.findByLabelText("Select all items").click();

--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -245,7 +245,7 @@ function uploadFile(testFile, valid = true) {
       cy.findByText("Start exploring").click();
     });
 
-    cy.url().should("include", `/model/4`);
+    cy.url().should("include", `/model/5`);
     cy.findByTestId("TableInteractive-root");
   } else {
     cy.findByRole("status").within(() => {

--- a/e2e/test/scenarios/custom-column/reproductions/13751-cc-allow-strings-in-filter.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/13751-cc-allow-strings-in-filter.cy.spec.js
@@ -15,9 +15,9 @@ describe("issue 13751", { tags: "@external" }, () => {
     cy.signInAsAdmin();
 
     startNewQuestion();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(PG_DB_NAME).should("be.visible").click();
-    cy.findByTextEnsureVisible("People").click();
+    popover().findByText("Raw Data").click();
+    popover().findByText(PG_DB_NAME).should("be.visible").click();
+    popover().findByTextEnsureVisible("People").click();
   });
 
   it("should allow using strings in filter based on a custom column (metabase#13751)", () => {

--- a/e2e/test/scenarios/custom-column/reproductions/27745-cc-numeric-missing-summarize.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/27745-cc-numeric-missing-summarize.cy.spec.js
@@ -22,10 +22,10 @@ import {
 
     it("should display all summarize options if the only numeric field is a custom column (metabase#27745)", () => {
       startNewQuestion();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText(/Writable/i).click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText(/colors/i).click();
+      cy.findByPlaceholderText(/Search for some data/).type("colors");
+      popover()
+        .findByRole("heading", { name: /colors/i })
+        .click();
       cy.icon("add_data").click();
       enterCustomColumnDetails({
         formula: "case([ID] > 1, 25, 5)",

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -88,7 +88,8 @@ describe("scenarios > dashboard", () => {
         .click();
 
       popover().within(() => {
-        cy.findByText("Sample Database").click();
+        cy.findByPlaceholderText(/Search for some/).type("Pro");
+        // cy.findByText("Sample Database").click();
         cy.findByText("Products").click();
       });
 

--- a/e2e/test/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -214,7 +214,7 @@ describeEE("scenarios > embedding > full app", () => {
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("New").click();
         popover().findByText("Question").click();
-        popover().findByText("Sample Database").click();
+        popover().findByText("Raw Data").click();
         popover().findByText("Orders").click();
       });
 

--- a/e2e/test/scenarios/filters/operators.cy.spec.js
+++ b/e2e/test/scenarios/filters/operators.cy.spec.js
@@ -1,4 +1,8 @@
-import { restore, popover, startNewQuestion } from "e2e/support/helpers";
+import { restore, popover, openTable } from "e2e/support/helpers";
+
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { PRODUCTS_ID, PEOPLE_ID } = SAMPLE_DATABASE;
 
 describe("operators in questions", () => {
   beforeEach(() => {
@@ -65,13 +69,7 @@ describe("operators in questions", () => {
 
   describe("fields have proper operators", () => {
     it("text operators", () => {
-      startNewQuestion();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("Sample Database").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("Products").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Add filters to narrow your answer").click();
+      setup(PRODUCTS_ID);
 
       popover().within(() => {
         cy.findByText("Title").click();
@@ -85,13 +83,7 @@ describe("operators in questions", () => {
     });
 
     it("number operators", () => {
-      startNewQuestion();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("Sample Database").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("Products").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Add filters to narrow your answer").click();
+      setup(PRODUCTS_ID);
 
       popover().within(() => {
         cy.findByText("Price").click();
@@ -105,13 +97,7 @@ describe("operators in questions", () => {
     });
 
     it("relative date operators", () => {
-      startNewQuestion();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("Sample Database").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("Products").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Add filters to narrow your answer").click();
+      setup(PRODUCTS_ID);
 
       popover().within(() => {
         cy.findByText("Created At").click();
@@ -136,13 +122,7 @@ describe("operators in questions", () => {
     });
 
     it("specific date operators", () => {
-      startNewQuestion();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("Sample Database").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("Products").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Add filters to narrow your answer").click();
+      setup(PRODUCTS_ID);
 
       popover().within(() => {
         cy.findByText("Created At").click();
@@ -167,13 +147,7 @@ describe("operators in questions", () => {
     });
 
     it("exclude date operators", () => {
-      startNewQuestion();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("Sample Database").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("Products").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Add filters to narrow your answer").click();
+      setup(PRODUCTS_ID);
 
       popover().within(() => {
         cy.findByText("Created At").click();
@@ -195,13 +169,7 @@ describe("operators in questions", () => {
     });
 
     it("id operators", () => {
-      startNewQuestion();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("Sample Database").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("Products").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Add filters to narrow your answer").click();
+      setup(PRODUCTS_ID);
 
       popover().within(() => {
         cy.findByText("ID").click();
@@ -215,13 +183,7 @@ describe("operators in questions", () => {
     });
 
     it("geo operators", () => {
-      startNewQuestion();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("Sample Database").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("People").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Add filters to narrow your answer").click();
+      setup(PEOPLE_ID);
 
       popover().within(() => {
         cy.findByText("State").click({ force: true });
@@ -235,3 +197,8 @@ describe("operators in questions", () => {
     });
   });
 });
+
+function setup(tableId) {
+  openTable({ table: tableId, mode: "notebook" });
+  cy.findByRole("button", { name: "Filter" }).click();
+}

--- a/e2e/test/scenarios/filters/reproductions/20683-postgres-current-quarter.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/20683-postgres-current-quarter.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, visualize } from "e2e/support/helpers";
+import { popover, restore, visualize } from "e2e/support/helpers";
 
 describe("issue 20683", { tags: "@external" }, () => {
   beforeEach(() => {
@@ -11,6 +11,7 @@ describe("issue 20683", { tags: "@external" }, () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Question").should("be.visible").click();
 
+    popover().findByText("Raw Data").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("QA Postgres12").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/filters/view.cy.spec.js
+++ b/e2e/test/scenarios/filters/view.cy.spec.js
@@ -6,6 +6,7 @@ import {
   addOrUpdateDashboardCard,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const { PRODUCTS } = SAMPLE_DATABASE;
 
@@ -56,11 +57,11 @@ describe("scenarios > question > view", () => {
         },
       });
 
-      addOrUpdateDashboardCard({ dashboard_id: 2, card_id: 4 });
+      addOrUpdateDashboardCard({ dashboard_id: 2, card_id: 5 });
     });
 
-    it("should show filters by search for Vendor", () => {
-      visitQuestion(4);
+    it.only("should show filters by search for Vendor", () => {
+      visitQuestion(5);
 
       cy.findAllByText("VENDOR").first().click();
       popover().within(() => {

--- a/e2e/test/scenarios/joins/joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins.cy.spec.js
@@ -147,7 +147,7 @@ describe("scenarios > question > joined questions", () => {
     });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("A_COLUMN");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+
     cy.get("@questionId").then(questionId => {
       cy.findByText(`Question ${questionId} → B Column`);
     });

--- a/e2e/test/scenarios/joins/joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins.cy.spec.js
@@ -117,10 +117,15 @@ describe("scenarios > question > joined questions", () => {
       native: { query: "select 'foo' as a_column" },
     });
 
-    cy.createNativeQuestion({
-      name: "question b",
-      native: { query: "select 'foo' as b_column" },
-    });
+    cy.createNativeQuestion(
+      {
+        name: "question b",
+        native: { query: "select 'foo' as b_column" },
+      },
+      {
+        wrapId: true,
+      },
+    );
 
     // start a custom question with question a
     startNewQuestion();
@@ -143,7 +148,10 @@ describe("scenarios > question > joined questions", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("A_COLUMN");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Question 5 → B Column");
+    cy.get("@questionId").then(questionId => {
+      cy.findByText(`Question ${questionId} → B Column`);
+    });
+
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 1 row");
   });
@@ -164,17 +172,23 @@ describe("scenarios > question > joined questions", () => {
       },
     });
 
-    cy.createQuestion({
-      name: "Q2",
-      query: {
-        aggregation: ["sum", ["field", PRODUCTS.RATING, null]],
-        breakout: [["field", PRODUCTS.ID, null]],
-        "source-table": PRODUCTS_ID,
+    cy.createQuestion(
+      {
+        name: "Q2",
+        query: {
+          aggregation: ["sum", ["field", PRODUCTS.RATING, null]],
+          breakout: [["field", PRODUCTS.ID, null]],
+          "source-table": PRODUCTS_ID,
+        },
       },
-    });
+      {
+        wrapId: true,
+      },
+    );
 
     startNewQuestion();
     popover().within(() => {
+      // cy.findByText("Raw Data").click();
       cy.findByText("Saved Questions").click();
       cy.findByText("Q1").click();
     });
@@ -185,6 +199,7 @@ describe("scenarios > question > joined questions", () => {
 
     popover().within(() => {
       cy.icon("chevronleft").click();
+      cy.findByText("Raw Data").click();
       cy.findByText("Saved Questions").click();
       cy.findByText("Q2").click();
     });
@@ -202,9 +217,11 @@ describe("scenarios > question > joined questions", () => {
     // that a question could be made by joining two previously saved questions
     cy.icon("add_data").click();
 
-    enterCustomColumnDetails({
-      formula: "[Question 5 → Sum of Rating] / [Sum of Total]",
-      name: "Sum Divide",
+    cy.get("@questionId").then(questionId => {
+      enterCustomColumnDetails({
+        formula: `[Question ${questionId} → Sum of Rating] / [Sum of Total]`,
+        name: "Sum Divide",
+      });
     });
 
     cy.button("Done").click();
@@ -376,6 +393,7 @@ describe("scenarios > question > joined questions", () => {
     cy.icon("join_left_outer").click();
 
     popover().findByText("Sample Database").click();
+    popover().findByText("Raw Data").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Saved Questions").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/joins/reproductions/15342-mysql-correct-joins-order.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/15342-mysql-correct-joins-order.cy.spec.js
@@ -17,10 +17,11 @@ describe("issue 15342", { tags: "@external" }, () => {
 
   it("should correctly order joins for MySQL queries (metabase#15342)", () => {
     startNewQuestion();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(MYSQL_DB_NAME).click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("People").click();
+    popover().within(() => {
+      cy.findByText("Raw Data").click();
+      cy.findByText(MYSQL_DB_NAME).click();
+      cy.findByText("People").click();
+    });
 
     addJoin({
       leftColumn: "ID",

--- a/e2e/test/scenarios/joins/reproductions/22859-multi-nested-joins-wrong-aliasing.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/22859-multi-nested-joins-wrong-aliasing.cy.spec.js
@@ -45,6 +45,7 @@ describe("issue 22859 - multiple levels of nesting", () => {
 
     popover().within(() => {
       cy.findByText("Sample Database").click();
+      cy.findByText("Raw Data").click();
       cy.findByText("Saved Questions").click();
       cy.findByText(questionDetails.name).click();
     });

--- a/e2e/test/scenarios/joins/reproductions/22859-multi-nested-joins-wrong-aliasing.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/22859-multi-nested-joins-wrong-aliasing.cy.spec.js
@@ -94,7 +94,10 @@ function saveQuestion(name) {
   cy.findByText("Save").click();
   // TODO -- this name is all wrong but the metadata for Question 4 appears to be missing here for whatever reason,
   //  if we fix that bug then this should actually be `Orders + 22859-Q1`
-  cy.findByDisplayValue("Orders + Question 4").clear().type(name).blur();
+  cy.findByDisplayValue(/Orders \+ Question \d+/)
+    .clear()
+    .type(name)
+    .blur();
 
   cy.button("Save").click();
   cy.wait(100);

--- a/e2e/test/scenarios/joins/reproductions/29795-native-query-join-question-misses-metadata.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/29795-native-query-join-question-misses-metadata.cy.spec.js
@@ -28,6 +28,7 @@ describe("issue 29795", () => {
 
     popover().within(() => {
       cy.icon("chevronleft").click();
+      cy.findByText("Raw Data").click();
       cy.findByText("Saved Questions").click();
       cy.findByRole("menuitem", { name: NATIVE_QUESTION }).click();
     });

--- a/e2e/test/scenarios/models/create.cy.spec.js
+++ b/e2e/test/scenarios/models/create.cy.spec.js
@@ -65,7 +65,7 @@ describe("scenarios > models > create", () => {
     navigateToNewModelPage("structured");
 
     popover().within(() => {
-      cy.findByText("Sample Database").click();
+      cy.findByText("Raw Data").click();
       cy.findByText("Orders").click();
     });
 

--- a/e2e/test/scenarios/models/model-indexes.cy.spec.js
+++ b/e2e/test/scenarios/models/model-indexes.cy.spec.js
@@ -11,7 +11,7 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 const { PRODUCTS_ID, PEOPLE_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > model indexes", () => {
-  const modelId = 4;
+  let modelId;
 
   beforeEach(() => {
     restore();
@@ -23,10 +23,17 @@ describe("scenarios > model indexes", () => {
     cy.intercept("PUT", "/api/card/*").as("cardUpdate");
     cy.intercept("GET", "/api/card/*").as("cardGet");
 
-    cy.createQuestion({
-      name: "Products Model",
-      query: { "source-table": PRODUCTS_ID },
-      dataset: true,
+    cy.createQuestion(
+      {
+        name: "Products Model",
+        query: { "source-table": PRODUCTS_ID },
+        dataset: true,
+      },
+      { wrapId: true, idAlias: "modelId" },
+    );
+
+    cy.get("@modelId").then(_modelId => {
+      modelId = _modelId;
     });
   });
 
@@ -147,12 +154,25 @@ describe("scenarios > model indexes", () => {
   });
 
   it("should be able to see details of a record outside the first 2000", () => {
-    cy.createQuestion({
-      name: "People Model",
-      query: { "source-table": PEOPLE_ID },
-      dataset: true,
+    cy.createQuestion(
+      {
+        name: "People Model",
+        query: { "source-table": PEOPLE_ID },
+        dataset: true,
+      },
+      {
+        wrapId: true,
+        idAlias: "people_model_id",
+      },
+    );
+
+    cy.get("@people_model_id").then(peopleModelId => {
+      createModelIndex({
+        modelId: peopleModelId,
+        pkName: "ID",
+        valueName: "NAME",
+      });
     });
-    createModelIndex({ modelId: 5, pkName: "ID", valueName: "NAME" });
 
     cy.visit("/");
 

--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -41,11 +41,7 @@ import {
   assertIsQuestion,
 } from "./helpers/e2e-models-helpers";
 
-<<<<<<< HEAD
-const { PRODUCTS, ORDERS_ID } = SAMPLE_DATABASE;
-=======
-const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
->>>>>>> 3b7620fa69 (Model Folder)
+const { PRODUCTS, ORDERS_ID, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > models", () => {
   beforeEach(() => {

--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -41,68 +41,89 @@ import {
   assertIsQuestion,
 } from "./helpers/e2e-models-helpers";
 
+<<<<<<< HEAD
 const { PRODUCTS, ORDERS_ID } = SAMPLE_DATABASE;
+=======
+const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+>>>>>>> 3b7620fa69 (Model Folder)
 
 describe("scenarios > models", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
+
+    cy.createQuestion(
+      {
+        name: "Products",
+        query: { "source-table": PRODUCTS_ID },
+      },
+      {
+        wrapId: true,
+        idAlias: "productsQuestionId",
+      },
+    );
   });
 
   it("allows to turn a GUI question into a model", () => {
-    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
-      name: "Orders Model",
+    cy.get("@productsQuestionId").then(id => {
+      cy.request("PUT", `/api/card/${id}`, {
+        name: "Products Model",
+      });
+      visitQuestion(id);
+
+      turnIntoModel();
+      openQuestionActions();
+      assertIsModel();
+
+      filter();
+      filterField("Vendor", {
+        operator: "Contains",
+        value: "Fisher",
+      });
+
+      cy.findByTestId("apply-filters").click();
+      cy.wait("@dataset");
+
+      assertQuestionIsBasedOnModel({
+        model: "Products Model",
+        collection: "Our analytics",
+        table: "Products",
+      });
+
+      saveQuestionBasedOnModel({ modelId: id, name: "Q1" });
+
+      assertQuestionIsBasedOnModel({
+        questionName: "Q1",
+        model: "Products Model",
+        collection: "Our analytics",
+        table: "Products",
+      });
+
+      cy.findByTestId("qb-header")
+        .findAllByText("Our analytics")
+        .first()
+        .click();
+      getCollectionItemCard("Products Model").within(() => {
+        cy.icon("model");
+      });
+      getCollectionItemRow("Q1").within(() => {
+        cy.icon("table");
+      });
+
+      cy.url().should("not.include", "/question/" + id);
     });
-    visitQuestion(ORDERS_QUESTION_ID);
-
-    turnIntoModel();
-    openQuestionActions();
-    assertIsModel();
-
-    filter();
-    filterField("Discount", {
-      operator: "Not empty",
-    });
-
-    cy.findByTestId("apply-filters").click();
-    cy.wait("@dataset");
-
-    assertQuestionIsBasedOnModel({
-      model: "Orders Model",
-      collection: "Our analytics",
-      table: "Orders",
-    });
-
-    saveQuestionBasedOnModel({ modelId: 1, name: "Q1" });
-
-    assertQuestionIsBasedOnModel({
-      questionName: "Q1",
-      model: "Orders Model",
-      collection: "Our analytics",
-      table: "Orders",
-    });
-
-    cy.findByTestId("qb-header").findAllByText("Our analytics").first().click();
-    getCollectionItemCard("Orders Model").within(() => {
-      cy.icon("model");
-    });
-    getCollectionItemRow("Q1").within(() => {
-      cy.icon("table");
-    });
-
-    cy.url().should("not.include", "/question/" + ORDERS_QUESTION_ID);
   });
 
   it("allows to turn a native question into a model", () => {
     cy.createNativeQuestion(
       {
-        name: "Orders Model",
+        name: "Product Model",
         native: {
-          query: "SELECT * FROM orders",
+          query: "SELECT * FROM products",
         },
       },
-      { visitQuestion: true },
+      { visitQuestion: true, wrapId: true },
     );
 
     turnIntoModel();
@@ -110,30 +131,33 @@ describe("scenarios > models", () => {
     assertIsModel();
 
     filter();
-    filterField("DISCOUNT", {
-      operator: "Not empty",
+    filterField("VENDOR", {
+      operator: "Contains",
+      value: "Fisher",
     });
 
     cy.findByTestId("apply-filters").click();
     cy.wait("@dataset");
 
     assertQuestionIsBasedOnModel({
-      model: "Orders Model",
+      model: "Product Model",
       collection: "Our analytics",
-      table: "Orders",
+      table: "Products",
     });
 
-    saveQuestionBasedOnModel({ modelId: 4, name: "Q1" });
+    cy.get("@questionId").then(questionId => {
+      saveQuestionBasedOnModel({ modelId: questionId, name: "Q1" });
+    });
 
     assertQuestionIsBasedOnModel({
       questionName: "Q1",
-      model: "Orders Model",
+      model: "Product Model",
       collection: "Our analytics",
-      table: "Orders",
+      table: "Products",
     });
 
     cy.findByTestId("qb-header").findAllByText("Our analytics").first().click();
-    getCollectionItemCard("Orders Model").within(() => {
+    getCollectionItemCard("Product Model").within(() => {
       cy.icon("model");
     });
     getCollectionItemRow("Q1").within(() => {
@@ -524,7 +548,7 @@ describe("scenarios > models", () => {
 
   describe("listing", () => {
     const modelDetails = {
-      name: "Orders Model",
+      name: "Orders Model 2",
       query: {
         "source-table": ORDERS_ID,
         limit: 5,

--- a/e2e/test/scenarios/models/reproductions/19737-data-picker-not-showing-moved-model.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/19737-data-picker-not-showing-moved-model.cy.spec.js
@@ -4,7 +4,6 @@ import {
   popover,
   navigationSidebar,
 } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const modelName = "Orders Model";
 
@@ -12,11 +11,6 @@ describe("issue 19737", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-
-    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
-      name: modelName,
-      dataset: true,
-    });
   });
 
   it("should show moved model in the data picker without refreshing (metabase#19737)", () => {

--- a/e2e/test/scenarios/models/reproductions/19776-data-picker-not-displayed-after-archiving-model.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/19776-data-picker-not-displayed-after-archiving-model.cy.spec.js
@@ -1,5 +1,4 @@
 import { restore, popover } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const modelName = "Orders Model";
 
@@ -7,11 +6,6 @@ describe("issue 19776", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-
-    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
-      name: modelName,
-      dataset: true,
-    });
   });
 
   it("should show moved model in the data picker without refreshing (metabase#19776)", () => {

--- a/e2e/test/scenarios/models/reproductions/28971-filters-model-new-model.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/28971-filters-model-new-model.cy.spec.js
@@ -20,14 +20,13 @@ describe("issue 28971", () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    popover().within(() => cy.findByText("Model").click());
+    popover().findByText("Model").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Use the notebook editor").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    popover().within(() => cy.findByText("Sample Database").click());
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    popover().within(() => cy.findByText("Orders").click());
+    popover().within(() => {
+      cy.findByText("Raw Data").click();
+      cy.findByText("Orders").click();
+    });
     cy.button("Save").click();
     modal().button("Save").click();
     cy.wait("@createCard");

--- a/e2e/test/scenarios/models/reproductions/31663-no-model-fks.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/31663-no-model-fks.cy.spec.js
@@ -2,7 +2,7 @@ import { appBar, main, popover, restore } from "e2e/support/helpers";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
-const { ORDERS_ID, PRODUCTS_ID } = SAMPLE_DATABASE;
+const { PRODUCTS_ID } = SAMPLE_DATABASE;
 
 // Should be removed once proper model FK support is implemented
 describe("issue 31663", () => {
@@ -14,12 +14,6 @@ describe("issue 31663", () => {
     cy.intercept("GET", `/api/database/${SAMPLE_DB_ID}/idfields`).as(
       "idFields",
     );
-
-    cy.createQuestion({
-      name: "Orders Model",
-      dataset: true,
-      query: { "source-table": ORDERS_ID },
-    });
 
     cy.createQuestion(
       {

--- a/e2e/test/scenarios/native/data_ref.cy.spec.js
+++ b/e2e/test/scenarios/native/data_ref.cy.spec.js
@@ -61,7 +61,7 @@ describe("scenarios > native question > data reference sidebar", () => {
     openNativeEditor();
     cy.icon("reference").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("1 model");
+    cy.findByText("2 models");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Native Products Model").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -223,20 +223,23 @@ describe("scenarios > question > native", () => {
       cy.findByText("Save").click();
 
       // parameters[] should reflect the template tags
-      cy.wait("@card").should(xhr => {
+      cy.wait("@card").then(xhr => {
         const requestBody = xhr.request?.body;
         expect(requestBody?.parameters?.length).to.equal(2);
+        cy.wrap(xhr.response.body.id).as("questionId");
       });
     });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Not now").click();
 
     // Now load the question again and parameters[] should still be there
-    cy.intercept("GET", "/api/card/*").as("cardQuestion");
-    cy.visit("/question/4?cat=Gizmo&stars=3");
-    cy.wait("@cardQuestion").should(xhr => {
-      const responseBody = xhr.response?.body;
-      expect(responseBody?.parameters?.length).to.equal(2);
+    cy.get("@questionId").then(questionId => {
+      cy.intercept("GET", `/api/card/${questionId}`).as("cardQuestion");
+      cy.visit(`/question/${questionId}?cat=Gizmo&stars=3`);
+      cy.wait("@cardQuestion").should(xhr => {
+        const responseBody = xhr.response?.body;
+        expect(responseBody?.parameters?.length).to.equal(2);
+      });
     });
   });
 

--- a/e2e/test/scenarios/native/native_subquery.cy.spec.js
+++ b/e2e/test/scenarios/native/native_subquery.cy.spec.js
@@ -181,6 +181,7 @@ describe("scenarios > question > native subquery", () => {
         query: "SELECT id AS a_unique_column_name FROM PEOPLE",
       },
     }).then(({ body: { id: questionId1 } }) => {
+      cy.wrap(questionId1).as("questionId");
       const tagID = `#${questionId1}`;
       cy.createNativeQuestion({
         name: "Count of People",
@@ -200,7 +201,11 @@ describe("scenarios > question > native subquery", () => {
         // check the original name is in the query
         cy.visit(`/question/${questionId2}`);
         cy.findByText("Open Editor").click();
-        cy.get(".ace_content:visible").contains("{{#4-a-people-question-1}}");
+        cy.get("@questionId").then(questionId => {
+          cy.get(".ace_content:visible").contains(
+            `{{#${questionId}-a-people-question-1}}`,
+          );
+        });
 
         // change the name
         cy.visit(`/question/${questionId1}`);
@@ -211,9 +216,11 @@ describe("scenarios > question > native subquery", () => {
         // check the name has changed
         cy.visit(`/question/${questionId2}`);
         cy.findByText("Open Editor").click();
-        cy.get(".ace_content:visible").contains(
-          "{{#4-a-people-question-1-changed}}",
-        );
+        cy.get("@questionId").then(questionId => {
+          cy.get(".ace_content:visible").contains(
+            `{{#${questionId}-a-people-question-1-changed}}`,
+          );
+        });
       });
     });
   });

--- a/e2e/test/scenarios/native/reproductions/15946-mongo-pre-select-table.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/15946-mongo-pre-select-table.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, startNewQuestion } from "e2e/support/helpers";
+import { popover, restore, startNewQuestion } from "e2e/support/helpers";
 
 const MONGO_DB_NAME = "QA Mongo4";
 
@@ -8,10 +8,11 @@ describe("issue 15946", { tags: "@external" }, () => {
     cy.signInAsAdmin();
 
     startNewQuestion();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(MONGO_DB_NAME).click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Orders").click();
+    popover().within(() => {
+      cy.findByText("Raw Data").click();
+      cy.findByText(MONGO_DB_NAME).click();
+      cy.findByText("Orders").click();
+    });
   });
 
   it("converting a question to the native query should pre-select a table (metabase#15946)", () => {

--- a/e2e/test/scenarios/native/reproductions/32121-sql-source-query-can-explore-results.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/32121-sql-source-query-can-explore-results.cy.spec.js
@@ -14,7 +14,7 @@ describe("issue 32121", () => {
       startNewQuestion();
 
       // Query the entire Orders table, then convert to SQL.
-      cy.get("#DataPopover").findByText("Sample Database").click();
+      cy.get("#DataPopover").findByText("Raw Data").click();
       cy.get("#DataPopover").findByText("Orders").click();
       cy.findByTestId("qb-header").find(".Icon-sql").click();
       cy.get(".Modal").findByText("Convert this question to SQL").click();
@@ -43,6 +43,7 @@ describe("issue 32121", () => {
       cy.signInAsAdmin();
 
       startNewQuestion();
+      cy.get("#DataPopover").findByText("Raw Data").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(MONGO_DB_NAME).click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/onboarding/reference/databases.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/reference/databases.cy.spec.js
@@ -95,7 +95,7 @@ function checkReferenceDatabasesOrder() {
 
 function checkQuestionSourceDatabasesOrder(question_type) {
   // Last item is "Saved Questions" for UI based questions so we have to check for the one before that (-2), and the last one for "Native" (-1)
-  const lastDatabaseIndex = question_type === "Native query" ? -1 : -2;
+  const lastDatabaseIndex = -1;
   const selector =
     question_type === "Native query"
       ? ".List-item-title"
@@ -103,7 +103,8 @@ function checkQuestionSourceDatabasesOrder(question_type) {
 
   startNewQuestion();
   popover().within(() => {
-    cy.get(selector).as("databaseName").first().should("have.text", "a");
+    cy.findByText("Raw Data").click();
+    cy.get(selector).as("databaseName").eq(1).should("have.text", "a");
     cy.get("@databaseName")
       .eq(lastDatabaseIndex)
       .should("have.text", "Sample Database");

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -37,11 +37,10 @@ describe("scenarios > question > new", () => {
       }
 
       startNewQuestion();
-
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("Pick your starting data");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Sample3").isVisibleInPopover();
+      popover().within(() => {
+        cy.findByText("Raw Data").click();
+        cy.findByText("Sample3").isVisibleInPopover();
+      });
     });
 
     it("new question data picker search should work for both saved questions and database tables", () => {
@@ -51,14 +50,16 @@ describe("scenarios > question > new", () => {
 
       startNewQuestion();
 
-      cy.get(".List-section")
-        .should("have.length", 2)
-        .and("contain", "Sample Database")
+      popover()
+        .findAllByRole("menuitem")
+        .should("have.length", 3)
+        .and("contain", "Models")
+        .and("contain", "Raw Data")
         .and("contain", "Saved Questions");
 
       // should not trigger search for an empty string
-      cy.findByPlaceholderText("Search for a table…").type("  ").blur();
-      cy.findByPlaceholderText("Search for a table…").type("ord");
+      cy.findByPlaceholderText("Search for some data…").type("  ").blur();
+      cy.findByPlaceholderText("Search for some data…").type("ord");
       cy.wait("@search");
       cy.get("@searchQuery").should("have.been.calledOnce");
 
@@ -82,7 +83,7 @@ describe("scenarios > question > new", () => {
 
       // Discarding the search query should take us back to the original selector
       // that starts with the list of databases and saved questions
-      cy.findByPlaceholderText("Search for a table…");
+      cy.findByPlaceholderText("Search for some data…");
       cy.findByTestId("input-reset-button").click();
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -118,9 +119,11 @@ describe("scenarios > question > new", () => {
       cy.findByText("Orders");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Saved Questions").click();
-      popover().contains("Sample Database").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Products").click();
+      popover().within(() => {
+        cy.contains("Raw Data").click();
+        cy.contains("Sample Database").click();
+        cy.findByText("Products").click();
+      });
       cy.findByTestId("data-step-cell").contains("Products");
       visualize();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -270,7 +273,7 @@ describe("scenarios > question > new", () => {
     popover().findByText("Question").click();
 
     popover().within(() => {
-      cy.findByText("Sample Database").click();
+      cy.findByText("Raw Data").click();
       cy.findByText("Orders").click();
     });
 
@@ -288,7 +291,7 @@ describe("scenarios > question > new", () => {
     cy.findByLabelText("Navigation bar").findByText("New").click();
     popover().findByText("Question").click();
     popover().within(() => {
-      cy.findByText("Sample Database").click();
+      cy.findByText("Raw Data").click();
       cy.findByText("Orders").click();
     });
     cy.findByTestId("qb-header").findByText("Save").click();

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -309,3 +309,64 @@ describe("scenarios > question > new", () => {
     cy.get("header").findByText(NEW_COLLECTION);
   });
 });
+
+// the data picker has different behavior if there are no models in the instance
+// the default instance image has a model in it, so we need to separately test the
+// model-less behavior
+describe("scenarios > question > new > data picker > without models", () => {
+  beforeEach(() => {
+    restore("without-models");
+    cy.signInAsAdmin();
+  });
+
+  it("can create a question from the sample database", () => {
+    cy.visit("/question/new");
+
+    cy.get("#DataPopover").within(() => {
+      cy.findByText("Saved Questions").should("be.visible");
+      cy.findByText("Models").should("not.exist");
+      cy.findByText("Sample Database").click();
+      cy.findByText("Products").click();
+    });
+    cy.get("main")
+      .findByText(/Doing Science/)
+      .should("not.exist");
+
+    cy.findByTestId("TableInteractive-root").within(() => {
+      cy.findByText("Rustic Paper Wallet").should("be.visible");
+    });
+  });
+
+  it("can create a question from a saved question", () => {
+    cy.visit("/question/new");
+
+    cy.get("#DataPopover").within(() => {
+      cy.findByText("Saved Questions").click();
+      cy.findByText("Models").should("not.exist");
+      cy.findByText("Orders").click();
+    });
+    cy.get("main")
+      .findByText(/Doing Science/)
+      .should("not.exist");
+
+    cy.findByTestId("TableInteractive-root").within(() => {
+      cy.findByText(39.72).should("be.visible");
+    });
+  });
+
+  it("shows models and raw data options after creating a model", () => {
+    cy.createQuestion({
+      name: "Orders Model",
+      query: { "source-table": ORDERS_ID },
+      dataset: true,
+    });
+
+    cy.visit("/question/new");
+
+    cy.get("#DataPopover").within(() => {
+      cy.findByText("Raw Data").should("be.visible");
+      cy.findByText("Saved Questions").should("be.visible");
+      cy.findByText("Models").should("be.visible");
+    });
+  });
+});

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -9,6 +9,7 @@ import {
   join,
   openOrdersTable,
   openProductsTable,
+  openTable,
   popover,
   restore,
   startNewQuestion,
@@ -17,7 +18,7 @@ import {
   visualize,
 } from "e2e/support/helpers";
 
-import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PEOPLE, PEOPLE_ID, PRODUCTS, PRODUCTS_ID } =
@@ -48,12 +49,12 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
   });
 
   it("should allow post-aggregation filters", () => {
-    // start a custom question with orders
-    startNewQuestion();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("Sample Database").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("Orders").click();
+    openTable({
+      table: ORDERS_ID,
+      mode: "notebook",
+    });
+
+    cy.findByRole("button", { name: "Summarize" }).click();
 
     // count orders by user id, filter to the one user with 46 orders
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -372,11 +373,11 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
   // intentional simplification of "Select none" to quickly
   // fix users' pain caused by the inability to unselect all columns
   it("select no columns select the first one", () => {
-    startNewQuestion();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("Sample Database").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("Orders").click();
+    openTable({
+      table: ORDERS_ID,
+      mode: "notebook",
+    });
+
     cy.findByTestId("fields-picker").click();
 
     popover().within(() => {
@@ -385,6 +386,8 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       cy.findByText("Tax").click();
       cy.findByLabelText("ID").should("be.enabled").click();
     });
+
+    cy.findByTestId("step-data-0-0").findByText("Data").click(); //Dismiss popover
 
     visualize();
 
@@ -521,7 +524,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
   it('should not show "median" aggregation option for databases that do not support "percentile-aggregations" driver feature', () => {
     startNewQuestion();
     popover().within(() => {
-      cy.contains("Sample Database").click();
+      cy.contains("Raw Data").click();
       cy.contains("Orders").click();
     });
 
@@ -538,15 +541,21 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     beforeEach(() => {
       restore("postgres-12");
       cy.signInAsAdmin();
+
+      cy.request(`/api/database/${WRITABLE_DB_ID}/schema/public`).then(
+        ({ body }) => {
+          const tableId = body.find(table => table.name === "products").id;
+          openTable({
+            database: WRITABLE_DB_ID,
+            table: tableId,
+            mode: "notebook",
+          });
+        },
+      );
     });
 
     it('should show "median" aggregation option for databases that support "percentile-aggregations" driver feature', () => {
-      // add a question with "Products" and "Median of Price" aggregation by "Category"
-      startNewQuestion();
-      popover().within(() => {
-        cy.findByText("QA Postgres12").click();
-        cy.findByText("Products").click();
-      });
+      cy.findByRole("button", { name: "Summarize" }).click();
 
       addSummaryField({ metric: "Median of ...", field: "Price" });
 
@@ -562,11 +571,11 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     });
 
     it("should support custom columns", () => {
-      startNewQuestion();
-      popover().within(() => {
-        cy.findByText("QA Postgres12").click();
-        cy.findByText("Products").click();
-      });
+      // startNewQuestion();
+      // popover().within(() => {
+      //   cy.findByText("QA Postgres12").click();
+      //   cy.findByText("Products").click();
+      // });
 
       addCustomColumn();
       enterCustomColumnDetails({
@@ -574,6 +583,8 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
         name: "Mega price",
       });
       cy.button("Done").click();
+
+      cy.findByRole("button", { name: "Summarize" }).click();
 
       addSummaryField({ metric: "Median of ...", field: "Mega price" });
       addSummaryField({ metric: "Count of rows" });
@@ -598,11 +609,11 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     });
 
     it("should support Summarize side panel", () => {
-      startNewQuestion();
-      popover().within(() => {
-        cy.findByText("QA Postgres12").click();
-        cy.findByText("Products").click();
-      });
+      // startNewQuestion();
+      // popover().within(() => {
+      //   cy.findByText("QA Postgres12").click();
+      //   cy.findByText("Products").click();
+      // });
 
       visualize();
 

--- a/e2e/test/scenarios/question/query-external.cy.spec.js
+++ b/e2e/test/scenarios/question/query-external.cy.spec.js
@@ -1,4 +1,5 @@
-import { restore, startNewQuestion, visualize } from "e2e/support/helpers";
+import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
+import { openTable, restore, visualize } from "e2e/support/helpers";
 
 const supportedDatabases = [
   {
@@ -20,14 +21,19 @@ supportedDatabases.forEach(({ database, snapshotName, dbName }) => {
 
       restore(snapshotName);
       cy.signInAsAdmin();
+
+      cy.request(`/api/database/${WRITABLE_DB_ID}/schema/`).as("schema");
     });
 
     it(`can query ${database} database`, () => {
-      startNewQuestion();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText(dbName).click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Orders").click();
+      cy.get("@schema").then(({ body }) => {
+        const tabelId = body.find(table => table.name === "ORDERS").id;
+        openTable({
+          database: WRITABLE_DB_ID,
+          table: tabelId,
+          mode: "notebook",
+        });
+      });
 
       visualize();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/question/query-external.cy.spec.js
+++ b/e2e/test/scenarios/question/query-external.cy.spec.js
@@ -27,7 +27,9 @@ supportedDatabases.forEach(({ database, snapshotName, dbName }) => {
 
     it(`can query ${database} database`, () => {
       cy.get("@schema").then(({ body }) => {
-        const tabelId = body.find(table => table.name === "ORDERS").id;
+        const tabelId = body.find(
+          table => table.name.toLowerCase() === "orders",
+        ).id;
         openTable({
           database: WRITABLE_DB_ID,
           table: tabelId,

--- a/e2e/test/scenarios/question/reproductions/13263-postgres-show-row-details-on-pk-click.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/13263-postgres-show-row-details-on-pk-click.cy.spec.js
@@ -1,16 +1,19 @@
-import { restore, startNewQuestion, visualize } from "e2e/support/helpers";
-
-const PG_DB_NAME = "QA Postgres12";
+import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
+import { openTable, restore } from "e2e/support/helpers";
 
 describe("postgres > user > query", { tags: "@external" }, () => {
   beforeEach(() => {
     restore("postgres-12");
     cy.signInAsAdmin();
-
-    startNewQuestion();
-    cy.findByTextEnsureVisible(PG_DB_NAME).click();
-    cy.findByTextEnsureVisible("Orders").click();
-    visualize();
+    cy.request(`/api/database/${WRITABLE_DB_ID}/schema/public`).then(
+      ({ body }) => {
+        const tableId = body.find(table => table.name === "orders").id;
+        openTable({
+          database: WRITABLE_DB_ID,
+          table: tableId,
+        });
+      },
+    );
   });
 
   it("should show row details when clicked on its entity key (metabase#13263)", () => {

--- a/e2e/test/scenarios/question/reproductions/15714-cc-postgres-percentile-accepts-two-params.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/15714-cc-postgres-percentile-accepts-two-params.cy.spec.js
@@ -1,20 +1,27 @@
+import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import {
   enterCustomColumnDetails,
   restore,
-  startNewQuestion,
+  openTable,
 } from "e2e/support/helpers";
-
-const PG_DB_NAME = "QA Postgres12";
 
 describe("postgres > question > custom columns", { tags: "@external" }, () => {
   beforeEach(() => {
     restore("postgres-12");
     cy.signInAsAdmin();
 
-    startNewQuestion();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(PG_DB_NAME).should("be.visible").click();
-    cy.findByTextEnsureVisible("Orders").click();
+    cy.request(`/api/database/${WRITABLE_DB_ID}/schema/public`).then(
+      ({ body }) => {
+        const tableId = body.find(table => table.name === "orders").id;
+        openTable({
+          database: WRITABLE_DB_ID,
+          table: tableId,
+          mode: "notebook",
+        });
+      },
+    );
+
+    cy.findByRole("button", { name: "Summarize" }).click();
   });
 
   it("`Percentile` custom expression function should accept two parameters (metabase#15714)", () => {

--- a/e2e/test/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.cy.spec.js
@@ -1,23 +1,23 @@
-import {
-  restore,
-  popover,
-  visualize,
-  startNewQuestion,
-} from "e2e/support/helpers";
+import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
+import { restore, popover, visualize, openTable } from "e2e/support/helpers";
 
 describe("issue 17963", { tags: "@external" }, () => {
   beforeEach(() => {
     restore("mongo-4");
     cy.signInAsAdmin();
 
-    startNewQuestion();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("QA Mongo4").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Orders").click();
+    cy.request(`/api/database/${WRITABLE_DB_ID}/schema/`).then(({ body }) => {
+      const tableId = body.find(table => table.name === "orders").id;
+      openTable({
+        database: WRITABLE_DB_ID,
+        table: tableId,
+        mode: "notebook",
+      });
+    });
   });
 
   it("should be able to compare two fields using filter expression (metabase#17963)", () => {
+    cy.findByRole("button", { name: "Filter" }).click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add filters to narrow your answer").click();
 
@@ -33,6 +33,8 @@ describe("issue 17963", { tags: "@external" }, () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Discount > Quantity");
+
+    cy.findByRole("button", { name: "Summarize" }).click();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick the metric you want to see").click();

--- a/e2e/test/scenarios/question/reproductions/19742-data-picker-closes-after-hiding-table.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/19742-data-picker-closes-after-hiding-table.cy.spec.js
@@ -13,7 +13,11 @@ describe("issue 19742", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
     selectFromDropdown("Question");
-    selectFromDropdown("Sample Database");
+    selectFromDropdown("Raw Data");
+
+    popover().within(() => {
+      cy.findByText("Orders").should("exist");
+    });
 
     openNavigationSidebar();
     cy.icon("gear").click();
@@ -28,7 +32,7 @@ describe("issue 19742", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
     selectFromDropdown("Question");
-    selectFromDropdown("Sample Database");
+    selectFromDropdown("Raw Data");
 
     popover().within(() => {
       cy.findByText("Products");

--- a/e2e/test/scenarios/question/reproductions/22285-schema-picker.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/22285-schema-picker.cy.spec.js
@@ -17,6 +17,7 @@ describe("issue 22285", () => {
     cy.wait("@fetchDatabases");
 
     popover().within(() => {
+      cy.findByText("Raw Data").click();
       cy.findByText("Sample Database").click();
 
       cy.findByText(/Fake Schema/i);
@@ -26,6 +27,7 @@ describe("issue 22285", () => {
       // go back to database picker
       cy.icon("chevronleft").click();
 
+      cy.findByText("Sample Database").click();
       cy.findByText(/Fake Schema/i);
       cy.findByText(/Public/i);
     });

--- a/e2e/test/scenarios/question/reproductions/4482-temporal-min-max.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/4482-temporal-min-max.cy.spec.js
@@ -9,12 +9,6 @@ describe("issue 4482", () => {
     restore();
     cy.signInAsAdmin();
 
-    // startNewQuestion();
-    // // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    // cy.contains("Sample Database").click();
-    // // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    // cy.contains("Products").click();
-
     openTable({
       table: PRODUCTS_ID,
       mode: "notebook",

--- a/e2e/test/scenarios/question/reproductions/4482-temporal-min-max.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/4482-temporal-min-max.cy.spec.js
@@ -1,15 +1,26 @@
-import { restore, visualize, startNewQuestion } from "e2e/support/helpers";
+import { restore, visualize, openTable } from "e2e/support/helpers";
+
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describe("issue 4482", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
 
-    startNewQuestion();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("Sample Database").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("Products").click();
+    // startNewQuestion();
+    // // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    // cy.contains("Sample Database").click();
+    // // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    // cy.contains("Products").click();
+
+    openTable({
+      table: PRODUCTS_ID,
+      mode: "notebook",
+    });
+
+    cy.findByRole("button", { name: "Summarize" }).click();
   });
 
   it("should be possible to summarize min of a temporal column (metabase#4482-1)", () => {

--- a/e2e/test/scenarios/sharing/alert/email-alert.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/email-alert.cy.spec.js
@@ -2,11 +2,13 @@ import {
   restore,
   setupSMTP,
   visitQuestion,
-  startNewQuestion,
-  popover,
-  visualize,
   modal,
+  openTable,
 } from "e2e/support/helpers";
+
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { PEOPLE_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > alert > email_alert", { tags: "@external" }, () => {
   beforeEach(() => {
@@ -58,14 +60,9 @@ describe("scenarios > alert > email_alert", { tags: "@external" }, () => {
   });
 
   it("should set up an email alert for newly created question", () => {
-    startNewQuestion();
-
-    popover().within(() => {
-      cy.contains("Sample Database").click();
-      cy.contains("People").click();
+    openTable({
+      table: PEOPLE_ID,
     });
-
-    visualize();
 
     cy.icon("bell").click();
 


### PR DESCRIPTION
This PR adds a model to the Cypress Sample Dataset, something done in preparation for the Audit V2 feature (which will seed models of instance data). An unfortunate side effect of this is that the Data Selector will act much differently with a model in the sample dataset. This PR attempted to make as many tests agnostic to the environment as possible, using the `openTable` function rather than `startNewQuestion` and navigating the data selector.

