### PR TITLE
Crazy fast QP tests! **I shaved 21 seconds off the test suite this week alone!**

### DIFF
--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -307,7 +307,7 @@
                   (is (= (mt/rows (qp.pivot/run-pivot-query query))
                          (mt/rows result))))))))))))
 
-(deftest pivot-with-order-by-test
+(deftest ^:parallel pivot-with-order-by-test
   (testing "Pivot queries should work if there is an `:order-by` clause (#17198)"
     (mt/dataset sample-dataset
       (let [query (mt/mbql-query products

--- a/test/metabase/query_processor/test_util.clj
+++ b/test/metabase/query_processor/test_util.clj
@@ -495,7 +495,8 @@
     (or (get-in results [:data :results_metadata :columns])
         (throw (ex-info "Missing [:data :results_metadata :columns] from query results" results)))))
 
-(defn ^:deprecated card-with-source-metadata-for-query
+;;; TODO -- we should mark this deprecated, I just don't want to have to update a million usages.
+(defn card-with-source-metadata-for-query
   "Given an MBQL `query`, return the relevant keys for creating a Card with that query and matching `:result_metadata`.
 
     (t2.with-temp/with-temp [Card card (qp.test-util/card-with-source-metadata-for-query

--- a/test/metabase/query_processor_test/explicit_joins_test.clj
+++ b/test/metabase/query_processor_test/explicit_joins_test.clj
@@ -12,6 +12,7 @@
    [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor :as qp]
    [metabase.query-processor-test.timezones-test :as timezones-test]
+   [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test-util :as qp.test-util]
    [metabase.test :as mt]
    [metabase.test.data :as data]

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -46,7 +46,6 @@
    [metabase.test.data.impl :as data.impl]
    [metabase.test.data.interface :as tx]
    [metabase.test.data.mbql-query-impl :as mbql-query-impl]
-   [metabase.util :as u]
    [metabase.util.malli :as mu]))
 
 (set! *warn-on-reflection* true)
@@ -208,7 +207,7 @@
   variable [[metabase.test.data.impl/*db-fn*]], which can be rebound with [[with-db]]."
   ([]
    (mb.hawk.init/assert-tests-are-not-initializing "(mt/id ...) or (data/id ...)")
-   (u/the-id (db)))
+   (data.impl/db-id))
 
   ([table-name]
    (data.impl/the-table-id (id) (format-name table-name)))

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -56,7 +56,7 @@
   []
   (*db-fn*))
 
-(def ^:private ^:dynamic *db-id-fn*
+(def ^:private ^:dynamic ^{:arglists '([])} *db-id-fn*
   (let [f (mdb.connection/memoize-for-application-db
            (fn [driver]
              (u/the-id (get-or-create-test-data-db! driver))))]
@@ -319,8 +319,9 @@
                              (binding [db/*disable-db-logging* true]
                                (let [db (get-or-create-database! driver dbdef)]
                                  (assert db)
-                                 (assert (t2/exists? Database :id (u/the-id db)))
-                                 db))))]
-    (binding [*db-fn* (fn []
-                         (get-db-for-driver (tx/driver)))]
+                                 (assert (pos-int? (:id db)))
+                                 db))))
+        db-fn             #(get-db-for-driver (tx/driver))]
+    (binding [*db-fn*    db-fn
+              *db-id-fn* #(u/the-id (db-fn))]
       (f))))


### PR DESCRIPTION
Wow! QP tests are getting so F A S T 

Between #33068, #33221, and now this PR, things are really getting faster! **21 seconds shaved off the test suite this week alone!**


### BEFORE #33068

```
$ time clj -X:dev:ee:ee-dev:test:test/qp
...
Ran 165 tests in parallel, 652 single-threaded.
Finding and running tests took 2.2 mins.
All tests passed.

real    2m19.155s
user    3m44.528s
sys     0m8.595s
```

### AFTER this PR

```
$ time clj -X:dev:test:ee:ee-dev:test/qp

Ran 545 tests in parallel, 357 single-threaded.
Finding and running tests took 1.7 mins.
All tests passed.

real    1m58.367s
user    3m47.933s
sys     0m7.523s
```

### WHAT'S NEW 

* Convert some of the tests in `explicit-joins-tests` to use MLv2 metadata providers so they don't need to use `with-temp` and can thus be made `^:parallel` 
* Cache ID lookups with `mt/id` and DB lookups with `mt/db`... we make thousands of calls to these in each test run and their value **never changes** (for a given application database + driver + dataset). `(mt/id :venues :name)` for example used to require **THREE** app DB calls, one to get the Database ID, another to get the Table ID, and a third to get the Field ID... some tests had dozens of calls like these! Now it requires ZERO calls! 