### PR TITLE
Add the official build for release workflow

### DIFF
--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -64,5 +64,17 @@ jobs:
     - name: Build Metabase ${{ steps.canonical_version.outputs.result }}
       run: ./bin/build.sh :edition :${{ matrix.edition }} :version ${{ steps.canonical_version.outputs.result }}
 
-    - name: Prepare uberjar artifact
-      uses: ./.github/actions/prepare-uberjar-artifact
+    - name: Store commit's SHA-1 hash
+      run:  echo ${{ inputs.commit }} > COMMIT-ID
+      shell: bash
+    - name: Calculate SHA256 checksum
+      run: sha256sum ./target/uberjar/metabase.jar > SHA256.sum
+      shell: bash
+    - name: Upload JARs as artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: metabase-${{ matrix.edition }}-uberjar
+        path: |
+          ./target/uberjar/metabase.jar
+          ./COMMIT-ID
+          ./SHA256.sum

--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -1,0 +1,68 @@
+name: Build for the official Metabase release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Metabase version (e.g. v0.46.3)'
+        type: string
+        required: true
+      commit:
+        description: 'A full-length commit SHA-1 hash'
+        required: true
+
+jobs:
+  build-uberjar-for-release:
+    if: ${{ github.repository }} != 'metabase/metabase'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 40
+    strategy:
+      matrix:
+        edition: [oss, ee]
+    env:
+      INTERACTIVE: false
+    steps:
+    - name: Fail early on the incorrect version format
+      if: ${{ !(startsWith(inputs.version,'v0.') || startsWith(inputs.version,'v1.')) }}
+      run: |
+        echo "The version format is invalid!"
+        echo "It must start with either 'v0.' or 'v1.'."
+        echo "Please, try again."
+        exit 1
+
+    # EE is always v1.x.y, OSS is always v0.x.y
+    - name: Determine the canonical version
+      uses: actions/github-script@v6
+      id: canonical_version
+      env:
+        VERSION: ${{ inputs.version }}
+        EDITION: ${{ matrix.edition }}
+      with:
+        result-encoding: string
+        script: |
+          var canonical_version;
+          const ver = process.env.VERSION;
+          if (process.env.EDITION === "ee") {
+            canonical_version = ver.replace(/^v0\./, "v1."); // always e.g. v1.47.2
+          } else {
+            canonical_version = ver.replace(/^v1\./, "v0."); // always e.g. v0.45.6
+          }
+          console.log("The canonical version of this Metabase", process.env.EDITION, "edition is", canonical_version);
+          return canonical_version;
+
+    - name: Check out the code
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.inputs.commit }}
+
+    - name: Prepare front-end environment
+      uses: ./.github/actions/prepare-frontend
+
+    - name: Prepare back-end environment
+      uses: ./.github/actions/prepare-backend
+
+    - name: Build Metabase ${{ steps.canonical_version.outputs.result }}
+      run: ./bin/build.sh :edition :${{ matrix.edition }} :version ${{ steps.canonical_version.outputs.result }}
+
+    - name: Prepare uberjar artifact
+      uses: ./.github/actions/prepare-uberjar-artifact

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -141,7 +141,7 @@ jobs:
   run-sanity-check:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
-    needs: check-uberjar-health
+    needs: [release-artifact, check-uberjar-health]
     strategy:
       matrix:
         edition: [oss, ee]
@@ -165,7 +165,7 @@ jobs:
     - name: Check out the code
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.inputs.commit }}
+        ref: ${{ needs.release-artifact.outputs.commit }}
     - name: Prepare front-end environment
       uses: ./.github/actions/prepare-frontend
     - name: Prepare JDK 11

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -200,8 +200,8 @@ jobs:
         if-no-files-found: ignore
 
   containerize:
+    needs: [release-artifact, run-sanity-check]
     runs-on: ubuntu-22.04
-    needs: run-sanity-check
     timeout-minutes: 15
     strategy:
       matrix:
@@ -215,10 +215,10 @@ jobs:
     - name: Check out the code
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.inputs.commit }}
+        ref: ${{ needs.release-artifact.version-properties.commit }}
     - name: Truncate commit hash
       run: |
-        commit_id=${{ github.event.inputs.commit }}
+        commit_id=${{ needs.release-artifact.version-properties.commit }}
         truncated_hash=${commit_id:0:${{ env.MAX_HASH_LENGTH }}}
 
         echo "COMMIT_IDENTIFIER=$truncated_hash" >> $GITHUB_ENV

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -21,6 +21,8 @@ jobs:
       version: ${{ steps.version-properties.outputs.version }}
       commit: ${{ steps.version-properties.outputs.commit }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
       - name: Download Metabase ${{ matrix.edition }} artifact
         run: |
           declare -a curlHeaders=('-H' "Accept: application/vnd.github+json" '-H' "Authorization: Bearer $GITHUB_TOKEN" '-H' "X-GitHub-Api-Version: 2022-11-28")

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Reveal Metabase ${{ matrix.edition }} properties
         id: version-properties
         run: |
-          echo version=$(grep -o '^tag=.*' ./resources/version.properties | cut -d'=' -f2) >> GITHUB_OUTPUT
-          echo commit=$(cat ./COMMIT-ID) >> GITHUB_OUTPUT
+          echo "version=$(grep -o '^tag=.*' ./resources/version.properties | cut -d'=' -f2)" >> $GITHUB_OUTPUT
+          echo "commit=$(cat ./COMMIT-ID)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Upload Metabase ${{ matrix.edition }} JAR as artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -115,7 +115,7 @@ jobs:
         COMMIT: ${{ needs.release-artifact.outputs.commit }}
 
   check-uberjar-health:
-    needs: release-artifact
+    needs: [release-artifact, check-commit]
     runs-on: ubuntu-22.04
     name: Is ${{ matrix.edition }} (java ${{ matrix.java-version }}) healthy?
     timeout-minutes: 10

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -217,10 +217,10 @@ jobs:
     - name: Check out the code
       uses: actions/checkout@v3
       with:
-        ref: ${{ needs.release-artifact.version-properties.commit }}
+        ref: ${{ needs.release-artifact.outputs.commit }}
     - name: Truncate commit hash
       run: |
-        commit_id=${{ needs.release-artifact.version-properties.commit }}
+        commit_id=${{ needs.release-artifact.outputs.commit }}
         truncated_hash=${commit_id:0:${{ env.MAX_HASH_LENGTH }}}
 
         echo "COMMIT_IDENTIFIER=$truncated_hash" >> $GITHUB_ENV

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -113,9 +113,9 @@ jobs:
         COMMIT: ${{ needs.release-artifact.outputs.commit }}
 
   check-uberjar-health:
+    needs: release-artifact
     runs-on: ubuntu-22.04
     name: Is ${{ matrix.edition }} (java ${{ matrix.java-version }}) healthy?
-    needs: build
     timeout-minutes: 10
     strategy:
       matrix:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -10,6 +10,52 @@ env:
   CUSTOM_REPO: ${{ secrets.CUSTOM_RELEASE_REPO }}
 
 jobs:
+  release-artifact:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        edition: [oss, ee]
+    outputs:
+      version: ${{ steps.version-properties.outputs.version }}
+      commit: ${{ steps.version-properties.outputs.commit }}
+    steps:
+      - name: Download Metabase ${{ matrix.edition }} artifact
+        run: |
+          declare -a curlHeaders=('-H' "Accept: application/vnd.github+json" '-H' "Authorization: Bearer $GITHUB_TOKEN" '-H' "X-GitHub-Api-Version: 2022-11-28")
+
+          download_link=$(
+            curl -sL \
+              "${curlHeaders[@]}" \
+              "${{ github.event.workflow_run.artifacts_url }}" \
+              | jq -r --arg name "$ARTIFACT_NAME" '.artifacts[] | select(.name == $name) | .archive_download_url')
+
+          curl -sL "${curlHeaders[@]}" $download_link -o mb.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARTIFACT_NAME: metabase-${{ matrix.edition }}-uberjar
+      - name: Unzip Metabase artifact containing an uberjar
+        run: unzip mb.zip
+      - name: Extract the version.properties file from the JAR
+        run: |
+          jar xf target/uberjar/metabase.jar version.properties
+          mv version.properties resources/
+      - name: Reveal Metabase ${{ matrix.edition }} properties
+        id: version-properties
+        run: |
+          echo version=$(grep -o '^tag=.*' ./resources/version.properties | cut -d'=' -f2) >> GITHUB_OUTPUT
+          echo commit=$(cat .COMMIT-ID) >> GITHUB_OUTPUT
+        shell: bash
+      - name: Upload Metabase ${{ matrix.edition }} JAR as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: metabase-${{ matrix.edition }}-uberjar
+          path: |
+            ./target/uberjar/metabase.jar
+            ./COMMIT-ID
+            ./SHA256.sum
+
   check-commit:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
@@ -65,58 +111,6 @@ jobs:
           echo "ABORT!."
           exit -1
         fi
-
-  build:
-    if: ${{ github.repository }} != 'metabase/metabase'
-    runs-on: ubuntu-22.04
-    needs: check-commit
-    name: Build Metabase ${{ matrix.edition }} @${{ github.event.inputs.commit }}
-    timeout-minutes: 40
-    strategy:
-      matrix:
-        edition: [oss, ee]
-    env:
-      MB_EDITION: ${{ matrix.edition }}
-      INTERACTIVE: false
-    steps:
-    - name: Fail early if custom docker release repo is missing
-      if: ${{ env.CUSTOM_REPO == null }}
-      run: exit 1
-    - name: Check out the code
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.inputs.commit }}
-    - name: Prepare front-end environment
-      uses: ./.github/actions/prepare-frontend
-    - name: Prepare back-end environment
-      uses: ./.github/actions/prepare-backend
-      with:
-        m2-cache-key: pre-release-build
-
-    - name: Determine the canonical version ## EE is always v1.x.y, OSS is always v0.x.y
-      uses: actions/github-script@v6
-      id: canonical_version
-      env:
-        INTENDED_VERSION: ${{ github.event.inputs.version }}
-        EDITION: ${{ matrix.edition }}
-      with:
-        result-encoding: string
-        script: |
-          var canonical_version;
-          const ver = process.env.INTENDED_VERSION;
-          if (process.env.EDITION === "ee") {
-            canonical_version = ver.replace(/^v0\./, "v1."); // always e.g. v1.47.2
-          } else {
-            canonical_version = ver.replace(/^v1\./, "v0."); // always e.g. v0.45.6
-          }
-          console.log("The canonical version of this", process.env.EDITION, "edition is", canonical_version);
-          return canonical_version;
-
-    - name: Build
-      run: ./bin/build.sh :edition :${{ matrix.edition }} :version ${{ steps.canonical_version.outputs.result }}
-
-    - name: Prepare uberjar artifact
-      uses: ./.github/actions/prepare-uberjar-artifact
 
   check-uberjar-health:
     runs-on: ubuntu-22.04

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -269,7 +269,7 @@ jobs:
 
   verify-docker-pull:
     runs-on: ubuntu-22.04
-    needs: containerize
+    needs: [release-artifact, containerize]
     timeout-minutes: 15
     strategy:
       matrix:
@@ -277,7 +277,7 @@ jobs:
     steps:
     - name: Truncate commit hash
       run: |
-        commit_id=${{ github.event.inputs.commit }}
+        commit_id=${{ needs.release-artifact.outputs.commit }}
         truncated_hash=${commit_id:0:${{ env.MAX_HASH_LENGTH }}}
 
         echo "COMMIT_IDENTIFIER=$truncated_hash" >> $GITHUB_ENV

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -57,20 +57,16 @@ jobs:
             ./SHA256.sum
 
   check-commit:
+    needs: release-artifact
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
-    - name: Ensure that the intended version (${{ github.event.inputs.version }}) was never released before
+    - name: Ensure that the intended version ($VERSION) was never released before
       run: |
-        if [[ "${{ github.event.inputs.version }}" = v* ]]; then
-          echo "Checking if ${{ github.event.inputs.version }} conflicts with a past release..."
-        else
-          echo "ERROR: the intended version must start with 'v', e.g. 'v0.46.3."
-          echo "ABORT!"
-          exit -1
-        fi
+        echo "Checking if $VERSION conflicts with a past release..."
+
         CANONICAL_REFS=https://github.com/metabase/metabase/archive/refs
-        URL=${CANONICAL_REFS}/tags/${{ github.event.inputs.version }}.zip
+        URL=${CANONICAL_REFS}/tags/$VERSION.zip
         HTTP_CODE=$(curl -s -L -o /dev/null --head -w "%{HTTP_CODE}" ${URL})
         if [[ $HTTP_CODE =~ "200" ]]; then
           echo "ERROR: that version was already released in the past."
@@ -87,6 +83,8 @@ jobs:
             exit -1
           fi
         fi
+      env:
+        VERSION: ${{ needs.release-artifact.outputs.version }}
 
     - name: Check out the code to verify the release branch
       uses: actions/checkout@v3
@@ -95,7 +93,7 @@ jobs:
     - name: Ensure that the specified commit exists in the latest release branch
       run: |
         echo "Checking if the specified commit is in a release branch..."
-        COMMIT=${{ github.event.inputs.commit }}
+
         git branch -a --contains $COMMIT > branches.txt
         if [[ $(grep -c master branches.txt) =~ 1 ]]; then
           echo "Found in master branch. ABORT!"
@@ -111,6 +109,8 @@ jobs:
           echo "ABORT!."
           exit -1
         fi
+      env:
+        COMMIT: ${{ needs.release-artifact.outputs.commit }}
 
   check-uberjar-health:
     runs-on: ubuntu-22.04

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -47,7 +47,7 @@ jobs:
         id: version-properties
         run: |
           echo version=$(grep -o '^tag=.*' ./resources/version.properties | cut -d'=' -f2) >> GITHUB_OUTPUT
-          echo commit=$(cat .COMMIT-ID) >> GITHUB_OUTPUT
+          echo commit=$(cat ./COMMIT-ID) >> GITHUB_OUTPUT
         shell: bash
       - name: Upload Metabase ${{ matrix.edition }} JAR as artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,14 +1,9 @@
 name: Pre-release [WIP]
 
 on:
-  workflow_dispatch:
-    inputs:
-      commit:
-        description: 'A full-length commit SHA-1 hash'
-        required: true
-      version:
-        description: 'Intended version (e.g. v0.46.3)'
-        required: true
+  workflow_run:
+    workflows: [Build for the official Metabase release]
+    types: [completed]
 
 env:
   MAX_HASH_LENGTH: 8


### PR DESCRIPTION
This PR adds _the one and only™_  official workflow for building release artifacts. They should and will be a source of truth for all future releases.

The new logic is as follows:
1. Give input to this workflow in the form of the version and the commit SHA-1
2. After it finishes building, it will automatically trigger pre-release workflow (which now downloads the official artifact instead of building it)
3. The pre-release workflow will then run a series of sanity checks and will push to the staging Docker repo in order to allow us to test the artifact for defects

> **Note**
> This will SOON require some changes to the current Clojure-based release script, but that's it NOT blocking this PR from getting merged.

---

This kind of workflow is best to test in one's Metabase fork. Which is exactly what I've been doing. Here are the results:
Building was never the problem:
![image](https://github.com/metabase/metabase/assets/31325167/a11b9d99-3f6b-401e-8f02-2b1c9d35282c)

But making sure that the newly adjusted pre-release workflow works was:
![image](https://github.com/metabase/metabase/assets/31325167/472ecc9f-96da-4c0f-8d2d-b72bc0b5b2d6)

Let's examine the last (successful) run:
https://github.com/nemanjaglumac/metabase/actions/runs/6109638595

It successfully downloaded the official uberjars (both OSS and EE), unzipped them and then read from the `version-properties` file that should be a source of truth for the release, did some sanity checking and finally containerized and pushed to the staging DockerHub. In my own fork, that's https://hub.docker.com/repository/docker/nemanjaglumac/mb-staging/general where we can see the two images
![image](https://github.com/metabase/metabase/assets/31325167/630cdc5b-7a63-47b7-9d2f-8de42ff95d82)

Note that the naming is weird and it doesn't include the version/tag, but that will be fixed in https://github.com/metabase/metabase/pull/33363.

It's just cleaner and easier to split these changes and to take baby steps.