### PR TITLE
Use field ID as name if the field cannot be resolved

### DIFF
--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -132,11 +132,11 @@
                   (when-let [unit (:temporal-unit opts)]
                     {::temporal-unit unit})
                   (cond
-                    (integer? id-or-name) (resolve-field-id query stage-number id-or-name)
+                    (integer? id-or-name) (or (resolve-field-id query stage-number id-or-name)
+                                              {:lib/type :metadata/column, :name id-or-name})
                     join-alias            {:lib/type :metadata/column, :name id-or-name}
                     :else                 (or (resolve-column-name query stage-number id-or-name)
-                                              {:lib/type :metadata/column
-                                               :name     id-or-name})))]
+                                              {:lib/type :metadata/column, :name id-or-name})))]
     (cond-> metadata
       join-alias (lib.join/with-join-alias join-alias))))
 
@@ -225,7 +225,9 @@
                        table-id           :table-id
                        :as                field-metadata} style]
   (let [field-display-name (or field-display-name
-                               (u.humanization/name->human-readable-name :simple field-name))
+                               (if (string? field-name)
+                                 (u.humanization/name->human-readable-name :simple field-name)
+                                 (str field-name)))
         join-display-name  (when (and (= style :long)
                                       ;; don't prepend a join display name if `:display-name` already contains one!
                                       ;; Legacy result metadata might include it for joined Fields, don't want to add

--- a/test/metabase/lib/metadata/calculation_test.cljc
+++ b/test/metabase/lib/metadata/calculation_test.cljc
@@ -1,10 +1,12 @@
 (ns metabase.lib.metadata.calculation-test
   (:require
+   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
    [clojure.test :refer [deftest is testing]]
    [metabase.lib.core :as lib]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
-   [metabase.util :as u]))
+   [metabase.util :as u]
+   [metabase.util.malli :as mu]))
 
 (deftest ^:parallel calculate-names-even-without-metadata-test
   (testing "Even if metadata is missing, we should still be able to calculate reasonable display names"
@@ -62,6 +64,17 @@
             "Product → Rating"
             "Product → Created At"]
            results))))
+
+(deftest ^:parallel display-name-without-metadata-test
+  (testing "Some display name is generated for fields even if they cannot be resolved (#33490)"
+    (let [query lib.tu/venues-query
+          field-id (inc (apply max (map :id (lib/visible-columns query))))
+          field-name (str field-id)]
+      (mu/disable-enforcement
+       (is (=? {:name field-id
+                :display-name field-name
+                :long-display-name (str "join → " field-name)}
+               (lib/display-info query [:field {:join-alias "join"} field-id])))))))
 
 (deftest ^:parallel visible-columns-test
   (testing "Include all visible columns, not just projected ones (#31233)"


### PR DESCRIPTION
Fixes #33490.

The goal here is to restore the behavior of version 46, the parts from hidden tables will still not be displayed properly.

After the fix:

![image](https://github.com/metabase/metabase/assets/103100869/ffb61d2a-44c1-4d54-9156-e224e22fc706)
