### PR TITLE
Lazy load EntityForm

### DIFF
--- a/frontend/src/metabase/entities/containers/EntityForm.jsx
+++ b/frontend/src/metabase/entities/containers/EntityForm.jsx
@@ -22,6 +22,7 @@ const EForm = ({
   resumedValues,
   ...props
 }) => {
+  // custom lazy loading to prevent circular deps problem
   const FormikForm = require("metabase/containers/FormikForm").default;
   const initialValues =
     typeof entityObject?.getPlainObject === "function"

--- a/frontend/src/metabase/entities/containers/EntityForm.jsx
+++ b/frontend/src/metabase/entities/containers/EntityForm.jsx
@@ -1,12 +1,9 @@
 /* eslint-disable react/prop-types */
-import { Component, lazy, Suspense } from "react";
+import { Component } from "react";
 import { t } from "ttag";
 
 import ModalContent from "metabase/components/ModalContent";
-import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
-
 import entityType from "./EntityType";
-const Form = lazy(() => import("metabase/containers/FormikForm"));
 
 export function getForm(entityDef) {
   // 1. default `form`
@@ -25,20 +22,19 @@ const EForm = ({
   resumedValues,
   ...props
 }) => {
+  const FormikForm = require("metabase/containers/FormikForm").default;
   const initialValues =
     typeof entityObject?.getPlainObject === "function"
       ? entityObject.getPlainObject()
       : entityObject;
   return (
-    <Suspense fallback={<LoadingAndErrorWrapper loading />}>
-      <Form
-        {...props}
-        form={form}
-        initialValues={{ ...initialValues, ...resumedValues }}
-        onSubmit={onSubmit}
-        onSubmitSuccess={action => onSaved && onSaved(action.payload.object)}
-      />
-    </Suspense>
+    <FormikForm
+      {...props}
+      form={form}
+      initialValues={{ ...initialValues, ...resumedValues }}
+      onSubmit={onSubmit}
+      onSubmitSuccess={action => onSaved && onSaved(action.payload.object)}
+    />
   );
 };
 

--- a/frontend/src/metabase/entities/containers/EntityForm.jsx
+++ b/frontend/src/metabase/entities/containers/EntityForm.jsx
@@ -1,11 +1,12 @@
 /* eslint-disable react/prop-types */
-import { Component } from "react";
+import { Component, lazy, Suspense } from "react";
 import { t } from "ttag";
 
-import Form from "metabase/containers/FormikForm";
 import ModalContent from "metabase/components/ModalContent";
+import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
 import entityType from "./EntityType";
+const Form = lazy(() => import("metabase/containers/FormikForm"));
 
 export function getForm(entityDef) {
   // 1. default `form`
@@ -29,13 +30,15 @@ const EForm = ({
       ? entityObject.getPlainObject()
       : entityObject;
   return (
-    <Form
-      {...props}
-      form={form}
-      initialValues={{ ...initialValues, ...resumedValues }}
-      onSubmit={onSubmit}
-      onSubmitSuccess={action => onSaved && onSaved(action.payload.object)}
-    />
+    <Suspense fallback={<LoadingAndErrorWrapper loading />}>
+      <Form
+        {...props}
+        form={form}
+        initialValues={{ ...initialValues, ...resumedValues }}
+        onSubmit={onSubmit}
+        onSubmitSuccess={action => onSaved && onSaved(action.payload.object)}
+      />
+    </Suspense>
   );
 };
 


### PR DESCRIPTION
related to https://github.com/metabase/metabase/issues/26178

Related to the circulal deps [RFC](https://www.notion.so/metabase/62-Prevent-circular-dependencies-a35135e3f0e445dc83c5a0dfc77d5d1a)

### Description

EntityForm collection is the reason of one of the existing circular deps problem:

**Entity** -> EntityForm -> Form -> FormWidget -> CollectionFormWidget -> Collection -> **Entity**

lazy loading helps with initialization as first Entity will be initialized at the moment of second Entity loading, but I used delayed `require` based on the feedback

<details><summary>Stacktrace before this change</summary>
<p>

```
at Object.get [as default] (frontend/src/metabase/entities/collections/index.ts:10:25)
      at Object.NormalCollections (frontend/src/metabase/entities/snippet-collections.js:22:5)
      at Object.<anonymous> (frontend/src/metabase/containers/SnippetCollectionName.tsx:3:1)
      at Object.<anonymous> (frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx:13:1)
      at Object.<anonymous> (frontend/src/metabase/collections/containers/FormCollectionPicker/index.ts:2:1)
      at Object.<anonymous> (frontend/src/metabase/collections/components/CreateCollectionForm/CreateCollectionForm.tsx:25:1)
      at Object.<anonymous> (frontend/src/metabase/collections/components/CreateCollectionForm/index.ts:1:1)
      at Object.<anonymous> (frontend/src/metabase/collections/containers/CreateCollectionModal.tsx:15:1)
      at Object.<anonymous> (frontend/src/metabase/containers/CreateCollectionOnTheGo.tsx:8:1)
      at Object.<anonymous> (frontend/src/metabase/containers/CollectionPicker.jsx:4:1)
      at Object.<anonymous> (frontend/src/metabase/containers/CollectionSelect.jsx:4:1)
      at Object.<anonymous> (frontend/src/metabase/components/form/widgets/FormCollectionWidget.jsx:2:1)
      at Object.<anonymous> (frontend/src/metabase/components/form/FormWidget.jsx:18:1)
      at Object.<anonymous> (frontend/src/metabase/components/form/FormikCustomForm/CustomFormField.tsx:7:1)
      at Object.<anonymous> (frontend/src/metabase/components/form/FormikCustomForm/index.ts:1:1)
      at Object.<anonymous> (frontend/src/metabase/containers/FormikForm/FormView.tsx:4:1)
      at Object.<anonymous> (frontend/src/metabase/containers/FormikForm/FormikFormViewAdapter.tsx:13:1)
      at Object.<anonymous> (frontend/src/metabase/containers/FormikForm/FormikForm.tsx:24:1)
      at Object.<anonymous> (frontend/src/metabase/containers/FormikForm/index.ts:1:1)
      at Object.<anonymous> (frontend/src/metabase/entities/containers/EntityForm.jsx:5:1)
      at Object.<anonymous> (frontend/src/metabase/entities/containers/index.js:5:1)
```

</p>
</details> 

### How to verify

- tests should pass
- manually go to the question and click "duplicate" from the menu
<img width="910" alt="image" src="https://github.com/metabase/metabase/assets/125459446/37cc0b32-f07a-48bd-93fe-aae7409bb045">


### Demo

no changes

### Checklist

~- [ ] Tests have been added/updated to cover changes in this PR~
