### PR TITLE
fix `landing-page` setting causing frontend to break

### DIFF
--- a/e2e/test/scenarios/admin/settings/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/settings.cy.spec.js
@@ -7,6 +7,7 @@ import {
   isOSS,
   isEE,
   setTokenFeatures,
+  main,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
@@ -341,5 +342,19 @@ describeEE("scenarios > admin > settings (EE)", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Metabase Admin");
     cy.findByLabelText("store icon").should("not.exist");
+  });
+
+  it("should not break the root path when given invalid `landing-page` value (metabase#18004) ", () => {
+    cy.visit("/admin/settings/whitelabel");
+
+    main().within(() => {
+      cy.get("#setting-landing-page").type("https://www.metabase.com/").blur();
+    });
+
+    cy.visit("/");
+
+    main().within(() => {
+      cy.findByText(`We're a little lost...`);
+    });
   });
 });

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -150,7 +150,7 @@ export const getRoutes = store => (
           onEnter={(nextState, replace) => {
             const page = PLUGIN_LANDING_PAGE[0] && PLUGIN_LANDING_PAGE[0]();
             if (page && page !== "/") {
-              replace(page);
+              replace(page[0] === "/" ? page : `/${page}`);
             }
           }}
         />


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/18004

### Description

We had a bug where inputing an invalid value (e.g. an entire url) into the `landing-page` white-labeling setting would cause the frontend to break. 

This PR fixes this by ensuring that the `landing-page` setting value that we pass to `react-router`'s `replace` method is prefixed by a `/`, so that it does not error.

### How to verify

1. Go to `/admin/settings/whitelabel`
2. Input a full url like `https://www.metabase.com/` to the `Landing page` setting.
3. Go to your instance's root url (e.g. `localhost:3000`).
4. Should see a 404 error, and the app should still work.

### Demo

https://github.com/metabase/metabase/assets/37751258/621fc92d-22cd-4c06-9bef-4e8e769fbbf5

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
