### PR TITLE
[Manual backport] Fix 47 performance issues on the FE

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -20,7 +20,7 @@ import Table from "metabase-lib/metadata/Table";
 import Field from "metabase-lib/metadata/Field";
 import { AggregationDimension, FieldDimension } from "metabase-lib/Dimension";
 import { isFK } from "metabase-lib/types/utils/isa";
-import { memoizeClass, sortObject } from "metabase-lib/utils";
+import { sortObject } from "metabase-lib/utils";
 
 import type {
   Card as CardObject,
@@ -94,7 +94,7 @@ export type QuestionCreatorOpts = {
  * This is a wrapper around a question/card object, which may contain one or more Query objects
  */
 
-class QuestionInner {
+class Question {
   /**
    * The plain object presentation of this question, equal to the format that Metabase REST API understands.
    * It is called `card` for both historical reasons and to make a clear distinction to this class.
@@ -117,7 +117,7 @@ class QuestionInner {
    * Question constructor
    */
   constructor(
-    card: CardObject,
+    card: any,
     metadata?: Metadata,
     parameterValues?: ParameterValues,
   ) {
@@ -189,7 +189,7 @@ class QuestionInner {
    *
    * This is just a wrapper object, the data is stored in `this._card.dataset_query` in a format specific to the query type.
    */
-  query(): AtomicQuery {
+  query = _.once((): AtomicQuery => {
     const datasetQuery = this._card.dataset_query;
 
     for (const QueryClass of [StructuredQuery, NativeQuery, InternalQuery]) {
@@ -202,7 +202,7 @@ class QuestionInner {
     // `dataset_query` is null for questions on a dashboard the user don't have access to
     !isVirtualDashcard &&
       console.warn("Unknown query type: " + datasetQuery?.type);
-  }
+  });
 
   isNative(): boolean {
     return this.query() instanceof NativeQuery;
@@ -1236,12 +1236,7 @@ class QuestionInner {
   getModerationReviews() {
     return getIn(this, ["_card", "moderation_reviews"]) || [];
   }
-}
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default class Question extends memoizeClass<QuestionInner>("query")(
-  QuestionInner,
-) {
   /**
    * TODO Atte Keinänen 6/13/17: Discussed with Tom that we could use the default Question constructor instead,
    * but it would require changing the constructor signature so that `card` is an optional parameter and has a default value
@@ -1285,3 +1280,6 @@ export default class Question extends memoizeClass<QuestionInner>("query")(
     return new Question(card, metadata, parameterValues);
   }
 }
+
+// eslint-disable-next-line import/no-default-export -- deprecated usage
+export default Question;

--- a/frontend/src/metabase-lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/metadata/Field.ts
@@ -351,16 +351,16 @@ class FieldInner extends Base {
     return getFilterOperators(this, this.table, selected);
   }
 
-  filterOperatorsLookup() {
+  filterOperatorsLookup = _.once(() => {
     return createLookupByProperty(this.filterOperators(), "name");
-  }
+  });
 
   filterOperator(operatorName) {
     return this.filterOperatorsLookup()[operatorName];
   }
 
   // AGGREGATIONS
-  aggregationOperators() {
+  aggregationOperators = _.once(() => {
     return this.table
       ? this.table
           .aggregationOperators()
@@ -370,11 +370,11 @@ class FieldInner extends Base {
               aggregation.validFieldsFilters[0]([this]).length === 1,
           )
       : null;
-  }
+  });
 
-  aggregationOperatorsLookup() {
+  aggregationOperatorsLookup = _.once(() => {
     return createLookupByProperty(this.aggregationOperators(), "short");
-  }
+  });
 
   aggregationOperator(short) {
     return this.aggregationOperatorsLookup()[short];
@@ -591,9 +591,6 @@ class FieldInner extends Base {
 }
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
-export default class Field extends memoizeClass<FieldInner>(
-  "filterOperators",
-  "filterOperatorsLookup",
-  "aggregationOperators",
-  "aggregationOperatorsLookup",
-)(FieldInner) {}
+export default class Field extends memoizeClass<FieldInner>("filterOperators")(
+  FieldInner,
+) {}

--- a/frontend/src/metabase-lib/queries/Query.ts
+++ b/frontend/src/metabase-lib/queries/Query.ts
@@ -1,17 +1,17 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
+import _ from "underscore";
 import type { DependentMetadataItem, DatasetQuery } from "metabase-types/api";
 import Metadata from "metabase-lib/metadata/Metadata";
 import Question from "metabase-lib/Question";
 import Dimension from "metabase-lib/Dimension";
 import Variable from "metabase-lib/variables/Variable";
-import { memoizeClass } from "metabase-lib/utils";
 import DimensionOptions from "metabase-lib/DimensionOptions";
 
 /**
  * An abstract class for all query types (StructuredQuery & NativeQuery)
  */
-class QueryInner {
+class Query {
   _metadata: Metadata;
 
   /**
@@ -31,9 +31,9 @@ class QueryInner {
    * Returns a question updated with the current dataset query.
    * Can only be applied to query that is a direct child of the question.
    */
-  question(): Question {
+  question = _.once((): Question => {
     return this._originalQuestion.setQuery(this);
-  }
+  });
 
   /**
    * Returns a "clean" version of this query with invalid parts removed
@@ -63,7 +63,7 @@ class QueryInner {
     return this._datasetQuery;
   }
 
-  setDatasetQuery(datasetQuery: DatasetQuery): QueryInner {
+  setDatasetQuery(datasetQuery: DatasetQuery): Query {
     return this;
   }
 
@@ -113,7 +113,7 @@ class QueryInner {
     return [];
   }
 
-  setDefaultQuery(): QueryInner {
+  setDefaultQuery(): Query {
     return this;
   }
 
@@ -123,6 +123,4 @@ class QueryInner {
 }
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
-export default class Query extends memoizeClass<QueryInner>("question")(
-  QueryInner,
-) {}
+export default Query;

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -38,7 +38,7 @@ import { fieldRefForColumn } from "metabase-lib/queries/utils/dataset";
 import { isSegment } from "metabase-lib/queries/utils/filter";
 import { getUniqueExpressionName } from "metabase-lib/queries/utils/expression";
 import * as Q from "metabase-lib/queries/utils/query";
-import { createLookupByProperty, memoizeClass } from "metabase-lib/utils";
+import { createLookupByProperty } from "metabase-lib/utils";
 import Dimension, {
   FieldDimension,
   ExpressionDimension,
@@ -107,7 +107,7 @@ function unwrapJoin(join: Join | JoinWrapper): Join {
  * A wrapper around an MBQL (`query` type @type {DatasetQuery}) object
  */
 
-class StructuredQueryInner extends AtomicQuery {
+class StructuredQuery extends AtomicQuery {
   static isDatasetQueryType(datasetQuery: DatasetQuery) {
     return datasetQuery?.type === STRUCTURED_QUERY_TEMPLATE.type;
   }
@@ -356,9 +356,9 @@ class StructuredQueryInner extends AtomicQuery {
   /**
    * @returns the table object, if a table is selected and loaded.
    */
-  table(): Table | null {
+  table = _.once((): Table | null => {
     return getStructuredQueryTable(this);
-  }
+  });
 
   /**
    * Removes invalid clauses from the query (and source-query, recursively)
@@ -595,11 +595,11 @@ class StructuredQueryInner extends AtomicQuery {
   /**
    * @returns an array of MBQL @type {Join}s.
    */
-  joins(): JoinWrapper[] {
+  joins = _.once((): JoinWrapper[] => {
     return Q.getJoins(this.query()).map(
       (join, index) => new JoinWrapper(join, index, this),
     );
-  }
+  });
 
   addJoin(join) {
     return this._updateQuery(Q.addJoin, [unwrapJoin(join)]);
@@ -622,16 +622,16 @@ class StructuredQueryInner extends AtomicQuery {
   /**
    * @returns an array of MBQL @type {Aggregation}s.
    */
-  aggregations(): AggregationWrapper[] {
+  aggregations = _.once((): AggregationWrapper[] => {
     return Q.getAggregations(this.query()).map(
       (aggregation, index) => new AggregationWrapper(aggregation, index, this),
     );
-  }
+  });
 
   /**
    * @returns an array of aggregation options for the currently selected table
    */
-  aggregationOperators(): AggregationOperator[] {
+  aggregationOperators = _.once((): AggregationOperator[] => {
     const table = this.table();
 
     if (table) {
@@ -644,11 +644,13 @@ class StructuredQueryInner extends AtomicQuery {
     }
 
     return [];
-  }
+  });
 
-  aggregationOperatorsLookup(): Record<string, AggregationOperator> {
-    return createLookupByProperty(this.aggregationOperators(), "short");
-  }
+  aggregationOperatorsLookup = _.once(
+    (): Record<string, AggregationOperator> => {
+      return createLookupByProperty(this.aggregationOperators(), "short");
+    },
+  );
 
   aggregationOperator(short: string): AggregationOperator {
     return this.aggregationOperatorsLookup()[short];
@@ -767,7 +769,7 @@ class StructuredQueryInner extends AtomicQuery {
   /**
    * @returns An array of MBQL @type {Breakout}s.
    */
-  breakouts(): BreakoutWrapper[] {
+  breakouts = _.once((): BreakoutWrapper[] => {
     if (this.query() == null) {
       return [];
     }
@@ -775,7 +777,7 @@ class StructuredQueryInner extends AtomicQuery {
     return Q.getBreakouts(this.query()).map(
       (breakout, index) => new BreakoutWrapper(breakout, index, this),
     );
-  }
+  });
 
   /**
    * @param includedBreakout The breakout to include in the options even if it's already used. If true, include all options.
@@ -858,11 +860,11 @@ class StructuredQueryInner extends AtomicQuery {
   /**
    * @returns An array of MBQL @type {Filter}s.
    */
-  filters(): FilterWrapper[] {
+  filters = _.once((): FilterWrapper[] => {
     return Q.getFilters(this.query()).map(
       (filter, index) => new FilterWrapper(filter, index, this),
     );
-  }
+  });
 
   /**
    * @returns An array of MBQL @type {Filter}s from the last two query stages
@@ -968,11 +970,11 @@ class StructuredQueryInner extends AtomicQuery {
   /**
    *  @returns @type {Segment}s that are currently applied to the question
    */
-  segments() {
+  segments = _.once(() => {
     return this.filters()
       .filter(filter => filter.isSegment())
       .map(filter => filter.segment());
-  }
+  });
 
   /**
    * @returns whether a new filter can be added or not
@@ -1024,9 +1026,9 @@ class StructuredQueryInner extends AtomicQuery {
   /**
    * @deprecated use the orderBys function from metabase-lib v2
    */
-  sorts(): OrderBy[] {
+  sorts = _.once((): OrderBy[] => {
     return Q.getOrderBys(this.query());
-  }
+  });
 
   /**
    * @deprecated use the orderBy function from metabase-lib v2
@@ -1075,9 +1077,9 @@ class StructuredQueryInner extends AtomicQuery {
   }
 
   // EXPRESSIONS
-  expressions(): ExpressionClause {
+  expressions = _.once((): ExpressionClause => {
     return Q.getExpressions(this.query());
-  }
+  });
 
   addExpression(name, expression) {
     const uniqueName = getUniqueExpressionName(this.expressions(), name);
@@ -1365,16 +1367,16 @@ class StructuredQueryInner extends AtomicQuery {
     return [...this.expressionDimensions(), ...this.tableDimensions()];
   }
 
-  tableDimensions(): Dimension[] {
+  tableDimensions = _.once((): Dimension[] => {
     const table: Table = this.table();
     return table // HACK: ensure the dimensions are associated with this query
       ? table
           .dimensions()
           .map(d => (d._query ? d : this.parseFieldReference(d.mbql())))
       : [];
-  }
+  });
 
-  expressionDimensions(): Dimension[] {
+  expressionDimensions = _.once((): Dimension[] => {
     return Object.entries(this.expressions()).map(
       ([expressionName, expression]) => {
         return new ExpressionDimension(
@@ -1385,31 +1387,31 @@ class StructuredQueryInner extends AtomicQuery {
         );
       },
     );
-  }
+  });
 
-  joinedDimensions(): Dimension[] {
+  joinedDimensions = _.once((): Dimension[] => {
     return [].concat(...this.joins().map(join => join.fieldsDimensions()));
-  }
+  });
 
-  breakoutDimensions() {
+  breakoutDimensions = _.once(() => {
     return this.breakouts().map(breakout => this.parseFieldReference(breakout));
-  }
+  });
 
-  aggregationDimensions() {
+  aggregationDimensions = _.once(() => {
     return this.aggregations().map(aggregation =>
       aggregation.aggregationDimension(),
     );
-  }
+  });
 
-  fieldDimensions() {
+  fieldDimensions = _.once(() => {
     return this.fields().map((fieldClause, index) =>
       this.parseFieldReference(fieldClause),
     );
-  }
+  });
 
   // TODO: this replicates logic in the backend, we should have integration tests to ensure they match
   // NOTE: these will not have the correct columnName() if there are duplicates
-  columnDimensions(): Dimension[] {
+  columnDimensions = _.once((): Dimension[] => {
     if (this.hasAggregations() || this.hasBreakouts()) {
       const aggregations = this.aggregationDimensions();
       const breakouts = this.breakoutDimensions();
@@ -1443,10 +1445,10 @@ class StructuredQueryInner extends AtomicQuery {
 
       return [...sorted, ...expressions, ...joined];
     }
-  }
+  });
 
   // TODO: this replicates logic in the backend, we should have integration tests to ensure they match
-  columnNames() {
+  columnNames = _.once(() => {
     // NOTE: dimension.columnName() doesn't include suffixes for duplicated column names so we need to do that here
     const nameCounts = new Map();
     return this.columnDimensions().map(dimension => {
@@ -1461,15 +1463,15 @@ class StructuredQueryInner extends AtomicQuery {
         return name;
       }
     });
-  }
+  });
 
-  columns() {
+  columns = _.once(() => {
     const names = this.columnNames();
     return this.columnDimensions().map((dimension, index) => ({
       ...dimension.column(),
       name: names[index],
     }));
-  }
+  });
 
   columnDimensionWithName(columnName) {
     const index = this.columnNames().findIndex(n => n === columnName);
@@ -1497,7 +1499,7 @@ class StructuredQueryInner extends AtomicQuery {
   /**
    * The (wrapped) source query, if any
    */
-  sourceQuery(): StructuredQuery | null | undefined {
+  sourceQuery = _.once((): StructuredQuery | null | undefined => {
     const sourceQuery = this.query()?.["source-query"];
 
     if (sourceQuery) {
@@ -1509,7 +1511,7 @@ class StructuredQueryInner extends AtomicQuery {
     } else {
       return null;
     }
-  }
+  });
 
   /**
    * Returns the "first" of the nested queries, or this query it not nested
@@ -1521,26 +1523,26 @@ class StructuredQueryInner extends AtomicQuery {
   /**
    * Returns the "last" nested query that is already summarized, or `null` if none are
    * */
-  lastSummarizedQuery(): StructuredQuery | null | undefined {
+  lastSummarizedQuery = _.once((): StructuredQuery | null | undefined => {
     if (this.hasAggregations() || !this.canNest()) {
       return this;
     } else {
       const sourceQuery = this.sourceQuery();
       return sourceQuery ? sourceQuery.lastSummarizedQuery() : null;
     }
-  }
+  });
 
   /**
    * Returns the "last" nested query that is already summarized, or the query itself.
    * Used in "view mode" to effectively ignore post-aggregation filter stages
    */
-  topLevelQuery(): StructuredQuery {
+  topLevelQuery = _.once((): StructuredQuery => {
     if (!this.canNest()) {
       return this;
     } else {
       return this.lastSummarizedQuery() || this;
     }
-  }
+  });
 
   /**
    * Returns the corresponding {Dimension} in the "top-level" {StructuredQuery}
@@ -1630,7 +1632,7 @@ class StructuredQueryInner extends AtomicQuery {
   /**
    * returns the original Table object at the beginning of the nested queries
    */
-  rootTable(): Table {
+  rootTable = _.once((): Table => {
     const question = this.question();
     const questionTableId = question?.tableId();
     if (questionTableId != null) {
@@ -1638,7 +1640,7 @@ class StructuredQueryInner extends AtomicQuery {
     }
 
     return this.rootQuery().table();
-  }
+  });
 
   /**
    * returns the original Table ID at the beginning of the nested queries
@@ -1750,26 +1752,7 @@ class StructuredQueryInner extends AtomicQuery {
       ),
     );
   }
-} // subclass of StructuredQuery that's returned by query.sourceQuery() to allow manipulation of source-query
-
-class StructuredQuery extends memoizeClass<StructuredQueryInner>(
-  "table",
-  "filters",
-  "sorts",
-  "tableDimensions",
-  "expressionDimensions",
-  "joinedDimensions",
-  "breakoutDimensions",
-  "aggregationDimensions",
-  "aggregationOperatorsLookup",
-  "fieldDimensions",
-  "columnDimensions",
-  "columnNames",
-  "sourceQuery",
-  "rootQuery",
-  "lastSummarizedQuery",
-  "topLevelQuery",
-)(StructuredQueryInner) {}
+}
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default StructuredQuery;
@@ -1790,9 +1773,9 @@ class NestedStructuredQuery extends StructuredQuery {
     );
   }
 
-  rootQuery(): StructuredQuery {
+  rootQuery = _.once((): StructuredQuery => {
     return this.parentQuery().rootQuery();
-  }
+  });
 
   parentQuery() {
     return this._parent.setSourceQuery(this.query());

--- a/frontend/src/metabase-lib/queries/structured/Aggregation.ts
+++ b/frontend/src/metabase-lib/queries/structured/Aggregation.ts
@@ -156,24 +156,7 @@ export default class Aggregation extends MBQLClause {
    * Predicate function to test if a given aggregation clause is valid
    */
   isValid() {
-    if (this.hasOptions()) {
-      return this.aggregation().isValid();
-    } else if (this.isStandard() && this.dimension()) {
-      const dimension = this.dimension()?.getMLv1CompatibleDimension();
-      const aggregationOperator = this.query().aggregationOperator(this[0]);
-      return (
-        aggregationOperator &&
-        (!aggregationOperator.requiresField ||
-          this.query()
-            .aggregationFieldOptions(aggregationOperator)
-            .hasDimension(dimension))
-      );
-    } else if (this.isMetric()) {
-      return !!this.metric();
-    } else {
-      // FIXME: custom aggregation validation
-      return true;
-    }
+    return true;
   }
 
   // There are currently 3 "classes" of aggregations that are handled differently, "standard", "segment", and "custom"

--- a/frontend/src/metabase-lib/queries/structured/Breakout.ts
+++ b/frontend/src/metabase-lib/queries/structured/Breakout.ts
@@ -45,14 +45,7 @@ export default class Breakout extends MBQLClause {
    * Predicate function to test if a given breakout clause is valid
    */
   isValid() {
-    const query = this.query();
-    if (!query) {
-      return true;
-    }
-    const dimension = this.dimension().getMLv1CompatibleDimension();
-    return query
-      .breakoutOptions(this, () => true, true)
-      .hasDimension(dimension);
+    return true;
   }
 
   /**

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.unit.spec.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.unit.spec.tsx
@@ -140,7 +140,6 @@ describe("DatabaseEditApp/Sidebar", () => {
       userEvent.click(
         within(getModal()).getByRole("button", { name: "Cancel" }),
       );
-      await waitForElementToBeRemoved(() => getModal());
 
       expect(getModal()).not.toBeInTheDocument();
       expect(discardSavedFieldValues).not.toHaveBeenCalled();
@@ -304,7 +303,6 @@ describe("DatabaseEditApp/Sidebar", () => {
       userEvent.click(
         await within(modal).findByRole("button", { name: "Cancel" }),
       );
-      await waitForElementToBeRemoved(() => getModal());
 
       expect(getModal()).not.toBeInTheDocument();
       expect(deleteDatabase).not.toHaveBeenCalled();

--- a/frontend/src/metabase/components/Triggerable/Triggerable.jsx
+++ b/frontend/src/metabase/components/Triggerable/Triggerable.jsx
@@ -170,15 +170,17 @@ const Triggerable = ComposedComponent =>
                 })
               : triggerElement}
           </Trigger>
-          <ComposedComponent
-            {...this.props}
-            isOpen={isOpen}
-            onClose={this.onClose}
-            target={() => this.target()}
-            sizeToFit
-          >
-            {children}
-          </ComposedComponent>
+          {isOpen && (
+            <ComposedComponent
+              {...this.props}
+              isOpen={isOpen}
+              onClose={this.onClose}
+              target={() => this.target()}
+              sizeToFit
+            >
+              {children}
+            </ComposedComponent>
+          )}
         </>
       );
     }

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import cx from "classnames";
 import { t } from "ttag";
 import { connect } from "react-redux";
@@ -130,6 +130,10 @@ function DashCardVisualization({
   onChangeLocation,
   onUpdateVisualizationSettings,
 }: DashCardVisualizationProps) {
+  const question = useMemo(() => {
+    return new Question(dashcard.card, metadata);
+  }, [dashcard.card, metadata]);
+
   const renderVisualizationOverlay = useCallback(() => {
     if (isClickBehaviorSidebarOpen) {
       const { disableClickBehavior } =
@@ -184,7 +188,6 @@ function DashCardVisualization({
   ]);
 
   const renderActionButtons = useCallback(() => {
-    const question = new Question(dashcard.card, metadata);
     const mainSeries = series[0] as unknown as Dataset;
 
     const shouldShowDashCardMenu = DashCardMenu.shouldRender({
@@ -211,10 +214,9 @@ function DashCardVisualization({
       />
     );
   }, [
-    dashcard.card,
+    question,
     dashcard.id,
     dashcard.dashboard_id,
-    metadata,
     series,
     isEmbed,
     isPublic,

--- a/frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx
@@ -151,7 +151,7 @@ export default class GuiQueryEditor extends Component {
 
     // aggregation clause.  must have table details available
     if (query.isEditable()) {
-      const aggregations = query.aggregations();
+      const aggregations = [...query.aggregations()];
 
       if (aggregations.length === 0) {
         // add implicit rows aggregation
@@ -211,7 +211,7 @@ export default class GuiQueryEditor extends Component {
 
     const breakoutList = [];
 
-    const breakouts = query.breakouts();
+    const breakouts = [...query.breakouts()];
 
     // Placeholder breakout for showing the add button
     if (query.canAddBreakout()) {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
@@ -1,10 +1,8 @@
+import { useMemo } from "react";
 import { t } from "ttag";
-
 import { AggregationPicker } from "metabase/common/components/AggregationPicker";
-
 import * as Lib from "metabase-lib";
 import type StructuredQuery from "metabase-lib/queries/StructuredQuery";
-
 import type { NotebookStepUiComponentProps } from "../../types";
 import ClauseStep from "../ClauseStep";
 
@@ -31,11 +29,9 @@ export function AggregateStep({
 }: NotebookStepUiComponentProps) {
   const { stageIndex } = step;
 
-  const clauses = Lib.aggregations(topLevelQuery, stageIndex);
-  const operators = Lib.availableAggregationOperators(
-    topLevelQuery,
-    stageIndex,
-  );
+  const clauses = useMemo(() => {
+    return Lib.aggregations(topLevelQuery, stageIndex);
+  }, [topLevelQuery, stageIndex]);
 
   const handleAddAggregation = (aggregation: Lib.Aggregatable) => {
     const nextQuery = Lib.aggregate(topLevelQuery, stageIndex, aggregation);
@@ -76,7 +72,6 @@ export function AggregateStep({
         <AggregationPopover
           query={topLevelQuery}
           stageIndex={stageIndex}
-          operators={operators}
           clause={aggregation}
           clauseIndex={index}
           legacyQuery={legacyQuery}
@@ -94,7 +89,6 @@ export function AggregateStep({
 interface AggregationPopoverProps {
   query: Lib.Query;
   stageIndex: number;
-  operators: Lib.AggregationOperator[];
   clause?: Lib.AggregationClause;
   onUpdateAggregation: (
     currentClause: Lib.AggregationClause,
@@ -113,7 +107,6 @@ interface AggregationPopoverProps {
 function AggregationPopover({
   query,
   stageIndex,
-  operators: baseOperators,
   clause,
   clauseIndex,
   legacyQuery,
@@ -124,9 +117,12 @@ function AggregationPopover({
 }: AggregationPopoverProps) {
   const isUpdate = clause != null && clauseIndex != null;
 
-  const operators = isUpdate
-    ? Lib.selectedAggregationOperators(baseOperators, clause)
-    : baseOperators;
+  const operators = useMemo(() => {
+    const baseOperators = Lib.availableAggregationOperators(query, stageIndex);
+    return isUpdate
+      ? Lib.selectedAggregationOperators(baseOperators, clause)
+      : baseOperators;
+  }, [query, clause, stageIndex, isUpdate]);
 
   const legacyClause = isUpdate
     ? legacyQuery.aggregations()[clauseIndex]

--- a/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.tsx
@@ -1,8 +1,7 @@
+import { useMemo } from "react";
 import { t } from "ttag";
-
 import QueryColumnPicker from "metabase/common/components/QueryColumnPicker";
 import * as Lib from "metabase-lib";
-
 import type { NotebookStepUiComponentProps } from "../../types";
 import ClauseStep from "../ClauseStep";
 
@@ -28,39 +27,19 @@ function BreakoutStep({
 }: NotebookStepUiComponentProps) {
   const { stageIndex } = step;
 
-  const clauses = Lib.breakouts(topLevelQuery, stageIndex);
+  const breakouts = useMemo(() => {
+    return Lib.breakouts(topLevelQuery, stageIndex);
+  }, [topLevelQuery, stageIndex]);
 
-  const checkColumnSelected = (
-    columnInfo: Lib.ColumnDisplayInfo,
-    breakoutIndex?: number,
-  ) => {
-    return (
-      typeof breakoutIndex === "number" &&
-      columnInfo.breakoutPosition === breakoutIndex
-    );
-  };
-
-  const getColumnGroups = (breakoutIndex?: number) => {
-    const columns = Lib.breakoutableColumns(topLevelQuery, stageIndex);
-
-    const filteredColumns = columns.filter(column => {
-      const columnInfo = Lib.displayInfo(topLevelQuery, stageIndex, column);
-
-      const isAlreadyUsed = columnInfo.breakoutPosition != null;
-      const isSelected = checkColumnSelected(columnInfo, breakoutIndex);
-
-      return isSelected || !isAlreadyUsed;
-    });
-
-    return Lib.groupColumns(filteredColumns);
-  };
+  const renderBreakoutName = (clause: Lib.BreakoutClause) =>
+    Lib.displayInfo(topLevelQuery, stageIndex, clause).longDisplayName;
 
   const handleAddBreakout = (column: Lib.ColumnMetadata) => {
     const nextQuery = Lib.breakout(topLevelQuery, stageIndex, column);
     updateQuery(nextQuery);
   };
 
-  const handleUpdateBreakoutField = (
+  const handleUpdateBreakoutColumn = (
     clause: Lib.BreakoutClause,
     column: Lib.ColumnMetadata,
   ) => {
@@ -78,12 +57,9 @@ function BreakoutStep({
     updateQuery(nextQuery);
   };
 
-  const renderBreakoutName = (clause: Lib.BreakoutClause) =>
-    Lib.displayInfo(topLevelQuery, stageIndex, clause).longDisplayName;
-
   return (
     <ClauseStep
-      items={clauses}
+      items={breakouts}
       initialAddText={t`Pick a column to group by`}
       readOnly={readOnly}
       color={color}
@@ -91,24 +67,13 @@ function BreakoutStep({
       tetherOptions={breakoutTetherOptions}
       renderName={renderBreakoutName}
       renderPopover={(breakout, breakoutIndex) => (
-        <QueryColumnPicker
+        <BreakoutPopover
           query={topLevelQuery}
           stageIndex={stageIndex}
-          columnGroups={getColumnGroups(breakoutIndex)}
-          hasBinning
-          hasTemporalBucketing
-          color="summarize"
-          checkIsColumnSelected={item =>
-            checkColumnSelected(item, breakoutIndex)
-          }
-          onSelect={(column: Lib.ColumnMetadata) => {
-            const isUpdate = breakout != null;
-            if (isUpdate) {
-              handleUpdateBreakoutField(breakout, column);
-            } else {
-              handleAddBreakout(column);
-            }
-          }}
+          breakout={breakout}
+          breakoutIndex={breakoutIndex}
+          onAddBreakout={handleAddBreakout}
+          onUpdateBreakoutColumn={handleUpdateBreakoutColumn}
         />
       )}
       onRemove={handleRemoveBreakout}
@@ -116,6 +81,70 @@ function BreakoutStep({
     />
   );
 }
+
+interface BreakoutPopoverProps {
+  query: Lib.Query;
+  stageIndex: number;
+  breakout: Lib.BreakoutClause | undefined;
+  breakoutIndex: number | undefined;
+  onAddBreakout: (column: Lib.ColumnMetadata) => void;
+  onUpdateBreakoutColumn: (
+    breakout: Lib.BreakoutClause,
+    column: Lib.ColumnMetadata,
+  ) => void;
+  onClose?: () => void;
+}
+
+const BreakoutPopover = ({
+  query,
+  stageIndex,
+  breakout,
+  breakoutIndex,
+  onAddBreakout,
+  onUpdateBreakoutColumn,
+  onClose,
+}: BreakoutPopoverProps) => {
+  const columnGroups = useMemo(() => {
+    const columns = Lib.breakoutableColumns(query, stageIndex);
+
+    const filteredColumns = columns.filter(column => {
+      const columnInfo = Lib.displayInfo(query, stageIndex, column);
+      const isAlreadyUsed = columnInfo.breakoutPosition != null;
+      const isSelected = checkColumnSelected(columnInfo, breakoutIndex);
+      return isSelected || !isAlreadyUsed;
+    });
+
+    return Lib.groupColumns(filteredColumns);
+  }, [query, stageIndex, breakoutIndex]);
+
+  return (
+    <QueryColumnPicker
+      query={query}
+      stageIndex={stageIndex}
+      columnGroups={columnGroups}
+      hasBinning
+      hasTemporalBucketing
+      color="summarize"
+      checkIsColumnSelected={item => checkColumnSelected(item, breakoutIndex)}
+      onSelect={(column: Lib.ColumnMetadata) => {
+        const isUpdate = breakout != null;
+        if (isUpdate) {
+          onUpdateBreakoutColumn(breakout, column);
+        } else {
+          onAddBreakout(column);
+        }
+      }}
+      onClose={onClose}
+    />
+  );
+};
+
+const checkColumnSelected = (
+  columnInfo: Lib.ColumnDisplayInfo,
+  breakoutIndex?: number,
+) => {
+  return breakoutIndex != null && columnInfo.breakoutPosition === breakoutIndex;
+};
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default BreakoutStep;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.tsx
@@ -1,10 +1,8 @@
+import { useMemo } from "react";
 import { t } from "ttag";
-
 import { Icon } from "metabase/core/components/Icon";
 import QueryColumnPicker from "metabase/common/components/QueryColumnPicker";
-
 import * as Lib from "metabase-lib";
-
 import type { NotebookStepUiComponentProps } from "../../types";
 import ClauseStep from "../ClauseStep";
 import { SortDirectionButton } from "./SortStep.styled";
@@ -19,32 +17,9 @@ function SortStep({
 }: NotebookStepUiComponentProps) {
   const { stageIndex } = step;
 
-  const clauses = Lib.orderBys(topLevelQuery, stageIndex);
-
-  const checkColumnSelected = (
-    columnInfo: Lib.ColumnDisplayInfo,
-    orderByIndex?: number,
-  ) => {
-    return (
-      typeof orderByIndex === "number" &&
-      columnInfo.orderByPosition === orderByIndex
-    );
-  };
-
-  const getColumnGroups = (orderByIndex?: number) => {
-    const columns = Lib.orderableColumns(topLevelQuery, stageIndex);
-
-    const filteredColumns = columns.filter(column => {
-      const columnInfo = Lib.displayInfo(topLevelQuery, stageIndex, column);
-
-      const isAlreadyUsed = columnInfo.orderByPosition != null;
-      const isSelected = checkColumnSelected(columnInfo, orderByIndex);
-
-      return isSelected || !isAlreadyUsed;
-    });
-
-    return Lib.groupColumns(filteredColumns);
-  };
+  const clauses = useMemo(() => {
+    return Lib.orderBys(topLevelQuery, stageIndex);
+  }, [topLevelQuery, stageIndex]);
 
   const handleAddOrderBy = (column: Lib.ColumnMetadata) => {
     const nextQuery = Lib.orderBy(topLevelQuery, stageIndex, column, "asc");
@@ -56,7 +31,7 @@ function SortStep({
     updateQuery(nextQuery);
   };
 
-  const handleUpdateOrderByField = (
+  const handleUpdateOrderByColumn = (
     clause: Lib.OrderByClause,
     column: Lib.ColumnMetadata,
   ) => {
@@ -88,28 +63,84 @@ function SortStep({
         />
       )}
       renderPopover={(orderBy, orderByIndex) => (
-        <QueryColumnPicker
+        <SortPopover
           query={topLevelQuery}
           stageIndex={stageIndex}
-          columnGroups={getColumnGroups(orderByIndex)}
-          color="text-dark"
-          checkIsColumnSelected={item =>
-            checkColumnSelected(item, orderByIndex)
-          }
-          onSelect={(column: Lib.ColumnMetadata) => {
-            const isUpdate = orderBy != null;
-            if (isUpdate) {
-              handleUpdateOrderByField(orderBy, column);
-            } else {
-              handleAddOrderBy(column);
-            }
-          }}
+          orderBy={orderBy}
+          orderByIndex={orderByIndex}
+          onAddOrderBy={handleAddOrderBy}
+          onUpdateOrderByColumn={handleUpdateOrderByColumn}
         />
       )}
       onRemove={handleRemoveOrderBy}
     />
   );
 }
+
+interface SortPopoverProps {
+  query: Lib.Query;
+  stageIndex: number;
+  orderBy: Lib.OrderByClause | undefined;
+  orderByIndex: number | undefined;
+  onAddOrderBy: (column: Lib.ColumnMetadata) => void;
+  onUpdateOrderByColumn: (
+    orderBy: Lib.OrderByClause,
+    column: Lib.ColumnMetadata,
+  ) => void;
+  onClose?: () => void;
+}
+
+const SortPopover = ({
+  query,
+  stageIndex,
+  orderBy,
+  orderByIndex,
+  onAddOrderBy,
+  onUpdateOrderByColumn,
+  onClose,
+}: SortPopoverProps) => {
+  const columnGroups = useMemo(() => {
+    const columns = Lib.orderableColumns(query, stageIndex);
+
+    const filteredColumns = columns.filter(column => {
+      const columnInfo = Lib.displayInfo(query, stageIndex, column);
+      const isAlreadyUsed = columnInfo.orderByPosition != null;
+      const isSelected = checkColumnSelected(columnInfo, orderByIndex);
+      return isSelected || !isAlreadyUsed;
+    });
+
+    return Lib.groupColumns(filteredColumns);
+  }, [query, stageIndex, orderByIndex]);
+
+  return (
+    <QueryColumnPicker
+      query={query}
+      stageIndex={stageIndex}
+      columnGroups={columnGroups}
+      color="text-dark"
+      checkIsColumnSelected={item => checkColumnSelected(item, orderByIndex)}
+      onSelect={(column: Lib.ColumnMetadata) => {
+        const isUpdate = orderBy != null;
+        if (isUpdate) {
+          onUpdateOrderByColumn(orderBy, column);
+        } else {
+          onAddOrderBy(column);
+        }
+      }}
+      onClose={onClose}
+    />
+  );
+};
+
+const checkColumnSelected = (
+  columnInfo: Lib.ColumnDisplayInfo,
+  orderByIndex?: number,
+) => {
+  return (
+    typeof orderByIndex === "number" &&
+    columnInfo.orderByPosition === orderByIndex
+  );
+};
 
 interface SortDisplayNameProps {
   displayInfo: Lib.OrderByClauseDisplayInfo;

--- a/frontend/src/metabase/visualizations/components/TableSimple/TableCell.jsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple/TableCell.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import cx from "classnames";
 
 import ExternalLink from "metabase/core/components/ExternalLink";
@@ -108,17 +108,20 @@ function TableCell({
   );
 
   const isLink = cellData && cellData.type === ExternalLink;
-  const isClickable = !isLink && checkIsVisualizationClickable(clicked);
+  const isClickable = !isLink;
 
-  const onClick = useMemo(() => {
-    return e => {
-      onVisualizationClick({
-        ...clicked,
-        element: e.currentTarget,
-        extraData,
-      });
-    };
-  }, [clicked, extraData, onVisualizationClick]);
+  const onClick = useCallback(
+    e => {
+      if (checkIsVisualizationClickable(clicked)) {
+        onVisualizationClick({
+          ...clicked,
+          element: e.currentTarget,
+          extraData,
+        });
+      }
+    },
+    [clicked, extraData, checkIsVisualizationClickable, onVisualizationClick],
+  );
 
   const backgroundColor = useMemo(
     () => getCellBackgroundColor?.(value, rowIndex, column.name),

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -272,24 +272,6 @@ const native_orders_count_question = new Question(
   metadata,
 );
 
-const invalid_orders_count_card = {
-  id: 2,
-  name: "# orders data",
-  display: "table",
-  visualization_settings: {},
-  dataset_query: {
-    type: "nosuchqueryprocessor",
-    database: SAMPLE_DB_ID,
-    query: {
-      query: "SELECT count(*) FROM orders",
-    },
-  },
-};
-const invalid_orders_count_question = new Question(
-  invalid_orders_count_card,
-  metadata,
-);
-
 const orders_count_by_id_card = {
   id: 2,
   name: "# orders data",
@@ -384,9 +366,6 @@ describe("Question", () => {
       it("returns a correct class instance for native query", () => {
         const query = native_orders_count_question.query();
         expect(query instanceof NativeQuery).toBe(true);
-      });
-      it("throws an error for invalid queries", () => {
-        expect(invalid_orders_count_question.query).toThrow();
       });
     });
     describe("setQuery(query)", () => {


### PR DESCRIPTION
Backports https://github.com/metabase/metabase/pull/33831

Issues:
- Popovers were rendered even when they were not opened
- MLv2 functions were called per-clause when they could be called only when the popover was opened
- Several Mlv1 calls were causing causes that could be memoized
- We checked for click actions being available for every table cell when it was possible to move this check on click