### PR TITLE
Auditv2 unzipping path fixes

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -135,8 +135,8 @@
         (u.files/unzip-file analytics-zip-resource
                             (fn [entry-name]
                               (str/replace entry-name
-                                           "/resources/instance_analytics/"
-                                           "/plugins/instance_analytics/")))
+                                           "resources/instance_analytics/"
+                                           "plugins/instance_analytics/")))
         (log/info "Unzipping done."))
     dir-resource
     (do

--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -3,6 +3,7 @@
    [clojure.core :as c]
    [clojure.java.io :as io]
    [clojure.java.shell :as sh]
+   [clojure.string :as str]
    [metabase-enterprise.internal-user :as ee.internal-user]
    [metabase-enterprise.serialization.cmd :as serialization.cmd]
    [metabase.db.env :as mdb.env]
@@ -120,7 +121,9 @@
   "A resource dir containing analytics content created by Metabase to load into the app instance on startup."
   (io/resource "instance_analytics"))
 
-(def plugin-dir (plugins/plugins-dir))
+(def plugin-dir
+  "The directory analytics content is unzipped or moved to, and loaded into the app from on startup."
+  (plugins/plugins-dir))
 
 (defn- ia-content->plugins
   "Load instance analytics content (collections/dashboards/cards/etc.) from resources dir or a zip file
@@ -129,7 +132,11 @@
   (cond
     zip-resource
     (do (log/info "Unzipping instance_analytics to " plugin-dir "...")
-        (u.files/unzip-file analytics-zip-resource plugin-dir)
+        (u.files/unzip-file analytics-zip-resource
+                            (fn [entry-name]
+                              (str/replace entry-name
+                                           "/resources/instance_analytics/"
+                                           "/plugins/instance_analytics/")))
         (log/info "Unzipping done."))
     dir-resource
     (do

--- a/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
@@ -59,8 +59,7 @@
 
 (deftest audit-db-instance-analytics-content-is-unzipped-properly
   (sh/sh "rm" "-rf" "plugins/instance_analytics")
-  (is (= (:err (sh/sh "ls" "plugins/instance_analytics"))
-         "ls: plugins/instance_analytics: No such file or directory\n"))
+  (is (= 1 (:exit (sh/sh "ls" "plugins/instance_analytics"))))
 
   (#'audit-db/ia-content->plugins audit-db/analytics-zip-resource nil)
   (is (= (str/split-lines (:out (sh/sh "ls" "plugins/instance_analytics")))
@@ -68,8 +67,7 @@
 
 (deftest audit-db-instance-analytics-content-is-coppied-properly
   (sh/sh "rm" "-rf" "plugins/instance_analytics")
-  (is (= (:err (sh/sh "ls" "plugins/instance_analytics"))
-         "ls: plugins/instance_analytics: No such file or directory\n"))
+  (is (= 1 (:exit (sh/sh "ls" "plugins/instance_analytics"))))
 
   (#'audit-db/ia-content->plugins nil audit-db/analytics-dir-resource)
   (is (= (str/split-lines (:out (sh/sh "ls" "plugins/instance_analytics")))

--- a/src/metabase/util/files.clj
+++ b/src/metabase/util/files.clj
@@ -160,11 +160,11 @@
 
 (defn unzip-file
   "Decompress a zip archive from input to output."
-  [zip-file out-dir]
+  [zip-file mod-fn]
   (with-open [stream (-> zip-file io/input-stream ZipInputStream.)]
     (loop [entry (.getNextEntry stream)]
       (when entry
-        (let [out-path (str out-dir File/separatorChar (.getName entry))
+        (let [out-path (mod-fn (.getName entry))
               out-file (File. out-path)]
           (if (.isDirectory entry)
             (when-not (.exists out-file) (.mkdirs out-file))


### PR DESCRIPTION
Instead of appending the path to the plugins dir, this updates unzip-file to take a function from entry-name to the path to put the file.

e.g.

If the entry is at `"/Users/user/dev/metabase/metabase/resources/instance_analytics/databases/Internal Metabase Database/Internal Metabase Database.yaml"`, we want it to end up at `"/Users/user/dev/metabase/metabase/plugins/instance_analytics/databases/Internal Metabase Database/Internal Metabase Database.yaml"`, not `"/Users/user/dev/metabase/metabase//Users/user/dev/metabase/metabase/plugins/instance_analytics/databases/Internal Metabase Database/Internal Metabase Database.yaml"`.

This should fix rows 0-23 of this handy table:
```
| :row | :plugins-dir | :ed |  :db | :jar | :extraction-mode |
|------+--------------+-----+------+------+------------------|
|    0 |      vanilla |  ee |   pg |   no |            unzip |
|    1 |      vanilla |  ee |   pg |   no |             copy |
|    2 |      vanilla |  ee |   h2 |   no |            unzip |
|    3 |      vanilla |  ee |   h2 |   no |             copy |
|    4 |      vanilla |  ee | msql |   no |            unzip |
|    5 |      vanilla |  ee | msql |   no |             copy |
|    6 |      vanilla |  ee |   pg |  jar |            unzip |
|    7 |      vanilla |  ee |   pg |  jar |             copy |
|    8 |      vanilla |  ee |   h2 |  jar |            unzip |
|    9 |      vanilla |  ee |   h2 |  jar |             copy |
|   10 |      vanilla |  ee | msql |  jar |            unzip |
|   11 |      vanilla |  ee | msql |  jar |             copy |
|   12 |      vanilla | oss |   pg |   no |            unzip |
|   13 |      vanilla | oss |   pg |   no |             copy |
|   14 |      vanilla | oss |   h2 |   no |            unzip |
|   15 |      vanilla | oss |   h2 |   no |             copy |
|   16 |      vanilla | oss | msql |   no |            unzip |
|   17 |      vanilla | oss | msql |   no |             copy |
|   18 |      vanilla | oss |   pg |  jar |            unzip |
|   19 |      vanilla | oss |   pg |  jar |             copy |
|   20 |      vanilla | oss |   h2 |  jar |            unzip |
|   21 |      vanilla | oss |   h2 |  jar |             copy |
|   22 |      vanilla | oss | msql |  jar |            unzip |
|   23 |      vanilla | oss | msql |  jar |             copy |
|   24 |   overridden |  ee |   pg |   no |            unzip |
|   25 |   overridden |  ee |   pg |   no |             copy |
|   26 |   overridden |  ee |   h2 |   no |            unzip |
|   27 |   overridden |  ee |   h2 |   no |             copy |
|   28 |   overridden |  ee | msql |   no |            unzip |
|   29 |   overridden |  ee | msql |   no |             copy |
|   30 |   overridden |  ee |   pg |  jar |            unzip |
|   31 |   overridden |  ee |   pg |  jar |             copy |
|   32 |   overridden |  ee |   h2 |  jar |            unzip |
|   33 |   overridden |  ee |   h2 |  jar |             copy |
|   34 |   overridden |  ee | msql |  jar |            unzip |
|   35 |   overridden |  ee | msql |  jar |             copy |
|   36 |   overridden | oss |   pg |   no |            unzip |
|   37 |   overridden | oss |   pg |   no |             copy |
|   38 |   overridden | oss |   h2 |   no |            unzip |
|   39 |   overridden | oss |   h2 |   no |             copy |
|   40 |   overridden | oss | msql |   no |            unzip |
|   41 |   overridden | oss | msql |   no |             copy |
|   42 |   overridden | oss |   pg |  jar |            unzip |
|   43 |   overridden | oss |   pg |  jar |             copy |
|   44 |   overridden | oss |   h2 |  jar |            unzip |
|   45 |   overridden | oss |   h2 |  jar |             copy |
|   46 |   overridden | oss | msql |  jar |            unzip |
|   47 |   overridden | oss | msql |  jar |             copy |
```

There's some more work to do for handling overriding the plugins directory. (which should have us working for the rest of the combinations in the table.)