### PR TITLE
Ignore internal user when reading has-user-setup setting

### DIFF
--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -13,7 +13,6 @@
    [metabase.driver.postgres]
    [metabase.events :as events]
    [metabase.logger :as mb.logger]
-   [metabase.models.user :refer [User]]
    [metabase.plugins :as plugins]
    [metabase.plugins.classloader :as classloader]
    [metabase.public-settings :as public-settings]
@@ -26,8 +25,7 @@
    [metabase.troubleshooting :as troubleshooting]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-trs trs]]
-   [metabase.util.log :as log]
-   [toucan2.core :as t2])
+   [metabase.util.log :as log])
   (:import
    (java.lang.management ManagementFactory)))
 
@@ -125,7 +123,7 @@
   (init-status/set-progress! 0.7)
   ;; run a very quick check to see if we are doing a first time installation
   ;; the test we are using is if there is at least 1 User in the database
-  (let [new-install? (not (t2/exists? User))]
+  (let [new-install? (not (setup/has-user-setup))]
     (when new-install?
       (log/info (trs "Looks like this is a new installation ... preparing setup wizard"))
       ;; create setup token

--- a/src/metabase/setup.clj
+++ b/src/metabase/setup.clj
@@ -4,7 +4,6 @@
    [metabase.config :as config]
    [metabase.db.connection :as mdb.connection]
    [metabase.models.setting :as setting :refer [defsetting Setting]]
-   [metabase.models.user :refer [User]]
    [metabase.util.i18n :refer [deferred-tru tru]]
    [toucan2.core :as t2]))
 

--- a/src/metabase/setup.clj
+++ b/src/metabase/setup.clj
@@ -61,7 +61,7 @@
                     (if (some? possible-override)
                       possible-override
                       (or (get @app-db-id->user-exists? (mdb.connection/unique-identifier))
-                          (let [exists? (t2/exists? User)]
+                          (let [exists? (boolean (seq (t2/select :model/User {:where [:not= :id config/internal-mb-user-id]})))]
                             (swap! app-db-id->user-exists? assoc (mdb.connection/unique-identifier) exists?)
                             exists?))))))
   :doc        false)

--- a/test/metabase/setup_test.clj
+++ b/test/metabase/setup_test.clj
@@ -1,12 +1,24 @@
 (ns ^:mb/once metabase.setup-test
   (:require
    [clojure.test :refer :all]
+   [metabase.core :as mbc]
    [metabase.db :as mdb]
    [metabase.db.schema-migrations-test.impl
     :as schema-migrations-test.impl]
    [metabase.setup :as setup]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
+
+(deftest has-user-setup-test
+  (testing "The has-user-setup getter should return falsey for an empty instance with only an internal user"
+    ;; create a new completely empty database.
+    (schema-migrations-test.impl/with-temp-empty-app-db [_conn :h2]
+      ;; make sure the DB is set up
+      (mdb/setup-db!)
+      ;; install audit DB, which creates an internal user as a side effect (on EE instances))
+      (mbc/ensure-audit-db-installed!)
+      (is (= false
+             (setup/has-user-setup))))))
 
 (deftest has-user-setup-cached-test
   (testing "The has-user-setup getter should cache truthy results since it can never become falsey"


### PR DESCRIPTION
This ensures that the creation of an internal user during instance initialization doesn't interfere with detecting the instance as a new install, and thus showing the setup screen.