### PR TITLE
Add Right Arrow Icon

### DIFF
--- a/frontend/src/metabase/core/components/Icon/icons/index.ts
+++ b/frontend/src/metabase/core/components/Icon/icons/index.ts
@@ -29,6 +29,8 @@ import arrow_left_component from "./arrow_left.svg?component";
 import arrow_left_source from "./arrow_left.svg?source";
 import arrow_left_to_line_component from "./arrow_left_to_line.svg?component";
 import arrow_left_to_line_source from "./arrow_left_to_line.svg?source";
+import arrow_right_component from "./arrow_right.svg?component";
+import arrow_right_source from "./arrow_right.svg?source";
 import arrow_split_component from "./arrow_split.svg?component";
 import arrow_split_source from "./arrow_split.svg?source";
 import badge_component from "./badge.svg?component";
@@ -408,6 +410,10 @@ export const Icons = {
   arrow_left_to_line: {
     component: arrow_left_to_line_component,
     source: arrow_left_to_line_source,
+  },
+  arrow_right: {
+    component: arrow_right_component,
+    source: arrow_right_source,
   },
   arrow_split: {
     component: arrow_split_component,


### PR DESCRIPTION
### Description

Adds the right arrow icon.

### How to verify

Check that Storybook now has an `arrow_right` icon
![Untitled 2](https://github.com/metabase/metabase/assets/25306947/c203b296-88b8-48c0-aa62-19a413f4a88e)

