### PR TITLE
What's new - adds white labeling check to logic

### DIFF
--- a/frontend/src/metabase/nav/components/WhatsNewNotification/WhatsNewNotification.tsx
+++ b/frontend/src/metabase/nav/components/WhatsNewNotification/WhatsNewNotification.tsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from "metabase/lib/redux";
 import { getIsEmbedded } from "metabase/selectors/embed";
 import { getSetting } from "metabase/selectors/settings";
 import { Anchor, Flex, Paper, Stack, Text } from "metabase/ui";
+import { getIsWhiteLabeling } from "metabase/selectors/whitelabel";
 import Sparkles from "./sparkles.svg?component";
 import { getLatestEligibleReleaseNotes } from "./utils";
 import { DismissIconButtonWrapper } from "./WhatsNewNotification.styled";
@@ -19,6 +20,7 @@ export function WhatsNewNotification() {
   const lastAcknowledgedVersion = useSelector(state =>
     getSetting(state, "last-acknowledged-version"),
   );
+  const isWhiteLabeling = useSelector(getIsWhiteLabeling);
 
   const url: string | undefined = useMemo(() => {
     const lastEligibleVersion = getLatestEligibleReleaseNotes({
@@ -26,10 +28,17 @@ export function WhatsNewNotification() {
       currentVersion: currentVersion.tag,
       lastAcknowledgedVersion: lastAcknowledgedVersion,
       isEmbedded,
+      isWhiteLabeling,
     });
 
     return lastEligibleVersion?.announcement_url;
-  }, [versionInfo, currentVersion.tag, lastAcknowledgedVersion, isEmbedded]);
+  }, [
+    versionInfo,
+    currentVersion.tag,
+    lastAcknowledgedVersion,
+    isEmbedded,
+    isWhiteLabeling,
+  ]);
 
   const dimiss = useCallback(() => {
     dispatch(

--- a/frontend/src/metabase/nav/components/WhatsNewNotification/utils.ts
+++ b/frontend/src/metabase/nav/components/WhatsNewNotification/utils.ts
@@ -15,7 +15,7 @@ export const getLatestEligibleReleaseNotes = ({
   isWhiteLabeling = false,
 }: {
   versionInfo: VersionInfo | null;
-  currentVersion?: string;
+  currentVersion: string | undefined;
   lastAcknowledgedVersion: string | null;
   isEmbedded: boolean;
   isWhiteLabeling: boolean;

--- a/frontend/src/metabase/nav/components/WhatsNewNotification/utils.ts
+++ b/frontend/src/metabase/nav/components/WhatsNewNotification/utils.ts
@@ -17,8 +17,8 @@ export const getLatestEligibleReleaseNotes = ({
   versionInfo: VersionInfo | null;
   currentVersion?: string;
   lastAcknowledgedVersion: string | null;
-  isEmbedded?: boolean;
-  isWhiteLabeling?: boolean;
+  isEmbedded: boolean;
+  isWhiteLabeling: boolean;
 }): VersionInfoRecord | undefined => {
   if (isWhiteLabeling || isEmbedded || currentVersion === undefined) {
     return undefined;

--- a/frontend/src/metabase/nav/components/WhatsNewNotification/utils.ts
+++ b/frontend/src/metabase/nav/components/WhatsNewNotification/utils.ts
@@ -12,13 +12,15 @@ export const getLatestEligibleReleaseNotes = ({
   currentVersion,
   lastAcknowledgedVersion,
   isEmbedded = false,
+  isWhiteLabeling = false,
 }: {
   versionInfo: VersionInfo | null;
   currentVersion?: string;
   lastAcknowledgedVersion: string | null;
   isEmbedded?: boolean;
+  isWhiteLabeling?: boolean;
 }): VersionInfoRecord | undefined => {
-  if (isEmbedded || currentVersion === undefined) {
+  if (isWhiteLabeling || isEmbedded || currentVersion === undefined) {
     return undefined;
   }
 

--- a/frontend/src/metabase/nav/components/WhatsNewNotification/utils.unit.spec.ts
+++ b/frontend/src/metabase/nav/components/WhatsNewNotification/utils.unit.spec.ts
@@ -44,6 +44,15 @@ describe("getLatestEligibleReleaseNotes", () => {
     ).toBe(undefined);
   });
 
+  it("should return nothing when white labeling, even if other conditions are satisfied", () => {
+    expect(
+      getLatestEligibleReleaseNotes({
+        ...DEFAULTS,
+        isWhiteLabeling: true,
+      }),
+    ).toBe(undefined);
+  });
+
   it("should ignore versions without the annoucement_url", () => {
     expect(
       getLatestEligibleReleaseNotes({

--- a/frontend/src/metabase/nav/components/WhatsNewNotification/utils.unit.spec.ts
+++ b/frontend/src/metabase/nav/components/WhatsNewNotification/utils.unit.spec.ts
@@ -13,6 +13,7 @@ const buildVersionInfo = (versions: VersionInfoRecord[]): VersionInfo => {
 // these args make should make the notification to appear
 const DEFAULTS: Parameters<typeof getLatestEligibleReleaseNotes>[0] = {
   isEmbedded: false,
+  isWhiteLabeling: false,
   lastAcknowledgedVersion: null,
   currentVersion: "v0.48.0",
   versionInfo: buildVersionInfo([
@@ -127,6 +128,7 @@ describe("getLatestEligibleReleaseNotes", () => {
   it("filters out future versions - lastAcknowledgedVersion not null", () => {
     expect(
       getLatestEligibleReleaseNotes({
+        ...DEFAULTS,
         versionInfo: buildVersionInfo([
           mockVersion({
             version: "v0.49.0",
@@ -145,6 +147,7 @@ describe("getLatestEligibleReleaseNotes", () => {
   it("filters out future versions - lastAcknowledgedVersion  null", () => {
     expect(
       getLatestEligibleReleaseNotes({
+        ...DEFAULTS,
         versionInfo: buildVersionInfo([
           mockVersion({
             version: "v0.49.0",
@@ -163,6 +166,7 @@ describe("getLatestEligibleReleaseNotes", () => {
   it("returns last version if more than one are eligible", () => {
     expect(
       getLatestEligibleReleaseNotes({
+        ...DEFAULTS,
         versionInfo: buildVersionInfo([
           mockVersion({
             version: "v0.49.2",


### PR DESCRIPTION
### Description

The requirements have been updated recently to add that the notification should not show if the user is using white labeling (it should still show if the feature is enabled but not used)

https://www.notion.so/metabase/Provide-a-heads-up-when-Metabase-is-upgraded-with-what-s-new-44a28b55624f48e28dc3f616ce7cda0f?pvs=4#754ebfe202414d15afc8611bdcf0be93

### How to verify
To verify we can run metabase in EE mode and manually edit the the getLatestEligibleReleaseNotes to return something right after the check for the white labeling, for example on line 26 we can put: 
```ts
return {
    version: "fake-version",
    announcement_url: "metabase.com/releases/pizza",
  };
  ```
  
The notification should show up in the home, but if we go on admin -> appearance, change the application name and go back to the home, it should not be shown anymore

### Open points
- [ ] is this check important enough to need a e2e test? I know we're trying to test as little things as possible in e2e tests as they're already slow