### PR TITLE
Run the backport CI job when pushing new commits

### DIFF
--- a/.github/workflows/backport-reminder.yml
+++ b/.github/workflows/backport-reminder.yml
@@ -2,7 +2,7 @@ name: Backport Reminder
 
 on:
   pull_request:
-    types: [auto_merge_enabled, review_requested, labeled, unlabeled]
+    types: [auto_merge_enabled, review_requested, labeled, unlabeled, synchronize]
     branches:
       - "master"
 

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -107,7 +107,7 @@
   (u/prog1 user
     (let [current-version (:tag config/mb-version-info)]
       (log/info (trs "Setting User {0}''s last_acknowledged_version to {1}, the current version" user-id current-version))
-      ;; Can't use mw.session/with-current-user-id due to circular require
+      ;; Can't use mw.session/with-current-user due to circular require
       (binding [api/*current-user-id*       user-id
                 setting/*user-local-values* (delay (atom (user-local-settings user)))]
         (setting/set! :last-acknowledged-version current-version)))


### PR DESCRIPTION
Nemanja did the real work here.

This started as an experimental PR (thus the typo fix), but it's a real typo, so we may as well keep it.

Edit (by @nemanjaglumac )
This PR fixes a bug related to the triggering of the `jesusvasquez333/verify-pr-label-action` GitHub action. We use it to check whether or not a particular set of labels exist in a PR.

**Before**
The action would trigger on an initial commit in a PR.
Every subsequent commit would be stuck, waiting for this action that was in a perpetual "pending" state.

**Now**
The action runs on every commit, due to the `synchronize` event trigger that's been added to the existing list of triggers.