### PR TITLE
Revert `metabase-enterprise.audit-app.permissions-test` to previous version

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
@@ -14,22 +14,20 @@
    [toucan2.core :as t2]))
 
 (deftest permissions-instance-analytics-audit-v2-test
-  (mt/with-temp [PermissionsGroup {group-id :id}                    {}
-                 Database         {database-id :id}                 {}
-                 Table            view-table                        {:db_id database-id :name "v_users"}
-                 Collection       {collection-id :id
-                                   collection-entity-id :entity_id} {}]
-    (with-redefs [audit-db/default-audit-db-id                (constantly database-id)
-                  audit-db/default-audit-collection-entity-id (constantly collection-entity-id)]
-      (testing "Adding instance analytics adds audit db permissions"
-        (update-graph! (assoc-in (graph :clear-revisions? true) [:groups group-id collection-id] :read))
-        (let [new-perms (t2/select-fn-set :object Permissions {:where [:= :group_id group-id]})]
-          (is (= "[group-id collection-id]" (pr-str [group-id collection-id])))
-          (is (= "new-perms"                (pr-str new-perms)))
-          (is (= "view-table"               (pr-str view-table)))
-          (is (contains? new-perms (table-query-path view-table)))))
-      (testing "Unable to update instance analytics to writable"
-        (is (thrown-with-msg?
-             Exception
-             #"Unable to make audit collections writable."
-             (update-graph! (assoc-in (graph :clear-revisions? true) [:groups group-id collection-id] :write))))))))
+  (premium-features-test/with-premium-features #{:audit-app}
+    (mt/with-temp [PermissionsGroup {group-id :id}                    {}
+                   Database         {database-id :id}                 {}
+                   Table            view-table                        {:db_id database-id :name "v_users"}
+                   Collection       {collection-id :id
+                                     collection-entity-id :entity_id} {}]
+      (with-redefs [audit-db/default-audit-db-id                (constantly database-id)
+                    audit-db/default-audit-collection-entity-id (constantly collection-entity-id)]
+        (testing "Adding instance analytics adds audit db permissions"
+          (update-graph! (assoc-in (graph :clear-revisions? true) [:groups group-id collection-id] :read))
+          (let [new-perms (t2/select-fn-set :object Permissions {:where [:= :group_id group-id]})]
+            (is (contains? new-perms (table-query-path view-table)))))
+        (testing "Unable to update instance analytics to writable"
+          (is (thrown-with-msg?
+               Exception
+               #"Unable to make audit collections writable."
+               (update-graph! (assoc-in (graph :clear-revisions? true) [:groups group-id collection-id] :write)))))))))


### PR DESCRIPTION
Reverts changes to test introduced by https://github.com/metabase/metabase/pull/33997