### PR TITLE
Fix e2e skipped test naming 2

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -391,7 +391,6 @@ jobs:
         java-version: [11]
         edition: [ee]
         folder:
-          - "auditing"
           - "actions"
           - "admin"
           - "admin-2"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -381,12 +381,13 @@ jobs:
       needs.files-changed.outputs.e2e_all == 'false' &&
       needs.build.result == 'skipped' &&
       needs.download_uberjar.result == 'skipped'
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 5
     name: e2e-tests-${{ matrix.folder }}${{ matrix.context }}-${{ matrix.edition }}
     strategy:
       fail-fast: false
       matrix:
+        runner: [ubuntu-22.04]
         java-version: [11]
         edition: [ee]
         folder:
@@ -414,9 +415,11 @@ jobs:
           - "visualizations"
         include:
           - edition: oss
+            runner: ubuntu-22.04
             java-version: 11
             context: oss-subset
           - edition: ee
+            runner: ubuntu-latest
             java-version: 11
             context: slow
 


### PR DESCRIPTION
The original attempt was https://github.com/metabase/metabase/pull/33777.

As revealed in #33799, the issue hasn't been fully fixed.
Take a look at this run: https://github.com/metabase/metabase/actions/runs/6110515399

The skipped test names are now in this format: `e2e-tests-collectionsslow-ee`
Let's see how do we create a name:
```yml
name: e2e-tests-${{ matrix.folder }}${{ matrix.context }}-${{ matrix.edition }}
```
So it's obvious that both `folder` and `context` are included, when in reality we need only one of the two.

The flaw in the logic was trying to remove the runner from the matrix. At least ONE matrix parameter needs to be different in the `slow` context. We achieve this by setting the runner to `ubuntu-latest` instead of `ubuntu-22.04`. This should now finally fix the names.