### PR TITLE
🍒 Manual Backport (#33337) 

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.js
+++ b/e2e/support/helpers/e2e-dashboard-helpers.js
@@ -191,3 +191,47 @@ export function toggleDashboardInfoSidebar() {
 export function openDashboardMenu() {
   dashboardHeader().findByLabelText("dashboard-menu-button").click();
 }
+
+/**
+ *
+ * @param {number} dashboardId
+ * @param {Object} option
+ * @param {number=} option.id
+ * @param {number=} option.col
+ * @param {number=} option.row
+ * @param {number=} option.size_x
+ * @param {number=} option.size_y
+ * @param {string} option.text
+ */
+export function createTextCard({
+  id = getNextUnsavedDashboardCardId(),
+  col = 0,
+  row = 0,
+  size_x = 4,
+  size_y = 6,
+  text,
+}) {
+  return {
+    id,
+    card_id: null,
+    col,
+    row,
+    size_x,
+    size_y,
+    visualization_settings: {
+      virtual_card: {
+        name: null,
+        display: "text",
+        visualization_settings: {},
+        dataset_query: {},
+        archived: false,
+      },
+      text,
+    },
+  };
+}
+
+export const getNextUnsavedDashboardCardId = (() => {
+  let id = 0;
+  return () => --id;
+})();


### PR DESCRIPTION
The manual backport of #33337

Note that this backport drops the refactoring part from 3 files so that I don't need to deal with the conflict.
1. `e2e/test/scenarios/dashboard-filters/reproductions/26230-dashboard-sticky-filter-incorrectly-positioned.cy.spec.js`
2. `e2e/test/scenarios/dashboard/dashboard.cy.spec.js`
3. `e2e/test/scenarios/dashboard/reproductions/31274-dashcard-actions-overlap.cy.spec.js`

In https://github.com/metabase/metabase/pull/33337, those 3 files are refactored to use the new util function `createTextCard`. So leaving them as is in the release branch would be fine.