### PR TITLE
Deprecate components for which mantine counterparts exist

### DIFF
--- a/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
@@ -14,6 +14,9 @@ import { Container } from "./EntityMenu.styled";
 
 const MENU_SHIFT_Y = 10;
 
+/**
+ * @deprecated: use Menu from "metabase/ui"
+ */
 class EntityMenu extends Component {
   state = {
     open: false,

--- a/frontend/src/metabase/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/frontend/src/metabase/components/LoadingSpinner/LoadingSpinner.tsx
@@ -10,7 +10,7 @@ interface Props {
   "data-testid"?: string;
 }
 
-const LoadingSpinner = ({
+const BaseLoadingSpinner = ({
   className,
   size = 32,
   borderWidth = 4,
@@ -28,7 +28,12 @@ const LoadingSpinner = ({
   </SpinnerRoot>
 );
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default Object.assign(LoadingSpinner, {
+/**
+ * @deprecated: use Loader from "metabase/ui"
+ */
+const LoadingSpinner = Object.assign(BaseLoadingSpinner, {
   Root: SpinnerRoot,
 });
+
+// eslint-disable-next-line import/no-default-export -- deprecated usage
+export default LoadingSpinner;

--- a/frontend/src/metabase/core/components/Button/Button.tsx
+++ b/frontend/src/metabase/core/components/Button/Button.tsx
@@ -127,13 +127,18 @@ const BaseButton = forwardRef(function BaseButton(
   );
 });
 
-const Button = styled(BaseButton)``;
+const StyledButton = styled(BaseButton)``;
 
-Button.displayName = "Button";
+StyledButton.displayName = "Button";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default Object.assign(Button, {
+/**
+ * @deprecated: use Button from "metabase/ui"
+ */
+const Button = Object.assign(StyledButton, {
   Root: ButtonRoot,
   Content: ButtonContent,
   TextContainer: ButtonTextContainer,
 });
+
+// eslint-disable-next-line import/no-default-export -- deprecated usage
+export default Button;

--- a/frontend/src/metabase/core/components/CheckBox/CheckBox.tsx
+++ b/frontend/src/metabase/core/components/CheckBox/CheckBox.tsx
@@ -47,81 +47,83 @@ interface CheckboxTooltipProps {
   children: ReactNode;
 }
 
-const CheckBox = forwardRef<HTMLLabelElement, CheckBoxProps>(function Checkbox(
-  {
-    name,
-    id,
-    label,
-    labelEllipsis = false,
-    checked,
-    indeterminate,
-    disabled = false,
-    size = DEFAULT_SIZE,
-    checkedColor = DEFAULT_CHECKED_COLOR,
-    uncheckedColor = DEFAULT_UNCHECKED_COLOR,
-    autoFocus,
-    onClick,
-    onChange,
-    onFocus,
-    onBlur,
-    ...props
-  }: CheckBoxProps,
-  ref: Ref<HTMLLabelElement>,
-): JSX.Element {
-  const isControlledCheckBoxInput = !!onChange;
-  const labelRef = useRef<HTMLSpanElement>(null);
-  const hasLabelEllipsis =
-    labelRef.current && isEllipsisActive(labelRef.current);
+const BaseCheckBox = forwardRef<HTMLLabelElement, CheckBoxProps>(
+  function Checkbox(
+    {
+      name,
+      id,
+      label,
+      labelEllipsis = false,
+      checked,
+      indeterminate,
+      disabled = false,
+      size = DEFAULT_SIZE,
+      checkedColor = DEFAULT_CHECKED_COLOR,
+      uncheckedColor = DEFAULT_UNCHECKED_COLOR,
+      autoFocus,
+      onClick,
+      onChange,
+      onFocus,
+      onBlur,
+      ...props
+    }: CheckBoxProps,
+    ref: Ref<HTMLLabelElement>,
+  ): JSX.Element {
+    const isControlledCheckBoxInput = !!onChange;
+    const labelRef = useRef<HTMLSpanElement>(null);
+    const hasLabelEllipsis =
+      labelRef.current && isEllipsisActive(labelRef.current);
 
-  return (
-    <CheckBoxRoot ref={ref} {...props}>
-      <CheckboxTooltip
-        hasTooltip={!!(labelEllipsis && hasLabelEllipsis)}
-        tooltipLabel={label}
-      >
-        <CheckBoxInput
-          id={id ?? name}
-          name={name}
-          type="checkbox"
-          checked={isControlledCheckBoxInput ? !!checked : undefined}
-          defaultChecked={isControlledCheckBoxInput ? undefined : !!checked}
-          size={size}
-          disabled={disabled}
-          autoFocus={autoFocus}
-          onClick={onClick}
-          onChange={isControlledCheckBoxInput ? onChange : undefined}
-          onFocus={onFocus}
-          onBlur={onBlur}
-        />
-        <CheckBoxContainer disabled={disabled}>
-          <CheckBoxIconContainer
-            checked={checked}
+    return (
+      <CheckBoxRoot ref={ref} {...props}>
+        <CheckboxTooltip
+          hasTooltip={!!(labelEllipsis && hasLabelEllipsis)}
+          tooltipLabel={label}
+        >
+          <CheckBoxInput
+            id={id ?? name}
+            name={name}
+            type="checkbox"
+            checked={isControlledCheckBoxInput ? !!checked : undefined}
+            defaultChecked={isControlledCheckBoxInput ? undefined : !!checked}
             size={size}
-            checkedColor={checkedColor}
-            uncheckedColor={uncheckedColor}
-          >
-            {(checked || indeterminate) && (
-              <CheckBoxIcon
-                name={indeterminate ? "dash" : "check"}
-                checked={!!checked}
-                size={size - DEFAULT_ICON_PADDING}
-                uncheckedColor={uncheckedColor}
-              />
-            )}
-          </CheckBoxIconContainer>
-          {label &&
-            (isValidElement(label) ? (
-              label
-            ) : (
-              <CheckBoxLabel labelEllipsis={labelEllipsis} ref={labelRef}>
-                {label}
-              </CheckBoxLabel>
-            ))}
-        </CheckBoxContainer>
-      </CheckboxTooltip>
-    </CheckBoxRoot>
-  );
-});
+            disabled={disabled}
+            autoFocus={autoFocus}
+            onClick={onClick}
+            onChange={isControlledCheckBoxInput ? onChange : undefined}
+            onFocus={onFocus}
+            onBlur={onBlur}
+          />
+          <CheckBoxContainer disabled={disabled}>
+            <CheckBoxIconContainer
+              checked={checked}
+              size={size}
+              checkedColor={checkedColor}
+              uncheckedColor={uncheckedColor}
+            >
+              {(checked || indeterminate) && (
+                <CheckBoxIcon
+                  name={indeterminate ? "dash" : "check"}
+                  checked={!!checked}
+                  size={size - DEFAULT_ICON_PADDING}
+                  uncheckedColor={uncheckedColor}
+                />
+              )}
+            </CheckBoxIconContainer>
+            {label &&
+              (isValidElement(label) ? (
+                label
+              ) : (
+                <CheckBoxLabel labelEllipsis={labelEllipsis} ref={labelRef}>
+                  {label}
+                </CheckBoxLabel>
+              ))}
+          </CheckBoxContainer>
+        </CheckboxTooltip>
+      </CheckBoxRoot>
+    );
+  },
+);
 
 function CheckboxTooltip({
   hasTooltip,
@@ -135,7 +137,12 @@ function CheckboxTooltip({
   );
 }
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default Object.assign(CheckBox, {
+/**
+ * @deprecated: use Checkbox from "metabase/ui"
+ */
+const Checkbox = Object.assign(BaseCheckBox, {
   Label: CheckBoxLabel,
 });
+
+// eslint-disable-next-line import/no-default-export -- deprecated usage
+export default Checkbox;

--- a/frontend/src/metabase/core/components/Input/Input.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.tsx
@@ -37,7 +37,7 @@ export interface InputProps extends InputAttributes {
   onResetClick?: () => void;
 }
 
-const Input = forwardRef(function Input(
+const BaseInput = forwardRef(function Input(
   {
     className,
     style,
@@ -127,9 +127,14 @@ const Input = forwardRef(function Input(
   );
 });
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default Object.assign(Input, {
+/**
+ * @deprecated: use TextInput from "metabase/ui"
+ */
+const Input = Object.assign(BaseInput, {
   Root: InputRoot,
   Field: InputField,
   Subtitle: InputSubtitle,
 });
+
+// eslint-disable-next-line import/no-default-export -- deprecated usage
+export default Input;

--- a/frontend/src/metabase/core/components/NumericInput/NumericInput.tsx
+++ b/frontend/src/metabase/core/components/NumericInput/NumericInput.tsx
@@ -14,6 +14,9 @@ export interface NumericInputProps extends NumericInputAttributes {
   onChange?: (value: number | undefined) => void;
 }
 
+/**
+ * @deprecated: use NumberInput from "metabase/ui"
+ */
 const NumericInput = forwardRef(function NumericInput(
   { value, onFocus, onBlur, onChange, ...props }: NumericInputProps,
   ref: Ref<HTMLDivElement>,

--- a/frontend/src/metabase/core/components/Radio/Radio.tsx
+++ b/frontend/src/metabase/core/components/Radio/Radio.tsx
@@ -55,7 +55,10 @@ export interface RadioOption<TValue> {
   value: TValue;
 }
 
-const Radio = forwardRef(function Radio<TValue, TOption = RadioOption<TValue>>(
+const BaseRadio = forwardRef(function Radio<
+  TValue,
+  TOption = RadioOption<TValue>,
+>(
   {
     name,
     value,
@@ -205,8 +208,10 @@ function isDefaultOption<TValue>(
   return typeof option === "object";
 }
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default Object.assign(Radio, {
+/**
+ * @deprecated: use Radio from "metabase/ui"
+ */
+const Radio = Object.assign(BaseRadio, {
   RadioGroupVariants: [RadioGroupBubble, RadioGroupNormal],
   RadioLabelVariants: [RadioLabelBubble, RadioLabelNormal],
   RadioLabelText: RadioLabelText,
@@ -216,3 +221,6 @@ export default Object.assign(Radio, {
     RadioContainerUnderlined,
   ],
 });
+
+// eslint-disable-next-line import/no-default-export -- deprecated usage
+export default Radio;

--- a/frontend/src/metabase/core/components/Select/Select.tsx
+++ b/frontend/src/metabase/core/components/Select/Select.tsx
@@ -96,7 +96,7 @@ export interface SelectChangeTarget<TValue> {
   value: TValue;
 }
 
-class Select<TValue, TOption = SelectOption<TValue>> extends Component<
+class BaseSelect<TValue, TOption = SelectOption<TValue>> extends Component<
   SelectProps<TValue, TOption>
 > {
   _popover?: any;
@@ -327,8 +327,13 @@ class Select<TValue, TOption = SelectOption<TValue>> extends Component<
   }
 }
 
+/**
+ * @deprecated: use Select from "metabase/ui"
+ */
+const Select = Uncontrollable()(BaseSelect);
+
 // eslint-disable-next-line import/no-default-export -- deprecated usage
-export default Uncontrollable()(Select);
+export default Select;
 
 export interface OptionSectionProps {
   name?: string;


### PR DESCRIPTION
Had to add some additional constants for default exports otherwise it doesn't work