### PR TITLE
Automatically re-run failed backports

### DIFF
--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: [Backend, Driver Tests, E2E Tests, Frontend]
     types: [completed]
-    branches: [master, 'release-x.**']
+    branches: [master, 'release-x.**', 'backport-**']
 
 jobs:
   rerun-on-failure:


### PR DESCRIPTION
Backported PRs are often piling up due to failed CI jobs.
In 95% of the cases it's just a matter of a flake, and not a real failure. So it makes sense to automatically retry these failures. This should help developers spend less time babysitting backported PRs, and (more importantly) will put the emphasis on the real failures.
