### PR TITLE
Fix `required-native-extras` for Cljs and add TypeScript wrappers

### DIFF
--- a/frontend/src/metabase-lib/native.ts
+++ b/frontend/src/metabase-lib/native.ts
@@ -1,0 +1,34 @@
+import * as ML from "cljs/metabase.lib.js";
+
+import type { DatabaseId } from "metabase-types/api";
+
+import type { MetadataProvider, Query } from "./types";
+
+/**
+ * Returns the extra keys that are required for this database's native queries, for example `:collection` name is
+ *  needed for MongoDB queries.
+ */
+export function requiredNativeExtras(
+  databaseId: DatabaseId,
+  metadata: MetadataProvider,
+): string[] {
+  return ML.required_native_extras(databaseID, metadata);
+}
+
+type NativeExtras = {
+  collection?: string | null;
+};
+
+/**
+ * Returns the extra keys for native queries associated with this query.
+ */
+export function nativeExtras(query: Query): NativeExtras | null;
+
+/**
+ * Updates the extras required for the db to run this query. The first stage must be a native type. Will ignore extras
+ * not in `required-native-extras`.
+ */
+export function withNativeExtras(
+  query: Query,
+  nativeExtras: NativeExtras | null,
+): Query;

--- a/frontend/src/metabase-lib/native.ts
+++ b/frontend/src/metabase-lib/native.ts
@@ -22,7 +22,9 @@ type NativeExtras = {
 /**
  * Returns the extra keys for native queries associated with this query.
  */
-export function nativeExtras(query: Query): NativeExtras | null;
+export function nativeExtras(query: Query): NativeExtras | null {
+  return ML.native_extras(query);
+}
 
 /**
  * Updates the extras required for the db to run this query. The first stage must be a native type. Will ignore extras
@@ -31,4 +33,6 @@ export function nativeExtras(query: Query): NativeExtras | null;
 export function withNativeExtras(
   query: Query,
   nativeExtras: NativeExtras | null,
-): Query;
+): Query {
+  return ML.with_native_extras(query, nativeExtras);
+}

--- a/frontend/src/metabase-lib/native.ts
+++ b/frontend/src/metabase-lib/native.ts
@@ -12,7 +12,7 @@ export function requiredNativeExtras(
   databaseId: DatabaseId,
   metadata: MetadataProvider,
 ): string[] {
-  return ML.required_native_extras(databaseID, metadata);
+  return ML.required_native_extras(databaseId, metadata);
 }
 
 type NativeExtras = {

--- a/frontend/src/metabase-lib/v2.ts
+++ b/frontend/src/metabase-lib/v2.ts
@@ -14,6 +14,7 @@ export * from "./filter";
 export * from "./join";
 export * from "./limit";
 export * from "./metadata";
+export * from "./native";
 export * from "./segments";
 export * from "./metrics";
 export * from "./order_by";

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -657,9 +657,12 @@
   (lib.core/TemplateTags-> (lib.core/template-tags a-query)))
 
 (defn ^:export required-native-extras
-  "Returns whether the extra keys required by the database."
+  "Returns the extra keys that are required for this database's native queries, for example `:collection` name is
+  needed for MongoDB queries."
   [database-id metadata]
-  (to-array (lib.core/required-native-extras (metadataProvider database-id metadata))))
+  (to-array
+   (map u/qualified-name
+        (lib.core/required-native-extras (metadataProvider database-id metadata)))))
 
 (defn ^:export with-different-database
   "Changes the database for this query. The first stage must be a native type.
@@ -670,8 +673,8 @@
    (lib.core/with-different-database a-query (metadataProvider database-id metadata) (js->clj native-extras :keywordize-keys true))))
 
 (defn ^:export with-native-extras
-  "Updates the extras required for the db to run this query.
-   The first stage must be a native type. Will ignore extras not in `required-native-extras`"
+  "Updates the extras required for the db to run this query. The first stage must be a native type. Will ignore extras
+  not in `required-native-extras`."
   [a-query native-extras]
   (lib.core/with-native-extras a-query (js->clj native-extras :keywordize-keys true)))
 

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -148,7 +148,8 @@
    [:collection {:optional true} ::common/non-blank-string]])
 
 (mu/defn required-native-extras :- set?
-  "Returns the extra keys that are required for this database's native queries."
+  "Returns the extra keys that are required for this database's native queries, for example `:collection` name is
+  needed for MongoDB queries."
   [metadata-provider :- lib.metadata/MetadataProviderable]
   (let [db (lib.metadata/database metadata-provider)]
    (cond-> #{}


### PR DESCRIPTION
It was returning Clojure keywords instead of strings in the JS version.

Fixes #33543