### PR TITLE
Modify User endpoints to prevent modification of the Internal User

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/internal_user_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/internal_user_test.clj
@@ -1,7 +1,7 @@
 (ns metabase-enterprise.internal-user-test
   (:require
    [clojure.string :as str]
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer :all]
    [metabase-enterprise.internal-user :as ee.internal-user]
    [metabase.config :as config]
    [metabase.models :refer [User]]

--- a/enterprise/backend/test/metabase_enterprise/internal_user_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/internal_user_test.clj
@@ -1,10 +1,13 @@
 (ns metabase-enterprise.internal-user-test
   (:require
-   [clojure.test :refer [deftest is]]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
    [metabase-enterprise.internal-user :as ee.internal-user]
    [metabase.config :as config]
    [metabase.models :refer [User]]
    [metabase.setup :as setup]
+   [metabase.test :as mt]
+   [metabase.util :as u]
    [toucan2.core :as t2]))
 
 (defmacro with-internal-user-restoration [& body]
@@ -48,3 +51,28 @@
          (with-internal-user-restoration
            ;; there's no internal-user in this block
            (setup/has-user-setup)))))
+
+(deftest internal-user-is-unmodifiable-via-api-test
+  ;; ensure the internal user exists for these test assertions
+  (ee.internal-user/ensure-internal-user-exists!)
+  (testing "GET /api/user"
+    ;; since the Internal user is deactivated, we only need to check in the `:include_deactivated` `true`
+    (let [{:keys [data total]} (mt/user-http-request :crowberto :get 200 "user", :include_deactivated true)]
+      (testing "does not return the internal user"
+        (is (not (some #{"internal@metabase.com"} (map :email data)))))
+      (testing "does not count the internal user"
+        (is (= total (count data))))))
+  (testing "User Endpoints with :id"
+    (doseq [[method endpoint status-code] [[:get "user/:id" 400]
+                                           [:put "user/:id" 400]
+                                           [:put "user/:id/reactivate" 400]
+                                           [:delete "user/:id" 400]
+                                           [:put "user/:id/modal/qbnewb" 400]
+                                           [:post "user/:id/send_invite" 400]]]
+      (let [endpoint (str/replace endpoint #":id" (str config/internal-mb-user-id))
+            testing-details-string (str/join " " [(u/upper-case-en (name :get))
+                                                  endpoint
+                                                  "does not allow modifying the internal user"])]
+        (testing testing-details-string
+          (is (= "Not able to modify the internal user"
+                 (mt/user-http-request :crowberto method status-code endpoint))))))))

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -57,6 +57,13 @@
     (= user-id api/*current-user-id*)
     api/*is-superuser?*)))
 
+(defn check-not-internal-user
+  "Check that `user-id` is not the id of the Internal User."
+  [user-id]
+  {:pre [(integer? user-id)]}
+  (api/check (not= user-id config/internal-mb-user-id)
+           [400 (tru "Not able to modify the internal user")]))
+
 (defn- fetch-user [& query-criteria]
   (apply t2/select-one (vec (cons User user/admin-or-self-visible-columns)) query-criteria))
 
@@ -145,6 +152,8 @@
   [status query group_ids include_deactivated]
   (cond-> {}
     true                                               (sql.helpers/where (status-clause status include_deactivated))
+    ;; don't send the internal user
+    true                                               (sql.helpers/where [:not [:= :core_user.id config/internal-mb-user-id]])
     (premium-features/sandboxed-or-impersonated-user?) (sql.helpers/where [:= :core_user.id api/*current-user-id*])
     (some? query)                                      (sql.helpers/where (query-clause query))
     (some? group_ids)                                  (sql.helpers/right-join
@@ -318,7 +327,6 @@
   (-> (api/check-404 (fetch-user :id id, :is_active true))
       (t2/hydrate :user_group_memberships)))
 
-
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                     Creating a new User -- POST /api/user                                      |
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -446,13 +454,13 @@
   "Reactivate user at `:id`"
   [id]
   (api/check-superuser)
+  (check-not-internal-user id)
   (let [user (t2/select-one [User :id :is_active :sso_source] :id id)]
     (api/check-404 user)
     ;; Can only reactivate inactive users
     (api/check (not (:is_active user))
       [400 {:message (tru "Not able to reactivate an active user")}])
     (reactivate-user! user)))
-
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                               Updating a Password -- PUT /api/user/:id/password                                |
@@ -488,6 +496,8 @@
   "Disable a `User`.  This does not remove the `User` from the DB, but instead disables their account."
   [id]
   (api/check-superuser)
+  ;; don't technically need to because the internal user is already 'deleted' (deactivated), but keeps the warnings consistent
+  (check-not-internal-user id)
   (api/check-500 (pos? (t2/update! User id {:is_active false})))
   {:success true})
 
@@ -501,6 +511,7 @@
   "Indicate that a user has been informed about the vast intricacies of 'the' Query Builder."
   [id modal]
   (check-self-or-superuser id)
+  (check-not-internal-user id)
   (let [k (or (get {"qbnewb"      :is_qbnewb
                     "datasetnewb" :is_datasetnewb}
                    modal)
@@ -515,6 +526,7 @@
   [id]
   {id ms/PositiveInt}
   (api/check-superuser)
+  (check-not-internal-user id)
   (when-let [user (t2/select-one User :id id, :is_active true)]
     (let [reset-token (user/set-password-reset-token! id)
           ;; NOTE: the new user join url is just a password reset with an indicator that this is a first time user

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -324,6 +324,7 @@
    (check-self-or-superuser id)
    (catch clojure.lang.ExceptionInfo _e
      (validation/check-group-manager)))
+  (check-not-internal-user id)
   (-> (api/check-404 (fetch-user :id id, :is_active true))
       (t2/hydrate :user_group_memberships)))
 
@@ -400,7 +401,7 @@
     (check-self-or-superuser id)
     (catch clojure.lang.ExceptionInfo _e
       (validation/check-group-manager)))
-
+  (check-not-internal-user id)
   ;; only allow updates if the specified account is active
   (api/let-404 [user-before-update (fetch-user :id id, :is_active true)]
     ;; Google/LDAP non-admin users can't change their email to prevent account hijacking

--- a/src/metabase/util/files.clj
+++ b/src/metabase/util/files.clj
@@ -170,5 +170,5 @@
             (when-not (.exists out-file) (.mkdirs out-file))
             (let [parent-dir (File. (.substring out-path 0 (.lastIndexOf out-path (int File/separatorChar))))]
               (when-not (.exists parent-dir) (.mkdirs parent-dir))
-              (clojure.java.io/copy stream out-file)))
+              (io/copy stream out-file)))
           (recur (.getNextEntry stream)))))))

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -3,6 +3,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.api.user :as api.user]
+   [metabase.config :as config]
    [metabase.http-client :as client]
    [metabase.models
     :refer [Card Collection Dashboard LoginHistory PermissionsGroup
@@ -229,9 +230,10 @@
       (is (= "You don't have permissions to do that."
              (mt/user-http-request :rasta :get 403 "user", :status "all"))))
 
-    (testing "Pagination gets the total users _in query_"
-      (is (= (t2/count User)
-             ((mt/user-http-request :crowberto :get 200 "user" :status "all") :total))))
+    (testing "Pagination gets the total users _in query_, not including the Internal User"
+      (let [f (if (t2/exists? User config/internal-mb-user-id) dec identity)] ;; is there a smarter way to do this?
+        (is (= (f (t2/count User))
+               ((mt/user-http-request :crowberto :get 200 "user" :status "all") :total)))))
     (testing "for admins, it should include those inactive users as we'd expect"
       (is (= (->> [{:email                  "crowberto@metabase.com"
                     :first_name             "Crowberto"
@@ -303,12 +305,13 @@
                   (map #(dissoc % :is_qbnewb :last_login)))))))
 
   (testing "GET /api/user?include_deactivated=false should return only active users"
-    (is (= (->> [{:email "crowberto@metabase.com"}
-                 {:email "lucky@metabase.com"}
-                 {:email "rasta@metabase.com"}])
+    (is (=  (set ["crowberto@metabase.com"
+                  "lucky@metabase.com"
+                  "rasta@metabase.com"])
            (->> ((mt/user-http-request :crowberto :get 200 "user", :include_deactivated false) :data)
                 (filter mt/test-user?)
-                (map #(select-keys % [:email])))))))
+                (map :email)
+                set)))))
 
 (deftest user-list-limit-test
   (testing "GET /api/user?limit=1&offset=1"

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -256,12 +256,12 @@
                     :personal_collection_id true
                     :common_name            "Rasta Toucan"}
                    {:email                  "trashbird@metabase.com"
-                     :first_name             "Trash"
-                     :last_name              "Bird"
-                     :is_active              false
-                     :group_ids              #{(u/the-id (perms-group/all-users))}
-                     :personal_collection_id true
-                     :common_name            "Trash Bird"}]
+                    :first_name             "Trash"
+                    :last_name              "Bird"
+                    :is_active              false
+                    :group_ids              #{(u/the-id (perms-group/all-users))}
+                    :personal_collection_id true
+                    :common_name            "Trash Bird"}]
                   (map (partial merge @user-defaults))
                   (map #(dissoc % :is_qbnewb :last_login)))
              (->> ((mt/user-http-request :crowberto :get 200 "user", :include_deactivated true) :data)
@@ -305,9 +305,9 @@
                   (map #(dissoc % :is_qbnewb :last_login)))))))
 
   (testing "GET /api/user?include_deactivated=false should return only active users"
-    (is (=  (set ["crowberto@metabase.com"
-                  "lucky@metabase.com"
-                  "rasta@metabase.com"])
+    (is (= #{"crowberto@metabase.com"
+             "lucky@metabase.com"
+             "rasta@metabase.com"}
            (->> ((mt/user-http-request :crowberto :get 200 "user", :include_deactivated false) :data)
                 (filter mt/test-user?)
                 (map :email)

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -165,7 +165,7 @@
 
 (defn user-http-request
   "A version of our test HTTP client that issues the request with credentials for a given User. User may be either a
-  redefined test User name, e.g. `:rasta`, or any User or User ID. (Because we don't have the User's original
+  predefined test User name, e.g. `:rasta`, or any User or User ID. (Because we don't have the User's original
   password, this function temporarily overrides the password for that User.)"
   {:arglists '([test-user-name-or-user-or-id method expected-status-code? endpoint
                 request-options? http-body-map? & {:as query-params}])}


### PR DESCRIPTION
Related Issue: https://github.com/metabase/metabase/issues/31450
Epic: https://github.com/metabase/metabase/issues/27792

This PR modifies the user endpoints to prevent changes to the Internal User. This is part of the Audit V2 project.

User Endpoints checked:

-   **GET /api/user**
    -   uses `user-clauses` which I modified to always include `(sql.helpers/where [:not [:= :core_user.id config/internal-mb-user-id]])`
    -   so, in the situation where the API is used with `?include_deactivated=true` the internal user ID is not included
-   **GET /api/user/recipients**
    -   can only return active users, and Internal is alawys deactivated
    -   even so, this also uses `user-clauses` fn which explicitly filters out the internal user id, so it's never a problem
-   **GET /api/user/current**
    -   should never be possible to get the internal user from here
-   **GET /api/user/:id**
    -   can only get users who are active, so this should never be possible to get the internal user
-   **POST /api/user**
    -   prevents using an email that already exists, so should be ok
-   **PUT /api/user/:id**
    -   only works on active accounts which should never be true for the internal user
-   **PUT /api/user/:id/reactivate**
    -   created helper fn `check-not-internal-user` to use in any places where a user id is passed for editing
    -   added `(check-not-internal-user id)`
    -   the user will not be able to be reactivated as the 400 error is thrown instead
    -   this should not be hit in the UI either since the internal user is filtered out of the GET /api/user endpoint which powers the admin 'People' page. Even if you visit the 'deactivated' section they do not appear, so you can't hit the reactivate button.
    -   small note: IF we don't care and maybe do want to show that, we should do some UI adjustment to either disable the reactivate button and/or pop a modal that explains why the action can't be taken
-   **PUT /api/user/:id/password**
    -   can't know the internal user's password so this endpoint should be safe from adjusting the internal user
-   **DELETE /api/user/:id**
    -   returns `{:success true}` and in theory actually does modify the user BUT it's just setting active false which is already true
    -   added the check anyway so it returns 400 "Cannot modify the internal user"
-   **PUT /api/user/:id/modal/:modal**
    -   similar to DELETE, doesn't really matter but have the check to keep consistency
    -   there's a TODO in the comments suggesting to remove this endpoint by putting the functionality inside PUT /api/user/:id, so maybe that's a worthwhile action item
-   **POST /api/user/:id/send_invite**
    -   put the check in to prevent needless email sending to the interal user's email (which may or may not exist anyway?).


With the changes to the endpoints, the following tests will be added:

# Table of Contents



Now, from the endpoints, I need to put a few tests in for the following endpoints:

-   [x] **`GET /api/user`** internal user is NOT shown in results for admin (implies no other users can see it either)
-   [x] ~~**`GET /api/user/recipients`** internal user is NOT show in results for any user~~
-   [x] **`GET /api/user/:id`** internal user is unreachable b/c its deactivated (should it just return 400 Internal User cannot be modified?)
-   [x] **`PUT /api/user/:id`** internal user is unreachable b/c its deactivated (should it just return 400 Internal User cannot be modified?)
-   [x] **`PUT /api/user/:id/reactivate`** internal user cannot be modified
-   [x] **`DELETE /api/user/:id`** internal user cannot be modified
-   [x] **`PUT /api/user/:id/modal/:modal`** internal user cannot be modified
-   [x] **`POST /api/user/:id/send_invite`** internal user cannot be modified

