### PR TITLE
[PivotTable] Improve scrolling performance

### DIFF
--- a/frontend/src/metabase/actions/components/ActionViz/ActionButtonView.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionButtonView.tsx
@@ -1,6 +1,6 @@
 import { t } from "ttag";
 
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import type { IconName } from "metabase/core/components/Icon";
 import { Icon } from "metabase/core/components/Icon";
 import type { VisualizationProps } from "metabase/visualizations/types";

--- a/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import Tooltip from "metabase/core/components/Tooltip";
 import Modal from "metabase/components/Modal";
 import ConfirmContent from "metabase/components/ConfirmContent";
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 
 import { PermissionsSelect } from "../PermissionsSelect";
 import {

--- a/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx
@@ -7,7 +7,7 @@ import cx from "classnames";
 import Utils from "metabase/lib/utils";
 import Select, { Option } from "metabase/core/components/Select";
 import Confirm from "metabase/components/Confirm";
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import Modal from "metabase/components/Modal";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 

--- a/frontend/src/metabase/collections/components/BaseTableItem.jsx
+++ b/frontend/src/metabase/collections/components/BaseTableItem.jsx
@@ -6,7 +6,7 @@ import { PLUGIN_MODERATION } from "metabase/plugins";
 
 import ItemDragSource from "metabase/containers/dnd/ItemDragSource";
 
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import EntityItem from "metabase/components/EntityItem";
 import DateTime from "metabase/components/DateTime";
 import Tooltip from "metabase/core/components/Tooltip";

--- a/frontend/src/metabase/components/Breadcrumbs/Breadcrumbs.jsx
+++ b/frontend/src/metabase/components/Breadcrumbs/Breadcrumbs.jsx
@@ -4,7 +4,7 @@ import { Link } from "react-router";
 
 import cx from "classnames";
 import { Icon } from "metabase/core/components/Icon";
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import S from "./Breadcrumbs.css";
 
 // TODO: merge with BrowserCrumbs

--- a/frontend/src/metabase/components/CollectionItem/CollectionItem.jsx
+++ b/frontend/src/metabase/components/CollectionItem/CollectionItem.jsx
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 
 import Card from "metabase/components/Card";
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 
 import { getCollectionIcon } from "metabase/entities/collections";
 

--- a/frontend/src/metabase/components/EntityItem/EntityItem.jsx
+++ b/frontend/src/metabase/components/EntityItem/EntityItem.jsx
@@ -7,7 +7,7 @@ import * as Urls from "metabase/lib/urls";
 import EntityMenu from "metabase/components/EntityMenu";
 import Swapper from "metabase/core/components/Swapper";
 import CheckBox from "metabase/core/components/CheckBox";
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import { Icon } from "metabase/core/components/Icon";
 import {
   isPreviewShown,

--- a/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.styled.tsx
+++ b/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.styled.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 
 export const StyledEllipsified = styled(Ellipsified)`
   font-weight: bold;

--- a/frontend/src/metabase/components/ListItem/ListItem.styled.tsx
+++ b/frontend/src/metabase/components/ListItem/ListItem.styled.tsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { Link } from "react-router";
 
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import { color } from "metabase/lib/colors";
 
 interface Props {

--- a/frontend/src/metabase/core/components/Ellipsified/Ellipsified.stories.tsx
+++ b/frontend/src/metabase/core/components/Ellipsified/Ellipsified.stories.tsx
@@ -1,5 +1,5 @@
 import type { ComponentStory } from "@storybook/react";
-import Ellipsified from "./Ellipsified";
+import { Ellipsified } from "./Ellipsified";
 
 const testLabels = [
   "Short Title",

--- a/frontend/src/metabase/core/components/Ellipsified/Ellipsified.tsx
+++ b/frontend/src/metabase/core/components/Ellipsified/Ellipsified.tsx
@@ -51,8 +51,6 @@ export const Ellipsified = ({
         data-testid={dataTestId}
       >
         {children}
-        {children}
-        {children}
       </EllipsifiedRoot>
     </Tooltip>
   );

--- a/frontend/src/metabase/core/components/Ellipsified/Ellipsified.tsx
+++ b/frontend/src/metabase/core/components/Ellipsified/Ellipsified.tsx
@@ -31,11 +31,14 @@ const Ellipsified = ({
   placement = "top",
   "data-testid": dataTestId,
 }: EllipsifiedProps) => {
-  const { isTruncated, ref } = useIsTruncated<HTMLDivElement>();
+  const canSkipTooltipRendering = !showTooltip && !alwaysShowTooltip;
+  const { isTruncated, ref } = useIsTruncated<HTMLDivElement>({
+    skip: canSkipTooltipRendering,
+  });
 
   return (
     <Tooltip
-      tooltip={tooltip || children || " "}
+      tooltip={canSkipTooltipRendering ? undefined : tooltip || children || " "}
       isEnabled={(showTooltip && (isTruncated || alwaysShowTooltip)) || false}
       maxWidth={tooltipMaxWidth}
       placement={placement}
@@ -47,6 +50,8 @@ const Ellipsified = ({
         style={style}
         data-testid={dataTestId}
       >
+        {children}
+        {children}
         {children}
       </EllipsifiedRoot>
     </Tooltip>

--- a/frontend/src/metabase/core/components/Ellipsified/Ellipsified.tsx
+++ b/frontend/src/metabase/core/components/Ellipsified/Ellipsified.tsx
@@ -19,7 +19,7 @@ interface EllipsifiedProps {
   "data-testid"?: string;
 }
 
-const Ellipsified = ({
+export const Ellipsified = ({
   style,
   className,
   showTooltip = true,
@@ -57,6 +57,3 @@ const Ellipsified = ({
     </Tooltip>
   );
 };
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default Ellipsified;

--- a/frontend/src/metabase/core/components/Ellipsified/Ellipsified.tsx
+++ b/frontend/src/metabase/core/components/Ellipsified/Ellipsified.tsx
@@ -33,7 +33,7 @@ export const Ellipsified = ({
 }: EllipsifiedProps) => {
   const canSkipTooltipRendering = !showTooltip && !alwaysShowTooltip;
   const { isTruncated, ref } = useIsTruncated<HTMLDivElement>({
-    skip: canSkipTooltipRendering,
+    disabled: canSkipTooltipRendering,
   });
 
   return (

--- a/frontend/src/metabase/core/components/Ellipsified/index.ts
+++ b/frontend/src/metabase/core/components/Ellipsified/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./Ellipsified";
+export { Ellipsified } from "./Ellipsified";

--- a/frontend/src/metabase/dashboard/components/ActionSidebar/ActionSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/ActionSidebar/ActionSidebar.tsx
@@ -13,7 +13,7 @@ import Form from "metabase/core/components/Form";
 import FormProvider from "metabase/core/components/FormProvider";
 import FormInput from "metabase/core/components/FormInput";
 import FormSelect from "metabase/core/components/FormSelect";
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import {
   FieldLabel,
   FieldLabelContainer,

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
@@ -26,7 +26,7 @@ import {
 } from "metabase/dashboard/utils";
 
 import { isActionDashCard } from "metabase/actions/utils";
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import Question from "metabase-lib/Question";
 import { isDateParameter } from "metabase-lib/parameters/utils/parameter-type";
 import { isVariableTarget } from "metabase-lib/parameters/utils/targets";

--- a/frontend/src/metabase/home/components/HomeModelCard/HomeModelCard.styled.tsx
+++ b/frontend/src/metabase/home/components/HomeModelCard/HomeModelCard.styled.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import { Icon } from "metabase/core/components/Icon";
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 
 export const CardIcon = styled(Icon)`
   display: block;

--- a/frontend/src/metabase/home/components/HomeXrayCard/HomeXrayCard.styled.tsx
+++ b/frontend/src/metabase/home/components/HomeXrayCard/HomeXrayCard.styled.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import { Icon } from "metabase/core/components/Icon";
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 
 export const CardIcon = styled(Icon)`
   display: block;

--- a/frontend/src/metabase/hooks/use-is-truncated.ts
+++ b/frontend/src/metabase/hooks/use-is-truncated.ts
@@ -2,14 +2,16 @@ import { useLayoutEffect, useRef, useState } from "react";
 
 import resizeObserver from "metabase/lib/resize-observer";
 
-export const useIsTruncated = <E extends Element>() => {
+export const useIsTruncated = <E extends Element>({
+  skip = false,
+}: { skip?: boolean } = {}) => {
   const ref = useRef<E | null>(null);
   const [isTruncated, setIsTruncated] = useState(false);
 
   useLayoutEffect(() => {
     const element = ref.current;
 
-    if (!element) {
+    if (!element || skip) {
       return;
     }
 
@@ -23,7 +25,7 @@ export const useIsTruncated = <E extends Element>() => {
     return () => {
       resizeObserver.unsubscribe(element, handleResize);
     };
-  }, []);
+  }, [skip]);
 
   return { isTruncated, ref };
 };

--- a/frontend/src/metabase/hooks/use-is-truncated.ts
+++ b/frontend/src/metabase/hooks/use-is-truncated.ts
@@ -3,15 +3,15 @@ import { useLayoutEffect, useRef, useState } from "react";
 import resizeObserver from "metabase/lib/resize-observer";
 
 export const useIsTruncated = <E extends Element>({
-  skip = false,
-}: { skip?: boolean } = {}) => {
+  disabled = false,
+}: { disabled?: boolean } = {}) => {
   const ref = useRef<E | null>(null);
   const [isTruncated, setIsTruncated] = useState(false);
 
   useLayoutEffect(() => {
     const element = ref.current;
 
-    if (!element || skip) {
+    if (!element || disabled) {
       return;
     }
 
@@ -25,7 +25,7 @@ export const useIsTruncated = <E extends Element>({
     return () => {
       resizeObserver.unsubscribe(element, handleResize);
     };
-  }, [skip]);
+  }, [disabled]);
 
   return { isTruncated, ref };
 };

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.styled.tsx
@@ -4,7 +4,7 @@ import { space, breakpointMaxSmall } from "metabase/styled-components/theme";
 
 import TabList from "metabase/core/components/TabList";
 import TabPanel from "metabase/core/components/TabPanel";
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import IconButtonWrapper from "metabase/components/IconButtonWrapper";
 import { Icon } from "metabase/core/components/Icon";
 

--- a/frontend/src/metabase/reference/components/EditableReferenceHeader.jsx
+++ b/frontend/src/metabase/reference/components/EditableReferenceHeader.jsx
@@ -7,7 +7,7 @@ import L from "metabase/components/List/List.css";
 
 import { Icon } from "metabase/core/components/Icon";
 import InputBlurChange from "metabase/components/InputBlurChange";
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import Button from "metabase/core/components/Button";
 import S from "./ReferenceHeader.css";
 

--- a/frontend/src/metabase/reference/components/ReferenceHeader.jsx
+++ b/frontend/src/metabase/reference/components/ReferenceHeader.jsx
@@ -7,7 +7,7 @@ import { t } from "ttag";
 import L from "metabase/components/List/List.css";
 
 import { Icon } from "metabase/core/components/Icon";
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import S from "./ReferenceHeader.css";
 
 const ReferenceHeader = ({

--- a/frontend/src/metabase/status/components/StatusLarge/StatusLarge.tsx
+++ b/frontend/src/metabase/status/components/StatusLarge/StatusLarge.tsx
@@ -1,4 +1,4 @@
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import type { IconName } from "metabase/core/components/Icon";
 import { Icon } from "metabase/core/components/Icon";
 import useStatusVisibility from "../../hooks/use-status-visibility";

--- a/frontend/src/metabase/timelines/common/components/ModalHeader/ModalHeader.styled.tsx
+++ b/frontend/src/metabase/timelines/common/components/ModalHeader/ModalHeader.styled.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import IconButtonWrapper from "metabase/components/IconButtonWrapper";
 import { Icon } from "metabase/core/components/Icon";
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 
 export const HeaderRoot = styled.div`
   display: flex;

--- a/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.tsx
@@ -4,7 +4,7 @@ import { t } from "ttag";
 import _ from "underscore";
 import type { Timeline, TimelineEvent } from "metabase-types/api";
 import { getTimelineName } from "metabase/lib/timelines";
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import EventCard from "../EventCard";
 import {
   CardHeader,

--- a/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
+++ b/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
@@ -3,7 +3,7 @@ import { Component } from "react";
 
 import cx from "classnames";
 
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import { formatValue } from "metabase/lib/formatting";
 import { getFriendlyName } from "metabase/visualizations/lib/utils";
 import { findSeriesByKey } from "metabase/visualizations/lib/series";

--- a/frontend/src/metabase/visualizations/components/LegendItem.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendItem.jsx
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import cx from "classnames";
 import { Icon } from "metabase/core/components/Icon";
 import Tooltip from "metabase/core/components/Tooltip";
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 
 import { IconContainer } from "./LegendItem.styled";
 

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
@@ -8,7 +8,7 @@ import ExpandableString from "metabase/query_builder/components/ExpandableString
 import EmptyState from "metabase/components/EmptyState";
 
 import { formatValue, formatColumn } from "metabase/lib/formatting";
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import {
   isa,
   isID,

--- a/frontend/src/metabase/visualizations/components/ScalarValue/ScalarValue.jsx
+++ b/frontend/src/metabase/visualizations/components/ScalarValue/ScalarValue.jsx
@@ -6,7 +6,7 @@ import { useMemo } from "react";
 import { t } from "ttag";
 
 import Tooltip from "metabase/core/components/Tooltip";
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import Markdown from "metabase/core/components/Markdown";
 import {
   ScalarRoot,

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -29,7 +29,7 @@ import { getQueryBuilderMode } from "metabase/query_builder/selectors";
 
 import ExplicitSize from "metabase/components/ExplicitSize";
 
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import DimensionInfoPopover from "metabase/components/MetadataInfo/DimensionInfoPopover";
 import { EmotionCacheProvider } from "metabase/styled-components/components/EmotionCacheProvider";
 import { isID, isPK, isFK } from "metabase-lib/types/utils/isa";

--- a/frontend/src/metabase/visualizations/components/TableSimple/TableSimple.jsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple/TableSimple.jsx
@@ -4,7 +4,7 @@ import { getIn } from "icepick";
 import _ from "underscore";
 
 import ExplicitSize from "metabase/components/ExplicitSize";
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 
 import { isPositiveInteger } from "metabase/lib/number";
 import { isColumnRightAligned } from "metabase/visualizations/lib/table";

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption.jsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption.jsx
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 
 import Tooltip from "metabase/core/components/Tooltip";
 import Markdown from "metabase/core/components/Markdown";
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import LegendActions from "./LegendActions";
 import {
   LegendCaptionRoot,

--- a/frontend/src/metabase/visualizations/components/legend/LegendItem.jsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendItem.jsx
@@ -1,6 +1,6 @@
 import { memo } from "react";
 import PropTypes from "prop-types";
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import {
   LegendItemDot,
   LegendItemLabel,

--- a/frontend/src/metabase/visualizations/components/skeletons/SkeletonCaption/SkeletonCaption.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/skeletons/SkeletonCaption/SkeletonCaption.styled.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import { Icon } from "metabase/core/components/Icon";
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import { animationStyles } from "metabase/visualizations/components/skeletons/ChartSkeleton/ChartSkeleton.styled";
 import type { SkeletonCaptionSize } from "./types";
 

--- a/frontend/src/metabase/visualizations/components/skeletons/StaticSkeleton/StaticSkeleton.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/skeletons/StaticSkeleton/StaticSkeleton.styled.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import { Icon } from "metabase/core/components/Icon";
 import { MarkdownPreview } from "metabase/core/components/MarkdownPreview";
 import { color } from "metabase/lib/colors";

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/EntityDisplay.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/EntityDisplay.styled.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 
 export const EntityDisplayContainer = styled.div`
   width: 100%;

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -452,10 +452,17 @@ function PivotTable({
                         return sumArray(subColumnWidths);
                       }}
                       estimatedColumnSize={DEFAULT_CELL_WIDTH}
-                      cellRenderer={({ rowIndex, columnIndex, key, style }) => (
+                      cellRenderer={({
+                        rowIndex,
+                        columnIndex,
+                        key,
+                        style,
+                        isScrolling,
+                      }) => (
                         <BodyCell
                           key={key}
                           style={style}
+                          isScrolling={isScrolling}
                           rowSection={getRowSection(columnIndex, rowIndex)}
                           isNightMode={isNightMode}
                           getCellClickHandler={getCellClickHandler}

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -462,7 +462,7 @@ function PivotTable({
                         <BodyCell
                           key={key}
                           style={style}
-                          isScrolling={isScrolling}
+                          showTooltip={!isScrolling}
                           rowSection={getRowSection(columnIndex, rowIndex)}
                           isNightMode={isNightMode}
                           getCellClickHandler={getCellClickHandler}

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
@@ -3,7 +3,7 @@ import cx from "classnames";
 import type { ControlPosition, DraggableBounds } from "react-draggable";
 import Draggable from "react-draggable";
 
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 
 import type { VisualizationSettings } from "metabase-types/api";
 

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
@@ -43,7 +43,7 @@ interface CellProps {
   hasTopBorder?: boolean;
   onClick?: ((e: React.SyntheticEvent) => void) | undefined;
   onResize?: (newWidth: number) => void;
-  isScrolling?: boolean;
+  showTooltip?: boolean;
 }
 
 export function Cell({
@@ -60,7 +60,7 @@ export function Cell({
   hasTopBorder,
   onClick,
   onResize,
-  isScrolling = false,
+  showTooltip = true,
 }: CellProps) {
   return (
     <PivotTableCell
@@ -83,7 +83,7 @@ export function Cell({
     >
       <>
         <div className={cx("px1 flex align-center", { "justify-end": isBody })}>
-          <Ellipsified showTooltip={!isScrolling}>{value}</Ellipsified>
+          <Ellipsified showTooltip={showTooltip}>{value}</Ellipsified>
           {icon && <div className="pl1">{icon}</div>}
         </div>
         {!!onResize && (
@@ -198,7 +198,7 @@ interface BodyCellProps {
   isNightMode: boolean;
   getCellClickHandler: CellClickHandler;
   cellWidths: number[];
-  isScrolling?: boolean;
+  showTooltip?: boolean;
 }
 
 export const BodyCell = ({
@@ -207,7 +207,7 @@ export const BodyCell = ({
   isNightMode,
   getCellClickHandler,
   cellWidths,
-  isScrolling = false,
+  showTooltip = true,
 }: BodyCellProps) => {
   return (
     <div style={style} className="flex">
@@ -222,7 +222,7 @@ export const BodyCell = ({
             value={value}
             isEmphasized={isSubtotal}
             isBold={isSubtotal}
-            isScrolling={isScrolling}
+            showTooltip={showTooltip}
             isBody
             onClick={getCellClickHandler(clicked)}
             backgroundColor={backgroundColor}

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
@@ -43,6 +43,7 @@ interface CellProps {
   hasTopBorder?: boolean;
   onClick?: ((e: React.SyntheticEvent) => void) | undefined;
   onResize?: (newWidth: number) => void;
+  isScrolling?: boolean;
 }
 
 export function Cell({
@@ -59,6 +60,7 @@ export function Cell({
   hasTopBorder,
   onClick,
   onResize,
+  isScrolling = false,
 }: CellProps) {
   return (
     <PivotTableCell
@@ -81,7 +83,7 @@ export function Cell({
     >
       <>
         <div className={cx("px1 flex align-center", { "justify-end": isBody })}>
-          <Ellipsified>{value}</Ellipsified>
+          <Ellipsified showTooltip={!isScrolling}>{value}</Ellipsified>
           {icon && <div className="pl1">{icon}</div>}
         </div>
         {!!onResize && (
@@ -196,6 +198,7 @@ interface BodyCellProps {
   isNightMode: boolean;
   getCellClickHandler: CellClickHandler;
   cellWidths: number[];
+  isScrolling?: boolean;
 }
 
 export const BodyCell = ({
@@ -204,6 +207,7 @@ export const BodyCell = ({
   isNightMode,
   getCellClickHandler,
   cellWidths,
+  isScrolling = false,
 }: BodyCellProps) => {
   return (
     <div style={style} className="flex">
@@ -218,6 +222,7 @@ export const BodyCell = ({
             value={value}
             isEmphasized={isSubtotal}
             isBold={isSubtotal}
+            isScrolling={isScrolling}
             isBody
             onClick={getCellClickHandler(clicked)}
             backgroundColor={backgroundColor}

--- a/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.styled.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
-import Ellipsified from "metabase/core/components/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import { color } from "metabase/lib/colors";
 import { Icon } from "metabase/core/components/Icon";
 import { space } from "metabase/styled-components/theme";

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.styled.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 
-import Ellipsified from "metabase/core/components/Ellipsified/Ellipsified";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import { Icon } from "metabase/core/components/Icon";
 import { color } from "metabase/lib/colors";
 import { breakpointMaxMedium, space } from "metabase/styled-components/theme";


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/14607

### Description

I wasn't able to reproduce the initial problem with older and new versions of the metabase (tried 0.39.5, 0.40.8, 0.45, 0.46, 0.46.5), but overall experience with PivotTable wasn't great during scrolling. I found there were added optimizations from @iethree (probably), but even virtualized table required calculating if cell has content which should be ellipsified together with tooltip rendering for _every cell_. 
Initial idea to skip rendering of the tooltip if text content doesn't overflow allocated space didn't work out because of the way we calculate if element overflows or not. 
But at least during scrolling we don't need to render tooltip and calculate text overflow - so I optimized that part and seems results are not that bad.

### How to verify

Create a question from Orders based on following configuration
<img width="350" alt="image" src="https://github.com/metabase/metabase/assets/125459446/e57ec339-7a20-46ed-a26f-d52282c672d5">
Choose `Pivot Table` visualization, save the question.

To get a more clear results, open devtools -> performance tab -> choose throttle CPU by 6 times. Now scroll by dragging scroll

### Demo

https://www.loom.com/share/36541f957bfb47d582d56f666cbee180

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
