### PR TITLE
Add the pull-request-number input as per the docs https://github.com/…

### DIFF
--- a/.github/workflows/backport-reminder.yml
+++ b/.github/workflows/backport-reminder.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: jesusvasquez333/verify-pr-label-action@v1.4.0
         with:
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
-          valid-labels: 'backport, no-backport'
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          valid-labels: "backport, no-backport"
           disable-reviews: true
+          pull-request-number: "${{ github.event.pull_request.number }}"


### PR DESCRIPTION
### Description

PR from a fork is failing because the `backport-reminder` action expects a mandatory `pull-request-number` input. Adding that to the workflow config.

Slack context: https://metaboat.slack.com/archives/C5XHN8GLW/p1692731099664709
Docs: https://github.com/jesusvasquez333/verify-pr-label-action/tree/v1.4.0/