### PR TITLE
Fix rendering issue with hidden columns

### DIFF
--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -214,7 +214,7 @@
   {:arglists '([chart-type render-type timezone-id card dashcard data])}
   (fn [chart-type _ _ _ _ _] chart-type))
 
-(defn- filter-rows [data viz-settings]
+(defn- order-data [data viz-settings]
   (if (some? (::mb.viz/table-columns viz-settings))
     (let [[ordered-cols output-order] (qp.streaming/order-cols (:cols data) viz-settings)
           keep-filtered-idx           (fn [row] (if output-order
@@ -227,7 +227,7 @@
 
 (s/defmethod render :table :- common/RenderedPulseCard
   [_ render-type timezone-id :- (s/maybe s/Str) card _dashcard {:keys [rows viz-settings] :as data}]
-  (let [[ordered-cols ordered-rows] (filter-rows data viz-settings)
+  (let [[ordered-cols ordered-rows] (order-data data viz-settings)
         data                        (-> data
                                         (assoc :rows ordered-rows)
                                         (assoc :cols ordered-cols))

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -214,30 +214,29 @@
   {:arglists '([chart-type render-type timezone-id card dashcard data])}
   (fn [chart-type _ _ _ _ _] chart-type))
 
-(defn- filter-rows [data table-columns rows]
-  (let [column-order      (qp.streaming/export-column-order (:cols data) table-columns)
-        keep-filtered-idx (fn [row] (if column-order
-                                      (let [row-v (into [] row)]
-                                        (for [i column-order] (row-v i)))
-                                      row))
-        filtered-rows     (map #(update % :row keep-filtered-idx) rows)]
-    filtered-rows))
+(defn- filter-rows [data viz-settings]
+  (if (some? (::mb.viz/table-columns viz-settings))
+    (let [[ordered-cols output-order] (qp.streaming/order-cols (:cols data) viz-settings)
+          keep-filtered-idx           (fn [row] (if output-order
+                                                  (let [row-v (into [] row)]
+                                                    (for [i output-order] (row-v i)))
+                                                  row))
+          ordered-rows                (map keep-filtered-idx (:rows data))]
+      [ordered-cols ordered-rows])
+    [(:cols data) (:rows data)]))
 
 (s/defmethod render :table :- common/RenderedPulseCard
   [_ render-type timezone-id :- (s/maybe s/Str) card _dashcard {:keys [rows viz-settings] :as data}]
-  (let [table-columns          (::mb.viz/table-columns viz-settings)
-        filter-columns?        (some? table-columns)
-        filtered-columns-names (if filter-columns?
-                                 (mapv ::mb.viz/table-column-name (filter ::mb.viz/table-column-enabled table-columns))
-                                 (mapv :name (:cols data)))
-        filtered-rows          (cond->> (prep-for-html-rendering timezone-id card data)
-                                 filter-columns? (filter-rows data table-columns))
-        table-body             [:div
-                                (table/render-table
-                                 (color/make-color-selector data viz-settings)
-                                 filtered-columns-names
-                                 filtered-rows)
-                                (render-truncation-warning rows-limit (count rows))]]
+  (let [[ordered-cols ordered-rows] (filter-rows data viz-settings)
+        data                        (-> data
+                                        (assoc :rows ordered-rows)
+                                        (assoc :cols ordered-cols))
+        table-body                  [:div
+                                     (table/render-table
+                                      (color/make-color-selector data viz-settings)
+                                      (mapv :name ordered-cols)
+                                      (prep-for-html-rendering timezone-id card data))
+                                     (render-truncation-warning rows-limit (count rows))]]
     {:attachments
      nil
 

--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -50,7 +50,7 @@
                   table-columns)
       table-columns)))
 
-(defn export-column-order
+(defn- export-column-order
   "For each entry in `table-columns` that is enabled, finds the index of the corresponding
   entry in `cols` by name or id. If a col has been remapped, uses the index of the new column.
 

--- a/test/metabase/pulse/render/table_test.clj
+++ b/test/metabase/pulse/render/table_test.clj
@@ -211,4 +211,29 @@
                           :display_name "a",
                           :base_type    :type/BigInteger
                           :semantic_type nil}]
-                  :rows [[2 1] [4 3]]}})))))
+                  :rows [[2 1] [4 3]]}}))))
+    (testing "visibility_type is respected in render."
+    (is (=
+         (render-table
+          {:visualization_settings {:table.columns
+                                    [{:name "a" :enabled true}
+                                     {:name "b" :enabled true}]}}
+          {:data {:cols [{:name            "a",
+                          :display_name    "a",
+                          :base_type       :type/BigInteger
+                          :visibility_type :normal
+                          :semantic_type   nil}
+                         {:name            "b",
+                          :display_name    "b",
+                          :base_type       :type/BigInteger
+                          :visibility_type :details-only
+                          :semantic_type   nil}]
+                  :rows [[1 2] [3 4]]}})
+         (render-table
+          {:visualization_settings {:table.columns
+                                    [{:name "a" :enabled true}]}}
+          {:data {:cols [{:name         "a",
+                          :display_name "a",
+                          :base_type    :type/BigInteger
+                          :semantic_type nil}]
+                  :rows [[1 2] [3 4]]}})))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/33279

### Description

Before rendering the html rows, we don't remove columns with visibility type of details-only, but after we do. So now we just process the rows before rendering the html. 

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a table/model/view
2. In the table metadata switch the visibility to details views
3. The table/model/view will still have the column, but newly created tables won't have the column
4. visualization settings swap a few a the columns around (for table.columns to be replicated in viz-settings), then trigger a pulse
