### PR TITLE
Fix the flaky test 'downgrade-dashboard-tabs-test' 

### DIFF
--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -255,6 +255,8 @@
 
 (deftest downgrade-dashboard-tabs-test
   (testing "Migrations v47.00-029: downgrade dashboard tab test"
+    ;; it's "v47.00-030" but not "v47.00-029" because for some reasons,
+    ;; SOMETIMES the rollback of custom migration doens't get triggered on mysql and this test got flaky.
     (impl/test-migrations "v47.00-030" [migrate!]
       (migrate!)
       (let [{:keys [db-type ^javax.sql.DataSource data-source]} mdb.connection/*application-db*

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -255,7 +255,7 @@
 
 (deftest downgrade-dashboard-tabs-test
   (testing "Migrations v47.00-029: downgrade dashboard tab test"
-    (impl/test-migrations "v47.00-029" [migrate!]
+    (impl/test-migrations "v47.00-030" [migrate!]
       (migrate!)
       (let [{:keys [db-type ^javax.sql.DataSource data-source]} mdb.connection/*application-db*
             migrate-down! (partial db.setup/migrate! db-type data-source :down)


### PR DESCRIPTION
Fix the flaky test 'downgrade-dashboard-tabs-test' by bumping the
migration version we upgraded to during the test. I'm not fully sure why
it was flaky in the first place. For some reason, the rollback step
doesn't get triggered on MySQL even though liqubiase does acknowledge
that the migration got ran?? either way bumping the version seems to take
the flaky away.


I was getting the failure ~20 runs, so stretch tested this with 100 runs and I don't see any failure
```clojure
(apply merge-with + (map #(select-keys % [:error :fail :pass])
                           (for [_ (range 100)]
                             (run-test-var #'downgrade-dashboard-tabs-test))))
{:error 0, :fail 0, :pass 100}
```

Closes https://github.com/metabase/metabase/issues/32088
