### PR TITLE
Use `clj-commons/fs` for filesystem operations

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -17,6 +17,8 @@
   camel-snake-kebab/camel-snake-kebab       {:mvn/version "0.4.3"}              ; util functions for converting between camel, snake, and kebob case
   cheshire/cheshire                         {:mvn/version "5.11.0"}             ; fast JSON encoding (used by Ring JSON middleware)
   clj-bom/clj-bom                           {:mvn/version "0.1.2"}              ; handle BOMs in imported CSVs
+  clj-commons/clj-yaml                      {:mvn/version "1.0.26"}             ; Clojure wrapper for YAML library SnakeYAML
+  clj-commons/fs                            {:mvn/version "1.6.310"}            ; file system utilities
   clj-commons/iapetos                       {:mvn/version "0.1.13"}             ; prometheus metrics
   clj-http/clj-http                         {:mvn/version "3.12.3"              ; HTTP client
                                              :exclusions  [commons-codec/commons-codec
@@ -70,7 +72,6 @@
   inflections/inflections                   {:mvn/version "0.14.1"}             ; Clojure/Script library used for prularizing words
   info.sunng/ring-jetty9-adapter            {:mvn/version "0.22.1"}             ; Drop-in replacement for official Ring Jetty adapter. Supports Jetty 11 webserver.
   instaparse/instaparse                     {:mvn/version "1.4.12"}             ; Make your own parser
-  clj-commons/clj-yaml                      {:mvn/version "1.0.26"}             ; Clojure wrapper for YAML library SnakeYAML
   io.github.camsaul/toucan2                 {:mvn/version "1.0.524"}
   io.github.camsaul/toucan2-toucan1         {:mvn/version "1.0.524"}
   ;; The 2.X line of Resilience4j requires Java 17, so we cannot upgrade this dependency until that is our minimum JVM version

--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -1,9 +1,8 @@
 (ns metabase-enterprise.audit-db
   (:require
-   [clojure.core :as c]
    [clojure.java.io :as io]
-   [clojure.java.shell :as sh]
    [clojure.string :as str]
+   [me.raynes.fs :as fs]
    [metabase-enterprise.internal-user :as ee.internal-user]
    [metabase-enterprise.serialization.cmd :as serialization.cmd]
    [metabase.db.env :as mdb.env]
@@ -125,6 +124,11 @@
   "The directory analytics content is unzipped or moved to, and loaded into the app from on startup."
   (plugins/plugins-dir))
 
+(defn analytics-dir-plugins-path
+  "The path to the analytics content dir in the plugins dir."
+  []
+  (u.files/append-to-path (plugins/plugins-dir) "instance_analytics"))
+
 (defn- ia-content->plugins
   "Load instance analytics content (collections/dashboards/cards/etc.) from resources dir or a zip file
    and put it into plugins/instance_analytics"
@@ -138,11 +142,11 @@
                                            "resources/instance_analytics/"
                                            "plugins/instance_analytics/")))
         (log/info "Unzipping done."))
+
     dir-resource
     (do
-      (log/info "Copying resources/instance_analytics to " plugin-dir "...")
-      ;; TODO add a recursive copy to u.files
-      (sh/sh "cp" "-r" "resources/instance_analytics" (str plugin-dir))
+      (log/info "Copying resources/instance_analytics to plugins...")
+      (fs/copy-dir-into analytics-dir-resource (analytics-dir-plugins-path))
       (log/info "Copying done."))))
 
 (defenterprise ensure-audit-db-installed!

--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -145,7 +145,7 @@
 
     dir-resource
     (do
-      (log/info "Copying resources/instance_analytics to plugins...")
+      (log/info (str "Copying resources/instance_analytics to " plugin-dir "..."))
       (fs/copy-dir-into analytics-dir-resource (analytics-dir-plugins-path))
       (log/info "Copying done."))))
 

--- a/src/metabase/util/files.clj
+++ b/src/metabase/util/files.clj
@@ -15,7 +15,7 @@
    (java.util.zip ZipInputStream)
    (java.io File FileNotFoundException)
    (java.net URL)
-   (java.nio.file CopyOption Files FileSystem FileSystems LinkOption OpenOption Path Paths StandardCopyOption)
+   (java.nio.file CopyOption Files SimpleFileVisitor FileSystem FileSystems FileVisitResult LinkOption OpenOption Path Paths StandardCopyOption)
    (java.nio.file.attribute FileAttribute)
    (java.util Collections)))
 
@@ -92,7 +92,7 @@
 
 (defn copy-files!
   "Copy all files in `source-dir` to `dest-dir`. Overwrites existing files if last modified timestamp is not the same as
-  that of the source file — see #11699 for more context."
+  that of the source file — see #11699 for more context. Does not copy subdirectories recursively."
   [^Path source-dir, ^Path dest-dir]
   (doseq [^Path source (files-seq source-dir)
           :let         [target (append-to-path dest-dir (str (.getFileName source)))]]

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -59,6 +59,7 @@
    (java.net ServerSocket)
    (java.util Locale)
    (java.util.concurrent TimeoutException)
+   (org.apache.commons.io FileUtils)
    (org.quartz CronTrigger JobDetail JobKey Scheduler Trigger)
    (org.quartz.impl StdSchedulerFactory)))
 
@@ -1132,7 +1133,7 @@
    (^:once fn* [path]
     (let [file (io/file path)]
       (when (.exists file)
-        (org.apache.commons.io.FileUtils/deleteDirectory file)))
+        (FileUtils/deleteDirectory file)))
     (u.files/create-dir-if-not-exists! (u.files/get-path path))
     (f path))))
 


### PR DESCRIPTION
Adds ` clj-commons/fs` as a dependency and uses it for the directory copy operations, as well as in tests which were previously using `sh/sh`. Also includes a few small cleanup items.