### PR TITLE
Fix memoization on the table cell

### DIFF
--- a/frontend/src/metabase-lib/utils/memoize-class.ts
+++ b/frontend/src/metabase-lib/utils/memoize-class.ts
@@ -18,6 +18,16 @@ const memoized = new WeakMap();
 
 const createMap = () => new Map();
 
+/**
+ * This method implements memoization for class methods
+ * It creates a map where class itself, method and all the parameters are used as keys for a nested map
+ * map<class, map<method, map<param1, map<param2, map<param3...>>>>>
+ *
+ * If you use objects as parameters, make sure their references are stable as they will be used as keys
+ *
+ * @param keys - class methods to memoize
+ * @returns the same class with memoized methods
+ */
 export function memoizeClass<T>(
   ...keys: string[]
 ): (Class: Constructor<T>) => Constructor<T> {

--- a/frontend/src/metabase-lib/utils/memoize-class.ts
+++ b/frontend/src/metabase-lib/utils/memoize-class.ts
@@ -32,7 +32,7 @@ export function memoizeClass<T>(
 
       const descriptor = descriptors[key];
       const method = descriptor.value;
-      // If we don't get a decsriptor.value, it must have a getter (i.e., ES6 class properties)
+      // If we don't get a descriptor.value, it must have a getter (i.e., ES6 class properties)
       if (!method) {
         throw new TypeError(`Class properties cannot be memoized`);
       }

--- a/frontend/src/metabase/visualizations/click-actions/Mode/Mode.ts
+++ b/frontend/src/metabase/visualizations/click-actions/Mode/Mode.ts
@@ -49,6 +49,8 @@ export class Mode {
         return question.setDatasetQuery(Lib.toLegacyQuery(updatedQuery));
       };
 
+      // TODO: those calculations are really expensive and must be memoized at some level
+      // check `_visualizationIsClickableCached` from TableInteractive
       const availableDrillThrus = Lib.availableDrillThrus(
         query,
         stageIndex,
@@ -58,7 +60,6 @@ export class Mode {
         clicked?.dimensions,
       );
 
-      // TODO: those calculations are really expensive and should be memoized at some level
       drills = availableDrillThrus
         .flatMap(drill => {
           const drillDisplayInfo = Lib.displayInfo(query, stageIndex, drill);

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -417,14 +417,9 @@ class TableInteractive extends Component {
     );
   }
 
-  getHeaderClickedObject(columnIndex) {
+  getHeaderClickedObject(data, columnIndex, isPivoted, query) {
     try {
-      return getTableHeaderClickedObject(
-        this.props.data,
-        columnIndex,
-        this.props.isPivoted,
-        this.props.query,
-      );
+      return getTableHeaderClickedObject(data, columnIndex, isPivoted, query);
     } catch (e) {
       console.error(e);
     }
@@ -692,15 +687,19 @@ class TableInteractive extends Component {
       hasMetadataPopovers,
       getColumnTitle,
       renderTableHeaderWrapper,
+      query,
     } = this.props;
     const { dragColIndex, showDetailShortcut } = this.state;
     const { cols } = data;
     const column = cols[columnIndex];
 
     const columnTitle = getColumnTitle(columnIndex);
-
-    const clicked = this.getHeaderClickedObject(columnIndex);
-
+    const clicked = this.getHeaderClickedObject(
+      data,
+      columnIndex,
+      isPivoted,
+      query,
+    );
     const isDraggable = !isPivoted;
     const isDragging = dragColIndex === columnIndex;
     const isClickable = this.visualizationIsClickable(clicked);
@@ -1152,6 +1151,7 @@ export default _.compose(
     "getCellBackgroundColor",
     "getCellFormattedValue",
     "getDimension",
+    "getHeaderClickedObject",
   ),
 )(TableInteractive);
 


### PR DESCRIPTION
### Description

There is a heavy and slow method in the MBQL - `Lib.availableDrillThrus` which we call per every cell through some function abstraction to understand if header cell is clickable or not.

To bypass this error there is a caching mechanism using `memoize-class` helper, which creates internally multi-level map, using every parameter passed as a key, except the last one.
It works fine, when we pass primitives, but with objects as a key map compares reference to the object, so even if we provide the object, which is equal to the key in map, map will not return the cached value as reference is different:

```
const a = {x: 1}
const b = {x: 1};

map.set(a, 1);
map.has(b); // -> false
```

That's why we had to add memoization for another method that returns `clickedObject`.

### How to verify

Best way to test it is to replicate a problematic question.
1. Go to stats -> `/model/4523-account`
2. click download full result using csv 
3. open local instance, any collection and click "import csv", save question
4. scroll horizontally - before the fix it should be laggish, after fix it shouldn't be
5. to measure performance, open FPS meter (dev tools -> cmd + shift + p ->  fps)

### Demo

https://www.loom.com/share/3d427d3d46b74b8882fc19288445dbce

### Checklist

~- [ ] Tests have been added/updated to cover changes in this PR~
