### PR TITLE
Add missing @external tag to test introduced by #33990

### DIFF
--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -208,41 +208,45 @@ describe("permissions", () => {
     });
   });
 
-  it("should show you upload buttons if you have unrestricted access to the upload schema", () => {
-    restore("postgres-12");
-    cy.signInAsAdmin();
+  it(
+    "should show you upload buttons if you have unrestricted access to the upload schema",
+    { tags: ["@external"] },
+    () => {
+      restore("postgres-12");
+      cy.signInAsAdmin();
 
-    setTokenFeatures("all");
-    enableUploads("postgres");
+      setTokenFeatures("all");
+      enableUploads("postgres");
 
-    cy.updatePermissionsGraph({
-      [ALL_USERS_GROUP]: {
-        [WRITABLE_DB_ID]: {
-          data: {
-            schemas: "block",
+      cy.updatePermissionsGraph({
+        [ALL_USERS_GROUP]: {
+          [WRITABLE_DB_ID]: {
+            data: {
+              schemas: "block",
+            },
           },
         },
-      },
-      [NOSQL_GROUP]: {
-        [WRITABLE_DB_ID]: {
-          data: {
-            schemas: "all",
+        [NOSQL_GROUP]: {
+          [WRITABLE_DB_ID]: {
+            data: {
+              schemas: "all",
+            },
           },
         },
-      },
-    });
+      });
 
-    cy.updateCollectionGraph({
-      [NOSQL_GROUP]: { root: "write" },
-    });
+      cy.updateCollectionGraph({
+        [NOSQL_GROUP]: { root: "write" },
+      });
 
-    cy.signIn("nosql");
-    cy.visit("/collection/root");
-    cy.findByTestId("collection-menu").within(() => {
-      cy.findByLabelText("Upload data").should("exist");
-      cy.findByRole("img", { name: /upload/i }).should("exist");
-    });
-  });
+      cy.signIn("nosql");
+      cy.visit("/collection/root");
+      cy.findByTestId("collection-menu").within(() => {
+        cy.findByLabelText("Upload data").should("exist");
+        cy.findByRole("img", { name: /upload/i }).should("exist");
+      });
+    },
+  );
 });
 
 function uploadFile(testFile, valid = true) {


### PR DESCRIPTION
This PR adds the missing @external tag to a test introduced by https://github.com/metabase/metabase/pull/33990.

Every time we use any external service, a test must contain @external tag.