### PR TITLE
Changed int to bigint for upload

### DIFF
--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -578,7 +578,7 @@
   (case upload-type
     ::upload/varchar_255 "VARCHAR"
     ::upload/text        "VARCHAR"
-    ::upload/int         "BIGINT"
+    ::upload/bigint      "BIGINT"
     ::upload/float       "DOUBLE PRECISION"
     ::upload/boolean     "BOOLEAN"
     ::upload/date        "DATE"

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -605,7 +605,7 @@
   (case upload-type
     ::upload/varchar_255 "VARCHAR(255)"
     ::upload/text        "TEXT"
-    ::upload/int         "BIGINT"
+    ::upload/bigint      "BIGINT"
     ::upload/float       "DOUBLE"
     ::upload/boolean     "BOOLEAN"
     ::upload/date        "DATE"

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -753,7 +753,7 @@
   (case upload-type
     ::upload/varchar_255 "VARCHAR(255)"
     ::upload/text        "TEXT"
-    ::upload/int         "BIGINT"
+    ::upload/bigint      "BIGINT"
     ::upload/float       "FLOAT"
     ::upload/boolean     "BOOLEAN"
     ::upload/date        "DATE"

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -35,7 +35,7 @@
 ;;         float   datetime
 ;;           |       |
 ;;           |       |
-;;          int    date
+;;        bigint    date
 ;;           |
 ;;           |
 ;;        boolean
@@ -44,8 +44,8 @@
   ;; listed in depth-first order
   {::varchar_255 ::text
    ::float       ::varchar_255
-   ::int         ::float
-   ::boolean     ::int
+   ::bigint      ::float
+   ::boolean     ::bigint
    ::datetime    ::varchar_255
    ::date        ::datetime})
 
@@ -113,7 +113,7 @@
 (defn value->type
   "The most-specific possible type for a given value. Possibilities are:
     - ::boolean
-    - ::int
+    - ::bigint
     - ::float
     - ::varchar_255
     - ::text
@@ -130,7 +130,7 @@
       (re-matches #"(?i)true|t|yes|y|1|false|f|no|n|0" value) ::boolean
       (datetime-string? value)                                ::datetime
       (date-string? value)                                    ::date
-      (re-matches (int-regex number-separators) value)        ::int
+      (re-matches (int-regex number-separators) value)        ::bigint
       (re-matches (float-regex number-separators) value)      ::float
       (re-matches #".{1,255}" value)                          ::varchar_255
       :else                                                   ::text)))
@@ -245,7 +245,7 @@
   (case upload-type
     ::varchar_255 identity
     ::text        identity
-    ::int         (partial parse-number (get-number-separators))
+    ::bigint      (partial parse-number (get-number-separators))
     ::float       (partial parse-number (get-number-separators))
     ::boolean     #(parse-bool (str/trim %))
     ::date        #(parse-date (str/trim %))
@@ -293,7 +293,7 @@
   "Returns an ordered map of `normalized-column-name -> type` for the given CSV file. The CSV file *must* have headers as the
   first row. Supported types are:
 
-    - ::int
+    - ::bigint
     - ::float
     - ::boolean
     - ::varchar_255

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -21,7 +21,7 @@
 (set! *warn-on-reflection* true)
 
 (def ^:private bool-type      :metabase.upload/boolean)
-(def ^:private int-type       :metabase.upload/int)
+(def ^:private bigint-type    :metabase.upload/bigint)
 (def ^:private float-type     :metabase.upload/float)
 (def ^:private vchar-type     :metabase.upload/varchar_255)
 (def ^:private date-type      :metabase.upload/date)
@@ -60,30 +60,30 @@
            ["0,0"        0              float-type ",."]
            ["0,0"        0              float-type ", "]
            ["0.0"        0              float-type ".’"]
-           ["$2"         2              int-type]
-           ["$ 3"        3              int-type]
-           ["-43€"       -43            int-type]
-           ["(86)"       -86            int-type]
-           ["($86)"      -86            int-type]
-           ["£1000"      1000           int-type]
-           ["£1000"      1000           int-type "."]
-           ["£1000"      1000           int-type ".,"]
-           ["£1000"      1000           int-type ",."]
-           ["£1000"      1000           int-type ", "]
-           ["£1000"      1000           int-type ".’"]
-           ["-¥9"        -9             int-type]
-           ["₹ -13"      -13            int-type]
-           ["₪13"        13             int-type]
-           ["₩-13"       -13            int-type]
-           ["₿42"        42             int-type]
-           ["-99¢"       -99            int-type]
-           ["2"          2              int-type]
-           ["-86"        -86            int-type]
-           ["9,986,000"  9986000        int-type]
-           ["9,986,000"  9986000        int-type "."]
-           ["9,986,000"  9986000        int-type ".,"]
-           ["9.986.000"  9986000        int-type ",."]
-           ["9’986’000"  9986000        int-type ".’"]
+           ["$2"         2              bigint-type]
+           ["$ 3"        3              bigint-type]
+           ["-43€"       -43            bigint-type]
+           ["(86)"       -86            bigint-type]
+           ["($86)"      -86            bigint-type]
+           ["£1000"      1000           bigint-type]
+           ["£1000"      1000           bigint-type "."]
+           ["£1000"      1000           bigint-type ".,"]
+           ["£1000"      1000           bigint-type ",."]
+           ["£1000"      1000           bigint-type ", "]
+           ["£1000"      1000           bigint-type ".’"]
+           ["-¥9"        -9             bigint-type]
+           ["₹ -13"      -13            bigint-type]
+           ["₪13"        13             bigint-type]
+           ["₩-13"       -13            bigint-type]
+           ["₿42"        42             bigint-type]
+           ["-99¢"       -99            bigint-type]
+           ["2"          2              bigint-type]
+           ["-86"        -86            bigint-type]
+           ["9,986,000"  9986000        bigint-type]
+           ["9,986,000"  9986000        bigint-type "."]
+           ["9,986,000"  9986000        bigint-type ".,"]
+           ["9.986.000"  9986000        bigint-type ",."]
+           ["9’986’000"  9986000        bigint-type ".’"]
            ["9.986.000"  "9.986.000"    vchar-type ".,"]
            ["3.14"       3.14           float-type]
            ["3.14"       3.14           float-type "."]
@@ -131,17 +131,17 @@
 
 (deftest ^:parallel type-coalescing-test
   (doseq [[type-a type-b expected] [[bool-type     bool-type     bool-type]
-                                    [bool-type     int-type      int-type]
+                                    [bool-type     bigint-type      bigint-type]
                                     [bool-type     date-type     vchar-type]
                                     [bool-type     datetime-type vchar-type]
                                     [bool-type     vchar-type    vchar-type]
                                     [bool-type     text-type     text-type]
-                                    [int-type      bool-type     int-type]
-                                    [int-type      float-type    float-type]
-                                    [int-type      date-type     vchar-type]
-                                    [int-type      datetime-type vchar-type]
-                                    [int-type      vchar-type    vchar-type]
-                                    [int-type      text-type     text-type]
+                                    [bigint-type      bool-type     bigint-type]
+                                    [bigint-type      float-type    float-type]
+                                    [bigint-type      date-type     vchar-type]
+                                    [bigint-type      datetime-type vchar-type]
+                                    [bigint-type      vchar-type    vchar-type]
+                                    [bigint-type      text-type     text-type]
                                     [float-type    vchar-type    vchar-type]
                                     [float-type    text-type     text-type]
                                     [float-type    date-type     vchar-type]
@@ -172,7 +172,7 @@
 (deftest ^:parallel detect-schema-test
   (testing "Well-formed CSV file"
     (is (= {"name"             vchar-type
-            "age"              int-type
+            "age"              bigint-type
             "favorite_pokemon" vchar-type}
            (upload/detect-schema
             (csv-file-with ["Name, Age, Favorite Pokémon"
@@ -180,7 +180,7 @@
                             "Ryan, 97, Paras"])))))
   (testing "CSV missing data"
     (is (= {"name"       vchar-type
-            "height"     int-type
+            "height"     bigint-type
             "birth_year" float-type}
            (upload/detect-schema
             (csv-file-with ["Name, Height, Birth Year"
@@ -199,7 +199,7 @@
   (testing "Boolean coalescing"
     (is (= {"name"          vchar-type
             "is_jedi_"      bool-type
-            "is_jedi__int_" int-type
+            "is_jedi__int_" bigint-type
             "is_jedi__vc_"  vchar-type}
            (upload/detect-schema
             (csv-file-with ["Name, Is Jedi?, Is Jedi (int), Is Jedi (VC)"
@@ -225,7 +225,7 @@
               (csv-file-with [""])))))
   (testing "CSV missing data in the top row"
     (is (= {"name"       vchar-type
-            "height"     int-type
+            "height"     bigint-type
             "birth_year" float-type}
            (upload/detect-schema
             (csv-file-with ["Name, Height, Birth Year"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/33735

### Description

- Instead of returning int and then converting it to driver level for bigint now we are returning bigint and then driver will decide what driver needs to implement(int/bigint/whatever)

### How to verify

- Verified the change on uploading file via metabase on MySQL,postgres,H2


### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
