### PR TITLE
Fix compare versions vunknown

### DIFF
--- a/frontend/src/metabase/lib/utils.js
+++ b/frontend/src/metabase/lib/utils.js
@@ -139,7 +139,7 @@ const MetabaseUtils = {
    * Converts a metabase version to a list of numeric components, it converts pre-release
    * components to numbers and pads the numeric part to 4 numbers to make comparison easier
    * @param {string} version
-   * @returns {number[]}
+   * @returns {number[] | null}
    */
   versionToNumericComponents(version) {
     const SPECIAL_COMPONENTS = {

--- a/frontend/src/metabase/lib/utils.js
+++ b/frontend/src/metabase/lib/utils.js
@@ -151,6 +151,13 @@ const MetabaseUtils = {
 
     const regex =
       /v?(?<ossOrEE>\d+)\.?(?<major>\d+)?\.?(?<minor>\d+)?\.?(?<patch>\d+)?-?(?<label>\D+)?(?<build>\d+)?/;
+
+    const result = regex.exec(version);
+
+    if (!result || !result.groups) {
+      return null;
+    }
+
     const {
       ossOrEE,
       major = 0,
@@ -158,7 +165,7 @@ const MetabaseUtils = {
       patch = 0,
       label,
       build = 0,
-    } = regex.exec(version).groups;
+    } = result.groups;
 
     return [
       ossOrEE,
@@ -186,6 +193,10 @@ const MetabaseUtils = {
 
     const aComponents = MetabaseUtils.versionToNumericComponents(aVersion);
     const bComponents = MetabaseUtils.versionToNumericComponents(bVersion);
+
+    if (!aComponents || !bComponents) {
+      return null;
+    }
 
     for (let i = 0; i < Math.max(aComponents.length, bComponents.length); i++) {
       const a = aComponents[i];

--- a/frontend/src/metabase/lib/utils.unit.spec.ts
+++ b/frontend/src/metabase/lib/utils.unit.spec.ts
@@ -7,11 +7,13 @@ describe("utils", () => {
         1, 0, 0, 0, 0, 0,
       ]);
     });
+
     it("should pad to 4 numeric components", () => {
       expect(
         MetabaseUtils.versionToNumericComponents("v1.2-BETA1"),
       ).toStrictEqual([1, 2, 0, 0, -2, 1]);
     });
+
     it("should return null when the version is not parsable", () => {
       expect(MetabaseUtils.versionToNumericComponents("vUNKNOWN")).toEqual(
         null,
@@ -50,60 +52,62 @@ describe("utils", () => {
       ];
       expect(unsorted.sort(MetabaseUtils.compareVersions)).toEqual(expected);
     });
-  });
 
-  it("should return null if one version is not valid", () => {
-    expect(MetabaseUtils.compareVersions("vUNKNOWN", "v0.46.0")).toBe(null);
-  });
+    it("should return null if one version is not valid", () => {
+      expect(MetabaseUtils.compareVersions("vUNKNOWN", "v0.46.0")).toBe(null);
+    });
 
-  it("should return 0 for equal versions", () => {
-    expect(MetabaseUtils.compareVersions("v0.46.0", "v0.46.0")).toBe(0);
-  });
+    it("should return 0 for equal versions", () => {
+      expect(MetabaseUtils.compareVersions("v0.46.0", "v0.46.0")).toBe(0);
+    });
 
-  it("should compare majors", () => {
-    expect(MetabaseUtils.compareVersions("v0.46.0", "v0.47.0")).toBe(-1);
-    expect(MetabaseUtils.compareVersions("v0.47.0", "v0.46.0")).toBe(1);
-  });
+    it("should compare majors", () => {
+      expect(MetabaseUtils.compareVersions("v0.46.0", "v0.47.0")).toBe(-1);
+      expect(MetabaseUtils.compareVersions("v0.47.0", "v0.46.0")).toBe(1);
+    });
 
-  it("should compare minors", () => {
-    expect(MetabaseUtils.compareVersions("v0.46.0", "v0.46.1")).toBe(-1);
-    expect(MetabaseUtils.compareVersions("v0.46.1", "v0.46.0")).toBe(1);
-  });
+    it("should compare minors", () => {
+      expect(MetabaseUtils.compareVersions("v0.46.0", "v0.46.1")).toBe(-1);
+      expect(MetabaseUtils.compareVersions("v0.46.1", "v0.46.0")).toBe(1);
+    });
 
-  it("should consider X-beta < X", () => {
-    expect(MetabaseUtils.compareVersions("v0.46.0-BETA", "v0.46.0")).toBe(-1);
-  });
+    it("should consider X-beta < X", () => {
+      expect(MetabaseUtils.compareVersions("v0.46.0-BETA", "v0.46.0")).toBe(-1);
+    });
 
-  it("should consider X-beta < X-RC", () => {
-    expect(MetabaseUtils.compareVersions("v0.46.0-BETA", "v0.46.0-RC")).toBe(
-      -1,
-    );
-  });
+    it("should consider X-beta < X-RC", () => {
+      expect(MetabaseUtils.compareVersions("v0.46.0-BETA", "v0.46.0-RC")).toBe(
+        -1,
+      );
+    });
 
-  it("should consider X-BETA1 < X-BETA2", () => {
-    expect(
-      MetabaseUtils.compareVersions("v0.46.0-BETA1", "v0.46.0-BETA2"),
-    ).toBe(-1);
-  });
+    it("should consider X-BETA1 < X-BETA2", () => {
+      expect(
+        MetabaseUtils.compareVersions("v0.46.0-BETA1", "v0.46.0-BETA2"),
+      ).toBe(-1);
+    });
 
-  it("should consider X.BETA and X.0-BETA equal", () => {
-    expect(MetabaseUtils.compareVersions("v0.46.0-BETA", "v0.46-BETA")).toBe(0);
-  });
+    it("should consider X.BETA and X.0-BETA equal", () => {
+      expect(MetabaseUtils.compareVersions("v0.46.0-BETA", "v0.46-BETA")).toBe(
+        0,
+      );
+    });
 
-  it("should treat missing subversions as 0", () => {
-    expect(MetabaseUtils.compareVersions("v0.46.0", "v0.46")).toBe(0);
-    expect(MetabaseUtils.compareVersions("v0.46.2", "v0.46.2.0")).toBe(0);
-    expect(MetabaseUtils.compareVersions("v0.46", "v0.46.1")).toBe(-1);
-  });
+    it("should treat missing subversions as 0", () => {
+      expect(MetabaseUtils.compareVersions("v0.46.0", "v0.46")).toBe(0);
+      expect(MetabaseUtils.compareVersions("v0.46.2", "v0.46.2.0")).toBe(0);
+      expect(MetabaseUtils.compareVersions("v0.46", "v0.46.1")).toBe(-1);
+    });
 
-  it("should consider v0.46-BETA1 < v0.46.0", () => {
-    expect(MetabaseUtils.compareVersions("v0.46-BETA1", "v0.46.0")).toBe(-1);
-  });
+    it("should consider v0.46-BETA1 < v0.46.0", () => {
+      expect(MetabaseUtils.compareVersions("v0.46-BETA1", "v0.46.0")).toBe(-1);
+    });
 
-  it("should consider v0.46-BETA1 < v0.46.1-BETA1", () => {
-    expect(MetabaseUtils.compareVersions("v0.46-BETA1", "v0.46.1-BETA1")).toBe(
-      -1,
-    );
+    it("should consider v0.46-BETA1 < v0.46.1-BETA1", () => {
+      expect(
+        MetabaseUtils.compareVersions("v0.46-BETA1", "v0.46.1-BETA1"),
+      ).toBe(-1);
+    });
   });
 
   describe("isEmpty", () => {

--- a/frontend/src/metabase/lib/utils.unit.spec.ts
+++ b/frontend/src/metabase/lib/utils.unit.spec.ts
@@ -12,6 +12,11 @@ describe("utils", () => {
         MetabaseUtils.versionToNumericComponents("v1.2-BETA1"),
       ).toStrictEqual([1, 2, 0, 0, -2, 1]);
     });
+    it("should return null when the version is not parsable", () => {
+      expect(MetabaseUtils.versionToNumericComponents("vUNKNOWN")).toEqual(
+        null,
+      );
+    });
   });
 
   describe("compareVersions", () => {
@@ -45,6 +50,10 @@ describe("utils", () => {
       ];
       expect(unsorted.sort(MetabaseUtils.compareVersions)).toEqual(expected);
     });
+  });
+
+  it("should return null if one version is not valid", () => {
+    expect(MetabaseUtils.compareVersions("vUNKNOWN", "v0.46.0")).toBe(null);
   });
 
   it("should return 0 for equal versions", () => {

--- a/frontend/src/metabase/nav/components/WhatsNewNotification/utils.unit.spec.ts
+++ b/frontend/src/metabase/nav/components/WhatsNewNotification/utils.unit.spec.ts
@@ -226,4 +226,13 @@ describe("getLatestEligibleReleaseNotes", () => {
       }),
     ).toBe(undefined);
   });
+
+  it("should not crash with vUNKNOWN versions", () => {
+    expect(
+      getLatestEligibleReleaseNotes({
+        ...DEFAULTS,
+        currentVersion: "vUNKNOWN",
+      }),
+    ).toBe(undefined);
+  });
 });


### PR DESCRIPTION
### Description

Fixes https://metaboat.slack.com/archives/C010L1Z4F9S/p1695062708061179

This has two commits:

- actual fix: https://github.com/metabase/metabase/pull/33946/commits/47e5e82e439e747d065dddd8d45a3361e83cb67f

- re-organization of tests: https://github.com/metabase/metabase/pull/33946/commits/aef569b1e90c2093c34f941c6f99681c99a062e8

### How to verify

This bug is specific to the version being "vUNKNOWN' on stats, to reproduce/verify locally I did this:
- in metabase/frontend/src/metabase/lib/settings.ts :
```diff ts
  currentVersion() {
    const version = this.get("version") || {};
-    return version.tag
+    return "vUNKNOWN";
  }
```
- in frontend/src/metabase/selectors/settings.ts
```diff
export const getSettings = createSelector(
  (state: State) => state.settings,
-  settings => settings.values,
+  settings => {
+    return {
+      ...settings.values,
+      version: { ...settings.values.version, tag: "vUNKNOWN" },
+    };
+  },
);

```
And then open the admin section

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
