### PR TITLE
Fix audit db tests by asserting on exit code of `rm` instead of error message

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -1,6 +1,5 @@
 (ns metabase-enterprise.audit-db
   (:require
-   [clojure.core :as c]
    [clojure.java.io :as io]
    [clojure.java.shell :as sh]
    [metabase-enterprise.internal-user :as ee.internal-user]
@@ -12,8 +11,7 @@
    [metabase.util :as u]
    [metabase.util.files :as u.files]
    [metabase.util.log :as log]
-   [toucan2.core :as t2])
-  (:import (java.io File)))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 

--- a/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
@@ -57,20 +57,19 @@
       (is (not= 0 (t2/count 'Card {:where [:= :database_id (audit-db/default-audit-db-id)]}))
           "Cards should be created for Audit DB when the content is there."))))
 
-(deftest audit-db-instance-analytics-content-is-unzipped-properly
+(defn- remove-instance-analytics
+  []
   (sh/sh "rm" "-rf" "plugins/instance_analytics")
-  (is (= (:err (sh/sh "ls" "plugins/instance_analytics"))
-         "ls: plugins/instance_analytics: No such file or directory\n"))
+  (is (= 1 (:exit (sh/sh "ls" "plugins/instance_analytics")))))
 
+(deftest audit-db-instance-analytics-content-is-unzipped-properly
+  (remove-instance-analytics)
   (#'audit-db/ia-content->plugins audit-db/analytics-zip-resource nil)
   (is (= (str/split-lines (:out (sh/sh "ls" "plugins/instance_analytics")))
          ["collections" "databases"])))
 
 (deftest audit-db-instance-analytics-content-is-coppied-properly
-  (sh/sh "rm" "-rf" "plugins/instance_analytics")
-  (is (= (:err (sh/sh "ls" "plugins/instance_analytics"))
-         "ls: plugins/instance_analytics: No such file or directory\n"))
-
+  (remove-instance-analytics)
   (#'audit-db/ia-content->plugins nil audit-db/analytics-dir-resource)
   (is (= (str/split-lines (:out (sh/sh "ls" "plugins/instance_analytics")))
          ["collections" "databases"])))


### PR DESCRIPTION
Previous tests removed the `instance_analytics` directory and asserted on the resulting error message.