### PR TITLE
Update changelog to include report-timezone-id-if-supported change

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -9,9 +9,9 @@ title: Driver interface changelog
 - The MBQL schema in `metabase.mbql.schema` now uses [Malli](https://github.com/metosin/malli) instead of
   [Schema](https://github.com/plumatic/schema). If you were using this namespace in combination with Schema, you'll
   want to update your code to use Malli instead.
-  
-- The multimethod `metabase.driver/current-user-table-privileges` has been added. This method is used to get 
-  the set of privileges the database connection's current user has. It needs to be implemented if the database 
+
+- The multimethod `metabase.driver/current-user-table-privileges` has been added. This method is used to get
+  the set of privileges the database connection's current user has. It needs to be implemented if the database
   supports the `:actions` feature.
 
 - The following functions in `metabase.query-processor.store` (`qp.store`) are now deprecated
@@ -92,6 +92,10 @@ title: Driver interface changelog
 
 - The multimethod `metabase.driver.sql-jdbc.sync.describe-table/get-table-pks` is changed to return a vector instea
   of a set.
+
+- The function `metabase.query-processor.timezone/report-timezone-id-if-supported` has been updated to take an additional
+  `database` argument for the arity which previously had one argument. This function might be used in the implementation
+  of a driver's multimethods.
 
 ## Metabase 0.46.0
 


### PR DESCRIPTION
This PR updates the driver changelog to include an entry for the change to `report-timezone-id-if-supported` that happened in [this commit](https://github.com/metabase/metabase/commit/ea25b6932fa988ad84214a1ed344c024cd2c4753#diff-26fb8e4d730e48cf504e70deb97d280896bf9d5c6ed1b951d5ccf6fbd5893d53). 

This is just a function in the query-processor namespaces, but it is used by a few drivers so warrants a mention in the changelog notes. This is a weird case where a function from the query processor code is apparently being used in a 3rd party driver implementation, and they just need to update their implementation. A partner driver developer reported that filtering by datetime on their driver isn’t working on 47.0 because it now expects two arguments instead of one.