### PR TITLE
Sync should handle multiple columns with same name

### DIFF
--- a/src/metabase/sync/sync_metadata/fields/common.clj
+++ b/src/metabase/sync/sync_metadata/fields/common.clj
@@ -68,16 +68,14 @@
                     (when (= (canonical-name field-metadata)
                              (canonical-name other-field-metadata))
                       other-field-metadata))
-                  other-metadata)
-        num-matches (count matches)]
-    (cond
-      (zero? num-matches)
+                  other-metadata)]
+    (case (count matches)
+      0
       nil
 
-      (= 1 num-matches)
+      1
       (first matches)
 
-      :else
       (or
         (some (fn [match]
                 (when (= (:name field-metadata) (:name match))

--- a/src/metabase/sync/sync_metadata/fields/common.clj
+++ b/src/metabase/sync/sync_metadata/fields/common.clj
@@ -2,10 +2,12 @@
   "Schemas and functions shared by different `metabase.sync.sync-metadata.fields.*` namespaces."
   (:require
    [metabase.lib.schema.id :as lib.schema.id]
+   [metabase.shared.util.i18n :as i18n]
    [metabase.sync.interface :as i]
    [metabase.sync.util :as sync-util]
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs]]
+   [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]))
@@ -76,10 +78,11 @@
       1
       (first matches)
 
-      (or
-        (some (fn [match]
-                (when (= (:name field-metadata) (:name match))
-                  match))
-              matches)
-        ;; Fallback if there's no exact match
-        (first matches)))))
+      (if-let [exact (some (fn [match]
+                             (when (= (:name field-metadata) (:name match))
+                               match))
+                           matches)]
+        exact
+        (do
+          (log/warn (i18n/trs "Found multiple matching field metadata for:") (:name field-metadata) (map :name matches))
+          (first matches))))))


### PR DESCRIPTION
Fixes #17387 

It's possible to name columns such that their names conflict when lowercased. e.g. "event" and "eVent"

Prior to this change we assumed that `canonical-name` would only match a single metadata but in the case above, we would incorrectly match `event` db-metadata with `eVent` field-metadata or vice-versa.
