### PR TITLE
Use question from state for navbar instead of api call

### DIFF
--- a/e2e/test/scenarios/admin/settings/localization.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/localization.cy.spec.js
@@ -23,6 +23,7 @@ describe("scenarios > admin > localization", () => {
     // filter: created before June 1st, 2022
     // summarize: Count by CreatedAt: Week
 
+    cy.intercept("POST", "/api/card/*/query").as("cardQuery");
     cy.createQuestion({
       name: "Orders created before June 1st 2022",
       query: {
@@ -38,6 +39,8 @@ describe("scenarios > admin > localization", () => {
     cy.visit("/collection/root");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders created before June 1st 2022").click();
+
+    cy.wait("@cardQuery");
 
     cy.log("Assert the dates on the X axis");
     // it's hard and tricky to invoke hover in Cypress, especially in our graphs

--- a/e2e/test/scenarios/models/model-indexes.cy.spec.js
+++ b/e2e/test/scenarios/models/model-indexes.cy.spec.js
@@ -214,8 +214,7 @@ describe("scenarios > model indexes", () => {
       cy.findByText("Doohickey");
     });
 
-    // for some reason we hit this endpoint twice on initial load
-    expectCardQueries(2);
+    expectCardQueries(1);
 
     cy.get("body").type("{esc}");
 
@@ -232,7 +231,7 @@ describe("scenarios > model indexes", () => {
       cy.findByText("Upton, Kovacek and Halvorson");
     });
 
-    expectCardQueries(2);
+    expectCardQueries(1);
   });
 });
 

--- a/e2e/test/scenarios/models/reproductions/31905-duplicated-api-request.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/31905-duplicated-api-request.cy.spec.js
@@ -1,0 +1,26 @@
+import { restore } from "e2e/support/helpers";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { ORDERS_ID } = SAMPLE_DATABASE;
+
+describe("issue 31905", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.intercept("GET", "/api/card/*").as("card");
+
+    cy.createQuestion(
+      {
+        name: "Orders Model",
+        dataset: true,
+        query: { "source-table": ORDERS_ID, limit: 2 },
+      },
+      { visitQuestion: true },
+    );
+  });
+
+  it("should not send more than one same api requests to load a model (metabase#31905)", () => {
+    cy.get("@card.all").should("have.length", 1);
+  });
+});

--- a/e2e/test/scenarios/sharing/alert/email-alert.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/email-alert.cy.spec.js
@@ -13,7 +13,7 @@ const { PEOPLE_ID } = SAMPLE_DATABASE;
 describe("scenarios > alert > email_alert", { tags: "@external" }, () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/alert").as("savedAlert");
-    cy.intercept("GET", "/api/card/*").as("card");
+    cy.intercept("POST", "/api/card").as("saveCard");
 
     restore();
     cy.signInAsAdmin();
@@ -71,7 +71,7 @@ describe("scenarios > alert > email_alert", { tags: "@external" }, () => {
       cy.findByRole("button", { name: "Save" }).click();
     });
 
-    cy.wait("@card");
+    cy.wait("@saveCard");
 
     modal().within(() => {
       cy.findByRole("button", { name: "Set up an alert" }).click();

--- a/frontend/src/metabase/lib/card.js
+++ b/frontend/src/metabase/lib/card.js
@@ -29,7 +29,14 @@ export async function loadCard(cardId, { dispatch, getState }) {
     await dispatch(
       Questions.actions.fetch(
         { id: cardId },
-        { properties: ["dataset_query", "display", "visualization_settings"] }, // complies with Card interface
+        {
+          properties: [
+            "id",
+            "dataset_query",
+            "display",
+            "visualization_settings",
+          ], // complies with Card interface
+        },
       ),
     );
 

--- a/frontend/src/metabase/lib/card.js
+++ b/frontend/src/metabase/lib/card.js
@@ -36,7 +36,7 @@ export async function loadCard(cardId, { dispatch, getState }) {
       Questions.actions.fetch({ id: cardId }, { reload: shouldReload }),
     );
 
-    if (shouldReload) {
+    if (shouldReload || !question) {
       question = Questions.selectors.getObject(getState(), {
         entityId: cardId,
       });
@@ -51,7 +51,7 @@ export async function loadCard(cardId, { dispatch, getState }) {
 
 function isFullQuestionData(question) {
   // data loaded from questions api contains this. results from search api don't
-  return question.isSaved() ? question.lastEditInfo() != null : true;
+  return question?.isSaved() ? question.lastEditInfo() != null : true;
 }
 
 function getCleanCard(card) {

--- a/frontend/src/metabase/lib/card.js
+++ b/frontend/src/metabase/lib/card.js
@@ -26,15 +26,32 @@ export function startNewCard(type, databaseId, tableId) {
 // TODO: move to redux
 export async function loadCard(cardId, { dispatch, getState }) {
   try {
-    await dispatch(Questions.actions.fetch({ id: cardId }, { reload: true }));
-    const question = Questions.selectors.getObject(getState(), {
+    let question = Questions.selectors.getObject(getState(), {
       entityId: cardId,
     });
+
+    const shouldReload = !isFullQuestionData(question);
+
+    await dispatch(
+      Questions.actions.fetch({ id: cardId }, { reload: shouldReload }),
+    );
+
+    if (shouldReload) {
+      question = Questions.selectors.getObject(getState(), {
+        entityId: cardId,
+      });
+    }
+
     return question?.card();
   } catch (error) {
     console.error("error loading card", error);
     throw error;
   }
+}
+
+function isFullQuestionData(question) {
+  // data loaded from questions api contains this. results from search api don't
+  return question.isSaved() ? question.lastEditInfo() != null : true;
 }
 
 function getCleanCard(card) {

--- a/frontend/src/metabase/lib/card.js
+++ b/frontend/src/metabase/lib/card.js
@@ -30,7 +30,7 @@ export async function loadCard(cardId, { dispatch, getState }) {
       entityId: cardId,
     });
 
-    const shouldReload = !isFullQuestionData(question);
+    const shouldReload = !isFullCardData(question?.card());
 
     await dispatch(
       Questions.actions.fetch({ id: cardId }, { reload: shouldReload }),
@@ -49,9 +49,13 @@ export async function loadCard(cardId, { dispatch, getState }) {
   }
 }
 
-function isFullQuestionData(question) {
-  // data loaded from questions api contains this. results from search api don't
-  return question?.isSaved() ? question.lastEditInfo() != null : true;
+function isFullCardData(maybeCard) {
+  // validate that maybeCard complies with Card interface
+  return (
+    maybeCard?.dataset_query != null &&
+    maybeCard?.display != null &&
+    maybeCard?.visualization_settings != null
+  );
 }
 
 function getCleanCard(card) {

--- a/frontend/src/metabase/lib/card.js
+++ b/frontend/src/metabase/lib/card.js
@@ -26,36 +26,22 @@ export function startNewCard(type, databaseId, tableId) {
 // TODO: move to redux
 export async function loadCard(cardId, { dispatch, getState }) {
   try {
-    let question = Questions.selectors.getObject(getState(), {
-      entityId: cardId,
-    });
-
-    const shouldReload = !isFullCardData(question?.card());
-
     await dispatch(
-      Questions.actions.fetch({ id: cardId }, { reload: shouldReload }),
+      Questions.actions.fetch(
+        { id: cardId },
+        { properties: ["dataset_query", "display", "visualization_settings"] }, // complies with Card interface
+      ),
     );
 
-    if (shouldReload || !question) {
-      question = Questions.selectors.getObject(getState(), {
-        entityId: cardId,
-      });
-    }
+    const question = Questions.selectors.getObject(getState(), {
+      entityId: cardId,
+    });
 
     return question?.card();
   } catch (error) {
     console.error("error loading card", error);
     throw error;
   }
-}
-
-function isFullCardData(maybeCard) {
-  // validate that maybeCard complies with Card interface
-  return (
-    maybeCard?.dataset_query != null &&
-    maybeCard?.display != null &&
-    maybeCard?.visualization_settings != null
-  );
 }
 
 function getCleanCard(card) {

--- a/frontend/src/metabase/lib/redux/utils.js
+++ b/frontend/src/metabase/lib/redux/utils.js
@@ -300,7 +300,7 @@ function withCachedData(
         reload !== true &&
         // reload if the query used to load an entity has changed even if it's already loaded
         newQueryKey === queryKey &&
-        // and we have a an non-error request state or have a list of properties that all exist on the object
+        // and we have a non-error request state or have a list of properties that all exist on the object
         (loading || loaded || hasRequestedProperties)
       ) {
         // TODO: if requestState is LOADING can we wait for the other reques

--- a/frontend/src/metabase/lib/redux/utils.unit.spec.js
+++ b/frontend/src/metabase/lib/redux/utils.unit.spec.js
@@ -50,7 +50,25 @@ describe("Metadata", () => {
       const argsDefault = getDefaultArgs({});
       const data = await fetchData(argsDefault);
       await delay(10);
-      expect(argsDefault.dispatch.mock.calls.length).toEqual(2);
+
+      expect(argsDefault.dispatch).toHaveBeenCalledTimes(3);
+
+      expect(argsDefault.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "metabase/requests/SET_REQUEST_LOADING",
+        }),
+      );
+      expect(argsDefault.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "metabase/requests/SET_REQUEST_PROMISE",
+        }),
+      );
+      expect(argsDefault.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "metabase/requests/SET_REQUEST_LOADED",
+        }),
+      );
+
       expect(data).toEqual(args.newData);
     });
 
@@ -59,14 +77,14 @@ describe("Metadata", () => {
         requestState: args.requestStateLoading,
       });
       const dataLoading = await fetchData(argsLoading);
-      expect(argsLoading.dispatch.mock.calls.length).toEqual(0);
+      expect(argsLoading.dispatch).toHaveBeenCalledTimes(0);
       expect(dataLoading).toEqual(args.existingData);
 
       const argsLoaded = getDefaultArgs({
         requestState: args.requestStateLoaded,
       });
       const dataLoaded = await fetchData(argsLoaded);
-      expect(argsLoaded.dispatch.mock.calls.length).toEqual(0);
+      expect(argsLoaded.dispatch).toHaveBeenCalledTimes(0);
       expect(dataLoaded).toEqual(args.existingData);
     });
 
@@ -76,7 +94,25 @@ describe("Metadata", () => {
       });
       const dataError = await fetchData(argsError);
       await delay(10);
-      expect(argsError.dispatch.mock.calls.length).toEqual(2);
+
+      expect(argsError.dispatch).toHaveBeenCalledTimes(3);
+
+      expect(argsError.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "metabase/requests/SET_REQUEST_LOADING",
+        }),
+      );
+      expect(argsError.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "metabase/requests/SET_REQUEST_PROMISE",
+        }),
+      );
+      expect(argsError.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "metabase/requests/SET_REQUEST_LOADED",
+        }),
+      );
+
       expect(dataError).toEqual(args.newData);
     });
 
@@ -92,7 +128,7 @@ describe("Metadata", () => {
         const dataFail = await fetchData(argsFail).catch(error =>
           console.log(error),
         );
-        expect(argsFail.dispatch.mock.calls.length).toEqual(2);
+        expect(argsFail.dispatch).toHaveBeenCalledTimes(2);
         expect(dataFail).toEqual(args.existingData);
       } catch (error) {
         return;
@@ -104,28 +140,28 @@ describe("Metadata", () => {
     it("should return new data regardless of previous request state", async () => {
       const argsDefault = getDefaultArgs({});
       const data = await updateData(argsDefault);
-      expect(argsDefault.dispatch.mock.calls.length).toEqual(2);
+      expect(argsDefault.dispatch).toHaveBeenCalledTimes(3);
       expect(data).toEqual(args.newData);
 
       const argsLoading = getDefaultArgs({
         requestState: args.requestStateLoading,
       });
       const dataLoading = await updateData(argsLoading);
-      expect(argsLoading.dispatch.mock.calls.length).toEqual(2);
+      expect(argsLoading.dispatch).toHaveBeenCalledTimes(3);
       expect(dataLoading).toEqual(args.newData);
 
       const argsLoaded = getDefaultArgs({
         requestState: args.requestStateLoaded,
       });
       const dataLoaded = await updateData(argsLoaded);
-      expect(argsLoaded.dispatch.mock.calls.length).toEqual(2);
+      expect(argsLoaded.dispatch).toHaveBeenCalledTimes(3);
       expect(dataLoaded).toEqual(args.newData);
 
       const argsError = getDefaultArgs({
         requestState: args.requestStateError,
       });
       const dataError = await updateData(argsError);
-      expect(argsError.dispatch.mock.calls.length).toEqual(2);
+      expect(argsError.dispatch).toHaveBeenCalledTimes(3);
       expect(dataError).toEqual(args.newData);
     });
 
@@ -137,7 +173,7 @@ describe("Metadata", () => {
       });
       const data = await updateData(argsFail);
       await delay(10);
-      expect(argsFail.dispatch.mock.calls.length).toEqual(2);
+      expect(argsFail.dispatch).toHaveBeenCalledTimes(2);
       expect(data).toEqual(args.existingData);
     });
   });

--- a/frontend/src/metabase/lib/utils.ts
+++ b/frontend/src/metabase/lib/utils.ts
@@ -205,3 +205,30 @@ export function compareVersions(
   }
   return 0;
 }
+
+export function waitFor(
+  conditionCb: () => boolean,
+  pollInterval = 50,
+  totalTimeout = 30000,
+): Promise<boolean> {
+  const startTime = Date.now();
+
+  return new Promise((resolve, reject) => {
+    if (conditionCb()) {
+      resolve(true);
+      return;
+    }
+
+    const interval = setInterval(() => {
+      if (conditionCb()) {
+        resolve(true);
+        clearInterval(interval);
+      }
+
+      if (Date.now() >= startTime + totalTimeout) {
+        resolve(false);
+        clearInterval(interval);
+      }
+    }, pollInterval);
+  });
+}

--- a/frontend/src/metabase/lib/utils.ts
+++ b/frontend/src/metabase/lib/utils.ts
@@ -205,30 +205,3 @@ export function compareVersions(
   }
   return 0;
 }
-
-export function waitFor(
-  conditionCb: () => boolean,
-  pollInterval = 50,
-  totalTimeout = 30000,
-): Promise<boolean> {
-  const startTime = Date.now();
-
-  return new Promise((resolve, reject) => {
-    if (conditionCb()) {
-      resolve(true);
-      return;
-    }
-
-    const interval = setInterval(() => {
-      if (conditionCb()) {
-        resolve(true);
-        clearInterval(interval);
-      }
-
-      if (Date.now() >= startTime + totalTimeout) {
-        resolve(false);
-        clearInterval(interval);
-      }
-    }, pollInterval);
-  });
-}

--- a/frontend/src/metabase/lib/utils.unit.spec.ts
+++ b/frontend/src/metabase/lib/utils.unit.spec.ts
@@ -3,7 +3,8 @@ import {
   compareVersions,
   isEmpty,
   isJWT,
-} from "metabase/lib/utils";
+  waitFor,
+} from "./utils";
 
 describe("utils", () => {
   describe("versionToNumericComponents", () => {
@@ -118,6 +119,39 @@ describe("utils", () => {
           "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXJhbXMiOnsicGFyYW0xIjoidGVzdCIsInBhcmFtMiI6ImFiIiwicGFyYW0zIjoiMjAwMC0wMC0wMFQwMDowMDowMCswMDowMCIsInBhcmFtNCI6Iu-8iO-8iSJ9LCJyZXNvdXJjZSI6eyJkYXNoYm9hcmQiOjB9fQ.wsNWliHJNwJBv_hx0sPo1EGY0nATdgEa31TM1AYotIA",
         ),
       ).toEqual(true);
+    });
+  });
+
+  describe("waitFor", () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("should resolve with true if passed condition is true at the beginning", async () => {
+      expect(await waitFor(() => true)).toBe(true);
+    });
+
+    it("should resolve with true if passed condition gets true within total timeout", async () => {
+      jest.useFakeTimers();
+
+      const now = Date.now();
+      const conditionFn = jest.fn(() => Date.now() - now > 1000);
+
+      const resultPromise = waitFor(conditionFn);
+
+      jest.advanceTimersByTime(1050);
+
+      expect(await resultPromise).toBe(true);
+    });
+
+    it("should resolve with false if passed condition doesn't get true within total timeout", async () => {
+      jest.useFakeTimers();
+
+      const resultPromise = waitFor(() => false);
+
+      jest.advanceTimersByTime(30050);
+
+      expect(await resultPromise).toBe(false);
     });
   });
 });

--- a/frontend/src/metabase/lib/utils.unit.spec.ts
+++ b/frontend/src/metabase/lib/utils.unit.spec.ts
@@ -3,7 +3,6 @@ import {
   compareVersions,
   isEmpty,
   isJWT,
-  waitFor,
 } from "./utils";
 
 describe("utils", () => {
@@ -119,39 +118,6 @@ describe("utils", () => {
           "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXJhbXMiOnsicGFyYW0xIjoidGVzdCIsInBhcmFtMiI6ImFiIiwicGFyYW0zIjoiMjAwMC0wMC0wMFQwMDowMDowMCswMDowMCIsInBhcmFtNCI6Iu-8iO-8iSJ9LCJyZXNvdXJjZSI6eyJkYXNoYm9hcmQiOjB9fQ.wsNWliHJNwJBv_hx0sPo1EGY0nATdgEa31TM1AYotIA",
         ),
       ).toEqual(true);
-    });
-  });
-
-  describe("waitFor", () => {
-    afterEach(() => {
-      jest.useRealTimers();
-    });
-
-    it("should resolve with true if passed condition is true at the beginning", async () => {
-      expect(await waitFor(() => true)).toBe(true);
-    });
-
-    it("should resolve with true if passed condition gets true within total timeout", async () => {
-      jest.useFakeTimers();
-
-      const now = Date.now();
-      const conditionFn = jest.fn(() => Date.now() - now > 1000);
-
-      const resultPromise = waitFor(conditionFn);
-
-      jest.advanceTimersByTime(1050);
-
-      expect(await resultPromise).toBe(true);
-    });
-
-    it("should resolve with false if passed condition doesn't get true within total timeout", async () => {
-      jest.useFakeTimers();
-
-      const resultPromise = waitFor(() => false);
-
-      jest.advanceTimersByTime(30050);
-
-      expect(await resultPromise).toBe(false);
     });
   });
 });

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.tsx
@@ -7,12 +7,12 @@ import type { LocationDescriptor } from "history";
 import * as Urls from "metabase/lib/urls";
 
 import { closeNavbar, openNavbar } from "metabase/redux/app";
-import Questions from "metabase/entities/questions";
 
 import { getDashboard } from "metabase/dashboard/selectors";
 
 import type { Dashboard } from "metabase-types/api";
 import type { State } from "metabase-types/store";
+import { useQuestionQuery } from "metabase/common/hooks";
 import type Question from "metabase-lib/Question";
 
 import MainNavbarContainer from "./MainNavbarContainer";
@@ -34,6 +34,7 @@ interface EntityLoaderProps {
 
 interface StateProps {
   dashboard?: Dashboard;
+  questionId?: number;
 }
 
 interface DispatchProps extends MainNavbarDispatchProps {
@@ -45,12 +46,14 @@ type Props = MainNavbarOwnProps &
   StateProps &
   DispatchProps;
 
-function mapStateToProps(state: State) {
+function mapStateToProps(state: State, props: MainNavbarOwnProps) {
   return {
     // Can't use dashboard entity loader instead.
     // The dashboard page uses DashboardsApi.get directly,
     // so we can't re-use data between these components.
     dashboard: getDashboard(state),
+
+    questionId: maybeGetQuestionId(state, props),
   };
 }
 
@@ -64,13 +67,17 @@ function MainNavbar({
   isOpen,
   location,
   params,
-  question,
+  questionId,
   dashboard,
   openNavbar,
   closeNavbar,
   onChangeLocation,
   ...props
 }: Props) {
+  const { data: question } = useQuestionQuery({
+    id: questionId,
+  });
+
   useEffect(() => {
     function handleSidebarKeyboardShortcut(e: KeyboardEvent) {
       if (e.key === "." && (e.ctrlKey || e.metaKey)) {
@@ -132,11 +139,6 @@ function maybeGetQuestionId(
 }
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
-export default _.compose(
-  connect(mapStateToProps, mapDispatchToProps),
-  Questions.load({
-    id: maybeGetQuestionId,
-    loadingAndErrorWrapper: false,
-    entityAlias: "question",
-  }),
-)(MainNavbar);
+export default _.compose(connect(mapStateToProps, mapDispatchToProps))(
+  MainNavbar,
+);

--- a/frontend/src/metabase/redux/requests.js
+++ b/frontend/src/metabase/redux/requests.js
@@ -3,7 +3,18 @@ import { updateIn, assoc, getIn } from "icepick";
 
 export const setRequestLoading = createAction(
   "metabase/requests/SET_REQUEST_LOADING",
-  (statePath, queryKey) => ({ statePath, queryKey }),
+  (statePath, queryKey) => ({
+    statePath,
+    queryKey,
+  }),
+);
+export const setRequestPromise = createAction(
+  "metabase/requests/SET_REQUEST_PROMISE",
+  (statePath, queryKey, queryPromise) => ({
+    statePath,
+    queryKey,
+    queryPromise,
+  }),
 );
 export const setRequestLoaded = createAction(
   "metabase/requests/SET_REQUEST_LOADED",
@@ -29,12 +40,20 @@ const initialRequestState = {
 const requestStateReducer = handleActions(
   {
     [setRequestLoading]: {
-      next: (state, { payload: { queryKey } }) => ({
+      next: (state, { payload: { queryKey, queryPromise } }) => ({
         ...state,
         queryKey,
+        queryPromise,
         loading: true,
         loaded: false,
         error: null,
+      }),
+    },
+    [setRequestPromise]: {
+      next: (state, { payload: { queryKey, queryPromise } }) => ({
+        ...state,
+        queryKey,
+        queryPromise,
       }),
     },
     [setRequestLoaded]: {
@@ -61,6 +80,7 @@ const requestStateReducer = handleActions(
         ...state,
         loaded: false,
         error: null,
+        queryPromise: null,
       }),
     },
   },


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31905

### Description

This removes arbitrary card reload in QueryBuilder.
Also: improves our entities fetch caching by waiting for a loading query with same parameters. This leads to deduplication of the same api requests.

### How to verify

1. Create a new question or model, save it.
2. Refresh the page.
3. You should not see 2 same api requests to load your question/model.
4. You should see a collection where your question/model is saved to as selected in the left menu.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
