### PR TITLE
Remove unused "No changes to permissions will be made." confirmation in PermissionsEditBar

### DIFF
--- a/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsEditBar.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsEditBar.jsx
@@ -11,18 +11,11 @@ import PermissionsConfirm from "../PermissionsConfirm";
 const propTypes = {
   onSave: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
-  shouldConfirmCancel: PropTypes.bool,
   isDirty: PropTypes.bool.isRequired,
   diff: PropTypes.object,
 };
 
-export function PermissionsEditBar({
-  diff,
-  isDirty,
-  shouldConfirmCancel,
-  onSave,
-  onCancel,
-}) {
+export function PermissionsEditBar({ diff, isDirty, onSave, onCancel }) {
   const saveButton = (
     <Confirm
       title={t`Save permissions?`}
@@ -35,16 +28,7 @@ export function PermissionsEditBar({
     </Confirm>
   );
 
-  const cancelButton = shouldConfirmCancel ? (
-    <Confirm
-      title={t`Discard changes?`}
-      action={onCancel}
-      content={t`No changes to permissions will be made.`}
-      key="discard"
-    >
-      <Button small>{t`Cancel`}</Button>
-    </Confirm>
-  ) : (
+  const cancelButton = (
     <Button small onClick={onCancel} key="cancel">{t`Cancel`}</Button>
   );
 

--- a/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsEditBar.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsEditBar.jsx
@@ -9,13 +9,13 @@ import Button from "metabase/core/components/Button";
 import PermissionsConfirm from "../PermissionsConfirm";
 
 const propTypes = {
-  onSave: PropTypes.func.isRequired,
-  onCancel: PropTypes.func.isRequired,
-  isDirty: PropTypes.bool.isRequired,
   diff: PropTypes.object,
+  isDirty: PropTypes.bool.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
 };
 
-export function PermissionsEditBar({ diff, isDirty, onSave, onCancel }) {
+export function PermissionsEditBar({ diff, isDirty, onCancel, onSave }) {
   const saveButton = (
     <Confirm
       title={t`Save permissions?`}


### PR DESCRIPTION
Closes #33783

### Description

- Remove unused code
- Make props and propTypes have the same order

It will be backported since it's refactoring (to reduce change of conflicts).

### How to verify

There should be no difference in behavior.
