### PR TITLE
🍒 Backport: Archived items fixes

### DIFF
--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -42,7 +42,7 @@ export interface Collection {
   path?: CollectionId[];
 }
 
-type CollectionItemModel =
+export type CollectionItemModel =
   | "card"
   | "dataset"
   | "dashboard"

--- a/frontend/src/metabase/archive/containers/ArchiveApp.jsx
+++ b/frontend/src/metabase/archive/containers/ArchiveApp.jsx
@@ -80,7 +80,7 @@ class ArchiveApp extends Component {
                 rowHeight={ROW_HEIGHT}
                 renderItem={({ item }) => (
                   <ArchivedItem
-                    type={item.type}
+                    model={item.model}
                     name={item.getName()}
                     icon={item.getIcon().name}
                     color={item.getColor()}

--- a/frontend/src/metabase/common/utils/model-names.ts
+++ b/frontend/src/metabase/common/utils/model-names.ts
@@ -8,6 +8,7 @@ const TRANSLATED_NAME_BY_MODEL_TYPE: Record<string, string> = {
   database: t`Database`,
   collection: t`Collection`,
   segment: t`Segment`,
+  "indexed-entity": t`Indexed Entity`,
   metric: t`Metric`,
   pulse: t`Pulse`,
 };

--- a/frontend/src/metabase/common/utils/model-names.unit.spec.ts
+++ b/frontend/src/metabase/common/utils/model-names.unit.spec.ts
@@ -1,0 +1,15 @@
+import { getTranslatedEntityName } from "./model-names";
+
+describe("common/utils/model-names", () => {
+  it("returns null if the model doesn't exist", () => {
+    expect(getTranslatedEntityName("foo")).toBeNull();
+    expect(getTranslatedEntityName("")).toBeNull();
+  });
+
+  it("returns the correct colloquial name for the underlying model", () => {
+    expect(getTranslatedEntityName("dashboard")).toBe("Dashboard");
+    expect(getTranslatedEntityName("card")).toBe("Question");
+    expect(getTranslatedEntityName("dataset")).toBe("Model");
+    expect(getTranslatedEntityName("indexed-entity")).toBe("Indexed Entity");
+  });
+});

--- a/frontend/src/metabase/components/ArchivedItem/ArchivedItem.jsx
+++ b/frontend/src/metabase/components/ArchivedItem/ArchivedItem.jsx
@@ -9,11 +9,12 @@ import Swapper from "metabase/core/components/Swapper";
 import Tooltip from "metabase/core/components/Tooltip";
 
 import { color as c } from "metabase/lib/colors";
+import { getTranslatedEntityName } from "metabase/common/utils/model-names";
 import { ItemIcon, ItemIconContainer } from "./ArchivedItem.styled";
 
 const ArchivedItem = ({
   name,
-  type,
+  model,
   icon,
   color = c("text-light"),
   isAdmin = false,
@@ -44,7 +45,11 @@ const ArchivedItem = ({
     {isAdmin && (onUnarchive || onDelete) && (
       <span className="ml-auto mr2">
         {onUnarchive && (
-          <Tooltip tooltip={t`Unarchive this ${type}`}>
+          <Tooltip
+            tooltip={t`Unarchive this ${getTranslatedEntityName(
+              model,
+            )?.toLowerCase()}`}
+          >
             <Icon
               onClick={onUnarchive}
               className="cursor-pointer text-brand-hover hover-child ml4"
@@ -53,7 +58,11 @@ const ArchivedItem = ({
           </Tooltip>
         )}
         {onDelete && (
-          <Tooltip tooltip={t`Delete this ${type}`}>
+          <Tooltip
+            tooltip={t`Delete this ${getTranslatedEntityName(
+              model,
+            )?.toLowerCase()}`}
+          >
             <Icon
               onClick={onDelete}
               className="cursor-pointer text-brand-hover hover-child ml4"
@@ -68,7 +77,7 @@ const ArchivedItem = ({
 
 ArchivedItem.propTypes = {
   name: PropTypes.string.isRequired,
-  type: PropTypes.string.isRequired,
+  model: PropTypes.string.isRequired,
   icon: PropTypes.string.isRequired,
   color: PropTypes.string,
   isAdmin: PropTypes.bool,

--- a/frontend/src/metabase/components/ArchivedItem/ArchivedItem.jsx
+++ b/frontend/src/metabase/components/ArchivedItem/ArchivedItem.jsx
@@ -57,7 +57,7 @@ const ArchivedItem = ({
             />
           </Tooltip>
         )}
-        {onDelete && (
+        {model !== "collection" && onDelete && (
           <Tooltip
             tooltip={t`Delete this ${getTranslatedEntityName(
               model,

--- a/frontend/src/metabase/nav/components/RecentsList.jsx
+++ b/frontend/src/metabase/nav/components/RecentsList.jsx
@@ -22,7 +22,7 @@ import EmptyState from "metabase/components/EmptyState";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import { useListKeyboardNavigation } from "metabase/hooks/use-list-keyboard-navigation";
 
-import { getTranslatedEntityName } from "../utils";
+import { getTranslatedEntityName } from "metabase/common/utils/model-names";
 import {
   Root,
   EmptyStateContainer,

--- a/frontend/src/metabase/nav/utils/index.js
+++ b/frontend/src/metabase/nav/utils/index.js
@@ -1,1 +1,0 @@
-export * from "./model-names";

--- a/frontend/src/metabase/search/components/InfoText.tsx
+++ b/frontend/src/metabase/search/components/InfoText.tsx
@@ -9,7 +9,7 @@ import Schema from "metabase/entities/schemas";
 import Database from "metabase/entities/databases";
 import Table from "metabase/entities/tables";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
-import { getTranslatedEntityName } from "metabase/nav/utils";
+import { getTranslatedEntityName } from "metabase/common/utils/model-names";
 
 import type { Collection } from "metabase-types/api";
 import type TableType from "metabase-lib/metadata/Table";


### PR DESCRIPTION
This is a manual backport of:
- #33970 and
- #33991

### Warning
The backport wasn't clean due to significant differences between the master and the `relase-x.47.x` branches.
- `ArchiveApp` and `ArchivedItem` have been converted to TS on `master`, for example.
- It also depended on the currently blocked backport #33839

I tried to cherry-pick only the needed parts and to make this as risk-free as possible.
If you think it's too risky to backport, the issue is not a severe one and it can wait the version 48.

### Manual test
Spun up Metabase from the release 47 branch.
https://www.loom.com/share/01183dc7421f4e6baa89a96895974742?sid=6f1bf06e-13c7-4f49-b929-47cf7def9582