### PR TITLE
Reduce the number of Cypress retries in run mode

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -128,7 +128,7 @@ const mainConfig = {
     json: true,
   },
   retries: {
-    runMode: 4,
+    runMode: 3,
     openMode: 0,
   },
 };

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -128,7 +128,7 @@ const mainConfig = {
     json: true,
   },
   retries: {
-    runMode: 3,
+    runMode: 2,
     openMode: 0,
   },
 };


### PR DESCRIPTION
At one point we bumped the number of internal Cypress retries to 5 to fight off flakes.
The deal was to gradually lower that number as we move towards the calmer waters.

We still have a decent amount of flakes, but the timing seems to be good enough to bring the number of retries down to 2.
That will still give us THREE Cypress runs for a flaky test (the initial attempt + two retries).

If a test fails three times in a row, it's pretty ok to call it a flake and to fix it.
