### PR TITLE
Error if a user in an impersonated group doesnt have the required attribute

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.advanced-permissions.driver.impersonation
   (:require
    [clojure.set :as set]
+   [clojure.string :as str]
    [metabase.api.common :as api]
    [metabase.driver :as driver]
    [metabase.driver.sql :as driver.sql]
@@ -68,8 +69,13 @@
       (when (not-empty role-attributes)
         (let [conn-impersonation (first conn-impersonations)
               role-attribute     (:attribute conn-impersonation)
-              user-attributes    (:login_attributes @api/*current-user*)]
-          (get user-attributes role-attribute))))))
+              user-attributes    (:login_attributes @api/*current-user*)
+              role               (get user-attributes role-attribute)]
+          (if (str/blank? role)
+            (throw (ex-info (tru "User does not have attribute required for connection impersonation.")
+                            {:user-id api/*current-user-id*
+                             :conn-impersonations conn-impersonations}))
+            role))))))
 
 (defenterprise hash-key-for-impersonation
   "Returns a hash-key for FieldValues if the current user uses impersonation for the database."

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
@@ -57,7 +57,15 @@
   (testing "Does not throw an exception if passed a nil `database-or-id`"
     (advanced-perms.api.tu/with-impersonations {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
                                                 :attributes     {"impersonation_attr" "impersonation_role"}}
-      (is (nil? (@#'impersonation/connection-impersonation-role nil))))))
+      (is (nil? (@#'impersonation/connection-impersonation-role nil)))))
+
+  (testing "Throws an exception if impersonation should be enforced, but the user doesn't have the required attribute"
+    (advanced-perms.api.tu/with-impersonations {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                :attributes     {}}
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"User does not have attribute required for connection impersonation."
+           (@#'impersonation/connection-impersonation-role (mt/db)))))))
 
 (deftest conn-impersonation-test-postgres
   (mt/test-driver :postgres


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/33365

Changes impersonation to fail closed when a user is lacking the necessary attribute, or the attribute is set but not filled in.