### PR TITLE
Move getIsNavbarOpen to selectors file to get rid of circular deps

### DIFF
--- a/frontend/src/metabase/archive/containers/ArchiveApp.tsx
+++ b/frontend/src/metabase/archive/containers/ArchiveApp.tsx
@@ -18,7 +18,8 @@ import Search from "metabase/entities/search";
 import { useListSelect } from "metabase/hooks/use-list-select";
 import { useSearchListQuery } from "metabase/common/hooks";
 
-import { getIsNavbarOpen, openNavbar } from "metabase/redux/app";
+import { openNavbar } from "metabase/redux/app";
+import { getIsNavbarOpen } from "metabase/selectors/app";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { isSmallScreen, getMainElement } from "metabase/lib/dom";
 

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -12,7 +12,8 @@ import Search from "metabase/entities/search";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { getIsBookmarked } from "metabase/collections/selectors";
 import { getSetting } from "metabase/selectors/settings";
-import { getIsNavbarOpen, openNavbar } from "metabase/redux/app";
+import { openNavbar } from "metabase/redux/app";
+import { getIsNavbarOpen } from "metabase/selectors/app";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
 import BulkActions from "metabase/collections/components/BulkActions";

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.jsx
@@ -16,7 +16,8 @@ import Dashboard from "metabase/dashboard/components/Dashboard/Dashboard";
 import { useLoadingTimer } from "metabase/hooks/use-loading-timer";
 import { useWebNotification } from "metabase/hooks/use-web-notification";
 
-import { closeNavbar, getIsNavbarOpen, setErrorPage } from "metabase/redux/app";
+import { closeNavbar, setErrorPage } from "metabase/redux/app";
+import { getIsNavbarOpen } from "metabase/selectors/app";
 
 import { getMetadata } from "metabase/selectors/metadata";
 import {

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -7,7 +7,7 @@ import _ from "underscore";
 
 import { trackExportDashboardToPDF } from "metabase/dashboard/analytics";
 
-import { getIsNavbarOpen } from "metabase/redux/app";
+import { getIsNavbarOpen } from "metabase/selectors/app";
 
 import ActionButton from "metabase/components/ActionButton";
 import Button from "metabase/core/components/Button";

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.tsx
@@ -3,9 +3,9 @@ import { withRouter } from "react-router";
 import _ from "underscore";
 import Collections from "metabase/entities/collections";
 import { logout } from "metabase/auth/actions";
-import { closeNavbar, getIsNavbarOpen, toggleNavbar } from "metabase/redux/app";
-import type { RouterProps } from "metabase/selectors/app";
+import { closeNavbar, toggleNavbar } from "metabase/redux/app";
 import {
+  getIsNavbarOpen,
   getIsCollectionPathVisible,
   getIsLogoVisible,
   getIsNavBarEnabled,
@@ -14,6 +14,8 @@ import {
   getIsQuestionLineageVisible,
   getIsSearchVisible,
 } from "metabase/selectors/app";
+import type { RouterProps } from "metabase/selectors/app";
+
 import { getUser } from "metabase/selectors/user";
 import type { State } from "metabase-types/store";
 import AppBar from "../../components/AppBar";

--- a/frontend/src/metabase/nav/containers/Navbar.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.tsx
@@ -5,7 +5,7 @@ import { connect } from "react-redux";
 import { withRouter } from "react-router";
 
 import Database from "metabase/entities/databases";
-import { getIsNavbarOpen } from "metabase/redux/app";
+import { getIsNavbarOpen } from "metabase/selectors/app";
 import { getUser } from "metabase/selectors/user";
 import { getAdminPaths } from "metabase/admin/app/selectors";
 

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -11,7 +11,8 @@ import Collections from "metabase/entities/collections";
 import Timelines from "metabase/entities/timelines";
 import { getSetting } from "metabase/selectors/settings";
 
-import { closeNavbar, getIsNavbarOpen } from "metabase/redux/app";
+import { closeNavbar } from "metabase/redux/app";
+import { getIsNavbarOpen } from "metabase/selectors/app";
 import { getMetadata } from "metabase/selectors/metadata";
 import {
   getUser,

--- a/frontend/src/metabase/redux/app.ts
+++ b/frontend/src/metabase/redux/app.ts
@@ -1,7 +1,4 @@
 import { push, LOCATION_CHANGE } from "react-router-redux";
-import { createSelector } from "@reduxjs/toolkit";
-import type { Selector } from "@reduxjs/toolkit";
-
 import {
   combineReducers,
   createAction,
@@ -13,9 +10,7 @@ import {
   shouldOpenInBlankWindow,
 } from "metabase/lib/dom";
 
-import { getEmbedOptions, getIsEmbedded } from "metabase/selectors/embed";
-import { getIsAppBarVisible } from "metabase/selectors/app";
-import type { State, Dispatch } from "metabase-types/store";
+import type { Dispatch } from "metabase-types/store";
 
 export const SET_ERROR_PAGE = "metabase/app/SET_ERROR_PAGE";
 export function setErrorPage(error: any) {
@@ -73,24 +68,6 @@ export const TOGGLE_NAVBAR = "metabase/app/TOGGLE_NAVBAR";
 export const openNavbar = createAction(OPEN_NAVBAR);
 export const closeNavbar = createAction(CLOSE_NAVBAR);
 export const toggleNavbar = createAction(TOGGLE_NAVBAR);
-
-export const getIsNavbarOpen: Selector<State, boolean> = createSelector(
-  [
-    getIsEmbedded,
-    getEmbedOptions,
-    getIsAppBarVisible,
-    (state: State) => state.app.isNavbarOpen,
-  ],
-  (isEmbedded, embedOptions, isAppBarVisible, isNavbarOpen) => {
-    // in an embedded instance, when the app bar is hidden, but the nav bar is not
-    // we need to force the sidebar to be open or else it will be totally inaccessible
-    if (isEmbedded && embedOptions.side_nav === true && !isAppBarVisible) {
-      return true;
-    }
-
-    return isNavbarOpen;
-  },
-);
 
 const isNavbarOpen = handleActions(
   {

--- a/frontend/src/metabase/search/components/SidebarFilter/SidebarFilter.tsx
+++ b/frontend/src/metabase/search/components/SidebarFilter/SidebarFilter.tsx
@@ -11,7 +11,7 @@ import type { IconName } from "metabase/core/components/Icon";
 import { Icon } from "metabase/core/components/Icon";
 import Popover from "metabase/components/Popover";
 import { useSelector } from "metabase/lib/redux";
-import { getIsNavbarOpen } from "metabase/redux/app";
+import { getIsNavbarOpen } from "metabase/selectors/app";
 import useIsSmallScreen from "metabase/hooks/use-is-small-screen";
 import {
   DropdownApplyButtonDivider,

--- a/frontend/src/metabase/selectors/app.ts
+++ b/frontend/src/metabase/selectors/app.ts
@@ -1,4 +1,5 @@
 import type { Location } from "history";
+import type { Selector } from "@reduxjs/toolkit";
 import { createSelector } from "@reduxjs/toolkit";
 import { getUser } from "metabase/selectors/user";
 import {
@@ -182,4 +183,22 @@ export const getCollectionId = createSelector(
   [getQuestion, getDashboard, getDashboardId],
   (question, dashboard, dashboardId) =>
     dashboardId ? dashboard?.collection_id : question?.collectionId(),
+);
+
+export const getIsNavbarOpen: Selector<State, boolean> = createSelector(
+  [
+    getIsEmbedded,
+    getEmbedOptions,
+    getIsAppBarVisible,
+    (state: State) => state.app.isNavbarOpen,
+  ],
+  (isEmbedded, embedOptions, isAppBarVisible, isNavbarOpen) => {
+    // in an embedded instance, when the app bar is hidden, but the nav bar is not
+    // we need to force the sidebar to be open or else it will be totally inaccessible
+    if (isEmbedded && embedOptions.side_nav === true && !isAppBarVisible) {
+      return true;
+    }
+
+    return isNavbarOpen;
+  },
 );


### PR DESCRIPTION
Related to the circulal deps [RFC](https://www.notion.so/metabase/62-Prevent-circular-dependencies-a35135e3f0e445dc83c5a0dfc77d5d1a)

### Description

`getIsNavbarOpen` imported from `metabase/redux/app` makes a circular dep.

### How to verify

- rely on tests
- add `"import/no-cycle": [2, { "commonjs": true }],` to the eslintrc
- run `yarn eslint --ext .js,.jsx,.ts,.tsx frontend/src/metabase/query_builder/actions/core`


| Before | After |
|--------|--------|
| <img width="769" alt="Screenshot 2023-09-27 at 15 19 59" src="https://github.com/metabase/metabase/assets/125459446/3d3c8618-9e76-4bbd-85e4-1944704cee06"> | <img width="697" alt="Screenshot 2023-09-27 at 15 20 24" src="https://github.com/metabase/metabase/assets/125459446/5a97a26f-7cb9-4af0-8e55-e23dc94fab9f"> | 


### Checklist

~- [ ] Tests have been added/updated to cover changes in this PR~
