### PR TITLE
Add test to cannot use click behavior on boolean columns on MySQL

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.js
+++ b/e2e/support/helpers/e2e-dashboard-helpers.js
@@ -62,7 +62,7 @@ export function getDashboardCardMenu(index = 0) {
 }
 
 export function showDashboardCardActions(index = 0) {
-  getDashboardCard(index).realHover();
+  getDashboardCard(index).realHover({ scrollBehavior: "bottom" });
 }
 
 export function removeDashboardCard(index = 0) {

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -1,9 +1,15 @@
 import {
   addOrUpdateDashboardCard,
   restore,
+  resetTestTable,
+  resyncDatabase,
   visitDashboard,
+  editDashboard,
+  showDashboardCardActions,
+  sidebar,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, REVIEWS, REVIEWS_ID } =
   SAMPLE_DATABASE;
@@ -192,6 +198,51 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders");
   });
+
+  it(
+    "should allow settings click behavior on boolean fields (metabase#18067)",
+    { tags: "@external" },
+    () => {
+      const dialect = "mysql";
+      const TEST_TABLE = "many_data_types";
+      resetTestTable({ type: dialect, table: TEST_TABLE });
+      restore(`${dialect}-writable`);
+      cy.signInAsAdmin();
+      resyncDatabase({
+        dbId: WRITABLE_DB_ID,
+        tableName: TEST_TABLE,
+        tableAlias: "testTable",
+      });
+
+      cy.get("@testTable").then(testTable => {
+        const dashboardDetails = {
+          name: "18067 dashboard",
+        };
+        const questionDetails = {
+          name: "18067 question",
+          database: WRITABLE_DB_ID,
+          query: { "source-table": testTable.id },
+        };
+        cy.createQuestionAndDashboard({
+          dashboardDetails,
+          questionDetails,
+        }).then(({ body: { dashboard_id } }) => {
+          visitDashboard(dashboard_id);
+        });
+      });
+
+      editDashboard();
+
+      cy.log('Select "click behavior" option');
+      showDashboardCardActions();
+      cy.findByTestId("dashboardcard-actions-panel").icon("click").click();
+
+      sidebar().within(() => {
+        cy.findByText("Boolean").scrollIntoView().click();
+        cy.contains("Click behavior for Boolean").should("be.visible");
+      });
+    },
+  );
 });
 
 const getQuestionDetails = ({ display }) => ({

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "build",
     "baseUrl": "./",
-    "types": ["cypress", "@testing-library/cypress"],
+    "types": ["cypress", "@testing-library/cypress", "cypress-real-events"],
     "paths": {
       "*": ["../frontend/src/*"],
       "e2e/*": ["./*"]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/18067

### Description

Add a reproduction test for #18067. The issue has already been fixed, but I'm not sure when. I've tested that 46.8 doesn't exhibit this issue, but didn't test the earlier version.

### How to verify

> **Note**
> To run the test, please use `yarn test-cypress-open-qa` since it relies on an external database.

1. Follow the reproduce steps from https://github.com/metabase/metabase/issues/18067
2. Or run the included E2E test, since it uses a MySQL table that has boolean columns.

### Demo
![Screenshot 2023-08-22 at 5 31 19 PM](https://github.com/metabase/metabase/assets/1937582/5310b565-ef91-408a-b674-5d8bb203f60c)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

### Note

This is a slightly modified version of the test that I ran against 0.46.0 which still passed.


```ts
  it(
    "should allow settings click behavior on boolean fields (metabase#18067)",
    { tags: "@external" },
    () => {
      const dialect = "mysql";
      const TEST_TABLE = "many_data_types";
      resetTestTable({ type: dialect, table: TEST_TABLE });
      restore(`${dialect}-writable`);
      cy.signInAsAdmin();
      resyncDatabase({
        dbId: WRITABLE_DB_ID,
        tableName: TEST_TABLE,
        tableAlias: "testTable",
      });

      cy.get("@testTable").then(testTable => {
        const dashboardDetails = {
          name: "18067 dashboard",
        };
        const questionDetails = {
          name: "18067 question",
          database: WRITABLE_DB_ID,
          query: { "source-table": testTable.id },
        };
        cy.createQuestionAndDashboard({
          dashboardDetails,
          questionDetails,
        }).then(({ body: { dashboard_id } }) => {
          visitDashboard(dashboard_id);
        });
      });

      editDashboard();

      cy.log('Select "click behavior" option');
      showDashboardCardActions();
      cy.findByTestId("dashboardcard-actions-panel").within(() => {
        cy.icon("click").click();
      });

      sidebar().within(() => {
        cy.findByText("Boolean").scrollIntoView().click();
        cy.contains("Click behavior for Boolean").should("be.visible");
      });
    },
  )
```

For this test to work, you also need to modify extra database utils with the change [from this PR](https://github.com/metabase/metabase/pull/33254/files#diff-897015056ddc23d6fe214a66198339d65036113600a564194e4dab1e9e16e560) since that change isn't on 46 branch