### PR TITLE
Don't show stacktraces in QP errors

### DIFF
--- a/src/metabase/query_processor/middleware/catch_exceptions.clj
+++ b/src/metabase/query_processor/middleware/catch_exceptions.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor.middleware.catch-exceptions
   "Middleware for catching exceptions thrown by the query processor and returning them in a friendlier format."
   (:require
+   [metabase.config :as config]
    [metabase.query-processor.context :as qp.context]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.middleware.permissions :as qp.perms]
@@ -22,10 +23,12 @@
 
 (defmethod format-exception Throwable
   [^Throwable e]
-  {:status     :failed
-   :class      (class e)
-   :error      (.getMessage e)
-   :stacktrace (u/filtered-stacktrace e)})
+  (merge
+   {:status :failed
+    :class  (class e)
+    :error  (.getMessage e)}
+   (when config/is-dev?
+     {:stacktrace (u/filtered-stacktrace e)})))
 
 (defmethod format-exception InterruptedException
   [^InterruptedException _e]

--- a/test/metabase/driver/sql_jdbc/native_test.clj
+++ b/test/metabase/driver/sql_jdbc/native_test.clj
@@ -5,8 +5,6 @@
    [medley.core :as m]
    [metabase.query-processor :as qp]
    [metabase.test.data :as data]
-   #_{:clj-kondo/ignore [:deprecated-namespace]}
-   [metabase.util.schema :as su]
    [schema.core :as s]))
 
 (deftest basic-query-test
@@ -68,7 +66,6 @@
     (is (schema= {:status     (s/eq :failed)
                   :class      (s/eq org.h2.jdbc.JdbcSQLSyntaxErrorException)
                   :error      #"^Column \"ZID\" not found"
-                  :stacktrace [su/NonBlankString]
                   :json_query {:native   {:query (s/eq "SELECT ZID FROM CHECKINS LIMIT 2")}
                                :type     (s/eq :native)
                                s/Keyword s/Any}

--- a/test/metabase/query_processor/middleware/catch_exceptions_test.clj
+++ b/test/metabase/query_processor/middleware/catch_exceptions_test.clj
@@ -30,25 +30,18 @@
         (is (= {:status     :failed
                 :class      clojure.lang.ExceptionInfo
                 :error      "1"
-                :stacktrace true
                 :error_type :qp
                 :ex-data    {:level 1}
                 :via        [{:status     :failed
                               :class      clojure.lang.ExceptionInfo
                               :error      "2"
-                              :stacktrace true
                               :ex-data    {:level 2, :type :qp}
                               :error_type :qp}
                              {:status     :failed
                               :class      clojure.lang.ExceptionInfo
                               :error      "3"
-                              :stacktrace true
                               :ex-data    {:level 3}}]}
-               (-> (#'catch-exceptions/exception-response e3)
-                   (update :stacktrace sequential?)
-                   (update :via (fn [causes]
-                                  (for [cause causes]
-                                    (update cause :stacktrace sequential?)))))))))))
+               (#'catch-exceptions/exception-response e3)))))))
 
 
 (defn- catch-exceptions
@@ -81,28 +74,23 @@
     (is (= {:status     :failed
             :class      java.lang.Exception
             :error      "Something went wrong"
-            :stacktrace true
             :json_query {}
             :row_count  0
             :data       {:cols []}}
-           (-> (catch-exceptions (fn [] (throw (Exception. "Something went wrong"))))
-               (update :stacktrace boolean))))))
+           (catch-exceptions (fn [] (throw (Exception. "Something went wrong"))))))))
 
 (deftest ^:parallel async-exception-test
   (testing "if an Exception is returned asynchronously by `raise`, should format it the same way"
     (is (= {:status     :failed
             :class      java.lang.Exception
             :error      "Something went wrong"
-            :stacktrace true
             :json_query {}
             :row_count  0
             :data       {:cols []}}
-           (-> (mt/test-qp-middleware catch-exceptions/catch-exceptions
-                                      {} {} []
-                                      {:runf (fn [_ _ context]
-                                               (qp.context/raisef (Exception. "Something went wrong") context))})
-               :metadata
-               (update :stacktrace boolean))))))
+           (:metadata (mt/test-qp-middleware catch-exceptions/catch-exceptions
+                                             {} {} []
+                                             {:runf (fn [_ _ context]
+                                                      (qp.context/raisef (Exception. "Something went wrong") context))}))))))
 
 (deftest ^:parallel catch-exceptions-test
   (testing "include-query-execution-info-test"
@@ -110,31 +98,28 @@
       (is (= {:status     :failed
               :class      java.lang.Exception
               :error      "Something went wrong"
-              :stacktrace true
               :card_id    300
               :json_query {}
               :row_count  0
               :data       {:cols []}
               :a          100
               :b          200}
-             (-> (mt/test-qp-middleware catch-exceptions/catch-exceptions
-                                        {} {} []
-                                        {:runf (fn [_ _ context]
-                                                 (qp.context/raisef (ex-info "Something went wrong."
-                                                                             {:query-execution {:a            100
-                                                                                                :b            200
-                                                                                                :card_id      300
-                                                                                                ;; these keys should all get removed
-                                                                                                :result_rows  400
-                                                                                                :hash         500
-                                                                                                :executor_id  500
-                                                                                                :dashboard_id 700
-                                                                                                :pulse_id     800
-                                                                                                :native       900}}
-                                                                             (Exception. "Something went wrong"))
-                                                                    context))})
-                 :metadata
-                 (update :stacktrace boolean))))))
+             (:metadata (mt/test-qp-middleware catch-exceptions/catch-exceptions
+                                               {} {} []
+                                               {:runf (fn [_ _ context]
+                                                        (qp.context/raisef (ex-info "Something went wrong."
+                                                                                    {:query-execution {:a            100
+                                                                                                       :b            200
+                                                                                                       :card_id      300
+                                                                                                       ;; these keys should all get removed
+                                                                                                       :result_rows  400
+                                                                                                       :hash         500
+                                                                                                       :executor_id  500
+                                                                                                       :dashboard_id 700
+                                                                                                       :pulse_id     800
+                                                                                                       :native       900}}
+                                                                                    (Exception. "Something went wrong"))
+                                                                           context))}))))))
   (testing "Should always include :error (#23258, #23281)"
     (testing "Uses error message if present"
       (is (= "Something went wrong"

--- a/test/metabase/query_processor_test/failure_test.clj
+++ b/test/metabase/query_processor_test/failure_test.clj
@@ -44,7 +44,6 @@
                  [:status       [:= :failed]]
                  [:class        (ms/InstanceOfClass Class)]
                  [:error        :string]
-                 [:stacktrace   [:sequential ms/NonBlankString]]
                  ;; `:database` is removed by the catch-exceptions middleware for historical reasons
                  [:json_query   (bad-query-schema)]
                  [:preprocessed (bad-query-preprocessed-schema)]
@@ -60,7 +59,6 @@
                  [:native       bad-query-native-schema]
                  [:status       [:= :failed]]
                  [:class        (ms/InstanceOfClass Class)]
-                 [:stacktrace   [:sequential ms/NonBlankString]]
                  [:context      [:= :question]]
                  [:error        ms/NonBlankString]
                  [:row_count    [:= 0]]


### PR DESCRIPTION
Fixes private issue 59.

Does this have unintended consequences wrt surfacing errors to the FE though?

Is it better to remove the stacktrace entirely?