### PR TITLE
[MLv2] Allow any type of arguments to :concat expressions

### DIFF
--- a/src/metabase/lib/schema/expression/string.cljc
+++ b/src/metabase/lib/schema/expression/string.cljc
@@ -27,4 +27,4 @@
   [:length [:? [:schema [:ref ::expression/integer]]]])
 
 (mbql-clause/define-catn-mbql-clause :concat :- :type/Text
-  [:args [:repeat {:min 2} [:schema [:ref ::expression/string]]]])
+  [:args [:repeat {:min 2} [:schema [:ref ::expression/expression]]]])


### PR DESCRIPTION
The QP supports this - it appears that every type can be `concat`-ed and
it will coerce the values to some kind of string - numbers, dates,
booleans, etc.

Fixes #34150.