### PR TITLE
🍒 Manual backport: Remove time-series grouping widget for custom date breakout

### DIFF
--- a/frontend/src/metabase-types/api/query.ts
+++ b/frontend/src/metabase-types/api/query.ts
@@ -357,7 +357,8 @@ export type Expression =
       ExpressionOperand,
       ExpressionOperand,
       ExpressionOperand,
-    ];
+    ]
+  | ConcreteFieldReference;
 
 type ExpressionOperator = string;
 type ExpressionOperand =

--- a/frontend/src/metabase/modes/components/TimeseriesGroupingWidget.jsx
+++ b/frontend/src/metabase/modes/components/TimeseriesGroupingWidget.jsx
@@ -30,7 +30,9 @@ export default class TimeseriesGroupingWidget extends Component {
       return (
         <PopoverWithTrigger
           triggerElement={
-            <SelectButton hasValue>{dimension.subDisplayName()}</SelectButton>
+            <SelectButton hasValue dataTestId="time-series-grouping">
+              {dimension.subDisplayName()}
+            </SelectButton>
           }
           triggerClasses="my2"
           ref={ref => (this._popover = ref)}

--- a/frontend/src/metabase/modes/components/modes/TimeseriesMode.jsx
+++ b/frontend/src/metabase/modes/components/modes/TimeseriesMode.jsx
@@ -1,29 +1,6 @@
-/* eslint-disable react/prop-types */
-import { t } from "ttag";
-import TimeseriesFilterWidget from "metabase/modes/components/TimeseriesFilterWidget";
-import TimeseriesGroupingWidget from "metabase/modes/components/TimeseriesGroupingWidget";
 import { getPivotDrill } from "metabase/modes/components/drill/PivotDrill";
+import { TimeseriesModeFooter } from "metabase/visualizations/click-actions/components/TimeseriesModeFooter";
 import DefaultMode from "./DefaultMode";
-
-const TimeseriesModeFooter = props => {
-  const onChange = question => {
-    const { updateQuestion } = props;
-    updateQuestion(question, { run: true });
-  };
-
-  return (
-    <div className="flex layout-centered">
-      <span className="mr1">{t`View`}</span>
-      <TimeseriesFilterWidget {...props} card={props.lastRunCard} />
-      <span className="mx1">{t`by`}</span>
-      <TimeseriesGroupingWidget
-        {...props}
-        onChange={onChange}
-        card={props.lastRunCard}
-      />
-    </div>
-  );
-};
 
 const TimeseriesMode = {
   name: "timeseries",

--- a/frontend/src/metabase/modes/types.ts
+++ b/frontend/src/metabase/modes/types.ts
@@ -1,11 +1,18 @@
 import type React from "react";
 import type { Dispatch, GetState } from "metabase-types/store";
-import type { Series, VisualizationSettings } from "metabase-types/api";
+import type {
+  Card,
+  DatasetQuery,
+  Series,
+  VisualizationSettings,
+} from "metabase-types/api";
+import { UpdateQuestionOpts } from "metabase/query_builder/actions";
 import type Question from "metabase-lib/Question";
 import type {
   ClickActionProps,
   OnChangeCardAndRun,
 } from "metabase-lib/queries/drills/types";
+import type StructuredQuery from "metabase-lib/queries/StructuredQuery";
 
 export type {
   ClickActionProps,
@@ -106,11 +113,25 @@ export const isQuestionChangeClickAction = (
   clickAction: ClickAction,
 ): clickAction is QuestionChangeClickAction => "question" in clickAction;
 
-export const AlwaysDefaultClickAction = (
+export const isAlwaysDefaultClickAction = (
   clickAction: ClickAction,
 ): clickAction is AlwaysDefaultClickAction =>
   "defaultAlways" in clickAction && clickAction.defaultAlways;
 
 export const isRegularClickAction = (
   clickAction: ClickAction,
-): clickAction is RegularClickAction => !AlwaysDefaultClickAction(clickAction);
+): clickAction is RegularClickAction =>
+  !isAlwaysDefaultClickAction(clickAction);
+
+export interface ModeFooterComponentProps {
+  lastRunCard: Card;
+  question: Question;
+  query: StructuredQuery;
+  className?: string;
+
+  updateQuestion: (newQuestion: Question, options?: UpdateQuestionOpts) => void;
+  setDatasetQuery: (
+    datasetQuery: DatasetQuery,
+    options?: UpdateQuestionOpts,
+  ) => void;
+}

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -51,6 +51,37 @@ const TEST_CARD = createMockCard({
   dataset: true,
 });
 
+const TEST_TIME_SERIES_WITH_DATE_BREAKOUT_CARD = createMockCard({
+  ...TEST_CARD,
+  dataset: false,
+  dataset_query: {
+    database: SAMPLE_DB_ID,
+    type: "query",
+    query: {
+      "source-table": ORDERS_ID,
+      aggregation: [["count"]],
+      breakout: [["field", ORDERS.CREATED_AT, null]],
+    },
+  },
+});
+
+const TEST_TIME_SERIES_WITH_CUSTOM_DATE_BREAKOUT_CARD = createMockCard({
+  ...TEST_CARD,
+  dataset: false,
+  dataset_query: {
+    database: SAMPLE_DB_ID,
+    type: "query",
+    query: {
+      "source-table": ORDERS_ID,
+      aggregation: [["count"]],
+      breakout: [["expression", "Custom Created At"]],
+      expressions: {
+        "Custom Created At": ["field", ORDERS.CREATED_AT, null],
+      },
+    },
+  },
+});
+
 const TEST_CARD_VISUALIZATION = createMockCard({
   ...TEST_CARD,
   dataset_query: {
@@ -228,6 +259,43 @@ describe("QueryBuilder", () => {
         });
 
         expect(screen.getByDisplayValue(TEST_CARD.name)).toBeInTheDocument();
+      });
+
+      it("renders time series grouping widget for date field breakout", async () => {
+        await setup({
+          card: TEST_TIME_SERIES_WITH_DATE_BREAKOUT_CARD,
+        });
+        const timeSeriesModeFooter = await screen.findByTestId(
+          "time-series-mode-footer",
+        );
+        expect(timeSeriesModeFooter).toBeInTheDocument();
+        expect(
+          within(timeSeriesModeFooter).getByText("by"),
+        ).toBeInTheDocument();
+        expect(
+          within(timeSeriesModeFooter).getByTestId(
+            "time-series-grouping-select-button",
+          ),
+        ).toBeInTheDocument();
+      });
+
+      it("doesn't render time series grouping widget for custom date field breakout (metabase#33504)", async () => {
+        await setup({
+          card: TEST_TIME_SERIES_WITH_CUSTOM_DATE_BREAKOUT_CARD,
+        });
+
+        const timeSeriesModeFooter = await screen.findByTestId(
+          "time-series-mode-footer",
+        );
+        expect(timeSeriesModeFooter).toBeInTheDocument();
+        expect(
+          within(timeSeriesModeFooter).queryByText("by"),
+        ).not.toBeInTheDocument();
+        expect(
+          within(timeSeriesModeFooter).queryByTestId(
+            "time-series-grouping-select-button",
+          ),
+        ).not.toBeInTheDocument();
       });
     });
 

--- a/frontend/src/metabase/visualizations/click-actions/components/TimeseriesModeFooter.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/components/TimeseriesModeFooter.tsx
@@ -1,0 +1,44 @@
+import { t } from "ttag";
+import type { ModeFooterComponentProps } from "metabase/modes/types";
+import TimeseriesFilterWidget from "metabase/modes/components/TimeseriesFilterWidget";
+import TimeseriesGroupingWidget from "metabase/modes/components/TimeseriesGroupingWidget";
+import type Question from "metabase-lib/Question";
+import StructuredQuery from "metabase-lib/queries/StructuredQuery";
+
+type Props = ModeFooterComponentProps;
+
+export const TimeseriesModeFooter = (props: Props): JSX.Element | null => {
+  const onChange = (question: Question) => {
+    const { updateQuestion } = props;
+    updateQuestion(question, { run: true });
+  };
+
+  // We could encounter stale `mode` e.g. when converting a question from GUI to native,
+  // the `mode` would remain `timeseries` when it should have been `native` instead.
+  // So we shouldn't assume we'll always get time series question here.
+  if (!(props.query instanceof StructuredQuery)) {
+    return null;
+  }
+  const [breakout] = props.query.breakouts();
+  if (!breakout) {
+    return null;
+  }
+  const hasTimeSeriesGroupingWidget = !breakout.dimension().isExpression();
+
+  return (
+    <div className="flex layout-centered" data-testid="time-series-mode-footer">
+      <span className="mr1">{t`View`}</span>
+      <TimeseriesFilterWidget {...props} card={props.lastRunCard} />
+      {hasTimeSeriesGroupingWidget && (
+        <>
+          <span className="mx1">{t`by`}</span>
+          <TimeseriesGroupingWidget
+            {...props}
+            onChange={onChange}
+            card={props.lastRunCard}
+          />
+        </>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
Manual backport of #33810 

Here is the summary of what I did differently from the original PR.
1. Fix conflicts in `frontend/src/metabase/modes/components/modes/TimeseriesMode.jsx`, removing the inline `TimeseriesModeFooter`
2. Ignore the test ID changes in 3 E2E test suites because they don't exist in this 47 branch.
3. Fix conflicts in `frontend/src/metabase/modes/types.ts`, on master the change is in `frontend/src/metabase/visualizations/types/click-actions.ts`, so I only backport `ModeFooterComponentProps` type which is used in the original PR.