### PR TITLE
Don't delete a connection impersonation policy when non-data perms are updated

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/connection_impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/connection_impersonation.clj
@@ -47,7 +47,7 @@
 (defn- delete-impersonations-for-group-database! [{:keys [group-id database-id]} changes]
   (log/debugf "Deleting unneeded Connection Impersonations for Group %d for Database %d. Graph changes: %s"
               group-id database-id (pr-str changes))
-  (when (not= :impersonated changes)
+  (when (and changes (not= :impersonated changes))
     (log/debugf "Group %d %s for Database %d, deleting all Connection Impersonations for this DB"
                 group-id
                 (case changes

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/permissions/delete_sandboxes.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/permissions/delete_sandboxes.clj
@@ -108,9 +108,10 @@
 (defn- delete-gtaps-for-group! [{:keys [group-id]} changes]
   (log/debugf "Deleting unneeded GTAPs for Group %d. Graph changes: %s" group-id (pr-str changes))
   (doseq [database-id (set (keys changes))]
-    (delete-gtaps-for-group-database!
-     {:group-id group-id, :database-id database-id}
-     (get-in changes [database-id :data :schemas]))))
+    (when-let [data-perm-changes (get-in changes [database-id :data :schemas])]
+      (delete-gtaps-for-group-database!
+       {:group-id group-id, :database-id database-id}
+       data-perm-changes))))
 
 (defenterprise delete-gtaps-if-needed-after-permissions-change!
   "For use only inside `metabase.models.permissions`; don't call this elsewhere. Delete GTAPs (sandboxes) that are no

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/impersonation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/impersonation_test.clj
@@ -98,3 +98,30 @@
                                                                  :attribute "Attribute Name"}]
           (mt/user-http-request :crowberto :get 402 "ee/advanced-permissions/impersonation")
           (is (= impersonation (t2/select-one :model/ConnectionImpersonation :id impersonation-id))))))))
+
+(deftest delete-impersonation-policy-after-permissions-change-test
+  (testing "A connection impersonation policy is deleted automatically if the data permissions are changed"
+    (t2.with-temp/with-temp [PermissionsGroup               {group-id :id} {}
+                             :model/ConnectionImpersonation {impersonation-id :id}
+                                                            {:group_id group-id
+                                                             :db_id    (mt/id)
+                                                             :attribute "Attribute Name"}]
+      ;; Grant full data access to the DB and group
+      (let [graph (assoc-in (perms/data-perms-graph)
+                            [:groups group-id (mt/id) :data :schemas]
+                            :all)]
+        (mt/user-http-request :crowberto :put 200 "permissions/graph" graph))
+      (is (nil? (t2/select-one :model/ConnectionImpersonation :id impersonation-id)))))
+
+  (testing "A connection impersonation policy is not deleted if unrelated permissions are changed"
+    (t2.with-temp/with-temp [PermissionsGroup               {group-id :id} {}
+                             :model/ConnectionImpersonation {impersonation-id :id}
+                                                            {:group_id group-id
+                                                             :db_id    (mt/id)
+                                                             :attribute "Attribute Name"}]
+      ;; Grant full database editing permissions
+      (let [graph (assoc-in (perms/data-perms-graph)
+                            [:groups group-id (mt/id) :details]
+                            :yes)]
+        (mt/user-http-request :crowberto :put 200 "permissions/graph" graph))
+      (is (not (nil? (t2/select-one :model/ConnectionImpersonation :id impersonation-id)))))))


### PR DESCRIPTION
We delete connection impersonation policies automatically if the data perms for a database in the graph are modified from `impersonated` to any other value. However, this was also being triggered when non-data perms, like data model or db detail perms are modified. I've fixed this check and made a similar fix in the GTAP code that this was derived from (though that wasn't broken due to another piece of logic that saved it) and added a test.

resolves https://github.com/metabase/metabase/issues/33754 (description is a different issue but it's the same root cause)