### PR TITLE
Fix passing args in storybook for mantine components

### DIFF
--- a/frontend/src/metabase/ui/components/buttons/Button/Button.stories.mdx
+++ b/frontend/src/metabase/ui/components/buttons/Button/Button.stories.mdx
@@ -85,7 +85,17 @@ Not to use:
 
 ## Examples
 
-export const ButtonRowTemplate = args => (
+export const DefaultTemplate = args => <Button {...args}>Button</Button>;
+
+export const ButtonGroupTemplate = args => (
+  <Button.Group>
+    <Button {...args}>One</Button>
+    <Button {...args}>Two</Button>
+    <Button {...args}>Three</Button>
+  </Button.Group>
+);
+
+export const GridRow = args => (
   <Group noWrap>
     <Button {...args}>Save</Button>
     <Button {...args} leftIcon={<Icon name="add" />}>
@@ -98,23 +108,23 @@ export const ButtonRowTemplate = args => (
   </Group>
 );
 
-export const ButtonRowGroupTemplate = args => (
+export const GridRowGroup = args => (
   <Fragment>
-    <ButtonRowTemplate {...args} />
-    <ButtonRowTemplate {...args} radius="xl" />
+    <GridRow {...args} />
+    <GridRow {...args} radius="xl" />
   </Fragment>
 );
 
-export const ButtonGridTemplate = args => (
+export const GridTemplate = args => (
   <Stack>
-    <ButtonRowGroupTemplate {...args} variant="filled" />
-    <ButtonRowGroupTemplate {...args} variant="outline" />
-    <ButtonRowGroupTemplate {...args} variant="default" />
-    <ButtonRowTemplate {...args} variant="subtle" />
+    <GridRowGroup {...args} variant="filled" />
+    <GridRowGroup {...args} variant="outline" />
+    <GridRowGroup {...args} variant="default" />
+    <GridRow {...args} variant="subtle" />
   </Stack>
 );
 
-export const LoadingButtonRowTemplate = args => (
+export const LoadingGridRow = args => (
   <Group noWrap>
     <Button {...args} loaderPosition="left">
       Save
@@ -126,23 +136,23 @@ export const LoadingButtonRowTemplate = args => (
   </Group>
 );
 
-export const LoadingButtonRowGroupTemplate = args => (
+export const LoadingGridRowGroup = args => (
   <Fragment>
-    <LoadingButtonRowTemplate {...args} />
-    <LoadingButtonRowTemplate {...args} radius="xl" />
+    <LoadingGridRow {...args} />
+    <LoadingGridRow {...args} radius="xl" />
   </Fragment>
 );
 
-export const LoadingButtonGridTemplate = args => (
+export const LoadingGridTemplate = args => (
   <Stack>
-    <LoadingButtonRowGroupTemplate {...args} variant="filled" />
-    <LoadingButtonRowGroupTemplate {...args} variant="outline" />
-    <LoadingButtonRowGroupTemplate {...args} variant="default" />
-    <LoadingButtonRowTemplate {...args} variant="subtle" />
+    <LoadingGridRowGroup {...args} variant="filled" />
+    <LoadingGridRowGroup {...args} variant="outline" />
+    <LoadingGridRowGroup {...args} variant="default" />
+    <LoadingGridRow {...args} variant="subtle" />
   </Stack>
 );
 
-export const Default = args => <Button {...args}>Button</Button>;
+export const Default = DefaultTemplate.bind({});
 
 <Canvas>
   <Story name="Default">{Default}</Story>
@@ -150,13 +160,7 @@ export const Default = args => <Button {...args}>Button</Button>;
 
 ### Button.Group
 
-export const ButtonGroup = args => (
-  <Button.Group>
-    <Button {...args}>One</Button>
-    <Button {...args}>Two</Button>
-    <Button {...args}>Three</Button>
-  </Button.Group>
-);
+export const ButtonGroup = ButtonGroupTemplate.bind({});
 
 <Canvas>
   <Story name="Button group">{ButtonGroup}</Story>
@@ -164,7 +168,7 @@ export const ButtonGroup = args => (
 
 ### Default size
 
-export const DefaultGrid = args => <ButtonGridTemplate {...args} />;
+export const DefaultGrid = GridTemplate.bind({});
 
 <Canvas>
   <Story name="Default size">{DefaultGrid}</Story>
@@ -172,116 +176,164 @@ export const DefaultGrid = args => <ButtonGridTemplate {...args} />;
 
 #### Disabled state
 
-export const DefaultDisabledGrid = args => (
-  <ButtonGridTemplate {...args} disabled />
-);
+export const DefaultDisabledGrid = GridTemplate.bind({});
+DefaultDisabledGrid.args = {
+  disabled: true,
+};
 
 <Canvas>
-  <Story name="Default size, disabled">{DefaultDisabledGrid}</Story>
+  <Story name="Default size, disabled" args={DefaultDisabledGrid.args}>
+    {DefaultDisabledGrid}
+  </Story>
 </Canvas>
 
 #### Loading state
 
-export const DefaultLoadingGrid = args => (
-  <ButtonGridTemplate {...args} loading />
-);
+export const DefaultLoadingGrid = LoadingGridTemplate.bind({});
+DefaultLoadingGrid.args = {
+  loading: true,
+};
 
 <Canvas>
-  <Story name="Default size, loading">{DefaultLoadingGrid}</Story>
+  <Story name="Default size, loading" args={DefaultLoadingGrid.args}>
+    {DefaultLoadingGrid}
+  </Story>
 </Canvas>
 
 ### Default size & full width
 
-export const DefaultFullWidthGrid = args => (
-  <ButtonGridTemplate {...args} fullWidth />
-);
+export const DefaultFullWidthGrid = GridTemplate.bind({});
+DefaultFullWidthGrid.args = {
+  fullWidth: true,
+};
 
 <Canvas>
-  <Story name="Default size, full width">{DefaultFullWidthGrid}</Story>
+  <Story name="Default size, full width" args={DefaultFullWidthGrid.args}>
+    {DefaultFullWidthGrid}
+  </Story>
 </Canvas>
 
 #### Disabled state
 
-export const DefaultDisabledFullWidthGrid = args => (
-  <ButtonGridTemplate {...args} disabled fullWidth />
-);
+export const DefaultDisabledFullWidthGrid = GridTemplate.bind({});
+DefaultDisabledFullWidthGrid.args = {
+  disabled: true,
+  fullWidth: true,
+};
 
 <Canvas>
-  <Story name="Default size, full width, disabled">
+  <Story
+    name="Default size, full width, disabled"
+    args={DefaultDisabledFullWidthGrid.args}
+  >
     {DefaultDisabledFullWidthGrid}
   </Story>
 </Canvas>
 
 #### Loading state
 
-export const DefaultLoadingFullWidthGrid = args => (
-  <LoadingButtonGridTemplate {...args} loading fullWidth />
-);
+export const DefaultLoadingFullWidthGrid = LoadingGridTemplate.bind({});
+DefaultLoadingFullWidthGrid.args = {
+  loading: true,
+  fullWidth: true,
+};
 
 <Canvas>
-  <Story name="Default size, full width, loading">
+  <Story
+    name="Default size, full width, loading"
+    args={DefaultLoadingFullWidthGrid.args}
+  >
     {DefaultLoadingFullWidthGrid}
   </Story>
 </Canvas>
 
 ### Compact size
 
-export const CompactGrid = args => <ButtonGridTemplate {...args} compact />;
+export const CompactGrid = GridTemplate.bind({});
+CompactGrid.args = {
+  compact: true,
+};
 
 <Canvas>
-  <Story name="Compact size">{CompactGrid}</Story>
+  <Story name="Compact size" args={CompactGrid.args}>
+    {CompactGrid}
+  </Story>
 </Canvas>
 
 #### Disabled state
 
-export const CompactDisabledGrid = args => (
-  <ButtonGridTemplate {...args} compact disabled />
-);
+export const CompactDisabledGrid = GridTemplate.bind({});
+CompactDisabledGrid.args = {
+  compact: true,
+  disabled: true,
+};
 
 <Canvas>
-  <Story name="Compact size, disabled">{CompactDisabledGrid}</Story>
+  <Story name="Compact size, disabled" args={CompactDisabledGrid.args}>
+    {CompactDisabledGrid}
+  </Story>
 </Canvas>
 
 #### Loading state
 
-export const CompactLoadingGrid = args => (
-  <LoadingButtonGridTemplate {...args} compact loading />
-);
+export const CompactLoadingGrid = LoadingGridTemplate.bind({});
+CompactLoadingGrid.args = {
+  compact: true,
+  loading: true,
+};
 
 <Canvas>
-  <Story name="Compact size, loading">{CompactLoadingGrid}</Story>
+  <Story name="Compact size, loading" args={CompactLoadingGrid.args}>
+    {CompactLoadingGrid}
+  </Story>
 </Canvas>
 
 ### Compact size & full width
 
-export const CompactFullWidthGrid = args => (
-  <ButtonGridTemplate {...args} compact fullWidth />
-);
+export const CompactFullWidthGrid = GridTemplate.bind({});
+CompactFullWidthGrid.args = {
+  compact: true,
+  fullWidth: true,
+};
 
 <Canvas>
-  <Story name="Compact size, full width">{CompactFullWidthGrid}</Story>
+  <Story name="Compact size, full width" args={CompactFullWidthGrid.args}>
+    {CompactFullWidthGrid}
+  </Story>
 </Canvas>
 
 #### Disabled state
 
-export const CompactDisabledFullWidthGrid = args => (
-  <ButtonGridTemplate {...args} compact disabled fullWidth />
-);
+export const CompactDisabledFullWidthGrid = GridTemplate.bind({});
+CompactDisabledFullWidthGrid.args = {
+  compact: true,
+  disabled: true,
+  fullWidth: true,
+};
 
 <Canvas>
-  <Story name="Compact size, full width, disabled">
+  <Story
+    name="Compact size, full width, disabled"
+    args={CompactDisabledFullWidthGrid.args}
+  >
     {CompactDisabledFullWidthGrid}
   </Story>
 </Canvas>
 
 #### Loading state
 
-export const CompactLoadingFullWidthGrid = args => (
-  <LoadingButtonGridTemplate {...args} compact loading fullWidth />
-);
+export const CompactLoadingFullWidthGrid = LoadingGridTemplate.bind({});
+CompactLoadingFullWidthGrid.args = {
+  compact: true,
+  loading: true,
+  fullWidth: true,
+};
 
 <Canvas>
-  <Story name="Compact size, full width, loading">
+  <Story
+    name="Compact size, full width, loading"
+    args={CompactLoadingFullWidthGrid.args}
+  >
     {CompactLoadingFullWidthGrid}
   </Story>
 </Canvas>

--- a/frontend/src/metabase/ui/components/feedback/Loader/Loader.stories.mdx
+++ b/frontend/src/metabase/ui/components/feedback/Loader/Loader.stories.mdx
@@ -37,15 +37,9 @@ Our themed wrapper around [Mantine Loader](https://mantine.dev/core/loader/).
 
 ## Examples
 
-export const Default = args => <Loader {...args} />;
+export const DefaultTemplate = args => <Loader {...args} />;
 
-<Canvas>
-  <Story name="Default">{Default}</Story>
-</Canvas>
-
-### Sizes
-
-export const Sizes = args => (
+export const SizeTemplate = args => (
   <Grid w="10rem" columns={2} align="center">
     {argTypes.size.options.map(size => (
       <Fragment key={size}>
@@ -59,6 +53,16 @@ export const Sizes = args => (
     ))}
   </Grid>
 );
+
+export const Default = DefaultTemplate.bind({});
+
+<Canvas>
+  <Story name="Default">{Default}</Story>
+</Canvas>
+
+### Sizes
+
+export const Sizes = SizeTemplate.bind({});
 
 <Canvas>
   <Story name="Sizes">{Sizes}</Story>

--- a/frontend/src/metabase/ui/components/inputs/Checkbox/Checkbox.stories.mdx
+++ b/frontend/src/metabase/ui/components/inputs/Checkbox/Checkbox.stories.mdx
@@ -54,7 +54,7 @@ Checkbox buttons allow users to select a single option from a list of mutually e
 
 export const DefaultTemplate = args => <Checkbox {...args} />;
 
-export const GroupTemplate = args => (
+export const CheckboxGroupTemplate = args => (
   <Checkbox.Group
     defaultValue={["react"]}
     label="An array of good frameworks"
@@ -105,10 +105,10 @@ export const Default = DefaultTemplate.bind({});
 
 ### Checkbox.Group
 
-export const Group = GroupTemplate.bind({});
+export const CheckboxGroup = CheckboxGroupTemplate.bind({});
 
 <Canvas>
-  <Story name="Checkbox group">{Group}</Story>
+  <Story name="Checkbox group">{CheckboxGroup}</Story>
 </Canvas>
 
 ### Label

--- a/frontend/src/metabase/ui/components/inputs/Checkbox/Checkbox.stories.mdx
+++ b/frontend/src/metabase/ui/components/inputs/Checkbox/Checkbox.stories.mdx
@@ -61,10 +61,10 @@ export const CheckboxGroupTemplate = args => (
     description="But which one to use?"
   >
     <Stack mt="md">
-      <Checkbox value="react" label="React" />
-      <Checkbox value="svelte" label="Svelte" />
-      <Checkbox value="ng" label="Angular" />
-      <Checkbox value="vue" label="Vue" />
+      <Checkbox {...args} value="react" label="React" />
+      <Checkbox {...args} value="svelte" label="Svelte" />
+      <Checkbox {...args} value="ng" label="Angular" />
+      <Checkbox {...args} value="vue" label="Vue" />
     </Stack>
   </Checkbox.Group>
 );

--- a/frontend/src/metabase/ui/components/inputs/Checkbox/Checkbox.stories.mdx
+++ b/frontend/src/metabase/ui/components/inputs/Checkbox/Checkbox.stories.mdx
@@ -3,7 +3,7 @@ import { Checkbox, Stack } from "metabase/ui";
 
 export const args = {
   label: "Label",
-  description: "",
+  description: undefined,
   disabled: false,
   labelPosition: "right",
 };
@@ -52,44 +52,9 @@ Checkbox buttons allow users to select a single option from a list of mutually e
 
 ## Examples
 
-export const Template = args => (
-  <Stack>
-    <Checkbox {...args} label="Default checkbox" />
-    <Checkbox {...args} label="Indeterminate checkbox" indeterminate />
-    <Checkbox
-      {...args}
-      label="Indeterminate checked checkbox"
-      checked
-      indeterminate
-    />
-    <Checkbox {...args} label="Checked checkbox" checked />
-    <Checkbox {...args} label="Disabled checkbox" disabled />
-    <Checkbox
-      {...args}
-      label="Disabled intermediate checkbox"
-      disabled
-      intermediate
-    />
-    <Checkbox
-      {...args}
-      label="Disabled indeterminate checked checkbox"
-      disabled
-      checked
-      indeterminate
-    />
-    <Checkbox {...args} label="Disabled checked checkbox" disabled checked />
-  </Stack>
-);
+export const DefaultTemplate = args => <Checkbox {...args} />;
 
-export const Default = args => <Checkbox {...args} />;
-
-<Canvas>
-  <Story name="Default">{Default}</Story>
-</Canvas>
-
-### Checkbox.Group
-
-export const CheckboxGroup = args => (
+export const GroupTemplate = args => (
   <Checkbox.Group
     defaultValue={["react"]}
     label="An array of good frameworks"
@@ -104,13 +69,51 @@ export const CheckboxGroup = args => (
   </Checkbox.Group>
 );
 
+export const StateTemplate = args => (
+  <Stack>
+    <Checkbox {...args} label="Default checkbox" />
+    <Checkbox {...args} label="Indeterminate checkbox" indeterminate />
+    <Checkbox
+      {...args}
+      label="Indeterminate checked checkbox"
+      defaultChecked
+      indeterminate
+    />
+    <Checkbox {...args} label="Checked checkbox" defaultChecked />
+    <Checkbox {...args} label="Disabled checkbox" disabled />
+    <Checkbox
+      {...args}
+      label="Disabled indeterminate checked checkbox"
+      disabled
+      defaultChecked
+      indeterminate
+    />
+    <Checkbox
+      {...args}
+      label="Disabled checked checkbox"
+      disabled
+      defaultChecked
+    />
+  </Stack>
+);
+
+export const Default = DefaultTemplate.bind({});
+
 <Canvas>
-  <Story name="Checkbox group">{CheckboxGroup}</Story>
+  <Story name="Default">{Default}</Story>
+</Canvas>
+
+### Checkbox.Group
+
+export const Group = GroupTemplate.bind({});
+
+<Canvas>
+  <Story name="Checkbox group">{Group}</Story>
 </Canvas>
 
 ### Label
 
-export const Label = args => <Template {...args} />;
+export const Label = StateTemplate.bind({});
 
 <Canvas>
   <Story name="Label">{Label}</Story>
@@ -118,30 +121,36 @@ export const Label = args => <Template {...args} />;
 
 #### Left label position
 
-export const LabelLeft = args => <Template {...args} labelPosition="left" />;
+export const LabelLeft = StateTemplate.bind({});
+LabelLeft.args = {
+  labelPosition: "left",
+};
 
 <Canvas>
-  <Story name="Label, left position">{LabelLeft}</Story>
+  <Story name="Label, left position" args={LabelLeft.args}>
+    {LabelLeft}
+  </Story>
 </Canvas>
 
 ### Description
 
-export const Description = args => (
-  <Template {...args} description="Description" />
-);
+export const Description = StateTemplate.bind({});
 
 <Canvas>
   <Story name="Description">{Description}</Story>
 </Canvas>
 
-export const DescriptionLeft = args => (
-  <Template {...args} description="Description" labelPosition="left" />
-);
-
 #### Left label position
 
+export const DescriptionLeft = StateTemplate.bind({});
+DescriptionLeft.args = {
+  labelPosition: "left",
+};
+
 <Canvas>
-  <Story name="Description, left position">{DescriptionLeft}</Story>
+  <Story name="Description, left position" args={DescriptionLeft.args}>
+    {DescriptionLeft}
+  </Story>
 </Canvas>
 
 ## Related components

--- a/frontend/src/metabase/ui/components/inputs/NumberInput/NumberInput.stories.mdx
+++ b/frontend/src/metabase/ui/components/inputs/NumberInput/NumberInput.stories.mdx
@@ -95,144 +95,16 @@ Our themed wrapper around [Mantine NumberInput](https://mantine.dev/core/number-
 
 ## Examples
 
-export const Default = args => <NumberInput {...args} />;
+export const DefaultTemplate = args => <NumberInput {...args} />;
 
-export const Template = args => (
+export const VariantTemplate = args => (
   <Stack>
     <NumberInput {...args} variant="default" />
     <NumberInput {...args} variant="unstyled" />
   </Stack>
 );
 
-export const Empty = args => (
-  <Template
-    {...args}
-    label={sampleArgs.label}
-    placeholder={sampleArgs.placeholder}
-  />
-);
-
-export const Filled = args => (
-  <Template
-    {...args}
-    defaultValue={sampleArgs.value}
-    label={sampleArgs.label}
-    placeholder={sampleArgs.placeholder}
-  />
-);
-
-export const Asterisk = args => (
-  <Template
-    {...args}
-    label={sampleArgs.label}
-    placeholder={sampleArgs.placeholder}
-    withAsterisk
-  />
-);
-
-export const Description = args => (
-  <Template
-    {...args}
-    label={sampleArgs.label}
-    description={sampleArgs.description}
-    placeholder={sampleArgs.placeholder}
-  />
-);
-
-export const Disabled = args => (
-  <Template
-    {...args}
-    label={sampleArgs.label}
-    description={sampleArgs.description}
-    placeholder={sampleArgs.placeholder}
-    disabled
-    withAsterisk
-  />
-);
-
-export const Error = args => (
-  <Template
-    {...args}
-    label={sampleArgs.label}
-    description={sampleArgs.description}
-    placeholder={sampleArgs.placeholder}
-    error={sampleArgs.error}
-    withAsterisk
-  />
-);
-
-export const Icons = args => (
-  <Template
-    {...args}
-    label={sampleArgs.label}
-    description={sampleArgs.description}
-    placeholder={sampleArgs.placeholder}
-    icon={<Icon name="int" />}
-    withAsterisk
-  />
-);
-
-export const ReadOnly = args => (
-  <Template
-    {...args}
-    defaultValue={sampleArgs.value}
-    label={sampleArgs.label}
-    description={sampleArgs.description}
-    placeholder={sampleArgs.placeholder}
-    icon={<Icon name="int" />}
-    readOnly
-  />
-);
-
-export const MinMax = args => (
-  <Template
-    {...args}
-    label={sampleArgs.label}
-    description={sampleArgs.description}
-    placeholder={`${sampleArgs.min} to ${sampleArgs.max}`}
-    icon={<Icon name="int" />}
-    min={sampleArgs.min}
-    max={sampleArgs.max}
-  />
-);
-
-export const Controls = args => (
-  <Template
-    {...args}
-    label={sampleArgs.label}
-    description={sampleArgs.description}
-    placeholder={`${sampleArgs.min} to ${sampleArgs.max}`}
-    icon={<Icon name="int" />}
-    min={sampleArgs.min}
-    max={sampleArgs.max}
-    hideControls={false}
-  />
-);
-
-export const Precision = args => (
-  <Template
-    {...args}
-    defaultValue={sampleArgs.value}
-    label={sampleArgs.label}
-    description={sampleArgs.description}
-    icon={<Icon name="int" />}
-    precision={2}
-    decimalSeparator="."
-  />
-);
-
-export const ParserFormatter = args => (
-  <Template
-    {...args}
-    defaultValue={sampleArgs.value}
-    label={sampleArgs.label}
-    description={sampleArgs.description}
-    placeholder={sampleArgs.placeholder}
-    icon={<Icon name="int" />}
-    parser={value => value.replace(/^\$/, "")}
-    formatter={value => (value != null ? `$${value}` : "$")}
-  />
-);
+export const Default = DefaultTemplate.bind({});
 
 <Canvas>
   <Story name="Default">{Default}</Story>
@@ -240,196 +112,370 @@ export const ParserFormatter = args => (
 
 ### Size - md
 
-export const EmptyMd = args => <Empty {...args} size="md" />;
+export const EmptyMd = VariantTemplate.bind({});
+EmptyMd.args = {
+  label: sampleArgs.label,
+  placeholder: sampleArgs.placeholder,
+};
 
 <Canvas>
-  <Story name="Empty, md">{EmptyMd}</Story>
+  <Story name="Empty, md" args={EmptyMd.args}>
+    {EmptyMd}
+  </Story>
 </Canvas>
 
 #### Filled
 
-export const FilledMd = args => <Filled {...args} size="md" />;
+export const FilledMd = VariantTemplate.bind({});
+FilledMd.args = {
+  defaultValue: sampleArgs.value,
+  label: sampleArgs.label,
+  placeholder: sampleArgs.placeholder,
+};
 
 <Canvas>
-  <Story name="Filled, md">{FilledMd}</Story>
+  <Story name="Filled, md" args={FilledMd.args}>
+    {FilledMd}
+  </Story>
 </Canvas>
 
 #### Asterisk
 
-export const AsteriskMd = args => <Asterisk {...args} size="md" />;
+export const AsteriskMd = VariantTemplate.bind({});
+AsteriskMd.args = {
+  label: sampleArgs.label,
+  placeholder: sampleArgs.placeholder,
+  withAsterisk: true,
+};
 
 <Canvas>
-  <Story name="Asterisk, md">{AsteriskMd}</Story>
+  <Story name="Asterisk, md" args={AsteriskMd.args}>
+    {AsteriskMd}
+  </Story>
 </Canvas>
 
 #### Description
 
-export const DescriptionMd = args => <Description {...args} size="md" />;
+export const DescriptionMd = VariantTemplate.bind({});
+DescriptionMd.args = {
+  label: sampleArgs.label,
+  description: sampleArgs.description,
+  placeholder: sampleArgs.placeholder,
+};
 
 <Canvas>
-  <Story name="Description, md">{DescriptionMd}</Story>
+  <Story name="Description, md" args={DescriptionMd.args}>
+    {DescriptionMd}
+  </Story>
 </Canvas>
 
 #### Disabled
 
-export const DisabledMd = args => <Disabled {...args} size="md" />;
+export const DisabledMd = VariantTemplate.bind({});
+DisabledMd.args = {
+  label: sampleArgs.label,
+  description: sampleArgs.description,
+  placeholder: sampleArgs.placeholder,
+  disabled: true,
+  withAsterisk: true,
+};
 
 <Canvas>
-  <Story name="Disabled, md">{Disabled}</Story>
+  <Story name="Disabled, md" args={DisabledMd.args}>
+    {DisabledMd}
+  </Story>
 </Canvas>
 
 #### Error
 
-export const ErrorMd = args => <Error {...args} size="md" />;
+export const ErrorMd = VariantTemplate.bind({});
+ErrorMd.args = {
+  label: sampleArgs.label,
+  description: sampleArgs.description,
+  placeholder: sampleArgs.placeholder,
+  error: sampleArgs.error,
+  withAsterisk: true,
+};
 
 <Canvas>
-  <Story name="Error, md">{ErrorMd}</Story>
+  <Story name="Error, md" args={ErrorMd.args}>
+    {ErrorMd}
+  </Story>
 </Canvas>
 
 #### Icon
 
-export const IconMd = args => <Icons {...args} size="md" />;
+export const IconMd = VariantTemplate.bind({});
+IconMd.args = {
+  label: sampleArgs.label,
+  description: sampleArgs.description,
+  placeholder: sampleArgs.placeholder,
+  icon: <Icon name="int" />,
+  withAsterisk: true,
+};
 
 <Canvas>
-  <Story name="Icon, md">{IconMd}</Story>
+  <Story name="Icon, md" args={IconMd.args}>
+    {IconMd}
+  </Story>
 </Canvas>
 
 #### Read only
 
-export const ReadOnlyMd = args => <ReadOnly {...args} size="md" />;
+export const ReadOnlyMd = VariantTemplate.bind({});
+ReadOnlyMd.args = {
+  defaultValue: sampleArgs.value,
+  label: sampleArgs.label,
+  description: sampleArgs.description,
+  placeholder: sampleArgs.placeholder,
+  icon: <Icon name="int" />,
+  readOnly: true,
+};
 
 <Canvas>
-  <Story name="Read only, md">{ReadOnlyMd}</Story>
+  <Story name="Read only, md" args={ReadOnlyMd.args}>
+    {ReadOnlyMd}
+  </Story>
 </Canvas>
 
 #### Min / max
 
-export const MinMaxMd = args => <MinMax {...args} size="md" />;
+export const MinMaxMd = args => VariantTemplate.bind({});
+MinMaxMd.args = {
+  label: sampleArgs.label,
+  description: sampleArgs.description,
+  placeholder: `${sampleArgs.min} to ${sampleArgs.max}`,
+  icon: <Icon name="int" />,
+  min: sampleArgs.min,
+  max: sampleArgs.max,
+};
 
 <Canvas>
-  <Story name="Min / max, md">{MinMaxMd}</Story>
+  <Story name="Min / max, md" args={MinMaxMd.args}>
+    {MinMaxMd}
+  </Story>
 </Canvas>
 
 #### Controls
 
-export const ControlsMd = args => <Controls {...args} size="md" />;
+export const ControlsMd = VariantTemplate.bind({});
+ControlsMd.args = {
+  label: sampleArgs.label,
+  description: sampleArgs.description,
+  placeholder: `${sampleArgs.min} to ${sampleArgs.max}`,
+  icon: <Icon name="int" />,
+  min: sampleArgs.min,
+  max: sampleArgs.max,
+  hideControls: false,
+};
 
 <Canvas>
-  <Story name="Controls, md">{ControlsMd}</Story>
+  <Story name="Controls, md" args={ControlsMd.args}>
+    {ControlsMd}
+  </Story>
 </Canvas>
 
 #### Precision and decimal separator
 
-export const PrecisionMd = args => <Precision {...args} size="md" />;
+export const PrecisionMd = VariantTemplate.bind({});
+PrecisionMd.args = {
+  defaultValue: sampleArgs.value,
+  label: sampleArgs.label,
+  description: sampleArgs.description,
+  icon: <Icon name="int" />,
+  precision: 2,
+  decimalSeparator: ".",
+};
 
 <Canvas>
-  <Story name="Precision and decimal separator, md">{PrecisionMd}</Story>
+  <Story name="Precision and decimal separator, md" args={PrecisionMd.md}>
+    {PrecisionMd}
+  </Story>
 </Canvas>
 
 #### Parser and formatter
 
-export const ParserFormatterMd = args => (
-  <ParserFormatter {...args} size="md" />
-);
+export const ParserFormatterMd = VariantTemplate.bind({});
+VariantTemplate.args = {
+  defaultValue: sampleArgs.value,
+  label: sampleArgs.label,
+  description: sampleArgs.description,
+  placeholder: sampleArgs.placeholder,
+  icon: <Icon name="int" />,
+  parser: value => value.replace(/^\$/, ""),
+  formatter: value => (value != null ? `$${value}` : "$"),
+};
 
 <Canvas>
-  <Story name="Parser and formatter, md">{ParserFormatterMd}</Story>
+  <Story name="Parser and formatter, md" args={VariantTemplate.args}>
+    {ParserFormatterMd}
+  </Story>
 </Canvas>
 
 ### Size - xs
 
-export const EmptyXs = args => <Empty {...args} size="xs" />;
+export const EmptyXs = VariantTemplate.bind({});
+EmptyXs.args = {
+  ...EmptyMd.args,
+  size: "xs",
+};
 
 <Canvas>
-  <Story name="Empty, xs">{EmptyXs}</Story>
+  <Story name="Empty, xs" args={EmptyXs.args}>
+    {EmptyXs}
+  </Story>
 </Canvas>
 
 #### Filled
 
-export const FilledXs = args => <Filled {...args} size="xs" />;
+export const FilledXs = VariantTemplate.bind({});
+FilledXs.args = {
+  ...FilledMd.args,
+  size: "xs",
+};
 
 <Canvas>
-  <Story name="Filled, xs">{FilledXs}</Story>
+  <Story name="Filled, xs" args={FilledXs.args}>
+    {FilledXs}
+  </Story>
 </Canvas>
 
 #### Asterisk
 
-export const AsteriskXs = args => <Asterisk {...args} size="xs" />;
+export const AsteriskXs = VariantTemplate.bind({});
+AsteriskXs.args = {
+  ...AsteriskMd.args,
+  size: "xs",
+};
 
 <Canvas>
-  <Story name="Asterisk, xs">{AsteriskXs}</Story>
+  <Story name="Asterisk, xs" args={AsteriskXs.args}>
+    {AsteriskXs}
+  </Story>
 </Canvas>
 
 #### Description
 
-export const DescriptionXs = args => <Description {...args} size="xs" />;
+export const DescriptionXs = VariantTemplate.bind({});
+DescriptionXs.args = {
+  ...DescriptionMd.args,
+  size: "xs",
+};
 
 <Canvas>
-  <Story name="Description, xs">{DescriptionXs}</Story>
+  <Story name="Description, xs" args={DescriptionXs.args}>
+    {DescriptionXs}
+  </Story>
 </Canvas>
 
 #### Disabled
 
-export const DisabledXs = args => <Disabled {...args} size="xs" />;
+export const DisabledXs = VariantTemplate.bind({});
+DisabledXs.args = {
+  ...DisabledMd.args,
+  size: "xs",
+};
 
 <Canvas>
-  <Story name="Disabled, xs">{Disabled}</Story>
+  <Story name="Disabled, xs" args={DisabledXs.args}>
+    {DisabledXs}
+  </Story>
 </Canvas>
 
 #### Error
 
-export const ErrorXs = args => <Error {...args} size="xs" />;
+export const ErrorXs = VariantTemplate.bind({});
+ErrorXs.args = {
+  ...ErrorMd.args,
+  size: "xs",
+};
 
 <Canvas>
-  <Story name="Error, xs">{ErrorXs}</Story>
+  <Story name="Error, xs" args={ErrorXs.args}>
+    {ErrorXs}
+  </Story>
 </Canvas>
 
 #### Icon
 
-export const IconXs = args => <Icons {...args} size="xs" />;
+export const IconXs = VariantTemplate.bind({});
+IconXs.args = {
+  ...IconMd.args,
+  size: "xs",
+};
 
 <Canvas>
-  <Story name="Icon, xs">{IconXs}</Story>
+  <Story name="Icon, xs" args={IconXs.args}>
+    {IconXs}
+  </Story>
 </Canvas>
 
 #### Read only
 
-export const ReadOnlyXs = args => <ReadOnly {...args} size="xs" />;
+export const ReadOnlyXs = VariantTemplate.bind({});
+ReadOnlyXs.args = {
+  ...ReadOnlyMd.args,
+  size: "xs",
+};
 
 <Canvas>
-  <Story name="Read only, xs">{ReadOnlyXs}</Story>
+  <Story name="Read only, xs" args={ReadOnlyXs.args}>
+    {ReadOnlyXs}
+  </Story>
 </Canvas>
 
 #### Min / max
 
-export const MinMaxXs = args => <MinMax {...args} size="xs" />;
+export const MinMaxXs = args => VariantTemplate.bind({});
+MinMaxXs.args = {
+  ...MinMaxMd.args,
+  size: "xs",
+};
 
 <Canvas>
-  <Story name="Min / max, xs">{MinMaxXs}</Story>
+  <Story name="Min / max, xs" args={MinMaxXs.args}>
+    {MinMaxXs}
+  </Story>
 </Canvas>
 
 #### Controls
 
-export const ControlsXs = args => <Controls {...args} size="xs" />;
+export const ControlsXs = VariantTemplate.bind({});
+ControlsXs.args = {
+  ...ControlsMd.args,
+  size: "xs",
+};
 
 <Canvas>
-  <Story name="Controls, xs">{ControlsXs}</Story>
+  <Story name="Controls, xs" args={ControlsXs.args}>
+    {ControlsXs}
+  </Story>
 </Canvas>
 
 #### Precision and decimal separator
 
-export const PrecisionXs = args => <Precision {...args} size="xs" />;
+export const PrecisionXs = VariantTemplate.bind({});
+PrecisionXs.args = {
+  ...PrecisionMd.args,
+  size: "xs",
+};
 
 <Canvas>
-  <Story name="Precision and decimal separator, xs">{PrecisionXs}</Story>
+  <Story name="Precision and decimal separator, xs" args={PrecisionXs.xs}>
+    {PrecisionXs}
+  </Story>
 </Canvas>
 
 #### Parser and formatter
 
-export const ParserFormatterXs = args => (
-  <ParserFormatter {...args} size="xs" />
-);
+export const ParserFormatterXs = VariantTemplate.bind({});
+ParserFormatterXs.args = {
+  ...ParserFormatterMd.args,
+  size: "xs",
+};
 
 <Canvas>
-  <Story name="Parser and formatter, xs">{ParserFormatterXs}</Story>
+  <Story name="Parser and formatter, xs" args={VariantTemplate.args}>
+    {ParserFormatterXs}
+  </Story>
 </Canvas>

--- a/frontend/src/metabase/ui/components/inputs/NumberInput/NumberInput.stories.mdx
+++ b/frontend/src/metabase/ui/components/inputs/NumberInput/NumberInput.stories.mdx
@@ -104,7 +104,7 @@ export const VariantTemplate = args => (
   </Stack>
 );
 
-export const VariantIconTemplate = args => (
+export const IconTemplate = args => (
   <VariantTemplate {...args} icon={<Icon name="int" />} />
 );
 
@@ -209,7 +209,7 @@ ErrorMd.args = {
 
 #### Icon
 
-export const IconMd = VariantIconTemplate.bind({});
+export const IconMd = IconTemplate.bind({});
 IconMd.args = {
   label: sampleArgs.label,
   description: sampleArgs.description,
@@ -225,7 +225,7 @@ IconMd.args = {
 
 #### Read only
 
-export const ReadOnlyMd = VariantIconTemplate.bind({});
+export const ReadOnlyMd = IconTemplate.bind({});
 ReadOnlyMd.args = {
   defaultValue: sampleArgs.value,
   label: sampleArgs.label,
@@ -242,7 +242,7 @@ ReadOnlyMd.args = {
 
 #### Min / max
 
-export const MinMaxMd = args => VariantIconTemplate.bind({});
+export const MinMaxMd = args => IconTemplate.bind({});
 MinMaxMd.args = {
   label: sampleArgs.label,
   description: sampleArgs.description,
@@ -259,7 +259,7 @@ MinMaxMd.args = {
 
 #### Controls
 
-export const ControlsMd = VariantIconTemplate.bind({});
+export const ControlsMd = IconTemplate.bind({});
 ControlsMd.args = {
   label: sampleArgs.label,
   description: sampleArgs.description,
@@ -277,7 +277,7 @@ ControlsMd.args = {
 
 #### Precision and decimal separator
 
-export const PrecisionMd = VariantIconTemplate.bind({});
+export const PrecisionMd = IconTemplate.bind({});
 PrecisionMd.args = {
   defaultValue: sampleArgs.value,
   label: sampleArgs.label,
@@ -294,7 +294,7 @@ PrecisionMd.args = {
 
 #### Parser and formatter
 
-export const ParserFormatterMd = VariantIconTemplate.bind({});
+export const ParserFormatterMd = IconTemplate.bind({});
 VariantTemplate.args = {
   defaultValue: sampleArgs.value,
   label: sampleArgs.label,

--- a/frontend/src/metabase/ui/components/inputs/NumberInput/NumberInput.stories.mdx
+++ b/frontend/src/metabase/ui/components/inputs/NumberInput/NumberInput.stories.mdx
@@ -104,6 +104,10 @@ export const VariantTemplate = args => (
   </Stack>
 );
 
+export const VariantIconTemplate = args => (
+  <VariantTemplate {...args} icon={<Icon name="int" />} />
+);
+
 export const Default = DefaultTemplate.bind({});
 
 <Canvas>
@@ -205,12 +209,11 @@ ErrorMd.args = {
 
 #### Icon
 
-export const IconMd = VariantTemplate.bind({});
+export const IconMd = VariantIconTemplate.bind({});
 IconMd.args = {
   label: sampleArgs.label,
   description: sampleArgs.description,
   placeholder: sampleArgs.placeholder,
-  icon: <Icon name="int" />,
   withAsterisk: true,
 };
 
@@ -222,13 +225,12 @@ IconMd.args = {
 
 #### Read only
 
-export const ReadOnlyMd = VariantTemplate.bind({});
+export const ReadOnlyMd = VariantIconTemplate.bind({});
 ReadOnlyMd.args = {
   defaultValue: sampleArgs.value,
   label: sampleArgs.label,
   description: sampleArgs.description,
   placeholder: sampleArgs.placeholder,
-  icon: <Icon name="int" />,
   readOnly: true,
 };
 
@@ -240,12 +242,11 @@ ReadOnlyMd.args = {
 
 #### Min / max
 
-export const MinMaxMd = args => VariantTemplate.bind({});
+export const MinMaxMd = args => VariantIconTemplate.bind({});
 MinMaxMd.args = {
   label: sampleArgs.label,
   description: sampleArgs.description,
   placeholder: `${sampleArgs.min} to ${sampleArgs.max}`,
-  icon: <Icon name="int" />,
   min: sampleArgs.min,
   max: sampleArgs.max,
 };
@@ -258,12 +259,11 @@ MinMaxMd.args = {
 
 #### Controls
 
-export const ControlsMd = VariantTemplate.bind({});
+export const ControlsMd = VariantIconTemplate.bind({});
 ControlsMd.args = {
   label: sampleArgs.label,
   description: sampleArgs.description,
   placeholder: `${sampleArgs.min} to ${sampleArgs.max}`,
-  icon: <Icon name="int" />,
   min: sampleArgs.min,
   max: sampleArgs.max,
   hideControls: false,
@@ -277,12 +277,11 @@ ControlsMd.args = {
 
 #### Precision and decimal separator
 
-export const PrecisionMd = VariantTemplate.bind({});
+export const PrecisionMd = VariantIconTemplate.bind({});
 PrecisionMd.args = {
   defaultValue: sampleArgs.value,
   label: sampleArgs.label,
   description: sampleArgs.description,
-  icon: <Icon name="int" />,
   precision: 2,
   decimalSeparator: ".",
 };
@@ -295,13 +294,12 @@ PrecisionMd.args = {
 
 #### Parser and formatter
 
-export const ParserFormatterMd = VariantTemplate.bind({});
+export const ParserFormatterMd = VariantIconTemplate.bind({});
 VariantTemplate.args = {
   defaultValue: sampleArgs.value,
   label: sampleArgs.label,
   description: sampleArgs.description,
   placeholder: sampleArgs.placeholder,
-  icon: <Icon name="int" />,
   parser: value => value.replace(/^\$/, ""),
   formatter: value => (value != null ? `$${value}` : "$"),
 };

--- a/frontend/src/metabase/ui/components/inputs/NumberInput/NumberInput.stories.mdx
+++ b/frontend/src/metabase/ui/components/inputs/NumberInput/NumberInput.stories.mdx
@@ -305,7 +305,7 @@ VariantTemplate.args = {
 };
 
 <Canvas>
-  <Story name="Parser and formatter, md" args={VariantTemplate.args}>
+  <Story name="Parser and formatter, md" args={ParserFormatterMd.args}>
     {ParserFormatterMd}
   </Story>
 </Canvas>
@@ -473,7 +473,7 @@ ParserFormatterXs.args = {
 };
 
 <Canvas>
-  <Story name="Parser and formatter, xs" args={VariantTemplate.args}>
+  <Story name="Parser and formatter, xs" args={ParserFormatterXs.args}>
     {ParserFormatterXs}
   </Story>
 </Canvas>

--- a/frontend/src/metabase/ui/components/inputs/Radio/Radio.stories.mdx
+++ b/frontend/src/metabase/ui/components/inputs/Radio/Radio.stories.mdx
@@ -47,24 +47,9 @@ Radio buttons allow users to select a single option from a list of mutually excl
 
 ## Examples
 
-export const Template = args => (
-  <Stack>
-    <Radio {...args} label="Default radio" />
-    <Radio {...args} label="Checked radio" checked />
-    <Radio {...args} label="Disabled radio" disabled />
-    <Radio {...args} label="Disabled checked radio" disabled checked />
-  </Stack>
-);
+export const DefaultTemplate = args => <Radio {...args} />;
 
-export const Default = args => <Radio {...args} />;
-
-<Canvas>
-  <Story name="Default">{Default}</Story>
-</Canvas>
-
-### Radio.Group
-
-export const RadioGroup = args => (
+export const RadioGroupTemplate = args => (
   <Radio.Group
     defaultValue={"react"}
     label="An array of good frameworks"
@@ -79,13 +64,32 @@ export const RadioGroup = args => (
   </Radio.Group>
 );
 
+export const StateTemplate = args => (
+  <Stack>
+    <Radio {...args} label="Default radio" />
+    <Radio {...args} label="Checked radio" defaultChecked />
+    <Radio {...args} label="Disabled radio" disabled />
+    <Radio {...args} label="Disabled checked radio" disabled defaultChecked />
+  </Stack>
+);
+
+export const Default = DefaultTemplate.bind({});
+
+<Canvas>
+  <Story name="Default">{Default}</Story>
+</Canvas>
+
+### Radio.Group
+
+export const RadioGroup = RadioGroupTemplate.bind({});
+
 <Canvas>
   <Story name="Radio group">{RadioGroup}</Story>
 </Canvas>
 
 ### Label
 
-export const Label = args => <Template {...args} />;
+export const Label = StateTemplate.bind({});
 
 <Canvas>
   <Story name="Label">{Label}</Story>
@@ -93,30 +97,42 @@ export const Label = args => <Template {...args} />;
 
 #### Left label position
 
-export const LabelLeft = args => <Template {...args} labelPosition="left" />;
+export const LabelLeft = StateTemplate.bind({});
+LabelLeft.args = {
+  labelPosition: "left",
+};
 
 <Canvas>
-  <Story name="Label, left position">{LabelLeft}</Story>
+  <Story name="Label, left position" args={LabelLeft.args}>
+    {LabelLeft}
+  </Story>
 </Canvas>
 
 ### Description
 
-export const Description = args => (
-  <Template {...args} description="Description" />
-);
+export const Description = StateTemplate.bind({});
+Description.args = {
+  description: "Description",
+};
 
 <Canvas>
-  <Story name="Description">{Description}</Story>
+  <Story name="Description" args={Description.args}>
+    {Description}
+  </Story>
 </Canvas>
 
-export const DescriptionLeft = args => (
-  <Template {...args} description="Description" labelPosition="left" />
-);
+export const DescriptionLeft = StateTemplate.bind({});
+DescriptionLeft.args = {
+  description: "Description",
+  labelPosition: "left",
+};
 
 #### Left label position
 
 <Canvas>
-  <Story name="Description, left position">{DescriptionLeft}</Story>
+  <Story name="Description, left position" args={DescriptionLeft.args}>
+    {DescriptionLeft}
+  </Story>
 </Canvas>
 
 ## Related components

--- a/frontend/src/metabase/ui/components/inputs/TextInput/TextInput.stories.mdx
+++ b/frontend/src/metabase/ui/components/inputs/TextInput/TextInput.stories.mdx
@@ -69,105 +69,24 @@ Our themed wrapper around [Mantine TextInput](https://mantine.dev/core/text-inpu
 
 ## Examples
 
-export const Default = args => <TextInput {...args} />;
+export const DefaultTemplate = args => <TextInput {...args} />;
 
-export const Template = args => (
+export const VariantTemplate = args => (
   <Stack>
     <TextInput {...args} variant="default" />
     <TextInput {...args} variant="unstyled" />
   </Stack>
 );
 
-export const Empty = args => (
-  <Template
-    {...args}
-    label={sampleArgs.label}
-    placeholder={sampleArgs.placeholder}
-  />
+export const IconTemplate = args => (
+  <VariantTemplate {...args} icon={<Icon name="dashboard" />} />
 );
 
-export const Filled = args => (
-  <Template
-    {...args}
-    defaultValue={sampleArgs.value}
-    label={sampleArgs.label}
-    placeholder={sampleArgs.placeholder}
-  />
+export const RightSectionTemplate = args => (
+  <VariantTemplate {...args} rightSection={<Icon name="chevrondown" />} />
 );
 
-export const Asterisk = args => (
-  <Template
-    {...args}
-    label={sampleArgs.label}
-    placeholder={sampleArgs.placeholder}
-    withAsterisk
-  />
-);
-
-export const Description = args => (
-  <Template
-    {...args}
-    label={sampleArgs.label}
-    description={sampleArgs.description}
-    placeholder={sampleArgs.placeholder}
-  />
-);
-
-export const Disabled = args => (
-  <Template
-    {...args}
-    label={sampleArgs.label}
-    description={sampleArgs.description}
-    placeholder={sampleArgs.placeholder}
-    disabled
-    withAsterisk
-  />
-);
-
-export const Error = args => (
-  <Template
-    {...args}
-    label={sampleArgs.label}
-    description={sampleArgs.description}
-    placeholder={sampleArgs.placeholder}
-    error={sampleArgs.error}
-    withAsterisk
-  />
-);
-
-export const Icons = args => (
-  <Template
-    {...args}
-    label={sampleArgs.label}
-    description={sampleArgs.description}
-    placeholder={sampleArgs.placeholder}
-    icon={<Icon name="dashboard" />}
-    withAsterisk
-  />
-);
-
-export const RightSection = args => (
-  <Template
-    {...args}
-    label={sampleArgs.label}
-    description={sampleArgs.description}
-    placeholder={sampleArgs.placeholder}
-    rightSection={<Icon name="chevrondown" />}
-    withAsterisk
-  />
-);
-
-export const ReadOnly = args => (
-  <Template
-    {...args}
-    defaultValue={sampleArgs.value}
-    label={sampleArgs.label}
-    description={sampleArgs.description}
-    placeholder={sampleArgs.placeholder}
-    rightSection={<Icon name="chevrondown" />}
-    readOnly
-  />
-);
+export const Default = DefaultTemplate.bind({});
 
 <Canvas>
   <Story name="Default">{Default}</Story>
@@ -175,7 +94,7 @@ export const ReadOnly = args => (
 
 ### Size - md
 
-export const EmptyMd = args => <Empty {...args} size="md" />;
+export const EmptyMd = VariantTemplate.bind({});
 
 <Canvas>
   <Story name="Empty, md">{EmptyMd}</Story>
@@ -183,71 +102,135 @@ export const EmptyMd = args => <Empty {...args} size="md" />;
 
 #### Filled
 
-export const FilledMd = args => <Filled {...args} size="md" />;
+export const FilledMd = VariantTemplate.bind({});
+FilledMd.args = {
+  defaultValue: sampleArgs.value,
+  label: sampleArgs.label,
+  placeholder: sampleArgs.placeholder,
+};
 
 <Canvas>
-  <Story name="Filled, md">{FilledMd}</Story>
+  <Story name="Filled, md" args={FilledMd.args}>
+    {FilledMd}
+  </Story>
 </Canvas>
 
 #### Asterisk
 
-export const AsteriskMd = args => <Asterisk {...args} size="md" />;
+export const AsteriskMd = VariantTemplate.bind({});
+AsteriskMd.args = {
+  label: sampleArgs.label,
+  placeholder: sampleArgs.placeholder,
+  withAsterisk: true,
+};
 
 <Canvas>
-  <Story name="Asterisk, md">{AsteriskMd}</Story>
+  <Story name="Asterisk, md" args={AsteriskMd.args}>
+    {AsteriskMd}
+  </Story>
 </Canvas>
 
 #### Description
 
-export const DescriptionMd = args => <Description {...args} size="md" />;
+export const DescriptionMd = VariantTemplate.bind({});
+DescriptionMd.args = {
+  label: sampleArgs.label,
+  description: sampleArgs.description,
+  placeholder: sampleArgs.placeholder,
+};
 
 <Canvas>
-  <Story name="Description, md">{DescriptionMd}</Story>
+  <Story name="Description, md" args={DescriptionMd.args}>
+    {DescriptionMd}
+  </Story>
 </Canvas>
 
 #### Disabled
 
-export const DisabledMd = args => <Disabled {...args} size="md" />;
+export const DisabledMd = VariantTemplate.bind({});
+DisabledMd.args = {
+  label: sampleArgs.label,
+  description: sampleArgs.description,
+  placeholder: sampleArgs.placeholder,
+  disabled: true,
+  withAsterisk: true,
+};
 
 <Canvas>
-  <Story name="Disabled, md">{Disabled}</Story>
+  <Story name="Disabled, md" args={DisabledMd.args}>
+    {DisabledMd}
+  </Story>
 </Canvas>
 
 #### Error
 
-export const ErrorMd = args => <Error {...args} size="md" />;
+export const ErrorMd = VariantTemplate.bind({});
+ErrorMd.args = {
+  label: sampleArgs.label,
+  description: sampleArgs.description,
+  placeholder: sampleArgs.placeholder,
+  error: sampleArgs.error,
+  withAsterisk: true,
+};
 
 <Canvas>
-  <Story name="Error, md">{ErrorMd}</Story>
+  <Story name="Error, md" args={ErrorMd.args}>
+    {ErrorMd}
+  </Story>
 </Canvas>
 
 #### Icon
 
-export const IconMd = args => <Icons {...args} size="md" />;
+export const IconMd = IconTemplate.bind({});
+IconMd.args = {
+  label: sampleArgs.label,
+  description: sampleArgs.description,
+  placeholder: sampleArgs.placeholder,
+  withAsterisk: true,
+};
 
 <Canvas>
-  <Story name="Icon, md">{IconMd}</Story>
+  <Story name="Icon, md" args={IconMd.args}>
+    {IconMd}
+  </Story>
 </Canvas>
 
 #### Right section
 
-export const RightSectionMd = args => <RightSection {...args} size="md" />;
+export const RightSectionMd = RightSectionTemplate.bind({});
+RightSectionMd.args = {
+  label: sampleArgs.label,
+  description: sampleArgs.description,
+  placeholder: sampleArgs.placeholder,
+  withAsterisk: true,
+};
 
 <Canvas>
-  <Story name="Right section, md">{RightSectionMd}</Story>
+  <Story name="Right section, md" args={RightSectionMd.args}>
+    {RightSectionMd}
+  </Story>
 </Canvas>
 
 #### Read only
 
-export const ReadOnlyMd = args => <ReadOnly {...args} size="md" />;
+export const ReadOnlyMd = RightSectionTemplate.bind({});
+RightSectionMd.args = {
+  defaultValue: sampleArgs.value,
+  label: sampleArgs.label,
+  description: sampleArgs.description,
+  placeholder: sampleArgs.placeholder,
+  readOnly: true,
+};
 
 <Canvas>
-  <Story name="Read only, md">{ReadOnlyMd}</Story>
+  <Story name="Read only, md" args={ReadOnlyMd.args}>
+    {ReadOnlyMd}
+  </Story>
 </Canvas>
 
 ### Size - xs
 
-export const EmptyXs = args => <Empty {...args} size="xs" />;
+export const EmptyXs = VariantTemplate.bind({});
 
 <Canvas>
   <Story name="Empty, xs">{EmptyXs}</Story>
@@ -255,64 +238,104 @@ export const EmptyXs = args => <Empty {...args} size="xs" />;
 
 #### Filled
 
-export const FilledXs = args => <Filled {...args} size="xs" />;
+export const FilledXs = VariantTemplate.bind({});
+FilledXs.args = {
+  ...FilledMd.args,
+};
 
 <Canvas>
-  <Story name="Filled, xs">{FilledXs}</Story>
+  <Story name="Filled, xs" args={FilledXs.args}>
+    {FilledXs}
+  </Story>
 </Canvas>
 
 #### Asterisk
 
-export const AsteriskXs = args => <Asterisk {...args} size="xs" />;
+export const AsteriskXs = VariantTemplate.bind({});
+AsteriskXs.args = {
+  ...AsteriskMd.args,
+};
 
 <Canvas>
-  <Story name="Asterisk, xs">{AsteriskXs}</Story>
+  <Story name="Asterisk, xs" args={AsteriskXs.args}>
+    {AsteriskXs}
+  </Story>
 </Canvas>
 
 #### Description
 
-export const DescriptionXs = args => <Description {...args} size="xs" />;
+export const DescriptionXs = VariantTemplate.bind({});
+DescriptionXs.args = {
+  ...DescriptionMd.args,
+};
 
 <Canvas>
-  <Story name="Description, xs">{DescriptionXs}</Story>
+  <Story name="Description, xs" args={DescriptionXs.args}>
+    {DescriptionXs}
+  </Story>
 </Canvas>
 
 #### Disabled
 
-export const DisabledXs = args => <Disabled {...args} size="xs" />;
+export const DisabledXs = VariantTemplate.bind({});
+DisabledXs.args = {
+  ...DisabledMd.args,
+};
 
 <Canvas>
-  <Story name="Disabled, xs">{Disabled}</Story>
+  <Story name="Disabled, xs" args={DisabledXs.args}>
+    {DisabledXs}
+  </Story>
 </Canvas>
 
 #### Error
 
-export const ErrorXs = args => <Error {...args} size="xs" />;
+export const ErrorXs = VariantTemplate.bind({});
+ErrorXs.args = {
+  ...ErrorMd.args,
+};
 
 <Canvas>
-  <Story name="Error, xs">{ErrorXs}</Story>
+  <Story name="Error, xs" args={ErrorXs.args}>
+    {ErrorXs}
+  </Story>
 </Canvas>
 
 #### Icon
 
-export const IconXs = args => <Icons {...args} size="xs" />;
+export const IconXs = IconTemplate.bind({});
+IconXs.args = {
+  ...IconMd.args,
+};
 
 <Canvas>
-  <Story name="Icon, xs">{IconXs}</Story>
+  <Story name="Icon, xs" args={IconXs.args}>
+    {IconXs}
+  </Story>
 </Canvas>
 
 #### Right section
 
-export const RightSectionXs = args => <RightSection {...args} size="xs" />;
+export const RightSectionXs = RightSectionTemplate.bind({});
+RightSectionXs.args = {
+  ...RightSectionMd.args,
+};
 
 <Canvas>
-  <Story name="Right section, xs">{RightSectionXs}</Story>
+  <Story name="Right section, xs" args={RightSectionXs.args}>
+    {RightSectionXs}
+  </Story>
 </Canvas>
 
 #### Read only
 
-export const ReadOnlyXs = args => <ReadOnly {...args} size="xs" />;
+export const ReadOnlyXs = RightSectionTemplate.bind({});
+RightSectionXs.args = {
+  ...ReadOnlyMd.args,
+};
 
 <Canvas>
-  <Story name="Read only, xs">{ReadOnlyXs}</Story>
+  <Story name="Read only, xs" args={ReadOnlyXs.args}>
+    {ReadOnlyXs}
+  </Story>
 </Canvas>

--- a/frontend/src/metabase/ui/components/overlays/Menu/Menu.stories.mdx
+++ b/frontend/src/metabase/ui/components/overlays/Menu/Menu.stories.mdx
@@ -97,7 +97,7 @@ Not to use:
 
 ## Examples
 
-export const Default = args => (
+export const DefaultTemplate = args => (
   <Flex justify="center">
     <Menu {...args}>
       <Menu.Target>
@@ -115,13 +115,7 @@ export const Default = args => (
   </Flex>
 );
 
-<Canvas>
-  <Story name="Default">{Default}</Story>
-</Canvas>
-
-### Right section
-
-export const RightSection = args => (
+export const RightSectionTemplate = args => (
   <Flex justify="center">
     <Menu {...args}>
       <Menu.Target>
@@ -141,13 +135,7 @@ export const RightSection = args => (
   </Flex>
 );
 
-<Canvas>
-  <Story name="Right section">{RightSection}</Story>
-</Canvas>
-
-### Icons
-
-export const Icons = args => (
+export const IconsTemplate = args => (
   <Flex justify="center">
     <Menu {...args}>
       <Menu.Target>
@@ -165,13 +153,7 @@ export const Icons = args => (
   </Flex>
 );
 
-<Canvas>
-  <Story name="Icons">{Icons}</Story>
-</Canvas>
-
-### Labels and dividers
-
-export const LabelsAndDividers = args => (
+export const LabelsAndDividersTemplate = args => (
   <Flex justify="center">
     <Menu {...args}>
       <Menu.Target>
@@ -196,6 +178,32 @@ export const LabelsAndDividers = args => (
     </Menu>
   </Flex>
 );
+
+export const Default = DefaultTemplate.bind({});
+
+<Canvas>
+  <Story name="Default">{Default}</Story>
+</Canvas>
+
+### Right section
+
+export const RightSection = RightSectionTemplate.bind({});
+
+<Canvas>
+  <Story name="Right section">{RightSection}</Story>
+</Canvas>
+
+### Icons
+
+export const Icons = IconsTemplate.bind({});
+
+<Canvas>
+  <Story name="Icons">{Icons}</Story>
+</Canvas>
+
+### Labels and dividers
+
+export const LabelsAndDividers = LabelsAndDividersTemplate.bind({});
 
 <Canvas>
   <Story name="Labels and dividers">{LabelsAndDividers}</Story>

--- a/frontend/src/metabase/ui/components/typography/Anchor/Anchor.stories.mdx
+++ b/frontend/src/metabase/ui/components/typography/Anchor/Anchor.stories.mdx
@@ -49,17 +49,11 @@ The Anchor component allows users to display links with themed styles, and repla
 
 ## Examples
 
-export const Default = args => (
+export const DefaultTemplate = args => (
   <Anchor href={sampleArgs.href}>{sampleArgs.text}</Anchor>
 );
 
-<Canvas>
-  <Story name="Default">{Default}</Story>
-</Canvas>
-
-### Sizes
-
-export const Sizes = args => (
+export const SizeTemplate = args => (
   <Grid align="center" maw="18rem">
     {argTypes.size.options.map(size => (
       <Fragment key={size}>
@@ -75,6 +69,16 @@ export const Sizes = args => (
     ))}
   </Grid>
 );
+
+export const Default = DefaultTemplate.bind({});
+
+<Canvas>
+  <Story name="Default">{Default}</Story>
+</Canvas>
+
+### Sizes
+
+export const Sizes = SizeTemplate.bind({});
 
 <Canvas>
   <Story name="Sizes">{Sizes}</Story>

--- a/frontend/src/metabase/ui/components/typography/Anchor/Anchor.stories.mdx
+++ b/frontend/src/metabase/ui/components/typography/Anchor/Anchor.stories.mdx
@@ -50,7 +50,9 @@ The Anchor component allows users to display links with themed styles, and repla
 ## Examples
 
 export const DefaultTemplate = args => (
-  <Anchor href={sampleArgs.href}>{sampleArgs.text}</Anchor>
+  <Anchor {...args} href={sampleArgs.href}>
+    {sampleArgs.text}
+  </Anchor>
 );
 
 export const SizeTemplate = args => (

--- a/frontend/src/metabase/ui/components/typography/Text/Text.stories.mdx
+++ b/frontend/src/metabase/ui/components/typography/Text/Text.stories.mdx
@@ -74,7 +74,11 @@ The Text component allows users to display text with themed styles, and replaces
 
 ## Examples
 
-export const Template = args => (
+export const DefaultTemplate = args => (
+  <Text {...args}>{sampleArgs.shortText}</Text>
+);
+
+export const SizeTemplate = args => (
   <Grid align="center" maw="18rem">
     {argTypes.size.options.map(size => (
       <Fragment key={size}>
@@ -89,7 +93,7 @@ export const Template = args => (
   </Grid>
 );
 
-export const Default = args => <Text {...args}>{sampleArgs.shortText}</Text>;
+export const Default = DefaultTemplate.bind({});
 
 <Canvas>
   <Story name="Default">{Default}</Story>
@@ -97,9 +101,10 @@ export const Default = args => <Text {...args}>{sampleArgs.shortText}</Text>;
 
 ### Sizes
 
-export const Sizes = args => (
-  <Template {...args}>{sampleArgs.shortText}</Template>
-);
+export const Sizes = SizeTemplate.bind({});
+Sizes.args = {
+  children: sampleArgs.shortText,
+};
 
 <Canvas>
   <Story name="Sizes">{Sizes}</Story>
@@ -107,9 +112,10 @@ export const Sizes = args => (
 
 ### Multiline
 
-export const Multiline = args => (
-  <Template {...args}>{sampleArgs.longText}</Template>
-);
+export const Multiline = SizeTemplate.bind({});
+Multiline.args = {
+  children: sampleArgs.longText,
+};
 
 <Canvas>
   <Story name="Multiline">{Multiline}</Story>
@@ -117,7 +123,11 @@ export const Multiline = args => (
 
 ### Truncated
 
-export const Truncated = args => <Multiline {...args} lineClamp={2} />;
+export const Truncated = SizeTemplate.bind({});
+Truncated.args = {
+  children: sampleArgs.longText,
+  lineClamp: 2,
+};
 
 <Canvas>
   <Story name="Truncated">{Truncated}</Story>

--- a/frontend/src/metabase/ui/components/typography/Title/Title.stories.mdx
+++ b/frontend/src/metabase/ui/components/typography/Title/Title.stories.mdx
@@ -55,7 +55,9 @@ TBD
 
 ## Examples
 
-export const Template = args => (
+export const DefaultTemplate = args => <Title {...args}>Header</Title>;
+
+export const SizeTemplate = args => (
   <Stack>
     <Title {...args} order={1}>
       Header 1
@@ -97,7 +99,7 @@ export const TruncatedTemplate = args => (
   </Stack>
 );
 
-export const Default = args => <Title {...args}>Header</Title>;
+export const Default = DefaultTemplate.bind({});
 
 <Canvas>
   <Story name="Default">{Default}</Story>
@@ -105,7 +107,7 @@ export const Default = args => <Title {...args}>Header</Title>;
 
 ### Sizes
 
-export const Sizes = args => <Template {...args} />;
+export const Sizes = SizeTemplate.bind({});
 
 <Canvas>
   <Story name="Sizes">{Sizes}</Story>
@@ -113,7 +115,10 @@ export const Sizes = args => <Template {...args} />;
 
 ### Underlined
 
-export const Underlined = args => <Template {...args} underline />;
+export const Underlined = SizeTemplate.bind({});
+Underlined.args = {
+  underline: true,
+};
 
 <Canvas>
   <Story name="Underlined">{Underlined}</Story>
@@ -121,7 +126,10 @@ export const Underlined = args => <Template {...args} underline />;
 
 ### Truncated
 
-export const Truncated = args => <TruncatedTemplate {...args} truncate />;
+export const Truncated = TruncatedTemplate.bind({});
+Truncated.args = {
+  truncate: true,
+};
 
 <Canvas>
   <Story name="Truncated">{Truncated}</Story>
@@ -129,9 +137,11 @@ export const Truncated = args => <TruncatedTemplate {...args} truncate />;
 
 ### Truncated and underlined
 
-export const TruncatedAndUnderlined = args => (
-  <TruncatedTemplate {...args} truncate underline />
-);
+export const TruncatedAndUnderlined = TruncatedTemplate.bind({});
+TruncatedAndUnderlined.args = {
+  truncate: true,
+  underline: true,
+};
 
 <Canvas>
   <Story name="Truncated and underlined">{TruncatedAndUnderlined}</Story>


### PR DESCRIPTION
Currently stories are implemented in a way that makes it impossible to re-configure arguments for any non-default story. This PR fixes the issue for all mantine components.

Before:

```
export const ReadOnly = args => <Template {...args} readOnly />

<Canvas>
  <Story name="Read only">
    {ReadOnly}
  </Story>
</Canvas>
```

After:

```
export const ReadOnly = Template.bind({});
ReadOnly.args = {
  readOnly: true
};

<Canvas>
  <Story name="Read only" args={ReadOnly.args}>
    {ReadOnly}
  </Story>
</Canvas>
```

How to verify:
- `yarn storybook`
- Compare with storybook in master for mantine components https://master--61d4abcd959e8c003aa51d4c.chromatic.com/
- In this branch you should be able to open any story with pre-configured args and change them later on