### PR TITLE
Add tests to dashboard filter connected to a custom column appears as if it was never connected 

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/reproductions/27768-cc-filter-appears-disconnected.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/27768-cc-filter-appears-disconnected.cy.spec.js
@@ -5,6 +5,7 @@ import {
   editDashboard,
   saveDashboard,
   filterWidget,
+  getDashboardCard,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
@@ -27,7 +28,7 @@ const filter = {
   sectionId: "string",
 };
 
-describe.skip("issue 27768", () => {
+describe("issue 27768", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
@@ -49,8 +50,7 @@ describe.skip("issue 27768", () => {
     editDashboard();
     getFilterOptions(filter.name);
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Select…").click();
+    getDashboardCard().findByText("Select…").click();
     popover().contains("CCategory").click();
     saveDashboard();
 
@@ -64,10 +64,10 @@ describe.skip("issue 27768", () => {
     editDashboard();
     getFilterOptions(filter.name);
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Select…").should("not.exist");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Column to filter on").parent().contains("Product.CCategory");
+    getDashboardCard().within(() => {
+      cy.findByText("Select…").should("not.exist");
+      cy.contains("Product.CCategory");
+    });
   });
 });
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/27768

### Description

As stated in [my comment](https://github.com/metabase/metabase/issues/27768#issuecomment-1697291239), this issue seemed to be fixed since 46.0.

This PR unskips + modifies the reproduction to match the current state of the app.

### How to verify

Run the repro, it should be green.

### Demo
Screenshot from the Cypress reproduced test.
![image](https://github.com/metabase/metabase/assets/1937582/c2898ada-45c9-4e85-a3ce-8e92937253f1)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
