### PR TITLE
Add custom warning message when leaving editing dashboard with unsaved changes

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -897,6 +897,32 @@ describe("scenarios > dashboard", () => {
       cy.findByText("There was a problem displaying this chart.");
     });
   });
+
+  it("warns about leaving with unsaved changes", () => {
+    cy.visit("/collection/root");
+    cy.findByTestId("collection-table")
+      .findByText("Orders in a dashboard")
+      .click();
+    visitDashboard(ORDERS_DASHBOARD_ID);
+    editDashboard();
+    cy.icon("filter").click();
+    popover().findByText("ID").click();
+
+    modal().should("not.exist");
+
+    cy.go("back");
+    // cy.realPress(["Alt", "ArrowLeft"]);
+    // cy.visit("/");
+
+    modal()
+      .should("exist")
+      .within(() => {
+        cy.findByText("Changes were not saved");
+        cy.findByText(
+          "Navigating away from here will cause you to lose any changes you have made.",
+        );
+      });
+  });
 });
 
 describeWithSnowplow("scenarios > dashboard", () => {

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -897,32 +897,6 @@ describe("scenarios > dashboard", () => {
       cy.findByText("There was a problem displaying this chart.");
     });
   });
-
-  it("warns about leaving with unsaved changes", () => {
-    cy.visit("/collection/root");
-    cy.findByTestId("collection-table")
-      .findByText("Orders in a dashboard")
-      .click();
-    visitDashboard(ORDERS_DASHBOARD_ID);
-    editDashboard();
-    cy.icon("filter").click();
-    popover().findByText("ID").click();
-
-    modal().should("not.exist");
-
-    cy.go("back");
-    // cy.realPress(["Alt", "ArrowLeft"]);
-    // cy.visit("/");
-
-    modal()
-      .should("exist")
-      .within(() => {
-        cy.findByText("Changes were not saved");
-        cy.findByText(
-          "Navigating away from here will cause you to lose any changes you have made.",
-        );
-      });
-  });
 });
 
 describeWithSnowplow("scenarios > dashboard", () => {

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.jsx
@@ -5,8 +5,8 @@ import { push } from "react-router-redux";
 import _ from "underscore";
 import { useUnmount } from "react-use";
 import { t } from "ttag";
-import useBeforeUnload from "metabase/hooks/use-before-unload";
 
+import { LeaveConfirmationModal } from "metabase/components/LeaveConfirmationModal";
 import title from "metabase/hoc/Title";
 import favicon from "metabase/hoc/Favicon";
 import titleWithLoadingTime from "metabase/hoc/TitleWithLoadingTime";
@@ -119,7 +119,8 @@ const mapDispatchToProps = {
 
 // NOTE: should use DashboardControls and DashboardData HoCs here?
 const DashboardApp = props => {
-  const { dashboard, isRunning, isLoadingComplete, isEditing, isDirty } = props;
+  const { dashboard, isRunning, isLoadingComplete, isEditing, isDirty, route } =
+    props;
 
   const options = parseHashOptions(window.location.hash);
   const editingOnLoad = options.edit;
@@ -135,7 +136,6 @@ const DashboardApp = props => {
   });
 
   const slowToastId = useUniqueId();
-  useBeforeUnload(isEditing && isDirty);
 
   useEffect(() => {
     if (isLoadingComplete) {
@@ -188,6 +188,8 @@ const DashboardApp = props => {
 
   return (
     <div className="shrink-below-content-size full-height">
+      <LeaveConfirmationModal isEnabled={isEditing && isDirty} route={route} />
+
       <Dashboard
         dashboardId={getDashboardId(props)}
         editingOnLoad={editingOnLoad}
@@ -230,6 +232,7 @@ DashboardApp.propTypes = {
   related: PropTypes.arrayOf(PropTypes.object),
   hasSidebar: PropTypes.bool,
   children: PropTypes.node,
+  route: PropTypes.object,
 };
 
 export default _.compose(

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
@@ -147,6 +147,28 @@ describe("DashboardApp", function () {
       expect(mockEvent.returnValue).toBe(undefined);
     });
 
+    it("does not show custom warning modal when leaving with no changes via SPA navigation", async () => {
+      const { dashboardId, history } = await setup();
+
+      checkNotNull(history).push("/");
+      checkNotNull(history).push(`/dashboard/${dashboardId}`);
+
+      await waitForElementToBeRemoved(() =>
+        screen.queryAllByTestId("loading-spinner"),
+      );
+
+      checkNotNull(history).goBack();
+
+      expect(
+        screen.queryByText("Changes were not saved"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          "Navigating away from here will cause you to lose any changes you have made.",
+        ),
+      ).not.toBeInTheDocument();
+    });
+
     it("shows custom warning modal when leaving with unsaved changes via SPA navigation", async () => {
       const { dashboardId, history } = await setup();
 

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
@@ -154,14 +154,14 @@ describe("DashboardApp", function () {
     it("does not show custom warning modal when leaving with no changes via SPA navigation", async () => {
       const { dashboardId, history } = await setup();
 
-      checkNotNull(history).push("/");
-      checkNotNull(history).push(`/dashboard/${dashboardId}`);
+      history.push("/");
+      history.push(`/dashboard/${dashboardId}`);
 
       await waitForElementToBeRemoved(() =>
         screen.queryAllByTestId("loading-spinner"),
       );
 
-      checkNotNull(history).goBack();
+      history.goBack();
 
       expect(
         screen.queryByText("Changes were not saved"),

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
@@ -109,7 +109,11 @@ async function setup({ dashboard }: Options = {}) {
     screen.queryAllByTestId("loading-spinner"),
   );
 
-  return { dashboardId, history, mockEventListener };
+  return {
+    dashboardId,
+    history: checkNotNull(history),
+    mockEventListener,
+  };
 }
 
 describe("DashboardApp", function () {
@@ -172,8 +176,8 @@ describe("DashboardApp", function () {
     it("shows custom warning modal when leaving with unsaved changes via SPA navigation", async () => {
       const { dashboardId, history } = await setup();
 
-      checkNotNull(history).push("/");
-      checkNotNull(history).push(`/dashboard/${dashboardId}`);
+      history.push("/");
+      history.push(`/dashboard/${dashboardId}`);
 
       await waitForElementToBeRemoved(() =>
         screen.queryAllByTestId("loading-spinner"),
@@ -184,7 +188,7 @@ describe("DashboardApp", function () {
       userEvent.type(screen.getByTestId("dashboard-name-heading"), "a");
       userEvent.tab(); // need to click away from the input to trigger the isDirty flag
 
-      checkNotNull(history).goBack();
+      history.goBack();
 
       expect(screen.getByText("Changes were not saved")).toBeInTheDocument();
       expect(


### PR DESCRIPTION
Closes #33790

### How to verify

#### Custom warning modal is shown when leaving with unsaved changes

1. Create a new dashboard and save it
2. Edit the dashboard
3. Make a change in the dashboard (e.g. add an ID filter)
4. Click the back button in your browser

Expected result: custom warning modal **is shown**. URL stays the same.

#### Custom warning modal is not shown when leaving with no changes

1. Create a new dashboard and save it
2. Edit the dashboard
3. Click the back button in your browser

Expected result: custom warning modal **is not shown**. URL changes.

### Demo

https://github.com/metabase/metabase/assets/6830683/dcff2f12-a0da-4277-91d9-25f68b5976cc

