### PR TITLE
Rename build.version-info to `version-properties`

### DIFF
--- a/bin/build/src/build.clj
+++ b/bin/build/src/build.clj
@@ -3,7 +3,7 @@
    [build-drivers :as build-drivers]
    [build.licenses :as license]
    [build.uberjar :as uberjar]
-   [build.version-info :as version-info]
+   [build.version-properties :as version-properties]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.string :as str]
@@ -87,7 +87,7 @@
 (def all-steps
   (ordered-map/ordered-map
    :version      (fn [{:keys [edition version]}]
-                   (version-info/generate-version-info-file! edition version))
+                   (version-properties/generate-version-properties-file! edition version))
    :translations (fn [_]
                    (i18n/create-all-artifacts!))
    :frontend     (fn [{:keys [edition]}]
@@ -108,7 +108,7 @@
      :or   {edition (edition-from-env-var)
             steps   (keys all-steps)}}]
    (let [version (or version
-                     (version-info/current-snapshot-version edition))]
+                     (version-properties/current-snapshot-version edition))]
      (u/step (format "Running build steps for %s version %s: %s"
                      (case edition
                        :oss "Community (OSS) Edition"

--- a/bin/build/src/build/version_properties.clj
+++ b/bin/build/src/build/version_properties.clj
@@ -1,4 +1,4 @@
-(ns build.version-info
+(ns build.version-properties
   (:require
    [clojure.string :as str]
    [metabuild-common.core :as u]))
@@ -70,10 +70,10 @@
        (format "v%d.%d.%d-SNAPSHOT" major minor patch))
      "UNKNOWN")))
 
-(defn generate-version-info-file!
+(defn generate-version-properties-file!
   "Generate version.properties file"
   ([edition]
-   (generate-version-info-file! edition (current-snapshot-version edition)))
+   (generate-version-properties-file! edition (current-snapshot-version edition)))
 
   ([edition version]
    (u/delete-file-if-exists! version-properties-filename)

--- a/bin/build/test/build/version_properties_test.clj
+++ b/bin/build/test/build/version_properties_test.clj
@@ -1,6 +1,6 @@
-(ns build.version-info-test
+(ns build.version-properties-test
   (:require
-   [build.version-info :as version-info]
+   [build.version-properties :as version-properties]
    [clojure.test :refer :all]))
 
 (deftest tag-parts-test
@@ -11,7 +11,7 @@
           tag            [tag (str \v tag)]]
     (testing (str (pr-str (list 'tag-parts tag)) " => " (pr-str expected))
       (is (= expected
-             (#'version-info/tag-parts tag))))))
+             (#'version-properties/tag-parts tag))))))
 
 (deftest current-snapshot-version-test
   (doseq [[branch edition->tag->expected] {"release-x.37.x" {:oss {nil          "UNKNOWN"
@@ -34,4 +34,4 @@
           [tag expected]                  tag->expected]
     (testing (str (pr-str (list 'current-snapshot-version edition branch tag)) " => " (pr-str expected))
       (is (= expected
-             (version-info/current-snapshot-version edition branch tag))))))
+             (version-properties/current-snapshot-version edition branch tag))))))


### PR DESCRIPTION
We have two sets of functions that deal with the information about Metabase version.
1. During build process we create `version.properties` file
2. During release we create new `version-info.json` or `version-info-ee.json` files that we store in AWS

The first contains the information about the current Metabase version. It's used to generate info in "About Metabase" window, among others.

Calling both namespaces `version-info` leads to unnecessary confusion. This commit should make the distinction between the two more obvious and more clear.

