### PR TITLE
Mantine Loader

### DIFF
--- a/frontend/src/metabase/ui/components/feedback/Loader/Loader.stories.mdx
+++ b/frontend/src/metabase/ui/components/feedback/Loader/Loader.stories.mdx
@@ -1,0 +1,65 @@
+import { Fragment } from "react";
+import { Canvas, Story, Meta } from "@storybook/addon-docs";
+import { Grid, Text } from "metabase/ui";
+import { Loader } from "./";
+
+export const args = {
+  size: "md",
+};
+
+export const argTypes = {
+  size: {
+    options: ["xs", "sm", "md", "lg", "xl"],
+    control: { type: "inline-radio" },
+  },
+};
+
+<Meta
+  title="Feedback/Loader"
+  component={Loader}
+  args={args}
+  argTypes={argTypes}
+/>
+
+# Loader
+
+Our themed wrapper around [Mantine Loader](https://mantine.dev/core/loader/).
+
+## Docs
+
+- [Figma File](https://www.figma.com/file/NUXRUa9Ot3HvgC1WwIA4UH/Loader?node-id=1%3A96)
+- [Mantine Loader Docs](https://mantine.dev/core/loader/)
+
+## Caveats
+
+- Only use the `oval` variant unless otherwise called out
+- Prefer usage of loader sizes less than `xl` unless specifically called out
+
+## Examples
+
+export const Default = args => <Loader {...args} />;
+
+<Canvas>
+  <Story name="Default">{Default}</Story>
+</Canvas>
+
+### Sizes
+
+export const Sizes = args => (
+  <Grid w="10rem" columns={2} align="center">
+    {argTypes.size.options.map(size => (
+      <Fragment key={size}>
+        <Grid.Col span={1} align="center">
+          <Text weight="bold">{size}</Text>
+        </Grid.Col>
+        <Grid.Col span={1} align="center">
+          <Loader size={size} />
+        </Grid.Col>
+      </Fragment>
+    ))}
+  </Grid>
+);
+
+<Canvas>
+  <Story name="Sizes">{Sizes}</Story>
+</Canvas>

--- a/frontend/src/metabase/ui/components/feedback/Loader/Loader.tsx
+++ b/frontend/src/metabase/ui/components/feedback/Loader/Loader.tsx
@@ -1,0 +1,14 @@
+import { Loader as MantineLoader } from "@mantine/core";
+import type { LoaderProps } from "@mantine/core";
+
+const SIZES: Record<string, string> = {
+  xs: "1rem",
+  sm: "1.25rem",
+  md: "1.5rem",
+  lg: "2rem",
+  xl: "3.5rem",
+};
+
+export const Loader = ({ size = "md", ...props }: LoaderProps) => (
+  <MantineLoader {...props} size={SIZES[size] ?? size} />
+);

--- a/frontend/src/metabase/ui/components/feedback/Loader/index.ts
+++ b/frontend/src/metabase/ui/components/feedback/Loader/index.ts
@@ -1,0 +1,1 @@
+export { Loader } from "@mantine/core";

--- a/frontend/src/metabase/ui/components/feedback/Loader/index.ts
+++ b/frontend/src/metabase/ui/components/feedback/Loader/index.ts
@@ -1,1 +1,1 @@
-export { Loader } from "@mantine/core";
+export { Loader } from "./Loader";

--- a/frontend/src/metabase/ui/components/feedback/index.ts
+++ b/frontend/src/metabase/ui/components/feedback/index.ts
@@ -1,0 +1,1 @@
+export * from "./Loader";

--- a/frontend/src/metabase/ui/components/index.ts
+++ b/frontend/src/metabase/ui/components/index.ts
@@ -1,5 +1,6 @@
 export * from "./buttons";
 export * from "./data-display";
+export * from "./feedback";
 export * from "./inputs";
 export * from "./layout";
 export * from "./overlays";


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/32309

Adds a wrapper for `Loader` component. 

The component doesn't use `useStyles` API so it's not possible to apply style overrides at all. That's why to override sizes I had to create out own wrapper component. 

How to verify:
- `yarn storybook`
- Open http://localhost:6006/?path=/docs/feedback-loader--sizes

<img width="1388" alt="Screenshot 2023-08-18 at 14 31 33" src="https://github.com/metabase/metabase/assets/8542534/cbb826ad-787c-4f7e-ae92-99c70248d2d1">
