### PR TITLE
fix url bug in sandbox editor

### DIFF
--- a/frontend/src/metabase/hoc/ModalRoute.tsx
+++ b/frontend/src/metabase/hoc/ModalRoute.tsx
@@ -5,6 +5,7 @@ import { push } from "react-router-redux";
 import { connect } from "react-redux";
 import type { LocationDescriptor } from "history";
 
+import MetabaseSettings from "metabase/lib/settings";
 import Modal from "metabase/components/Modal";
 
 type IRoute = {
@@ -12,7 +13,23 @@ type IRoute = {
 };
 
 export const getParentPath = (route: IRoute, location: Location) => {
-  const fullPathSegments = location.pathname.split("/");
+  // If instance has a custom url we need to exclude its subpath
+  const siteUrlSegments = (MetabaseSettings.get("site-url") ?? "").split("/");
+  const subPath = siteUrlSegments.slice(3).join("/");
+
+  let pathName: string;
+  if (subPath) {
+    const subPathSplit = location.pathname.split(subPath);
+
+    pathName =
+      subPathSplit.length === 1
+        ? subPathSplit[0]
+        : subPathSplit.slice(1).join(subPath);
+  } else {
+    pathName = location.pathname;
+  }
+
+  const fullPathSegments = pathName.split("/");
   const routeSegments = route.path.split("/");
 
   fullPathSegments.splice(-routeSegments.length);

--- a/frontend/src/metabase/hoc/ModalRoute.unit.spec.js
+++ b/frontend/src/metabase/hoc/ModalRoute.unit.spec.js
@@ -1,6 +1,11 @@
+import { mockSettings } from "__support__/settings";
 import { getParentPath } from "./ModalRoute";
 
-const setup = (routePath, locationPath) => {
+const setup = (routePath, locationPath, siteURL = undefined) => {
+  if (siteURL) {
+    mockSettings({ "site-url": siteURL });
+  }
+
   return getParentPath({ path: routePath }, { pathname: locationPath });
 };
 
@@ -32,6 +37,40 @@ describe("getParentPath", () => {
       const parentPath = setup("c", "/a/b/c");
 
       expect(parentPath).toEqual("/a/b");
+    });
+
+    it("without single segment site url subpath", () => {
+      const parentPath = setup(
+        "c",
+        "metabase/a/b/c",
+        "https://somesite.com/metabase",
+      );
+
+      expect(parentPath).toEqual("/a/b");
+    });
+
+    it("without multi segment site url subpath", () => {
+      const parentPath = setup(
+        "c",
+        "meta/base/a/b/c",
+        "https://somesite.com/meta/base",
+      );
+
+      expect(parentPath).toEqual("/a/b");
+    });
+
+    // This is to handle the edge case where someone uses a subpath name
+    // like "data" that is also used within Metabase's routes
+    // e.g. If the site-url is "https://corp.com/data", it should not
+    // remove the second "data" from the path in "https://corp.com/data/admin/permissions/data/groups"
+    it("without leading url subpath while preserving later occurances", () => {
+      const parentPath = setup(
+        "groups",
+        "data/admin/permissions/data/groups",
+        "https://corp.com/data",
+      );
+
+      expect(parentPath).toEqual("/admin/permissions/data");
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/33458

### Description

There was an issue with URL manipulation when hosting on a subpath domain that caused a 404 after attempting to save in the sandbox editor modal. This PR fixes the issue by correcting the implementation of the underlying `getParentPath` helper function to account for a custom url with a subpath.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a user, add them to a group, and give them an attribute such as `State = CA`
2. In the permissions tab, add granular permissions to the sample database, and on a table such as `People` click to add sandboxed permissions
3. In the sandbox edtior modal, map a column to a user attribute (e.g. `State` column to `State` attribute), then click save
4. There should be no 404 error

### Demo

https://github.com/metabase/metabase/assets/37751258/b5e4031a-c40a-4a1a-b30f-0dc0bc3ba85d

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
