### PR TITLE
moves ia content to /plugins from zip or resoruces

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -151,7 +151,7 @@
         (ee.internal-user/ensure-internal-user-exists!)
         (adjust-audit-db-to-source! audit-db)
         (log/info "Loading Analytics Content...")
-        (ia-content->plugins nil analytics-dir-resource)
+        (ia-content->plugins analytics-zip-resource analytics-dir-resource)
         (log/info (str "Loading Analytics Content from: plugins/instance_analytics"))
         ;; The EE token might not have :serialization enabled, but audit features should still be able to use it.
         (let [report (log/with-no-logs

--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -9,7 +9,6 @@
    [metabase.models.database :refer [Database]]
    [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.sync.sync-metadata :as sync-metadata]
-   [metabase.sync.util :as sync-util]
    [metabase.util :as u]
    [metabase.util.files :as u.files]
    [metabase.util.log :as log]
@@ -112,14 +111,6 @@
       :else
       ::no-op)))
 
-(defn- map-instance-analytics-files-to-plugins-dir [path]
-  (let [sep File/separatorChar
-        pattern (re-pattern (str ".*" sep "(instance_analytics" sep ".*)"))]
-    (->> path
-         (re-find pattern)
-         second
-         (str "plugins" sep))))
-
 (def analytics-zip-resource
   "A zip file containing analytics content created by Metabase to load into the app instance on startup."
   (io/resource "instance_analytics.zip"))
@@ -128,21 +119,19 @@
   "A resource dir containing analytics content created by Metabase to load into the app instance on startup."
   (io/resource "instance_analytics"))
 
-(defn- plug-in-ia-content
+(defn- ia-content->plugins
   "Load instance analytics content (collections/dashboards/cards/etc.) from resources dir or a zip file
    and put it into plugins/instance_analytics"
   [zip-resource dir-resource]
   (cond
     zip-resource
     (do (log/info "Unzipping instance_analytics to plugins...")
-        (u.files/unzip-file
-          analytics-zip-resource
-          map-instance-analytics-files-to-plugins-dir)
+        (u.files/unzip-file analytics-zip-resource "plugins")
         (log/info "Unzipping done."))
     dir-resource
     (do
       (log/info "Copying resources/instance_analytics to plugins...")
-      ;; TODO use clojure.java.io or fs library?
+      ;; TODO use clojure.java.io or fs lib?
       (sh/sh "cp" "-r" "resources/instance_analytics" "plugins")
       (log/info "Copying done."))))
 
@@ -159,21 +148,18 @@
       (log/info "Audit DB Sync Complete.")
       (when (or analytics-zip-resource analytics-dir-resource)
         ;; prevent sync while loading
-        ((sync-util/with-duplicate-ops-prevented :sync-database audit-db
-           (fn []
-             (ee.internal-user/ensure-internal-user-exists!)
-             (adjust-audit-db-to-source! audit-db)
-
-             (log/info "Loading Analytics Content...")
-             (plug-in-ia-content analytics-zip-resource analytics-dir-resource)
-             (log/info (str "Loading Analytics Content from: plugins/instance_analytics"))
-             ;; The EE token might not have :serialization enabled, but audit features should still be able to use it.
-             (let [report (log/with-no-logs
-                            (serialization.cmd/v2-load-internal "plugins/instance_analytics"
-                                                                {}
-                                                                :token-check? false))]
-               (if (not-empty (:errors report))
-                 (log/info (str "Error Loading Analytics Content: " (pr-str report)))
-                 (log/info (str "Loading Analytics Content Complete (" (count (:seen report)) ") entities synchronized."))))
-             (when-let [audit-db (t2/select-one :model/Database :is_audit true)]
-               (adjust-audit-db-to-host! audit-db)))))))))
+        (ee.internal-user/ensure-internal-user-exists!)
+        (adjust-audit-db-to-source! audit-db)
+        (log/info "Loading Analytics Content...")
+        (ia-content->plugins nil analytics-dir-resource)
+        (log/info (str "Loading Analytics Content from: plugins/instance_analytics"))
+        ;; The EE token might not have :serialization enabled, but audit features should still be able to use it.
+        (let [report (log/with-no-logs
+                       (serialization.cmd/v2-load-internal "plugins/instance_analytics"
+                                                           {}
+                                                           :token-check? false))]
+          (if (not-empty (:errors report))
+            (log/info (str "Error Loading Analytics Content: " (pr-str report)))
+            (log/info (str "Loading Analytics Content Complete (" (count (:seen report)) ") entities synchronized."))))
+        (when-let [audit-db (t2/select-one :model/Database :is_audit true)]
+          (adjust-audit-db-to-host! audit-db))))))

--- a/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
@@ -57,7 +57,6 @@
       (is (not= 0 (t2/count 'Card {:where [:= :database_id (audit-db/default-audit-db-id)]}))
           "Cards should be created for Audit DB when the content is there."))))
 
-
 (deftest audit-db-instance-analytics-content-is-unzipped-properly
   (sh/sh "rm" "-rf" "plugins/instance_analytics")
   (is (= (:err (sh/sh "ls" "plugins/instance_analytics"))

--- a/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
@@ -1,5 +1,7 @@
 (ns metabase-enterprise.audit-db-test
   (:require [clojure.java.io :as io]
+            [clojure.java.shell :as sh]
+            [clojure.string :as str]
             [clojure.test :refer [deftest is]]
             [metabase-enterprise.audit-db :as audit-db]
             [metabase.core :as mbc]
@@ -54,3 +56,22 @@
                    (io/resource "instance_analytics"))))
       (is (not= 0 (t2/count 'Card {:where [:= :database_id (audit-db/default-audit-db-id)]}))
           "Cards should be created for Audit DB when the content is there."))))
+
+
+(deftest audit-db-instance-analytics-content-is-unzipped-properly
+  (sh/sh "rm" "-rf" "plugins/instance_analytics")
+  (is (= (:err (sh/sh "ls" "plugins/instance_analytics"))
+         "ls: plugins/instance_analytics: No such file or directory\n"))
+
+  (#'audit-db/ia-content->plugins audit-db/analytics-zip-resource nil)
+  (is (= (str/split-lines (:out (sh/sh "ls" "plugins/instance_analytics")))
+         ["collections" "databases"])))
+
+(deftest audit-db-instance-analytics-content-is-coppied-properly
+  (sh/sh "rm" "-rf" "plugins/instance_analytics")
+  (is (= (:err (sh/sh "ls" "plugins/instance_analytics"))
+         "ls: plugins/instance_analytics: No such file or directory\n"))
+
+  (#'audit-db/ia-content->plugins nil audit-db/analytics-dir-resource)
+  (is (= (str/split-lines (:out (sh/sh "ls" "plugins/instance_analytics")))
+         ["collections" "databases"])))

--- a/src/metabase/util/files.clj
+++ b/src/metabase/util/files.clj
@@ -159,18 +159,16 @@
           (slurp is))))))
 
 (defn unzip-file
-  "Decompress a zip archive from input to path-mod-fn(input).
-
-  path-mod-fn is a function that takes the full file path, and returns where that file should go. "
-  [input path-mod-fn]
-  (with-open [stream (-> input io/input-stream ZipInputStream.)]
+  "Decompress a zip archive from input to output."
+  [zip-file out-dir]
+  (with-open [stream (-> zip-file io/input-stream ZipInputStream.)]
     (loop [entry (.getNextEntry stream)]
       (when entry
-        (let [out-path (path-mod-fn (.getName entry))
-              out-file (io/file out-path)]
+        (let [out-path (str out-dir File/separatorChar (.getName entry))
+              out-file (File. out-path)]
           (if (.isDirectory entry)
             (when-not (.exists out-file) (.mkdirs out-file))
-            (let [parent-dir (io/file (subs out-path 0 (.lastIndexOf ^String out-path (int File/separatorChar))))]
+            (let [parent-dir (File. (.substring out-path 0 (.lastIndexOf out-path (int File/separatorChar))))]
               (when-not (.exists parent-dir) (.mkdirs parent-dir))
               (io/copy stream out-file)))
           (recur (.getNextEntry stream)))))))


### PR DESCRIPTION
copying or unzipping IA content to /plugins on app startup

How does it work? We check for a file at `resources/instance_analytics.zip`, if it's not found we use the `resources/instance_analytics` directory. The information at either resource is unzipped or copied to `plugins/instance_analytics`.

----

Besides the included tests, here is what I see when:

1. the `resources/instance_analytics.zip` is missing but `resources/instance_analytics` is there:
```
2023-09-25 03:46:10,232 INFO metabase-enterprise.audit-db :: Audit DB Sync Complete.
2023-09-25 03:46:10,241 INFO metabase-enterprise.audit-db :: Loading Analytics Content...
2023-09-25 03:46:10,242 INFO metabase-enterprise.audit-db :: Copying resources/instance_analytics to plugins...
2023-09-25 03:46:10,283 INFO metabase-enterprise.audit-db :: Copying done.
2023-09-25 03:46:10,284 INFO metabase-enterprise.audit-db :: Loading Analytics Content from: plugins/instance_analytics
2023-09-25 03:46:13,985 INFO metabase-enterprise.audit-db :: Loading Analytics Content Complete (102) entities synchronized.
```

2. `resources/instance_analytics` is missing and the `resources/instance_analytics.zip` file is found:
```
2023-09-25 04:00:01,431 INFO metabase-enterprise.audit-db :: Audit DB Sync Complete.
2023-09-25 04:00:01,447 INFO metabase-enterprise.audit-db :: Loading Analytics Content...
2023-09-25 04:00:01,448 INFO metabase-enterprise.audit-db :: Unzipping instance_analytics to plugins...
2023-09-25 04:00:01,467 INFO metabase-enterprise.audit-db :: Unzipping done.
2023-09-25 04:00:01,468 INFO metabase-enterprise.audit-db :: Loading Analytics Content from: plugins/instance_analytics
2023-09-25 04:00:04,805 INFO metabase-enterprise.audit-db :: Loading Analytics Content Complete (102) entities synchronized.
```