### PR TITLE
Don't decode SSO redirect URLs before extracting host

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
@@ -9,12 +9,11 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs tru]]
    [metabase.util.log :as log]
-   #_{:clj-kondo/ignore [:deprecated-namespace]}
    [metabase.util.schema :as su]
    [schema.core :as s]
    [toucan2.core :as t2])
   (:import
-   (java.net URI URLDecoder)))
+   (java.net URI)))
 
 (set! *warn-on-reflection* true)
 

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
@@ -9,6 +9,7 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs tru]]
    [metabase.util.log :as log]
+   #_{:clj-kondo/ignore [:deprecated-namespace]}
    [metabase.util.schema :as su]
    [schema.core :as s]
    [toucan2.core :as t2])

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
@@ -56,10 +56,9 @@
   "Check if open redirect is being exploited in SSO. If so, or if the redirect-url is invalid, throw a 400."
   [redirect-url]
   (try
-    (let [decoded-url (some-> ^String redirect-url (URLDecoder/decode "UTF-8"))
-          host        (some-> decoded-url (URI.) (.getHost))
+    (let [host        (some-> redirect-url (URI.) (.getHost))
           our-host    (some-> (public-settings/site-url) (URI.) (.getHost))]
-      (api/check-400 (or (nil? decoded-url) (nil? host) (= host our-host))))
+      (api/check-400 (or (nil? redirect-url) (nil? host) (= host our-host))))
     (catch Exception e
       (log/error e "Invalid redirect URL")
       (throw (ex-info (tru "Invalid redirect URL")

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/sso_utils_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/sso_utils_test.clj
@@ -9,9 +9,11 @@
       "/test"
       "localhost"
       "localhost:3000"
-      "http://localhost:3000"))
+      "http://localhost:3000"
+      "http://localhost:3000/dashboard/1-test-dashboard?currency=British%20Pound"))
 
   (testing "check-sso-redirect- throws an error for invalid redirect URIs"
     (are [uri] (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid redirect URL" (sso-utils/check-sso-redirect uri))
       "http://example.com"
-      "//example.com")))
+      "//example.com"
+      "not a url")))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/sso_utils_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/sso_utils_test.clj
@@ -1,19 +1,22 @@
 (ns metabase-enterprise.sso.integrations.sso-utils-test
   (:require [clojure.test :refer :all]
-            [metabase-enterprise.sso.integrations.sso-utils :as sso-utils]))
+            [metabase-enterprise.sso.integrations.sso-utils :as sso-utils]
+            [metabase.test :as mt]))
 
-(deftest ^:parallel check-sso-redirect-test
-  (testing "check-sso-redirect properly validates redirect URIs"
-    (are [uri] (sso-utils/check-sso-redirect uri)
-      "/"
-      "/test"
-      "localhost"
-      "localhost:3000"
-      "http://localhost:3000"
-      "http://localhost:3000/dashboard/1-test-dashboard?currency=British%20Pound"))
+(deftest check-sso-redirect-test
+  (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
+   (testing "check-sso-redirect properly validates redirect URIs"
+     (are [uri] (sso-utils/check-sso-redirect uri)
+       "/"
+       "/test"
+       "localhost"
+       "localhost:3000"
+       "http://localhost:3000"
+       "http://localhost:3000/dashboard/1-test-dashboard?currency=British%20Pound"))
 
-  (testing "check-sso-redirect- throws an error for invalid redirect URIs"
-    (are [uri] (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid redirect URL" (sso-utils/check-sso-redirect uri))
-      "http://example.com"
-      "//example.com"
-      "not a url")))
+   (testing "check-sso-redirect- throws an error for invalid redirect URIs"
+     (are [uri] (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid redirect URL" (sso-utils/check-sso-redirect uri))
+       "http://example.com"
+       "//example.com"
+       "not a url"
+       "http://localhost:3000?a=not a param"))))


### PR DESCRIPTION
Annoying discrepancies between `java.net.URL` and `java.net.URI` strike again!

We've always decoded URLs before doing the validation in `check-sso-redirect`, which worked fine with `java.net.URL`. However, `java.net.URI` (which I recently switched this code to using) throws an exception when the URI contains characters like spaces that _aren't_ encoded.

I've fixed this by simply not decoding the URL before creating a `URI` object and extracting the host. The host itself can never contain encodings, and that's the only part that we care about here, so this should be a perfectly safe change. Also added a test case that would have caught this.

resolves https://github.com/metabase/metabase/issues/33028