### PR TITLE
Rework FieldValuesWidget to skip initialization of Fields entity

### DIFF
--- a/frontend/src/metabase-types/api/mocks/presets/sample_database.ts
+++ b/frontend/src/metabase-types/api/mocks/presets/sample_database.ts
@@ -94,6 +94,12 @@ export const PEOPLE_SOURCE_VALUES: FieldValuesResult = {
   has_more_values: false,
 };
 
+export const PEOPLE_STATE_VALUES: FieldValuesResult = {
+  field_id: PEOPLE.STATE,
+  values: [["CA"], ["NY"], ["TX"], ["FL"], ["IL"]],
+  has_more_values: false,
+};
+
 const DEFAULT_NUMERIC_BINNING_OPTION: FieldDimensionOption = {
   name: "Auto bin",
   mbql: ["field", null, { binning: { strategy: "default" } }],

--- a/frontend/src/metabase-types/api/mocks/presets/sample_database.ts
+++ b/frontend/src/metabase-types/api/mocks/presets/sample_database.ts
@@ -94,12 +94,6 @@ export const PEOPLE_SOURCE_VALUES: FieldValuesResult = {
   has_more_values: false,
 };
 
-export const PEOPLE_STATE_VALUES: FieldValuesResult = {
-  field_id: PEOPLE.STATE,
-  values: [["CA"], ["NY"], ["TX"], ["FL"], ["IL"]],
-  has_more_values: false,
-};
-
 const DEFAULT_NUMERIC_BINNING_OPTION: FieldDimensionOption = {
   name: "Auto bin",
   mbql: ["field", null, { binning: { strategy: "default" } }],

--- a/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.tsx
+++ b/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.tsx
@@ -38,6 +38,7 @@ import type {
 } from "metabase-types/api";
 
 import { useDispatch } from "metabase/lib/redux";
+import { isNotNull } from "metabase/core/utils/types";
 import type Field from "metabase-lib/metadata/Field";
 import type Question from "metabase-lib/Question";
 
@@ -174,17 +175,18 @@ export function FieldValuesWidgetInner({
     try {
       if (canUseDashboardEndpoints(dashboard)) {
         const { values, has_more_values } =
-          await _fetchDashboardParameterValues(query);
+          await dispatchFetchDashboardParameterValues(query);
         newOptions = values;
         newValuesMode = has_more_values ? "search" : newValuesMode;
       } else if (canUseCardEndpoints(question)) {
-        const { values, has_more_values } = await _fetchCardParameterValues(
-          query,
-        );
+        const { values, has_more_values } =
+          await dispatchFetchCardParameterValues(query);
         newOptions = values;
         newValuesMode = has_more_values ? "search" : newValuesMode;
       } else if (canUseParameterEndpoints(parameter)) {
-        const { values, has_more_values } = await _fetchParameterValues(query);
+        const { values, has_more_values } = await dispatchFetchParameterValues(
+          query,
+        );
         newOptions = values;
         newValuesMode = has_more_values ? "search" : newValuesMode;
       } else {
@@ -250,7 +252,7 @@ export function FieldValuesWidgetInner({
     }
   };
 
-  const _fetchParameterValues = async (query?: string) => {
+  const dispatchFetchParameterValues = async (query?: string) => {
     if (!parameter) {
       return { has_more_values: false, values: [] };
     }
@@ -263,10 +265,10 @@ export function FieldValuesWidgetInner({
     );
   };
 
-  const _fetchCardParameterValues = async (query?: string) => {
+  const dispatchFetchCardParameterValues = async (query?: string) => {
     const cardId = question?.id();
 
-    if (!cardId || !parameter) {
+    if (!isNotNull(cardId) || !parameter) {
       return { has_more_values: false, values: [] };
     }
 
@@ -279,10 +281,10 @@ export function FieldValuesWidgetInner({
     );
   };
 
-  const _fetchDashboardParameterValues = async (query?: string) => {
+  const dispatchFetchDashboardParameterValues = async (query?: string) => {
     const dashboardId = dashboard?.id;
 
-    if (!dashboardId || !parameter || !parameters) {
+    if (!isNotNull(dashboardId) || !parameter || !parameters) {
       return { has_more_values: false, values: [] };
     }
 

--- a/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.unit.spec.tsx
+++ b/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.unit.spec.tsx
@@ -5,10 +5,7 @@ import {
   screen,
   waitFor,
 } from "__support__/ui";
-import {
-  setupFieldSearchValuesEndpoints,
-  setupFieldsValuesEndpoints,
-} from "__support__/server-mocks";
+import { setupFieldSearchValuesEndpoints } from "__support__/server-mocks";
 import Fields from "metabase/entities/fields";
 
 import { checkNotNull } from "metabase/core/utils/types";
@@ -21,7 +18,6 @@ import {
   PEOPLE,
   PRODUCT_CATEGORY_VALUES,
   PEOPLE_SOURCE_VALUES,
-  PEOPLE_STATE_VALUES,
 } from "metabase-types/api/mocks/presets";
 import type Field from "metabase-lib/metadata/Field";
 
@@ -59,12 +55,6 @@ async function setup({
       setupFieldSearchValuesEndpoints(field?.id as number, searchValue);
     });
   }
-
-  setupFieldsValuesEndpoints([
-    PRODUCT_CATEGORY_VALUES,
-    PEOPLE_SOURCE_VALUES,
-    PEOPLE_STATE_VALUES,
-  ]);
 
   renderWithProviders(
     <FieldValuesWidget

--- a/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.unit.spec.tsx
+++ b/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.unit.spec.tsx
@@ -5,7 +5,11 @@ import {
   screen,
   waitFor,
 } from "__support__/ui";
-import { setupFieldSearchValuesEndpoints } from "__support__/server-mocks";
+import {
+  setupFieldSearchValuesEndpoints,
+  setupFieldsValuesEndpoints,
+} from "__support__/server-mocks";
+import Fields from "metabase/entities/fields";
 
 import { checkNotNull } from "metabase/core/utils/types";
 import type { IFieldValuesWidgetProps } from "metabase/components/FieldValuesWidget";
@@ -17,6 +21,7 @@ import {
   PEOPLE,
   PRODUCT_CATEGORY_VALUES,
   PEOPLE_SOURCE_VALUES,
+  PEOPLE_STATE_VALUES,
 } from "metabase-types/api/mocks/presets";
 import type Field from "metabase-lib/metadata/Field";
 
@@ -42,7 +47,12 @@ async function setup({
 } & Omit<Partial<IFieldValuesWidgetProps>, "fields">) {
   const fetchFieldValues = jest.fn(({ id }) => ({
     payload: fields.filter(checkNotNull).find(f => f?.id === id),
+    type: "__MOCK__",
   }));
+
+  jest
+    .spyOn(Fields.objectActions, "fetchFieldValues")
+    .mockImplementation(fetchFieldValues);
 
   if (searchValue) {
     fields.forEach(field => {
@@ -50,16 +60,17 @@ async function setup({
     });
   }
 
+  setupFieldsValuesEndpoints([
+    PRODUCT_CATEGORY_VALUES,
+    PEOPLE_SOURCE_VALUES,
+    PEOPLE_STATE_VALUES,
+  ]);
+
   renderWithProviders(
     <FieldValuesWidget
       value={[]}
       fields={fields.filter(checkNotNull)}
       onChange={jest.fn()}
-      fetchFieldValues={fetchFieldValues as any}
-      fetchParameterValues={jest.fn()}
-      fetchDashboardParameterValues={jest.fn()}
-      fetchCardParameterValues={jest.fn()}
-      addRemappings={jest.fn()}
       prefix={prefix}
       {...props}
     />,


### PR DESCRIPTION
Related to the circulal deps [RFC](https://www.notion.so/metabase/62-Prevent-circular-dependencies-a35135e3f0e445dc83c5a0dfc77d5d1a)

### Description

FieldValuesWidget had `Fields.objectActions.fetchFieldValues` in the `mapDispatchToProps` object, what required initialization of the object right during the loading of the file, which led to the circular dependency problem as 
Fields entity cannot initialize before the query_builder actions - circle as entities are not ready and required in question_builder actions

```
TypeError: Cannot read properties of undefined (reading 'objectActions')

      71 | const mapDispatchToProps = {
      72 |   addRemappings,
    > 73 |   fetchFieldValues: Fields.objectActions.fetchFieldValues,
         |                            ^
      74 |   fetchParameterValues,
      75 |   fetchCardParameterValues,
      76 |   fetchDashboardParameterValues,

      at Object.objectActions (frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.tsx:73
```

<details><summary>Stacktrace</summary>
<p>

```
at Object.objectActions (frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.tsx:73:28)
      at Object.<anonymous> (frontend/src/metabase/components/FieldValuesWidget/index.ts:2:1)
      at Object.<anonymous> (frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker/DefaultPicker.tsx:6:1)
      at Object.<anonymous> (frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker/index.ts:1:1)
      at Object.<anonymous> (frontend/src/metabase/query_builder/components/filters/FilterPopover/FilterPopoverPicker.tsx:6:1)
      at Object.<anonymous> (frontend/src/metabase/query_builder/components/filters/FilterPopover/FilterPopover.tsx:30:1)
      at Object.<anonymous> (frontend/src/metabase/query_builder/components/filters/FilterPopover/index.tsx:1:1)
      at Object.<anonymous> (frontend/src/metabase/visualizations/click-actions/components/ColumnFilterDrillPopover.tsx:3:1)
      at Object.<anonymous> (frontend/src/metabase/visualizations/click-actions/drills/QuickFilterDrill/QuickFilterDrill.tsx:18:1)
      at Object.<anonymous> (frontend/src/metabase/visualizations/click-actions/drills/QuickFilterDrill/index.ts:1:1)
      at Object.<anonymous> (frontend/src/metabase/visualizations/click-actions/modes/DefaultMode.ts:3:1)
      at Object.<anonymous> (frontend/src/metabase/visualizations/click-actions/modes/SegmentMode.ts:4:1)
      at Object.<anonymous> (frontend/src/metabase/visualizations/click-actions/lib/modes.ts:10:1)
      at Object.<anonymous> (frontend/src/metabase/query_builder/selectors.js:24:1)
      at Object.<anonymous> (frontend/src/metabase/selectors/app.ts:9:1)
      at Object.<anonymous> (frontend/src/metabase/redux/app.ts:17:1)
      at Object.<anonymous> (frontend/src/metabase/query_builder/actions/core/core.js:14:1)
      at Object.<anonymous> (frontend/src/metabase/entities/questions.js:16:1)
      at Object.<anonymous> (frontend/src/metabase/lib/card.js:4:1)
      at Object.<anonymous> (frontend/src/metabase/lib/urls/questions.ts:3:1)
```

</p>
</details> 



### How to verify

I rely on jest and e2e tests as nothing should have been changed

### Checklist

~- [ ] Tests have been added/updated to cover changes in this PR~
