### PR TITLE
Fix eslint/import plugin config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
     "curly": [1, "all"],
     "eqeqeq": [1, "smart"],
     "import/no-default-export": 2,
+    "import/no-named-as-default": 0,
     "import/no-commonjs": 1,
     "import/order": [
       "error",
@@ -121,11 +122,16 @@
     "plugin:react/jsx-runtime",
     "plugin:react-hooks/recommended",
     "plugin:import/errors",
-    "plugin:import/warnings"
+    "plugin:import/warnings",
+    "plugin:import/typescript"
   ],
   "settings": {
     "import/internal-regex": "^metabase/|^metabase-lib/",
-    "import/resolver": "webpack",
+    "import/resolver": {
+      "webpack": {
+        "typescript": true
+      }
+    },
     "import/ignore": ["\\.css$"],
     "react": {
       "version": "detect"

--- a/frontend/src/metabase-lib/v2.ts
+++ b/frontend/src/metabase-lib/v2.ts
@@ -3,7 +3,6 @@
 export * from "./aggregation";
 export * from "./binning";
 export * from "./breakout";
-export * from "./breakout";
 export * from "./buckets";
 export * from "./column_types";
 export * from "./common";

--- a/frontend/src/metabase/components/SchedulePicker/index.ts
+++ b/frontend/src/metabase/components/SchedulePicker/index.ts
@@ -1,4 +1,3 @@
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export { default } from "./SchedulePicker";
-export type { SchedulePickerProps } from "./SchedulePicker";
 export * from "./SchedulePicker";

--- a/frontend/src/metabase/core/components/Link/index.ts
+++ b/frontend/src/metabase/core/components/Link/index.ts
@@ -1,4 +1,3 @@
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export { default } from "./Link";
-export * from "./Link";
 export type { LinkProps } from "./types";

--- a/frontend/src/metabase/core/components/TabButton/index.ts
+++ b/frontend/src/metabase/core/components/TabButton/index.ts
@@ -1,2 +1,1 @@
 export * from "./TabButton";
-export * from "./TabButton";

--- a/frontend/src/metabase/core/components/TabRow/index.ts
+++ b/frontend/src/metabase/core/components/TabRow/index.ts
@@ -1,2 +1,1 @@
 export * from "./TabRow";
-export * from "./TabRow";

--- a/frontend/src/metabase/metabot/components/Metabot/index.ts
+++ b/frontend/src/metabase/metabot/components/Metabot/index.ts
@@ -1,3 +1,2 @@
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export { default } from "./Metabot";
-export * from "./Metabot";

--- a/frontend/src/metabase/reducers-common.js
+++ b/frontend/src/metabase/reducers-common.js
@@ -8,7 +8,6 @@ import { settings } from "metabase/redux/settings";
 import undo from "metabase/redux/undo";
 import upload from "metabase/redux/uploads";
 import { reducer as auth } from "metabase/redux/auth";
-// eslint-disable-next-line import/no-named-as-default
 import entities, { enhanceRequestsReducer } from "metabase/redux/entities";
 
 /* user */


### PR DESCRIPTION
Previously `eslint/import` plugin wasn't configured for TypeScript. This PR fixes it, and addresses some found issues.

How to verify:
- CI green (`yarn lint` and `yarn type-check` passes)