### PR TITLE
Fix E2E model actions CRUD flake

### DIFF
--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -7,8 +7,6 @@ import {
   restore,
   fillActionQuery,
   createAction,
-  navigationSidebar,
-  openNavigationSidebar,
   resetTestTable,
   resyncDatabase,
   createModelFromTableName,
@@ -182,11 +180,8 @@ describe(
           cy.findByText("Delete").should("not.exist");
         });
 
-      openNavigationSidebar();
-      navigationSidebar().within(() => {
-        cy.icon("ellipsis").click();
-      });
-      popover().findByText("View archive").click();
+      cy.log("Go to the archive");
+      cy.visit("/archive");
 
       getArchiveListItem("Delete Order").within(() => {
         cy.icon("unarchive").click({ force: true });

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -183,16 +183,16 @@ describe(
       cy.log("Go to the archive");
       cy.visit("/archive");
 
-      getArchiveListItem("Delete Order").within(() => {
-        cy.icon("unarchive").click({ force: true });
-      });
+      getArchiveListItem("Delete Order")
+        .icon("unarchive")
+        .click({ force: true });
 
       cy.get("main").within(() => {
         cy.findByText("Items you archive will appear here.");
         cy.findByText("Delete Order").should("not.exist");
       });
 
-      cy.findByRole("button", { name: "Undo" }).click();
+      cy.findByTestId("toast-undo").button("Undo").click();
 
       cy.get("main").within(() => {
         cy.findByText("Items you archive will appear here.").should(

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -188,20 +188,27 @@ describe(
       });
 
       cy.get("main").within(() => {
-        cy.findByText("Delete Order");
+        cy.findByText("Items you archive will appear here.");
+        cy.findByText("Delete Order").should("not.exist");
       });
 
       cy.findByRole("button", { name: "Undo" }).click();
 
       cy.get("main").within(() => {
+        cy.findByText("Items you archive will appear here.").should(
+          "not.exist",
+        );
         cy.findByText("Delete Order").should("be.visible");
       });
 
-      getArchiveListItem("Delete Order").within(() => {
-        cy.icon("trash").click({ force: true });
+      cy.log("Delete the action");
+      getArchiveListItem("Delete Order").icon("trash").click({ force: true });
+
+      cy.get("main").within(() => {
+        cy.findByText("Items you archive will appear here.");
+        cy.findByText("Delete Order").should("not.exist");
       });
 
-      cy.findByTestId("Delete Order").should("not.exist");
       cy.findByRole("button", { name: "Undo" }).should("not.exist");
     });
 

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -208,8 +208,6 @@ describe(
         cy.findByText("Items you archive will appear here.");
         cy.findByText("Delete Order").should("not.exist");
       });
-
-      cy.findByRole("button", { name: "Undo" }).should("not.exist");
     });
 
     it("should allow to create an action with the New button", () => {


### PR DESCRIPTION
The example of a failed run:
https://www.deploysentinel.com/ci/runs/6508ba9d98a3d35cdcdf9230

Honestly, this was never supposed to work. One of the assertions was wrong to begin with.
After we unarchive the action, the assertion was:
```js
cy.get("main").within(() => {
  cy.findByText("Delete Order");
});
```

My guess for why this wasn't failing constantly is just the slow CI.

### The correct behavior:
- after we unarchive the action
- there should be a blank archive page without the "Delete Order" action
- and then when we press "Undo"
- we should see the "Delete Order" action in the archive again

### The fix
It was enough to simply add an intermediary assertion that the archive page is empty and (even more important change) to assert that the action doesn't appear on the page anymore:
```js
cy.get("main").within(() => {
  cy.findByText("Items you archive will appear here.");
  cy.findByText("Delete Order").should("not.exist");
});
```
