### PR TITLE
Cache frequently used slow functions at the top level

### DIFF
--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -112,11 +112,17 @@
   [a-query]
   (lib.core/drop-stage a-query))
 
-(defn ^:export orderable-columns
+(defn orderable-columns*
   "Return a sequence of Column metadatas about the columns you can add order bys for in a given stage of `a-query.` To
   add an order by, pass the result to [[order-by]]."
   [a-query stage-number]
   (to-array (lib.core/orderable-columns a-query stage-number)))
+
+(def ^{:export true
+       :arglists '([query stage-number])}
+  orderable-columns
+  "The cached version of [[orderable-columns*]]."
+  (memoize/lru orderable-columns* :lru/threshold 4))
 
 (defn display-info*
   "Given an opaque Cljs object, return a plain JS object with info you'd need to implement UI for it.

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -17,8 +17,8 @@
    [metabase.mbql.js :as mbql.js]
    [metabase.mbql.normalize :as mbql.normalize]
    [metabase.util :as u]
-   [metabase.util.memoize :as memoize]
-   [metabase.util.log :as log]))
+   [metabase.util.log :as log]
+   [metabase.util.memoize :as memoize]))
 
 ;;; this is mostly to ensure all the relevant namespaces with multimethods impls get loaded.
 (comment lib.core/keep-me)


### PR DESCRIPTION
Part of #33676.

The reason for caching top level MLv2 functions is partly in order to make it obvious if the cache is working even with advanced CLJS compilation.

This is not a backport, because on `master` another optimizations are better.