### PR TITLE
Fix issue with some table columns that are unable to be rendered

### DIFF
--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -216,7 +216,8 @@
 
 (defn- filter-rows [data table-columns rows]
   (let [column-order      (qp.streaming/export-column-order (:cols data) table-columns)
-        keep-filtered-idx (fn [col] (map #(nth col %) column-order))
+        keep-filtered-idx (fn [row] (let [row-v (into [] row)]
+                                      (for [i column-order] (row-v i))))
         filtered-rows     (map #(update % :row keep-filtered-idx) rows)]
     filtered-rows))
 

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -216,8 +216,10 @@
 
 (defn- filter-rows [data table-columns rows]
   (let [column-order      (qp.streaming/export-column-order (:cols data) table-columns)
-        keep-filtered-idx (fn [row] (let [row-v (into [] row)]
-                                      (for [i column-order] (row-v i))))
+        keep-filtered-idx (fn [row] (if column-order
+                                      (let [row-v (into [] row)]
+                                        (for [i column-order] (row-v i)))
+                                      row))
         filtered-rows     (map #(update % :row keep-filtered-idx) rows)]
     filtered-rows))
 


### PR DESCRIPTION
For https://github.com/metabase/metabase/issues/33279

### Description

For the stack trace, it seems like `export-column-order` can somehow produce a value that creates an OOB. Unsure how this is possible, but after reading how the [csv](https://github.com/metabase/metabase/blob/master/src/metabase/query_processor/streaming/csv.clj#L34-L37) is being processed (csv processing works on the Details example), I saw that I probably need to check if `output-order` is non-nil. Not entirely sure this will resolve the issue, will verify though (could be that we do the html rendering first, but reading that code doesn't seem to modify the # of columns, so not sure)
