### PR TITLE
fix multi-color selection in `ColorRangeSelector`

### DIFF
--- a/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangePopover.tsx
+++ b/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangePopover.tsx
@@ -47,7 +47,9 @@ const ColorSelectorContent = forwardRef(function ColorRangeSelector(
   );
 
   const [value, setValue] = useState(() =>
-    getColorRange(color, colorMapping, isInverted),
+    color === "" // empty string is for multi-color selection
+      ? initialValue
+      : getColorRange(color, colorMapping, isInverted),
   );
 
   const handleColorSelect = useCallback(
@@ -61,13 +63,29 @@ const ColorSelectorContent = forwardRef(function ColorRangeSelector(
     [colorMapping, isInverted, onChange],
   );
 
+  const handleColorRangeSelect = useCallback(
+    (newColorRange: string[]) => {
+      const newValue = isInverted
+        ? [...newColorRange].reverse()
+        : newColorRange;
+
+      setColor("");
+      setValue(newValue);
+      onChange?.(newValue);
+    },
+    [isInverted, onChange],
+  );
+
   const handleToggleInvertedClick = useCallback(() => {
-    const newValue = getColorRange(color, colorMapping, !isInverted);
+    const newValue =
+      color === ""
+        ? [...value].reverse()
+        : getColorRange(color, colorMapping, !isInverted);
 
     setIsInverted(!isInverted);
     setValue(newValue);
     onChange?.(newValue);
-  }, [color, colorMapping, isInverted, onChange]);
+  }, [color, value, colorMapping, isInverted, onChange]);
 
   return (
     <PopoverRoot {...props} ref={ref}>
@@ -84,7 +102,8 @@ const ColorSelectorContent = forwardRef(function ColorRangeSelector(
       <ColorRangeToggle
         value={value}
         isQuantile={isQuantile}
-        onClick={handleToggleInvertedClick}
+        onToggleClick={handleToggleInvertedClick}
+        showToggleButton
       />
       {colorRanges.length > 0 && <PopoverDivider />}
       <PopoverColorRangeList>
@@ -93,7 +112,8 @@ const ColorSelectorContent = forwardRef(function ColorRangeSelector(
             key={index}
             value={range}
             isQuantile={isQuantile}
-            onClick={handleToggleInvertedClick}
+            onToggleClick={handleToggleInvertedClick}
+            onColorRangeSelect={handleColorRangeSelect}
           />
         ))}
       </PopoverColorRangeList>
@@ -126,7 +146,7 @@ const getDefaultColor = (
     } else {
       return selection;
     }
-  }, colors[0]);
+  }, "" as string);
 };
 
 const getDefaultColorMapping = (colors: string[]) => {

--- a/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.unit.spec.tsx
@@ -1,10 +1,19 @@
 import { render, screen } from "@testing-library/react";
 
 import { color } from "metabase/lib/colors";
+
 import ColorRangeSelector from "./ColorRangeSelector";
+import { getColorRangeLabel } from "./ColorRangeToggle";
 
 const DEFAULT_VALUE = [color("white"), color("brand")];
 const DEFAULT_COLORS = [color("brand"), color("summarize"), color("filter")];
+
+const WHITE_COLOR_RANGE = [color("error"), color("white"), color("success")];
+const WARNING_COLOR_RANGE = [
+  color("error"),
+  color("warning"),
+  color("success"),
+];
 
 function setup() {
   const onChange = jest.fn();
@@ -12,6 +21,7 @@ function setup() {
     <ColorRangeSelector
       value={DEFAULT_VALUE}
       colors={DEFAULT_COLORS}
+      colorRanges={[WHITE_COLOR_RANGE, WARNING_COLOR_RANGE]}
       onChange={onChange}
     />,
   );
@@ -34,6 +44,18 @@ describe("ColorRangeSelector", () => {
   });
 
   it("should call `onChange` upon clicking a non-initial range", async () => {
-    expect(1).toBe(1);
+    const { onChange } = setup();
+
+    screen.getByRole("button").click();
+    expect(await screen.findByRole("tooltip")).toBeInTheDocument();
+
+    screen.getByLabelText(getColorRangeLabel(DEFAULT_VALUE)).click();
+    expect(onChange).not.toHaveBeenCalled();
+
+    screen.getByLabelText(getColorRangeLabel(WHITE_COLOR_RANGE)).click();
+    expect(onChange).toHaveBeenCalled();
+
+    screen.getByLabelText(getColorRangeLabel(WARNING_COLOR_RANGE)).click();
+    expect(onChange).toHaveBeenCalled();
   });
 });

--- a/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.unit.spec.tsx
@@ -32,4 +32,8 @@ describe("ColorRangeSelector", () => {
     screen.getByLabelText(color("filter")).click();
     expect(onChange).toHaveBeenCalled();
   });
+
+  it("should call `onChange` upon clicking a non-initial range", async () => {
+    expect(1).toBe(1);
+  });
 });

--- a/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeToggle.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeToggle.styled.tsx
@@ -2,13 +2,15 @@ import styled from "@emotion/styled";
 import ColorRange from "metabase/core/components/ColorRange";
 import Button from "metabase/core/components/Button";
 
+import type { ColorRangeProps } from "../ColorRange/ColorRange";
+
 export const ToggleRoot = styled.div`
   display: flex;
 `;
 
-export const ToggleColorRange = styled(ColorRange)`
+export const ToggleColorRange = styled(ColorRange)<ColorRangeProps>`
   flex: 1 1 auto;
-  cursor: default;
+  cursor: ${props => (props.onSelect ? "pointer" : " default")};
 `;
 
 export const ToggleButton = styled(Button)`

--- a/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeToggle.tsx
+++ b/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeToggle.tsx
@@ -7,18 +7,28 @@ import {
 export interface ColorRangeToggleProps {
   value: string[];
   isQuantile?: boolean;
-  onClick?: () => void;
+  onToggleClick?: () => void;
+  onColorRangeSelect?: (newColorRange: string[]) => void;
+  showToggleButton?: boolean;
 }
 
 const ColorRangeToggle = ({
   value,
   isQuantile,
-  onClick,
+  onToggleClick,
+  onColorRangeSelect,
+  showToggleButton = false,
 }: ColorRangeToggleProps) => {
   return (
     <ToggleRoot>
-      <ToggleColorRange colors={value} isQuantile={isQuantile} />
-      <ToggleButton icon="compare" small onClick={onClick} />
+      <ToggleColorRange
+        colors={value}
+        isQuantile={isQuantile}
+        onSelect={onColorRangeSelect}
+      />
+      {showToggleButton && (
+        <ToggleButton icon="compare" small onClick={onToggleClick} />
+      )}
     </ToggleRoot>
   );
 };

--- a/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeToggle.tsx
+++ b/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeToggle.tsx
@@ -25,6 +25,7 @@ const ColorRangeToggle = ({
         colors={value}
         isQuantile={isQuantile}
         onSelect={onColorRangeSelect}
+        aria-label={getColorRangeLabel(value)}
       />
       {showToggleButton && (
         <ToggleButton icon="compare" small onClick={onToggleClick} />
@@ -35,3 +36,7 @@ const ColorRangeToggle = ({
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default ColorRangeToggle;
+
+export function getColorRangeLabel(value: string[]) {
+  return value.join("-");
+}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/33229

### Description

In https://github.com/metabase/metabase/pull/29480 we accidentally broke the ability to click on and select additional color ranges for conditional table formatting in the `ColorRangeSelector` component. This PR restores that functionality.

### How to verify

1. New -> SQL Query
2. Run the following query
```sql
select 
1 as val
union
select 
6 as val
union
select 
10 as val
```
3. Viz settings -> conditional formatting -> add a rule -> color range
4. Open color picker, confirm you can select individual colors or the two additional ranges, and reversing the range works properly

### Demo

https://github.com/metabase/metabase/assets/37751258/bceded78-7b32-405b-be3e-9139f59612b4

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
