### PR TITLE
Forbid mantine usages outside of ui folder

### DIFF
--- a/frontend/src/metabase/.eslintrc
+++ b/frontend/src/metabase/.eslintrc
@@ -3,11 +3,6 @@
     "no-restricted-imports": [
       "error",
       {
-        "patterns": [
-          "metabase-enterprise",
-          "metabase-enterprise/*",
-          "cljs/metabase.lib*"
-        ],
         "paths": [
           {
             "name": "react-redux",
@@ -16,8 +11,7 @@
           },
           {
             "name": "@mantine/core",
-            "importNames": ["createStyles"],
-            "message": "Avoid using `createStyles` because of breaking changes in the upcoming Mantine update"
+            "message": "Please import from `metabase/ui` instead."
           }
         ]
       }
@@ -39,16 +33,13 @@
     {
       "files": ["lib/redux/hooks.ts"],
       "rules": {
-        "no-restricted-imports": [
-          "error",
-          {
-            "patterns": [
-              "metabase-enterprise",
-              "metabase-enterprise/*",
-              "cljs/metabase.lib*"
-            ]
-          }
-        ]
+        "no-restricted-imports": 0
+      }
+    },
+    {
+      "files": ["ui/**/*.{js,jsx,ts,tsx}"],
+      "rules": {
+        "no-restricted-imports": 0
       }
     }
   ]

--- a/frontend/src/metabase/.eslintrc
+++ b/frontend/src/metabase/.eslintrc
@@ -3,6 +3,11 @@
     "no-restricted-imports": [
       "error",
       {
+        "patterns": [
+          "metabase-enterprise",
+          "metabase-enterprise/*",
+          "cljs/metabase.lib*"
+        ],
         "paths": [
           {
             "name": "react-redux",

--- a/frontend/src/metabase/search/components/TypeSearchSidebar/TypeSearchSidebar.tsx
+++ b/frontend/src/metabase/search/components/TypeSearchSidebar/TypeSearchSidebar.tsx
@@ -1,5 +1,5 @@
 import { t } from "ttag";
-import { Flex } from "@mantine/core";
+import { Flex } from "metabase/ui";
 import { TypeSidebarButton } from "metabase/search/components/TypeSearchSidebar/TypeSearchSidebar.styled";
 import type { SearchModelType } from "metabase-types/api";
 import { SEARCH_FILTERS } from "metabase/search/constants";


### PR DESCRIPTION
`mantine` shouldn't be used directly. Only re-exported usages are allowed. The reasoning here is that we might need to wrap these components in the future:
- to implement features that cannot be done with the style API
- to forbid usages of certain props
- etc

How to verify:
- `yarn lint` passes
- If you rollback the change with the incorrect import it should fail