### PR TITLE
fix stacked tooltip shows only first data point value instead of a sum

### DIFF
--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.js
@@ -350,18 +350,25 @@ export const getStackedTooltipModel = (
   const tooltipRows = seriesWithGroupedData
     .map(series => {
       const { card, groupedData, data } = series;
-      const datum = groupedData?.find(
+      const dataForXValue = groupedData?.filter(
         datum => datum[DIMENSION_INDEX] === xValue,
       );
 
-      if (!datum) {
+      if (dataForXValue.length === 0) {
         return null;
       }
 
-      const value = datum[METRIC_INDEX];
+      const value = dataForXValue.reduce((totalValue, datum) => {
+        const datumValue = datum[METRIC_INDEX];
+        if (totalValue == null && datumValue == null) {
+          return null;
+        }
+        return totalValue + datum[METRIC_INDEX];
+      }, null);
+
       const valueColumn = data.cols[METRIC_INDEX];
 
-      let name = null;
+      let name;
       if (hasBreakout) {
         name = settings.series(series)?.["title"] ?? card.name;
       } else {

--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.unit.spec.js
@@ -260,6 +260,33 @@ describe("getStackedTooltipModel", () => {
       }),
     );
   });
+
+  it("should show sum of a metric for the same X-axis value", () => {
+    const hasBreakout = true;
+    const series = [
+      getMockSeries({
+        card: { id: 1, name: "Series 1", _breakoutColumn: StringColumn() },
+        rows: [
+          ["foo", 100],
+          ["foo", 100],
+        ],
+        hasBreakout,
+      }),
+    ];
+    const datas = getDatas({ series, settings });
+    const { headerRows } = getStackedTooltipModel(
+      series,
+      datas,
+      settings,
+      hoveredIndex,
+      dashboard,
+      xValue,
+    );
+
+    expect(headerRows).toHaveLength(1);
+    expect(headerRows[0].value).toBe(200);
+  });
+
   it("should include breakouts from all cards", () => {
     const cardA = { id: 1, name: "Series 1" };
     const cardB = { id: 2, name: "Series 2" };
@@ -285,6 +312,7 @@ describe("getStackedTooltipModel", () => {
     expect(showTotal).toBe(true);
     expect(showPercentages).toBe(true);
   });
+
   it("should include metrics and breakouts from all cards", () => {
     const cardA = { id: 1, name: "Series 1" };
     const cardB = { id: 2, name: "Series 2" };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/30906

### Description

The stacked tooltip showed incorrect data because it looked only for the first datum for a given X-axis value. This works fine if there are <= 2 groupings. However, when there are more than two, the dataset contains multiple rows with the same X-axis value so we sum values of all of them.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a question from [this](https://github.com/metabase/metabase/issues/30906#issuecomment-1705635618) comment
2. Make it a stacked area
3. Hover 2026
4. Ensure it shows 599k for the basic series

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
