### PR TITLE
Index unindexed FKs for Postgres

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15175,6 +15175,7 @@ databaseChangeLog:
                   CREATE INDEX IF NOT EXISTS idx_application_permissions_revision_user_id ON application_permissions_revision (user_id);
                   CREATE INDEX IF NOT EXISTS idx_collection_permission_graph_revision_user_id ON collection_permission_graph_revision (user_id);
                   CREATE INDEX IF NOT EXISTS idx_core_session_user_id ON core_session (user_id);
+                  CREATE INDEX IF NOT EXISTS idx_dashboard_tab_dashboard_id ON dashboard_tab (dashboard_id);
                   CREATE INDEX IF NOT EXISTS idx_dimension_human_readable_field_id ON dimension (human_readable_field_id);
                   CREATE INDEX IF NOT EXISTS idx_metabase_database_creator_id ON metabase_database (creator_id);
                   CREATE INDEX IF NOT EXISTS idx_model_index_creator_id ON model_index (creator_id);

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15160,45 +15160,46 @@ databaseChangeLog:
                 name: action_id
 
   - changeSet:
-      id: v48.00-006
+      id: v48.00-013
       author: qnkhuat
       comment: Index unindexed FKs for postgres
       preConditions:
         - onFail: MARK_RAN
         - dbms:
-          type: postgresql
+            type: postgresql
       changes:
-        - sql:
-            sql: >-
-              CREATE INDEX IF NOT EXISTS idx_action_made_public_by_id ON action (made_public_by_id);
-              CREATE INDEX IF NOT EXISTS idx_action_model_id ON action (model_id);
-              CREATE INDEX IF NOT EXISTS idx_application_permissions_revision_user_id ON application_permissions_revision (user_id);
-              CREATE INDEX IF NOT EXISTS idx_collection_permission_graph_revision_user_id ON collection_permission_graph_revision (user_id);
-              CREATE INDEX IF NOT EXISTS idx_core_session_user_id ON core_session (user_id);
-              CREATE INDEX IF NOT EXISTS idx_dimension_human_readable_field_id ON dimension (human_readable_field_id);
-              CREATE INDEX IF NOT EXISTS idx_metabase_database_creator_id ON metabase_database (creator_id);
-              CREATE INDEX IF NOT EXISTS idx_model_index_creator_id ON model_index (creator_id);
-              CREATE INDEX IF NOT EXISTS idx_native_query_snippet_creator_id ON native_query_snippet (creator_id);
-              CREATE INDEX IF NOT EXISTS idx_permissions_revision_user_id ON permissions_revision (user_id);
-              CREATE INDEX IF NOT EXISTS idx_persisted_info_creator_id ON persisted_info (creator_id);
-              CREATE INDEX IF NOT EXISTS idx_persisted_info_database_id ON persisted_info (database_id);
-              CREATE INDEX IF NOT EXISTS idx_pulse_dashboard_id ON pulse (dashboard_id);
-              CREATE INDEX IF NOT EXISTS idx_pulse_card_dashboard_card_id ON pulse_card (dashboard_card_id);
-              CREATE INDEX IF NOT EXISTS idx_pulse_channel_recipient_pulse_channel_id ON pulse_channel_recipient (pulse_channel_id);
-              CREATE INDEX IF NOT EXISTS idx_pulse_channel_recipient_user_id ON pulse_channel_recipient (user_id);
-              CREATE INDEX IF NOT EXISTS idx_query_action_database_id ON query_action (database_id);
-              CREATE INDEX IF NOT EXISTS idx_report_card_database_id ON report_card (database_id);
-              CREATE INDEX IF NOT EXISTS idx_report_card_made_public_by_id ON report_card (made_public_by_id);
-              CREATE INDEX IF NOT EXISTS idx_report_card_table_id ON report_card (table_id);
-              CREATE INDEX IF NOT EXISTS idx_report_dashboard_made_public_by_id ON report_dashboard (made_public_by_id);
-              CREATE INDEX IF NOT EXISTS idx_report_dashboardcard_action_id ON report_dashboardcard (action_id);
-              CREATE INDEX IF NOT EXISTS idx_report_dashboardcard_dashboard_tab_id ON report_dashboardcard (dashboard_tab_id);
-              CREATE INDEX IF NOT EXISTS idx_revision_user_id ON revision (user_id);
-              CREATE INDEX IF NOT EXISTS idx_sandboxes_card_id ON sandboxes (card_id);
-              CREATE INDEX IF NOT EXISTS idx_sandboxes_permission_id ON sandboxes (permission_id);
-              CREATE INDEX IF NOT EXISTS idx_secret_creator_id ON secret (creator_id);
-              CREATE INDEX IF NOT EXISTS idx_timeline_creator_id ON timeline (creator_id);
-              CREATE INDEX IF NOT EXISTS idx_timeline_event_creator_id ON timeline_event (creator_id);
+          - sql:
+              sql: >-
+                  CREATE INDEX IF NOT EXISTS idx_action_made_public_by_id ON action (made_public_by_id);
+                  CREATE INDEX IF NOT EXISTS idx_action_model_id ON action (model_id);
+                  CREATE INDEX IF NOT EXISTS idx_application_permissions_revision_user_id ON application_permissions_revision (user_id);
+                  CREATE INDEX IF NOT EXISTS idx_collection_permission_graph_revision_user_id ON collection_permission_graph_revision (user_id);
+                  CREATE INDEX IF NOT EXISTS idx_core_session_user_id ON core_session (user_id);
+                  CREATE INDEX IF NOT EXISTS idx_dimension_human_readable_field_id ON dimension (human_readable_field_id);
+                  CREATE INDEX IF NOT EXISTS idx_metabase_database_creator_id ON metabase_database (creator_id);
+                  CREATE INDEX IF NOT EXISTS idx_model_index_creator_id ON model_index (creator_id);
+                  CREATE INDEX IF NOT EXISTS idx_native_query_snippet_creator_id ON native_query_snippet (creator_id);
+                  CREATE INDEX IF NOT EXISTS idx_permissions_revision_user_id ON permissions_revision (user_id);
+                  CREATE INDEX IF NOT EXISTS idx_persisted_info_creator_id ON persisted_info (creator_id);
+                  CREATE INDEX IF NOT EXISTS idx_persisted_info_database_id ON persisted_info (database_id);
+                  CREATE INDEX IF NOT EXISTS idx_pulse_dashboard_id ON pulse (dashboard_id);
+                  CREATE INDEX IF NOT EXISTS idx_pulse_card_dashboard_card_id ON pulse_card (dashboard_card_id);
+                  CREATE INDEX IF NOT EXISTS idx_pulse_channel_recipient_pulse_channel_id ON pulse_channel_recipient (pulse_channel_id);
+                  CREATE INDEX IF NOT EXISTS idx_pulse_channel_recipient_user_id ON pulse_channel_recipient (user_id);
+                  CREATE INDEX IF NOT EXISTS idx_query_action_database_id ON query_action (database_id);
+                  CREATE INDEX IF NOT EXISTS idx_report_card_database_id ON report_card (database_id);
+                  CREATE INDEX IF NOT EXISTS idx_report_card_made_public_by_id ON report_card (made_public_by_id);
+                  CREATE INDEX IF NOT EXISTS idx_report_card_table_id ON report_card (table_id);
+                  CREATE INDEX IF NOT EXISTS idx_report_dashboard_made_public_by_id ON report_dashboard (made_public_by_id);
+                  CREATE INDEX IF NOT EXISTS idx_report_dashboardcard_action_id ON report_dashboardcard (action_id);
+                  CREATE INDEX IF NOT EXISTS idx_report_dashboardcard_dashboard_tab_id ON report_dashboardcard (dashboard_tab_id);
+                  CREATE INDEX IF NOT EXISTS idx_revision_user_id ON revision (user_id);
+                  CREATE INDEX IF NOT EXISTS idx_sandboxes_card_id ON sandboxes (card_id);
+                  CREATE INDEX IF NOT EXISTS idx_sandboxes_permission_id ON sandboxes (permission_id);
+                  CREATE INDEX IF NOT EXISTS idx_secret_creator_id ON secret (creator_id);
+                  CREATE INDEX IF NOT EXISTS idx_timeline_creator_id ON timeline (creator_id);
+                  CREATE INDEX IF NOT EXISTS idx_timeline_event_creator_id ON timeline_event (creator_id);
+      rollback: # no need
 
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15159,6 +15159,48 @@ databaseChangeLog:
               column:
                 name: action_id
 
+  - changeSet:
+      id: v48.00-006
+      author: qnkhuat
+      comment: Index unindexed FKs for postgres
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+          type: postgresql
+      changes:
+        - sql:
+            sql: >-
+              CREATE INDEX IF NOT EXISTS idx_action_made_public_by_id ON action (made_public_by_id);
+              CREATE INDEX IF NOT EXISTS idx_action_model_id ON action (model_id);
+              CREATE INDEX IF NOT EXISTS idx_application_permissions_revision_user_id ON application_permissions_revision (user_id);
+              CREATE INDEX IF NOT EXISTS idx_collection_permission_graph_revision_user_id ON collection_permission_graph_revision (user_id);
+              CREATE INDEX IF NOT EXISTS idx_core_session_user_id ON core_session (user_id);
+              CREATE INDEX IF NOT EXISTS idx_dimension_human_readable_field_id ON dimension (human_readable_field_id);
+              CREATE INDEX IF NOT EXISTS idx_metabase_database_creator_id ON metabase_database (creator_id);
+              CREATE INDEX IF NOT EXISTS idx_model_index_creator_id ON model_index (creator_id);
+              CREATE INDEX IF NOT EXISTS idx_native_query_snippet_creator_id ON native_query_snippet (creator_id);
+              CREATE INDEX IF NOT EXISTS idx_permissions_revision_user_id ON permissions_revision (user_id);
+              CREATE INDEX IF NOT EXISTS idx_persisted_info_creator_id ON persisted_info (creator_id);
+              CREATE INDEX IF NOT EXISTS idx_persisted_info_database_id ON persisted_info (database_id);
+              CREATE INDEX IF NOT EXISTS idx_pulse_dashboard_id ON pulse (dashboard_id);
+              CREATE INDEX IF NOT EXISTS idx_pulse_card_dashboard_card_id ON pulse_card (dashboard_card_id);
+              CREATE INDEX IF NOT EXISTS idx_pulse_channel_recipient_pulse_channel_id ON pulse_channel_recipient (pulse_channel_id);
+              CREATE INDEX IF NOT EXISTS idx_pulse_channel_recipient_user_id ON pulse_channel_recipient (user_id);
+              CREATE INDEX IF NOT EXISTS idx_query_action_database_id ON query_action (database_id);
+              CREATE INDEX IF NOT EXISTS idx_report_card_database_id ON report_card (database_id);
+              CREATE INDEX IF NOT EXISTS idx_report_card_made_public_by_id ON report_card (made_public_by_id);
+              CREATE INDEX IF NOT EXISTS idx_report_card_table_id ON report_card (table_id);
+              CREATE INDEX IF NOT EXISTS idx_report_dashboard_made_public_by_id ON report_dashboard (made_public_by_id);
+              CREATE INDEX IF NOT EXISTS idx_report_dashboardcard_action_id ON report_dashboardcard (action_id);
+              CREATE INDEX IF NOT EXISTS idx_report_dashboardcard_dashboard_tab_id ON report_dashboardcard (dashboard_tab_id);
+              CREATE INDEX IF NOT EXISTS idx_revision_user_id ON revision (user_id);
+              CREATE INDEX IF NOT EXISTS idx_sandboxes_card_id ON sandboxes (card_id);
+              CREATE INDEX IF NOT EXISTS idx_sandboxes_permission_id ON sandboxes (permission_id);
+              CREATE INDEX IF NOT EXISTS idx_secret_creator_id ON secret (creator_id);
+              CREATE INDEX IF NOT EXISTS idx_timeline_creator_id ON timeline (creator_id);
+              CREATE INDEX IF NOT EXISTS idx_timeline_event_creator_id ON timeline_event (creator_id);
+
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -1120,7 +1120,7 @@
   (mt/test-driver :postgres
     (testing "all FKs should be indexed"
      (is (= [] (t2/query
-                ["SELECT
+                "SELECT
                      conrelid::regclass AS table_name,
                      a.attname AS column_name
                  FROM
@@ -1136,4 +1136,4 @@
                      )
                  ORDER BY
                      table_name,
-                     column_name;"]))))))
+                     column_name;"))))))

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -1118,7 +1118,7 @@
 
 (deftest fks-are-indexed-test
   (mt/test-driver :postgres
-    (testing "all FKs should have be indexex"
+    (testing "all FKs should be indexed"
      (is (= [] (t2/query
                 ["SELECT
                      conrelid::regclass AS table_name,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/30924
By adding indexes for unindexed FKs and adding a future-proof test to remind us adding an index for FKs.

We only need to do this for Postgres bc on MySQL and h2 creating a FK will automatically create an index.

MySQL: 
https://dev.mysql.com/doc/refman/8.0/en/constraint-foreign-key.html
> MySQL requires that foreign key columns be indexed; if you create a table with a foreign key constraint but no index on a given column, an index is created. 

h2: (can't find docs but I've also double checked this)
https://groups.google.com/g/h2-database/c/Hi_JnOPM9vI
