### PR TITLE
Auditv2 dir or zip ia loading

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.core :as c]
    [clojure.java.io :as io]
+   [clojure.java.shell :as sh]
    [metabase-enterprise.internal-user :as ee.internal-user]
    [metabase-enterprise.serialization.cmd :as serialization.cmd]
    [metabase.db.env :as mdb.env]
@@ -54,10 +55,6 @@
                              :creator_id       nil
                              :auto_run_queries true})))))
 
-
-(def analytics-root-dir-resource
-  "Where to look for analytics content created by Metabase to load into the app instance on startup."
-  (io/resource "instance_analytics.zip"))
 
 (defn- adjust-audit-db-to-source!
   [{audit-db-id :id}]
@@ -116,11 +113,35 @@
       ::no-op)))
 
 (defn- map-instance-analytics-files-to-plugins-dir [path]
-  (let [pattern (re-pattern (str ".*" File/separatorChar "(instance_analytics" File/separatorChar ".*)"))]
+  (let [sep File/separatorChar
+        pattern (re-pattern (str ".*" sep "(instance_analytics" sep ".*)"))]
     (->> path
          (re-find pattern)
          second
-         (str "plugins" File/separatorChar))))
+         (str "plugins" sep))))
+
+(def analytics-zip-resource
+  "Where to look for analytics content created by Metabase to load into the app instance on startup."
+  (io/resource "instance_analytics.zip"))
+
+(defn- plug-in-ia-content [zip-resource dir-resource]
+  "Load instance analytics content (collections/dashboards/cards/etc.) from resources dir or a zip file
+   and put it into plugins/instance_analytics"
+  (cond
+    ;; the zip file:
+    zip-resource
+    (do (log/info "Unzipping instance_analytics to plugins...")
+        (u.files/unzip-file
+          analytics-zip-resource
+          map-instance-analytics-files-to-plugins-dir)
+        (log/info "Unzipping done."))
+    ;; the directory in resources
+    dir-resource
+    (do
+      (log/info "Copying resources/instance_analytics to plugins...")
+      ;; TODO use clojure.java.io or fs library?
+      (sh/sh "cp" "-r" "resources/instance_analytics" "plugins")
+      (log/info "Copying done."))))
 
 (defenterprise ensure-audit-db-installed!
   "EE implementation of `ensure-db-installed!`. Also forces an immediate sync on audit-db."
@@ -133,32 +154,21 @@
       (log/info "Beginning Audit DB Sync...")
       (sync-metadata/sync-db-metadata! audit-db)
       (log/info "Audit DB Sync Complete.")
-
-      ;; load instance analytics content (collections/dashboards/cards/etc.) when the resource exists:
-      (when analytics-root-dir-resource
-        ;; prevent sync while loading
-        ((sync-util/with-duplicate-ops-prevented :sync-database audit-db
-           (fn []
-             (ee.internal-user/ensure-internal-user-exists!)
-             (adjust-audit-db-to-source! audit-db)
-             (log/info "Loading Analytics Content...")
-             (log/info "Unzipping instance_analytics to plugins...")
-             (log/info "analytics-root-dir-resource is:"
-                       (pr-str analytics-root-dir-resource)
-                       " | "
-                       analytics-root-dir-resource)
-             (u.files/unzip-file
-               analytics-root-dir-resource
-               map-instance-analytics-files-to-plugins-dir)
-             (log/info "Unzipping done.")
-             (log/info (str "Loading Analytics Content from: " "plugins/instance_analytics"))
-             ;; The EE token might not have :serialization enabled, but audit features should still be able to use it.
-             (let [report (log/with-no-logs
-                            (serialization.cmd/v2-load-internal "plugins/instance_analytics"
-                                                                {}
-                                                                :token-check? false))]
-               (if (not-empty (:errors report))
-                 (log/info (str "Error Loading Analytics Content: " (pr-str report)))
-                 (log/info (str "Loading Analytics Content Complete (" (count (:seen report)) ") entities synchronized."))))
-             (when-let [audit-db (t2/select-one :model/Database :is_audit true)]
-               (adjust-audit-db-to-host! audit-db)))))))))
+      ;; prevent sync while loading
+      ((sync-util/with-duplicate-ops-prevented :sync-database audit-db
+         (fn []
+           (ee.internal-user/ensure-internal-user-exists!)
+           (adjust-audit-db-to-source! audit-db)
+           (log/info "Loading Analytics Content...")
+           (plug-in-ia-content analytics-zip-resource (io/resource "instance_analytics"))
+           (log/info (str "Loading Analytics Content from: plugins/instance_analytics"))
+           ;; The EE token might not have :serialization enabled, but audit features should still be able to use it.
+           (let [report (log/with-no-logs
+                          (serialization.cmd/v2-load-internal "plugins/instance_analytics"
+                                                              {}
+                                                              :token-check? false))]
+             (if (not-empty (:errors report))
+               (log/info (str "Error Loading Analytics Content: " (pr-str report)))
+               (log/info (str "Loading Analytics Content Complete (" (count (:seen report)) ") entities synchronized."))))
+           (when-let [audit-db (t2/select-one :model/Database :is_audit true)]
+             (adjust-audit-db-to-host! audit-db))))))))

--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -121,8 +121,12 @@
          (str "plugins" sep))))
 
 (def analytics-zip-resource
-  "Where to look for analytics content created by Metabase to load into the app instance on startup."
+  "A zip file containing analytics content created by Metabase to load into the app instance on startup."
   (io/resource "instance_analytics.zip"))
+
+(def analytics-dir-resource
+  "A resource dir containing analytics content created by Metabase to load into the app instance on startup."
+  (io/resource "instance_analytics"))
 
 (defn- plug-in-ia-content
   "Load instance analytics content (collections/dashboards/cards/etc.) from resources dir or a zip file
@@ -159,7 +163,7 @@
            (ee.internal-user/ensure-internal-user-exists!)
            (adjust-audit-db-to-source! audit-db)
            (log/info "Loading Analytics Content...")
-           (plug-in-ia-content analytics-zip-resource (io/resource "instance_analytics"))
+           (plug-in-ia-content analytics-zip-resource analytics-dir-resource)
            (log/info (str "Loading Analytics Content from: plugins/instance_analytics"))
            ;; The EE token might not have :serialization enabled, but audit features should still be able to use it.
            (let [report (log/with-no-logs

--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -124,9 +124,10 @@
   "Where to look for analytics content created by Metabase to load into the app instance on startup."
   (io/resource "instance_analytics.zip"))
 
-(defn- plug-in-ia-content [zip-resource dir-resource]
+(defn- plug-in-ia-content
   "Load instance analytics content (collections/dashboards/cards/etc.) from resources dir or a zip file
    and put it into plugins/instance_analytics"
+  [zip-resource dir-resource]
   (cond
     zip-resource
     (do (log/info "Unzipping instance_analytics to plugins...")

--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -128,14 +128,12 @@
   "Load instance analytics content (collections/dashboards/cards/etc.) from resources dir or a zip file
    and put it into plugins/instance_analytics"
   (cond
-    ;; the zip file:
     zip-resource
     (do (log/info "Unzipping instance_analytics to plugins...")
         (u.files/unzip-file
           analytics-zip-resource
           map-instance-analytics-files-to-plugins-dir)
         (log/info "Unzipping done."))
-    ;; the directory in resources
     dir-resource
     (do
       (log/info "Copying resources/instance_analytics to plugins...")

--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -31,9 +31,7 @@
    #_{:clj-kondo/ignore [:deprecated-namespace]}
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan2.core :as t2])
-  (:import
-   (java.net URL)))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 

--- a/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
@@ -34,6 +34,7 @@
       (with-redefs [audit-db/analytics-zip-resource nil
                     audit-db/analytics-dir-resource nil]
         (is (= nil audit-db/analytics-zip-resource))
+        (is (= nil audit-db/analytics-dir-resource))
         (is (= :metabase-enterprise.audit-db/installed (audit-db/ensure-audit-db-installed!)))
         (is (= (audit-db/default-audit-db-id) (t2/select-one-fn :id 'Database {:where [:= :is_audit true]}))
             "Audit DB is installed.")

--- a/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.audit-db-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is]]
             [metabase-enterprise.audit-db :as audit-db]
             [metabase.core :as mbc]
             [metabase.models.database :refer [Database]]
@@ -30,8 +31,8 @@
 (deftest audit-db-content-is-not-installed-when-not-found
   (mt/test-drivers #{:postgres :h2 :mysql}
     (with-audit-db-restoration
-      (with-redefs [audit-db/analytics-root-dir-resource nil]
-        (is (= nil audit-db/analytics-root-dir-resource))
+      (with-redefs [audit-db/analytics-zip-resource nil]
+        (is (= nil audit-db/analytics-zip-resource))
         (is (= :metabase-enterprise.audit-db/installed (audit-db/ensure-audit-db-installed!)))
         (is (= (audit-db/default-audit-db-id) (t2/select-one-fn :id 'Database {:where [:= :is_audit true]}))
             "Audit DB is installed.")
@@ -44,5 +45,10 @@
       (is (= :metabase-enterprise.audit-db/installed (audit-db/ensure-audit-db-installed!)))
       (is (= (audit-db/default-audit-db-id) (t2/select-one-fn :id 'Database {:where [:= :is_audit true]}))
           "Audit DB is installed.")
+      (is (some? (or
+                   ;; the zip file
+                   audit-db/analytics-zip-resource
+                   ;; the directory
+                   (io/resource "instance_analytics"))))
       (is (not= 0 (t2/count 'Card {:where [:= :database_id (audit-db/default-audit-db-id)]}))
           "Cards should be created for Audit DB when the content is there."))))

--- a/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
@@ -31,12 +31,13 @@
 (deftest audit-db-content-is-not-installed-when-not-found
   (mt/test-drivers #{:postgres :h2 :mysql}
     (with-audit-db-restoration
-      (with-redefs [audit-db/analytics-zip-resource nil]
+      (with-redefs [audit-db/analytics-zip-resource nil
+                    audit-db/analytics-dir-resource nil]
         (is (= nil audit-db/analytics-zip-resource))
         (is (= :metabase-enterprise.audit-db/installed (audit-db/ensure-audit-db-installed!)))
         (is (= (audit-db/default-audit-db-id) (t2/select-one-fn :id 'Database {:where [:= :is_audit true]}))
             "Audit DB is installed.")
-        (is (= [] (t2/select 'Card {:where [:= :database_id (audit-db/default-audit-db-id)]}))
+        (is (= 0 (t2/count 'Card {:where [:= :database_id (audit-db/default-audit-db-id)]}))
             "No cards created for Audit DB.")))))
 
 (deftest audit-db-content-is-installed-when-found


### PR DESCRIPTION
## Improves loading behavior for ia content

first, look for the zip file. this file will be here when running as an
uberjar. when found, unzip it to plugins/instance_analytics

If that's not found, look for the resources/instance_analytics dir,
which will be copied to plugins/instance_analytics

The serialization piece doesn't care where the yaml data in
plugins/instance_analytics came from, it just loads it as usual.