### PR TITLE
Updates to FE `external_op`

### DIFF
--- a/frontend/src/metabase-lib/common.ts
+++ b/frontend/src/metabase-lib/common.ts
@@ -1,7 +1,11 @@
 import * as ML from "cljs/metabase.lib.js";
 
-import type { Clause, ExternalOp } from "./types";
+import type { FilterClause, FilterParts } from "./types";
 
-export function externalOp(clause: Clause): ExternalOp {
-  return ML.external_op(clause);
+export function filterParts(filter: FilterClause): FilterParts {
+  const {
+    args: [column, ...args],
+    ...externalOp
+  } = ML.external_op(filter);
+  return { ...externalOp, column, args };
 }

--- a/frontend/src/metabase-lib/filter.ts
+++ b/frontend/src/metabase-lib/filter.ts
@@ -4,7 +4,6 @@ import type {
   ColumnMetadata,
   ColumnWithOperators,
   ExpressionArg,
-  ExternalOp,
   FilterOperator,
   FilterClause,
   Query,
@@ -34,9 +33,9 @@ export function filterClause(
 export function filter(
   query: Query,
   stageIndex: number,
-  booleanExpression: ExternalOp,
+  filterClause: FilterClause,
 ): Query {
-  return ML.filter(query, stageIndex, booleanExpression);
+  return ML.filter(query, stageIndex, filter);
 }
 
 export function filters(query: Query, stageIndex: number): FilterClause[] {

--- a/frontend/src/metabase-lib/join.ts
+++ b/frontend/src/metabase-lib/join.ts
@@ -4,7 +4,6 @@ import type {
   CardMetadata,
   Clause,
   ColumnMetadata,
-  ExternalOp,
   FilterClause,
   FilterOperator,
   Join,
@@ -32,7 +31,7 @@ export function joins(query: Query, stageIndex: number): Join[] {
 
 export function joinClause(
   joinable: Joinable,
-  conditions: FilterClause[] | ExternalOp[],
+  conditions: FilterClause[],
 ): Join {
   return ML.join_clause(joinable, conditions);
 }
@@ -62,7 +61,7 @@ export function joinConditions(join: Join): FilterClause[] {
 
 export function withJoinConditions(
   join: Join,
-  newConditions: FilterClause[] | ExternalOp[],
+  newConditions: FilterClause[],
 ): Join {
   return ML.with_join_conditions(join, newConditions);
 }

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -150,10 +150,13 @@ export type ExpressionArg =
   | ColumnMetadata
   | Clause;
 
-export type ExternalOp = {
+// Known as `external_op` on the BE side
+// `external_op` returns a column as the first `args` element, but we unpack it for convenience
+export type FilterParts = {
   operator: string;
+  column: ColumnMetadata;
+  args: ExpressionArg[];
   options: Record<string, unknown>;
-  args: [ColumnMetadata, ...ExpressionArg[]];
 };
 
 declare const Join: unique symbol;


### PR DESCRIPTION
`external_op` doesn't communicate enough meaning to FE engs and we expect that having a `ColumnMetadata` in external op's `args` would lead to a lot of duplicate code unpacking it. This PR does three things:

* renames `external_op`'s TypeScript wrapper to `filterParts` (and `ExternalOp` type to `FilterParts`)
* extends `filterParts` TypeScript wrapper to unpack a `column` from external op's `args` (a column is always the first arg)
* updates typings in `filter` and `join`, so `FilterParts` can't be used to build new filters or join conditions. Let's keep things consistent on the FE and always pass around `FilterClause` or `JoinConditionClause` and keep the `FilterParts` only for visualizing filters