### PR TITLE
Prefer secret value to secret instance ID

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -880,7 +880,7 @@
                                    (upsert-sensitive-fields existing-database))
         ;; verify that we can connect to the database if `:details` OR `:engine` have changed.
         details-changed?  (some-> details (not= (:details existing-database)))
-        engine-changed?   (some-> engine (not= (:engine existing-database)))
+        engine-changed?   (some-> engine keyword (not= (:engine existing-database)))
         conn-error        (when (or details-changed? engine-changed?)
                             (test-database-connection (or engine (:engine existing-database))
                                                       (or details (:details existing-database))))


### PR DESCRIPTION
Fixes #33452.

When secrets get updated, both the new value and the ID of the old secret instance are in the details. Preferring the ID of the old instance means that the connection test uses the old (and likely invalid) secret.
