### PR TITLE
[AuditV2] Don't show curate permission option for Instance Analytics Collection

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/collections/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/collections/index.ts
@@ -64,4 +64,6 @@ if (hasPremiumFeature("audit_app")) {
     CollectionInstanceAnalyticsIcon;
 
   PLUGIN_COLLECTIONS.getCollectionType = getCollectionType;
+
+  PLUGIN_COLLECTIONS.INSTANCE_ANALYTICS_ADMIN_READONLY_MESSAGE = t`This instance analytics collection is read-only for admin users`;
 }

--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/common.unit.spec.tsx
@@ -1,124 +1,9 @@
-import { Route } from "react-router";
 import { within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
+import { screen } from "__support__/ui";
 
-import { renderWithProviders, screen } from "__support__/ui";
-import { createMockState } from "metabase-types/store/mocks";
-
-import { createMockCollection } from "metabase-types/api/mocks";
-
-import {
-  setupCollectionPermissionsGraphEndpoint,
-  setupCollectionsEndpoints,
-  setupGroupsEndpoint,
-} from "__support__/server-mocks";
-
-import type { CollectionPermissionsGraph } from "metabase-types/api";
-import { CollectionPermissionsPage } from "./CollectionPermissionsPage";
-
-const personalCollection = createMockCollection({
-  id: "personal",
-  name: "Personal",
-  personal_owner_id: 1,
-});
-
-const nestedCollectionOne = createMockCollection({
-  id: 3,
-  name: "Nested One",
-  location: "/1/",
-  children: [],
-});
-const nestedCollectionTwo = createMockCollection({
-  id: 4,
-  name: "Nested Two",
-  location: "/2/",
-  children: [],
-});
-
-const collectionOne = createMockCollection({
-  id: 1,
-  name: "Collection One",
-  children: [nestedCollectionOne],
-});
-const collectionTwo = createMockCollection({
-  id: 2,
-  name: "Collection Two",
-  children: [nestedCollectionTwo],
-});
-
-const rootCollection = createMockCollection({
-  id: "root",
-  name: "Our analytics",
-  children: [collectionOne, collectionTwo],
-});
-
-const permissionGroups = [
-  { id: 1, name: "All Users", member_count: 40 },
-  { id: 2, name: "Administrators", member_count: 2 },
-  { id: 3, name: "Other Users", member_count: 33 },
-];
-
-const permissionsGraph: CollectionPermissionsGraph = {
-  revision: 23,
-  groups: {
-    1: {
-      // all users
-      1: "write", // one
-      2: "write", // two
-      3: "read", // nested one
-      4: "none", // nested two
-      root: "read",
-    },
-    2: {
-      // Administrators
-      1: "write", // one
-      2: "write", // two
-      3: "write", // nested one
-      4: "write", // nested two
-      root: "write",
-    },
-    3: {
-      // Other users
-      1: "read", // one
-      2: "read", // two
-      3: "none", // nested one
-      4: "none", // nested two
-      root: "read",
-    },
-  },
-};
-
-function setup() {
-  setupCollectionsEndpoints({
-    collections: [collectionOne, collectionTwo, personalCollection],
-    rootCollection: rootCollection,
-  });
-
-  setupCollectionPermissionsGraphEndpoint(permissionsGraph);
-
-  setupGroupsEndpoint(permissionGroups);
-
-  const initialState = createMockState();
-
-  renderWithProviders(
-    <>
-      <Route
-        path="/admin/permissions/collections/root"
-        component={CollectionPermissionsPage}
-      />
-      <Route
-        path="/admin/permissions/collections/:collectionId"
-        component={CollectionPermissionsPage}
-      />
-    </>,
-    {
-      storeInitialState: initialState,
-      withRouter: true,
-      initialRoute: "/admin/permissions/collections/root",
-    },
-  );
-}
+import { defaultPermissionsGraph, setup } from "./setup";
 
 describe("Admin > CollectionPermissionsPage", () => {
   describe("CollectionPermissionsPage", () => {
@@ -211,11 +96,11 @@ describe("Admin > CollectionPermissionsPage", () => {
         ?.request?.json();
 
       expect(lastRequest).toEqual({
-        ...permissionsGraph,
+        ...defaultPermissionsGraph,
         groups: {
-          ...permissionsGraph.groups,
+          ...defaultPermissionsGraph.groups,
           3: {
-            ...permissionsGraph.groups[3],
+            ...defaultPermissionsGraph.groups[3],
             3: "read",
           },
         },
@@ -267,11 +152,11 @@ describe("Admin > CollectionPermissionsPage", () => {
         ?.request?.json();
 
       expect(lastRequest).toEqual({
-        ...permissionsGraph,
+        ...defaultPermissionsGraph,
         groups: {
-          ...permissionsGraph.groups,
+          ...defaultPermissionsGraph.groups,
           3: {
-            ...permissionsGraph.groups[3],
+            ...defaultPermissionsGraph.groups[3],
             1: "write",
             3: "write",
           },

--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/enterprise.unit.spec.tsx
@@ -1,0 +1,122 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import { screen } from "__support__/ui";
+import { createMockCollection } from "metabase-types/api/mocks";
+
+import type { CollectionPermissionsGraph } from "metabase-types/api";
+import { setup, defaultPermissionsGraph, defaultCollections } from "./setup";
+
+describe("Admin > CollectionPermissionsPage (enterprise)", () => {
+  describe("Instance Analytics", () => {
+    const iaCollection = createMockCollection({
+      id: 13371337,
+      name: "Instance Analytics",
+      type: "instance-analytics",
+      children: [],
+    });
+
+    const iaPermissionsGraph: CollectionPermissionsGraph = {
+      ...defaultPermissionsGraph,
+      groups: Object.entries(defaultPermissionsGraph.groups).reduce(
+        (graph, [groupId, groupPermissions]) => {
+          return {
+            ...graph,
+            [groupId]: {
+              ...groupPermissions,
+              [iaCollection.id]: "read",
+            },
+          };
+        },
+        {},
+      ),
+    };
+
+    it("should not allow curate permissions for instance analytics collection", async () => {
+      await setup({
+        collections: [...defaultCollections, iaCollection],
+        permissionsGraph: iaPermissionsGraph,
+        initialRoute: `/admin/permissions/collections/${iaCollection.id}`,
+        tokenFeatures: { audit_app: true },
+      });
+
+      expect(await screen.findByText("Instance Analytics")).toBeInTheDocument();
+      expect(await screen.findAllByText("View")).toHaveLength(3);
+
+      userEvent.click(
+        await screen.findAllByText("View").then(dropdowns => dropdowns[2]),
+      );
+
+      expect(await screen.findByText("No access")).toBeInTheDocument();
+      expect(screen.queryByText("Curate")).not.toBeInTheDocument();
+    });
+
+    it("should display tooltip explaining why instance analytics collection cannot be curated by admins", async () => {
+      await setup({
+        collections: [...defaultCollections, iaCollection],
+        permissionsGraph: iaPermissionsGraph,
+        initialRoute: `/admin/permissions/collections/${iaCollection.id}`,
+        tokenFeatures: { audit_app: true },
+      });
+
+      expect(await screen.findByText("Instance Analytics")).toBeInTheDocument();
+      expect(await screen.findAllByText("View")).toHaveLength(3);
+
+      userEvent.hover(
+        await screen.findAllByText("View").then(dropdowns => dropdowns[1]),
+      );
+
+      expect(
+        await screen.findByText(/read-only for admin users/i),
+      ).toBeInTheDocument();
+    });
+
+    it("should be able to change instance analytics collection permissions", async () => {
+      await setup({
+        collections: [...defaultCollections, iaCollection],
+        permissionsGraph: iaPermissionsGraph,
+        initialRoute: `/admin/permissions/collections/${iaCollection.id}`,
+        tokenFeatures: { audit_app: true },
+      });
+
+      // change all users users view to no access
+      userEvent.click(
+        await screen.findAllByText("View").then(dropdowns => dropdowns[0]),
+      );
+      userEvent.click(await screen.findByText("No access"));
+
+      expect(
+        await screen.findByText("You've made changes to permissions."),
+      ).toBeInTheDocument();
+
+      userEvent.click(await screen.findByText("Save changes"));
+
+      // are you sure you want to save?
+      userEvent.click(await screen.findByText("Yes"));
+
+      expect(
+        await screen.findByText("You've made changes to permissions."),
+      ).not.toBeInTheDocument();
+
+      expect(await screen.findAllByText("View")).toHaveLength(2);
+      expect(await screen.findByText("No access")).toBeInTheDocument();
+
+      const lastRequest = await fetchMock
+        .lastCall("path:/api/collection/graph", {
+          method: "PUT",
+        })
+        ?.request?.json();
+
+      expect(lastRequest).toEqual({
+        ...iaPermissionsGraph,
+        groups: {
+          ...iaPermissionsGraph.groups,
+          1: {
+            ...iaPermissionsGraph.groups[1],
+            13371337: "none",
+          },
+        },
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/setup.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/setup.tsx
@@ -1,0 +1,161 @@
+import { Route } from "react-router";
+
+import { renderWithProviders } from "__support__/ui";
+import { mockSettings } from "__support__/settings";
+import { setupEnterprisePlugins } from "__support__/enterprise";
+
+import { createMockState } from "metabase-types/store/mocks";
+
+import {
+  createMockCollection,
+  createMockTokenFeatures,
+} from "metabase-types/api/mocks";
+
+import {
+  setupCollectionPermissionsGraphEndpoint,
+  setupCollectionsEndpoints,
+  setupGroupsEndpoint,
+} from "__support__/server-mocks";
+
+import type {
+  CollectionPermissionsGraph,
+  Collection,
+  Group,
+  TokenFeatures,
+} from "metabase-types/api";
+import { CollectionPermissionsPage } from "../CollectionPermissionsPage";
+
+const personalCollection = createMockCollection({
+  id: "personal",
+  name: "Personal",
+  personal_owner_id: 1,
+});
+
+const nestedCollectionOne = createMockCollection({
+  id: 3,
+  name: "Nested One",
+  location: "/1/",
+  children: [],
+});
+
+const nestedCollectionTwo = createMockCollection({
+  id: 4,
+  name: "Nested Two",
+  location: "/2/",
+  children: [],
+});
+
+const collectionOne = createMockCollection({
+  id: 1,
+  name: "Collection One",
+  children: [nestedCollectionOne],
+});
+
+const collectionTwo = createMockCollection({
+  id: 2,
+  name: "Collection Two",
+  children: [nestedCollectionTwo],
+});
+
+export const defaultCollections = [
+  collectionOne,
+  collectionTwo,
+  personalCollection,
+];
+
+export const defaultRootCollection = createMockCollection({
+  id: "root",
+  name: "Our analytics",
+  children: [collectionOne, collectionTwo],
+});
+
+const defaultPermissionGroups: Omit<Group, "members">[] = [
+  { id: 1, name: "All Users", member_count: 40 },
+  { id: 2, name: "Administrators", member_count: 2 },
+  { id: 3, name: "Other Users", member_count: 33 },
+];
+
+export const defaultPermissionsGraph: CollectionPermissionsGraph = {
+  revision: 23,
+  groups: {
+    1: {
+      // all users
+      1: "write", // one
+      2: "write", // two
+      3: "read", // nested one
+      4: "none", // nested two
+      root: "read",
+    },
+    2: {
+      // Administrators
+      1: "write", // one
+      2: "write", // two
+      3: "write", // nested one
+      4: "write", // nested two
+      root: "write",
+    },
+    3: {
+      // Other users
+      1: "read", // one
+      2: "read", // two
+      3: "none", // nested one
+      4: "none", // nested two
+      root: "read",
+    },
+  },
+};
+
+interface SetupOptions {
+  initialRoute?: string;
+  collections?: Collection[];
+  rootCollection?: Collection;
+  permissionsGraph?: CollectionPermissionsGraph;
+  permissionGroups?: Omit<Group, "members">[];
+  tokenFeatures?: Partial<TokenFeatures>;
+}
+
+export function setup({
+  initialRoute = "/admin/permissions/collections/root",
+  collections = defaultCollections,
+  rootCollection = defaultRootCollection,
+  permissionsGraph = defaultPermissionsGraph,
+  permissionGroups = defaultPermissionGroups,
+  tokenFeatures,
+}: Partial<SetupOptions> = {}) {
+  const initialState = createMockState({
+    settings: mockSettings({
+      "application-colors": {},
+      "token-features": createMockTokenFeatures(tokenFeatures ?? {}),
+    }),
+  });
+
+  if (tokenFeatures) {
+    setupEnterprisePlugins();
+  }
+
+  setupCollectionsEndpoints({
+    collections,
+    rootCollection,
+  });
+
+  setupCollectionPermissionsGraphEndpoint(permissionsGraph);
+  setupGroupsEndpoint(permissionGroups);
+
+  renderWithProviders(
+    <>
+      <Route
+        path="/admin/permissions/collections/root"
+        component={CollectionPermissionsPage}
+      />
+      <Route
+        path="/admin/permissions/collections/:collectionId"
+        component={CollectionPermissionsPage}
+      />
+    </>,
+    {
+      storeInitialState: initialState,
+      withRouter: true,
+      initialRoute,
+    },
+  );
+}

--- a/frontend/src/metabase/admin/permissions/selectors/collection-permissions.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/collection-permissions.ts
@@ -30,6 +30,7 @@ import type {
   CollectionPermissions,
   CollectionId,
 } from "metabase-types/api";
+import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import { COLLECTION_OPTIONS } from "../constants/collections-permissions";
 import { UNABLE_TO_CHANGE_ADMIN_PERMISSIONS } from "../constants/messages";
 import { getPermissionWarningModal } from "./confirmations";
@@ -253,13 +254,19 @@ export const getCollectionsPermissionEditor = createSelector(
         ),
       ];
 
-      const options = isInstanceAnalyticsCollection(collection)
+      const isIACollection = isInstanceAnalyticsCollection(collection);
+
+      const options = isIACollection
         ? [COLLECTION_OPTIONS.read, COLLECTION_OPTIONS.none]
         : [
             COLLECTION_OPTIONS.write,
             COLLECTION_OPTIONS.read,
             COLLECTION_OPTIONS.none,
           ];
+
+      const disabledTooltip = isIACollection
+        ? PLUGIN_COLLECTIONS.INSTANCE_ANALYTICS_ADMIN_READONLY_MESSAGE
+        : UNABLE_TO_CHANGE_ADMIN_PERMISSIONS;
 
       return {
         id: group.id,
@@ -269,9 +276,7 @@ export const getCollectionsPermissionEditor = createSelector(
             toggleLabel,
             hasChildren,
             isDisabled: isAdmin,
-            disabledTooltip: isAdmin
-              ? UNABLE_TO_CHANGE_ADMIN_PERMISSIONS
-              : null,
+            disabledTooltip: isAdmin ? disabledTooltip : null,
             value: getCollectionPermission(
               permissions,
               group.id,

--- a/frontend/src/metabase/admin/permissions/selectors/collection-permissions.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/collection-permissions.ts
@@ -9,7 +9,10 @@ import Collections, {
   ROOT_COLLECTION,
 } from "metabase/entities/collections";
 import SnippetCollections from "metabase/entities/snippet-collections";
-import { nonPersonalOrArchivedCollection } from "metabase/collections/utils";
+import {
+  nonPersonalOrArchivedCollection,
+  isInstanceAnalyticsCollection,
+} from "metabase/collections/utils";
 import {
   getGroupNameLocalized,
   isAdminGroup,
@@ -250,6 +253,14 @@ export const getCollectionsPermissionEditor = createSelector(
         ),
       ];
 
+      const options = isInstanceAnalyticsCollection(collection)
+        ? [COLLECTION_OPTIONS.read, COLLECTION_OPTIONS.none]
+        : [
+            COLLECTION_OPTIONS.write,
+            COLLECTION_OPTIONS.read,
+            COLLECTION_OPTIONS.none,
+          ];
+
       return {
         id: group.id,
         name: getGroupNameLocalized(group),
@@ -268,11 +279,7 @@ export const getCollectionsPermissionEditor = createSelector(
             ),
             warning: getCollectionWarning(group.id, collection, permissions),
             confirmations,
-            options: [
-              COLLECTION_OPTIONS.write,
-              COLLECTION_OPTIONS.read,
-              COLLECTION_OPTIONS.none,
-            ],
+            options,
           },
         ],
       };

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -23,6 +23,9 @@ import type {
   User,
   UserListResult,
 } from "metabase-types/api";
+
+import { UNABLE_TO_CHANGE_ADMIN_PERMISSIONS } from "metabase/admin/permissions/constants/messages";
+
 import type { AdminPathKey, State } from "metabase-types/store";
 import type { ADMIN_SETTINGS_SECTIONS } from "metabase/admin/settings/selectors";
 import type Question from "metabase-lib/Question";
@@ -161,6 +164,7 @@ export const PLUGIN_COLLECTIONS = {
     _: Partial<Collection>,
   ): CollectionAuthorityLevelConfig | CollectionInstanceAnaltyicsConfig =>
     AUTHORITY_LEVEL_REGULAR,
+  INSTANCE_ANALYTICS_ADMIN_READONLY_MESSAGE: UNABLE_TO_CHANGE_ADMIN_PERMISSIONS,
   getAuthorityLevelMenuItems: (
     _collection: Collection,
     _onUpdate: (collection: Collection, values: Partial<Collection>) => void,

--- a/frontend/test/__support__/settings.ts
+++ b/frontend/test/__support__/settings.ts
@@ -2,8 +2,11 @@ import MetabaseSettings from "metabase/lib/settings";
 import { createMockSettings } from "metabase-types/api/mocks";
 import { createMockSettingsState } from "metabase-types/store/mocks";
 import type { Settings } from "metabase-types/api";
+import type { EnterpriseSettings } from "metabase-enterprise/settings/types";
 
-export function mockSettings(params: Partial<Settings> = {}) {
+export function mockSettings(
+  params: Partial<Settings | EnterpriseSettings> = {},
+) {
   const settings = createMockSettings(params);
   const state = createMockSettingsState(settings);
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/34032

Would like to get this in https://github.com/metabase/metabase/pull/34186 before merging this to make testing easier

### Description

Don't show curate permissions option for instance analytics collection, even for admins


### Demo

![Screen Shot 2023-10-03 at 2 31 38 PM](https://github.com/metabase/metabase/assets/30528226/061171f0-0038-4b7c-90bb-ce20a6cc0eb1)
![Screen Shot 2023-10-03 at 2 32 01 PM](https://github.com/metabase/metabase/assets/30528226/07f6ed34-abb8-41cd-b27d-4936aacc471d)



### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
