### PR TITLE
Fix uploads-disabled-for-sandboxed-user-test test by using root collection

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/upload_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/upload_test.clj
@@ -10,10 +10,9 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
     (mt/with-temporary-setting-values [uploads-enabled true]
       (met/with-gtaps-for-user :rasta {:gtaps {:venues {}}}
-
         (is (thrown-with-msg? Exception #"Uploads are not permitted for sandboxed users\."
                               (api.card/upload-csv!
-                               1
+                               nil
                                "star_wars.csv"
                                (upload-test/csv-file-with ["id,ship,captain"
                                                            "1,Serenity,Malcolm Reynolds"


### PR DESCRIPTION
This PR fixes a test failure in the cloverage job that is failing on master ([example run](https://github.com/metabase/metabase/actions/runs/6274045898/job/17041641400#step:5:3681)). The test failure was introduced by this PR #33990

It simply changes the collection ID in the test to `nil`, meaning that the root collection is used instead. Rasta always curate access to the root collection, so the test passes.