### PR TITLE
Auditv2 more content transfer fixes

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
@@ -59,8 +59,7 @@
 
 (deftest audit-db-instance-analytics-content-is-unzipped-properly
   (sh/sh "rm" "-rf" "plugins/instance_analytics")
-  (is (= (:err (sh/sh "ls" "plugins/instance_analytics"))
-         "ls: plugins/instance_analytics: No such file or directory\n"))
+  (is (= 1 (:exit (sh/sh "ls" "plugins/instance_analytics"))))
 
   (#'audit-db/ia-content->plugins audit-db/analytics-zip-resource nil)
   (is (= (str/split-lines (:out (sh/sh "ls" "plugins/instance_analytics")))
@@ -68,8 +67,7 @@
 
 (deftest audit-db-instance-analytics-content-is-coppied-properly
   (sh/sh "rm" "-rf" "plugins/instance_analytics")
-  (is (= (:err (sh/sh "ls" "plugins/instance_analytics"))
-         "ls: plugins/instance_analytics: No such file or directory\n"))
+  (is (= 1 (:exit (sh/sh "ls" "plugins/instance_analytics"))))
 
   (#'audit-db/ia-content->plugins nil audit-db/analytics-dir-resource)
   (is (= (str/split-lines (:out (sh/sh "ls" "plugins/instance_analytics")))


### PR DESCRIPTION
This mostly fixes an issue where we rename h2 tables there was a bug where we were updating the schema to the lowercase value of the _table name_ instead of a lowercase value of the schema.