### PR TITLE
Adapt the "search" keyboard E2E test

### DIFF
--- a/e2e/test/scenarios/onboarding/search/search.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search.cy.spec.js
@@ -117,7 +117,7 @@ describe("scenarios > search", () => {
       cy.signInAsNormalUser();
       cy.visit("/");
       getSearchBar().type("ord");
-      cy.wait("@search");
+      cy.wait(["@search", "@search"]);
       cy.findAllByTestId("search-result-item-name")
         .first()
         .should("have.text", "Orders");

--- a/e2e/test/scenarios/onboarding/search/search.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search.cy.spec.js
@@ -120,7 +120,8 @@ describe("scenarios > search", () => {
       cy.wait(["@search", "@search"]);
       cy.findAllByTestId("search-result-item-name")
         .first()
-        .should("have.text", "Orders");
+        .should("be.visible")
+        .and("have.text", "Orders");
 
       cy.realPress("ArrowDown");
       cy.realPress("Enter");


### PR DESCRIPTION
Something recently changed in the search wrt debounce, most likely.
Typing even two letters really fast now results in two `GET` requests.

This resulted in a very flaky test, because keyboard navigation is particularly sensitive to re-renders.
An example of a failed run: https://www.deploysentinel.com/ci/runs/650af02a98a3d35cdc5e8629

The source of the flake was most likely a re-render in between these two requests.
We were previously waiting for the first one and then pressing the arrow down.