### PR TITLE
Create pre-release Docker staging images that include Metabase version in the name

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -258,7 +258,7 @@ jobs:
         IMAGE_TAG=${{ env.VERSION }}-$SHORT_HASH
         CONTAINER_IMAGE=${{ github.repository_owner }}/${{ secrets.DOCKERHUB_STAGING_REPO }}:$IMAGE_TAG
 
-        echo "image=$CONTAINER_IMAGE" >> GITHUB_OUTPUT
+        echo "image=$CONTAINER_IMAGE" >> $GITHUB_OUTPUT
 
         echo "Retag local image for staging"
         docker tag localhost:5000/local-metabase:$VERSION $CONTAINER_IMAGE

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -209,6 +209,8 @@ jobs:
         image: registry:2
         ports:
           - 5000:5000
+    outputs:
+      container-image: ${{ steps.target.outputs.image }}
     steps:
     - name: Check out the code
       uses: actions/checkout@v3
@@ -248,12 +250,15 @@ jobs:
         username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
         password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
     - name: Retag and push container image to ${{ github.repository_owner }} staging Docker Hub repo
+      id: target
       run: |
         # SHA-1 truncated to 7 digits should be enough
         SHORT_HASH=${COMMIT:0:7}
 
         IMAGE_TAG=${{ env.VERSION }}-$SHORT_HASH
         CONTAINER_IMAGE=${{ github.repository_owner }}/${{ secrets.DOCKERHUB_STAGING_REPO }}:$IMAGE_TAG
+
+        echo "image=$CONTAINER_IMAGE" >> GITHUB_OUTPUT
 
         echo "Retag local image for staging"
         docker tag localhost:5000/local-metabase:$VERSION $CONTAINER_IMAGE
@@ -275,29 +280,18 @@ jobs:
       matrix:
         edition: [oss, ee]
     steps:
-    - name: Truncate commit hash
-      run: |
-        commit_id=${{ needs.release-artifact.outputs.commit }}
-        truncated_hash=${commit_id:0:${{ env.MAX_HASH_LENGTH }}}
-
-        echo "COMMIT_IDENTIFIER=$truncated_hash" >> $GITHUB_ENV
-      shell: bash
     - name: Login to Docker Hub # authenticated, to avoid being rate-throttled
       uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
         password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
-    - name: Determine the container image to pull
-      run: |
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/${{ env.STAGING_REPO }}" >> $GITHUB_ENV
-          echo "IMAGE_NAME=${{ env.COMMIT_IDENTIFIER }}-${{ matrix.edition }}" >> $GITHUB_ENV
     - name: Pull the container image
       run: |
-        echo "Pulling container image ${{ env.DOCKERHUB_REPO }}:${{ env.IMAGE_NAME }} ..."
-        docker pull ${{ env.DOCKERHUB_REPO }}:${{ env.IMAGE_NAME }}
+        echo "Pulling container image ${{ needs.containerize.outputs.container-image }} ..."
+        docker pull ${{ needs.containerize.outputs.container-image }}
         echo "Successful!"
     - name: Launch container
-      run: docker run --rm -dp 3000:3000 ${{ env.DOCKERHUB_REPO }}:${{ env.IMAGE_NAME }}
+      run: docker run --rm -dp 3000:3000 ${{ needs.containerize.outputs.container-image }}
       timeout-minutes: 5
     - name: Wait for Metabase to start
       run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -14,7 +14,8 @@ jobs:
       matrix:
         edition: [oss, ee]
     outputs:
-      version: ${{ steps.version-properties.outputs.version }}
+      ee_version: ${{ steps.version-properties.outputs.ee_version }}
+      oss_version: ${{ steps.version-properties.outputs.oss_version }}
       commit: ${{ steps.version-properties.outputs.commit }}
     steps:
       - name: Checkout repository
@@ -42,8 +43,16 @@ jobs:
       - name: Reveal Metabase ${{ matrix.edition }} properties
         id: version-properties
         run: |
-          echo "version=$(grep -o '^tag=.*' ./resources/version.properties | cut -d'=' -f2)" >> $GITHUB_OUTPUT
+          cat ./resources/version.properties
           echo "commit=$(cat ./COMMIT-ID)" >> $GITHUB_OUTPUT
+
+          version=$(grep -o '^tag=.*' ./resources/version.properties | cut -d'=' -f2)
+
+          if [[ "${{ matrix.edition }}" == "ee" ]]; then
+            echo "ee_version=$version" >> $GITHUB_OUTPUT
+          else
+            echo "oss_version=$version" >> $GITHUB_OUTPUT
+          fi
         shell: bash
       - name: Upload Metabase ${{ matrix.edition }} JAR as artifact
         uses: actions/upload-artifact@v3
@@ -59,6 +68,13 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
+    - name: Get the version
+      run: |
+        if [[ "${{ matrix.edition }}" == "ee" ]]; then
+          echo "VERSION=${{ needs.release-artifact.outputs.ee_version }}" >> $GITHUB_ENV
+        else
+          echo "VERSION=${{ needs.release-artifact.outputs.oss_version }}" >> $GITHUB_ENV
+        fi
     - name: Ensure that the intended version ($VERSION) was never released before
       run: |
         echo "Checking if $VERSION conflicts with a past release..."
@@ -81,8 +97,6 @@ jobs:
             exit -1
           fi
         fi
-      env:
-        VERSION: ${{ needs.release-artifact.outputs.version }}
 
     - name: Check out the code to verify the release branch
       uses: actions/checkout@v3
@@ -212,6 +226,13 @@ jobs:
     outputs:
       container-image: ${{ steps.target.outputs.image }}
     steps:
+    - name: Get the version
+      run: |
+        if [[ "${{ matrix.edition }}" == "ee" ]]; then
+          echo "VERSION=${{ needs.release-artifact.outputs.ee_version }}" >> $GITHUB_ENV
+        else
+          echo "VERSION=${{ needs.release-artifact.outputs.oss_version }}" >> $GITHUB_ENV
+        fi
     - name: Check out the code
       uses: actions/checkout@v3
       with:
@@ -233,12 +254,12 @@ jobs:
         context: bin/docker/.
         platforms: linux/amd64
         network: host
-        tags: localhost:5000/local-metabase:${{ needs.release-artifact.outputs.version }}
+        tags: localhost:5000/local-metabase:${{ env.VERSION }}
         no-cache: true
         push: true
 
     - name: Launch container
-      run: docker run --rm -dp 3000:3000 localhost:5000/local-metabase:${{ needs.release-artifact.outputs.version }}
+      run: docker run --rm -dp 3000:3000 localhost:5000/local-metabase:${{ env.VERSION }}
       timeout-minutes: 5
     - name: Wait for Metabase to start
       run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
@@ -270,7 +291,6 @@ jobs:
       shell: bash
       env:
         COMMIT: ${{ needs.release-artifact.outputs.commit }}
-        VERSION: ${{ needs.release-artifact.outputs.version }}
 
   verify-docker-pull:
     runs-on: ubuntu-22.04

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -224,7 +224,7 @@ jobs:
         ports:
           - 5000:5000
     outputs:
-      container-image: ${{ steps.target.outputs.image }}
+      image_tag: ${{ steps.target.outputs.image_tag }}
     steps:
     - name: Get the version
       run: |
@@ -276,10 +276,10 @@ jobs:
         # SHA-1 truncated to 7 digits should be enough
         SHORT_HASH=${COMMIT:0:7}
 
-        IMAGE_TAG=${{ env.VERSION }}-$SHORT_HASH
         CONTAINER_IMAGE=${{ github.repository_owner }}/${{ secrets.DOCKERHUB_STAGING_REPO }}:$IMAGE_TAG
+        IMAGE_TAG=$VERSION-$SHORT_HASH
 
-        echo "image=$CONTAINER_IMAGE" >> $GITHUB_OUTPUT
+        echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
         echo "Retag local image for staging"
         docker tag localhost:5000/local-metabase:$VERSION $CONTAINER_IMAGE
@@ -299,6 +299,8 @@ jobs:
     strategy:
       matrix:
         edition: [oss, ee]
+    env:
+      IMAGE_TAG: ${{ needs.containerize.outputs.image_tag }}
     steps:
     - name: Login to Docker Hub # authenticated, to avoid being rate-throttled
       uses: docker/login-action@v2

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -5,10 +5,6 @@ on:
     workflows: [Build for the official Metabase release]
     types: [completed]
 
-env:
-  MAX_HASH_LENGTH: 8
-  STAGING_REPO: ${{ secrets.DOCKERHUB_STAGING_REPO }}
-
 jobs:
   release-artifact:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
@@ -251,16 +247,25 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
         password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
-    - name: Determine the target Docker Hub repository
+    - name: Retag and push container image to ${{ github.repository_owner }} staging Docker Hub repo
       run: |
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/${{ env.STAGING_REPO }}" >> $GITHUB_ENV
-          echo "IMAGE_NAME=${{ env.COMMIT_IDENTIFIER }}-${{ matrix.edition }}" >> $GITHUB_ENV
-    - name: Retag and push container image to Docker Hub
-      run: |
-        echo "Pushing container image ${{ env.IMAGE_NAME}} to ${{ env.DOCKERHUB_REPO }} ..."
-        docker tag localhost:5000/local-metabase:${{ needs.release-artifact.outputs.version }} ${{ env.DOCKERHUB_REPO }}:${{ env.IMAGE_NAME }}
-        docker push ${{ env.DOCKERHUB_REPO }}:${{ env.IMAGE_NAME }}
+        # SHA-1 truncated to 7 digits should be enough
+        SHORT_HASH=${COMMIT:0:7}
+
+        IMAGE_TAG=${{ env.VERSION }}-$SHORT_HASH
+        CONTAINER_IMAGE=${{ github.repository_owner }}/${{ secrets.DOCKERHUB_STAGING_REPO }}:$IMAGE_TAG
+
+        echo "Retag local image for staging"
+        docker tag localhost:5000/local-metabase:$VERSION $CONTAINER_IMAGE
+
+        echo "Pushing container image $CONTAINER_IMAGE ..."
+        docker push $CONTAINER_IMAGE
+
         echo "Finished!"
+      shell: bash
+      env:
+        COMMIT: ${{ needs.release-artifact.outputs.commit }}
+        VERSION: ${{ needs.release-artifact.outputs.version }}
 
   verify-docker-pull:
     runs-on: ubuntu-22.04

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   MAX_HASH_LENGTH: 8
-  CUSTOM_REPO: ${{ secrets.CUSTOM_RELEASE_REPO }}
+  STAGING_REPO: ${{ secrets.DOCKERHUB_STAGING_REPO }}
 
 jobs:
   release-artifact:
@@ -253,7 +253,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
     - name: Determine the target Docker Hub repository
       run: |
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/${{ env.CUSTOM_REPO }}" >> $GITHUB_ENV
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/${{ env.STAGING_REPO }}" >> $GITHUB_ENV
           echo "IMAGE_NAME=${{ env.COMMIT_IDENTIFIER }}-${{ matrix.edition }}" >> $GITHUB_ENV
     - name: Retag and push container image to Docker Hub
       run: |
@@ -284,7 +284,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
     - name: Determine the container image to pull
       run: |
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/${{ env.CUSTOM_REPO }}" >> $GITHUB_ENV
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/${{ env.STAGING_REPO }}" >> $GITHUB_ENV
           echo "IMAGE_NAME=${{ env.COMMIT_IDENTIFIER }}-${{ matrix.edition }}" >> $GITHUB_ENV
     - name: Pull the container image
       run: |

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -218,13 +218,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ needs.release-artifact.outputs.commit }}
-    - name: Truncate commit hash
-      run: |
-        commit_id=${{ needs.release-artifact.outputs.commit }}
-        truncated_hash=${commit_id:0:${{ env.MAX_HASH_LENGTH }}}
-
-        echo "COMMIT_IDENTIFIER=$truncated_hash" >> $GITHUB_ENV
-      shell: bash
     - uses: actions/download-artifact@v3
       name: Retrieve uberjar artifact
       with:
@@ -242,12 +235,12 @@ jobs:
         context: bin/docker/.
         platforms: linux/amd64
         network: host
-        tags: localhost:5000/local-metabase:${{ env.COMMIT_IDENTIFIER }}-${{ matrix.edition }}
+        tags: localhost:5000/local-metabase:${{ needs.release-artifact.outputs.version }}
         no-cache: true
         push: true
 
     - name: Launch container
-      run: docker run --rm -dp 3000:3000 localhost:5000/local-metabase:${{ env.COMMIT_IDENTIFIER }}-${{ matrix.edition }}
+      run: docker run --rm -dp 3000:3000 localhost:5000/local-metabase:${{ needs.release-artifact.outputs.version }}
       timeout-minutes: 5
     - name: Wait for Metabase to start
       run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
@@ -265,7 +258,7 @@ jobs:
     - name: Retag and push container image to Docker Hub
       run: |
         echo "Pushing container image ${{ env.IMAGE_NAME}} to ${{ env.DOCKERHUB_REPO }} ..."
-        docker tag localhost:5000/local-metabase:${{ env.IMAGE_NAME }} ${{ env.DOCKERHUB_REPO }}:${{ env.IMAGE_NAME }}
+        docker tag localhost:5000/local-metabase:${{ needs.release-artifact.outputs.version }} ${{ env.DOCKERHUB_REPO }}:${{ env.IMAGE_NAME }}
         docker push ${{ env.DOCKERHUB_REPO }}:${{ env.IMAGE_NAME }}
         echo "Finished!"
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -270,14 +270,14 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
         password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
-    - name: Retag and push container image to ${{ github.repository_owner }} staging Docker Hub repo
+    - name: Retag and push container image to ${{ vars.DOCKERHUB_OWNER }} staging Docker Hub repo
       id: target
       run: |
         # SHA-1 truncated to 7 digits should be enough
         SHORT_HASH=${COMMIT:0:7}
 
-        CONTAINER_IMAGE=${{ github.repository_owner }}/${{ secrets.DOCKERHUB_STAGING_REPO }}:$IMAGE_TAG
         IMAGE_TAG=$VERSION-$SHORT_HASH
+        CONTAINER_IMAGE=${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_STAGING_REPO }}:$IMAGE_TAG
 
         echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
@@ -309,11 +309,14 @@ jobs:
         password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
     - name: Pull the container image
       run: |
-        echo "Pulling container image ${{ needs.containerize.outputs.container-image }} ..."
-        docker pull ${{ needs.containerize.outputs.container-image }}
+        CONTAINER_IMAGE=${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_STAGING_REPO }}:$IMAGE_TAG
+        echo "Pulling container image $CONTAINER_IMAGE ..."
+        docker pull $CONTAINER_IMAGE
         echo "Successful!"
     - name: Launch container
-      run: docker run --rm -dp 3000:3000 ${{ needs.containerize.outputs.container-image }}
+      run: |
+        CONTAINER_IMAGE=${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_STAGING_REPO }}:$IMAGE_TAG
+        docker run --rm -dp 3000:3000 $CONTAINER_IMAGE
       timeout-minutes: 5
     - name: Wait for Metabase to start
       run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done


### PR DESCRIPTION
This is the continuation of https://github.com/metabase/metabase/pull/33362.
Up until now, pre-release was creating Docker images in the following format:
```
$commit_hash-$edition
```
![image](https://github.com/metabase/metabase/assets/31325167/4f64de25-76c0-479d-897d-f25a8900d6f3)

After this PR gets merged, we will have much more readable and usable Docker image names:
```
$version-$commit_hash
```
![image](https://github.com/metabase/metabase/assets/31325167/324fd200-c295-48dc-b5f1-05f679ccbe46)

### Notable changes
- This workflow now uses repository variables for the Docker staging repo, instead of secrets (`DOCKERHUB_STAGING_REPO`)
- Rather than defaulting to the GitHub repo owner, we now allow setting a `DOCKERHUB_OWNER`
- Truncated commit hash now has the length of 7 - GitHub uses this length so it should be more than enough

### How to test?
The only way to truly test changes in this workflow is to try it out in your Metabase fork.
As the screenshot above reveals, I was able to produce two valid DockerHub images:
- https://hub.docker.com/layers/nemanjaglumac/mb-staging/v1.33.77-c949a3e/images/sha256-4810d0b28a84593790f441cf62c81c93038315f7abf177174652f658c1d1d1dc
- https://hub.docker.com/layers/nemanjaglumac/mb-staging/v0.33.77-c949a3e/images/sha256-bd61f9c4b148a9b84f9009cc4b628ff215696c3d7c9b11c6069acf42206078cd

> **Warning**
> These are not the official Metabase releases! Do not use them!
> Both images rely on a random commit in a release 46 branch and are meant only for testing.