### PR TITLE
Moving Dashboard name to HTML Node

### DIFF
--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
@@ -21,6 +21,11 @@ export const saveDashboardPdf = async (
     useCORS: true,
     onclone: (doc: Document, node: HTMLElement) => {
       node.classList.add(SAVING_DOM_IMAGE_CLASS);
+      const title = doc.createElement("h2") as HTMLElement;
+      title.innerHTML = dashboardName;
+      title.style["borderBottom"] = `1px solid ${color("border")}`;
+      title.style["paddingBottom"] = "1rem";
+      node.insertBefore(title, node.firstChild);
     },
   });
 
@@ -38,11 +43,6 @@ export const saveDashboardPdf = async (
   });
 
   pdf.addImage(image, "JPEG", 0, 60, imageWidth, imageHeight, "", "FAST", 0);
-  pdf.setFont("helvetica", "bold");
-  pdf.setTextColor(color("text-dark"));
-  pdf.text(dashboardName, 32, 40);
-  pdf.setDrawColor(color("border"));
-  pdf.line(32, 52, imageWidth - 32, 52, "S");
 
   pdf.save(fileName);
 };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/33121

### Description
This PR moves the name of the dashboard to the dashboard to the be part of the HTML to be converted to an image, rather than adding the title as text to the PDF above the image. This allows the browser to render the title correctly, rather than rely on setting the correct font in JsPDF. 

### How to verify
1. Set the dashboard name to non latin characters. For example:
- Вре́дний кіт
- 特げぼん会式詳ア
- தமிழ் அரிச்சுவடி

2. Export the dashboard as a PDF and observe the name at the top of the document

### Demo
<img width="727" alt="image" src="https://github.com/metabase/metabase/assets/1328979/8a1ee6c7-409a-444b-8fcd-9acc8cb3caf7">

