### PR TITLE
Fix "the their" typo in Impersonation access docs

### DIFF
--- a/docs/developers-guide/contributing.md
+++ b/docs/developers-guide/contributing.md
@@ -24,7 +24,7 @@ We don't like getting sued, so before merging any pull request, we'll need each 
 
 ## What we're trying to build
 
-Metabase is all about letting non-technical users get access to the their organization's data. We're trying to maximize the amount of power that can be comfortably used by someone who understands their business, is quantitatively bent, but probably only comfortable with Excel.
+Metabase is all about letting non-technical users get access to their organization's data. We're trying to maximize the amount of power that can be comfortably used by someone who understands their business, is quantitatively bent, but probably only comfortable with Excel.
 
 It's important to keep in mind these goals of the Metabase project. Many times
 proposals will be marked "Out of Scope" or otherwise deprioritized. This doesn't mean the proposal isn't useful, or that we wouldn't be interested in seeing it done as a side project or as an experimental branch. However, it does mean that we won't point the core team or contributors to it in the near term. Issues that are slightly out of scope will be kept open in case there is community support (and ideally contributions).


### PR DESCRIPTION
Fixes a typo in the Impersonation access docs. "the their" was used when it should be either "the" or "their". I chose "their".