### PR TITLE
Remove extra search API call

### DIFF
--- a/e2e/test/scenarios/onboarding/search/search.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search.cy.spec.js
@@ -117,7 +117,9 @@ describe("scenarios > search", () => {
       cy.signInAsNormalUser();
       cy.visit("/");
       getSearchBar().type("ord");
+
       cy.wait("@search");
+
       cy.findAllByTestId("search-result-item-name")
         .first()
         .should("have.text", "Orders");
@@ -129,6 +131,8 @@ describe("scenarios > search", () => {
         "eq",
         `/question/${ORDERS_QUESTION_ID}-orders`,
       );
+
+      cy.get("@search.all").should("have.length", 1);
     });
   });
 

--- a/e2e/test/scenarios/onboarding/search/search.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search.cy.spec.js
@@ -120,6 +120,7 @@ describe("scenarios > search", () => {
 
       cy.wait("@search");
 
+      cy.findByTestId("app-bar").findByDisplayValue("ord");
       cy.findAllByTestId("search-result-item-name")
         .first()
         .should("have.text", "Orders");

--- a/frontend/src/metabase/nav/components/SearchResults.tsx
+++ b/frontend/src/metabase/nav/components/SearchResults.tsx
@@ -55,7 +55,7 @@ export const SearchResults = ({
   const { data: list = [], isLoading } = useSearchListQuery({
     query,
     reload: true,
-    enabled: !isWaitingForDebounce,
+    enabled: !!debouncedSearchText,
   });
 
   const { reset, getRef, cursorIndex } = useListKeyboardNavigation<

--- a/frontend/src/metabase/nav/components/SearchResults.tsx
+++ b/frontend/src/metabase/nav/components/SearchResults.tsx
@@ -78,7 +78,7 @@ export const SearchResults = ({
   if (isLoading || isWaitingForDebounce) {
     return (
       <Stack p="xl" align="center">
-        <Loader size="lg" />
+        <Loader size="lg" data-testid="loading-spinner" />
         <Text size="xl" color="text.0">
           {t`Loading…`}
         </Text>

--- a/frontend/src/metabase/nav/components/SearchResults.tsx
+++ b/frontend/src/metabase/nav/components/SearchResults.tsx
@@ -35,6 +35,7 @@ export const SearchResults = ({
   const dispatch = useDispatch();
 
   const [debouncedSearchText, setDebouncedSearchText] = useState<string>();
+  const isWaitingForDebounce = searchText !== debouncedSearchText;
 
   useDebounce(
     () => {
@@ -53,7 +54,8 @@ export const SearchResults = ({
 
   const { data: list = [], isLoading } = useSearchListQuery({
     query,
-    reload: true,
+    // reload: true,
+    enabled: !isWaitingForDebounce,
   });
 
   const { reset, getRef, cursorIndex } = useListKeyboardNavigation<
@@ -73,7 +75,7 @@ export const SearchResults = ({
 
   const hasResults = list.length > 0;
 
-  if (isLoading) {
+  if (isLoading || isWaitingForDebounce) {
     return (
       <Stack p="xl" align="center">
         <Loader size="lg" />

--- a/frontend/src/metabase/nav/components/SearchResults.tsx
+++ b/frontend/src/metabase/nav/components/SearchResults.tsx
@@ -54,7 +54,7 @@ export const SearchResults = ({
 
   const { data: list = [], isLoading } = useSearchListQuery({
     query,
-    // reload: true,
+    reload: true,
     enabled: !isWaitingForDebounce,
   });
 

--- a/frontend/src/metabase/nav/components/SearchResults.tsx
+++ b/frontend/src/metabase/nav/components/SearchResults.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { t } from "ttag";
 import { push } from "react-router-redux";
 import { useDebounce } from "react-use";
@@ -34,7 +34,7 @@ export const SearchResults = ({
 }: SearchResultsProps) => {
   const dispatch = useDispatch();
 
-  const [debouncedSearchText, setDebouncedSearchText] = useState(searchText);
+  const [debouncedSearchText, setDebouncedSearchText] = useState<string>();
 
   useDebounce(
     () => {
@@ -44,15 +44,12 @@ export const SearchResults = ({
     [searchText],
   );
 
-  const query = useMemo(
-    () => ({
-      q: debouncedSearchText,
-      limit: DEFAULT_SEARCH_LIMIT,
-      ...searchFilters,
-      models: models ?? searchFilters.type,
-    }),
-    [debouncedSearchText, searchFilters, models],
-  );
+  const query = {
+    q: debouncedSearchText,
+    limit: DEFAULT_SEARCH_LIMIT,
+    ...searchFilters,
+    models: models ?? searchFilters.type,
+  };
 
   const { data: list = [], isLoading } = useSearchListQuery({
     query,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/34001

### Description

Removes extraneous initial call to the search API when we load the `SearchResults` component.

### How to verify

1. Go to the search bar and type something quickly (for example, 'Products')
2. Previously, two calls would have been made: one for `/search?q=P` and `/search?q=Products`. Now, go to the Network tab to verify that there is only one call made

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
