### PR TITLE
Fix occasional issues with snapshots/Liquibase when running Cypress tests using backend from REPL

### DIFF
--- a/src/metabase/api/testing.clj
+++ b/src/metabase/api/testing.clj
@@ -5,7 +5,9 @@
    [clojure.string :as str]
    [compojure.core :refer [POST]]
    [metabase.api.common :as api]
+   [metabase.config :as config]
    [metabase.db.connection :as mdb.connection]
+   [metabase.db.setup :as mdb.setup]
    [metabase.util.files :as u.files]
    [metabase.util.log :as log])
   (:import
@@ -61,7 +63,15 @@
     (doseq [sql-args [["SET LOCK_TIMEOUT 180000"]
                       ["DROP ALL OBJECTS"]
                       ["RUNSCRIPT FROM ?" snapshot-path]]]
-      (jdbc/execute! {:connection conn} sql-args))))
+      (jdbc/execute! {:connection conn} sql-args)))
+  ;; don't know why this happens but when I try to test things locally with `yarn-test-cypress-open-no-backend` and a
+  ;; backend server started with `dev/start!` the snapshots are always missing columms added by DB migrations. So let's
+  ;; just check and make sure it's fully up to date in this scenario. Not doing this outside of dev because it seems to
+  ;; work fine for whatever reason normally and we don't want tests taking 5 million years to run because we're wasting
+  ;; a bunch of time initializing Liquibase and checking for unrun migrations for every test when we don't need to. --
+  ;; Cam
+  (when config/is-dev?
+    (mdb.setup/migrate! (mdb.connection/db-type) mdb.connection/*application-db* :up)))
 
 (defn- increment-app-db-unique-indentifier!
   "Increment the [[mdb.connection/unique-identifier]] for the Metabase application DB. This effectively flushes all

--- a/src/metabase/db/setup.clj
+++ b/src/metabase/db/setup.clj
@@ -9,7 +9,7 @@
   (:require
    [honey.sql :as sql]
    [metabase.db.connection :as mdb.connection]
-   metabase.db.custom-migrations ;; load our custom migrations
+   [metabase.db.custom-migrations]
    [metabase.db.jdbc-protocols :as mdb.jdbc-protocols]
    [metabase.db.liquibase :as liquibase]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
@@ -29,8 +29,11 @@
 
 (set! *warn-on-reflection* true)
 
-;;; needed so the `:h2` dialect gets registered with Honey SQL
-(comment metabase.util.honey-sql-2/keep-me)
+(comment
+  ;; load our custom migrations
+  metabase.db.custom-migrations/keep-me
+  ;; needed so the `:h2` dialect gets registered with Honey SQL
+  metabase.util.honey-sql-2/keep-me)
 
 (defn- print-migrations-and-quit-if-needed!
   "If we are not doing auto migrations then print out migration SQL for user to run manually. Then throw an exception to


### PR DESCRIPTION
I run Cypress tests locally with a combination of `yarn run build-hot` + `yarn test-cypress-open-no-backend` + `(dev/start!`) (with an H2 app DB) all the time, but I'm always running into weird issues with it

- Sometimes when restoring the app DB from a snapshot it's missing some of the newer migrations
- If I try to manually run the migrations sometimes Liquibase can't find out custom migration classes, but it's apparently using the application classloader to do so so of course it can't. I guess when running the JAR this isn't a problem since those classes are AOTed but I don't know why this normally works from the REPL. Maybe Liquibase defaults to the current context classloader if one is bound if you don't say otherwise, which would explain why this normally works when triggering on launch or from the REPL but not from a Jetty thread 
- 
This PR fixes these problems by:

- Call `mdb.setup/migrate` after restoring the app DB from a snapshot (only in dev (REPL) mode)
- Tell Liquibase to explicitly use the official Metabase ClassLoader