### PR TITLE
Fix permissions-instance-analytics-audit-v2-test

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
@@ -6,27 +6,28 @@
    [metabase.models.collection.graph :refer [update-graph!]]
    [metabase.models.collection.graph-test :refer [graph]]
    [metabase.models.database :refer [Database]]
-   [metabase.models.permissions :refer [Permissions
-                                        table-query-path]]
+   [metabase.models.permissions :refer [Permissions table-query-path]]
    [metabase.models.permissions-group :refer [PermissionsGroup]]
    [metabase.models.table :refer [Table]]
+   [metabase.public-settings.premium-features-test :as premium-features-test]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
 (deftest permissions-instance-analytics-audit-v2-test
-  (mt/with-temp [PermissionsGroup {group-id :id}                    {}
-                 Database         {database-id :id}                 {}
-                 Table            view-table                        {:db_id database-id :name "v_users"}
-                 Collection       {collection-id :id
-                                   collection-entity-id :entity_id} {}]
-    (with-redefs [audit-db/default-audit-db-id                (constantly database-id)
-                  audit-db/default-audit-collection-entity-id (constantly collection-entity-id)]
-      (testing "Adding instance analytics adds audit db permissions"
-        (update-graph! (assoc-in (graph :clear-revisions? true) [:groups group-id collection-id] :read))
-        (let [new-perms (t2/select-fn-set :object Permissions {:where [:= :group_id group-id]})]
-          (is (contains? new-perms (table-query-path view-table)))))
-      (testing "Unable to update instance analytics to writable"
-        (is (thrown-with-msg?
-             Exception
-             #"Unable to make audit collections writable."
-             (update-graph! (assoc-in (graph :clear-revisions? true) [:groups group-id collection-id] :write))))))))
+  (premium-features-test/with-premium-features #{:audit-app}
+    (mt/with-temp [PermissionsGroup {group-id :id}                    {}
+                   Database         {database-id :id}                 {}
+                   Table            view-table                        {:db_id database-id :name "v_users"}
+                   Collection       {collection-id :id
+                                     collection-entity-id :entity_id} {}]
+      (with-redefs [audit-db/default-audit-db-id                (constantly database-id)
+                    audit-db/default-audit-collection-entity-id (constantly collection-entity-id)]
+        (testing "Adding instance analytics adds audit db permissions"
+          (update-graph! (assoc-in (graph :clear-revisions? true) [:groups group-id collection-id] :read))
+          (let [new-perms (t2/select-fn-set :object Permissions {:where [:= :group_id group-id]})]
+            (is (contains? new-perms (table-query-path view-table)))))
+        (testing "Unable to update instance analytics to writable"
+          (is (thrown-with-msg?
+               Exception
+               #"Unable to make audit collections writable."
+               (update-graph! (assoc-in (graph :clear-revisions? true) [:groups group-id collection-id] :write)))))))))


### PR DESCRIPTION
Fix `permissions-instance-analytics-audit-v2-test` failing in terminal. Unsure why the original test passes in REPL though :thinking: