### PR TITLE
fix static bundle dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -328,7 +328,7 @@
     "build-release": "yarn build-release:cljs && yarn build-release:js",
     "build-stats": "yarn && webpack --json > stats.json",
     "build-shared": "yarn && webpack --config webpack.shared.config.js",
-    "build-static-viz": "yarn && yarn build-release:cljs && webpack --config webpack.static-viz.config.js",
+    "build-static-viz": "yarn && yarn build-release:cljs && WEBPACK_BUNDLE=production webpack --config webpack.static-viz.config.js",
     "build-static-viz:watch": "webpack --config webpack.static-viz.config.js --watch",
     "precommit": "lint-staged",
     "preinstall": "echo $npm_execpath | grep -q yarn || echo '\\033[0;33mSorry, npm is not supported. Please use Yarn (https://yarnpkg.com/).\\033[0m'",

--- a/webpack.static-viz.config.js
+++ b/webpack.static-viz.config.js
@@ -1,12 +1,16 @@
 const SRC_PATH = __dirname + "/frontend/src/metabase";
 const BUILD_PATH = __dirname + "/resources/frontend_client";
 const CLJS_SRC_PATH = __dirname + "/frontend/src/cljs_release";
+const CLJS_SRC_PATH_DEV = __dirname + "/frontend/src/cljs";
 const LIB_SRC_PATH = __dirname + "/frontend/src/metabase-lib";
 const TYPES_SRC_PATH = __dirname + "/frontend/src/metabase-types";
 
 const BABEL_CONFIG = {
   cacheDirectory: process.env.BABEL_DISABLE_CACHE ? null : ".babel_cache",
 };
+
+const WEBPACK_BUNDLE = process.env.WEBPACK_BUNDLE || "development";
+const devMode = WEBPACK_BUNDLE !== "production";
 
 module.exports = env => {
   const shouldDisableMinimization = env.WEBPACK_WATCH === true;
@@ -47,7 +51,7 @@ module.exports = env => {
       extensions: [".webpack.js", ".web.js", ".js", ".jsx", ".ts", ".tsx"],
       alias: {
         metabase: SRC_PATH,
-        cljs: CLJS_SRC_PATH,
+        cljs: devMode ? CLJS_SRC_PATH_DEV : CLJS_SRC_PATH,
         "metabase-lib": LIB_SRC_PATH,
         "metabase-types": TYPES_SRC_PATH,
       },


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/33643

### Description

The static viz bundle started depending on the CLJS code but the `cljs` alias should be resolved to a different path in the dev mode which caused seeing sometimes [very unexpected](https://metaboat.slack.com/archives/C010L1Z4F9S/p1692207286284189) static charts.

### How to verify

- Run `yarn dev` or `yarn dev-ee`
- Send a test subscription with any chart
- Change the code of the chart
- Send a test subscription
- Ensure the changes you made have been applied

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
