### PR TITLE
Fix argument passing in docker entry script

### DIFF
--- a/bin/docker/run_metabase.sh
+++ b/bin/docker/run_metabase.sh
@@ -60,7 +60,7 @@ if [ $(id -u) -ne 0 ]; then
     # exec is here twice on purpose to  ensure that metabase runs as PID 1 (the init process)
     # and thus receives signals sent to the container. This allows it to shutdown cleanly on exit
     docker_setup_env
-    exec /bin/sh -c "exec java $JAVA_OPTS -jar /app/metabase.jar $@"
+    exec /bin/sh -c "exec java $JAVA_OPTS -jar /app/metabase.jar $*"
 else
     # Avoid running metabase (or any server) as root where possible
     # If you want to use specific user and group ids that matches an existing
@@ -155,7 +155,7 @@ else
     if [ -f "${INITIAL_DB}" ]; then
         echo "Initializing Metabase database from H2 database ${INITIAL_DB}..."
         chmod o+r ${INITIAL_DB}
-        su metabase -s /bin/sh -c "exec java $JAVA_OPTS -jar /app/metabase.jar load-from-h2 ${INITIAL_DB%.mv.db} $@"
+        su metabase -s /bin/sh -c "exec java $JAVA_OPTS -jar /app/metabase.jar load-from-h2 ${INITIAL_DB%.mv.db} $*"
 
         if [ $? -ne 0 ]; then
             echo "Failed to initialize database from H2 database!"
@@ -168,5 +168,5 @@ else
     # Launch the application
     # exec is here twice on purpose to  ensure that metabase runs as PID 1 (the init process)
     # and thus receives signals sent to the container. This allows it to shutdown cleanly on exit
-    exec su metabase -s /bin/sh -c "exec java $JAVA_OPTS -jar /app/metabase.jar $@"
+    exec su metabase -s /bin/sh -c "exec java $JAVA_OPTS -jar /app/metabase.jar $*"
 fi


### PR DESCRIPTION
> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/33485

### Description

`run_metabase.sh` is passing argument to `java` with `$@` which triggers shellcheck warning [SC2145]. The warning suggest replacing `$@` with `$*` and it worked.

[SC2145]: https://www.shellcheck.net/wiki/SC2145

### How to verify

Describe the steps to verify that the changes are working as expected.

I didn't create a new docker image for this. Instead I was editing the script in bash shell inside docker and verify this patch is working

1. Run `docker run -it --entrypoint /bin/bash metabase/metabase:v0.47.0`
2. In docker, run `/app/run_metabase.sh migrate release-locks` to verify current argument passing fails. The last log message should be `The 'migrate' command requires the following arguments: [direction], but received: [].`
3. Edit `/app/run_metabase.sh` with `vi`. Change all `$@` with `$*` (basically what this patch is doing)
4. Run `/app/run_metabase.sh migrate release-locks` again. Java should exit without error and last log message is `INFO db.setup :: Liquibase is ready.`

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

N/A

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
