### PR TITLE
Manual backport - Fix redundant network requests triggered in object detail modal

### DIFF
--- a/e2e/test/scenarios/visualizations/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/object_detail.cy.spec.js
@@ -181,6 +181,24 @@ describe("scenarios > question > object details", () => {
     cy.findByText(`Showing ${EXPECTED_LINKED_ORDERS_COUNT} rows`);
   });
 
+  it("should fetch linked entities data only once per entity type when reopening the modal (metabase#32720)", () => {
+    cy.intercept("POST", "/api/dataset", cy.spy().as("fetchDataset"));
+
+    openProductsTable();
+    cy.get("@fetchDataset").should("have.callCount", 1);
+
+    drillPK({ id: 5 });
+    cy.get("@fetchDataset").should("have.callCount", 3);
+
+    cy.findByTestId("object-detail-close-button").click();
+
+    drillPK({ id: 5 });
+    cy.get("@fetchDataset").should("have.callCount", 5);
+
+    cy.wait(100);
+    cy.get("@fetchDataset").should("have.callCount", 5);
+  });
+
   it("should not offer drill-through on the object detail records (metabase#20560)", () => {
     openPeopleTable({ limit: 2 });
 

--- a/e2e/test/scenarios/visualizations/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/object_detail.cy.spec.js
@@ -190,7 +190,7 @@ describe("scenarios > question > object details", () => {
     drillPK({ id: 5 });
     cy.get("@fetchDataset").should("have.callCount", 3);
 
-    cy.findByTestId("object-detail-close-button").click();
+    cy.realPress("{esc}");
 
     drillPK({ id: 5 });
     cy.get("@fetchDataset").should("have.callCount", 5);

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -46,9 +46,7 @@ const mapStateToProps = (state: State, { data }: ObjectDetailProps) => {
   const canZoomNextRow = isZooming ? Boolean(getCanZoomNextRow(state)) : false;
 
   return {
-    // FIXME: remove the non-null assertion operator
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    question: getQuestion(state)!,
+    question: getQuestion(state),
     table,
     tableForeignKeys: getTableForeignKeys(state),
     tableForeignKeyReferences: getTableForeignKeyReferences(state),


### PR DESCRIPTION
Manual backport of #33710 (which is a fix for #32720)

This PR is smaller than #33710 because the original PR also included extracting `ObjectRelationships.styled.tsx` & `ObjectDetailTable.styled.tsx` out of `ObjectDetailView.styled.tsx`, which I forgot to do in #33694.
After this backport is merged, release and master branches will be in sync regarding `ObjectDetail` file structure (#33694).