### PR TITLE
Fix E2E archive/unarchive dashboard flaky test

### DIFF
--- a/e2e/test/scenarios/collections/archive.cy.spec.js
+++ b/e2e/test/scenarios/collections/archive.cy.spec.js
@@ -52,6 +52,9 @@ describe("scenarios > collections > archive", () => {
     cy.intercept("PUT", "/api/dashboard/*").as("updateDashboard");
     cy.intercept("PUT", "/api/collection/*").as("updateCollection");
     cy.intercept("PUT", "/api/card/*").as("updateQuestion");
+    cy.intercept("DELETE", "/api/dashboard/*").as("deleteDashboard");
+    cy.intercept("DELETE", "/api/collection/*").as("deleteCollection");
+    cy.intercept("DELETE", "/api/card/*").as("deleteQuestion");
 
     cy.log("Test individual archive and undo");
     cy.findByTestId(`archive-item-${DASHBOARD_NAME}`)
@@ -95,29 +98,35 @@ describe("scenarios > collections > archive", () => {
     cy.findByTestId(`archive-item-${COLLECTION_NAME}`).should("exist");
     cy.findByTestId(`archive-item-${QUESTION_NAME}`).should("exist");
 
-    // test individual delete
+    cy.log("test individual delete");
     cy.findByTestId(`archive-item-${DASHBOARD_NAME}`)
       .findByText(`${DASHBOARD_NAME}`)
       .realHover()
       .findByLabelText("trash icon")
       .click();
+    cy.wait("@deleteDashboard");
+    cy.findByTestId(`archive-item-${QUESTION_NAME}`).should("exist");
     cy.findByTestId(`archive-item-${DASHBOARD_NAME}`).should("not.exist");
 
     cy.findByTestId("toast-undo").should("not.exist");
 
-    // test bulk delete
+    cy.log("test bulk delete");
     cy.findByTestId(`archive-item-${COLLECTION_NAME}`)
       .findByLabelText("archive-item-swapper")
       .realHover()
       .click();
 
-    cy.findByTestId("bulk-action-bar", { timeout: 5000 }).should("be.visible");
-    cy.findByTestId("bulk-action-bar").within(() => {
-      cy.findByLabelText("bulk-actions-input").click();
-      cy.findByText("Delete").click();
-    });
+    cy.findByTestId("bulk-action-bar", { timeout: 5000 })
+      .should("be.visible")
+      .within(() => {
+        cy.findByLabelText("bulk-actions-input").click();
+        cy.findByText("2 items selected");
+        cy.button("Delete").click();
+      });
+    cy.wait("@deleteQuestion");
 
-    cy.findByTestId(`archive-item-${COLLECTION_NAME}`).should("exist"); // cannot delete collections
+    cy.log("Cannot delete collections");
+    cy.findByTestId(`archive-item-${COLLECTION_NAME}`).should("exist");
     cy.findByTestId(`archive-item-${QUESTION_NAME}`).should("not.exist");
   });
 

--- a/e2e/test/scenarios/collections/archive.cy.spec.js
+++ b/e2e/test/scenarios/collections/archive.cy.spec.js
@@ -50,6 +50,8 @@ describe("scenarios > collections > archive", () => {
     cy.visit("/archive");
 
     cy.intercept("PUT", "/api/dashboard/*").as("updateDashboard");
+    cy.intercept("PUT", "/api/collection/*").as("updateCollection");
+    cy.intercept("PUT", "/api/card/*").as("updateQuestion");
 
     // test individual archive and undo
     cy.findByTestId(`archive-item-${DASHBOARD_NAME}`)
@@ -68,19 +70,27 @@ describe("scenarios > collections > archive", () => {
     // test bulk archive and undo
     cy.findByTestId(`archive-item-${COLLECTION_NAME}`).within(() => {
       cy.findByLabelText("archive-item-swapper").realHover().click();
+      cy.get("input").should("be.checked");
     });
 
-    cy.findByTestId("bulk-action-bar", { timeout: 5000 }).should("be.visible");
-    cy.findByTestId("bulk-action-bar").within(() => {
-      cy.findByLabelText("bulk-actions-input").click();
-      cy.findByText("Unarchive").click();
-    });
+    cy.findByTestId("bulk-action-bar", { timeout: 5000 })
+      .should("be.visible")
+      .within(() => {
+        cy.findByLabelText("bulk-actions-input").click();
+        cy.findByText("Unarchive").click();
+        cy.wait(["@updateDashboard", "@updateCollection", "@updateQuestion"]);
+      });
 
+    cy.get("main").findByText("Items you archive will appear here.");
     cy.findByTestId(`archive-item-${DASHBOARD_NAME}`).should("not.exist");
     cy.findByTestId(`archive-item-${COLLECTION_NAME}`).should("not.exist");
     cy.findByTestId(`archive-item-${QUESTION_NAME}`).should("not.exist");
 
     cy.findByTestId("toast-undo").findByText("Undo").click();
+    cy.wait(["@updateDashboard", "@updateCollection", "@updateQuestion"]);
+    cy.get("main")
+      .findByText("Items you archive will appear here.")
+      .should("not.exist");
     cy.findByTestId(`archive-item-${DASHBOARD_NAME}`).should("exist");
     cy.findByTestId(`archive-item-${COLLECTION_NAME}`).should("exist");
     cy.findByTestId(`archive-item-${QUESTION_NAME}`).should("exist");

--- a/e2e/test/scenarios/collections/archive.cy.spec.js
+++ b/e2e/test/scenarios/collections/archive.cy.spec.js
@@ -49,15 +49,20 @@ describe("scenarios > collections > archive", () => {
 
     cy.visit("/archive");
 
+    cy.intercept("PUT", "/api/dashboard/*").as("updateDashboard");
+
     // test individual archive and undo
     cy.findByTestId(`archive-item-${DASHBOARD_NAME}`)
       .findByText(`${DASHBOARD_NAME}`)
       .realHover()
       .findByLabelText("unarchive icon")
       .click();
+    cy.wait("@updateDashboard");
+    cy.findByTestId(`archive-item-${QUESTION_NAME}`).should("exist");
     cy.findByTestId(`archive-item-${DASHBOARD_NAME}`).should("not.exist");
 
     cy.findByTestId("toast-undo").findByText("Undo").click();
+    cy.wait("@updateDashboard");
     cy.findByTestId(`archive-item-${DASHBOARD_NAME}`).should("exist");
 
     // test bulk archive and undo

--- a/e2e/test/scenarios/collections/archive.cy.spec.js
+++ b/e2e/test/scenarios/collections/archive.cy.spec.js
@@ -53,7 +53,7 @@ describe("scenarios > collections > archive", () => {
     cy.intercept("PUT", "/api/collection/*").as("updateCollection");
     cy.intercept("PUT", "/api/card/*").as("updateQuestion");
 
-    // test individual archive and undo
+    cy.log("Test individual archive and undo");
     cy.findByTestId(`archive-item-${DASHBOARD_NAME}`)
       .findByText(`${DASHBOARD_NAME}`)
       .realHover()
@@ -67,7 +67,7 @@ describe("scenarios > collections > archive", () => {
     cy.wait("@updateDashboard");
     cy.findByTestId(`archive-item-${DASHBOARD_NAME}`).should("exist");
 
-    // test bulk archive and undo
+    cy.log("Test bulk archive and undo");
     cy.findByTestId(`archive-item-${COLLECTION_NAME}`).within(() => {
       cy.findByLabelText("archive-item-swapper").realHover().click();
       cy.get("input").should("be.checked");


### PR DESCRIPTION
This recently failed in `master` and @uladzimirdev said it keeps failing for him locally.
https://github.com/metabase/metabase/actions/runs/6209765106/job/16857998048

I could also reproduce the behavior locally. The test was failing due to the race condition.

An example of the failure from the DeploySentinel recording
https://www.deploysentinel.com/ci/runs/650637cad3adbb9d6bc0d802

tl;dr
After clicking the first "Undo" after unarchiving the a dashboard, we didn't wait for the UI to update.

Stress-testing this change shows 10/10 passes
https://github.com/metabase/metabase/actions/runs/6227806121/job/16903227026

EDIT:
The test was introduced in https://github.com/metabase/metabase/pull/33601. If that PR gets backported (https://github.com/metabase/metabase/pull/33839), so should be this fix. cc @JesseSDevaney 