### PR TITLE
Reduce flakes in x-ray e2e test

### DIFF
--- a/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
@@ -106,10 +106,12 @@ describe("scenarios > x-rays", () => {
       });
 
       startNewQuestion();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Saved Questions").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("15655").click();
+
+      popover().within(() => {
+        cy.findByText("Saved Questions").click();
+        cy.findByText("15655").click();
+      });
+
       visualize();
       summarize();
       getDimensionByName({ name: "SOURCE" }).click();
@@ -119,14 +121,14 @@ describe("scenarios > x-rays", () => {
       cy.button("Done").click();
       cy.get(".bar").first().click({ force: true });
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Automatic insights…").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText(action).click();
+      popover().within(() => {
+        cy.findByText("Automatic insights…").click();
+        cy.findByText(action).click();
+      });
 
-      for (let c = 0; c < XRAY_DATASETS; ++c) {
-        cy.wait("@postDataset");
-      }
+      cy.wait(Array(XRAY_DATASETS).fill("@postDataset"), {
+        timeout: 15 * 1000,
+      });
 
       cy.wait("@xray").then(xhr => {
         expect(xhr.response.body.cause).not.to.exist;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/33416

### Description

This is the current flakiest test on master:
![Screen Shot 2023-08-22 at 1 01 29 PM](https://github.com/metabase/metabase/assets/30528226/d23f594d-14c9-4ac8-9fd5-7bd4eded7bb6)

This appears to be a many-requests-are-slow sort of failure with many network requests taking more than 10 seconds
[flake a](https://www.deploysentinel.com/ci/runs/64e4daab593861711f9bdd3c) | [flake b](https://www.deploysentinel.com/ci/runs/64e4be415605d799c907a1aa) | [flake c](https://www.deploysentinel.com/ci/runs/64e4855dc9d4347430510321)
-- | -- | --
![Screen Shot 2023-08-22 at 1 03 06 PM](https://github.com/metabase/metabase/assets/30528226/e3fe2ba2-e24c-4a81-9884-b16f2ba2edae) | ![Screen Shot 2023-08-22 at 1 20 42 PM](https://github.com/metabase/metabase/assets/30528226/85d7aa75-5426-46ce-a35a-431bddc2fc32) | ![Screen Shot 2023-08-22 at 1 21 45 PM](https://github.com/metabase/metabase/assets/30528226/86e7c7a5-e481-4301-bf30-9b174d56a64f)

Here, I increased the api wait timeout to 15 seconds from the default 5 seconds. Note: this will still flake on some of the obscenely long request above. I couldn't in good conscience increase the timeout that far.  I kid you not, some of these requests [take over 2 minutes](https://www.deploysentinel.com/ci/runs/64e4be415605d799c907a1aa)

Without upgrading runners, there's not a lot we can do here except extending the timeouts

