### PR TITLE
Add tests to ensure numeric field filter always has a default field widget

### DIFF
--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.unit.spec.tsx
@@ -18,6 +18,7 @@ import {
   createSampleDatabase,
   ORDERS,
   PEOPLE,
+  REVIEWS,
 } from "metabase-types/api/mocks/presets";
 import {
   createMockQueryBuilderState,
@@ -164,6 +165,25 @@ describe("TagEditorParam", () => {
       expect(setTemplateTag).toHaveBeenCalledWith({
         ...tag,
         dimension: ["field", ORDERS.QUANTITY, null],
+        "widget-type": "number/=",
+        options: undefined,
+      });
+    });
+
+    it("should default to number/= for a new reviews->rating field filter (metabase#16151)", async () => {
+      const tag = createMockTemplateTag({
+        type: "dimension",
+        dimension: undefined,
+        "widget-type": undefined,
+      });
+      const { setTemplateTag } = setup({ tag });
+
+      userEvent.click(await screen.findByText("Reviews"));
+      userEvent.click(await screen.findByText("Rating"));
+
+      expect(setTemplateTag).toHaveBeenCalledWith({
+        ...tag,
+        dimension: ["field", REVIEWS.RATING, null],
         "widget-type": "number/=",
         options: undefined,
       });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/16151

### Description

I tried to reproduce this with tag v0.44.0 but couldn't. This PR adds a unit test to cover this specific case.

### How to verify

1. New > SQL Query and paste the following code
    ```sql
    select * from REVIEWS
    where {{high_rating}}
    ```
2. Set *Variable type* to *Field filter* and map it to Reviews -> Rating

You should see the *Filter widget type* option defaults to *Equals to* unlike *None* in the screenshot from the original issue.

### Demo
![Screenshot 2023-08-23 at 4 17 39 PM](https://github.com/metabase/metabase/assets/1937582/fb9de196-8106-4e70-8b01-4de3fd12e643)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
