### PR TITLE
Require default role to be set for using connection impersonation

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
@@ -67,7 +67,7 @@
 (defn- impersonation-enabled?
   "Is connection impersonation enabled for the given database for any users?"
   [database]
-  (t2/exists? :model/ConnectionImpersonation :db_id (u/the-id database)))
+  (t2/exists? :model/ConnectionImpersonation :db_id (u/id database)))
 
 (defenterprise hash-key-for-impersonation
   "Returns a hash-key for FieldValues if the current user uses impersonation for the database."
@@ -89,15 +89,14 @@
       (let [enabled?           (impersonation-enabled? database)
             default-role       (driver.sql/default-database-role driver database)
             impersonation-role (and enabled? (connection-impersonation-role database))]
-        (if-let [role (or impersonation-role default-role)]
+        (when (and (impersonation-enabled? database) (not default-role))
+          (throw (ex-info (tru "Connection impersonation is enabled for this database, but no default role is found")
+                          {:user-id api/*current-user-id*
+                           :database-id (u/the-id database)})))
+        (when-let [role (or impersonation-role default-role)]
           ;; If impersonation is not enabled for any groups but we have a default role, we should still set it, just
           ;; in case impersonation used to be enabled and the connection still uses an impersonated role.
-          (driver/set-role! driver conn role)
-          ;; We require a default role to be provided for databases with connection impersonation enabled
-          (when (impersonation-enabled? database)
-            (throw (ex-info (tru "Connection impersonation is enabled for this database, but no default role is found")
-                            {:user-id api/*current-user-id*
-                             :database-id (u/the-id database)})))))
+          (driver/set-role! driver conn role)))
       (catch Throwable e
         (log/debug e (tru "Error setting role on connection"))
         (throw e)))))

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModal.unit.spec.tsx
@@ -176,7 +176,10 @@ describe("impersonation modal", () => {
     await setup({
       hasImpersonation: false,
       userAttributes: [],
-      databaseDetails: { engine: "snowflake" },
+      databaseDetails: {
+        engine: "snowflake",
+        features: ["connection-impersonation-requires-role"],
+      },
     });
 
     expect(

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModal.unit.spec.tsx
@@ -26,10 +26,12 @@ const defaultUserAttributes = ["foo", "bar"];
 const setup = async ({
   userAttributes = defaultUserAttributes,
   hasImpersonation = true,
+  databaseDetails = {},
 } = {}) => {
   const database = createMockDatabase({
     id: databaseId,
     tables: [createMockTable()],
+    ...databaseDetails,
   });
   setupDatabaseEndpoints(database);
   fetchMock.get(
@@ -168,6 +170,26 @@ describe("impersonation modal", () => {
 
     await screen.findByText(selectedAttribute);
     expect(await screen.findByRole("button", { name: /save/i })).toBeEnabled();
+  });
+
+  it("should show a link to the database settings if the engine requires a role and there is no role", async () => {
+    await setup({
+      hasImpersonation: false,
+      userAttributes: [],
+      databaseDetails: { engine: "snowflake" },
+    });
+
+    expect(
+      await screen.findByText(
+        "Connection impersonation requires specifying a user role on the database connection.",
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      await screen.findByRole("link", { name: /edit connection/i }),
+    ).toHaveAttribute("href", "/admin/databases/1");
+
+    expect(await screen.findByRole("button", { name: /close/i })).toBeEnabled();
   });
 
   it("should show the link to people settings if there is no impersonation and no attributes", async () => {

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModalView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModalView.tsx
@@ -87,7 +87,7 @@ export const ImpersonationModalView = ({
           <Alert icon="warning" variant="warning">
             {t`Connection impersonation requires specifying a user role on the database connection.`}{" "}
             <Link
-              className="link"
+              variant="brand"
               to={`/admin/databases/${database.id}`}
             >{t`Edit connection`}</Link>
           </Alert>
@@ -127,7 +127,7 @@ export const ImpersonationModalView = ({
           <Alert icon="warning" variant="warning">
             {t`To associate a user with a database role, you'll need to give that user at least one user attribute.`}{" "}
             <Link
-              className="link"
+              variant="brand"
               to="/admin/people"
             >{t`Edit user settings`}</Link>
           </Alert>

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModalView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModalView.tsx
@@ -66,6 +66,10 @@ export const ImpersonationModalView = ({
     }
   };
 
+  // Does the "role" field need to first be filled out on the DB details page?
+  const roleRequired =
+    database.engine === "snowflake" && database.details["role"] == null;
+
   return (
     <ImpersonationModalViewRoot>
       <h2>{t`Map a user attribute to database roles`}</h2>
@@ -77,7 +81,21 @@ export const ImpersonationModalView = ({
         >{t`Learn More`}</ExternalLink>
       </ImpersonationDescription>
 
-      {hasAttributes ? (
+      {roleRequired ? (
+        <>
+          <Alert icon="warning" variant="warning">
+            {t`Connection impersonation requires specifying a user role on the database connection.`}{" "}
+            <Link
+              className="link"
+              to={`/admin/databases/${database.id}`}
+            >{t`Edit connection`}</Link>
+          </Alert>
+
+          <FormFooter hasTopBorder>
+            <Button type="button" onClick={onCancel}>{t`Close`}</Button>
+          </FormFooter>
+        </>
+      ) : hasAttributes ? (
         <FormProvider
           initialValues={initialValues}
           validationSchema={ROLE_ATTRIBUTION_MAPPING_SCHEMA}

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModalView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModalView.tsx
@@ -68,7 +68,8 @@ export const ImpersonationModalView = ({
 
   // Does the "role" field need to first be filled out on the DB details page?
   const roleRequired =
-    database.engine === "snowflake" && database.details["role"] == null;
+    database.features.includes("connection-impersonation-requires-role") &&
+    database.details["role"] == null;
 
   return (
     <ImpersonationModalViewRoot>

--- a/frontend/src/metabase-types/api/database.ts
+++ b/frontend/src/metabase-types/api/database.ts
@@ -32,7 +32,9 @@ export type DatabaseFeature =
   | "right-join"
   | "inner-join"
   | "full-join"
-  | "nested-field-columns";
+  | "nested-field-columns"
+  | "connection-impersonation"
+  | "connection-impersonation-requires-role";
 
 export interface Database extends DatabaseData {
   id: DatabaseId;

--- a/modules/drivers/snowflake/resources/metabase-plugin.yaml
+++ b/modules/drivers/snowflake/resources/metabase-plugin.yaml
@@ -33,7 +33,7 @@ driver:
       type: schema-filters
       display-name: Schemas
     - name: role
-      display-name: Role (optional)
+      display-name: Role (required for connection impersonation)
       helper-text: Specify a role to override the database user’s default role.
       placeholder: user
     - cloud-ip-address-info

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -42,10 +42,11 @@
 
 (driver/register! :snowflake, :parent #{:sql-jdbc ::sql-jdbc.legacy/use-legacy-classes-for-read-and-set})
 
-(doseq [[feature supported?] {:datetime-diff            true
-                              :now                      true
-                              :convert-timezone         true
-                              :connection-impersonation true}]
+(doseq [[feature supported?] {:datetime-diff                          true
+                              :now                                    true
+                              :convert-timezone                       true
+                              :connection-impersonation               true
+                              :connection-impersonation-requires-role true}]
   (defmethod driver/database-supports? [:snowflake feature] [_driver _feature _db] supported?))
 
 (defmethod driver/humanize-connection-error-message :snowflake

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -586,6 +586,4 @@
 
 (defmethod driver.sql/default-database-role :snowflake
   [_ database]
-  (or
-   (-> database :details :role)
-   "ACCOUNTADMIN"))
+  (-> database :details :role))

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -524,6 +524,9 @@
     ;; Does the driver support connection impersonation (i.e. overriding the role used for individual queries)?
     :connection-impersonation
 
+    ;; Does the driver require specifying the default connection role for connection impersonation to work?
+    :connection-impersonation-requires-role
+
     ;; Does the driver require specifying a collection (table) for native queries? (mongo)
     :native-requires-specified-collection})
 

--- a/src/metabase/models/permissions/util.clj
+++ b/src/metabase/models/permissions/util.clj
@@ -1,0 +1,9 @@
+(ns metabase.models.permissions.util
+  "Misc utilities for working with permissions and related topics."
+  (:require [metabase.public-settings.premium-features :refer [defenterprise]]))
+
+(defenterprise impersonation-enabled-for-db?
+  "Is impersonation enabled for the given database, for any groups? OSS implementation always returns false."
+  metabase-enterprise.advanced-permissions.driver.impersonation
+  [_db-or-id]
+  false)


### PR DESCRIPTION
Updates the connection impersonation configuration process for Snowflake databases to require `role` to be filled out in the database details page. This allows Metabase to determine what role should be used to reset connections to for non-impersonated users, since there's no easy way to obtain that from Snowflake (unlike with Postgres). Discussion is in [this thread](https://metaboat.slack.com/archives/C056QEW4KNF/p1692795342224929).

This also includes a small frontend change & a new unit test to show a different warning in the impersonation modal if the `role` field is not filled out for a Snowflake DB.

Resolves https://github.com/metabase/metabase/issues/33423