### PR TITLE
Export Prop types for Mantine Components

### DIFF
--- a/frontend/src/metabase/ui/components/buttons/Button/index.ts
+++ b/frontend/src/metabase/ui/components/buttons/Button/index.ts
@@ -1,2 +1,3 @@
 export { Button } from "@mantine/core";
+export type { ButtonProps } from "@mantine/core";
 export { getButtonOverrides } from "./Button.styled";

--- a/frontend/src/metabase/ui/components/data-display/Accordion/index.ts
+++ b/frontend/src/metabase/ui/components/data-display/Accordion/index.ts
@@ -1,2 +1,3 @@
 export { Accordion } from "@mantine/core";
+export type { AccordionProps } from "@mantine/core";
 export { getAccordionOverrides } from "./Accordion.styled";

--- a/frontend/src/metabase/ui/components/feedback/Loader/index.ts
+++ b/frontend/src/metabase/ui/components/feedback/Loader/index.ts
@@ -1,1 +1,2 @@
 export { Loader } from "./Loader";
+export type { LoaderProps } from "@mantine/core";

--- a/frontend/src/metabase/ui/components/inputs/Checkbox/index.ts
+++ b/frontend/src/metabase/ui/components/inputs/Checkbox/index.ts
@@ -1,2 +1,3 @@
 export { Checkbox } from "@mantine/core";
+export type { CheckboxProps } from "@mantine/core";
 export { getCheckboxOverrides } from "./Checkbox.styled";

--- a/frontend/src/metabase/ui/components/inputs/NumberInput/index.ts
+++ b/frontend/src/metabase/ui/components/inputs/NumberInput/index.ts
@@ -1,2 +1,3 @@
 export { NumberInput } from "@mantine/core";
+export type { NumberInputProps } from "@mantine/core";
 export { getNumberInputOverrides } from "./NumberInput.styled";

--- a/frontend/src/metabase/ui/components/inputs/Radio/index.ts
+++ b/frontend/src/metabase/ui/components/inputs/Radio/index.ts
@@ -1,2 +1,3 @@
 export { Radio } from "@mantine/core";
+export type { RadioProps } from "@mantine/core";
 export { getRadioOverrides } from "./Radio.styled";

--- a/frontend/src/metabase/ui/components/inputs/TextInput/index.ts
+++ b/frontend/src/metabase/ui/components/inputs/TextInput/index.ts
@@ -1,2 +1,3 @@
 export { TextInput } from "@mantine/core";
+export type { TextInputProps } from "@mantine/core";
 export { getTextInputOverrides } from "./TextInput.styled";

--- a/frontend/src/metabase/ui/components/layout/Center/index.ts
+++ b/frontend/src/metabase/ui/components/layout/Center/index.ts
@@ -1,1 +1,2 @@
 export { Center } from "@mantine/core";
+export type { CenterProps } from "@mantine/core";

--- a/frontend/src/metabase/ui/components/layout/Flex/index.ts
+++ b/frontend/src/metabase/ui/components/layout/Flex/index.ts
@@ -1,1 +1,2 @@
 export { Flex } from "@mantine/core";
+export type { FlexProps } from "@mantine/core";

--- a/frontend/src/metabase/ui/components/layout/Grid/index.ts
+++ b/frontend/src/metabase/ui/components/layout/Grid/index.ts
@@ -1,1 +1,2 @@
 export { Grid } from "@mantine/core";
+export type { GridProps } from "@mantine/core";

--- a/frontend/src/metabase/ui/components/layout/Group/index.ts
+++ b/frontend/src/metabase/ui/components/layout/Group/index.ts
@@ -1,1 +1,2 @@
 export { Group } from "@mantine/core";
+export type { GroupProps } from "@mantine/core";

--- a/frontend/src/metabase/ui/components/layout/Stack/index.ts
+++ b/frontend/src/metabase/ui/components/layout/Stack/index.ts
@@ -1,1 +1,2 @@
 export { Stack } from "@mantine/core";
+export type { StackProps } from "@mantine/core";

--- a/frontend/src/metabase/ui/components/overlays/Menu/index.ts
+++ b/frontend/src/metabase/ui/components/overlays/Menu/index.ts
@@ -1,2 +1,3 @@
 export { Menu } from "@mantine/core";
+export type { MenuProps } from "@mantine/core";
 export { getMenuOverrides } from "./Menu.styled";

--- a/frontend/src/metabase/ui/components/typography/Anchor/index.ts
+++ b/frontend/src/metabase/ui/components/typography/Anchor/index.ts
@@ -1,2 +1,3 @@
 export { Anchor } from "@mantine/core";
+export type { AnchorProps } from "@mantine/core";
 export { getAnchorOverrides } from "./Anchor.styled";

--- a/frontend/src/metabase/ui/components/typography/Text/index.ts
+++ b/frontend/src/metabase/ui/components/typography/Text/index.ts
@@ -1,2 +1,3 @@
 export { Text } from "@mantine/core";
+export type { TextProps } from "@mantine/core";
 export { getTextOverrides } from "./Text.styled";

--- a/frontend/src/metabase/ui/components/typography/Title/index.ts
+++ b/frontend/src/metabase/ui/components/typography/Title/index.ts
@@ -1,2 +1,3 @@
 export { Title } from "@mantine/core";
+export type { TitleProps } from "@mantine/core";
 export { getTitleOverrides } from "./Title.styled";

--- a/frontend/src/metabase/ui/components/utils/FocusTrap/index.ts
+++ b/frontend/src/metabase/ui/components/utils/FocusTrap/index.ts
@@ -1,1 +1,2 @@
 export { FocusTrap } from "@mantine/core";
+export type { FocusTrapProps } from "@mantine/core";

--- a/frontend/src/metabase/ui/components/utils/Paper/index.ts
+++ b/frontend/src/metabase/ui/components/utils/Paper/index.ts
@@ -1,2 +1,3 @@
 export { Paper } from "@mantine/core";
+export type { PaperProps } from "@mantine/core";
 export { getPaperOverrides } from "./Paper.styled";


### PR DESCRIPTION
Exports all prop types for all Mantine components so we can use them in our styled components, [more context here](https://metaboat.slack.com/archives/C057WD5L0JG/p1693837602080549)