### PR TITLE
Fix some bugs with timezone mocking logic and parallelize more QP tests

### DIFF
--- a/modules/drivers/druid/test/metabase/driver/druid/query_processor_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/query_processor_test.clj
@@ -244,7 +244,7 @@
        (sort-by first)
        (take 5)))
 
-(deftest table-rows-sample-test
+(deftest ^:parallel table-rows-sample-test
   (mt/test-driver :druid
     (tqpt/with-flattened-dbdef
       (testing "Druid driver doesn't need to convert results to the expected timezone for us. QP middleware can handle that."
@@ -256,7 +256,7 @@
           (testing "UTC timezone"
             (is (= expected
                    (table-rows-sample))))
-          (mt/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
+          (mt/with-report-timezone-id "America/Los_Angeles"
             (is (= expected
                    (table-rows-sample))))
           (mt/with-system-timezone-id "America/Chicago"

--- a/modules/drivers/presto-jdbc/test/metabase/driver/presto_jdbc_test.clj
+++ b/modules/drivers/presto-jdbc/test/metabase/driver/presto_jdbc_test.clj
@@ -111,10 +111,10 @@
     (is (= nil
            (driver/db-default-timezone :presto-jdbc (mt/db))))))
 
-(deftest template-tag-timezone-test
+(deftest ^:parallel template-tag-timezone-test
   (mt/test-driver :presto-jdbc
     (testing "Make sure date params work correctly when report timezones are set (#10487)"
-      (mt/with-temporary-setting-values [report-timezone "Asia/Hong_Kong"]
+      (mt/with-report-timezone-id "Asia/Hong_Kong"
         ;; the `read-column-thunk` for `Types/TIMESTAMP` always returns an `OffsetDateTime`, not a `LocalDateTime`, as
         ;; the original Presto version of this test expected; therefore, convert the `ZonedDateTime` corresponding to
         ;; midnight on this date (at the report TZ) to `OffsetDateTime` for comparison's sake

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -188,7 +188,7 @@
                                   (merge {:db pk-db :user pk-user} to-merge))]
                   (is (can-connect? details)))))))))))
 
-(deftest report-timezone-test
+(deftest ^:parallel report-timezone-test
   (mt/test-driver :snowflake
     (testing "Make sure temporal parameters are set and returned correctly when report-timezone is set (#11036)"
       (letfn [(run-query []
@@ -207,9 +207,12 @@
           (is (= [["2014-08-02T00:00:00Z"]]
                  (run-query))))
         (testing "with report-timezone"
-          (mt/with-temporary-setting-values [report-timezone "US/Pacific"]
+          (mt/with-report-timezone-id "US/Pacific"
             (is (= [["2014-08-02T00:00:00-07:00"]]
-                   (run-query)))))))
+                   (run-query)))))))))
+
+(deftest ^:parallel report-timezone-test-2
+  (mt/test-driver :snowflake
     (testing "Make sure temporal values are returned correctly when report-timezone is set (#11036)"
       (letfn [(run-query []
                 (mt/rows
@@ -234,7 +237,7 @@
         (testing "with report timezone set"
           (is (= [["2014-08-02T00:00:00-07:00" "2014-08-02T12:30:00-07:00"]
                   ["2014-08-02T00:00:00-07:00" "2014-08-02T09:30:00-07:00"]]
-                 (mt/with-temporary-setting-values [report-timezone "US/Pacific"]
+                 (mt/with-report-timezone-id "US/Pacific"
                    (run-query)))))))))
 
 (deftest week-start-test

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -152,6 +152,8 @@
 
 (defn- destroy-pool! [database-id pool-spec]
   (log/debug (u/format-color 'red (trs "Closing old connection pool for database {0} ..." database-id)))
+  (when config/tests-available?
+    ((requiring-resolve 'mb.hawk.parallel/assert-test-is-not-parallel) "destroy-pool!"))
   (connection-pool/destroy-connection-pool! pool-spec)
   (ssh/close-tunnel! pool-spec))
 

--- a/src/metabase/query_processor/timezone.clj
+++ b/src/metabase/query_processor/timezone.clj
@@ -4,9 +4,15 @@
    [java-time :as t]
    [metabase.config :as config]
    [metabase.driver :as driver]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.schema.expression.temporal
+    :as lib.schema.expression.temporal]
    [metabase.query-processor.store :as qp.store]
    [metabase.util.i18n :refer [tru]]
-   [metabase.util.log :as log])
+   [metabase.util.log :as log]
+   [metabase.util.malli :as mu]
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.malli.schema :as ms])
   (:import
    (java.time ZonedDateTime)))
 
@@ -19,7 +25,8 @@
 (def ^:private ^:dynamic *results-timezone-id-override* nil)
 
 ;; TODO - consider making this `metabase.util.date-2/the-timezone-id`
-(defn- valid-timezone-id [timezone-id]
+(mu/defn ^:private valid-timezone-id :- [:maybe ::lib.schema.expression.temporal/timezone-id]
+  [timezone-id]
   (when (and (string? timezone-id)
              (seq timezone-id))
     (try
@@ -29,59 +36,78 @@
         (log/warn (tru "Invalid timezone ID ''{0}''" timezone-id))
         nil))))
 
-(defn- report-timezone-id* []
-  (or *report-timezone-id-override*
-      (driver/report-timezone)))
+(mu/defn ^:private report-timezone-id* :- [:maybe :string]
+  []
+  (when-not (= *report-timezone-id-override* ::nil)
+    (or *report-timezone-id-override*
+        (driver/report-timezone))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                Public Interface                                                |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(defn report-timezone-id-if-supported
+(mr/def ::db-from-store
+  [:= ::db-from-store])
+
+(def ^:private Database
+  [:or
+   lib.metadata/DatabaseMetadata
+   (ms/InstanceOf :model/Database)])
+
+(mu/defn ^:private resolve-database :- Database
+  [database :- [:or Database ::db-from-store]]
+  (if (= database ::db-from-store)
+    (lib.metadata/database (qp.store/metadata-provider))
+    database))
+
+(mu/defn report-timezone-id-if-supported :- [:maybe ::lib.schema.expression.temporal/timezone-id]
   "Timezone ID for the report timezone, if the current driver and database supports it. (If the current driver supports it, this is
   bound by the `bind-effective-timezone` middleware.)"
   (^String []
-   (report-timezone-id-if-supported driver/*driver* (qp.store/database)))
+   (report-timezone-id-if-supported driver/*driver* ::db-from-store))
 
-  (^String [driver database]
-   (when (driver/database-supports? driver :set-timezone database)
+  (^String [driver database :- [:or Database ::db-from-store]]
+   (when (driver/database-supports? driver :set-timezone (resolve-database database))
      (valid-timezone-id (report-timezone-id*)))))
 
-(defn database-timezone-id
+(mu/defn database-timezone-id :- [:maybe ::lib.schema.expression.temporal/timezone-id]
   "The timezone that the current database is in, as determined by the most recent sync."
   (^String []
    (database-timezone-id ::db-from-store))
 
-  (^String [database]
-   (valid-timezone-id
-    (or *database-timezone-id-override*
-        (:timezone (if (= database ::db-from-store) (qp.store/database) database))))))
+  (^String [database :- [:or Database ::db-from-store]]
+   (when-not (= *database-timezone-id-override* ::nil)
+     (valid-timezone-id
+      (or *database-timezone-id-override*
+          (:timezone (resolve-database database)))))))
 
-(defn system-timezone-id
+(mu/defn system-timezone-id :- ::lib.schema.expression.temporal/timezone-id
   "The system timezone of this Metabase instance."
   ^String []
   (.. (t/system-clock) getZone getId))
 
-(defn requested-timezone-id
+(mu/defn requested-timezone-id :- [:maybe ::lib.schema.expression.temporal/timezone-id]
   "The timezone that we would *like* to run a query in, regardless of whether we are actually able to do so. This is
   always equal to the value of the `report-timezone` Setting (if it is set), otherwise the database timezone (if known),
   otherwise the system timezone."
   ^String []
   (valid-timezone-id (report-timezone-id*)))
 
-(defn results-timezone-id
+(mu/defn results-timezone-id :- ::lib.schema.expression.temporal/timezone-id
   "The timezone that a query is actually ran in ­ report timezone, if set and supported by the current driver;
   otherwise the timezone of the database (if known), otherwise the system timezone. Guaranteed to always return a
   timezone ID ­ never returns `nil`."
   (^String []
    (results-timezone-id driver/*driver* ::db-from-store))
 
-  (^String [database]
+  (^String [database :- Database]
    (results-timezone-id (:engine database) database))
 
-  (^String [driver database & {:keys [use-report-timezone-id-if-unsupported?]
-                               :or   {use-report-timezone-id-if-unsupported? false}}]
+  (^String [driver   :- :keyword
+            database :- [:or Database ::db-from-store]
+            & {:keys [use-report-timezone-id-if-unsupported?]
+               :or   {use-report-timezone-id-if-unsupported? false}}]
    (valid-timezone-id
     (or *results-timezone-id-override*
         (if use-report-timezone-id-if-unsupported?

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -349,10 +349,10 @@
                             {:default "b"}]}}))
                    :query first :$project :E)))))))
 
-(deftest report-timezone-test
+(deftest ^:parallel report-timezone-test
   (mt/test-driver :postgres
     (testing "expected (desired) and actual timezone should be returned as part of query results"
-      (mt/with-temporary-setting-values [report-timezone "US/Pacific"]
+      (mt/with-report-timezone-id "US/Pacific"
         (let [results (mt/user-http-request :rasta :post 202 "dataset" (mt/mbql-query checkins
                                                                          {:aggregation [[:count]]}))]
           (is (= {:requested_timezone "US/Pacific"

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -212,7 +212,7 @@
                   (catch Throwable e
                     e)))))))
 
-(deftest timezone-date-formatting-test
+(deftest ^:parallel timezone-date-formatting-test
   (mt/test-driver :mysql
     ;; Most of our tests either deal in UTC (offset 00:00) or America/Los_Angeles timezones (-07:00/-08:00). When dealing
     ;; with dates, we will often truncate the timestamp to a date. When we only test with negative timezone offsets, in
@@ -223,7 +223,7 @@
     ;; 2018-08-16, instead of 2018-08-17
     (mt/with-system-timezone-id "Asia/Hong_Kong"
       (letfn [(run-query-with-report-timezone [report-timezone]
-                (mt/with-temporary-setting-values [report-timezone report-timezone]
+                (mt/with-report-timezone-id report-timezone
                   (mt/first-row
                     (qp/process-query
                      {:database   (mt/id)
@@ -359,10 +359,10 @@
                    (->> (t2/hydrate (t2/select Table :db_id (:id database) {:order-by [:name]}) :fields)
                         (map table-fingerprint))))))))))
 
-(deftest group-on-time-column-test
+(deftest ^:parallel group-on-time-column-test
   (mt/test-driver :mysql
     (testing "can group on TIME columns (#12846)"
-      (mt/with-temporary-setting-values [report-timezone "UTC"]
+      (mt/with-report-timezone-id "UTC"
         (mt/dataset attempted-murders
           (let [now-date-str (u.date/format (t/local-date (t/zone-id "UTC")))
                 add-date-fn  (fn [t] [(str now-date-str "T" t)])]

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -899,10 +899,10 @@
 
 ;;; ------------------------------------------------ Timezone-related ------------------------------------------------
 
-(deftest timezone-test
+(deftest ^:parallel timezone-test
   (mt/test-driver :postgres
     (letfn [(get-timezone-with-report-timezone [report-timezone]
-              (mt/with-temporary-setting-values [report-timezone report-timezone]
+              (mt/with-report-timezone-id report-timezone
                 (ffirst
                  (mt/rows
                   (qp/process-query {:database (mt/id)

--- a/test/metabase/query_processor/middleware/add_timezone_info_test.clj
+++ b/test/metabase/query_processor/middleware/add_timezone_info_test.clj
@@ -17,7 +17,7 @@
 (defn- add-timezone-info [metadata]
   ((add-timezone-info/add-timezone-info {} identity) metadata))
 
-(deftest post-processing-test
+(deftest ^:parallel post-processing-test
   (doseq [[driver timezone->expected] {::timezone-driver    {"US/Pacific" {:results_timezone   "US/Pacific"
                                                                            :requested_timezone "US/Pacific"}
                                                              nil          {:results_timezone "UTC"}}
@@ -26,7 +26,7 @@
                                                              nil          {:results_timezone "UTC"}}}
           [timezone expected]         timezone->expected]
     (testing driver
-      (mt/with-temporary-setting-values [report-timezone timezone]
+      (mt/with-report-timezone-id timezone
         (driver/with-driver driver
           (mt/with-database-timezone-id nil
             (is (= expected

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -136,7 +136,7 @@
 
 ;; see also `metabase.query-processor.streaming.xlsx-test/report-timezone-test`
 ;; TODO this test doesn't seem to run?
-(deftest report-timezone-test
+(deftest ^:parallel report-timezone-test
   (testing "Export downloads should format stuff with the report timezone rather than UTC (#13677)"
     (mt/test-driver :postgres
       (let [query     (mt/dataset attempted-murders
@@ -185,7 +185,7 @@
                   :time           #inst "1899-12-31T00:23:18.000-00:00"
                   :time-ltz       #inst "1899-12-31T07:23:18.000-00:00"
                   :time-tz        #inst "1899-12-31T07:23:18.000-00:00"})))
-            (mt/with-temporary-setting-values [report-timezone "US/Pacific"]
+            (mt/with-report-timezone-id "US/Pacific"
               (test-results
                (case export-format
                  (:csv :json)

--- a/test/metabase/query_processor/test_util.clj
+++ b/test/metabase/query_processor/test_util.clj
@@ -14,11 +14,13 @@
    [metabase.db.connection :as mdb.connection]
    [metabase.driver :as driver]
    [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
+   [metabase.lib.schema.expression.temporal
+    :as lib.schema.expression.temporal]
    [metabase.lib.test-util :as lib.tu]
    [metabase.models.field :refer [Field]]
-   [metabase.models.table :refer [Table]]
    [metabase.query-processor :as qp]
    [metabase.query-processor.middleware.add-implicit-joins
     :as qp.add-implicit-joins]
@@ -30,6 +32,7 @@
    [metabase.test.util :as tu]
    [metabase.util :as u]
    [metabase.util.log :as log]
+   [metabase.util.malli :as mu]
    #_{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2]))
 
@@ -96,9 +99,14 @@
   [table-kw field-kw]
   (merge
    (col-defaults)
-   (t2/select-one [Field :id :table_id :semantic_type :base_type :effective_type
-                   :coercion_strategy :name :display_name :fingerprint]
-     :id (data/id table-kw field-kw))
+   (if (qp.store/initialized?)
+     (-> (lib.metadata/field (qp.store/metadata-provider) (data/id table-kw field-kw))
+         (select-keys [:lib/type :id :table-id :semantic-type :base-type :effective-type :coercion-strategy :name :display-name :fingerprint])
+         #_{:clj-kondo/ignore [:deprecated-var]}
+         qp.store/->legacy-metadata)
+     (t2/select-one [:model/Field :id :table_id :semantic_type :base_type :effective_type
+                     :coercion_strategy :name :display_name :fingerprint]
+                    :id (data/id table-kw field-kw)))
    {:field_ref [:field (data/id table-kw field-kw) nil]}
    (when (#{:last_login :date} field-kw)
      {:unit      :default
@@ -187,8 +195,10 @@
         (update :display_name (partial format "%s → %s" (str/replace (:display_name source-col) #"(?i)\sid$" "")))
         (assoc :field_ref    [:field (:id dest-col) {:source-field (:id source-col)}]
                :fk_field_id  (:id source-col)
-               :source_alias (#'qp.add-implicit-joins/join-alias (t2/select-one-fn :name Table :id (data/id dest-table-kw))
-                                                                 (:name source-col))))))
+               :source_alias (let [table-name (if (qp.store/initialized?)
+                                                (:name (lib.metadata/table (qp.store/metadata-provider) (data/id dest-table-kw)))
+                                                (t2/select-one-fn :name :model/Table :id (data/id dest-table-kw)))]
+                               (#'qp.add-implicit-joins/join-alias table-name (:name source-col)))))))
 
 (declare cols)
 
@@ -393,7 +403,7 @@
                    (assoc outer-query :query {:source-query (:query outer-query)}))]
       (recur nested (dec n-levels)))))
 
-(deftest nest-query-test
+(deftest ^:parallel nest-query-test
   (testing "MBQL"
     (is (= {:database 1, :type :query, :query {:source-table 2}}
            {:database 1, :type :query, :query {:source-table 2}}))
@@ -553,16 +563,11 @@
 
 ;;; ------------------------------------------------- Timezone Stuff -------------------------------------------------
 
-(defn do-with-report-timezone-id
+(mu/defn do-with-report-timezone-id
   "Impl for `with-report-timezone-id`."
-  [timezone-id thunk]
-  {:pre [((some-fn nil? string?) timezone-id)]}
-  ;; This will fail if the app DB isn't initialized yet. That's fine — there's no DBs to notify if the app DB isn't
-  ;; set up.
-  (try
-    (#'driver/notify-all-databases-updated)
-    (catch Throwable _))
-  (binding [qp.timezone/*report-timezone-id-override* (or timezone-id ::nil)]
+  [timezone-id :- [:maybe ::lib.schema.expression.temporal/timezone-id]
+   thunk]
+  (binding [qp.timezone/*report-timezone-id-override* (or timezone-id ::qp.timezone/nil)]
     (testing (format "\nreport timezone id = %s" timezone-id)
       (thunk))))
 
@@ -571,11 +576,11 @@
   [timezone-id & body]
   `(do-with-report-timezone-id ~timezone-id (fn [] ~@body)))
 
-(defn do-with-database-timezone-id
+(mu/defn do-with-database-timezone-id
   "Impl for `with-database-timezone-id`."
-  [timezone-id thunk]
-  {:pre [((some-fn nil? string?) timezone-id)]}
-  (binding [qp.timezone/*database-timezone-id-override* (or timezone-id ::nil)]
+  [timezone-id :- [:maybe ::lib.schema.expression.temporal/timezone-id]
+   thunk]
+  (binding [qp.timezone/*database-timezone-id-override* (or timezone-id ::qp.timezone/nil)]
     (testing (format "\ndatabase timezone id = %s" timezone-id)
       (thunk))))
 
@@ -584,15 +589,17 @@
   [timezone-id & body]
   `(do-with-database-timezone-id ~timezone-id (fn [] ~@body)))
 
-(defn do-with-results-timezone-id
+(mu/defn do-with-results-timezone-id
   "Impl for `with-results-timezone-id`."
-  [timezone-id thunk]
+  [timezone-id :- ::lib.schema.expression.temporal/timezone-id
+   thunk]
   {:pre [((some-fn nil? string?) timezone-id)]}
-  (binding [qp.timezone/*results-timezone-id-override* (or timezone-id ::nil)]
-    (testing (format "\nresults timezone id = %s" timezone-id)
+  (binding [qp.timezone/*results-timezone-id-override* (or timezone-id ::qp.timezone/nil)]
+    (testing (format "\nresults timezone id = %s" (pr-str timezone-id))
       (thunk))))
 
 (defmacro with-results-timezone-id
-  "Override the determined results timezone ID and execute `body`. Intended primarily for REPL and test usage."
+  "Override the determined results timezone ID and execute `body`. Intended primarily for REPL and test usage.
+  `timezone-id` cannot be `nil`."
   [timezone-id & body]
   `(do-with-results-timezone-id ~timezone-id (fn [] ~@body)))

--- a/test/metabase/query_processor_test/alternative_date_test.clj
+++ b/test/metabase/query_processor_test/alternative_date_test.clj
@@ -47,7 +47,7 @@
              (set (mt/rows (mt/dataset toucan-microsecond-incidents
                              (mt/run-mbql-query incidents)))))))))
 
-(deftest filter-test
+(deftest ^:parallel xfilter-test
   (mt/test-drivers (mt/normal-drivers)
     (mt/dataset sad-toucan-incidents
       (let [query (mt/mbql-query incidents
@@ -56,13 +56,13 @@
         ;; There's a race condition with this test. If we happen to grab a connection that is in a session with the
         ;; timezone set to pacific, we'll get 9 results even when the above if statement is true. It seems to be pretty
         ;; rare, but explicitly specifying UTC will make the issue go away
-        (mt/with-temporary-setting-values [report-timezone "UTC"]
+        (mt/with-report-timezone-id "UTC"
           (testing "There were 10 'sad toucan incidents' on 2015-06-02 in UTC"
             (mt/with-native-query-testing-context query
               (is (= 10
                      (count (mt/rows (qp/process-query query))))))))))))
 
-(deftest results-test
+(deftest ^:parallel results-test
   (mt/test-drivers (mt/normal-drivers)
     (is (= (cond
              (= :sqlite driver/*driver*)
@@ -112,7 +112,7 @@
               ["2015-06-08T00:00:00Z" 9]
               ["2015-06-09T00:00:00Z" 7]
               ["2015-06-10T00:00:00Z" 9]])
-           (mt/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
+           (mt/with-report-timezone-id "America/Los_Angeles"
              (->> (mt/dataset sad-toucan-incidents
                     (mt/run-mbql-query incidents
                       {:aggregation [[:count]]

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -1124,7 +1124,7 @@
       (mt/test-drivers (mt/normal-drivers)
         (doseq [[expected-count unit filter-value] addition-unit-filtering-vals]
           (doseq [tz [nil "UTC"]]         ;iterate on at least two report time zones to suss out bugs related to that
-            (mt/with-temporary-setting-values [report-timezone tz]
+            (mt/with-report-timezone-id tz
               (testing (format "\nunit = %s" unit)
                 (is (= expected-count (count-of-checkins unit filter-value))
                     (format
@@ -1133,7 +1133,7 @@
                      filter-value
                      expected-count))))))))))
 
-(deftest legacy-default-datetime-bucketing-test
+(deftest ^:parallel legacy-default-datetime-bucketing-test
   (testing (str ":type/Date or :type/DateTime fields that don't have `:temporal-unit` clauses should get default `:day` "
                 "bucketing for legacy reasons. See #9014")
     (is (= (str "SELECT COUNT(*) AS \"count\" "
@@ -1149,7 +1149,7 @@
                {:aggregation [[:count]]
                 :filter      [:= $date [:relative-datetime :current]]})))))))
 
-(deftest compile-time-interval-test
+(deftest ^:parallel compile-time-interval-test
   (testing "Make sure time-intervals work the way they're supposed to."
     (testing "[:time-interval $date -4 :month] should give us something like Oct 01 2020 - Feb 01 2021 if today is Feb 17 2021"
       (is (= (str "SELECT CHECKINS.DATE AS DATE "
@@ -1251,9 +1251,9 @@
                (mt/formatted-rows [int] (qp/process-query query)))))))))
 
 ;; TODO -- is this really date BUCKETING? Does this BELONG HERE?!
-(deftest june-31st-test
+(deftest ^:parallel june-31st-test
   (testing "What happens when you try to add 3 months to March 31st? It should still work (#10072, #21968, #21969)"
-    (mt/with-temporary-setting-values [report-timezone "UTC"]
+    (mt/with-report-timezone-id "UTC"
       ;; only testing the SQL drivers for now since I'm not 100% sure how to mock this for everyone else. Maybe one day
       ;; when we support expressions like `+` for temporal types we can do an `:absolute-datetime` plus
       ;; `:relative-datetime` expression and do this directly in MBQL.

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -266,14 +266,14 @@
     (for [s strs]
       [(format-fn (u.date/parse s "UTC"))])))
 
-(deftest temporal-arithmetic-test
+(deftest ^:parallel temporal-arithmetic-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions :date-arithmetics)
     (testing "Test that we can do datetime arithemtics using MBQL `:interval` clause in expressions"
       (is (= (robust-dates
               ["2014-09-02T13:45:00"
                "2014-07-02T09:30:00"
                "2014-07-01T10:30:00"])
-             (mt/with-temporary-setting-values [report-timezone "UTC"]
+             (mt/with-report-timezone-id "UTC"
                (-> (mt/run-mbql-query users
                      {:expressions {:prev_month [:+ $last_login [:interval -31 :day]]}
                       :fields      [[:expression :prev_month]]
@@ -285,7 +285,7 @@
               ["2014-09-02T00:00:00"
                "2014-07-02T00:00:00"
                "2014-07-01T00:00:00"])
-             (mt/with-temporary-setting-values [report-timezone "UTC"]
+             (mt/with-report-timezone-id "UTC"
                (-> (mt/run-mbql-query users
                      {:expressions {:prev_month [:+ !day.last_login [:interval -31 :day]]}
                       :fields      [[:expression :prev_month]]

--- a/test/metabase/query_processor_test/remapping_test.clj
+++ b/test/metabase/query_processor_test/remapping_test.clj
@@ -223,7 +223,7 @@
         ;; doesn't currently work with any other metadata.
 
 (deftest remappings-with-implicit-joins-test
-  (mt/with-temporary-setting-values [report-timezone "UTC"]
+  (mt/with-report-timezone-id "UTC"
     (mt/test-drivers (mt/normal-drivers-with-feature :foreign-keys :nested-queries)
       (testing "Queries with implicit joins should still work when FK remaps are used (#13641)"
         (mt/dataset sample-dataset

--- a/test/metabase/query_processor_test/time_field_test.clj
+++ b/test/metabase/query_processor_test/time_field_test.clj
@@ -51,9 +51,9 @@
              [[3 "Kaneonuskatew Eiran" "16:15:00Z"]])
            (time-query := "16:15:00Z")))))
 
-(deftest report-timezone-test
+(deftest ^:parallel report-timezone-test
   (mt/test-drivers (normal-drivers-that-support-time-type)
-    (mt/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
+    (mt/with-report-timezone-id "America/Los_Angeles"
       (is (= (cond
                (= :sqlite driver/*driver*)
                [[1 "Plato Yeshua" "08:30:00"]

--- a/test/metabase/query_processor_test/timezones_test.clj
+++ b/test/metabase/query_processor_test/timezones_test.clj
@@ -43,7 +43,7 @@
   (conj (set-timezone-drivers) :h2 :bigquery-cloud-sdk :sqlserver))
 
 ;; TODO - we should also do similar tests for timezone-unaware columns
-(deftest result-rows-test
+(deftest ^:parallel result-rows-test
   (mt/dataset test-data-with-timezones
     (mt/test-drivers (timezone-aware-column-drivers)
       (is (= [[12 "2014-07-03T01:30:00Z"]
@@ -58,7 +58,7 @@
       (doseq [[timezone expected-rows] {"UTC"        [[12 "2014-07-03T01:30:00Z"]
                                                       [10 "2014-07-03T19:30:00Z"]]
                                         "US/Pacific" [[10 "2014-07-03T12:30:00-07:00"]]}]
-        (mt/with-temporary-setting-values [report-timezone timezone]
+        (mt/with-report-timezone-id timezone
           (is (= expected-rows
                  (mt/formatted-rows [int identity]
                    (mt/run-mbql-query users
@@ -67,10 +67,10 @@
                       :order-by [[:asc $last_login]]})))
               (format "There should be %d checkins on July 3rd in the %s timezone" (count expected-rows) timezone)))))))
 
-(deftest filter-test
+(deftest ^:parallel filter-test
   (mt/dataset test-data-with-timezones
     (mt/test-drivers (set-timezone-drivers)
-      (mt/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
+      (mt/with-report-timezone-id "America/Los_Angeles"
         (is (= [[6 "Shad Ferdynand" "2014-08-02T05:30:00-07:00"]]
                (mt/formatted-rows [int identity identity]
                  (mt/run-mbql-query users
@@ -81,7 +81,11 @@
                (mt/formatted-rows [int identity identity]
                  (mt/run-mbql-query users
                    {:filter [:between $last_login "2014-08-02T10:00:00.000000Z" "2014-08-02T13:00:00.000000Z"]})))
-            "MBQL datetime literal strings that include timezone should be parsed in it regardless of report timezone")))
+            "MBQL datetime literal strings that include timezone should be parsed in it regardless of report timezone")))))
+
+(deftest ^:parallel filter-test-2
+  (mt/dataset test-data-with-timezones
+    (mt/test-drivers (set-timezone-drivers))
     (testing "UTC timezone"
       (let [run-query   (fn []
                           (mt/formatted-rows [int identity identity]
@@ -90,7 +94,7 @@
             utc-results [[6 "Shad Ferdynand" "2014-08-02T12:30:00Z"]]]
         (mt/test-drivers (set-timezone-drivers)
           (is (= utc-results
-                 (mt/with-temporary-setting-values [report-timezone "UTC"]
+                 (mt/with-report-timezone-id "UTC"
                    (run-query)))
               "Checking UTC report timezone filtering and responses"))
         (mt/test-drivers (timezone-aware-column-drivers)
@@ -167,7 +171,7 @@
                     :target ["dimension" ["template-tag" "just_a_date"]]
                     :value  "2014-08-02"}]}}))
 
-(deftest native-sql-params-filter-test
+(deftest ^:parallel native-sql-params-filter-test
   ;; parameters always get `date` bucketing so doing something the between stuff we do below is basically just going
   ;; to match anything with a `2014-08-02` date
   (mt/test-drivers (filter
@@ -175,7 +179,7 @@
                      (set/intersection (set-timezone-drivers)
                                        (mt/normal-drivers-with-feature :native-parameters)))
     (mt/dataset test-data-with-timezones
-      (mt/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
+      (mt/with-report-timezone-id "America/Los_Angeles"
         (testing "Native dates should be parsed with the report timezone"
           (doseq [[params-description query] (native-params-queries)]
             (testing (format "Query with %s" params-description)
@@ -226,13 +230,13 @@
    (when (supports-datetime-with-zone-id?)
      {:datetime_tz_id (t/zoned-date-time "2019-11-01T00:23:18.331-07:00[America/Los_Angeles]")})))
 
-(deftest sql-time-timezone-handling-test
+(deftest ^:parallel sql-time-timezone-handling-test
   ;; Actual value : "2019-11-01T00:23:18.331-07:00[America/Los_Angeles]"
   ;; Oracle doesn't have a time type
   (mt/test-drivers (filter #(isa? driver/hierarchy % :sql) (set-timezone-drivers))
     (mt/dataset attempted-murders
       (doseq [timezone [nil "US/Pacific" "US/Eastern" "Asia/Hong_Kong"]]
-        (mt/with-temporary-setting-values [report-timezone timezone]
+        (mt/with-report-timezone-id timezone
           (let [expected (expected-attempts)
                 actual   (select-keys (attempts) (keys expected))]
             (is (= expected actual))))))))
@@ -244,7 +248,7 @@
       (for [i (range 366)]
         [(u.date/add start-date :day i)])]]))
 
-(deftest general-timezone-support-test
+(deftest ^:parallel general-timezone-support-test
   (mt/dataset all-dates-leap-year
     (mt/test-drivers (set-timezone-drivers)
       (let [extract-units (disj u.date/extract-units :day-of-year)
@@ -268,7 +272,7 @@
                                           (-> in-tz
                                               u.date/format-sql
                                               (str/replace #" " "T"))]]))]]
-          (mt/with-temporary-setting-values [report-timezone timezone]
+          (mt/with-report-timezone-id timezone
             (let [rows (->> (mt/run-mbql-query alldates
                               {:expressions (->> extract-units
                                                  (map
@@ -298,7 +302,7 @@
               (doseq [[expected-row row] (map vector expected-rows rows)]
                 (is (= expected-row row))))))))))
 
-(deftest filter-datetime-by-date-in-timezone-relative-to-current-date-test
+(deftest ^:parallel filter-datetime-by-date-in-timezone-relative-to-current-date-test
   (mt/test-drivers (set-timezone-drivers)
     (testing "Relative to current date"
       (let [expected-datetime (u.date/truncate (t/zoned-date-time) :second)]
@@ -306,7 +310,7 @@
                                  [{:field-name "created", :base-type :type/DateTimeWithTZ}]
                                  [[expected-datetime]]]
           (doseq [timezone ["UTC" "America/Los_Angeles"]]
-            (mt/with-temporary-setting-values [report-timezone timezone]
+            (mt/with-report-timezone-id timezone
               (let [query (mt/mbql-query relative_filter {:fields [$created]
                                                           :filter [:time-interval $created :current :day]})]
                 (mt/with-native-query-testing-context query
@@ -322,7 +326,7 @@
                                    (u.date/parse nil)
                                    t/offset-date-time)))))))))))))
 
-(deftest filter-datetime-by-date-in-timezone-relative-to-days-since-test
+(deftest ^:parallel filter-datetime-by-date-in-timezone-relative-to-days-since-test
   (mt/test-drivers (set-timezone-drivers)
     (testing "Relative to days since"
       (let [expected-datetime (u.date/truncate (u.date/add (t/zoned-date-time) :day -1) :second)]
@@ -330,7 +334,7 @@
                                  [{:field-name "created", :base-type :type/DateTimeWithTZ}]
                                  [[expected-datetime]]]
           (doseq [timezone ["UTC" "US/Pacific" "US/Eastern" "Asia/Hong_Kong"]]
-            (mt/with-temporary-setting-values [report-timezone timezone]
+            (mt/with-report-timezone-id timezone
               (let [query (mt/mbql-query relative_filter {:fields [$created]
                                                           :filter [:time-interval $created -1 :day]})]
                 (mt/with-native-query-testing-context query
@@ -346,7 +350,7 @@
                                    (u.date/parse nil)
                                    t/offset-date-time)))))))))))))
 
-(deftest filter-datetime-by-date-in-timezone-fixed-date-test
+(deftest ^:parallel filter-datetime-by-date-in-timezone-fixed-date-test
   (mt/test-drivers (set-timezone-drivers)
     (testing "Fixed date"
       (mt/dataset test-data-with-timezones
@@ -358,7 +362,7 @@
                   :let [expected (-> (u.date/with-time-zone-same-instant expected-datetime timezone)
                                      (u.date/format-sql)
                                      (str/replace #" " "T"))]]
-            (mt/with-temporary-setting-values [report-timezone timezone]
+            (mt/with-report-timezone-id timezone
               (is (= [expected]
                      (mt/first-row
                       (mt/run-mbql-query users

--- a/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
+++ b/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
@@ -13,12 +13,12 @@
 
 (set! *warn-on-reflection* true)
 
-(deftest fingerprint-temporal-values-test
+(deftest ^:parallel fingerprint-temporal-values-test
   ;; we want to test h2 and postgres, because h2 doesn't
   ;; support overriding the timezone for a session / report
   (mt/test-drivers #{:h2 :postgres}
     (doseq [tz ["UTC" nil]]
-      (mt/with-temporary-setting-values [report-timezone tz]
+      (mt/with-report-timezone-id tz
         (mt/with-database-timezone-id "UTC"
           (mt/with-everything-store
             (is (= {:global {:distinct-count 4


### PR DESCRIPTION
Instead of using 

```clj
(mt/with-temporary-setting-values [report-timezone "US/Pacific"]
  ...)
```

which is (currently) not thread-safe, we've had a thread-safe `mt/with-report-timezone-id` helper around for a while now (I sort of forgot I wrote it TBH). Update a bunch of tests to use this and make them `^:parallel.`

Fix some bugs with the impl for the test helper. If you used it with `nil` it would bind the `*results-timezone-id-override*` to `::nil` which didn't work because it was invalid. Also there were some bugs with the 1-arities for `(qp.timezone/results-timezone-id)` and the like, they passed around a key called `::db-from-store` which was supposed to mean use `(qp.store/database)` (or equivalent) but some of the functions forgot to do this and tried to get stuff out of it as it it were a map e.g. `(:timezone ::db-from-store)` which of course didn't work. Fixed by adding copious Malli schemas to everything.

Also made some minor improvements to QP tests utils to use the current QP store if already bound rather than fetching objects from the app DB again.