### PR TITLE
Add reproduction test - Broken added series on dashcard prevents you from editing the card

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/reproductions/22265-broken-added-series-prevents-editing-card.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/reproductions/22265-broken-added-series-prevents-editing-card.cy.spec.js
@@ -18,7 +18,7 @@ const invalidQuestion = {
   name: "Invalid question",
   display: "scalar",
   native: {
-    query: "SELECT --1",
+    query: "SELECT 1",
   },
 };
 
@@ -61,8 +61,7 @@ describe("issue 22265", () => {
 
     cy.findByTestId("add-series-modal").within(() => {
       cy.icon("warning").should("not.exist");
-      cy.findByLabelText(invalidQuestion.name).should("exist");
-      cy.icon("warning").should("not.exist");
+      cy.findByLabelText(invalidQuestion.name).should("exist").click();
       cy.button("Done").click();
     });
 

--- a/e2e/test/scenarios/dashboard-cards/reproductions/22265-broken-added-series-prevents-editing-card.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/reproductions/22265-broken-added-series-prevents-editing-card.cy.spec.js
@@ -1,0 +1,70 @@
+import { editDashboard, restore, visitDashboard } from "e2e/support/helpers";
+
+const baseQuestion = {
+  name: "Base question",
+  display: "scalar",
+  native: {
+    query: "SELECT 1",
+  },
+};
+
+const invalidQuestion = {
+  name: "Invalid question",
+  display: "scalar",
+  native: {
+    query: "SELECT --1",
+  },
+};
+
+describe("issue 22265", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.intercept("GET", "/api/card/*/series?limit=*").as("seriesQuery");
+  });
+
+  it("should allow editing dashcard series when added series are broken (metabase#22265)", () => {
+    cy.createNativeQuestion(invalidQuestion);
+    cy.createNativeQuestionAndDashboard({ questionDetails: baseQuestion }).then(
+      ({ body: { id, card_id, dashboard_id } }) => {
+        cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
+          cards: [
+            {
+              id,
+              card_id,
+              row: 0,
+              col: 0,
+              size_x: 16,
+              size_y: 10,
+            },
+          ],
+        });
+
+        visitDashboard(dashboard_id);
+      },
+    );
+
+    editDashboard();
+    cy.findByTestId("add-series-button").click({ force: true });
+    cy.wait("@seriesQuery");
+
+    cy.findByTestId("add-series-modal").within(() => {
+      cy.icon("warning").should("not.exist");
+      cy.findByLabelText(invalidQuestion.name).should("exist");
+      cy.icon("warning").should("not.exist");
+      cy.button("Done").click();
+    });
+
+    cy.button("Save").click();
+
+    editDashboard();
+    cy.findByTestId("add-series-button").click({ force: true });
+    cy.wait("@seriesQuery");
+
+    cy.findByTestId("add-series-modal").within(() => {
+      cy.findByLabelText(invalidQuestion.name).should("exist");
+      cy.icon("warning").should("not.exist");
+    });
+  });
+});

--- a/e2e/test/scenarios/dashboard-cards/reproductions/22265-broken-added-series-prevents-editing-card.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/reproductions/22265-broken-added-series-prevents-editing-card.cy.spec.js
@@ -1,10 +1,4 @@
-import {
-  editDashboard,
-  modal,
-  restore,
-  visitDashboard,
-  visitQuestion,
-} from "e2e/support/helpers";
+import { editDashboard, restore, visitDashboard } from "e2e/support/helpers";
 
 const baseQuestion = {
   name: "Base question",
@@ -68,17 +62,20 @@ describe("issue 22265", () => {
     cy.button("Save").click();
     cy.button("Saving…").should("not.exist");
 
+    cy.log("Update the added series' question so that it's broken");
+    const questionDetailUpdate = {
+      dataset_query: {
+        type: "native",
+        native: {
+          query: "SELECT --2",
+          "template-tags": {},
+        },
+        database: 1,
+      },
+    };
     cy.get("@invalidQuestionId").then(invalidQuestionId => {
-      visitQuestion(invalidQuestionId);
-      cy.icon("expand").click();
-      cy.get(".ace_content").type("{backspace}--2");
-      cy.findByTestId("native-query-editor-sidebar")
-        .button("Get Answer")
-        .click();
-      cy.findByText("Save").click();
+      cy.request("PUT", `/api/card/${invalidQuestionId}`, questionDetailUpdate);
     });
-
-    modal().findByText("Save").click();
 
     cy.get("@dashboardId").then(dashboardId => {
       visitDashboard(dashboardId);

--- a/e2e/test/scenarios/dashboard-cards/reproductions/22265-broken-added-series-prevents-editing-card.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/reproductions/22265-broken-added-series-prevents-editing-card.cy.spec.js
@@ -79,9 +79,7 @@ describe("issue 22265", () => {
       cy.findByText("Save").click();
     });
 
-    modal().within(() => {
-      cy.findByText("Save").click();
-    });
+    modal().findByText("Save").click();
 
     cy.get("@dashboardId").then(dashboardId => {
       visitDashboard(dashboardId);

--- a/e2e/test/scenarios/dashboard-cards/reproductions/32231-add-incompatible-series.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/reproductions/32231-add-incompatible-series.cy.spec.js
@@ -73,14 +73,14 @@ describe("issue 32231", () => {
       cy.findByText(multipleSeriesError).should("not.exist");
       cy.findByText(defaultError).should("not.exist");
 
-      cy.findByText(incompleteQuestion.name).click();
+      cy.findByLabelText(incompleteQuestion.name).click();
 
       cy.get(".LineAreaBarChart").should("not.exist");
       cy.findByText(issue32231Error).should("not.exist");
       cy.findByText(multipleSeriesError).should("exist");
       cy.findByText(defaultError).should("not.exist");
 
-      cy.findByText(incompleteQuestion.name).click();
+      cy.findByLabelText(incompleteQuestion.name).click();
 
       cy.get(".LineAreaBarChart").should("exist");
       cy.findByText(issue32231Error).should("not.exist");


### PR DESCRIPTION
Closes #22265

### Description

The issue has already been fixed. This PR just adds a reproduction test for it.

[Before](https://github.com/metabase/metabase/assets/6830683/44cdd869-e6ef-4014-9f5b-735377675fcb) it was not possible to edit series in dashcards where non-base series was broken.



### How to verify

- Tests are green
- Run test against older Metabase version, e.g. `v0.45.4.3`

To run the test against older version, it needs few changes:

<details>
<summary>Test code for v0.45.4.3 (disclaimer: rough version)</summary>

```js
import {
  restore,
  modal,
  visitDashboard,
  visitQuestion,
} from "__support__/e2e/helpers";

const baseQuestion = {
  name: "21665 Q1",
  native: { query: "select 1" },
  display: "scalar",
};

const invalidQuestion = {
  name: "21665 Q2",
  native: { query: "select 2" },
  display: "scalar",
};

describe("issue 22265", () => {
  beforeEach(() => {
    restore();
    cy.signInAsAdmin();
  });

  it("should allow editing dashcard series when added series are broken (metabase#22265)", () => {
    cy.createNativeQuestion(invalidQuestion, {
      wrapId: true,
      idAlias: "invalidQuestionId",
    });
    cy.createNativeQuestionAndDashboard({ questionDetails: baseQuestion }).then(
      ({ body: { id, card_id, dashboard_id } }) => {
        cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
          cards: [
            {
              id,
              card_id,
              row: 0,
              col: 0,
              size_x: 16,
              size_y: 10,
            },
          ],
        });

        visitDashboard(dashboard_id);
        cy.wrap(dashboard_id).as('dashboardId');
      },
    );

    cy.get("header").icon("pencil").click();
    cy.findByTestId("add-series-button").click({ force: true });

    cy.get(".AddSeriesModal").within(() => {
      cy.findByLabelText(invalidQuestion.name).should("exist").click();
      cy.button("Done").click();
    });

    cy.button("Save").click();
    cy.button("Saving…").should("not.exist");

    cy.get("@invalidQuestionId").then(invalidQuestionId => {
      visitQuestion(invalidQuestionId);
      cy.icon("expand").click();
      cy.get(".ace_content").type("{backspace}--2");
      cy.icon("play").eq(0).click();
      cy.findByText("Save").click();
    });

    modal().within(() => {
      cy.findByText("Save").click();
    })

    cy.get('@dashboardId').then((dashboardId)=> {
      visitDashboard(dashboardId);
    })

    cy.get("header").icon("pencil").click();
    cy.findByTestId("add-series-button").click({ force: true });

    cy.get(".AddSeriesModal").within(() => {
      cy.findByLabelText(invalidQuestion.name).should("exist");
    });
  });
});
```
</details>