### PR TITLE
Fix null series title in line charts

### DIFF
--- a/e2e/test/scenarios/visualizations/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/line_chart.cy.spec.js
@@ -170,9 +170,9 @@ describe("scenarios > visualizations > line chart", () => {
       cy.wait(500);
     });
     // Now do the same for the input with no value
-    openSeriesSettings("Unknown", true);
+    openSeriesSettings("(empty)", true);
     popover().within(() => {
-      cy.findAllByLabelText("series-name-input").type("cat2").blur();
+      cy.findAllByLabelText("series-name-input").clear().type("cat2").blur();
       cy.findByDisplayValue("cat2");
     });
     cy.button("Done").click();
@@ -233,6 +233,39 @@ describe("scenarios > visualizations > line chart", () => {
     });
 
     cy.get(".LineAreaBarChart").get(".trend").should("be.visible");
+  });
+
+  it("should show label for empty value series breakout (metabase#32107)", () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        type: "native",
+        native: {
+          query: `
+            select 1 id, 50 val1, null val2
+            union all select 2, 75, null
+            union all select 3, 175, null
+            union all select 4, 200, null
+            union all select 5, 280, null
+          `,
+        },
+        database: SAMPLE_DB_ID,
+      },
+      display: "line",
+      visualization_settings: {
+        "graph.dimensions": ["ID", "VAL2"],
+        "graph.series_order_dimension": null,
+        "graph.series_order": null,
+        "graph.metrics": ["VAL1"],
+      },
+    });
+
+    cy.findByTestId("visualization-root")
+      .findByTestId("legend-item")
+      .findByText("(empty)")
+      .should("be.visible");
+
+    cy.findByTestId("viz-settings-button").click();
+    cy.findByTestId("chartsettings-sidebar").findByText("(empty)");
   });
 
   describe("y-axis splitting (metabase#12939)", () => {

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -21,6 +21,7 @@ import {
 import { getOrderedSeries } from "metabase/visualizations/lib/series";
 import { getAccentColors } from "metabase/lib/colors/groups";
 import { isEmpty } from "metabase/lib/validate";
+import { NULL_DISPLAY_VALUE } from "metabase/lib/constants";
 import { isDimension, isMetric } from "metabase-lib/types/utils/isa";
 
 import {
@@ -387,7 +388,10 @@ function transformSingleSeries(s, series, seriesIndex) {
           // show series title if it's multiseries
           series.length > 1 && card.name,
           // always show grouping value
-          formatValue(breakoutValue, { column: cols[seriesColumnIndex] }),
+          formatValue(
+            isEmpty(breakoutValue) ? NULL_DISPLAY_VALUE : breakoutValue,
+            { column: cols[seriesColumnIndex] },
+          ),
         ]
           .filter(n => n)
           .join(": "),

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -456,7 +456,11 @@ class Visualization extends PureComponent {
 
     return (
       <ErrorBoundary>
-        <VisualizationRoot className={className} style={style}>
+        <VisualizationRoot
+          className={className}
+          style={style}
+          data-testid="visualization-root"
+        >
           {!!hasHeader && (
             <VisualizationHeader>
               <ChartCaption

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedSimple.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedSimple.tsx
@@ -3,6 +3,8 @@ import { t } from "ttag";
 
 import type { Series } from "metabase-types/api";
 
+import { NULL_DISPLAY_VALUE } from "metabase/lib/constants";
+import { isEmpty } from "metabase/lib/validate";
 import { ChartSettingOrderedItems } from "./ChartSettingOrderedItems";
 import {
   ChartSettingMessage,
@@ -53,7 +55,7 @@ export const ChartSettingOrderedSimple = ({
   };
 
   const getItemTitle = (item: SortableItem) => {
-    return item.name || "Unknown";
+    return isEmpty(item.name) ? NULL_DISPLAY_VALUE : item.name;
   };
 
   const handleOnEdit = (item: SortableItem, ref: HTMLElement | undefined) => {

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -66,6 +66,9 @@ export interface VisualizationProps {
   onVisualizationClick: (clickObject?: ClickObject) => void;
   onUpdateVisualizationSettings: (settings: VisualizationSettings) => void;
 
+  "graph.dimensions"?: string[];
+  "graph.metrics"?: string[];
+
   onAddSeries?: any;
   onEditSeries?: any;
   onRemoveSeries?: any;

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
@@ -255,6 +255,10 @@ const RowChartVisualization = ({
       });
   }, [fontFamily]);
 
+  const hasBreakout =
+    settings["graph.dimensions"] && settings["graph.dimensions"]?.length > 1;
+  const hasLegend = series.length > 1 || hasBreakout;
+
   return (
     <RowVisualizationRoot className={className} isQueryBuilder={isQueryBuilder}>
       {hasTitle && (
@@ -267,7 +271,7 @@ const RowChartVisualization = ({
         />
       )}
       <RowChartLegendLayout
-        hasLegend={series.length > 1}
+        hasLegend={hasLegend}
         labels={labels}
         colors={colors}
         actionButtons={!hasTitle ? actionButtons : undefined}

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/format.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/format.ts
@@ -12,6 +12,8 @@ import {
 import { getStackOffset } from "metabase/visualizations/lib/settings/stacking";
 import { getLabelsMetricColumn } from "metabase/visualizations/shared/utils/series";
 import { formatValue } from "metabase/lib/formatting";
+import { NULL_DISPLAY_VALUE } from "metabase/lib/constants";
+import { isEmpty } from "metabase/lib/validate";
 
 export const getFormatters = (
   chartColumns: ChartColumns,
@@ -82,5 +84,7 @@ export const getLabelsFormatter = (
 
 export const getColumnValueFormatter = () => {
   return (value: RowValue, column: DatasetColumn) =>
-    String(formatValue(value, { column }));
+    isEmpty(value)
+      ? NULL_DISPLAY_VALUE
+      : String(formatValue(value, { column }));
 };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/32107

### Description

When we had empty series breakouts, we didn't show the label. Also updated the series settings to use the localized `(empty)` instead of unlocalized `UNKNOWN`

It seems a little strange to show an empty series breakout, but I think it's the correct behavior, the only problem was the label not showing up. See discussion in #32959 as well as issues: https://github.com/metabase/metabase/issues/12782 and https://github.com/metabase/metabase/issues/4995

![Screen Shot 2023-08-18 at 6 27 11 AM](https://github.com/metabase/metabase/assets/30528226/0d556e42-1ae0-47ac-a8c2-c378b00661ff)

### How to verify

- sample query

```
select 1 id, 50 val1, null val2
union all select 2, 75, null
union all select 3, 175, null
union all select 4, 200, null
union all select 5, 280, null
```
- choose a line chart
- update column settings like this:
![Screen Shot 2023-08-18 at 6 29 46 AM](https://github.com/metabase/metabase/assets/30528226/c9f3257e-3e53-4161-877c-5e49875af84b)

- see that (empty) appears in the chart legend now


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
