### PR TITLE
Add remove columns panel

### DIFF
--- a/e2e/test/scenarios/joins/reproductions/23293-drill-through-implicit-join-add-remove-column.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/23293-drill-through-implicit-join-add-remove-column.cy.spec.js
@@ -82,7 +82,12 @@ describe("issue 23293", () => {
  * @param {("add"|"remove")} action
  */
 function modifyColumn(columnName, action) {
-  const icon = action === "add" ? "add" : "eye_outline";
-  const iconSelector = `.Icon-${icon}`;
-  cy.findAllByRole("listitem", { name: columnName }).find(iconSelector).click();
+  cy.findByRole("button", { name: "Add or remove columns" }).click();
+  if (action === "add") {
+    cy.findByLabelText(columnName).should("not.be.checked").click();
+  } else {
+    cy.findByLabelText(columnName).should("be.checked").click();
+  }
+
+  cy.findByRole("button", { name: "Done picking columns" }).click();
 }

--- a/e2e/test/scenarios/models/reproductions/23421-visualization-settins-breaks-ui.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/23421-visualization-settins-breaks-ui.cy.spec.js
@@ -29,7 +29,13 @@ describe("issue 23421", () => {
     cy.findByText("Edit query definition").click();
 
     cy.get(".ace_content").should("contain", query);
-    cy.get(".cellData").should("have.length", 4);
+    // This test used to check for the presense of 4 cell data elements, implying that we should generate a default
+    // value for table.columns. However, as of #33841, having an empty table.columns setting is valid, so the
+    // assertion in this test has changed
+    cy.findByTestId("visualization-root").should(
+      "contain.text",
+      "Every field is hidden right now",
+    );
 
     cy.button("Save changes").should("be.disabled");
   });

--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -831,13 +831,9 @@ describeEE("formatting > sandboxes", () => {
           // Remove the "Subtotal" column from within sidebar
           cy.findByText("Subtotal").parent().find(".Icon-eye_outline").click();
         });
-      cy.button("Done").click();
-      // Rerun the query
-      cy.icon("play").last().click();
 
-      cy.wait("@dataset").then(xhr => {
-        expect(xhr.response.body.error).not.to.exist;
-      });
+      cy.button("Done").click();
+
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Subtotal").should("not.exist");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -7,7 +7,6 @@ import {
   popover,
   modal,
   sidebar,
-  moveColumnDown,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
@@ -36,34 +35,31 @@ describe("scenarios > question > settings", () => {
 
       cy.findByTestId("sidebar-content").as("tableOptions");
 
+      cy.findByRole("button", { name: "Add or remove columns" }).click();
+
       // remove Total column
       cy.get("@tableOptions")
-        .contains("Total")
-        .scrollIntoView()
-        .siblings("[data-testid$=hide-button]")
+        .findByLabelText("Total")
+        .should("be.checked")
         .click();
 
       // Add people.category
       cy.get("@tableOptions")
-        .contains("Category")
-        .scrollIntoView()
-        .siblings("[data-testid$=add-button]")
+        .findByLabelText("Category")
+        .should("not.be.checked")
         .click();
 
       // wait a Category value to appear in the table, so we know the query completed
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("Widget");
+      cy.findByTestId("visualization-root").contains("Widget");
 
       // Add people.ean
       cy.get("@tableOptions")
-        .contains("Ean")
-        .scrollIntoView()
-        .siblings("[data-testid$=add-button]")
+        .findByLabelText("Ean")
+        .should("not.be.checked")
         .click();
 
       // wait a Ean value to appear in the table, so we know the query completed
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("8833419218504");
+      cy.findByTestId("visualization-root").contains("8833419218504");
 
       // confirm that the table contains the right columns
       cy.get(".Visualization .TableInteractive").as("table");
@@ -178,14 +174,11 @@ describe("scenarios > question > settings", () => {
       // Remove "Total"
       hideColumn("Total");
 
-      refreshResultsInOverlay();
+      // refreshResultsInOverlay();
 
       cy.findByTestId("query-builder-main")
         .findByText("117.03")
         .should("not.exist");
-
-      // This click doesn't do anything, but simply allows the array to be updated (test gives false positive without this step)
-      cy.findByTestId("sidebar-left").findByText("More columns").click();
 
       findColumnAtIndex("Products → Category", 5);
 
@@ -193,11 +186,14 @@ describe("scenarios > question > settings", () => {
       // https://github.com/metabase/metabase/pull/21338#pullrequestreview-928807257
 
       // Add "Address"
-      addColumn("Address");
+      cy.findByRole("button", { name: "Add or remove columns" }).click();
+      cy.findByLabelText("Address").should("not.be.checked").click();
 
       // The result automatically load when adding new fields but two requests are fired.
       // Please see: https://github.com/metabase/metabase/pull/21338#discussion_r842816687
       cy.wait(["@dataset", "@dataset"]);
+
+      cy.findByRole("button", { name: "Done picking columns" }).click();
 
       findColumnAtIndex("User → Address", -1).as("user-address");
 
@@ -240,8 +236,9 @@ describe("scenarios > question > settings", () => {
 
       cy.findByTestId("viz-settings-button").click();
 
-      addColumn("City");
-      // cy.findByText("City").siblings("button").find(".Icon-add").click();
+      cy.findByRole("button", { name: "Add or remove columns" }).click();
+      cy.findByLabelText("Name").should("not.be.checked").click();
+      cy.findByRole("button", { name: "Done picking columns" }).click();
 
       // Remove "Product ID"
       hideColumn("Product ID");
@@ -249,10 +246,8 @@ describe("scenarios > question > settings", () => {
       // Remove "Subtotal"
       hideColumn("Subtotal");
 
-      refreshResultsInOverlay();
-
-      // Remove "City"
-      hideColumn("City");
+      // Remove "Name"
+      hideColumn("User → Name");
       cy.findByTestId("query-builder-main").findByText(
         "Every field is hidden right now",
       );
@@ -493,10 +488,6 @@ function refreshResultsInHeader() {
   cy.findByTestId("qb-header").button("Refresh").click();
 }
 
-function refreshResultsInOverlay() {
-  cy.findByTestId("query-builder-main").button("Get Answer").click();
-}
-
 function getSidebarColumns() {
   return cy
     .findByText("Columns", { selector: "label" })
@@ -515,13 +506,5 @@ function hideColumn(name) {
     .contains(name)
     .parentsUntil("[role=listitem]")
     .icon("eye_outline")
-    .click();
-}
-
-function addColumn(name) {
-  getSidebarColumns()
-    .contains(name)
-    .parentsUntil("[role=listitem]")
-    .icon("add")
     .click();
 }

--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -7,6 +7,7 @@ import {
   popover,
   modal,
   sidebar,
+  moveColumnDown,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
@@ -173,8 +174,6 @@ describe("scenarios > question > settings", () => {
 
       // Remove "Total"
       hideColumn("Total");
-
-      // refreshResultsInOverlay();
 
       cy.findByTestId("query-builder-main")
         .findByText("117.03")

--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -99,14 +99,14 @@ describe("scenarios > question > settings", () => {
       cy.findByTestId("Subtotal-hide-button").click();
       cy.findByTestId("Tax-hide-button").click();
 
-      getSidebarColumns().eq("3").as("total").contains("Total");
+      getSidebarColumns().eq("5").as("total").contains("Total");
 
       moveColumnDown(cy.get("@total"), -2);
 
-      getSidebarColumns().eq("1").should("contain.text", "Total");
+      getSidebarColumns().eq("3").should("contain.text", "Total");
 
       getVisibleSidebarColumns()
-        .eq("9")
+        .eq("11")
         .as("title")
         .should("have.text", "Products → Title");
 

--- a/e2e/test/scenarios/visualizations/pie_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/pie_chart.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, visitQuestionAdhoc } from "e2e/support/helpers";
+import { restore, visitQuestionAdhoc, popover } from "e2e/support/helpers";
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
@@ -21,13 +21,22 @@ describe("scenarios > visualizations > pie chart", () => {
     cy.signInAsNormalUser();
   });
 
-  it("should render a pie chart (metabase#12506)", () => {
+  it("should render a pie chart (metabase#12506) (#35244)", () => {
     visitQuestionAdhoc({
       dataset_query: testQuery,
       display: "pie",
     });
 
     ensurePieChartRendered(["Doohickey", "Gadget", "Gizmo", "Widget"], 200);
+
+    cy.log("#35244");
+    cy.findByLabelText("Switch to data").click();
+    cy.findAllByTestId("header-cell").contains("Count").click();
+    popover().within(() => {
+      cy.findByRole("img", { name: /filter/ }).should("exist");
+      cy.findByRole("img", { name: /gear/ }).should("not.exist");
+      cy.findByRole("img", { name: /eye_crossed_out/ }).should("not.exist");
+    });
   });
 
   it("should mute items in legend when hovering (metabase#29224)", () => {

--- a/e2e/test/scenarios/visualizations/reproductions/22206-add-remove-column.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/22206-add-remove-column.cy.spec.js
@@ -28,11 +28,8 @@ describe("#22206 adding and removing columns doesn't duplicate columns", () => {
     cy.findByTestId("sidebar-content")
       .findByText("Subtotal")
       .parent()
-      .find(".Icon-add")
+      .find(".Icon-eye_crossed_out")
       .click();
-
-    cy.wait("@dataset");
-    cy.findByTestId("loading-spinner").should("not.exist");
 
     // fails because there are 2 columns, when there should be one
     cy.findByTestId("sidebar-content").findByText("Subtotal");

--- a/e2e/test/scenarios/visualizations/table-column-settings.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/table-column-settings.cy.spec.js
@@ -203,6 +203,164 @@ const nestedQuestionWithJoinOnQuestion = card => ({
   },
 });
 
+const scenarios = [
+  // {
+  //   name: "table fields",
+  //   question: tableQuestion,
+  //   existingColumns: [{ column: "Tax", columnName: "Tax" }],
+  //   sanityCheck: "ID",
+  // },
+  // {
+  //   name: "table fields with in a join",
+  //   question: tableQuestionWithJoin,
+  //   existingColumns: [{ column: "Rating", columnName: "Products → Rating" }],
+  //   sanityCheck: "Products → Ean",
+  // },
+  // {
+  //   name: "Table fields with a self join",
+  //   question: tableQuestionWithSelfJoinAndFields,
+  //   existingColumns: [{ column: "Tax", columnName: "Orders → Tax" }],
+  //   sanityCheck: "ID",
+  // },
+  // {
+  //   name: "table fields with implicit joins",
+  //   question: tableQuestion,
+  //   existingColumns: [],
+  //   extraColumns: [{ column: "Category", columnName: "Product → Category" }],
+  //   sanityCheck: "ID",
+  // },
+  // {
+  //   name: "table with custom expressions",
+  //   question: tableQuestionWithExpression,
+  //   existingColumns: [{ column: "Math", columnName: "Math" }],
+  // },
+  // {
+  //   name: "table with custom expressions and fields",
+  //   question: tableQuestionWithExpressionAndFields,
+  //   existingColumns: [{ column: "Math", columnName: "Math" }],
+  // },
+  // {
+  //   name: "table with aggregrations",
+  //   question: tableWithAggregations,
+  //   existingColumns: [{ column: "Count", columnName: "Count" }],
+  //   needsScroll: false,
+  // },
+  // {
+  //   name: "multistage question",
+  //   question: multiStageQuestion,
+  //   existingColumns: [{ column: "Count", columnName: "Count" }],
+  //   sanityCheck: "Product ID",
+  // },
+  // {
+  //   name: "nested question",
+  //   question: () => {
+  //     cy.createQuestion(tableQuestion).then(({ body: card }) => {
+  //       cy.createQuestion(nestedQuestion(card), { visitQuestion: true });
+  //     });
+  //   },
+  //   existingColumns: [{ column: "Tax", columnName: "Tax" }],
+  // },
+  // {
+  //   name: "nested question with joins",
+  //   question: () => {
+  //     cy.createQuestion(tableQuestionWithJoin).then(({ body: card }) => {
+  //       cy.createQuestion(nestedQuestion(card), { visitQuestion: true });
+  //     });
+  //   },
+  //   existingColumns: [
+  //     { column: "Products → Ean", columnName: "Products → Ean" },
+  //   ],
+  // },
+  // {
+  //   name: "nested question qith join and fields",
+  //   question: () => {
+  //     cy.createQuestion(tableQuestionWithJoinAndFields).then(
+  //       ({ body: card }) => {
+  //         cy.createQuestion(nestedQuestion(card), { visitQuestion: true });
+  //       },
+  //     );
+  //   },
+  //   existingColumns: [
+  //     { column: "Products → Category", columnName: "Products → Category" },
+  //   ],
+  // },
+  // {
+  //   name: "show and hide implicitly joinable fields for a nested query with joins and fields",
+  //   question: () => {
+  //     cy.createQuestion(tableQuestion).then(({ body: card }) => {
+  //       cy.createQuestion(nestedQuestionWithJoinOnTable(card), {
+  //         visitQuestion: true,
+  //       });
+  //     });
+  //   },
+  //   extraColumns: [{ column: "ID", columnName: "User → ID", table: "user" }],
+  // },
+  // {
+  //   name: "show and hide implicitly joinable fields for a nested query",
+  //   question: () => {
+  //     cy.createQuestion(tableQuestion).then(({ body: card }) => {
+  //       cy.createQuestion(nestedQuestion(card), { visitQuestion: true });
+  //     });
+  //   },
+  //   extraColumns: [
+  //     {
+  //       column: "Category",
+  //       columnName: "Product → Category",
+  //       table: "product",
+  //     },
+  //   ],
+  // },
+  // {
+  //   name: "show and hide custom expressions from a nested query",
+  //   question: () => {
+  //     cy.createQuestion(tableQuestionWithExpression).then(({ body: card }) => {
+  //       cy.createQuestion(nestedQuestion(card), { visitQuestion: true });
+  //     });
+  //   },
+  //   existingColumns: [
+  //     { column: "Math", columnName: "Math", table: "test question" },
+  //   ],
+  // },
+  // {
+  //   name: "show and hide columns from aggregations from a nested query",
+  //   question: () => {
+  //     cy.createQuestion(tableWithAggregations).then(({ body: card }) => {
+  //       cy.createQuestion(nestedQuestion(card), { visitQuestion: true });
+  //     });
+  //   },
+  //   existingColumns: [
+  //     { column: "Count", columnName: "Count", table: "test question" },
+  //     {
+  //       column: "Sum of Quantity",
+  //       columnName: "Sum of Quantity",
+  //       table: "test question",
+  //     },
+  //   ],
+  //   needsScroll: false,
+  // },
+  // {
+  //   name: "show and hide columns from aggregations from a nested query",
+  //   question: () => {
+  //     cy.createQuestion(tableQuestion, { wrapId: true }).then(
+  //       ({ body: card }) => {
+  //         cy.get("@questionId").then(id => {
+  //           cy.createQuestion(nestedQuestionWithJoinOnQuestion({ id }), {
+  //             visitQuestion: true,
+  //           });
+  //         });
+  //       },
+  //     );
+  //   },
+  //   existingColumns: cardId => [
+  //     {
+  //       column: "Tax",
+  //       columnName: `Question ${cardId} → Tax`,
+  //       table: `question ${cardId}`,
+  //     },
+  //   ],
+  // },
+];
+
 describe("scenarios > visualizations > table column settings", () => {
   beforeEach(() => {
     restore();
@@ -210,34 +368,332 @@ describe("scenarios > visualizations > table column settings", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
+  const _hideColumn = ({
+    column,
+    columnName,
+    table,
+    sanityCheck,
+    needsScroll = true,
+    scrollTimes = 1,
+  }) => {
+    cy.log("hide the column");
+    visibleColumns().within(() => hideColumn(columnName));
+    assertColumnHidden(getColumn(columnName));
+    if (sanityCheck) {
+      assertColumnEnabled(getColumn(sanityCheck));
+    }
+    if (needsScroll) {
+      [...Array(scrollTimes)].forEach(() => {
+        scrollVisualization();
+        cy.wait(200);
+      });
+    }
+    visualization().findByText(columnName).should("not.exist");
+
+    cy.findByRole("button", { name: /Add or remove columns/ }).click();
+    cy.findByRole("list", { name: `${table}-table-columns` })
+      .findByLabelText(column)
+      .should("be.checked");
+    cy.findByRole("button", { name: /Done picking columns/ }).click();
+  };
+
+  const _showColumn = ({
+    columnName,
+    sanityCheck,
+    needsScroll = true,
+    scrollTimes = 1,
+  }) => {
+    visibleColumns().within(() => showColumn(columnName));
+    assertColumnEnabled(getColumn(columnName));
+    if (sanityCheck) {
+      assertColumnEnabled(getColumn(sanityCheck));
+    }
+    if (needsScroll) {
+      [...Array(scrollTimes)].forEach(() => {
+        scrollVisualization();
+        cy.wait(200);
+      });
+    }
+    visualization().findByText(columnName).should("exist");
+  };
+
+  const _removeColumn = ({
+    column,
+    columnName,
+    table,
+    sanityCheck,
+    needsScroll = true,
+    scrollTimes = 1,
+  }) => {
+    cy.log("remove the column");
+    cy.findByRole("button", { name: /Add or remove columns/ }).click();
+    cy.findByRole("list", { name: `${table}-table-columns` })
+      .findByLabelText(column)
+      .should("be.checked")
+      .click();
+    runQuery();
+    cy.wait("@dataset");
+    cy.findByText("Doing science...").should("not.exist");
+    if (needsScroll) {
+      [...Array(scrollTimes)].forEach(() => {
+        scrollVisualization();
+        cy.wait(200);
+      });
+    }
+    visualization().findByText(columnName).should("not.exist");
+    cy.findByRole("button", { name: /Done picking columns/ }).click();
+    getColumn(columnName).should("not.exist");
+    if (sanityCheck) {
+      assertColumnEnabled(getColumn(sanityCheck));
+    }
+  };
+
+  const _addColumn = ({
+    column,
+    columnName,
+    table,
+    sanityCheck,
+    needsScroll = true,
+    scrollTimes = 1,
+  }) => {
+    cy.log("add the column");
+    cy.findByRole("button", { name: /Add or remove columns/ }).click();
+    cy.findByRole("list", { name: `${table}-table-columns` })
+      .findByLabelText(column)
+      .should("not.be.checked")
+      .click();
+    cy.wait("@dataset");
+    cy.findByText("Doing science...").should("not.exist");
+    if (needsScroll) {
+      [...Array(scrollTimes)].forEach(() => {
+        scrollVisualization();
+        cy.wait(200);
+      });
+    }
+    visualization().findByText(columnName).should("exist");
+    cy.findByRole("button", { name: /Done picking columns/ }).click();
+    assertColumnEnabled(getColumn(columnName));
+    if (sanityCheck) {
+      assertColumnEnabled(getColumn(sanityCheck));
+    }
+  };
+
   describe("tables", () => {
     it("should be able to show and hide table fields", () => {
       cy.createQuestion(tableQuestion, { visitQuestion: true });
       openSettings();
 
-      cy.log("hide a column");
-      visibleColumns().within(() => hideColumn("Tax"));
-      visibleColumns().findByText("Tax").should("not.exist");
-      visibleColumns().findByText("ID").should("exist");
-      disabledColumns().findByText("Tax").should("exist");
-      additionalColumns().findByText("Tax").should("not.exist");
-      visualization().findByText("Tax").should("not.exist");
+      const testData = {
+        column: "Tax",
+        columnName: "Tax",
+        sanityCheck: "ID",
+        table: "orders",
+      };
 
-      cy.log("re-run the query");
-      runQuery();
-      cy.wait("@dataset");
-      visualization().findByText("Tax").should("not.exist");
+      _hideColumn(testData);
+      _showColumn(testData);
+      _removeColumn(testData);
+      _addColumn(testData);
 
-      cy.log("show a column");
-      additionalColumns().within(() => showColumn("Tax"));
-      cy.wait("@dataset");
-      visibleColumns().findByText("Tax").should("exist");
-      visibleColumns().findByText("ID").should("exist");
-      disabledColumns().findByText("Tax").should("not.exist");
-      additionalColumns().findByText("Tax").should("not.exist");
-      scrollVisualization();
-      visualization().findByText("Tax").should("exist");
+      // cy.log("hide a column");
+      // visibleColumns().within(() => hideColumn("Tax"));
+      // visibleColumns().findByText("Tax").should("not.exist");
+      // visibleColumns().findByText("ID").should("exist");
+      // disabledColumns().findByText("Tax").should("exist");
+      // additionalColumns().findByText("Tax").should("not.exist");
+      // visualization().findByText("Tax").should("not.exist");
+
+      // cy.log("re-run the query");
+      // runQuery();
+      // cy.wait("@dataset");
+      // visualization().findByText("Tax").should("not.exist");
+
+      // cy.log("show a column");
+      // additionalColumns().within(() => showColumn("Tax"));
+      // cy.wait("@dataset");
+      // visibleColumns().findByText("Tax").should("exist");
+      // visibleColumns().findByText("ID").should("exist");
+      // disabledColumns().findByText("Tax").should("not.exist");
+      // additionalColumns().findByText("Tax").should("not.exist");
+      // scrollVisualization();
+      // visualization().findByText("Tax").should("exist");
     });
+
+    // scenarios.forEach(scenario => {
+    //   it.only(`should be able to show, hide, add and remove columns - ${scenario.name}`, () => {
+    //     const {
+    //       question,
+    //       existingColumns = [],
+    //       extraColumns = [],
+    //       sanityCheck,
+    //       needsScroll = true,
+    //     } = scenario;
+
+    //     if (typeof question === "function") {
+    //       question();
+    //     } else {
+    //       cy.createQuestion(question, { visitQuestion: true });
+    //     }
+
+    //     openSettings();
+
+    //     let cardId;
+
+    //     cy.get("@questionId").then(questionId => {
+    //       cardId = questionId;
+    //       cy.log(cardId);
+    //       cy.log(questionId);
+    //     });
+
+    //     cy.log(cardId);
+
+    //     const _existingColumns =
+    //       typeof existingColumns === "function"
+    //         ? existingColumns(cardId)
+    //         : existingColumns;
+
+    //     _existingColumns.forEach(existingColumn => {
+    //       const { column, columnName, table } = existingColumn;
+    //       cy.log("hide the column");
+    //       visibleColumns().within(() => hideColumn(columnName));
+    //       assertColumnHidden(getColumn(columnName));
+    //       if (sanityCheck) {
+    //         assertColumnEnabled(getColumn(sanityCheck));
+    //       }
+    //       if (needsScroll) {
+    //         scrollVisualization();
+    //       }
+    //       visualization().findByText(columnName).should("not.exist");
+
+    //       cy.findByRole("button", { name: /Add or remove columns/ }).click();
+    //       cy.findByRole("list", { name: `${table}-table-columns` })
+    //         .findByLabelText(column)
+    //         .should("be.checked");
+    //       cy.findByRole("button", { name: /Done picking columns/ }).click();
+
+    //       cy.log("show the column");
+    //       visibleColumns().within(() => showColumn(columnName));
+    //       assertColumnEnabled(getColumn(columnName));
+    //       if (sanityCheck) {
+    //         assertColumnEnabled(getColumn(sanityCheck));
+    //       }
+    //       if (needsScroll) {
+    //         scrollVisualization();
+    //       }
+    //       visualization().findByText(columnName).should("exist");
+
+    //       cy.log("remove the column");
+    //       cy.findByRole("button", { name: /Add or remove columns/ }).click();
+    //       cy.findByRole("list", { name: `${table}-table-columns` })
+    //         .findByLabelText(column)
+    //         .should("be.checked")
+    //         .click();
+    //       runQuery();
+    //       cy.wait("@dataset");
+    //       cy.findByText("Doing science...").should("not.exist");
+    //       if (needsScroll) {
+    //         scrollVisualization();
+    //       }
+    //       visualization().findByText(columnName).should("not.exist");
+    //       cy.findByRole("button", { name: /Done picking columns/ }).click();
+    //       getColumn(columnName).should("not.exist");
+    //       if (sanityCheck) {
+    //         assertColumnEnabled(getColumn(sanityCheck));
+    //       }
+
+    //       cy.log("add the column");
+    //       cy.findByRole("button", { name: /Add or remove columns/ }).click();
+    //       cy.findByRole("list", { name: `${table}-table-columns` })
+    //         .findByLabelText(column)
+    //         .should("not.be.checked")
+    //         .click();
+    //       cy.wait("@dataset");
+    //       cy.findByText("Doing science...").should("not.exist");
+    //       if (needsScroll) {
+    //         scrollVisualization();
+    //       }
+    //       visualization().findByText(columnName).should("exist");
+    //       cy.findByRole("button", { name: /Done picking columns/ }).click();
+    //       assertColumnEnabled(getColumn(columnName));
+    //       if (sanityCheck) {
+    //         assertColumnEnabled(getColumn(sanityCheck));
+    //       }
+    //     });
+
+    //     extraColumns.forEach(extraColumn => {
+    //       const { column, columnName, table } = extraColumn;
+    //       getColumn(columnName).should("not.exist");
+
+    //       cy.log("add the column");
+    //       cy.findByRole("button", { name: /Add or remove columns/ }).click();
+    //       cy.findByRole("list", { name: `${table}-table-columns` })
+    //         .findByLabelText(column)
+    //         .should("not.be.checked")
+    //         .click();
+    //       cy.wait("@dataset");
+    //       cy.findByText("Doing science...").should("not.exist");
+    //       if (needsScroll) {
+    //         scrollVisualization();
+    //         cy.wait(200);
+    //         scrollVisualization();
+    //         cy.wait(200);
+    //         scrollVisualization();
+    //       }
+    //       visualization().findByText(columnName).should("exist");
+    //       cy.findByRole("button", { name: /Done picking columns/ }).click();
+    //       assertColumnEnabled(getColumn(columnName));
+    //       if (sanityCheck) {
+    //         assertColumnEnabled(getColumn(sanityCheck));
+    //       }
+
+    //       cy.log("hide the column");
+    //       visibleColumns().within(() => hideColumn(columnName));
+    //       assertColumnHidden(getColumn(columnName));
+    //       if (sanityCheck) {
+    //         assertColumnEnabled(getColumn(sanityCheck));
+    //       }
+    //       if (needsScroll) {
+    //         scrollVisualization();
+    //       }
+    //       visualization().findByText(columnName).should("not.exist");
+
+    //       cy.findByRole("button", { name: /Add or remove columns/ }).click();
+    //       cy.findByRole("list", { name: `${table}-table-columns` })
+    //         .findByLabelText(column)
+    //         .should("be.checked");
+    //       cy.findByRole("button", { name: /Done picking columns/ }).click();
+
+    //       cy.log("show the column");
+    //       visibleColumns().within(() => showColumn(columnName));
+    //       assertColumnEnabled(getColumn(columnName));
+    //       if (sanityCheck) {
+    //         assertColumnEnabled(getColumn(sanityCheck));
+    //       }
+    //       if (needsScroll) {
+    //         scrollVisualization();
+    //       }
+    //       visualization().findByText(columnName).should("exist");
+
+    //       cy.log("remove the column");
+    //       cy.findByRole("button", { name: /Add or remove columns/ }).click();
+    //       cy.findByRole("list", { name: `${table}-table-columns` })
+    //         .findByLabelText(column)
+    //         .should("be.checked")
+    //         .click();
+    //       runQuery();
+    //       cy.wait("@dataset");
+    //       if (needsScroll) {
+    //         scrollVisualization();
+    //       }
+    //       visualization().findByText(columnName).should("not.exist");
+    //       cy.findByRole("button", { name: /Done picking columns/ }).click();
+    //       getColumn(columnName).should("not.exist");
+    //       if (sanityCheck) {
+    //         assertColumnEnabled(getColumn(sanityCheck));
+    //       }
+    //     });
+    //   });
+    // });
 
     it("should be able to rename table columns via popover", () => {
       cy.createQuestion(tableQuestion, { visitQuestion: true });
@@ -263,28 +719,40 @@ describe("scenarios > visualizations > table column settings", () => {
       cy.createQuestion(tableQuestionWithJoin, { visitQuestion: true });
       openSettings();
 
-      cy.log("hide a column");
-      visibleColumns().within(() => hideColumn("Products → Category"));
-      visibleColumns().findByText("Products → Category").should("not.exist");
-      visibleColumns().findByText("Products → Ean").should("exist");
-      disabledColumns().findByText("Products → Category").should("exist");
-      additionalColumns().findByText("Category").should("not.exist");
-      visualization().findByText("Products → Category").should("not.exist");
+      const testData = {
+        column: "Category",
+        columnName: "Products → Category",
+        sanityCheck: "Products → Ean",
+        table: "products",
+      };
 
-      cy.log("re-run the query");
-      runQuery();
-      cy.wait("@dataset");
-      visualization().findByText("Products → Category").should("not.exist");
+      _hideColumn(testData);
+      _showColumn(testData);
+      _removeColumn(testData);
+      _addColumn(testData);
 
-      cy.log("show a column");
-      additionalColumns().within(() => showColumn("Category"));
-      cy.wait("@dataset");
-      visibleColumns().findByText("Products → Category").should("exist");
-      visibleColumns().findByText("Products → Ean").should("exist");
-      disabledColumns().findByText("Category").should("not.exist");
-      additionalColumns().findByText("Category").should("not.exist");
-      scrollVisualization();
-      visualization().findByText("Products → Category").should("exist");
+      // cy.log("hide a column");
+      // visibleColumns().within(() => hideColumn("Products → Category"));
+      // visibleColumns().findByText("Products → Category").should("not.exist");
+      // visibleColumns().findByText("Products → Ean").should("exist");
+      // disabledColumns().findByText("Products → Category").should("exist");
+      // additionalColumns().findByText("Category").should("not.exist");
+      // visualization().findByText("Products → Category").should("not.exist");
+
+      // cy.log("re-run the query");
+      // runQuery();
+      // cy.wait("@dataset");
+      // visualization().findByText("Products → Category").should("not.exist");
+
+      // cy.log("show a column");
+      // additionalColumns().within(() => showColumn("Category"));
+      // cy.wait("@dataset");
+      // visibleColumns().findByText("Products → Category").should("exist");
+      // visibleColumns().findByText("Products → Ean").should("exist");
+      // disabledColumns().findByText("Category").should("not.exist");
+      // additionalColumns().findByText("Category").should("not.exist");
+      // scrollVisualization();
+      // visualization().findByText("Products → Category").should("exist");
     });
 
     it("should be able to show and hide table fields with a join with fields", () => {
@@ -293,40 +761,57 @@ describe("scenarios > visualizations > table column settings", () => {
       });
       openSettings();
 
-      cy.log("hide an existing column");
-      visibleColumns().within(() => hideColumn("Products → Category"));
-      visibleColumns().findByText("Products → Category").should("not.exist");
-      visibleColumns().findByText("Products → Ean").should("not.exist");
-      disabledColumns().findByText("Products → Category").should("exist");
-      additionalColumns().findByText("Category").should("not.exist");
-      visualization().findByText("Products → Category").should("not.exist");
+      const firstColumn = {
+        column: "Category",
+        columnName: "Products → Category",
+        table: "products",
+      };
 
-      cy.log("re-run the query");
-      runQuery();
-      cy.wait("@dataset");
-      visualization().findByText("Products → Category").should("not.exist");
+      const secondColumn = {
+        column: "Ean",
+        columnName: "Products → Ean",
+        table: "products",
+      };
 
-      cy.log("show an existing column");
-      additionalColumns().within(() => showColumn("Ean"));
-      cy.wait("@dataset");
-      visibleColumns().findByText("Products → Ean").should("exist");
-      visibleColumns().findByText("Products → Category").should("not.exist");
-      disabledColumns().findByText("Products → Ean").should("not.exist");
-      additionalColumns().findByText("Ean").should("not.exist");
-      additionalColumns().findByText("Category").should("exist");
-      scrollVisualization();
-      visualization().findByText("Products → Ean").should("exist");
+      _hideColumn(firstColumn);
+      _removeColumn(firstColumn);
 
-      cy.log("show a new column");
-      additionalColumns().within(() => showColumn("Category"));
-      cy.wait("@dataset");
-      visibleColumns().findByText("Products → Ean").should("exist");
-      visibleColumns().findByText("Products → Category").should("exist");
-      additionalColumns().findByText("Ean").should("not.exist");
-      additionalColumns().findByText("Category").should("not.exist");
-      additionalColumns().findByText("Rating").should("exist");
-      scrollVisualization();
-      visualization().findByText("Products → Category").should("exist");
+      _addColumn(secondColumn);
+
+      // cy.log("hide an existing column");
+      // visibleColumns().within(() => hideColumn("Products → Category"));
+      // visibleColumns().findByText("Products → Category").should("not.exist");
+      // visibleColumns().findByText("Products → Ean").should("not.exist");
+      // disabledColumns().findByText("Products → Category").should("exist");
+      // additionalColumns().findByText("Category").should("not.exist");
+      // visualization().findByText("Products → Category").should("not.exist");
+
+      // cy.log("re-run the query");
+      // runQuery();
+      // cy.wait("@dataset");
+      // visualization().findByText("Products → Category").should("not.exist");
+
+      // cy.log("show an existing column");
+      // additionalColumns().within(() => showColumn("Ean"));
+      // cy.wait("@dataset");
+      // visibleColumns().findByText("Products → Ean").should("exist");
+      // visibleColumns().findByText("Products → Category").should("not.exist");
+      // disabledColumns().findByText("Products → Ean").should("not.exist");
+      // additionalColumns().findByText("Ean").should("not.exist");
+      // additionalColumns().findByText("Category").should("exist");
+      // scrollVisualization();
+      // visualization().findByText("Products → Ean").should("exist");
+
+      // cy.log("show a new column");
+      // additionalColumns().within(() => showColumn("Category"));
+      // cy.wait("@dataset");
+      // visibleColumns().findByText("Products → Ean").should("exist");
+      // visibleColumns().findByText("Products → Category").should("exist");
+      // additionalColumns().findByText("Ean").should("not.exist");
+      // additionalColumns().findByText("Category").should("not.exist");
+      // additionalColumns().findByText("Rating").should("exist");
+      // scrollVisualization();
+      // visualization().findByText("Products → Category").should("exist");
     });
 
     it("should be able to show and hide table fields with a self join with fields", () => {
@@ -335,24 +820,19 @@ describe("scenarios > visualizations > table column settings", () => {
       });
       openSettings();
 
-      cy.log("hide an existing column");
-      visibleColumns().within(() => hideColumn("Orders → Tax"));
-      visibleColumns().findByText("Tax").should("exist");
-      visibleColumns().findByText("Orders → Tax").should("not.exist");
-      disabledColumns().findByText("Tax").should("not.exist");
-      disabledColumns().findByText("Orders → Tax").should("exist");
-      additionalColumns().findByText("Tax").should("not.exist");
-      visualization().findByText("Orders → Tax").should("not.exist");
+      const testData = {
+        column: "Tax",
+        columnName: "Orders → Tax",
+        table: "orders 2",
+        needsScroll: false,
+      };
 
-      cy.log("re-run the query");
-      runQuery();
-      cy.wait("@dataset");
-      visibleColumns().findByText("Tax").should("exist");
-      disabledColumns().findByText("Tax").should("not.exist");
-      disabledColumns().findByText("Orders → Tax").should("not.exist");
-      additionalColumns().findByText("Tax").should("exist");
-      visualization().findByText("Orders → Tax").should("not.exist");
+      _hideColumn(testData);
+      _showColumn(testData);
+      _removeColumn(testData);
+      _addColumn(testData);
 
+<<<<<<< HEAD
       cy.log("show the column");
       additionalColumns().within(() => showColumn("Tax"));
       cy.wait("@dataset");
@@ -362,36 +842,77 @@ describe("scenarios > visualizations > table column settings", () => {
       disabledColumns().findByText("Tax").should("not.exist");
       additionalColumns().findByText("Tax").should("not.exist");
       visualization().findByText("Orders → Tax").should("exist");
+=======
+      // cy.log("hide an existing column");
+      // visibleColumns().within(() => hideColumn("Orders → Tax"));
+      // visibleColumns().findByText("Tax").should("exist");
+      // visibleColumns().findByText("Orders → Tax").should("not.exist");
+      // disabledColumns().findByText("Tax").should("not.exist");
+      // disabledColumns().findByText("Orders → Tax").should("exist");
+      // additionalColumns().findByText("Tax").should("not.exist");
+      // visualization().findByText("Orders → Tax").should("not.exist");
+
+      // cy.log("re-run the query");
+      // runQuery();
+      // cy.wait("@dataset");
+      // visibleColumns().findByText("Tax").should("exist");
+      // disabledColumns().findByText("Tax").should("not.exist");
+      // disabledColumns().findByText("Orders → Tax").should("not.exist");
+      // additionalColumns().findByText("Tax").should("exist");
+      // visualization().findByText("Orders → Tax").should("not.exist");
+
+      // cy.log("show the column");
+      // additionalColumns().within(() => showColumn("Tax"));
+      // cy.wait("@dataset");
+      // visibleColumns().findByText("Orders → Tax").should("exist");
+      // visibleColumns().findByText("Tax").should("exist");
+      // disabledColumns().findByText("Orders → Tax").should("not.exist");
+      // disabledColumns().findByText("Tax").should("not.exist");
+      // additionalColumns().findByText("Tax").should("not.exist");
+      // scrollVisualization();
+      // visualization().findByText("Orders → Tax").should("exist");
+>>>>>>> 97d973099a (e2e tests passing)
     });
 
     it("should be able to show and hide implicitly joinable fields for a table", () => {
       cy.createQuestion(tableQuestion, { visitQuestion: true });
       openSettings();
 
-      cy.log("show a column");
-      additionalColumns().within(() => showColumn("Category"));
-      cy.wait("@dataset");
-      visibleColumns().findByText("Product → Category").should("exist");
-      additionalColumns().findByText("Category").should("not.exist");
-      scrollVisualization();
-      visualization().findByText("Product → Category").should("exist");
+      const testData = {
+        column: "Category",
+        columnName: "Product → Category",
+        table: "product",
+      };
 
-      cy.log("hide a column");
-      visibleColumns().within(() => hideColumn("Product → Category"));
-      visibleColumns().findByText("Product → Category").should("not.exist");
-      disabledColumns().findByText("Product → Category").should("exist");
-      additionalColumns().findByText("Category").should("not.exist");
-      scrollVisualization();
-      visualization().findByText("Product → Category").should("not.exist");
+      _addColumn(testData);
+      _hideColumn(testData);
+      _showColumn(testData);
+      _removeColumn(testData);
 
-      cy.log("re-run the query");
-      runQuery();
-      cy.wait("@dataset");
-      visibleColumns().findByText("Product → Category").should("not.exist");
-      disabledColumns().findByText("Product → Category").should("not.exist");
-      additionalColumns().findByText("Category").should("exist");
-      scrollVisualization();
-      visualization().findByText("Product → Category").should("not.exist");
+      //   cy.log("show a column");
+      //   additionalColumns().within(() => showColumn("Category"));
+      //   cy.wait("@dataset");
+      //   visibleColumns().findByText("Product → Category").should("exist");
+      //   additionalColumns().findByText("Category").should("not.exist");
+      //   scrollVisualization();
+      //   visualization().findByText("Product → Category").should("exist");
+
+      //   cy.log("hide a column");
+      //   visibleColumns().within(() => hideColumn("Product → Category"));
+      //   visibleColumns().findByText("Product → Category").should("not.exist");
+      //   disabledColumns().findByText("Product → Category").should("exist");
+      //   additionalColumns().findByText("Category").should("not.exist");
+      //   scrollVisualization();
+      //   visualization().findByText("Product → Category").should("not.exist");
+
+      //   cy.log("re-run the query");
+      //   runQuery();
+      //   cy.wait("@dataset");
+      //   visibleColumns().findByText("Product → Category").should("not.exist");
+      //   disabledColumns().findByText("Product → Category").should("not.exist");
+      //   additionalColumns().findByText("Category").should("exist");
+      //   scrollVisualization();
+      //   visualization().findByText("Product → Category").should("not.exist");
     });
 
     it("should be able to show and hide custom expressions for a table", () => {
@@ -400,26 +921,37 @@ describe("scenarios > visualizations > table column settings", () => {
       });
       openSettings();
 
-      cy.log("hide a column");
-      visibleColumns().within(() => hideColumn("Math"));
-      visibleColumns().findByText("Math").should("not.exist");
-      disabledColumns().findByText("Math").should("exist");
-      scrollVisualization();
-      visualization().findByText("Math").should("not.exist");
+      const testData = {
+        column: "Math",
+        columnName: "Math",
+        table: "orders",
+      };
 
-      cy.log("re-run the query");
-      runQuery();
-      cy.wait("@dataset");
-      scrollVisualization();
-      visualization().findByText("Math").should("not.exist");
+      _hideColumn(testData);
+      _showColumn(testData);
+      _removeColumn(testData);
+      _addColumn(testData);
 
-      cy.log("show a column");
-      additionalColumns().within(() => showColumn("Math"));
-      cy.wait("@dataset");
-      visibleColumns().findByText("Math").should("exist");
-      additionalColumns().findByText("Math").should("not.exist");
-      scrollVisualization();
-      visualization().findByText("Math").should("exist");
+      // cy.log("hide a column");
+      // visibleColumns().within(() => hideColumn("Math"));
+      // visibleColumns().findByText("Math").should("not.exist");
+      // disabledColumns().findByText("Math").should("exist");
+      // scrollVisualization();
+      // visualization().findByText("Math").should("not.exist");
+
+      // cy.log("re-run the query");
+      // runQuery();
+      // cy.wait("@dataset");
+      // scrollVisualization();
+      // visualization().findByText("Math").should("not.exist");
+
+      // cy.log("show a column");
+      // additionalColumns().within(() => showColumn("Math"));
+      // cy.wait("@dataset");
+      // visibleColumns().findByText("Math").should("exist");
+      // additionalColumns().findByText("Math").should("not.exist");
+      // scrollVisualization();
+      // visualization().findByText("Math").should("exist");
     });
 
     it("should be able to show and hide custom expressions for a table with selected fields", () => {
@@ -428,54 +960,87 @@ describe("scenarios > visualizations > table column settings", () => {
       });
       openSettings();
 
-      cy.log("hide a column");
-      visibleColumns().within(() => hideColumn("Math"));
-      visibleColumns().findByText("Math").should("not.exist");
-      disabledColumns().findByText("Math").should("exist");
-      visualization().findByText("Math").should("not.exist");
+      const testData = {
+        column: "Math",
+        columnName: "Math",
+        table: "orders",
+        needsScroll: false,
+      };
 
-      cy.log("re-run the query");
-      runQuery();
-      cy.wait("@dataset");
-      visualization().findByText("Math").should("not.exist");
+      _hideColumn(testData);
+      _showColumn(testData);
+      _removeColumn(testData);
+      _addColumn(testData);
 
-      cy.log("show a column");
-      additionalColumns().within(() => showColumn("Math"));
-      cy.wait("@dataset");
-      visibleColumns().findByText("Math").should("exist");
-      additionalColumns().findByText("Math").should("not.exist");
-      visualization().findByText("Math").should("exist");
+      // cy.log("hide a column");
+      // visibleColumns().within(() => hideColumn("Math"));
+      // visibleColumns().findByText("Math").should("not.exist");
+      // disabledColumns().findByText("Math").should("exist");
+      // visualization().findByText("Math").should("not.exist");
+
+      // cy.log("re-run the query");
+      // runQuery();
+      // cy.wait("@dataset");
+      // visualization().findByText("Math").should("not.exist");
+
+      // cy.log("show a column");
+      // additionalColumns().within(() => showColumn("Math"));
+      // cy.wait("@dataset");
+      // visibleColumns().findByText("Math").should("exist");
+      // additionalColumns().findByText("Math").should("not.exist");
+      // visualization().findByText("Math").should("exist");
     });
 
     it("should be able to show and hide columns from aggregations", () => {
       cy.createQuestion(tableWithAggregations, { visitQuestion: true });
       openSettings();
 
-      cy.log("hide a column");
-      visibleColumns().within(() => hideColumn("Count"));
-      visibleColumns().findByText("Count").should("not.exist");
-      visibleColumns().findByText("Sum of Quantity").should("exist");
-      disabledColumns().findByText("Count").should("exist");
-      visualization().findByText("Count").should("not.exist");
+      const testData = {
+        column: "Count",
+        columnName: "Count",
+        table: "orders",
+        sanityCheck: "Sum of Quantity",
+        needsScroll: false,
+      };
 
-      cy.log("show a column");
-      disabledColumns().within(() => showColumn("Count"));
-      visibleColumns().findByText("Count").should("exist");
-      visibleColumns().findByText("Sum of Quantity").should("exist");
-      visualization().findByText("Count").should("exist");
+      const testData2 = {
+        column: "Sum of Quantity",
+        columnName: "Sum of Quantity",
+        table: "orders",
+        sanityCheck: "Count",
+        needsScroll: false,
+      };
 
-      cy.log("hide a column with an inner field");
-      visibleColumns().within(() => hideColumn("Sum of Quantity"));
-      visibleColumns().findByText("Sum of Quantity").should("not.exist");
-      visibleColumns().findByText("Count").should("exist");
-      disabledColumns().findByText("Sum of Quantity").should("exist");
-      visualization().findByText("Sum of Quantity").should("not.exist");
+      _hideColumn(testData);
+      _showColumn(testData);
+      _hideColumn(testData2);
+      _showColumn(testData2);
 
-      cy.log("show a column with an inner field");
-      disabledColumns().within(() => showColumn("Sum of Quantity"));
-      visibleColumns().findByText("Sum of Quantity").should("exist");
-      visibleColumns().findByText("Count").should("exist");
-      visualization().findByText("Sum of Quantity").should("exist");
+      //   cy.log("hide a column");
+      //   visibleColumns().within(() => hideColumn("Count"));
+      //   visibleColumns().findByText("Count").should("not.exist");
+      //   visibleColumns().findByText("Sum of Quantity").should("exist");
+      //   disabledColumns().findByText("Count").should("exist");
+      //   visualization().findByText("Count").should("not.exist");
+
+      //   cy.log("show a column");
+      //   disabledColumns().within(() => showColumn("Count"));
+      //   visibleColumns().findByText("Count").should("exist");
+      //   visibleColumns().findByText("Sum of Quantity").should("exist");
+      //   visualization().findByText("Count").should("exist");
+
+      //   cy.log("hide a column with an inner field");
+      //   visibleColumns().within(() => hideColumn("Sum of Quantity"));
+      //   visibleColumns().findByText("Sum of Quantity").should("not.exist");
+      //   visibleColumns().findByText("Count").should("exist");
+      //   disabledColumns().findByText("Sum of Quantity").should("exist");
+      //   visualization().findByText("Sum of Quantity").should("not.exist");
+
+      //   cy.log("show a column with an inner field");
+      //   disabledColumns().within(() => showColumn("Sum of Quantity"));
+      //   visibleColumns().findByText("Sum of Quantity").should("exist");
+      //   visibleColumns().findByText("Count").should("exist");
+      //   visualization().findByText("Sum of Quantity").should("exist");
     });
   });
 
@@ -484,49 +1049,70 @@ describe("scenarios > visualizations > table column settings", () => {
       cy.createQuestion(multiStageQuestion, { visitQuestion: true });
       openSettings();
 
-      cy.log("hide an aggregation column");
-      visibleColumns().within(() => hideColumn("Count"));
-      visibleColumns().findByText("Count").should("not.exist");
-      visibleColumns().findByText("Product ID").should("exist");
-      disabledColumns().findByText("Count").should("exist");
-      additionalColumns().findByText("Count").should("not.exist");
-      visualization().findByText("Count").should("not.exist");
+      const testData = {
+        column: "Count",
+        columnName: "Count",
+        table: "question",
+        sanityCheck: "Product ID",
+        needsScroll: false,
+      };
 
-      cy.log("re-run the query");
-      runQuery();
-      cy.wait("@dataset");
-      visualization().findByText("Count").should("not.exist");
+      const testData2 = {
+        column: "Product ID",
+        columnName: "Product ID",
+        table: "question",
+        sanityCheck: "Count",
+        needsScroll: false,
+      };
 
-      cy.log("show an aggregation column");
-      additionalColumns().within(() => showColumn("Count"));
-      cy.wait("@dataset");
-      visibleColumns().findByText("Count").should("exist");
-      visibleColumns().findByText("Product ID").should("exist");
-      disabledColumns().findByText("Count").should("not.exist");
-      additionalColumns().findByText("Count").should("not.exist");
-      visualization().findByText("Count").should("exist");
+      _hideColumn(testData);
+      _showColumn(testData);
+      _hideColumn(testData2);
+      _showColumn(testData2);
 
-      cy.log("hide a breakout column");
-      visibleColumns().within(() => hideColumn("Product ID"));
-      visibleColumns().findByText("Product ID").should("not.exist");
-      visibleColumns().findByText("Count").should("exist");
-      disabledColumns().findByText("Product ID").should("exist");
-      additionalColumns().findByText("Product ID").should("not.exist");
-      visualization().findByText("Product ID").should("not.exist");
+      // cy.log("hide an aggregation column");
+      // visibleColumns().within(() => hideColumn("Count"));
+      // visibleColumns().findByText("Count").should("not.exist");
+      // visibleColumns().findByText("Product ID").should("exist");
+      // disabledColumns().findByText("Count").should("exist");
+      // additionalColumns().findByText("Count").should("not.exist");
+      // visualization().findByText("Count").should("not.exist");
 
-      cy.log("re-run the query");
-      runQuery();
-      cy.wait("@dataset");
-      visualization().findByText("Product ID").should("not.exist");
+      // cy.log("re-run the query");
+      // runQuery();
+      // cy.wait("@dataset");
+      // visualization().findByText("Count").should("not.exist");
 
-      cy.log("show a breakout column");
-      additionalColumns().within(() => showColumn("Product ID"));
-      cy.wait("@dataset");
-      visibleColumns().findByText("Product ID").should("exist");
-      visibleColumns().findByText("Count").should("exist");
-      disabledColumns().findByText("Product ID").should("not.exist");
-      additionalColumns().findByText("Product ID").should("not.exist");
-      visualization().findByText("Product ID").should("exist");
+      // cy.log("show an aggregation column");
+      // additionalColumns().within(() => showColumn("Count"));
+      // cy.wait("@dataset");
+      // visibleColumns().findByText("Count").should("exist");
+      // visibleColumns().findByText("Product ID").should("exist");
+      // disabledColumns().findByText("Count").should("not.exist");
+      // additionalColumns().findByText("Count").should("not.exist");
+      // visualization().findByText("Count").should("exist");
+
+      // cy.log("hide a breakout column");
+      // visibleColumns().within(() => hideColumn("Product ID"));
+      // visibleColumns().findByText("Product ID").should("not.exist");
+      // visibleColumns().findByText("Count").should("exist");
+      // disabledColumns().findByText("Product ID").should("exist");
+      // additionalColumns().findByText("Product ID").should("not.exist");
+      // visualization().findByText("Product ID").should("not.exist");
+
+      // cy.log("re-run the query");
+      // runQuery();
+      // cy.wait("@dataset");
+      // visualization().findByText("Product ID").should("not.exist");
+
+      // cy.log("show a breakout column");
+      // additionalColumns().within(() => showColumn("Product ID"));
+      // cy.wait("@dataset");
+      // visibleColumns().findByText("Product ID").should("exist");
+      // visibleColumns().findByText("Count").should("exist");
+      // disabledColumns().findByText("Product ID").should("not.exist");
+      // additionalColumns().findByText("Product ID").should("not.exist");
+      // visualization().findByText("Product ID").should("exist");
     });
   });
 
@@ -537,29 +1123,40 @@ describe("scenarios > visualizations > table column settings", () => {
       });
       openSettings();
 
-      cy.log("hide a column");
-      visibleColumns().within(() => hideColumn("Tax"));
-      visibleColumns().findByText("Tax").should("not.exist");
-      disabledColumns().findByText("Tax").should("exist");
-      scrollVisualization();
-      visualization().findByText("Tax").should("not.exist");
+      const testData = {
+        column: "Tax",
+        columnName: "Tax",
+        table: "test question",
+      };
 
-      cy.log("re-run the query");
-      runQuery();
-      cy.wait("@dataset");
-      visibleColumns().findByText("Tax").should("not.exist");
-      disabledColumns().findByText("Tax").should("not.exist");
-      additionalColumns().findByText("Tax").should("exist");
-      scrollVisualization();
-      visualization().findByText("Tax").should("not.exist");
+      _hideColumn(testData);
+      _showColumn(testData);
+      _removeColumn(testData);
+      _addColumn(testData);
 
-      cy.log("show a column");
-      additionalColumns().within(() => showColumn("Tax"));
-      cy.wait("@dataset");
-      visibleColumns().findByText("Tax").should("exist");
-      additionalColumns().findByText("Tax").should("not.exist");
-      scrollVisualization();
-      visualization().findByText("Tax").should("exist");
+      // cy.log("hide a column");
+      // visibleColumns().within(() => hideColumn("Tax"));
+      // visibleColumns().findByText("Tax").should("not.exist");
+      // disabledColumns().findByText("Tax").should("exist");
+      // scrollVisualization();
+      // visualization().findByText("Tax").should("not.exist");
+
+      // cy.log("re-run the query");
+      // runQuery();
+      // cy.wait("@dataset");
+      // visibleColumns().findByText("Tax").should("not.exist");
+      // disabledColumns().findByText("Tax").should("not.exist");
+      // additionalColumns().findByText("Tax").should("exist");
+      // scrollVisualization();
+      // visualization().findByText("Tax").should("not.exist");
+
+      // cy.log("show a column");
+      // additionalColumns().within(() => showColumn("Tax"));
+      // cy.wait("@dataset");
+      // visibleColumns().findByText("Tax").should("exist");
+      // additionalColumns().findByText("Tax").should("not.exist");
+      // scrollVisualization();
+      // visualization().findByText("Tax").should("exist");
     });
 
     it("should be able to show and hide fields from a nested query with joins (metabase#32373)", () => {
@@ -568,24 +1165,35 @@ describe("scenarios > visualizations > table column settings", () => {
       });
       openSettings();
 
-      cy.log("hide a column");
-      visibleColumns().within(() => hideColumn("Products → Ean"));
-      visibleColumns().findByText("Products → Ean").should("not.exist");
-      disabledColumns().findByText("Products → Ean").should("exist");
+      const testData = {
+        column: "Products → Ean",
+        columnName: "Products → Ean",
+        table: "test question",
+      };
 
-      cy.log("re-run the query");
-      runQuery();
-      cy.wait("@dataset");
-      scrollVisualization("center");
-      visualization().findByText("Products → Ean").should("not.exist");
+      _hideColumn(testData);
+      _showColumn(testData);
+      _removeColumn(testData);
+      _addColumn(testData);
 
-      cy.log("show a column");
-      additionalColumns().within(() => showColumn("Products → Ean"));
-      cy.wait("@dataset");
-      visibleColumns().findByText("Products → Ean").should("exist");
-      additionalColumns().findByText("Products → Ean").should("not.exist");
-      scrollVisualization("center");
-      visualization().findByText("Products → Ean").should("exist");
+      // cy.log("hide a column");
+      // visibleColumns().within(() => hideColumn("Products → Ean"));
+      // visibleColumns().findByText("Products → Ean").should("not.exist");
+      // disabledColumns().findByText("Products → Ean").should("exist");
+
+      // cy.log("re-run the query");
+      // runQuery();
+      // cy.wait("@dataset");
+      // scrollVisualization("center");
+      // visualization().findByText("Products → Ean").should("not.exist");
+
+      // cy.log("show a column");
+      // additionalColumns().within(() => showColumn("Products → Ean"));
+      // cy.wait("@dataset");
+      // visibleColumns().findByText("Products → Ean").should("exist");
+      // additionalColumns().findByText("Products → Ean").should("not.exist");
+      // scrollVisualization("center");
+      // visualization().findByText("Products → Ean").should("exist");
     });
 
     // TODO: This is currently broken by some subtleties of `:lib/source` in MLv2.
@@ -598,39 +1206,65 @@ describe("scenarios > visualizations > table column settings", () => {
       );
       openSettings();
 
-      cy.log("hide an existing column");
-      visibleColumns().within(() => hideColumn("Products → Category"));
-      visibleColumns().findByText("Products → Category").should("not.exist");
-      disabledColumns().findByText("Products → Category").should("exist");
-      scrollVisualization();
-      visualization().findByText("Products → Category").should("not.exist");
+      const testData = {
+        column: "Products → Category",
+        columnName: "Products → Category",
+        table: "test question",
+      };
 
-      cy.log("re-run the query");
-      runQuery();
-      cy.wait("@dataset");
-      scrollVisualization();
-      visualization().findByText("Products → Category").should("not.exist");
+      const testData2 = {
+        column: "Ean",
+        columnName: "Product → Ean",
+        table: "product",
+      };
 
-      cy.log("show a new column");
-      additionalColumns().within(() => showColumn("Ean"));
-      cy.wait("@dataset");
-      visibleColumns().findByText("Product → Ean").should("exist");
-      additionalColumns().findByText("Ean").should("not.exist");
-      scrollVisualization();
-      visualization().findByText("Product → Ean").should("exist");
+      _hideColumn(testData);
+      _removeColumn(testData);
 
-      cy.log("show an existing column");
-      additionalColumns().within(() => showColumn("Products → Category"));
-      cy.wait("@dataset");
-      // TODO: Once #33972 is fixed in the QP, this test will start failing.
-      // The correct display name is "Products -> Category", but the QP is incorrectly marking this column as coming
-      // from the implicit join (so it's using PRODUCT_ID -> "Product", not the table name "Products").
-      visibleColumns().findByText("Product → Category").should("exist");
-      visibleColumns().findByText("Product → Ean").should("exist");
-      additionalColumns().findByText("Product → Category").should("not.exist");
-      scrollVisualization();
-      visualization().findByText("Product → Category").should("exist");
-      visualization().findByText("Product → Ean").should("exist");
+      _addColumn(testData2);
+
+      // // TODO: Once #33972 is fixed in the QP, this test will start failing.
+      // // The correct display name is "Products -> Category", but the QP is incorrectly marking this column as coming
+      // // from the implicit join (so it's using PRODUCT_ID -> "Product", not the table name "Products").
+      _addColumn({
+        ...testData,
+        column: "Products → Category",
+        columnName: "Product → Category",
+      });
+
+      // cy.log("hide an existing column");
+      // visibleColumns().within(() => hideColumn("Products → Category"));
+      // visibleColumns().findByText("Products → Category").should("not.exist");
+      // disabledColumns().findByText("Products → Category").should("exist");
+      // scrollVisualization();
+      // visualization().findByText("Products → Category").should("not.exist");
+
+      // cy.log("re-run the query");
+      // runQuery();
+      // cy.wait("@dataset");
+      // scrollVisualization();
+      // visualization().findByText("Products → Category").should("not.exist");
+
+      // cy.log("show a new column");
+      // additionalColumns().within(() => showColumn("Ean"));
+      // cy.wait("@dataset");
+      // visibleColumns().findByText("Product → Ean").should("exist");
+      // additionalColumns().findByText("Ean").should("not.exist");
+      // scrollVisualization();
+      // visualization().findByText("Product → Ean").should("exist");
+
+      // cy.log("show an existing column");
+      // additionalColumns().within(() => showColumn("Products → Category"));
+      // cy.wait("@dataset");
+      // // TODO: Once #33972 is fixed in the QP, this test will start failing.
+      // // The correct display name is "Products -> Category", but the QP is incorrectly marking this column as coming
+      // // from the implicit join (so it's using PRODUCT_ID -> "Product", not the table name "Products").
+      // visibleColumns().findByText("Product → Category").should("exist");
+      // visibleColumns().findByText("Product → Ean").should("exist");
+      // additionalColumns().findByText("Product → Category").should("not.exist");
+      // scrollVisualization();
+      // visualization().findByText("Product → Category").should("exist");
+      // visualization().findByText("Product → Ean").should("exist");
     });
 
     it("should be able to show and hide implicitly joinable fields for a nested query with joins and fields", () => {
@@ -641,34 +1275,45 @@ describe("scenarios > visualizations > table column settings", () => {
       });
       openSettings();
 
-      cy.log("show a new column");
-      additionalColumns().within(() => showColumn("ID"));
-      cy.wait("@dataset");
-      visibleColumns().findByText("User → ID").should("exist");
-      additionalColumns().findByText("ID").should("not.exist");
-      // Simply scrolling once doesn't bring the column into view reliably.
-      scrollVisualization();
-      cy.wait(200);
-      scrollVisualization();
-      cy.wait(200);
-      scrollVisualization();
-      visualization().findByText("User → ID").should("exist");
+      const newColumn = {
+        column: "ID",
+        columnName: "User → ID",
+        table: "user",
+        scrollTimes: 3,
+      };
 
-      cy.log("hide the column");
-      visibleColumns().within(() => hideColumn("User → ID"));
-      visibleColumns().findByText("User → ID").should("not.exist");
-      disabledColumns().findByText("User → ID").should("exist");
-      scrollVisualization();
-      visualization().findByText("User → ID").should("not.exist");
+      _addColumn(newColumn);
+      _hideColumn(newColumn);
+      _removeColumn(newColumn);
 
-      cy.log("re-run the query");
-      runQuery();
-      cy.wait("@dataset");
-      visibleColumns().findByText("User → ID").should("not.exist");
-      disabledColumns().findByText("User → ID").should("not.exist");
-      additionalColumns().findByText("ID").should("exist");
-      scrollVisualization();
-      visualization().findByText("User → ID").should("not.exist");
+      // cy.log("show a new column");
+      // additionalColumns().within(() => showColumn("ID"));
+      // cy.wait("@dataset");
+      // visibleColumns().findByText("User → ID").should("exist");
+      // additionalColumns().findByText("ID").should("not.exist");
+      // // Simply scrolling once doesn't bring the column into view reliably.
+      // scrollVisualization();
+      // cy.wait(200);
+      // scrollVisualization();
+      // cy.wait(200);
+      // scrollVisualization();
+      // visualization().findByText("User → ID").should("exist");
+
+      // cy.log("hide the column");
+      // visibleColumns().within(() => hideColumn("User → ID"));
+      // visibleColumns().findByText("User → ID").should("not.exist");
+      // disabledColumns().findByText("User → ID").should("exist");
+      // scrollVisualization();
+      // visualization().findByText("User → ID").should("not.exist");
+
+      // cy.log("re-run the query");
+      // runQuery();
+      // cy.wait("@dataset");
+      // visibleColumns().findByText("User → ID").should("not.exist");
+      // disabledColumns().findByText("User → ID").should("not.exist");
+      // additionalColumns().findByText("ID").should("exist");
+      // scrollVisualization();
+      // visualization().findByText("User → ID").should("not.exist");
     });
 
     it("should be able to show and hide implicitly joinable fields for a nested query", () => {
@@ -677,27 +1322,37 @@ describe("scenarios > visualizations > table column settings", () => {
       });
       openSettings();
 
-      cy.log("show a column");
-      additionalColumns().within(() => showColumn("Category"));
-      cy.wait("@dataset");
-      visibleColumns().findByText("Product → Category").should("exist");
-      additionalColumns().findByText("Category").should("not.exist");
-      scrollVisualization();
-      visualization().findByText("Product → Category").should("exist");
+      const newColumn = {
+        column: "Category",
+        columnName: "Product → Category",
+        table: "product",
+      };
 
-      cy.log("hide a column");
-      visibleColumns().within(() => hideColumn("Product → Category"));
-      visibleColumns().findByText("Product → Category").should("not.exist");
-      disabledColumns().findByText("Product → Category").should("exist");
-      visualization().findByText("Product → Category").should("not.exist");
+      _addColumn(newColumn);
+      _hideColumn(newColumn);
+      _removeColumn(newColumn);
 
-      cy.log("re-run the query");
-      runQuery();
-      cy.wait("@dataset");
-      visibleColumns().findByText("Product → Category").should("not.exist");
-      additionalColumns().findByText("Category").should("exist");
-      scrollVisualization();
-      visualization().findByText("Product → Category").should("not.exist");
+      // cy.log("show a column");
+      // additionalColumns().within(() => showColumn("Category"));
+      // cy.wait("@dataset");
+      // visibleColumns().findByText("Product → Category").should("exist");
+      // additionalColumns().findByText("Category").should("not.exist");
+      // scrollVisualization();
+      // visualization().findByText("Product → Category").should("exist");
+
+      // cy.log("hide a column");
+      // visibleColumns().within(() => hideColumn("Product → Category"));
+      // visibleColumns().findByText("Product → Category").should("not.exist");
+      // disabledColumns().findByText("Product → Category").should("exist");
+      // visualization().findByText("Product → Category").should("not.exist");
+
+      // cy.log("re-run the query");
+      // runQuery();
+      // cy.wait("@dataset");
+      // visibleColumns().findByText("Product → Category").should("not.exist");
+      // additionalColumns().findByText("Category").should("exist");
+      // scrollVisualization();
+      // visualization().findByText("Product → Category").should("not.exist");
     });
 
     it("should be able to show and hide custom expressions from a nested query", () => {
@@ -706,26 +1361,37 @@ describe("scenarios > visualizations > table column settings", () => {
       });
       openSettings();
 
-      cy.log("hide a column");
-      visibleColumns().within(() => hideColumn("Math"));
-      visibleColumns().findByText("Math").should("not.exist");
-      disabledColumns().findByText("Math").should("exist");
-      scrollVisualization();
-      visualization().findByText("Math").should("not.exist");
+      const mathColumn = {
+        column: "Math",
+        columnName: "Math",
+        table: "test question",
+      };
 
-      cy.log("re-run the query");
-      runQuery();
-      cy.wait("@dataset");
-      scrollVisualization();
-      visualization().findByText("Math").should("not.exist");
+      _hideColumn(mathColumn);
+      _showColumn(mathColumn);
+      _removeColumn(mathColumn);
+      _addColumn(mathColumn);
 
-      cy.log("show a column");
-      additionalColumns().within(() => showColumn("Math"));
-      cy.wait("@dataset");
-      visibleColumns().findByText("Math").should("exist");
-      additionalColumns().findByText("Math").should("not.exist");
-      scrollVisualization();
-      visualization().findByText("Math").should("exist");
+      // cy.log("hide a column");
+      // visibleColumns().within(() => hideColumn("Math"));
+      // visibleColumns().findByText("Math").should("not.exist");
+      // disabledColumns().findByText("Math").should("exist");
+      // scrollVisualization();
+      // visualization().findByText("Math").should("not.exist");
+
+      // cy.log("re-run the query");
+      // runQuery();
+      // cy.wait("@dataset");
+      // scrollVisualization();
+      // visualization().findByText("Math").should("not.exist");
+
+      // cy.log("show a column");
+      // additionalColumns().within(() => showColumn("Math"));
+      // cy.wait("@dataset");
+      // visibleColumns().findByText("Math").should("exist");
+      // additionalColumns().findByText("Math").should("not.exist");
+      // scrollVisualization();
+      // visualization().findByText("Math").should("exist");
     });
 
     it("should be able to show and hide columns from aggregations from a nested query", () => {
@@ -734,76 +1400,104 @@ describe("scenarios > visualizations > table column settings", () => {
       });
       openSettings();
 
-      cy.log("hide a column");
-      visibleColumns().within(() => hideColumn("Count"));
-      visibleColumns().findByText("Count").should("not.exist");
-      visibleColumns().findByText("Sum of Quantity").should("exist");
-      disabledColumns().findByText("Count").should("exist");
-      visualization().findByText("Count").should("not.exist");
-      runQuery();
-      cy.wait("@dataset");
+      const countColumn = {
+        column: "Count",
+        columnName: "Count",
+        table: "test question",
+        needsScroll: false,
+      };
 
-      cy.log("show a column");
-      additionalColumns().within(() => showColumn("Count"));
-      cy.wait("@dataset");
-      visibleColumns().findByText("Count").should("exist");
-      visibleColumns().findByText("Sum of Quantity").should("exist");
-      visualization().findByText("Count").should("exist");
+      const sumColumn = {
+        column: "Sum of Quantity",
+        columnName: "Sum of Quantity",
+        table: "test question",
+        needsScroll: false,
+      };
 
-      cy.log("hide a column with an inner field");
-      visibleColumns().within(() => hideColumn("Sum of Quantity"));
-      visibleColumns().findByText("Sum of Quantity").should("not.exist");
-      visibleColumns().findByText("Count").should("exist");
-      disabledColumns().findByText("Sum of Quantity").should("exist");
-      visualization().findByText("Sum of Quantity").should("not.exist");
-      runQuery();
-      cy.wait("@dataset");
+      _hideColumn(countColumn);
+      _showColumn(countColumn);
+      _hideColumn(sumColumn);
+      _showColumn(sumColumn);
 
-      cy.log("show a column with an inner field");
-      additionalColumns().within(() => showColumn("Sum of Quantity"));
-      cy.wait("@dataset");
-      visibleColumns().findByText("Sum of Quantity").should("exist");
-      visibleColumns().findByText("Count").should("exist");
-      visualization().findByText("Sum of Quantity").should("exist");
+      //   cy.log("hide a column");
+      //   visibleColumns().within(() => hideColumn("Count"));
+      //   visibleColumns().findByText("Count").should("not.exist");
+      //   visibleColumns().findByText("Sum of Quantity").should("exist");
+      //   disabledColumns().findByText("Count").should("exist");
+      //   visualization().findByText("Count").should("not.exist");
+      //   runQuery();
+      //   cy.wait("@dataset");
+
+      //   cy.log("show a column");
+      //   additionalColumns().within(() => showColumn("Count"));
+      //   cy.wait("@dataset");
+      //   visibleColumns().findByText("Count").should("exist");
+      //   visibleColumns().findByText("Sum of Quantity").should("exist");
+      //   visualization().findByText("Count").should("exist");
+
+      //   cy.log("hide a column with an inner field");
+      //   visibleColumns().within(() => hideColumn("Sum of Quantity"));
+      //   visibleColumns().findByText("Sum of Quantity").should("not.exist");
+      //   visibleColumns().findByText("Count").should("exist");
+      //   disabledColumns().findByText("Sum of Quantity").should("exist");
+      //   visualization().findByText("Sum of Quantity").should("not.exist");
+      //   runQuery();
+      //   cy.wait("@dataset");
+
+      //   cy.log("show a column with an inner field");
+      //   additionalColumns().within(() => showColumn("Sum of Quantity"));
+      //   cy.wait("@dataset");
+      //   visibleColumns().findByText("Sum of Quantity").should("exist");
+      //   visibleColumns().findByText("Count").should("exist");
+      //   visualization().findByText("Sum of Quantity").should("exist");
     });
 
-    it("should be able to show and hide columns from a nested query with a self join", () => {
+    it.only("should be able to show and hide columns from a nested query with a self join", () => {
       cy.createQuestion(tableQuestion).then(({ body: card }) => {
-        const columnName = "Tax";
-        const columnLongName = `Question ${card.id} → ${columnName}`;
-
         cy.createQuestion(nestedQuestionWithJoinOnQuestion(card), {
           visitQuestion: true,
         });
         openSettings();
 
-        cy.log("hide a column");
-        visibleColumns().within(() => hideColumn(columnLongName));
-        visibleColumns().findByText(columnLongName).should("not.exist");
-        disabledColumns().findByText(columnLongName).should("exist");
-        scrollVisualization();
-        visualization().findByText(columnLongName).should("not.exist");
+        const taxColumn = {
+          column: "Tax",
+          columnName: `Question ${card.id} → Tax`,
+          table: `question ${card.id}`,
+          scrollTimes: 3,
+        };
 
-        cy.log("re-run the query");
-        runQuery();
-        cy.wait("@dataset");
-        scrollVisualization();
-        visualization().findByText(columnLongName).should("not.exist");
+        _hideColumn(taxColumn);
+        _showColumn(taxColumn);
+        _removeColumn(taxColumn);
+        _addColumn(taxColumn);
 
-        cy.log("show a column");
-        additionalColumns().within(() => showColumn(columnName));
-        cy.wait("@dataset");
-        visibleColumns().findByText(columnLongName).should("exist");
+        //   cy.log("hide a column");
+        //   visibleColumns().within(() => hideColumn(columnLongName));
+        //   visibleColumns().findByText(columnLongName).should("not.exist");
+        //   disabledColumns().findByText(columnLongName).should("exist");
+        //   scrollVisualization();
+        //   visualization().findByText(columnLongName).should("not.exist");
 
-        // Scrolling the table does not work consistently for this query. The columns are wider than it estimates, so
-        // the first attempt to scroll to the right edge doesn't actually reach it.
-        // Three attempts with brief pauses seems to work consistently.
-        scrollVisualization();
-        cy.wait(60);
-        scrollVisualization();
-        cy.wait(60);
-        scrollVisualization();
-        visualization().findByText(columnLongName).should("exist");
+        //   cy.log("re-run the query");
+        //   runQuery();
+        //   cy.wait("@dataset");
+        //   scrollVisualization();
+        //   visualization().findByText(columnLongName).should("not.exist");
+
+        //   cy.log("show a column");
+        //   additionalColumns().within(() => showColumn(columnName));
+        //   cy.wait("@dataset");
+        //   visibleColumns().findByText(columnLongName).should("exist");
+
+        //   // Scrolling the table does not work consistently for this query. The columns are wider than it estimates, so
+        //   // the first attempt to scroll to the right edge doesn't actually reach it.
+        //   // Three attempts with brief pauses seems to work consistently.
+        //   scrollVisualization();
+        //   cy.wait(60);
+        //   scrollVisualization();
+        //   cy.wait(60);
+        //   scrollVisualization();
+        //   visualization().findByText(columnLongName).should("exist");
       });
     });
 
@@ -812,31 +1506,41 @@ describe("scenarios > visualizations > table column settings", () => {
         cy.createQuestion(tableQuestionWithJoinOnQuestion(card), {
           visitQuestion: true,
         });
-        const columnName = "Math";
-        const columnLongName = `Question ${card.id} → ${columnName}`;
 
         openSettings();
 
-        cy.log("hide a column");
-        visibleColumns().within(() => hideColumn(columnLongName));
-        visibleColumns().findByText(columnLongName).should("not.exist");
-        disabledColumns().findByText(columnLongName).should("exist");
-        scrollVisualization();
-        visualization().findByText(columnLongName).should("not.exist");
+        const mathColumn = {
+          column: "Math",
+          columnName: `Question ${card.id} → Math`,
+          table: `question ${card.id}`,
+          scrollTimes: 2,
+        };
 
-        cy.log("re-run the query");
-        runQuery();
-        cy.wait("@dataset");
-        scrollVisualization();
-        visualization().findByText(columnLongName).should("not.exist");
+        _hideColumn(mathColumn);
+        _showColumn(mathColumn);
+        _removeColumn(mathColumn);
+        _addColumn(mathColumn);
 
-        cy.log("show a column");
-        additionalColumns().within(() => showColumn(columnName));
-        cy.wait("@dataset");
-        visibleColumns().findByText(columnLongName).should("exist");
-        additionalColumns().findByText(columnName).should("not.exist");
-        scrollVisualization();
-        visualization().findByText(columnLongName).should("exist");
+        // cy.log("hide a column");
+        // visibleColumns().within(() => hideColumn(columnLongName));
+        // visibleColumns().findByText(columnLongName).should("not.exist");
+        // disabledColumns().findByText(columnLongName).should("exist");
+        // scrollVisualization();
+        // visualization().findByText(columnLongName).should("not.exist");
+
+        // cy.log("re-run the query");
+        // runQuery();
+        // cy.wait("@dataset");
+        // scrollVisualization();
+        // visualization().findByText(columnLongName).should("not.exist");
+
+        // cy.log("show a column");
+        // additionalColumns().within(() => showColumn(columnName));
+        // cy.wait("@dataset");
+        // visibleColumns().findByText(columnLongName).should("exist");
+        // additionalColumns().findByText(columnName).should("not.exist");
+        // scrollVisualization();
+        // visualization().findByText(columnLongName).should("exist");
       });
     });
 
@@ -851,13 +1555,22 @@ describe("scenarios > visualizations > table column settings", () => {
       visualize();
 
       openSettings();
-      cy.log("show a column");
-      additionalColumns().within(() => showColumn("Tax"));
-      cy.wait("@dataset");
-      visibleColumns().findByText("Tax").should("exist");
-      additionalColumns().findByText("Tax").should("not.exist");
-      scrollVisualization();
-      visualization().findByText("Tax").should("exist");
+
+      const taxColumn = {
+        column: "Tax",
+        columnName: "Tax",
+        table: "test question",
+      };
+
+      _addColumn(taxColumn);
+
+      // cy.log("show a column");
+      // additionalColumns().within(() => showColumn("Tax"));
+      // cy.wait("@dataset");
+      // visibleColumns().findByText("Tax").should("exist");
+      // additionalColumns().findByText("Tax").should("not.exist");
+      // scrollVisualization();
+      // visualization().findByText("Tax").should("exist");
     });
   });
 
@@ -868,25 +1581,36 @@ describe("scenarios > visualizations > table column settings", () => {
       });
       openSettings();
 
-      cy.log("hide a column");
-      visibleColumns().within(() => hideColumn("TAX"));
-      visibleColumns().findByText("TAX").should("not.exist");
-      disabledColumns().findByText("TAX").should("exist");
-      scrollVisualization();
-      visualization().findByText("TAX").should("not.exist");
+      const taxColumn = {
+        column: "TAX",
+        columnName: "TAX",
+        table: "test question",
+      };
 
-      cy.log("re-run the query");
-      runQuery();
-      cy.wait("@dataset");
-      scrollVisualization();
-      visualization().findByText("TAX").should("not.exist");
+      _hideColumn(taxColumn);
+      _showColumn(taxColumn);
+      _removeColumn(taxColumn);
+      _addColumn(taxColumn);
 
-      cy.log("show a column");
-      additionalColumns().within(() => showColumn("TAX"));
-      cy.wait("@dataset");
-      visibleColumns().findByText("TAX").should("exist");
-      scrollVisualization();
-      visualization().findByText("TAX").should("exist");
+      // cy.log("hide a column");
+      // visibleColumns().within(() => hideColumn("TAX"));
+      // visibleColumns().findByText("TAX").should("not.exist");
+      // disabledColumns().findByText("TAX").should("exist");
+      // scrollVisualization();
+      // visualization().findByText("TAX").should("not.exist");
+
+      // cy.log("re-run the query");
+      // runQuery();
+      // cy.wait("@dataset");
+      // scrollVisualization();
+      // visualization().findByText("TAX").should("not.exist");
+
+      // cy.log("show a column");
+      // additionalColumns().within(() => showColumn("TAX"));
+      // cy.wait("@dataset");
+      // visibleColumns().findByText("TAX").should("exist");
+      // scrollVisualization();
+      // visualization().findByText("TAX").should("exist");
     });
   });
 });
@@ -896,7 +1620,7 @@ const runQuery = () => {
 };
 
 const showColumn = column => {
-  cy.findByTestId(`${column}-add-button`).click();
+  cy.findByTestId(`${column}-show-button`).click();
 };
 
 const hideColumn = column => {
@@ -912,7 +1636,9 @@ const visualization = () => {
 };
 
 const scrollVisualization = (position = "right") => {
-  cy.get("#main-data-grid").scrollTo(position);
+  cy.get(".TableInteractive-header.scroll-hide-all").scrollTo(position, {
+    force: true,
+  });
 };
 
 const visibleColumns = () => {
@@ -925,4 +1651,16 @@ const disabledColumns = () => {
 
 const additionalColumns = () => {
   return cy.findByTestId("additional-columns");
+};
+
+const getColumn = columnName => {
+  return visibleColumns().contains("[role=listitem]", columnName);
+};
+
+const assertColumnEnabled = column => {
+  column.should("have.attr", "data-enabled", "true");
+};
+
+const assertColumnHidden = column => {
+  column.should("have.attr", "data-enabled", "false");
 };

--- a/e2e/test/scenarios/visualizations/table-column-settings.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/table-column-settings.cy.spec.js
@@ -203,164 +203,6 @@ const nestedQuestionWithJoinOnQuestion = card => ({
   },
 });
 
-const scenarios = [
-  // {
-  //   name: "table fields",
-  //   question: tableQuestion,
-  //   existingColumns: [{ column: "Tax", columnName: "Tax" }],
-  //   sanityCheck: "ID",
-  // },
-  // {
-  //   name: "table fields with in a join",
-  //   question: tableQuestionWithJoin,
-  //   existingColumns: [{ column: "Rating", columnName: "Products → Rating" }],
-  //   sanityCheck: "Products → Ean",
-  // },
-  // {
-  //   name: "Table fields with a self join",
-  //   question: tableQuestionWithSelfJoinAndFields,
-  //   existingColumns: [{ column: "Tax", columnName: "Orders → Tax" }],
-  //   sanityCheck: "ID",
-  // },
-  // {
-  //   name: "table fields with implicit joins",
-  //   question: tableQuestion,
-  //   existingColumns: [],
-  //   extraColumns: [{ column: "Category", columnName: "Product → Category" }],
-  //   sanityCheck: "ID",
-  // },
-  // {
-  //   name: "table with custom expressions",
-  //   question: tableQuestionWithExpression,
-  //   existingColumns: [{ column: "Math", columnName: "Math" }],
-  // },
-  // {
-  //   name: "table with custom expressions and fields",
-  //   question: tableQuestionWithExpressionAndFields,
-  //   existingColumns: [{ column: "Math", columnName: "Math" }],
-  // },
-  // {
-  //   name: "table with aggregrations",
-  //   question: tableWithAggregations,
-  //   existingColumns: [{ column: "Count", columnName: "Count" }],
-  //   needsScroll: false,
-  // },
-  // {
-  //   name: "multistage question",
-  //   question: multiStageQuestion,
-  //   existingColumns: [{ column: "Count", columnName: "Count" }],
-  //   sanityCheck: "Product ID",
-  // },
-  // {
-  //   name: "nested question",
-  //   question: () => {
-  //     cy.createQuestion(tableQuestion).then(({ body: card }) => {
-  //       cy.createQuestion(nestedQuestion(card), { visitQuestion: true });
-  //     });
-  //   },
-  //   existingColumns: [{ column: "Tax", columnName: "Tax" }],
-  // },
-  // {
-  //   name: "nested question with joins",
-  //   question: () => {
-  //     cy.createQuestion(tableQuestionWithJoin).then(({ body: card }) => {
-  //       cy.createQuestion(nestedQuestion(card), { visitQuestion: true });
-  //     });
-  //   },
-  //   existingColumns: [
-  //     { column: "Products → Ean", columnName: "Products → Ean" },
-  //   ],
-  // },
-  // {
-  //   name: "nested question qith join and fields",
-  //   question: () => {
-  //     cy.createQuestion(tableQuestionWithJoinAndFields).then(
-  //       ({ body: card }) => {
-  //         cy.createQuestion(nestedQuestion(card), { visitQuestion: true });
-  //       },
-  //     );
-  //   },
-  //   existingColumns: [
-  //     { column: "Products → Category", columnName: "Products → Category" },
-  //   ],
-  // },
-  // {
-  //   name: "show and hide implicitly joinable fields for a nested query with joins and fields",
-  //   question: () => {
-  //     cy.createQuestion(tableQuestion).then(({ body: card }) => {
-  //       cy.createQuestion(nestedQuestionWithJoinOnTable(card), {
-  //         visitQuestion: true,
-  //       });
-  //     });
-  //   },
-  //   extraColumns: [{ column: "ID", columnName: "User → ID", table: "user" }],
-  // },
-  // {
-  //   name: "show and hide implicitly joinable fields for a nested query",
-  //   question: () => {
-  //     cy.createQuestion(tableQuestion).then(({ body: card }) => {
-  //       cy.createQuestion(nestedQuestion(card), { visitQuestion: true });
-  //     });
-  //   },
-  //   extraColumns: [
-  //     {
-  //       column: "Category",
-  //       columnName: "Product → Category",
-  //       table: "product",
-  //     },
-  //   ],
-  // },
-  // {
-  //   name: "show and hide custom expressions from a nested query",
-  //   question: () => {
-  //     cy.createQuestion(tableQuestionWithExpression).then(({ body: card }) => {
-  //       cy.createQuestion(nestedQuestion(card), { visitQuestion: true });
-  //     });
-  //   },
-  //   existingColumns: [
-  //     { column: "Math", columnName: "Math", table: "test question" },
-  //   ],
-  // },
-  // {
-  //   name: "show and hide columns from aggregations from a nested query",
-  //   question: () => {
-  //     cy.createQuestion(tableWithAggregations).then(({ body: card }) => {
-  //       cy.createQuestion(nestedQuestion(card), { visitQuestion: true });
-  //     });
-  //   },
-  //   existingColumns: [
-  //     { column: "Count", columnName: "Count", table: "test question" },
-  //     {
-  //       column: "Sum of Quantity",
-  //       columnName: "Sum of Quantity",
-  //       table: "test question",
-  //     },
-  //   ],
-  //   needsScroll: false,
-  // },
-  // {
-  //   name: "show and hide columns from aggregations from a nested query",
-  //   question: () => {
-  //     cy.createQuestion(tableQuestion, { wrapId: true }).then(
-  //       ({ body: card }) => {
-  //         cy.get("@questionId").then(id => {
-  //           cy.createQuestion(nestedQuestionWithJoinOnQuestion({ id }), {
-  //             visitQuestion: true,
-  //           });
-  //         });
-  //       },
-  //     );
-  //   },
-  //   existingColumns: cardId => [
-  //     {
-  //       column: "Tax",
-  //       columnName: `Question ${cardId} → Tax`,
-  //       table: `question ${cardId}`,
-  //     },
-  //   ],
-  // },
-];
-
 describe("scenarios > visualizations > table column settings", () => {
   beforeEach(() => {
     restore();
@@ -494,206 +336,7 @@ describe("scenarios > visualizations > table column settings", () => {
       _showColumn(testData);
       _removeColumn(testData);
       _addColumn(testData);
-
-      // cy.log("hide a column");
-      // visibleColumns().within(() => hideColumn("Tax"));
-      // visibleColumns().findByText("Tax").should("not.exist");
-      // visibleColumns().findByText("ID").should("exist");
-      // disabledColumns().findByText("Tax").should("exist");
-      // additionalColumns().findByText("Tax").should("not.exist");
-      // visualization().findByText("Tax").should("not.exist");
-
-      // cy.log("re-run the query");
-      // runQuery();
-      // cy.wait("@dataset");
-      // visualization().findByText("Tax").should("not.exist");
-
-      // cy.log("show a column");
-      // additionalColumns().within(() => showColumn("Tax"));
-      // cy.wait("@dataset");
-      // visibleColumns().findByText("Tax").should("exist");
-      // visibleColumns().findByText("ID").should("exist");
-      // disabledColumns().findByText("Tax").should("not.exist");
-      // additionalColumns().findByText("Tax").should("not.exist");
-      // scrollVisualization();
-      // visualization().findByText("Tax").should("exist");
     });
-
-    // scenarios.forEach(scenario => {
-    //   it.only(`should be able to show, hide, add and remove columns - ${scenario.name}`, () => {
-    //     const {
-    //       question,
-    //       existingColumns = [],
-    //       extraColumns = [],
-    //       sanityCheck,
-    //       needsScroll = true,
-    //     } = scenario;
-
-    //     if (typeof question === "function") {
-    //       question();
-    //     } else {
-    //       cy.createQuestion(question, { visitQuestion: true });
-    //     }
-
-    //     openSettings();
-
-    //     let cardId;
-
-    //     cy.get("@questionId").then(questionId => {
-    //       cardId = questionId;
-    //       cy.log(cardId);
-    //       cy.log(questionId);
-    //     });
-
-    //     cy.log(cardId);
-
-    //     const _existingColumns =
-    //       typeof existingColumns === "function"
-    //         ? existingColumns(cardId)
-    //         : existingColumns;
-
-    //     _existingColumns.forEach(existingColumn => {
-    //       const { column, columnName, table } = existingColumn;
-    //       cy.log("hide the column");
-    //       visibleColumns().within(() => hideColumn(columnName));
-    //       assertColumnHidden(getColumn(columnName));
-    //       if (sanityCheck) {
-    //         assertColumnEnabled(getColumn(sanityCheck));
-    //       }
-    //       if (needsScroll) {
-    //         scrollVisualization();
-    //       }
-    //       visualization().findByText(columnName).should("not.exist");
-
-    //       cy.findByRole("button", { name: /Add or remove columns/ }).click();
-    //       cy.findByRole("list", { name: `${table}-table-columns` })
-    //         .findByLabelText(column)
-    //         .should("be.checked");
-    //       cy.findByRole("button", { name: /Done picking columns/ }).click();
-
-    //       cy.log("show the column");
-    //       visibleColumns().within(() => showColumn(columnName));
-    //       assertColumnEnabled(getColumn(columnName));
-    //       if (sanityCheck) {
-    //         assertColumnEnabled(getColumn(sanityCheck));
-    //       }
-    //       if (needsScroll) {
-    //         scrollVisualization();
-    //       }
-    //       visualization().findByText(columnName).should("exist");
-
-    //       cy.log("remove the column");
-    //       cy.findByRole("button", { name: /Add or remove columns/ }).click();
-    //       cy.findByRole("list", { name: `${table}-table-columns` })
-    //         .findByLabelText(column)
-    //         .should("be.checked")
-    //         .click();
-    //       runQuery();
-    //       cy.wait("@dataset");
-    //       cy.findByText("Doing science...").should("not.exist");
-    //       if (needsScroll) {
-    //         scrollVisualization();
-    //       }
-    //       visualization().findByText(columnName).should("not.exist");
-    //       cy.findByRole("button", { name: /Done picking columns/ }).click();
-    //       getColumn(columnName).should("not.exist");
-    //       if (sanityCheck) {
-    //         assertColumnEnabled(getColumn(sanityCheck));
-    //       }
-
-    //       cy.log("add the column");
-    //       cy.findByRole("button", { name: /Add or remove columns/ }).click();
-    //       cy.findByRole("list", { name: `${table}-table-columns` })
-    //         .findByLabelText(column)
-    //         .should("not.be.checked")
-    //         .click();
-    //       cy.wait("@dataset");
-    //       cy.findByText("Doing science...").should("not.exist");
-    //       if (needsScroll) {
-    //         scrollVisualization();
-    //       }
-    //       visualization().findByText(columnName).should("exist");
-    //       cy.findByRole("button", { name: /Done picking columns/ }).click();
-    //       assertColumnEnabled(getColumn(columnName));
-    //       if (sanityCheck) {
-    //         assertColumnEnabled(getColumn(sanityCheck));
-    //       }
-    //     });
-
-    //     extraColumns.forEach(extraColumn => {
-    //       const { column, columnName, table } = extraColumn;
-    //       getColumn(columnName).should("not.exist");
-
-    //       cy.log("add the column");
-    //       cy.findByRole("button", { name: /Add or remove columns/ }).click();
-    //       cy.findByRole("list", { name: `${table}-table-columns` })
-    //         .findByLabelText(column)
-    //         .should("not.be.checked")
-    //         .click();
-    //       cy.wait("@dataset");
-    //       cy.findByText("Doing science...").should("not.exist");
-    //       if (needsScroll) {
-    //         scrollVisualization();
-    //         cy.wait(200);
-    //         scrollVisualization();
-    //         cy.wait(200);
-    //         scrollVisualization();
-    //       }
-    //       visualization().findByText(columnName).should("exist");
-    //       cy.findByRole("button", { name: /Done picking columns/ }).click();
-    //       assertColumnEnabled(getColumn(columnName));
-    //       if (sanityCheck) {
-    //         assertColumnEnabled(getColumn(sanityCheck));
-    //       }
-
-    //       cy.log("hide the column");
-    //       visibleColumns().within(() => hideColumn(columnName));
-    //       assertColumnHidden(getColumn(columnName));
-    //       if (sanityCheck) {
-    //         assertColumnEnabled(getColumn(sanityCheck));
-    //       }
-    //       if (needsScroll) {
-    //         scrollVisualization();
-    //       }
-    //       visualization().findByText(columnName).should("not.exist");
-
-    //       cy.findByRole("button", { name: /Add or remove columns/ }).click();
-    //       cy.findByRole("list", { name: `${table}-table-columns` })
-    //         .findByLabelText(column)
-    //         .should("be.checked");
-    //       cy.findByRole("button", { name: /Done picking columns/ }).click();
-
-    //       cy.log("show the column");
-    //       visibleColumns().within(() => showColumn(columnName));
-    //       assertColumnEnabled(getColumn(columnName));
-    //       if (sanityCheck) {
-    //         assertColumnEnabled(getColumn(sanityCheck));
-    //       }
-    //       if (needsScroll) {
-    //         scrollVisualization();
-    //       }
-    //       visualization().findByText(columnName).should("exist");
-
-    //       cy.log("remove the column");
-    //       cy.findByRole("button", { name: /Add or remove columns/ }).click();
-    //       cy.findByRole("list", { name: `${table}-table-columns` })
-    //         .findByLabelText(column)
-    //         .should("be.checked")
-    //         .click();
-    //       runQuery();
-    //       cy.wait("@dataset");
-    //       if (needsScroll) {
-    //         scrollVisualization();
-    //       }
-    //       visualization().findByText(columnName).should("not.exist");
-    //       cy.findByRole("button", { name: /Done picking columns/ }).click();
-    //       getColumn(columnName).should("not.exist");
-    //       if (sanityCheck) {
-    //         assertColumnEnabled(getColumn(sanityCheck));
-    //       }
-    //     });
-    //   });
-    // });
 
     it("should be able to rename table columns via popover", () => {
       cy.createQuestion(tableQuestion, { visitQuestion: true });
@@ -730,29 +373,45 @@ describe("scenarios > visualizations > table column settings", () => {
       _showColumn(testData);
       _removeColumn(testData);
       _addColumn(testData);
+    });
 
-      // cy.log("hide a column");
-      // visibleColumns().within(() => hideColumn("Products → Category"));
-      // visibleColumns().findByText("Products → Category").should("not.exist");
-      // visibleColumns().findByText("Products → Ean").should("exist");
-      // disabledColumns().findByText("Products → Category").should("exist");
-      // additionalColumns().findByText("Category").should("not.exist");
-      // visualization().findByText("Products → Category").should("not.exist");
+    it("should be able to show and hide all table fields with a single click", () => {
+      cy.createQuestion(tableQuestionWithJoin, { visitQuestion: true });
+      openSettings();
 
-      // cy.log("re-run the query");
-      // runQuery();
-      // cy.wait("@dataset");
-      // visualization().findByText("Products → Category").should("not.exist");
+      cy.findByRole("button", { name: /Add or remove columns/ }).click();
 
-      // cy.log("show a column");
-      // additionalColumns().within(() => showColumn("Category"));
-      // cy.wait("@dataset");
-      // visibleColumns().findByText("Products → Category").should("exist");
-      // visibleColumns().findByText("Products → Ean").should("exist");
-      // disabledColumns().findByText("Category").should("not.exist");
-      // additionalColumns().findByText("Category").should("not.exist");
-      // scrollVisualization();
-      // visualization().findByText("Products → Category").should("exist");
+      cy.findByRole("list", { name: "products-table-columns" })
+        .findByLabelText("Remove all")
+        .click();
+
+      runQuery();
+      cy.wait("@dataset");
+      cy.findByTestId("query-builder-main")
+        .findByText("Doing science...")
+        .should("not.exist");
+
+      cy.findByRole("list", { name: "products-table-columns" }).within(() => {
+        //Check a few columns as a sanity check
+        cy.findByLabelText("Title").should("not.be.checked");
+        cy.findByLabelText("Category").should("not.be.checked");
+        cy.findByLabelText("Price").should("not.be.checked");
+
+        //Enable all columns
+        cy.findByLabelText("Add all").should("not.be.checked").click();
+      });
+
+      cy.wait("@dataset");
+      cy.findByTestId("query-builder-main")
+        .findByText("Doing science...")
+        .should("not.exist");
+
+      cy.findByRole("list", { name: "products-table-columns" }).within(() => {
+        //Check a few columns as a sanity check
+        cy.findByLabelText("Title").should("be.checked");
+        cy.findByLabelText("Category").should("be.checked");
+        cy.findByLabelText("Price").should("be.checked");
+      });
     });
 
     it("should be able to show and hide table fields with a join with fields", () => {
@@ -777,41 +436,6 @@ describe("scenarios > visualizations > table column settings", () => {
       _removeColumn(firstColumn);
 
       _addColumn(secondColumn);
-
-      // cy.log("hide an existing column");
-      // visibleColumns().within(() => hideColumn("Products → Category"));
-      // visibleColumns().findByText("Products → Category").should("not.exist");
-      // visibleColumns().findByText("Products → Ean").should("not.exist");
-      // disabledColumns().findByText("Products → Category").should("exist");
-      // additionalColumns().findByText("Category").should("not.exist");
-      // visualization().findByText("Products → Category").should("not.exist");
-
-      // cy.log("re-run the query");
-      // runQuery();
-      // cy.wait("@dataset");
-      // visualization().findByText("Products → Category").should("not.exist");
-
-      // cy.log("show an existing column");
-      // additionalColumns().within(() => showColumn("Ean"));
-      // cy.wait("@dataset");
-      // visibleColumns().findByText("Products → Ean").should("exist");
-      // visibleColumns().findByText("Products → Category").should("not.exist");
-      // disabledColumns().findByText("Products → Ean").should("not.exist");
-      // additionalColumns().findByText("Ean").should("not.exist");
-      // additionalColumns().findByText("Category").should("exist");
-      // scrollVisualization();
-      // visualization().findByText("Products → Ean").should("exist");
-
-      // cy.log("show a new column");
-      // additionalColumns().within(() => showColumn("Category"));
-      // cy.wait("@dataset");
-      // visibleColumns().findByText("Products → Ean").should("exist");
-      // visibleColumns().findByText("Products → Category").should("exist");
-      // additionalColumns().findByText("Ean").should("not.exist");
-      // additionalColumns().findByText("Category").should("not.exist");
-      // additionalColumns().findByText("Rating").should("exist");
-      // scrollVisualization();
-      // visualization().findByText("Products → Category").should("exist");
     });
 
     it("should be able to show and hide table fields with a self join with fields", () => {
@@ -831,47 +455,6 @@ describe("scenarios > visualizations > table column settings", () => {
       _showColumn(testData);
       _removeColumn(testData);
       _addColumn(testData);
-
-<<<<<<< HEAD
-      cy.log("show the column");
-      additionalColumns().within(() => showColumn("Tax"));
-      cy.wait("@dataset");
-      visibleColumns().findByText("Orders → Tax").should("exist");
-      visibleColumns().findByText("Tax").should("exist");
-      disabledColumns().findByText("Orders → Tax").should("not.exist");
-      disabledColumns().findByText("Tax").should("not.exist");
-      additionalColumns().findByText("Tax").should("not.exist");
-      visualization().findByText("Orders → Tax").should("exist");
-=======
-      // cy.log("hide an existing column");
-      // visibleColumns().within(() => hideColumn("Orders → Tax"));
-      // visibleColumns().findByText("Tax").should("exist");
-      // visibleColumns().findByText("Orders → Tax").should("not.exist");
-      // disabledColumns().findByText("Tax").should("not.exist");
-      // disabledColumns().findByText("Orders → Tax").should("exist");
-      // additionalColumns().findByText("Tax").should("not.exist");
-      // visualization().findByText("Orders → Tax").should("not.exist");
-
-      // cy.log("re-run the query");
-      // runQuery();
-      // cy.wait("@dataset");
-      // visibleColumns().findByText("Tax").should("exist");
-      // disabledColumns().findByText("Tax").should("not.exist");
-      // disabledColumns().findByText("Orders → Tax").should("not.exist");
-      // additionalColumns().findByText("Tax").should("exist");
-      // visualization().findByText("Orders → Tax").should("not.exist");
-
-      // cy.log("show the column");
-      // additionalColumns().within(() => showColumn("Tax"));
-      // cy.wait("@dataset");
-      // visibleColumns().findByText("Orders → Tax").should("exist");
-      // visibleColumns().findByText("Tax").should("exist");
-      // disabledColumns().findByText("Orders → Tax").should("not.exist");
-      // disabledColumns().findByText("Tax").should("not.exist");
-      // additionalColumns().findByText("Tax").should("not.exist");
-      // scrollVisualization();
-      // visualization().findByText("Orders → Tax").should("exist");
->>>>>>> 97d973099a (e2e tests passing)
     });
 
     it("should be able to show and hide implicitly joinable fields for a table", () => {
@@ -888,31 +471,6 @@ describe("scenarios > visualizations > table column settings", () => {
       _hideColumn(testData);
       _showColumn(testData);
       _removeColumn(testData);
-
-      //   cy.log("show a column");
-      //   additionalColumns().within(() => showColumn("Category"));
-      //   cy.wait("@dataset");
-      //   visibleColumns().findByText("Product → Category").should("exist");
-      //   additionalColumns().findByText("Category").should("not.exist");
-      //   scrollVisualization();
-      //   visualization().findByText("Product → Category").should("exist");
-
-      //   cy.log("hide a column");
-      //   visibleColumns().within(() => hideColumn("Product → Category"));
-      //   visibleColumns().findByText("Product → Category").should("not.exist");
-      //   disabledColumns().findByText("Product → Category").should("exist");
-      //   additionalColumns().findByText("Category").should("not.exist");
-      //   scrollVisualization();
-      //   visualization().findByText("Product → Category").should("not.exist");
-
-      //   cy.log("re-run the query");
-      //   runQuery();
-      //   cy.wait("@dataset");
-      //   visibleColumns().findByText("Product → Category").should("not.exist");
-      //   disabledColumns().findByText("Product → Category").should("not.exist");
-      //   additionalColumns().findByText("Category").should("exist");
-      //   scrollVisualization();
-      //   visualization().findByText("Product → Category").should("not.exist");
     });
 
     it("should be able to show and hide custom expressions for a table", () => {
@@ -931,27 +489,6 @@ describe("scenarios > visualizations > table column settings", () => {
       _showColumn(testData);
       _removeColumn(testData);
       _addColumn(testData);
-
-      // cy.log("hide a column");
-      // visibleColumns().within(() => hideColumn("Math"));
-      // visibleColumns().findByText("Math").should("not.exist");
-      // disabledColumns().findByText("Math").should("exist");
-      // scrollVisualization();
-      // visualization().findByText("Math").should("not.exist");
-
-      // cy.log("re-run the query");
-      // runQuery();
-      // cy.wait("@dataset");
-      // scrollVisualization();
-      // visualization().findByText("Math").should("not.exist");
-
-      // cy.log("show a column");
-      // additionalColumns().within(() => showColumn("Math"));
-      // cy.wait("@dataset");
-      // visibleColumns().findByText("Math").should("exist");
-      // additionalColumns().findByText("Math").should("not.exist");
-      // scrollVisualization();
-      // visualization().findByText("Math").should("exist");
     });
 
     it("should be able to show and hide custom expressions for a table with selected fields", () => {
@@ -971,24 +508,6 @@ describe("scenarios > visualizations > table column settings", () => {
       _showColumn(testData);
       _removeColumn(testData);
       _addColumn(testData);
-
-      // cy.log("hide a column");
-      // visibleColumns().within(() => hideColumn("Math"));
-      // visibleColumns().findByText("Math").should("not.exist");
-      // disabledColumns().findByText("Math").should("exist");
-      // visualization().findByText("Math").should("not.exist");
-
-      // cy.log("re-run the query");
-      // runQuery();
-      // cy.wait("@dataset");
-      // visualization().findByText("Math").should("not.exist");
-
-      // cy.log("show a column");
-      // additionalColumns().within(() => showColumn("Math"));
-      // cy.wait("@dataset");
-      // visibleColumns().findByText("Math").should("exist");
-      // additionalColumns().findByText("Math").should("not.exist");
-      // visualization().findByText("Math").should("exist");
     });
 
     it("should be able to show and hide columns from aggregations", () => {
@@ -1015,32 +534,6 @@ describe("scenarios > visualizations > table column settings", () => {
       _showColumn(testData);
       _hideColumn(testData2);
       _showColumn(testData2);
-
-      //   cy.log("hide a column");
-      //   visibleColumns().within(() => hideColumn("Count"));
-      //   visibleColumns().findByText("Count").should("not.exist");
-      //   visibleColumns().findByText("Sum of Quantity").should("exist");
-      //   disabledColumns().findByText("Count").should("exist");
-      //   visualization().findByText("Count").should("not.exist");
-
-      //   cy.log("show a column");
-      //   disabledColumns().within(() => showColumn("Count"));
-      //   visibleColumns().findByText("Count").should("exist");
-      //   visibleColumns().findByText("Sum of Quantity").should("exist");
-      //   visualization().findByText("Count").should("exist");
-
-      //   cy.log("hide a column with an inner field");
-      //   visibleColumns().within(() => hideColumn("Sum of Quantity"));
-      //   visibleColumns().findByText("Sum of Quantity").should("not.exist");
-      //   visibleColumns().findByText("Count").should("exist");
-      //   disabledColumns().findByText("Sum of Quantity").should("exist");
-      //   visualization().findByText("Sum of Quantity").should("not.exist");
-
-      //   cy.log("show a column with an inner field");
-      //   disabledColumns().within(() => showColumn("Sum of Quantity"));
-      //   visibleColumns().findByText("Sum of Quantity").should("exist");
-      //   visibleColumns().findByText("Count").should("exist");
-      //   visualization().findByText("Sum of Quantity").should("exist");
     });
   });
 
@@ -1069,50 +562,6 @@ describe("scenarios > visualizations > table column settings", () => {
       _showColumn(testData);
       _hideColumn(testData2);
       _showColumn(testData2);
-
-      // cy.log("hide an aggregation column");
-      // visibleColumns().within(() => hideColumn("Count"));
-      // visibleColumns().findByText("Count").should("not.exist");
-      // visibleColumns().findByText("Product ID").should("exist");
-      // disabledColumns().findByText("Count").should("exist");
-      // additionalColumns().findByText("Count").should("not.exist");
-      // visualization().findByText("Count").should("not.exist");
-
-      // cy.log("re-run the query");
-      // runQuery();
-      // cy.wait("@dataset");
-      // visualization().findByText("Count").should("not.exist");
-
-      // cy.log("show an aggregation column");
-      // additionalColumns().within(() => showColumn("Count"));
-      // cy.wait("@dataset");
-      // visibleColumns().findByText("Count").should("exist");
-      // visibleColumns().findByText("Product ID").should("exist");
-      // disabledColumns().findByText("Count").should("not.exist");
-      // additionalColumns().findByText("Count").should("not.exist");
-      // visualization().findByText("Count").should("exist");
-
-      // cy.log("hide a breakout column");
-      // visibleColumns().within(() => hideColumn("Product ID"));
-      // visibleColumns().findByText("Product ID").should("not.exist");
-      // visibleColumns().findByText("Count").should("exist");
-      // disabledColumns().findByText("Product ID").should("exist");
-      // additionalColumns().findByText("Product ID").should("not.exist");
-      // visualization().findByText("Product ID").should("not.exist");
-
-      // cy.log("re-run the query");
-      // runQuery();
-      // cy.wait("@dataset");
-      // visualization().findByText("Product ID").should("not.exist");
-
-      // cy.log("show a breakout column");
-      // additionalColumns().within(() => showColumn("Product ID"));
-      // cy.wait("@dataset");
-      // visibleColumns().findByText("Product ID").should("exist");
-      // visibleColumns().findByText("Count").should("exist");
-      // disabledColumns().findByText("Product ID").should("not.exist");
-      // additionalColumns().findByText("Product ID").should("not.exist");
-      // visualization().findByText("Product ID").should("exist");
     });
   });
 
@@ -1133,30 +582,6 @@ describe("scenarios > visualizations > table column settings", () => {
       _showColumn(testData);
       _removeColumn(testData);
       _addColumn(testData);
-
-      // cy.log("hide a column");
-      // visibleColumns().within(() => hideColumn("Tax"));
-      // visibleColumns().findByText("Tax").should("not.exist");
-      // disabledColumns().findByText("Tax").should("exist");
-      // scrollVisualization();
-      // visualization().findByText("Tax").should("not.exist");
-
-      // cy.log("re-run the query");
-      // runQuery();
-      // cy.wait("@dataset");
-      // visibleColumns().findByText("Tax").should("not.exist");
-      // disabledColumns().findByText("Tax").should("not.exist");
-      // additionalColumns().findByText("Tax").should("exist");
-      // scrollVisualization();
-      // visualization().findByText("Tax").should("not.exist");
-
-      // cy.log("show a column");
-      // additionalColumns().within(() => showColumn("Tax"));
-      // cy.wait("@dataset");
-      // visibleColumns().findByText("Tax").should("exist");
-      // additionalColumns().findByText("Tax").should("not.exist");
-      // scrollVisualization();
-      // visualization().findByText("Tax").should("exist");
     });
 
     it("should be able to show and hide fields from a nested query with joins (metabase#32373)", () => {
@@ -1175,25 +600,6 @@ describe("scenarios > visualizations > table column settings", () => {
       _showColumn(testData);
       _removeColumn(testData);
       _addColumn(testData);
-
-      // cy.log("hide a column");
-      // visibleColumns().within(() => hideColumn("Products → Ean"));
-      // visibleColumns().findByText("Products → Ean").should("not.exist");
-      // disabledColumns().findByText("Products → Ean").should("exist");
-
-      // cy.log("re-run the query");
-      // runQuery();
-      // cy.wait("@dataset");
-      // scrollVisualization("center");
-      // visualization().findByText("Products → Ean").should("not.exist");
-
-      // cy.log("show a column");
-      // additionalColumns().within(() => showColumn("Products → Ean"));
-      // cy.wait("@dataset");
-      // visibleColumns().findByText("Products → Ean").should("exist");
-      // additionalColumns().findByText("Products → Ean").should("not.exist");
-      // scrollVisualization("center");
-      // visualization().findByText("Products → Ean").should("exist");
     });
 
     // TODO: This is currently broken by some subtleties of `:lib/source` in MLv2.
@@ -1231,40 +637,6 @@ describe("scenarios > visualizations > table column settings", () => {
         column: "Products → Category",
         columnName: "Product → Category",
       });
-
-      // cy.log("hide an existing column");
-      // visibleColumns().within(() => hideColumn("Products → Category"));
-      // visibleColumns().findByText("Products → Category").should("not.exist");
-      // disabledColumns().findByText("Products → Category").should("exist");
-      // scrollVisualization();
-      // visualization().findByText("Products → Category").should("not.exist");
-
-      // cy.log("re-run the query");
-      // runQuery();
-      // cy.wait("@dataset");
-      // scrollVisualization();
-      // visualization().findByText("Products → Category").should("not.exist");
-
-      // cy.log("show a new column");
-      // additionalColumns().within(() => showColumn("Ean"));
-      // cy.wait("@dataset");
-      // visibleColumns().findByText("Product → Ean").should("exist");
-      // additionalColumns().findByText("Ean").should("not.exist");
-      // scrollVisualization();
-      // visualization().findByText("Product → Ean").should("exist");
-
-      // cy.log("show an existing column");
-      // additionalColumns().within(() => showColumn("Products → Category"));
-      // cy.wait("@dataset");
-      // // TODO: Once #33972 is fixed in the QP, this test will start failing.
-      // // The correct display name is "Products -> Category", but the QP is incorrectly marking this column as coming
-      // // from the implicit join (so it's using PRODUCT_ID -> "Product", not the table name "Products").
-      // visibleColumns().findByText("Product → Category").should("exist");
-      // visibleColumns().findByText("Product → Ean").should("exist");
-      // additionalColumns().findByText("Product → Category").should("not.exist");
-      // scrollVisualization();
-      // visualization().findByText("Product → Category").should("exist");
-      // visualization().findByText("Product → Ean").should("exist");
     });
 
     it("should be able to show and hide implicitly joinable fields for a nested query with joins and fields", () => {
@@ -1285,35 +657,6 @@ describe("scenarios > visualizations > table column settings", () => {
       _addColumn(newColumn);
       _hideColumn(newColumn);
       _removeColumn(newColumn);
-
-      // cy.log("show a new column");
-      // additionalColumns().within(() => showColumn("ID"));
-      // cy.wait("@dataset");
-      // visibleColumns().findByText("User → ID").should("exist");
-      // additionalColumns().findByText("ID").should("not.exist");
-      // // Simply scrolling once doesn't bring the column into view reliably.
-      // scrollVisualization();
-      // cy.wait(200);
-      // scrollVisualization();
-      // cy.wait(200);
-      // scrollVisualization();
-      // visualization().findByText("User → ID").should("exist");
-
-      // cy.log("hide the column");
-      // visibleColumns().within(() => hideColumn("User → ID"));
-      // visibleColumns().findByText("User → ID").should("not.exist");
-      // disabledColumns().findByText("User → ID").should("exist");
-      // scrollVisualization();
-      // visualization().findByText("User → ID").should("not.exist");
-
-      // cy.log("re-run the query");
-      // runQuery();
-      // cy.wait("@dataset");
-      // visibleColumns().findByText("User → ID").should("not.exist");
-      // disabledColumns().findByText("User → ID").should("not.exist");
-      // additionalColumns().findByText("ID").should("exist");
-      // scrollVisualization();
-      // visualization().findByText("User → ID").should("not.exist");
     });
 
     it("should be able to show and hide implicitly joinable fields for a nested query", () => {
@@ -1331,28 +674,6 @@ describe("scenarios > visualizations > table column settings", () => {
       _addColumn(newColumn);
       _hideColumn(newColumn);
       _removeColumn(newColumn);
-
-      // cy.log("show a column");
-      // additionalColumns().within(() => showColumn("Category"));
-      // cy.wait("@dataset");
-      // visibleColumns().findByText("Product → Category").should("exist");
-      // additionalColumns().findByText("Category").should("not.exist");
-      // scrollVisualization();
-      // visualization().findByText("Product → Category").should("exist");
-
-      // cy.log("hide a column");
-      // visibleColumns().within(() => hideColumn("Product → Category"));
-      // visibleColumns().findByText("Product → Category").should("not.exist");
-      // disabledColumns().findByText("Product → Category").should("exist");
-      // visualization().findByText("Product → Category").should("not.exist");
-
-      // cy.log("re-run the query");
-      // runQuery();
-      // cy.wait("@dataset");
-      // visibleColumns().findByText("Product → Category").should("not.exist");
-      // additionalColumns().findByText("Category").should("exist");
-      // scrollVisualization();
-      // visualization().findByText("Product → Category").should("not.exist");
     });
 
     it("should be able to show and hide custom expressions from a nested query", () => {
@@ -1371,27 +692,6 @@ describe("scenarios > visualizations > table column settings", () => {
       _showColumn(mathColumn);
       _removeColumn(mathColumn);
       _addColumn(mathColumn);
-
-      // cy.log("hide a column");
-      // visibleColumns().within(() => hideColumn("Math"));
-      // visibleColumns().findByText("Math").should("not.exist");
-      // disabledColumns().findByText("Math").should("exist");
-      // scrollVisualization();
-      // visualization().findByText("Math").should("not.exist");
-
-      // cy.log("re-run the query");
-      // runQuery();
-      // cy.wait("@dataset");
-      // scrollVisualization();
-      // visualization().findByText("Math").should("not.exist");
-
-      // cy.log("show a column");
-      // additionalColumns().within(() => showColumn("Math"));
-      // cy.wait("@dataset");
-      // visibleColumns().findByText("Math").should("exist");
-      // additionalColumns().findByText("Math").should("not.exist");
-      // scrollVisualization();
-      // visualization().findByText("Math").should("exist");
     });
 
     it("should be able to show and hide columns from aggregations from a nested query", () => {
@@ -1418,41 +718,9 @@ describe("scenarios > visualizations > table column settings", () => {
       _showColumn(countColumn);
       _hideColumn(sumColumn);
       _showColumn(sumColumn);
-
-      //   cy.log("hide a column");
-      //   visibleColumns().within(() => hideColumn("Count"));
-      //   visibleColumns().findByText("Count").should("not.exist");
-      //   visibleColumns().findByText("Sum of Quantity").should("exist");
-      //   disabledColumns().findByText("Count").should("exist");
-      //   visualization().findByText("Count").should("not.exist");
-      //   runQuery();
-      //   cy.wait("@dataset");
-
-      //   cy.log("show a column");
-      //   additionalColumns().within(() => showColumn("Count"));
-      //   cy.wait("@dataset");
-      //   visibleColumns().findByText("Count").should("exist");
-      //   visibleColumns().findByText("Sum of Quantity").should("exist");
-      //   visualization().findByText("Count").should("exist");
-
-      //   cy.log("hide a column with an inner field");
-      //   visibleColumns().within(() => hideColumn("Sum of Quantity"));
-      //   visibleColumns().findByText("Sum of Quantity").should("not.exist");
-      //   visibleColumns().findByText("Count").should("exist");
-      //   disabledColumns().findByText("Sum of Quantity").should("exist");
-      //   visualization().findByText("Sum of Quantity").should("not.exist");
-      //   runQuery();
-      //   cy.wait("@dataset");
-
-      //   cy.log("show a column with an inner field");
-      //   additionalColumns().within(() => showColumn("Sum of Quantity"));
-      //   cy.wait("@dataset");
-      //   visibleColumns().findByText("Sum of Quantity").should("exist");
-      //   visibleColumns().findByText("Count").should("exist");
-      //   visualization().findByText("Sum of Quantity").should("exist");
     });
 
-    it.only("should be able to show and hide columns from a nested query with a self join", () => {
+    it("should be able to show and hide columns from a nested query with a self join", () => {
       cy.createQuestion(tableQuestion).then(({ body: card }) => {
         cy.createQuestion(nestedQuestionWithJoinOnQuestion(card), {
           visitQuestion: true,
@@ -1470,34 +738,6 @@ describe("scenarios > visualizations > table column settings", () => {
         _showColumn(taxColumn);
         _removeColumn(taxColumn);
         _addColumn(taxColumn);
-
-        //   cy.log("hide a column");
-        //   visibleColumns().within(() => hideColumn(columnLongName));
-        //   visibleColumns().findByText(columnLongName).should("not.exist");
-        //   disabledColumns().findByText(columnLongName).should("exist");
-        //   scrollVisualization();
-        //   visualization().findByText(columnLongName).should("not.exist");
-
-        //   cy.log("re-run the query");
-        //   runQuery();
-        //   cy.wait("@dataset");
-        //   scrollVisualization();
-        //   visualization().findByText(columnLongName).should("not.exist");
-
-        //   cy.log("show a column");
-        //   additionalColumns().within(() => showColumn(columnName));
-        //   cy.wait("@dataset");
-        //   visibleColumns().findByText(columnLongName).should("exist");
-
-        //   // Scrolling the table does not work consistently for this query. The columns are wider than it estimates, so
-        //   // the first attempt to scroll to the right edge doesn't actually reach it.
-        //   // Three attempts with brief pauses seems to work consistently.
-        //   scrollVisualization();
-        //   cy.wait(60);
-        //   scrollVisualization();
-        //   cy.wait(60);
-        //   scrollVisualization();
-        //   visualization().findByText(columnLongName).should("exist");
       });
     });
 
@@ -1520,27 +760,6 @@ describe("scenarios > visualizations > table column settings", () => {
         _showColumn(mathColumn);
         _removeColumn(mathColumn);
         _addColumn(mathColumn);
-
-        // cy.log("hide a column");
-        // visibleColumns().within(() => hideColumn(columnLongName));
-        // visibleColumns().findByText(columnLongName).should("not.exist");
-        // disabledColumns().findByText(columnLongName).should("exist");
-        // scrollVisualization();
-        // visualization().findByText(columnLongName).should("not.exist");
-
-        // cy.log("re-run the query");
-        // runQuery();
-        // cy.wait("@dataset");
-        // scrollVisualization();
-        // visualization().findByText(columnLongName).should("not.exist");
-
-        // cy.log("show a column");
-        // additionalColumns().within(() => showColumn(columnName));
-        // cy.wait("@dataset");
-        // visibleColumns().findByText(columnLongName).should("exist");
-        // additionalColumns().findByText(columnName).should("not.exist");
-        // scrollVisualization();
-        // visualization().findByText(columnLongName).should("exist");
       });
     });
 
@@ -1563,14 +782,6 @@ describe("scenarios > visualizations > table column settings", () => {
       };
 
       _addColumn(taxColumn);
-
-      // cy.log("show a column");
-      // additionalColumns().within(() => showColumn("Tax"));
-      // cy.wait("@dataset");
-      // visibleColumns().findByText("Tax").should("exist");
-      // additionalColumns().findByText("Tax").should("not.exist");
-      // scrollVisualization();
-      // visualization().findByText("Tax").should("exist");
     });
   });
 
@@ -1591,26 +802,6 @@ describe("scenarios > visualizations > table column settings", () => {
       _showColumn(taxColumn);
       _removeColumn(taxColumn);
       _addColumn(taxColumn);
-
-      // cy.log("hide a column");
-      // visibleColumns().within(() => hideColumn("TAX"));
-      // visibleColumns().findByText("TAX").should("not.exist");
-      // disabledColumns().findByText("TAX").should("exist");
-      // scrollVisualization();
-      // visualization().findByText("TAX").should("not.exist");
-
-      // cy.log("re-run the query");
-      // runQuery();
-      // cy.wait("@dataset");
-      // scrollVisualization();
-      // visualization().findByText("TAX").should("not.exist");
-
-      // cy.log("show a column");
-      // additionalColumns().within(() => showColumn("TAX"));
-      // cy.wait("@dataset");
-      // visibleColumns().findByText("TAX").should("exist");
-      // scrollVisualization();
-      // visualization().findByText("TAX").should("exist");
     });
   });
 });
@@ -1643,14 +834,6 @@ const scrollVisualization = (position = "right") => {
 
 const visibleColumns = () => {
   return cy.findByTestId("visible-columns");
-};
-
-const disabledColumns = () => {
-  return cy.findByTestId("disabled-columns");
-};
-
-const additionalColumns = () => {
-  return cy.findByTestId("additional-columns");
 };
 
 const getColumn = columnName => {

--- a/e2e/test/scenarios/visualizations/table-column-settings.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/table-column-settings.cy.spec.js
@@ -732,7 +732,7 @@ describe("scenarios > visualizations > table column settings", () => {
         const taxColumn = {
           column: "Tax",
           columnName: `Question ${card.id} → Tax`,
-          table: `question ${card.id}`,
+          table: `test question 2`,
           scrollTimes: 3,
         };
 
@@ -754,7 +754,7 @@ describe("scenarios > visualizations > table column settings", () => {
         const mathColumn = {
           column: "Math",
           columnName: `Question ${card.id} → Math`,
-          table: `question ${card.id}`,
+          table: `test question`,
           scrollTimes: 2,
         };
 

--- a/e2e/test/scenarios/visualizations/table-column-settings.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/table-column-settings.cy.spec.js
@@ -1,3 +1,5 @@
+import _ from "underscore";
+
 import { openNotebook, popover, restore, visualize } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
@@ -225,7 +227,7 @@ describe("scenarios > visualizations > table column settings", () => {
       assertColumnEnabled(getColumn(sanityCheck));
     }
     if (needsScroll) {
-      [...Array(scrollTimes)].forEach(() => {
+      _.times(scrollTimes, () => {
         scrollVisualization();
         cy.wait(200);
       });
@@ -251,7 +253,7 @@ describe("scenarios > visualizations > table column settings", () => {
       assertColumnEnabled(getColumn(sanityCheck));
     }
     if (needsScroll) {
-      [...Array(scrollTimes)].forEach(() => {
+      _.times(scrollTimes, () => {
         scrollVisualization();
         cy.wait(200);
       });
@@ -277,7 +279,7 @@ describe("scenarios > visualizations > table column settings", () => {
     cy.wait("@dataset");
     cy.findByText("Doing science...").should("not.exist");
     if (needsScroll) {
-      [...Array(scrollTimes)].forEach(() => {
+      _.times(scrollTimes, () => {
         scrollVisualization();
         cy.wait(200);
       });
@@ -307,7 +309,7 @@ describe("scenarios > visualizations > table column settings", () => {
     cy.wait("@dataset");
     cy.findByText("Doing science...").should("not.exist");
     if (needsScroll) {
-      [...Array(scrollTimes)].forEach(() => {
+      _.times(scrollTimes, () => {
         scrollVisualization();
         cy.wait(200);
       });

--- a/e2e/test/scenarios/visualizations/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/table.cy.spec.js
@@ -55,7 +55,7 @@ describe("scenarios > visualizations > table", () => {
     headerCells().findAllByText("ID updated").should("have.length", 1);
   });
 
-  it("should allow you to reorder columns in the table header", () => {
+  it("should allow you to reorder and hide columns in the table header", () => {
     openNativeEditor().type("select * from orders LIMIT 2");
     cy.findByTestId("native-query-editor-container").icon("play").click();
 
@@ -74,6 +74,11 @@ describe("scenarios > visualizations > table", () => {
       .trigger("mouseup", -220, 0, { force: true });
 
     headerCells().eq(1).should("contain.text", "TOTAL");
+
+    headerCells().contains("QUANTITY").click();
+    popover().icon("eye_crossed_out").click();
+
+    headerCells().contains("QUANTITY").should("not.exist");
   });
 
   it("should allow to display any column as link with extrapolated url and text", () => {
@@ -355,7 +360,7 @@ describe("scenarios > visualizations > table > conditional formatting", () => {
     });
   });
 
-  it("should work with boolean columns", () => {
+  it("should work with boolean columns", { tags: ["@external"] }, () => {
     cy.findByTestId("viz-settings-button").click();
     leftSidebar().findByText("Conditional Formatting").click();
     cy.findByRole("button", { name: /add a rule/i }).click();

--- a/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.tsx
@@ -132,7 +132,7 @@ const LicenseAndBillingSettings = ({
           <>
             <Text color="text.1">
               {t`To manage your billing preferences, please email `}
-              <Anchor span href="mailto:billing@metabase.com">
+              <Anchor href="mailto:billing@metabase.com">
                 billing@metabase.com
               </Anchor>
             </Text>

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -184,6 +184,13 @@ export function visibleColumns(
   return ML.visible_columns(query, stageIndex);
 }
 
+export function returnedColumns(
+  query: Query,
+  stageIndex: number,
+): ColumnMetadata[] {
+  return ML.returned_columns(query, stageIndex);
+}
+
 export function isColumnMetadata(arg: unknown): arg is ColumnMetadata {
   return ML.is_column_metadata(arg);
 }

--- a/frontend/src/metabase-types/api/mocks/presets/sample_database.ts
+++ b/frontend/src/metabase-types/api/mocks/presets/sample_database.ts
@@ -1349,7 +1349,7 @@ export const createOrdersIdDatasetColumn = (
     ...createOrdersIdField(),
     id: ORDERS.ID,
     source: "fields",
-    field_ref: ["field", ORDERS.ID, null],
+    field_ref: ["field", ORDERS.ID, {"base-type": "type/Integer"}],
     semantic_type: "type/PK",
     ...opts,
   });
@@ -1361,7 +1361,7 @@ export const createOrdersUserIdDatasetColumn = (
     ...createOrdersUserIdField(),
     id: ORDERS.USER_ID,
     source: "fields",
-    field_ref: ["field", ORDERS.USER_ID, null],
+    field_ref: ["field", ORDERS.USER_ID, {"base-type": "type/Integer"}],
     ...opts,
   });
 
@@ -1372,7 +1372,7 @@ export const createOrdersProductIdDatasetColumn = (
     ...createOrdersProductIdField(),
     id: ORDERS.PRODUCT_ID,
     source: "fields",
-    field_ref: ["field", ORDERS.PRODUCT_ID, null],
+    field_ref: ["field", ORDERS.PRODUCT_ID, {"base-type": "type/Integer"}],
     ...opts,
   });
 
@@ -1383,7 +1383,7 @@ export const createOrdersSubtotalDatasetColumn = (
     ...createOrdersSubtotalField(),
     id: ORDERS.SUBTOTAL,
     source: "fields",
-    field_ref: ["field", ORDERS.SUBTOTAL, null],
+    field_ref: ["field", ORDERS.SUBTOTAL, {"base-type": "type/Float"}],
     ...opts,
   });
 
@@ -1394,7 +1394,7 @@ export const createOrdersTaxDatasetColumn = (
     ...createOrdersTaxField(),
     id: ORDERS.TAX,
     source: "fields",
-    field_ref: ["field", ORDERS.TAX, null],
+    field_ref: ["field", ORDERS.TAX, {"base-type": "type/Float"}],
     ...opts,
   });
 
@@ -1405,7 +1405,7 @@ export const createOrdersTotalDatasetColumn = (
     ...createOrdersTotalField(),
     id: ORDERS.TOTAL,
     source: "fields",
-    field_ref: ["field", ORDERS.TOTAL, null],
+    field_ref: ["field", ORDERS.TOTAL, {"base-type": "type/Float"}],
     ...opts,
   });
 
@@ -1416,7 +1416,7 @@ export const createOrdersDiscountDatasetColumn = (
     ...createOrdersDiscountField(),
     id: ORDERS.DISCOUNT,
     source: "fields",
-    field_ref: ["field", ORDERS.DISCOUNT, null],
+    field_ref: ["field", ORDERS.DISCOUNT, {"base-type": "type/Float"}],
     ...opts,
   });
 
@@ -1432,6 +1432,7 @@ export const createOrdersCreatedAtDatasetColumn = (
       ORDERS.CREATED_AT,
       {
         "temporal-unit": "default",
+        "base-type": "type/DateTime"
       },
     ],
     ...opts,
@@ -1444,7 +1445,7 @@ export const createOrdersQuantityDatasetColumn = (
     ...createOrdersQuantityField(),
     id: ORDERS.QUANTITY,
     source: "fields",
-    field_ref: ["field", ORDERS.QUANTITY, null],
+    field_ref: ["field", ORDERS.QUANTITY, {"base-type": "type/Integer"}],
     ...opts,
   });
 

--- a/frontend/src/metabase-types/api/mocks/presets/sample_database.ts
+++ b/frontend/src/metabase-types/api/mocks/presets/sample_database.ts
@@ -1349,7 +1349,7 @@ export const createOrdersIdDatasetColumn = (
     ...createOrdersIdField(),
     id: ORDERS.ID,
     source: "fields",
-    field_ref: ["field", ORDERS.ID, {"base-type": "type/Integer"}],
+    field_ref: ["field", ORDERS.ID, { "base-type": "type/Integer" }],
     semantic_type: "type/PK",
     ...opts,
   });
@@ -1361,7 +1361,7 @@ export const createOrdersUserIdDatasetColumn = (
     ...createOrdersUserIdField(),
     id: ORDERS.USER_ID,
     source: "fields",
-    field_ref: ["field", ORDERS.USER_ID, {"base-type": "type/Integer"}],
+    field_ref: ["field", ORDERS.USER_ID, { "base-type": "type/Integer" }],
     ...opts,
   });
 
@@ -1372,7 +1372,7 @@ export const createOrdersProductIdDatasetColumn = (
     ...createOrdersProductIdField(),
     id: ORDERS.PRODUCT_ID,
     source: "fields",
-    field_ref: ["field", ORDERS.PRODUCT_ID, {"base-type": "type/Integer"}],
+    field_ref: ["field", ORDERS.PRODUCT_ID, { "base-type": "type/Integer" }],
     ...opts,
   });
 
@@ -1383,7 +1383,7 @@ export const createOrdersSubtotalDatasetColumn = (
     ...createOrdersSubtotalField(),
     id: ORDERS.SUBTOTAL,
     source: "fields",
-    field_ref: ["field", ORDERS.SUBTOTAL, {"base-type": "type/Float"}],
+    field_ref: ["field", ORDERS.SUBTOTAL, { "base-type": "type/Float" }],
     ...opts,
   });
 
@@ -1394,7 +1394,7 @@ export const createOrdersTaxDatasetColumn = (
     ...createOrdersTaxField(),
     id: ORDERS.TAX,
     source: "fields",
-    field_ref: ["field", ORDERS.TAX, {"base-type": "type/Float"}],
+    field_ref: ["field", ORDERS.TAX, { "base-type": "type/Float" }],
     ...opts,
   });
 
@@ -1405,7 +1405,7 @@ export const createOrdersTotalDatasetColumn = (
     ...createOrdersTotalField(),
     id: ORDERS.TOTAL,
     source: "fields",
-    field_ref: ["field", ORDERS.TOTAL, {"base-type": "type/Float"}],
+    field_ref: ["field", ORDERS.TOTAL, { "base-type": "type/Float" }],
     ...opts,
   });
 
@@ -1416,7 +1416,7 @@ export const createOrdersDiscountDatasetColumn = (
     ...createOrdersDiscountField(),
     id: ORDERS.DISCOUNT,
     source: "fields",
-    field_ref: ["field", ORDERS.DISCOUNT, {"base-type": "type/Float"}],
+    field_ref: ["field", ORDERS.DISCOUNT, { "base-type": "type/Float" }],
     ...opts,
   });
 
@@ -1432,7 +1432,7 @@ export const createOrdersCreatedAtDatasetColumn = (
       ORDERS.CREATED_AT,
       {
         "temporal-unit": "default",
-        "base-type": "type/DateTime"
+        "base-type": "type/DateTime",
       },
     ],
     ...opts,
@@ -1445,7 +1445,7 @@ export const createOrdersQuantityDatasetColumn = (
     ...createOrdersQuantityField(),
     id: ORDERS.QUANTITY,
     source: "fields",
-    field_ref: ["field", ORDERS.QUANTITY, {"base-type": "type/Integer"}],
+    field_ref: ["field", ORDERS.QUANTITY, { "base-type": "type/Integer" }],
     ...opts,
   });
 

--- a/frontend/src/metabase/components/StackedCheckBox/StackedCheckBox.tsx
+++ b/frontend/src/metabase/components/StackedCheckBox/StackedCheckBox.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import React, { useCallback } from "react";
 import type { ChangeEvent } from "react";
 
 import {
@@ -25,6 +25,7 @@ interface StackedCheckBoxPropTypes {
   className?: string;
   indeterminate?: boolean;
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+  onClick?: (event: React.MouseEvent<HTMLInputElement>) => void;
 }
 
 export function StackedCheckBox({
@@ -38,6 +39,7 @@ export function StackedCheckBox({
   className,
   indeterminate = false,
   onChange,
+  onClick,
 }: StackedCheckBoxPropTypes) {
   const renderLabel = useCallback(() => {
     if (label == null) {
@@ -61,6 +63,7 @@ export function StackedCheckBox({
         size={size}
         indeterminate={indeterminate}
         onChange={onChange}
+        onClick={onClick}
       />
       <StackedBackground
         checked={checked}

--- a/frontend/src/metabase/components/StackedCheckBox/StackedCheckBox.tsx
+++ b/frontend/src/metabase/components/StackedCheckBox/StackedCheckBox.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback } from "react";
-import type { ChangeEvent } from "react";
+import type React from "react";
+import { useCallback } from "react";
 
 import {
   DEFAULT_CHECKED_COLOR,
@@ -15,7 +15,7 @@ import {
 } from "./StackedCheckBox.styled";
 
 interface StackedCheckBoxPropTypes {
-  label?: string;
+  label?: string | React.ReactNode;
   ariaLabel?: string;
   checked?: boolean;
   disabled?: boolean;
@@ -24,7 +24,7 @@ interface StackedCheckBoxPropTypes {
   size?: number;
   className?: string;
   indeterminate?: boolean;
-  onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onClick?: (event: React.MouseEvent<HTMLInputElement>) => void;
 }
 

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -53,8 +53,11 @@ export const getIsShowingSnippetSidebar = state =>
   getUiControls(state).isShowingSnippetSidebar;
 export const getIsShowingDataReference = state =>
   getUiControls(state).isShowingDataReference;
+
+// This selector can be called from public questions / dashboards, which do not
+// have state.qb
 export const getIsShowingRawTable = state =>
-  getUiControls(state).isShowingRawTable;
+  !!state.qb?.uiControls.isShowingRawTable;
 
 const SIDEBARS = [
   "isShowingQuestionDetailsSidebar",

--- a/frontend/src/metabase/visualizations/click-actions/actions/ColumnFormattingAction/ColumnFormattingAction.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/ColumnFormattingAction/ColumnFormattingAction.tsx
@@ -70,7 +70,7 @@ export const ColumnFormattingAction: LegacyDrill = ({ question, clicked }) => {
       name: "formatting",
       title: t`Column formatting`,
       section: "sort",
-      buttonType: "formatting",
+      buttonType: "sort",
       icon: "gear",
       tooltip: t`Column formatting`,
       popoverProps: {

--- a/frontend/src/metabase/visualizations/click-actions/actions/ColumnFormattingAction/ColumnFormattingAction.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/ColumnFormattingAction/ColumnFormattingAction.tsx
@@ -18,6 +18,7 @@ export const ColumnFormattingAction: LegacyDrill = ({ question, clicked }) => {
     !clicked ||
     clicked.value !== undefined ||
     !clicked.column ||
+    clicked?.extraData?.isRawTable ||
     !question.query().isEditable()
   ) {
     return [];

--- a/frontend/src/metabase/visualizations/click-actions/actions/HideColumnAction/HideColumnAction.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/HideColumnAction/HideColumnAction.tsx
@@ -20,6 +20,8 @@ export const HideColumnAction: LegacyDrill = ({
     return [];
   }
 
+  const { column } = clicked;
+
   return [
     {
       name: "formatting",
@@ -30,15 +32,10 @@ export const HideColumnAction: LegacyDrill = ({
       tooltip: t`Hide column`,
       default: true,
       action: () => {
-        const { column } = clicked;
         const columnSettings = getColumnSettingsWithRefs(
           settings?.["table.columns"] || [],
         );
         const query = question._getMLv2Query();
-
-        if (column === undefined) {
-          return null;
-        }
 
         const columnSettingIndex = findColumnSettingIndex(
           query,

--- a/frontend/src/metabase/visualizations/click-actions/actions/HideColumnAction/HideColumnAction.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/HideColumnAction/HideColumnAction.tsx
@@ -1,0 +1,62 @@
+import { t } from "ttag";
+import type { LegacyDrill } from "metabase/visualizations/types";
+import { onUpdateVisualizationSettings } from "metabase/query_builder/actions";
+import {
+  findColumnSettingIndex,
+  getColumnSettingsWithRefs,
+} from "metabase/visualizations/components/settings/ChartSettingTableColumns/utils";
+
+export const HideColumnAction: LegacyDrill = ({
+  question,
+  clicked,
+  settings,
+}) => {
+  if (
+    !clicked ||
+    clicked.value !== undefined ||
+    !clicked.column ||
+    !question.query().isEditable()
+  ) {
+    return [];
+  }
+
+  return [
+    {
+      name: "formatting",
+      title: t`Hide column`,
+      section: "sort",
+      buttonType: "sort",
+      icon: "eye_crossed_out",
+      tooltip: t`Hide column`,
+      default: true,
+      action: () => {
+        const { column } = clicked;
+        const columnSettings = getColumnSettingsWithRefs(
+          settings?.["table.columns"] || [],
+        );
+        const query = question._getMLv2Query();
+
+        if (column === undefined) {
+          return null;
+        }
+
+        const columnSettingIndex = findColumnSettingIndex(
+          query,
+          column,
+          columnSettings,
+        );
+
+        const columnSettingsCopy = [...columnSettings];
+        if (columnSettingIndex !== -1) {
+          columnSettingsCopy[columnSettingIndex] = {
+            ...columnSettingsCopy[columnSettingIndex],
+            enabled: false,
+          };
+        }
+        return onUpdateVisualizationSettings({
+          "table.columns": columnSettingsCopy,
+        });
+      },
+    },
+  ];
+};

--- a/frontend/src/metabase/visualizations/click-actions/actions/HideColumnAction/HideColumnAction.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/HideColumnAction/HideColumnAction.tsx
@@ -15,6 +15,7 @@ export const HideColumnAction: LegacyDrill = ({
     !clicked ||
     clicked.value !== undefined ||
     !clicked.column ||
+    clicked?.extraData?.isRawTable ||
     !question.query().isEditable()
   ) {
     return [];

--- a/frontend/src/metabase/visualizations/click-actions/actions/HideColumnAction/index.ts
+++ b/frontend/src/metabase/visualizations/click-actions/actions/HideColumnAction/index.ts
@@ -1,0 +1,1 @@
+export { HideColumnAction } from "./HideColumnAction";

--- a/frontend/src/metabase/visualizations/click-actions/modes/DefaultMode.ts
+++ b/frontend/src/metabase/visualizations/click-actions/modes/DefaultMode.ts
@@ -6,6 +6,7 @@ import ZoomDrill from "metabase/visualizations/click-actions/drills/ZoomDrill";
 import { ColumnFilterDrill } from "metabase/visualizations/click-actions/drills/ColumnFilterDrill";
 import type { QueryClickActionsMode } from "../../types";
 import { ColumnFormattingAction } from "../actions/ColumnFormattingAction";
+import { HideColumnAction } from "../actions/HideColumnAction";
 import { DashboardClickAction } from "../actions/DashboardClickAction";
 
 export const DefaultMode: QueryClickActionsMode = {
@@ -17,6 +18,7 @@ export const DefaultMode: QueryClickActionsMode = {
     QuickFilterDrill,
     ColumnFilterDrill,
     AutomaticInsightsDrill,
+    HideColumnAction,
     ColumnFormattingAction,
     DashboardClickAction,
   ],

--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -103,7 +103,11 @@ class ChartSettings extends Component {
   }
 
   handleShowSection = section => {
-    this.setState({ currentSection: section, currentWidget: null });
+    this.setState({
+      currentSection: section,
+      currentWidget: null,
+      widgetOverride: null,
+    });
   };
 
   // allows a widget to temporarily replace itself with a different widget
@@ -336,8 +340,6 @@ class ChartSettings extends Component {
         : _.find(DEFAULT_TAB_PRIORITY, name => name in sections) ||
           sectionNames[0];
 
-    console.log(widgets);
-
     const visibleWidgets = widgetOverride
       ? [
           {
@@ -395,8 +397,7 @@ class ChartSettings extends Component {
         visibleWidgets[0].id === "column_settings" &&
         // and this section doesn't doesn't have that as a direct child
         !currentSectionHasColumnSettings
-      ) &&
-      !widgetOverride;
+      );
 
     // default layout with visualization
     return (

--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -97,6 +97,7 @@ class ChartSettings extends Component {
       this.setState({
         currentSection: (initial && initial.section) || null,
         currentWidget: (initial && initial.widget) || null,
+        widgetOverride: null,
       });
     }
   }
@@ -272,6 +273,12 @@ class ChartSettings extends Component {
     return null;
   };
 
+  handleWidgetOverride = key => {
+    this.setState({
+      widgetOverride: key,
+    });
+  };
+
   render() {
     const {
       className,
@@ -282,7 +289,7 @@ class ChartSettings extends Component {
       dashcard,
       isDashboard,
     } = this.props;
-    const { popoverRef } = this.state;
+    const { popoverRef, widgetOverride } = this.state;
 
     const settings = this._getSettings();
     const widgets = this._getWidgets();
@@ -329,7 +336,16 @@ class ChartSettings extends Component {
         : _.find(DEFAULT_TAB_PRIORITY, name => name in sections) ||
           sectionNames[0];
 
-    const visibleWidgets = sections[currentSection] || [];
+    console.log(widgets);
+
+    const visibleWidgets = widgetOverride
+      ? [
+          {
+            ...widgets.find(widget => widget.id === widgetOverride),
+            hidden: false,
+          },
+        ]
+      : sections[currentSection] || [];
 
     // This checks whether the current section contains a column settings widget
     // at the top level. If it does, we avoid hiding the section tabs and
@@ -348,6 +364,7 @@ class ChartSettings extends Component {
       columnHasSettings: col => this.columnHasSettings(col),
       onChangeSeriesColor: (seriesKey, color) =>
         this.handleChangeSeriesColor(seriesKey, color),
+      onWidgetOverride: key => this.handleWidgetOverride(key),
     };
 
     const sectionPicker = (
@@ -378,7 +395,8 @@ class ChartSettings extends Component {
         visibleWidgets[0].id === "column_settings" &&
         // and this section doesn't doesn't have that as a direct child
         !currentSectionHasColumnSettings
-      );
+      ) &&
+      !widgetOverride;
 
     // default layout with visualization
     return (

--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -97,7 +97,6 @@ class ChartSettings extends Component {
       this.setState({
         currentSection: (initial && initial.section) || null,
         currentWidget: (initial && initial.widget) || null,
-        widgetOverride: null,
       });
     }
   }
@@ -106,7 +105,6 @@ class ChartSettings extends Component {
     this.setState({
       currentSection: section,
       currentWidget: null,
-      widgetOverride: null,
     });
   };
 
@@ -277,12 +275,6 @@ class ChartSettings extends Component {
     return null;
   };
 
-  handleWidgetOverride = key => {
-    this.setState({
-      widgetOverride: key,
-    });
-  };
-
   render() {
     const {
       className,
@@ -293,7 +285,7 @@ class ChartSettings extends Component {
       dashcard,
       isDashboard,
     } = this.props;
-    const { popoverRef, widgetOverride } = this.state;
+    const { popoverRef } = this.state;
 
     const settings = this._getSettings();
     const widgets = this._getWidgets();
@@ -340,14 +332,7 @@ class ChartSettings extends Component {
         : _.find(DEFAULT_TAB_PRIORITY, name => name in sections) ||
           sectionNames[0];
 
-    const visibleWidgets = widgetOverride
-      ? [
-          {
-            ...widgets.find(widget => widget.id === widgetOverride),
-            hidden: false,
-          },
-        ]
-      : sections[currentSection] || [];
+    const visibleWidgets = sections[currentSection] || [];
 
     // This checks whether the current section contains a column settings widget
     // at the top level. If it does, we avoid hiding the section tabs and
@@ -366,7 +351,6 @@ class ChartSettings extends Component {
       columnHasSettings: col => this.columnHasSettings(col),
       onChangeSeriesColor: (seriesKey, color) =>
         this.handleChangeSeriesColor(seriesKey, color),
-      onWidgetOverride: key => this.handleWidgetOverride(key),
     };
 
     const sectionPicker = (

--- a/frontend/src/metabase/visualizations/components/ChartSettings.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.styled.tsx
@@ -56,7 +56,7 @@ export const ChartSettingsMenu = styled.div`
 
 export const ChartSettingsListContainer = styled.div`
   position: relative;
-  padding: 2rem 0;
+  padding: 1.5rem 0;
 `;
 
 export const ChartSettingsPreview = styled.div`

--- a/frontend/src/metabase/visualizations/components/ClickActions/ClickActionControl.tsx
+++ b/frontend/src/metabase/visualizations/components/ClickActions/ClickActionControl.tsx
@@ -60,7 +60,7 @@ export const ClickActionControl = ({
         <Tooltip tooltip={action.tooltip}>
           <SortControl onlyIcon onClick={() => onClick(action)}>
             {typeof action.icon === "string" && (
-              <Icon size={12} name={action.icon as unknown as IconName} />
+              <Icon size={14} name={action.icon as unknown as IconName} />
             )}
           </SortControl>
         </Tooltip>

--- a/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsPopover.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsPopover.unit.spec.tsx
@@ -73,9 +73,10 @@ describe("ClickActionsPopover", function () {
         expect(props.onUpdateVisualizationSettings).toHaveBeenCalledTimes(1);
         expect(props.onUpdateVisualizationSettings).toHaveBeenLastCalledWith({
           column_settings: {
-            [`["ref",["field",${ORDERS.ID},null]]`]: {
-              column_title: "ID NEW NAME",
-            },
+            [`["ref",["field",${ORDERS.ID},{\"base-type\":\"type/Integer\"}]]`]:
+              {
+                column_title: "ID NEW NAME",
+              },
           },
         });
       });
@@ -103,7 +104,11 @@ describe("ClickActionsPopover", function () {
             dataset_query: {
               database: SAMPLE_DB_ID,
               query: {
-                filter: ["=", ["field", ORDERS.ID, null], filterValue],
+                filter: [
+                  "=",
+                  ["field", ORDERS.ID, { "base-type": "type/Integer" }],
+                  filterValue,
+                ],
                 "source-table": ORDERS_ID,
               },
               type: "query",
@@ -295,6 +300,7 @@ describe("ClickActionsPopover", function () {
             dataset_query: getQuickFilterResultDatasetQuery({
               filteredColumnId: ORDERS.TOTAL,
               filterOperator: ">",
+              filterColumnType: "type/Float",
               cellValue: ORDERS_ROW_VALUES.TOTAL,
             }),
             display: "table",
@@ -310,6 +316,7 @@ describe("ClickActionsPopover", function () {
             dataset_query: getQuickFilterResultDatasetQuery({
               filteredColumnId: ORDERS.CREATED_AT,
               filterOperator: "<",
+              filterColumnType: "type/DateTime",
               cellValue: ORDERS_ROW_VALUES.CREATED_AT,
             }),
             display: "table",
@@ -325,6 +332,7 @@ describe("ClickActionsPopover", function () {
             dataset_query: getQuickFilterResultDatasetQuery({
               filteredColumnId: ORDERS.DISCOUNT,
               filterOperator: "is-null",
+              filterColumnType: "type/Float",
               cellValue: null,
             }),
             display: "table",
@@ -531,17 +539,22 @@ function getFKFilteredResultDatasetQuery(
 function getQuickFilterResultDatasetQuery({
   filteredColumnId,
   filterOperator,
+  filterColumnType,
   cellValue,
 }: {
   filteredColumnId: number;
   filterOperator: "=" | "!=" | ">" | "<" | "is-null" | "not-null";
+  filterColumnType: string;
   cellValue: string | number | null | undefined;
 }): DatasetQuery {
   const filterClause = ["is-null", "not-null"].includes(filterOperator)
-    ? ([filterOperator, ["field", filteredColumnId, null]] as Filter)
+    ? ([
+        filterOperator,
+        ["field", filteredColumnId, { "base-type": filterColumnType }],
+      ] as Filter)
     : ([
         filterOperator,
-        ["field", filteredColumnId, null],
+        ["field", filteredColumnId, { "base-type": filterColumnType }],
         cellValue,
       ] as Filter);
 

--- a/frontend/src/metabase/visualizations/components/ClickActions/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ClickActions/utils.ts
@@ -76,13 +76,6 @@ export const getGroupedAndSortedActions = (
     });
     delete groupedClickActions["sum"];
   }
-  if (groupedClickActions["sort"]?.length === 1) {
-    // restyle the Formatting action when there is only one option
-    groupedClickActions["sort"][0] = {
-      ...groupedClickActions["sort"][0],
-      buttonType: "horizontal",
-    };
-  }
 
   return _.chain(groupedClickActions)
     .pairs()
@@ -163,9 +156,7 @@ export const getSectionContentDirection = (
     }
 
     case "sort": {
-      if (actions.length > 1) {
-        return "row";
-      }
+      return "row";
     }
   }
 

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -237,7 +237,7 @@ class Visualization extends PureComponent {
     return mode
       ? mode.actionsForClick(
           { ...clicked, extraData: getExtraDataForClick(clicked) },
-          {},
+          this.state.computedSettings,
         )
       : [];
   }

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -30,6 +30,7 @@ import { isSameSeries, getCardKey } from "metabase/visualizations/lib/utils";
 
 import { getMode } from "metabase/visualizations/click-actions/lib/modes";
 import { getFont } from "metabase/styled-components/selectors";
+import { getIsShowingRawTable } from "metabase/query_builder/selectors";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
 import { isRegularClickAction } from "metabase/visualizations/types";
@@ -64,6 +65,7 @@ const defaultProps = {
 
 const mapStateToProps = state => ({
   fontFamily: getFont(state),
+  isRawTable: getIsShowingRawTable(state),
 });
 
 class Visualization extends PureComponent {
@@ -227,7 +229,11 @@ class Visualization extends PureComponent {
     if (!clicked) {
       return [];
     }
-    const { metadata, getExtraDataForClick = () => ({}) } = this.props;
+    const {
+      metadata,
+      isRawTable,
+      getExtraDataForClick = () => ({}),
+    } = this.props;
 
     const seriesIndex = clicked.seriesIndex || 0;
     const card = this.state.series[seriesIndex].card;
@@ -236,7 +242,13 @@ class Visualization extends PureComponent {
 
     return mode
       ? mode.actionsForClick(
-          { ...clicked, extraData: getExtraDataForClick(clicked) },
+          {
+            ...clicked,
+            extraData: {
+              ...getExtraDataForClick(clicked),
+              isRawTable,
+            },
+          },
           this.state.computedSettings,
         )
       : [];

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingAddRemoveColumns/ChartSettingAddRemoveColumns.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingAddRemoveColumns/ChartSettingAddRemoveColumns.tsx
@@ -1,0 +1,152 @@
+import { useCallback } from "react";
+import { t } from "ttag";
+import type Question from "metabase-lib/Question";
+import { Checkbox } from "metabase/ui";
+import { Box, Flex, Text } from "metabase/ui";
+import { Icon } from "metabase/core/components/Icon";
+import type { ConcreteFieldReference, DatasetColumn } from "metabase-types/api";
+import { getColumnIcon } from "metabase/common/utils/columns";
+import StackedCheckBox from "metabase/components/StackedCheckBox/StackedCheckBox";
+import {
+  getColumnGroups,
+  getMetadataColumns,
+  enableColumnInQuery,
+  enableColumnInSettings,
+  disableColumnInQuery,
+  disableColumnInSettings,
+  findColumnSettingIndex,
+} from "../ChartSettingTableColumns/utils";
+
+import type {
+  ColumnSetting,
+  ColumnMetadataItem,
+} from "../ChartSettingTableColumns/types";
+
+import * as Lib from "metabase-lib";
+
+interface ChartSettingAddRemoveColumnsProps {
+  question: Question;
+  value: ColumnSetting[];
+  onChange: (value: ColumnSetting[], quesion?: Question) => void;
+  columns: DatasetColumn[];
+}
+
+export const ChartSettingAddRemoveColumns = ({
+  value: columnSettings,
+  onChange,
+  question,
+  columns,
+}: ChartSettingAddRemoveColumnsProps) => {
+  const query = question._getMLv2Query();
+
+  const metadataColumnGroups = getColumnGroups(
+    query,
+    getMetadataColumns(query),
+  );
+
+  console.log(metadataColumnGroups);
+  console.log(columns);
+
+  const datasetRefs = columns.map(({ field_ref }) => field_ref);
+  // const columnSettingsRefs = columnSettings.map((fieldRef) => fieldRef)
+
+  const isColumnInQuery = (column: Lib.ColumnMetadata) => {
+    const indexes = Lib.findColumnIndexesFromLegacyRefs(
+      query,
+      -1,
+      [column],
+      datasetRefs,
+    );
+
+    return indexes.some(index => index >= 0);
+  };
+
+  const areAllColumnsInQuery = (columns: Lib.ColumnMetadata) => {
+    const indexes = Lib.findColumnIndexesFromLegacyRefs(
+      query,
+      -1,
+      columns,
+      datasetRefs,
+    );
+
+    return indexes.every(index => index >= 0);
+  };
+
+  const toggleColumn = (columnItem: ColumnMetadataItem) => {
+    const { column } = columnItem;
+    if (isColumnInQuery(column)) {
+      handleDisableColumn(column);
+    } else {
+      handleEnableColumn(column);
+    }
+  };
+
+  const handleEnableColumn = useCallback(
+    (columnItem: Lib.ColumnMetadata) => {
+      const index = findColumnSettingIndex(query, columnItem, columnSettings);
+      const newSettings = enableColumnInSettings(columnSettings, { index });
+      const newQuery = enableColumnInQuery(query, {
+        metadataColumn: columnItem,
+      });
+      onChange(newSettings, question?._setMLv2Query(newQuery));
+    },
+    [query, columnSettings, onChange],
+  );
+
+  const handleDisableColumn = useCallback(
+    (columnItem: Lib.ColumnMetadata) => {
+      const index = findColumnSettingIndex(query, columnItem, columnSettings);
+      const newSettings = disableColumnInSettings(columnSettings, { index });
+      const newQuery = disableColumnInQuery(query, {
+        metadataColumn: columnItem,
+      });
+      onChange(newSettings, question?._setMLv2Query(newQuery));
+    },
+    [query, columnSettings, onChange],
+  );
+
+  return (
+    <div>
+      {metadataColumnGroups.map(columnGroup => (
+        <>
+          <Text fz="lg" fw={700} mb="1rem">
+            {columnGroup.displayName}
+          </Text>
+          <Box mb="0.75rem">
+            {areAllColumnsInQuery(columnGroup.columns) ? (
+              <StackedCheckBox
+                label={<Text fw={700} ml="0.75rem">{t`Remove all`}</Text>}
+                checked={true}
+                // onClick={() => removeAllColumnsForTable(questionTable)}
+              />
+            ) : (
+              <StackedCheckBox
+                label={<Text fw={700} ml="0.75rem">{t`Select all`}</Text>}
+                checked={false}
+                // onClick={() => enableAllColumnsForTable(questionTable)}
+              />
+            )}
+          </Box>
+          {columnGroup.columns.map(column => (
+            <Box mb="1rem">
+              <Checkbox
+                label={
+                  <Flex ml="0.75rem" align="center">
+                    <Icon name={getColumnIcon(column.column)}></Icon>
+                    <Text span ml="0.75rem">
+                      {column.displayName}
+                    </Text>
+                  </Flex>
+                }
+                checked={isColumnInQuery(column.column)}
+                onClick={() => toggleColumn(column)}
+              />
+            </Box>
+          ))}
+        </>
+      ))}
+    </div>
+  );
+
+  return <p>Hello World</p>;
+};

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingAddRemoveColumns/ChartSettingAddRemoveColumns.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingAddRemoveColumns/ChartSettingAddRemoveColumns.tsx
@@ -60,15 +60,18 @@ export const ChartSettingAddRemoveColumns = ({
     });
   }, [query]);
 
+  const columnInQuery = (columnItem: ColumnMetadataItem) =>
+    findColumnSettingIndex(query, columnItem.column, columnSettings) !== -1;
+
   const areAllColumnsInQuery = (columns: ColumnMetadataItem[]) => {
-    return columns.every(({ selected }) => selected);
+    return columns.every(columnInQuery);
   };
 
   const addAllColumnsFromTable = (columns: ColumnMetadataItem[]) => {
     let newQuery = query;
     let newSettings = columnSettings;
     columns.forEach(columnItem => {
-      if (!columnItem.selected) {
+      if (!columnInQuery(columnItem)) {
         newSettings = addColumnInSettings(newQuery, newSettings, columnItem);
         newQuery = enableColumnInQuery(newQuery, {
           metadataColumn: columnItem.column,
@@ -84,7 +87,7 @@ export const ChartSettingAddRemoveColumns = ({
     let newSettings = columnSettings;
 
     columns.forEach(columnItem => {
-      if (columnItem.selected) {
+      if (columnInQuery(columnItem)) {
         const columnSettingIndex = findColumnSettingIndex(
           newQuery,
           columnItem.column,
@@ -104,7 +107,7 @@ export const ChartSettingAddRemoveColumns = ({
   };
 
   const toggleColumn = (columnItem: ColumnMetadataItem) => {
-    if (columnItem.selected) {
+    if (columnInQuery(columnItem)) {
       handleDisableColumn(columnItem);
     } else {
       handleEnableColumn(columnItem);
@@ -154,8 +157,6 @@ export const ChartSettingAddRemoveColumns = ({
     );
   };
 
-  console.log(metadataColumnGroups);
-
   return (
     <div>
       <Button variant="subtle" pl="0" onClick={() => onWidgetOverride(null)}>
@@ -185,6 +186,7 @@ export const ChartSettingAddRemoveColumns = ({
           <div
             role="list"
             aria-label={`${columnGroup.displayName.toLocaleLowerCase()}-table-columns`}
+            key={`column-group-${columnGroup.displayName}`}
           >
             <Text fz="lg" fw={700} mb="1rem">
               {columnGroup.displayName}
@@ -219,7 +221,7 @@ export const ChartSettingAddRemoveColumns = ({
                       </Text>
                     </Flex>
                   }
-                  checked={columnItem.selected}
+                  checked={columnInQuery(columnItem)}
                   onClick={() => toggleColumn(columnItem)}
                   disabled={columnItem.isBreakout || columnItem.isAggregation}
                 />

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingAddRemoveColumns/ChartSettingAddRemoveColumns.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingAddRemoveColumns/ChartSettingAddRemoveColumns.tsx
@@ -146,6 +146,14 @@ export const ChartSettingAddRemoveColumns = ({
     [question, query, columnSettings, onChange],
   );
 
+  const showAddRemoveAll = (columns: ColumnMetadataItem[]) => {
+    return (
+      !columns.some(
+        columnItem => columnItem.isAggregation || columnItem.isBreakout,
+      ) && !search
+    );
+  };
+
   console.log(metadataColumnGroups);
 
   return (
@@ -181,7 +189,7 @@ export const ChartSettingAddRemoveColumns = ({
             <Text fz="lg" fw={700} mb="1rem">
               {columnGroup.displayName}
             </Text>
-            {!search && (
+            {showAddRemoveAll(columnGroup.columns) && (
               <Box mb="0.75rem">
                 {areAllColumnsInQuery(columnGroup.columns) ? (
                   <StackedCheckBox
@@ -213,6 +221,7 @@ export const ChartSettingAddRemoveColumns = ({
                   }
                   checked={columnItem.selected}
                   onClick={() => toggleColumn(columnItem)}
+                  disabled={columnItem.isBreakout || columnItem.isAggregation}
                 />
               </Box>
             ))}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingAddRemoveColumns/ChartSettingAddRemoveColumns.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingAddRemoveColumns/ChartSettingAddRemoveColumns.tsx
@@ -1,13 +1,12 @@
 import { useCallback, useState, useMemo } from "react";
 import { t } from "ttag";
-import { Button, Checkbox, TextInput, Box, Flex, Text } from "metabase/ui";
+import { Checkbox, TextInput, Box, Flex, Text } from "metabase/ui";
 
 import { Icon } from "metabase/core/components/Icon";
 import type { TableColumnOrderSetting } from "metabase-types/api";
 import { getColumnIcon } from "metabase/common/utils/columns";
 import { StackedCheckBox } from "metabase/components/StackedCheckBox/StackedCheckBox";
-
-import type Question from "metabase-lib/Question";
+import type * as Lib from "metabase-lib";
 import type {
   ColumnSetting,
   ColumnMetadataItem,
@@ -24,20 +23,17 @@ import {
 } from "../ChartSettingTableColumns/utils";
 
 interface ChartSettingAddRemoveColumnsProps {
-  question: Question;
+  query: Lib.Query;
   value: TableColumnOrderSetting[];
-  onChange: (value: ColumnSetting[], quesion?: Question) => void;
-  onWidgetOverride: (key: string | null) => void;
+  onChange: (value: ColumnSetting[], quesion?: Lib.Query) => void;
 }
 
 export const ChartSettingAddRemoveColumns = ({
   value,
   onChange,
-  question,
-  onWidgetOverride,
+  query,
 }: ChartSettingAddRemoveColumnsProps) => {
   const [search, setSearch] = useState("");
-  const query = question._getMLv2Query();
 
   const columnSettings = useMemo(
     () => getColumnSettingsWithRefs(value),
@@ -79,7 +75,7 @@ export const ChartSettingAddRemoveColumns = ({
       }
     });
 
-    onChange(newSettings, question?._setMLv2Query(newQuery));
+    onChange(newSettings, newQuery);
   };
 
   const removeAllColumnsFromTable = (columns: ColumnMetadataItem[]) => {
@@ -103,7 +99,7 @@ export const ChartSettingAddRemoveColumns = ({
       }
     });
 
-    onChange(newSettings, question?._setMLv2Query(newQuery));
+    onChange(newSettings, newQuery);
   };
 
   const toggleColumn = (columnItem: ColumnMetadataItem) => {
@@ -124,9 +120,9 @@ export const ChartSettingAddRemoveColumns = ({
       const newQuery = enableColumnInQuery(query, {
         metadataColumn: columnItem.column,
       });
-      onChange(newSettings, question?._setMLv2Query(newQuery));
+      onChange(newSettings, newQuery);
     },
-    [question, query, columnSettings, onChange],
+    [query, columnSettings, onChange],
   );
 
   const handleDisableColumn = useCallback(
@@ -144,9 +140,9 @@ export const ChartSettingAddRemoveColumns = ({
         metadataColumn: columnItem.column,
       });
 
-      onChange(newSettings, question?._setMLv2Query(newQuery));
+      onChange(newSettings, newQuery);
     },
-    [question, query, columnSettings, onChange],
+    [query, columnSettings, onChange],
   );
 
   const showAddRemoveAll = (columns: ColumnMetadataItem[]) => {
@@ -159,9 +155,9 @@ export const ChartSettingAddRemoveColumns = ({
 
   return (
     <div>
-      <Button variant="subtle" pl="0" onClick={() => onWidgetOverride(null)}>
+      {/* <Button variant="subtle" pl="0" onClick={() => onWidgetOverride(null)}>
         Done picking columns
-      </Button>
+      </Button> */}
       <TextInput
         value={search}
         onChange={e => setSearch(e.target.value)}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingAddRemoveColumns/ChartSettingAddRemoveColumns.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingAddRemoveColumns/ChartSettingAddRemoveColumns.tsx
@@ -155,9 +155,6 @@ export const ChartSettingAddRemoveColumns = ({
 
   return (
     <div>
-      {/* <Button variant="subtle" pl="0" onClick={() => onWidgetOverride(null)}>
-        Done picking columns
-      </Button> */}
       <TextInput
         value={search}
         onChange={e => setSearch(e.target.value)}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingAddRemoveColumns/ChartSettingAddRemoveColumns.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingAddRemoveColumns/ChartSettingAddRemoveColumns.unit.spec.tsx
@@ -1,10 +1,7 @@
-import { renderWithProviders, screen } from "__support__/ui";
-import {
-  DEFAULT_QUERY,
-  SAMPLE_DATABASE,
-  SAMPLE_METADATA,
-} from "metabase-lib/test-helpers";
-import Question from "metabase-lib/Question";
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders, screen, within } from "__support__/ui";
+
 import { createMockTableColumnOrderSetting } from "metabase-types/api/mocks";
 import {
   ORDERS,
@@ -12,12 +9,20 @@ import {
   PRODUCTS,
   createOrdersTableDatasetColumns,
 } from "metabase-types/api/mocks/presets";
-import { ChartSettingAddRemoveColumns } from "./ChartSettingAddRemoveColumns";
-import userEvent from "@testing-library/user-event";
+
 import type {
   FieldReference,
   TableColumnOrderSetting,
 } from "metabase-types/api";
+
+import {
+  DEFAULT_QUERY,
+  SAMPLE_DATABASE,
+  SAMPLE_METADATA,
+} from "metabase-lib/test-helpers";
+import Question from "metabase-lib/Question";
+
+import { ChartSettingAddRemoveColumns } from "./ChartSettingAddRemoveColumns";
 
 const COLUMN_SETTINGS = [
   createMockTableColumnOrderSetting({
@@ -69,9 +74,8 @@ const setup = ({
 };
 
 describe("AddRemoveColumns", () => {
-  it.only("should render and display columns present in column settings", () => {
+  it("should render and display columns present in column settings", () => {
     setup();
-    screen.logTestingPlaygroundURL();
     expect(screen.getByLabelText("Total")).toBeChecked();
     expect(screen.getByLabelText("Tax")).toBeChecked();
     expect(screen.getByLabelText("Discount")).not.toBeChecked();
@@ -164,7 +168,6 @@ describe("AddRemoveColumns", () => {
       ),
     });
 
-    screen.logTestingPlaygroundURL();
     expect(screen.getByLabelText("Count")).toBeDisabled();
     expect(screen.getByLabelText("Sum of Total")).toBeDisabled();
     expect(screen.getByLabelText("Product ID")).toBeDisabled();
@@ -193,7 +196,11 @@ describe("AddRemoveColumns", () => {
       expect(screen.getByLabelText("Quantity")).not.toBeChecked();
       expect(screen.getAllByLabelText("Add all")[0]).not.toBeChecked();
 
-      userEvent.click(screen.getAllByLabelText("Add all")[0]);
+      userEvent.click(
+        within(
+          screen.getByRole("list", { name: "orders-table-columns" }),
+        ).getByLabelText("Add all"),
+      );
 
       expect(onChange).toHaveBeenCalledWith(
         ordersTableColumnSettings,

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingAddRemoveColumns/ChartSettingAddRemoveColumns.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingAddRemoveColumns/ChartSettingAddRemoveColumns.unit.spec.tsx
@@ -1,0 +1,180 @@
+import { renderWithProviders, screen } from "__support__/ui";
+import { DEFAULT_QUERY, SAMPLE_METADATA } from "metabase-lib/test-helpers";
+import Question from "metabase-lib/Question";
+import { createMockTableColumnOrderSetting } from "metabase-types/api/mocks";
+import {
+  ORDERS,
+  PRODUCTS,
+  ORDERS_ID,
+  SAMPLE_DB_ID,
+  createOrdersTableDatasetColumns,
+  createOrdersTable,
+} from "metabase-types/api/mocks/presets";
+import { ChartSettingAddRemoveColumns } from "./ChartSettingAddRemoveColumns";
+import userEvent from "@testing-library/user-event";
+import type {
+  FieldReference,
+  TableColumnOrderSetting,
+} from "metabase-types/api";
+
+const COLUMN_SETTINGS = [
+  createMockTableColumnOrderSetting({
+    name: "TOTAL",
+    fieldRef: ["field", ORDERS.TOTAL, null],
+    enabled: true,
+  }),
+  createMockTableColumnOrderSetting({
+    name: "ID",
+    fieldRef: ["field", ORDERS.ID, null],
+    enabled: true,
+  }),
+  createMockTableColumnOrderSetting({
+    name: "TAX",
+    fieldRef: ["field", ORDERS.TAX, null],
+    enabled: false,
+  }),
+  createMockTableColumnOrderSetting({
+    name: "SUBTOTAL",
+    fieldRef: ["field", ORDERS.SUBTOTAL, null],
+    enabled: false,
+  }),
+];
+
+const setup = ({ value = COLUMN_SETTINGS } = {}) => {
+  const onChange = jest.fn();
+  const onWidgetOverride = jest.fn();
+
+  const question = new Question(
+    {
+      dataset_query: DEFAULT_QUERY,
+    },
+    SAMPLE_METADATA,
+  );
+
+  renderWithProviders(
+    <ChartSettingAddRemoveColumns
+      value={value}
+      question={question}
+      onChange={onChange}
+      onWidgetOverride={onWidgetOverride}
+    />,
+  );
+
+  return {
+    onChange,
+  };
+};
+
+describe("AddRemoveColumns", () => {
+  it("should render and display columns present in column settings", () => {
+    setup();
+    expect(screen.getByLabelText("Total")).toBeChecked();
+    expect(screen.getByLabelText("Tax")).toBeChecked();
+    expect(screen.getByLabelText("Discount")).not.toBeChecked();
+  });
+  it("should allow you to remove columns", () => {
+    const { onChange } = setup();
+    userEvent.click(screen.getByLabelText("Total"));
+
+    const [_, ...columnsWithoutTotal] = COLUMN_SETTINGS;
+
+    expect(onChange).toHaveBeenCalledWith(
+      columnsWithoutTotal,
+      expect.anything(),
+    );
+  });
+  it("should show fk tables and allow you to add columns", () => {
+    const { onChange } = setup();
+    expect(screen.getByText("User")).toBeInTheDocument();
+    expect(screen.getByText("Product")).toBeInTheDocument();
+
+    userEvent.click(screen.getByLabelText("Category"));
+
+    expect(onChange).toHaveBeenCalledWith(
+      [
+        ...COLUMN_SETTINGS,
+        createMockTableColumnOrderSetting({
+          name: "CATEGORY",
+          fieldRef: [
+            "field",
+            PRODUCTS.CATEGORY,
+            { "source-field": ORDERS.PRODUCT_ID, "base-type": "type/Text" },
+          ],
+          enabled: true,
+        }),
+      ],
+      expect.anything(),
+    );
+  });
+
+  it("should allow you to search for columns", () => {
+    const { onChange } = setup();
+
+    userEvent.type(screen.getByPlaceholderText("Search for a column..."), "Pr");
+
+    expect(screen.getByLabelText("Product ID")).toBeInTheDocument();
+    expect(screen.getByLabelText("Price")).toBeInTheDocument();
+    expect(screen.queryByText("User")).not.toBeInTheDocument();
+
+    userEvent.click(screen.getByLabelText("Price"));
+
+    expect(onChange).toHaveBeenCalledWith(
+      [
+        ...COLUMN_SETTINGS,
+        createMockTableColumnOrderSetting({
+          name: "PRICE",
+          fieldRef: [
+            "field",
+            PRODUCTS.PRICE,
+            { "source-field": ORDERS.PRODUCT_ID, "base-type": "type/Float" },
+          ],
+          enabled: true,
+        }),
+      ],
+      expect.anything(),
+    );
+  });
+
+  describe("bulk add / remove", () => {
+    const ordersTableColumnSettings = createOrdersTableDatasetColumns().reduce(
+      (memo: TableColumnOrderSetting[], column) => {
+        console.log(column);
+        memo.push(
+          createMockTableColumnOrderSetting({
+            name: column.name,
+            fieldRef: column.field_ref as FieldReference,
+            enabled: true,
+          }),
+        );
+        return memo;
+      },
+      [],
+    );
+
+    it("should allow you to add all columns in a table with a single click", () => {
+      const ordersWithoutQuantity = ordersTableColumnSettings?.slice(0, -1);
+
+      const { onChange } = setup({ value: ordersWithoutQuantity });
+
+      expect(screen.getByLabelText("Quantity")).not.toBeChecked();
+      expect(screen.getAllByLabelText("Add all")[0]).not.toBeChecked();
+
+      userEvent.click(screen.getAllByLabelText("Add all")[0]);
+
+      expect(onChange).toHaveBeenCalledWith(
+        ordersTableColumnSettings,
+        expect.anything(),
+      );
+    });
+
+    it("should allow you to remove all columns from a table with a single click", () => {
+      const { onChange } = setup({ value: ordersTableColumnSettings });
+
+      expect(screen.getByLabelText("Remove all")).toBeChecked();
+
+      userEvent.click(screen.getByLabelText("Remove all"));
+
+      expect(onChange).toHaveBeenCalledWith([], expect.anything());
+    });
+  });
+});

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingAddRemoveColumns/ChartSettingAddRemoveColumns.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingAddRemoveColumns/ChartSettingAddRemoveColumns.unit.spec.tsx
@@ -57,14 +57,12 @@ const setup = ({
   ),
 } = {}) => {
   const onChange = jest.fn();
-  const onWidgetOverride = jest.fn();
 
   renderWithProviders(
     <ChartSettingAddRemoveColumns
       value={value}
-      question={question}
+      query={question._getMLv2Query()}
       onChange={onChange}
-      onWidgetOverride={onWidgetOverride}
     />,
   );
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems/ChartSettingOrderedItems.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems/ChartSettingOrderedItems.tsx
@@ -4,11 +4,13 @@ import {
   SortableContainer,
   SortableElement,
 } from "metabase/components/sortable";
+import type { IconProps } from "metabase/core/components/Icon";
 import { ColumnItem } from "../ColumnItem";
 
 interface SortableItem {
   enabled: boolean;
   color?: string;
+  icon?: IconProps["name"];
 }
 
 interface SortableColumnFunctions<T> {
@@ -17,7 +19,7 @@ interface SortableColumnFunctions<T> {
   onClick?: (item: T) => void;
   onAdd?: (item: T) => void;
   onEnable?: (item: T) => void;
-  getItemName: (item: T) => string | React.ReactChild;
+  getItemName: (item: T) => string;
   onColorChange?: (item: T, color: string) => void;
 }
 
@@ -58,6 +60,7 @@ const SortableColumn = SortableElement(function SortableColumn<
       }
       color={item.color}
       draggable={!isDragDisabled}
+      icon={item.icon}
       role="listitem"
     />
   );

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems/ChartSettingOrderedItems.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems/ChartSettingOrderedItems.tsx
@@ -1,6 +1,5 @@
-import type { ReactElement } from "react";
-
 import type { SortableElementProps } from "react-sortable-hoc";
+import type React from "react";
 import {
   SortableContainer,
   SortableElement,
@@ -18,7 +17,7 @@ interface SortableColumnFunctions<T> {
   onClick?: (item: T) => void;
   onAdd?: (item: T) => void;
   onEnable?: (item: T) => void;
-  getItemName: (item: T) => string;
+  getItemName: (item: T) => string | React.ReactChild;
   onColorChange?: (item: T, color: string) => void;
 }
 
@@ -64,7 +63,7 @@ const SortableColumn = SortableElement(function SortableColumn<
   );
 }) as unknown as <T extends SortableItem>(
   props: SortableColumnProps<T> & SortableElementProps,
-) => ReactElement;
+) => React.ReactElement;
 
 interface SortableColumnListProps<T extends SortableItem>
   extends SortableColumnFunctions<T> {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/ChartSettingTableColumns.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/ChartSettingTableColumns.tsx
@@ -16,6 +16,7 @@ interface ChartSettingTableColumnsProps {
   getColumnName: (column: DatasetColumn) => string;
   onChange: (value: TableColumnOrderSetting[], question?: Question) => void;
   onShowWidget: (config: EditWidgetConfig, targetElement: HTMLElement) => void;
+  onWidgetOverride: (key: string) => void;
 }
 
 export const ChartSettingTableColumns = ({
@@ -25,6 +26,7 @@ export const ChartSettingTableColumns = ({
   getColumnName,
   onChange,
   onShowWidget,
+  onWidgetOverride,
 }: ChartSettingTableColumnsProps) => {
   const handleChange = useCallback(
     (newValue: TableColumnOrderSetting[], newQuery?: Lib.Query) => {
@@ -42,6 +44,7 @@ export const ChartSettingTableColumns = ({
 
     return (
       <QueryColumnSelector
+        handleWidgetOverride={onWidgetOverride}
         value={value}
         query={query}
         columns={columns}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/ChartSettingTableColumns.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/ChartSettingTableColumns.tsx
@@ -28,7 +28,6 @@ export const ChartSettingTableColumns = ({
   onShowWidget,
   onWidgetOverride,
 }: ChartSettingTableColumnsProps) => {
-  console.log(value);
   const handleChange = useCallback(
     (newValue: TableColumnOrderSetting[], newQuery?: Lib.Query) => {
       if (newQuery) {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/ChartSettingTableColumns.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/ChartSettingTableColumns.tsx
@@ -28,6 +28,7 @@ export const ChartSettingTableColumns = ({
   onShowWidget,
   onWidgetOverride,
 }: ChartSettingTableColumnsProps) => {
+  console.log(value);
   const handleChange = useCallback(
     (newValue: TableColumnOrderSetting[], newQuery?: Lib.Query) => {
       if (newQuery) {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/DatasetColumnSelector.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/DatasetColumnSelector.tsx
@@ -40,14 +40,6 @@ export const DatasetColumnSelector = ({
     return getDatasetColumnSettingItems(datasetColumns, columnSettings);
   }, [datasetColumns, columnSettings]);
 
-  const enabledColumnItems = useMemo(() => {
-    return columnItems.filter(({ enabled }) => enabled);
-  }, [columnItems]);
-
-  const disabledColumnItems = useMemo(() => {
-    return columnItems.filter(({ enabled }) => !enabled);
-  }, [columnItems]);
-
   const handleEnableColumn = useCallback(
     (columnItem: ColumnSettingItem) => {
       onChange(enableColumnInSettings(columnSettings, columnItem));
@@ -64,16 +56,15 @@ export const DatasetColumnSelector = ({
 
   const handleDragColumn = useCallback(
     (props: DragColumnProps) => {
-      onChange(moveColumnInSettings(columnSettings, enabledColumnItems, props));
+      onChange(moveColumnInSettings(columnSettings, columnItems, props));
     },
-    [columnSettings, enabledColumnItems, onChange],
+    [columnSettings, columnItems, onChange],
   );
 
   return (
     <TableColumnSelector
-      enabledColumnItems={enabledColumnItems}
-      disabledColumnItems={disabledColumnItems}
-      getColumnName={getColumnName}
+      columnItems={columnItems}
+      getColumnName={({ datasetColumn }) => getColumnName(datasetColumn)}
       onEnableColumn={handleEnableColumn}
       onDisableColumn={handleDisableColumn}
       onDragColumn={handleDragColumn}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/DatasetColumnSelector.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/DatasetColumnSelector.tsx
@@ -65,7 +65,13 @@ export const DatasetColumnSelector = ({
 
   return (
     <>
-      <Text fw={700} mb="0.5rem" fz="0.875rem">{t`Columns`}</Text>
+      <Text
+        component="label"
+        display="block"
+        fw={700}
+        mb="0.5rem"
+        fs="0.875em"
+      >{t`Columns`}</Text>
       <TableColumnSelector
         columnItems={columnItems}
         getColumnName={({ datasetColumn }) => getColumnName(datasetColumn)}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/DatasetColumnSelector.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/DatasetColumnSelector.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useMemo } from "react";
+import { t } from "ttag";
 import type {
   DatasetColumn,
   TableColumnOrderSetting,
 } from "metabase-types/api";
+import { Text } from "metabase/ui";
 import { TableColumnSelector } from "./TableColumnSelector";
 import {
   disableColumnInSettings,
@@ -62,13 +64,16 @@ export const DatasetColumnSelector = ({
   );
 
   return (
-    <TableColumnSelector
-      columnItems={columnItems}
-      getColumnName={({ datasetColumn }) => getColumnName(datasetColumn)}
-      onEnableColumn={handleEnableColumn}
-      onDisableColumn={handleDisableColumn}
-      onDragColumn={handleDragColumn}
-      onShowWidget={onShowWidget}
-    />
+    <>
+      <Text fw={700} mb="0.5rem" fz="0.875rem">{t`Columns`}</Text>
+      <TableColumnSelector
+        columnItems={columnItems}
+        getColumnName={({ datasetColumn }) => getColumnName(datasetColumn)}
+        onEnableColumn={handleEnableColumn}
+        onDisableColumn={handleDisableColumn}
+        onDragColumn={handleDragColumn}
+        onShowWidget={onShowWidget}
+      />
+    </>
   );
 };

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/DatasetColumnSelector.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/DatasetColumnSelector.unit.spec.tsx
@@ -31,6 +31,12 @@ const COLUMNS = [
     display_name: "Tax",
     field_ref: ["field", ORDERS.TAX, null],
   }),
+  createMockColumn({
+    id: ORDERS.SUBTOTAL,
+    name: "SUBTOTAL",
+    display_name: "Subtotal",
+    field_ref: ["field", ORDERS.SUBTOTAL, null],
+  }),
 ];
 
 const COLUMN_SETTINGS = [
@@ -84,12 +90,14 @@ const setup = ({
 };
 
 describe("DatasetColumnSelector", () => {
-  it("should display enabled columns in the order of the setting", () => {
+  it("should display columns in the order of the setting", () => {
     setup();
     const items = screen.getAllByTestId(/draggable-item/);
-    expect(items).toHaveLength(2);
+    expect(items).toHaveLength(4);
     expect(items[0]).toHaveTextContent("Total");
     expect(items[1]).toHaveTextContent("ID");
+    expect(items[2]).toHaveTextContent("Tax");
+    expect(items[3]).toHaveTextContent("Subtotal");
   });
 
   it("should allow to enable a column", () => {
@@ -111,15 +119,10 @@ describe("DatasetColumnSelector", () => {
       assocIn(COLUMN_SETTINGS, [columnIndex, "enabled"], false),
     );
   });
-
-  it("should not show columns which don't exist in the query response", () => {
-    setup();
-    expect(screen.queryByText("Subtotal")).not.toBeInTheDocument();
-  });
 });
 
 const enableColumn = (columnName: string) => {
-  userEvent.click(screen.getByTestId(`${columnName}-add-button`));
+  userEvent.click(screen.getByTestId(`${columnName}-show-button`));
 };
 
 const disableColumn = (columnName: string) => {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/QueryColumnSelector.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/QueryColumnSelector.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useMemo } from "react";
+import { t } from "ttag";
+import { Button } from "metabase/ui";
 import type {
   DatasetColumn,
   TableColumnOrderSetting,
@@ -33,6 +35,7 @@ export interface QueryColumnSelectorProps {
   getColumnName: (column: DatasetColumn) => string;
   onChange: (value: TableColumnOrderSetting[], query?: Lib.Query) => void;
   onShowWidget: (config: EditWidgetConfig, targetElement: HTMLElement) => void;
+  handleWidgetOverride: (key: string) => void;
 }
 
 export const QueryColumnSelector = ({
@@ -42,6 +45,7 @@ export const QueryColumnSelector = ({
   getColumnName,
   onChange,
   onShowWidget,
+  handleWidgetOverride,
 }: QueryColumnSelectorProps) => {
   const columnSettings = useMemo(() => {
     return getColumnSettingsWithRefs(value);
@@ -114,16 +118,22 @@ export const QueryColumnSelector = ({
   );
 
   return (
-    <TableColumnSelector
-      enabledColumnItems={enabledColumnItems}
-      disabledColumnItems={disabledColumnItems}
-      additionalColumnGroups={additionalColumnGroups}
-      getColumnName={getColumnName}
-      onAddColumn={handleAddColumn}
-      onEnableColumn={handleEnableColumn}
-      onDisableColumn={handleDisableColumn}
-      onDragColumn={handleDragColumn}
-      onShowWidget={onShowWidget}
-    />
+    <>
+      <Button
+        variant="subtle"
+        onClick={() => handleWidgetOverride("table.columnVisibility")}
+      >{t`Click me`}</Button>
+      <TableColumnSelector
+        enabledColumnItems={enabledColumnItems}
+        disabledColumnItems={disabledColumnItems}
+        additionalColumnGroups={additionalColumnGroups}
+        getColumnName={getColumnName}
+        onAddColumn={handleAddColumn}
+        onEnableColumn={handleEnableColumn}
+        onDisableColumn={handleDisableColumn}
+        onDragColumn={handleDragColumn}
+        onShowWidget={onShowWidget}
+      />
+    </>
   );
 };

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/QueryColumnSelector.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/QueryColumnSelector.tsx
@@ -95,8 +95,8 @@ export const QueryColumnSelector = ({
   const handleEnableColumn = useCallback(
     (columnItem: ColumnSettingItem) => {
       const newSettings = enableColumnInSettings(columnSettings, columnItem);
-      const newQuery = enableColumnInQuery(query, columnItem);
-      onChange(newSettings, newQuery);
+      // const newQuery = enableColumnInQuery(query, columnItem);
+      onChange(newSettings);
     },
     [query, columnSettings, onChange],
   );
@@ -104,17 +104,17 @@ export const QueryColumnSelector = ({
   const handleDisableColumn = useCallback(
     (columnItem: ColumnSettingItem) => {
       const newSettings = disableColumnInSettings(columnSettings, columnItem);
-      const newQuery = disableColumnInQuery(query, columnItem);
-      onChange(newSettings, newQuery);
+      // const newQuery = disableColumnInQuery(query, columnItem);
+      onChange(newSettings);
     },
     [query, columnSettings, onChange],
   );
 
   const handleDragColumn = useCallback(
     (props: DragColumnProps) => {
-      onChange(moveColumnInSettings(columnSettings, enabledColumnItems, props));
+      onChange(moveColumnInSettings(columnSettings, columnItems, props));
     },
-    [columnSettings, enabledColumnItems, onChange],
+    [columnSettings, columnItems, onChange],
   );
 
   return (
@@ -122,11 +122,12 @@ export const QueryColumnSelector = ({
       <Button
         variant="subtle"
         onClick={() => handleWidgetOverride("table.columnVisibility")}
-      >{t`Click me`}</Button>
+        pl="0"
+      >{t`Add or remove columns`}</Button>
       <TableColumnSelector
-        enabledColumnItems={enabledColumnItems}
-        disabledColumnItems={disabledColumnItems}
-        additionalColumnGroups={additionalColumnGroups}
+        enabledColumnItems={columnItems}
+        disabledColumnItems={[]}
+        // additionalColumnGroups={additionalColumnGroups}
         getColumnName={getColumnName}
         onAddColumn={handleAddColumn}
         onEnableColumn={handleEnableColumn}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/QueryColumnSelector.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/QueryColumnSelector.tsx
@@ -1,28 +1,23 @@
 import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import { Button } from "metabase/ui";
+import { Icon } from "metabase/core/components/Icon";
 import type {
   DatasetColumn,
   TableColumnOrderSetting,
 } from "metabase-types/api";
 import type * as Lib from "metabase-lib";
+import { getColumnIcon } from "metabase/common/utils/columns";
 import { TableColumnSelector } from "./TableColumnSelector";
 import {
-  addColumnInQuery,
-  addColumnInSettings,
-  disableColumnInQuery,
   disableColumnInSettings,
-  enableColumnInQuery,
   enableColumnInSettings,
-  getAdditionalMetadataColumns,
-  getColumnGroups,
   getColumnSettingsWithRefs,
   getMetadataColumns,
   getQueryColumnSettingItems,
   moveColumnInSettings,
 } from "./utils";
 import type {
-  ColumnMetadataItem,
   ColumnSettingItem,
   DragColumnProps,
   EditWidgetConfig,
@@ -64,50 +59,20 @@ export const QueryColumnSelector = ({
     );
   }, [query, metadataColumns, datasetColumns, columnSettings]);
 
-  const additionalColumnGroups = useMemo(() => {
-    return getColumnGroups(
-      query,
-      getAdditionalMetadataColumns(metadataColumns, columnItems),
-    );
-  }, [query, metadataColumns, columnItems]);
-
-  const enabledColumnItems = useMemo(() => {
-    return columnItems.filter(({ enabled }) => enabled);
-  }, [columnItems]);
-
-  const disabledColumnItems = useMemo(() => {
-    return columnItems.filter(({ enabled }) => !enabled);
-  }, [columnItems]);
-
-  const handleAddColumn = useCallback(
-    (columnItem: ColumnMetadataItem) => {
-      const newSettings = addColumnInSettings(
-        query,
-        columnSettings,
-        columnItem,
-      );
-      const newQuery = addColumnInQuery(query, columnItem);
-      onChange(newSettings, newQuery);
-    },
-    [query, columnSettings, onChange],
-  );
-
   const handleEnableColumn = useCallback(
     (columnItem: ColumnSettingItem) => {
       const newSettings = enableColumnInSettings(columnSettings, columnItem);
-      // const newQuery = enableColumnInQuery(query, columnItem);
       onChange(newSettings);
     },
-    [query, columnSettings, onChange],
+    [columnSettings, onChange],
   );
 
   const handleDisableColumn = useCallback(
     (columnItem: ColumnSettingItem) => {
       const newSettings = disableColumnInSettings(columnSettings, columnItem);
-      // const newQuery = disableColumnInQuery(query, columnItem);
       onChange(newSettings);
     },
-    [query, columnSettings, onChange],
+    [columnSettings, onChange],
   );
 
   const handleDragColumn = useCallback(
@@ -125,11 +90,13 @@ export const QueryColumnSelector = ({
         pl="0"
       >{t`Add or remove columns`}</Button>
       <TableColumnSelector
-        enabledColumnItems={columnItems}
-        disabledColumnItems={[]}
-        // additionalColumnGroups={additionalColumnGroups}
-        getColumnName={getColumnName}
-        onAddColumn={handleAddColumn}
+        columnItems={columnItems}
+        getColumnName={({ datasetColumn, metadataColumn }) => (
+          <>
+            <Icon name={getColumnIcon(metadataColumn)} />{" "}
+            {getColumnName(datasetColumn)}
+          </>
+        )}
         onEnableColumn={handleEnableColumn}
         onDisableColumn={handleDisableColumn}
         onDragColumn={handleDragColumn}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/QueryColumnSelector.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/QueryColumnSelector.tsx
@@ -93,7 +93,7 @@ export const QueryColumnSelector = ({
         columnItems={columnItems}
         getColumnName={({ datasetColumn, metadataColumn }) => (
           <>
-            <Icon name={getColumnIcon(metadataColumn)} />{" "}
+            {metadataColumn && <Icon name={getColumnIcon(metadataColumn)} />}{" "}
             {getColumnName(datasetColumn)}
           </>
         )}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/QueryColumnSelector.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/QueryColumnSelector.tsx
@@ -1,13 +1,11 @@
 import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import { Button } from "metabase/ui";
-import { Icon } from "metabase/core/components/Icon";
 import type {
   DatasetColumn,
   TableColumnOrderSetting,
 } from "metabase-types/api";
 import type * as Lib from "metabase-lib";
-import { getColumnIcon } from "metabase/common/utils/columns";
 import { TableColumnSelector } from "./TableColumnSelector";
 import {
   disableColumnInSettings,
@@ -91,12 +89,7 @@ export const QueryColumnSelector = ({
       >{t`Add or remove columns`}</Button>
       <TableColumnSelector
         columnItems={columnItems}
-        getColumnName={({ datasetColumn, metadataColumn }) => (
-          <>
-            {metadataColumn && <Icon name={getColumnIcon(metadataColumn)} />}{" "}
-            {getColumnName(datasetColumn)}
-          </>
-        )}
+        getColumnName={({ datasetColumn }) => getColumnName(datasetColumn)}
         onEnableColumn={handleEnableColumn}
         onDisableColumn={handleDisableColumn}
         onDragColumn={handleDragColumn}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/QueryColumnSelector.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/QueryColumnSelector.tsx
@@ -1,11 +1,12 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
-import { Button } from "metabase/ui";
+import { Button, Text } from "metabase/ui";
 import type {
   DatasetColumn,
   TableColumnOrderSetting,
 } from "metabase-types/api";
 import type * as Lib from "metabase-lib";
+import { ChartSettingAddRemoveColumns } from "../ChartSettingAddRemoveColumns/ChartSettingAddRemoveColumns";
 import { TableColumnSelector } from "./TableColumnSelector";
 import {
   disableColumnInSettings,
@@ -38,8 +39,9 @@ export const QueryColumnSelector = ({
   getColumnName,
   onChange,
   onShowWidget,
-  handleWidgetOverride,
 }: QueryColumnSelectorProps) => {
+  const [addRemoveColumns, setAddRemoveColumns] = useState(false);
+
   const columnSettings = useMemo(() => {
     return getColumnSettingsWithRefs(value);
   }, [value]);
@@ -82,19 +84,32 @@ export const QueryColumnSelector = ({
 
   return (
     <>
+      {!addRemoveColumns && (
+        <Text fw={700} mb="0.5rem" fs="0.875em">{t`Columns`}</Text>
+      )}
       <Button
         variant="subtle"
-        onClick={() => handleWidgetOverride("table.columnVisibility")}
+        onClick={() => setAddRemoveColumns(value => !value)}
         pl="0"
-      >{t`Add or remove columns`}</Button>
-      <TableColumnSelector
-        columnItems={columnItems}
-        getColumnName={({ datasetColumn }) => getColumnName(datasetColumn)}
-        onEnableColumn={handleEnableColumn}
-        onDisableColumn={handleDisableColumn}
-        onDragColumn={handleDragColumn}
-        onShowWidget={onShowWidget}
-      />
+      >
+        {addRemoveColumns ? t`Done picking columns` : t`Add or remove columns`}
+      </Button>
+      {addRemoveColumns ? (
+        <ChartSettingAddRemoveColumns
+          value={value}
+          onChange={onChange}
+          query={query}
+        />
+      ) : (
+        <TableColumnSelector
+          columnItems={columnItems}
+          getColumnName={({ datasetColumn }) => getColumnName(datasetColumn)}
+          onEnableColumn={handleEnableColumn}
+          onDisableColumn={handleDisableColumn}
+          onDragColumn={handleDragColumn}
+          onShowWidget={onShowWidget}
+        />
+      )}
     </>
   );
 };

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/QueryColumnSelector.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/QueryColumnSelector.tsx
@@ -85,7 +85,13 @@ export const QueryColumnSelector = ({
   return (
     <>
       {!addRemoveColumns && (
-        <Text fw={700} mb="0.5rem" fs="0.875em">{t`Columns`}</Text>
+        <Text
+          component="label"
+          display="block"
+          fw={700}
+          mb="0.5rem"
+          fs="0.875em"
+        >{t`Columns`}</Text>
       )}
       <Button
         variant="subtle"

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/QueryColumnSelector.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/QueryColumnSelector.unit.spec.tsx
@@ -85,6 +85,7 @@ const setup = ({
 }: SetupOpts = {}) => {
   const onChange = jest.fn();
   const onShowWidget = jest.fn();
+  const onWidgetOverride = jest.fn();
 
   renderWithProviders(
     <QueryColumnSelector
@@ -94,6 +95,7 @@ const setup = ({
       getColumnName={getColumnName}
       onChange={onChange}
       onShowWidget={onShowWidget}
+      handleWidgetOverride={onWidgetOverride}
     />,
   );
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/QueryColumnSelector.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/QueryColumnSelector.unit.spec.tsx
@@ -45,6 +45,12 @@ const COLUMNS = [
     display_name: "Tax",
     field_ref: ["field", ORDERS.TAX, null],
   }),
+  createMockColumn({
+    id: ORDERS.SUBTOTAL,
+    name: "SUBTOTAL",
+    display_name: "Subtotal",
+    field_ref: ["field", ORDERS.SUBTOTAL, null],
+  }),
 ];
 
 const COLUMN_SETTINGS = [
@@ -103,12 +109,14 @@ const setup = ({
 };
 
 describe("QueryColumnSelector", () => {
-  it("should display enabled columns in the order of the setting", () => {
+  it("should columns in the order of the setting", () => {
     setup();
     const items = screen.getAllByTestId(/draggable-item/);
-    expect(items).toHaveLength(2);
+    expect(items).toHaveLength(4);
     expect(items[0]).toHaveTextContent("Total");
     expect(items[1]).toHaveTextContent("ID");
+    expect(items[2]).toHaveTextContent("Tax");
+    expect(items[3]).toHaveTextContent("Subtotal");
   });
 
   it("should allow to enable a column", () => {
@@ -118,7 +126,6 @@ describe("QueryColumnSelector", () => {
     enableColumn("Tax");
     expect(onChange).toHaveBeenCalledWith(
       assocIn(COLUMN_SETTINGS, [columnIndex, "enabled"], true),
-      expect.anything(),
     );
   });
 
@@ -129,30 +136,12 @@ describe("QueryColumnSelector", () => {
     disableColumn("ID");
     expect(onChange).toHaveBeenCalledWith(
       assocIn(COLUMN_SETTINGS, [columnIndex, "enabled"], false),
-      expect.anything(),
-    );
-  });
-
-  it("should add a column from the source table", () => {
-    const { onChange } = setup();
-
-    enableColumn("Discount");
-    expect(onChange).toHaveBeenCalledWith(
-      [
-        ...COLUMN_SETTINGS,
-        {
-          name: "DISCOUNT",
-          enabled: true,
-          fieldRef: ["field", ORDERS.DISCOUNT, { "base-type": "type/Float" }],
-        },
-      ],
-      expect.anything(),
     );
   });
 });
 
 const enableColumn = (columnName: string) => {
-  userEvent.click(screen.getByTestId(`${columnName}-add-button`));
+  userEvent.click(screen.getByTestId(`${columnName}-show-button`));
 };
 
 const disableColumn = (columnName: string) => {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnSelector.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnSelector.styled.tsx
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+import { ColumnItem } from "../ColumnItem";
+
+export const TableColumnSelectorRoot = styled.div`
+  ${ColumnItem.Root}[data-enabled="false"] {
+    color: ${color("text-light")};
+
+    ${ColumnItem.Icon} {
+      color: ${color("text-light")};
+    }
+  }
+`;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnSelector.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnSelector.tsx
@@ -2,8 +2,11 @@ import { t } from "ttag";
 import { useCallback } from "react";
 import type { DatasetColumn } from "metabase-types/api";
 import { getEditWidgetConfig } from "metabase/visualizations/components/settings/ChartSettingTableColumns/utils";
+import { getColumnIcon } from "metabase/common/utils/columns";
+import { Icon } from "metabase/core/components/Icon";
 import { ColumnItem } from "../ColumnItem";
 import { ChartSettingOrderedItems } from "../ChartSettingOrderedItems";
+import { TableColumnSelectorRoot } from "./TableColumnSelector.styled";
 import type {
   ColumnGroupItem,
   ColumnMetadataItem,
@@ -16,7 +19,7 @@ interface TableColumnSelectorProps {
   enabledColumnItems: ColumnSettingItem[];
   disabledColumnItems: ColumnSettingItem[];
   additionalColumnGroups?: ColumnGroupItem[];
-  getColumnName: (column: DatasetColumn) => string;
+  getColumnName: (column: DatasetColumn) => string | Element;
   onAddColumn?: (columnItem: ColumnMetadataItem) => void;
   onEnableColumn: (columnItem: ColumnSettingItem) => void;
   onDisableColumn: (columnItem: ColumnSettingItem) => void;
@@ -46,15 +49,21 @@ export const TableColumnSelector = ({
   );
 
   return (
-    <div role="list">
+    <TableColumnSelectorRoot role="list">
       {enabledColumnItems.length > 0 ? (
         <div role="group" data-testid="visible-columns">
           <ChartSettingOrderedItems
             items={enabledColumnItems}
-            getItemName={({ datasetColumn }) => getColumnName(datasetColumn)}
+            getItemName={({ datasetColumn, metadataColumn }) => (
+              <>
+                <Icon name={getColumnIcon(metadataColumn)} />{" "}
+                {getColumnName(datasetColumn)}
+              </>
+            )}
             distance={5}
             onEdit={handleEditColumn}
             onRemove={onDisableColumn}
+            onEnable={onEnableColumn}
             onSortEnd={onDragColumn}
           />
         </div>
@@ -96,6 +105,6 @@ export const TableColumnSelector = ({
           </div>
         ))}
       </div>
-    </div>
+    </TableColumnSelectorRoot>
   );
 };

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnSelector.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnSelector.tsx
@@ -1,26 +1,16 @@
-import { t } from "ttag";
 import { useCallback } from "react";
-import type { DatasetColumn } from "metabase-types/api";
 import { getEditWidgetConfig } from "metabase/visualizations/components/settings/ChartSettingTableColumns/utils";
-import { getColumnIcon } from "metabase/common/utils/columns";
-import { Icon } from "metabase/core/components/Icon";
-import { ColumnItem } from "../ColumnItem";
 import { ChartSettingOrderedItems } from "../ChartSettingOrderedItems";
 import { TableColumnSelectorRoot } from "./TableColumnSelector.styled";
 import type {
-  ColumnGroupItem,
-  ColumnMetadataItem,
   ColumnSettingItem,
   DragColumnProps,
   EditWidgetConfig,
 } from "./types";
 
 interface TableColumnSelectorProps {
-  enabledColumnItems: ColumnSettingItem[];
-  disabledColumnItems: ColumnSettingItem[];
-  additionalColumnGroups?: ColumnGroupItem[];
-  getColumnName: (column: DatasetColumn) => string | Element;
-  onAddColumn?: (columnItem: ColumnMetadataItem) => void;
+  columnItems: ColumnSettingItem[];
+  getColumnName: (columnItem: ColumnSettingItem) => string | React.ReactChild;
   onEnableColumn: (columnItem: ColumnSettingItem) => void;
   onDisableColumn: (columnItem: ColumnSettingItem) => void;
   onDragColumn: (props: DragColumnProps) => void;
@@ -28,11 +18,8 @@ interface TableColumnSelectorProps {
 }
 
 export const TableColumnSelector = ({
-  enabledColumnItems,
-  disabledColumnItems,
-  additionalColumnGroups = [],
+  columnItems,
   getColumnName,
-  onAddColumn,
   onEnableColumn,
   onDisableColumn,
   onDragColumn,
@@ -50,16 +37,11 @@ export const TableColumnSelector = ({
 
   return (
     <TableColumnSelectorRoot role="list">
-      {enabledColumnItems.length > 0 ? (
+      {columnItems.length > 0 && (
         <div role="group" data-testid="visible-columns">
           <ChartSettingOrderedItems
-            items={enabledColumnItems}
-            getItemName={({ datasetColumn, metadataColumn }) => (
-              <>
-                <Icon name={getColumnIcon(metadataColumn)} />{" "}
-                {getColumnName(datasetColumn)}
-              </>
-            )}
+            items={columnItems}
+            getItemName={getColumnName}
             distance={5}
             onEdit={handleEditColumn}
             onRemove={onDisableColumn}
@@ -67,44 +49,7 @@ export const TableColumnSelector = ({
             onSortEnd={onDragColumn}
           />
         </div>
-      ) : (
-        <div className="my2 p2 flex layout-centered bg-grey-0 text-light text-bold rounded">
-          {t`Add fields from the list below`}
-        </div>
       )}
-      {(disabledColumnItems.length > 0 ||
-        additionalColumnGroups.length > 0) && (
-        <h4 className="mb2 mt4 pt4 border-top">{t`More columns`}</h4>
-      )}
-      <div data-testid="disabled-columns">
-        {disabledColumnItems.map((columnItem, columnIndex) => (
-          <ColumnItem
-            key={columnIndex}
-            title={getColumnName(columnItem.datasetColumn)}
-            role="listitem"
-            onAdd={() => onEnableColumn(columnItem)}
-          />
-        ))}
-      </div>
-      <div data-testid="additional-columns">
-        {additionalColumnGroups.map((groupItem, groupIndex) => (
-          <div key={groupIndex}>
-            {groupItem.isJoinable && (
-              <div className="my2 text-medium text-bold text-uppercase text-small">
-                {groupItem.displayName}
-              </div>
-            )}
-            {groupItem.columns.map((columnItem, columnIndex) => (
-              <ColumnItem
-                key={columnIndex}
-                title={columnItem.displayName}
-                role="listitem"
-                onAdd={() => onAddColumn?.(columnItem)}
-              />
-            ))}
-          </div>
-        ))}
-      </div>
     </TableColumnSelectorRoot>
   );
 };

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnSelector.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnSelector.tsx
@@ -10,7 +10,7 @@ import type {
 
 interface TableColumnSelectorProps {
   columnItems: ColumnSettingItem[];
-  getColumnName: (columnItem: ColumnSettingItem) => string | React.ReactChild;
+  getColumnName: (columnItem: ColumnSettingItem) => string;
   onEnableColumn: (columnItem: ColumnSettingItem) => void;
   onDisableColumn: (columnItem: ColumnSettingItem) => void;
   onDragColumn: (props: DragColumnProps) => void;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/types.ts
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/types.ts
@@ -4,6 +4,7 @@ import type {
   TableColumnOrderSetting,
 } from "metabase-types/api";
 import type * as Lib from "metabase-lib";
+import type { IconProps } from "metabase/core/components/Icon";
 
 export interface ColumnSetting extends TableColumnOrderSetting {
   fieldRef: FieldReference;
@@ -14,6 +15,7 @@ export interface ColumnSettingItem {
   metadataColumn?: Lib.ColumnMetadata;
   datasetColumn: DatasetColumn;
   columnSettingIndex: number;
+  icon?: IconProps["name"];
 }
 
 export interface ColumnMetadataItem {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/types.ts
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/types.ts
@@ -22,6 +22,7 @@ export interface ColumnMetadataItem {
   column: Lib.ColumnMetadata;
   name: string;
   displayName: string;
+  selected?: boolean;
 }
 
 export interface ColumnGroupItem {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/types.ts
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/types.ts
@@ -23,6 +23,8 @@ export interface ColumnMetadataItem {
   name: string;
   displayName: string;
   selected?: boolean;
+  isAggregation?: boolean;
+  isBreakout?: boolean;
 }
 
 export interface ColumnGroupItem {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/utils.ts
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/utils.ts
@@ -13,6 +13,7 @@ import type {
   DragColumnProps,
   EditWidgetConfig,
 } from "./types";
+import { columnSettings } from "metabase/visualizations/lib/settings/column";
 
 const STAGE_INDEX = -1;
 
@@ -255,6 +256,14 @@ export const disableColumnInSettings = (
 
   return newSettings;
 };
+
+export const removeColumnFromSettings = (
+  columnSettings: ColumnSetting[],
+  {columnSettingIndex}: {columnSettingIndex: number}
+) => {
+  const newSettings = [...columnSettings];
+  return newSettings.toSpliced(columnSettingIndex, 1);
+}
 
 export const moveColumnInSettings = (
   columnSettings: ColumnSetting[],

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/utils.ts
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/utils.ts
@@ -197,7 +197,7 @@ export const disableColumnInQuery = (
   return Lib.removeField(query, STAGE_INDEX, metadataColumn);
 };
 
-const findColumnSettingIndex = (
+export const findColumnSettingIndex = (
   query: Lib.Query,
   column: Lib.ColumnMetadata,
   columnSettings: ColumnSetting[],

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/utils.ts
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/utils.ts
@@ -1,3 +1,4 @@
+import {t} from "ttag"
 import { getColumnIcon } from "metabase/common/utils/columns";
 import type { IconName } from "metabase/core/components/Icon";
 import type {
@@ -39,7 +40,7 @@ export const getMetadataColumns = (query: Lib.Query): Lib.ColumnMetadata[] => {
 
   return aggregations.length === 0 && breakouts.length === 0
     ? Lib.visibleColumns(query, STAGE_INDEX)
-    : [];
+    : Lib.returnedColumns(query, STAGE_INDEX);
 };
 
 export const getQueryColumnSettingItems = (
@@ -128,6 +129,7 @@ export const getAdditionalMetadataColumns = (
 const getColumnGroupName = (
   displayInfo: Lib.ColumnDisplayInfo | Lib.TableDisplayInfo,
 ) => {
+  // console.log(displayInfo)
   const columnInfo = displayInfo as Lib.ColumnDisplayInfo;
   const tableInfo = displayInfo as Lib.TableDisplayInfo;
   return columnInfo.fkReferenceName || tableInfo.displayName;
@@ -139,20 +141,20 @@ export const getColumnGroups = (
 ): ColumnGroupItem[] => {
   const groups = Lib.groupColumns(metadataColumns);
 
+  console.log(metadataColumns, groups)
+
   return groups.map(group => {
     const displayInfo = Lib.displayInfo(query, STAGE_INDEX, group);
     const columns = Lib.getColumnsFromColumnGroup(group);
-
     return {
       columns: columns.map(column => {
-        const displayInfo = Lib.displayInfo(query, STAGE_INDEX, column);
+        const columnDisplayInfo = Lib.displayInfo(query, STAGE_INDEX, column);
         return {
           column,
-          name: displayInfo.name,
-          displayName: displayInfo.displayName,
+          ...columnDisplayInfo
         };
       }),
-      displayName: getColumnGroupName(displayInfo),
+      displayName: getColumnGroupName(displayInfo) || t`Question`,
       isJoinable: displayInfo.isFromJoin || displayInfo.isImplicitlyJoinable,
     };
   });
@@ -213,7 +215,7 @@ export const findColumnSettingIndex = (
     [column] as Lib.ColumnMetadata[] | DatasetColumn[],
     columnSettings.map(({ fieldRef }) => fieldRef),
   );
-
+  
   return columnIndexes.findIndex(index => index >= 0);
 };
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/utils.ts
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/utils.ts
@@ -1,9 +1,12 @@
+import { getColumnIcon } from "metabase/common/utils/columns";
+import type { IconName } from "metabase/core/components/Icon";
 import type {
   DatasetColumn,
   TableColumnOrderSetting,
 } from "metabase-types/api";
 import * as Lib from "metabase-lib";
 import { getColumnKey } from "metabase-lib/queries/utils/get-column-key";
+import { getIconForField } from "metabase-lib/metadata/utils/fields";
 import { findColumnIndexForColumnSetting } from "metabase-lib/queries/utils/dataset";
 import type {
   ColumnGroupItem,
@@ -70,6 +73,7 @@ export const getQueryColumnSettingItems = (
           metadataColumn: metadataColumns[metadataIndex],
           datasetColumn: datasetColumns[datasetIndex],
           columnSettingIndex: settingIndex,
+          icon: getColumnIcon(metadataColumns[metadataIndex]),
         });
       }
 
@@ -96,6 +100,7 @@ export const getDatasetColumnSettingItems = (
           enabled: columnSetting.enabled,
           datasetColumn: datasetColumns[datasetIndex],
           columnSettingIndex: settingIndex,
+          icon: getIconForField(datasetColumns[datasetIndex]) as IconName,
         });
       }
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/utils.ts
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/utils.ts
@@ -13,7 +13,6 @@ import type {
   DragColumnProps,
   EditWidgetConfig,
 } from "./types";
-import { columnSettings } from "metabase/visualizations/lib/settings/column";
 
 const STAGE_INDEX = -1;
 
@@ -175,7 +174,7 @@ export const addColumnInQuery = (
 
 export const enableColumnInQuery = (
   query: Lib.Query,
-  { metadataColumn }: ColumnSettingItem,
+  { metadataColumn }: Partial<ColumnSettingItem>,
 ) => {
   if (!metadataColumn) {
     return query;
@@ -189,7 +188,7 @@ export const enableColumnInQuery = (
 
 export const disableColumnInQuery = (
   query: Lib.Query,
-  { metadataColumn }: ColumnSettingItem,
+  { metadataColumn }: Partial<ColumnSettingItem>,
 ) => {
   if (!metadataColumn) {
     return query;
@@ -259,11 +258,12 @@ export const disableColumnInSettings = (
 
 export const removeColumnFromSettings = (
   columnSettings: ColumnSetting[],
-  {columnSettingIndex}: {columnSettingIndex: number}
+  { columnSettingIndex }: { columnSettingIndex: number },
 ) => {
   const newSettings = [...columnSettings];
-  return newSettings.toSpliced(columnSettingIndex, 1);
-}
+  newSettings.splice(columnSettingIndex, 1);
+  return newSettings;
+};
 
 export const moveColumnInSettings = (
   columnSettings: ColumnSetting[],

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/utils.ts
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/utils.ts
@@ -1,4 +1,4 @@
-import {t} from "ttag"
+import { t } from "ttag";
 import { getColumnIcon } from "metabase/common/utils/columns";
 import type { IconName } from "metabase/core/components/Icon";
 import type {
@@ -141,8 +141,6 @@ export const getColumnGroups = (
 ): ColumnGroupItem[] => {
   const groups = Lib.groupColumns(metadataColumns);
 
-  console.log(metadataColumns, groups)
-
   return groups.map(group => {
     const displayInfo = Lib.displayInfo(query, STAGE_INDEX, group);
     const columns = Lib.getColumnsFromColumnGroup(group);
@@ -151,7 +149,7 @@ export const getColumnGroups = (
         const columnDisplayInfo = Lib.displayInfo(query, STAGE_INDEX, column);
         return {
           column,
-          ...columnDisplayInfo
+          ...columnDisplayInfo,
         };
       }),
       displayName: getColumnGroupName(displayInfo) || t`Question`,
@@ -215,7 +213,7 @@ export const findColumnSettingIndex = (
     [column] as Lib.ColumnMetadata[] | DatasetColumn[],
     columnSettings.map(({ fieldRef }) => fieldRef),
   );
-  
+
   return columnIndexes.findIndex(index => index >= 0);
 };
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/utils.ts
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/utils.ts
@@ -199,13 +199,13 @@ export const disableColumnInQuery = (
 
 export const findColumnSettingIndex = (
   query: Lib.Query,
-  column: Lib.ColumnMetadata,
+  column: Lib.ColumnMetadata | DatasetColumn,
   columnSettings: ColumnSetting[],
 ) => {
   const columnIndexes = Lib.findColumnIndexesFromLegacyRefs(
     query,
     STAGE_INDEX,
-    [column],
+    [column] as Lib.ColumnMetadata[] | DatasetColumn[],
     columnSettings.map(({ fieldRef }) => fieldRef),
   );
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/utils.ts
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/utils.ts
@@ -129,7 +129,6 @@ export const getAdditionalMetadataColumns = (
 const getColumnGroupName = (
   displayInfo: Lib.ColumnDisplayInfo | Lib.TableDisplayInfo,
 ) => {
-  // console.log(displayInfo)
   const columnInfo = displayInfo as Lib.ColumnDisplayInfo;
   const tableInfo = displayInfo as Lib.TableDisplayInfo;
   return columnInfo.fkReferenceName || tableInfo.displayName;

--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem/ColumnItem.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem/ColumnItem.styled.tsx
@@ -23,6 +23,8 @@ export const ColumnItemRoot = styled.div<ColumnItemRootProps>`
     pointer-events: auto !important;
   }
 
+  color: ${color("text-medium")};
+
   ${props =>
     props.isDraggable &&
     `
@@ -44,7 +46,8 @@ export const ColumnItemSpan = styled.span`
   font-size: 0.875rem;
   line-height: 1rem;
   flex: auto;
-  color: ${color("text-dark")};
+  display: inline-flex;
+  gap: 0.25rem;
 `;
 
 export const ColumnItemContent = styled.div`
@@ -73,7 +76,6 @@ export const ColumnItemIcon = styled(Button)`
 `;
 
 export const ColumnItemDragHandle = styled(Icon)`
-  color: ${color("text-medium")};
   flex-shrink: 0;
 `;
 

--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem/ColumnItem.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem/ColumnItem.tsx
@@ -22,7 +22,7 @@ interface ColumnItemProps {
   onColorChange?: (newColor: string) => void;
 }
 
-export const ColumnItem = ({
+const ColumnIteme = ({
   className,
   title,
   color,
@@ -43,6 +43,7 @@ export const ColumnItem = ({
       isDraggable={draggable}
       onClick={onClick}
       data-testid={draggable ? `draggable-item-${title}` : null}
+      data-enabled={!!onRemove}
     >
       <ColumnItemContainer>
         {draggable && <ColumnItemDragHandle name="grabber" />}
@@ -112,7 +113,9 @@ const ActionIcon = ({
   />
 );
 
-Object.assign(ColumnItem, {
+export const ColumnItem = Object.assign(ColumnIteme, {
   Root: ColumnItemRoot,
   Container: ColumnItemContainer,
+  Icon: ColumnItemIcon,
+  Handle: ColumnItemDragHandle,
 });

--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem/ColumnItem.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem/ColumnItem.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import {
   ColumnItemIcon,
   ColumnItemSpan,
@@ -10,7 +11,7 @@ import {
 
 interface ColumnItemProps {
   className?: string;
-  title: string;
+  title: string | React.ReactChild;
   color?: string;
   role?: string;
   draggable?: boolean;
@@ -22,7 +23,7 @@ interface ColumnItemProps {
   onColorChange?: (newColor: string) => void;
 }
 
-const ColumnIteme = ({
+const BaseColumnItem = ({
   className,
   title,
   color,
@@ -113,7 +114,7 @@ const ActionIcon = ({
   />
 );
 
-export const ColumnItem = Object.assign(ColumnIteme, {
+export const ColumnItem = Object.assign(BaseColumnItem, {
   Root: ColumnItemRoot,
   Container: ColumnItemContainer,
   Icon: ColumnItemIcon,

--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem/ColumnItem.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem/ColumnItem.tsx
@@ -1,4 +1,5 @@
-import type React from "react";
+import type { IconProps } from "metabase/core/components/Icon";
+import { Icon } from "metabase/core/components/Icon";
 import {
   ColumnItemIcon,
   ColumnItemSpan,
@@ -11,10 +12,11 @@ import {
 
 interface ColumnItemProps {
   className?: string;
-  title: string | React.ReactChild;
+  title: string;
   color?: string;
   role?: string;
   draggable?: boolean;
+  icon?: IconProps["name"];
   onClick?: () => void;
   onAdd?: (target: HTMLElement) => void;
   onRemove?: (target: HTMLElement) => void;
@@ -29,6 +31,7 @@ const BaseColumnItem = ({
   color,
   role,
   draggable = false,
+  icon,
   onClick,
   onAdd,
   onRemove,
@@ -56,7 +59,10 @@ const BaseColumnItem = ({
           />
         )}
         <ColumnItemContent>
-          <ColumnItemSpan>{title}</ColumnItemSpan>
+          <ColumnItemSpan>
+            {icon && <Icon name={icon} />}
+            {title}
+          </ColumnItemSpan>
           {onEdit && (
             <ActionIcon
               icon="ellipsis"

--- a/frontend/src/metabase/visualizations/lib/settings.js
+++ b/frontend/src/metabase/visualizations/lib/settings.js
@@ -92,6 +92,12 @@ function getComputedSetting(
     }
 
     if (storedSettings[settingId] !== undefined) {
+      if (settingId === "table.columns") {
+        console.log(
+          "is Valid table.columns",
+          settingDef.isValid(object, settings, extra),
+        );
+      }
       if (!settingDef.isValid || settingDef.isValid(object, settings, extra)) {
         return (computedSettings[settingId] = storedSettings[settingId]);
       }
@@ -124,7 +130,7 @@ function getSettingWidget(
   const settingDef = settingDefs[settingId];
   const value = computedSettings[settingId];
   const onChange = (value, question) => {
-    const newSettings = { [settingId]: value };
+    const newSettings = { [settingDef.writeSettingId || settingId]: value };
     for (const settingId of settingDef.writeDependencies || []) {
       newSettings[settingId] = computedSettings[settingId];
     }

--- a/frontend/src/metabase/visualizations/lib/settings.js
+++ b/frontend/src/metabase/visualizations/lib/settings.js
@@ -92,12 +92,6 @@ function getComputedSetting(
     }
 
     if (storedSettings[settingId] !== undefined) {
-      if (settingId === "table.columns") {
-        console.log(
-          "is Valid table.columns",
-          settingDef.isValid(object, settings, extra),
-        );
-      }
       if (!settingDef.isValid || settingDef.isValid(object, settings, extra)) {
         return (computedSettings[settingId] = storedSettings[settingId]);
       }

--- a/frontend/src/metabase/visualizations/lib/settings.js
+++ b/frontend/src/metabase/visualizations/lib/settings.js
@@ -124,7 +124,7 @@ function getSettingWidget(
   const settingDef = settingDefs[settingId];
   const value = computedSettings[settingId];
   const onChange = (value, question) => {
-    const newSettings = { [settingDef.writeSettingId || settingId]: value };
+    const newSettings = { [settingId]: value };
     for (const settingId of settingDef.writeDependencies || []) {
       newSettings[settingId] = computedSettings[settingId];
     }

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -46,6 +46,7 @@ export function columnSettings({
 }
 
 import MetabaseSettings from "metabase/lib/settings";
+import { ChartSettingAddRemoveColumns } from "metabase/visualizations/components/settings/ChartSettingAddRemoveColumns/ChartSettingAddRemoveColumns";
 import {
   isDate,
   isNumber,
@@ -56,7 +57,6 @@ import {
 import { findColumnIndexForColumnSetting } from "metabase-lib/queries/utils/dataset";
 import { getColumnKey } from "metabase-lib/queries/utils/get-column-key";
 import { nestedSettings } from "./nested";
-import { ChartSettingAddRemoveColumns } from "metabase/visualizations/components/settings/ChartSettingAddRemoveColumns/ChartSettingAddRemoveColumns";
 
 export function getGlobalSettingsForColumn(column) {
   const columnSettings = {};
@@ -516,17 +516,10 @@ export const buildTableColumnSettings = ({
     isValid: ([{ card, data }]) => {
       const columns = card.visualization_settings["table.columns"];
       const enabledColumns = columns.filter(column => column.enabled);
-      // If "table.columns" happened to be an empty array,
-      // it will be treated as "all columns are hidden",
-      // This check ensures it's not empty,
-      // otherwise it will be overwritten by `getDefault` below
-      return (
-        card.visualization_settings["table.columns"].length !== 0 &&
-        _.all(
-          enabledColumns,
-          columnSetting =>
-            findColumnIndexForColumnSetting(data.cols, columnSetting) >= 0,
-        )
+      return _.all(
+        enabledColumns,
+        columnSetting =>
+          findColumnIndexForColumnSetting(data.cols, columnSetting) >= 0,
       );
     },
     getDefault: ([

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -56,6 +56,7 @@ import {
 import { findColumnIndexForColumnSetting } from "metabase-lib/queries/utils/dataset";
 import { getColumnKey } from "metabase-lib/queries/utils/get-column-key";
 import { nestedSettings } from "./nested";
+import { ChartSettingAddRemoveColumns } from "metabase/visualizations/components/settings/ChartSettingAddRemoveColumns/ChartSettingAddRemoveColumns";
 
 export function getGlobalSettingsForColumn(column) {
   const columnSettings = {};
@@ -550,5 +551,19 @@ export const buildTableColumnSettings = ({
         getColumnName: column => getTitleForColumn(column, series, settings),
       };
     },
+  },
+  "table.columnVisibility": {
+    widget: ChartSettingAddRemoveColumns,
+    hidden: true,
+    writeSettingId: "table.columns",
+    readDependencies: ["table.columns"],
+    getValue: (_series, vizSettings) => vizSettings["table.columns"],
+    getProps: ([
+      {
+        data: { cols },
+      },
+    ]) => ({
+      columns: cols,
+    }),
   },
 });

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -46,7 +46,6 @@ export function columnSettings({
 }
 
 import MetabaseSettings from "metabase/lib/settings";
-import { ChartSettingAddRemoveColumns } from "metabase/visualizations/components/settings/ChartSettingAddRemoveColumns/ChartSettingAddRemoveColumns";
 import {
   isDate,
   isNumber,
@@ -510,7 +509,7 @@ export const buildTableColumnSettings = ({
   //   { fieldRef: ["field", 2, {"source-field": 1}], enabled: true }
   "table.columns": {
     section: t`Columns`,
-    title: t`Columns`,
+    // title: t`Columns`,
     widget: ChartSettingTableColumns,
     getHidden: (series, vizSettings) => vizSettings["table.pivot"],
     isValid: ([{ card, data }]) => {
@@ -544,19 +543,5 @@ export const buildTableColumnSettings = ({
         getColumnName: column => getTitleForColumn(column, series, settings),
       };
     },
-  },
-  "table.columnVisibility": {
-    widget: ChartSettingAddRemoveColumns,
-    hidden: true,
-    writeSettingId: "table.columns",
-    readDependencies: ["table.columns"],
-    getValue: (_series, vizSettings) => vizSettings["table.columns"],
-    getProps: ([
-      {
-        data: { cols },
-      },
-    ]) => ({
-      columns: cols,
-    }),
   },
 });

--- a/frontend/src/metabase/visualizations/types/click-actions.ts
+++ b/frontend/src/metabase/visualizations/types/click-actions.ts
@@ -54,7 +54,7 @@ export type ClickActionBase = {
 };
 
 type ReduxClickActionBase = {
-  action: () => Dispatcher;
+  action: () => Dispatcher | null;
 };
 
 export type ReduxClickAction = ClickActionBase & ReduxClickActionBase;

--- a/frontend/src/metabase/visualizations/types/click-actions.ts
+++ b/frontend/src/metabase/visualizations/types/click-actions.ts
@@ -54,7 +54,7 @@ export type ClickActionBase = {
 };
 
 type ReduxClickActionBase = {
-  action: () => Dispatcher | null;
+  action: () => Dispatcher;
 };
 
 export type ReduxClickAction = ClickActionBase & ReduxClickActionBase;

--- a/frontend/src/metabase/visualizations/visualizations/Table.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/Table.unit.spec.js
@@ -70,26 +70,33 @@ const setup = ({ vizType }) => {
 // these visualizations share column settings, so all the tests should work for both
 ["table", "object"].forEach(vizType => {
   describe(`${vizType} column settings`, () => {
-    it("should show you related columns in structured queries", async () => {
+    it("should show you related columns in structured queries", () => {
       setup({ vizType });
-      expect(await screen.findByText("More columns")).toBeInTheDocument();
-      expect(await screen.findByText("User")).toBeInTheDocument();
-      expect(await screen.findByText("Product")).toBeInTheDocument();
+      userEvent.click(screen.getByText("Add or remove columns"));
+
+      expect(screen.getByText("User")).toBeInTheDocument();
+      expect(screen.getByText("Product")).toBeInTheDocument();
+
+      const userColumList = screen.getByRole("list", {
+        name: "user-table-columns",
+      });
+
+      expect(within(userColumList).getByLabelText("Address")).not.toBeChecked();
+      expect(within(userColumList).getByLabelText("State")).not.toBeChecked();
     });
 
-    it("should allow you to show and hide columns", async () => {
+    it("should allow you to show and hide columns", () => {
       setup({ vizType });
-      userEvent.click(await screen.findByTestId("Tax-hide-button"));
+      userEvent.click(screen.getByTestId("Tax-hide-button"));
 
-      expect(
-        await within(await screen.findByTestId("disabled-columns")).findByText(
-          "Tax",
-        ),
-      ).toBeInTheDocument();
+      expect(screen.getByRole("listitem", { name: "Tax" })).toHaveAttribute(
+        "data-enabled",
+        "false",
+      );
 
-      userEvent.click(await screen.findByTestId("Tax-add-button"));
+      userEvent.click(screen.getByTestId("Tax-show-button"));
       //If we can see the hide button, then we know it's been added back in.
-      expect(await screen.findByTestId("Tax-hide-button")).toBeInTheDocument();
+      expect(screen.getByTestId("Tax-hide-button")).toBeInTheDocument();
     });
 
     it("should allow you to update a column name", async () => {

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -326,7 +326,7 @@
   [n unit]
   (let [n    (if (string? n) (keyword n) n)
         unit (if (string? unit) (keyword unit) unit)]
-      (lib.core/describe-relative-datetime n unit)))
+    (lib.core/describe-relative-datetime n unit)))
 
 (defn ^:export aggregate
   "Adds an aggregation to query."
@@ -398,14 +398,14 @@
   [a-query stage-number an-expression-clause]
   (let [parts (lib.core/expression-parts a-query stage-number an-expression-clause)]
     (walk/postwalk
-      (fn [node]
-        (if (and (map? node) (= :mbql/expression-parts (:lib/type node)))
-          (let [{:keys [operator options args]} node]
-            #js {:operator (name operator)
-                 :options (clj->js (select-keys options [:case-sensitive :include-current]))
-                 :args (to-array (map #(if (keyword? %) (u/qualified-name %) %) args))})
-          node))
-      parts)))
+     (fn [node]
+       (if (and (map? node) (= :mbql/expression-parts (:lib/type node)))
+         (let [{:keys [operator options args]} node]
+           #js {:operator (name operator)
+                :options (clj->js (select-keys options [:case-sensitive :include-current]))
+                :args (to-array (map #(if (keyword? %) (u/qualified-name %) %) args))})
+         node))
+     parts)))
 
 (defn ^:export is-column-metadata
   "Returns true if arg is a a ColumnMetadata"
@@ -505,6 +505,14 @@
         vis-columns    (lib.metadata.calculation/visible-columns a-query stage-number stage)
         ret-columns    (lib.metadata.calculation/returned-columns a-query stage-number stage)]
     (to-array (lib.equality/mark-selected-columns a-query stage-number vis-columns ret-columns))))
+
+(defn ^:export returned-columns
+  "Return a sequence of column metadatas for columns returned by the query."
+  [a-query stage-number]
+  (let [stage (lib.util/query-stage a-query stage-number)]
+    (->> (lib.metadata.calculation/returned-columns a-query stage-number stage)
+         (map #(assoc % :selected? true))
+         to-array)))
 
 (defn ^:export legacy-field-ref
   "Given a column metadata from eg. [[fieldable-columns]], return it as a legacy JSON field ref."

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -271,42 +271,42 @@
   :hierarchy lib.hierarchy/hierarchy)
 
 (mr/register! ::display-info
-  [:map
-   [:display-name :string]
-   [:long-display-name {:optional true} :string]
+              [:map
+               [:display-name :string]
+               [:long-display-name {:optional true} :string]
    ;; for things that have a Table, e.g. a Field
-   [:table {:optional true} [:maybe [:ref ::display-info]]]
+               [:table {:optional true} [:maybe [:ref ::display-info]]]
    ;; these are derived from the `:lib/source`/`:metabase.lib.schema.metadata/column-source`, but instead of using
    ;; that value directly we're returning a different property so the FE doesn't break if we change those keys in the
    ;; future, e.g. if we consolidate or split some of those keys. This is all the FE really needs to know.
    ;;
    ;; if this is a Column, does it come from a previous stage?
-   [:is-from-previous-stage {:optional true} [:maybe :boolean]]
+               [:is-from-previous-stage {:optional true} [:maybe :boolean]]
    ;; if this is a Column, does it come from a join in this stage?
-   [:is-from-join {:optional true} [:maybe :boolean]]
+               [:is-from-join {:optional true} [:maybe :boolean]]
    ;; if this is a Column, is it 'calculated', i.e. does it come from an expression in this stage?
-   [:is-calculated {:optional true} [:maybe :boolean]]
+               [:is-calculated {:optional true} [:maybe :boolean]]
    ;; if this is a Column, is it an implicitly joinable one? I.e. is it from a different table that we have not
    ;; already joined, but could implicitly join against?
-   [:is-implicitly-joinable {:optional true} [:maybe :boolean]]
+               [:is-implicitly-joinable {:optional true} [:maybe :boolean]]
    ;; For the `:table` field of a Column, is this the source table, or a joined table?
-   [:is-source-table {:optional true} [:maybe :boolean]]
+               [:is-source-table {:optional true} [:maybe :boolean]]
    ;; does this column occur in the breakout clause?
-   [:is-breakout-column {:optional true} [:maybe :boolean]]
+               [:is-breakout-column {:optional true} [:maybe :boolean]]
    ;; does this column occur in the order-by clause?
-   [:is-order-by-column {:optional true} [:maybe :boolean]]
+               [:is-order-by-column {:optional true} [:maybe :boolean]]
    ;; for joins
-   [:name {:optional true} :string]
+               [:name {:optional true} :string]
    ;; for aggregation operators
-   [:column-name {:optional true} :string]
-   [:description {:optional true} :string]
-   [:short-name {:optional true} :string]
-   [:requires-column {:optional true} :boolean]
-   [:selected {:optional true} :boolean]
+               [:column-name {:optional true} :string]
+               [:description {:optional true} :string]
+               [:short-name {:optional true} :string]
+               [:requires-column {:optional true} :boolean]
+               [:selected {:optional true} :boolean]
    ;; for binning and bucketing
-   [:default {:optional true} :boolean]
+               [:default {:optional true} :boolean]
    ;; for order by
-   [:direction {:optional true} [:enum :asc :desc]]])
+               [:direction {:optional true} [:enum :asc :desc]]])
 
 (mu/defn display-info :- ::display-info
   "Given some sort of Cljs object, return a map with the info you'd need to implement UI for it. This is mostly meant to
@@ -356,7 +356,9 @@
        {:is-from-previous-stage (= source :source/previous-stage)
         :is-from-join           (= source :source/joins)
         :is-calculated          (= source :source/expressions)
-        :is-implicitly-joinable (= source :source/implicitly-joinable)})
+        :is-implicitly-joinable (= source :source/implicitly-joinable)
+        :is-aggregation         (= source :source/aggregations)
+        :is-breakout            (= source :source/breakouts)})
      (when-some [selected (:selected? x-metadata)]
        {:selected selected})
      (select-keys x-metadata [:breakout-position :order-by-position :filter-positions]))))

--- a/yarn.lock
+++ b/yarn.lock
@@ -4463,17 +4463,20 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@floating-ui/core@^1.2.6":
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.2.6.tgz#d21ace437cc919cdd8f1640302fa8851e65e75c0"
-  integrity sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg==
+"@floating-ui/core@^1.4.2":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.5.0.tgz#5c05c60d5ae2d05101c3021c1a2a350ddc027f8c"
+  integrity sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==
+  dependencies:
+    "@floating-ui/utils" "^0.1.3"
 
 "@floating-ui/dom@^1.2.1":
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.2.9.tgz#b9ed1c15d30963419a6736f1b7feb350dd49c603"
-  integrity sha512-sosQxsqgxMNkV3C+3UqTS6LxP7isRLwX8WMepp843Rb3/b0Wz8+MdUkxJksByip3C2WwLugLHN1b4ibn//zKwQ==
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.5.3.tgz#54e50efcb432c06c23cd33de2b575102005436fa"
+  integrity sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==
   dependencies:
-    "@floating-ui/core" "^1.2.6"
+    "@floating-ui/core" "^1.4.2"
+    "@floating-ui/utils" "^0.1.3"
 
 "@floating-ui/react-dom@^1.3.0":
   version "1.3.0"
@@ -4490,6 +4493,11 @@
     "@floating-ui/react-dom" "^1.3.0"
     aria-hidden "^1.1.3"
     tabbable "^6.0.1"
+
+"@floating-ui/utils@^0.1.3":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.4.tgz#19654d1026cc410975d46445180e70a5089b3e7d"
+  integrity sha512-qprfWkn82Iw821mcKofJ5Pk9wgioHicxcQMxx+5zt5GSKoqdWvgG5AxVmpmUUjzTLPVSH5auBrhI93Deayn/DA==
 
 "@gar/promisify@^1.0.1":
   version "1.1.2"
@@ -4945,13 +4953,13 @@
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
 "@mantine/core@^6.0.13":
-  version "6.0.13"
-  resolved "https://registry.yarnpkg.com/@mantine/core/-/core-6.0.13.tgz#f05a952e1e2e3cc6eb24d4d77b6c96a1c23fb0bb"
-  integrity sha512-FjVUGgat2qISV9WD1maVJa81y7H0JjKJ3m0cJj65PzgrXT20hzdEda7S3i4j+a8vUnx+836x5q/yS+RDHvoSlA==
+  version "6.0.21"
+  resolved "https://registry.yarnpkg.com/@mantine/core/-/core-6.0.21.tgz#6e3a1b8d0f6869518a644d5f5e3d55a5db7e1e51"
+  integrity sha512-Kx4RrRfv0I+cOCIcsq/UA2aWcYLyXgW3aluAuW870OdXnbII6qg7RW28D+r9D76SHPxWFKwIKwmcucAG08Divg==
   dependencies:
     "@floating-ui/react" "^0.19.1"
-    "@mantine/styles" "6.0.13"
-    "@mantine/utils" "6.0.13"
+    "@mantine/styles" "6.0.21"
+    "@mantine/utils" "6.0.21"
     "@radix-ui/react-scroll-area" "1.0.2"
     react-remove-scroll "^2.5.5"
     react-textarea-autosize "8.3.4"
@@ -4964,22 +4972,22 @@
     "@mantine/utils" "6.0.21"
 
 "@mantine/hooks@^6.0.13":
-  version "6.0.13"
-  resolved "https://registry.yarnpkg.com/@mantine/hooks/-/hooks-6.0.13.tgz#d90fa315ee30a900e0d9a460c6bb00c9a65f18e0"
-  integrity sha512-fHuE3zXo5OP/Q1dMOTnegU6U+tI9GuhO2tgOz6szVuOxrrk0Hzuq1Na9NUSv27HShSRbAfQk+hvyIh+iVV7KXA==
+  version "6.0.21"
+  resolved "https://registry.yarnpkg.com/@mantine/hooks/-/hooks-6.0.21.tgz#bc009d8380ad18455b90f3ddaf484de16a13da95"
+  integrity sha512-sYwt5wai25W6VnqHbS5eamey30/HD5dNXaZuaVEAJ2i2bBv8C0cCiczygMDpAFiSYdXoSMRr/SZ2CrrPTzeNew==
 
-"@mantine/styles@6.0.13":
-  version "6.0.13"
-  resolved "https://registry.yarnpkg.com/@mantine/styles/-/styles-6.0.13.tgz#a3dc542e1613e7cc461dd8b11c6069b5dd8143d7"
-  integrity sha512-+27oX8ObiBv8jHHDxXKjqe+7cfTJyaAV/Ie00T49EE4LuHuS6nL4vlXHmqamFtDCj2ypEWBV0sdXDev/DNAXSg==
+"@mantine/styles@6.0.21":
+  version "6.0.21"
+  resolved "https://registry.yarnpkg.com/@mantine/styles/-/styles-6.0.21.tgz#8ea097fc76cbb3ed55f5cfd719d2f910aff5031b"
+  integrity sha512-PVtL7XHUiD/B5/kZ/QvZOZZQQOj12QcRs3Q6nPoqaoPcOX5+S7bMZLMH0iLtcGq5OODYk0uxlvuJkOZGoPj8Mg==
   dependencies:
     clsx "1.1.1"
     csstype "3.0.9"
 
-"@mantine/utils@6.0.13":
-  version "6.0.13"
-  resolved "https://registry.yarnpkg.com/@mantine/utils/-/utils-6.0.13.tgz#a7adc128a2e7c07031c7221c1533800d0c80279a"
-  integrity sha512-iqIU9wurqAeccVbWjM0yr1JGne5VP+ob55M03QAXOEN4+ck93VDTjCkZJR2RFhDcs5q0twQFoOmU/gULR8aKIA==
+"@mantine/utils@6.0.21":
+  version "6.0.21"
+  resolved "https://registry.yarnpkg.com/@mantine/utils/-/utils-6.0.21.tgz#6185506e91cba3e308aaa8ea9ababc8e767995d6"
+  integrity sha512-33RVDRop5jiWFao3HKd3Yp7A9mEq4HAJxJPTuYm1NkdqX6aTKOQK7wT8v8itVodBp+sb4cJK6ZVdD1UurK/txQ==
 
 "@mantine/utils@6.0.21":
   version "6.0.21"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/33841

### Description
This PR adds a new panel to control adding and removing table columns from a query, separating the idea of add/remove from show/hide in viz settings. The new panel is only available in structured queries (and should not be displayed for dashcards), and should allow you to implicitly add fields from related tables, search available columns, and perform bulk add / remove column operations per table.

### How to verify
Create a structured question and try adding / removing columns from a query. A few points:
- Showing / Hiding should not re-run queries
- Try using saved questions as table sources
- You should now be able to hide columns from the table header


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
