### PR TITLE
fix: Correct cache control for static js/css files

### DIFF
--- a/src/metabase/server/request/util.clj
+++ b/src/metabase/server/request/util.clj
@@ -34,14 +34,13 @@
 
 (defn cacheable?
   "Can the ring request be permanently cached?"
-  [{:keys [request-method uri query-string], :as _request}]
+  [{:keys [request-method uri], :as _request}]
   (and (= request-method :get)
        (or
-        ;; match requests that are js/css and have a cache-busting query string
-        (and query-string
-             (re-matches #"^/app/dist/.*\.(js|css)$" uri))
+        ;; match requests that are js/css and have a cache-busting hex string
+        (re-matches #"^/app/dist/.+\.[a-f0-9]{20}\.(js|css)$" uri)
         ;; any resource that is named as a cache-busting hex string (e.g. fonts, images)
-        (re-matches #"^/app/dist/[a-f0-9]{20}+.*$" uri))))
+        (re-matches #"^/app/dist/[a-f0-9]{20}.*$" uri))))
 
 (defn https?
   "True if the original request made by the frontend client (i.e., browser) was made over HTTPS.


### PR DESCRIPTION
> [!IMPORTANT]
> If you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

Fixes https://github.com/metabase/metabase/issues/34169

Adapts caching to https://github.com/metabase/metabase/pull/33459

### How to verify

Start a Metabase server and perform a request for a JS bundle such as `/app/dist/app-embed.98f66cefbfa7fb5b94db.js`.

The cache-control header should have a max-age

Regexes tested:
![image](https://github.com/metabase/metabase/assets/17657014/34d106a6-4ee0-487e-b832-30d7a3643186)


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
