### PR TITLE
Convert lib/utils.js to ts

### DIFF
--- a/frontend/src/metabase-lib/queries/utils/card.js
+++ b/frontend/src/metabase-lib/queries/utils/card.js
@@ -1,7 +1,7 @@
 import _ from "underscore";
 import { updateIn } from "icepick";
 
-import Utils from "metabase/lib/utils";
+import { copy } from "metabase/lib/utils";
 import { normalizeParameterValue } from "metabase-lib/parameters/utils/parameter-values";
 import { deriveFieldOperatorFromParameter } from "metabase-lib/parameters/utils/operators";
 import * as Q_DEPRECATED from "metabase-lib/queries/utils"; // legacy
@@ -53,7 +53,7 @@ export function applyParameters(
   parameterValues = {},
   parameterMappings = [],
 ) {
-  const datasetQuery = Utils.copy(card.dataset_query);
+  const datasetQuery = copy(card.dataset_query);
   // clean the query
   if (datasetQuery.type === "query") {
     datasetQuery.query = Q_DEPRECATED.cleanQuery(datasetQuery.query);

--- a/frontend/src/metabase-lib/queries/utils/index.js
+++ b/frontend/src/metabase-lib/queries/utils/index.js
@@ -1,5 +1,5 @@
 import _ from "underscore";
-import Utils from "metabase/lib/utils";
+import { copy } from "metabase/lib/utils";
 
 import * as QUERY from "./query";
 import * as FieldRef from "./field-ref";
@@ -28,7 +28,7 @@ const NEW_QUERY_TEMPLATES = {
 };
 
 export function createQuery(type = "query", databaseId, tableId) {
-  const dataset_query = Utils.copy(NEW_QUERY_TEMPLATES[type]);
+  const dataset_query = copy(NEW_QUERY_TEMPLATES[type]);
 
   if (databaseId) {
     dataset_query.database = databaseId;

--- a/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
@@ -11,18 +11,18 @@ import { t } from "ttag";
 import Breadcrumbs from "metabase/components/Breadcrumbs";
 import Button from "metabase/core/components/Button";
 import DisclosureTriangle from "metabase/components/DisclosureTriangle";
-import MetabaseUtils from "metabase/lib/utils";
+import { isEmail, isEmpty } from "metabase/lib/utils";
 import { updateSettings as defaultUpdateSettings } from "../settings";
 import SettingsSetting from "./SettingsSetting";
 import { CollapsibleSectionContent } from "./SettingsBatchForm.styled";
 
 const VALIDATIONS = {
   email: {
-    validate: value => MetabaseUtils.isEmail(value),
+    validate: value => isEmail(value),
     message: t`That's not a valid email address`,
   },
   email_list: {
-    validate: value => value.every(MetabaseUtils.isEmail),
+    validate: value => value.every(isEmail),
     message: t`That's not a valid email address`,
   },
   integer: {
@@ -88,7 +88,7 @@ class SettingsBatchForm extends Component {
 
   // return null if element passes validation, otherwise return an error message
   validateElement(validation, value, element) {
-    if (MetabaseUtils.isEmpty(value)) {
+    if (isEmpty(value)) {
       return;
     }
 
@@ -119,7 +119,7 @@ class SettingsBatchForm extends Component {
     if (!enabledKey || formData[enabledKey]) {
       availableElements.forEach(function (element) {
         // test for required elements
-        if (element.required && MetabaseUtils.isEmpty(formData[element.key])) {
+        if (element.required && isEmpty(formData[element.key])) {
           valid = false;
         }
 

--- a/frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import _ from "underscore";
 import { t, jt } from "ttag";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
-import MetabaseUtils from "metabase/lib/utils";
+import { isEmail, isEmpty } from "metabase/lib/utils";
 
 import Button from "metabase/core/components/Button";
 import { Icon } from "metabase/core/components/Icon";
@@ -50,13 +50,13 @@ class SettingsSlackForm extends Component {
 
   // return null if element passes validation, otherwise return an error message
   validateElement([validationType, validationMessage], value, element) {
-    if (MetabaseUtils.isEmpty(value)) {
+    if (isEmpty(value)) {
       return;
     }
 
     switch (validationType) {
       case "email":
-        return !MetabaseUtils.isEmail(value)
+        return !isEmail(value)
           ? validationMessage || t`That's not a valid email address`
           : null;
       case "integer":
@@ -86,7 +86,7 @@ class SettingsSlackForm extends Component {
 
     elements.forEach(function (element) {
       // test for required elements
-      if (element.required && MetabaseUtils.isEmpty(formData[element.key])) {
+      if (element.required && isEmpty(formData[element.key])) {
         valid = false;
       }
 
@@ -116,7 +116,7 @@ class SettingsSlackForm extends Component {
     this.setState({
       formData: {
         ...this.state.formData,
-        [element.key]: MetabaseUtils.isEmpty(value) ? null : value,
+        [element.key]: isEmpty(value) ? null : value,
       },
     });
   }

--- a/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import { t } from "ttag";
 
 import cx from "classnames";
-import Utils from "metabase/lib/utils";
+import { uuid } from "metabase/lib/utils";
 import Select, { Option } from "metabase/core/components/Select";
 import Confirm from "metabase/components/Confirm";
 import Ellipsified from "metabase/core/components/Ellipsified";
@@ -150,7 +150,7 @@ export default class CustomGeoJSONWidget extends Component {
               onClick={() =>
                 this.setState({
                   map: {
-                    id: Utils.uuid(),
+                    id: uuid(),
                     name: "",
                     url: "",
                     region_key: null,

--- a/frontend/src/metabase/components/UserAvatar/UserAvatar.tsx
+++ b/frontend/src/metabase/components/UserAvatar/UserAvatar.tsx
@@ -1,4 +1,4 @@
-import MetabaseUtils from "metabase/lib/utils";
+import { isEmail } from "metabase/lib/utils";
 import type { AvatarProps } from "./UserAvatar.styled";
 import { Avatar as StyledAvatar } from "./UserAvatar.styled";
 
@@ -56,7 +56,7 @@ function nameInitials(user: User | Group) {
 
 function emailInitials(user: User) {
   const email = [user.email, user.common_name].find(maybeEmail =>
-    MetabaseUtils.isEmail(maybeEmail),
+    isEmail(maybeEmail),
   );
   if (email) {
     const emailUsername = email.split("@")[0];

--- a/frontend/src/metabase/components/UserPicker/UserPicker.jsx
+++ b/frontend/src/metabase/components/UserPicker/UserPicker.jsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import TokenField from "metabase/components/TokenField";
-import MetabaseUtils from "metabase/lib/utils";
+import { isEmail } from "metabase/lib/utils";
 import {
   UserPickerAvatar,
   UserPickerOption,
@@ -52,7 +52,7 @@ const UserPicker = ({ value, validateValue, users, canAddItems, onChange }) => {
   }, []);
 
   const parseFreeformValue = useCallback(text => {
-    if (MetabaseUtils.isEmail(text)) {
+    if (isEmail(text)) {
       return { email: text };
     }
   }, []);

--- a/frontend/src/metabase/dashboard/actions/data-fetching.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.js
@@ -9,7 +9,7 @@ import { defer } from "metabase/lib/promise";
 import { getDashboardUiParameters } from "metabase/parameters/utils/dashboards";
 import { getParameterValuesByIdFromQueryParams } from "metabase/parameters/utils/parameter-values";
 
-import Utils from "metabase/lib/utils";
+import { equals } from "metabase/lib/utils";
 
 import { addParamValues, addFields } from "metabase/redux/metadata";
 
@@ -297,7 +297,7 @@ export const fetchCardData = createThunkAction(
         const lastResult = getIn(dashcardData, [dashcard.id, card.id]);
         if (
           lastResult &&
-          Utils.equals(
+          equals(
             getDatasetQueryParams(lastResult.json_query),
             getDatasetQueryParams(datasetQuery),
           )

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -5,7 +5,7 @@ import type { LocationDescriptor } from "history";
 import { useMount } from "react-use";
 import type { IconProps } from "metabase/core/components/Icon";
 
-import Utils from "metabase/lib/utils";
+import { isJWT } from "metabase/lib/utils";
 
 import { mergeSettings } from "metabase/visualizations/lib/settings";
 
@@ -164,7 +164,7 @@ function DashCard({
   );
 
   const isAction = isActionCard(mainCard);
-  const isEmbed = Utils.isJWT(dashcard.dashboard_id);
+  const isEmbed = isJWT(dashcard.dashboard_id);
 
   const { expectedDuration, isSlow } = useMemo(() => {
     const expectedDuration = Math.max(

--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -1,6 +1,6 @@
 import _ from "underscore";
 import { t } from "ttag";
-import Utils from "metabase/lib/utils";
+import { isUUID, isJWT } from "metabase/lib/utils";
 import { SERVER_ERROR_TYPES } from "metabase/lib/errors";
 import {
   getGenericErrorMessage,
@@ -147,9 +147,9 @@ export function getDashboardType(id: unknown) {
   if (id == null || typeof id === "object") {
     // HACK: support inline dashboards
     return "inline";
-  } else if (Utils.isUUID(id)) {
+  } else if (isUUID(id)) {
     return "public";
-  } else if (Utils.isJWT(id)) {
+  } else if (isJWT(id)) {
     return "embed";
   } else if (typeof id === "string" && /\/auto\/dashboard/.test(id)) {
     return "transient";

--- a/frontend/src/metabase/lib/card.js
+++ b/frontend/src/metabase/lib/card.js
@@ -1,4 +1,4 @@
-import Utils from "metabase/lib/utils";
+import { equals, copy } from "metabase/lib/utils";
 
 import { b64hash_to_utf8, utf8_to_b64url } from "metabase/lib/encoding";
 import Questions from "metabase/entities/questions";
@@ -38,7 +38,7 @@ export async function loadCard(cardId, { dispatch, getState }) {
 }
 
 function getCleanCard(card) {
-  const dataset_query = Utils.copy(card.dataset_query);
+  const dataset_query = copy(card.dataset_query);
   if (dataset_query.query) {
     dataset_query.query = Q_DEPRECATED.cleanQuery(dataset_query.query);
   }
@@ -60,7 +60,7 @@ function getCleanCard(card) {
 
 export function isEqualCard(card1, card2) {
   if (card1 && card2) {
-    return Utils.equals(getCleanCard(card1), getCleanCard(card2));
+    return equals(getCleanCard(card1), getCleanCard(card2));
   } else {
     return false;
   }

--- a/frontend/src/metabase/lib/pulse.ts
+++ b/frontend/src/metabase/lib/pulse.ts
@@ -1,6 +1,6 @@
 import _ from "underscore";
 import MetabaseSettings from "metabase/lib/settings";
-import MetabaseUtils from "metabase/lib/utils";
+import { getEmailDomain } from "metabase/lib/utils";
 
 import type {
   Channel,
@@ -97,7 +97,7 @@ export function recipientIsValid(recipient: NotificationRecipient) {
     return true;
   }
 
-  const recipientDomain = MetabaseUtils.getEmailDomain(recipient.email);
+  const recipientDomain = getEmailDomain(recipient.email);
   const allowedDomains = MetabaseSettings.subscriptionAllowedDomains();
   return (
     _.isEmpty(allowedDomains) ||

--- a/frontend/src/metabase/lib/settings.ts
+++ b/frontend/src/metabase/lib/settings.ts
@@ -3,7 +3,7 @@ import { t, ngettext, msgid } from "ttag";
 import moment from "moment-timezone";
 
 import { parseTimestamp } from "metabase/lib/time";
-import MetabaseUtils from "metabase/lib/utils";
+import { numberToWord, compareVersions } from "metabase/lib/utils";
 import { getDocsUrlForVersion } from "metabase/selectors/settings";
 
 import type {
@@ -12,7 +12,7 @@ import type {
   Settings,
 } from "metabase-types/api";
 
-const n2w = (n: number) => MetabaseUtils.numberToWord(n);
+const n2w = (n: number) => numberToWord(n);
 
 const PASSWORD_COMPLEXITY_CLAUSES = {
   total: {
@@ -316,18 +316,12 @@ class MetabaseSettings {
   }
 
   newVersionAvailable() {
-    const result = MetabaseUtils.compareVersions(
-      this.currentVersion(),
-      this.latestVersion(),
-    );
+    const result = compareVersions(this.currentVersion(), this.latestVersion());
     return result != null && result < 0;
   }
 
   versionIsLatest() {
-    const result = MetabaseUtils.compareVersions(
-      this.currentVersion(),
-      this.latestVersion(),
-    );
+    const result = compareVersions(this.currentVersion(), this.latestVersion());
     return result != null && result >= 0;
   }
 

--- a/frontend/src/metabase/lib/utils.ts
+++ b/frontend/src/metabase/lib/utils.ts
@@ -35,165 +35,160 @@ function s4() {
     .substring(1);
 }
 
-// provides functions for building urls to things we care about
-const MetabaseUtils = {
-  isEmpty(str: string | null) {
-    if (str != null) {
-      str = String(str);
-    } // make sure 'str' is actually a string
-    return str == null || 0 === str.length || str.match(/^\s+$/) != null;
-  },
+export function isEmpty(str: string | null) {
+  if (str != null) {
+    str = String(str);
+  } // make sure 'str' is actually a string
+  return str == null || 0 === str.length || str.match(/^\s+$/) != null;
+}
 
-  // pretty limited.  just does 0-9 for right now.
-  numberToWord(num: number) {
-    const names = [
-      t`zero`,
-      t`one`,
-      t`two`,
-      t`three`,
-      t`four`,
-      t`five`,
-      t`six`,
-      t`seven`,
-      t`eight`,
-      t`nine`,
-    ];
+// pretty limited.  just does 0-9 for right now.
+export function numberToWord(num: number) {
+  const names = [
+    t`zero`,
+    t`one`,
+    t`two`,
+    t`three`,
+    t`four`,
+    t`five`,
+    t`six`,
+    t`seven`,
+    t`eight`,
+    t`nine`,
+  ];
 
-    if (num >= 0 && num <= 9) {
-      return names[num];
-    } else {
-      return "" + num;
-    }
-  },
+  if (num >= 0 && num <= 9) {
+    return names[num];
+  } else {
+    return "" + num;
+  }
+}
 
-  uuid() {
-    return (
-      s4() +
-      s4() +
-      "-" +
-      s4() +
-      "-" +
-      s4() +
-      "-" +
-      s4() +
-      "-" +
-      s4() +
-      s4() +
-      s4()
-    );
-  },
+export function uuid() {
+  return (
+    s4() +
+    s4() +
+    "-" +
+    s4() +
+    "-" +
+    s4() +
+    "-" +
+    s4() +
+    "-" +
+    s4() +
+    s4() +
+    s4()
+  );
+}
 
-  isUUID(uuid: unknown) {
-    return (
-      typeof uuid === "string" &&
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(
-        uuid,
-      )
-    );
-  },
+export function isUUID(uuid: unknown) {
+  return (
+    typeof uuid === "string" &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(uuid)
+  );
+}
 
-  isBase64(string: unknown) {
-    return (
-      typeof string === "string" &&
-      /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
-        string,
-      )
-    );
-  },
+export function isBase64(string: unknown) {
+  return (
+    typeof string === "string" &&
+    /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
+      string,
+    )
+  );
+}
 
-  isJWT(string: unknown) {
-    return (
-      typeof string === "string" &&
-      /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(string)
-    );
-  },
+export function isJWT(string: unknown) {
+  return (
+    typeof string === "string" &&
+    /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(string)
+  );
+}
 
-  isEmail(email: string | undefined | null) {
-    if (email === null || email === undefined) {
+export function isEmail(email: string | undefined | null) {
+  if (email === null || email === undefined) {
+    return false;
+  }
+  return EMAIL_REGEX.test(email);
+}
+
+export function getEmailDomain(email: string) {
+  const match = EMAIL_REGEX.exec(email);
+  return match && match[5];
+}
+
+export function equals(a: unknown, b: unknown) {
+  return _.isEqual(a, b);
+}
+
+export function propertiesEqual(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+  properties = [...Object.keys(a), ...Object.keys(b)],
+) {
+  for (const property of properties) {
+    if (a[property] !== b[property]) {
       return false;
     }
-    return EMAIL_REGEX.test(email);
-  },
+  }
+  return true;
+}
 
-  getEmailDomain(email: string) {
-    const match = EMAIL_REGEX.exec(email);
-    return match && match[5];
-  },
+export function copy(a: unknown) {
+  // FIXME: ugghhhhhhhhh
+  return JSON.parse(JSON.stringify(a));
+}
 
-  equals(a: unknown, b: unknown) {
-    return _.isEqual(a, b);
-  },
+/**
+ * Converts a metabase version to a list of numeric components, it converts pre-release
+ * components to numbers and pads the numeric part to 4 numbers to make comparison easier
+ */
+export function versionToNumericComponents(version: string): number[] | null {
+  const SPECIAL_COMPONENTS: Record<string, number> = {
+    snapshot: -4,
+    alpha: -3,
+    beta: -2,
+    rc: -1,
+  };
 
-  propertiesEqual(
-    a: Record<string, unknown>,
-    b: Record<string, unknown>,
-    properties = [...Object.keys(a), ...Object.keys(b)],
-  ) {
-    for (const property of properties) {
-      if (a[property] !== b[property]) {
-        return false;
-      }
-    }
-    return true;
-  },
+  const regex =
+    /v?(?<ossOrEE>\d+)\.?(?<major>\d+)?\.?(?<minor>\d+)?\.?(?<patch>\d+)?-?(?<label>\D+)?(?<build>\d+)?/;
 
-  copy(a: unknown) {
-    // FIXME: ugghhhhhhhhh
-    return JSON.parse(JSON.stringify(a));
-  },
+  const result = regex.exec(version);
 
-  /**
-   * Converts a metabase version to a list of numeric components, it converts pre-release
-   * components to numbers and pads the numeric part to 4 numbers to make comparison easier
-   */
-  versionToNumericComponents(version: string): number[] | null {
-    const SPECIAL_COMPONENTS: Record<string, number> = {
-      snapshot: -4,
-      alpha: -3,
-      beta: -2,
-      rc: -1,
-    };
+  if (!result || !result.groups) {
+    return null;
+  }
 
-    const regex =
-      /v?(?<ossOrEE>\d+)\.?(?<major>\d+)?\.?(?<minor>\d+)?\.?(?<patch>\d+)?-?(?<label>\D+)?(?<build>\d+)?/;
+  const {
+    ossOrEE,
+    major = 0,
+    minor = 0,
+    patch = 0,
+    label,
+    build = 0,
+  } = result.groups;
 
-    const result = regex.exec(version);
-
-    if (!result || !result.groups) {
-      return null;
-    }
-
-    const {
-      ossOrEE,
-      major = 0,
-      minor = 0,
-      patch = 0,
-      label,
-      build = 0,
-    } = result.groups;
-
-    return [
-      ossOrEE,
-      major,
-      minor,
-      patch,
-      SPECIAL_COMPONENTS[label.toLowerCase()] ?? 0,
-      build,
-    ].map(part => (typeof part === "string" ? parseInt(part, 10) : part));
-  },
-};
+  return [
+    ossOrEE,
+    major,
+    minor,
+    patch,
+    SPECIAL_COMPONENTS[label.toLowerCase()] ?? 0,
+    build,
+  ].map(part => (typeof part === "string" ? parseInt(part, 10) : part));
+}
 
 /**
  * this should correctly compare all version formats Metabase uses, e.g.
  * 0.0.9, 0.0.10-snapshot, 0.0.10-alpha1, 0.0.10-rc1, 0.0.10-rc2, 0.0.10-rc10
  * 0.0.10, 0.1.0, 0.2.0, 0.10.0, 1.1.0
  */
-function compareVersions(aVersion: string, bVersion: string): -1 | 0 | 1;
-function compareVersions(
+export function compareVersions(aVersion: string, bVersion: string): -1 | 0 | 1;
+export function compareVersions(
   aVersion: string | null | undefined,
   bVersion: string | null | undefined,
 ): null;
-function compareVersions(
+export function compareVersions(
   aVersion: string | null | undefined,
   bVersion: string | null | undefined,
 ): -1 | 0 | 1 | null {
@@ -201,8 +196,8 @@ function compareVersions(
     return null;
   }
 
-  const aComponents = MetabaseUtils.versionToNumericComponents(aVersion);
-  const bComponents = MetabaseUtils.versionToNumericComponents(bVersion);
+  const aComponents = versionToNumericComponents(aVersion);
+  const bComponents = versionToNumericComponents(bVersion);
 
   if (!aComponents || !bComponents) {
     return null;
@@ -219,6 +214,3 @@ function compareVersions(
   }
   return 0;
 }
-
-// eslint-disable-next-line import/no-default-export
-export default Object.assign(MetabaseUtils, { compareVersions });

--- a/frontend/src/metabase/lib/utils.ts
+++ b/frontend/src/metabase/lib/utils.ts
@@ -88,15 +88,6 @@ export function isUUID(uuid: unknown) {
   );
 }
 
-export function isBase64(string: unknown) {
-  return (
-    typeof string === "string" &&
-    /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
-      string,
-    )
-  );
-}
-
 export function isJWT(string: unknown) {
   return (
     typeof string === "string" &&

--- a/frontend/src/metabase/lib/utils.ts
+++ b/frontend/src/metabase/lib/utils.ts
@@ -173,7 +173,7 @@ export function versionToNumericComponents(version: string): number[] | null {
     major,
     minor,
     patch,
-    SPECIAL_COMPONENTS[label.toLowerCase()] ?? 0,
+    SPECIAL_COMPONENTS[label?.toLowerCase()] ?? 0,
     build,
   ].map(part => (typeof part === "string" ? parseInt(part, 10) : part));
 }

--- a/frontend/src/metabase/lib/utils.unit.spec.ts
+++ b/frontend/src/metabase/lib/utils.unit.spec.ts
@@ -1,23 +1,26 @@
-import MetabaseUtils from "metabase/lib/utils";
+import {
+  versionToNumericComponents,
+  compareVersions,
+  isEmpty,
+  isJWT,
+} from "metabase/lib/utils";
 
 describe("utils", () => {
   describe("versionToNumericComponents", () => {
     it("should understand v1 and use defaults for the rest of fields", () => {
-      expect(MetabaseUtils.versionToNumericComponents("v1")).toStrictEqual([
+      expect(versionToNumericComponents("v1")).toStrictEqual([
         1, 0, 0, 0, 0, 0,
       ]);
     });
 
     it("should pad to 4 numeric components", () => {
-      expect(
-        MetabaseUtils.versionToNumericComponents("v1.2-BETA1"),
-      ).toStrictEqual([1, 2, 0, 0, -2, 1]);
+      expect(versionToNumericComponents("v1.2-BETA1")).toStrictEqual([
+        1, 2, 0, 0, -2, 1,
+      ]);
     });
 
     it("should return null when the version is not parsable", () => {
-      expect(MetabaseUtils.versionToNumericComponents("vUNKNOWN")).toEqual(
-        null,
-      );
+      expect(versionToNumericComponents("vUNKNOWN")).toEqual(null);
     });
   });
 
@@ -50,76 +53,68 @@ describe("utils", () => {
         "1.1.0",
         "0.2.0",
       ];
-      expect(unsorted.sort(MetabaseUtils.compareVersions)).toEqual(expected);
+      expect(unsorted.sort(compareVersions)).toEqual(expected);
     });
 
     it("should return null if one version is not valid", () => {
-      expect(MetabaseUtils.compareVersions("vUNKNOWN", "v0.46.0")).toBe(null);
+      expect(compareVersions("vUNKNOWN", "v0.46.0")).toBe(null);
     });
 
     it("should return 0 for equal versions", () => {
-      expect(MetabaseUtils.compareVersions("v0.46.0", "v0.46.0")).toBe(0);
+      expect(compareVersions("v0.46.0", "v0.46.0")).toBe(0);
     });
 
     it("should compare majors", () => {
-      expect(MetabaseUtils.compareVersions("v0.46.0", "v0.47.0")).toBe(-1);
-      expect(MetabaseUtils.compareVersions("v0.47.0", "v0.46.0")).toBe(1);
+      expect(compareVersions("v0.46.0", "v0.47.0")).toBe(-1);
+      expect(compareVersions("v0.47.0", "v0.46.0")).toBe(1);
     });
 
     it("should compare minors", () => {
-      expect(MetabaseUtils.compareVersions("v0.46.0", "v0.46.1")).toBe(-1);
-      expect(MetabaseUtils.compareVersions("v0.46.1", "v0.46.0")).toBe(1);
+      expect(compareVersions("v0.46.0", "v0.46.1")).toBe(-1);
+      expect(compareVersions("v0.46.1", "v0.46.0")).toBe(1);
     });
 
     it("should consider X-beta < X", () => {
-      expect(MetabaseUtils.compareVersions("v0.46.0-BETA", "v0.46.0")).toBe(-1);
+      expect(compareVersions("v0.46.0-BETA", "v0.46.0")).toBe(-1);
     });
 
     it("should consider X-beta < X-RC", () => {
-      expect(MetabaseUtils.compareVersions("v0.46.0-BETA", "v0.46.0-RC")).toBe(
-        -1,
-      );
+      expect(compareVersions("v0.46.0-BETA", "v0.46.0-RC")).toBe(-1);
     });
 
     it("should consider X-BETA1 < X-BETA2", () => {
-      expect(
-        MetabaseUtils.compareVersions("v0.46.0-BETA1", "v0.46.0-BETA2"),
-      ).toBe(-1);
+      expect(compareVersions("v0.46.0-BETA1", "v0.46.0-BETA2")).toBe(-1);
     });
 
     it("should consider X.BETA and X.0-BETA equal", () => {
-      expect(MetabaseUtils.compareVersions("v0.46.0-BETA", "v0.46-BETA")).toBe(
-        0,
-      );
+      expect(compareVersions("v0.46.0-BETA", "v0.46-BETA")).toBe(0);
     });
 
     it("should treat missing subversions as 0", () => {
-      expect(MetabaseUtils.compareVersions("v0.46.0", "v0.46")).toBe(0);
-      expect(MetabaseUtils.compareVersions("v0.46.2", "v0.46.2.0")).toBe(0);
-      expect(MetabaseUtils.compareVersions("v0.46", "v0.46.1")).toBe(-1);
+      expect(compareVersions("v0.46.0", "v0.46")).toBe(0);
+      expect(compareVersions("v0.46.2", "v0.46.2.0")).toBe(0);
+      expect(compareVersions("v0.46", "v0.46.1")).toBe(-1);
     });
 
     it("should consider v0.46-BETA1 < v0.46.0", () => {
-      expect(MetabaseUtils.compareVersions("v0.46-BETA1", "v0.46.0")).toBe(-1);
+      expect(compareVersions("v0.46-BETA1", "v0.46.0")).toBe(-1);
     });
 
     it("should consider v0.46-BETA1 < v0.46.1-BETA1", () => {
-      expect(
-        MetabaseUtils.compareVersions("v0.46-BETA1", "v0.46.1-BETA1"),
-      ).toBe(-1);
+      expect(compareVersions("v0.46-BETA1", "v0.46.1-BETA1")).toBe(-1);
     });
   });
 
   describe("isEmpty", () => {
     it("should not allow all-blank strings", () => {
-      expect(MetabaseUtils.isEmpty(" ")).toEqual(true);
+      expect(isEmpty(" ")).toEqual(true);
     });
   });
 
   describe("isJWT", () => {
     it("should allow for JWT tokens with dashes", () => {
       expect(
-        MetabaseUtils.isJWT(
+        isJWT(
           "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXJhbXMiOnsicGFyYW0xIjoidGVzdCIsInBhcmFtMiI6ImFiIiwicGFyYW0zIjoiMjAwMC0wMC0wMFQwMDowMDowMCswMDowMCIsInBhcmFtNCI6Iu-8iO-8iSJ9LCJyZXNvdXJjZSI6eyJkYXNoYm9hcmQiOjB9fQ.wsNWliHJNwJBv_hx0sPo1EGY0nATdgEa31TM1AYotIA",
         ),
       ).toEqual(true);

--- a/frontend/src/metabase/lib/validate.js
+++ b/frontend/src/metabase/lib/validate.js
@@ -1,5 +1,5 @@
 import { t } from "ttag";
-import Utils from "metabase/lib/utils";
+import { isEmail } from "metabase/lib/utils";
 import Settings from "metabase/lib/settings";
 
 // we need this to allow 0 as a valid form value
@@ -8,8 +8,7 @@ export const isEmpty = value =>
 
 export const validators = {
   required: () => value => isEmpty(value) && t`required`,
-  email: () => value =>
-    !Utils.isEmail(value) && t`must be a valid email address`,
+  email: () => value => !isEmail(value) && t`must be a valid email address`,
   maxLength: max => value =>
     value && value.length > max && t`must be ${max} characters or less`,
   passwordComplexity: () => value =>

--- a/frontend/src/metabase/nav/components/WhatsNewNotification/utils.ts
+++ b/frontend/src/metabase/nav/components/WhatsNewNotification/utils.ts
@@ -1,5 +1,5 @@
 import type { VersionInfoRecord } from "metabase-types/api";
-import MetabaseUtils from "metabase/lib/utils";
+import { compareVersions } from "metabase/lib/utils";
 import type { VersionInfo } from "metabase-types/api/settings";
 import { isNotFalsy } from "metabase/core/utils/types";
 /**
@@ -35,16 +35,16 @@ export const getLatestEligibleReleaseNotes = ({
 
   const eligibleVersions = versions.filter(({ version }) => {
     return (
-      //                            version <= currentVersion
-      MetabaseUtils.compareVersions(version, currentVersion) !== 1 &&
+      //             version <= currentVersion
+      compareVersions(version, currentVersion) !== 1 &&
       // shortcircuit lower bound if lastAcknowledgedVersion is null
       (lastAcknowledgedVersion == null ||
-        //                            version > lastAcknowledgedVersion
-        MetabaseUtils.compareVersions(version, lastAcknowledgedVersion) === 1)
+        //              version > lastAcknowledgedVersion
+        compareVersions(version, lastAcknowledgedVersion) === 1)
     );
   });
 
   return eligibleVersions
-    .sort((a, b) => MetabaseUtils.compareVersions(b.version, a.version))
+    .sort((a, b) => compareVersions(b.version, a.version))
     .find(({ announcement_url }) => announcement_url);
 };

--- a/frontend/src/metabase/pulse/components/RecipientPicker.jsx
+++ b/frontend/src/metabase/pulse/components/RecipientPicker.jsx
@@ -5,7 +5,7 @@ import { t } from "ttag";
 import { recipientIsValid } from "metabase/lib/pulse";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import MetabaseSettings from "metabase/lib/settings";
-import MetabaseUtils from "metabase/lib/utils";
+import { isEmail } from "metabase/lib/utils";
 import TokenField from "metabase/components/TokenField";
 import UserAvatar from "metabase/components/UserAvatar";
 import { Text } from "metabase/ui";
@@ -82,7 +82,7 @@ export default class RecipientPicker extends Component {
             filterOption={filterOption}
             validateValue={value => recipientIsValid(value)}
             parseFreeformValue={inputValue => {
-              if (MetabaseUtils.isEmail(inputValue)) {
+              if (isEmail(inputValue)) {
                 return { email: inputValue };
               }
             }}

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -5,7 +5,7 @@ import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { loadCard } from "metabase/lib/card";
 import { shouldOpenInBlankWindow } from "metabase/lib/dom";
 import * as Urls from "metabase/lib/urls";
-import Utils from "metabase/lib/utils";
+import { copy } from "metabase/lib/utils";
 import { createThunkAction } from "metabase/lib/redux";
 
 import { loadMetadataForCard } from "metabase/questions/actions";
@@ -100,7 +100,7 @@ export const SET_CARD_AND_RUN = "metabase/qb/SET_CARD_AND_RUN";
 export const setCardAndRun = (nextCard, shouldUpdateUrl = true) => {
   return async (dispatch, getState) => {
     // clone
-    const card = Utils.copy(nextCard);
+    const card = copy(nextCard);
 
     const originalCard = card.original_card_id
       ? // If the original card id is present, dynamically load its information for showing lineage

--- a/frontend/src/metabase/query_builder/actions/navigation.js
+++ b/frontend/src/metabase/query_builder/actions/navigation.js
@@ -3,7 +3,7 @@ import { createAction } from "redux-actions";
 import { push, replace } from "react-router-redux";
 
 import { createThunkAction } from "metabase/lib/redux";
-import Utils from "metabase/lib/utils";
+import { equals } from "metabase/lib/utils";
 
 import { isEqualCard } from "metabase/lib/card";
 
@@ -56,7 +56,7 @@ export const popState = createThunkAction(
 
     const card = getCard(getState());
     if (location.state && location.state.card) {
-      if (!Utils.equals(card, location.state.card)) {
+      if (!equals(card, location.state.card)) {
         const shouldRefreshUrl = location.state.card.dataset;
         await dispatch(setCardAndRun(location.state.card, shouldRefreshUrl));
         await dispatch(setCurrentState(location.state));

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -5,7 +5,7 @@ import { t } from "ttag";
 import cx from "classnames";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 
-import Utils from "metabase/lib/utils";
+import { copy } from "metabase/lib/utils";
 import { HARD_ROW_LIMIT } from "metabase-lib/queries/utils";
 import VisualizationError from "./VisualizationError";
 import VisualizationResult from "./VisualizationResult";
@@ -25,8 +25,8 @@ export default class QueryVisualization extends Component {
 
   _getStateFromProps(props) {
     return {
-      lastRunDatasetQuery: Utils.copy(props.question.query().datasetQuery()),
-      lastRunParameterValues: Utils.copy(props.parameterValues),
+      lastRunDatasetQuery: copy(props.question.query().datasetQuery()),
+      lastRunParameterValues: copy(props.parameterValues),
     };
   }
 

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.tsx
@@ -3,7 +3,7 @@ import Code from "metabase/components/Code";
 import Button from "metabase/core/components/Button";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import MetabaseSettings from "metabase/lib/settings";
-import Utils from "metabase/lib/utils";
+import { uuid } from "metabase/lib/utils";
 import type { DatabaseId, NativeDatasetQuery } from "metabase-types/api";
 import type Database from "metabase-lib/metadata/Database";
 
@@ -15,7 +15,7 @@ const SQL_EXAMPLES: Record<string, NativeDatasetQuery> = {
       query: "SELECT count(*)\nFROM products\nWHERE category = {{category}}",
       "template-tags": {
         category: {
-          id: Utils.uuid(),
+          id: uuid(),
           name: "category",
           "display-name": "Category",
           type: "text",
@@ -32,7 +32,7 @@ const SQL_EXAMPLES: Record<string, NativeDatasetQuery> = {
       query: "SELECT count(*)\nFROM products\nWHERE {{created_at}}",
       "template-tags": {
         created_at: {
-          id: Utils.uuid(),
+          id: uuid(),
           name: "created_at",
           "display-name": "Created At",
           type: "dimension",
@@ -49,7 +49,7 @@ const SQL_EXAMPLES: Record<string, NativeDatasetQuery> = {
         "SELECT count(*)\nFROM products\n[[WHERE category = {{category}}]]",
       "template-tags": {
         category: {
-          id: Utils.uuid(),
+          id: uuid(),
           name: "category",
           "display-name": "Category",
           type: "text",
@@ -66,14 +66,14 @@ const SQL_EXAMPLES: Record<string, NativeDatasetQuery> = {
         "SELECT count(*)\nFROM products\nWHERE 1=1\n  [[AND id = {{id}}]]\n  [[AND category = {{category}}]]",
       "template-tags": {
         id: {
-          id: Utils.uuid(),
+          id: uuid(),
           name: "id",
           "display-name": "ID",
           type: "number",
           required: false,
         },
         category: {
-          id: Utils.uuid(),
+          id: uuid(),
           name: "category",
           "display-name": "Category",
           type: "text",
@@ -90,7 +90,7 @@ const SQL_EXAMPLES: Record<string, NativeDatasetQuery> = {
         "SELECT count(*)\nFROM products\nWHERE 1=1\n  [[AND {{category}}]]",
       "template-tags": {
         category: {
-          id: Utils.uuid(),
+          id: uuid(),
           name: "category",
           "display-name": "Category",
           type: "dimension",
@@ -109,7 +109,7 @@ const MONGO_EXAMPLES: Record<string, NativeDatasetQuery> = {
       query: "[{ $match: { price: {{price}} } }]",
       "template-tags": {
         category: {
-          id: Utils.uuid(),
+          id: uuid(),
           name: "price",
           "display-name": "Price",
           type: "number",
@@ -126,7 +126,7 @@ const MONGO_EXAMPLES: Record<string, NativeDatasetQuery> = {
       query: "[{ $match: {{created_at}} }]",
       "template-tags": {
         created_at: {
-          id: Utils.uuid(),
+          id: uuid(),
           name: "created_at",
           "display-name": "Created At",
           type: "dimension",
@@ -142,7 +142,7 @@ const MONGO_EXAMPLES: Record<string, NativeDatasetQuery> = {
       query: "[{ $match: { [[ _id: {{id}} ]] } }]",
       "template-tags": {
         category: {
-          id: Utils.uuid(),
+          id: uuid(),
           name: "id",
           "display-name": "ID",
           type: "text",
@@ -159,14 +159,14 @@ const MONGO_EXAMPLES: Record<string, NativeDatasetQuery> = {
         "[{ $match: { [[ _id: {{id}} [[, category: {{category}} ]]  ]] } }]",
       "template-tags": {
         id: {
-          id: Utils.uuid(),
+          id: uuid(),
           name: "id",
           "display-name": "ID",
           type: "number",
           required: false,
         },
         category: {
-          id: Utils.uuid(),
+          id: uuid(),
           name: "category",
           "display-name": "Category",
           type: "text",
@@ -182,7 +182,7 @@ const MONGO_EXAMPLES: Record<string, NativeDatasetQuery> = {
       query: "[{ $match: { $and: [ { _id: 1 } [[, {{category}} ]] ] } }]",
       "template-tags": {
         category: {
-          id: Utils.uuid(),
+          id: uuid(),
           name: "category",
           "display-name": "Category",
           type: "dimension",

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -1,7 +1,7 @@
 import { handleActions } from "redux-actions";
 import { assoc, merge } from "icepick";
 import _ from "underscore";
-import Utils from "metabase/lib/utils";
+import { copy } from "metabase/lib/utils";
 
 import TimelineEvents from "metabase/entities/timeline-events";
 import {
@@ -412,20 +412,20 @@ export const originalCard = handleActions(
   {
     [INITIALIZE_QB]: {
       next: (state, { payload }) =>
-        payload.originalCard ? Utils.copy(payload.originalCard) : null,
+        payload.originalCard ? copy(payload.originalCard) : null,
     },
     [RELOAD_CARD]: {
-      next: (state, { payload }) => (payload.id ? Utils.copy(payload) : null),
+      next: (state, { payload }) => (payload.id ? copy(payload) : null),
     },
     [SET_CARD_AND_RUN]: {
       next: (state, { payload }) =>
-        payload.originalCard ? Utils.copy(payload.originalCard) : null,
+        payload.originalCard ? copy(payload.originalCard) : null,
     },
     [API_CREATE_QUESTION]: {
-      next: (state, { payload }) => Utils.copy(payload),
+      next: (state, { payload }) => copy(payload),
     },
     [API_UPDATE_QUESTION]: {
-      next: (state, { payload }) => Utils.copy(payload),
+      next: (state, { payload }) => copy(payload),
     },
   },
   null,

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -10,7 +10,7 @@ import ExplicitSize from "metabase/components/ExplicitSize";
 
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { formatNumber } from "metabase/lib/formatting";
-import Utils from "metabase/lib/utils";
+import { equals } from "metabase/lib/utils";
 
 import {
   getVisualizationTransformed,
@@ -85,9 +85,9 @@ class Visualization extends PureComponent {
   UNSAFE_componentWillReceiveProps(newProps) {
     if (
       !isSameSeries(newProps.rawSeries, this.props.rawSeries) ||
-      !Utils.equals(newProps.settings, this.props.settings) ||
-      !Utils.equals(newProps.timelineEvents, this.props.timelineEvents) ||
-      !Utils.equals(
+      !equals(newProps.settings, this.props.settings) ||
+      !equals(newProps.timelineEvents, this.props.timelineEvents) ||
+      !equals(
         newProps.selectedTimelineEventIds,
         this.props.selectedTimelineEventIds,
       )
@@ -101,9 +101,7 @@ class Visualization extends PureComponent {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (
-      !Utils.equals(this.getWarnings(prevProps, prevState), this.getWarnings())
-    ) {
+    if (!equals(this.getWarnings(prevProps, prevState), this.getWarnings())) {
       this.updateWarnings();
     }
   }

--- a/frontend/test/metabase/lib/query.unit.spec.js
+++ b/frontend/test/metabase/lib/query.unit.spec.js
@@ -1,4 +1,4 @@
-import Utils from "metabase/lib/utils";
+import { copy } from "metabase/lib/utils";
 import { createMockStructuredDatasetQuery } from "metabase-types/api/mocks";
 import * as Q_DEPRECATED from "metabase-lib/queries/utils";
 
@@ -57,7 +57,7 @@ describe("Legacy Q_DEPRECATED library", () => {
       });
 
       // We have to take a copy because the original object isn't extensible
-      const copiedDatasetQuery = Utils.copy(datasetQuery);
+      const copiedDatasetQuery = copy(datasetQuery);
       Q_DEPRECATED.cleanQuery(copiedDatasetQuery);
 
       expect(copiedDatasetQuery).toBeDefined();


### PR DESCRIPTION
### Description

After the [recent bug](https://github.com/metabase/metabase/pull/33946) in the `compareVersions` function I migrated the file to TS.
- https://github.com/metabase/metabase/commit/028fe83729311bc1affd9904ff3db5bb15175ffa  migrates to ts, some functions don't accept anything as input so there's a lot of `unknown` in there
- https://github.com/metabase/metabase/commit/f88fb88ba31edb31f6478962532d04ed0f8630b4 I removed the "MetabaseUtils" object/namespace so that we can use the usual approach of exporting the functions

