### PR TITLE
Do not offer to delete archived collections

### DIFF
--- a/e2e/test/scenarios/collections/archive.cy.spec.js
+++ b/e2e/test/scenarios/collections/archive.cy.spec.js
@@ -110,8 +110,19 @@ describe("scenarios > collections > archive", () => {
 
     cy.findByTestId("toast-undo").should("not.exist");
 
-    cy.log("test bulk delete");
+    cy.log(
+      "Make sure we don't offer to delete archived collections (metabase#33996)",
+    );
     cy.findByTestId(`archive-item-${COLLECTION_NAME}`)
+      .as("archivedCollection")
+      .findByLabelText("unarchive icon")
+      .should("exist");
+    cy.get("@archivedCollection")
+      .findByLabelText("trash icon")
+      .should("not.exist");
+
+    cy.log("test bulk delete");
+    cy.get("@archivedCollection")
       .findByLabelText("archive-item-swapper")
       .realHover()
       .click();

--- a/frontend/src/metabase/components/ArchivedItem/ArchivedItem.tsx
+++ b/frontend/src/metabase/components/ArchivedItem/ArchivedItem.tsx
@@ -71,7 +71,7 @@ export const ArchivedItem = ({
             />
           </Tooltip>
         )}
-        {onDelete && (
+        {model !== "collection" && onDelete && (
           <Tooltip
             tooltip={t`Delete this ${getTranslatedEntityName(
               model,


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/33996

### Description

We are checking the underlying model type of the archived item, and if it is a "collection" we will simply not even display the trash icon. This will remove the confusion caused by this UI element AND it also removes the error that inevitably shows once someone clicks on that icon, but deleting is not possible.

### How to verify

1. Create a new collection inside "Our analytics"
2. Archive that new collection
3. Visit `/archive`
4. Hover the archived collection and make sure that there is no "trash" icon visible - it should only show "unarchive" icon

### Demo

**Before**
![image](https://github.com/metabase/metabase/assets/31325167/50726367-0081-4335-9660-964de80a212b)

**After**
![image](https://github.com/metabase/metabase/assets/31325167/d8577a8d-5051-44d6-ac6d-6535e66aa1f7)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
