### PR TITLE
Global search: last edited by, last edited at

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15211,11 +15211,7 @@ databaseChangeLog:
       preConditions:
           # If preconditions fail (i.e., dbms is not mysql or mariadb) then mark this migration as 'ran'
           - onFail: MARK_RAN
-          - or:
-              - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
+          - dbms: mysql,mariadb
       changes:
           - sql:
                 sql: ALTER TABLE `revision` CHANGE `timestamp` `timestamp` timestamp(6) NOT NULL DEFAULT current_timestamp(6);

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15159,6 +15159,37 @@ databaseChangeLog:
               column:
                 name: action_id
 
+  - changeSet:
+      id: v48.00-007
+      author: qnkhuat
+      comment: Added 0.48.0 - Add revision.most_recent
+      changes:
+        - addColumn:
+            tableName: revision
+            columns:
+              - column:
+                  name: most_recent
+                  type: boolean
+                  defaultValueBoolean: false
+                  remarks: 'Whether a revision is the most recent one'
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v48.00-008
+      author: qnkhuat
+      comment: Added 0.48.0 - Set revision.most_recent = true for latest revisions
+      changes:
+        - sql:
+            sql: >-
+              UPDATE revision r
+              SET most_recent = true
+              WHERE (model, model_id, timestamp) IN (
+                                 SELECT model, model_id, MAX(timestamp)
+                                 FROM revision
+                                 GROUP BY model, model_id);
+      rollback: # nothing to do since the most_recent will be dropped anyway
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15211,7 +15211,8 @@ databaseChangeLog:
       preConditions:
           # If preconditions fail (i.e., dbms is not mysql or mariadb) then mark this migration as 'ran'
           - onFail: MARK_RAN
-          - dbms: mysql,mariadb
+          - dbms:
+              type: mysql,mariadb
       changes:
           - sql:
                 sql: ALTER TABLE `revision` CHANGE `timestamp` `timestamp` timestamp(6) NOT NULL DEFAULT current_timestamp(6);

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15181,6 +15181,7 @@ databaseChangeLog:
       comment: Added 0.48.0 - Set revision.most_recent = true for latest revisions
       changes:
         - sql:
+            dbms: postgresql,h2
             sql: >-
               UPDATE revision r
               SET most_recent = true
@@ -15188,6 +15189,19 @@ databaseChangeLog:
                                  SELECT model, model_id, MAX(timestamp)
                                  FROM revision
                                  GROUP BY model, model_id);
+          # mysql and mariadb does not allow update on a table that is in the select part
+          # so it we join for them
+        - sql:
+            dbms: mysql,mariadb
+            sql: >-
+              UPDATE revision r
+              JOIN (
+                  SELECT model, model_id, MAX(timestamp) AS max_timestamp
+                  FROM revision
+                  GROUP BY model, model_id
+              ) AS subquery
+              ON r.model = subquery.model AND r.model_id = subquery.model_id AND r.timestamp = subquery.max_timestamp
+              SET r.most_recent = true;
       rollback: # nothing to do since the most_recent will be dropped anyway
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15178,7 +15178,7 @@ databaseChangeLog:
   - changeSet:
       id: v48.00-008
       author: qnkhuat
-      comment: Added 0.48.0 - Set revision.most_recent = true for latest revisions
+      comment: Set revision.most_recent = true for latest revisions
       changes:
         - sql:
             dbms: postgresql,h2
@@ -15219,6 +15219,19 @@ databaseChangeLog:
       changes:
           - sql:
                 sql: ALTER TABLE `revision` CHANGE `timestamp` `timestamp` timestamp(6) NOT NULL DEFAULT current_timestamp(6);
+      rollback: # no need
+
+  - changeSet:
+      id: v48.00-011
+      author: qnkhuat
+      comment: Index revision.most_recent
+      changes:
+        - createIndex:
+            tableName: revision
+            indexName: idx_revision_most_recent
+            columns:
+              column:
+                name: most_recent
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15204,6 +15204,22 @@ databaseChangeLog:
               SET r.most_recent = true;
       rollback: # nothing to do since the most_recent will be dropped anyway
 
+  - changeSet:
+      id: v48.00-010
+      author: qnkhuat
+      comment: Remove ON UPDATE for revision.timestamp on mysql, mariadb
+      preConditions:
+          # If preconditions fail (i.e., dbms is not mysql or mariadb) then mark this migration as 'ran'
+          - onFail: MARK_RAN
+          - or:
+              - dbms:
+                    type: mysql
+              - dbms:
+                    type: mariadb
+      changes:
+          - sql:
+                sql: ALTER TABLE `revision` CHANGE `timestamp` `timestamp` timestamp(6) NOT NULL DEFAULT current_timestamp(6);
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -412,6 +412,8 @@
   [{:keys [archived
            created-at
            created-by
+           last-edited-at
+           last-edited-by
            limit
            models
            offset
@@ -423,6 +425,8 @@
                                [:archived        {:optional true} [:maybe :boolean]]
                                [:created-at      {:optional true} [:maybe ms/NonBlankString]]
                                [:created-by      {:optional true} [:maybe ms/PositiveInt]]
+                               [:last-edited-at  {:optional true} [:maybe ms/NonBlankString]]
+                               [:last-edited-by  {:optional true} [:maybe ms/PositiveInt]]
                                [:limit           {:optional true} [:maybe ms/Int]]
                                [:offset          {:optional true} [:maybe ms/Int]]
                                [:table-db-id     {:optional true} [:maybe ms/PositiveInt]]
@@ -436,29 +440,35 @@
                         :current-user-perms @api/*current-user-permissions-set*
                         :archived?          (boolean archived)
                         :models             models}
-                 (some? created-at)  (assoc :created-at created-at)
-                 (some? created-by)  (assoc :created-by created-by)
-                 (some? table-db-id) (assoc :table-db-id table-db-id)
-                 (some? limit)       (assoc :limit-int limit)
-                 (some? offset)      (assoc :offset-int offset)
-                 (some? verified)    (assoc :verified verified))]
+                 (some? created-at)     (assoc :created-at created-at)
+                 (some? created-by)     (assoc :created-by created-by)
+                 (some? last-edited-at) (assoc :last-edited-at last-edited-at)
+                 (some? last-edited-by) (assoc :last-edited-by last-edited-by)
+                 (some? table-db-id)    (assoc :table-db-id table-db-id)
+                 (some? limit)          (assoc :limit-int limit)
+                 (some? offset)         (assoc :offset-int offset)
+                 (some? verified)       (assoc :verified verified))]
     (assoc ctx :models (search.filter/search-context->applicable-models ctx))))
 
 (api/defendpoint GET "/models"
   "Get the set of models that a search query will return"
-  [q archived table-db-id created_at created_by verified]
-  {archived    [:maybe ms/BooleanValue]
-   table-db-id [:maybe ms/PositiveInt]
-   created_at  [:maybe ms/NonBlankString]
-   created_by  [:maybe ms/PositiveInt]
-   verified    [:maybe true?]}
-  (query-model-set (search-context {:search-string q
-                                    :archived      archived
-                                    :table-db-id   table-db-id
-                                    :created-at    created_at
-                                    :created-by    created_by
-                                    :verified      verified
-                                    :models        search.config/all-models})))
+  [q archived table-db-id created_at created_by last_edited_at last_edited_by verified]
+  {archived       [:maybe ms/BooleanValue]
+   table-db-id    [:maybe ms/PositiveInt]
+   created_at     [:maybe ms/NonBlankString]
+   created_by     [:maybe ms/PositiveInt]
+   last_edited_at [:maybe ms/PositiveInt]
+   last_edited_by [:maybe ms/PositiveInt]
+   verified       [:maybe true?]}
+  (query-model-set (search-context {:search-string  q
+                                    :archived       archived
+                                    :table-db-id    table-db-id
+                                    :created-at     created_at
+                                    :created-by     created_by
+                                    :last-edited-at last_edited_at
+                                    :last-edited-by last_edited_by
+                                    :verified       verified
+                                    :models         search.config/all-models})))
 
 (api/defendpoint GET "/"
   "Search within a bunch of models for the substring `q`.
@@ -469,14 +479,16 @@
   to `table_db_id`.
   To specify a list of models, pass in an array to `models`.
   "
-  [q archived created_at created_by table_db_id models verified]
-  {q           [:maybe ms/NonBlankString]
-   archived    [:maybe :boolean]
-   table_db_id [:maybe ms/PositiveInt]
-   models      [:maybe [:or SearchableModel [:sequential SearchableModel]]]
-   created_at  [:maybe ms/NonBlankString]
-   created_by  [:maybe ms/PositiveInt]
-   verified    [:maybe true?]}
+  [q archived created_at created_by table_db_id models last_edited_at last_edited_by verified]
+  {q              [:maybe ms/NonBlankString]
+   archived       [:maybe :boolean]
+   table_db_id    [:maybe ms/PositiveInt]
+   models         [:maybe [:or SearchableModel [:sequential SearchableModel]]]
+   created_at     [:maybe ms/NonBlankString]
+   created_by     [:maybe ms/PositiveInt]
+   last_edited_at [:maybe ms/NonBlankString]
+   last_edited_by [:maybe ms/PositiveInt]
+   verified       [:maybe true?]}
   (api/check-valid-page-params mw.offset-paging/*limit* mw.offset-paging/*offset*)
   (let [start-time (System/currentTimeMillis)
         models-set (cond
@@ -484,15 +496,17 @@
                     (string? models) #{models}
                     :else            (set models))
         results    (search (search-context
-                            {:search-string q
-                             :archived      archived
-                             :created-at    created_at
-                             :created-by    created_by
-                             :table-db-id   table_db_id
-                             :models        models-set
-                             :limit         mw.offset-paging/*limit*
-                             :offset        mw.offset-paging/*offset*
-                             :verified      verified}))
+                            {:search-string  q
+                             :archived       archived
+                             :created-at     created_at
+                             :created-by     created_by
+                             :last-edited-at last_edited_at
+                             :last-edited-by last_edited_by
+                             :table-db-id    table_db_id
+                             :models         models-set
+                             :limit          mw.offset-paging/*limit*
+                             :offset         mw.offset-paging/*offset*
+                             :verified       verified}))
         duration   (- (System/currentTimeMillis) start-time)]
     ;; Only track global searches
     (when (and (nil? models)

--- a/src/metabase/models/metric.clj
+++ b/src/metabase/models/metric.clj
@@ -49,6 +49,10 @@
       (when (not= (:creator_id <>) (t2/select-one-fn :creator_id Metric :id id))
         (throw (UnsupportedOperationException. (tru "You cannot update the creator_id of a Metric.")))))))
 
+(t2/define-before-delete :model/Metric
+  [{:keys [id] :as _metric}]
+  (t2/delete! :model/Revision :model "Metric" :model_id id))
+
 (defmethod mi/perms-objects-set Metric
   [metric read-or-write]
   (let [table (or (:table metric)

--- a/src/metabase/models/revision.clj
+++ b/src/metabase/models/revision.clj
@@ -104,14 +104,15 @@
 
 (t2/define-after-insert :model/Revision
   [revision]
-  (let [{:keys [id model model_id]} revision]
-    ;; Note 1: Update the last `most_recent revision` to false (not including the current revision)
-    ;; Note 2: We don't allow updating revision but this is a special case, so we by pass the check by
-    ;; updating directly with the table name
-    (t2/update! (t2/table-name :model/Revision)
-                {:model model :model_id model_id :most_recent true :id [:not= id]}
-                {:most_recent false})
-    (delete-old-revisions! model model_id)))
+  (u/prog1 revision
+    (let [{:keys [id model model_id]} revision]
+      ;; Note 1: Update the last `most_recent revision` to false (not including the current revision)
+      ;; Note 2: We don't allow updating revision but this is a special case, so we by pass the check by
+      ;; updating directly with the table name
+      (t2/update! (t2/table-name :model/Revision)
+                  {:model model :model_id model_id :most_recent true :id [:not= id]}
+                  {:most_recent false})
+      (delete-old-revisions! model model_id))))
 
 ;;; # Functions
 

--- a/src/metabase/models/revision.clj
+++ b/src/metabase/models/revision.clj
@@ -73,7 +73,9 @@
 
 (t2/define-before-insert :model/Revision
   [revision]
-  (assoc revision :timestamp :%now))
+  (assoc revision
+         :timestamp :%now
+         :most_recent true))
 
 (t2/define-before-update :model/Revision
   [_revision]
@@ -89,6 +91,27 @@
   (let [model (u/ignore-exceptions (t2.model/resolve-model (symbol model)))]
     (cond-> revision
       model (update :object (partial mi/do-after-select model)))))
+
+(defn- delete-old-revisions!
+  "Delete old revisions of `model` with `id` when there are more than `max-revisions` in the DB."
+  [model id]
+  (when-let [old-revisions (seq (drop max-revisions (t2/select-fn-vec :id :model/Revision
+                                                                      :model    (name model)
+                                                                      :model_id id
+                                                                      {:order-by [[:timestamp :desc]
+                                                                                  [:id :desc]]})))]
+    (t2/delete! :model/Revision :id [:in old-revisions])))
+
+(t2/define-after-insert :model/Revision
+  [revision]
+  (let [{:keys [id model model_id]} revision]
+    ;; Note 1: Update the last `most_recent revision` to false (not including the current revision)
+    ;; Note 2: We don't allow updating revision but this is a special case, so we by pass the check by
+    ;; updating directly with the table name
+    (t2/update! (t2/table-name :model/Revision)
+                {:model model :model_id model_id :most_recent true :id [:not= id]}
+                {:most_recent false})
+    (delete-old-revisions! model model_id)))
 
 ;;; # Functions
 
@@ -143,17 +166,6 @@
         (recur (conj acc (add-revision-details model r1 r2))
                (conj more r2))))))
 
-(defn- delete-old-revisions!
-  "Delete old revisions of `model` with `id` when there are more than `max-revisions` in the DB."
-  [model id]
-  {:pre [(mdb.u/toucan-model? model) (integer? id)]}
-  (when-let [old-revisions (seq (drop max-revisions (map :id (t2/select [Revision :id]
-                                                               :model    (name model)
-                                                               :model_id id
-                                                               {:order-by [[:timestamp :desc]
-                                                                           [:id :desc]]}))))]
-    (t2/delete! Revision :id [:in old-revisions])))
-
 (defn push-revision!
   "Record a new Revision for `entity` with `id` if it's changed compared to the last revision.
   Returns `object` or `nil` if the object does not changed."
@@ -186,7 +198,6 @@
                  :is_creation  is-creation?
                  :is_reversion false
                  :message      message)
-     (delete-old-revisions! entity id)
      object)))
 
 (defn revert!

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -91,6 +91,8 @@
     [:models                              [:set SearchableModel]]
     [:created-at         {:optional true} ms/NonBlankString]
     [:created-by         {:optional true} ms/PositiveInt]
+    [:last-edited-at     {:optional true} ms/NonBlankString]
+    [:last-edited-by     {:optional true} ms/PositiveInt]
     [:table-db-id        {:optional true} ms/PositiveInt]
     [:limit-int          {:optional true} ms/Int]
     [:offset-int         {:optional true} ms/Int]

--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -172,13 +172,13 @@
 (doseq [model ["dashboard" "card" "dataset" "metric"]]
   (defmethod build-optional-filter-query [:last-edited-by model]
     [_filter model query last-edited-by]
-    #p (-> query
-           (sql.helpers/join :revision
-                             [:= :revision.model_id
-                              (search.config/column-with-model-alias model :id)])
-           (sql.helpers/where [:= :revision.most_recent true]
-                              [:= :revision.model (search-model->revision-model model)]
-                              [:= :revision.user_id last-edited-by])))
+    (-> query
+        (sql.helpers/join :revision
+                          [:= :revision.model_id
+                           (search.config/column-with-model-alias model :id)])
+        (sql.helpers/where [:= :revision.most_recent true]
+                           [:= :revision.model (search-model->revision-model model)]
+                           [:= :revision.user_id last-edited-by])))
 
   (defmethod build-optional-filter-query [:last-edited-at model]
     [_filter model query last-edited-at]

--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -182,13 +182,13 @@
 
   (defmethod build-optional-filter-query [:last-edited-at model]
     [_filter model query last-edited-at]
-    #p (-> query
-           (sql.helpers/join :revision
-                             [:= :revision.model_id
-                              (search.config/column-with-model-alias model :id)])
-           (sql.helpers/where [:= :revision.most_recent true]
-                              [:= :revision.model (search-model->revision-model model)]
-                              (date-range-filter-clause :revision.timestamp last-edited-at)))))
+    (-> query
+        (sql.helpers/join :revision
+                          [:= :revision.model_id
+                           (search.config/column-with-model-alias model :id)])
+        (sql.helpers/where [:= :revision.most_recent true]
+                           [:= :revision.model (search-model->revision-model model)]
+                           (date-range-filter-clause :revision.timestamp last-edited-at)))))
 
 (defn- feature->supported-models
   "Return A map of filter to its support models.

--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -178,17 +178,14 @@
                            (search.config/column-with-model-alias model :id)])
         (sql.helpers/where [:= :revision.most_recent true]
                            [:= :revision.model (search-model->revision-model model)]
-                           [:= :revision.user_id last-edited-by])))
+                           [:= :revision.user_id last-edited-by]))))
 
+(doseq [model ["action" "dashboard" "card" "dataset" "metric"]]
   (defmethod build-optional-filter-query [:last-edited-at model]
     [_filter model query last-edited-at]
-    (-> query
-        (sql.helpers/join :revision
-                          [:= :revision.model_id
-                           (search.config/column-with-model-alias model :id)])
-        (sql.helpers/where [:= :revision.most_recent true]
-                           [:= :revision.model (search-model->revision-model model)]
-                           (date-range-filter-clause :revision.timestamp last-edited-at)))))
+    (sql.helpers/where query (date-range-filter-clause
+                              (search.config/column-with-model-alias model :updated_at)
+                              last-edited-at))))
 
 (defn- feature->supported-models
   "Return A map of filter to its support models.

--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -283,7 +283,6 @@
       (some? last-edited-at)
       (#(build-optional-filter-query :last-edited-at model % last-edited-at))
 
-
       (int? last-edited-by)
       (#(build-optional-filter-query :last-edited-by model % last-edited-by))
 

--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -166,7 +166,7 @@
 (defn- joined-with-table?
   "Check if  the query have a join with `table`.
   Note: this does a very shallow check by only checking the join-clause is already the same.
-  For edge cases like same table but different alias, or different join keys, it assumes we can still make the join.
+  Using the same table with a different alias will return false.
 
     (-> (sql.helpers/select :*)
     (sql.helpers/from [:a])
@@ -187,7 +187,7 @@
   (defmethod build-optional-filter-query [:last-edited-by model]
     [_filter model query last-edited-by]
     (cond-> query
-      ;; both last-edited-by and last-edited at join with reivsion, so we should be careful not to join twice
+      ;; both last-edited-by and last-edited at join with revision, so we should be careful not to join twice
       (not (joined-with-table? query :join :revision))
       (-> (sql.helpers/join :revision [:= :revision.model_id (search.config/column-with-model-alias model :id)])
           (sql.helpers/where [:= :revision.most_recent true]
@@ -199,7 +199,7 @@
   (defmethod build-optional-filter-query [:last-edited-at model]
     [_filter model query last-edited-at]
     (cond-> query
-      ;; both last-edited-by and last-edited at join with reivsion, so we should be careful not to join twice
+      ;; both last-edited-by and last-edited at join with revision, so we should be careful not to join twice
       (not (joined-with-table? query :join :revision))
       (-> (sql.helpers/join :revision [:= :revision.model_id (search.config/column-with-model-alias model :id)])
           (sql.helpers/where [:= :revision.most_recent true]

--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -163,17 +163,18 @@
 
 ;; Last edited by filter
 
-(defn- joined-with-table? [query join-type table]
+(defn- joined-with-table?
   "Check if  the query have a join with `table`.
   Note: this does a very shallow check by only checking the join-clause is already the same.
   For edge cases like same table but different alias, or different join keys, it assumes we can still make the join.
 
-  (-> (sql.helpers/select :*)
-  (sql.helpers/from [:a])
-  (sql.helpers/join :b [:= :a.id :b.id])
-  (joined-with-table? :join :b))
+    (-> (sql.helpers/select :*)
+    (sql.helpers/from [:a])
+    (sql.helpers/join :b [:= :a.id :b.id])
+    (joined-with-table? :join :b))
 
-  ;; => true"
+    ;; => true"
+  [query join-type table]
   (->> (get query join-type) (partition 2) (map first) (some #(= % table)) boolean))
 
 (defn- search-model->revision-model

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -2112,29 +2112,29 @@
                                                              :card_id 123
                                                              :series  [8 9]}]}
                                   :message  "updated"}]]
-      (is (= [{:is_reversion          false
-               :is_creation           false
-               :message               "updated"
-               :user                  (-> (user-details (mt/fetch-user :crowberto))
+      (is (=? [{:is_reversion          false
+                :is_creation           false
+                :message               "updated"
+                :user                  (-> (user-details (mt/fetch-user :crowberto))
+                                           (dissoc :email :date_joined :last_login :is_superuser :is_qbnewb))
+                :diff                  {:before {:name        "b"
+                                                 :description nil
+                                                 :cards       [{:series nil, :size_y 4, :size_x 4}]}
+                                        :after  {:name        "c"
+                                                 :description "something"
+                                                 :cards       [{:series [8 9], :size_y 3, :size_x 5}]}}
+                :has_multiple_changes true
+                :description          "added a description and renamed it from \"b\" to \"c\", modified the cards and added some series to card 123."}
+               {:is_reversion         false
+                :is_creation          true
+                :message              nil
+                :user                 (-> (user-details (mt/fetch-user :rasta))
                                           (dissoc :email :date_joined :last_login :is_superuser :is_qbnewb))
-               :diff                  {:before {:name        "b"
-                                                :description nil
-                                                :cards       [{:series nil, :size_y 4, :size_x 4}]}
-                                       :after  {:name        "c"
-                                                :description "something"
-                                                :cards       [{:series [8 9], :size_y 3, :size_x 5}]}}
-               :has_multiple_changes true
-               :description          "added a description and renamed it from \"b\" to \"c\", modified the cards and added some series to card 123."}
-              {:is_reversion         false
-               :is_creation          true
-               :message              nil
-               :user                 (-> (user-details (mt/fetch-user :rasta))
-                                         (dissoc :email :date_joined :last_login :is_superuser :is_qbnewb))
-               :diff                 nil
-               :has_multiple_changes false
-               :description          "created this."}]
-             (doall (for [revision (mt/user-http-request :crowberto :get 200 (format "dashboard/%d/revisions" dashboard-id))]
-                      (dissoc revision :timestamp :id))))))))
+                :diff                 nil
+                :has_multiple_changes false
+                :description          "created this."}]
+              (doall (for [revision (mt/user-http-request :crowberto :get 200 (format "dashboard/%d/revisions" dashboard-id))]
+                       (dissoc revision :timestamp :id))))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -2162,20 +2162,7 @@
                                                              :description nil
                                                              :cards       []}
                                                   :message  "updated"}]]
-      (is (= {:is_reversion         true
-              :is_creation          false
-              :message              nil
-              :user                 (-> (user-details (mt/fetch-user :crowberto))
-                                        (dissoc :email :date_joined :last_login :is_superuser :is_qbnewb))
-              :diff                 {:before {:name "b"}
-                                     :after  {:name "a"}}
-              :has_multiple_changes false
-              :description          "reverted to an earlier version."}
-             (dissoc (mt/user-http-request :crowberto :post 200 (format "dashboard/%d/revert" dashboard-id)
-                                           {:revision_id revision-id})
-                     :id :timestamp)))
-
-      (is (= [{:is_reversion         true
+      (is (=? {:is_reversion         true
                :is_creation          false
                :message              nil
                :user                 (-> (user-details (mt/fetch-user :crowberto))
@@ -2184,25 +2171,38 @@
                                       :after  {:name "a"}}
                :has_multiple_changes false
                :description          "reverted to an earlier version."}
-              {:is_reversion         false
-               :is_creation          false
-               :message              "updated"
-               :user                 (-> (user-details (mt/fetch-user :crowberto))
-                                         (dissoc :email :date_joined :last_login :is_superuser :is_qbnewb))
-               :diff                 {:before {:name "a"}
-                                      :after  {:name "b"}}
-               :has_multiple_changes false
-               :description          "renamed this Dashboard from \"a\" to \"b\"."}
-              {:is_reversion         false
-               :is_creation          true
-               :message              nil
-               :user                 (-> (user-details (mt/fetch-user :rasta))
-                                         (dissoc :email :date_joined :last_login :is_superuser :is_qbnewb))
-               :diff                 nil
-               :has_multiple_changes false
-               :description          "created this."}]
-             (doall (for [revision (mt/user-http-request :crowberto :get 200 (format "dashboard/%d/revisions" dashboard-id))]
-                      (dissoc revision :timestamp :id))))))))
+              (dissoc (mt/user-http-request :crowberto :post 200 (format "dashboard/%d/revert" dashboard-id)
+                                            {:revision_id revision-id})
+                      :id :timestamp)))
+
+      (is (=? [{:is_reversion         true
+                :is_creation          false
+                :message              nil
+                :user                 (-> (user-details (mt/fetch-user :crowberto))
+                                          (dissoc :email :date_joined :last_login :is_superuser :is_qbnewb))
+                :diff                 {:before {:name "b"}
+                                       :after  {:name "a"}}
+                :has_multiple_changes false
+                :description          "reverted to an earlier version."}
+               {:is_reversion         false
+                :is_creation          false
+                :message              "updated"
+                :user                 (-> (user-details (mt/fetch-user :crowberto))
+                                          (dissoc :email :date_joined :last_login :is_superuser :is_qbnewb))
+                :diff                 {:before {:name "a"}
+                                       :after  {:name "b"}}
+                :has_multiple_changes false
+                :description          "renamed this Dashboard from \"a\" to \"b\"."}
+               {:is_reversion         false
+                :is_creation          true
+                :message              nil
+                :user                 (-> (user-details (mt/fetch-user :rasta))
+                                          (dissoc :email :date_joined :last_login :is_superuser :is_qbnewb))
+                :diff                 nil
+                :has_multiple_changes false
+                :description          "created this."}]
+              (doall (for [revision (mt/user-http-request :crowberto :get 200 (format "dashboard/%d/revisions" dashboard-id))]
+                       (dissoc revision :timestamp :id))))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/api/revision_test.clj
+++ b/test/metabase/api/revision_test.clj
@@ -72,7 +72,7 @@
 (deftest get-revision-for-entity-with-revision-exceeds-max-revision-test
   (t2.with-temp/with-temp [Card {:keys [id] :as card} {:name "A card"}]
     (create-card-revision! (:id card) true :rasta)
-    (doseq [i (range (+ revision/max-revisions 2))]
+    (doseq [i (range (inc revision/max-revisions))]
       (t2/update! :model/Card (:id card) {:name (format "New name %d" i)})
       (create-card-revision! (:id card) false :rasta))
 

--- a/test/metabase/api/revision_test.clj
+++ b/test/metabase/api/revision_test.clj
@@ -72,7 +72,7 @@
 (deftest get-revision-for-entity-with-revision-exceeds-max-revision-test
   (t2.with-temp/with-temp [Card {:keys [id] :as card} {:name "A card"}]
     (create-card-revision! (:id card) true :rasta)
-    (doseq [i (range (inc revision/max-revisions))]
+    (doseq [i (range (+ revision/max-revisions 2))]
       (t2/update! :model/Card (:id card) {:name (format "New name %d" i)})
       (create-card-revision! (:id card) false :rasta))
 

--- a/test/metabase/api/revision_test.clj
+++ b/test/metabase/api/revision_test.clj
@@ -60,14 +60,14 @@
   (testing "Loading a single revision works"
     (t2.with-temp/with-temp [Card {:keys [id] :as card}]
       (create-card-revision! (:id card) true :rasta)
-      (is (= [{:is_reversion         false
-               :is_creation          true
-               :message              nil
-               :user                 @rasta-revision-info
-               :diff                 nil
-               :has_multiple_changes false
-               :description          "created this."}]
-             (get-revisions :card id))))))
+      (is (=? [{:is_reversion         false
+                :is_creation          true
+                :message              nil
+                :user                 @rasta-revision-info
+                :diff                 nil
+                :has_multiple_changes false
+                :description          "created this."}]
+              (get-revisions :card id))))))
 
 (deftest get-revision-for-entity-with-revision-exceeds-max-revision-test
   (t2.with-temp/with-temp [Card {:keys [id] :as card} {:name "A card"}]
@@ -108,30 +108,30 @@
                   :message      "because i wanted to"
                   :is_creation  false
                   :is_reversion true)
-      (is (= [{:is_reversion         true
-               :is_creation          false
-               :message              "because i wanted to"
-               :user                 @rasta-revision-info
-               :diff                 {:before {:name "something else"}
-                                      :after  {:name name}}
-               :description          "reverted to an earlier version."
-               :has_multiple_changes false}
-              {:is_reversion         false
-               :is_creation          false
-               :message              nil
-               :user                 @rasta-revision-info
-               :diff                 {:before {:name name}
-                                      :after  {:name "something else"}}
-               :description          (format "renamed this Card from \"%s\" to \"something else\"." name)
-               :has_multiple_changes false}
-              {:is_reversion         false
-               :is_creation          true
-               :message              nil
-               :user                 @rasta-revision-info
-               :diff                 nil
-               :description          "created this."
-               :has_multiple_changes false}]
-             (get-revisions :card id))))))
+      (is (=? [{:is_reversion         true
+                :is_creation          false
+                :message              "because i wanted to"
+                :user                 @rasta-revision-info
+                :diff                 {:before {:name "something else"}
+                                       :after  {:name name}}
+                :description          "reverted to an earlier version."
+                :has_multiple_changes false}
+               {:is_reversion         false
+                :is_creation          false
+                :message              nil
+                :user                 @rasta-revision-info
+                :diff                 {:before {:name name}
+                                       :after  {:name "something else"}}
+                :description          (format "renamed this Card from \"%s\" to \"something else\"." name)
+                :has_multiple_changes false}
+               {:is_reversion         false
+                :is_creation          true
+                :message              nil
+                :user                 @rasta-revision-info
+                :diff                 nil
+                :description          "created this."
+                :has_multiple_changes false}]
+              (get-revisions :card id))))))
 
 ;;; # POST /revision/revert
 
@@ -176,44 +176,44 @@
                   (mt/user-http-request :rasta :post 200 "revision/revert" {:entity      :dashboard
                                                                             :id          id
                                                                             :revision_id previous-revision-id})))))
-      (is (= [{:is_reversion         true
-               :is_creation          false
-               :message              nil
-               :user                 @rasta-revision-info
-               :diff                 {:before {:cards nil}
-                                      :after  {:cards [(merge default-revision-card {:card_id card-id :dashboard_id id})]}}
-               :has_multiple_changes false
-               :description          "reverted to an earlier version."}
-              {:is_reversion         false
-               :is_creation          false
-               :message              nil
-               :user                 @rasta-revision-info
-               :diff                 {:before {:cards [(merge default-revision-card {:card_id card-id :dashboard_id id})]}
-                                      :after  {:cards nil}}
-               :has_multiple_changes false
-               :description          "removed a card."}
-              {:is_reversion         false
-               :is_creation          false
-               :message              nil
-               :user                 @rasta-revision-info
-               :diff                 {:before {:cards nil}
-                                      :after  {:cards [(merge default-revision-card {:card_id card-id :dashboard_id id})]}}
-               :has_multiple_changes false
-               :description          "added a card."}
-              {:is_reversion         false
-               :is_creation          true
-               :message              nil
-               :user                 @rasta-revision-info
-               :diff                 nil
-               :has_multiple_changes false
-               :description          "created this."}]
-             (->> (get-revisions :dashboard id)
-                  (mapv (fn [rev]
-                          (if-not (:diff rev)
-                            rev
-                            (if (get-in rev [:diff :before :cards])
-                              (update-in rev [:diff :before :cards] strip-ids)
-                              (update-in rev [:diff :after :cards] strip-ids)))))))))))
+      (is (=? [{:is_reversion         true
+                :is_creation          false
+                :message              nil
+                :user                 @rasta-revision-info
+                :diff                 {:before {:cards nil}
+                                       :after  {:cards [(merge default-revision-card {:card_id card-id :dashboard_id id})]}}
+                :has_multiple_changes false
+                :description          "reverted to an earlier version."}
+               {:is_reversion         false
+                :is_creation          false
+                :message              nil
+                :user                 @rasta-revision-info
+                :diff                 {:before {:cards [(merge default-revision-card {:card_id card-id :dashboard_id id})]}
+                                       :after  {:cards nil}}
+                :has_multiple_changes false
+                :description          "removed a card."}
+               {:is_reversion         false
+                :is_creation          false
+                :message              nil
+                :user                 @rasta-revision-info
+                :diff                 {:before {:cards nil}
+                                       :after  {:cards [(merge default-revision-card {:card_id card-id :dashboard_id id})]}}
+                :has_multiple_changes false
+                :description          "added a card."}
+               {:is_reversion         false
+                :is_creation          true
+                :message              nil
+                :user                 @rasta-revision-info
+                :diff                 nil
+                :has_multiple_changes false
+                :description          "created this."}]
+              (->> (get-revisions :dashboard id)
+                   (mapv (fn [rev]
+                           (if-not (:diff rev)
+                             rev
+                             (if (get-in rev [:diff :before :cards])
+                               (update-in rev [:diff :before :cards] strip-ids)
+                               (update-in rev [:diff :after :cards] strip-ids)))))))))))
 
 (deftest permission-check-on-revert-test
   (testing "Are permissions enforced by the revert action in the revision api?"

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -859,14 +859,14 @@
 (deftest filter-by-last-edited-by-test
   (let [search-term "last-edited-by"]
     (t2.with-temp/with-temp
-      [:model/Card       {rasta-card-id :id}   {:name (format "%s Rasta Card" search-term)}
-       :model/Card       {lucky-card-id :id}   {:name (format "%s Lucky Card" search-term)}
-       :model/Card       {rasta-model-id :id}  {:name (format "%s Rasta Model" search-term) :dataset true}
-       :model/Card       {lucky-model-id :id}  {:name (format "%s Lucky Model" search-term) :dataset true}
-       :model/Dashboard  {rasta-dash-id :id}   {:name (format "%s Rasta Dashboard" search-term)}
-       :model/Dashboard  {lucky-dash-id :id}   {:name (format "%s Lucky Dashboard" search-term)}
-       :model/Metric     {rasta-metric-id :id} {:name (format "%s Rasta Metric" search-term)}
-       :model/Metric     {lucky-metric-id :id} {:name (format "%s Lucky Metric" search-term)}]
+      [:model/Card       {rasta-card-id :id}   {:name search-term}
+       :model/Card       {lucky-card-id :id}   {:name search-term}
+       :model/Card       {rasta-model-id :id}  {:name search-term :dataset true}
+       :model/Card       {lucky-model-id :id}  {:name search-term :dataset true}
+       :model/Dashboard  {rasta-dash-id :id}   {:name search-term}
+       :model/Dashboard  {lucky-dash-id :id}   {:name search-term}
+       :model/Metric     {rasta-metric-id :id} {:name search-term}
+       :model/Metric     {lucky-metric-id :id} {:name search-term}]
       (let [rasta-user-id (mt/user->id :rasta)
             lucky-user-id (mt/user->id :lucky)]
         (doseq [[model id user-id] [[:model/Card rasta-card-id rasta-user-id] [:model/Card rasta-model-id rasta-user-id]
@@ -887,12 +887,12 @@
               (is (= #{"dashboard" "dataset" "metric" "card"} (set (:available_models resp)))))
 
             (testing "results contains only entities with the specified creator"
-              (is (= #{[rasta-metric-id "metric"    "last-edited-by Rasta Metric"]
-                       [rasta-card-id   "card"      "last-edited-by Rasta Card"]
-                       [rasta-model-id  "dataset"   "last-edited-by Rasta Model"]
-                       [rasta-dash-id   "dashboard" "last-edited-by Rasta Dashboard"]}
+              (is (= #{[rasta-metric-id "metric"]
+                       [rasta-card-id   "card"]
+                       [rasta-model-id  "dataset"]
+                       [rasta-dash-id   "dashboard"]}
                      (->> (:data resp)
-                          (map (juxt :id :model :name))
+                          (map (juxt :id :model))
                           set))))))
 
         (testing "error if last_edited_by is not an integer"
@@ -1004,7 +1004,7 @@
                      :available_models
                      set)))))
 
-      (testing "works with the last_edited_by filter  too"
+      (testing "works with the last_edited_by filter too"
         (doseq [[model id] [[:model/Card card-id] [:model/Card model-id]
                             [:model/Dashboard dash-id] [:model/Metric metric-id]]]
           (revision/push-revision!
@@ -1111,12 +1111,12 @@
          (test-search "today" new-result))))))
 
 (deftest last-edited-at-correctness-test
-  (let [search-term "last-edited-at-filtering"
-        new          #t "2023-05-04T10:00Z[UTC]"
+  (let [search-term   "last-edited-at-filtering"
+        new           #t "2023-05-04T10:00Z[UTC]"
         two-years-ago (t/minus new (t/years 2))]
     (mt/with-clock new
       (t2.with-temp/with-temp
-        [:model/Dashboard  {dashboard-new :id} {:name        search-term
+        [:model/Dashboard  {dashboard-new :id} {:name       search-term
                                                 :updated_at new}
          :model/Dashboard  {dashboard-old :id} {:name       search-term
                                                 :updated_at two-years-ago}

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -114,17 +114,17 @@
                                     :where  [:= :id card-id]})
                      :visualization_settings
                      json/parse-string))))
-        (testing "visualization_settings are equivalent before and after migration"
-          (is (= (-> visualization-settings
-                     mi/normalize-visualization-settings
-                     (#'mi/migrate-viz-settings))
-                 (-> (t2/query-one {:select [:visualization_settings]
-                                    :from   [:report_card]
-                                    :where  [:= :id card-id]})
-                     :visualization_settings
-                     json/parse-string
-                     mi/normalize-visualization-settings
-                     (#'mi/migrate-viz-settings)))))))))
+       (testing "visualization_settings are equivalent before and after migration"
+         (is (= (-> visualization-settings
+                    mi/normalize-visualization-settings
+                    (#'mi/migrate-viz-settings))
+                (-> (t2/query-one {:select [:visualization_settings]
+                                   :from   [:report_card]
+                                   :where  [:= :id card-id]})
+                    :visualization_settings
+                    json/parse-string
+                    mi/normalize-visualization-settings
+                    (#'mi/migrate-viz-settings)))))))))
 
 (deftest migrate-legacy-result-metadata-field-refs-test
   (testing "Migrations v47.00-027: update report_card.result_metadata legacy field refs"
@@ -244,14 +244,14 @@
                                     :where  [:= :id card-id]})
                      :visualization_settings
                      json/parse-string))))
-        (db.setup/migrate! db-type data-source :down 46)
-        (testing "After reversing the migration, column_settings field refs are updated to remove join-alias"
-          (is (= visualization-settings
-                 (-> (t2/query-one {:select [:visualization_settings]
-                                    :from   [:report_card]
-                                    :where  [:= :id card-id]})
-                     :visualization_settings
-                     json/parse-string))))))))
+       (db.setup/migrate! db-type data-source :down 46)
+       (testing "After reversing the migration, column_settings field refs are updated to remove join-alias"
+         (is (= visualization-settings
+                (-> (t2/query-one {:select [:visualization_settings]
+                                   :from   [:report_card]
+                                   :where  [:= :id card-id]})
+                    :visualization_settings
+                    json/parse-string))))))))
 
 (deftest downgrade-dashboard-tabs-test
   (testing "Migrations v47.00-029: downgrade dashboard tab test"
@@ -283,50 +283,50 @@
                           :visualization_settings {:virtual_card {:display "text"}
                                                    :text         "A text card"}}
             tab1-card1-id (first (t2/insert-returning-pks! :model/DashboardCard (merge
-                                                                                  default-card
-                                                                                  {:dashboard_tab_id tab1-id
-                                                                                   :row              0
-                                                                                   :col              0
-                                                                                   :size_x           4
-                                                                                   :size_y           4})))
+                                                                                 default-card
+                                                                                 {:dashboard_tab_id tab1-id
+                                                                                  :row              0
+                                                                                  :col              0
+                                                                                  :size_x           4
+                                                                                  :size_y           4})))
 
             tab1-card2-id (first (t2/insert-returning-pks! :model/DashboardCard (merge
-                                                                                  default-card
-                                                                                  {:dashboard_tab_id tab1-id
-                                                                                   :row              2
-                                                                                   :col              0
-                                                                                   :size_x           2
-                                                                                   :size_y           6})))
+                                                                                 default-card
+                                                                                 {:dashboard_tab_id tab1-id
+                                                                                  :row              2
+                                                                                  :col              0
+                                                                                  :size_x           2
+                                                                                  :size_y           6})))
 
             tab2-card1-id (first (t2/insert-returning-pks! :model/DashboardCard (merge
-                                                                                  default-card
-                                                                                  {:dashboard_tab_id tab2-id
-                                                                                   :row              0
-                                                                                   :col              0
-                                                                                   :size_x           4
-                                                                                   :size_y           4})))
+                                                                                 default-card
+                                                                                 {:dashboard_tab_id tab2-id
+                                                                                  :row              0
+                                                                                  :col              0
+                                                                                  :size_x           4
+                                                                                  :size_y           4})))
 
             tab2-card2-id (first (t2/insert-returning-pks! :model/DashboardCard (merge
-                                                                                  default-card
-                                                                                  {:dashboard_tab_id tab2-id
-                                                                                   :row              4
-                                                                                   :col              0
-                                                                                   :size_x           4
-                                                                                   :size_y           2})))
+                                                                                 default-card
+                                                                                 {:dashboard_tab_id tab2-id
+                                                                                  :row              4
+                                                                                  :col              0
+                                                                                  :size_x           4
+                                                                                  :size_y           2})))
             tab4-card1-id (first (t2/insert-returning-pks! :model/DashboardCard (merge
-                                                                                  default-card
-                                                                                  {:dashboard_tab_id tab4-id
-                                                                                   :row              0
-                                                                                   :col              0
-                                                                                   :size_x           4
-                                                                                   :size_y           4})))
+                                                                                 default-card
+                                                                                 {:dashboard_tab_id tab4-id
+                                                                                  :row              0
+                                                                                  :col              0
+                                                                                  :size_x           4
+                                                                                  :size_y           4})))
             tab4-card2-id (first (t2/insert-returning-pks! :model/DashboardCard (merge
-                                                                                  default-card
-                                                                                  {:dashboard_tab_id tab4-id
-                                                                                   :row              4
-                                                                                   :col              0
-                                                                                   :size_x           4
-                                                                                   :size_y           2})))]
+                                                                                 default-card
+                                                                                 {:dashboard_tab_id tab4-id
+                                                                                  :row              4
+                                                                                  :col              0
+                                                                                  :size_x           4
+                                                                                  :size_y           2})))]
        (migrate-down! 46)
        (is (= [;; tab 1
                {:id  tab1-card1-id
@@ -372,11 +372,12 @@
                         ;; it's to test an edge case to make sure downgrade from 24 -> 18 does not remove this card
                         {:row 36 :col 0  :size_x 17 :size_y 1}
                         {:row 36 :col 17 :size_x 1  :size_y 1}]
-          revision-id (first (t2/insert-returning-pks! 'Revision
-                                                        {:object   {:cards cards}
-                                                         :model    "Dashboard"
-                                                         :model_id 1
-                                                         :user_id  user-id}))]
+          revision-id (first (t2/insert-returning-pks! (t2/table-name :model/Revision)
+                                                       {:object    (json/generate-string {:cards cards})
+                                                        :model     "Dashboard"
+                                                        :model_id  1
+                                                        :user_id   user-id
+                                                        :timestamp :%now}))]
 
       (migrate!)
       (testing "forward migration migrate correclty"
@@ -394,9 +395,9 @@
                 {:row 36 :col 0  :size_x 23 :size_y 1}
                 {:row 36 :col 23 :size_x 1  :size_y 1}]
                (t2/select-one-fn (comp :cards :object) :model/Revision :id revision-id))))
-     (migrate-down! 46)
-     (testing "downgrade works correctly"
-      (is (= cards (t2/select-one-fn (comp :cards :object) :model/Revision :id revision-id)))))))
+      (migrate-down! 46)
+      (testing "downgrade works correctly"
+        (is (= cards (t2/select-one-fn (comp :cards :object) :model/Revision :id revision-id)))))))
 
 (deftest migrate-dashboard-revision-grid-from-18-to-24-handle-faliure-test
   (impl/test-migrations ["v47.00-032" "v47.00-033"] [migrate!]
@@ -413,11 +414,12 @@
                         {:id 3 :row nil :col nil :size_x nil :size_y nil}  ; contains nil fields
                         {:id 4 :row "x" :col "x" :size_x "x" :size_y "x"}  ; string values need to be skipped
                         {:id 5 :row 0 :col 0 :size_x 4 :size_y 4 :series [1 2 3]}]  ; include keys other than size
-          revision-id (first (t2/insert-returning-pks! 'Revision
-                                                       {:object   {:cards cards}
-                                                        :model    "Dashboard"
-                                                        :model_id 1
-                                                        :user_id  user-id}))]
+          revision-id (first (t2/insert-returning-pks! (t2/table-name :model/Revision)
+                                                       {:object    (json/generate-string {:cards cards})
+                                                        :model     "Dashboard"
+                                                        :model_id  1
+                                                        :user_id   user-id
+                                                        :timestamp :%now}))]
 
       (migrate!)
       (testing "forward migration migrate correclty and ignore failures"
@@ -475,20 +477,20 @@
               (if (> i num-rows)
                 acc
                 (recur
-                  (inc i)
-                  (+ row size-y)
-                  (concat acc
-                          (loop [col     0
-                                 acc-row []]
-                            (let [size-x  (inc (math/round (* 9 (math/random))))
-                                  new-col (+ col size-x)]
-                              ;; we want to ensure we have a card at the end of the row
-                              (if (>= new-col 18)
-                                (cons [col row (- 18 col) size-y] acc-row)
-                                ;; probability of skipping is 5%
-                                (if (> (math/random) 0.95)
-                                  (recur (+ col size-x) acc-row)
-                                  (recur (+ col size-x) (cons [col row size-x size-y] acc-row)))))))))))]
+                 (inc i)
+                 (+ row size-y)
+                 (concat acc
+                         (loop [col     0
+                                acc-row []]
+                           (let [size-x  (inc (math/round (* 9 (math/random))))
+                                 new-col (+ col size-x)]
+                             ;; we want to ensure we have a card at the end of the row
+                             (if (>= new-col 18)
+                               (cons [col row (- 18 col) size-y] acc-row)
+                               ;; probability of skipping is 5%
+                               (if (> (math/random) 0.95)
+                                 (recur (+ col size-x) acc-row)
+                                 (recur (+ col size-x) (cons [col row size-x size-y] acc-row)))))))))))]
       {:row    row
        :col    col
        :size_x size_x
@@ -539,10 +541,12 @@
                                                         :password    "superstrong"
                                                         :date_joined :%now})
             card        {:visualization_settings visualization-settings}
-            revision-id (t2/insert-returning-pks! Revision {:model    "Card"
-                                                            :model_id 1 ;; TODO: this could be a foreign key in the future
-                                                            :user_id  user-id
-                                                            :object   (json/generate-string card)})]
+            revision-id (t2/insert-returning-pks! (t2/table-name :model/Revision)
+                                                  {:model    "Card"
+                                                   :model_id 1 ;; TODO: this could be a foreign key in the future
+                                                   :user_id  user-id
+                                                   :object   (json/generate-string card)
+                                                   :timestamp :%now})]
         (migrate!)
         (testing "legacy column_settings are updated"
           (is (= expected
@@ -613,10 +617,12 @@
                                                         :email       "howard@aircraft.com"
                                                         :password    "superstrong"
                                                         :date_joined :%now})
-            revision-id (t2/insert-returning-pks! Revision {:model    "Card"
-                                                            :model_id 1 ;; TODO: this could be a foreign key in the future
-                                                            :user_id  user-id
-                                                            :object   (json/generate-string card)})]
+            revision-id (t2/insert-returning-pks! (t2/table-name Revision)
+                                                  {:model     "Card"
+                                                   :model_id  1 ;; TODO: this could be a foreign key in the future
+                                                   :user_id   user-id
+                                                   :object    (json/generate-string card)
+                                                   :timestamp :%now})]
         (migrate!)
         (testing "column_settings field refs are updated"
           (is (= expected
@@ -693,27 +699,27 @@
                                     :where  [:= :id dashcard-id]})
                      :visualization_settings
                      json/parse-string))))
-        (testing "legacy column_settings are updated to the current format"
-          (is (= (-> visualization-settings
-                     mi/normalize-visualization-settings
-                     (#'mi/migrate-viz-settings)
-                     walk/stringify-keys)
-                 (-> (t2/query-one {:select [:visualization_settings]
-                                    :from   [:report_dashboardcard]
-                                    :where  [:= :id dashcard-id]})
-                     :visualization_settings
-                     json/parse-string))))
-        (testing "visualization_settings are equivalent before and after migration"
-          (is (= (-> visualization-settings
-                     mi/normalize-visualization-settings
-                     (#'mi/migrate-viz-settings))
-                 (-> (t2/query-one {:select [:visualization_settings]
-                                    :from   [:report_dashboardcard]
-                                    :where  [:= :id dashcard-id]})
-                     :visualization_settings
-                     json/parse-string
-                     mi/normalize-visualization-settings
-                     (#'mi/migrate-viz-settings)))))))))
+       (testing "legacy column_settings are updated to the current format"
+         (is (= (-> visualization-settings
+                    mi/normalize-visualization-settings
+                    (#'mi/migrate-viz-settings)
+                    walk/stringify-keys)
+                (-> (t2/query-one {:select [:visualization_settings]
+                                   :from   [:report_dashboardcard]
+                                   :where  [:= :id dashcard-id]})
+                    :visualization_settings
+                    json/parse-string))))
+       (testing "visualization_settings are equivalent before and after migration"
+         (is (= (-> visualization-settings
+                    mi/normalize-visualization-settings
+                    (#'mi/migrate-viz-settings))
+                (-> (t2/query-one {:select [:visualization_settings]
+                                   :from   [:report_dashboardcard]
+                                   :where  [:= :id dashcard-id]})
+                    :visualization_settings
+                    json/parse-string
+                    mi/normalize-visualization-settings
+                    (#'mi/migrate-viz-settings)))))))))
 
 (deftest add-join-alias-to-dashboard-card-visualization-settings-field-refs-test
   (testing "Migrations v47.00-044: update report_dashboardcard.visualization_settings.column_settings legacy field refs"
@@ -775,22 +781,22 @@
                                                                          :size_y       4
                                                                          :col          1
                                                                          :row          1})]
-        (migrate!)
-        (testing "After the migration, column_settings field refs are updated to include join-alias"
-          (is (= expected
-                 (-> (t2/query-one {:select [:visualization_settings]
-                                    :from   [:report_dashboardcard]
-                                    :where  [:= :id dashcard-id]})
-                     :visualization_settings
-                     json/parse-string))))
-        (db.setup/migrate! db-type data-source :down 46)
-        (testing "After reversing the migration, column_settings field refs are updated to remove join-alias"
-          (is (= visualization-settings
-                 (-> (t2/query-one {:select [:visualization_settings]
-                                    :from   [:report_dashboardcard]
-                                    :where  [:= :id dashcard-id]})
-                     :visualization_settings
-                     json/parse-string))))))))
+       (migrate!)
+       (testing "After the migration, column_settings field refs are updated to include join-alias"
+         (is (= expected
+                (-> (t2/query-one {:select [:visualization_settings]
+                                   :from   [:report_dashboardcard]
+                                   :where  [:= :id dashcard-id]})
+                    :visualization_settings
+                    json/parse-string))))
+       (db.setup/migrate! db-type data-source :down 46)
+       (testing "After reversing the migration, column_settings field refs are updated to remove join-alias"
+         (is (= visualization-settings
+                (-> (t2/query-one {:select [:visualization_settings]
+                                   :from   [:report_dashboardcard]
+                                   :where  [:= :id dashcard-id]})
+                    :visualization_settings
+                    json/parse-string))))))))
 
 (deftest revision-migrate-legacy-dashboard-card-column-settings-field-refs-test
   (testing "Migrations v47.00-045: update dashboard cards' visualization_settings.column_settings legacy field refs"
@@ -817,10 +823,12 @@
                                                         :password    "superstrong"
                                                         :date_joined :%now})
             dashboard   {:cards [{:visualization_settings visualization-settings}]}
-            revision-id (t2/insert-returning-pks! :model/Revision {:model    "Dashboard"
-                                                                   :model_id 1
-                                                                   :user_id  user-id
-                                                                   :object   (json/generate-string dashboard)})]
+            revision-id (t2/insert-returning-pks! (t2/table-name :model/Revision)
+                                                  {:model     "Dashboard"
+                                                   :model_id  1
+                                                   :user_id   user-id
+                                                   :object    (json/generate-string dashboard)
+                                                   :timestamp :%now})]
         (migrate!)
         (testing "legacy column_settings are updated"
           (is (= expected
@@ -908,29 +916,31 @@
                                  :collection_id          nil})
             dashboard   {:cards [{:card_id                card-id
                                   :visualization_settings visualization-settings}]}
-            revision-id (t2/insert-returning-pks! :model/Revision {:model    "Dashboard"
-                                                                   :model_id 1
-                                                                   :user_id  user-id
-                                                                   :object   (json/generate-string dashboard)})]
-        (migrate!)
-        (testing "column_settings field refs are updated"
-          (is (= expected
-                 (-> (t2/query-one {:select [:object]
-                                    :from   [:revision]
-                                    :where  [:= :id revision-id]})
-                     :object
-                     json/parse-string
-                     (get-in ["cards" 0 "visualization_settings"])))))
-        (db.setup/migrate! db-type data-source :down 46)
-        (testing "down migration restores original visualization_settings, except it's okay if join-alias are missing"
-          (is (= (m/dissoc-in visualization-settings
-                              ["column_settings" (json/generate-string ["ref" ["field" 1 {"join-alias" "Joined table"}]])])
-                 (-> (t2/query-one {:select [:object]
-                                    :from   [:revision]
-                                    :where  [:= :id revision-id]})
-                     :object
-                     json/parse-string
-                     (get-in ["cards" 0 "visualization_settings"])))))))))
+            revision-id (t2/insert-returning-pks! (t2/table-name :model/Revision)
+                                                  {:model     "Dashboard"
+                                                   :model_id  1
+                                                   :user_id   user-id
+                                                   :object    (json/generate-string dashboard)
+                                                   :timestamp :%now})]
+       (migrate!)
+       (testing "column_settings field refs are updated"
+         (is (= expected
+                (-> (t2/query-one {:select [:object]
+                                   :from   [:revision]
+                                   :where  [:= :id revision-id]})
+                    :object
+                    json/parse-string
+                    (get-in ["cards" 0 "visualization_settings"])))))
+       (db.setup/migrate! db-type data-source :down 46)
+       (testing "down migration restores original visualization_settings, except it's okay if join-alias are missing"
+         (is (= (m/dissoc-in visualization-settings
+                             ["column_settings" (json/generate-string ["ref" ["field" 1 {"join-alias" "Joined table"}]])])
+                (-> (t2/query-one {:select [:object]
+                                   :from   [:revision]
+                                   :where  [:= :id revision-id]})
+                    :object
+                    json/parse-string
+                    (get-in ["cards" 0 "visualization_settings"])))))))))
 
 (deftest migrate-database-options-to-database-settings-test
   (let [do-test

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -114,17 +114,17 @@
                                     :where  [:= :id card-id]})
                      :visualization_settings
                      json/parse-string))))
-       (testing "visualization_settings are equivalent before and after migration"
-         (is (= (-> visualization-settings
-                    mi/normalize-visualization-settings
-                    (#'mi/migrate-viz-settings))
-                (-> (t2/query-one {:select [:visualization_settings]
-                                   :from   [:report_card]
-                                   :where  [:= :id card-id]})
-                    :visualization_settings
-                    json/parse-string
-                    mi/normalize-visualization-settings
-                    (#'mi/migrate-viz-settings)))))))))
+        (testing "visualization_settings are equivalent before and after migration"
+          (is (= (-> visualization-settings
+                     mi/normalize-visualization-settings
+                     (#'mi/migrate-viz-settings))
+                 (-> (t2/query-one {:select [:visualization_settings]
+                                    :from   [:report_card]
+                                    :where  [:= :id card-id]})
+                     :visualization_settings
+                     json/parse-string
+                     mi/normalize-visualization-settings
+                     (#'mi/migrate-viz-settings)))))))))
 
 (deftest migrate-legacy-result-metadata-field-refs-test
   (testing "Migrations v47.00-027: update report_card.result_metadata legacy field refs"
@@ -244,14 +244,14 @@
                                     :where  [:= :id card-id]})
                      :visualization_settings
                      json/parse-string))))
-       (db.setup/migrate! db-type data-source :down 46)
-       (testing "After reversing the migration, column_settings field refs are updated to remove join-alias"
-         (is (= visualization-settings
-                (-> (t2/query-one {:select [:visualization_settings]
-                                   :from   [:report_card]
-                                   :where  [:= :id card-id]})
-                    :visualization_settings
-                    json/parse-string))))))))
+        (db.setup/migrate! db-type data-source :down 46)
+        (testing "After reversing the migration, column_settings field refs are updated to remove join-alias"
+          (is (= visualization-settings
+                 (-> (t2/query-one {:select [:visualization_settings]
+                                    :from   [:report_card]
+                                    :where  [:= :id card-id]})
+                     :visualization_settings
+                     json/parse-string))))))))
 
 (deftest downgrade-dashboard-tabs-test
   (testing "Migrations v47.00-029: downgrade dashboard tab test"
@@ -283,50 +283,50 @@
                           :visualization_settings {:virtual_card {:display "text"}
                                                    :text         "A text card"}}
             tab1-card1-id (first (t2/insert-returning-pks! :model/DashboardCard (merge
-                                                                                 default-card
-                                                                                 {:dashboard_tab_id tab1-id
-                                                                                  :row              0
-                                                                                  :col              0
-                                                                                  :size_x           4
-                                                                                  :size_y           4})))
+                                                                                  default-card
+                                                                                  {:dashboard_tab_id tab1-id
+                                                                                   :row              0
+                                                                                   :col              0
+                                                                                   :size_x           4
+                                                                                   :size_y           4})))
 
             tab1-card2-id (first (t2/insert-returning-pks! :model/DashboardCard (merge
-                                                                                 default-card
-                                                                                 {:dashboard_tab_id tab1-id
-                                                                                  :row              2
-                                                                                  :col              0
-                                                                                  :size_x           2
-                                                                                  :size_y           6})))
+                                                                                  default-card
+                                                                                  {:dashboard_tab_id tab1-id
+                                                                                   :row              2
+                                                                                   :col              0
+                                                                                   :size_x           2
+                                                                                   :size_y           6})))
 
             tab2-card1-id (first (t2/insert-returning-pks! :model/DashboardCard (merge
-                                                                                 default-card
-                                                                                 {:dashboard_tab_id tab2-id
-                                                                                  :row              0
-                                                                                  :col              0
-                                                                                  :size_x           4
-                                                                                  :size_y           4})))
+                                                                                  default-card
+                                                                                  {:dashboard_tab_id tab2-id
+                                                                                   :row              0
+                                                                                   :col              0
+                                                                                   :size_x           4
+                                                                                   :size_y           4})))
 
             tab2-card2-id (first (t2/insert-returning-pks! :model/DashboardCard (merge
-                                                                                 default-card
-                                                                                 {:dashboard_tab_id tab2-id
-                                                                                  :row              4
-                                                                                  :col              0
-                                                                                  :size_x           4
-                                                                                  :size_y           2})))
+                                                                                  default-card
+                                                                                  {:dashboard_tab_id tab2-id
+                                                                                   :row              4
+                                                                                   :col              0
+                                                                                   :size_x           4
+                                                                                   :size_y           2})))
             tab4-card1-id (first (t2/insert-returning-pks! :model/DashboardCard (merge
-                                                                                 default-card
-                                                                                 {:dashboard_tab_id tab4-id
-                                                                                  :row              0
-                                                                                  :col              0
-                                                                                  :size_x           4
-                                                                                  :size_y           4})))
+                                                                                  default-card
+                                                                                  {:dashboard_tab_id tab4-id
+                                                                                   :row              0
+                                                                                   :col              0
+                                                                                   :size_x           4
+                                                                                   :size_y           4})))
             tab4-card2-id (first (t2/insert-returning-pks! :model/DashboardCard (merge
-                                                                                 default-card
-                                                                                 {:dashboard_tab_id tab4-id
-                                                                                  :row              4
-                                                                                  :col              0
-                                                                                  :size_x           4
-                                                                                  :size_y           2})))]
+                                                                                  default-card
+                                                                                  {:dashboard_tab_id tab4-id
+                                                                                   :row              4
+                                                                                   :col              0
+                                                                                   :size_x           4
+                                                                                   :size_y           2})))]
        (migrate-down! 46)
        (is (= [;; tab 1
                {:id  tab1-card1-id
@@ -477,20 +477,20 @@
               (if (> i num-rows)
                 acc
                 (recur
-                 (inc i)
-                 (+ row size-y)
-                 (concat acc
-                         (loop [col     0
-                                acc-row []]
-                           (let [size-x  (inc (math/round (* 9 (math/random))))
-                                 new-col (+ col size-x)]
-                             ;; we want to ensure we have a card at the end of the row
-                             (if (>= new-col 18)
-                               (cons [col row (- 18 col) size-y] acc-row)
-                               ;; probability of skipping is 5%
-                               (if (> (math/random) 0.95)
-                                 (recur (+ col size-x) acc-row)
-                                 (recur (+ col size-x) (cons [col row size-x size-y] acc-row)))))))))))]
+                  (inc i)
+                  (+ row size-y)
+                  (concat acc
+                          (loop [col     0
+                                 acc-row []]
+                            (let [size-x  (inc (math/round (* 9 (math/random))))
+                                  new-col (+ col size-x)]
+                              ;; we want to ensure we have a card at the end of the row
+                              (if (>= new-col 18)
+                                (cons [col row (- 18 col) size-y] acc-row)
+                                ;; probability of skipping is 5%
+                                (if (> (math/random) 0.95)
+                                  (recur (+ col size-x) acc-row)
+                                  (recur (+ col size-x) (cons [col row size-x size-y] acc-row)))))))))))]
       {:row    row
        :col    col
        :size_x size_x
@@ -699,27 +699,27 @@
                                     :where  [:= :id dashcard-id]})
                      :visualization_settings
                      json/parse-string))))
-       (testing "legacy column_settings are updated to the current format"
-         (is (= (-> visualization-settings
-                    mi/normalize-visualization-settings
-                    (#'mi/migrate-viz-settings)
-                    walk/stringify-keys)
-                (-> (t2/query-one {:select [:visualization_settings]
-                                   :from   [:report_dashboardcard]
-                                   :where  [:= :id dashcard-id]})
-                    :visualization_settings
-                    json/parse-string))))
-       (testing "visualization_settings are equivalent before and after migration"
-         (is (= (-> visualization-settings
-                    mi/normalize-visualization-settings
-                    (#'mi/migrate-viz-settings))
-                (-> (t2/query-one {:select [:visualization_settings]
-                                   :from   [:report_dashboardcard]
-                                   :where  [:= :id dashcard-id]})
-                    :visualization_settings
-                    json/parse-string
-                    mi/normalize-visualization-settings
-                    (#'mi/migrate-viz-settings)))))))))
+        (testing "legacy column_settings are updated to the current format"
+          (is (= (-> visualization-settings
+                     mi/normalize-visualization-settings
+                     (#'mi/migrate-viz-settings)
+                     walk/stringify-keys)
+                 (-> (t2/query-one {:select [:visualization_settings]
+                                    :from   [:report_dashboardcard]
+                                    :where  [:= :id dashcard-id]})
+                     :visualization_settings
+                     json/parse-string))))
+        (testing "visualization_settings are equivalent before and after migration"
+          (is (= (-> visualization-settings
+                     mi/normalize-visualization-settings
+                     (#'mi/migrate-viz-settings))
+                 (-> (t2/query-one {:select [:visualization_settings]
+                                    :from   [:report_dashboardcard]
+                                    :where  [:= :id dashcard-id]})
+                     :visualization_settings
+                     json/parse-string
+                     mi/normalize-visualization-settings
+                     (#'mi/migrate-viz-settings)))))))))
 
 (deftest add-join-alias-to-dashboard-card-visualization-settings-field-refs-test
   (testing "Migrations v47.00-044: update report_dashboardcard.visualization_settings.column_settings legacy field refs"

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -1120,48 +1120,48 @@
   (testing "Migrations v48.00-008-v48.00-009: add `revision.most_recent`"
     (impl/test-migrations ["v48.00-007" "v48.00-009"] [migrate!]
       (let [user-id          (:id (create-raw-user! (tu.random/random-email)))
-            rev-dash-1-first (first (t2/insert-returning-pks! (t2/table-name :model/Revision)
-                                                              {:model       "dashboard"
-                                                               :model_id    1
-                                                               :user_id     user-id
-                                                               :object      "{}"
-                                                               :is_creation true
-                                                               :timestamp   :%now}))
-            rev-dash-1-second (first (t2/insert-returning-pks! (t2/table-name :model/Revision)
-                                                               {:model       "dashboard"
-                                                                :model_id    1
-                                                                :user_id     user-id
-                                                                :object      "{}"
-                                                                :timestamp   :%now}))
-            rev-dash-2-first (first (t2/insert-returning-pks! (t2/table-name :model/Revision)
-                                                              {:model       "dashboard"
-                                                               :model_id    2
-                                                               :user_id     user-id
-                                                               :object      "{}"
-                                                               :is_creation true
-                                                               :timestamp   :%now}))
-            rev-dash-2-second (first (t2/insert-returning-pks! (t2/table-name :model/Revision)
-                                                               {:model       "dashboard"
-                                                                :model_id    2
-                                                                :user_id     user-id
-                                                                :object      "{}"
-                                                                :timestamp   :%now}))
-
-            rev-card-1-first (first (t2/insert-returning-pks! (t2/table-name :model/Revision)
-                                                              {:model       "card"
-                                                               :model_id    1
-                                                               :user_id     user-id
-                                                               :object      "{}"
-                                                               :is_creation true
-                                                               :timestamp   :%now}))
-            rev-card-1-second (first (t2/insert-returning-pks! (t2/table-name :model/Revision)
-                                                               {:model       "card"
-                                                                :model_id    1
-                                                                :user_id     user-id
-                                                                :object      "{}"
-                                                                :timestamp   :%now}))]
+            old              (t/minus (t/local-date-time) (t/hours 1))
+            rev-dash-1-old (first (t2/insert-returning-pks! (t2/table-name :model/Revision)
+                                                            {:model       "dashboard"
+                                                             :model_id    1
+                                                             :user_id     user-id
+                                                             :object      "{}"
+                                                             :is_creation true
+                                                             :timestamp   old}))
+            rev-dash-1-new (first (t2/insert-returning-pks! (t2/table-name :model/Revision)
+                                                            {:model       "dashboard"
+                                                             :model_id    1
+                                                             :user_id     user-id
+                                                             :object      "{}"
+                                                             :timestamp   :%now}))
+            rev-dash-2-old (first (t2/insert-returning-pks! (t2/table-name :model/Revision)
+                                                            {:model       "dashboard"
+                                                             :model_id    2
+                                                             :user_id     user-id
+                                                             :object      "{}"
+                                                             :is_creation true
+                                                             :timestamp   old}))
+            rev-dash-2-new (first (t2/insert-returning-pks! (t2/table-name :model/Revision)
+                                                            {:model       "dashboard"
+                                                             :model_id    2
+                                                             :user_id     user-id
+                                                             :object      "{}"
+                                                             :timestamp   :%now}))
+            rev-card-1-old (first (t2/insert-returning-pks! (t2/table-name :model/Revision)
+                                                            {:model       "card"
+                                                             :model_id    1
+                                                             :user_id     user-id
+                                                             :object      "{}"
+                                                             :is_creation true
+                                                             :timestamp   old}))
+            rev-card-1-new (first (t2/insert-returning-pks! (t2/table-name :model/Revision)
+                                                            {:model       "card"
+                                                             :model_id    1
+                                                             :user_id     user-id
+                                                             :object      "{}"
+                                                             :timestamp   :%now}))]
         (migrate!)
         (is (= #{false} (t2/select-fn-set :most_recent (t2/table-name :model/Revision)
-                                          :id [:in [rev-dash-1-first rev-dash-2-first rev-card-1-first]])))
+                                          :id [:in [rev-dash-1-old rev-dash-2-old rev-card-1-old]])))
         (is (= #{true} (t2/select-fn-set :most_recent (t2/table-name :model/Revision)
-                                         :id [:in [rev-dash-1-second rev-dash-2-second rev-card-1-second]])))))))
+                                         :id [:in [rev-dash-1-new rev-dash-2-new rev-card-1-new]])))))))

--- a/test/metabase/models/revision_test.clj
+++ b/test/metabase/models/revision_test.clj
@@ -48,11 +48,11 @@
 
 (defn- push-fake-revision! [card-id & {:keys [message] :as object}]
   (revision/push-revision!
-    :entity   :model/FakedCard
-    :id       card-id
-    :user-id  (mt/user->id :rasta)
-    :object   (dissoc object :message)
-    :message  message))
+   :entity   :model/FakedCard
+   :id       card-id
+   :user-id  (mt/user->id :rasta)
+   :object   (dissoc object :message)
+   :message  message))
 
 (deftest ^:parallel post-select-test
   (testing (str "make sure we call the appropriate post-select methods on `:object` when a revision comes out of the "
@@ -107,232 +107,258 @@
              (revision/revisions :model/FakedCard card-id))))))
 
 (deftest add-revision-test
-  (testing "Test that we can add a revision"
-    (t2.with-temp/with-temp [Card {card-id :id}]
-      (push-fake-revision! card-id, :name "Tips Created by Day", :message "yay!")
-      (is (= [(mi/instance
-               Revision
-               {:model        "FakedCard"
-                :user_id      (mt/user->id :rasta)
-                :object       (mi/instance :model/FakedCard {:name "Tips Created by Day", :serialized true})
-                :is_reversion false
-                :is_creation  false
-                :message      "yay!"})]
-             (for [revision (revision/revisions :model/FakedCard card-id)]
-               (dissoc revision :timestamp :id :model_id)))))))
+  (mt/with-model-cleanup [:model/Revision]
+    (testing "Test that we can add a revision"
+      (t2.with-temp/with-temp [Card {card-id :id}]
+        (push-fake-revision! card-id, :name "Tips Created by Day", :message "yay!")
+        (is (=? [(mi/instance
+                  Revision
+                  {:model        "FakedCard"
+                   :user_id      (mt/user->id :rasta)
+                   :object       (mi/instance :model/FakedCard {:name "Tips Created by Day", :serialized true})
+                   :is_reversion false
+                   :is_creation  false
+                   :message      "yay!"})]
+                (for [revision (revision/revisions :model/FakedCard card-id)]
+                  (dissoc revision :timestamp :id :model_id))))))
+
+    (testing "test that most_recent is correct"
+      (t2.with-temp/with-temp [Card {card-id :id}]
+        (doseq [i (range 3)]
+          (push-fake-revision! card-id :name (format "%d Tips Created by Day" i) :message "yay!"))
+        (is (=? [{:model       "FakedCard"
+                  :model_id    card-id
+                  :most_recent true}
+                 {:model       "FakedCard"
+                  :model_id    card-id
+                  :most_recent false}
+                 {:model       "FakedCard"
+                  :model_id    card-id
+                  :most_recent false}]
+                (t2/select :model/Revision :model "FakedCard" :model_id card-id {:order-by [[:timestamp :desc]]})))))))
 
 (deftest sorting-test
   (testing "Test that revisions are sorted in reverse chronological order"
-    (t2.with-temp/with-temp [Card {card-id :id}]
-      (push-fake-revision! card-id, :name "Tips Created by Day")
-      (push-fake-revision! card-id, :name "Spots Created by Day")
-      (is (= [(mi/instance
-               Revision
-               {:model        "FakedCard"
-                :user_id      (mt/user->id :rasta)
-                :object       (mi/instance :model/FakedCard {:name "Spots Created by Day", :serialized true})
-                :is_reversion false
-                :is_creation  false
-                :message      nil})
-              (mi/instance
-               Revision
-               {:model        "FakedCard"
-                :user_id      (mt/user->id :rasta)
-                :object       (mi/instance :model/FakedCard {:name "Tips Created by Day", :serialized true})
-                :is_reversion false
-                :is_creation  false
-                :message      nil})]
-             (->> (revision/revisions :model/FakedCard card-id)
-                  (map #(dissoc % :timestamp :id :model_id))))))))
+    (mt/with-model-cleanup [:model/Revision]
+      (t2.with-temp/with-temp [Card {card-id :id}]
+        (push-fake-revision! card-id, :name "Tips Created by Day")
+        (push-fake-revision! card-id, :name "Spots Created by Day")
+        (is (=? [(mi/instance
+                  Revision
+                  {:model        "FakedCard"
+                   :user_id      (mt/user->id :rasta)
+                   :object       (mi/instance :model/FakedCard {:name "Spots Created by Day", :serialized true})
+                   :is_reversion false
+                   :is_creation  false
+                   :message      nil})
+                 (mi/instance
+                  Revision
+                  {:model        "FakedCard"
+                   :user_id      (mt/user->id :rasta)
+                   :object       (mi/instance :model/FakedCard {:name "Tips Created by Day", :serialized true})
+                   :is_reversion false
+                   :is_creation  false
+                   :message      nil})]
+                (->> (revision/revisions :model/FakedCard card-id)
+                     (map #(dissoc % :timestamp :id :model_id)))))))))
 
 (deftest delete-old-revisions-test
   (testing "Check that old revisions get deleted"
-    (t2.with-temp/with-temp [Card {card-id :id}]
-      ;; e.g. if max-revisions is 15 then insert 16 revisions
-      (dorun (doseq [i (range (inc revision/max-revisions))]
-               (push-fake-revision! card-id, :name (format "Tips Created by Day %d" i))))
-      (is (= revision/max-revisions
-             (count (revision/revisions :model/FakedCard card-id)))))))
+    (mt/with-model-cleanup [:model/Revision]
+      (t2.with-temp/with-temp [Card {card-id :id}]
+        ;; e.g. if max-revisions is 15 then insert 16 revisions
+        (dorun (doseq [i (range (inc revision/max-revisions))]
+                 (push-fake-revision! card-id, :name (format "Tips Created by Day %d" i))))
+        (is (= revision/max-revisions
+               (count (revision/revisions :model/FakedCard card-id))))))))
 
 (deftest do-not-record-if-object-is-not-changed-test
-  (testing "Check that we don't record a revision if the object hasn't changed"
-    (t2.with-temp/with-temp [Card {card-id :id}]
-      (let [new-revision (fn [x]
-                           (push-fake-revision! card-id, :name (format "Tips Created by Day %s" x)))]
-        (testing "first revision should be recorded"
-          (new-revision 1)
-          (is (= 1 (count (revision/revisions :model/FakedCard card-id)))))
+  (mt/with-model-cleanup [:model/Revision]
+    (testing "Check that we don't record a revision if the object hasn't changed"
+      (mt/with-model-cleanup [:model/Revision]
+        (t2.with-temp/with-temp [Card {card-id :id}]
+          (let [new-revision (fn [x]
+                               (push-fake-revision! card-id, :name (format "Tips Created by Day %s" x)))]
+            (testing "first revision should be recorded"
+              (new-revision 1)
+              (is (= 1 (count (revision/revisions :model/FakedCard card-id)))))
 
-        (testing "repeatedly push reivisions with the same object shouldn't create new revision"
-          (dorun (repeatedly 5 #(new-revision 1)))
-          (is (= 1 (count (revision/revisions :model/FakedCard card-id)))))
+            (testing "repeatedly push reivisions with the same object shouldn't create new revision"
+              (dorun (repeatedly 5 #(new-revision 1)))
+              (is (= 1 (count (revision/revisions :model/FakedCard card-id)))))
 
-        (testing "push a revision with different object should create new revision"
-          (new-revision 2)
-          (is (= 2 (count (revision/revisions :model/FakedCard card-id))))))))
+            (testing "push a revision with different object should create new revision"
+              (new-revision 2)
+              (is (= 2 (count (revision/revisions :model/FakedCard card-id))))))))
 
-  (testing "Check that we don't record revision on dashboard if it has a filter"
-    (t2.with-temp/with-temp
-      [:model/Dashboard     {dash-id :id} {:parameters [{:name "Category Name"
-                                                         :slug "category_name"
-                                                         :id   "_CATEGORY_NAME_"
-                                                         :type "category"}]}
-       :model/Card          {card-id :id} {}
-       :model/DashboardCard {}            {:dashboard_id       dash-id
-                                           :card_id            card-id
-                                           :parameter_mappings [{:parameter_id "_CATEGORY_NAME_"
-                                                                 :card_id      card-id
-                                                                 :target       [:dimension (mt/$ids $categories.name)]}]}]
-      (let [push-revision (fn [] (revision/push-revision!
-                                   :entity :model/Dashboard
-                                   :id     dash-id
-                                   :user-id (mt/user->id :rasta)
-                                   :object (t2/select-one :model/Dashboard dash-id)))]
-        (testing "first revision should be recorded"
-          (push-revision)
-          (is (= 1 (count (revision/revisions :model/Dashboard dash-id)))))
-        (testing "push again without changes shouldn't record new revision"
-          (push-revision)
-          (is (= 1 (count (revision/revisions :model/Dashboard dash-id)))))
-        (testing "now do some updates and new revision should be reocrded"
-          (t2/update! :model/Dashboard :id dash-id {:name "New name"})
-          (push-revision)
-          (is (= 2 (count (revision/revisions :model/Dashboard dash-id)))))))))
+      (testing "Check that we don't record revision on dashboard if it has a filter"
+        (t2.with-temp/with-temp
+          [:model/Dashboard     {dash-id :id} {:parameters [{:name "Category Name"
+                                                             :slug "category_name"
+                                                             :id   "_CATEGORY_NAME_"
+                                                             :type "category"}]}
+           :model/Card          {card-id :id} {}
+           :model/DashboardCard {}            {:dashboard_id       dash-id
+                                               :card_id            card-id
+                                               :parameter_mappings [{:parameter_id "_CATEGORY_NAME_"
+                                                                     :card_id      card-id
+                                                                     :target       [:dimension (mt/$ids $categories.name)]}]}]
+          (let [push-revision (fn [] (revision/push-revision!
+                                      :entity :model/Dashboard
+                                      :id     dash-id
+                                      :user-id (mt/user->id :rasta)
+                                      :object (t2/select-one :model/Dashboard dash-id)))]
+            (testing "first revision should be recorded"
+              (push-revision)
+              (is (= 1 (count (revision/revisions :model/Dashboard dash-id)))))
+            (testing "push again without changes shouldn't record new revision"
+              (push-revision)
+              (is (= 1 (count (revision/revisions :model/Dashboard dash-id)))))
+            (testing "now do some updates and new revision should be reocrded"
+              (t2/update! :model/Dashboard :id dash-id {:name "New name"})
+              (push-revision)
+              (is (= 2 (count (revision/revisions :model/Dashboard dash-id)))))))))))
 
 ;;; # REVISIONS+DETAILS
 
 (deftest add-revision-details-test
-  (testing "Test that add-revision-details properly enriches our revision objects"
-    (t2.with-temp/with-temp [Card {card-id :id}]
-      (push-fake-revision! card-id, :name "Initial Name")
-      (push-fake-revision! card-id, :name "Modified Name")
-      (is (= {:is_creation          false
-              :is_reversion         false
-              :message              nil
-              :user                 {:id (mt/user->id :rasta), :common_name "Rasta Toucan", :first_name "Rasta", :last_name "Toucan"}
-              :diff                 {:o1 {:name "Initial Name", :serialized true}
-                                     :o2 {:name "Modified Name", :serialized true}}
-              :has_multiple_changes false
-              :description          "BEFORE={:name \"Initial Name\", :serialized true},AFTER={:name \"Modified Name\", :serialized true}."}
-             (let [revisions (revision/revisions :model/FakedCard card-id)]
-               (assert (= 2 (count revisions)))
-               (-> (revision/add-revision-details :model/FakedCard (first revisions) (last revisions))
-                   (dissoc :timestamp :id :model_id)
-                   mt/derecordize))))))
+  (mt/with-model-cleanup [:model/Revision]
+    (testing "Test that add-revision-details properly enriches our revision objects"
+      (t2.with-temp/with-temp [Card {card-id :id}]
+        (push-fake-revision! card-id, :name "Initial Name")
+        (push-fake-revision! card-id, :name "Modified Name")
+        (is (=? {:is_creation          false
+                 :is_reversion         false
+                 :message              nil
+                 :user                 {:id (mt/user->id :rasta), :common_name "Rasta Toucan", :first_name "Rasta", :last_name "Toucan"}
+                 :diff                 {:o1 {:name "Initial Name", :serialized true}
+                                        :o2 {:name "Modified Name", :serialized true}}
+                 :has_multiple_changes false
+                 :description          "BEFORE={:name \"Initial Name\", :serialized true},AFTER={:name \"Modified Name\", :serialized true}."}
+                (let [revisions (revision/revisions :model/FakedCard card-id)]
+                  (assert (= 2 (count revisions)))
+                  (-> (revision/add-revision-details :model/FakedCard (first revisions) (last revisions))
+                      (dissoc :timestamp :id :model_id)
+                      mt/derecordize))))))
 
-  (testing "test that we return a description even when there is no change between revision"
-    (is (= "created a revision with no change."
-           (str (:description (revision/add-revision-details :model/FakedCard {:name "Apple"} {:name "Apple"}))))))
+    (testing "test that we return a description even when there is no change between revision"
+      (is (= "created a revision with no change."
+             (str (:description (revision/add-revision-details :model/FakedCard {:name "Apple"} {:name "Apple"}))))))
 
-  (testing "that we return a descrtiopn when there is no previous revision"
-    (is (= "modified this."
-           (str (:description (revision/add-revision-details :model/FakedCard {:name "Apple"} nil)))))))
+    (testing "that we return a descrtiopn when there is no previous revision"
+      (is (= "modified this."
+             (str (:description (revision/add-revision-details :model/FakedCard {:name "Apple"} nil))))))))
 
 (deftest revisions+details-test
-  (testing "Check that revisions+details pulls in user info and adds description"
-    (t2.with-temp/with-temp [Card {card-id :id}]
-      (push-fake-revision! card-id, :name "Tips Created by Day")
-      (is (= [(mi/instance
-               Revision
-               {:is_reversion         false,
-                :is_creation          false,
-                :message              nil,
-                :user                 {:id (mt/user->id :rasta), :common_name "Rasta Toucan", :first_name "Rasta", :last_name "Toucan"},
-                :diff                 {:o1 nil
-                                       :o2 {:name "Tips Created by Day", :serialized true}}
-                :has_multiple_changes false
-                :description          "modified this."})]
-             (->> (revision/revisions+details :model/FakedCard card-id)
-                  (map #(dissoc % :timestamp :id :model_id))
-                  (map #(update % :description str))))))))
+  (mt/with-model-cleanup [:model/Revision]
+    (testing "Check that revisions+details pulls in user info and adds description"
+      (t2.with-temp/with-temp [Card {card-id :id}]
+        (push-fake-revision! card-id, :name "Tips Created by Day")
+        (is (=? [(mi/instance
+                  Revision
+                  {:is_reversion         false,
+                   :is_creation          false,
+                   :message              nil,
+                   :user                 {:id (mt/user->id :rasta), :common_name "Rasta Toucan", :first_name "Rasta", :last_name "Toucan"},
+                   :diff                 {:o1 nil
+                                          :o2 {:name "Tips Created by Day", :serialized true}}
+                   :has_multiple_changes false
+                   :description          "modified this."})]
+                (->> (revision/revisions+details :model/FakedCard card-id)
+                     (map #(dissoc % :timestamp :id :model_id))
+                     (map #(update % :description str)))))))))
 
 (deftest defer-to-describe-diff-test
-  (testing "Check that revisions properly defer to describe-diff"
-    (t2.with-temp/with-temp [Card {card-id :id}]
-      (push-fake-revision! card-id, :name "Tips Created by Day")
-      (push-fake-revision! card-id, :name "Spots Created by Day")
-      (is (= [(mi/instance
-               Revision
-               {:is_reversion         false,
-                :is_creation          false,
-                :message              nil
-                :user                 {:id (mt/user->id :rasta), :common_name "Rasta Toucan", :first_name "Rasta", :last_name "Toucan"},
-                :diff                 {:o1 {:name "Tips Created by Day", :serialized true}
-                                       :o2 {:name "Spots Created by Day", :serialized true}}
-                :has_multiple_changes false
-                :description          (str "BEFORE={:name \"Tips Created by Day\", :serialized true},AFTER="
-                                           "{:name \"Spots Created by Day\", :serialized true}.")})
-              (mi/instance
-               Revision
-               {:is_reversion         false,
-                :is_creation          false,
-                :message              nil
-                :user                 {:id (mt/user->id :rasta), :common_name "Rasta Toucan", :first_name "Rasta", :last_name "Toucan"},
-                :diff                 {:o1 nil
-                                       :o2 {:name "Tips Created by Day", :serialized true}}
-                :has_multiple_changes false
-                :description          "modified this."})]
-             (->> (revision/revisions+details :model/FakedCard card-id)
-                  (map #(dissoc % :timestamp :id :model_id))
-                  (map #(update % :description str))))))))
+  (mt/with-model-cleanup [:model/Revision]
+    (testing "Check that revisions properly defer to describe-diff"
+      (t2.with-temp/with-temp [Card {card-id :id}]
+        (push-fake-revision! card-id, :name "Tips Created by Day")
+        (push-fake-revision! card-id, :name "Spots Created by Day")
+        (is (=? [(mi/instance
+                  Revision
+                  {:is_reversion         false,
+                   :is_creation          false,
+                   :message              nil
+                   :user                 {:id (mt/user->id :rasta), :common_name "Rasta Toucan", :first_name "Rasta", :last_name "Toucan"},
+                   :diff                 {:o1 {:name "Tips Created by Day", :serialized true}
+                                          :o2 {:name "Spots Created by Day", :serialized true}}
+                   :has_multiple_changes false
+                   :description          (str "BEFORE={:name \"Tips Created by Day\", :serialized true},AFTER="
+                                              "{:name \"Spots Created by Day\", :serialized true}.")})
+                 (mi/instance
+                  Revision
+                  {:is_reversion         false,
+                   :is_creation          false,
+                   :message              nil
+                   :user                 {:id (mt/user->id :rasta), :common_name "Rasta Toucan", :first_name "Rasta", :last_name "Toucan"},
+                   :diff                 {:o1 nil
+                                          :o2 {:name "Tips Created by Day", :serialized true}}
+                   :has_multiple_changes false
+                   :description          "modified this."})]
+                (->> (revision/revisions+details :model/FakedCard card-id)
+                     (map #(dissoc % :timestamp :id :model_id))
+                     (map #(update % :description str)))))))))
 
 ;;; # REVERT
 
 (deftest revert-defer-to-revert-to-revision!-test
-  (testing "Check that revert defers to revert-to-revision!"
-    (t2.with-temp/with-temp [Card {card-id :id}]
-      (push-fake-revision! card-id, :name "Tips Created by Day")
-      (let [[{revision-id :id}] (revision/revisions :model/FakedCard card-id)]
-        (revision/revert! :entity :model/FakedCard, :id card-id, :user-id (mt/user->id :rasta), :revision-id revision-id)
-        (is (= {:name "Tips Created by Day"}
-               @reverted-to))))))
+  (mt/with-model-cleanup [:model/Revision]
+    (testing "Check that revert defers to revert-to-revision!"
+      (t2.with-temp/with-temp [Card {card-id :id}]
+        (push-fake-revision! card-id, :name "Tips Created by Day")
+        (let [[{revision-id :id}] (revision/revisions :model/FakedCard card-id)]
+          (revision/revert! :entity :model/FakedCard, :id card-id, :user-id (mt/user->id :rasta), :revision-id revision-id)
+          (is (= {:name "Tips Created by Day"}
+                 @reverted-to)))))))
 
 (deftest revert-to-revision!-default-impl-test
-  (testing "Check default impl of revert-to-revision! just does mapply upd"
-    (t2.with-temp/with-temp [Card {card-id :id} {:name "Spots Created By Day"}]
-      (revision/push-revision! :entity Card, :id card-id, :user-id (mt/user->id :rasta), :object {:name "Tips Created by Day"})
-      (revision/push-revision! :entity Card, :id card-id, :user-id (mt/user->id :rasta), :object {:name "Spots Created by Day"})
-      (is (= "Spots Created By Day"
-             (:name (t2/select-one Card :id card-id))))
-      (let [[_ {old-revision-id :id}] (revision/revisions Card card-id)]
-        (revision/revert! :entity Card, :id card-id, :user-id (mt/user->id :rasta), :revision-id old-revision-id)
-        (is (= "Tips Created by Day"
-               (:name (t2/select-one Card :id card-id))))))))
+  (mt/with-model-cleanup [:model/Revision]
+    (testing "Check default impl of revert-to-revision! just does mapply upd"
+      (t2.with-temp/with-temp [Card {card-id :id} {:name "Spots Created By Day"}]
+        (revision/push-revision! :entity Card, :id card-id, :user-id (mt/user->id :rasta), :object {:name "Tips Created by Day"})
+        (revision/push-revision! :entity Card, :id card-id, :user-id (mt/user->id :rasta), :object {:name "Spots Created by Day"})
+        (is (= "Spots Created By Day"
+               (:name (t2/select-one Card :id card-id))))
+        (let [[_ {old-revision-id :id}] (revision/revisions Card card-id)]
+          (revision/revert! :entity Card, :id card-id, :user-id (mt/user->id :rasta), :revision-id old-revision-id)
+          (is (= "Tips Created by Day"
+                 (:name (t2/select-one Card :id card-id)))))))))
 
 (deftest reverting-should-add-revision-test
-  (testing "Check that reverting to a previous revision adds an appropriate revision"
-    (t2.with-temp/with-temp [Card {card-id :id}]
-      (push-fake-revision! card-id, :name "Tips Created by Day")
-      (push-fake-revision! card-id, :name "Spots Created by Day")
-      (let [[_ {old-revision-id :id}] (revision/revisions :model/FakedCard card-id)]
-        (revision/revert! :entity :model/FakedCard, :id card-id, :user-id (mt/user->id :rasta), :revision-id old-revision-id)
-        (is (partial=
-             [(mi/instance
-               Revision
-               {:model        "FakedCard"
-                :user_id      (mt/user->id :rasta)
-                :object       {:name "Tips Created by Day", :serialized true}
-                :is_reversion true
-                :is_creation  false
-                :message      nil})
-              (mi/instance
-               Revision
-               {:model        "FakedCard",
-                :user_id      (mt/user->id :rasta)
-                :object       {:name "Spots Created by Day", :serialized true}
-                :is_reversion false
-                :is_creation  false
-                :message      nil})
-              (mi/instance
-               Revision
-               {:model        "FakedCard",
-                :user_id      (mt/user->id :rasta)
-                :object       {:name "Tips Created by Day", :serialized true}
-                :is_reversion false
-                :is_creation  false
-                :message      nil})]
-             (->> (revision/revisions :model/FakedCard card-id)
-                  (map #(dissoc % :timestamp :id :model_id)))))))))
+  (mt/with-model-cleanup [:model/Revision]
+    (testing "Check that reverting to a previous revision adds an appropriate revision"
+      (t2.with-temp/with-temp [Card {card-id :id}]
+        (push-fake-revision! card-id, :name "Tips Created by Day")
+        (push-fake-revision! card-id, :name "Spots Created by Day")
+        (let [[_ {old-revision-id :id}] (revision/revisions :model/FakedCard card-id)]
+          (revision/revert! :entity :model/FakedCard, :id card-id, :user-id (mt/user->id :rasta), :revision-id old-revision-id)
+          (is (partial=
+               [(mi/instance
+                 Revision
+                 {:model        "FakedCard"
+                  :user_id      (mt/user->id :rasta)
+                  :object       {:name "Tips Created by Day", :serialized true}
+                  :is_reversion true
+                  :is_creation  false
+                  :message      nil})
+                (mi/instance
+                 Revision
+                 {:model        "FakedCard",
+                  :user_id      (mt/user->id :rasta)
+                  :object       {:name "Spots Created by Day", :serialized true}
+                  :is_reversion false
+                  :is_creation  false
+                  :message      nil})
+                (mi/instance
+                 Revision
+                 {:model        "FakedCard",
+                  :user_id      (mt/user->id :rasta)
+                  :object       {:name "Tips Created by Day", :serialized true}
+                  :is_reversion false
+                  :is_creation  false
+                  :message      nil})]
+               (->> (revision/revisions :model/FakedCard card-id)
+                    (map #(dissoc % :timestamp :id :model_id))))))))))
 
 (deftest generic-models-revision-title+description-test
   (do-with-model-i18n-strs!

--- a/test/metabase/models/revision_test.clj
+++ b/test/metabase/models/revision_test.clj
@@ -126,16 +126,16 @@
       (t2.with-temp/with-temp [Card {card-id :id}]
         (doseq [i (range 3)]
           (push-fake-revision! card-id :name (format "%d Tips Created by Day" i) :message "yay!"))
-        (is (=? [{:model       "FakedCard"
-                  :model_id    card-id
-                  :most_recent true}
-                 {:model       "FakedCard"
-                  :model_id    card-id
-                  :most_recent false}
-                 {:model       "FakedCard"
-                  :model_id    card-id
-                  :most_recent false}]
-                (t2/select :model/Revision :model "FakedCard" :model_id card-id {:order-by [[:timestamp :desc]]})))))))
+       (is (=? [{:model       "FakedCard"
+                 :model_id    card-id
+                 :most_recent true}
+                {:model       "FakedCard"
+                 :model_id    card-id
+                 :most_recent false}
+                {:model       "FakedCard"
+                 :model_id    card-id
+                 :most_recent false}]
+               (t2/select :model/Revision :model "FakedCard" :model_id card-id {:order-by [[:timestamp :desc] [:id :desc]]})))))))
 
 (deftest sorting-test
   (testing "Test that revisions are sorted in reverse chronological order"

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -90,28 +90,30 @@
                     {:models   #{"dashboard" "dataset" "table"}
                      :last-edited-at "past3days"})))))))
 
-(deftest maybe-join-test
+(deftest joined-with-table?-test
   (are [expected args]
-       (= expected (apply #'search.filter/maybe-join args))
+       (= expected (apply #'search.filter/joined-with-table? args))
 
-       {:join [:a [:= :a.b :c.d]]}
-       [{} :join :a [:= :a.b :c.d]]
+       false
+       [{} :join :a]
 
-       ;; do not duplicate join
-       {:join [:a [:= :a.b :c.d]]}
-       [{:join [:a [:= :a.b :c.d]]} :join :a [:= :a.b :c.d]]
+       true
+       [{:join [:a [:= :a.b :c.d]]} :join :a]
+
+       false
+       [{:join [:a [:= :a.b :c.d]]} :join :d]
 
        ;; work with multiple join types
-       {:join [:a [:= :a.b :c.d]] :left-join [:d [:= :d.e :e.f]]}
-       [{:join [:a [:= :a.b :c.d]]} :left-join :d [:= :d.e :e.f]]
-
-       ;; concatnate join if can join
-       {:join [:a [:= :a.b :c.d] :d [:= :d.e :e.f]]}
-       [{:join [:a [:= :a.b :c.d]]} :join :d [:= :d.e :e.f]]
+       false
+       [{:join [:a [:= :a.b :c.d]]} :left-join :d]
 
        ;; do the same with other join types too
-       {:left-join [:a [:= :a.b :c.d]]}
-       [{:left-join [:a [:= :a.b :c.d]]} :left-join :a [:= :a.b :c.d]]))
+       true
+       [{:left-join [:a [:= :a.b :c.d]]} :left-join :a]
+
+       false
+       [{:left-join [:a [:= :a.b :c.d]]} :left-join :d]))
+
 
 (def ^:private base-search-query
   {:select [:*]
@@ -219,8 +221,6 @@
                       [:= :revision.model "Card"]
                       [:>= [:cast :revision.timestamp :date] #t "2016-04-18"]
                       [:< [:cast :revision.timestamp :date] #t "2016-04-24"]
-                      [:= :revision.most_recent true]
-                      [:= :revision.model "Card"]
                       [:= :revision.user_id 1]]}
             (search.filter/build-filters
              base-search-query "dataset"

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -79,7 +79,7 @@
                       :last-edited-by 1})))))
 
    (testing "last edited at"
-     (is (= #{"dashboard" "dataset" "card" "metric"}
+     (is (= #{"dashboard" "dataset" "collection" "action" "metric" "card"}
             (search.filter/search-context->applicable-models
              (merge default-search-ctx
                     {:last-edited-at "past3days"}))))
@@ -156,6 +156,9 @@
          "yesterday"                               [:and [:>= [:cast :card.created_at :date] #t "2023-05-03"]
                                                     [:< [:cast :card.created_at :date] #t "2023-05-04"]])))
 
+;; both created at and last-edited-at use [[search.filter/date-range-filter-clause]]
+;; to generate the filter clause so for the full test cases, check [[date-range-filter-clause-test]]
+;; these 2 tests are for checking the shape of the query
 (deftest ^:parallel created-at-filter-test
   (testing "created-at filter"
     (is (= {:select [:*]
@@ -174,11 +177,8 @@
             :from   [:table]
             :where  [:and
                      [:= :card.archived false]
-                     [:= :revision.most_recent true]
-                     [:= :revision.model "Card"]
-                     [:>= [:cast :revision.timestamp :date] #t "2016-04-18"]
-                     [:< [:cast :revision.timestamp :date] #t "2016-04-24"]],
-            :join   [:revision [:= :revision.model_id :card.id]]}
+                     [:>= [:cast :card.updated_at :date] #t "2016-04-18"]
+                     [:< [:cast :card.updated_at :date] #t "2016-04-24"]],}
            (search.filter/build-filters
             base-search-query "dataset"
             (merge default-search-ctx {:last-edited-at "2016-04-18~2016-04-23"}))))))

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -79,7 +79,7 @@
                       :last-edited-by 1})))))
 
    (testing "last edited at"
-     (is (= #{"dashboard" "dataset" "collection" "action" "metric" "card"}
+     (is (= #{"dashboard" "dataset" "action" "metric" "card"}
             (search.filter/search-context->applicable-models
              (merge default-search-ctx
                     {:last-edited-at "past3days"}))))

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -42,6 +42,18 @@
                      {:models #{"dashboard" "dataset" "table"}
                       :created-by 1})))))
 
+    (testing "created at"
+      (is (= #{"dashboard" "table" "dataset" "collection" "database" "action" "card"}
+             (search.filter/search-context->applicable-models
+              (merge default-search-ctx
+                     {:created-at "past3days"}))))
+
+      (is (= #{"dashboard" "table" "dataset"}
+             (search.filter/search-context->applicable-models
+              (merge default-search-ctx
+                     {:models #{"dashboard" "dataset" "table"}
+                      :created-at "past3days"})))))
+
     (testing "verified"
       (is (= #{"dataset" "card"}
              (search.filter/search-context->applicable-models
@@ -52,7 +64,31 @@
              (search.filter/search-context->applicable-models
               (merge default-search-ctx
                      {:models   #{"dashboard" "dataset" "table"}
-                      :verified true})))))))
+                      :verified true})))))
+
+    (testing "last edited by"
+      (is (= #{"dashboard" "dataset" "card" "metric"}
+             (search.filter/search-context->applicable-models
+              (merge default-search-ctx
+                     {:last-edited-by 1}))))
+
+      (is (= #{"dashboard" "dataset"}
+             (search.filter/search-context->applicable-models
+              (merge default-search-ctx
+                     {:models         #{"dashboard" "dataset" "table"}
+                      :last-edited-by 1})))))
+
+   (testing "last edited at"
+     (is (= #{"dashboard" "dataset" "card" "metric"}
+            (search.filter/search-context->applicable-models
+             (merge default-search-ctx
+                    {:last-edited-at "past3days"}))))
+
+     (is (= #{"dashboard" "dataset"}
+            (search.filter/search-context->applicable-models
+             (merge default-search-ctx
+                    {:models   #{"dashboard" "dataset" "table"}
+                     :last-edited-at "past3days"})))))))
 
 (def ^:private base-search-query
   {:select [:*]
@@ -81,51 +117,71 @@
                     base-search-query "card"
                     (merge default-search-ctx {:search-string "a string"})))))))
 
-(deftest build-created-at-filter-test
+(deftest date-range-filter-clause-test
+  (mt/with-clock #t "2023-05-04T10:02:05Z[UTC]"
+    (are [created-at expected-where]
+         (= expected-where (#'search.filter/date-range-filter-clause :card.created_at created-at))
+         ;; absolute datetime
+         "Q1-2023"                                 [:and [:>= [:cast :card.created_at :date] #t "2023-01-01"]
+                                                    [:< [:cast :card.created_at :date]  #t "2023-04-01"]]
+         "2016-04-18~2016-04-23"                   [:and [:>= [:cast :card.created_at :date] #t "2016-04-18"]
+                                                    [:< [:cast :card.created_at :date]  #t "2016-04-24"]]
+         "2016-04-18"                              [:and [:>= [:cast :card.created_at :date] #t "2016-04-18"]
+                                                    [:< [:cast :card.created_at :date]  #t "2016-04-19"]]
+         "2023-05-04~"                             [:> [:cast :card.created_at :date]  #t "2023-05-04"]
+         "~2023-05-04"                             [:< [:cast :card.created_at :date]  #t "2023-05-05"]
+         "2016-04-18T10:30:00~2016-04-23T11:30:00" [:and [:>= :card.created_at #t "2016-04-18T10:30"]
+                                                    [:< :card.created_at #t "2016-04-23T11:31:00"]]
+         "2016-04-23T10:00:00"                     [:and [:>= :card.created_at #t "2016-04-23T10:00"]
+                                                    [:< :card.created_at  #t "2016-04-23T10:01"]]
+         "2016-04-18T10:30:00~"                    [:> :card.created_at #t "2016-04-18T10:30"]
+         "~2016-04-18T10:30:00"                    [:< :card.created_at #t "2016-04-18T10:31"]
+         ;; relative datetime
+         "past3days"                               [:and [:>= [:cast :card.created_at :date] #t "2023-05-01"]
+                                                    [:< [:cast :card.created_at :date]  #t "2023-05-04"]]
+         "past3days~"                              [:and [:>= [:cast :card.created_at :date] #t "2023-05-01"]
+                                                    [:< [:cast :card.created_at :date] #t "2023-05-05"]]
+         "past3hours~"                             [:and [:>= :card.created_at #t "2023-05-04T07:00"]
+                                                    [:< :card.created_at #t "2023-05-04T11:00"]]
+         "next3days"                               [:and [:>= [:cast :card.created_at :date] #t "2023-05-05"]
+                                                    [:< [:cast :card.created_at :date]  #t "2023-05-08"]]
+         "thisminute"                              [:and [:>= :card.created_at #t "2023-05-04T10:02"]
+                                                    [:< :card.created_at #t "2023-05-04T10:03"]]
+         "lasthour"                                [:and [:>= :card.created_at #t "2023-05-04T09:00"]
+                                                    [:< :card.created_at #t "2023-05-04T10:00"]]
+         "past1months-from-36months"               [:and [:>= [:cast :card.created_at :date] #t "2020-04-01"]
+                                                    [:< [:cast :card.created_at :date]  #t "2020-05-01"]]
+         "today"                                   [:and [:>= [:cast :card.created_at :date] #t "2023-05-04"]
+                                                    [:< [:cast :card.created_at :date] #t "2023-05-05"]]
+         "yesterday"                               [:and [:>= [:cast :card.created_at :date] #t "2023-05-03"]
+                                                    [:< [:cast :card.created_at :date] #t "2023-05-04"]])))
+
+(deftest ^:parallel created-at-filter-test
   (testing "created-at filter"
-    (mt/with-clock #t "2023-05-04T10:02:05Z[UTC]"
-      (are [created-at expected-where]
-           (= expected-where
-              (->> (search.filter/build-filters
-                    base-search-query "card"
-                    (merge default-search-ctx {:created-at created-at}))
-                   :where
-                   ;; drop the first 2 clauses [:and [:= :card.archived false]]
-                   (drop 2)))
-           ;; absolute datetime
-           "Q1-2023"                                 [[:>= [:cast :card.created_at :date] #t "2023-01-01"]
-                                                      [:< [:cast :card.created_at :date]  #t "2023-04-01"]]
-           "2016-04-18~2016-04-23"                   [[:>= [:cast :card.created_at :date] #t "2016-04-18"]
-                                                      [:< [:cast :card.created_at :date]  #t "2016-04-24"]]
-           "2016-04-18"                              [[:>= [:cast :card.created_at :date] #t "2016-04-18"]
-                                                      [:< [:cast :card.created_at :date]  #t "2016-04-19"]]
-           "2023-05-04~"                             [[:> [:cast :card.created_at :date]  #t "2023-05-04"]]
-           "~2023-05-04"                             [[:< [:cast :card.created_at :date]  #t "2023-05-05"]]
-           "2016-04-18T10:30:00~2016-04-23T11:30:00" [[:>= :card.created_at #t "2016-04-18T10:30"]
-                                                      [:< :card.created_at #t "2016-04-23T11:31:00"]]
-           "2016-04-23T10:00:00"                     [[:>= :card.created_at #t "2016-04-23T10:00"]
-                                                      [:< :card.created_at  #t "2016-04-23T10:01"]]
-           "2016-04-18T10:30:00~"                    [[:> :card.created_at #t "2016-04-18T10:30"]]
-           "~2016-04-18T10:30:00"                    [[:< :card.created_at #t "2016-04-18T10:31"]]
-           ;; relative datetime
-           "past3days"                               [[:>= [:cast :card.created_at :date] #t "2023-05-01"]
-                                                      [:< [:cast :card.created_at :date]  #t "2023-05-04"]]
-           "past3days~"                              [[:>= [:cast :card.created_at :date] #t "2023-05-01"]
-                                                      [:< [:cast :card.created_at :date] #t "2023-05-05"]]
-           "past3hours~"                             [[:>= :card.created_at #t "2023-05-04T07:00"]
-                                                      [:< :card.created_at #t "2023-05-04T11:00"]]
-           "next3days"                               [[:>= [:cast :card.created_at :date] #t "2023-05-05"]
-                                                      [:< [:cast :card.created_at :date]  #t "2023-05-08"]]
-           "thisminute"                              [[:>= :card.created_at #t "2023-05-04T10:02"]
-                                                      [:< :card.created_at #t "2023-05-04T10:03"]]
-           "lasthour"                                [[:>= :card.created_at #t "2023-05-04T09:00"]
-                                                      [:< :card.created_at #t "2023-05-04T10:00"]]
-           "past1months-from-36months"               [[:>= [:cast :card.created_at :date] #t "2020-04-01"]
-                                                      [:< [:cast :card.created_at :date]  #t "2020-05-01"]]
-           "today"                                   [[:>= [:cast :card.created_at :date] #t "2023-05-04"]
-                                                      [:< [:cast :card.created_at :date] #t "2023-05-05"]]
-           "yesterday"                               [[:>= [:cast :card.created_at :date] #t "2023-05-03"]
-                                                      [:< [:cast :card.created_at :date] #t "2023-05-04"]]))))
+    (is (= {:select [:*]
+            :from   [:table]
+            :where  [:and
+                     [:= :card.archived false]
+                     [:>= [:cast :card.created_at :date] #t "2016-04-18"]
+                     [:< [:cast :card.created_at :date]  #t "2016-04-24"]]}
+           (search.filter/build-filters
+            base-search-query "card"
+            (merge default-search-ctx {:created-at "2016-04-18~2016-04-23"}))))))
+
+(deftest ^:parallel last-edited-at-filter-test
+  (testing "last edited at filter"
+    (is (= {:select [:*]
+            :from   [:table]
+            :where  [:and
+                     [:= :card.archived false]
+                     [:= :revision.most_recent true]
+                     [:= :revision.model "Card"]
+                     [:>= [:cast :revision.timestamp :date] #t "2016-04-18"]
+                     [:< [:cast :revision.timestamp :date] #t "2016-04-24"]],
+            :join   [:revision [:= :revision.model_id :card.id]]}
+           (search.filter/build-filters
+            base-search-query "dataset"
+            (merge default-search-ctx {:last-edited-at "2016-04-18~2016-04-23"}))))))
 
 (deftest ^:parallel build-created-by-filter-test
   (testing "created-by filter"
@@ -134,6 +190,21 @@
                     base-search-query "card"
                     (merge default-search-ctx
                            {:created-by 1})))))))
+
+(deftest ^:parallel build-last-edited-by-filter-test
+  (testing "last edited by filter"
+    (is (= {:select [:*]
+            :from   [:table]
+            :where  [:and
+                     [:= :card.archived false]
+                     [:= :revision.most_recent true]
+                     [:= :revision.model "Card"]
+                     [:= :revision.user_id 1]]
+            :join   [:revision [:= :revision.model_id :card.id]]}
+           (search.filter/build-filters
+            base-search-query "dataset"
+            (merge default-search-ctx
+                   {:last-edited-by 1}))))))
 
 (deftest build-verified-filter-test
   (testing "verified filter"


### PR DESCRIPTION
Part of https://github.com/metabase/metabase/pull/32624

This adds 2 filter options to the search API: `last_edited_at` and `last_edited_by`. 

In order to do filter last_edited_by efficiently, I added a new column `revision.most_recent` and updated the revision model to make sure new revision are marked with `most_recent=true` and the old ones has `most_recent=false`

For `last_edited_at`, we use the `updated_at` column.