### PR TITLE
Revamped audit log table & auditing infrastructure

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -140,7 +140,7 @@
              (log/info "Unzipping done.")
              (log/info (str "Loading Analytics Content from: " "plugins/instance_analytics"))
              ;; The EE token might not have :serialization enabled, but audit features should still be able to use it.
-             (let [report (log/with-no-logs (serialization.cmd/v2-load-internal (.toURL (.toURI (io/file "plugins/instance_analytics")))
+             (let [report (log/with-no-logs (serialization.cmd/v2-load-internal (.getPath (.toURI (io/file "plugins/instance_analytics")))
                                                                                 {}
                                                                                 :token-check? false))]
                (if (not-empty (:errors report))

--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -28,12 +28,9 @@
    [metabase.util.i18n :refer [deferred-trs trs]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   #_{:clj-kondo/ignore [:deprecated-namespace]}
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan2.core :as t2])
-  (:import
-   (java.net URL)))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -85,7 +82,7 @@
   "SerDes v2 load entry point for internal users.
 
   `opts` are passed to [[v2.load/load-metabase]]."
-  [path
+  [path :- :string
    opts :- [:map [:abort-on-error {:optional true} [:maybe :boolean]]]
    ;; Deliberately separate from the opts so it can't be set from the CLI.
    & {:keys [token-check?]
@@ -99,13 +96,13 @@
   ;  (log/warn (trs "Dump was produced using a different version of Metabase. Things may break!")))
   (log/info (trs "Loading serialized Metabase files from {0}" path))
   (serdes/with-cache
-    (v2.load/load-metabase (v2.ingest/ingest-yaml (.getPath ^URL path)) opts)))
+    (v2.load/load-metabase (v2.ingest/ingest-yaml path) opts)))
 
 (mu/defn v2-load
   "SerDes v2 load entry point.
 
    opts are passed to load-metabase"
-  [path
+  [path :- :string
    opts :- [:map [:abort-on-error {:optional true} [:maybe :boolean]]]]
   (v2-load-internal path opts :token-check? true))
 

--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -28,6 +28,7 @@
    [metabase.util.i18n :refer [deferred-trs trs]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   #_{:clj-kondo/ignore [:deprecated-namespace]}
    [metabase.util.schema :as su]
    [schema.core :as s]
    [toucan2.core :as t2]))

--- a/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
@@ -40,6 +40,7 @@
     :model/QueryAction
     :model/Activity
     :model/ApplicationPermissionsRevision
+    :model/AuditLog
     :model/BookmarkOrdering
     :model/CardBookmark
     :model/CollectionBookmark

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15288,6 +15288,65 @@ databaseChangeLog:
                   name: role
       rollback: # not needed, it will be removed with the table
 
+  - changeSet:
+      id: v48.00-016
+      author: noahmoss
+      comment: Add new audit_log table
+      changes:
+        - createTable:
+            tableName: audit_log
+            remarks: Used to store application events for auditing use cases
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: topic
+                  type: varchar(32)
+                  remarks: The topic of a given audit event
+                  constraints:
+                    nullable: false
+              - column:
+                  name: timestamp
+                  type: DATETIME
+                  remarks: The time an event was recorded
+                  constraints:
+                    nullable: false
+              - column:
+                  name: end_timestamp
+                  type: DATETIME
+                  remarks: The time an event ended, if applicable
+                  constraints:
+                    nullable: true
+              - column:
+                  name: user_id
+                  type: int
+                  remarks: The user who performed an action or triggered an event
+                  constraints:
+                    nullable: true
+              - column:
+                  name: model
+                  type: varchar(16)
+                  remarks: The name of the model this event applies to (e.g. Card, Dashboard), if applicable
+                  constraints:
+                    nullable: true
+              - column:
+                  name: model_id
+                  type: int
+                  remarks: The ID of the model this event applies to, if applicable
+                  constraints:
+                    nullable: true
+              - column:
+                  name: details
+                  type: ${text.type}
+                  remarks: A JSON map with metadata about the event
+                  constraints:
+                    nullable: false
+
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15289,7 +15289,7 @@ databaseChangeLog:
       rollback: # not needed, it will be removed with the table
 
   - changeSet:
-      id: v48.00-016
+      id: v48.00-017
       author: noahmoss
       comment: Add new audit_log table
       changes:

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -210,7 +210,7 @@
                  (last-edit/with-last-edit-info :card))]
     (u/prog1 card
       (when-not ignore_view
-        (events/publish-event! :event/card-read (assoc <> :actor_id api/*current-user-id*))))))
+        (events/publish-event! :event/card-read <>)))))
 
 (defn- card-columns-from-names
   [card names]
@@ -618,7 +618,7 @@ saved later when it is ready."
                 (and (false? archived?)
                      (:archived card))       :event/card-unarchive
                 :else                        :event/card-update)]
-    (events/publish-event! event (assoc card :actor_id api/*current-user-id*))))
+    (events/publish-event! event card)))
 
 (defn- card-archived? [old-card new-card]
   (and (not (:archived old-card))
@@ -846,7 +846,7 @@ saved later when it is ready."
   (log/warn (tru "DELETE /api/card/:id is deprecated. Instead, change its `archived` value via PUT /api/card/:id."))
   (let [card (api/write-check Card id)]
     (t2/delete! Card :id id)
-    (events/publish-event! :event/card-delete (assoc card :actor_id api/*current-user-id*)))
+    (events/publish-event! :event/card-delete card))
   api/generic-204-no-content)
 
 ;;; -------------------------------------------- Bulk Collections Update ---------------------------------------------

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -684,7 +684,7 @@
                       (select-keys tabs-changes-stats [:created-tab-ids :updated-tab-ids :deleted-tab-ids :total-num-tabs])
                       (select-keys dashcards-changes-stats [:created-dashcards :deleted-dashcards :updated-dashcards])))))
         ;; trigger events out of tx so rows are committed and visible from other threads
-        (track-dashcard-and-tab-events!  id @changes-stats)
+        (track-dashcard-and-tab-events! id @changes-stats)
         true))
    {:cards        (t2/hydrate (dashboard/ordered-cards id) :series)
     :ordered_tabs (dashboard/ordered-tabs id)}))

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -393,7 +393,7 @@
   [id]
   {id ms/PositiveInt}
   (let [dashboard (get-dashboard id)]
-    (events/publish-event! :event/dashboard-read (assoc dashboard :actor_id api/*current-user-id*))
+    (events/publish-event! :event/dashboard-read dashboard)
     (last-edit/with-last-edit-info dashboard :dashboard)))
 
 (defn- check-allowed-to-change-embedding
@@ -445,7 +445,7 @@
         (t2/update! Dashboard id updates))))
   ;; now publish an event and return the updated Dashboard
   (let [dashboard (t2/select-one :model/Dashboard :id id)]
-    (events/publish-event! :event/dashboard-update (assoc dashboard :actor_id api/*current-user-id*))
+    (events/publish-event! :event/dashboard-update dashboard)
     (assoc dashboard :last-edit-info (last-edit/edit-information-for-user @api/*current-user*))))
 
 ;; TODO - We can probably remove this in the near future since it should no longer be needed now that we're going to
@@ -460,7 +460,7 @@
                  "`archived` value via PUT /api/dashboard/:id."))
   (let [dashboard (api/write-check :model/Dashboard id)]
     (t2/delete! :model/Dashboard :id id)
-    (events/publish-event! :event/dashboard-delete (assoc dashboard :actor_id api/*current-user-id*)))
+    (events/publish-event! :event/dashboard-delete dashboard))
   api/generic-204-no-content)
 
 (defn- param-target->field-id [target query]
@@ -597,10 +597,10 @@
   ;; Dashcard events
   (when (seq deleted-dashcards)
     (events/publish-event! :event/dashboard-remove-cards
-                           {:id dashboard-id :actor_id api/*current-user-id* :dashcards deleted-dashcards}))
+                           {:id dashboard-id :dashcards deleted-dashcards}))
   (when (seq created-dashcards)
     (events/publish-event! :event/dashboard-add-cards
-                           {:id dashboard-id :actor_id api/*current-user-id* :dashcards created-dashcards})
+                           {:id dashboard-id :dashcards created-dashcards})
     (for [{:keys [card_id]} created-dashcards
           :when             (pos-int? card_id)]
       (snowplow/track-event! ::snowplow/question-added-to-dashboard
@@ -609,7 +609,7 @@
   ;; TODO this is potentially misleading, we don't know for sure here that the dashcards are repositioned
   (when (seq updated-dashcards)
     (events/publish-event! :event/dashboard-reposition-cards
-                           {:id dashboard-id :actor_id api/*current-user-id* :dashcards updated-dashcards}))
+                           {:id dashboard-id :dashcards updated-dashcards}))
 
   ;; Tabs events
   (when (seq deleted-tab-ids)
@@ -619,7 +619,7 @@
                             :num-tabs       (count deleted-tab-ids)
                             :total-num-tabs total-num-tabs})
     (events/publish-event! :event/dashboard-remove-tabs
-                           {:id dashboard-id :actor_id api/*current-user-id* :tab-ids deleted-tab-ids}))
+                           {:id dashboard-id :tab-ids deleted-tab-ids}))
   (when (seq created-tab-ids)
     (snowplow/track-event! ::snowplow/dashboard-tab-created
                            api/*current-user-id*
@@ -627,10 +627,10 @@
                             :num-tabs       (count created-tab-ids)
                             :total-num-tabs total-num-tabs})
     (events/publish-event! :event/dashboard-add-tabs
-                           {:id dashboard-id :actor_id api/*current-user-id* :tab-ids created-tab-ids}))
+                           {:id dashboard-id :tab-ids created-tab-ids}))
   (when (seq updated-tab-ids)
     (events/publish-event! :event/dashboard-update-tabs
-                           {:id dashboard-id :actor_id api/*current-user-id* :tab-ids updated-tab-ids})))
+                           {:id dashboard-id :tab-ids updated-tab-ids})))
 
 (api/defendpoint PUT "/:id/cards"
   "Update `Cards` and `Tabs` on a Dashboard. Request body should have the form:

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -32,11 +32,6 @@
 
 (methodical/defmethod events/publish-event! ::dashboard-card-event
   [topic {:keys [dashcards id]}]
-  (def topic topic)
-  (def dashcards dashcards)
-  (def id id)
-
-  (def dash (t2/select-one [:model/Dashboard :description :name] :id id))
   ;; we expect that the object has just a dashboard :id at the top level
   ;; plus a `:dashcards` attribute which is a vector of the cards added/removed
   (let [details (-> (t2/select-one [:model/Dashboard :description :name] :id id)

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -3,8 +3,6 @@
    [metabase.events :as events]
    [metabase.models.activity :as activity :refer [Activity]]
    [metabase.models.audit-log :as audit-log]
-   [metabase.models.card :refer [Card]]
-   [metabase.models.dashboard :refer [Dashboard]]
    [metabase.models.table :as table]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
@@ -18,7 +16,7 @@
 
 (methodical/defmethod events/publish-event! ::card-event
   [topic object]
-  (audit-log/record-event! topic object))
+  (audit-log/record-event! topic object :model/Card))
 
 (derive ::dashboard-event ::event)
 (derive :event/dashboard-create ::dashboard-event)
@@ -28,7 +26,7 @@
 
 (methodical/defmethod events/publish-event! ::dashboard-event
   [topic object]
-  (audit-log/record-event! topic object))
+  (audit-log/record-event! topic object :model/Dashboard))
 
 (derive ::metric-event ::event)
 (derive :event/metric-create ::metric-event)

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -16,17 +16,35 @@
 
 (methodical/defmethod events/publish-event! ::card-event
   [topic object]
-  (audit-log/record-event! topic object :model/Card))
+  (audit-log/record-event! topic object))
 
 (derive ::dashboard-event ::event)
 (derive :event/dashboard-create ::dashboard-event)
 (derive :event/dashboard-delete ::dashboard-event)
-(derive :event/dashboard-add-cards ::dashboard-event)
-(derive :event/dashboard-remove-cards ::dashboard-event)
 
 (methodical/defmethod events/publish-event! ::dashboard-event
   [topic object]
-  (audit-log/record-event! topic object :model/Dashboard))
+  (audit-log/record-event! topic object))
+
+(derive ::dashboard-card-event ::event)
+(derive :event/dashboard-add-cards ::dashboard-card-event)
+(derive :event/dashboard-remove-cards ::dashboard-card-event)
+
+(methodical/defmethod events/publish-event! ::dashboard-card-event
+  [topic {:keys [dashcards id]}]
+  (def topic topic)
+  (def dashcards dashcards)
+  (def id id)
+
+  (def dash (t2/select-one [:model/Dashboard :description :name] :id id))
+  ;; we expect that the object has just a dashboard :id at the top level
+  ;; plus a `:dashcards` attribute which is a vector of the cards added/removed
+  (let [details (-> (t2/select-one [:model/Dashboard :description :name] :id id)
+                    (assoc :dashcards (for [{:keys [id card_id]} dashcards]
+                                           (-> (t2/select-one [:model/Card :name :description], :id card_id)
+                                               (assoc :id id)
+                                               (assoc :card_id card_id)))))]
+   (audit-log/record-event! topic details :model/Dashboard id)))
 
 (derive ::metric-event ::event)
 (derive :event/metric-create ::metric-event)

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -28,26 +28,7 @@
 
 (methodical/defmethod events/publish-event! ::dashboard-event
   [topic object]
-  (let [create-delete-details
-        #(select-keys % [:description :name])
-
-        add-remove-card-details
-        (fn [{:keys [dashcards] :as obj}]
-          ;; we expect that the object has just a dashboard :id at the top level
-          ;; plus a `:dashcards` attribute which is a vector of the cards added/removed
-          (-> (t2/select-one [Dashboard :description :name], :id (events/object->model-id topic obj))
-              (assoc :dashcards (for [{:keys [id card_id]} dashcards]
-                                  (-> (t2/select-one [Card :name :description], :id card_id)
-                                      (assoc :id id)
-                                      (assoc :card_id card_id))))))]
-    (activity/record-activity!
-      :topic      topic
-      :object     object
-      :details-fn (case topic
-                    :event/dashboard-create       create-delete-details
-                    :event/dashboard-delete       create-delete-details
-                    :event/dashboard-add-cards    add-remove-card-details
-                    :event/dashboard-remove-cards add-remove-card-details))))
+  (audit-log/record-event! topic object))
 
 (derive ::metric-event ::event)
 (derive :event/metric-create ::metric-event)

--- a/src/metabase/models/activity.clj
+++ b/src/metabase/models/activity.clj
@@ -2,23 +2,18 @@
   (:require
    [metabase.api.common :as api]
    [metabase.events :as events]
-   [metabase.models.card :refer [Card]]
-   [metabase.models.dashboard :refer [Dashboard]]
    [metabase.models.interface :as mi]
-   [metabase.models.metric :refer [Metric]]
-   [metabase.models.pulse :refer [Pulse]]
-   [metabase.models.segment :refer [Segment]]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
 ;;; ------------------------------------------------- Perms Checking -------------------------------------------------
 
 (def ^:private model->entity
-  {"card"      Card
-   "dashboard" Dashboard
-   "metric"    Metric
-   "pulse"     Pulse
-   "segment"   Segment})
+  {"card"      :model/Card
+   "dashboard" :model/Dashboard
+   "metric"    :model/Metric
+   "pulse"     :model/Pulse
+   "segment"   :model/Segment})
 
 (defmulti can-?
   "Implementation for `can-read?`/`can-write?` for items in the activity feed. Dispatches off of the activity `:topic`,
@@ -38,7 +33,7 @@
 ;; or Dashboard). For all other activity feed items with no model everyone can read/write
 (defmethod can-? :default [perms-check-fn {model :model, model-id :model_id}]
   (if-let [object (when-let [entity (model->entity model)]
-                    (entity model-id))]
+                    (t2/select entity model-id))]
     (perms-check-fn object)
     true))
 

--- a/src/metabase/models/audit_log.clj
+++ b/src/metabase/models/audit_log.clj
@@ -68,7 +68,7 @@
 
   ([topic object model]
    (let [unqualified-topic (keyword (name topic))
-         model-name        (name (name model))
+         model-name        (some-> model name)
          details           (if (t2/model object)
                              (model-details object unqualified-topic)
                              (or object {}))]

--- a/src/metabase/models/audit_log.clj
+++ b/src/metabase/models/audit_log.clj
@@ -61,12 +61,15 @@
   object which are recorded are determined by the `model-details` multimethod, which is typically implemented in the
   appropriate model namespace.
 
-  `object` can also be a map of arbitrary details relavent to the event, which is recorded as-is. If the name of a model
-  is also relevant to the event and should be recorded, it can be passed as a third argument."
+  `object` can also be a map of arbitrary details relavent to the event, which is recorded as-is. If the name and/or ID
+  of a model are also relevant to the event and should be recorded, they can be passed as third and fourth arguments."
   ([topic object]
    (record-event! topic object (some-> (t2/model object) name)))
 
   ([topic object model]
+   (record-event! topic object model (u/id object)))
+
+  ([topic object model model-id]
    (let [unqualified-topic (keyword (name topic))
          model-name        (some-> model name)
          details           (if (t2/model object)
@@ -76,7 +79,7 @@
                  :topic    unqualified-topic
                  :details  details
                  :model    model-name
-                 :model_id (u/id object))
+                 :model_id model-id)
      ;; TODO: temporarily double-writing to the `activity` table
      (activity/record-activity!
       :topic      topic

--- a/src/metabase/models/audit_log.clj
+++ b/src/metabase/models/audit_log.clj
@@ -1,0 +1,76 @@
+(ns metabase.models.audit-log
+  "Model defenition for the Metabase Audit Log, which tracks actions taken by users across the Metabase app. This is a
+  distinct from the Activity and View Log models, which predate this namespace, and which power specific API endpoints
+  used for in-app functionality, such as the recently-viewed items displayed on the homepage."
+  (:require
+   [metabase.api.common :as api]
+   [metabase.events :as events]
+   [metabase.mbql.util :as mbql.u]
+   [metabase.models.card :refer [Card]]
+   [metabase.models.interface :as mi]
+   [metabase.query-processor :as qp]
+   [metabase.util :as u]
+   [metabase.util.i18n :refer [tru]]
+   [metabase.util.log :as log]
+   [methodical.core :as m]
+   [toucan2.core :as t2]
+   [metabase.models.activity :as activity]))
+
+(doto :model/AuditLog
+  (derive :metabase/model))
+
+(m/defmethod t2/table-name :model/AuditLog
+  [_model]
+  :audit_log)
+
+(t2/deftransforms :model/AuditLog
+  {:topic   mi/transform-keyword
+   :details mi/transform-json})
+
+(defmulti model-details
+  "Returns a map with data about an entity that should be included in the `details` column of the Audit Log."
+  {:arglists '([entity event-type])}
+  mi/dispatch-on-model)
+
+(defmethod model-details :default
+  [_entity _event-type]
+  {})
+
+;; This is in this namespace instead of `metabase.models.card` to avoid circular dependencies with
+;; `metabase.query-processor`
+(defmethod model-details Card
+  [{query :dataset_query, dataset? :dataset :as card} _event-type]
+  (let [query (when (seq query)
+                (try (qp/preprocess query)
+                     (catch Throwable e
+                       (log/error e (tru "Error preprocessing query:")))))
+        database-id (some-> query :database u/the-id)
+        table-id    (mbql.u/query->source-table-id query)]
+    (merge (select-keys card [:name :description])
+           {:database_id database-id
+            :table_id    table-id
+            ;; Use `model` instead of `dataset` to mirror product terminology
+            :model?      dataset?})))
+
+(defn record-event!
+  "Record an event in the Audit Log."
+  [topic object]
+  (let [details (model-details object topic)]
+    (t2/insert! :model/AuditLog
+                {:topic    (name topic)
+                 :details  details
+                 :model    (name (t2/model object))
+                 :model_id (u/the-id object)})
+    ;; TODO: temporarily double-writing to the `activity` table; remove in v49
+    (activity/record-activity!
+     :topic      topic
+     :object     object
+     :details-fn (fn [_] details)
+     :user-id    api/*current-user-id*)))
+
+(t2/define-before-insert :model/AuditLog
+  [activity]
+  (let [defaults {:timestamp :%now
+                  :details   {}
+                  :user_id   api/*current-user-id*}]
+    (merge defaults activity)))

--- a/src/metabase/models/audit_log.clj
+++ b/src/metabase/models/audit_log.clj
@@ -1,5 +1,5 @@
 (ns metabase.models.audit-log
-  "Model defenition for the Metabase Audit Log, which tracks actions taken by users across the Metabase app. This is a
+  "Model defenition for the Metabase Audit Log, which tracks actions taken by users across the Metabase app. This is
   distinct from the Activity and View Log models, which predate this namespace, and which power specific API endpoints
   used for in-app functionality, such as the recently-viewed items displayed on the homepage."
   (:require

--- a/src/metabase/models/audit_log.clj
+++ b/src/metabase/models/audit_log.clj
@@ -4,8 +4,8 @@
   used for in-app functionality, such as the recently-viewed items displayed on the homepage."
   (:require
    [metabase.api.common :as api]
-   [metabase.events :as events]
    [metabase.mbql.util :as mbql.u]
+   [metabase.models.activity :as activity]
    [metabase.models.card :refer [Card]]
    [metabase.models.interface :as mi]
    [metabase.query-processor :as qp]
@@ -13,8 +13,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [methodical.core :as m]
-   [toucan2.core :as t2]
-   [metabase.models.activity :as activity]))
+   [toucan2.core :as t2]))
 
 (doto :model/AuditLog
   (derive :metabase/model))
@@ -55,7 +54,8 @@
 (defn record-event!
   "Record an event in the Audit Log."
   [topic object]
-  (let [details (model-details object topic)]
+  (let [topic   (keyword (name topic))
+        details (model-details object topic)]
     (t2/insert! :model/AuditLog
                 {:topic    (name topic)
                  :details  details

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -8,6 +8,7 @@
    [metabase.automagic-dashboards.populate :as populate]
    [metabase.db.query :as mdb.query]
    [metabase.events :as events]
+   [metabase.models.audit-log :as audit-log]
    [metabase.models.card :as card :refer [Card]]
    [metabase.models.collection :as collection :refer [Collection]]
    [metabase.models.dashboard-card
@@ -605,3 +606,20 @@
       ;; parameter with values_source_type = "card" will depend on a card
      (set (for [card-id (some->> dashboard :parameters (keep (comp :card_id :values_source_config)))]
             ["Card" card-id])))))
+
+
+;;; ------------------------------------------------ Audit Log --------------------------------------------------------
+
+(defmethod audit-log/model-details Dashboard
+  [dashboard event-type]
+  (case event-type
+    (:dashboard-create :dashboard-delete)
+    (select-keys dashboard [:description :name])
+
+    (:dashboard-add-cards :dashboard-remove-cards)
+    (-> (select-keys dashboard [:description :name :parameters :dashcards])
+        (update :dashcards (fn [dashcards]
+                             (for [{:keys [id card_id]} dashcards]
+                                  (-> (t2/select-one [Card :name :description], :id card_id)
+                                      (assoc :id id)
+                                      (assoc :card_id card_id))))))))

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -86,7 +86,7 @@
   []
   (if-not config/ee-available?
     #{}
-    (let [colls (mapv #(select-keys % [:id :name :location :type]) (t2/select Collection))
+    (let [colls (mapv #(select-keys % [:id :name :location :type]) (t2/select Collection :archived false))
           id->coll (m/index-by :id colls)
           collection-tree (collection/collections->tree {} colls)]
       (->> (loop [[tree & coll-tree] collection-tree
@@ -160,7 +160,8 @@
                 crowbertos               (set (map :name (mt/user-http-request :crowberto :get 200 "collection")))
                 crowbertos-with-excludes (set (map :name (mt/user-http-request :crowberto :get 200 "collection" :exclude-other-user-collections true)))
                 luckys                   (set (map :name (mt/user-http-request :lucky :get 200 "collection")))]
-            (is (= (into (t2/select-fn-set :name Collection {:where [:= :type nil]}) public-collection-names)
+            (is (= (into (t2/select-fn-set :name Collection {:where [:and [:= :type nil] [:= :archived false]]})
+                         public-collection-names)
                    crowbertos))
             (is (= (into public-collection-names #{"Crowberto Corv's Personal Collection" "Crowberto's Child Collection"})
                    crowbertos-with-excludes))

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -2,45 +2,53 @@
   (:require
    [clojure.test :refer :all]
    [metabase.events :as events]
-   [metabase.events.activity-feed :as events.activity-feed]
+   [metabase.events.audit-log :as events.audit-log]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.models
-    :refer [Activity Card Dashboard DashboardCard Metric Pulse Segment]]
+    :refer [Card Dashboard DashboardCard Metric Pulse Segment]]
    [metabase.test :as mt]
    [metabase.util :as u]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
-;; TODO update tests to use new AuditLog table
-
 (set! *warn-on-reflection* true)
 
-(comment events.activity-feed/keep-me)
+(comment events.audit-log/keep-me)
+
+(defn- event
+  ([topic]
+   (event topic nil))
+
+  ([topic model-id]
+   (t2/select-one [:model/AuditLog :topic :user_id :model :model_id :details]
+                  :topic    topic
+                  :model_id model-id
+                  {:order-by [[:id :desc]]})))
 
 (defn- activity
   ([topic]
    (activity topic nil))
 
   ([topic model-id]
-   (t2/select-one [Activity :topic :user_id :model :model_id :database_id :table_id :details]
+   (t2/select-one [:model/Activity :topic :user_id :model :model_id :details]
                   :topic    topic
                   :model_id model-id
                   {:order-by [[:id :desc]]})))
 
 (deftest card-create-test
   (testing :card-create
-    (t2.with-temp/with-temp [Card card {:name "My Cool Card"}]
-      (mt/with-model-cleanup [Activity]
-        (is (= card
-               (events/publish-event! :event/card-create card)))
-        (is (= {:topic       :card-create
-                :user_id     (mt/user->id :rasta)
-                :model       "card"
-                :model_id    (:id card)
-                :database_id nil
-                :table_id    nil
-                :details     {:name "My Cool Card", :description nil}}
-               (activity "card-create" (:id card))))))))
+    (mt/with-model-cleanup [:model/AuditLog]
+      (mt/with-test-user :rasta
+        (t2.with-temp/with-temp [Card card {:name "My Cool Card"}]
+          (is (= card
+                 (events/publish-event! :event/card-create card)))
+          (is (partial=
+               {:topic    :card-create
+                :user_id  (mt/user->id :rasta)
+                :model    "Card"
+                :model_id (:id card)
+                :details  {:name "My Cool Card", :description nil, :database_id nil, :table_id nil}}
+               (event "card-create" (:id card)))))))))
 
 (deftest card-create-nested-query-test
   (testing :card-create
@@ -53,108 +61,114 @@
                                   :dataset_query {:database lib.schema.id/saved-questions-virtual-database-id
                                                   :type     :query
                                                   :query    {:source-table (str "card__" (u/the-id card-1))}}}]
-        (mt/with-model-cleanup [Activity]
-          (is (= card-2
-                 (events/publish-event! :event/card-create card-2)))
-          (is (= {:topic       :card-create
-                  :user_id     (mt/user->id :rasta)
-                  :model       "card"
-                  :model_id    (:id card-2)
-                  :database_id (mt/id)
-                  :table_id    (mt/id :venues)
-                  :details     {:name "My Cool NESTED Card", :description nil}}
-                 (activity "card-create" (:id card-2)))))))))
+        (mt/with-model-cleanup [:model/AuditLog]
+          (mt/with-test-user :rasta
+            (is (= card-2
+                   (events/publish-event! :event/card-create card-2)))
+            (is (partial=
+                 {:topic    :card-create
+                  :user_id  (mt/user->id :rasta)
+                  :model    "Card"
+                  :model_id (:id card-2)
+                  :details  {:name        "My Cool NESTED Card"
+                             :description nil
+                             :database_id (mt/id)
+                             :table_id    (mt/id :venues)}}
+                 (event "card-create" (:id card-2))))))))))
 
 (deftest card-update-event-test
   (testing :card-update
     (doseq [dataset? [false true]]
       (testing (if dataset? "Dataset" "Card")
         (t2.with-temp/with-temp [Card card {:name "My Cool Card" :dataset dataset?}]
-          (mt/with-model-cleanup [Activity]
-            (is (= card
-                   (events/publish-event! :event/card-update card)))
-            (is (= {:topic       :card-update
-                    :user_id     (mt/user->id :rasta)
-                    :model       (if dataset? "dataset" "card")
-                    :model_id    (:id card)
-                    :database_id nil
-                    :table_id    nil
-                    :details     (cond-> {:name "My Cool Card", :description nil}
-                                   dataset? (assoc :original-model "card"))}
-                   (activity "card-update" (:id card))))))))))
+          (mt/with-model-cleanup [:model/AuditLog]
+           (mt/with-test-user :rasta
+             (is (= card
+                    (events/publish-event! :event/card-update card)))
+             (is (partial=
+                  {:topic    :card-update
+                   :user_id  (mt/user->id :rasta)
+                   :model    "Card"
+                   :model_id (:id card)
+                   :details  (cond-> {:name        "My Cool Card"
+                                      :description nil
+                                      :table_id    nil
+                                      :database_id nil}
+                               dataset? (assoc :model? true))}
+                  (event "card-update" (:id card)))))))))))
 
 (deftest card-delete-event-test
   (testing :card-delete
     (doseq [dataset? [false true]]
       (testing (if dataset? "Dataset" "Card")
         (t2.with-temp/with-temp [Card card {:name "My Cool Card", :dataset dataset?}]
-          (mt/with-model-cleanup [Activity]
-            (is (= card
-                   (events/publish-event! :event/card-delete card)))
-            (is (= {:topic       :card-delete
-                    :user_id     (mt/user->id :rasta)
-                    :model       (if dataset? "dataset" "card")
+          (mt/with-model-cleanup [:model/AuditLog]
+            (mt/with-test-user :rasta
+              (is (= card
+                     (events/publish-event! :event/card-delete card)))
+              (is (partial=
+                   {:topic    :card-delete
+                    :user_id  (mt/user->id :rasta)
+                    :model    "Card"
                     :model_id (:id card)
-                    :database_id nil
-                    :table_id    nil
-                    :details     (cond-> {:name "My Cool Card", :description nil}
-                                   dataset? (assoc :original-model "card"))}
-                   (activity "card-delete" (:id card))))))))))
+                    :details  (cond-> {:name "My Cool Card", :description nil}
+                                dataset? (assoc :model? true))}
+                   (event "card-delete" (:id card)))))))))))
 
 (deftest dashboard-create-event-test
   (testing :dashboard-create
     (t2.with-temp/with-temp [Dashboard dashboard {:name "My Cool Dashboard"}]
-      (mt/with-model-cleanup [Activity]
-        (is (= dashboard
-               (events/publish-event! :event/dashboard-create dashboard)))
-        (is (= {:topic       :dashboard-create
-                :user_id     (mt/user->id :rasta)
-                :model       "dashboard"
-                :model_id    (:id dashboard)
-                :database_id nil
-                :table_id    nil
-                :details     {:name "My Cool Dashboard", :description nil}}
-               (activity "dashboard-create" (:id dashboard))))))))
+      (mt/with-model-cleanup [:model/AuditLog]
+        (mt/with-test-user :rasta
+          (is (= dashboard
+                 (events/publish-event! :event/dashboard-create dashboard)))
+          (is (partial=
+               {:topic    :dashboard-create
+                :user_id  (mt/user->id :rasta)
+                :model    "Dashboard"
+                :model_id (:id dashboard)
+                :details  {:name "My Cool Dashboard", :description nil}}
+               (event "dashboard-create" (:id dashboard)))))))))
 
 (deftest dashboard-delete-event-test
   (testing :dashboard-delete
     (t2.with-temp/with-temp [Dashboard dashboard {:name "My Cool Dashboard"}]
-      (mt/with-model-cleanup [Activity]
-        (is (= dashboard
-               (events/publish-event! :event/dashboard-delete dashboard)))
-        (is (= {:topic       :dashboard-delete
-                :user_id     (mt/user->id :rasta)
-                :model       "dashboard"
-                :model_id    (:id dashboard)
-                :database_id nil
-                :table_id    nil
-                :details     {:name "My Cool Dashboard", :description nil}}
-               (activity "dashboard-delete" (:id dashboard))))))))
+      (mt/with-model-cleanup [:model/AuditLog]
+        (mt/with-test-user :rasta
+          (is (= dashboard
+                 (events/publish-event! :event/dashboard-delete dashboard)))
+          (is (partial=
+               {:topic    :dashboard-delete
+                :user_id  (mt/user->id :rasta)
+                :model    "Dashboard"
+                :model_id (:id dashboard)
+                :details  {:name "My Cool Dashboard", :description nil}}
+               (event "dashboard-delete" (:id dashboard)))))))))
 
 (deftest dashboard-add-cards-event-test
   (testing :dashboard-add-cards
     (mt/with-temp [Dashboard     dashboard {:name "My Cool Dashboard"}
                    Card          card {}
                    DashboardCard dashcard  {:dashboard_id (:id dashboard), :card_id (:id card)}]
-      (mt/with-model-cleanup [Activity]
-        (let [event {:id        (:id dashboard)
-                     :actor_id  (mt/user->id :rasta)
-                     :dashcards [dashcard]}]
-          (is (= event
-                 (events/publish-event! :event/dashboard-add-cards event))))
-        (is (= {:topic       :dashboard-add-cards
-                :user_id     (mt/user->id :rasta)
-                :model       "dashboard"
-                :model_id    (:id dashboard)
-                :database_id nil
-                :table_id    nil
-                :details     {:name        "My Cool Dashboard"
-                              :description nil
-                              :dashcards   [{:description (:description card)
-                                             :name        (:name card)
-                                             :id          (:id dashcard)
-                                             :card_id     (:id card)}]}}
-               (activity "dashboard-add-cards" (:id dashboard))))))))
+      (mt/with-model-cleanup [:model/AuditLog]
+        (mt/with-test-user :rasta
+         (let [event {:id        (:id dashboard)
+                      :actor_id  (mt/user->id :rasta)
+                      :dashcards [dashcard]}]
+           (is (= event
+                  (events/publish-event! :event/dashboard-add-cards event))))
+         (is (partial=
+              {:topic    :dashboard-add-cards
+               :user_id  (mt/user->id :rasta)
+               :model    "Dashboard"
+               :model_id (:id dashboard)
+               :details  {:name        "My Cool Dashboard"
+                          :description nil
+                          :dashcards   [{:description (:description card)
+                                         :name        (:name card)
+                                         :id          (:id dashcard)
+                                         :card_id     (:id card)}]}}
+              (event "dashboard-add-cards" (:id dashboard)))))))))
 
 (deftest dashboard-remove-cards-event-test
   (testing :dashboard-remove-cards

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -1,4 +1,4 @@
-(ns metabase.events.activity-feed-test
+(ns metabase.events.audit-log-test
   (:require
    [clojure.test :refer :all]
    [metabase.events :as events]
@@ -10,6 +10,8 @@
    [metabase.util :as u]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))
+
+;; TODO update tests to use new AuditLog table
 
 (set! *warn-on-reflection* true)
 

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -355,13 +355,13 @@
                               :revision_message "deleted"}}
                (activity "segment-delete" (:id segment))))))))
 
-(deftest user-login-event-test
-  (testing :user-login
+(deftest user-joined-event-test
+  (testing :user-joined
     ;; TODO - what's the difference between `user-login` / `user-joined`?
     (mt/with-model-cleanup [Activity]
       (let [event {:user-id (mt/user->id :rasta)}]
         (is (= event
-               (events/publish-event! :event/user-login event))))
+               (events/publish-event! :event/user-joined event))))
       (is (= {:topic       :user-joined
               :user_id     (mt/user->id :rasta)
               :model       "user"
@@ -369,4 +369,4 @@
               :database_id nil
               :table_id    nil
               :details     {}}
-             (activity "user-login" (mt/user->id :rasta)))))))
+             (activity "user-joined" (mt/user->id :rasta)))))))

--- a/test/metabase/models/audit_log_test.clj
+++ b/test/metabase/models/audit_log_test.clj
@@ -1,0 +1,44 @@
+(ns metabase.models.audit-log-test
+  (:require [clojure.test :refer :all]
+            [metabase.models.audit-log :as audit-log]
+            [metabase.test :as mt]
+            [toucan2.core :as t2]
+            [toucan2.tools.with-temp :as t2.with-temp]))
+
+(derive :event/test-event :metabase/event)
+
+(deftest basic-record-event-test
+  (mt/with-model-cleanup [:model/AuditLog]
+    (mt/with-test-user :rasta
+      (testing "Test that `record-event!` succesfully records basic card events"
+        (t2.with-temp/with-temp [:model/Card {card-id :id :as card} {:name "Test card"}]
+          (audit-log/record-event! :event/card-create card)
+          ;; Not an exhaustive match since we're mainly testing that the event is recorded
+          (is (partial=
+               {:topic    :card-create
+                :user_id  (mt/user->id :rasta)
+                :model    "Card"
+                :model_id card-id
+                :details  {:name "Test card"}}
+               (t2/select-one :model/AuditLog :model_id card-id)))))
+
+      (testing "Test that `record-event!` succesfully records basic card events with the model specified"
+        (t2.with-temp/with-temp [:model/Card {card-id :id :as card} {:name "Test card"}]
+          (audit-log/record-event! :event/card-create card :model/Card)
+          (is (partial=
+               {:topic    :card-create
+                :user_id  (mt/user->id :rasta)
+                :model    "Card"
+                :model_id card-id
+                :details  {:name "Test card"}}
+               (t2/select-one :model/AuditLog :model_id card-id)))))
+
+      (testing "Test that `record-event!` records an event with arbitrary data and no model specified"
+        (audit-log/record-event! :event/test-event {:foo "bar"})
+        (is (partial=
+             {:topic :test-event
+              :user_id (mt/user->id :rasta)
+              :model nil
+              :model_id nil
+              :details {:foo "bar"}}
+             (t2/select-one :model/AuditLog :topic :test-event)))))))


### PR DESCRIPTION
Pursuant to milestone 1 of https://github.com/metabase/metabase/issues/27661

This PR:
* Adds a new `audit_log` table which will be used to power Audit v2 content. This is similar to the existing `activity` table, but with a few changes to the schema to make it more generic and able to accommodate a wider variety of events.
* Adds a new `record-event!` function which is the entry point for writing entries to the audit log. _This still writes to the `activity` table for now as well, to preserve the existing behavior until we are ready to remove it entirely._
* Adds a new `model-details` multimethod which dispatches on a model, and allows individual model namespaces to define the information that should be included in the `details` field for any events recorded related to the model.
* Renames `metabase.events.activity-feed` to `metabase.events.audit-log` and migrates dashboard and card events to use the new audit log events. Also adapts the relevant tests to read from the new table. Other events will be migrated/added in subsequent PRs.

What is the goal of these changes?
* Have a single table which is used solely for powering audit content, and is not used to power any other in-app functionality.
* Have a uniform API that makes it simple to add new events, and which can handle both events that are tied directly to a model (e.g. `card-add`) as well as arbitrary other events in the application (`install`, `task-run`, etc)