### PR TITLE
Migrate the remaining existing events to the new audit_log API & table

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -31,9 +31,7 @@
    #_{:clj-kondo/ignore [:deprecated-namespace]}
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan2.core :as t2])
-  (:import
-   (java.net URL)))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -3,7 +3,6 @@
    [metabase.events :as events]
    [metabase.models.activity :as activity :refer [Activity]]
    [metabase.models.audit-log :as audit-log]
-   [metabase.models.table :as table]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -48,15 +47,7 @@
 
 (methodical/defmethod events/publish-event! ::metric-event
   [topic object]
-  (let [details-fn  #(select-keys % [:name :description :revision_message])
-        table-id    (:table_id object)
-        database-id (table/table-id->database-id table-id)]
-    (activity/record-activity!
-      :topic       topic
-      :object      object
-      :details-fn  details-fn
-      :database-id database-id
-      :table-id    table-id)))
+  (audit-log/record-event! topic object))
 
 (derive ::pulse-event ::event)
 (derive :event/pulse-create ::pulse-event)
@@ -92,15 +83,7 @@
 
 (methodical/defmethod events/publish-event! ::segment-event
   [topic object]
-  (let [details-fn  #(select-keys % [:name :description :revision_message])
-        table-id    (:table_id object)
-        database-id (table/table-id->database-id table-id)]
-    (activity/record-activity!
-      :topic       topic
-      :object      object
-      :details-fn  details-fn
-      :database-id database-id
-      :table-id    table-id)))
+  (audit-log/record-event! topic object))
 
 (derive ::user-joined-event ::event)
 (derive :event/user-joined ::user-joined-event)

--- a/src/metabase/events/revision.clj
+++ b/src/metabase/events/revision.clj
@@ -22,7 +22,7 @@
                         (get event (keyword (str (u/lower-case-en (name model)) "_id")))
                         (throw (ex-info "Event does not have ID associated with it"
                                         {:mode model, :event event})))
-            user-id (events/object->user-id event)]
+            user-id api/*current-user-id*]
         (revision/push-revision! :entity       model
                                  :id           id
                                  :object       (api/check-404 (t2/select-one model :id id))

--- a/src/metabase/models/audit_log.clj
+++ b/src/metabase/models/audit_log.clj
@@ -62,7 +62,7 @@
   appropriate model namespace.
 
   `object` can also be a map of arbitrary details relavent to the event, which is recorded as-is. If the name and/or ID
-  of a model are also relevant to the event and should be recorded, they can be passed as third and fourth arguments."
+  of a model are also relevant to the event and should be recorded, they can be passed as fourth and fifth arguments."
   ([topic object]
    (record-event! topic object api/*current-user-id*))
 
@@ -84,7 +84,7 @@
                  :model    model-name
                  :model_id model-id
                  :user_id  user-id)
-     ;; TODO: temporarily double-writing to the `activity` table
+     ;; TODO: temporarily double-writing to the `activity` table, delete this in Metabase v48
      (activity/record-activity!
       :topic      topic
       :object     object

--- a/src/metabase/models/audit_log.clj
+++ b/src/metabase/models/audit_log.clj
@@ -64,12 +64,15 @@
   `object` can also be a map of arbitrary details relavent to the event, which is recorded as-is. If the name and/or ID
   of a model are also relevant to the event and should be recorded, they can be passed as third and fourth arguments."
   ([topic object]
-   (record-event! topic object (some-> (t2/model object) name)))
+   (record-event! topic object api/*current-user-id*))
 
-  ([topic object model]
-   (record-event! topic object model (u/id object)))
+  ([topic object user-id]
+   (record-event! topic object user-id (some-> (t2/model object) name)))
 
-  ([topic object model model-id]
+  ([topic object user-id model]
+   (record-event! topic object user-id model (u/id object)))
+
+  ([topic object user-id model model-id]
    (let [unqualified-topic (keyword (name topic))
          model-name        (some-> model name)
          details           (if (t2/model object)
@@ -79,17 +82,17 @@
                  :topic    unqualified-topic
                  :details  details
                  :model    model-name
-                 :model_id model-id)
+                 :model_id model-id
+                 :user_id  user-id)
      ;; TODO: temporarily double-writing to the `activity` table
      (activity/record-activity!
       :topic      topic
       :object     object
       :details-fn (fn [_] details)
-      :user-id    api/*current-user-id*))))
+      :user-id    user-id))))
 
 (t2/define-before-insert :model/AuditLog
   [activity]
   (let [defaults {:timestamp :%now
-                  :details   {}
-                  :user_id   api/*current-user-id*}]
+                  :details   {}}]
     (merge defaults activity)))

--- a/src/metabase/models/metric.clj
+++ b/src/metabase/models/metric.clj
@@ -23,7 +23,9 @@
    [metabase.util.malli.schema :as ms]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
-   [toucan2.tools.hydrate :as t2.hydrate]))
+   [toucan2.tools.hydrate :as t2.hydrate]
+   [metabase.models.audit-log :as audit-log]
+   [metabase.models.table :as table]))
 
 (def Metric
   "Used to be the toucan1 model name defined using [[toucan.models/defmodel]], not it's a reference to the toucan2 model name.
@@ -176,3 +178,15 @@
         serdes/table->path
         serdes/storage-table-path-prefix
         (concat ["metrics" (serdes/storage-leaf-file-name id label)]))))
+
+
+;;; ------------------------------------------------ Audit Log --------------------------------------------------------
+
+(defmethod audit-log/model-details :model/Metric
+  [metric _event-type]
+  (let [table-id (:table_id metric)
+        db-id    (table/table-id->database-id table-id)]
+    (assoc
+     (select-keys metric [:name :description :revision_message])
+     :table-id    table-id
+     :database-id db-id)))

--- a/src/metabase/models/metric.clj
+++ b/src/metabase/models/metric.clj
@@ -13,9 +13,11 @@
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.mbql.util :as mbql.u]
+   [metabase.models.audit-log :as audit-log]
    [metabase.models.interface :as mi]
    [metabase.models.revision :as revision]
    [metabase.models.serialization :as serdes]
+   [metabase.models.table :as table]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
@@ -23,9 +25,7 @@
    [metabase.util.malli.schema :as ms]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
-   [toucan2.tools.hydrate :as t2.hydrate]
-   [metabase.models.audit-log :as audit-log]
-   [metabase.models.table :as table]))
+   [toucan2.tools.hydrate :as t2.hydrate]))
 
 (def Metric
   "Used to be the toucan1 model name defined using [[toucan.models/defmodel]], not it's a reference to the toucan2 model name.
@@ -188,5 +188,5 @@
         db-id    (table/table-id->database-id table-id)]
     (assoc
      (select-keys metric [:name :description :revision_message])
-     :table-id    table-id
-     :database-id db-id)))
+     :table_id    table-id
+     :database_id db-id)))

--- a/src/metabase/models/segment.clj
+++ b/src/metabase/models/segment.clj
@@ -12,9 +12,11 @@
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.mbql.util :as mbql.u]
+   [metabase.models.audit-log :as audit-log]
    [metabase.models.interface :as mi]
    [metabase.models.revision :as revision]
    [metabase.models.serialization :as serdes]
+   [metabase.models.table :as table]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
@@ -168,3 +170,15 @@
         serdes/table->path
         serdes/storage-table-path-prefix
         (concat ["segments" (serdes/storage-leaf-file-name id label)]))))
+
+
+;;; ------------------------------------------------ Audit Log --------------------------------------------------------
+
+(defmethod audit-log/model-details :model/Segment
+  [metric _event-type]
+  (let [table-id (:table_id metric)
+        db-id    (table/table-id->database-id table-id)]
+    (assoc
+     (select-keys metric [:name :description :revision_message])
+     :table_id    table-id
+     :database-id db-id)))

--- a/src/metabase/models/segment.clj
+++ b/src/metabase/models/segment.clj
@@ -181,4 +181,4 @@
     (assoc
      (select-keys metric [:name :description :revision_message])
      :table_id    table-id
-     :database-id db-id)))
+     :database_id db-id)))

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -8,9 +8,7 @@
    [metabase.models.field-values :refer [FieldValues]]
    [metabase.models.humanization :as humanization]
    [metabase.models.interface :as mi]
-   [metabase.models.metric :refer [Metric]]
    [metabase.models.permissions :as perms :refer [Permissions]]
-   [metabase.models.segment :refer [Segment]]
    [metabase.models.serialization :as serdes]
    [metabase.util :as u]
    [methodical.core :as methodical]
@@ -179,7 +177,7 @@
   [tables]
   (with-objects :segments
     (fn [table-ids]
-      (t2/select Segment :table_id [:in table-ids], :archived false, {:order-by [[:name :asc]]}))
+      (t2/select :model/Segment :table_id [:in table-ids], :archived false, {:order-by [[:name :asc]]}))
     tables))
 
 (mi/define-batched-hydration-method with-metrics
@@ -188,7 +186,7 @@
   [tables]
   (with-objects :metrics
     (fn [table-ids]
-      (t2/select Metric :table_id [:in table-ids], :archived false, {:order-by [[:name :asc]]}))
+      (t2/select :model/Metric :table_id [:in table-ids], :archived false, {:order-by [[:name :asc]]}))
     tables))
 
 (defn with-fields

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -10,7 +10,7 @@
    [metabase.driver.h2 :as h2]
    [metabase.events :as events]
    [metabase.http-client :as client]
-   [metabase.models :refer [Activity Database Table User]]
+   [metabase.models :refer [Database Table User]]
    [metabase.models.setting :as setting]
    [metabase.models.setting.cache-test :as setting.cache-test]
    [metabase.public-settings :as public-settings]
@@ -90,13 +90,13 @@
           (testing "Creating a new admin user should set the `admin-email` Setting"
             (is (= email
                    (public-settings/admin-email))))
-          (testing "Should record :user-joined Activity (#12933)"
+          (testing "Should record :user-joined in the Audit Log (#12933)"
             (let [user-id (u/the-id (t2/select-one-pk User :email email))]
               (is (=? {:topic         :user-joined
                        :model_id      user-id
                        :user_id       user-id
-                       :model         "user"}
-                      (t2/select-one Activity :topic "user-joined", :user_id user-id))))))))))
+                       :model         "User"}
+                      (t2/select-one :model/AuditLog :topic "user-joined", :user_id user-id))))))))))
 
 (deftest invite-user-test
   (testing "POST /api/setup"

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -213,147 +213,151 @@
   (testing :metric-create
     (t2.with-temp/with-temp [Metric metric {:table_id (mt/id :venues)}]
       (mt/with-model-cleanup [Activity]
-        (is (= metric
-               (events/publish-event! :event/metric-create metric)))
-        (is (= {:topic       :metric-create
-                :user_id     (mt/user->id :rasta)
-                :model       "metric"
-                :model_id    (:id metric)
-                :database_id (mt/id)
-                :table_id    (mt/id :venues)
-                :details     {:name        (:name metric)
-                              :description (:description metric)}}
-               (activity "metric-create" (:id metric))))))))
+        (mt/with-test-user :rasta
+          (is (= metric
+                 (events/publish-event! :event/metric-create metric)))
+          (is (= {:topic       :metric-create
+                  :user_id     (mt/user->id :rasta)
+                  :model       "Metric"
+                  :model_id    (:id metric)
+                  :details     {:name        (:name metric)
+                                :description (:description metric)
+                                :database_id (mt/id)
+                                :table_id    (mt/id :venues)}}
+                 (event "metric-create" (:id metric)))))))))
 
 (deftest metric-update-event-test
   (testing :metric-update
     (t2.with-temp/with-temp [Metric metric {:table_id (mt/id :venues)}]
       (mt/with-model-cleanup [Activity]
-        (let [event (-> (assoc metric
-                               :actor_id         (mt/user->id :rasta)
-                               :revision_message "update this mofo")
-                        ;; doing this specifically to ensure :actor_id is utilized
-                        (dissoc :creator_id))]
-          (is (= event
-                 (events/publish-event! :event/metric-update event))))
-        (is (= {:topic       :metric-update
-                :user_id     (mt/user->id :rasta)
-                :model       "metric"
-                :model_id    (:id metric)
-                :database_id (mt/id)
-                :table_id    (mt/id :venues)
-                :details     {:name             (:name metric)
-                              :description      (:description metric)
-                              :revision_message "update this mofo"}}
-               (activity "metric-update" (:id metric))))))))
+        (mt/with-test-user :rasta
+         (let [event (-> (assoc metric
+                                :actor_id         (mt/user->id :rasta)
+                                :revision_message "update this mofo")
+                         ;; doing this specifically to ensure :actor_id is utilized
+                         (dissoc :creator_id))]
+           (is (= event
+                  (events/publish-event! :event/metric-update event))))
+         (is (= {:topic       :metric-update
+                 :user_id     (mt/user->id :rasta)
+                 :model       "Metric"
+                 :model_id    (:id metric)
+                 :details     {:name             (:name metric)
+                               :description      (:description metric)
+                               :revision_message "update this mofo"
+                               :database_id (mt/id)
+                               :table_id    (mt/id :venues)}}
+                (event "metric-update" (:id metric)))))))))
 
 (deftest metric-delete-event-test
   (testing :metric-delete
     (t2.with-temp/with-temp [Metric metric {:table_id (mt/id :venues)}]
       (mt/with-model-cleanup [Activity]
-        (let [event (assoc metric
-                           :actor_id         (mt/user->id :rasta)
-                           :revision_message "deleted")]
-          (is (= event
-                 (events/publish-event! :event/metric-delete event))))
-        (is (= {:topic       :metric-delete
-                :user_id     (mt/user->id :rasta)
-                :model       "metric"
-                :model_id    (:id metric)
-                :database_id (mt/id)
-                :table_id    (mt/id :venues)
-                :details     {:name             (:name metric)
-                              :description      (:description metric)
-                              :revision_message "deleted"}}
-               (activity "metric-delete" (:id metric))))))))
+        (mt/with-test-user :rasta
+         (let [event (assoc metric
+                            :actor_id         (mt/user->id :rasta)
+                            :revision_message "deleted")]
+           (is (= event
+                  (events/publish-event! :event/metric-delete event))))
+         (is (= {:topic       :metric-delete
+                 :user_id     (mt/user->id :rasta)
+                 :model       "Metric"
+                 :model_id    (:id metric)
+                 :details     {:name             (:name metric)
+                               :description      (:description metric)
+                               :revision_message "deleted"
+                               :database_id (mt/id)
+                               :table_id    (mt/id :venues)}}
+                (event "metric-delete" (:id metric)))))))))
 
 (deftest pulse-create-event-test
   (testing :pulse-create
     (t2.with-temp/with-temp [Pulse pulse]
       (mt/with-model-cleanup [Activity]
-        (is (= pulse
-               (events/publish-event! :event/pulse-create pulse)))
-        (is (= {:topic       :pulse-create
-                :user_id     (mt/user->id :rasta)
-                :model       "pulse"
-                :model_id    (:id pulse)
-                :database_id nil
-                :table_id    nil
-                :details     {:name (:name pulse)}}
-               (activity "pulse-create" (:id pulse))))))))
+        (mt/with-test-user :rasta
+         (is (= pulse
+                (events/publish-event! :event/pulse-create pulse)))
+         (is (= {:topic       :pulse-create
+                 :user_id     (mt/user->id :rasta)
+                 :model       "Pulse"
+                 :model_id    (:id pulse)
+                 :details     {:name (:name pulse)}}
+                (event "pulse-create" (:id pulse)))))))))
 
 (deftest pulse-delete-event-test
   (testing :pulse-delete
     (t2.with-temp/with-temp [Pulse pulse]
       (mt/with-model-cleanup [Activity]
-        (is (= pulse
-               (events/publish-event! :event/pulse-delete pulse)))
-        (is (= {:topic       :pulse-delete
-                :user_id     (mt/user->id :rasta)
-                :model       "pulse"
-                :model_id    (:id pulse)
-                :database_id nil
-                :table_id    nil
-                :details     {:name (:name pulse)}}
-               (activity "pulse-delete" (:id pulse))))))))
+        (mt/with-test-user :rasta
+         (is (= pulse
+                (events/publish-event! :event/pulse-delete pulse)))
+         (is (= {:topic       :pulse-delete
+                 :user_id     (mt/user->id :rasta)
+                 :model       "Pulse"
+                 :model_id    (:id pulse)
+                 :details     {:name (:name pulse)}}
+                (event "pulse-delete" (:id pulse)))))))))
 
 (deftest segment-create-event-test
   (testing :segment-create
     (t2.with-temp/with-temp [Segment segment]
       (mt/with-model-cleanup [Activity]
-        (is (= segment
-               (events/publish-event! :event/segment-create segment)))
-        (is (= {:topic       :segment-create
-                :user_id     (mt/user->id :rasta)
-                :model       "segment"
-                :model_id    (:id segment)
-                :database_id (mt/id)
-                :table_id    (mt/id :checkins)
-                :details     {:name        (:name segment)
-                              :description (:description segment)}}
-               (activity "segment-create" (:id segment))))))))
+        (mt/with-test-user :rasta
+         (is (= segment
+                 (events/publish-event! :event/segment-create segment)))
+         (is (= {:topic       :segment-create
+                 :user_id     (mt/user->id :rasta)
+                 :model       "Segment"
+                 :model_id    (:id segment)
+                 :details     {:name        (:name segment)
+                               :description (:description segment)
+                               :database_id (mt/id)
+                               :table_id    (mt/id :checkins)}}
+                (event "segment-create" (:id segment)))))))))
 
 (deftest segment-update-event-test
   (testing :segment-update
     (t2.with-temp/with-temp [Segment segment]
       (mt/with-model-cleanup [Activity]
-        (let [event (-> segment
-                        (assoc :actor_id         (mt/user->id :rasta)
-                               :revision_message "update this mofo")
-                        ;; doing this specifically to ensure :actor_id is utilized
-                        (dissoc :creator_id))]
-          (is (= event
-                 (events/publish-event! :event/segment-update event))))
-        (is (= {:topic       :segment-update
-                :user_id     (mt/user->id :rasta)
-                :model       "segment"
-                :model_id    (:id segment)
-                :database_id (mt/id)
-                :table_id    (mt/id :checkins)
-                :details     {:name             (:name segment)
-                              :description      (:description segment)
-                              :revision_message "update this mofo"}}
-               (activity "segment-update" (:id segment))))))))
+        (mt/with-test-user :rasta
+         (let [event (-> segment
+                         (assoc :actor_id         (mt/user->id :rasta)
+                                :revision_message "update this mofo")
+                         ;; doing this specifically to ensure :actor_id is utilized
+                         (dissoc :creator_id))]
+           (is (= event
+                  (events/publish-event! :event/segment-update event))))
+         (is (= {:topic       :segment-update
+                 :user_id     (mt/user->id :rasta)
+                 :model       "Segment"
+                 :model_id    (:id segment)
+                 :details     {:name             (:name segment)
+                               :description      (:description segment)
+                               :revision_message "update this mofo"
+                               :database_id (mt/id)
+                               :table_id    (mt/id :checkins)}}
+                (event "segment-update" (:id segment)))))))))
 
 (deftest segment-delete-event-test
   (testing :segment-delete
     (t2.with-temp/with-temp [Segment segment]
       (mt/with-model-cleanup [Activity]
-        (let [event (assoc segment
-                             :actor_id         (mt/user->id :rasta)
-                             :revision_message "deleted")]
-          (is (= event
-                 (events/publish-event! :event/segment-delete event))))
-        (is (= {:topic       :segment-delete
-                :user_id     (mt/user->id :rasta)
-                :model       "segment"
-                :model_id    (:id segment)
-                :database_id (mt/id)
-                :table_id    (mt/id :checkins)
-                :details     {:name             (:name segment)
-                              :description      (:description segment)
-                              :revision_message "deleted"}}
-               (activity "segment-delete" (:id segment))))))))
+        (mt/with-test-user :rasta
+         (let [event (assoc segment
+                              :actor_id         (mt/user->id :rasta)
+                              :revision_message "deleted")]
+           (is (= event
+                  (events/publish-event! :event/segment-delete event))))
+         (is (= {:topic       :segment-delete
+                 :user_id     (mt/user->id :rasta)
+                 :model       "Segment"
+                 :model_id    (:id segment)
+                 :details     {:name             (:name segment)
+                               :description      (:description segment)
+                               :revision_message "deleted"
+                               :database_id (mt/id)
+                               :table_id    (mt/id :checkins)}}
+                (event "segment-delete" (:id segment)))))))))
 
 (deftest user-joined-event-test
   (testing :user-joined
@@ -364,9 +368,7 @@
                (events/publish-event! :event/user-joined event))))
       (is (= {:topic       :user-joined
               :user_id     (mt/user->id :rasta)
-              :model       "user"
+              :model       "User"
               :model_id    (mt/user->id :rasta)
-              :database_id nil
-              :table_id    nil
               :details     {}}
-             (activity "user-joined" (mt/user->id :rasta)))))))
+             (event "user-joined" (mt/user->id :rasta)))))))

--- a/test/metabase/events/revision_test.clj
+++ b/test/metabase/events/revision_test.clj
@@ -56,31 +56,33 @@
 
 (deftest card-create-test
   (testing :event/card-create
-    (t2.with-temp/with-temp [Card {card-id :id, :as card} (card-properties)]
-      (events/publish-event! :event/card-create card)
-      (is (= {:model        "Card"
-              :model_id     card-id
-              :user_id      (mt/user->id :crowberto)
-              :object       (card->revision-object card)
-              :is_reversion false
-              :is_creation  true}
-             (t2/select-one [Revision :model :model_id :user_id :object :is_reversion :is_creation]
-                            :model       "Card"
-                            :model_id    card-id))))))
+    (mt/with-test-user :crowberto
+     (t2.with-temp/with-temp [Card {card-id :id, :as card} (card-properties)]
+       (events/publish-event! :event/card-create card)
+       (is (= {:model        "Card"
+               :model_id     card-id
+               :user_id      (mt/user->id :crowberto)
+               :object       (card->revision-object card)
+               :is_reversion false
+               :is_creation  true}
+              (t2/select-one [Revision :model :model_id :user_id :object :is_reversion :is_creation]
+                             :model       "Card"
+                             :model_id    card-id)))))))
 
 (deftest card-update-test
   (testing :event/card-update
-    (t2.with-temp/with-temp [Card {card-id :id, :as card} (card-properties)]
-      (events/publish-event! :event/card-update card)
-      (is (= {:model        "Card"
-              :model_id     card-id
-              :user_id      (mt/user->id :crowberto)
-              :object       (card->revision-object card)
-              :is_reversion false
-              :is_creation  false}
-             (t2/select-one [Revision :model :model_id :user_id :object :is_reversion :is_creation]
-                            :model       "Card"
-                            :model_id    card-id))))))
+    (mt/with-test-user :crowberto
+     (t2.with-temp/with-temp [Card {card-id :id, :as card} (card-properties)]
+       (events/publish-event! :event/card-update card)
+       (is (= {:model        "Card"
+               :model_id     card-id
+               :user_id      (mt/user->id :crowberto)
+               :object       (card->revision-object card)
+               :is_reversion false
+               :is_creation  false}
+              (t2/select-one [Revision :model :model_id :user_id :object :is_reversion :is_creation]
+                             :model       "Card"
+                             :model_id    card-id)))))))
 
 (deftest card-update-shoud-not-contains-public-info-test
   (testing :event/card-update
@@ -96,347 +98,354 @@
 
 (deftest dashboard-create-test
   (testing :event/dashboard-create
-    (t2.with-temp/with-temp [Dashboard {dashboard-id :id, :as dashboard}]
-      (events/publish-event! :event/dashboard-create dashboard)
-      (is (= {:model        "Dashboard"
-              :model_id     dashboard-id
-              :user_id      (mt/user->id :rasta)
-              :object       (assoc (dashboard->revision-object dashboard) :cards [])
-              :is_reversion false
-              :is_creation  true}
-             (t2/select-one [Revision :model :model_id :user_id :object :is_reversion :is_creation]
-                            :model "Dashboard"
-                            :model_id dashboard-id))))))
+    (mt/with-test-user :rasta
+     (t2.with-temp/with-temp [Dashboard {dashboard-id :id, :as dashboard}]
+       (events/publish-event! :event/dashboard-create dashboard)
+       (is (= {:model        "Dashboard"
+               :model_id     dashboard-id
+               :user_id      (mt/user->id :rasta)
+               :object       (assoc (dashboard->revision-object dashboard) :cards [])
+               :is_reversion false
+               :is_creation  true}
+              (t2/select-one [Revision :model :model_id :user_id :object :is_reversion :is_creation]
+                             :model "Dashboard"
+                             :model_id dashboard-id)))))))
 
 (deftest dashboard-update-test
   (testing :event/dashboard-update
-    (t2.with-temp/with-temp [Dashboard {dashboard-id :id, :as dashboard}]
-      (events/publish-event! :event/dashboard-update dashboard)
-      (is (= {:model        "Dashboard"
-              :model_id     dashboard-id
-              :user_id      (mt/user->id :rasta)
-              :object       (dashboard->revision-object dashboard)
-              :is_reversion false
-              :is_creation  false}
-             (t2/select-one [Revision :model :model_id :user_id :object :is_reversion :is_creation]
-                            :model    "Dashboard"
-                            :model_id dashboard-id))))))
+    (mt/with-test-user :rasta
+     (t2.with-temp/with-temp [Dashboard {dashboard-id :id, :as dashboard}]
+       (events/publish-event! :event/dashboard-update dashboard)
+       (is (= {:model        "Dashboard"
+               :model_id     dashboard-id
+               :user_id      (mt/user->id :rasta)
+               :object       (dashboard->revision-object dashboard)
+               :is_reversion false
+               :is_creation  false}
+              (t2/select-one [Revision :model :model_id :user_id :object :is_reversion :is_creation]
+                             :model    "Dashboard"
+                             :model_id dashboard-id)))))))
 
 
 (deftest dashboard-update-shoud-not-contains-public-info-test
   (testing :event/dashboard-update
-    (t2.with-temp/with-temp [Dashboard {dashboard-id :id, :as dashboard}]
-      (events/publish-event! :event/dashboard-update dashboard)
+    (mt/with-test-user :rasta
+     (t2.with-temp/with-temp [Dashboard {dashboard-id :id, :as dashboard}]
+       (events/publish-event! :event/dashboard-update dashboard)
 
-      ;; we don't want the public_uuid and made_public_by_id to be recorded in a revision
-      ;; otherwise revert a card to earlier revision might toggle the public sharing settings
-      (is (empty? (set/intersection #{:public_uuid :made_public_by_id}
-                                    (->> (t2/select-one-fn :object Revision
-                                                           :model       "Dashboard"
-                                                           :model_id    dashboard-id)
-                                         keys set)))))))
+       ;; we don't want the public_uuid and made_public_by_id to be recorded in a revision
+       ;; otherwise revert a card to earlier revision might toggle the public sharing settings
+       (is (empty? (set/intersection #{:public_uuid :made_public_by_id}
+                                     (->> (t2/select-one-fn :object Revision
+                                                            :model       "Dashboard"
+                                                            :model_id    dashboard-id)
+                                          keys set))))))))
 (deftest dashboard-add-cards-test
   (testing :event/dashboard-add-cards
-    (t2.with-temp/with-temp [Dashboard     {dashboard-id :id, :as dashboard} {}
-                             Card          {card-id :id}                     (card-properties)
-                             DashboardCard dashcard                          {:card_id card-id, :dashboard_id dashboard-id}]
-      (events/publish-event! :event/dashboard-add-cards {:id        dashboard-id
-                                                         :actor_id  (mt/user->id :rasta)
-                                                         :dashcards [dashcard]})
-      (is (= {:model        "Dashboard"
-              :model_id     dashboard-id
-              :user_id      (mt/user->id :rasta)
-              :object       (assoc (dashboard->revision-object dashboard)
-                                   :cards [(assoc (apply dissoc dashcard @#'dashboard/excluded-columns-for-dashcard-revision) :series [])])
-              :is_reversion false
-              :is_creation  false}
-             (t2/select-one [Revision :model :model_id :user_id :object :is_reversion :is_creation]
-                            :model    "Dashboard"
-                            :model_id dashboard-id))))))
+    (mt/with-test-user :rasta
+     (t2.with-temp/with-temp [Dashboard     {dashboard-id :id, :as dashboard} {}
+                              Card          {card-id :id}                     (card-properties)
+                              DashboardCard dashcard                          {:card_id card-id, :dashboard_id dashboard-id}]
+       (events/publish-event! :event/dashboard-add-cards {:id        dashboard-id
+                                                          :dashcards [dashcard]})
+       (is (= {:model        "Dashboard"
+               :model_id     dashboard-id
+               :user_id      (mt/user->id :rasta)
+               :object       (assoc (dashboard->revision-object dashboard)
+                                    :cards [(assoc (apply dissoc dashcard @#'dashboard/excluded-columns-for-dashcard-revision) :series [])])
+               :is_reversion false
+               :is_creation  false}
+              (t2/select-one [Revision :model :model_id :user_id :object :is_reversion :is_creation]
+                             :model    "Dashboard"
+                             :model_id dashboard-id)))))))
 
 (deftest dashboard-remove-cards-test
   (testing :event/dashboard-remove-cards
-    (t2.with-temp/with-temp [Dashboard     {dashboard-id :id, :as dashboard} {}
-                             Card          {card-id :id}                     (card-properties)
-                             DashboardCard dashcard                          {:card_id card-id, :dashboard_id dashboard-id}]
-      (t2/delete! (t2/table-name DashboardCard), :id (:id dashcard))
-      (events/publish-event! :event/dashboard-remove-cards
-                             {:id        dashboard-id
-                              :actor_id  (mt/user->id :rasta)
-                              :dashcards [dashcard]})
-      (is (= {:model        "Dashboard"
-              :model_id     dashboard-id
-              :user_id      (mt/user->id :rasta)
-              :object       (assoc (dashboard->revision-object dashboard) :cards [])
-              :is_reversion false
-              :is_creation  false}
-             (t2/select-one [Revision :model :model_id :user_id :object :is_reversion :is_creation]
-                            :model    "Dashboard"
-                            :model_id dashboard-id))))))
+    (mt/with-test-user :rasta
+     (t2.with-temp/with-temp [Dashboard     {dashboard-id :id, :as dashboard} {}
+                              Card          {card-id :id}                     (card-properties)
+                              DashboardCard dashcard                          {:card_id card-id, :dashboard_id dashboard-id}]
+       (t2/delete! (t2/table-name DashboardCard), :id (:id dashcard))
+       (events/publish-event! :event/dashboard-remove-cards
+                              {:id        dashboard-id
+                               :dashcards [dashcard]})
+       (is (= {:model        "Dashboard"
+               :model_id     dashboard-id
+               :user_id      (mt/user->id :rasta)
+               :object       (assoc (dashboard->revision-object dashboard) :cards [])
+               :is_reversion false
+               :is_creation  false}
+              (t2/select-one [Revision :model :model_id :user_id :object :is_reversion :is_creation]
+                             :model    "Dashboard"
+                             :model_id dashboard-id)))))))
 
 (deftest dashboard-reposition-cards-test
   (testing :event/dashboard-reposition-cards
-    (t2.with-temp/with-temp [Dashboard     {dashboard-id :id, :as dashboard} {}
-                             Card          {card-id :id}                     (card-properties)
-                             DashboardCard dashcard                          {:card_id card-id, :dashboard_id dashboard-id}]
-      (t2/update! DashboardCard (:id dashcard) {:size_x 3})
-      (events/publish-event! :event/dashboard-reposition-cards
-                             {:id        dashboard-id
-                              :actor_id  (mt/user->id :crowberto)
-                              :dashcards [(assoc dashcard :size_x 4)]})
-      (is (= {:model        "Dashboard"
-              :model_id     dashboard-id
-              :user_id      (mt/user->id :crowberto)
-              :object       (assoc (dashboard->revision-object dashboard) :cards [{:id                    (:id dashcard)
-                                                                                   :card_id               card-id
-                                                                                   :size_x                3
-                                                                                   :size_y                4
-                                                                                   :row                   0
-                                                                                   :col                   0
-                                                                                   :series                []
-                                                                                   :dashboard_tab_id      nil
-                                                                                   :action_id nil
-                                                                                   :parameter_mappings     []
-                                                                                   :visualization_settings {}
-                                                                                   :dashboard_id           dashboard-id}])
-              :is_reversion false
-              :is_creation  false}
-             (t2/select-one [Revision :model :model_id :user_id :object :is_reversion :is_creation]
-                            :model    "Dashboard"
-                            :model_id dashboard-id))))))
+    (mt/with-test-user :crowberto
+     (t2.with-temp/with-temp [Dashboard     {dashboard-id :id, :as dashboard} {}
+                              Card          {card-id :id}                     (card-properties)
+                              DashboardCard dashcard                          {:card_id card-id, :dashboard_id dashboard-id}]
+       (t2/update! DashboardCard (:id dashcard) {:size_x 3})
+       (events/publish-event! :event/dashboard-reposition-cards
+                              {:id        dashboard-id
+                               :dashcards [(assoc dashcard :size_x 4)]})
+       (is (= {:model        "Dashboard"
+               :model_id     dashboard-id
+               :user_id      (mt/user->id :crowberto)
+               :object       (assoc (dashboard->revision-object dashboard) :cards [{:id                    (:id dashcard)
+                                                                                    :card_id               card-id
+                                                                                    :size_x                3
+                                                                                    :size_y                4
+                                                                                    :row                   0
+                                                                                    :col                   0
+                                                                                    :series                []
+                                                                                    :dashboard_tab_id      nil
+                                                                                    :action_id nil
+                                                                                    :parameter_mappings     []
+                                                                                    :visualization_settings {}
+                                                                                    :dashboard_id           dashboard-id}])
+               :is_reversion false
+               :is_creation  false}
+              (t2/select-one [Revision :model :model_id :user_id :object :is_reversion :is_creation]
+                             :model    "Dashboard"
+                             :model_id dashboard-id)))))))
 
 (deftest dashboard-add-tabs-test
   (testing :event/dashboard-add-tabs
-    (t2.with-temp/with-temp
-      [:model/Dashboard     {dashboard-id :id, :as dashboard} {:name "A dashboard"}
-       :model/DashboardTab  {dashtab-id :id}                  {:name         "First tab"
-                                                               :position     0
-                                                               :dashboard_id dashboard-id}]
-      (events/publish-event! :event/dashboard-add-tabs
-                             {:id        dashboard-id
-                              :actor_id  (mt/user->id :rasta)
-                              :tab_ids   [dashtab-id]})
-      (is (= {:model        "Dashboard"
-              :model_id     dashboard-id
-              :user_id      (mt/user->id :rasta)
-              :object       (assoc (dashboard->revision-object dashboard)
-                                   :tabs [{:id           dashtab-id
-                                           :name         "First tab"
-                                           :position     0
-                                           :dashboard_id dashboard-id}])
-              :is_reversion false
-              :is_creation  false}
-             (t2/select-one [Revision :model :model_id :user_id :object :is_reversion :is_creation]
-                            :model    "Dashboard"
-                            :model_id dashboard-id))))))
+    (mt/with-test-user :rasta
+     (t2.with-temp/with-temp
+       [:model/Dashboard     {dashboard-id :id, :as dashboard} {:name "A dashboard"}
+        :model/DashboardTab  {dashtab-id :id}                  {:name         "First tab"
+                                                                :position     0
+                                                                :dashboard_id dashboard-id}]
+       (events/publish-event! :event/dashboard-add-tabs
+                              {:id        dashboard-id
+                               :tab_ids   [dashtab-id]})
+       (is (= {:model        "Dashboard"
+               :model_id     dashboard-id
+               :user_id      (mt/user->id :rasta)
+               :object       (assoc (dashboard->revision-object dashboard)
+                                    :tabs [{:id           dashtab-id
+                                            :name         "First tab"
+                                            :position     0
+                                            :dashboard_id dashboard-id}])
+               :is_reversion false
+               :is_creation  false}
+              (t2/select-one [Revision :model :model_id :user_id :object :is_reversion :is_creation]
+                             :model    "Dashboard"
+                             :model_id dashboard-id)))))))
 
 (deftest dashboard-update-tabs-test
   (testing :event/dashboard-update-tabs
-    (t2.with-temp/with-temp
-      [:model/Dashboard     {dashboard-id :id, :as dashboard} {:name "A dashboard"}
-       :model/DashboardTab  {dashtab-id :id}                  {:name         "First tab"
-                                                               :position     0
-                                                               :dashboard_id dashboard-id}]
-      (t2/update! :model/DashboardTab dashtab-id {:name "New name"})
-      (events/publish-event! :event/dashboard-update-tabs
-                             {:id        dashboard-id
-                              :actor_id  (mt/user->id :rasta)
-                              :tab_ids   [dashtab-id]})
-      (is (= {:model        "Dashboard"
-              :model_id     dashboard-id
-              :user_id      (mt/user->id :rasta)
-              :object       (assoc (dashboard->revision-object dashboard)
-                                   :tabs [{:id           dashtab-id
-                                           :name         "New name"
-                                           :position     0
-                                           :dashboard_id dashboard-id}])
-              :is_reversion false
-              :is_creation  false}
-             (t2/select-one [Revision :model :model_id :user_id :object :is_reversion :is_creation]
-                            :model    "Dashboard"
-                            :model_id dashboard-id))))))
+    (mt/with-test-user :rasta
+     (t2.with-temp/with-temp
+       [:model/Dashboard     {dashboard-id :id, :as dashboard} {:name "A dashboard"}
+        :model/DashboardTab  {dashtab-id :id}                  {:name         "First tab"
+                                                                :position     0
+                                                                :dashboard_id dashboard-id}]
+       (t2/update! :model/DashboardTab dashtab-id {:name "New name"})
+       (events/publish-event! :event/dashboard-update-tabs
+                              {:id        dashboard-id
+                               :tab_ids   [dashtab-id]})
+       (is (= {:model        "Dashboard"
+               :model_id     dashboard-id
+               :user_id      (mt/user->id :rasta)
+               :object       (assoc (dashboard->revision-object dashboard)
+                                    :tabs [{:id           dashtab-id
+                                            :name         "New name"
+                                            :position     0
+                                            :dashboard_id dashboard-id}])
+               :is_reversion false
+               :is_creation  false}
+              (t2/select-one [Revision :model :model_id :user_id :object :is_reversion :is_creation]
+                             :model    "Dashboard"
+                             :model_id dashboard-id)))))))
 
 (deftest dashboard-delete-tabs-test
   (testing :event/dashboard-remove-tabs
-    (t2.with-temp/with-temp
-      [:model/Dashboard     {dashboard-id :id, :as dashboard} {:name "A dashboard"}
-       :model/DashboardTab  {dashtab-id :id}                  {:name         "First tab"
-                                                               :position     0
-                                                               :dashboard_id dashboard-id}]
-      (t2/delete! :model/DashboardTab dashtab-id)
-      (events/publish-event! :event/dashboard-remove-tabs
-                             {:id        dashboard-id
-                              :actor_id  (mt/user->id :rasta)
-                              :tab_ids   [dashtab-id]})
-      (is (= {:model        "Dashboard"
-              :model_id     dashboard-id
-              :user_id      (mt/user->id :rasta)
-              :object       (dashboard->revision-object dashboard)
-              :is_reversion false
-              :is_creation  false}
-             (t2/select-one [Revision :model :model_id :user_id :object :is_reversion :is_creation]
-                            :model    "Dashboard"
-                            :model_id dashboard-id))))))
+    (mt/with-test-user :rasta
+     (t2.with-temp/with-temp
+       [:model/Dashboard     {dashboard-id :id, :as dashboard} {:name "A dashboard"}
+        :model/DashboardTab  {dashtab-id :id}                  {:name         "First tab"
+                                                                :position     0
+                                                                :dashboard_id dashboard-id}]
+       (t2/delete! :model/DashboardTab dashtab-id)
+       (events/publish-event! :event/dashboard-remove-tabs
+                              {:id        dashboard-id
+                               :tab_ids   [dashtab-id]})
+       (is (= {:model        "Dashboard"
+               :model_id     dashboard-id
+               :user_id      (mt/user->id :rasta)
+               :object       (dashboard->revision-object dashboard)
+               :is_reversion false
+               :is_creation  false}
+              (t2/select-one [Revision :model :model_id :user_id :object :is_reversion :is_creation]
+                             :model    "Dashboard"
+                             :model_id dashboard-id)))))))
 
 (deftest metric-create-test
   (testing :event/metric-create
-    (t2.with-temp/with-temp [Database {database-id :id} {}
-                             Table    {:keys [id]}      {:db_id database-id}
-                             Metric   metric            {:table_id id, :definition {:a "b"}}]
-      (events/publish-event! :event/metric-create metric)
-      (let [revision (t2/select-one [Revision :model :user_id :object :is_reversion :is_creation :message]
-                                    :model "Metric"
-                                    :model_id (:id metric))]
-        (is (= {:model        "Metric"
-                :user_id      (mt/user->id :rasta)
-                :object       {:name                    "Toucans in the rainforest"
-                               :description             "Lookin' for a blueberry"
-                               :entity_id               (:entity_id metric)
-                               :how_is_this_calculated  nil
-                               :show_in_getting_started false
-                               :caveats                 nil
-                               :points_of_interest      nil
-                               :archived                false
-                               :creator_id              (mt/user->id :rasta)
-                               :definition              {:a "b"}}
-                :is_reversion false
-                :is_creation  true
-                :message      nil}
-               (assoc revision :object (dissoc (:object revision) :id :table_id))))))))
+    (mt/with-test-user :rasta
+     (t2.with-temp/with-temp [Database {database-id :id} {}
+                              Table    {:keys [id]}      {:db_id database-id}
+                              Metric   metric            {:table_id id, :definition {:a "b"}}]
+       (events/publish-event! :event/metric-create metric)
+       (let [revision (t2/select-one [Revision :model :user_id :object :is_reversion :is_creation :message]
+                                     :model "Metric"
+                                     :model_id (:id metric))]
+         (is (= {:model        "Metric"
+                 :user_id      (mt/user->id :rasta)
+                 :object       {:name                    "Toucans in the rainforest"
+                                :description             "Lookin' for a blueberry"
+                                :entity_id               (:entity_id metric)
+                                :how_is_this_calculated  nil
+                                :show_in_getting_started false
+                                :caveats                 nil
+                                :points_of_interest      nil
+                                :archived                false
+                                :creator_id              (mt/user->id :rasta)
+                                :definition              {:a "b"}}
+                 :is_reversion false
+                 :is_creation  true
+                 :message      nil}
+                (assoc revision :object (dissoc (:object revision) :id :table_id)))))))))
 
 (deftest metric-update-test
   (testing :event/metric-update
-    (t2.with-temp/with-temp [Database {database-id :id} {}
-                             Table    {:keys [id]}      {:db_id database-id}
-                             Metric   metric            {:table_id id, :definition {:a "b"}}]
-      (events/publish-event! :event/metric-update
-                             (assoc metric
-                                    :actor_id         (mt/user->id :crowberto)
-                                    :revision_message "updated"))
-      (let [revision (t2/select-one [Revision :model :user_id :object :is_reversion :is_creation :message]
-                                    :model "Metric"
-                                    :model_id (:id metric))]
-        (is (= {:model        "Metric"
-                :user_id      (mt/user->id :crowberto)
-                :object       {:name                    "Toucans in the rainforest"
-                               :description             "Lookin' for a blueberry"
-                               :entity_id               (:entity_id metric)
-                               :how_is_this_calculated  nil
-                               :show_in_getting_started false
-                               :caveats                 nil
-                               :points_of_interest      nil
-                               :archived                false
-                               :creator_id              (mt/user->id :rasta)
-                               :definition              {:a "b"}}
-                :is_reversion false
-                :is_creation  false
-                :message      "updated"}
-               (assoc revision :object (dissoc (:object revision) :id :table_id))))))))
+    (mt/with-test-user :crowberto
+     (t2.with-temp/with-temp [Database {database-id :id} {}
+                              Table    {:keys [id]}      {:db_id database-id}
+                              Metric   metric            {:table_id id, :definition {:a "b"}}]
+       (events/publish-event! :event/metric-update
+                              (assoc metric
+                                     :revision_message "updated"))
+       (let [revision (t2/select-one [Revision :model :user_id :object :is_reversion :is_creation :message]
+                                     :model "Metric"
+                                     :model_id (:id metric))]
+         (is (= {:model        "Metric"
+                 :user_id      (mt/user->id :crowberto)
+                 :object       {:name                    "Toucans in the rainforest"
+                                :description             "Lookin' for a blueberry"
+                                :entity_id               (:entity_id metric)
+                                :how_is_this_calculated  nil
+                                :show_in_getting_started false
+                                :caveats                 nil
+                                :points_of_interest      nil
+                                :archived                false
+                                :creator_id              (mt/user->id :rasta)
+                                :definition              {:a "b"}}
+                 :is_reversion false
+                 :is_creation  false
+                 :message      "updated"}
+                (assoc revision :object (dissoc (:object revision) :id :table_id)))))))))
 
 (deftest metric-delete-test
   (testing ":metric-delete"
-    (t2.with-temp/with-temp [Database {database-id :id} {}
-                             Table    {:keys [id]}      {:db_id database-id}
-                             Metric   metric            {:table_id id, :definition {:a "b"}, :archived true}]
-      (events/publish-event! :event/metric-delete metric)
-      (let [revision (t2/select-one [Revision :model :user_id :object :is_reversion :is_creation :message]
-                                    :model "Metric"
-                                    :model_id (:id metric))]
-        (is (= {:model        "Metric"
-                :user_id      (mt/user->id :rasta)
-                :object       {:name                    "Toucans in the rainforest"
-                               :description             "Lookin' for a blueberry"
-                               :how_is_this_calculated  nil
-                               :show_in_getting_started false
-                               :caveats                 nil
-                               :entity_id               (:entity_id metric)
-                               :points_of_interest      nil
-                               :archived                true
-                               :creator_id              (mt/user->id :rasta)
-                               :definition              {:a "b"}}
-                :is_reversion false
-                :is_creation  false
-                :message      nil}
-               (assoc revision :object (dissoc (:object revision) :id :table_id))))))))
+    (mt/with-test-user :rasta
+     (t2.with-temp/with-temp [Database {database-id :id} {}
+                              Table    {:keys [id]}      {:db_id database-id}
+                              Metric   metric            {:table_id id, :definition {:a "b"}, :archived true}]
+       (events/publish-event! :event/metric-delete metric)
+       (let [revision (t2/select-one [Revision :model :user_id :object :is_reversion :is_creation :message]
+                                     :model "Metric"
+                                     :model_id (:id metric))]
+         (is (= {:model        "Metric"
+                 :user_id      (mt/user->id :rasta)
+                 :object       {:name                    "Toucans in the rainforest"
+                                :description             "Lookin' for a blueberry"
+                                :how_is_this_calculated  nil
+                                :show_in_getting_started false
+                                :caveats                 nil
+                                :entity_id               (:entity_id metric)
+                                :points_of_interest      nil
+                                :archived                true
+                                :creator_id              (mt/user->id :rasta)
+                                :definition              {:a "b"}}
+                 :is_reversion false
+                 :is_creation  false
+                 :message      nil}
+                (assoc revision :object (dissoc (:object revision) :id :table_id)))))))))
 
 
 (deftest segment-create-test
   (testing :event/segment-create
-    (t2.with-temp/with-temp [Database {database-id :id} {}
-                             Table    {:keys [id]}      {:db_id database-id}
-                             Segment  segment           {:table_id   id
-                                                         :definition {:a "b"}}]
-      (events/publish-event! :event/segment-create segment)
-      (let [revision (-> (t2/select-one Revision :model "Segment", :model_id (:id segment))
-                         (select-keys [:model :user_id :object :is_reversion :is_creation :message]))]
-        (is (= {:model        "Segment"
-                :user_id      (mt/user->id :rasta)
-                :object       {:name                    "Toucans in the rainforest"
-                               :description             "Lookin' for a blueberry"
-                               :show_in_getting_started false
-                               :caveats                 nil
-                               :points_of_interest      nil
-                               :entity_id               (:entity_id segment)
-                               :archived                false
-                               :creator_id              (mt/user->id :rasta)
-                               :definition              {:a "b"}}
-                :is_reversion false
-                :is_creation  true
-                :message      nil}
-               (assoc revision :object (dissoc (:object revision) :id :table_id))))))))
+    (mt/with-test-user :rasta
+     (t2.with-temp/with-temp [Database {database-id :id} {}
+                              Table    {:keys [id]}      {:db_id database-id}
+                              Segment  segment           {:table_id   id
+                                                          :definition {:a "b"}}]
+       (events/publish-event! :event/segment-create segment)
+       (let [revision (-> (t2/select-one Revision :model "Segment", :model_id (:id segment))
+                          (select-keys [:model :user_id :object :is_reversion :is_creation :message]))]
+         (is (= {:model        "Segment"
+                 :user_id      (mt/user->id :rasta)
+                 :object       {:name                    "Toucans in the rainforest"
+                                :description             "Lookin' for a blueberry"
+                                :show_in_getting_started false
+                                :caveats                 nil
+                                :points_of_interest      nil
+                                :entity_id               (:entity_id segment)
+                                :archived                false
+                                :creator_id              (mt/user->id :rasta)
+                                :definition              {:a "b"}}
+                 :is_reversion false
+                 :is_creation  true
+                 :message      nil}
+                (assoc revision :object (dissoc (:object revision) :id :table_id)))))))))
 
 (deftest segment-update-test
   (testing :event/segment-update
-    (t2.with-temp/with-temp [Database {database-id :id} {}
-                             Table    {:keys [id]}      {:db_id database-id}
-                             Segment  segment           {:table_id   id
-                                                         :definition {:a "b"}}]
-      (events/publish-event! :event/segment-update
-                             (assoc segment
-                                    :actor_id         (mt/user->id :crowberto)
-                                    :revision_message "updated"))
-      (is (= {:model        "Segment"
-              :user_id      (mt/user->id :crowberto)
-              :object       {:name                    "Toucans in the rainforest"
-                             :description             "Lookin' for a blueberry"
-                             :show_in_getting_started false
-                             :caveats                 nil
-                             :points_of_interest      nil
-                             :entity_id               (:entity_id segment)
-                             :archived                false
-                             :creator_id              (mt/user->id :rasta)
-                             :definition              {:a "b"}}
-              :is_reversion false
-              :is_creation  false
-              :message      "updated"}
-             (update (t2/select-one [Revision :model :user_id :object :is_reversion :is_creation :message]
-                                    :model "Segment"
-                                    :model_id (:id segment))
-                     :object dissoc :id :table_id))))))
+    (mt/with-test-user :crowberto
+     (t2.with-temp/with-temp [Database {database-id :id} {}
+                              Table    {:keys [id]}      {:db_id database-id}
+                              Segment  segment           {:table_id   id
+                                                          :definition {:a "b"}}]
+       (events/publish-event! :event/segment-update
+                              (assoc segment
+                                     :revision_message "updated"))
+       (is (= {:model        "Segment"
+               :user_id      (mt/user->id :crowberto)
+               :object       {:name                    "Toucans in the rainforest"
+                              :description             "Lookin' for a blueberry"
+                              :show_in_getting_started false
+                              :caveats                 nil
+                              :points_of_interest      nil
+                              :entity_id               (:entity_id segment)
+                              :archived                false
+                              :creator_id              (mt/user->id :rasta)
+                              :definition              {:a "b"}}
+               :is_reversion false
+               :is_creation  false
+               :message      "updated"}
+              (update (t2/select-one [Revision :model :user_id :object :is_reversion :is_creation :message]
+                                     :model "Segment"
+                                     :model_id (:id segment))
+                      :object dissoc :id :table_id)))))))
 
 (deftest segment-delete-test
   (testing :event/segment-delete
-    (t2.with-temp/with-temp [Database {database-id :id} {}
-                             Table    {:keys [id]}      {:db_id database-id}
-                             Segment  segment           {:table_id   id
-                                                         :definition {:a "b"}
-                                                         :archived   true}]
-      (events/publish-event! :event/segment-delete segment)
-      (is (= {:model        "Segment"
-              :user_id      (mt/user->id :rasta)
-              :object       {:name                    "Toucans in the rainforest"
-                             :description             "Lookin' for a blueberry"
-                             :show_in_getting_started false
-                             :caveats                 nil
-                             :points_of_interest      nil
-                             :entity_id               (:entity_id segment)
-                             :archived                true
-                             :creator_id              (mt/user->id :rasta)
-                             :definition              {:a "b"}}
-              :is_reversion false
-              :is_creation  false
-              :message      nil}
-             (update (t2/select-one [Revision :model :user_id :object :is_reversion :is_creation :message]
-                                    :model "Segment"
-                                    :model_id (:id segment))
-                     :object dissoc :id :table_id))))))
+    (mt/with-test-user :rasta
+     (t2.with-temp/with-temp [Database {database-id :id} {}
+                              Table    {:keys [id]}      {:db_id database-id}
+                              Segment  segment           {:table_id   id
+                                                          :definition {:a "b"}
+                                                          :archived   true}]
+       (events/publish-event! :event/segment-delete segment)
+       (is (= {:model        "Segment"
+               :user_id      (mt/user->id :rasta)
+               :object       {:name                    "Toucans in the rainforest"
+                              :description             "Lookin' for a blueberry"
+                              :show_in_getting_started false
+                              :caveats                 nil
+                              :points_of_interest      nil
+                              :entity_id               (:entity_id segment)
+                              :archived                true
+                              :creator_id              (mt/user->id :rasta)
+                              :definition              {:a "b"}}
+               :is_reversion false
+               :is_creation  false
+               :message      nil}
+              (update (t2/select-one [Revision :model :user_id :object :is_reversion :is_creation :message]
+                                     :model "Segment"
+                                     :model_id (:id segment))
+                      :object dissoc :id :table_id)))))))

--- a/test/metabase/models/audit_log_test.clj
+++ b/test/metabase/models/audit_log_test.clj
@@ -22,9 +22,9 @@
                 :details  {:name "Test card"}}
                (t2/select-one :model/AuditLog :model_id card-id)))))
 
-      (testing "Test that `record-event!` succesfully records basic card events with the model specified"
+      (testing "Test that `record-event!` succesfully records basic card events with the user, model, and model ID specified"
         (t2.with-temp/with-temp [:model/Card {card-id :id :as card} {:name "Test card"}]
-          (audit-log/record-event! :event/card-create card :model/Card)
+          (audit-log/record-event! :event/card-create card (mt/user->id :rasta) :model/Card card-id)
           (is (partial=
                {:topic    :card-create
                 :user_id  (mt/user->id :rasta)


### PR DESCRIPTION
Migrates the remaining pre-existing events to the new `audit_log` API which I introduced in https://github.com/metabase/metabase/pull/33953. Also tweaks the API a bit to allow user_id to be passed in as the third (optional) argument.