### PR TITLE
Use snake_case for archive item selector

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -125,3 +125,9 @@ export const undoToast = () => {
 export function dashboardCards() {
   return cy.get("#Dashboard-Cards-Container");
 }
+
+export function getArchiveListItem(itemName) {
+  return cy.findByTestId(
+    `archive-item-${itemName.replaceAll(" ", "-").toLowerCase()}`,
+  );
+}

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -14,6 +14,7 @@ import {
   createModelFromTableName,
   queryWritableDB,
   setTokenFeatures,
+  getArchiveListItem,
 } from "e2e/support/helpers";
 
 import {
@@ -928,10 +929,6 @@ function disableSharingFor(actionName) {
   cy.findByRole("dialog").within(() => {
     cy.button("Cancel").click();
   });
-}
-
-function getArchiveListItem(itemName) {
-  return cy.findByTestId(`archive-item-${itemName}`);
 }
 
 function resetAndVerifyScoreValue(dialect) {

--- a/e2e/test/scenarios/collections/archive.cy.spec.js
+++ b/e2e/test/scenarios/collections/archive.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "e2e/support/helpers";
+import { restore, getArchiveListItem } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { FIRST_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data";
 
@@ -50,18 +50,18 @@ describe("scenarios > collections > archive", () => {
     cy.visit("/archive");
 
     // test individual archive and undo
-    cy.findByTestId(`archive-item-${DASHBOARD_NAME}`)
+    getArchiveListItem(DASHBOARD_NAME)
       .findByText(`${DASHBOARD_NAME}`)
       .realHover()
       .findByLabelText("unarchive icon")
       .click();
-    cy.findByTestId(`archive-item-${DASHBOARD_NAME}`).should("not.exist");
+    getArchiveListItem(DASHBOARD_NAME).should("not.exist");
 
     cy.findByTestId("toast-undo").findByText("Undo").click();
-    cy.findByTestId(`archive-item-${DASHBOARD_NAME}`).should("exist");
+    getArchiveListItem(DASHBOARD_NAME).should("exist");
 
     // test bulk archive and undo
-    cy.findByTestId(`archive-item-${COLLECTION_NAME}`).within(() => {
+    getArchiveListItem(COLLECTION_NAME).within(() => {
       cy.findByLabelText("archive-item-swapper").realHover().click();
     });
 
@@ -71,27 +71,27 @@ describe("scenarios > collections > archive", () => {
       cy.findByText("Unarchive").click();
     });
 
-    cy.findByTestId(`archive-item-${DASHBOARD_NAME}`).should("not.exist");
-    cy.findByTestId(`archive-item-${COLLECTION_NAME}`).should("not.exist");
-    cy.findByTestId(`archive-item-${QUESTION_NAME}`).should("not.exist");
+    getArchiveListItem(DASHBOARD_NAME).should("not.exist");
+    getArchiveListItem(COLLECTION_NAME).should("not.exist");
+    getArchiveListItem(QUESTION_NAME).should("not.exist");
 
     cy.findByTestId("toast-undo").findByText("Undo").click();
-    cy.findByTestId(`archive-item-${DASHBOARD_NAME}`).should("exist");
-    cy.findByTestId(`archive-item-${COLLECTION_NAME}`).should("exist");
-    cy.findByTestId(`archive-item-${QUESTION_NAME}`).should("exist");
+    getArchiveListItem(DASHBOARD_NAME).should("exist");
+    getArchiveListItem(COLLECTION_NAME).should("exist");
+    getArchiveListItem(QUESTION_NAME).should("exist");
 
     // test individual delete
-    cy.findByTestId(`archive-item-${DASHBOARD_NAME}`)
+    getArchiveListItem(DASHBOARD_NAME)
       .findByText(`${DASHBOARD_NAME}`)
       .realHover()
       .findByLabelText("trash icon")
       .click();
-    cy.findByTestId(`archive-item-${DASHBOARD_NAME}`).should("not.exist");
+    getArchiveListItem(DASHBOARD_NAME).should("not.exist");
 
     cy.findByTestId("toast-undo").should("not.exist");
 
     // test bulk delete
-    cy.findByTestId(`archive-item-${COLLECTION_NAME}`)
+    getArchiveListItem(COLLECTION_NAME)
       .findByLabelText("archive-item-swapper")
       .realHover()
       .click();
@@ -102,8 +102,8 @@ describe("scenarios > collections > archive", () => {
       cy.findByText("Delete").click();
     });
 
-    cy.findByTestId(`archive-item-${COLLECTION_NAME}`).should("exist"); // cannot delete collections
-    cy.findByTestId(`archive-item-${QUESTION_NAME}`).should("not.exist");
+    getArchiveListItem(COLLECTION_NAME).should("exist"); // cannot delete collections
+    getArchiveListItem(QUESTION_NAME).should("not.exist");
   });
 
   it("should load initially hidden archived items on scroll (metabase#24213)", () => {

--- a/frontend/src/metabase/components/ArchivedItem/ArchivedItem.tsx
+++ b/frontend/src/metabase/components/ArchivedItem/ArchivedItem.tsx
@@ -36,7 +36,7 @@ export const ArchivedItem = ({
 }: ArchivedItemProps) => (
   <div
     className="flex align-center p2 hover-parent hover--visibility border-bottom bg-light-hover"
-    data-testid={`archive-item-${name}`}
+    data-testid={`archive-item-${name.replaceAll(" ", "-").toLowerCase()}`}
   >
     <Swapper
       aria-label={"archive-item-swapper"}


### PR DESCRIPTION
### Description

`archive.cy.spec.js` is [flaky](https://www.deploysentinel.com/ci/runs/650818a8d3adbb9d6bd14884) and my bet it is because of using spaces in the selector `findByTestId("archive-item-Database Name")`, so I replaced spaces with `-` and converted it to lower case.

### How to verify

check archive functionality - it should work

### Demo

- 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
