### PR TITLE
[jest] Move builtin plugins to specific specs

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -93,7 +93,7 @@ jobs:
         run: yarn run test-unit --coverage --silent
       - name: Run frontend unit tests
         if: github.ref_name != 'master'
-        run: yarn run test-unit
+        run: yarn run test-unit --silent
       - name: Upload coverage to codecov.io
         if: github.ref_name == 'master'
         uses: codecov/codecov-action@v3

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/enterprise.unit.spec.tsx
@@ -1,3 +1,4 @@
+import "metabase/plugins/builtin";
 import userEvent from "@testing-library/user-event";
 import {
   createMockGroup,

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/password-login.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/password-login.unit.spec.tsx
@@ -1,3 +1,4 @@
+import "metabase/plugins/builtin";
 import userEvent from "@testing-library/user-event";
 import {
   createMockSettingDefinition,

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/sso-google.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/sso-google.unit.spec.tsx
@@ -1,3 +1,4 @@
+import "metabase/plugins/builtin";
 import { screen } from "__support__/ui";
 import {
   createMockGroup,

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/sso-ldap.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/sso-ldap.unit.spec.tsx
@@ -1,3 +1,4 @@
+import "metabase/plugins/builtin";
 import { screen } from "__support__/ui";
 import {
   createMockGroup,

--- a/frontend/src/metabase/auth/components/Login/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/auth/components/Login/tests/common.unit.spec.tsx
@@ -1,5 +1,5 @@
+import "metabase/plugins/builtin";
 import { screen } from "__support__/ui";
-
 import { setup } from "./setup";
 
 describe("Login", () => {

--- a/frontend/src/metabase/auth/components/Login/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/auth/components/Login/tests/enterprise.unit.spec.tsx
@@ -1,5 +1,5 @@
+import "metabase/plugins/builtin";
 import { screen } from "__support__/ui";
-
 import { setup } from "./setup";
 
 describe("Login", () => {

--- a/frontend/src/metabase/auth/components/PasswordPanel/PasswordPanel.unit.spec.tsx
+++ b/frontend/src/metabase/auth/components/PasswordPanel/PasswordPanel.unit.spec.tsx
@@ -1,3 +1,4 @@
+import "metabase/plugins/builtin";
 import fetchMock from "fetch-mock";
 import userEvent from "@testing-library/user-event";
 import MetabaseSettings from "metabase/lib/settings";

--- a/frontend/test/register-visualizations.js
+++ b/frontend/test/register-visualizations.js
@@ -1,5 +1,3 @@
-import "metabase/plugins/builtin";
-
 // We need to mock this *before* registering the visualizations. Otherwise
 // `ChartWithLegend` with already load the real one.
 jest.mock("metabase/components/ExplicitSize");


### PR DESCRIPTION
## Description

This change moves import of heavy dependency of builtin plugins to the specific tests, so all other tests do not have to load lots of useless files what is one of the bottlenecks of jest.

It makes unit tests ~25% faster (35% together with https://github.com/metabase/metabase/pull/34133) if you run them locally with `yarn jest --maxWorkers=4 --silent --no-cache` 

previous related PRs:
- https://github.com/metabase/metabase/pull/33916
- https://github.com/metabase/metabase/pull/33978
- https://github.com/metabase/metabase/pull/33983
- https://github.com/metabase/metabase/pull/34133
- https://github.com/metabase/metabase/pull/31751 - allowed to cut ~2min


| Before | After |
|--------|--------|
|  <img width="690" alt="Screenshot 2023-09-28 at 13 48 46" src="https://github.com/metabase/metabase/assets/125459446/3e8155e9-49d8-47aa-979d-b718cf5530fb"> | <img width="648" alt="Screenshot 2023-09-28 at 13 56 10" src="https://github.com/metabase/metabase/assets/125459446/f6771f46-78d7-4894-a04d-e908f6ca293f"> | 