### PR TITLE
Make mantine colors compatible with v7

### DIFF
--- a/frontend/src/metabase/ui/components/buttons/Button/Button.styled.tsx
+++ b/frontend/src/metabase/ui/components/buttons/Button/Button.styled.tsx
@@ -50,29 +50,8 @@ export const getButtonOverrides = (): MantineThemeOverride["components"] => ({
           borderColor: theme.colors.border[0],
           backgroundColor: theme.white,
           "&:hover": {
-            color: theme.fn.primaryColor(),
+            color: theme.colors.brand[1],
             backgroundColor: theme.colors.bg[0],
-          },
-          "&:disabled": {
-            color: theme.colors.text[0],
-            borderColor: theme.colors.border[0],
-            backgroundColor: theme.colors.bg[0],
-          },
-          "&[data-loading]": {
-            [`& .${getStylesRef("leftIcon")}`]: {
-              color: theme.fn.primaryColor(),
-            },
-          },
-        },
-      }),
-      filled: theme => ({
-        root: {
-          color: theme.white,
-          borderColor: theme.fn.primaryColor(),
-          backgroundColor: theme.fn.primaryColor(),
-          "&:hover": {
-            borderColor: getHoverColor(theme),
-            backgroundColor: getHoverColor(theme),
           },
           "&:disabled": {
             color: theme.colors.text[0],
@@ -86,10 +65,31 @@ export const getButtonOverrides = (): MantineThemeOverride["components"] => ({
           },
         },
       }),
+      filled: theme => ({
+        root: {
+          color: theme.white,
+          borderColor: theme.colors.brand[1],
+          backgroundColor: theme.colors.brand[1],
+          "&:hover": {
+            borderColor: getHoverColor(theme),
+            backgroundColor: getHoverColor(theme),
+          },
+          "&:disabled": {
+            color: theme.colors.text[0],
+            borderColor: theme.colors.border[0],
+            backgroundColor: theme.colors.bg[0],
+          },
+          "&[data-loading]": {
+            [`& .${getStylesRef("leftIcon")}`]: {
+              color: theme.colors.focus[0],
+            },
+          },
+        },
+      }),
       outline: theme => ({
         root: {
-          color: theme.fn.primaryColor(),
-          borderColor: theme.fn.primaryColor(),
+          color: theme.colors.brand[1],
+          borderColor: theme.colors.brand[1],
           "&:hover": {
             color: getHoverColor(theme),
             borderColor: getHoverColor(theme),
@@ -104,7 +104,7 @@ export const getButtonOverrides = (): MantineThemeOverride["components"] => ({
       }),
       subtle: theme => ({
         root: {
-          color: theme.fn.primaryColor(),
+          color: theme.colors.brand[1],
           "&:hover": {
             color: getHoverColor(theme),
             backgroundColor: "transparent",
@@ -121,5 +121,5 @@ export const getButtonOverrides = (): MantineThemeOverride["components"] => ({
 });
 
 const getHoverColor = (theme: MantineTheme) => {
-  return theme.fn.rgba(theme.fn.primaryColor(), 0.88);
+  return theme.fn.rgba(theme.colors.brand[1], 0.88);
 };

--- a/frontend/src/metabase/ui/components/data-display/Accordion/Accordion.styled.tsx
+++ b/frontend/src/metabase/ui/components/data-display/Accordion/Accordion.styled.tsx
@@ -12,7 +12,7 @@ export const getAccordionOverrides =
             },
           },
           label: {
-            color: theme.fn.primaryColor(),
+            color: theme.colors.brand[1],
             fontWeight: 700,
           },
           item: {

--- a/frontend/src/metabase/ui/components/inputs/Checkbox/Checkbox.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Checkbox/Checkbox.styled.tsx
@@ -22,7 +22,7 @@ export const getCheckboxOverrides = (): MantineThemeOverride["components"] => ({
           borderRadius: theme.radius.xs,
 
           "&:focus": {
-            outline: `2px solid ${theme.fn.primaryColor()}`,
+            outline: `2px solid ${theme.colors.brand[1]}`,
           },
           "&:disabled": {
             background: theme.colors.border[0],
@@ -33,8 +33,8 @@ export const getCheckboxOverrides = (): MantineThemeOverride["components"] => ({
           },
           cursor: "pointer",
           ...(params.indeterminate && {
-            background: theme.fn.primaryColor(),
-            border: `1px solid ${theme.fn.primaryColor()}`,
+            background: theme.colors.brand[1],
+            border: `1px solid ${theme.colors.brand[1]}`,
           }),
           transform: `scale(0.75)`,
         },

--- a/frontend/src/metabase/ui/components/overlays/Menu/Menu.styled.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Menu/Menu.styled.tsx
@@ -21,11 +21,11 @@ export const getMenuOverrides = (): MantineThemeOverride["components"] => ({
         padding: theme.spacing.md,
 
         "&:hover, &:focus": {
-          color: theme.fn.primaryColor(),
+          color: theme.colors.brand[1],
           backgroundColor: theme.colors.bg[0],
 
           [`& .${getStylesRef("itemRightSection")}`]: {
-            color: theme.fn.primaryColor(),
+            color: theme.colors.brand[1],
           },
         },
       },

--- a/frontend/src/metabase/ui/components/typography/Anchor/Anchor.styled.tsx
+++ b/frontend/src/metabase/ui/components/typography/Anchor/Anchor.styled.tsx
@@ -6,7 +6,7 @@ export const getAnchorOverrides = (): MantineThemeOverride["components"] => ({
       return {
         root: {
           fontFamily: "inherit",
-          color: theme.fn.primaryColor(),
+          color: theme.colors.brand[1],
           "&:focus": {
             outline: `2px solid ${theme.colors.brand[0]}`,
             outlineOffset: "2px",

--- a/frontend/src/metabase/ui/theme.ts
+++ b/frontend/src/metabase/ui/theme.ts
@@ -14,8 +14,9 @@ import {
 
 export const getThemeOverrides = (): MantineThemeOverride => ({
   colors: {
-    brand: [color("brand-lighter"), color("focus"), color("brand")],
+    brand: [color("brand-lighter"), color("brand")],
     text: [color("text-light"), color("text-medium"), color("text-dark")],
+    focus: [color("focus")],
     border: [color("border")],
     bg: [color("bg-light"), color("bg-medium"), color("bg-dark")],
   },
@@ -68,7 +69,7 @@ export const getThemeOverrides = (): MantineThemeOverride => ({
   fontFamilyMonospace: "Monaco, monospace",
   focusRingStyles: {
     styles: theme => ({
-      outline: `0.125rem solid ${theme.colors.brand[1]}`,
+      outline: `0.125rem solid ${theme.colors.focus[0]}`,
       outlineOffset: "0.125rem",
     }),
   },

--- a/frontend/src/metabase/ui/theme.ts
+++ b/frontend/src/metabase/ui/theme.ts
@@ -1,4 +1,4 @@
-import type { MantineThemeOverride } from "@mantine/core";
+import type { MantineTheme, MantineThemeOverride } from "@mantine/core";
 import { rem } from "@mantine/core";
 import { color } from "metabase/lib/colors";
 import {
@@ -12,13 +12,30 @@ import {
   getTitleOverrides,
 } from "./components";
 
+type ThemeColors = MantineTheme["colors"]["brand"];
+
+const getThemeColors = (colors: string[]): ThemeColors => {
+  return Array.from(
+    { length: 10 },
+    (_, index) => colors[index] ?? "transparent",
+  ) as ThemeColors;
+};
+
 export const getThemeOverrides = (): MantineThemeOverride => ({
   colors: {
-    brand: [color("brand-lighter"), color("brand")],
-    text: [color("text-light"), color("text-medium"), color("text-dark")],
-    focus: [color("focus")],
-    border: [color("border")],
-    bg: [color("bg-light"), color("bg-medium"), color("bg-dark")],
+    brand: getThemeColors([color("brand-lighter"), color("brand")]),
+    text: getThemeColors([
+      color("text-light"),
+      color("text-medium"),
+      color("text-dark"),
+    ]),
+    focus: getThemeColors([color("focus")]),
+    border: getThemeColors([color("border")]),
+    bg: getThemeColors([
+      color("bg-light"),
+      color("bg-medium"),
+      color("bg-dark"),
+    ]),
   },
   primaryColor: "brand",
   primaryShade: 2,


### PR DESCRIPTION
Context: https://metaboat.slack.com/archives/C057WD5L0JG/p1692612437317219
[Mantine 7.0 changelog](https://v7.mantine.dev/changelog/7-0-0)

Changes:
- Always 10 theme colors per color name
- Move focus to its own name to avoid confusion with brand colors
- Remove `theme.fn.primaryColor()` since it was removed in v7

How to verify:
- `yarn storybook`
- Mantine components should look normal