### PR TITLE
Parameterize collection and dashboard ids in e2e tests

### DIFF
--- a/e2e/support/cypress_sample_instance_data.js
+++ b/e2e/support/cypress_sample_instance_data.js
@@ -34,3 +34,28 @@ export const NORMAL_PERSONAL_COLLECTION_ID = _.findWhere(
   SAMPLE_INSTANCE_DATA.collections,
   { name: "Robert Tableton's Personal Collection" },
 ).id;
+
+export const NO_DATA_PERSONAL_COLLECTION_ID = _.findWhere(
+  SAMPLE_INSTANCE_DATA.collections,
+  { name: "No Data Tableton's Personal Collection" },
+).id;
+
+export const FIRST_COLLECTION_ID = _.findWhere(
+  SAMPLE_INSTANCE_DATA.collections,
+  { name: "First collection" },
+).id;
+
+export const SECOND_COLLECTION_ID = _.findWhere(
+  SAMPLE_INSTANCE_DATA.collections,
+  { name: "Second collection" },
+).id;
+
+export const THIRD_COLLECTION_ID = _.findWhere(
+  SAMPLE_INSTANCE_DATA.collections,
+  { name: "Third collection" },
+).id;
+
+export const ORDERS_DASHBOARD_ID = _.findWhere(
+  SAMPLE_INSTANCE_DATA.dashboards,
+  { name: "Orders in a dashboard" },
+).id;

--- a/e2e/test/scenarios/actions/reproductions/31587-bottom-corner-radius-action-buttons.cy.spec.js
+++ b/e2e/test/scenarios/actions/reproductions/31587-bottom-corner-radius-action-buttons.cy.spec.js
@@ -6,6 +6,7 @@ import {
   visitDashboard,
 } from "e2e/support/helpers";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 const viewports = [
   [768, 800],
@@ -22,7 +23,7 @@ describe("metabase#31587", () => {
         cy.viewport(width, height);
       });
       it("should not allow action buttons to overflow when editing dashboard", () => {
-        visitDashboard(1);
+        visitDashboard(ORDERS_DASHBOARD_ID);
         editDashboard();
         cy.button("Add action").click();
 
@@ -43,7 +44,7 @@ describe("metabase#31587", () => {
       });
 
       it("should not allow action buttons to overflow when viewing info sidebar", () => {
-        visitDashboard(1);
+        visitDashboard(ORDERS_DASHBOARD_ID);
         editDashboard();
         cy.findByLabelText("Add action").click();
 

--- a/e2e/test/scenarios/admin-2/auditing/approved-domains.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/auditing/approved-domains.cy.spec.js
@@ -8,7 +8,10 @@ import {
   visitDashboard,
   setTokenFeatures,
 } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ORDERS_QUESTION_ID,
+  ORDERS_DASHBOARD_ID,
+} from "e2e/support/cypress_sample_instance_data";
 
 const allowedDomain = "metabase.test";
 const deniedDomain = "metabase.example";
@@ -51,7 +54,7 @@ describeEE(
     });
 
     it("should validate approved email domains for a dashboard subscription in the audit app", () => {
-      visitDashboard(1);
+      visitDashboard(ORDERS_DASHBOARD_ID);
       cy.icon("subscription").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Create a dashboard subscription").click();

--- a/e2e/test/scenarios/admin/databases/database-prompt-banner.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/database-prompt-banner.cy.spec.js
@@ -12,6 +12,8 @@ import {
   setTokenFeatures,
 } from "e2e/support/helpers";
 
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
+
 describeEE("database prompt banner", () => {
   beforeEach(() => {
     restore();
@@ -66,7 +68,7 @@ describeEE("database prompt banner", () => {
     "should show info sidebar correctly on Firefox",
     { browser: "firefox" },
     function () {
-      visitDashboard(1);
+      visitDashboard(ORDERS_DASHBOARD_ID);
       cy.findByRole("main").findByText("Loading...").should("not.exist");
       cy.findByRole("main").icon("info").click();
 

--- a/e2e/test/scenarios/collections/archive.cy.spec.js
+++ b/e2e/test/scenarios/collections/archive.cy.spec.js
@@ -1,5 +1,6 @@
-import { getCollectionIdFromSlug, restore } from "e2e/support/helpers";
+import { restore } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { FIRST_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const { PEOPLE_ID } = SAMPLE_DATABASE;
 
@@ -39,22 +40,18 @@ describe("scenarios > collections > archive", () => {
   });
 
   it("shows correct page when visiting page of question that was in archived collection (metabase##23501)", () => {
-    getCollectionIdFromSlug("first_collection", collectionId => {
-      const questionDetails = getQuestionDetails(collectionId);
+    const questionDetails = getQuestionDetails(FIRST_COLLECTION_ID);
 
-      cy.createQuestion(questionDetails).then(
-        ({ body: { id: questionId } }) => {
-          cy.request("PUT", `/api/collection/${collectionId}`, {
-            archived: true,
-          });
+    cy.createQuestion(questionDetails).then(({ body: { id: questionId } }) => {
+      cy.request("PUT", `/api/collection/${FIRST_COLLECTION_ID}`, {
+        archived: true,
+      });
 
-          // Question belonging to collection
-          // will have been archived,
-          // and archived page should be displayed
-          cy.visit(`/question/${questionId}`);
-          cy.findByText("This question has been archived");
-        },
-      );
+      // Question belonging to collection
+      // will have been archived,
+      // and archived page should be displayed
+      cy.visit(`/question/${questionId}`);
+      cy.findByText("This question has been archived");
     });
   });
 });

--- a/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
+++ b/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
@@ -7,7 +7,10 @@ import {
   openUnpinnedItemMenu,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ORDERS_QUESTION_ID,
+  ORDERS_DASHBOARD_ID,
+} from "e2e/support/cypress_sample_instance_data";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -70,7 +73,7 @@ describe("scenarios > collection pinned items overview", () => {
       cy.icon("dashboard").should("be.visible");
       cy.findByText("A dashboard").should("be.visible");
       cy.findByText(DASHBOARD_NAME).click();
-      cy.url().should("include", "/dashboard/1");
+      cy.url().should("include", `/dashboard/${ORDERS_DASHBOARD_ID}`);
     });
   });
 
@@ -119,7 +122,9 @@ describe("scenarios > collection pinned items overview", () => {
   });
 
   it("should be able to unpin a pinned dashboard", () => {
-    cy.request("PUT", "/api/dashboard/1", { collection_position: 1 });
+    cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}`, {
+      collection_position: 1,
+    });
 
     openRootCollection();
     openPinnedItemMenu(DASHBOARD_NAME);
@@ -130,7 +135,9 @@ describe("scenarios > collection pinned items overview", () => {
   });
 
   it("should be able to move a pinned dashboard", () => {
-    cy.request("PUT", "/api/dashboard/1", { collection_position: 1 });
+    cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}`, {
+      collection_position: 1,
+    });
 
     openRootCollection();
     openPinnedItemMenu(DASHBOARD_NAME);
@@ -141,7 +148,9 @@ describe("scenarios > collection pinned items overview", () => {
   });
 
   it("should be able to duplicate a pinned dashboard", () => {
-    cy.request("PUT", "/api/dashboard/1", { collection_position: 1 });
+    cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}`, {
+      collection_position: 1,
+    });
 
     openRootCollection();
     openPinnedItemMenu(DASHBOARD_NAME);
@@ -154,7 +163,9 @@ describe("scenarios > collection pinned items overview", () => {
   });
 
   it("should be able to archive a pinned dashboard", () => {
-    cy.request("PUT", "/api/dashboard/1", { collection_position: 1 });
+    cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}`, {
+      collection_position: 1,
+    });
 
     openRootCollection();
     openPinnedItemMenu(DASHBOARD_NAME);

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -6,7 +6,6 @@ import {
   popover,
   openOrdersTable,
   navigationSidebar,
-  getCollectionIdFromSlug,
   openNavigationSidebar,
   closeNavigationSidebar,
   visitCollection,
@@ -16,7 +15,12 @@ import {
   moveOpenedCollectionTo,
 } from "e2e/support/helpers";
 import { USERS, USER_GROUPS } from "e2e/support/cypress_data";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ORDERS_QUESTION_ID,
+  FIRST_COLLECTION_ID,
+  SECOND_COLLECTION_ID,
+  THIRD_COLLECTION_ID,
+} from "e2e/support/cypress_sample_instance_data";
 
 import { displaySidebarChildOf } from "./helpers/e2e-collections-sidebar.js";
 
@@ -112,9 +116,7 @@ describe("scenarios > collection defaults", () => {
         "navigating directly to a collection should expand it and show its children",
       );
 
-      getCollectionIdFromSlug("second_collection", id => {
-        visitCollection(id);
-      });
+      visitCollection(SECOND_COLLECTION_ID);
 
       navigationSidebar().within(() => {
         cy.findByText("Second collection");
@@ -127,21 +129,19 @@ describe("scenarios > collection defaults", () => {
     });
 
     it("should correctly display deep nested collections with long names", () => {
-      getCollectionIdFromSlug("third_collection", THIRD_COLLECTION_ID => {
-        cy.log("Create two more nested collections");
+      cy.log("Create two more nested collections");
 
-        ["Fourth collection", "Fifth collection with a very long name"].forEach(
-          (collection, index) => {
-            cy.request("POST", "/api/collection", {
-              name: collection,
-              parent_id: THIRD_COLLECTION_ID + index,
-              color: "#509ee3",
-            });
-          },
-        );
+      ["Fourth collection", "Fifth collection with a very long name"].forEach(
+        (collection, index) => {
+          cy.request("POST", "/api/collection", {
+            name: collection,
+            parent_id: THIRD_COLLECTION_ID + index,
+            color: "#509ee3",
+          });
+        },
+      );
 
-        visitCollection(THIRD_COLLECTION_ID);
-      });
+      visitCollection(THIRD_COLLECTION_ID);
 
       // 1. Expand so that deeply nested collection is showing
       navigationSidebar().within(() => {
@@ -189,7 +189,7 @@ describe("scenarios > collection defaults", () => {
   });
 
   it("should support markdown in collection description", () => {
-    cy.request("PUT", "/api/collection/10", {
+    cy.request("PUT", `/api/collection/${FIRST_COLLECTION_ID}`, {
       description: "[link](https://metabase.com)",
     });
 
@@ -282,9 +282,7 @@ describe("scenarios > collection defaults", () => {
     it("should be able to drag an item to the root collection (metabase#16498)", () => {
       moveItemToCollection("Orders", "First collection");
 
-      getCollectionIdFromSlug("first_collection", id => {
-        visitCollection(id);
-      });
+      visitCollection(FIRST_COLLECTION_ID);
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders").as("dragSubject");
@@ -418,9 +416,7 @@ describe("scenarios > collection defaults", () => {
         "when nested child collection is moved to the root collection (metabase#14482)",
       );
 
-      getCollectionIdFromSlug("second_collection", id => {
-        visitCollection(id);
-      });
+      visitCollection(SECOND_COLLECTION_ID);
 
       moveOpenedCollectionTo("Our analytics");
 
@@ -568,18 +564,16 @@ describe("scenarios > collection defaults", () => {
     });
 
     it("should create new collections within the current collection", () => {
-      getCollectionIdFromSlug("third_collection", collection_id => {
-        visitCollection(collection_id);
-        cy.findByText("New").click();
+      visitCollection(THIRD_COLLECTION_ID);
+      cy.findByTestId("app-bar").findByText("New").click();
 
-        popover().within(() => {
-          cy.findByText("Collection").click();
-        });
+      popover().within(() => {
+        cy.findByText("Collection").click();
+      });
 
-        modal().within(() => {
-          cy.findByText("Collection it's saved in").should("be.visible");
-          cy.findByText("Third collection").should("be.visible");
-        });
+      modal().within(() => {
+        cy.findByText("Collection it's saved in").should("be.visible");
+        cy.findByText("Third collection").should("be.visible");
       });
     });
   });

--- a/e2e/test/scenarios/collections/personal-collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/personal-collections.cy.spec.js
@@ -9,9 +9,10 @@ import {
 } from "e2e/support/helpers";
 
 import { USERS } from "e2e/support/cypress_data";
-
-const ADMIN_PERSONAL_COLLECTION_ID = 1;
-const NODATA_PERSONAL_COLLECTION_ID = 5;
+import {
+  NO_DATA_PERSONAL_COLLECTION_ID,
+  ADMIN_PERSONAL_COLLECTION_ID,
+} from "e2e/support/cypress_sample_instance_data";
 
 describe("personal collections", () => {
   beforeEach(() => {
@@ -120,7 +121,7 @@ describe("personal collections", () => {
       // });
 
       // Go to random user's personal collection
-      cy.visit("/collection/5");
+      cy.visit(`/collection/${NO_DATA_PERSONAL_COLLECTION_ID}`);
 
       getCollectionActions().within(() => {
         cy.icon("ellipsis").should("not.exist");
@@ -130,10 +131,10 @@ describe("personal collections", () => {
     it("should be able view other users' personal sub-collections (metabase#15339)", () => {
       cy.createCollection({
         name: "Foo",
-        parent_id: NODATA_PERSONAL_COLLECTION_ID,
+        parent_id: NO_DATA_PERSONAL_COLLECTION_ID,
       });
 
-      cy.visit(`/collection/${NODATA_PERSONAL_COLLECTION_ID}`);
+      cy.visit(`/collection/${NO_DATA_PERSONAL_COLLECTION_ID}`);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Foo");
     });

--- a/e2e/test/scenarios/collections/reproductions/20911-include-subcollections-permissions.cy.spec.js
+++ b/e2e/test/scenarios/collections/reproductions/20911-include-subcollections-permissions.cy.spec.js
@@ -1,6 +1,6 @@
+import { FIRST_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data";
 import {
   restore,
-  getCollectionIdFromSlug,
   assertPermissionTable,
   modifyPermission,
   modal,
@@ -11,7 +11,6 @@ import {
 
 const COLLECTION_ACCESS_PERMISSION_INDEX = 0;
 const FIRST_COLLECTION = "First collection";
-const FIRST_COLLECTION_SLUG = "first_collection";
 
 describe("issue 20911", () => {
   beforeEach(() => {
@@ -65,13 +64,11 @@ describe("issue 20911", () => {
       ["readonly", "View"],
     ]);
 
-    getCollectionIdFromSlug(FIRST_COLLECTION_SLUG, id => {
-      cy.signInAsNormalUser();
-      cy.visit("/collection/root");
-      cy.findByText("You don't have permissions to do that.");
+    cy.signInAsNormalUser();
+    cy.visit("/collection/root");
+    cy.get("main").findByText("You don't have permissions to do that.");
 
-      cy.visit(`/collection/${id}`);
-      cy.findByText("Sorry, you don’t have permission to see that.");
-    });
+    cy.visit(`/collection/${FIRST_COLLECTION_ID}`);
+    cy.get("main").findByText("Sorry, you don’t have permission to see that.");
   });
 });

--- a/e2e/test/scenarios/collections/revision-history.cy.spec.js
+++ b/e2e/test/scenarios/collections/revision-history.cy.spec.js
@@ -9,7 +9,10 @@ import {
   openQuestionsSidebar,
 } from "e2e/support/helpers";
 
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ORDERS_QUESTION_ID,
+  ORDERS_DASHBOARD_ID,
+} from "e2e/support/cypress_sample_instance_data";
 
 const PERMISSIONS = {
   curate: ["admin", "normal", "nodata"],
@@ -86,7 +89,7 @@ describe("revision history", () => {
 
             // skipped because it's super flaky in CI
             it.skip("should be able to revert a dashboard (metabase#15237)", () => {
-              visitDashboard(1);
+              visitDashboard(ORDERS_DASHBOARD_ID);
               openRevisionHistory();
               clickRevert(/created this/);
 
@@ -158,7 +161,7 @@ describe("revision history", () => {
             it("should not see question nor dashboard revert buttons (metabase#13229)", () => {
               cy.signIn(user);
 
-              visitDashboard(1);
+              visitDashboard(ORDERS_DASHBOARD_ID);
               openRevisionHistory();
               cy.findAllByRole("button", { name: "Revert" }).should(
                 "not.exist",

--- a/e2e/test/scenarios/dashboard-cards/dashboard-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-drill.cy.spec.js
@@ -6,6 +6,8 @@ import {
   showDashboardCardActions,
   visitDashboard,
   addOrUpdateDashboardCard,
+  sidebar,
+  getDashboardCard,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
@@ -32,22 +34,17 @@ describe("scenarios > dashboard > dashboard drill", () => {
     createDashboardWithQuestion({}, dashboardId => {
       visitDashboard(dashboardId);
 
-      cy.icon("pencil").click();
+      cy.findByTestId("dashboard-header").icon("pencil").click();
       showDashboardCardActions();
-      cy.findByTestId("dashboardcard-actions-panel").within(() => {
-        cy.icon("click").click();
-      });
+      cy.findByTestId("dashboardcard-actions-panel").icon("click").click();
 
       // configure a URL click through on the  "MY_NUMBER" column
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("On-click behavior for each column")
+      sidebar()
+        .findByText("On-click behavior for each column")
         .parent()
         .parent()
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         .within(() => cy.findByText("MY_NUMBER").click());
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Go to a custom destination").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("URL").click();
 
       // set the url and text template
@@ -61,14 +58,12 @@ describe("scenarios > dashboard > dashboard drill", () => {
         cy.findByText("Done").click();
       });
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Save").click();
+      cy.findByTestId("edit-bar").findByText("Save").click();
 
       setParamValue("My Param", "param-value");
-
       // click value and confirm url updates
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("column value: 111").click();
+
+      getDashboardCard().findByText("column value: 111").click();
       cy.location("pathname").should("eq", "/foo/111/param-value");
     });
   });

--- a/e2e/test/scenarios/dashboard-cards/dashboard-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-drill.cy.spec.js
@@ -10,6 +10,7 @@ import {
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 const {
   ORDERS,
@@ -28,45 +29,48 @@ describe("scenarios > dashboard > dashboard drill", () => {
   });
 
   it("should handle URL click through on a table", () => {
-    createDashboardWithQuestion({}, dashboardId => visitDashboard(dashboardId));
-    cy.icon("pencil").click();
-    showDashboardCardActions();
-    cy.findByTestId("dashboardcard-actions-panel").within(() => {
-      cy.icon("click").click();
-    });
+    createDashboardWithQuestion({}, dashboardId => {
+      visitDashboard(dashboardId);
 
-    // configure a URL click through on the  "MY_NUMBER" column
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("On-click behavior for each column")
-      .parent()
-      .parent()
+      cy.icon("pencil").click();
+      showDashboardCardActions();
+      cy.findByTestId("dashboardcard-actions-panel").within(() => {
+        cy.icon("click").click();
+      });
+
+      // configure a URL click through on the  "MY_NUMBER" column
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      .within(() => cy.findByText("MY_NUMBER").click());
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Go to a custom destination").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("URL").click();
+      cy.findByText("On-click behavior for each column")
+        .parent()
+        .parent()
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+        .within(() => cy.findByText("MY_NUMBER").click());
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Go to a custom destination").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("URL").click();
 
-    // set the url and text template
-    modal().within(() => {
-      cy.get("input").first().type("/foo/{{my_number}}/{{my_param}}", {
-        parseSpecialCharSequences: false,
+      // set the url and text template
+      modal().within(() => {
+        cy.get("input").first().type("/foo/{{my_number}}/{{my_param}}", {
+          parseSpecialCharSequences: false,
+        });
+        cy.get("input").last().type("column value: {{my_number}}", {
+          parseSpecialCharSequences: false,
+        });
+        cy.findByText("Done").click();
       });
-      cy.get("input").last().type("column value: {{my_number}}", {
-        parseSpecialCharSequences: false,
-      });
-      cy.findByText("Done").click();
+
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Save").click();
+
+      setParamValue("My Param", "param-value");
+
+      // click value and confirm url updates
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("column value: 111").click();
+      cy.location("pathname").should("eq", "/foo/111/param-value");
     });
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Save").click();
-
-    setParamValue("My Param", "param-value");
-
-    // click value and confirm url updates
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("column value: 111").click();
-    cy.location("pathname").should("eq", "/foo/111/param-value");
   });
 
   it("should insert values from hidden column on custom destination URL click through (metabase#13927)", () => {
@@ -280,38 +284,42 @@ describe("scenarios > dashboard > dashboard drill", () => {
   });
 
   it("should open the same dashboard when a custom URL click behavior points to the same dashboard (metabase#22702)", () => {
-    createDashboardWithQuestion({}, dashboardId => visitDashboard(dashboardId));
-    cy.icon("pencil").click();
-    showDashboardCardActions();
-    cy.findByTestId("dashboardcard-actions-panel").within(() => {
-      cy.icon("click").click();
-    });
+    createDashboardWithQuestion({}, dashboardId => {
+      visitDashboard(dashboardId);
+      cy.icon("pencil").click();
+      showDashboardCardActions();
+      cy.findByTestId("dashboardcard-actions-panel").within(() => {
+        cy.icon("click").click();
+      });
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("On-click behavior for each column")
-      .parent()
-      .parent()
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      .within(() => cy.findByText("MY_NUMBER").click());
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Go to a custom destination").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("URL").click();
+      cy.findByText("On-click behavior for each column")
+        .parent()
+        .parent()
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+        .within(() => cy.findByText("MY_NUMBER").click());
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Go to a custom destination").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("URL").click();
 
-    modal().within(() => {
-      cy.get("input").first().type("/dashboard/2?my_param=Aaron Hand");
-      cy.get("input").last().type("Click behavior");
-      cy.findByText("Done").click();
+      modal().within(() => {
+        cy.get("input")
+          .first()
+          .type(`/dashboard/${dashboardId}?my_param=Aaron Hand`);
+        cy.get("input").last().type("Click behavior");
+        cy.findByText("Done").click();
+      });
+
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Save").click();
+
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Click behavior").click();
+
+      cy.location("pathname").should("eq", `/dashboard/${dashboardId}`);
+      cy.location("search").should("eq", "?my_param=Aaron%20Hand");
     });
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Save").click();
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Click behavior").click();
-
-    cy.location("pathname").should("eq", "/dashboard/2");
-    cy.location("search").should("eq", "?my_param=Aaron%20Hand");
   });
 
   // This was flaking. Example: https://dashboard.cypress.io/projects/a394u1/runs/2109/test-results/91a15b66-4b80-40bf-b569-de28abe21f42
@@ -442,7 +450,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
     const FILTER_ID = "7c9ege62";
     const PK_VALUE = "7602";
 
-    cy.request("PUT", "/api/dashboard/1", {
+    cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}`, {
       parameters: [
         {
           id: FILTER_ID,
@@ -453,7 +461,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
         },
       ],
     });
-    cy.request("PUT", "/api/dashboard/1/cards", {
+    cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}/cards`, {
       cards: [
         {
           id: 1,
@@ -481,7 +489,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       ],
     });
 
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
     cy.findAllByTestId("column-header").contains("ID").click().click();
 
     cy.get(".Table-ID").contains(PK_VALUE).first().click();
@@ -501,7 +509,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
     const FILTER_ID = "7c9ege62";
 
     cy.log("Add filter (with the default Category) to the dashboard");
-    cy.request("PUT", "/api/dashboard/1", {
+    cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}`, {
       parameters: [
         {
           id: FILTER_ID,
@@ -514,7 +522,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
     });
 
     cy.log("Connect filter to the existing card");
-    cy.request("PUT", "/api/dashboard/1/cards", {
+    cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}/cards`, {
       cards: [
         {
           id: 1,
@@ -543,7 +551,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
     });
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
     // Product ID in the first row (query fails for User ID as well)
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("105").click();
@@ -873,12 +881,12 @@ describe("scenarios > dashboard > dashboard drill", () => {
 
     beforeEach(() => {
       // Add filters to the dashboard
-      cy.request("PUT", "/api/dashboard/1", {
+      cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}`, {
         parameters,
       });
 
       // Connect those filters to the existing dashboard card
-      cy.request("PUT", "/api/dashboard/1/cards", {
+      cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}/cards`, {
         cards: [
           {
             id: 1,
@@ -914,7 +922,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
         ],
       });
 
-      visitDashboard(1);
+      visitDashboard(ORDERS_DASHBOARD_ID);
     });
 
     it("should correctly drill-through on Orders filter (metabase#11503-1)", () => {

--- a/e2e/test/scenarios/dashboard-cards/dashboard-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-drill.cy.spec.js
@@ -287,15 +287,11 @@ describe("scenarios > dashboard > dashboard drill", () => {
         cy.icon("click").click();
       });
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("On-click behavior for each column")
         .parent()
         .parent()
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         .within(() => cy.findByText("MY_NUMBER").click());
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Go to a custom destination").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("URL").click();
 
       modal().within(() => {
@@ -306,10 +302,8 @@ describe("scenarios > dashboard > dashboard drill", () => {
         cy.findByText("Done").click();
       });
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save").click();
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Click behavior").click();
 
       cy.location("pathname").should("eq", `/dashboard/${dashboardId}`);

--- a/e2e/test/scenarios/dashboard-cards/visualization-options.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/visualization-options.cy.spec.js
@@ -6,6 +6,7 @@ import {
   editDashboard,
   showDashboardCardActions,
 } from "e2e/support/helpers";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 describe("scenarios > dashboard cards > visualization options", () => {
   beforeEach(() => {
@@ -14,7 +15,7 @@ describe("scenarios > dashboard cards > visualization options", () => {
   });
 
   it("should allow empty card title (metabase#12013)", () => {
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
 
     cy.findByTextEnsureVisible("Orders");
     cy.findByTestId("legend-caption").should("exist");
@@ -30,7 +31,7 @@ describe("scenarios > dashboard cards > visualization options", () => {
   });
 
   it("column reordering should work (metabase#16229)", () => {
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
     cy.findByLabelText("Edit dashboard").click();
     getDashboardCard().realHover();
     cy.findByLabelText("Show visualization options").click();
@@ -61,7 +62,7 @@ describe("scenarios > dashboard cards > visualization options", () => {
   });
 
   it("should refelct column settings accurately when changing (metabase#30966)", () => {
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
     cy.findByLabelText("Edit dashboard").click();
     getDashboardCard().realHover();
     cy.findByLabelText("Show visualization options").click();

--- a/e2e/test/scenarios/dashboard-filters/dashboard-chained-filters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-chained-filters.cy.spec.js
@@ -8,6 +8,8 @@ import {
   resetTestTable,
   resyncDatabase,
 } from "e2e/support/helpers";
+
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
 
@@ -22,7 +24,7 @@ describe("scenarios > dashboard > chained filter", () => {
   for (const has_field_values of ["search", "list"]) {
     it(`limit ${has_field_values} options based on linked filter`, () => {
       cy.request("PUT", `/api/field/${PEOPLE.CITY}`, { has_field_values }),
-        visitDashboard(1);
+        visitDashboard(ORDERS_DASHBOARD_ID);
       // start editing
       cy.icon("pencil").click();
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filter-data-permissions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filter-data-permissions.cy.spec.js
@@ -4,9 +4,10 @@ import {
   selectDashboardFilter,
   visitDashboard,
 } from "e2e/support/helpers";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 function filterDashboard(suggests = true) {
-  visitDashboard(1);
+  visitDashboard(ORDERS_DASHBOARD_ID);
   cy.contains("Orders");
   cy.contains("Text").click();
 
@@ -29,13 +30,16 @@ function filterDashboard(suggests = true) {
 
 describe("support > permissions (metabase#8472)", () => {
   beforeEach(() => {
-    cy.intercept("GET", "/api/dashboard/1/params/*/search/*").as("search");
+    cy.intercept(
+      "GET",
+      `/api/dashboard/${ORDERS_DASHBOARD_ID}/params/*/search/*").as("search`,
+    );
 
     restore();
     cy.signInAsAdmin();
 
     // Setup a dashboard with a text filter
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
     // click pencil icon to edit
     cy.icon("pencil").click();
 
@@ -68,7 +72,7 @@ describe("support > permissions (metabase#8472)", () => {
     cy.signIn("nocollection");
     cy.request({
       method: "GET",
-      url: "/api/dashboard/1",
+      url: `/api/dashboard/${ORDERS_DASHBOARD_ID}`,
       failOnStatusCode: false,
     }).should(xhr => {
       expect(xhr.status).to.equal(403);

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
@@ -8,6 +8,7 @@ import {
   setFilter,
   visitDashboard,
 } from "e2e/support/helpers";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 import * as DateFilter from "../native-filters/helpers/e2e-date-filter-helpers";
 import { DASHBOARD_DATE_FILTERS } from "./shared/dashboard-filters-date";
@@ -19,7 +20,7 @@ describe("scenarios > dashboard > filters > date", () => {
     restore();
     cy.signInAsAdmin();
 
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
 
     editDashboard();
   });
@@ -89,7 +90,7 @@ describe("scenarios > dashboard > filters > date", () => {
   });
 
   it("should show sub-day resolutions in relative date filter (metabase#6660)", () => {
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
     cy.icon("pencil").click();
     cy.icon("filter").click();
 
@@ -127,7 +128,7 @@ describe("scenarios > dashboard > filters > date", () => {
       cy.request("PUT", `/api/user/${USER_ID}`, { locale: "fr" });
     });
 
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
     cy.icon("pencil").click();
     cy.icon("filter").click();
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-id.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-id.cy.spec.js
@@ -8,6 +8,7 @@ import {
   checkFilterLabelAndValue,
   visitDashboard,
 } from "e2e/support/helpers";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 import { addWidgetStringFilter } from "../native-filters/helpers/e2e-field-filter-helpers";
 
@@ -16,7 +17,7 @@ describe("scenarios > dashboard > filters > ID", () => {
     restore();
     cy.signInAsAdmin();
 
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
 
     editDashboard();
     setFilter("ID");

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-location.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-location.cy.spec.js
@@ -8,6 +8,7 @@ import {
   setFilter,
   visitDashboard,
 } from "e2e/support/helpers";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 import { addWidgetStringFilter } from "../native-filters/helpers/e2e-field-filter-helpers";
 import { DASHBOARD_LOCATION_FILTERS } from "./shared/dashboard-filters-location";
@@ -17,7 +18,7 @@ describe("scenarios > dashboard > filters > location", () => {
     restore();
     cy.signInAsAdmin();
 
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
 
     editDashboard();
   });

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
@@ -8,6 +8,7 @@ import {
   setFilter,
   visitDashboard,
 } from "e2e/support/helpers";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 import { addWidgetNumberFilter } from "../native-filters/helpers/e2e-field-filter-helpers";
 import { DASHBOARD_NUMBER_FILTERS } from "./shared/dashboard-filters-number";
@@ -19,7 +20,7 @@ describe("scenarios > dashboard > filters > number", () => {
     restore();
     cy.signInAsAdmin();
 
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
 
     editDashboard();
   });

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
@@ -8,6 +8,7 @@ import {
   setFilter,
   visitDashboard,
 } from "e2e/support/helpers";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 import { applyFilterByType } from "../native-filters/helpers/e2e-field-filter-helpers";
 import { DASHBOARD_TEXT_FILTERS } from "./shared/dashboard-filters-text-category";
@@ -17,7 +18,7 @@ describe("scenarios > dashboard > filters > text/category", () => {
     restore();
     cy.signInAsAdmin();
 
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
 
     editDashboard();
   });

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -10,6 +10,7 @@ import {
   saveDashboard,
   updateDashboardCards,
 } from "e2e/support/helpers";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 
@@ -503,7 +504,7 @@ describe("scenarios > dashboard > parameters", () => {
 
   describe("when the user does not have self-service data permissions", () => {
     beforeEach(() => {
-      visitDashboard(1);
+      visitDashboard(ORDERS_DASHBOARD_ID);
       cy.findByTextEnsureVisible("Created At");
 
       cy.icon("pencil").click();
@@ -518,7 +519,7 @@ describe("scenarios > dashboard > parameters", () => {
       cy.findByText("You're editing this dashboard.").should("not.exist");
 
       cy.signIn("nodata");
-      visitDashboard(1);
+      visitDashboard(ORDERS_DASHBOARD_ID);
     });
 
     it("should not see mapping options", () => {

--- a/e2e/test/scenarios/dashboard-filters/reproductions/12720-no-data-permissions-connected-filter.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/12720-no-data-permissions-connected-filter.cy.spec.js
@@ -5,6 +5,7 @@ import {
   updateDashboardCards,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 const { ORDERS } = SAMPLE_DATABASE;
 
@@ -41,7 +42,7 @@ describe("issue 12720", () => {
     cy.signInAsAdmin();
 
     // In this test we're using already present question ("Orders") and the dashboard with that question ("Orders in a dashboard")
-    cy.request("PUT", "/api/dashboard/1", {
+    cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}`, {
       parameters: [dashboardFilter],
     });
 
@@ -95,7 +96,7 @@ describe("issue 12720", () => {
 });
 
 function clickThrough(title) {
-  visitDashboard(1);
+  visitDashboard(ORDERS_DASHBOARD_ID);
   cy.get(".DashCard").contains(title).click();
 
   cy.location("search").should("contain", dashboardFilter.default);

--- a/e2e/test/scenarios/dashboard-filters/reproductions/19494-wrong-default-value-multiple-cards-same-question.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/19494-wrong-default-value-multiple-cards-same-question.cy.spec.js
@@ -7,6 +7,8 @@ import {
   updateDashboardCards,
 } from "e2e/support/helpers";
 
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
+
 const filter1 = {
   name: "Card 1 Filter",
   slug: "card1_filter",
@@ -50,7 +52,7 @@ describe("issue 19494", () => {
     });
 
     // Add two dashboard filters (not yet connected to any of the cards)
-    cy.request("PUT", "/api/dashboard/1", {
+    cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}`, {
       parameters: [filter1, filter2],
     });
   });
@@ -58,7 +60,7 @@ describe("issue 19494", () => {
   it("should correctly apply different filters with default values to all cards of the same question (metabase#19494)", () => {
     // Instead of using the API to connect filters to the cards,
     // let's use UI to replicate user experience as closely as possible
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
 
     editDashboard();
 

--- a/e2e/test/scenarios/dashboard-filters/reproductions/22482-round-relative-ranges.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/22482-round-relative-ranges.cy.spec.js
@@ -8,13 +8,14 @@ import {
   setFilter,
   visitDashboard,
 } from "e2e/support/helpers";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 describe("issue 22482", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
 
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
 
     editDashboard();
     setFilter("Time", "All Options");

--- a/e2e/test/scenarios/dashboard/caching.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/caching.cy.spec.js
@@ -19,7 +19,7 @@ describeEE("scenarios > dashboard > caching", () => {
   });
 
   it("can set cache ttl for a saved question", () => {
-    cy.intercept("PUT", `dashboard/${ORDERS_DASHBOARD_ID}`).as(
+    cy.intercept("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}`).as(
       "updateDashboard",
     );
     visitDashboard(ORDERS_DASHBOARD_ID);

--- a/e2e/test/scenarios/dashboard/caching.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/caching.cy.spec.js
@@ -8,6 +8,8 @@ import {
   toggleDashboardInfoSidebar,
 } from "e2e/support/helpers";
 
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
+
 describeEE("scenarios > dashboard > caching", () => {
   beforeEach(() => {
     restore();
@@ -17,8 +19,10 @@ describeEE("scenarios > dashboard > caching", () => {
   });
 
   it("can set cache ttl for a saved question", () => {
-    cy.intercept("PUT", "/api/dashboard/1").as("updateDashboard");
-    visitDashboard(1);
+    cy.intercept("PUT", `dashboard/${ORDERS_DASHBOARD_ID}`).as(
+      "updateDashboard",
+    );
+    visitDashboard(ORDERS_DASHBOARD_ID);
 
     toggleDashboardInfoSidebar();
 

--- a/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
@@ -21,7 +21,10 @@ import {
   filterWidget,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ORDERS_QUESTION_ID,
+  ORDERS_DASHBOARD_ID,
+} from "e2e/support/cypress_sample_instance_data";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
@@ -48,7 +51,7 @@ describe("scenarios > dashboard > dashboard back navigation", () => {
     const dashboardName = "Orders in a dashboard";
     const backButtonLabel = `Back to ${dashboardName}`;
 
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
     cy.wait("@dashboard");
     cy.findByTestId("dashcard").findByText("Orders").click();
     cy.wait("@cardQuery");
@@ -162,7 +165,7 @@ describe("scenarios > dashboard > dashboard back navigation", () => {
   });
 
   it("should not preserve query results when the question changes during navigation", () => {
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
     cy.wait("@dashboard");
     cy.wait("@dashcardQuery");
 

--- a/e2e/test/scenarios/dashboard/dashboard-management.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-management.cy.spec.js
@@ -13,6 +13,7 @@ import {
 } from "e2e/support/helpers";
 
 import { USERS } from "e2e/support/cypress_data";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 const PERMISSIONS = {
   curate: ["admin", "normal", "nodata"],
@@ -282,7 +283,7 @@ describe("managing dashboard from the dashboard's edit menu", () => {
           beforeEach(() => {
             cy.signIn(user);
 
-            visitDashboard(1);
+            visitDashboard(ORDERS_DASHBOARD_ID);
 
             cy.get("main header").within(() => {
               cy.icon("ellipsis").should("be.visible").click();

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -32,6 +32,7 @@ import {
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
 
@@ -155,7 +156,7 @@ describe("scenarios > dashboard", () => {
     it("adding question to one dashboard shouldn't affect previously visited unrelated dashboards (metabase#26826)", () => {
       cy.intercept("POST", "/api/card").as("saveQuestion");
 
-      visitDashboard(1);
+      visitDashboard(ORDERS_DASHBOARD_ID);
 
       cy.log("Save new question from an ad-hoc query");
       openProductsTable();
@@ -263,7 +264,7 @@ describe("scenarios > dashboard", () => {
       });
 
       it("should allow navigating to the notebook editor directly from a dashboard card", () => {
-        visitDashboard(1);
+        visitDashboard(ORDERS_DASHBOARD_ID);
         showDashboardCardActions();
         getDashboardCardMenu().click();
         popover().findByText("Edit question").should("be.visible").click();
@@ -459,7 +460,7 @@ describe("scenarios > dashboard", () => {
   });
 
   it("should add a filter", () => {
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
     cy.icon("pencil").click();
     cy.icon("filter").click();
     // Adding location/state doesn't make much sense for this case,
@@ -670,7 +671,7 @@ describe("scenarios > dashboard", () => {
     const FILTER_ID = "d7988e02";
 
     cy.log("Add filter to the dashboard");
-    cy.request("PUT", "/api/dashboard/1", {
+    cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}`, {
       parameters: [
         {
           id: FILTER_ID,
@@ -682,7 +683,7 @@ describe("scenarios > dashboard", () => {
     });
 
     cy.log("Connect filter to the existing card");
-    cy.request("PUT", "/api/dashboard/1/cards", {
+    cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}/cards`, {
       cards: [
         {
           id: 1,
@@ -711,7 +712,7 @@ describe("scenarios > dashboard", () => {
     });
 
     cy.intercept(
-      `/api/dashboard/1/params/${FILTER_ID}/values`,
+      `/api/dashboard/${ORDERS_DASHBOARD_ID}/params/${FILTER_ID}/values`,
       cy.spy().as("fetchDashboardParams"),
     );
     cy.intercept(`/api/field/${PRODUCTS.CATEGORY}`, cy.spy().as("fetchField"));
@@ -720,7 +721,7 @@ describe("scenarios > dashboard", () => {
       cy.spy().as("fetchFieldValues"),
     );
 
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
 
     filterWidget().as("filterWidget").click();
 
@@ -743,7 +744,7 @@ describe("scenarios > dashboard", () => {
         }).then(({ body: { id: NEW_DASHBOARD_ID } }) => {
           const COLUMN_REF = `["ref",["field-id",${ORDERS.ID}]]`;
           // Add click behavior to the existing "Orders in a dashboard" dashboard
-          cy.request("PUT", "/api/dashboard/1/cards", {
+          cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}/cards`, {
             cards: [
               {
                 id: 1,
@@ -777,7 +778,7 @@ describe("scenarios > dashboard", () => {
       },
     );
     cy.signInAsNormalUser();
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
 
     cy.wait("@loadDashboard");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -788,7 +789,7 @@ describe("scenarios > dashboard", () => {
 
   it("should be possible to scroll vertically after fullscreen layer is closed (metabase#15596)", () => {
     // Make this dashboard card extremely tall so that it spans outside of visible viewport
-    cy.request("PUT", "/api/dashboard/1/cards", {
+    cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}/cards`, {
       cards: [
         {
           id: 1,
@@ -804,7 +805,7 @@ describe("scenarios > dashboard", () => {
       ],
     });
 
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("37.65");
     assertScrollBarExists();
@@ -820,7 +821,7 @@ describe("scenarios > dashboard", () => {
     const FILTER_ID = "d7988e02";
 
     cy.log("Add filter to the dashboard");
-    cy.request("PUT", "/api/dashboard/1", {
+    cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}`, {
       parameters: [
         {
           id: FILTER_ID,
@@ -832,7 +833,7 @@ describe("scenarios > dashboard", () => {
     });
 
     cy.log("Connect filter to the existing card");
-    cy.request("PUT", "/api/dashboard/1/cards", {
+    cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}/cards`, {
       cards: [
         {
           id: 1,
@@ -853,7 +854,7 @@ describe("scenarios > dashboard", () => {
       ],
     });
 
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
     editDashboard();
 
     cy.findByTestId("dashboardcard-actions-panel").within(() => {
@@ -912,7 +913,7 @@ describeWithSnowplow("scenarios > dashboard", () => {
   });
 
   it("should allow users to add link cards to dashboards", () => {
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
     editDashboard();
     cy.findByTestId("dashboard-header").icon("link").click();
 
@@ -940,7 +941,7 @@ describeWithSnowplow("scenarios > dashboard", () => {
   });
 
   it("should track enabling the hide empty cards setting", () => {
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
     editDashboard();
 
     cy.findByTestId("dashboardcard-actions-panel").within(() => {

--- a/e2e/test/scenarios/dashboard/reproductions/21830-slow-loading-card-viz-options-error.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/21830-slow-loading-card-viz-options-error.cy.spec.js
@@ -5,6 +5,8 @@ import {
   showDashboardCardActions,
 } from "e2e/support/helpers";
 
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
+
 describe("issue 21830", () => {
   beforeEach(() => {
     restore();
@@ -27,7 +29,7 @@ describe("issue 21830", () => {
       },
     ).as("getCardQuery");
 
-    cy.visit("/dashboard/1");
+    cy.visit(`/dashboard/${ORDERS_DASHBOARD_ID}`);
     cy.wait("@getDashboard");
 
     // it's crucial that we try to click on this icon BEFORE we wait for the `getCardQuery` response!

--- a/e2e/test/scenarios/dashboard/reproductions/29076-dashboard-card-drill-sandbox.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/29076-dashboard-card-drill-sandbox.cy.spec.js
@@ -4,8 +4,9 @@ import {
   visitDashboard,
   setTokenFeatures,
 } from "e2e/support/helpers";
-import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 const { PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
 describeEE("issue 29076", () => {
@@ -26,7 +27,7 @@ describeEE("issue 29076", () => {
   });
 
   it("should be able to drilldown to a saved question in a dashboard with sandboxing (metabase#29076)", () => {
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
     cy.wait("@cardQuery");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -19,6 +19,8 @@ import {
   main,
 } from "e2e/support/helpers";
 
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
+
 describe("scenarios > dashboard > tabs", () => {
   beforeEach(() => {
     restore();
@@ -93,17 +95,17 @@ describe("scenarios > dashboard > tabs", () => {
 
     cy.intercept(
       "POST",
-      `/api/dashboard/1/dashcard/1/card/1/query`,
+      `/api/dashboard/${ORDERS_DASHBOARD_ID}/card/1/query`,
       cy.spy().as("firstTabQuery"),
     );
     cy.intercept(
       "POST",
-      `/api/dashboard/1/dashcard/2/card/2/query`,
+      `/api/dashboard/${ORDERS_DASHBOARD_ID}/dashcard/2/card/2/query`,
       cy.spy().as("secondTabQuery"),
     );
 
     // Visit first tab and confirm only first card was queried
-    visitDashboard(1, { params: { tab: 1 } });
+    visitDashboard(ORDERS_DASHBOARD_ID, { params: { tab: 1 } });
     cy.get("@firstTabQuery").should("have.been.calledOnce");
     cy.get("@secondTabQuery").should("not.have.been.called");
 
@@ -119,22 +121,23 @@ describe("scenarios > dashboard > tabs", () => {
 
     // Go to public dashboard
     cy.request("PUT", "/api/setting/enable-public-sharing", { value: true });
-    cy.request("POST", `/api/dashboard/1/public_link`).then(
-      ({ body: { uuid } }) => {
-        cy.intercept(
-          "GET",
-          `/api/public/dashboard/${uuid}/dashcard/1/card/1?parameters=%5B%5D`,
-          cy.spy().as("publicFirstTabQuery"),
-        );
-        cy.intercept(
-          "GET",
-          `/api/public/dashboard/${uuid}/dashcard/2/card/2?parameters=%5B%5D`,
-          cy.spy().as("publicSecondTabQuery"),
-        );
+    cy.request(
+      "POST",
+      `/api/dashboard/${ORDERS_DASHBOARD_ID}/public_link`,
+    ).then(({ body: { uuid } }) => {
+      cy.intercept(
+        "GET",
+        `/api/public/dashboard/${uuid}/dashcard/1/card/1?parameters=%5B%5D`,
+        cy.spy().as("publicFirstTabQuery"),
+      );
+      cy.intercept(
+        "GET",
+        `/api/public/dashboard/${uuid}/dashcard/2/card/2?parameters=%5B%5D`,
+        cy.spy().as("publicSecondTabQuery"),
+      );
 
-        cy.visit(`public/dashboard/${uuid}`);
-      },
-    );
+      cy.visit(`public/dashboard/${uuid}`);
+    });
 
     // Check first tab requests
     cy.get("@publicFirstTabQuery").should("have.been.calledOnce");
@@ -162,7 +165,7 @@ describeWithSnowplow("scenarios > dashboard > tabs", () => {
   });
 
   it("should send snowplow events when dashboard tabs are created and deleted", () => {
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
     expectGoodSnowplowEvents(PAGE_VIEW_EVENT);
 
     editDashboard();

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -95,7 +95,7 @@ describe("scenarios > dashboard > tabs", () => {
 
     cy.intercept(
       "POST",
-      `/api/dashboard/${ORDERS_DASHBOARD_ID}/card/1/query`,
+      `/api/dashboard/${ORDERS_DASHBOARD_ID}/dashcard/1/card/1/query`,
       cy.spy().as("firstTabQuery"),
     );
     cy.intercept(

--- a/e2e/test/scenarios/dashboard/text-dashcards.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/text-dashcards.cy.spec.js
@@ -13,6 +13,8 @@ import {
   expectGoodSnowplowEvent,
 } from "e2e/support/helpers";
 
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
+
 describe("scenarios > dashboard > text and headings", () => {
   beforeEach(() => {
     resetSnowplow();
@@ -23,7 +25,7 @@ describe("scenarios > dashboard > text and headings", () => {
 
   describeWithSnowplow("text", () => {
     beforeEach(() => {
-      visitDashboard(1);
+      visitDashboard(ORDERS_DASHBOARD_ID);
     });
 
     afterEach(() => {
@@ -156,7 +158,7 @@ describe("scenarios > dashboard > text and headings", () => {
 
   describeWithSnowplow("heading", () => {
     beforeEach(() => {
-      visitDashboard(1);
+      visitDashboard(ORDERS_DASHBOARD_ID);
     });
 
     afterEach(() => {

--- a/e2e/test/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -11,7 +11,10 @@ import {
   closeNavigationSidebar,
   updateDashboardCards,
 } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ORDERS_QUESTION_ID,
+  ORDERS_DASHBOARD_ID,
+} from "e2e/support/cypress_sample_instance_data";
 
 describeEE("scenarios > embedding > full app", () => {
   beforeEach(() => {
@@ -274,7 +277,7 @@ describeEE("scenarios > embedding > full app", () => {
 
   describe("dashboards", () => {
     it("should show the dashboard header by default", () => {
-      visitDashboardUrl({ url: "/dashboard/1" });
+      visitDashboardUrl({ url: `/dashboard/${ORDERS_DASHBOARD_ID}` });
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders in a dashboard").should("be.visible");
@@ -283,7 +286,10 @@ describeEE("scenarios > embedding > full app", () => {
     });
 
     it("should hide the dashboard header by a param", () => {
-      visitDashboardUrl({ url: "/dashboard/1", qs: { header: false } });
+      visitDashboardUrl({
+        url: `/dashboard/${ORDERS_DASHBOARD_ID}`,
+        qs: { header: false },
+      });
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders in a dashboard").should("not.exist");
@@ -291,7 +297,7 @@ describeEE("scenarios > embedding > full app", () => {
 
     it("should hide the dashboard's additional info by a param", () => {
       visitDashboardUrl({
-        url: "/dashboard/1",
+        url: `/dashboard/${ORDERS_DASHBOARD_ID}`,
         qs: { additional_info: false },
       });
 
@@ -312,7 +318,7 @@ describeEE("scenarios > embedding > full app", () => {
         linkTemplate: "/question/" + ORDERS_QUESTION_ID,
       });
       visitDashboardUrl({
-        url: "/dashboard/1",
+        url: `/dashboard/${ORDERS_DASHBOARD_ID}`,
       });
 
       cy.findAllByRole("cell").first().click();

--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -6,7 +6,10 @@ import {
   visitIframe,
 } from "e2e/support/helpers";
 import { METABASE_SECRET_KEY } from "e2e/support/cypress_data";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ORDERS_QUESTION_ID,
+  ORDERS_DASHBOARD_ID,
+} from "e2e/support/cypress_sample_instance_data";
 
 const embeddingPage = "/admin/settings/embedding-in-other-applications";
 const standalonePath =
@@ -192,7 +195,7 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
     });
 
     it("should not let you embed the dashboard", () => {
-      visitDashboard(1);
+      visitDashboard(ORDERS_DASHBOARD_ID);
       cy.icon("share").click();
 
       ensureEmbeddingIsDisabled();
@@ -386,7 +389,7 @@ function visitAndEnableSharing(object) {
   }
 
   if (object === "dashboard") {
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
 
     cy.icon("share").click();
     cy.findByText(/Embed in your application/).click();

--- a/e2e/test/scenarios/embedding/embedding-snippets.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-snippets.cy.spec.js
@@ -5,7 +5,10 @@ import {
   visitQuestion,
   setTokenFeatures,
 } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ORDERS_QUESTION_ID,
+  ORDERS_DASHBOARD_ID,
+} from "e2e/support/cypress_sample_instance_data";
 
 import { JS_CODE, IFRAME_CODE } from "./shared/embedding-snippets";
 
@@ -20,7 +23,7 @@ features.forEach(feature => {
     });
 
     it("dashboard should have the correct embed snippet", () => {
-      visitDashboard(1);
+      visitDashboard(ORDERS_DASHBOARD_ID);
       cy.icon("share").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Embed in your application").click();

--- a/e2e/test/scenarios/filters/view.cy.spec.js
+++ b/e2e/test/scenarios/filters/view.cy.spec.js
@@ -5,7 +5,6 @@ import {
   visitDashboard,
   addOrUpdateDashboardCard,
 } from "e2e/support/helpers";
-import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { PRODUCTS } = SAMPLE_DATABASE;
@@ -28,7 +27,9 @@ describe("scenarios > question > view", () => {
       cy.findByText("Yes").click();
 
       // Native query saved in dasbhoard
-      cy.createDashboard();
+      cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) =>
+        cy.wrap(DASHBOARD_ID).as("dashboardId"),
+      );
 
       cy.createNativeQuestion({
         name: "Question",
@@ -96,7 +97,9 @@ describe("scenarios > question > view", () => {
     it("should be able to filter Q by Vendor as user (from Dashboard) (metabase#12654)", () => {
       // Navigate to Q from Dashboard
       cy.signIn("nodata");
-      visitDashboard(ORDERS_DASHBOARD_ID);
+      cy.get("@dashboardId").then(dashboardId => {
+        visitDashboard(dashboardId);
+      });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Question").click();
 

--- a/e2e/test/scenarios/filters/view.cy.spec.js
+++ b/e2e/test/scenarios/filters/view.cy.spec.js
@@ -5,6 +5,7 @@ import {
   visitDashboard,
   addOrUpdateDashboardCard,
 } from "e2e/support/helpers";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { PRODUCTS } = SAMPLE_DATABASE;
@@ -95,7 +96,7 @@ describe("scenarios > question > view", () => {
     it("should be able to filter Q by Vendor as user (from Dashboard) (metabase#12654)", () => {
       // Navigate to Q from Dashboard
       cy.signIn("nodata");
-      visitDashboard(2);
+      visitDashboard(ORDERS_DASHBOARD_ID);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Question").click();
 

--- a/e2e/test/scenarios/models/create.cy.spec.js
+++ b/e2e/test/scenarios/models/create.cy.spec.js
@@ -1,10 +1,6 @@
-import {
-  getCollectionIdFromSlug,
-  modal,
-  popover,
-  restore,
-  visitCollection,
-} from "e2e/support/helpers";
+import { modal, popover, restore, visitCollection } from "e2e/support/helpers";
+
+import { THIRD_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const modelName = "A name";
 
@@ -50,9 +46,7 @@ describe("scenarios > models > create", () => {
   });
 
   it("suggest the currently viewed collection when saving a new native query", () => {
-    getCollectionIdFromSlug("third_collection", THIRD_COLLECTION_ID => {
-      visitCollection(THIRD_COLLECTION_ID);
-    });
+    visitCollection(THIRD_COLLECTION_ID);
 
     navigateToNewModelPage();
     cy.get(".ace_editor").should("be.visible").type("select * from ORDERS");
@@ -66,9 +60,7 @@ describe("scenarios > models > create", () => {
   });
 
   it("suggest the currently viewed collection when saving a new structured query", () => {
-    getCollectionIdFromSlug("third_collection", THIRD_COLLECTION_ID => {
-      visitCollection(THIRD_COLLECTION_ID);
-    });
+    visitCollection(THIRD_COLLECTION_ID);
 
     navigateToNewModelPage("structured");
 

--- a/e2e/test/scenarios/models/reproductions/29517-native-remapped-model-drill-through-click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29517-native-remapped-model-drill-through-click-behavior.cy.spec.js
@@ -99,11 +99,10 @@ describe("issue 29517 - nested question based on native model with remapped valu
       visitDashboard(id);
     });
 
-    cy.intercept(
-      "GET",
-      `/api/dashboard/${ORDERS_DASHBOARD_ID}").as("loadTargetDashboard`,
-    );
-    cy.get("circle").eq(25).click({ force: true });
+    cy
+      .intercept("GET", `/api/dashboard/${ORDERS_DASHBOARD_ID}`)
+      .as("loadTargetDashboard"),
+      cy.get("circle").eq(25).click({ force: true });
     cy.wait("@loadTargetDashboard");
 
     cy.location("pathname").should("eq", `/dashboard/${ORDERS_DASHBOARD_ID}`);

--- a/e2e/test/scenarios/models/reproductions/29517-native-remapped-model-drill-through-click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29517-native-remapped-model-drill-through-click-behavior.cy.spec.js
@@ -5,6 +5,7 @@ import {
   visitDashboard,
 } from "e2e/support/helpers";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 const questionDetails = {
   name: "29517",
@@ -98,11 +99,14 @@ describe("issue 29517 - nested question based on native model with remapped valu
       visitDashboard(id);
     });
 
-    cy.intercept("GET", "/api/dashboard/1").as("loadTargetDashboard");
+    cy.intercept(
+      "GET",
+      `/api/dashboard/${ORDERS_DASHBOARD_ID}").as("loadTargetDashboard`,
+    );
     cy.get("circle").eq(25).click({ force: true });
     cy.wait("@loadTargetDashboard");
 
-    cy.location("pathname").should("eq", "/dashboard/1");
+    cy.location("pathname").should("eq", `/dashboard/${ORDERS_DASHBOARD_ID}`);
     cy.get(".cellData").contains("37.65");
   });
 });

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -7,12 +7,12 @@ import {
   rightSidebar,
   filter,
   filterField,
-  getCollectionIdFromSlug,
   visitCollection,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { THIRD_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -33,9 +33,8 @@ describe("scenarios > question > native", () => {
   });
 
   it("should suggest the currently viewed collection when saving question", () => {
-    getCollectionIdFromSlug("third_collection", THIRD_COLLECTION_ID => {
-      visitCollection(THIRD_COLLECTION_ID);
-    });
+    visitCollection(THIRD_COLLECTION_ID);
+
     openNativeEditor({ fromCurrentPage: true }).type(
       "select count(*) from orders",
     );

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -13,7 +13,10 @@ import {
   main,
 } from "e2e/support/helpers";
 import { USERS } from "e2e/support/cypress_data";
-import { ADMIN_PERSONAL_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ADMIN_PERSONAL_COLLECTION_ID,
+  ORDERS_DASHBOARD_ID,
+} from "e2e/support/cypress_sample_instance_data";
 
 const { admin } = USERS;
 
@@ -100,7 +103,7 @@ describe("scenarios > home > homepage", () => {
     it("should display recent items", () => {
       cy.signInAsAdmin();
 
-      visitDashboard(1);
+      visitDashboard(ORDERS_DASHBOARD_ID);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders in a dashboard");
 
@@ -118,7 +121,7 @@ describe("scenarios > home > homepage", () => {
 
     it("should display popular items for a new user", () => {
       cy.signInAsAdmin();
-      visitDashboard(1);
+      visitDashboard(ORDERS_DASHBOARD_ID);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders in a dashboard");
       cy.signOut();
@@ -138,7 +141,7 @@ describe("scenarios > home > homepage", () => {
     it("should not show pinned questions in recent items when viewed in a collection", () => {
       cy.signInAsAdmin();
 
-      visitDashboard(1);
+      visitDashboard(ORDERS_DASHBOARD_ID);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders in a dashboard");
 
@@ -197,11 +200,17 @@ describe("scenarios > home > custom homepage", () => {
       popover().findByText("Orders in a dashboard").click();
 
       cy.findByRole("navigation").findByText("Exit admin").click();
-      cy.location("pathname").should("equal", "/dashboard/1");
+      cy.location("pathname").should(
+        "equal",
+        `/dashboard/${ORDERS_DASHBOARD_ID}`,
+      );
 
       // Do a page refresh and test dashboard header
       cy.visit("/");
-      cy.location("pathname").should("equal", "/dashboard/1");
+      cy.location("pathname").should(
+        "equal",
+        `/dashboard/${ORDERS_DASHBOARD_ID}`,
+      );
 
       cy.findByLabelText("Edit dashboard").click();
       cy.findByTestId("edit-bar").findByText(
@@ -256,7 +265,10 @@ describe("scenarios > home > custom homepage", () => {
       });
 
       modal().findByRole("button", { name: "Save" }).click();
-      cy.location("pathname").should("equal", "/dashboard/1");
+      cy.location("pathname").should(
+        "equal",
+        `/dashboard/${ORDERS_DASHBOARD_ID}`,
+      );
 
       cy.findByRole("status").within(() => {
         cy.findByText("This dashboard has been set as your homepage.").should(
@@ -330,7 +342,7 @@ describe("scenarios > home > custom homepage", () => {
 
     it("should show the default homepage if the dashboard was archived (#31599)", () => {
       // Archive dashboard
-      visitDashboard(1);
+      visitDashboard(ORDERS_DASHBOARD_ID);
       dashboardHeader().within(() => {
         cy.findByLabelText("dashboard-menu-button").click();
       });

--- a/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
@@ -9,7 +9,10 @@ import {
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ORDERS_QUESTION_ID,
+  ORDERS_DASHBOARD_ID,
+} from "e2e/support/cypress_sample_instance_data";
 
 const { PEOPLE_ID } = SAMPLE_DATABASE;
 
@@ -25,7 +28,7 @@ describe("search > recently viewed", () => {
     visitQuestion(ORDERS_QUESTION_ID);
 
     // "Orders in a dashboard" dashboard
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
     cy.findByTextEnsureVisible("Product ID");
 
     // inside the "Orders in a dashboard" dashboard, the order is queried again,
@@ -45,7 +48,7 @@ describe("search > recently viewed", () => {
       0,
       "Orders in a dashboard",
       "Dashboard",
-      "/dashboard/1-orders-in-a-dashboard",
+      `/dashboard/${ORDERS_DASHBOARD_ID}-orders-in-a-dashboard`,
     );
     assertRecentlyViewedItem(
       ORDERS_QUESTION_ID,

--- a/e2e/test/scenarios/onboarding/urls.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/urls.cy.spec.js
@@ -9,6 +9,8 @@ import {
   ORDERS_QUESTION_ID,
   ADMIN_PERSONAL_COLLECTION_ID,
   NORMAL_PERSONAL_COLLECTION_ID,
+  FIRST_COLLECTION_ID,
+  ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
 
 import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase-lib/metadata/utils/saved-questions";
@@ -53,7 +55,7 @@ describe("URLs", () => {
       cy.findByText("Orders in a dashboard").click();
       cy.location("pathname").should(
         "eq",
-        "/dashboard/1-orders-in-a-dashboard",
+        `/dashboard/${ORDERS_DASHBOARD_ID}-orders-in-a-dashboard`,
       );
     });
   });
@@ -75,7 +77,10 @@ describe("URLs", () => {
       cy.visit("/collection/root");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("First collection").click();
-      cy.location("pathname").should("eq", "/collection/10-first-collection");
+      cy.location("pathname").should(
+        "eq",
+        `/collection/${FIRST_COLLECTION_ID}-first-collection`,
+      );
     });
 
     it("should slugify current user's personal collection name correctly", () => {
@@ -114,7 +119,7 @@ describe("URLs", () => {
     });
 
     it("should open slugified URLs correctly", () => {
-      cy.visit("/collection/10-first-collection");
+      cy.visit(`/collection/${FIRST_COLLECTION_ID}-first-collection`);
       cy.findByTestId("collection-name-heading").should(
         "have.text",
         "First collection",

--- a/e2e/test/scenarios/organization/bookmarks-collection.cy.spec.js
+++ b/e2e/test/scenarios/organization/bookmarks-collection.cy.spec.js
@@ -1,12 +1,14 @@
 import {
-  getCollectionIdFromSlug,
   restore,
   popover,
   navigationSidebar,
   visitCollection,
 } from "e2e/support/helpers";
 import { USERS, SAMPLE_DB_TABLES } from "e2e/support/cypress_data";
-import { ADMIN_PERSONAL_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ADMIN_PERSONAL_COLLECTION_ID,
+  FIRST_COLLECTION_ID,
+} from "e2e/support/cypress_sample_instance_data";
 
 import { getSidebarSectionTitle as getSectionTitle } from "e2e/support/helpers/e2e-collection-helpers";
 
@@ -35,9 +37,7 @@ describe("scenarios > organization > bookmarks > collection", () => {
   });
 
   it("can add, update bookmark name when collection name is updated, and remove bookmarks from collection from its page", () => {
-    getCollectionIdFromSlug("first_collection", id => {
-      visitCollection(id);
-    });
+    visitCollection(FIRST_COLLECTION_ID);
 
     // Add bookmark
     cy.icon("bookmark").click();

--- a/e2e/test/scenarios/organization/bookmarks-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/organization/bookmarks-dashboard.cy.spec.js
@@ -4,6 +4,7 @@ import {
   openNavigationSidebar,
   visitDashboard,
 } from "e2e/support/helpers";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 describe("scenarios > dashboard > bookmarks", () => {
   beforeEach(() => {
@@ -12,7 +13,7 @@ describe("scenarios > dashboard > bookmarks", () => {
   });
 
   it("should add, update bookmark name when dashboard name is updated, and then remove bookmark", () => {
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
     openNavigationSidebar();
 
     // Add bookmark

--- a/e2e/test/scenarios/organization/edit-history-metadata.cy.spec.js
+++ b/e2e/test/scenarios/organization/edit-history-metadata.cy.spec.js
@@ -1,6 +1,9 @@
 import { restore, visitQuestion, visitDashboard } from "e2e/support/helpers";
 import { USERS } from "e2e/support/cypress_data";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ORDERS_QUESTION_ID,
+  ORDERS_DASHBOARD_ID,
+} from "e2e/support/cypress_sample_instance_data";
 
 describe("scenarios > collection items metadata", () => {
   beforeEach(() => {
@@ -13,7 +16,7 @@ describe("scenarios > collection items metadata", () => {
     });
 
     it("should display last edit moment for dashboards", () => {
-      visitDashboard(1);
+      visitDashboard(ORDERS_DASHBOARD_ID);
       changeDashboard();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Edited a few seconds ago/i);
@@ -30,7 +33,7 @@ describe("scenarios > collection items metadata", () => {
   describe("last editor", () => {
     it("should display if user is the last editor", () => {
       cy.signInAsAdmin();
-      visitDashboard(1);
+      visitDashboard(ORDERS_DASHBOARD_ID);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Edited .* by you/i);
       visitQuestion(ORDERS_QUESTION_ID);
@@ -44,7 +47,7 @@ describe("scenarios > collection items metadata", () => {
       const expectedName = `${first_name} ${last_name.charAt(0)}.`;
 
       cy.signIn("normal");
-      visitDashboard(1);
+      visitDashboard(ORDERS_DASHBOARD_ID);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(new RegExp(`Edited .* by ${expectedName}`, "i"));
       visitQuestion(ORDERS_QUESTION_ID);

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -18,7 +18,10 @@ import {
 
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ORDERS_QUESTION_ID,
+  ORDERS_DASHBOARD_ID,
+} from "e2e/support/cypress_sample_instance_data";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -731,7 +734,7 @@ describeEE("scenarios > admin > permissions", () => {
     });
 
     cy.signIn("nodata");
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sorry, you don't have permission to see this card.");

--- a/e2e/test/scenarios/permissions/application-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/application-permissions.cy.spec.js
@@ -13,7 +13,10 @@ import {
 
 import { USERS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ORDERS_QUESTION_ID,
+  ORDERS_DASHBOARD_ID,
+} from "e2e/support/cypress_sample_instance_data";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -69,7 +72,7 @@ describeEE("scenarios > admin > permissions > application", () => {
       });
 
       it("revokes ability to create subscriptions and alerts and manage them", () => {
-        visitDashboard(1);
+        visitDashboard(ORDERS_DASHBOARD_ID);
         cy.icon("subscription").should("not.exist");
 
         visitQuestion(ORDERS_QUESTION_ID);
@@ -86,7 +89,7 @@ describeEE("scenarios > admin > permissions > application", () => {
       it("gives ability to create dashboard subscriptions", () => {
         setupSMTP();
         cy.signInAsNormalUser();
-        visitDashboard(1);
+        visitDashboard(ORDERS_DASHBOARD_ID);
         cy.findByLabelText("subscriptions").click();
 
         sidebar().findByText("Email this dashboard").should("exist");

--- a/e2e/test/scenarios/permissions/permissions-baseline.cy.spec.js
+++ b/e2e/test/scenarios/permissions/permissions-baseline.cy.spec.js
@@ -7,13 +7,14 @@ import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import {
   ORDERS_QUESTION_ID,
   ADMIN_PERSONAL_COLLECTION_ID,
+  ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
 
 describe("scenarios > permissions", () => {
   beforeEach(restore);
 
   const PATHS = [
-    "/dashboard/1",
+    `/dashboard/${ORDERS_DASHBOARD_ID}`,
     `/question/${ORDERS_QUESTION_ID}`,
     `/collection/${ADMIN_PERSONAL_COLLECTION_ID}`,
     "/admin",

--- a/e2e/test/scenarios/permissions/reproductions/22473-cannot-unsubscribe-from-notifications-without-collection-perms.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/22473-cannot-unsubscribe-from-notifications-without-collection-perms.cy.spec.js
@@ -1,6 +1,7 @@
 import { restore, setupSMTP, sidebar } from "e2e/support/helpers";
 import { modal } from "e2e/support/helpers/e2e-ui-elements-helpers";
 
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 import { USERS } from "e2e/support/cypress_data";
 const { nocollection } = USERS;
 
@@ -12,7 +13,7 @@ describe("issue 22473", () => {
   });
 
   it("nocollection user should be able to view and unsubscribe themselves from a subscription", () => {
-    cy.visit(`/dashboard/1`);
+    cy.visit(`/dashboard/${ORDERS_DASHBOARD_ID}`);
     cy.icon("subscription").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Email it").click();

--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -18,9 +18,8 @@ import {
   sendEmailAndAssert,
   setTokenFeatures,
 } from "e2e/support/helpers";
-
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 import { USER_GROUPS, SAMPLE_DB_ID } from "e2e/support/cypress_data";
-
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const {
@@ -920,7 +919,7 @@ describeEE("formatting > sandboxes", () => {
       });
 
       cy.signInAsSandboxedUser();
-      visitDashboard(1);
+      visitDashboard(ORDERS_DASHBOARD_ID);
       cy.findByLabelText("subscriptions").click();
 
       // should forward to email since that is the only one setup
@@ -1042,7 +1041,7 @@ describeEE("formatting > sandboxes", () => {
         });
 
         cy.signInAsSandboxedUser();
-        visitDashboard(1);
+        visitDashboard(ORDERS_DASHBOARD_ID);
         cy.findByLabelText("subscriptions").click();
 
         sidebar()

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -5,7 +5,6 @@ import {
   visualize,
   startNewQuestion,
   visitQuestionAdhoc,
-  getCollectionIdFromSlug,
   saveQuestion,
   getPersonalCollectionName,
   visitCollection,
@@ -14,7 +13,11 @@ import {
 
 import { SAMPLE_DB_ID, USERS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ORDERS_QUESTION_ID,
+  SECOND_COLLECTION_ID,
+  THIRD_COLLECTION_ID,
+} from "e2e/support/cypress_sample_instance_data";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -149,11 +152,9 @@ describe("scenarios > question > new", () => {
     });
 
     it("'Saved Questions' prompt should respect nested collections structure (metabase#14178)", () => {
-      getCollectionIdFromSlug("second_collection", id => {
-        // Move first question in a DB snapshot ("Orders") to a "Second collection"
-        cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
-          collection_id: id,
-        });
+      // Move first question in a DB snapshot ("Orders") to a "Second collection"
+      cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
+        collection_id: SECOND_COLLECTION_ID,
       });
 
       startNewQuestion();
@@ -260,9 +261,7 @@ describe("scenarios > question > new", () => {
   });
 
   it("should suggest the currently viewed collection when saving question", () => {
-    getCollectionIdFromSlug("third_collection", THIRD_COLLECTION_ID => {
-      visitCollection(THIRD_COLLECTION_ID);
-    });
+    visitCollection(THIRD_COLLECTION_ID);
 
     cy.findByLabelText("Navigation bar").within(() => {
       cy.findByText("New").click();
@@ -284,9 +283,8 @@ describe("scenarios > question > new", () => {
   });
 
   it("should be able to save a question to a collection created on the go", () => {
-    getCollectionIdFromSlug("third_collection", THIRD_COLLECTION_ID => {
-      visitCollection(THIRD_COLLECTION_ID);
-    });
+    visitCollection(THIRD_COLLECTION_ID);
+
     cy.findByLabelText("Navigation bar").findByText("New").click();
     popover().findByText("Question").click();
     popover().within(() => {

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -19,7 +19,10 @@ import {
 } from "e2e/support/helpers";
 
 import { USERS, USER_GROUPS } from "e2e/support/cypress_data";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ORDERS_QUESTION_ID,
+  ORDERS_DASHBOARD_ID,
+} from "e2e/support/cypress_sample_instance_data";
 
 const PERMISSIONS = {
   curate: ["admin", "normal", "nodata"],
@@ -213,7 +216,7 @@ describe("managing question from the question's details sidebar", () => {
                   findSelectedItem().should("not.exist");
 
                   // before visiting the dashboard, we don't have any history
-                  visitDashboard(1);
+                  visitDashboard(ORDERS_DASHBOARD_ID);
 
                   visitQuestion(ORDERS_QUESTION_ID);
 
@@ -240,7 +243,7 @@ describe("managing question from the question's details sidebar", () => {
                   findSelectedItem().should("not.exist");
 
                   // before visiting the dashboard, we don't have any history
-                  visitDashboard(1);
+                  visitDashboard(ORDERS_DASHBOARD_ID);
                   visitQuestion(ORDERS_QUESTION_ID);
 
                   openQuestionActions();
@@ -343,7 +346,7 @@ describe("managing question from the question's details sidebar", () => {
               findSelectedItem().should("not.exist");
 
               // before visiting the dashboard, we don't have any history
-              visitDashboard(1);
+              visitDashboard(ORDERS_DASHBOARD_ID);
 
               visitQuestion(ORDERS_QUESTION_ID);
 

--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -9,10 +9,12 @@ import {
   questionInfoButton,
   rightSidebar,
   appBar,
-  getCollectionIdFromSlug,
 } from "e2e/support/helpers";
 
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ORDERS_QUESTION_ID,
+  SECOND_COLLECTION_ID,
+} from "e2e/support/cypress_sample_instance_data";
 
 describe("scenarios > question > saved", () => {
   beforeEach(() => {
@@ -227,8 +229,8 @@ describe("scenarios > question > saved", () => {
   });
 
   it("should show collection breadcrumbs for a saved question in a non-root collection", () => {
-    getCollectionIdFromSlug("second_collection", collection_id => {
-      cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { collection_id });
+    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
+      collection_id: SECOND_COLLECTION_ID,
     });
 
     visitQuestion(ORDERS_QUESTION_ID);

--- a/e2e/test/scenarios/sharing/approved-domains.cy.spec.js
+++ b/e2e/test/scenarios/sharing/approved-domains.cy.spec.js
@@ -7,7 +7,10 @@ import {
   visitDashboard,
   setTokenFeatures,
 } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ORDERS_QUESTION_ID,
+  ORDERS_DASHBOARD_ID,
+} from "e2e/support/cypress_sample_instance_data";
 
 const allowedDomain = "metabase.test";
 const deniedDomain = "metabase.example";
@@ -46,7 +49,7 @@ describeEE(
 
     // Adding test on Quarantine to understand a bit better some H2 Lock issue.
     it.skip("should validate approved email domains for a dashboard subscription (metabase#17977)", () => {
-      visitDashboard(1);
+      visitDashboard(ORDERS_DASHBOARD_ID);
       cy.icon("subscription").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Email it").click();

--- a/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
@@ -16,6 +16,7 @@ import {
   enableTracking,
   addOrUpdateDashboardCard,
 } from "e2e/support/helpers";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -73,7 +74,7 @@ describe("scenarios > question > download", () => {
   describe("from dashboards", () => {
     it("should allow downloading card data", () => {
       cy.intercept("GET", "/api/dashboard/**").as("dashboard");
-      visitDashboard(1);
+      visitDashboard(ORDERS_DASHBOARD_ID);
       cy.findByTestId("dashcard").within(() => {
         cy.findByTestId("legend-caption").realHover();
       });

--- a/e2e/test/scenarios/sharing/reproductions/17657.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/17657.cy.spec.js
@@ -1,5 +1,6 @@
 import { restore, sidebar, visitDashboard } from "e2e/support/helpers";
 import { USERS } from "e2e/support/cypress_data";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 const {
   admin: { first_name, last_name },
@@ -14,7 +15,7 @@ describe("issue 17657", () => {
   });
 
   it("frontend should gracefully handle the case of a subscription without a recipient (metabase#17657)", () => {
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
 
     cy.icon("subscription").click();
 

--- a/e2e/test/scenarios/sharing/reproductions/17658.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/17658.cy.spec.js
@@ -6,6 +6,7 @@ import {
 } from "e2e/support/helpers";
 
 import { USERS } from "e2e/support/cypress_data";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 const { admin } = USERS;
 
@@ -21,7 +22,7 @@ describe("issue 17658", { tags: "@external" }, () => {
   });
 
   it("should delete dashboard subscription from any collection (metabase#17658)", () => {
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
 
     cy.icon("subscription").click();
 
@@ -54,7 +55,9 @@ function moveDashboardToCollection(collectionName) {
       );
 
       // Move dashboard
-      cy.request("PUT", "/api/dashboard/1", { collection_id: id });
+      cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}`, {
+        collection_id: id,
+      });
 
       // Create subscription
       cy.request("POST", "/api/pulse", {

--- a/e2e/test/scenarios/sharing/reproductions/18009-nodata-creates-subscription-receives-error.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/18009-nodata-creates-subscription-receives-error.cy.spec.js
@@ -6,6 +6,7 @@ import {
   sendEmailAndAssert,
   sidebar,
 } from "e2e/support/helpers";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 describe("issue 18009", { tags: "@external" }, () => {
   beforeEach(() => {
@@ -18,7 +19,7 @@ describe("issue 18009", { tags: "@external" }, () => {
   });
 
   it("nodata user should be able to create and receive an email subscription without errors (metabase#18009)", () => {
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
 
     cy.findByLabelText("subscriptions").click();
 

--- a/e2e/test/scenarios/sharing/reproductions/18344-subscription-shows-original-question-name.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/18344-subscription-shows-original-question-name.cy.spec.js
@@ -6,6 +6,7 @@ import {
   visitDashboard,
   sendEmailAndAssert,
 } from "e2e/support/helpers";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 import { USERS } from "e2e/support/cypress_data";
 
@@ -21,7 +22,7 @@ describe("issue 18344", { tags: "@external" }, () => {
     setupSMTP();
 
     // Rename the question
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
 
     editDashboard();
 

--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -16,6 +16,7 @@ import {
   setupSubscriptionWithRecipient,
   openPulseSubscription,
 } from "e2e/support/helpers";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 import { USERS } from "e2e/support/cypress_data";
 
 const { admin, normal } = USERS;
@@ -157,7 +158,7 @@ describe("scenarios > dashboard > subscriptions", () => {
         const nonUserEmail = "non-user@example.com";
         const dashboardName = "Orders in a dashboard";
 
-        visitDashboard(1);
+        visitDashboard(ORDERS_DASHBOARD_ID);
 
         setupSubscriptionWithRecipient(nonUserEmail);
 
@@ -181,7 +182,7 @@ describe("scenarios > dashboard > subscriptions", () => {
       it("should allow non-user to undo-unsubscribe from subscription", () => {
         const nonUserEmail = "non-user@example.com";
         const dashboardName = "Orders in a dashboard";
-        visitDashboard(1);
+        visitDashboard(ORDERS_DASHBOARD_ID);
 
         setupSubscriptionWithRecipient(nonUserEmail);
 
@@ -359,7 +360,7 @@ describe("scenarios > dashboard > subscriptions", () => {
     it("should include text cards (metabase#15744)", () => {
       const TEXT_CARD = "FooBar";
 
-      visitDashboard(1);
+      visitDashboard(ORDERS_DASHBOARD_ID);
       addTextBox(TEXT_CARD);
       cy.button("Save").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -426,7 +427,7 @@ describe("scenarios > dashboard > subscriptions", () => {
   describe("OSS email subscriptions", { tags: ["@OSS", "external"] }, () => {
     beforeEach(() => {
       cy.onlyOn(isOSS);
-      cy.visit(`/dashboard/1`);
+      cy.visit(`/dashboard/${ORDERS_DASHBOARD_ID}`);
       setupSMTP();
     });
 
@@ -451,7 +452,7 @@ describe("scenarios > dashboard > subscriptions", () => {
     beforeEach(() => {
       setTokenFeatures("all");
       setupSMTP();
-      cy.visit(`/dashboard/1`);
+      cy.visit(`/dashboard/${ORDERS_DASHBOARD_ID}`);
     });
 
     it("should only show current user in recipients dropdown if `user-visiblity` setting is `none`", () => {


### PR DESCRIPTION
Part of https://github.com/metabase/metabase/issues/33571

### Description

Removes hardcoded dashboard ids and collection ids in preparation for having variable numbers of collections and dashboards in the our base testing snapshots due to audit db entities.

This should be safe to do in master, because we shouldn't be hardcoding ids in master anyway.

### How to verify

Tests should pass