### PR TITLE
Scope test selectors in models metadata tests

### DIFF
--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -12,6 +12,7 @@ import {
   setColumnType,
   mapColumnTo,
   setModelMetadata,
+  sidebar,
 } from "e2e/support/helpers";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
@@ -41,21 +42,18 @@ describe("scenarios > models metadata", () => {
     it("should edit GUI model metadata", () => {
       openQuestionActions();
 
-      popover().within(() => {
-        cy.findByTextEnsureVisible("89%").trigger("mouseenter");
+      popover().findByTextEnsureVisible("89%").trigger("mouseenter");
+
+      cy.findByTestId("tooltip-content").within(() => {
+        cy.findByText(
+          "Some columns are missing a column type, description, or friendly name.",
+        );
+        cy.findByText(
+          "Adding metadata makes it easier for your team to explore this data.",
+        );
       });
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText(
-        "Some columns are missing a column type, description, or friendly name.",
-      );
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText(
-        "Adding metadata makes it easier for your team to explore this data.",
-      );
-
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Edit metadata").click();
+      popover().findByText("Edit metadata").click();
 
       cy.url().should("include", "/metadata");
       cy.findByTextEnsureVisible("Product ID");
@@ -69,15 +67,13 @@ describe("scenarios > models metadata", () => {
       startQuestionFromModel("GUI Model");
 
       visualize();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Pre-tax ($)");
+      cy.findByTestId("TableInteractive-root").findByText("Pre-tax ($)");
     });
 
     it("allows for canceling changes", () => {
       openQuestionActions();
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Edit metadata").click();
+      popover().findByText("Edit metadata").click();
 
       openColumnOptions("Subtotal");
 
@@ -86,15 +82,13 @@ describe("scenarios > models metadata", () => {
 
       cy.button("Cancel").click();
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Subtotal");
+      cy.findByTestId("TableInteractive-root").findByText("Subtotal");
     });
 
     it("clears custom metadata when a model is turned back into a question", () => {
       openQuestionActions();
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Edit metadata").click();
+      popover().findByText("Edit metadata").click();
 
       openColumnOptions("Subtotal");
 
@@ -103,14 +97,10 @@ describe("scenarios > models metadata", () => {
       cy.button("Save changes").click();
 
       openQuestionActions();
-      popover().within(() => {
-        cy.findByText("Turn back to saved question").click();
-      });
+      popover().findByText("Turn back to saved question").click();
 
       cy.wait("@dataset");
-
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Subtotal");
+      cy.findByTestId("TableInteractive-root").findByText("Subtotal");
     });
   });
 
@@ -132,17 +122,16 @@ describe("scenarios > models metadata", () => {
       cy.findByTextEnsureVisible("37%").trigger("mouseenter");
     });
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(
-      "Most columns are missing a column type, description, or friendly name.",
-    );
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(
-      "Adding metadata makes it easier for your team to explore this data.",
-    );
+    cy.findByTestId("tooltip-content").within(() => {
+      cy.findByText(
+        "Most columns are missing a column type, description, or friendly name.",
+      );
+      cy.findByText(
+        "Adding metadata makes it easier for your team to explore this data.",
+      );
+    });
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Edit metadata").click();
+    popover().findByText("Edit metadata").click();
 
     cy.url().should("include", "/metadata");
     cy.findByTextEnsureVisible("PRODUCT_ID");
@@ -160,8 +149,7 @@ describe("scenarios > models metadata", () => {
     startQuestionFromModel("Native Model");
 
     visualize();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Pre-tax ($)");
+    cy.findByTestId("TableInteractive-root").findByText("Pre-tax ($)");
   });
 
   it("should allow setting column relations (metabase#29318)", () => {
@@ -176,15 +164,12 @@ describe("scenarios > models metadata", () => {
       { visitQuestion: true },
     );
     openQuestionActions();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Edit metadata").click();
+    popover().findByText("Edit metadata").click();
     openColumnOptions("USER_ID");
     setColumnType("No special type", "Foreign Key");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Select a target").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("People → ID").click();
-    cy.button("Save changes").click();
+    sidebar().findByText("Select a target").click();
+    popover().findByText("People → ID").click();
+    cy.findByTestId("dataset-edit-bar").button("Save changes").click();
     // TODO: Not much to do with it at the moment beyond saving it.
     // Check that the relation is automatically suggested in the notebook once it is implemented.
   });
@@ -243,8 +228,7 @@ describe("scenarios > models metadata", () => {
       .and("not.contain", "SUBTOTAL");
 
     openQuestionActions();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Edit metadata").click();
+    popover().findByText("Edit metadata").click();
 
     cy.findByTextEnsureVisible("TAX");
 
@@ -393,12 +377,13 @@ describe("scenarios > models metadata", () => {
 
       cy.createQuestion(questionDetails, { visitQuestion: true });
       openQuestionActions();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Vendor").should("not.exist");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Edit metadata").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Vendor").should("be.visible");
+      cy.findByTestId("TableInteractive-root")
+        .findByText("Vendor")
+        .should("not.exist");
+      popover().findByText("Edit metadata").click();
+      cy.findByTestId("TableInteractive-root")
+        .findByText("Vendor")
+        .should("be.visible");
     });
   });
 });

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
@@ -34,7 +34,7 @@ function getTooltipMessage(percentage: number) {
     percentage <= 0.5 ? t`Most` : percentage >= 0.8 ? t`Some` : t`Many`;
 
   return (
-    <TooltipContent>
+    <TooltipContent data-testid="tooltip-content">
       <TooltipParagraph>
         {t`${columnCountDescription} columns are missing a column type, description, or friendly name.`}
       </TooltipParagraph>


### PR DESCRIPTION
### Description

The models Metadata tests have gotten themselves on the naughty list:

![Screen Shot 2023-09-08 at 2 15 50 PM](https://github.com/metabase/metabase/assets/30528226/3ad7de4f-0e93-461b-a7fb-ccf67be5d518)
![Screen Shot 2023-09-08 at 2 32 47 PM](https://github.com/metabase/metabase/assets/30528226/b54942a9-9d7c-4670-a25b-d4ad7a0198fd)
![Screen Shot 2023-09-08 at 2 32 40 PM](https://github.com/metabase/metabase/assets/30528226/726e4ce0-0c93-4e05-91d8-d064a3ec28b3)

I think this is mostly because they don't use properly scoped text selectors, causing elements to be looked for before their correct parent elements are fully rendered.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
