### PR TITLE
[MLv2] Don't discard extra variadic args to drill-thru

### DIFF
--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -855,8 +855,8 @@
   "Applies the given `drill-thru` to the specified query and stage. Returns the updated query.
 
   Each type of drill-thru has a different effect on the query."
-  [a-query stage-number a-drill-thru]
-  (lib.core/drill-thru a-query stage-number a-drill-thru))
+  [a-query stage-number a-drill-thru & args]
+  (apply lib.core/drill-thru a-query stage-number a-drill-thru args))
 
 (defn ^:export pivot-types
   "Returns an array of pivot types that are available in this drill-thru, which must be a pivot drill-thru."


### PR DESCRIPTION
The `metabase.lib.js/drill-thru` wrapper was dropping the ball on any varargs, and not passing them on to the drill thru
code.

Fixes #33480.
