### PR TITLE
Kondo should check inline def in test ns

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -730,8 +730,7 @@
  :config-in-ns
  {test-namespaces
   {:linters
-   {:inline-def                                    {:level :off}
-    :missing-docstring                             {:level :off}
+   {:missing-docstring                             {:level :off}
     :private-call                                  {:level :off}
     :hooks.metabase.test.data/mbql-query-first-arg {:level :error}}}
 


### PR DESCRIPTION
Not really sure why we allow it in the first place