### PR TITLE
add materialize as a partner driver and remove it from community

### DIFF
--- a/docs/developers-guide/partner-and-community-drivers.md
+++ b/docs/developers-guide/partner-and-community-drivers.md
@@ -45,6 +45,7 @@ Current partner drivers:
 - [Clickhouse](https://github.com/ClickHouse/metabase-clickhouse-driver)
 - [Exasol](https://github.com/exasol/metabase-driver)
 - [Firebolt](https://docs.firebolt.io/integrations/business-intelligence/connecting-to-metabase.html)
+- [Materialize](https://github.com/MaterializeInc/metabase-materialize-driver)
 - [Ocient](https://github.com/Xeograph/metabase-ocient-driver)
 - [Starburst (compatible with Trino)](https://github.com/starburstdata/metabase-driver)
 
@@ -71,7 +72,6 @@ You install these drivers at your own risk. The plugins will run as part of your
 | [Firebird](https://github.com/evosec/metabase-firebird-driver)                         | ![GitHub stars](https://img.shields.io/github/stars/evosec/metabase-firebird-driver)                 | ![GitHub (Pre-)Release Date](https://img.shields.io/github/release-date-pre/evosec/metabase-firebird-driver)                 |
 | [Hydra](https://hydras.io/blog/2022-09-28-metabase-and-hydra)                          | Hydra connections use the official [Postgres driver](../databases/connections/postgresql.md).        | Not applicable.                                                                                                              |
 | [Impala](https://github.com/brenoae/metabase-impala-driver)                            | ![GitHub stars](https://img.shields.io/github/stars/brenoae/metabase-impala-driver)                  | ![GitHub (Pre-)Release Date](https://img.shields.io/github/release-date-pre/brenoae/metabase-impala-driver)                  |
-| [Materialize](https://github.com/MaterializeInc/metabase-materialize-driver)           | ![GitHub stars](https://img.shields.io/github/stars/MaterializeInc/metabase-materialize-driver)      | ![GitHub (Pre-)Release Date](https://img.shields.io/github/release-date-pre/MaterializeInc/metabase-materialize-driver)      |
 | [Neo4j](https://github.com/StronkMan/metabase-neo4j-driver)                            | ![GitHub stars](https://img.shields.io/github/stars/StronkMan/metabase-neo4j-driver)                 | ![GitHub (Pre-)Release Date](https://img.shields.io/github/release-date-pre/StronkMan/metabase-neo4j-driver)                 |
 | [Spark Databricks](https://github.com/relferreira/metabase-sparksql-databricks-driver) | ![GitHub stars](https://img.shields.io/github/stars/relferreira/metabase-sparksql-databricks-driver) | ![GitHub (Pre-)Release Date](https://img.shields.io/github/release-date-pre/relferreira/metabase-sparksql-databricks-driver) |
 | [Teradata](https://github.com/swisscom-bigdata/metabase-teradata-driver)               | ![GitHub stars](https://img.shields.io/github/stars/swisscom-bigdata/metabase-teradata-driver)       | ![GitHub (Pre-)Release Date](https://img.shields.io/github/release-date-pre/swisscom-bigdata/metabase-teradata-driver)       |


### PR DESCRIPTION
We are adding Materialize as a partner driver on 47 (Cloud)

@jeff-bruemmer should I backport this? I added the backport label