### PR TITLE
Refactoring: Add clearFilterWidget e2e helper

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -71,7 +71,7 @@ export function filterWidget() {
 }
 
 export function clearFilterWidget(index = 0) {
-  return filterWidget().eq(index).find(".Icon-close").click();
+  return filterWidget().eq(index).icon("close").click();
 }
 
 export const openQuestionActions = () => {

--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -70,6 +70,10 @@ export function filterWidget() {
   return cy.get("fieldset");
 }
 
+export function clearFilterWidget(index = 0) {
+  return filterWidget().eq(index).find(".Icon-close").click();
+}
+
 export const openQuestionActions = () => {
   cy.findByTestId("qb-header-action-panel").icon("ellipsis").click();
 };

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
@@ -1,6 +1,7 @@
 import {
   restore,
   popover,
+  clearFilterWidget,
   filterWidget,
   editDashboard,
   saveDashboard,
@@ -50,7 +51,8 @@ describe("scenarios > dashboard > filters > date", () => {
           cy.findByText(representativeResult);
         });
 
-        clearFilter(index);
+        clearFilterWidget(index);
+        cy.wait("@dashcardQuery1");
       },
     );
   });
@@ -194,9 +196,4 @@ function dateFilterSelector({ filterType, filterValue } = {}) {
     default:
       throw new Error("Wrong filter type!");
   }
-}
-
-function clearFilter(index) {
-  filterWidget().eq(index).find(".Icon-close").click();
-  cy.wait("@dashcardQuery1");
 }

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-location.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-location.cy.spec.js
@@ -1,6 +1,7 @@
 import {
   restore,
   popover,
+  clearFilterWidget,
   filterWidget,
   editDashboard,
   saveDashboard,
@@ -41,7 +42,8 @@ describe("scenarios > dashboard > filters > location", () => {
           cy.contains(representativeResult);
         });
 
-        clearFilter(index);
+        clearFilterWidget(index);
+        cy.wait("@dashcardQuery1");
       },
     );
   });
@@ -64,8 +66,3 @@ describe("scenarios > dashboard > filters > location", () => {
     });
   });
 });
-
-function clearFilter(index = 0) {
-  filterWidget().eq(index).find(".Icon-close").click();
-  cy.wait("@dashcardQuery1");
-}

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
@@ -1,6 +1,7 @@
 import {
   restore,
   popover,
+  clearFilterWidget,
   filterWidget,
   editDashboard,
   saveDashboard,
@@ -44,7 +45,9 @@ describe("scenarios > dashboard > filters > number", () => {
           cy.findByText(representativeResult);
         });
 
-        clearFilter(index);
+        console.log(cy.state());
+        clearFilterWidget(index);
+        cy.wait("@dashcardQuery1");
       },
     );
   });
@@ -62,7 +65,7 @@ describe("scenarios > dashboard > filters > number", () => {
       cy.findByText("37.65");
     });
 
-    filterWidget().find(".Icon-close").click();
+    clearFilterWidget();
 
     filterWidget().click();
 
@@ -73,9 +76,3 @@ describe("scenarios > dashboard > filters > number", () => {
     });
   });
 });
-
-function clearFilter(index = 0) {
-  console.log(cy.state());
-  filterWidget().eq(index).find(".Icon-close").click();
-  cy.wait("@dashcardQuery1");
-}

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
@@ -45,7 +45,6 @@ describe("scenarios > dashboard > filters > number", () => {
           cy.findByText(representativeResult);
         });
 
-        console.log(cy.state());
         clearFilterWidget(index);
         cy.wait("@dashcardQuery1");
       },

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-date.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-date.cy.spec.js
@@ -1,6 +1,7 @@
 import {
   restore,
   popover,
+  clearFilterWidget,
   filterWidget,
   editDashboard,
   saveDashboard,
@@ -55,7 +56,8 @@ describe("scenarios > dashboard > filters > SQL > date", () => {
           cy.contains(representativeResult);
         });
 
-        clearFilter(index);
+        clearFilterWidget(index);
+        cy.wait("@dashcardQuery2");
       },
     );
   });
@@ -120,9 +122,4 @@ function dateFilterSelector({ filterType, filterValue } = {}) {
     default:
       throw new Error("Wrong filter type!");
   }
-}
-
-function clearFilter(index) {
-  filterWidget().eq(index).find(".Icon-close").click();
-  cy.wait("@dashcardQuery2");
 }

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-location.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-location.cy.spec.js
@@ -1,6 +1,7 @@
 import {
   restore,
   popover,
+  clearFilterWidget,
   filterWidget,
   editDashboard,
   saveDashboard,
@@ -50,7 +51,8 @@ describe("scenarios > dashboard > filters > location", () => {
           cy.contains(representativeResult);
         });
 
-        clearFilter(index);
+        clearFilterWidget(index);
+        cy.wait("@dashcardQuery2");
       },
     );
   });
@@ -73,7 +75,7 @@ describe("scenarios > dashboard > filters > location", () => {
       cy.contains("Arnold Adams");
     });
 
-    filterWidget().find(".Icon-close").click();
+    clearFilterWidget();
 
     cy.url().should("not.include", "Rye");
 
@@ -86,8 +88,3 @@ describe("scenarios > dashboard > filters > location", () => {
     });
   });
 });
-
-function clearFilter(index) {
-  filterWidget().eq(index).find(".Icon-close").click();
-  cy.wait("@dashcardQuery2");
-}

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-number.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-number.cy.spec.js
@@ -1,6 +1,7 @@
 import {
   restore,
   popover,
+  clearFilterWidget,
   filterWidget,
   editDashboard,
   saveDashboard,
@@ -53,7 +54,8 @@ describe("scenarios > dashboard > filters > SQL > text/category", () => {
           cy.contains(representativeResult);
         });
 
-        clearFilter(index);
+        clearFilterWidget(index);
+        cy.wait("@dashcardQuery2");
       },
     );
   });
@@ -76,7 +78,7 @@ describe("scenarios > dashboard > filters > SQL > text/category", () => {
       cy.contains("Rustic Paper Wallet").should("not.exist");
     });
 
-    filterWidget().find(".Icon-close").click();
+    clearFilterWidget();
 
     filterWidget().click();
 
@@ -88,8 +90,3 @@ describe("scenarios > dashboard > filters > SQL > text/category", () => {
     });
   });
 });
-
-function clearFilter(index) {
-  filterWidget().eq(index).find(".Icon-close").click();
-  cy.wait("@dashcardQuery2");
-}

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-required-field-filter.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-required-field-filter.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, filterWidget, visitDashboard } from "e2e/support/helpers";
+import {
+  restore,
+  clearFilterWidget,
+  filterWidget,
+  visitDashboard,
+} from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { PRODUCTS } = SAMPLE_DATABASE;
@@ -70,7 +75,7 @@ describe("scenarios > dashboard > filters > SQL > field filter > required ", () 
 
     filterWidget().contains("Widget");
 
-    removeWidgetFilterValue();
+    clearFilterWidget();
 
     cy.location("search").should("eq", "?category=");
 
@@ -101,7 +106,3 @@ describe("scenarios > dashboard > filters > SQL > field filter > required ", () 
     cy.location("search").should("eq", "?category=Widget");
   });
 });
-
-function removeWidgetFilterValue() {
-  filterWidget().find(".Icon-close").click();
-}

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-required-simple-filter.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-required-simple-filter.cy.spec.js
@@ -1,6 +1,6 @@
 import {
+  clearFilterWidget,
   restore,
-  filterWidget,
   sidebar,
   editDashboard,
   saveDashboard,
@@ -74,7 +74,7 @@ describe("scenarios > dashboard > filters > SQL > simple filter > required ", ()
 
     cy.findByDisplayValue("Bar");
 
-    removeWidgetFilterValue();
+    clearFilterWidget();
 
     cy.location("search").should("eq", "?text=");
 
@@ -114,10 +114,6 @@ describe("scenarios > dashboard > filters > SQL > simple filter > required ", ()
     cy.url().should("not.include", "?text=");
   });
 });
-
-function removeWidgetFilterValue() {
-  filterWidget().find(".Icon-close").click();
-}
 
 function openFilterOptions(filterDisplayName) {
   cy.findByText(filterDisplayName).parent().find(".Icon-gear").click();

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-text-category.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-text-category.cy.spec.js
@@ -1,6 +1,7 @@
 import {
   restore,
   popover,
+  clearFilterWidget,
   filterWidget,
   editDashboard,
   saveDashboard,
@@ -52,7 +53,8 @@ describe("scenarios > dashboard > filters > SQL > text/category", () => {
           cy.contains(representativeResult);
         });
 
-        clearFilter(index);
+        clearFilterWidget(index);
+        cy.wait("@dashcardQuery2");
       },
     );
   });
@@ -75,7 +77,7 @@ describe("scenarios > dashboard > filters > SQL > text/category", () => {
       cy.contains("Rustic Paper Wallet");
     });
 
-    filterWidget().find(".Icon-close").click();
+    clearFilterWidget();
 
     cy.url().should("not.include", "Gizmo");
 
@@ -87,8 +89,3 @@ describe("scenarios > dashboard > filters > SQL > text/category", () => {
     cy.findByText("Rustic Paper Wallet").should("not.exist");
   });
 });
-
-function clearFilter(index) {
-  filterWidget().eq(index).find(".Icon-close").click();
-  cy.wait("@dashcardQuery2");
-}

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
@@ -43,7 +43,7 @@ describe("scenarios > dashboard > filters > text/category", () => {
           cy.contains(representativeResult);
         });
 
-        clearFilterWidget();
+        clearFilterWidget(index);
         cy.wait("@dashcardQuery1");
       },
     );

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
@@ -1,6 +1,7 @@
 import {
   restore,
   popover,
+  clearFilterWidget,
   filterWidget,
   editDashboard,
   saveDashboard,
@@ -42,7 +43,8 @@ describe("scenarios > dashboard > filters > text/category", () => {
           cy.contains(representativeResult);
         });
 
-        clearFilter(index);
+        clearFilterWidget();
+        cy.wait("@dashcardQuery1");
       },
     );
   });
@@ -123,8 +125,3 @@ describe("scenarios > dashboard > filters > text/category", () => {
     filterWidget().contains("Arnold Adams");
   });
 });
-
-function clearFilter(index = 0) {
-  filterWidget().eq(index).find(".Icon-close").click();
-  cy.wait("@dashcardQuery1");
-}

--- a/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
@@ -1,6 +1,7 @@
 import {
   restore,
   openNativeEditor,
+  clearFilterWidget,
   filterWidget,
   popover,
 } from "e2e/support/helpers";
@@ -136,7 +137,7 @@ describe("scenarios > filters > sql filters > field filter", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 42 rows");
 
-      clearFilterValue();
+      clearFilterWidget();
       filterWidget().click();
 
       popover().within(() => {
@@ -160,7 +161,3 @@ describe("scenarios > filters > sql filters > field filter", () => {
     });
   });
 });
-
-function clearFilterValue() {
-  filterWidget().find(".Icon-close").click();
-}


### PR DESCRIPTION
This PR simply adds a new clearFilterWidget helper for e2e tests. 

It clears the filter widget value when there is one, by clicking this close icon:
<img width="447" alt="image" src="https://github.com/metabase/metabase/assets/39073188/bb92e5b6-75ef-42b4-a37c-f23ed7ad70e6">
