### PR TITLE
~~Bump h2~~ inline parameter to fix flaky test

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -40,7 +40,7 @@
   com.fasterxml.jackson.core/jackson-databind
                                             {:mvn/version "2.15.2"}             ; JSON processor used by snowplow-java-tracker
   com.fasterxml.woodstox/woodstox-core      {:mvn/version "6.5.1"}              ; trans dep of commons-codec (pinned version due to CVE-2022-40151)
-  com.h2database/h2                         {:mvn/version "2.1.214"}            ; embedded SQL database
+  com.h2database/h2                         {:mvn/version "2.2.224"}            ; embedded SQL database
   com.gfredericks/test.chuck                {:mvn/version "0.2.14"}             ; generating strings from regex
   com.snowplowanalytics/snowplow-java-tracker
                                             {:mvn/version "1.0.0"               ; Snowplow analytics

--- a/deps.edn
+++ b/deps.edn
@@ -40,7 +40,7 @@
   com.fasterxml.jackson.core/jackson-databind
                                             {:mvn/version "2.15.2"}             ; JSON processor used by snowplow-java-tracker
   com.fasterxml.woodstox/woodstox-core      {:mvn/version "6.5.1"}              ; trans dep of commons-codec (pinned version due to CVE-2022-40151)
-  com.h2database/h2                         {:mvn/version "2.2.224"}            ; embedded SQL database
+  com.h2database/h2                         {:mvn/version "2.1.214"}            ; embedded SQL database
   com.gfredericks/test.chuck                {:mvn/version "0.2.14"}             ; generating strings from regex
   com.snowplowanalytics/snowplow-java-tracker
                                             {:mvn/version "1.0.0"               ; Snowplow analytics

--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/dashboards.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/dashboards.clj
@@ -68,7 +68,7 @@
                                            :where     [:= :vl.model (h2x/literal "dashboard")]
                                            :group-by  [:d.id]
                                            :order-by  [[:%count.* :desc]]
-                                           :limit     10}]
+                                           :limit     [:inline 10]}]
                            [:card_running_time {:select   [:qe.card_id
                                                            [[:avg :qe.running_time] :avg_running_time]]
                                                 :from     [[:query_execution :qe]]


### PR DESCRIPTION
Edit: Some tests failed in other, unrelated drivers. I just reverted the h2 bump and I'm just preventing the `limit 10` in the CTE from being a parameter.

Symptom:
--------

error in linter job:
```
With premium token features = #{"audit-app"}
:metabase-enterprise.audit-app.pages.dashboards/most-popular-with-avg-speed

expected: (schema= {:status (s/eq :completed), s/Keyword s/Any} (qp/process-query query))
  actual: clojure.lang.ExceptionInfo: Error reducing result rows: Error running audit query: Invalid value "NULL" for parameter "result FETCH"; SQL statement:
WITH "MOST_POPULAR" AS (SELECT "D"."ID" AS "DASHBOARD_ID", "D"."NAME" AS "DASHBOARD_NAME", COUNT(*) AS "VIEWS" FROM "VIEW_LOG" AS "VL" LEFT JOIN "REPORT_DASHBOARD" AS "D" ON "VL"."MODEL_ID" = "D"."ID" WHERE "VL"."MODEL" = 'dashboard' GROUP BY "D"."ID" ORDER BY COUNT(*) DESC LIMIT ?), "CARD_RUNNING_TIME" AS (SELECT "QE"."CARD_ID", AVG("QE"."RUNNING_TIME") AS "AVG_RUNNING_TIME" FROM "QUERY_EXECUTION" AS "QE" WHERE "QE"."CARD_ID" IS NOT NULL GROUP BY "QE"."CARD_ID"), "DASH_AVG_RUNNING_TIME" AS (SELECT "D"."ID" AS "DASHBOARD_ID", AVG("RT"."AVG_RUNNING_TIME") AS "AVG_RUNNING_TIME" FROM "REPORT_DASHBOARDCARD" AS "DC" LEFT JOIN "CARD_RUNNING_TIME" AS "RT" ON "DC"."CARD_ID" = "RT"."CARD_ID" LEFT JOIN "REPORT_DASHBOARD" AS "D" ON "DC"."DASHBOARD_ID" = "D"."ID" WHERE "D"."ID" IN (SELECT "DASHBOARD_ID" FROM "MOST_POPULAR") GROUP BY "D"."ID") SELECT "MP"."DASHBOARD_ID", "MP"."DASHBOARD_NAME", "MP"."VIEWS", "RT"."AVG_RUNNING_TIME" FROM "MOST_POPULAR" AS "MP" LEFT JOIN "DASH_AVG_RUNNING_TIME" AS "RT" ON "MP"."DASHBOARD_ID" = "RT"."DASHBOARD_ID" ORDER BY "MP"."VIEWS" DESC LIMIT ? [90008-214]

<stack traces of us catching and rethrowing>
Caused by: org.h2.jdbc.JdbcSQLDataException: Invalid value "NULL" for parameter "result FETCH"; SQL statement:
WITH "MOST_POPULAR" AS (SELECT "D"."ID" AS "DASHBOARD_ID", "D"."NAME" AS "DASHBOARD_NAME", COUNT(*) AS "VIEWS" FROM "VIEW_LOG" AS "VL" LEFT JOIN "REPORT_DASHBOARD" AS "D" ON "VL"."MODEL_ID" = "D"."ID" WHERE "VL"."MODEL" = 'dashboard' GROUP BY "D"."ID" ORDER BY COUNT(*) DESC LIMIT ?), "CARD_RUNNING_TIME" AS (SELECT "QE"."CARD_ID", AVG("QE"."RUNNING_TIME") AS "AVG_RUNNING_TIME" FROM "QUERY_EXECUTION" AS "QE" WHERE "QE"."CARD_ID" IS NOT NULL GROUP BY "QE"."CARD_ID"), "DASH_AVG_RUNNING_TIME" AS (SELECT "D"."ID" AS "DASHBOARD_ID", AVG("RT"."AVG_RUNNING_TIME") AS "AVG_RUNNING_TIME" FROM "REPORT_DASHBOARDCARD" AS "DC" LEFT JOIN "CARD_RUNNING_TIME" AS "RT" ON "DC"."CARD_ID" = "RT"."CARD_ID" LEFT JOIN "REPORT_DASHBOARD" AS "D" ON "DC"."DASHBOARD_ID" = "D"."ID" WHERE "D"."ID" IN (SELECT "DASHBOARD_ID" FROM "MOST_POPULAR") GROUP BY "D"."ID") SELECT "MP"."DASHBOARD_ID", "MP"."DASHBOARD_NAME", "MP"."VIEWS", "RT"."AVG_RUNNING_TIME" FROM "MOST_POPULAR" AS "MP" LEFT JOIN "DASH_AVG_RUNNING_TIME" AS "RT" ON "MP"."DASHBOARD_ID" = "RT"."DASHBOARD_ID" ORDER BY "MP"."VIEWS" DESC LIMIT ? [90008-214]
 at org.h2.message.DbException.getJdbcSQLException (DbException.java:646)
    org.h2.message.DbException.getJdbcSQLException (DbException.java:477)
    org.h2.message.DbException.get (DbException.java:223)
    org.h2.message.DbException.getInvalidValueException (DbException.java:298)
    org.h2.command.query.Query.getOffsetFetch (Query.java:912)
    org.h2.command.query.Select.queryWithoutCache (Select.java:768)
    org.h2.command.query.Query.queryWithoutCacheLazyCheck (Query.java:197)
    org.h2.command.query.Query.query (Query.java:512)
    ...
```

BUT this only causes an issue for tests run under the cloverage linter. It's not an issue under any other test scenarios.

Reproduction:
-------------

I can get the same stack traces with the following:

```clojure
dashboards=> (clojure.java.jdbc/query {:datasource
                                       (:data-source metabase.db.connection/*application-db*)}
                                      ["select 1 limit null"])
Execution error (JdbcSQLDataException) at org.h2.message.DbException/getJdbcSQLException (DbException.java:646).
Invalid value "NULL" for parameter "result FETCH"; SQL statement:
select 1 limit null [90008-214]

dashboards=> (clojure.java.jdbc/query {:datasource
                                       (:data-source metabase.db.connection/*application-db*)}
                                      ["select 1 limit ?" nil])
Execution error (JdbcSQLDataException) at org.h2.message.DbException/getJdbcSQLException (DbException.java:646).
Invalid value "NULL" for parameter "result FETCH"; SQL statement:
select 1 limit ? [90008-214]
```

But with a normal repl, running the test does not error:

```clojure
(deftest all-queries-test
  (mt/with-test-user :crowberto
    (with-temp-objects [objects]
      (premium-features-test/with-premium-features #{:audit-app}
                             ;; limit to just the version
        (doseq [query-type #_(all-query-methods) [:metabase-enterprise.audit-app.pages.dashboards/most-popular-with-avg-speed]]
          (testing query-type
            (do-tests-for-query-type query-type objects)))))))

pages-test=> (clojure.test/run-test all-queries-test)

Testing metabase-enterprise.audit-app.pages-test

Ran 1 tests containing 1 assertions.
0 failures, 0 errors.
{:test 1, :pass 1, :fail 0, :error 0, :type :summary}
```

And even more frustrating, just grabbing the sql and params and calling the same code:

```clojure
common=> (let [driver (mdb/db-type)
               sql check/sql
               params check/params]
           (with-open [conn (.getConnection mdb.connection/*application-db*)
                       stmt (doto (sql-jdbc.execute/prepared-statement driver conn sql params)
                              foo
                              )
                       rs   (sql-jdbc.execute/execute-prepared-statement! driver stmt)]
             (into [] (clojure.java.jdbc/result-set-seq rs))))
[]
```

I can get the test to fail by running the cloverage runner with a socket repl started and then running the test during that instrumented run:

```
clojure -J"$(socket-repl 6000)" -X:dev:ee:ee-dev:test:cloverage
```

But I'm not able to find anything interesting. It's a bug in CTEs with parameters in h2, and it seems that only this query is sensitive.

If I inline the value it works under 2.1.214. And if I bump the version to 2.2.224 it works. So I'm bumping the version.

What's really weird is that when running tests in the cloverage process, the _test_ will still fail, but calling the version on the sql and params with the connection and prepared-statement still succeeds. If it turns out this is not sufficient then we can add `[:inline 10]` around the limit value in the CTE clause in https://github.com/metabase/metabase/blob/master/enterprise/backend/src/metabase_enterprise/audit_app/pages/dashboards.clj#L71