### PR TITLE
Add metadata reload on question to model conversion

### DIFF
--- a/e2e/test/scenarios/question/reproductions/28599-model-conversion-time-footer.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/28599-model-conversion-time-footer.cy.spec.js
@@ -1,0 +1,54 @@
+import {
+  modal,
+  openQuestionActions,
+  popover,
+  restore,
+} from "e2e/support/helpers";
+import { ORDERS, ORDERS_ID } from "metabase-types/api/mocks/presets";
+
+describe("issue 28599", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+
+    cy.createQuestion(
+      {
+        name: "28599",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            [
+              "field",
+              ORDERS.CREATED_AT,
+              {
+                "base-type": "type/DateTime",
+                "temporal-unit": "year",
+              },
+            ],
+          ],
+        },
+      },
+      { visitQuestion: true },
+    );
+
+    cy.intercept("PUT", `/api/card/*`).as("updateCard");
+  });
+
+  it("should not show time granularity footer after question conversion to a model (metabase#28599)", () => {
+    cy.findByTestId("timeseries-mode-bar").within(() => {
+      cy.findByText(`View`).should("be.visible");
+      cy.findByText(`All Time`).should("be.visible");
+      cy.findByText(`by`).should("be.visible");
+      cy.findByText(`Year`).should("be.visible");
+    });
+
+    openQuestionActions();
+    popover().findByText("Turn into a model").click();
+    modal().findByText("Turn this into a model").click();
+
+    cy.wait("@updateCard");
+
+    cy.findByTestId("timeseries-mode-bar").should("not.exist");
+  });
+});

--- a/frontend/src/metabase/query_builder/actions/models.js
+++ b/frontend/src/metabase/query_builder/actions/models.js
@@ -12,7 +12,7 @@ import { isSameField } from "metabase-lib/queries/utils/field-ref";
 import { getOriginalCard, getQuestion, getResultsMetadata } from "../selectors";
 
 import { apiUpdateQuestion, updateQuestion, API_UPDATE_QUESTION } from "./core";
-import { runDirtyQuestionQuery } from "./querying";
+import { runDirtyQuestionQuery, runQuestionQuery } from "./querying";
 import { setQueryBuilderMode } from "./ui";
 
 export const setDatasetEditorTab = datasetEditorTab => dispatch => {
@@ -51,7 +51,13 @@ export const turnQuestionIntoDataset = () => async (dispatch, getState) => {
 
   await dispatch(loadMetadataForQueries([], [dataset.dependentMetadata()]));
 
-  dispatch({ type: API_UPDATE_QUESTION, payload: dataset.card() });
+  await dispatch({ type: API_UPDATE_QUESTION, payload: dataset.card() });
+
+  await dispatch(
+    runQuestionQuery({
+      shouldUpdateUrl: true,
+    }),
+  );
 
   dispatch(
     addUndo({


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/28599

### Description

This adds model metadata reload to recalculate the state and trigger proper drills mode.
In proper drills mode we don't show extra footer that causes reported bug.

### Demo

https://github.com/metabase/metabase/assets/7983744/1e04db7a-edd5-4280-a188-ec415ad2d545

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
