### PR TITLE
MLv2 Joins 9 — Remove `externalOp` usage

### DIFF
--- a/frontend/src/metabase-lib/common.ts
+++ b/frontend/src/metabase-lib/common.ts
@@ -1,15 +1,7 @@
 import * as ML from "cljs/metabase.lib.js";
 
-import type {
-  Clause,
-  ExternalOp,
-  JoinConditionClause,
-  JoinConditionExternalOp,
-} from "./types";
+import type { Clause, ExternalOp } from "./types";
 
-declare function ExternalOpFn(
-  condition: JoinConditionClause,
-): JoinConditionExternalOp;
-declare function ExternalOpFn(clause: Clause): ExternalOp;
-
-export const externalOp: typeof ExternalOpFn = ML.external_op;
+export function externalOp(clause: Clause): ExternalOp {
+  return ML.external_op(clause);
+}

--- a/frontend/src/metabase-lib/join.ts
+++ b/frontend/src/metabase-lib/join.ts
@@ -8,7 +8,6 @@ import type {
   FilterOperator,
   Join,
   JoinConditionClause,
-  JoinConditionExternalOp,
   JoinStrategy,
   Query,
   TableMetadata,
@@ -33,7 +32,7 @@ export function joins(query: Query, stageIndex: number): Join[] {
 
 export function joinClause(
   joinable: Joinable,
-  conditions: JoinConditionClause[] | JoinConditionExternalOp[],
+  conditions: JoinConditionClause[],
 ): Join {
   return ML.join_clause(joinable, conditions);
 }
@@ -71,7 +70,7 @@ export function joinConditions(join: Join): JoinConditionClause[] {
 
 export function withJoinConditions(
   join: Join,
-  newConditions: JoinConditionClause[] | JoinConditionExternalOp[],
+  newConditions: JoinConditionClause[],
 ): Join {
   return ML.with_join_conditions(join, newConditions);
 }

--- a/frontend/src/metabase-lib/join.ts
+++ b/frontend/src/metabase-lib/join.ts
@@ -8,6 +8,7 @@ import type {
   FilterOperator,
   Join,
   JoinConditionClause,
+  JoinConditionParts,
   JoinStrategy,
   Query,
   TableMetadata,
@@ -66,6 +67,29 @@ export function withJoinStrategy(join: Join, strategy: JoinStrategy): Join {
 
 export function joinConditions(join: Join): JoinConditionClause[] {
   return ML.join_conditions(join);
+}
+
+export function joinConditionParts(
+  query: Query,
+  stageIndex: number,
+  condition: JoinConditionClause,
+): JoinConditionParts {
+  const {
+    operator,
+    column: lhsColumn,
+    args,
+    options,
+  } = ML.filter_parts(query, stageIndex, condition);
+
+  // Join conditions have a single arg and it's always a column
+  const rhsColumn = args[0] as ColumnMetadata;
+
+  return {
+    operator,
+    lhsColumn,
+    rhsColumn,
+    options,
+  };
 }
 
 export function withJoinConditions(

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -171,8 +171,9 @@ export type FilterParts = {
   args: ExpressionArg[];
 };
 
-export type JoinConditionExternalOp = Omit<ExternalOp, "args"> & {
-  args: [ColumnMetadata, ColumnMetadata];
+export type JoinConditionParts = Omit<FilterParts, "column" | "args"> & {
+  lhsColumn: ColumnMetadata;
+  rhsColumn: ColumnMetadata;
 };
 
 declare const Join: unique symbol;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -163,11 +163,16 @@ function setup(step = createMockNotebookStep(), { readOnly = false } = {}) {
     const fields = Lib.joinFields(join);
 
     const conditions = Lib.joinConditions(join).map(condition => {
-      const externalOp = Lib.externalOp(condition);
-      const [lhsColumn, rhsColumn] = externalOp.args.map(column =>
-        Lib.displayInfo(query, 0, column),
+      const { operator, lhsColumn, rhsColumn } = Lib.joinConditionParts(
+        query,
+        0,
+        condition,
       );
-      return { ...externalOp, lhsColumn, rhsColumn };
+      return {
+        operator: Lib.displayInfo(query, 0, operator),
+        lhsColumn: Lib.displayInfo(query, 0, lhsColumn),
+        rhsColumn: Lib.displayInfo(query, 0, rhsColumn),
+      };
     });
 
     return {
@@ -309,7 +314,7 @@ describe("Notebook Editor > Join Step", () => {
     const { conditions } = getRecentJoin();
     const [condition] = conditions;
     expect(conditions).toHaveLength(1);
-    expect(condition.operator).toBe("=");
+    expect(condition.operator.shortName).toBe("=");
     expect(condition.lhsColumn.longDisplayName).toBe("Product ID");
     expect(condition.rhsColumn.longDisplayName).toBe("Products → ID");
   });
@@ -427,7 +432,7 @@ describe("Notebook Editor > Join Step", () => {
     expect(notEqualsOperator).toHaveAttribute("aria-selected", "true");
 
     const [condition] = getRecentJoin().conditions;
-    expect(condition.operator).toBe("!=");
+    expect(condition.operator.shortName).toBe("!=");
   });
 
   describe("join fields", () => {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -522,7 +522,7 @@ describe("Notebook Editor > Join Step", () => {
       userEvent.click(within(rhsColumnPicker).getByText("Rating"));
 
       const { fields } = getRecentJoin();
-      expect(fields).toHaveLength(0);
+      expect(fields).toBe("none");
     });
 
     it("should select a few columns for an existing join", async () => {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/use-join.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/use-join.ts
@@ -20,9 +20,9 @@ export function useJoin(query: Lib.Query, stageIndex: number, join?: Lib.Join) {
   // After that, we use `displayInfo(query, stageIndex, column).selected` to determine if a column is selected
   // We use "all" instead of `joinableColumns(query, stageIndex, table)`
   // to avoid race-conditions when the table metadata is not yet loaded
-  const [selectedColumns, _setSelectedColumns] = useState<
-    Lib.ColumnMetadata[] | "all"
-  >(join ? [] : "all");
+  const [selectedColumns, _setSelectedColumns] = useState<Lib.JoinFields>(
+    join ? [] : "all",
+  );
 
   const columns = useMemo(() => {
     if (join) {
@@ -55,6 +55,9 @@ export function useJoin(query: Lib.Query, stageIndex: number, join?: Lib.Join) {
     if (selectedColumns === "all") {
       return true;
     }
+    if (selectedColumns === "none") {
+      return false;
+    }
     return selectedColumns.some(selectedColumn => column === selectedColumn);
   };
 
@@ -73,8 +76,6 @@ export function useJoin(query: Lib.Query, stageIndex: number, join?: Lib.Join) {
     if (nextSelectedColumns === "all") {
       const columns = Lib.joinableColumns(query, stageIndex, table);
       _setSelectedColumns(columns);
-    } else if (nextSelectedColumns === "none") {
-      _setSelectedColumns([]);
     } else {
       _setSelectedColumns(nextSelectedColumns);
     }


### PR DESCRIPTION
Part of #31070, epic #30514

We're about to remove `externalOp` from the FE (#33433) in favor of `filterParts` (#33419). External ops used to be a convenient way to get various parts of a filter clause (and a join condition is essentially a filter clause — `[ operator, lhsColumn, rhsColumn ]`). `filterParts` is a newer method that's a bit more convenient for the FE.

This PR adds a wrapper for `filterParts` (called `joinConditionParts`) and migrates the FE joins code to use it instead of `externalOp`