### PR TITLE
Optimize Mlv2 compatibility on the FE

### DIFF
--- a/frontend/src/metabase-lib/Dimension.ts
+++ b/frontend/src/metabase-lib/Dimension.ts
@@ -540,23 +540,23 @@ export default class Dimension {
     return this;
   }
 
-  /**
-   * Return a copy of this Dimension with any temporal unit options removed.
-   */
-  withoutTemporalBucketing(): Dimension {
+  // memoize to avoid performance issues (metabase#33676)
+
+  baseDimension = _.once(() =>
+    this.withoutOptions(...BASE_DIMENSION_REFERENCE_OMIT_OPTIONS),
+  );
+
+  withoutTemporalBucketing = _.once(() => {
     return this.withoutOptions("temporal-unit");
-  }
+  });
 
-  withoutJoinAlias(): Dimension {
+  withoutJoinAlias = _.once(() => {
     return this.withoutOptions("join-alias");
-  }
+  });
 
-  /**
-   * Return a copy of this Dimension with any temporal bucketing or binning options removed.
-   */
-  baseDimension(): Dimension {
-    return this.withoutOptions(...BASE_DIMENSION_REFERENCE_OMIT_OPTIONS);
-  }
+  withoutBinning = _.once(() => {
+    return this.withoutOptions("binning");
+  });
 
   isValidFKRemappingTarget() {
     return !(
@@ -859,11 +859,12 @@ export class FieldDimension extends Dimension {
     return this._createFallbackField();
   }
 
-  getMLv1CompatibleDimension() {
+  // memoize to avoid performance issues (metabase#33676)
+  getMLv1CompatibleDimension = _.once(() => {
     return this.isIntegerFieldId()
       ? this.withoutOptions("base-type", "effective-type")
       : this;
-  }
+  });
 
   tableId() {
     return this.field()?.table?.id;
@@ -1311,9 +1312,10 @@ export class ExpressionDimension extends Dimension {
     });
   }
 
-  getMLv1CompatibleDimension() {
+  // memoize to avoid performance issues (metabase#33676)
+  getMLv1CompatibleDimension = _.once(() => {
     return this.withoutOptions("base-type", "effective-type");
-  }
+  });
 
   icon(): string {
     const field = this.field();
@@ -1489,9 +1491,10 @@ export class AggregationDimension extends Dimension {
     });
   }
 
-  getMLv1CompatibleDimension() {
+  // memoize to avoid performance issues (metabase#33676)
+  getMLv1CompatibleDimension = _.once(() => {
     return this.withoutOptions("base-type", "effective-type");
-  }
+  });
 
   /**
    * Raw aggregation

--- a/frontend/src/metabase-lib/queries/utils/pivot.js
+++ b/frontend/src/metabase-lib/queries/utils/pivot.js
@@ -27,5 +27,5 @@ function canonicalFieldRef(ref) {
   if (!dimension) {
     return ref;
   }
-  return dimension.withoutOptions("binning").mbql();
+  return dimension.withoutBinning().mbql();
 }


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/33676

Based on the profiler logs we spend a lot of time on creating Mlv1-compatible dimensions. This is a quick fix that memoizes dimension creation.

<img width="857" alt="Screenshot 2023-09-08 at 14 27 43" src="https://github.com/metabase/metabase/assets/8542534/7093b513-0033-4436-92e1-17222953d32d">

<img width="873" alt="Screenshot 2023-09-08 at 14 34 58" src="https://github.com/metabase/metabase/assets/8542534/beb8f773-803f-476d-96be-54a2787a193a">
