### PR TITLE
Fix parameter mappings on x-ray dashboards

### DIFF
--- a/src/metabase/automagic_dashboards/filters.clj
+++ b/src/metabase/automagic_dashboards/filters.clj
@@ -78,7 +78,7 @@
 
 (defn- build-fk-map
   [fks field]
-  (if (and (seq fks) (:id field))
+  (if (:id field)
     (->> fks
          (filter (comp #{(:table_id field)} :table_id :target))
          (group-by :table_id)


### PR DESCRIPTION
fixes #33821

when running an x-ray on tables, we were sending back the following parameter mappings:

BEFORE with bug:
```clojure
core=> (let [table (t2/select-one 'Table :id 1)]
         ;; products table
         (-> (automagic-analysis table {})
             :ordered_cards first
             (select-keys [:parameter_mappings :card])
             (update-in [:card] #(select-keys % [:dataset_query]))))
{:parameter_mappings ({:parameter_id "-1185138340",
                       :target [:dimension
                                [:field
                                 "CREATED_AT"  ;; <----- field reference by name
                                 {:base-type :type/DateTime}]],
                       :card_id G__246876}
                      {:parameter_id "241800831",
                       :target [:dimension
                                [:field
                                 "CATEGORY"    ;; <----- field reference by name
                                 {:base-type :type/Text}]],
                       :card_id G__246876}),
 :card {:dataset_query {:type :query,          ;; <----- mbql query
                        :database 1,
                        :query {:source-table 1,
                                :breakout ([:field
                                            64
                                            {:temporal-unit :quarter-of-year}]),
                                :aggregation (["count"])}}}}
```

After this change we have the following parameter mappings which use ids as field references:

```clojure
core=> (let [table (t2/select-one 'Table :id 1)]
              ;; products table
              (-> (automagic-analysis table {})
                  :ordered_cards first
                  (select-keys [:parameter_mappings :card])
                  (update-in [:card] #(select-keys % [:dataset_query]))))
{:parameter_mappings ({:parameter_id "-1185138340",
                       :target [:dimension [:field 64 nil]], ;; <-- by id
                       :card_id G__186662}
                      {:parameter_id "241800831",
                       :target [:dimension [:field 58 nil]], ;; <-- by id
                       :card_id G__186662}),
 :card {:dataset_query {:type :query,
                        :database 1,
                        :query {:source-table 1,
                                :breakout ([:field
                                            64
                                            {:temporal-unit :quarter-of-year}]),
                                :aggregation (["count"])}}}}
```

This change was introduced in our refactoring to support x-rays on models with commit message

* metabase.automagic-dashboards.filters - Fix to build-fk-map so that parameters show up on model x-rays

I'm not sure what the reasoning was but we can revisit it when we want to do some filters on models

and of course, now x-raying products and adding a product category filter works:
<img width="797" alt="image" src="https://github.com/metabase/metabase/assets/6377293/0032172e-c327-4484-9ccf-ebe49d5be7d0">
before this change those queries all showed errors
