### PR TITLE
[E2E] Fix "back to x-ray model dashboard" navigation flake

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
@@ -21,10 +21,7 @@ import {
   filterWidget,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  ORDERS_QUESTION_ID,
-  ORDERS_DASHBOARD_ID,
-} from "e2e/support/cypress_sample_instance_data";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
@@ -121,22 +118,39 @@ describe("scenarios > dashboard > dashboard back navigation", () => {
     "should display a back to the dashboard button in model x-ray dashboards",
     { tags: "@slow" },
     () => {
-      const cardTitle = "Orders by Subtotal";
-      cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { dataset: true });
-      cy.visit("/auto/dashboard/model/1");
-      cy.wait("@dataset");
+      const modelDetails = {
+        name: "Simple Native Model",
+        native: { query: 'select 1 as "Foo"' },
+        dataset: true,
+      };
 
-      getDashboardCards()
-        .filter(`:contains("${cardTitle}")`)
-        .findByText(cardTitle)
-        .click();
-      cy.wait("@dataset");
+      cy.createNativeQuestion(modelDetails).then(({ body: { id } }) => {
+        const modelUrl = `/auto/dashboard/model/${id}`;
 
-      queryBuilderHeader()
-        .findByLabelText(/Back to .*Orders.*/)
-        .click();
+        cy.visit(modelUrl);
+        cy.log("There will always be just two cards since the model is simple");
+        cy.wait(["@dataset", "@dataset"]);
 
-      getDashboardCards().filter(`:contains("${cardTitle}")`).should("exist");
+        cy.log("Drill through to see the ad-hoc question");
+        cy.findByTestId("scalar-title")
+          .should("have.text", `Total ${modelDetails.name}`)
+          .click();
+
+        cy.log("Make sure we're on the question page");
+        // ad-hoc question format is `/question` followed by hash `#`
+        cy.location("pathname").should("eq", "/question");
+        cy.findByTestId("view-footer").findByText("Showing 1 row");
+        cy.findByTestId("scalar-value").should("have.text", 1);
+
+        cy.log("Go back to the model x-ray dashboard");
+        const labelRegex = new RegExp(`Back to .*${modelDetails.name}`, "i");
+        queryBuilderHeader().findByLabelText(labelRegex).click();
+        cy.location("pathname").should("eq", modelUrl);
+        cy.findByTestId("scalar-title").should(
+          "have.text",
+          `Total ${modelDetails.name}`,
+        );
+      });
     },
   );
 

--- a/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
@@ -114,45 +114,41 @@ describe("scenarios > dashboard > dashboard back navigation", () => {
     },
   );
 
-  it(
-    "should display 'back to the model x-ray dashboard' button after drill-through",
-    { tags: "@slow" },
-    () => {
-      const modelDetails = {
-        name: "Simple Native Model",
-        native: { query: 'select 1 as "Foo"' },
-        dataset: true,
-      };
+  it("should display 'back to the model x-ray dashboard' button after drill-through", () => {
+    const modelDetails = {
+      name: "Simple Native Model",
+      native: { query: 'select 1 as "Foo"' },
+      dataset: true,
+    };
 
-      cy.createNativeQuestion(modelDetails).then(({ body: { id } }) => {
-        const modelUrl = `/auto/dashboard/model/${id}`;
+    cy.createNativeQuestion(modelDetails).then(({ body: { id } }) => {
+      const modelUrl = `/auto/dashboard/model/${id}`;
 
-        cy.visit(modelUrl);
-        cy.log("There will always be just two cards since the model is simple");
-        cy.wait(["@dataset", "@dataset"]);
+      cy.visit(modelUrl);
+      cy.log("There will always be just two cards since the model is simple");
+      cy.wait(["@dataset", "@dataset"]);
 
-        cy.log("Drill through to see the ad-hoc question");
-        cy.findByTestId("scalar-title")
-          .should("have.text", `Total ${modelDetails.name}`)
-          .click();
+      cy.log("Drill through to see the ad-hoc question");
+      cy.findByTestId("scalar-title")
+        .should("have.text", `Total ${modelDetails.name}`)
+        .click();
 
-        cy.log("Make sure we're on the question page");
-        // ad-hoc question format is `/question` followed by hash `#`
-        cy.location("pathname").should("eq", "/question");
-        cy.findByTestId("view-footer").findByText("Showing 1 row");
-        cy.findByTestId("scalar-value").should("have.text", 1);
+      cy.log("Make sure we're on the question page");
+      // ad-hoc question format is `/question` followed by hash `#`
+      cy.location("pathname").should("eq", "/question");
+      cy.findByTestId("view-footer").findByText("Showing 1 row");
+      cy.findByTestId("scalar-value").should("have.text", 1);
 
-        cy.log("Go back to the model x-ray dashboard");
-        const labelRegex = new RegExp(`Back to .*${modelDetails.name}`, "i");
-        queryBuilderHeader().findByLabelText(labelRegex).click();
-        cy.location("pathname").should("eq", modelUrl);
-        cy.findByTestId("scalar-title").should(
-          "have.text",
-          `Total ${modelDetails.name}`,
-        );
-      });
-    },
-  );
+      cy.log("Go back to the model x-ray dashboard");
+      const labelRegex = new RegExp(`Back to .*${modelDetails.name}`, "i");
+      queryBuilderHeader().findByLabelText(labelRegex).click();
+      cy.location("pathname").should("eq", modelUrl);
+      cy.findByTestId("scalar-title").should(
+        "have.text",
+        `Total ${modelDetails.name}`,
+      );
+    });
+  });
 
   it("should preserve query results when navigating between the dashboard and the query builder", () => {
     createDashboardWithCards();

--- a/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
@@ -115,7 +115,7 @@ describe("scenarios > dashboard > dashboard back navigation", () => {
   );
 
   it(
-    "should display a back to the dashboard button in model x-ray dashboards",
+    "should display 'back to the model x-ray dashboard' button after drill-through",
     { tags: "@slow" },
     () => {
       const modelDetails = {


### PR DESCRIPTION
Fix back to x-ray dashboard flake

No need to load thousands of rows and to rely on overly complicated automagic calculations.
The only thing this test wants to know is whether or not we display "back to dashboard" button.

By simplifying the underlying model, automagic dashboard becomes MUCH simpler.
The test will also be significantly faster as a result of this change.

### Notes:
- This test has historically been very flaky
- Running it on a faster and more powerful runner helped somewhat but it seems that even that wasn't enough
- The test title was somewhat inaccurate - this PR fixes that
- This PR also removes the `@slow` test tag from this test. It should now be safe to run it even on a very slow CI runner, because the test is dead simple and the automagic calculations are not that resource-heavy anymore

All this was achieved without compromising the confidence that the feature is working as expected.