### PR TITLE
Refactor useListSelect hook

### DIFF
--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -106,7 +106,7 @@ function CollectionContent({
   });
   const { handleNextPage, handlePreviousPage, setPage, page, resetPage } =
     usePagination();
-  const { selected, toggleItem, toggleAll, getIsSelected, clear } =
+  const { clear, getIsSelected, selected, selectOnlyTheseItems, toggleItem } =
     useListSelect(itemKeyFn);
   const previousCollection = usePrevious(collection);
 
@@ -293,7 +293,7 @@ function CollectionContent({
                     const hasUnselected = unselected.length > 0;
 
                     const handleSelectAll = () => {
-                      toggleAll(unselected);
+                      selectOnlyTheseItems(unpinnedItems);
                     };
 
                     const loading = loadingPinnedItems || loadingUnpinnedItems;

--- a/frontend/src/metabase/hooks/use-list-select.js
+++ b/frontend/src/metabase/hooks/use-list-select.js
@@ -4,29 +4,35 @@ export const useListSelect = (keyFn = item => item) => {
   const [selectedKeys, setSelectedKeys] = useState(new Set());
   const [selected, setSelected] = useState([]);
 
-  const toggleAll = useCallback(
-    items => {
-      const additions = items.filter(item => !selectedKeys.has(keyFn(item)));
-      const deletionsKeys = new Set(
-        items.filter(item => selectedKeys.has(keyFn(item))).map(keyFn),
-      );
+  const getIsSelected = useCallback(
+    item => selectedKeys.has(keyFn(item)),
+    [keyFn, selectedKeys],
+  );
 
-      const newSelected = selected
-        .filter(item => !deletionsKeys.has(keyFn(item)))
-        .concat(additions);
+  const selectOnlyTheseItems = useCallback(
+    items => {
+      const newSelected = items;
       const newSelectedKeys = new Set(newSelected.map(keyFn));
 
       setSelectedKeys(newSelectedKeys);
       setSelected(newSelected);
     },
-    [keyFn, selected, selectedKeys],
+    [keyFn],
   );
 
-  const toggleItem = useCallback(item => toggleAll([item]), [toggleAll]);
+  const toggleItem = useCallback(
+    itemBeingToggled => {
+      const isItemSelected = getIsSelected(itemBeingToggled);
 
-  const getIsSelected = useCallback(
-    item => selectedKeys.has(keyFn(item)),
-    [keyFn, selectedKeys],
+      const newSelected = isItemSelected
+        ? selected.filter(item => keyFn(item) !== keyFn(itemBeingToggled))
+        : [...selected, itemBeingToggled];
+      const newSelectedKeys = new Set(newSelected.map(keyFn));
+
+      setSelectedKeys(newSelectedKeys);
+      setSelected(newSelected);
+    },
+    [keyFn, selected, getIsSelected],
   );
 
   const clear = useCallback(() => {
@@ -35,10 +41,10 @@ export const useListSelect = (keyFn = item => item) => {
   }, []);
 
   return {
-    selected,
-    toggleItem,
-    toggleAll,
-    getIsSelected,
     clear,
+    getIsSelected,
+    selected,
+    selectOnlyTheseItems,
+    toggleItem,
   };
 };

--- a/frontend/src/metabase/hooks/use-list-select.ts
+++ b/frontend/src/metabase/hooks/use-list-select.ts
@@ -1,8 +1,8 @@
 import { useState, useCallback } from "react";
 
-export const useListSelect = (keyFn = item => item) => {
+export const useListSelect = (keyFn = (item: any) => item) => {
   const [selectedKeys, setSelectedKeys] = useState(new Set());
-  const [selected, setSelected] = useState([]);
+  const [selected, setSelected] = useState<any[]>([]);
 
   const getIsSelected = useCallback(
     item => selectedKeys.has(keyFn(item)),

--- a/frontend/src/metabase/hooks/use-list-select.ts
+++ b/frontend/src/metabase/hooks/use-list-select.ts
@@ -1,16 +1,16 @@
 import { useState, useCallback } from "react";
 
-export const useListSelect = (keyFn = (item: any) => item) => {
-  const [selectedKeys, setSelectedKeys] = useState(new Set());
-  const [selected, setSelected] = useState<any[]>([]);
+export function useListSelect<T>(keyFn: (item: T) => string) {
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
+  const [selected, setSelected] = useState<T[]>([]);
 
   const getIsSelected = useCallback(
-    item => selectedKeys.has(keyFn(item)),
+    (item: T) => selectedKeys.has(keyFn(item)),
     [keyFn, selectedKeys],
   );
 
   const selectOnlyTheseItems = useCallback(
-    items => {
+    (items: T[]) => {
       const newSelected = items;
       const newSelectedKeys = new Set(newSelected.map(keyFn));
 
@@ -21,7 +21,7 @@ export const useListSelect = (keyFn = (item: any) => item) => {
   );
 
   const toggleItem = useCallback(
-    itemBeingToggled => {
+    (itemBeingToggled: T) => {
       const isItemSelected = getIsSelected(itemBeingToggled);
 
       const newSelected = isItemSelected
@@ -47,4 +47,4 @@ export const useListSelect = (keyFn = (item: any) => item) => {
     selectOnlyTheseItems,
     toggleItem,
   };
-};
+}

--- a/frontend/src/metabase/hooks/use-list-select.unit.spec.ts
+++ b/frontend/src/metabase/hooks/use-list-select.unit.spec.ts
@@ -1,0 +1,90 @@
+import { renderHook, act } from "@testing-library/react-hooks";
+import { useListSelect } from "./use-list-select";
+
+interface objectType {
+  id: number;
+  name: string;
+}
+
+const OBJECT_LIST = [
+  { id: 1, name: "first" },
+  { id: 2, name: "second" },
+  { id: 3, name: "third" },
+];
+
+const OBJECT_KEY_FN = (item: objectType) => `${item.id}:${item.name}`;
+
+const setup = () => {
+  const { result } = renderHook(() => useListSelect<objectType>(OBJECT_KEY_FN));
+
+  return result;
+};
+
+describe("useListSelect", () => {
+  it("should have no selected items initially", () => {
+    const result = setup();
+
+    expect(result.current.selected).toHaveLength(0);
+  });
+
+  it("should select a disabled item when toggling it", () => {
+    const result = setup();
+
+    const itemToToggle = OBJECT_LIST[0];
+    act(() => result.current.toggleItem(itemToToggle));
+
+    expect(result.current.getIsSelected(OBJECT_LIST[0])).toBeTruthy();
+
+    expect(result.current.selected).toHaveLength(1);
+    expect(result.current.selected.includes(itemToToggle)).toBeTruthy();
+  });
+
+  it("should un-select an enabled item when toggling it", () => {
+    const result = setup();
+
+    // select items first
+    const itemsToSelect = [OBJECT_LIST[0], OBJECT_LIST[2]];
+    act(() => result.current.selectOnlyTheseItems(itemsToSelect));
+    expect(result.current.getIsSelected(OBJECT_LIST[0])).toBeTruthy();
+
+    expect(result.current.selected.includes(OBJECT_LIST[0])).toBeTruthy();
+    expect(result.current.selected).toHaveLength(itemsToSelect.length);
+
+    // toggle it to un-select it
+    act(() => result.current.toggleItem(OBJECT_LIST[0]));
+    expect(result.current.getIsSelected(OBJECT_LIST[0])).toBeFalsy();
+
+    expect(result.current.selected.includes(OBJECT_LIST[0])).toBeFalsy();
+    expect(result.current.selected).toHaveLength(1);
+  });
+
+  it("should select only the items passed when using selectOnlyTheseItems() (clear all items not passed)", () => {
+    const result = setup();
+
+    // select one item
+    const firstSelection = OBJECT_LIST[0];
+    act(() => result.current.toggleItem(firstSelection));
+    expect(result.current.getIsSelected(firstSelection)).toBeTruthy();
+
+    // select all items except item one
+    const itemsToSelect = [OBJECT_LIST[1], OBJECT_LIST[2]];
+    act(() => result.current.selectOnlyTheseItems(itemsToSelect));
+
+    expect(result.current.getIsSelected(firstSelection)).toBeFalsy();
+    itemsToSelect.forEach(item => {
+      expect(result.current.getIsSelected(item)).toBeTruthy();
+    });
+  });
+
+  it("should clear all items when calling clear()", () => {
+    const result = setup();
+
+    // select all items
+    act(() => result.current.selectOnlyTheseItems(OBJECT_LIST));
+    expect(result.current.selected).toHaveLength(OBJECT_LIST.length);
+
+    // clear items
+    act(() => result.current.clear());
+    expect(result.current.selected).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
**Problem:** The `useListSelect` hook felt non-intuitive when toggling multiple items, so I wanted to refactor it to make it easier to use and understand.

**Context:**
- I use this hook in the refactoring of https://github.com/metabase/metabase/issues/24018. I created a separate PR to make it easier to review the changes in the hook and its consumers.

---
**Desired Behavior**/**Acceptance Criteria**
- [ ] implement a function to select multiple items (reset selected items to only these items): `selectOnlyTheseItems(items)`
- [ ] refactor consumers of `toggleAll(items)` to use `selectOnlyTheseItems(items)` instead
  - _why:_ `toggleAll(items)` would select "non-selected" items while at the same time unselect "selected " items. This made the consumer responsible of keeping track of what was selected and then remove those items from the list they keep track off in order to select all items. Not very consumer friendly.
- the consumers have no altered behaviors (in this case only `CollectionContent`)
  - [ ] Collection selections behave the same before and after the updates
    ![useListSelect](https://github.com/metabase/metabase/assets/22608765/c9f8ff58-ce6d-48ce-aa30-336431fc14f0)

---
**How to Verify**

1. Open up a collection that has items in it
2. Test out selecting and unselecting items
3. Test out selecting-all and unselecting-all items
4. Verify that it behaves in the way you would expect