### PR TITLE
re-export BoxProps from mantine/core

### DIFF
--- a/frontend/src/metabase/ui/components/layout/Box/index.ts
+++ b/frontend/src/metabase/ui/components/layout/Box/index.ts
@@ -1,1 +1,2 @@
 export { Box } from "@mantine/core";
+export type { BoxProps } from "@mantine/core";


### PR DESCRIPTION

### Description

Because of a [typescript limitation](https://github.com/Microsoft/TypeScript/issues/26591), we can't infer the props of the Box component via `React.ComponentProps`

This also affects `styled(Box)` which is going to lose the typing of all the style props.

We can work around it by using BoxProps re-exported from @mantine/core, for example: `styled(Box)<BoxProps>({...styles)`

### How to verify

- Write `const FancyBox = styled(Box)<BoxProps>();` and import BoxProps from `metabase/ui`
- FancyBox should have all the props of Box

