### PR TITLE
ChartWithLegend refresh mode

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartWithLegend.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartWithLegend.jsx
@@ -148,5 +148,5 @@ class ChartWithLegend extends Component {
 
 export default ExplicitSize({
   wrapped: true,
-  refreshMode: props => (props.isDashboard ? "debounce" : "throttle"),
+  refreshMode: props => (props.isDashboard ? "debounceLeading" : "throttle"),
 })(ChartWithLegend);


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/33267

### Description
Small update to how `ChartWithLegend` re-renders on size change in Dashboards. Most Visualizations use debounceLeading when rendering on a dashboard, but `ChartWithLegend` was simply using debounce, which was not re-rendering at the end of the events. Most other visualizations use `CardRenderer`, which @alxnddr already updated to use debounceLeading in https://github.com/metabase/metabase/pull/31963

### How to verify

1. Add a pie chart to the dashboard
2. resize the grid and ensure that the pie chart is rendered correctly for the size of the card. An easy way to do this is to open and close the left side App Bar.

### Demo
![chrome_EGJ59JD5Uc](https://github.com/metabase/metabase/assets/1328979/0aee6463-b6c7-4e3c-8367-5dd7b27167a8)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
