### PR TITLE
[InteractiveTable] Improve peformance during scrolling

### DIFF
--- a/frontend/src/metabase/visualizations/click-actions/Mode/Mode.ts
+++ b/frontend/src/metabase/visualizations/click-actions/Mode/Mode.ts
@@ -58,6 +58,7 @@ export class Mode {
         clicked?.dimensions,
       );
 
+      // TODO: those calculations are really expensive and should be memoized at some level
       drills = availableDrillThrus
         .flatMap(drill => {
           const drillDisplayInfo = Lib.displayInfo(query, stageIndex, drill);

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -502,7 +502,7 @@ class TableInteractive extends Component {
     }
   };
 
-  cellRenderer = ({ key, style, rowIndex, columnIndex }) => {
+  cellRenderer = ({ key, style, rowIndex, columnIndex, isScrolling }) => {
     const { data, settings } = this.props;
     const { dragColIndex, showDetailShortcut } = this.state;
     const { rows, cols } = data;
@@ -527,7 +527,8 @@ class TableInteractive extends Component {
     );
 
     const isLink = cellData && cellData.type === ExternalLink;
-    const isClickable = !isLink && this.visualizationIsClickable(clicked);
+    const isClickable =
+      !isLink && !isScrolling && this.visualizationIsClickable(clicked);
     const backgroundColor = this.getCellBackgroundColor(
       settings,
       value,


### PR DESCRIPTION
### Description

We run heavy calculations if action is clickable or not during scrolling, what makes rendering slow (less than 30FPS), so it's slow visually. 
Current change actually skips heavy calculations during scrolling

### How to verify

- create a question from `Accounts` with Table visualization type
<img width="950" alt="image" src="https://github.com/metabase/metabase/assets/125459446/35515786-6cc3-403a-bfca-160b406762f1">
- open the question and scroll dragging the scrollbar - you should notice difference in the rendering of cell
- to rely on numbers, open dev tools, press `cmd + shift + p` and type "fps" to show FPS (press enter)
<img width="615" alt="image" src="https://github.com/metabase/metabase/assets/125459446/9b7b8e05-2eae-40e5-9826-aa566b17c43e">
check numbers before the fix and after during scrolling

### Demo

https://www.loom.com/share/64e13e46d4f64332b3a28af917029bc2

### Checklist

~- [ ] Tests have been added/updated to cover changes in this PR~
