### PR TITLE
Only log session cookie SameSite=None warning when connection is insecure

### DIFF
--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -139,7 +139,7 @@
   #_{:clj-kondo/ignore [:discouraged-var]}
   (let [same-site (str/lower-case (config-str :mb-session-cookie-samesite))]
     (when-not (#{"none", "lax", "strict"} same-site)
-      (throw (ex-info "Invalid value for MB_COOKIE_SAMESITE" {:mb-session-cookie-samesite same-site})))
+      (throw (ex-info "Invalid value for MB_SESSION_COOKIE_SAMESITE" {:mb-session-cookie-samesite same-site})))
     (keyword same-site)))
 
 (def ^Keyword mb-session-cookie-samesite

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -156,7 +156,7 @@
                         ;; max-session age-is in minutes; Max-Age= directive should be in seconds
                         (when (use-permanent-cookies? request)
                           {:max-age (* 60 (config/config-int :max-session-age))}))]
-    (when (and (= config/mb-session-cookie-samesite :none) (request.u/https? request))
+    (when (and (= config/mb-session-cookie-samesite :none) (not (request.u/https? request)))
       (log/warn
        (str (deferred-trs "Session cookie's SameSite is configured to \"None\", but site is served over an insecure connection. Some browsers will reject cookies under these conditions.")
             " "

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -52,7 +52,7 @@
            (with-redefs [env/env (assoc env/env :mb-session-cookie-samesite "NONE")]
              (#'config/mb-session-cookie-samesite*))))
 
-    (is (thrown-with-msg? ExceptionInfo #"Invalid value for MB_COOKIE_SAMESITE"
+    (is (thrown-with-msg? ExceptionInfo #"Invalid value for MB_SESSION_COOKIE_SAMESITE"
           (with-redefs [env/env (assoc env/env :mb-session-cookie-samesite "invalid value")]
             (#'config/mb-session-cookie-samesite*))))))
 

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -85,7 +85,7 @@
                      (get-in [:cookies "metabase.SESSION"])))))))))
 
 (deftest samesite-none-log-warning-test
-  (with-redefs [metabase.config/mb-session-cookie-samesite :none]
+  (with-redefs [config/mb-session-cookie-samesite :none]
     (let [session {:id   (random-uuid)
                    :type :normal}
           request-time (t/zoned-date-time "2022-07-06T02:00Z[UTC]")]


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/33385

`(not is-https?)` was changed to `(request.u/https? request)` incorrectly [here](https://github.com/metabase/metabase/pull/24744/files#diff-617d1714503834ee7e6001ce5af175143cfbc70475355184b1a0253f074c8502R155). 

This PR changes it back to `(not (request.u/https? request))`