### PR TITLE
Fix CSP issues in the color picker

### DIFF
--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
@@ -17,8 +17,8 @@ export const ContentContainer = styled.div`
 
 // react-css inserts inline styles, but it's forbidden with our CSP headers
 // to fix this we copy relevant styles here
-// https://github.com/casesandberg/react-color/blob/master/src/components/common/Hue.js#L78
-// https://github.com/casesandberg/react-color/blob/master/src/components/common/Saturation.js#L105
+// https://github.com/casesandberg/react-color/blob/v2.18.1/src/components/common/Hue.js#L78
+// https://github.com/casesandberg/react-color/blob/v2.18.1/src/components/common/Saturation.js#L94
 export const ControlsRoot = styled.div`
   .hue-horizontal {
     background: linear-gradient(

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
@@ -15,6 +15,33 @@ export const ContentContainer = styled.div`
   padding: 1rem;
 `;
 
+// react-css inserts inline styles, but it's forbidden with our CSP headers
+// to fix this we copy relevant styles here
+// https://github.com/casesandberg/react-color/blob/master/src/components/common/Hue.js#L78
+// https://github.com/casesandberg/react-color/blob/master/src/components/common/Saturation.js#L105
+export const ControlsRoot = styled.div`
+  .hue-horizontal {
+    background: linear-gradient(
+      to right,
+      #f00 0%,
+      #ff0 17%,
+      #0f0 33%,
+      #0ff 50%,
+      #00f 67%,
+      #f0f 83%,
+      #f00 100%
+    );
+  }
+
+  .saturation-white {
+    background: linear-gradient(to right, #fff, rgba(255, 255, 255, 0));
+  }
+
+  .saturation-black {
+    background: linear-gradient(to top, #000, rgba(0, 0, 0, 0));
+  }
+`;
+
 export const SaturationContainer = styled.div`
   position: relative;
   height: 10rem;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPickerControls.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPickerControls.tsx
@@ -1,6 +1,7 @@
 import { CustomPicker, CustomPickerInjectedProps } from "react-color";
 import { Hue, Saturation } from "react-color/lib/components/common";
 import {
+  ControlsRoot,
   HueContainer,
   HuePointer,
   SaturationContainer,
@@ -18,7 +19,7 @@ const ColorPickerControls = CustomPicker(function ColorControls(
   props: CustomPickerInjectedProps,
 ) {
   return (
-    <div>
+    <ControlsRoot>
       <SaturationContainer>
         <Saturation
           {...props}
@@ -29,7 +30,7 @@ const ColorPickerControls = CustomPicker(function ColorControls(
       <HueContainer>
         <Hue {...props} pointer={HuePointer} />
       </HueContainer>
-    </div>
+    </ControlsRoot>
   );
 });
 


### PR DESCRIPTION
Related https://github.com/metabase/metabase-private/issues/73

Please note this is just a short-term fix. A better solution would be migrating to `ColorPicker` from `mantine`.

How to verify:
- Run Metabase EE with a valid token
- Go to Admin -> Settings -> Appearance and click on the color pill/swatch

Before
<img width="335" alt="Screenshot 2023-08-18 at 21 28 54" src="https://github.com/metabase/metabase/assets/8542534/4ab54927-59f7-462b-a542-b8e68ffc8857">

After
<img width="367" alt="Screenshot 2023-08-18 at 21 28 36" src="https://github.com/metabase/metabase/assets/8542534/260ada84-ead0-4e9a-a26b-bff7b691122c">
