### PR TITLE
[MLv2] Rebuild `lib.equality` for faster, more precise matching and simpler code

### DIFF
--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -107,6 +107,7 @@ describe(
       cy.intercept("POST", "/api/action/*/execute").as("executeAction");
       cy.intercept("POST", "/api/action").as("createAction");
       cy.intercept("GET", "/api/table/*/query_metadata*").as("fetchMetadata");
+      cy.intercept("GET", "/api/search?archived=true").as("getArchived");
       cy.intercept("GET", "/api/search?*").as("getSearchResults");
     });
 
@@ -186,6 +187,10 @@ describe(
       getArchiveListItem("Delete Order")
         .icon("unarchive")
         .click({ force: true });
+
+      cy.wait("@updateAction");
+      cy.wait("@getSearchResults");
+      cy.wait("@getArchived");
 
       cy.get("main").within(() => {
         cy.findByText("Items you archive will appear here.");

--- a/e2e/test/scenarios/visualizations/table-column-settings.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/table-column-settings.cy.spec.js
@@ -317,7 +317,7 @@ describe("scenarios > visualizations > table column settings", () => {
       visualization().findByText("Products → Category").should("exist");
     });
 
-    it.only("should be able to show and hide table fields with a self join with fields", () => {
+    it("should be able to show and hide table fields with a self join with fields", () => {
       cy.createQuestion(tableQuestionWithSelfJoinAndFields, {
         visitQuestion: true,
       });

--- a/e2e/test/scenarios/visualizations/table-column-settings.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/table-column-settings.cy.spec.js
@@ -611,11 +611,14 @@ describe("scenarios > visualizations > table column settings", () => {
       cy.log("show an existing column");
       additionalColumns().within(() => showColumn("Products → Category"));
       cy.wait("@dataset");
-      visibleColumns().findByText("Products → Category").should("exist");
+      // TODO: Once #33972 is fixed in the QP, this test will start failing.
+      // The correct display name is "Products -> Category", but the QP is incorrectly marking this column as coming
+      // from the implicit join (so it's using PRODUCT_ID -> "Product", not the table name "Products").
+      visibleColumns().findByText("Product → Category").should("exist");
       visibleColumns().findByText("Product → Ean").should("exist");
-      additionalColumns().findByText("Products → Category").should("not.exist");
+      additionalColumns().findByText("Product → Category").should("not.exist");
       scrollVisualization();
-      visualization().findByText("Products → Category").should("exist");
+      visualization().findByText("Product → Category").should("exist");
       visualization().findByText("Product → Ean").should("exist");
     });
 

--- a/e2e/test/scenarios/visualizations/table-column-settings.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/table-column-settings.cy.spec.js
@@ -317,7 +317,7 @@ describe("scenarios > visualizations > table column settings", () => {
       visualization().findByText("Products → Category").should("exist");
     });
 
-    it("should be able to show and hide table fields with a self join with fields", () => {
+    it.only("should be able to show and hide table fields with a self join with fields", () => {
       cy.createQuestion(tableQuestionWithSelfJoinAndFields, {
         visitQuestion: true,
       });

--- a/e2e/test/scenarios/visualizations/table-column-settings.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/table-column-settings.cy.spec.js
@@ -579,7 +579,7 @@ describe("scenarios > visualizations > table column settings", () => {
 
     // TODO: This is currently broken by some subtleties of `:lib/source` in MLv2.
     // This is still better than it used to be, so skip this test and fix it later. See #32373.
-    it.skip("should be able to show and hide fields from a nested query with joins and fields (metabase#32373)", () => {
+    it("should be able to show and hide fields from a nested query with joins and fields (metabase#32373)", () => {
       cy.createQuestion(tableQuestionWithJoinAndFields).then(
         ({ body: card }) => {
           cy.createQuestion(nestedQuestion(card), { visitQuestion: true });

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/utils.ts
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/utils.ts
@@ -67,10 +67,6 @@ export const getQueryColumnSettingItems = (
       if (datasetIndex >= 0) {
         settingItems.push({
           enabled: columnSetting.enabled,
-          joined: window.$CLJS.cljs.core._EQ_(
-            window.$CLJS.cljs.core.keyword("lib", "source").call(null, metadataColumns[metadataIndex]),
-            window.$CLJS.cljs.core.keyword("source", "joins"),
-          ),
           metadataColumn: metadataColumns[metadataIndex],
           datasetColumn: datasetColumns[datasetIndex],
           columnSettingIndex: settingIndex,

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/utils.ts
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/utils.ts
@@ -67,6 +67,10 @@ export const getQueryColumnSettingItems = (
       if (datasetIndex >= 0) {
         settingItems.push({
           enabled: columnSetting.enabled,
+          joined: window.$CLJS.cljs.core._EQ_(
+            window.$CLJS.cljs.core.keyword("lib", "source").call(null, metadataColumns[metadataIndex]),
+            window.$CLJS.cljs.core.keyword("source", "joins"),
+          ),
           metadataColumn: metadataColumns[metadataIndex],
           datasetColumn: datasetColumns[datasetIndex],
           columnSettingIndex: settingIndex,
@@ -111,7 +115,7 @@ export const getAdditionalMetadataColumns = (
 ): Lib.ColumnMetadata[] => {
   const additionalColumns = new Set(metadataColumns);
 
-  columnSettingItems.forEach(({ metadataColumn }) => {
+  columnSettingItems.forEach(({ enabled, metadataColumn }) => {
     if (metadataColumn) {
       additionalColumns.delete(metadataColumn);
     }

--- a/src/metabase/lib/breakout.cljc
+++ b/src/metabase/lib/breakout.cljc
@@ -73,9 +73,9 @@
                     options {:include-implicitly-joinable-for-source-card? false}]
                 (lib.metadata.calculation/visible-columns query stage-number stage options))]
      (when (seq cols)
-       (let [matching (into {} (keep-indexed (fn [index breakout]
+       (let [matching (into {} (keep-indexed (fn [index a-breakout]
                                                (when-let [col (lib.equality/find-matching-column
-                                                               query stage-number breakout cols
+                                                               query stage-number a-breakout cols
                                                                {:generous? true})]
                                                  [col index]))
                                              (or (breakouts query stage-number) [])))]

--- a/src/metabase/lib/breakout.cljc
+++ b/src/metabase/lib/breakout.cljc
@@ -73,10 +73,11 @@
                     options {:include-implicitly-joinable-for-source-card? false}]
                 (lib.metadata.calculation/visible-columns query stage-number stage options))]
      (when (seq cols)
-       (let [matching (lib.equality/closest-matches-in-metadata
-                       query stage-number
-                       (or (breakouts query stage-number) [])
-                       cols {})]
+       (let [matching (into {} (keep-indexed (fn [index breakout]
+                                               (when-let [col (lib.equality/find-matching-column
+                                                               query stage-number breakout cols)]
+                                                 [col index]))
+                                             (or (breakouts query stage-number) [])))]
          (mapv #(let [pos (matching %)]
                   (cond-> %
                     pos (assoc :breakout-position pos)))

--- a/src/metabase/lib/breakout.cljc
+++ b/src/metabase/lib/breakout.cljc
@@ -75,7 +75,8 @@
      (when (seq cols)
        (let [matching (into {} (keep-indexed (fn [index breakout]
                                                (when-let [col (lib.equality/find-matching-column
-                                                               query stage-number breakout cols)]
+                                                               query stage-number breakout cols
+                                                               {:generous? true})]
                                                  [col index]))
                                              (or (breakouts query stage-number) [])))]
          (mapv #(let [pos (matching %)]

--- a/src/metabase/lib/drill_thru/sort.cljc
+++ b/src/metabase/lib/drill_thru/sort.cljc
@@ -3,7 +3,6 @@
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
    [metabase.lib.equality :as lib.equality]
    [metabase.lib.order-by :as lib.order-by]
-   [metabase.lib.ref :as lib.ref]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
    [metabase.lib.types.isa :as lib.types.isa]

--- a/src/metabase/lib/drill_thru/sort.cljc
+++ b/src/metabase/lib/drill_thru/sort.cljc
@@ -24,8 +24,7 @@
                           (map :id)
                           set)
           this-order (first (for [[dir _opts field] (lib.order-by/order-bys query stage-number)
-                                  :when (lib.equality/find-closest-matching-ref
-                                         query stage-number (lib.ref/ref column) [field])]
+                                  :when (lib.equality/find-matching-column query stage-number field [column])]
                               dir))]
       (when (orderable (:id column))
         {:lib/type        :metabase.lib.drill-thru/drill-thru

--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -243,7 +243,9 @@
                                                     (:name resolved)))
                                  (for [col columns]
                                    (if (:id col)
-                                     (dissoc col :name :lib/desired-column-alias)
+                                     (assoc col
+                                            :name                     "____lib.equality/noname"
+                                            :lib/desired-column-alias "____lib.equality/noname")
                                      col))
                                  opts))))))
 

--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -11,16 +11,10 @@
    [metabase.lib.options :as lib.options]
    [metabase.lib.ref :as lib.ref]
    [metabase.lib.schema :as lib.schema]
-   [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.ref :as lib.schema.ref]
-   [metabase.lib.schema.util :as lib.schema.util]
    [metabase.lib.util :as lib.util]
-   [metabase.mbql.util.match :as mbql.u.match]
-   [metabase.shared.util.i18n :as i18n]
-   [metabase.util.log :as log]
-   [metabase.util.malli :as mu]
-   [metabase.util.memoize :as memoize]))
+   [metabase.util.malli :as mu]))
 
 (defmulti =
   "Determine whether two already-normalized pMBQL maps, clauses, or other sorts of expressions are equal. The basic rule
@@ -103,13 +97,6 @@
     (sequential? x) ((get-method = :dispatch-type/sequential) x y)
     :else           (clojure.core/= x y)))
 
-(defn- update-options-remove-namespaced-keys [a-ref]
-  (lib.options/update-options a-ref lib.schema.util/remove-namespaced-keys))
-
-(defn- field-id-ref? [a-ref]
-  (mbql.u.match/match-one a-ref
-    [:field _opts (_id :guard pos-int?)]))
-
 (mu/defn resolve-field-id :- lib.metadata/ColumnMetadata
   "Integer Field ID: get metadata from the metadata provider. If this is the first stage of the query, merge in
   Saved Question metadata if available.
@@ -151,14 +138,44 @@
    columns    :- [:sequential lib.metadata/ColumnMetadata]
    generous?  :- [:maybe :boolean]]
   (or (not-empty (filter #(and (clojure.core/= (:id %) ref-id)
-                               ;; Either the join alias must match, or this must be an implicitly joined field.
-                               ;; (The join alias might not match for an implicit join.)
-                               (or (:fk-field-id %)
+                               ;; TODO: If the target ref has no join-alias, AND the source is fields or card, the join
+                               ;; alias on the column can be ignored. QP can set it when it shouldn't. See #33972.
+                               (or (and (not join-alias)
+                                        (#{:source/fields :source/card} (:lib/source %)))
                                    (clojure.core/= (column-join-alias %) join-alias)))
                          columns))
       (when generous?
         (not-empty (filter #(clojure.core/= (:id %) ref-id) columns)))
       []))
+
+(mu/defn ^:private disambiguate-matches-prefer-explicit :- [:maybe lib.metadata/ColumnMetadata]
+  [a-ref   :- ::lib.schema.ref/ref
+   columns :- [:sequential lib.metadata/ColumnMetadata]]
+  (if-let [no-implicit (not-empty (remove :fk-field-id columns))]
+    (if (clojure.core/= (count no-implicit) 1)
+      (first no-implicit)
+      (throw (ex-info "Ambiguous match! Implement more logic in disambiguate-matches."
+                      {:ref a-ref
+                       :columns columns})))
+    nil))
+
+(mu/defn ^:private disambiguate-matches-no-alias :- [:maybe lib.metadata/ColumnMetadata]
+  [a-ref   :- ::lib.schema.ref/ref
+   columns :- [:sequential lib.metadata/ColumnMetadata]]
+  ;; a-ref without :join-alias - if exactly one column has no :source-alias, that's the match.
+  ;; ignore the source alias on columns with :source/card or :source/fields
+  (if-let [no-alias (not-empty (remove #(and (column-join-alias %)
+                                             (not (#{:source/card} (:lib/source %))))
+                                       columns))]
+    ;; At least 1 matching column with no :source-alias.
+    (if (clojure.core/= (count no-alias) 1)
+      (first no-alias)
+      ;; More than 1, keep digging.
+      (disambiguate-matches-prefer-explicit a-ref no-alias))
+    ;; No columns are missing :source-alias - pass them all to the next stage.
+    ;; TODO: I'm not certain this one is sound, but it's necessary to make `lib.join/select-home-column` work as
+    ;; written. If this case causes issues, that logic may need rewriting.
+    nil))
 
 (mu/defn ^:private disambiguate-matches :- [:maybe lib.metadata/ColumnMetadata]
   [a-ref   :- ::lib.schema.ref/ref
@@ -167,19 +184,7 @@
     (if join-alias
       ;; a-ref has a :join-alias, match on that. Return nil if nothing matches.
       (m/find-first #(clojure.core/= (column-join-alias %) join-alias) columns)
-      ;; a-ref without :join-alias - if exactly one column has no :source-alias, that's the match.
-      (if-let [no-alias (not-empty (remove column-join-alias columns))]
-        ;; At least 1 matching column with no :source-alias.
-        (if (clojure.core/= (count no-alias) 1)
-          (first no-alias)
-          ;; More than 1, it's ambiguous.
-          (throw (ex-info "Ambiguous match! Implement more logic in disambiguate-matches."
-                          {:ref a-ref
-                           :columns columns})))
-        ;; No columns are missing :source-alias - fail to match.
-        ;; TODO: I'm not certain this one is sound, but it's necessary to make `lib.join/select-home-column` work as
-        ;; written. If this case causes issues, that logic may need rewriting.
-        nil))))
+      (disambiguate-matches-no-alias a-ref columns))))
 
 (def ^:private FindMatchingColumnOptions
   [:map [:generous? {:optional true} :boolean]])
@@ -226,17 +231,21 @@
   ([query stage-number a-ref columns]
    (find-matching-column query stage-number a-ref columns {}))
 
-  ([query                             :- [:maybe ::lib.schema/query]
-    stage-number                      :- :int
-    [ref-kind _opts ref-id :as a-ref] :- ::lib.schema.ref/ref
-    columns                           :- [:sequential lib.metadata/ColumnMetadata]
-    opts                              :- FindMatchingColumnOptions]
+  ([query                              :- [:maybe ::lib.schema/query]
+    stage-number                       :- :int
+    [_ref-kind _opts ref-id :as a-ref] :- ::lib.schema.ref/ref
+    columns                            :- [:sequential lib.metadata/ColumnMetadata]
+    opts                               :- FindMatchingColumnOptions]
    (or (find-matching-column a-ref columns opts)
        (when (and query (number? ref-id))
-         (if-let [resolved (resolve-field-id query stage-number ref-id)]
+         (when-let [resolved (resolve-field-id query stage-number ref-id)]
            (find-matching-column (assoc a-ref 2 (or (:lib/desired-column-alias resolved)
                                                     (:name resolved)))
-                                 columns opts))))))
+                                 (for [col columns]
+                                   (if (:id col)
+                                     (dissoc col :name :lib/desired-column-alias)
+                                     col))
+                                 opts))))))
 
 (mu/defn find-matching-ref :- [:maybe ::lib.schema.ref/ref]
   "Given `column` and a list of `refs`, finds the ref that best matches this column.
@@ -270,10 +279,13 @@
    stage-number :- :int
    needles      :- [:sequential ::lib.schema.ref/ref]
    haystack     :- [:sequential lib.metadata/ColumnMetadata]]
-  (let [by-column (into {} (for [[i column] (m/indexed haystack)]
-                             [column i]))]
-    (for [needle needles]
-      (get by-column (find-matching-column query stage-number needle haystack) -1))))
+  (let [by-column (into {}
+                        (map-indexed (fn [index column]
+                                       [column index]))
+                        haystack)]
+    (for [needle needles
+          :let [matched (find-matching-column query stage-number needle haystack)]]
+      (get by-column matched -1))))
 
 ;; TODO: Refactor this away. Handle legacy refs in `lib.js`, then call [[find-matching-column]] directly.
 (mu/defn find-column-for-legacy-ref :- [:maybe lib.metadata/ColumnMetadata]
@@ -308,350 +320,3 @@
                                         (map #(find-matching-column query stage-number % cols))
                                         selected-refs)]
        (mapv #(assoc % :selected? (contains? (set matching-selected-cols) %)) cols)))))
-
-;;; Original versions - to be deleted!
-;;; ------------------------------------------------ Squinting -------------------------------------------------------
-;;; When trying to match columns and refs, there are lots of details that might not match up.
-;;; For example, we might have a column with a breakout by `:temporal-unit` in the query, but then try to match a naive
-;;; `[:field {} 12]` against it. That should succeed, but we want to match including the `:temporal-unit` if given.
-;;;
-;;; To implement this, we define a set of "squinting" strategies. I call this "squinting" because we're blurring the
-;;; details more and more until two things look the same.
-;;;
-;;; Squinting at a value returns a lazy sequence of successively more generic versions of the value. Note that many of
-;;; the versions might be the same as their predecessor (eg. if the value has no `:temporal-unit`); that's okay.
-;;; Since we want to squint the "same amount" at many values, trying to find a match, it's important that each sequence
-;;; has the same number of steps.
-(defn- ->ref [ref-or-column]
-  (cond-> ref-or-column
-    (and (map? ref-or-column)
-         (= (:lib/type ref-or-column) :metadata/column)) lib.ref/ref))
-
-(def ^:private squints
-  [;; ignore irrelevant keys from :binning options
-   #(lib.options/update-options % m/update-existing :binning dissoc :metadata-fn :lib/type)
-   ;; ignore namespaced keys
-   update-options-remove-namespaced-keys
-   ;; ignore type info
-   #(lib.options/update-options % dissoc :base-type :effective-type)
-   ;; ignore temporal-unit
-   #(lib.options/update-options % dissoc :temporal-unit)
-   ;; ignore binning
-   #(lib.options/update-options % dissoc :binning)])
-
-(defn- squint-by [xforms ref-or-column]
-  (when ref-or-column
-    (reductions (fn [r f] (f r)) (->ref ref-or-column) xforms)))
-
-(defn- squint-keep-join [ref-or-column]
-  (squint-by squints ref-or-column))
-
-(defn- squint-drop-join [ref-or-column]
-  ;; This tries the full chain of squints with any :join-alias, and if that doesn't match, then we start from the
-  ;; original ref, drop the :join-alias, and then run the full chain of squints again.
-  (when ref-or-column
-    (let [a-ref (->ref ref-or-column)]
-      (concat (squint-keep-join a-ref)
-              (squint-keep-join (lib.options/update-options a-ref dissoc :join-alias))))))
-
-;;; ------------------------------------------------ Matching --------------------------------------------------------
-(defn- match-needle-to-haystack
-  ([squinty-needle squinty-haystack] (match-needle-to-haystack squinty-needle squinty-haystack 0))
-  ([squinty-needle squinty-haystack depth]
-   (when (seq squinty-needle)
-     (let [needle  (first squinty-needle)
-           matches (keep-indexed (fn [i squinty-hay]
-                                   (when (= needle (first squinty-hay))
-                                     i))
-                                 squinty-haystack)]
-       (if (empty? matches)
-         (recur (rest squinty-needle) (map rest squinty-haystack) (inc depth))
-         (do
-           (when (> (count matches) 1)
-             (log/warn (i18n/tru "Ambiguous match for {0}: got {1}" (pr-str needle) (pr-str matches))))
-           [(first matches) depth]))))))
-
-(defn- lowest-depth
-  "Given a list of [haystack-index [needle-index depth]] pairs, find the one with the lowest depth.
-  If there's more than one pair with that depth, throw an error.
-
-  Returns the `needle-index` with the lowest depth."
-  [pairs]
-  (let [pairs     (map second pairs) ; Drop the unnecessary [haystack-index ...] outer layer.
-        min-depth (reduce (fn [m [_needle-index depth]] (min m depth)) 100 pairs)
-        at-depth  (filter #(= (second %) min-depth) pairs)]
-    (if (= (count at-depth) 1)
-      (ffirst at-depth)
-      ;; TODO: This should be thrown as an exception rather than a warning, but currently there are some ambiguous
-      ;; columns returned in certain cases of nested queries. Eg. Orders joined to Products, then nest that query.
-      ;; Then for each column in Products, `visible-columns` returns two: one with `:source/card`, and one with
-      ;; `:source/implicitly-joinable`. For regular queries we use the IDs to de-dupe them, but the columns from the
-      ;; nested query have no `:id` or `:table-id`.
-      (do
-        (log/warn  (i18n/tru "Ambiguous match: needles at {0} matched a single haystack value"
-                             (pr-str (map first at-depth))))
-        ;; Arbitrarily returning the earlier of the two matches.
-        (ffirst at-depth)))))
-
-(defn find-closest-matches-for-refs
-  "For each of `needles` (which must be a ref) find the column or ref in `haystack` that it most closely matches. This
-  is meant to power things like [[metabase.lib.breakout/breakoutable-columns]] which are supposed to include
-  `:breakout-position` for columns that are already present as a breakout; sometimes the column in the breakout does not
-  exactly match what MLv2 would have generated. So try to figure out which column it is referring to. The fuzzy matching
-  is powered by the \"squinting\" logic defined in this namespace.
-
-  As a special case, if the input ref has an ID, and 1 or more `haystacks` have the same ID, those are immediately
-  matched.
-
-  The `haystack` can be either `MetadataColumns` or refs.
-
-  Returns a map with `haystack` values as keys (whether they be columns or refs) and the corresponding index in
-  `needles` as values. If for some `needle` there is no match, that index will not appear in the map.
-
-  If there are multiple matches for a `needle` at the same level of \"squinting\", an error is thrown.
-  TODO: Perhaps there are legitimate cases where this will happen? If so, we should add logic to disambiguate matches.
-  (For example, prefer any other `:source/*` over `:source/implicitly-joinable`, if the `needle` has no `:join-alias`.)
-
-  `opts` can be used to influence the level of flexibility.
-    :keep-join? if truthy, the join information will not be ignored
-
-  If you want to check that a single ref exists in a set of columns, call [[find-closest-matching-ref]] instead.
-
-  The four- and five-arity versions can also find matches between integer Field ID references like `[:field {} 1]` and
-  equivalent string column name field literal references like `[:field {} \"bird_type\"]` by resolving Field IDs using
-  the `query` and `stage-number`. This is ultimately a hacky workaround for totally busted legacy queries.
-
-  Note that this currently only works when `needles` contain integer Field IDs. Any refs in the `haystack` must have
-  string literal column names. Luckily we currently don't have problems with MLv1/legacy queries accidentally using
-  string `:field` literals where it shouldn't have been doing so.
-
-  Returns a list parallel to `needles`, where each element is either nil (no match) or the index of the most closely
-  matching ref in `haystack`.
-
-  IMPORTANT!
-
-  When trying to find the matching ref for a sequence of metadatas, prefer [[closest-matching-metadata]] instead, which
-  is less broken (see [[metabase.lib.equality-test/closest-matching-metadata-test]]) and slightly more performant, since
-  it converts metadatas to refs in a lazy fashion."
-  ([needles haystack]
-   (find-closest-matches-for-refs needles haystack {}))
-  ([needles haystack opts]
-   (let [squint           (if (:keep-join? opts) squint-keep-join squint-drop-join)
-         ;; There's an important performance trade-off here - the lazy transformations for each value in the haystack
-         ;; are kept in memory and reused for each needle, so we avoid repeatedly transforming the haystack.
-         ;; This costs memory while this function is running, but saves a lot of time.
-         squinty-needles  (map squint needles)
-         squinty-haystack (map squint haystack)
-         matches          (keep-indexed (fn [index squinty-needle]
-                                          (when-let [[haystack-index depth] (match-needle-to-haystack squinty-needle squinty-haystack)]
-                                            [haystack-index [index depth]]))
-                                        squinty-needles)
-         match-groups     (-> (group-by first matches)
-                              (update-vals lowest-depth))]
-     ;; A successful match! match-groups is {haystack-index needle-index}, so map the keys to be haystack values.
-     (update-keys match-groups #(nth haystack %))))
-
-  ([query stage-number needles haystack]
-   (find-closest-matches-for-refs query stage-number needles haystack {}))
-  ([query stage-number needles haystack opts]
-   ;; First run with the needles as given.
-   (let [matches       (find-closest-matches-for-refs needles haystack opts)
-         ;; Those that were matched are replaced with nil.
-         blank-matched (reduce #(assoc %1 %2 nil) (vec needles) (vals matches))
-         ;; Those that remain are converted to [:field {} "name"] refs if possible, or nil if not.
-         converted     (when (and query
-                                  (some some? blank-matched))
-                         (for [needle blank-matched
-                               :let [field-id (last needle)]]
-                           (when (integer? field-id)
-                             (-> (resolve-field-id query stage-number field-id)
-                                 (dissoc :id ; Remove any :id to force the ref to use the field name.
-                                         :lib/desired-column-alias) ; Hack: resolving by name doesn't work if this is present
-                                 lib.ref/ref))))]
-     (if converted
-       ;; If any of the needles were not found, and were converted successfully, try to match them again.
-       (merge matches (find-closest-matches-for-refs converted haystack opts))
-       ;; If we found them all, just return the matches.
-       matches))))
-
-(defn find-closest-matching-ref
-  "Given a target `a-ref` and a list `refs-or-cols` of `MetadataColumns` or refs, and finds the closest match.
-  Returns the value from `refs-or-cols` which most closely corresponds to `a-ref`, or nil if nothing matches.
-
-  See [[find-closest-matches-for-refs]] for details of how the approximate matching works. (Where
-  [[find-closest-matches-for-refs]] would return `{column 0}`, this returns just `column`.)"
-  ([a-ref refs-or-cols]
-   (find-closest-matching-ref a-ref refs-or-cols {}))
-  ([a-ref refs-or-cols opts]
-   (->> (find-closest-matches-for-refs [a-ref] refs-or-cols opts)
-        keys
-        first))
-
-  ([query stage-number a-ref refs-or-cols]
-   (find-closest-matching-ref query stage-number a-ref refs-or-cols {}))
-  ([query stage-number a-ref refs-or-cols opts]
-   (->> (find-closest-matches-for-refs query stage-number [a-ref] refs-or-cols opts)
-        keys
-        first)))
-
-(defn- annotate-index [xs]
-  (map-indexed (fn [i x]
-                 (when x
-                   (vary-meta x assoc ::index i)))
-               xs))
-
-(defn- cascading-matches
-  "For each of `ref-fns`, this does the following:
-  - Map `(first ref-fns)` over the `haystack-metadatas`.
-  - Annotate these results with metadata to map them back to the original `haystack-metadatas`.
-  - Call [[find-closest-matches-for-refs]] with `needles` and this list of refs.
-  - Map the results back to use the original `haystack-metadatas` as keys, rather than the refs.
-  - Merge the results right-to-left, so that **earlier matches win**.
-  - Remove any matched `needles` and `haystack-metadatas` from the inputs.
-  - If both inputs are nonempty, continue to the next `ref-fns`, if any."
-  [needles haystack-metadatas opts ref-fns]
-  (let [original-needles (annotate-index needles)]
-    (loop [current-needles         original-needles
-           current-haystack        haystack-metadatas
-           [ref-fn & more-ref-fns] ref-fns
-           result                  {}]
-      (cond
-        (or (empty? current-needles)
-            (empty? current-haystack)
-            (nil? ref-fn))            result
-        (nil? ref-fn)                 (recur current-needles current-haystack more-ref-fns result)
-        :else
-        (let [haystack-ref->col  (m/index-by ref-fn current-haystack)
-              matches            (-> (find-closest-matches-for-refs current-needles (keys haystack-ref->col) opts)
-                                     ;; This returns a map {haystack-ref index-in-current-needles}.
-                                     ;; We want to adjust both keys and vals to
-                                     ;; {haystack-metadata index-in-original-needles}
-                                     (update-vals #(->> % (nth current-needles) meta ::index))
-                                     (update-keys haystack-ref->col))
-              matched-needles    (set (vals matches))]
-          (recur (remove #(matched-needles (::index (meta %))) current-needles)
-                 ;; Replace the matched haystacks with nil so they can't match again.
-                 (for [metadata current-haystack]
-                   (when-not (contains? matches metadata)
-                     metadata))
-                 more-ref-fns
-                 ;; TODO: Merging in this direction gives priority to the earliest match.
-                 ;; Perhaps any collision should be an error?
-                 (merge matches result)))))))
-
-(mu/defn closest-matches-in-metadata* :- [:map-of
-                                          lib.metadata/ColumnMetadata
-                                          ::lib.schema.common/int-greater-than-or-equal-to-zero]
-  "Like [[find-closest-matches-for-refs]], but finds the closest match for each element of `needles` from a haystack of
-  Column `metadatas` rather than a haystack of refs. This allows us to do more sophisticated fuzzy matching than
-  [[find-closest-matches-for-refs]], because column metadatas inherently have more information than they do after they
-  are converted to refs.
-
-  Returns a map `{column-metadata index-in-needles}` for each successful match. If nothing is found that matches a
-  `needle`, no entry for it appears in the map.
-
-  If you only have a single `needle` ref to look up, use [[closest-matching-metadata]]."
-  ([needles haystack-metadatas]
-   (closest-matches-in-metadata* needles haystack-metadatas {}))
-
-  ([needles haystack-metadatas opts]
-   (when (seq haystack-metadatas)
-     ;; The matching is done in two passes: first as plain refs, second by forcing ID refs.
-     ;; Each of these returns a map of `{^{::index i} haystack-ref needle-index}`. Those haystack values which match
-     ;; are removed between stages.
-     (cascading-matches
-       needles haystack-metadatas opts
-       [;; The first pass attempts to match the refs using the regular [[find-closest-matches-for-refs]].
-        lib.ref/ref
-        ;; If that fails to match some needles, and there's at least some needles which are "Field ID" refs like
-        ;;
-        ;;    [:field {} 1]
-        ;;
-        ;; then try again, forcing creation of Field ID refs for all of the metadatas. This way we can match
-        ;; things where the FE incorrectly used a Field ID ref even tho we were expecting a nominal :field
-        ;; literal ref like
-        ;;
-        ;;    [:field {} "my_field"]
-        (when (some field-id-ref? needles)
-          ;; Force creation of a Field ID ref by giving it a `:lib/source` that will make the ref creation code
-          ;; treat it as coming from a source table. This only makes sense for metadatas that have an associated
-          ;; Field `:id`, so others are left as-is.
-          (fn [metadata]
-            (cond-> metadata
-              (:id metadata) (assoc :lib/source :source/table-defaults)
-              metadata       lib.ref/ref)))])))
-
-  ([query stage-number needles haystack-metadatas]
-   (closest-matches-in-metadata* query stage-number needles haystack-metadatas {}))
-
-  ([query                 :- [:maybe ::lib.schema/query]
-    stage-number          :- :int
-    needles               :- [:sequential [:maybe ::lib.schema.ref/ref]]
-    haystack-metadatas    :- [:sequential lib.metadata/ColumnMetadata]
-    opts                  :- [:map [:keep-join? {:optional true} :boolean]]]
-   ;; This could be more efficient if the second pass were run on the un-matched subset, like cascading-matches.
-   (let [basic   (closest-matches-in-metadata* needles haystack-metadatas opts)
-         ;; In case that fails, we need to fall back and try matching any integer IDs by name like the four-arity
-         ;; version of [[find-closest-matching-ref]].
-         by-name (when (and query
-                            (some field-id-ref? needles))
-                   (closest-matches-in-metadata*
-                     (for [[_field _opts field-id] needles]
-                       (when (pos-int? field-id)
-                         (lib.ref/ref (resolve-field-id query stage-number field-id))))
-                     haystack-metadatas
-                     opts))]
-     ;; Prefer the more precise integer ID matches over the name-based ones.
-     (merge by-name basic))))
-
-(def ^{:arglists '([needles haystack-metadatas]
-                   [needles haystack-metadatas opts]
-                   [query stage-number needles haystack-metadatas]
-                   [query stage-number needles haystack-metadatas opts])}
-  closest-matches-in-metadata
-  "The cached version of [[closest-matches-in-metadata*]]."
-  (memoize/lru closest-matches-in-metadata* :lru/threshold 8))
-
-(mu/defn closest-matching-metadata :- [:maybe lib.metadata/ColumnMetadata]
-  "Like [[find-closest-matching-ref]], but finds the closest match for `a-ref` from a sequence of Column `metadatas`
-  rather than a sequence of refs. See [[index-of-closet-matching-metadata]] for more info."
-  ([a-ref metadatas]
-   (closest-matching-metadata a-ref metadatas {}))
-
-  ([a-ref metadatas opts]
-   (closest-matching-metadata nil -1 a-ref metadatas opts))
-
-  ([query stage-number a-ref metadatas]
-   (closest-matching-metadata query stage-number a-ref metadatas {}))
-
-  ([query                 :- [:maybe ::lib.schema/query]
-    stage-number          :- :int
-    a-ref                 :- ::lib.schema.ref/ref
-    metadatas             :- [:sequential lib.metadata/ColumnMetadata]
-    opts                  :- [:map [:keep-join? {:optional true} :boolean]]]
-   (->> (closest-matches-in-metadata query stage-number [a-ref] metadatas opts)
-        keys
-        first)))
-
-(mu/defn legacy-find-column-indexes-for-refs :- [:sequential :int]
-  "Given a list `haystack` of columns or refs, and a list `needles` of refs to searc for, this returns a list parallel
-  to `needles` with the corresponding index into the `haystack`, or -1 if not found.
-
-  DISCOURAGED: This is intended for use only by [[metabase.lib.js/find-column-indexes-from-legacy-refs]].
-  Other MLv2 code should use [[closest-matching-metadata]] if the `haystack` is columns, or
-  [[find-closest-matches-for-refs]] if it's refs."
-  [query        :- ::lib.schema/query
-   stage-number :- :int
-   needles      :- [:sequential ::lib.schema.ref/ref]
-   haystack     :- [:sequential [:or lib.metadata/ColumnMetadata ::lib.schema.ref/ref]]]
-  (let [;; matches is a map of haystack values to the corresponding index in needles.
-        matches (find-closest-matches-for-refs query stage-number needles haystack {:keep-join? true})
-        ;; We want to return a parallel list to needles, giving the index of the matching column (or -1).
-        ;; First, map each column to its index (in the haystack).
-        column->index (into {} (for [index (range (count haystack))]
-                                 [(nth haystack index) index]))
-        ;; And use that to map each match's needle-index to its column-index.
-        by-index      (into {} (for [[column needle-index] matches]
-                                 [needle-index (column->index column)]))]
-    (->> (range (count needles))
-         (map #(by-index % -1)))))

--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -130,355 +130,123 @@
      (catch #?(:clj Throwable :cljs :default) _
        nil))))
 
-;;; ------------------------------------------------ Squinting -------------------------------------------------------
-;;; When trying to match columns and refs, there are lots of details that might not match up.
-;;; For example, we might have a column with a breakout by `:temporal-unit` in the query, but then try to match a naive
-;;; `[:field {} 12]` against it. That should succeed, but we want to match including the `:temporal-unit` if given.
-;;;
-;;; To implement this, we define a set of "squinting" strategies. I call this "squinting" because we're blurring the
-;;; details more and more until two things look the same.
-;;;
-;;; Squinting at a value returns a lazy sequence of successively more generic versions of the value. Note that many of
-;;; the versions might be the same as their predecessor (eg. if the value has no `:temporal-unit`); that's okay.
-;;; Since we want to squint the "same amount" at many values, trying to find a match, it's important that each sequence
-;;; has the same number of steps.
-(defn- ->ref [ref-or-column]
-  (cond-> ref-or-column
-    (and (map? ref-or-column)
-         (= (:lib/type ref-or-column) :metadata/column)) lib.ref/ref))
+(mu/defn ^:private plausible-matches-for-name :- [:sequential lib.metadata/ColumnMetadata]
+  [ref-name :- :string
+   columns  :- [:sequential lib.metadata/ColumnMetadata]]
+  (or (not-empty (filter #(= (:lib/desired-column-alias %) ref-name) columns))
+      (filter #(= (:name %) ref-name) columns)))
 
-(def ^:private squints
-  [;; ignore irrelevant keys from :binning options
-   #(lib.options/update-options % m/update-existing :binning dissoc :metadata-fn :lib/type)
-   ;; ignore namespaced keys
-   update-options-remove-namespaced-keys
-   ;; ignore type info
-   #(lib.options/update-options % dissoc :base-type :effective-type)
-   ;; ignore temporal-unit
-   #(lib.options/update-options % dissoc :temporal-unit)
-   ;; ignore binning
-   #(lib.options/update-options % dissoc :binning)])
+(mu/defn ^:private plausible-matches-for-id :- [:sequential lib.metadata/ColumnMetadata]
+  [ref-id :- :int
+   columns  :- [:sequential lib.metadata/ColumnMetadata]]
+  (filter #(= (:id %) ref-id) columns))
 
-(defn- squint-by [xforms ref-or-column]
-  (when ref-or-column
-    (reductions (fn [r f] (f r)) (->ref ref-or-column) xforms)))
+(mu/defn ^:private disambiguate-matches :- [:maybe lib.metadata/ColumnMetadata]
+  [a-ref   :- ::lib.schema.ref/ref
+   columns :- [:sequential lib.metadata/ColumnMetadata]]
+  (let [{:keys [join-alias]} (lib.options/options a-ref)]
+    (if join-alias
+      ;; a-ref has a :join-alias, match on that. Return nil if nothing matches.
+      (m/find-first #(= (:source-alias %) join-alias) columns)
+      ;; a-ref without :join-alias - if exactly one column has no :source-alias, that's the match.
+      (if-let [no-alias (not-empty (remove :source-alias columns))]
+        ;; At least 1 matching column with no :source-alias.
+        (if (= (count no-alias) 1)
+          (first no-alias)
+          ;; More than 1, it's ambiguous.
+          (throw (ex-info "Ambiguous match! Implement more logic in disambiguate-matches."
+                          {:ref a-ref
+                           :columns columns})))
+        ;; No columns are missing :source-alias - fail to match.
+        ;; TODO: I'm not certain this one is sound, but it's necessary to make `lib.join/select-home-column` work as
+        ;; written. If this case causes issues, that logic may need rewriting.
+        nil))))
 
-(defn- squint-keep-join [ref-or-column]
-  (squint-by squints ref-or-column))
+(mu/defn find-matching-column :- [:maybe lib.metadata/ColumnMetadata]
+  "Given `a-ref` and a list of `columns`, finds the column that best matches this ref.
 
-(defn- squint-drop-join [ref-or-column]
-  ;; This tries the full chain of squints with any :join-alias, and if that doesn't match, then we start from the
-  ;; original ref, drop the :join-alias, and then run the full chain of squints again.
-  (when ref-or-column
-    (let [a-ref (->ref ref-or-column)]
-      (concat (squint-keep-join a-ref)
-              (squint-keep-join (lib.options/update-options a-ref dissoc :join-alias))))))
+  Matching is based on finding the basically plausible matches first, which is usually sufficient. If there are multiple
+  plausible matches, they are disambiguated by the most important extra included in the `ref`. (`:join-alias` first,
+  then `:temporal-unit`, etc.)
 
-;;; ------------------------------------------------ Matching --------------------------------------------------------
-(defn- match-needle-to-haystack
-  ([squinty-needle squinty-haystack] (match-needle-to-haystack squinty-needle squinty-haystack 0))
-  ([squinty-needle squinty-haystack depth]
-   (when (seq squinty-needle)
-     (let [needle  (first squinty-needle)
-           matches (keep-indexed (fn [i squinty-hay]
-                                   (when (= needle (first squinty-hay))
-                                     i))
-                                 squinty-haystack)]
-       (if (empty? matches)
-         (recur (rest squinty-needle) (map rest squinty-haystack) (inc depth))
-         (do
-           (when (> (count matches) 1)
-             (log/warn (i18n/tru "Ambiguous match for {0}: got {1}" (pr-str needle) (pr-str matches))))
-           [(first matches) depth]))))))
+  - Integer IDs in the `ref` are matched by ID; this usually is unambiguous. In the case of multiple joins on one table,
+    the `:join-alias` settles the question.
+    - There may be broken cases where the ID must be resolved to a name or `:lib/desired-column-alias` and matched.
+      `query` and `stage-number` are required for this case.
+  - For string IDs, these are checked against `:lib/desired-column-alias` first.
+    - If that doesn't match any columns, `:name` is compared next.
+    - If that *still* doesn't match, and `query` and `stage-number` were supplied.
 
-(defn- lowest-depth
-  "Given a list of [haystack-index [needle-index depth]] pairs, find the one with the lowest depth.
-  If there's more than one pair with that depth, throw an error.
+  Returns the column, or nil if no match is found."
+  ([[ref-kind _opts ref-id :as a-ref] :- ::lib.schema.ref/ref
+    columns                           :- [:sequential lib.metadata/ColumnMetadata]]
+   (case ref-kind
+     ;; Aggregations are referenced by the UUID of the column being aggregated.
+     :aggregation  (->> columns
+                        (filter #(= (:lib/source %) :source/aggregations))
+                        (filter #(= (:lib/source-uuid %) ref-id))
+                        first)
+     ;; Expressions are referenced by name; fields by ID or name.
+     (:expression
+       :field)     (let [plausible (if (string? ref-id)
+                                     (plausible-matches-for-name ref-id columns)
+                                     (plausible-matches-for-id   ref-id columns))]
+                     (case (count plausible)
+                       0 nil
+                       1 (first plausible)
+                       (disambiguate-matches a-ref plausible)))
+     (throw (ex-info "Unknown type of ref" {:ref a-ref}))))
 
-  Returns the `needle-index` with the lowest depth."
-  [pairs]
-  (let [pairs     (map second pairs) ; Drop the unnecessary [haystack-index ...] outer layer.
-        min-depth (reduce (fn [m [_needle-index depth]] (min m depth)) 100 pairs)
-        at-depth  (filter #(= (second %) min-depth) pairs)]
-    (if (= (count at-depth) 1)
-      (ffirst at-depth)
-      ;; TODO: This should be thrown as an exception rather than a warning, but currently there are some ambiguous
-      ;; columns returned in certain cases of nested queries. Eg. Orders joined to Products, then nest that query.
-      ;; Then for each column in Products, `visible-columns` returns two: one with `:source/card`, and one with
-      ;; `:source/implicitly-joinable`. For regular queries we use the IDs to de-dupe them, but the columns from the
-      ;; nested query have no `:id` or `:table-id`.
-      (do
-        (log/warn  (i18n/tru "Ambiguous match: needles at {0} matched a single haystack value"
-                             (pr-str (map first at-depth))))
-        ;; Arbitrarily returning the earlier of the two matches.
-        (ffirst at-depth)))))
+  ([query                            :- [:maybe ::lib.schema/query]
+    stage-number                     :- :int
+    [ref-kind opts ref-id :as a-ref] :- ::lib.schema.ref/ref
+    columns                          :- [:sequential lib.metadata/ColumnMetadata]]
+   (or (find-matching-column a-ref columns)
+       (when (and query (number? ref-id))
+         (if-let [resolved (resolve-field-id query stage-number ref-id)]
+           (find-matching-column (assoc a-ref 2 (or (:lib/desired-column-alias resolved)
+                                                    (:name resolved)))
+                                 columns))))))
 
-(defn find-closest-matches-for-refs
-  "For each of `needles` (which must be a ref) find the column or ref in `haystack` that it most closely matches. This
-  is meant to power things like [[metabase.lib.breakout/breakoutable-columns]] which are supposed to include
-  `:breakout-position` for columns that are already present as a breakout; sometimes the column in the breakout does not
-  exactly match what MLv2 would have generated. So try to figure out which column it is referring to. The fuzzy matching
-  is powered by the \"squinting\" logic defined in this namespace.
+(mu/defn find-matching-ref :- [:maybe ::lib.schema.ref/ref]
+  "Given `column` and a list of `refs`, finds the ref that best matches this column.
 
-  As a special case, if the input ref has an ID, and 1 or more `haystacks` have the same ID, those are immediately
-  matched.
+  Throws if there are multiple, ambiguous matches.
 
-  The `haystack` can be either `MetadataColumns` or refs.
-
-  Returns a map with `haystack` values as keys (whether they be columns or refs) and the corresponding index in
-  `needles` as values. If for some `needle` there is no match, that index will not appear in the map.
-
-  If there are multiple matches for a `needle` at the same level of \"squinting\", an error is thrown.
-  TODO: Perhaps there are legitimate cases where this will happen? If so, we should add logic to disambiguate matches.
-  (For example, prefer any other `:source/*` over `:source/implicitly-joinable`, if the `needle` has no `:join-alias`.)
-
-  `opts` can be used to influence the level of flexibility.
-    :keep-join? if truthy, the join information will not be ignored
-
-  If you want to check that a single ref exists in a set of columns, call [[find-closest-matching-ref]] instead.
-
-  The four- and five-arity versions can also find matches between integer Field ID references like `[:field {} 1]` and
-  equivalent string column name field literal references like `[:field {} \"bird_type\"]` by resolving Field IDs using
-  the `query` and `stage-number`. This is ultimately a hacky workaround for totally busted legacy queries.
-
-  Note that this currently only works when `needles` contain integer Field IDs. Any refs in the `haystack` must have
-  string literal column names. Luckily we currently don't have problems with MLv1/legacy queries accidentally using
-  string `:field` literals where it shouldn't have been doing so.
-
-  Returns a list parallel to `needles`, where each element is either nil (no match) or the index of the most closely
-  matching ref in `haystack`.
-
-  IMPORTANT!
-
-  When trying to find the matching ref for a sequence of metadatas, prefer [[closest-matching-metadata]] instead, which
-  is less broken (see [[metabase.lib.equality-test/closest-matching-metadata-test]]) and slightly more performant, since
-  it converts metadatas to refs in a lazy fashion."
-  ([needles haystack]
-   (find-closest-matches-for-refs needles haystack {}))
-  ([needles haystack opts]
-   (let [squint           (if (:keep-join? opts) squint-keep-join squint-drop-join)
-         ;; There's an important performance trade-off here - the lazy transformations for each value in the haystack
-         ;; are kept in memory and reused for each needle, so we avoid repeatedly transforming the haystack.
-         ;; This costs memory while this function is running, but saves a lot of time.
-         squinty-needles  (map squint needles)
-         squinty-haystack (map squint haystack)
-         matches          (keep-indexed (fn [index squinty-needle]
-                                          (when-let [[haystack-index depth] (match-needle-to-haystack squinty-needle squinty-haystack)]
-                                            [haystack-index [index depth]]))
-                                        squinty-needles)
-         match-groups     (-> (group-by first matches)
-                              (update-vals lowest-depth))]
-     ;; A successful match! match-groups is {haystack-index needle-index}, so map the keys to be haystack values.
-     (update-keys match-groups #(nth haystack %))))
-
-  ([query stage-number needles haystack]
-   (find-closest-matches-for-refs query stage-number needles haystack {}))
-  ([query stage-number needles haystack opts]
-   ;; First run with the needles as given.
-   (let [matches       (find-closest-matches-for-refs needles haystack opts)
-         ;; Those that were matched are replaced with nil.
-         blank-matched (reduce #(assoc %1 %2 nil) (vec needles) (vals matches))
-         ;; Those that remain are converted to [:field {} "name"] refs if possible, or nil if not.
-         converted     (when (and query
-                                  (some some? blank-matched))
-                         (for [needle blank-matched
-                               :let [field-id (last needle)]]
-                           (when (integer? field-id)
-                             (-> (resolve-field-id query stage-number field-id)
-                                 (dissoc :id ; Remove any :id to force the ref to use the field name.
-                                         :lib/desired-column-alias) ; Hack: resolving by name doesn't work if this is present
-                                 lib.ref/ref))))]
-     (if converted
-       ;; If any of the needles were not found, and were converted successfully, try to match them again.
-       (merge matches (find-closest-matches-for-refs converted haystack opts))
-       ;; If we found them all, just return the matches.
-       matches))))
-
-(defn find-closest-matching-ref
-  "Given a target `a-ref` and a list `refs-or-cols` of `MetadataColumns` or refs, and finds the closest match.
-  Returns the value from `refs-or-cols` which most closely corresponds to `a-ref`, or nil if nothing matches.
-
-  See [[find-closest-matches-for-refs]] for details of how the approximate matching works. (Where
-  [[find-closest-matches-for-refs]] would return `{column 0}`, this returns just `column`.)"
-  ([a-ref refs-or-cols]
-   (find-closest-matching-ref a-ref refs-or-cols {}))
-  ([a-ref refs-or-cols opts]
-   (->> (find-closest-matches-for-refs [a-ref] refs-or-cols opts)
-        keys
-        first))
-
-  ([query stage-number a-ref refs-or-cols]
-   (find-closest-matching-ref query stage-number a-ref refs-or-cols {}))
-  ([query stage-number a-ref refs-or-cols opts]
-   (->> (find-closest-matches-for-refs query stage-number [a-ref] refs-or-cols opts)
-        keys
-        first)))
-
-(defn- annotate-index [xs]
-  (map-indexed (fn [i x]
-                 (when x
-                   (vary-meta x assoc ::index i)))
-               xs))
-
-(defn- cascading-matches
-  "For each of `ref-fns`, this does the following:
-  - Map `(first ref-fns)` over the `haystack-metadatas`.
-  - Annotate these results with metadata to map them back to the original `haystack-metadatas`.
-  - Call [[find-closest-matches-for-refs]] with `needles` and this list of refs.
-  - Map the results back to use the original `haystack-metadatas` as keys, rather than the refs.
-  - Merge the results right-to-left, so that **earlier matches win**.
-  - Remove any matched `needles` and `haystack-metadatas` from the inputs.
-  - If both inputs are nonempty, continue to the next `ref-fns`, if any."
-  [needles haystack-metadatas opts ref-fns]
-  (let [original-needles (annotate-index needles)]
-    (loop [current-needles         original-needles
-           current-haystack        haystack-metadatas
-           [ref-fn & more-ref-fns] ref-fns
-           result                  {}]
-      (cond
-        (or (empty? current-needles)
-            (empty? current-haystack)
-            (nil? ref-fn))            result
-        (nil? ref-fn)                 (recur current-needles current-haystack more-ref-fns result)
-        :else
-        (let [haystack-ref->col  (m/index-by ref-fn current-haystack)
-              matches            (-> (find-closest-matches-for-refs current-needles (keys haystack-ref->col) opts)
-                                     ;; This returns a map {haystack-ref index-in-current-needles}.
-                                     ;; We want to adjust both keys and vals to
-                                     ;; {haystack-metadata index-in-original-needles}
-                                     (update-vals #(->> % (nth current-needles) meta ::index))
-                                     (update-keys haystack-ref->col))
-              matched-needles    (set (vals matches))]
-          (recur (remove #(matched-needles (::index (meta %))) current-needles)
-                 ;; Replace the matched haystacks with nil so they can't match again.
-                 (for [metadata current-haystack]
-                   (when-not (contains? matches metadata)
-                     metadata))
-                 more-ref-fns
-                 ;; TODO: Merging in this direction gives priority to the earliest match.
-                 ;; Perhaps any collision should be an error?
-                 (merge matches result)))))))
-
-(mu/defn closest-matches-in-metadata* :- [:map-of
-                                          lib.metadata/ColumnMetadata
-                                          ::lib.schema.common/int-greater-than-or-equal-to-zero]
-  "Like [[find-closest-matches-for-refs]], but finds the closest match for each element of `needles` from a haystack of
-  Column `metadatas` rather than a haystack of refs. This allows us to do more sophisticated fuzzy matching than
-  [[find-closest-matches-for-refs]], because column metadatas inherently have more information than they do after they
-  are converted to refs.
-
-  Returns a map `{column-metadata index-in-needles}` for each successful match. If nothing is found that matches a
-  `needle`, no entry for it appears in the map.
-
-  If you only have a single `needle` ref to look up, use [[closest-matching-metadata]]."
-  ([needles haystack-metadatas]
-   (closest-matches-in-metadata* needles haystack-metadatas {}))
-
-  ([needles haystack-metadatas opts]
-   (when (seq haystack-metadatas)
-     ;; The matching is done in two passes: first as plain refs, second by forcing ID refs.
-     ;; Each of these returns a map of `{^{::index i} haystack-ref needle-index}`. Those haystack values which match
-     ;; are removed between stages.
-     (cascading-matches
-       needles haystack-metadatas opts
-       [;; The first pass attempts to match the refs using the regular [[find-closest-matches-for-refs]].
-        lib.ref/ref
-        ;; If that fails to match some needles, and there's at least some needles which are "Field ID" refs like
-        ;;
-        ;;    [:field {} 1]
-        ;;
-        ;; then try again, forcing creation of Field ID refs for all of the metadatas. This way we can match
-        ;; things where the FE incorrectly used a Field ID ref even tho we were expecting a nominal :field
-        ;; literal ref like
-        ;;
-        ;;    [:field {} "my_field"]
-        (when (some field-id-ref? needles)
-          ;; Force creation of a Field ID ref by giving it a `:lib/source` that will make the ref creation code
-          ;; treat it as coming from a source table. This only makes sense for metadatas that have an associated
-          ;; Field `:id`, so others are left as-is.
-          (fn [metadata]
-            (cond-> metadata
-              (:id metadata) (assoc :lib/source :source/table-defaults)
-              metadata       lib.ref/ref)))])))
-
-  ([query stage-number needles haystack-metadatas]
-   (closest-matches-in-metadata* query stage-number needles haystack-metadatas {}))
-
-  ([query                 :- [:maybe ::lib.schema/query]
-    stage-number          :- :int
-    needles               :- [:sequential [:maybe ::lib.schema.ref/ref]]
-    haystack-metadatas    :- [:sequential lib.metadata/ColumnMetadata]
-    opts                  :- [:map [:keep-join? {:optional true} :boolean]]]
-   ;; This could be more efficient if the second pass were run on the un-matched subset, like cascading-matches.
-   (let [basic   (closest-matches-in-metadata* needles haystack-metadatas opts)
-         ;; In case that fails, we need to fall back and try matching any integer IDs by name like the four-arity
-         ;; version of [[find-closest-matching-ref]].
-         by-name (when (and query
-                            (some field-id-ref? needles))
-                   (closest-matches-in-metadata*
-                     (for [[_field _opts field-id] needles]
-                       (when (pos-int? field-id)
-                         (lib.ref/ref (resolve-field-id query stage-number field-id))))
-                     haystack-metadatas
-                     opts))]
-     ;; Prefer the more precise integer ID matches over the name-based ones.
-     (merge by-name basic))))
-
-(def ^{:arglists '([needles haystack-metadatas]
-                   [needles haystack-metadatas opts]
-                   [query stage-number needles haystack-metadatas]
-                   [query stage-number needles haystack-metadatas opts])}
-  closest-matches-in-metadata
-  "The cached version of [[closest-matches-in-metadata*]]."
-  (memoize/lru closest-matches-in-metadata* :lru/threshold 8))
-
-(mu/defn closest-matching-metadata :- [:maybe lib.metadata/ColumnMetadata]
-  "Like [[find-closest-matching-ref]], but finds the closest match for `a-ref` from a sequence of Column `metadatas`
-  rather than a sequence of refs. See [[index-of-closet-matching-metadata]] for more info."
-  ([a-ref metadatas]
-   (closest-matching-metadata a-ref metadatas {}))
-
-  ([a-ref metadatas opts]
-   (closest-matching-metadata nil -1 a-ref metadatas opts))
-
-  ([query stage-number a-ref metadatas]
-   (closest-matching-metadata query stage-number a-ref metadatas {}))
-
-  ([query                 :- [:maybe ::lib.schema/query]
-    stage-number          :- :int
-    a-ref                 :- ::lib.schema.ref/ref
-    metadatas             :- [:sequential lib.metadata/ColumnMetadata]
-    opts                  :- [:map [:keep-join? {:optional true} :boolean]]]
-   (->> (closest-matches-in-metadata query stage-number [a-ref] metadatas opts)
-        keys
-        first)))
+  Returns the matching ref, or nil if no plausible matches are found."
+  [column       :- lib.metadata/ColumnMetadata
+   refs         :- [:sequential ::lib.schema.ref/ref]]
+  (let [ref-tails (group-by last refs)
+        matches   (or (some->> column :lib/source-uuid (get ref-tails) not-empty)
+                      (not-empty (get ref-tails (:id column)))
+                      (not-empty (get ref-tails (:lib/desired-column-alias column)))
+                      (get ref-tails (:name column))
+                      [])]
+    (case (count matches)
+      0 nil
+      1 (first matches)
+      (throw (ex-info "Ambiguous match: given column matches multiple refs"
+                      {:column        column
+                       :matching-refs matches})))))
 
 (mu/defn find-column-indexes-for-refs :- [:sequential :int]
   "Given a list `haystack` of columns or refs, and a list `needles` of refs to searc for, this returns a list parallel
   to `needles` with the corresponding index into the `haystack`, or -1 if not found.
 
   DISCOURAGED: This is intended for use only by [[metabase.lib.js/find-column-indexes-from-legacy-refs]].
-  Other MLv2 code should use [[closest-matching-metadata]] if the `haystack` is columns, or
-  [[find-closest-matches-for-refs]] if it's refs."
+  Other MLv2 code should use [[find-matching-column]] if the `haystack` is columns, or
+  [[find-matching-ref]] if it's refs."
   [query        :- ::lib.schema/query
    stage-number :- :int
    needles      :- [:sequential ::lib.schema.ref/ref]
-   haystack     :- [:sequential [:or lib.metadata/ColumnMetadata ::lib.schema.ref/ref]]]
-  (let [;; matches is a map of haystack values to the corresponding index in needles.
-        matches (find-closest-matches-for-refs query stage-number needles haystack {:keep-join? true})
-        ;; We want to return a parallel list to needles, giving the index of the matching column (or -1).
-        ;; First, map each column to its index (in the haystack).
-        column->index (into {} (for [index (range (count haystack))]
-                                 [(nth haystack index) index]))
-        ;; And use that to map each match's needle-index to its column-index.
-        by-index      (into {} (for [[column needle-index] matches]
-                                 [needle-index (column->index column)]))]
-    (->> (range (count needles))
-         (map #(by-index % -1)))))
+   haystack     :- [:sequential lib.metadata/ColumnMetadata]]
+  (for [needle needles]
+    (or (find-matching-column query stage-number needle haystack)
+        -1)))
 
-;; TODO: Refactor this away. Handle legacy refs in `lib.js`, then call [[closest-matching-metadata]] directly.
+;; TODO: Refactor this away. Handle legacy refs in `lib.js`, then call [[find-matching-column]] directly.
 (mu/defn find-column-for-legacy-ref :- [:maybe lib.metadata/ColumnMetadata]
-  "Like [[closest-matching-metadata]], but takes a legacy MBQL reference. The name here is for consistency with other
+  "Like [[find-matching-column]], but takes a legacy MBQL reference. The name here is for consistency with other
   FE names for similar functions."
   ([query legacy-ref metadatas]
    (find-column-for-legacy-ref query -1 legacy-ref metadatas))
@@ -487,11 +255,11 @@
     stage-number :- :int
     legacy-ref   :- some?
     metadatas    :- [:maybe [:sequential lib.metadata/ColumnMetadata]]]
-   (closest-matching-metadata (lib.convert/legacy-ref->pMBQL query stage-number legacy-ref) metadatas)))
+   (find-matching-column query stage-number (lib.convert/legacy-ref->pMBQL query stage-number legacy-ref) metadatas)))
 
 (defn mark-selected-columns
-  "Mark `columns` as `:selected?` if they appear in `selected-columns-or-refs`. Uses fuzzy matching
-  with [[closest-matching-metadata]].
+  "Mark `columns` as `:selected?` if they appear in `selected-columns-or-refs`. Uses fuzzy matching with
+  [[find-matching-column]].
 
   Example usage:
 
@@ -500,16 +268,15 @@
     ;; return (visibile-columns query), but if any of those appear in `:fields`, mark then `:selected?`
     (mark-selected-columns (visible-columns query) (:fields stage))"
   ([cols selected-columns-or-refs]
-   (mark-selected-columns cols selected-columns-or-refs {}))
-
-  ([cols selected-columns-or-refs opts]
-   (mark-selected-columns nil -1 cols selected-columns-or-refs opts))
+   (mark-selected-columns nil -1 cols selected-columns-or-refs))
 
   ([query stage-number cols selected-columns-or-refs]
-   (mark-selected-columns query stage-number cols selected-columns-or-refs {}))
-
-  ([query stage-number cols selected-columns-or-refs opts]
-   (when (seq cols)
-     (let [selected-refs          (mapv lib.ref/ref selected-columns-or-refs)
-           matching-selected-cols (closest-matches-in-metadata query stage-number selected-refs cols opts)]
-       (mapv #(assoc % :selected? (contains? matching-selected-cols %)) cols)))))
+   #?(:cljs (js/console.log "MSC" (map :lib/desired-column-alias cols) (map :lib/desired-column-alias selected-columns-or-refs)))
+   (let [res (when (seq cols)
+               (let [selected-refs          (mapv lib.ref/ref selected-columns-or-refs)
+                     matching-selected-cols (into #{}
+                                                  (map #(find-matching-column query stage-number % cols))
+                                                  selected-refs)]
+                 (mapv #(assoc % :selected? (contains? matching-selected-cols %)) cols)))]
+     #?(:cljs (js/console.log "MSC out" (map (comp boolean :selected?) res)))
+     res)))

--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -130,16 +130,32 @@
      (catch #?(:clj Throwable :cljs :default) _
        nil))))
 
+(mu/defn ^:private column-join-alias :- [:maybe :string]
+  [column :- lib.metadata/ColumnMetadata]
+  ((some-fn :metabase.lib.join/join-alias :source-alias) column))
+
 (mu/defn ^:private plausible-matches-for-name :- [:sequential lib.metadata/ColumnMetadata]
-  [ref-name :- :string
-   columns  :- [:sequential lib.metadata/ColumnMetadata]]
-  (or (not-empty (filter #(clojure.core/= (:lib/desired-column-alias %) ref-name) columns))
-      (filter #(clojure.core/= (:name %) ref-name) columns)))
+  [ref-name   :- :string
+   join-alias :- [:maybe :string]
+   columns    :- [:sequential lib.metadata/ColumnMetadata]]
+  (or (not-empty (filter #(and (clojure.core/= (:lib/desired-column-alias %) ref-name)
+                               (clojure.core/= (column-join-alias %) join-alias))
+                         columns))
+      (filter #(and (clojure.core/= (:name %) ref-name)
+                    (clojure.core/= (column-join-alias %) join-alias))
+              columns)))
 
 (mu/defn ^:private plausible-matches-for-id :- [:sequential lib.metadata/ColumnMetadata]
-  [ref-id :- :int
-   columns  :- [:sequential lib.metadata/ColumnMetadata]]
-  (filter #(clojure.core/= (:id %) ref-id) columns))
+  [ref-id     :- :int
+   join-alias :- [:maybe :string]
+   columns    :- [:sequential lib.metadata/ColumnMetadata]
+   generous?  :- [:maybe :boolean]]
+  (or (not-empty (filter #(and (clojure.core/= (:id %) ref-id)
+                               (clojure.core/= (column-join-alias %) join-alias))
+                         columns))
+      (when generous?
+        (not-empty (filter #(clojure.core/= (:id %) ref-id) columns)))
+      []))
 
 (mu/defn ^:private disambiguate-matches :- [:maybe lib.metadata/ColumnMetadata]
   [a-ref   :- ::lib.schema.ref/ref
@@ -147,9 +163,9 @@
   (let [{:keys [join-alias]} (lib.options/options a-ref)]
     (if join-alias
       ;; a-ref has a :join-alias, match on that. Return nil if nothing matches.
-      (m/find-first #(clojure.core/= (:source-alias %) join-alias) columns)
+      (m/find-first #(clojure.core/= (column-join-alias %) join-alias) columns)
       ;; a-ref without :join-alias - if exactly one column has no :source-alias, that's the match.
-      (if-let [no-alias (not-empty (remove :source-alias columns))]
+      (if-let [no-alias (not-empty (remove column-join-alias columns))]
         ;; At least 1 matching column with no :source-alias.
         (if (clojure.core/= (count no-alias) 1)
           (first no-alias)
@@ -161,6 +177,9 @@
         ;; TODO: I'm not certain this one is sound, but it's necessary to make `lib.join/select-home-column` work as
         ;; written. If this case causes issues, that logic may need rewriting.
         nil))))
+
+(def ^:private FindMatchingColumnOptions
+  [:map [:generous? {:optional true} :boolean]])
 
 (mu/defn find-matching-column :- [:maybe lib.metadata/ColumnMetadata]
   "Given `a-ref` and a list of `columns`, finds the column that best matches this ref.
@@ -178,8 +197,12 @@
     - If that *still* doesn't match, and `query` and `stage-number` were supplied.
 
   Returns the column, or nil if no match is found."
-  ([[ref-kind _opts ref-id :as a-ref] :- ::lib.schema.ref/ref
-    columns                           :- [:sequential lib.metadata/ColumnMetadata]]
+  ([a-ref columns]
+   (find-matching-column a-ref columns {}))
+
+  ([[ref-kind opts ref-id :as a-ref] :- ::lib.schema.ref/ref
+    columns                          :- [:sequential lib.metadata/ColumnMetadata]
+    {:keys [generous?]}              :- FindMatchingColumnOptions]
    (case ref-kind
      ;; Aggregations are referenced by the UUID of the column being aggregated.
      :aggregation  (->> columns
@@ -189,24 +212,28 @@
      ;; Expressions are referenced by name; fields by ID or name.
      (:expression
        :field)     (let [plausible (if (string? ref-id)
-                                     (plausible-matches-for-name ref-id columns)
-                                     (plausible-matches-for-id   ref-id columns))]
+                                     (plausible-matches-for-name ref-id (:join-alias opts) columns)
+                                     (plausible-matches-for-id   ref-id (:join-alias opts) columns generous?))]
                      (case (count plausible)
                        0 nil
                        1 (first plausible)
                        (disambiguate-matches a-ref plausible)))
      (throw (ex-info "Unknown type of ref" {:ref a-ref}))))
 
-  ([query                            :- [:maybe ::lib.schema/query]
-    stage-number                     :- :int
-    [ref-kind opts ref-id :as a-ref] :- ::lib.schema.ref/ref
-    columns                          :- [:sequential lib.metadata/ColumnMetadata]]
-   (or (find-matching-column a-ref columns)
+  ([query stage-number a-ref columns]
+   (find-matching-column query stage-number a-ref columns {}))
+
+  ([query                             :- [:maybe ::lib.schema/query]
+    stage-number                      :- :int
+    [ref-kind _opts ref-id :as a-ref] :- ::lib.schema.ref/ref
+    columns                           :- [:sequential lib.metadata/ColumnMetadata]
+    opts                              :- FindMatchingColumnOptions]
+   (or (find-matching-column a-ref columns opts)
        (when (and query (number? ref-id))
          (if-let [resolved (resolve-field-id query stage-number ref-id)]
            (find-matching-column (assoc a-ref 2 (or (:lib/desired-column-alias resolved)
                                                     (:name resolved)))
-                                 columns))))))
+                                 columns opts))))))
 
 (mu/defn find-matching-ref :- [:maybe ::lib.schema.ref/ref]
   "Given `column` and a list of `refs`, finds the ref that best matches this column.
@@ -272,12 +299,356 @@
    (mark-selected-columns nil -1 cols selected-columns-or-refs))
 
   ([query stage-number cols selected-columns-or-refs]
-   #?(:cljs (js/console.log "MSC" (map :lib/desired-column-alias cols) (map :lib/desired-column-alias selected-columns-or-refs)))
-   (let [res (when (seq cols)
-               (let [selected-refs          (mapv lib.ref/ref selected-columns-or-refs)
-                     matching-selected-cols (into #{}
-                                                  (map #(find-matching-column query stage-number % cols))
-                                                  selected-refs)]
-                 (mapv #(assoc % :selected? (contains? matching-selected-cols %)) cols)))]
-     #?(:cljs (js/console.log "MSC out" (map (comp boolean :selected?) res)))
-     res)))
+   (when (seq cols)
+     (let [selected-refs          (mapv lib.ref/ref selected-columns-or-refs)
+           matching-selected-cols (into []
+                                        (map #(find-matching-column query stage-number % cols))
+                                        selected-refs)]
+       (mapv #(assoc % :selected? (contains? (set matching-selected-cols) %)) cols)))))
+
+;;; Original versions - to be deleted!
+;;; ------------------------------------------------ Squinting -------------------------------------------------------
+;;; When trying to match columns and refs, there are lots of details that might not match up.
+;;; For example, we might have a column with a breakout by `:temporal-unit` in the query, but then try to match a naive
+;;; `[:field {} 12]` against it. That should succeed, but we want to match including the `:temporal-unit` if given.
+;;;
+;;; To implement this, we define a set of "squinting" strategies. I call this "squinting" because we're blurring the
+;;; details more and more until two things look the same.
+;;;
+;;; Squinting at a value returns a lazy sequence of successively more generic versions of the value. Note that many of
+;;; the versions might be the same as their predecessor (eg. if the value has no `:temporal-unit`); that's okay.
+;;; Since we want to squint the "same amount" at many values, trying to find a match, it's important that each sequence
+;;; has the same number of steps.
+(defn- ->ref [ref-or-column]
+  (cond-> ref-or-column
+    (and (map? ref-or-column)
+         (= (:lib/type ref-or-column) :metadata/column)) lib.ref/ref))
+
+(def ^:private squints
+  [;; ignore irrelevant keys from :binning options
+   #(lib.options/update-options % m/update-existing :binning dissoc :metadata-fn :lib/type)
+   ;; ignore namespaced keys
+   update-options-remove-namespaced-keys
+   ;; ignore type info
+   #(lib.options/update-options % dissoc :base-type :effective-type)
+   ;; ignore temporal-unit
+   #(lib.options/update-options % dissoc :temporal-unit)
+   ;; ignore binning
+   #(lib.options/update-options % dissoc :binning)])
+
+(defn- squint-by [xforms ref-or-column]
+  (when ref-or-column
+    (reductions (fn [r f] (f r)) (->ref ref-or-column) xforms)))
+
+(defn- squint-keep-join [ref-or-column]
+  (squint-by squints ref-or-column))
+
+(defn- squint-drop-join [ref-or-column]
+  ;; This tries the full chain of squints with any :join-alias, and if that doesn't match, then we start from the
+  ;; original ref, drop the :join-alias, and then run the full chain of squints again.
+  (when ref-or-column
+    (let [a-ref (->ref ref-or-column)]
+      (concat (squint-keep-join a-ref)
+              (squint-keep-join (lib.options/update-options a-ref dissoc :join-alias))))))
+
+;;; ------------------------------------------------ Matching --------------------------------------------------------
+(defn- match-needle-to-haystack
+  ([squinty-needle squinty-haystack] (match-needle-to-haystack squinty-needle squinty-haystack 0))
+  ([squinty-needle squinty-haystack depth]
+   (when (seq squinty-needle)
+     (let [needle  (first squinty-needle)
+           matches (keep-indexed (fn [i squinty-hay]
+                                   (when (= needle (first squinty-hay))
+                                     i))
+                                 squinty-haystack)]
+       (if (empty? matches)
+         (recur (rest squinty-needle) (map rest squinty-haystack) (inc depth))
+         (do
+           (when (> (count matches) 1)
+             (log/warn (i18n/tru "Ambiguous match for {0}: got {1}" (pr-str needle) (pr-str matches))))
+           [(first matches) depth]))))))
+
+(defn- lowest-depth
+  "Given a list of [haystack-index [needle-index depth]] pairs, find the one with the lowest depth.
+  If there's more than one pair with that depth, throw an error.
+
+  Returns the `needle-index` with the lowest depth."
+  [pairs]
+  (let [pairs     (map second pairs) ; Drop the unnecessary [haystack-index ...] outer layer.
+        min-depth (reduce (fn [m [_needle-index depth]] (min m depth)) 100 pairs)
+        at-depth  (filter #(= (second %) min-depth) pairs)]
+    (if (= (count at-depth) 1)
+      (ffirst at-depth)
+      ;; TODO: This should be thrown as an exception rather than a warning, but currently there are some ambiguous
+      ;; columns returned in certain cases of nested queries. Eg. Orders joined to Products, then nest that query.
+      ;; Then for each column in Products, `visible-columns` returns two: one with `:source/card`, and one with
+      ;; `:source/implicitly-joinable`. For regular queries we use the IDs to de-dupe them, but the columns from the
+      ;; nested query have no `:id` or `:table-id`.
+      (do
+        (log/warn  (i18n/tru "Ambiguous match: needles at {0} matched a single haystack value"
+                             (pr-str (map first at-depth))))
+        ;; Arbitrarily returning the earlier of the two matches.
+        (ffirst at-depth)))))
+
+(defn find-closest-matches-for-refs
+  "For each of `needles` (which must be a ref) find the column or ref in `haystack` that it most closely matches. This
+  is meant to power things like [[metabase.lib.breakout/breakoutable-columns]] which are supposed to include
+  `:breakout-position` for columns that are already present as a breakout; sometimes the column in the breakout does not
+  exactly match what MLv2 would have generated. So try to figure out which column it is referring to. The fuzzy matching
+  is powered by the \"squinting\" logic defined in this namespace.
+
+  As a special case, if the input ref has an ID, and 1 or more `haystacks` have the same ID, those are immediately
+  matched.
+
+  The `haystack` can be either `MetadataColumns` or refs.
+
+  Returns a map with `haystack` values as keys (whether they be columns or refs) and the corresponding index in
+  `needles` as values. If for some `needle` there is no match, that index will not appear in the map.
+
+  If there are multiple matches for a `needle` at the same level of \"squinting\", an error is thrown.
+  TODO: Perhaps there are legitimate cases where this will happen? If so, we should add logic to disambiguate matches.
+  (For example, prefer any other `:source/*` over `:source/implicitly-joinable`, if the `needle` has no `:join-alias`.)
+
+  `opts` can be used to influence the level of flexibility.
+    :keep-join? if truthy, the join information will not be ignored
+
+  If you want to check that a single ref exists in a set of columns, call [[find-closest-matching-ref]] instead.
+
+  The four- and five-arity versions can also find matches between integer Field ID references like `[:field {} 1]` and
+  equivalent string column name field literal references like `[:field {} \"bird_type\"]` by resolving Field IDs using
+  the `query` and `stage-number`. This is ultimately a hacky workaround for totally busted legacy queries.
+
+  Note that this currently only works when `needles` contain integer Field IDs. Any refs in the `haystack` must have
+  string literal column names. Luckily we currently don't have problems with MLv1/legacy queries accidentally using
+  string `:field` literals where it shouldn't have been doing so.
+
+  Returns a list parallel to `needles`, where each element is either nil (no match) or the index of the most closely
+  matching ref in `haystack`.
+
+  IMPORTANT!
+
+  When trying to find the matching ref for a sequence of metadatas, prefer [[closest-matching-metadata]] instead, which
+  is less broken (see [[metabase.lib.equality-test/closest-matching-metadata-test]]) and slightly more performant, since
+  it converts metadatas to refs in a lazy fashion."
+  ([needles haystack]
+   (find-closest-matches-for-refs needles haystack {}))
+  ([needles haystack opts]
+   (let [squint           (if (:keep-join? opts) squint-keep-join squint-drop-join)
+         ;; There's an important performance trade-off here - the lazy transformations for each value in the haystack
+         ;; are kept in memory and reused for each needle, so we avoid repeatedly transforming the haystack.
+         ;; This costs memory while this function is running, but saves a lot of time.
+         squinty-needles  (map squint needles)
+         squinty-haystack (map squint haystack)
+         matches          (keep-indexed (fn [index squinty-needle]
+                                          (when-let [[haystack-index depth] (match-needle-to-haystack squinty-needle squinty-haystack)]
+                                            [haystack-index [index depth]]))
+                                        squinty-needles)
+         match-groups     (-> (group-by first matches)
+                              (update-vals lowest-depth))]
+     ;; A successful match! match-groups is {haystack-index needle-index}, so map the keys to be haystack values.
+     (update-keys match-groups #(nth haystack %))))
+
+  ([query stage-number needles haystack]
+   (find-closest-matches-for-refs query stage-number needles haystack {}))
+  ([query stage-number needles haystack opts]
+   ;; First run with the needles as given.
+   (let [matches       (find-closest-matches-for-refs needles haystack opts)
+         ;; Those that were matched are replaced with nil.
+         blank-matched (reduce #(assoc %1 %2 nil) (vec needles) (vals matches))
+         ;; Those that remain are converted to [:field {} "name"] refs if possible, or nil if not.
+         converted     (when (and query
+                                  (some some? blank-matched))
+                         (for [needle blank-matched
+                               :let [field-id (last needle)]]
+                           (when (integer? field-id)
+                             (-> (resolve-field-id query stage-number field-id)
+                                 (dissoc :id ; Remove any :id to force the ref to use the field name.
+                                         :lib/desired-column-alias) ; Hack: resolving by name doesn't work if this is present
+                                 lib.ref/ref))))]
+     (if converted
+       ;; If any of the needles were not found, and were converted successfully, try to match them again.
+       (merge matches (find-closest-matches-for-refs converted haystack opts))
+       ;; If we found them all, just return the matches.
+       matches))))
+
+(defn find-closest-matching-ref
+  "Given a target `a-ref` and a list `refs-or-cols` of `MetadataColumns` or refs, and finds the closest match.
+  Returns the value from `refs-or-cols` which most closely corresponds to `a-ref`, or nil if nothing matches.
+
+  See [[find-closest-matches-for-refs]] for details of how the approximate matching works. (Where
+  [[find-closest-matches-for-refs]] would return `{column 0}`, this returns just `column`.)"
+  ([a-ref refs-or-cols]
+   (find-closest-matching-ref a-ref refs-or-cols {}))
+  ([a-ref refs-or-cols opts]
+   (->> (find-closest-matches-for-refs [a-ref] refs-or-cols opts)
+        keys
+        first))
+
+  ([query stage-number a-ref refs-or-cols]
+   (find-closest-matching-ref query stage-number a-ref refs-or-cols {}))
+  ([query stage-number a-ref refs-or-cols opts]
+   (->> (find-closest-matches-for-refs query stage-number [a-ref] refs-or-cols opts)
+        keys
+        first)))
+
+(defn- annotate-index [xs]
+  (map-indexed (fn [i x]
+                 (when x
+                   (vary-meta x assoc ::index i)))
+               xs))
+
+(defn- cascading-matches
+  "For each of `ref-fns`, this does the following:
+  - Map `(first ref-fns)` over the `haystack-metadatas`.
+  - Annotate these results with metadata to map them back to the original `haystack-metadatas`.
+  - Call [[find-closest-matches-for-refs]] with `needles` and this list of refs.
+  - Map the results back to use the original `haystack-metadatas` as keys, rather than the refs.
+  - Merge the results right-to-left, so that **earlier matches win**.
+  - Remove any matched `needles` and `haystack-metadatas` from the inputs.
+  - If both inputs are nonempty, continue to the next `ref-fns`, if any."
+  [needles haystack-metadatas opts ref-fns]
+  (let [original-needles (annotate-index needles)]
+    (loop [current-needles         original-needles
+           current-haystack        haystack-metadatas
+           [ref-fn & more-ref-fns] ref-fns
+           result                  {}]
+      (cond
+        (or (empty? current-needles)
+            (empty? current-haystack)
+            (nil? ref-fn))            result
+        (nil? ref-fn)                 (recur current-needles current-haystack more-ref-fns result)
+        :else
+        (let [haystack-ref->col  (m/index-by ref-fn current-haystack)
+              matches            (-> (find-closest-matches-for-refs current-needles (keys haystack-ref->col) opts)
+                                     ;; This returns a map {haystack-ref index-in-current-needles}.
+                                     ;; We want to adjust both keys and vals to
+                                     ;; {haystack-metadata index-in-original-needles}
+                                     (update-vals #(->> % (nth current-needles) meta ::index))
+                                     (update-keys haystack-ref->col))
+              matched-needles    (set (vals matches))]
+          (recur (remove #(matched-needles (::index (meta %))) current-needles)
+                 ;; Replace the matched haystacks with nil so they can't match again.
+                 (for [metadata current-haystack]
+                   (when-not (contains? matches metadata)
+                     metadata))
+                 more-ref-fns
+                 ;; TODO: Merging in this direction gives priority to the earliest match.
+                 ;; Perhaps any collision should be an error?
+                 (merge matches result)))))))
+
+(mu/defn closest-matches-in-metadata* :- [:map-of
+                                          lib.metadata/ColumnMetadata
+                                          ::lib.schema.common/int-greater-than-or-equal-to-zero]
+  "Like [[find-closest-matches-for-refs]], but finds the closest match for each element of `needles` from a haystack of
+  Column `metadatas` rather than a haystack of refs. This allows us to do more sophisticated fuzzy matching than
+  [[find-closest-matches-for-refs]], because column metadatas inherently have more information than they do after they
+  are converted to refs.
+
+  Returns a map `{column-metadata index-in-needles}` for each successful match. If nothing is found that matches a
+  `needle`, no entry for it appears in the map.
+
+  If you only have a single `needle` ref to look up, use [[closest-matching-metadata]]."
+  ([needles haystack-metadatas]
+   (closest-matches-in-metadata* needles haystack-metadatas {}))
+
+  ([needles haystack-metadatas opts]
+   (when (seq haystack-metadatas)
+     ;; The matching is done in two passes: first as plain refs, second by forcing ID refs.
+     ;; Each of these returns a map of `{^{::index i} haystack-ref needle-index}`. Those haystack values which match
+     ;; are removed between stages.
+     (cascading-matches
+       needles haystack-metadatas opts
+       [;; The first pass attempts to match the refs using the regular [[find-closest-matches-for-refs]].
+        lib.ref/ref
+        ;; If that fails to match some needles, and there's at least some needles which are "Field ID" refs like
+        ;;
+        ;;    [:field {} 1]
+        ;;
+        ;; then try again, forcing creation of Field ID refs for all of the metadatas. This way we can match
+        ;; things where the FE incorrectly used a Field ID ref even tho we were expecting a nominal :field
+        ;; literal ref like
+        ;;
+        ;;    [:field {} "my_field"]
+        (when (some field-id-ref? needles)
+          ;; Force creation of a Field ID ref by giving it a `:lib/source` that will make the ref creation code
+          ;; treat it as coming from a source table. This only makes sense for metadatas that have an associated
+          ;; Field `:id`, so others are left as-is.
+          (fn [metadata]
+            (cond-> metadata
+              (:id metadata) (assoc :lib/source :source/table-defaults)
+              metadata       lib.ref/ref)))])))
+
+  ([query stage-number needles haystack-metadatas]
+   (closest-matches-in-metadata* query stage-number needles haystack-metadatas {}))
+
+  ([query                 :- [:maybe ::lib.schema/query]
+    stage-number          :- :int
+    needles               :- [:sequential [:maybe ::lib.schema.ref/ref]]
+    haystack-metadatas    :- [:sequential lib.metadata/ColumnMetadata]
+    opts                  :- [:map [:keep-join? {:optional true} :boolean]]]
+   ;; This could be more efficient if the second pass were run on the un-matched subset, like cascading-matches.
+   (let [basic   (closest-matches-in-metadata* needles haystack-metadatas opts)
+         ;; In case that fails, we need to fall back and try matching any integer IDs by name like the four-arity
+         ;; version of [[find-closest-matching-ref]].
+         by-name (when (and query
+                            (some field-id-ref? needles))
+                   (closest-matches-in-metadata*
+                     (for [[_field _opts field-id] needles]
+                       (when (pos-int? field-id)
+                         (lib.ref/ref (resolve-field-id query stage-number field-id))))
+                     haystack-metadatas
+                     opts))]
+     ;; Prefer the more precise integer ID matches over the name-based ones.
+     (merge by-name basic))))
+
+(def ^{:arglists '([needles haystack-metadatas]
+                   [needles haystack-metadatas opts]
+                   [query stage-number needles haystack-metadatas]
+                   [query stage-number needles haystack-metadatas opts])}
+  closest-matches-in-metadata
+  "The cached version of [[closest-matches-in-metadata*]]."
+  (memoize/lru closest-matches-in-metadata* :lru/threshold 8))
+
+(mu/defn closest-matching-metadata :- [:maybe lib.metadata/ColumnMetadata]
+  "Like [[find-closest-matching-ref]], but finds the closest match for `a-ref` from a sequence of Column `metadatas`
+  rather than a sequence of refs. See [[index-of-closet-matching-metadata]] for more info."
+  ([a-ref metadatas]
+   (closest-matching-metadata a-ref metadatas {}))
+
+  ([a-ref metadatas opts]
+   (closest-matching-metadata nil -1 a-ref metadatas opts))
+
+  ([query stage-number a-ref metadatas]
+   (closest-matching-metadata query stage-number a-ref metadatas {}))
+
+  ([query                 :- [:maybe ::lib.schema/query]
+    stage-number          :- :int
+    a-ref                 :- ::lib.schema.ref/ref
+    metadatas             :- [:sequential lib.metadata/ColumnMetadata]
+    opts                  :- [:map [:keep-join? {:optional true} :boolean]]]
+   (->> (closest-matches-in-metadata query stage-number [a-ref] metadatas opts)
+        keys
+        first)))
+
+(mu/defn legacy-find-column-indexes-for-refs :- [:sequential :int]
+  "Given a list `haystack` of columns or refs, and a list `needles` of refs to searc for, this returns a list parallel
+  to `needles` with the corresponding index into the `haystack`, or -1 if not found.
+
+  DISCOURAGED: This is intended for use only by [[metabase.lib.js/find-column-indexes-from-legacy-refs]].
+  Other MLv2 code should use [[closest-matching-metadata]] if the `haystack` is columns, or
+  [[find-closest-matches-for-refs]] if it's refs."
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   needles      :- [:sequential ::lib.schema.ref/ref]
+   haystack     :- [:sequential [:or lib.metadata/ColumnMetadata ::lib.schema.ref/ref]]]
+  (let [;; matches is a map of haystack values to the corresponding index in needles.
+        matches (find-closest-matches-for-refs query stage-number needles haystack {:keep-join? true})
+        ;; We want to return a parallel list to needles, giving the index of the matching column (or -1).
+        ;; First, map each column to its index (in the haystack).
+        column->index (into {} (for [index (range (count haystack))]
+                                 [(nth haystack index) index]))
+        ;; And use that to map each match's needle-index to its column-index.
+        by-index      (into {} (for [[column needle-index] matches]
+                                 [needle-index (column->index column)]))]
+    (->> (range (count needles))
+         (map #(by-index % -1)))))

--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -123,7 +123,7 @@
    (when (lib.util/first-stage? query stage-number)
      (when-let [card-id (lib.util/source-card-id query)]
        (when-let [card-metadata (lib.card/saved-question-metadata query card-id)]
-         (m/find-first #(= (:id %) field-id)
+         (m/find-first #(clojure.core/= (:id %) field-id)
                        card-metadata))))
    (try
      (lib.metadata/field query field-id)
@@ -133,13 +133,13 @@
 (mu/defn ^:private plausible-matches-for-name :- [:sequential lib.metadata/ColumnMetadata]
   [ref-name :- :string
    columns  :- [:sequential lib.metadata/ColumnMetadata]]
-  (or (not-empty (filter #(= (:lib/desired-column-alias %) ref-name) columns))
-      (filter #(= (:name %) ref-name) columns)))
+  (or (not-empty (filter #(clojure.core/= (:lib/desired-column-alias %) ref-name) columns))
+      (filter #(clojure.core/= (:name %) ref-name) columns)))
 
 (mu/defn ^:private plausible-matches-for-id :- [:sequential lib.metadata/ColumnMetadata]
   [ref-id :- :int
    columns  :- [:sequential lib.metadata/ColumnMetadata]]
-  (filter #(= (:id %) ref-id) columns))
+  (filter #(clojure.core/= (:id %) ref-id) columns))
 
 (mu/defn ^:private disambiguate-matches :- [:maybe lib.metadata/ColumnMetadata]
   [a-ref   :- ::lib.schema.ref/ref
@@ -147,11 +147,11 @@
   (let [{:keys [join-alias]} (lib.options/options a-ref)]
     (if join-alias
       ;; a-ref has a :join-alias, match on that. Return nil if nothing matches.
-      (m/find-first #(= (:source-alias %) join-alias) columns)
+      (m/find-first #(clojure.core/= (:source-alias %) join-alias) columns)
       ;; a-ref without :join-alias - if exactly one column has no :source-alias, that's the match.
       (if-let [no-alias (not-empty (remove :source-alias columns))]
         ;; At least 1 matching column with no :source-alias.
-        (if (= (count no-alias) 1)
+        (if (clojure.core/= (count no-alias) 1)
           (first no-alias)
           ;; More than 1, it's ambiguous.
           (throw (ex-info "Ambiguous match! Implement more logic in disambiguate-matches."
@@ -183,8 +183,8 @@
    (case ref-kind
      ;; Aggregations are referenced by the UUID of the column being aggregated.
      :aggregation  (->> columns
-                        (filter #(= (:lib/source %) :source/aggregations))
-                        (filter #(= (:lib/source-uuid %) ref-id))
+                        (filter #(clojure.core/= (:lib/source %) :source/aggregations))
+                        (filter #(clojure.core/= (:lib/source-uuid %) ref-id))
                         first)
      ;; Expressions are referenced by name; fields by ID or name.
      (:expression

--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -240,9 +240,10 @@
    stage-number :- :int
    needles      :- [:sequential ::lib.schema.ref/ref]
    haystack     :- [:sequential lib.metadata/ColumnMetadata]]
-  (for [needle needles]
-    (or (find-matching-column query stage-number needle haystack)
-        -1)))
+  (let [by-column (into {} (for [[i column] (m/indexed haystack)]
+                             [column i]))]
+    (for [needle needles]
+      (get by-column (find-matching-column query stage-number needle haystack) -1))))
 
 ;; TODO: Refactor this away. Handle legacy refs in `lib.js`, then call [[find-matching-column]] directly.
 (mu/defn find-column-for-legacy-ref :- [:maybe lib.metadata/ColumnMetadata]

--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -151,7 +151,10 @@
    columns    :- [:sequential lib.metadata/ColumnMetadata]
    generous?  :- [:maybe :boolean]]
   (or (not-empty (filter #(and (clojure.core/= (:id %) ref-id)
-                               (clojure.core/= (column-join-alias %) join-alias))
+                               ;; Either the join alias must match, or this must be an implicitly joined field.
+                               ;; (The join alias might not match for an implicit join.)
+                               (or (:fk-field-id %)
+                                   (clojure.core/= (column-join-alias %) join-alias)))
                          columns))
       (when generous?
         (not-empty (filter #(clojure.core/= (:id %) ref-id) columns)))

--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -31,9 +31,9 @@
     stage-number :- :int
     filter-clause :- ::lib.schema.expression/boolean]
    (let [[op options first-arg & rest-args] filter-clause
-         stage (lib.util/query-stage query stage-number)
-         columns (lib.metadata.calculation/visible-columns query stage-number stage)
-         col (lib.equality/closest-matching-metadata first-arg columns)
+         stage            (lib.util/query-stage query stage-number)
+         columns          (lib.metadata.calculation/visible-columns query stage-number stage)
+         col              (lib.equality/find-matching-column first-arg columns)
          add-ref-metadata #(lib.field/extend-column-metadata-from-ref query stage-number % first-arg)]
      {:lib/type :mbql/filter-parts
       :operator (or (m/find-first #(= (:short %) op)

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -625,8 +625,7 @@
       (< (count new-fields) (count old-fields)) (lib.util/update-query-stage stage-number assoc :fields new-fields))))
 
 (defn- remove-field-from-join [query stage-number column]
-  (let [field-ref   (lib.ref/ref column)
-        join        (lib.join/resolve-join query stage-number (::lib.join/join-alias column))
+  (let [join        (lib.join/resolve-join query stage-number (::lib.join/join-alias column))
         join-fields (lib.join/join-fields join)]
     (if (or (nil? join-fields)
             (= join-fields :none))

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -442,18 +442,17 @@
                            (column-metadata->field-ref metadata))
     (column-metadata->field-ref metadata)))
 
-(defn- expression-refs
+(defn- expression-columns
   "Create refs for all the expressions in a stage of a query."
   [query stage-number]
-  (for [col   (lib.metadata.calculation/visible-columns
-               query
-               stage-number
-               (lib.util/query-stage query stage-number)
-               {:include-joined?              false
-                :include-expressions?         true
-                :include-implicitly-joinable? false})
-        :when (= (:lib/source col) :source/expressions)]
-    (lib.ref/ref col)))
+  (filter #(= (:lib/source %) :source/expressions)
+          (lib.metadata.calculation/visible-columns
+           query
+           stage-number
+           (lib.util/query-stage query stage-number)
+           {:include-joined?              false
+            :include-expressions?         true
+            :include-implicitly-joinable? false})))
 
 (mu/defn with-fields :- ::lib.schema/query
   "Specify the `:fields` for a query. Pass `nil` or an empty sequence to remove `:fields`."
@@ -469,13 +468,14 @@
     xs]
    (let [xs        (not-empty (mapv lib.ref/ref xs))
          ;; If any fields are specified, include all expressions not yet included.
-         expr-refs (expression-refs query stage-number)
-         ;; Set of indexes of expr-refs which are *already* included.
+         expr-cols (expression-columns query stage-number)
+         ;; Set of expr-cols which are *already* included.
          included  (set (when xs
-                          (vals (lib.equality/find-closest-matches-for-refs expr-refs xs {:keep-join? true}))))
+                          (keep #(lib.equality/find-matching-column query stage-number % expr-cols)
+                                xs)))
          ;; Those expr-refs which must still be included.
-         to-add    (keep-indexed #(when-not (included %1) %2) expr-refs)
-         xs        (when xs (into xs to-add))]
+         to-add    (remove included expr-cols)
+         xs        (when xs (into xs (map lib.ref/ref) to-add))]
      (lib.util/update-query-stage query stage-number u/assoc-dissoc :fields xs))))
 
 (mu/defn fields :- [:maybe [:ref ::lib.schema/fields]]
@@ -526,7 +526,7 @@
   (lib.util/update-query-stage query stage-number
                                (fn [stage]
                                  (assoc stage :fields
-                                        (into [] (comp (remove (comp #{:source/joins}
+                                        (into [] (comp (remove (comp #{:source/joins :source/implicitly-joinable}
                                                                      :lib/source))
                                                        (map lib.ref/ref))
                                               (lib.metadata.calculation/returned-columns query stage-number stage))))))
@@ -540,13 +540,9 @@
 
 (defn- include-field [query stage-number column]
   (let [populated  (query-with-fields query stage-number)
-        column-ref (lib.ref/ref column)
         field-refs (fields populated stage-number)
-        match-opts {:keep-join? true}
-        match-ref  (if (and (integer? (last column-ref))
-                            (every? (comp integer? last) field-refs))
-                     (lib.equality/find-closest-matching-ref column-ref field-refs match-opts)
-                     (lib.equality/find-closest-matching-ref populated stage-number column-ref field-refs match-opts))]
+        match-ref  (lib.equality/find-matching-ref column field-refs)
+        column-ref (lib.ref/ref column)]
     (if (and match-ref
              (or (string? (last column-ref))
                  (integer? (last match-ref))))
@@ -558,10 +554,8 @@
   (let [column-ref   (lib.ref/ref column)
         [join field] (first (for [join  (lib.join/joins query stage-number)
                                   :let [joinables (lib.join/joinable-columns query stage-number join)
-                                        field     (lib.equality/closest-matching-metadata
-                                                    query stage-number column-ref
-                                                    joinables
-                                                    {:keep-join? true})]
+                                        field     (lib.equality/find-matching-column
+                                                   query stage-number column-ref joinables)]
                                   :when field]
                               [join field]))
         join-fields  (lib.join/join-fields join)]
@@ -611,8 +605,8 @@
         (log/warn (i18n/tru "Cannot add-field with unknown source {0}" (pr-str source)))
         query))))
 
-(defn- remove-matching-ref [query stage-number a-ref refs]
-  (let [match (lib.equality/find-closest-matching-ref query stage-number a-ref refs {:keep-join? true})]
+(defn- remove-matching-ref [column refs]
+  (let [match (lib.equality/find-matching-ref column refs)]
      (remove #(= % match) refs)))
 
 (defn- exclude-field
@@ -623,7 +617,7 @@
   (let [old-fields (-> (query-with-fields query stage-number)
                        (lib.util/query-stage stage-number)
                        :fields)
-        new-fields (remove-matching-ref query stage-number (lib.ref/ref column) old-fields)]
+        new-fields (remove-matching-ref column old-fields)]
     (cond-> query
       ;; If we couldn't find the field, return the original query unchanged.
       (< (count new-fields) (count old-fields)) (lib.util/update-query-stage stage-number assoc :fields new-fields))))
@@ -637,17 +631,9 @@
       ;; Nothing to do if there's already no join fields.
       query
       (let [resolved-join-fields (if (= join-fields :all)
-                                   (lib.metadata.calculation/returned-columns query stage-number join)
+                                   (map lib.ref/ref (lib.metadata.calculation/returned-columns query stage-number join))
                                    join-fields)
-            removed              (if (= join-fields :all)
-                                   ;; for `:fields :all` use [[lib.equality/closest-matching-metadata]] since we have
-                                   ;; actual ColumnMetdatas, since it's more sophisticated
-                                   ;; than [[lib.equality/find-closest-matching-ref]]. We will have to use the latter
-                                   ;; if we only have refs to work with
-                                   (remove #(lib.equality/closest-matching-metadata query stage-number field-ref [%])
-                                           resolved-join-fields)
-                                   (remove #(lib.equality/find-closest-matching-ref query stage-number field-ref [%])
-                                           resolved-join-fields))]
+            removed              (remove-matching-ref column resolved-join-fields)]
         (cond-> query
           ;; If we actually removed a field, replace the join. Otherwise return the query unchanged.
           (< (count removed) (count resolved-join-fields))
@@ -700,7 +686,7 @@
                     lib.metadata.calculation/returned-columns
                     lib.metadata.calculation/visible-columns)
                   query stage-number stage)]
-     (lib.equality/closest-matching-metadata query stage-number field-ref columns))))
+     (lib.equality/find-matching-column query stage-number field-ref columns))))
 
 ;; TODO: Refactor this away - handle legacy refs in lib.js and using `lib.equality` directly from there.
 (mu/defn find-visible-column-for-legacy-ref :- [:maybe lib.metadata/ColumnMetadata]

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -443,7 +443,7 @@
     (column-metadata->field-ref metadata)))
 
 (defn- expression-columns
-  "Create refs for all the expressions in a stage of a query."
+  "Return the [[lib.metadata/ColumnMetadata]] for all the expressions in a stage of a query."
   [query stage-number]
   (filter #(= (:lib/source %) :source/expressions)
           (lib.metadata.calculation/visible-columns
@@ -470,9 +470,9 @@
          ;; If any fields are specified, include all expressions not yet included.
          expr-cols (expression-columns query stage-number)
          ;; Set of expr-cols which are *already* included.
-         included  (set (when xs
-                          (keep #(lib.equality/find-matching-column query stage-number % expr-cols)
-                                xs)))
+         included  (into #{}
+                         (keep #(lib.equality/find-matching-column query stage-number % expr-cols))
+                         (or xs []))
          ;; Those expr-refs which must still be included.
          to-add    (remove included expr-cols)
          xs        (when xs (into xs (map lib.ref/ref) to-add))]

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -562,8 +562,8 @@
 
     ;; Nothing to do if it's already selected, or if this join already has :fields :all.
     ;; Otherwise, append it to the list of fields.
-    (if (or (and field (:selected? field))
-            (= join-fields :all))
+    (if (or (= join-fields :all)
+            (and field (lib.equality/find-matching-ref field join-fields)))
       query
       (lib.remove-replace/replace-join query stage-number join
                                        (lib.join/with-join-fields join

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -563,7 +563,9 @@
     ;; Nothing to do if it's already selected, or if this join already has :fields :all.
     ;; Otherwise, append it to the list of fields.
     (if (or (= join-fields :all)
-            (and field (lib.equality/find-matching-ref field join-fields)))
+            (and field
+                 (not= join-fields :none)
+                 (lib.equality/find-matching-ref field join-fields)))
       query
       (lib.remove-replace/replace-join query stage-number join
                                        (lib.join/with-join-fields join

--- a/src/metabase/lib/filter.cljc
+++ b/src/metabase/lib/filter.cljc
@@ -250,7 +250,7 @@
    (let [[op _ first-arg] a-filter-clause
          stage   (lib.util/query-stage query stage-number)
          columns (lib.metadata.calculation/visible-columns query stage-number stage)
-         col     (lib.equality/closest-matching-metadata query stage-number first-arg columns)]
+         col     (lib.equality/find-matching-column query stage-number first-arg columns)]
      (clojure.core/or (m/find-first #(clojure.core/= (:short %) op)
                                     (lib.filter.operator/filter-operators col))
                       (lib.filter.operator/operator-def op)))))
@@ -291,7 +291,7 @@
     legacy-ref   :- some?]
    (let [a-ref   (lib.convert/legacy-ref->pMBQL query stage-number legacy-ref)
          columns (filterable-columns query stage-number)]
-     (lib.equality/closest-matching-metadata a-ref columns))))
+     (lib.equality/find-matching-column a-ref columns))))
 
 (def ^:private FilterParts
   [:map
@@ -313,7 +313,7 @@
    (let [[op options first-arg & rest-args] a-filter-clause
          stage   (lib.util/query-stage query stage-number)
          columns (lib.metadata.calculation/visible-columns query stage-number stage)
-         col     (lib.equality/closest-matching-metadata query stage-number first-arg columns)]
+         col     (lib.equality/find-matching-column query stage-number first-arg columns)]
      {:lib/type :mbql/filter-parts
       :operator (clojure.core/or (m/find-first #(clojure.core/= (:short %) op)
                                                (lib.filter.operator/filter-operators col))

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -729,10 +729,9 @@
                                (when (join? join-or-joinable)
                                  (standard-join-condition-rhs (first (join-conditions join-or-joinable)))))
          rhs-column-or-nil (when rhs-column-or-nil
-                             (if (not join-alias)
+                             (cond-> rhs-column-or-nil
                                ;; Drop the :join-alias from the RHS if the joinable doesn't have one either.
-                               (lib.options/update-options rhs-column-or-nil dissoc :join-alias)
-                               rhs-column-or-nil))]
+                               (not join-alias) (lib.options/update-options dissoc :join-alias)))]
      (->> (lib.metadata.calculation/visible-columns query stage-number joinable {:include-implicitly-joinable? false})
           (map (fn [col]
                  (cond-> (assoc col :lib/source :source/joins)

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -727,7 +727,12 @@
                              (lib.join.util/current-join-alias join-or-joinable))
          rhs-column-or-nil (or rhs-column-or-nil
                                (when (join? join-or-joinable)
-                                 (standard-join-condition-rhs (first (join-conditions join-or-joinable)))))]
+                                 (standard-join-condition-rhs (first (join-conditions join-or-joinable)))))
+         rhs-column-or-nil (when rhs-column-or-nil
+                             (if (not join-alias)
+                               ;; Drop the :join-alias from the RHS if the joinable doesn't have one either.
+                               (lib.options/update-options rhs-column-or-nil dissoc :join-alias)
+                               rhs-column-or-nil))]
      (->> (lib.metadata.calculation/visible-columns query stage-number joinable {:include-implicitly-joinable? false})
           (map (fn [col]
                  (cond-> (assoc col :lib/source :source/joins)

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -379,12 +379,7 @@
 
 (defn- select-home-column
   [home-cols cond-fields]
-  ;; cond-fields can have duplicates, which breaks [[lib.equality/find-closest-matches-for-refs]] and friends.
-  ;; So we look them up one at a time.
-  (let [cond-home-cols (for [field cond-fields
-                             :let [home-col (lib.equality/closest-matching-metadata field home-cols)]
-                             :when home-col]
-                         home-col)]
+  (let [cond-home-cols (keep #(lib.equality/find-matching-column % home-cols) cond-fields)]
     ;; first choice: the leftmost FK or PK in the condition referring to a home column
     (or (m/find-first (some-fn lib.types.isa/foreign-key? lib.types.isa/primary-key?) cond-home-cols)
         ;; otherwise the leftmost home column in the condition
@@ -435,7 +430,7 @@
   (mbql.u.match/replace form
     (field :guard (fn [field-clause]
                     (and (lib.util/field-clause? field-clause)
-                         (boolean (lib.equality/closest-matching-metadata query stage-number field-clause join-cols)))))
+                         (boolean (lib.equality/find-matching-column query stage-number field-clause join-cols)))))
     (with-join-alias field join-alias)))
 
 (defn- add-alias-to-condition
@@ -453,7 +448,7 @@
         (cond
           ;; no sides obviously belong to joined
           (not (or lhs-alias rhs-alias))
-          (if (lib.equality/closest-matching-metadata query stage-number rhs home-cols)
+          (if (lib.equality/find-matching-column query stage-number rhs home-cols)
             [op op-opts (with-join-alias lhs join-alias) rhs]
             [op op-opts lhs (with-join-alias rhs join-alias)])
 
@@ -463,8 +458,8 @@
           (and (= lhs-alias join-alias) (= rhs-alias join-alias))
           (let [bare-lhs (lib.options/update-options lhs dissoc :join-alias)
                 bare-rhs (lib.options/update-options rhs dissoc :join-alias)]
-            (if (and (nil? (lib.equality/closest-matching-metadata query stage-number bare-lhs home-cols))
-                     (lib.equality/closest-matching-metadata query stage-number bare-rhs home-cols))
+            (if (and (nil? (lib.equality/find-matching-column query stage-number bare-lhs home-cols))
+                     (lib.equality/find-matching-column query stage-number bare-rhs home-cols))
               [op op-opts lhs bare-rhs]
               [op op-opts bare-lhs rhs]))
 

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -489,10 +489,6 @@
         vis-columns    (lib.metadata.calculation/visible-columns a-query stage-number stage)
         ret-columns    (lib.metadata.calculation/returned-columns a-query stage-number stage)
         ret (lib.equality/mark-selected-columns a-query stage-number vis-columns ret-columns)]
-    (js/console.log "viz cols query" a-query)
-    (js/console.log "viz cols viz  " vis-columns)
-    (js/console.log "viz cols ret  " ret-columns)
-    (js/console.log "viz cols msc  " ret)
     (to-array ret)))
 
 (defn ^:export legacy-field-ref
@@ -519,6 +515,16 @@
     ;; It's already a :metadata/column map
     column))
 
+(defn- legacy->column-or-ref [column]
+  (if-let [^js legacy-column (when (object? column) column)]
+    (if (.-field_ref legacy-column)
+      ;; Prefer the attached field_ref if provided.
+      (legacy-ref->pMBQL (.-field_ref legacy-column))
+      ;; Fall back to converting like metadata.
+      (js.metadata/parse-column legacy-column))
+    ;; It's already a :metadata/column map
+    column))
+
 (defn ^:export find-column-indexes-from-legacy-refs
   "Given a list of columns (either JS `data.cols` or MLv2 `ColumnMetadata`) and a list of legacy refs, find each ref's
   corresponding index into the list of columns.
@@ -529,9 +535,15 @@
   ;; `[:aggregation 0]` refs into pMBQL `[:aggregation uuid]` refs.
   (lib.convert/with-aggregation-list (:aggregation (lib.util/query-stage a-query stage-number))
     (let [haystack (mapv ->column-or-ref legacy-columns)
-          needles  (map legacy-ref->pMBQL legacy-refs)]
+          needles  (map legacy-ref->pMBQL legacy-refs)
+          legacy-haystack (mapv legacy->column-or-ref legacy-columns)
+          legacy-indexes  (lib.equality/legacy-find-column-indexes-for-refs a-query stage-number needles legacy-haystack)
+          modern-indexes  (lib.equality/find-column-indexes-for-refs a-query stage-number needles haystack)]
+      (when (not= legacy-indexes modern-indexes)
+        (js/console.log "Difference detected!" legacy-indexes modern-indexes
+                        legacy-haystack haystack needles))
       #_{:clj-kondo/ignore [:discouraged-var]}
-      (to-array (lib.equality/find-column-indexes-for-refs a-query stage-number needles haystack)))))
+      (to-array modern-indexes))))
 
 (defn ^:export join-strategy
   "Get the strategy (type) of a given join as an opaque JoinStrategy object."

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -488,8 +488,7 @@
   (let [stage          (lib.util/query-stage a-query stage-number)
         vis-columns    (lib.metadata.calculation/visible-columns a-query stage-number stage)
         ret-columns    (lib.metadata.calculation/returned-columns a-query stage-number stage)]
-    (to-array (lib.equality/mark-selected-columns
-                a-query stage-number vis-columns ret-columns {:keep-join? true}))))
+    (to-array (lib.equality/mark-selected-columns a-query stage-number vis-columns ret-columns))))
 
 (defn ^:export legacy-field-ref
   "Given a column metadata from eg. [[fieldable-columns]], return it as a legacy JSON field ref."

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -487,8 +487,13 @@
   [a-query stage-number]
   (let [stage          (lib.util/query-stage a-query stage-number)
         vis-columns    (lib.metadata.calculation/visible-columns a-query stage-number stage)
-        ret-columns    (lib.metadata.calculation/returned-columns a-query stage-number stage)]
-    (to-array (lib.equality/mark-selected-columns a-query stage-number vis-columns ret-columns))))
+        ret-columns    (lib.metadata.calculation/returned-columns a-query stage-number stage)
+        ret (lib.equality/mark-selected-columns a-query stage-number vis-columns ret-columns)]
+    (js/console.log "viz cols query" a-query)
+    (js/console.log "viz cols viz  " vis-columns)
+    (js/console.log "viz cols ret  " ret-columns)
+    (js/console.log "viz cols msc  " ret)
+    (to-array ret)))
 
 (defn ^:export legacy-field-ref
   "Given a column metadata from eg. [[fieldable-columns]], return it as a legacy JSON field ref."

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -509,11 +509,8 @@
 
 (defn- ->column-or-ref [column]
   (if-let [^js legacy-column (when (object? column) column)]
-    (if (.-field_ref legacy-column)
-      ;; Prefer the attached field_ref if provided.
-      (legacy-ref->pMBQL (.-field_ref legacy-column))
-      ;; Fall back to converting like metadata.
-      (js.metadata/parse-column legacy-column))
+    ;; Convert legacy columns like we do for metadata.
+    (js.metadata/parse-column legacy-column)
     ;; It's already a :metadata/column map
     column))
 

--- a/src/metabase/lib/js/metadata.cljs
+++ b/src/metabase/lib/js/metadata.cljs
@@ -231,7 +231,9 @@
                            (walk/keywordize-keys v)
                            (js->clj v :keywordize-keys true))
       :has-field-values  (keyword v)
-      :lib/source        (keyword "source" v)
+      :lib/source        (if (= v "aggregation")
+                           :source/aggregations
+                           (keyword "source" v))
       :semantic-type     (keyword v)
       :visibility-type   (keyword v)
       :id                (parse-field-id v)

--- a/src/metabase/lib/order_by.cljc
+++ b/src/metabase/lib/order_by.cljc
@@ -152,8 +152,11 @@
        (vec columns)
 
        :else
-       (let [matching (lib.equality/closest-matches-in-metadata
-                        query stage-number (map lib.ref/ref existing-order-bys) columns)]
+       (let [matching (into {} (keep-indexed (fn [index an-order-by]
+                                               (when-let [col (lib.equality/find-matching-column
+                                                               query stage-number an-order-by columns)]
+                                                 [col index]))
+                                             (map lib.ref/ref existing-order-bys)))]
          (mapv #(let [pos (matching %)]
                   (cond-> %
                     pos (assoc :order-by-position pos)))

--- a/src/metabase/lib/order_by.cljc
+++ b/src/metabase/lib/order_by.cljc
@@ -152,11 +152,13 @@
        (vec columns)
 
        :else
-       (let [matching (into {} (keep-indexed (fn [index an-order-by]
-                                               (when-let [col (lib.equality/find-matching-column
-                                                               query stage-number an-order-by columns)]
-                                                 [col index]))
-                                             (map lib.ref/ref existing-order-bys)))]
+       (let [matching (into {}
+                            (comp (map lib.ref/ref)
+                                  (keep-indexed (fn [index an-order-by]
+                                                  (when-let [col (lib.equality/find-matching-column
+                                                                   query stage-number an-order-by columns)]
+                                                    [col index]))))
+                            existing-order-bys)]
          (mapv #(let [pos (matching %)]
                   (cond-> %
                     pos (assoc :order-by-position pos)))

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -280,7 +280,6 @@
                       (or (not (:source-card (lib.util/query-stage query stage-number)))
                           (:include-implicitly-joinable-for-source-card? options)))
              (lib.metadata.calculation/implicitly-joinable-columns query stage-number existing-columns unique-name-fn)))
-         #_(#(do #?(:cljs (js/console.log "post-IJC" %)) %))
          (mark-selected-breakouts query stage-number))))
 
 ;;; Return results metadata about the expected columns in an MBQL query stage. If the query has

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -280,6 +280,7 @@
                       (or (not (:source-card (lib.util/query-stage query stage-number)))
                           (:include-implicitly-joinable-for-source-card? options)))
              (lib.metadata.calculation/implicitly-joinable-columns query stage-number existing-columns unique-name-fn)))
+         #_(#(do #?(:cljs (js/console.log "post-IJC" %)) %))
          (mark-selected-breakouts query stage-number))))
 
 ;;; Return results metadata about the expected columns in an MBQL query stage. If the query has

--- a/src/metabase/query_processor/middleware/binning.clj
+++ b/src/metabase/query_processor/middleware/binning.clj
@@ -207,7 +207,7 @@
     (let [mlv2-metadatas (for [col source-metadata]
                            (lib.card/->card-metadata-column (qp.store/metadata-provider) col))]
       (or
-       (lib.equality/closest-matching-metadata
+       (lib.equality/find-matching-column
         [:field {:lib/uuid (str (random-uuid)), :base-type :type/*} field-name]
         mlv2-metadatas)
        (throw (ex-info (tru "Cannot update binned field: could not find matching source metadata for Field {0}"

--- a/test/metabase/lib/breakout_test.cljc
+++ b/test/metabase/lib/breakout_test.cljc
@@ -464,13 +464,14 @@
   (testing "Field refs that differ from what we return should still show up as selected if they refer to the same Field (#31482)"
     (doseq [[message field-ref] {;; this ref is basically what we [[lib/breakout]] would have added but doesn't
                                  ;; contain type info, shouldn't matter tho.
-                                 "correct ref but missing :base-type/:effective-type"
+                                 #_#_"correct ref but missing :base-type/:effective-type"
                                  [:field {:lib/uuid (str (random-uuid)), :join-alias "Categories"} (meta/id :categories :name)]
 
                                  ;; this is a busted Field ref, it's referring to a Field from a joined Table but
                                  ;; does not include `:join-alias`. It should still work anyway.
                                  "busted ref"
-                                 [:field {:lib/uuid (str (random-uuid))} (meta/id :categories :name)]}]
+                                 [:field {:lib/uuid (str (random-uuid)) :base-type :type/Text}
+                                  (meta/id :categories :name)]}]
       (testing (str \newline message " ref = " (pr-str field-ref))
         (let [query (-> lib.tu/venues-query
                         (lib/join (-> (lib/join-clause
@@ -495,7 +496,9 @@
       ;; technically wrong.
       ;;
       ;; Actually a correct reference would be [:field {} "Products__Category"], see #29763
-      (lib/breakout [:field {:lib/uuid (str (random-uuid))} (meta/id :products :category)])))
+      (lib/breakout [:field {:lib/uuid (str (random-uuid))
+                             :base-type :type/Text}
+                     (meta/id :products :category)])))
 
 (deftest ^:parallel legacy-query-with-broken-breakout-breakouts-test
   (testing "Handle busted references to joined Fields in broken breakouts from broken drill-thrus (#31482)"

--- a/test/metabase/lib/breakout_test.cljc
+++ b/test/metabase/lib/breakout_test.cljc
@@ -464,7 +464,7 @@
   (testing "Field refs that differ from what we return should still show up as selected if they refer to the same Field (#31482)"
     (doseq [[message field-ref] {;; this ref is basically what we [[lib/breakout]] would have added but doesn't
                                  ;; contain type info, shouldn't matter tho.
-                                 #_#_"correct ref but missing :base-type/:effective-type"
+                                 "correct ref but missing :base-type/:effective-type"
                                  [:field {:lib/uuid (str (random-uuid)), :join-alias "Categories"} (meta/id :categories :name)]
 
                                  ;; this is a busted Field ref, it's referring to a Field from a joined Table but

--- a/test/metabase/lib/column_group_test.cljc
+++ b/test/metabase/lib/column_group_test.cljc
@@ -4,6 +4,7 @@
    [malli.core :as mc]
    [metabase.lib.column-group :as lib.column-group]
    [metabase.lib.core :as lib]
+   [metabase.lib.equality :as lib.equality]
    [metabase.lib.join :as lib.join]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
@@ -314,7 +315,7 @@
                                        (lib/with-join-fields (for [field [:id :tax]]
                                                                (lib/ref (meta/field-metadata :orders field)))))))
         columns      (lib/visible-columns query)
-        marked       (metabase.lib.equality/mark-selected-columns query -1 columns (lib/returned-columns query))
+        marked       (lib.equality/mark-selected-columns query -1 columns (lib/returned-columns query))
         user-cols    ["ID" "ADDRESS" "EMAIL" "PASSWORD" "NAME" "CITY" "LONGITUDE"
                       "STATE" "SOURCE" "BIRTH_DATE" "ZIP" "LATITUDE" "CREATED_AT"]
         product-cols ["ID" "EAN" "TITLE" "CATEGORY" "VENDOR" "PRICE" "RATING" "CREATED_AT"]

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -810,7 +810,9 @@
                   (-> field-query
                       (lib/with-fields -1 extended-subset)
                       (lib/add-field -1 created-at)
-                      fields-of)))))))
+                      fields-of))))))))
+
+(deftest ^:parallel add-field-expressions-test
   (testing "custom expressions are ignored"
     (let [query       (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
                           (lib/expression "custom" (lib/* 3 2)))
@@ -826,7 +828,9 @@
                 (lib/add-field query -1 expr-column))))
       (testing "with explicit :fields list"
         (is (=? field-query
-                (lib/add-field field-query -1 expr-column))))))
+                (lib/add-field field-query -1 expr-column)))))))
+
+(deftest ^:parallel add-field-join-test
   (testing "single join"
     (let [query  (as-> (meta/table-metadata :orders) <>
                    (lib/query meta/metadata-provider <>)
@@ -872,9 +876,9 @@
 
       (testing "join :fields list"
         (let [join-fields-query (lib.util/update-query-stage
-                                 query -1
-                                 update-in [:joins 0]
-                                 lib/with-join-fields (map lib/ref (take 4 join-columns)))]
+                                  query -1
+                                  update-in [:joins 0]
+                                  lib/with-join-fields (map lib/ref (take 4 join-columns)))]
           (testing "returns those plus all the main table fields"
             (is (=? (->> (concat table-columns
                                  (take 4 join-columns))
@@ -897,8 +901,9 @@
                          sorted-fields))))
           (testing "does nothing if the join field is already selected"
             (is (=? join-fields-query
-                    (lib/add-field join-fields-query -1 (nth join-columns 3)))))))))
+                    (lib/add-field join-fields-query -1 (nth join-columns 3))))))))))
 
+(deftest ^:parallel add-field-implicit-join-test
   (testing "adding implicit join fields"
     (let [query            (lib/query meta/metadata-provider (meta/table-metadata :orders))
           viz-columns      (lib/visible-columns query)

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -1056,6 +1056,12 @@
           implied-query    (lib/add-field query -1 (first implicit-columns))]
       (is (= (map #(dissoc % :selected?) table-columns)
              (lib/returned-columns query)))
+
+      (testing "attaching the implicitly joined field should alter the query"
+        (is (not= query implied-query))
+        (is (nil? (lib.equality/find-matching-ref (first implicit-columns)
+                                                  (map lib/ref (lib/returned-columns query))))))
+
       (testing "with no :fields set does nothing"
         (is (=? query
                 (lib/remove-field query -1 (first implicit-columns)))))

--- a/test/metabase/lib/metadata/calculation_test.cljc
+++ b/test/metabase/lib/metadata/calculation_test.cljc
@@ -7,6 +7,7 @@
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
+   [metabase.lib.util :as lib.util]
    [metabase.util :as u]
    [metabase.util.malli :as mu]))
 
@@ -142,3 +143,59 @@
         (testing "are not included by returned-columns"
           (is (=? (sort-by (juxt :name :id) own-fields)
                   (sort-by (juxt :name :id) (lib.metadata.calculation/returned-columns query)))))))))
+
+(deftest ^:parallel self-join-visible-columns-test
+  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                  (lib/with-fields (for [field [:id :tax]]
+                                     (lib/ref (meta/field-metadata :orders field))))
+                  (lib/join (-> (lib/join-clause (meta/table-metadata :orders)
+                                                 [(lib/= (meta/field-metadata :orders :id)
+                                                         (meta/field-metadata :orders :id))])
+                                (lib/with-join-fields (for [field [:id :tax]]
+                                                        (lib/ref (meta/field-metadata :orders field)))))))
+        orders-cols (for [field-name ["ID" "USER_ID" "PRODUCT_ID" "SUBTOTAL" "TAX"
+                                      "TOTAL" "DISCOUNT" "CREATED_AT" "QUANTITY"]]
+                      {:name field-name
+                       :lib/desired-column-alias field-name
+                       :lib/source :source/table-defaults})
+        joined-cols (for [field-name ["ID" "USER_ID" "PRODUCT_ID" "SUBTOTAL" "TAX"
+                                      "TOTAL" "DISCOUNT" "CREATED_AT" "QUANTITY"]]
+                      {:name field-name
+                       :lib/desired-column-alias (str "Orders__" field-name)
+                       :lib/source :source/joins})]
+    (testing "just own columns"
+      (is (=? (concat orders-cols joined-cols)
+              (lib/visible-columns query -1 (lib.util/query-stage query -1) {:include-implicitly-joinable? false}))))
+    (testing "with implicit joins"
+      (is (=? (concat orders-cols
+                      joined-cols
+                      (sort-by :position
+                               (for [field (meta/fields :people)]
+                                 (meta/field-metadata :people field)))
+                      (sort-by :position
+                               (for [field (meta/fields :products)]
+                                 (meta/field-metadata :products field))))
+              (lib/visible-columns query -1 (lib.util/query-stage query -1)))))))
+
+(comment
+  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                  (lib/with-fields (for [field [:id :tax]]
+                                     (lib/ref (meta/field-metadata :orders field))))
+                  (lib/join (-> (lib/join-clause (meta/table-metadata :orders)
+                                                 [(lib/= (meta/field-metadata :orders :id)
+                                                         (meta/field-metadata :orders :id))])
+                                (lib/with-join-fields (for [field [:id :tax]]
+                                                        (lib/ref (meta/field-metadata :orders field)))))))
+        orders-cols (for [field-name ["ID" "USER_ID" "PRODUCT_ID" "SUBTOTAL" "TAX"
+                                      "TOTAL" "DISCOUNT" "CREATED_AT" "QUANTITY"]]
+                      {:name field-name
+                       :lib/desired-column-alias field-name
+                       :lib/source :source/table-defaults})
+        joined-cols (for [field-name ["ID" "USER_ID" "PRODUCT_ID" "SUBTOTAL" "TAX"
+                                      "TOTAL" "DISCOUNT" "CREATED_AT" "QUANTITY"]]
+                      {:name field-name
+                       :lib/desired-column-alias (str "Orders__" field-name)
+                       :lib/source :source/joins})]
+    (.-length (metabase.lib.js/visible-columns query -1))
+    )
+  )

--- a/test/metabase/lib/metadata/calculation_test.cljc
+++ b/test/metabase/lib/metadata/calculation_test.cljc
@@ -169,6 +169,14 @@
     (testing "with implicit joins"
       (is (=? (concat orders-cols
                       joined-cols
+                      ;; First set of implicit joins
+                      (sort-by :position
+                               (for [field (meta/fields :people)]
+                                 (meta/field-metadata :people field)))
+                      (sort-by :position
+                               (for [field (meta/fields :products)]
+                                 (meta/field-metadata :products field)))
+                      ;; Second set of implicit joins
                       (sort-by :position
                                (for [field (meta/fields :people)]
                                  (meta/field-metadata :people field)))

--- a/test/metabase/lib/metadata/calculation_test.cljc
+++ b/test/metabase/lib/metadata/calculation_test.cljc
@@ -184,26 +184,3 @@
                                (for [field (meta/fields :products)]
                                  (meta/field-metadata :products field))))
               (lib/visible-columns query -1 (lib.util/query-stage query -1)))))))
-
-(comment
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
-                  (lib/with-fields (for [field [:id :tax]]
-                                     (lib/ref (meta/field-metadata :orders field))))
-                  (lib/join (-> (lib/join-clause (meta/table-metadata :orders)
-                                                 [(lib/= (meta/field-metadata :orders :id)
-                                                         (meta/field-metadata :orders :id))])
-                                (lib/with-join-fields (for [field [:id :tax]]
-                                                        (lib/ref (meta/field-metadata :orders field)))))))
-        orders-cols (for [field-name ["ID" "USER_ID" "PRODUCT_ID" "SUBTOTAL" "TAX"
-                                      "TOTAL" "DISCOUNT" "CREATED_AT" "QUANTITY"]]
-                      {:name field-name
-                       :lib/desired-column-alias field-name
-                       :lib/source :source/table-defaults})
-        joined-cols (for [field-name ["ID" "USER_ID" "PRODUCT_ID" "SUBTOTAL" "TAX"
-                                      "TOTAL" "DISCOUNT" "CREATED_AT" "QUANTITY"]]
-                      {:name field-name
-                       :lib/desired-column-alias (str "Orders__" field-name)
-                       :lib/source :source/joins})]
-    (.-length (metabase.lib.js/visible-columns query -1))
-    )
-  )

--- a/test/metabase/lib/test_util.cljc
+++ b/test/metabase/lib/test_util.cljc
@@ -159,6 +159,13 @@
                     (lib/with-join-fields [(-> (meta/field-metadata :categories :name)
                                                (lib/with-join-alias "Cat"))])))))
 
+(def query-with-self-join
+  "A query against `ORDERS` joined to `ORDERS` by ID."
+  (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+      (lib/join (lib/join-clause (meta/table-metadata :orders)
+                                 [(lib/= (lib/ref (meta/field-metadata :orders :id))
+                                         (lib/ref (meta/field-metadata :orders :id)))]))))
+
 (def query-with-expression
   "A query with an expression."
   (-> venues-query


### PR DESCRIPTION
Unskips the handful of e2e tests for #32373 that weren't working.

Fixes #32373.

