### PR TITLE
Make sure QP can match MLv2-generated references that contain extra info like `:base-type` 

### DIFF
--- a/src/metabase/query_processor/util/add_alias_info.clj
+++ b/src/metabase/query_processor/util/add_alias_info.clj
@@ -105,7 +105,8 @@
     [:field id-or-name opts]
     ;; this doesn't use [[mbql.u/update-field-options]] because this gets called a lot and the overhead actually adds up
     ;; a bit
-    [:field id-or-name (remove-namespaced-options (dissoc opts :source-field))]
+    [:field id-or-name (remove-namespaced-options (cond-> (dissoc opts :source-field :effective-type)
+                                                    (integer? id-or-name) (dissoc :base-type)))]
 
     ;; for `:expression` and `:aggregation` references, remove the options map if they are empty.
     [:expression expression-name opts]

--- a/test/metabase/query_processor/util/add_alias_info_test.clj
+++ b/test/metabase/query_processor/util/add_alias_info_test.clj
@@ -739,3 +739,30 @@
                (#'add/field-alias-in-source-query
                 {:source-query source-query}
                 [:field "PRICE" {:base-type :type/Float}])))))))
+
+(deftest ^:parallel find-matching-field-ignore-MLv2-extra-type-info-in-field-opts-test
+  (testing "MLv2 refs can include extra info like `:base-type`; make sure we ignore that when finding matching refs (#33083)"
+    (let [source-query {:joins [{:alias        "Card_2"
+                                 :source-query {:breakout    [[:field 78 {:join-alias         "Products"
+                                                                          :temporal-unit      :month
+                                                                          ::add/source-table  "Products"
+                                                                          ::add/source-alias  "CREATED_AT"
+                                                                          ::add/desired-alias "Products__CREATED_AT"
+                                                                          ::add/position      0}]]
+                                                :aggregation [[:aggregation-options
+                                                               [:distinct [:field 76 {:join-alias        "Products"
+                                                                                      ::add/source-table "Products"
+                                                                                      ::add/source-alias "ID"}]]
+                                                               {:name               "count"
+                                                                ::add/source-alias  "count"
+                                                                ::add/position      1
+                                                                ::add/desired-alias "count"}]]}}]}
+          field-clause [:field 78 {:base-type :type/DateTime, :temporal-unit :month, :join-alias "Card_2"}]]
+      (is (=? [:field
+               78
+               {:join-alias         "Products"
+                :temporal-unit      :month
+                ::add/source-table  "Products"
+                ::add/source-alias  "CREATED_AT"
+                ::add/desired-alias "Products__CREATED_AT"}]
+              (#'add/matching-field-in-join-at-this-level source-query field-clause))))))


### PR DESCRIPTION
Fixes #33083

The issue was that MLv2 was generating join conditions that had `:field` integer ID refs that included `:base-type`, and the QP code didn't know how to match this up with `:field` refs that did not include `:base-type`. Updated the `add-alias-info` code to handle both situations.

This would have likely already been fixed if some of the MLv2-QP PRs had landed by now, especially #33221 plus #33070, since those rework `add-alias-info` to use the same logic from MLv2. But #33221 has been waiting on review for a week now. Also if #33068 had landed by now I could have marked these tests `^:parallel`, that PR has been waiting on review for 2 weeks.