### PR TITLE
Fix unresolved var `lib.join/current-join-alias`

### DIFF
--- a/src/metabase/lib/drill_thru/zoom_in_timeseries.cljc
+++ b/src/metabase/lib/drill_thru/zoom_in_timeseries.cljc
@@ -4,7 +4,7 @@
    [metabase.lib.breakout :as lib.breakout]
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
    [metabase.lib.filter :as lib.filter]
-   [metabase.lib.join :as lib.join]
+   [metabase.lib.join.util :as lib.join.util]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.remove-replace :as lib.remove-replace]
    [metabase.lib.schema :as lib.schema]
@@ -30,8 +30,8 @@
        (let [[_field _opts id-or-name] a-ref]
          (if (integer? id-or-name)
            (= id-or-name (:id column))
-           (and (if-let [join-alias (lib.join/current-join-alias a-ref)]
-                  (= join-alias (lib.join/current-join-alias column))
+           (and (if-let [join-alias (lib.join.util/current-join-alias a-ref)]
+                  (= join-alias (lib.join.util/current-join-alias column))
                   true)
                 (= id-or-name (:lib/source-column-alias column)))))))
 


### PR DESCRIPTION
The build is failing on master due to `:cause "No such var: lib.join/current-join-alias"`
This breaking change was introduced in #33574.

Searching for `current-join-alias` shows that all other references use a different namespace. Namely, `lib.join.util`.
This PR uses that namespace instead.

Addendum:
The function was moved in #32698. Both PRs have been opened, and have had CI green before the merge, but got out of sync. A merge queue would've prevented this.