### PR TITLE
PDF export doesn't wait for dashboard questions to finish loading

### DIFF
--- a/frontend/src/metabase/containers/UndoListing.jsx
+++ b/frontend/src/metabase/containers/UndoListing.jsx
@@ -51,6 +51,16 @@ UndoToast.propTypes = {
 };
 
 function UndoToast({ undo, onUndo, onDismiss }) {
+  const getIcon = () => {
+    if (undo.icon) {
+      if (typeof undo.icon === "string") {
+        return <CardIcon name={undo.icon} color="white" />;
+      } else {
+        return undo.icon;
+      }
+    }
+  };
+
   return (
     <Motion
       defaultStyle={{ opacity: 0, translateY: 100 }}
@@ -66,7 +76,7 @@ function UndoToast({ undo, onUndo, onDismiss }) {
         >
           <CardContent>
             <CardContentSide>
-              {undo.icon && <CardIcon name={undo.icon} color="white" />}
+              {getIcon()}
               {renderMessage(undo)}
             </CardContentSide>
             <CardContentSide>

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -102,6 +102,8 @@ class Dashboard extends Component {
     closeNavbar: PropTypes.func.isRequired,
     embedOptions: PropTypes.object,
     isAutoApplyFilters: PropTypes.bool,
+
+    onSaveAsPDF: PropTypes.func,
   };
 
   static defaultProps = {
@@ -360,6 +362,7 @@ class Dashboard extends Component {
                   addParameter={addParameter}
                   parametersWidget={parametersWidget}
                   onSharingClick={this.onSharingClick}
+                  onSaveAsPDF={this.props.onSaveAsPDF}
                 />
 
                 {shouldRenderParametersWidgetInEditMode && (

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -5,8 +5,6 @@ import PropTypes from "prop-types";
 import { t } from "ttag";
 import _ from "underscore";
 
-import { trackExportDashboardToPDF } from "metabase/dashboard/analytics";
-
 import { getIsNavbarOpen } from "metabase/redux/app";
 
 import ActionButton from "metabase/components/ActionButton";
@@ -33,7 +31,6 @@ import {
 } from "metabase/dashboard/actions";
 
 import { hasDatabaseActionsEnabled } from "metabase/dashboard/utils";
-import { saveDashboardPdf } from "metabase/visualizations/lib/save-dashboard-pdf";
 import { getSetting } from "metabase/selectors/settings";
 
 import { DashboardHeaderComponent } from "../components/DashboardHeader";
@@ -133,6 +130,8 @@ class DashboardHeader extends Component {
     hideAddParameterPopover: PropTypes.func,
     addParameter: PropTypes.func,
     isHomepageDashboard: PropTypes.bool,
+
+    onSaveAsPDF: PropTypes.func,
   };
 
   handleEdit(dashboard) {
@@ -413,7 +412,7 @@ class DashboardHeader extends Component {
         icon: "document",
         testId: "dashboard-export-pdf-button",
         action: () => {
-          this.saveAsPDF();
+          this.props.onSaveAsPDF();
         },
       });
 
@@ -471,14 +470,6 @@ class DashboardHeader extends Component {
 
     return buttons;
   }
-
-  saveAsPDF = async () => {
-    const { dashboard } = this.props;
-    const cardNodeSelector = "#Dashboard-Cards-Container";
-    await saveDashboardPdf(cardNodeSelector, dashboard.name).then(() => {
-      trackExportDashboardToPDF(dashboard.id);
-    });
-  };
 
   render() {
     const {


### PR DESCRIPTION
Closes #33263 

### Description

Adds a "Loading" when the user clicks `Export to PDF` on a dashboard, prompting the user to wait for the dashboard to load before the PDF is downloaded.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Go to a complex dashboard that takes a while to load
2. Click on ... icon (Move, archive or more)
3. Click on 'Export as PDF'
4. The PDF should not have any loading spinners, just the graphs

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
