### PR TITLE
Add PKs to CSVs

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -877,11 +877,12 @@
   :hierarchy #'hierarchy)
 
 (defmulti pk-options
-  "The HoneySQL column spec for a primary key column. Does not include the actual column name, just its options. Examples:
+  "The HoneySQL column spec for a primary key column. Does not include the actual column name, just its options. Should
+  be something like:
 
-     - [:auto-increment [:not nil]]  ;; (most SQLs)
-     - [:serial]                     ;; (Postgres)"
-  {:added "0.48.0", :arglists '([driver])}
+  [:generated-always :as :identity :primary-key]  ;; if auto-increment? is true
+  [:primary-key]                                  ;; if it's not"
+  {:added "0.48.0", :arglists '([driver auto-increment?])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -876,6 +876,15 @@
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 
+(defmulti pk-options
+  "The HoneySQL column spec for a primary key column. Does not include the actual column name, just its options. Examples:
+
+     - [:auto-increment [:not nil]]  ;; (most SQLs)
+     - [:serial]                     ;; (Postgres)"
+  {:added "0.48.0", :arglists '([driver])}
+  dispatch-on-initialized-driver
+  :hierarchy #'hierarchy)
+
 (defmulti syncable-schemas
   "Returns the set of syncable schemas in the database (as strings)."
   {:added "0.47.0", :arglists '([driver database])}
@@ -885,7 +894,7 @@
 (defmethod syncable-schemas ::driver [_ _] #{})
 
 (defmulti upload-type->database-type
-  "Returns the database type for a given `metabase.upload` type."
+  "Returns the database type for a given `metabase.upload` type as a HoneySQL keyword."
   {:added "0.47.0", :arglists '([driver upload-type])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -876,16 +876,6 @@
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 
-(defmulti pk-options
-  "The HoneySQL column spec for a primary key column. Does not include the actual column name, just its options. Should
-  be something like:
-
-  [:generated-always :as :identity :primary-key]  ;; if auto-increment? is true
-  [:primary-key]                                  ;; if it's not"
-  {:added "0.48.0", :arglists '([driver auto-increment?])}
-  dispatch-on-initialized-driver
-  :hierarchy #'hierarchy)
-
 (defmulti syncable-schemas
   "Returns the set of syncable schemas in the database (as strings)."
   {:added "0.47.0", :arglists '([driver database])}
@@ -895,7 +885,12 @@
 (defmethod syncable-schemas ::driver [_ _] #{})
 
 (defmulti upload-type->database-type
-  "Returns the database type for a given `metabase.upload` type as a HoneySQL keyword."
+  "Returns the database type for a given `metabase.upload` type as a HoneySQL spec. This will be a vector, which allows
+  for additional options. Sample values:
+
+  - [:bigint]
+  - [[:varchar 255]]
+  - [:generated-always :as :identity :primary-key]"
   {:added "0.47.0", :arglists '([driver upload-type])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -573,13 +573,14 @@
 (defmethod driver/upload-type->database-type :h2
   [_driver upload-type]
   (case upload-type
-    ::upload/varchar_255 "VARCHAR"
-    ::upload/text        "VARCHAR"
-    ::upload/int         "BIGINT"
-    ::upload/float       "DOUBLE PRECISION"
-    ::upload/boolean     "BOOLEAN"
-    ::upload/date        "DATE"
-    ::upload/datetime    "TIMESTAMP"))
+    ::upload/varchar_255 :varchar
+    ::upload/text        :varchar
+    ::upload/int         :bigint
+    ::upload/pk          :int
+    ::upload/float       (keyword "DOUBLE PRECISION")
+    ::upload/boolean     :boolean
+    ::upload/date        :date
+    ::upload/datetime    :timestamp))
 
 (defmethod driver/table-name-length-limit :h2
   [_driver]

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -573,14 +573,15 @@
 (defmethod driver/upload-type->database-type :h2
   [_driver upload-type]
   (case upload-type
-    ::upload/varchar_255 :varchar
-    ::upload/text        :varchar
-    ::upload/int         :bigint
-    ::upload/pk          :int
-    ::upload/float       (keyword "DOUBLE PRECISION")
-    ::upload/boolean     :boolean
-    ::upload/date        :date
-    ::upload/datetime    :timestamp))
+    ::upload/varchar_255              [:varchar]
+    ::upload/text                     [:varchar]
+    ::upload/int                      [:bigint]
+    ::upload/int-pk                   [:bigint :primary-key]
+    ::upload/auto-incrementing-int-pk [:bigint :generated-always :as :identity :primary-key]
+    ::upload/float                    [(keyword "DOUBLE PRECISION")]
+    ::upload/boolean                  [:boolean]
+    ::upload/date                     [:date]
+    ::upload/datetime                 [:timestamp]))
 
 (defmethod driver/table-name-length-limit :h2
   [_driver]

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -608,13 +608,14 @@
 (defmethod driver/upload-type->database-type :mysql
   [_driver upload-type]
   (case upload-type
-    ::upload/varchar_255 "VARCHAR(255)"
-    ::upload/text        "TEXT"
-    ::upload/int         "BIGINT"
-    ::upload/float       "DOUBLE"
-    ::upload/boolean     "BOOLEAN"
-    ::upload/date        "DATE"
-    ::upload/datetime    "TIMESTAMP"))
+    ::upload/varchar_255 [:varchar 255]
+    ::upload/text        :text
+    ::upload/int         :bigint
+    ::upload/pk          :int
+    ::upload/float       :double
+    ::upload/boolean     :boolean
+    ::upload/date        :date
+    ::upload/datetime    :timestamp))
 
 (defmethod driver/table-name-length-limit :mysql
   [_driver]

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -675,7 +675,7 @@
         (let [tsvs (map (partial row->tsv (count column-names)) values)
               sql  (sql/format {::load   [file-path (keyword table-name)]
                                 :columns (map keyword column-names)}
-                               :quoted true
+                               :quoted  true
                                :dialect (sql.qp/quote-style driver))]
           (with-open [^java.io.Writer writer (jio/writer file-path)]
             (doseq [value (interpose \newline tsvs)]
@@ -683,6 +683,12 @@
           (qp.writeback/execute-write-sql! db-id sql))
         (finally
           (.delete temp-file))))))
+
+(defmethod driver/pk-options :mysql
+  [_driver auto-increment?]
+  (if auto-increment?
+    [:not-null :auto-increment :primary-key]
+    [:primary-key]))
 
 (defn- parse-grant
   "Parses the contents of a row from the output of a `SHOW GRANTS` statement, to extract the data needed

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -608,14 +608,15 @@
 (defmethod driver/upload-type->database-type :mysql
   [_driver upload-type]
   (case upload-type
-    ::upload/varchar_255 [:varchar 255]
-    ::upload/text        :text
-    ::upload/int         :bigint
-    ::upload/pk          :int
-    ::upload/float       :double
-    ::upload/boolean     :boolean
-    ::upload/date        :date
-    ::upload/datetime    :timestamp))
+    ::upload/varchar_255              [[:varchar 255]]
+    ::upload/text                     [:text]
+    ::upload/int                      [:bigint]
+    ::upload/int-pk                   [:bigint :primary-key]
+    ::upload/auto-incrementing-int-pk [:bigint :not-null :auto-increment :primary-key]
+    ::upload/float                    [:double]
+    ::upload/boolean                  [:boolean]
+    ::upload/date                     [:date]
+    ::upload/datetime                 [:timestamp]))
 
 (defmethod driver/table-name-length-limit :mysql
   [_driver]
@@ -683,12 +684,6 @@
           (qp.writeback/execute-write-sql! db-id sql))
         (finally
           (.delete temp-file))))))
-
-(defmethod driver/pk-options :mysql
-  [_driver auto-increment?]
-  (if auto-increment?
-    [:not-null :auto-increment :primary-key]
-    [:primary-key]))
 
 (defn- parse-grant
   "Parses the contents of a row from the output of a `SHOW GRANTS` statement, to extract the data needed

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -755,7 +755,7 @@
     ::upload/varchar_255 [:varchar 255]
     ::upload/text        :text
     ::upload/int         :bigint
-    ::upload/pk          :serial ;; bit of a hack, but we need to get it in the right order with :primary-key
+    ::upload/pk          :integer
     ::upload/float       :float
     ::upload/boolean     :boolean
     ::upload/date        :date
@@ -819,10 +819,6 @@
                          (str/join "\n")
                          (StringReader.))]
            (.copyIn copy-manager ^String sql tsvs)))))))
-
-(defmethod driver/pk-options :postgres
-  [_driver]
-  [:primary-key])
 
 (defmethod driver/current-user-table-privileges :postgres
   [_driver database]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -752,14 +752,15 @@
 (defmethod driver/upload-type->database-type :postgres
   [_driver upload-type]
   (case upload-type
-    ::upload/varchar_255 [:varchar 255]
-    ::upload/text        :text
-    ::upload/int         :bigint
-    ::upload/pk          :integer
-    ::upload/float       :float
-    ::upload/boolean     :boolean
-    ::upload/date        :date
-    ::upload/datetime    :timestamp))
+    ::upload/varchar_255              [[:varchar 255]]
+    ::upload/text                     [:text]
+    ::upload/int                      [:bigint]
+    ::upload/int-pk                   [:bigint :primary-key]
+    ::upload/auto-incrementing-int-pk [:bigserial]
+    ::upload/float                    [:float]
+    ::upload/boolean                  [:boolean]
+    ::upload/date                     [:date]
+    ::upload/datetime                 [:timestamp]))
 
 (defmethod driver/table-name-length-limit :postgres
   [_driver]

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -159,8 +159,10 @@
       (qp.writeback/execute-write-sql! db-id sql))))
 
 (defmethod driver/pk-options :sql-jdbc
-  [_driver]
-  [:auto-increment [:not nil]])
+  [_driver auto-increment?]
+  (if auto-increment?
+    [:generated-always :as :identity :primary-key]
+    [:primary-key]))
 
 (defmethod driver/syncable-schemas :sql-jdbc
   [driver database]

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -120,7 +120,9 @@
 (defn- create-table-sql
   [driver table-name col->type]
   (first (sql/format {:create-table (keyword table-name)
-                      :with-columns (map (fn [kv] (map keyword kv)) col->type)}
+                      :with-columns (map (fn [[name type-spec]]
+                                           (vec (cons name type-spec)))
+                                         col->type)}
                      :quoted true
                      :dialect (sql.qp/quote-style driver))))
 
@@ -155,6 +157,10 @@
     ;; across all drivers. With that in mind, 100 seems like a safe compromise.
     (doseq [sql sqls]
       (qp.writeback/execute-write-sql! db-id sql))))
+
+(defmethod driver/pk-options :sql-jdbc
+  [_driver]
+  [:auto-increment [:not nil]])
 
 (defmethod driver/syncable-schemas :sql-jdbc
   [driver database]

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -158,12 +158,6 @@
     (doseq [sql sqls]
       (qp.writeback/execute-write-sql! db-id sql))))
 
-(defmethod driver/pk-options :sql-jdbc
-  [_driver auto-increment?]
-  (if auto-increment?
-    [:generated-always :as :identity :primary-key]
-    [:primary-key]))
-
 (defmethod driver/syncable-schemas :sql-jdbc
   [driver database]
   (sql-jdbc.execute/do-with-connection-with-options

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -187,13 +187,13 @@
                                  (if (and (not @found-it)
                                           (is-pk? p))
                                    (do (reset! found-it true)
-                                       [(keyword name) {:type ::pk :opts (driver/pk-options driver)}])
+                                       [(keyword name) {:type ::pk :opts (driver/pk-options driver false)}])
                                    p))
                                name-type-pairs))]
     (if @found-it ;; we already have a PK, just return them
       pked-pairs
       ;;otherwise, prepend a new ID column
-      (cons [:id {:type ::pk :opts (driver/pk-options driver) :exclude-in-insert? true}]
+      (cons [:id {:type ::pk :opts (driver/pk-options driver true) :exclude-in-insert? true}]
             name-type-pairs))))
 
 (defn- upload-type->column-spec

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -350,7 +350,8 @@
           (driver/insert-into! driver db-id table-name csv-col-names rows)
           {:num-rows          (count rows)
            :num-columns       (count csv-col-names)
-           :generated-columns (count gen-col->upload-type)
+           :generated-columns (- (count col-to-create->col-spec)
+                                 (count col-to-insert->upload-type))
            :size-mb           (/ (.length csv-file)
                                  1048576.0)}))
       (catch Throwable e

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -51,7 +51,7 @@
    ::float                    ::varchar_255
    ::int                      ::float
    ::int-pk                   ::int
-   ::auto-incrementing-int-pk :int-pk
+   ::auto-incrementing-int-pk ::int-pk
    ::boolean                  ::int
    ::datetime                 ::varchar_255
    ::date                     ::datetime})
@@ -192,9 +192,9 @@
   (if-let [pk-name (first (keep (fn [[name _type :as p]]
                                   (when (is-pk? p) name))
                                 name-type-pairs))]
-    {:extant-columns (assoc (ordered-map/ordered-map name-type-pairs) pk-name ::int-pk)
+    {:extant-columns    (assoc (ordered-map/ordered-map name-type-pairs) pk-name ::int-pk)
      :generated-columns (ordered-map/ordered-map)}
-    {:extant-columns (ordered-map/ordered-map name-type-pairs)
+    {:extant-columns    (ordered-map/ordered-map name-type-pairs)
      :generated-columns (ordered-map/ordered-map :id ::auto-incrementing-int-pk)}))
 
 (defn- rows->schema

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -30,8 +30,7 @@
 (def ^:private pk-type          :metabase.upload/pk)
 (def ^:private pk-schema [:map
                           [:type [:= pk-type]]
-                          [:opts [:or [:= [:primary-key]]
-                                      [:= [:auto-increment [:not nil]]]]]
+                          [:opts  [:vector keyword?]]
                           [:exclude-in-insert? {:optional true} boolean?]])
 
 (defn- do-with-mysql-local-infile-activated
@@ -517,7 +516,7 @@
                      (column-names-for-table table)))
               (is (=? {:name                       #"(?i)id"
                        :semantic_type              :type/PK
-                       :database_is_auto_increment true}
+                       :database_is_auto_increment false}
                       (t2/select-one Field :database_position 0 :table_id (:id table)))))))))))
 
 (deftest load-from-csv-reserved-db-words-test

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -20,15 +20,15 @@
 
 (set! *warn-on-reflection* true)
 
-(def ^:private bool-type      :metabase.upload/boolean)
-(def ^:private int-type       :metabase.upload/int)
-(def ^:private float-type     :metabase.upload/float)
-(def ^:private vchar-type     :metabase.upload/varchar_255)
-(def ^:private date-type      :metabase.upload/date)
-(def ^:private datetime-type  :metabase.upload/datetime)
-(def ^:private text-type      :metabase.upload/text)
-(def ^:private int-pk-type    :metabase.upload/int-pk)
-(def ^:private ai-int-pk-type :metabase.upload/auto-incrementing-int-pk)
+(def ^:private bool-type      ::upload/boolean)
+(def ^:private int-type       ::upload/int)
+(def ^:private float-type     ::upload/float)
+(def ^:private vchar-type     ::upload/varchar_255)
+(def ^:private date-type      ::upload/date)
+(def ^:private datetime-type  ::upload/datetime)
+(def ^:private text-type      ::upload/text)
+(def ^:private int-pk-type    ::upload/int-pk)
+(def ^:private ai-int-pk-type ::upload/auto-incrementing-int-pk)
 
 (defn- do-with-mysql-local-infile-activated
   "Helper for [[with-mysql-local-infile-activated]]"
@@ -484,7 +484,9 @@
            "upload_test"
            (csv-file-with ["id,ship,name,weapon"
                            "1,Serenity,Malcolm Reynolds,Pistol"
-                           "2,Millennium Falcon, Han Solo,Blaster"])))
+                           "2,Millennium Falcon,Han Solo,Blaster"
+                           ;; A huge ID to make extra sure we're using bigints
+                           "9000000000,Razor Crest,Din Djarin,Spear"])))
         (testing "Table and Fields exist after sync"
           (sync/sync-database! (mt/db))
           (let [table (t2/select-one Table :db_id (mt/id))]
@@ -494,6 +496,7 @@
                      (column-names-for-table table)))
               (is (=? {:name                       #"(?i)id"
                        :semantic_type              :type/PK
+                       :base_type                  :type/BigInteger
                        :database_is_auto_increment false}
                       (t2/select-one Field :database_position 0 :table_id (:id table)))))))))))
 


### PR DESCRIPTION
Closes #33714

[Product doc](https://www.notion.so/metabase/Auto-generate-assign-PKs-for-CSV-uploads-b083f9aa198c4040bc09bb1214321d74)

* it was easier to return the column names as keywords than keywordize them later
* big decision was to make the PK column part of the schema detection instead of adding it later. I think overall that worked out pretty clean. Slightly annoying to update all the tests, but I think it's worth it. Will also give us some nice flexibility down the road, I think.