### PR TITLE
Quote connection impersonation roles

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
@@ -103,7 +103,7 @@
   (mt/test-driver :snowflake
     (premium-features-test/with-premium-features #{:advanced-permissions}
       (advanced-perms.api.tu/with-impersonations {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                  :attributes     {"impersonation_attr" "limited.role"}}
+                                                  :attributes     {"impersonation_attr" "LIMITED.ROLE"}}
         ;; Test database initially has no default role set. All queries should fail, even for non-impersonated users,
         ;; since there is no way to reset the connection after impersonation is applied.
         (is (thrown-with-msg?

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
@@ -78,15 +78,15 @@
                            "DROP TABLE IF EXISTS PUBLIC.table_without_access;"
                            "CREATE TABLE PUBLIC.table_with_access (x INTEGER NOT NULL);"
                            "CREATE TABLE PUBLIC.table_without_access (y INTEGER NOT NULL);"
-                           "DROP ROLE IF EXISTS impersonation_role;"
-                           "CREATE ROLE impersonation_role;"
-                           "REVOKE ALL PRIVILEGES ON DATABASE \"conn_impersonation_test\" FROM impersonation_role;"
-                           "GRANT SELECT ON TABLE \"conn_impersonation_test\".PUBLIC.table_with_access TO impersonation_role;"]]
+                           "DROP ROLE IF EXISTS \"impersonation.role\";"
+                           "CREATE ROLE \"impersonation.role\";"
+                           "REVOKE ALL PRIVILEGES ON DATABASE \"conn_impersonation_test\" FROM \"impersonation.role\";"
+                           "GRANT SELECT ON TABLE \"conn_impersonation_test\".PUBLIC.table_with_access TO \"impersonation.role\";"]]
           (jdbc/execute! spec [statement]))
         (t2.with-temp/with-temp [Database database {:engine :postgres, :details details}]
           (mt/with-db database (sync/sync-database! database)
             (advanced-perms.api.tu/with-impersonations {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                        :attributes     {"impersonation_attr" "impersonation_role"}}
+                                                        :attributes     {"impersonation_attr" "impersonation.role"}}
               (is (= []
                      (-> {:query "SELECT * FROM \"table_with_access\";"}
                          mt/native-query

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
@@ -103,7 +103,7 @@
   (mt/test-driver :snowflake
     (premium-features-test/with-premium-features #{:advanced-permissions}
       (advanced-perms.api.tu/with-impersonations {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                  :attributes     {"impersonation_attr" "limited_role"}}
+                                                  :attributes     {"impersonation_attr" "limited.role"}}
         ;; Test database initially has no default role set. All queries should fail, even for non-impersonated users,
         ;; since there is no way to reset the connection after impersonation is applied.
         (is (thrown-with-msg?
@@ -123,7 +123,7 @@
 
         (try
           ;; User with connection impersonation should not be able to query a table they don't have access to
-          ;; (`limited_role` in CI Snowflake has no data access)
+          ;; (`limited.role` in CI Snowflake has no data access)
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
                #"SQL compilation error:\nDatabase.*does not exist or not authorized"

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
@@ -119,11 +119,11 @@
                                  {:aggregation [[:count]]}))))
 
         ;; Update the test database with a default role that has full permissions
-        (t2/update! :model/Database :id (mt/id) (assoc-in (mt/db) [:details :role] "accountadmin"))
+        (t2/update! :model/Database :id (mt/id) (assoc-in (mt/db) [:details :role] "ACCOUNTADMIN"))
 
         (try
           ;; User with connection impersonation should not be able to query a table they don't have access to
-          ;; (`limited.role` in CI Snowflake has no data access)
+          ;; (`LIMITED.ROLE` in CI Snowflake has no data access)
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
                #"SQL compilation error:\nDatabase.*does not exist or not authorized"

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -583,7 +583,7 @@
 
 (defmethod driver.sql/set-role-statement :snowflake
   [_ role]
-  (format "USE ROLE %s;" role))
+  (format "USE ROLE \"%s\";" role))
 
 (defmethod driver.sql/default-database-role :snowflake
   [_ database]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -817,7 +817,9 @@
 
 (defmethod driver.sql/set-role-statement :postgres
   [_ role]
-  (format "SET ROLE %s;" role))
+  (if (= (u/upper-case-en role) "NONE")
+   (format "SET ROLE %s;" role)
+   (format "SET ROLE \"%s\";" role)))
 
 (defmethod driver.sql/default-database-role :postgres
   [_ _]


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/33364

Quotes roles in `SET ROLE`/`USE ROLE` commands for postgres & snowflake, respectively. Updates tests to use role names with a `.` in them, similar to the report in the issue.

Omits quote the `SET ROLE NONE` command to reset the role for postgres. It seems to work with quotes on my local postgres instance but causes a very confusing exception in tests. I think it's triggering a bug deep in the test infra somehow which I want to figure out, but don't want it to block this PR since it's fixing a release blocker.

```
ERROR in metabase-enterprise.advanced-permissions.driver.impersonation-test during :clojure.test/each-fixtures (core_deftype.clj:584)
Uncaught exception during fixture initialization.

java.lang.IllegalArgumentException: No implementation of method: :explain of protocol: #'schema.core/Schema found for class: clojure.lang.Var$Unbound
                          clojure.core/-cache-protocol-fn  core_deftype.clj:  584
```