### PR TITLE
[WIP] Use github actions reporter for jest

### DIFF
--- a/frontend/src/metabase/entities/collections/utils.unit.spec.ts
+++ b/frontend/src/metabase/entities/collections/utils.unit.spec.ts
@@ -18,6 +18,8 @@ describe("buildCollectionTree", () => {
       icon: { name: "folder" },
       children: [],
     });
+
+    expect(1).toBeLessThan(0); // FIXME testing this failure
   });
 
   it("prefers originalName over name for schema names", () => {

--- a/jest.config.json
+++ b/jest.config.json
@@ -38,6 +38,7 @@
     "ace": {},
     "ga": {}
   },
+  "reporters": [["github-actions", {"silent": false}], "summary"],
   "coverageDirectory": "./coverage",
   "coverageReporters": ["html", "lcov"],
   "collectCoverageFrom": [


### PR DESCRIPTION
### Description

As of v28, Jest now includes a github actions annotation reporter:

https://jestjs.io/blog/2022/04/25/jest-28#github-actions-reporter
https://jestjs.io/docs/configuration#github-actions-reporter

This enables it

![newReporter](https://github.com/metabase/metabase/assets/30528226/831c127c-dcac-40ef-b02c-72a78ceeaa27)
![Screen Shot 2023-09-27 at 11 17 31 AM](https://github.com/metabase/metabase/assets/30528226/89ad5a7e-d466-4b83-93ce-b97e7916d248)


### How to verify

I made a test fail, check it out.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
