### PR TITLE
[E2E] Fix flaky reproduction #22859

### DIFF
--- a/e2e/test/scenarios/joins/reproductions/22859-multi-nested-joins-wrong-aliasing.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/22859-multi-nested-joins-wrong-aliasing.cy.spec.js
@@ -3,12 +3,12 @@ import {
   popover,
   visualize,
   startNewQuestion,
-  openOrdersTable,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
-const { REVIEWS, REVIEWS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+const { REVIEWS, REVIEWS_ID, PRODUCTS, PRODUCTS_ID, ORDERS_ID, ORDERS } =
+  SAMPLE_DATABASE;
 
 const questionDetails = {
   name: "22859-Q1",
@@ -31,38 +31,45 @@ const questionDetails = {
 
 describe("issue 22859 - multiple levels of nesting", () => {
   beforeEach(() => {
-    cy.intercept("POST", "/api/card").as("saveQuestion");
-
     restore();
     cy.signInAsAdmin();
 
     cy.createQuestion(questionDetails, { wrapId: true, idAlias: "q1Id" });
 
     // Join Orders table with the previously saved question and save it again
-    openOrdersTable({ mode: "notebook" });
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Join data").click();
+    cy.get("@q1Id").then(id => {
+      const nestedQuestionDetails = {
+        name: "22859-Q2",
+        query: {
+          "source-table": ORDERS_ID,
+          joins: [
+            {
+              fields: "all",
+              alias: `Question ${id}`,
+              condition: [
+                "=",
+                ["field", ORDERS.PRODUCT_ID, { "base-type": "type/Integer" }],
+                [
+                  "field",
+                  REVIEWS.PRODUCT_ID,
+                  {
+                    "base-type": "type/Integer",
+                    "join-alias": `Question ${id}`,
+                  },
+                ],
+              ],
+              "source-table": `card__${id}`,
+            },
+          ],
+          limit: 5,
+        },
+      };
 
-    popover().within(() => {
-      cy.findByText("Sample Database").click();
-      cy.findByText("Raw Data").click();
-      cy.findByText("Saved Questions").click();
-      cy.findByText(questionDetails.name).click();
+      cy.createQuestion(nestedQuestionDetails, {
+        wrapId: true,
+        idAlias: "q2Id",
+      });
     });
-
-    popover().contains("Product ID").click();
-
-    popover().contains("Product ID").click();
-
-    visualize();
-
-    saveQuestion("22859-Q2");
-
-    cy.wait("@saveQuestion").then(({ response: { body } }) =>
-      cy.wrap(body.id).as("q2Id"),
-    );
-
-    getJoinedTableColumnHeader();
   });
 
   it("model based on multi-level nested saved question should work (metabase#22859-1)", () => {
@@ -70,6 +77,7 @@ describe("issue 22859 - multiple levels of nesting", () => {
       // Convert the second question to a model
       cy.request("PUT", `/api/card/${id}`, { dataset: true });
 
+      cy.intercept("POST", "/api/dataset").as("dataset");
       cy.visit(`/model/${id}`);
       cy.wait("@dataset");
     });
@@ -79,30 +87,16 @@ describe("issue 22859 - multiple levels of nesting", () => {
 
   it("third level of nesting with joins should result in proper column aliasing (metabase#22859-2)", () => {
     startNewQuestion();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Saved Questions").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("22859-Q2").click();
+    popover().within(() => {
+      cy.findByText("Saved Questions").click();
+      cy.findByText("22859-Q2").click();
+    });
 
     visualize();
 
     getJoinedTableColumnHeader();
   });
 });
-
-function saveQuestion(name) {
-  cy.findByText("Save").click();
-  // TODO -- this name is all wrong but the metadata for Question 4 appears to be missing here for whatever reason,
-  //  if we fix that bug then this should actually be `Orders + 22859-Q1`
-  cy.findByDisplayValue(/Orders \+ Question \d+/)
-    .clear()
-    .type(name)
-    .blur();
-
-  cy.button("Save").click();
-  cy.wait(100);
-  cy.button("Not now").click();
-}
 
 function getJoinedTableColumnHeader() {
   cy.get("@q1Id").then(id => {


### PR DESCRIPTION
This reproduction relies heavily on the UI user flow, but that wasn't a broken part in the original issue. Ironically, the flake always happens in the unrelated UI part.

Example: https://www.deploysentinel.com/ci/runs/6512dbd198a3d35cdc93375b

### The fix
By using API to set up the nested question, we've removed the need for slow and flaky UI flow while still retaining the confidence that this test actually reproduces the original issue.

The stress-test (20x) is running here:
https://github.com/metabase/metabase/actions/runs/6330584560