### PR TITLE
[backport] Fix 33971: CSV uploads aren't possible when native query editing is disabled

### DIFF
--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -10,7 +10,9 @@ import {
   setTokenFeatures,
 } from "e2e/support/helpers";
 
-import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
+import { WRITABLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
+
+const { NOSQL_GROUP, ALL_USERS_GROUP } = USER_GROUPS;
 
 const FIXTURE_PATH = "../../e2e/support/assets";
 
@@ -203,6 +205,42 @@ describe("permissions", () => {
     cy.findByTestId("collection-menu").within(() => {
       cy.get(".Icon-calendar").should("exist");
       cy.findByLabelText("Upload data").should("not.exist");
+    });
+  });
+
+  it("should show you upload buttons if you have unrestricted access to the upload schema", () => {
+    restore("postgres-12");
+    cy.signInAsAdmin();
+
+    setTokenFeatures("all");
+    enableUploads("postgres");
+
+    cy.updatePermissionsGraph({
+      [ALL_USERS_GROUP]: {
+        [WRITABLE_DB_ID]: {
+          data: {
+            schemas: "block",
+          },
+        },
+      },
+      [NOSQL_GROUP]: {
+        [WRITABLE_DB_ID]: {
+          data: {
+            schemas: "all",
+          },
+        },
+      },
+    });
+
+    cy.updateCollectionGraph({
+      [NOSQL_GROUP]: { root: "write" },
+    });
+
+    cy.signIn("nosql");
+    cy.visit("/collection/root");
+    cy.findByTestId("collection-menu").within(() => {
+      cy.findByLabelText("Upload data").should("exist");
+      cy.findByRole("img", { name: /upload/i }).should("exist");
     });
   });
 });

--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -208,41 +208,45 @@ describe("permissions", () => {
     });
   });
 
-  it("should show you upload buttons if you have unrestricted access to the upload schema", () => {
-    restore("postgres-12");
-    cy.signInAsAdmin();
+  it(
+    "should show you upload buttons if you have unrestricted access to the upload schema",
+    { tags: ["@external"] },
+    () => {
+      restore("postgres-12");
+      cy.signInAsAdmin();
 
-    setTokenFeatures("all");
-    enableUploads("postgres");
+      setTokenFeatures("all");
+      enableUploads("postgres");
 
-    cy.updatePermissionsGraph({
-      [ALL_USERS_GROUP]: {
-        [WRITABLE_DB_ID]: {
-          data: {
-            schemas: "block",
+      cy.updatePermissionsGraph({
+        [ALL_USERS_GROUP]: {
+          [WRITABLE_DB_ID]: {
+            data: {
+              schemas: "block",
+            },
           },
         },
-      },
-      [NOSQL_GROUP]: {
-        [WRITABLE_DB_ID]: {
-          data: {
-            schemas: "all",
+        [NOSQL_GROUP]: {
+          [WRITABLE_DB_ID]: {
+            data: {
+              schemas: "all",
+            },
           },
         },
-      },
-    });
+      });
 
-    cy.updateCollectionGraph({
-      [NOSQL_GROUP]: { root: "write" },
-    });
+      cy.updateCollectionGraph({
+        [NOSQL_GROUP]: { root: "write" },
+      });
 
-    cy.signIn("nosql");
-    cy.visit("/collection/root");
-    cy.findByTestId("collection-menu").within(() => {
-      cy.findByLabelText("Upload data").should("exist");
-      cy.findByRole("img", { name: /upload/i }).should("exist");
-    });
-  });
+      cy.signIn("nosql");
+      cy.visit("/collection/root");
+      cy.findByTestId("collection-menu").within(() => {
+        cy.findByLabelText("Upload data").should("exist");
+        cy.findByRole("img", { name: /upload/i }).should("exist");
+      });
+    },
+  );
 });
 
 function uploadFile(testFile, valid = true) {

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -723,7 +723,7 @@
                     (is (some? (api.card-test/upload-example-csv! nil false)))))))))))))
 
 (deftest get-database-can-upload-test
-  (mt/test-driver (disj (mt/normal-drivers-with-feature :uploads) :mysql) ; MySQL doesn't support schemas
+  (mt/test-drivers (disj (mt/normal-drivers-with-feature :uploads) :mysql) ; MySQL doesn't support schemas
     (mt/with-empty-db
       (let [db-id (u/the-id (mt/db))]
         (testing "GET /api/database and GET /api/database/:id responses should include can_upload depending on unrestricted data access to the upload schema"

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -8,12 +8,14 @@
    [metabase.api.database :as api.database]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
-   [metabase.models :refer [Dashboard DashboardCard Database Field FieldValues Permissions Table]]
+   [metabase.models :refer [Dashboard DashboardCard Database Field FieldValues
+                            Permissions Table]]
    [metabase.models.database :as database]
    [metabase.models.field :as field]
    [metabase.models.permissions :as perms]
    [metabase.models.permissions-group :as perms-group]
    [metabase.public-settings.premium-features-test :as premium-features-test]
+   [metabase.sync :as sync]
    [metabase.sync.concurrent :as sync.concurrent]
    [metabase.test :as mt]
    [metabase.util :as u]
@@ -39,6 +41,7 @@
 (defmacro ^:private with-all-users-data-perms
   "Runs `body` with perms for the All Users group temporarily set to the values in `graph`. Also enables the advanced
   permissions feature flag, and clears the (5 second TTL) cache used for Field permissions, for convenience."
+  {:style/indent 1}
   [graph & body]
   `(do-with-all-user-data-perms ~graph (fn [] ~@body)))
 
@@ -370,7 +373,7 @@
                    (:target (update-target))))))))))
 
 (deftest update-field-test
-  (t2.with-temp/with-temp [Field {field-id :id, table-id :table_id} {:name "Field Test"}]
+  (t2.with-temp/with-temp [Field {field-id :id, table-id :table_id} {:name "Field "}]
     (let [{table-id :id, schema :schema, db-id :db_id} (t2/select-one Table :id table-id)]
       (testing "PUT /api/field/:id"
         (let [endpoint (format "field/%d" field-id)]
@@ -695,21 +698,58 @@
     (mt/with-empty-db
       (let [db-id (u/the-id (mt/db))]
         (testing "Should be blocked without data access"
-          (perms/grant-application-permissions! (perms-group/all-users) :setting)
           ;; Create not_public schema
           (let [details (mt/dbdef->connection-details driver/*driver* :db {:database-name (:name (mt/db))})]
             (jdbc/execute! (sql-jdbc.conn/connection-details->spec driver/*driver* details)
-                           ["CREATE SCHEMA \"not_public\";"])
-            (mt/with-temporary-setting-values [uploads-enabled      true
-                                               uploads-database-id  db-id
-                                               uploads-schema-name  "not_public"
-                                               uploads-table-prefix "uploaded_magic_"]
-              (with-all-users-data-perms {db-id {:data {:native :none, :schemas :none}}}
-                (is (thrown-with-msg?
-                     clojure.lang.ExceptionInfo
-                     #"You don't have permissions to do that\."
-                     (api.card-test/upload-example-csv! nil false))))
-              (with-all-users-data-perms {db-id {:data {:native :none, :schemas ["not_public"]}}}
-                (is
-                 (api.card-test/upload-example-csv! nil false)))))
-          (perms/revoke-application-permissions! (perms-group/all-users) :setting))))))
+                           ["CREATE SCHEMA \"not_public\"; CREATE TABLE \"not_public\".\"table_name\" (id INTEGER)"])
+            (sync/sync-database! (mt/db))
+            (let [table-id (t2/select-one-pk :model/Table :db_id db-id)]
+              (mt/with-temporary-setting-values [uploads-enabled      true
+                                                 uploads-database-id  db-id
+                                                 uploads-schema-name  "not_public"
+                                                 uploads-table-prefix "uploaded_magic_"]
+                (doseq [[schema-perms can-upload?] {:all            true
+                                                    :none           false
+                                                    {table-id :all} false}]
+                  (with-all-users-data-perms {db-id {:data {:native :none, :schemas {"public"     :all
+                                                                                     "not_public" schema-perms}}}}
+                    (if can-upload?
+                      (is (some? (api.card-test/upload-example-csv! nil false)))
+                      (is (thrown-with-msg?
+                           clojure.lang.ExceptionInfo
+                           #"You don't have permissions to do that\."
+                           (api.card-test/upload-example-csv! nil false)))))
+                  (with-all-users-data-perms {db-id {:data {:native :write, :schemas ["not_public"]}}}
+                    (is (some? (api.card-test/upload-example-csv! nil false)))))))))))))
+
+(deftest get-database-can-upload-test
+  (mt/test-driver (disj (mt/normal-drivers-with-feature :uploads) :mysql) ; MySQL doesn't support schemas
+    (mt/with-empty-db
+      (let [db-id (u/the-id (mt/db))]
+        (testing "GET /api/database and GET /api/database/:id responses should include can_upload depending on unrestricted data access to the upload schema"
+          (let [details (mt/dbdef->connection-details driver/*driver* :db {:database-name (:name (mt/db))})]
+            (jdbc/execute! (sql-jdbc.conn/connection-details->spec driver/*driver* details)
+                           ["CREATE SCHEMA \"not_public\"; CREATE TABLE \"not_public\".\"table_name\" (id INTEGER)"])
+            (sync/sync-database! (mt/db))
+            (let [table-id (t2/select-one-pk :model/Table :db_id db-id)]
+              (mt/with-temporary-setting-values [uploads-enabled      true
+                                                 uploads-database-id  db-id
+                                                 uploads-schema-name  "not_public"
+                                                 uploads-table-prefix "uploaded_magic_"]
+                (doseq [[schema-perms can-upload?] {:all            true
+                                                    :none           false
+                                                    {table-id :all} false}]
+                  (testing (format "can_upload should be %s if the user has %s access to the upload schema"
+                                   can-upload? schema-perms)
+                    (with-all-users-data-perms {db-id {:data {:native :none
+                                                              :schemas {"public"     :all
+                                                                        "not_public" schema-perms}}}}
+                      (testing "GET /api/database"
+                        (let [result (->> (mt/user-http-request :rasta :get 200 "database")
+                                          :data
+                                          (filter #(= (:id %) db-id))
+                                          first)]
+                          (is (= can-upload? (:can_upload result)))))
+                      (testing "GET /api/database/:id"
+                          (let [result (mt/user-http-request :rasta :get 200 (format "database/%d" db-id))]
+                            (is (= can-upload? (:can_upload result))))))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/upload_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/upload_test.clj
@@ -10,10 +10,9 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
     (mt/with-temporary-setting-values [uploads-enabled true]
       (met/with-gtaps-for-user :rasta {:gtaps {:venues {}}}
-
         (is (thrown-with-msg? Exception #"Uploads are not permitted for sandboxed users\."
                               (api.card/upload-csv!
-                               1
+                               nil
                                "star_wars.csv"
                                (upload-test/csv-file-with ["id,ship,captain"
                                                            "1,Serenity,Malcolm Reynolds"

--- a/frontend/src/metabase-lib/metadata/Database.ts
+++ b/frontend/src/metabase-lib/metadata/Database.ts
@@ -95,6 +95,10 @@ class Database {
     return this.native_permissions === "write";
   }
 
+  canUpload() {
+    return this.can_upload;
+  }
+
   isPersisted() {
     return this.hasFeature("persist-models-enabled");
   }

--- a/frontend/src/metabase-types/api/database.ts
+++ b/frontend/src/metabase-types/api/database.ts
@@ -48,6 +48,7 @@ export interface Database extends DatabaseData {
   points_of_interest?: string;
   created_at: ISO8601Time;
   updated_at: ISO8601Time;
+  can_upload: boolean;
 
   // Only appears in  GET /api/database/:id
   "can-manage"?: boolean;

--- a/frontend/src/metabase-types/api/mocks/database.ts
+++ b/frontend/src/metabase-types/api/mocks/database.ts
@@ -28,6 +28,7 @@ export const createMockDatabase = (opts?: Partial<Database>): Database => ({
   ...createMockDatabaseData(opts),
   id: 1,
   engine: "H2",
+  can_upload: false,
   is_sample: false,
   is_saved_questions: false,
   created_at: "2015-01-01T20:10:30.200",

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -57,21 +57,20 @@ const itemKeyFn = item => `${item.id}:${item.model}`;
 function mapStateToProps(state, props) {
   const uploadDbId = getSetting(state, "uploads-database-id");
   const uploadsEnabled = getSetting(state, "uploads-enabled");
-  const canAccessUploadsDb =
-    uploadsEnabled &&
+  const canUploadToDb =
     uploadDbId &&
     Databases.selectors
       .getObject(state, {
         entityId: uploadDbId,
       })
-      ?.canWrite();
+      ?.canUpload();
 
   return {
     isAdmin: getUserIsAdmin(state),
     isBookmarked: getIsBookmarked(state, props),
     isNavbarOpen: getIsNavbarOpen(state),
     uploadsEnabled,
-    canAccessUploadsDb,
+    canUploadToDb,
   };
 }
 
@@ -95,7 +94,7 @@ function CollectionContent({
   openNavbar,
   uploadFile,
   uploadsEnabled,
-  canAccessUploadsDb,
+  canUploadToDb,
 }) {
   const [isBookmarked, setIsBookmarked] = useState(false);
   const [selectedItems, setSelectedItems] = useState(null);
@@ -205,8 +204,7 @@ function CollectionContent({
     deleteBookmark(collectionId, "collection");
   };
 
-  const canUpload =
-    uploadsEnabled && canAccessUploadsDb && collection.can_write;
+  const canUpload = uploadsEnabled && canUploadToDb && collection.can_write;
 
   const dropzoneProps = canUpload ? getComposedDragProps(getRootProps()) : {};
 

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -1159,16 +1159,50 @@ saved later when it is ready."
        :num-columns (count (first rows))
        :num-rows    (count (rest rows))})))
 
+(defn- can-upload-error
+  "Returns an ExceptionInfo object if the user cannot upload to the given database and schema. Returns nil otherwise."
+  [db schema-name]
+  (let [driver (driver.u/database->driver db)]
+    (cond
+      (not (public-settings/uploads-enabled))
+      (ex-info (tru "Uploads are not enabled.")
+               {:status-code 422})
+      (premium-features/sandboxed-user?)
+      (ex-info (tru "Uploads are not permitted for sandboxed users.")
+               {:status-code 403})
+      (not (driver/database-supports? driver :uploads nil))
+      (ex-info (tru "Uploads are not supported on {0} databases." (str/capitalize (name driver)))
+               {:status-code 422})
+      (and (str/blank? schema-name)
+           (driver/database-supports? driver :schemas db))
+      (ex-info (tru "A schema has not been set.")
+               {:status-code 422})
+      (not (perms/set-has-full-permissions? @api/*current-user-permissions-set*
+                                            (perms/data-perms-path (u/the-id db) schema-name)))
+      (ex-info (tru "You don''t have permissions to do that.")
+               {:status-code 403})
+      (and (some? schema-name)
+           (not (driver.s/include-schema? db schema-name)))
+      (ex-info (tru "The schema {0} is not syncable." schema-name)
+               {:status-code 422}))))
+
+(defn- check-can-upload
+  "Throws an error if the user cannot upload to the given database and schema."
+  [db schema-name]
+  (when-let [error (can-upload-error db schema-name)]
+    (throw error)))
+
+(defn can-upload?
+  "Returns true if the user can upload to the given database and schema, and false otherwise."
+  [db schema-name]
+  (nil? (can-upload-error db schema-name)))
+
 (defn upload-csv!
   "Main entry point for CSV uploading. Coordinates detecting the schema, inserting it into an appropriate database,
   syncing and scanning the new data, and creating an appropriate model which is then returned. May throw validation or
   DB errors."
   [collection-id filename ^File csv-file]
   {collection-id ms/PositiveInt}
-  (when (not (public-settings/uploads-enabled))
-    (throw (Exception. (tru "Uploads are not enabled."))))
-  (when (premium-features/sandboxed-user?)
-    (throw (Exception. (tru "Uploads are not permitted for sandboxed users."))))
   (collection/check-write-perms-for-collection collection-id)
   (try
     (let [start-time        (System/currentTimeMillis)
@@ -1177,21 +1211,9 @@ saved later when it is ready."
                                 (throw (Exception. (tru "The uploads database does not exist."))))
           driver            (driver.u/database->driver database)
           schema-name       (public-settings/uploads-schema-name)
-          _check-schema     (when (and (str/blank? schema-name)
-                                       (driver/database-supports? driver :schemas database))
-                              (throw (ex-info (tru "A schema has not been set.")
-                                              {:status-code 422})))
-          _check_perms      (api/check-403 (perms/set-has-full-permissions? @api/*current-user-permissions-set*
-                                                                            (perms/data-perms-path db-id schema-name)))
-
-          _check-schema     (when-not (or (nil? schema-name)
-                                          (driver.s/include-schema? database schema-name))
-                              (throw (ex-info (tru "The schema {0} is not syncable." schema-name)
-                                              {:status-code 422})))
+          _                 (check-can-upload database schema-name)
           filename-prefix   (or (second (re-matches #"(.*)\.csv$" filename))
                                 filename)
-          _check-setting    (when-not (driver/database-supports? driver :uploads nil)
-                              (throw (Exception. (tru "Uploads are not supported on {0} databases." (str/capitalize (name driver))))))
           table-name        (->> (str (public-settings/uploads-table-prefix) filename-prefix)
                                  (upload/unique-table-name driver)
                                  (u/lower-case-en))

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -5,6 +5,7 @@
    [compojure.core :refer [DELETE GET POST PUT]]
    [medley.core :as m]
    [metabase.analytics.snowplow :as snowplow]
+   [metabase.api.card :as api.card]
    [metabase.api.common :as api]
    [metabase.api.table :as api.table]
    [metabase.db.connection :as mdb.connection]
@@ -228,6 +229,14 @@
   [db]
   (driver/database-supports? (driver.u/database->driver db) :uploads db))
 
+(defn- add-can-upload-to-dbs
+  "Add an entry to each DB about whether the user can upload to it."
+  [dbs]
+  (let [uploads-db-id (public-settings/uploads-database-id)]
+    (for [db dbs]
+      (assoc db :can_upload (and (= (:id db) uploads-db-id)
+                                 (api.card/can-upload? db (public-settings/uploads-schema-name)))))))
+
 (defn- dbs-list
   [& {:keys [include-tables?
              include-saved-questions-db?
@@ -242,6 +251,7 @@
         filter-by-data-access? (not (or include-editable-data-model? exclude-uneditable-details?))]
     (cond-> (add-native-perms-info dbs)
       include-tables?              add-tables
+      true                         add-can-upload-to-dbs
       include-editable-data-model? filter-databases-by-data-model-perms
       exclude-uneditable-details?  (#(filter mi/can-write? %))
       filter-by-data-access?       (#(filter mi/can-read? %))
@@ -319,6 +329,12 @@
                             ; filter hidden fields
                             (= include "tables.fields") (map #(update % :fields filter-sensitive-fields))))))))
 
+(defn- add-can-upload
+  "Add an entry about whether the user can upload to this DB."
+  [db]
+  (assoc db :can_upload (and (= (u/the-id db) (public-settings/uploads-database-id))
+                             (api.card/can-upload? db (public-settings/uploads-schema-name)))))
+
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema GET "/:id"
   "Get a single Database with `id`. Optionally pass `?include=tables` or `?include=tables.fields` to include the Tables
@@ -341,6 +357,7 @@
       exclude-uneditable-details?  api/write-check
       true                         add-expanded-schedules
       true                         (get-database-hydrate-include include)
+      true                         add-can-upload
       include-editable-data-model? check-db-data-model-perms
       (mi/can-write? database)     (->
                                      secret/expand-db-details-inferred-secret-values

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -121,12 +121,11 @@
         (is (= (-> (db-details)
                    (dissoc :details :schedules))
                (-> (mt/user-http-request :rasta :get 200 (format "database/%d" (mt/id)))
-                   (dissoc :schedules)))))
-
+                   (dissoc :schedules :can_upload)))))
       (testing "Superusers should see DB details"
         (is (= (assoc (db-details) :can-manage true)
                (-> (mt/user-http-request :crowberto :get 200 (format "database/%d" (mt/id)))
-                   (dissoc :schedules))))))
+                   (dissoc :schedules :can_upload))))))))
 
     (mt/with-temp* [Database [db  {:name "My DB", :engine ::test-driver}]
                     Table    [t1  {:name "Table 1", :db_id (:id db)}]
@@ -156,6 +155,17 @@
     (testing "Invalid `?include` should return an error"
       (is (= {:errors {:include "value may be nil, or if non-nil, value must be one of: `tables`, `tables.fields`."}}
              (mt/user-http-request :lucky :get 400 (format "database/%d?include=schemas" (mt/id))))))))
+
+(deftest get-database-can-upload-test
+  (testing "GET /api/database"
+    (t2.with-temp/with-temp [Database {db-id :id} {:engine :postgres :name "The Chosen One"}]
+      (doseq [uploads-enabled? [true false]]
+        (testing (format "The database with uploads enabled for the public schema has can_upload=%s" uploads-enabled?)
+          (mt/with-temporary-setting-values [uploads-enabled uploads-enabled?
+                                             uploads-schema-name "public"
+                                             uploads-database-id db-id]
+            (let [result (mt/user-http-request :crowberto :get 200 (format "database/%d" db-id))]
+              (is (= uploads-enabled? (:can_upload result))))))))))
 
 (deftest get-database-usage-info-test
   (mt/with-temp*
@@ -622,7 +632,8 @@
   (testing "GET /api/database"
     (testing "Test that we can get all the DBs (ordered by name, then driver)"
       (testing "Database details/settings *should not* come back for Rasta since she's not a superuser"
-        (let [expected-keys (-> (into #{:features :native_permissions} (keys (t2/select-one Database :id (mt/id))))
+        (let [expected-keys (-> #{:features :native_permissions :can_upload}
+                                (into (keys (t2/select-one Database :id (mt/id))))
                                 (disj :details))]
           (doseq [db (:data (mt/user-http-request :rasta :get 200 "database"))]
             (testing (format "Database %s %d %s" (:engine db) (u/the-id db) (pr-str (:name db)))
@@ -659,6 +670,19 @@
             (is (= {:data []
                     :total 0}
                    (get-all :rasta "database?include_only_uploadable=true" old-ids)))))))))
+
+(deftest databases-list-can-upload-test
+  (testing "GET /api/database"
+    (let [old-ids (t2/select-pks-set Database)]
+      (t2.with-temp/with-temp [Database {db-id :id} {:engine :postgres :name "The Chosen One"}]
+        (doseq [uploads-enabled? [true false]]
+          (testing (format "The database with uploads enabled for the public schema has can_upload=%s" uploads-enabled?)
+            (mt/with-temporary-setting-values [uploads-enabled uploads-enabled?
+                                               uploads-schema-name "public"
+                                               uploads-database-id db-id]
+              (let [result (get-all :crowberto "database" old-ids)]
+                (is (= (:total result) 1))
+                (is (= uploads-enabled? (-> result :data first :can_upload)))))))))))
 
 (deftest databases-list-include-saved-questions-test
   (testing "GET /api/database?saved=true"

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -125,7 +125,7 @@
       (testing "Superusers should see DB details"
         (is (= (assoc (db-details) :can-manage true)
                (-> (mt/user-http-request :crowberto :get 200 (format "database/%d" (mt/id)))
-                   (dissoc :schedules :can_upload))))))))
+                   (dissoc :schedules :can_upload))))))
 
     (mt/with-temp* [Database [db  {:name "My DB", :engine ::test-driver}]
                     Table    [t1  {:name "Table 1", :db_id (:id db)}]


### PR DESCRIPTION
Backports https://github.com/metabase/metabase/pull/33990

Also backports fixes:
#34073
#34083