### PR TITLE
Add basic MLv2-based `FilterPicker` and `FilterStep`

### DIFF
--- a/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
@@ -5,16 +5,15 @@ import { QueryColumnPicker } from "../QueryColumnPicker";
 export interface FilterPickerProps {
   query: Lib.Query;
   stageIndex: number;
+  filter?: Lib.FilterClause;
   onSelect: (filter: Lib.FilterClause) => void;
   onClose?: () => void;
 }
 
-export function FilterPicker({
-  query,
-  stageIndex,
-  onClose,
-}: FilterPickerProps) {
-  const [, setColumn] = useState<Lib.ColumnMetadata | null>(null);
+export function FilterPicker({ query, stageIndex, filter }: FilterPickerProps) {
+  const [column, setColumn] = useState<Lib.ColumnMetadata | null>(
+    getInitialColumn(query, stageIndex, filter),
+  );
 
   const columnGroups = useMemo(() => {
     const columns = Lib.filterableColumns(query, stageIndex);
@@ -22,6 +21,10 @@ export function FilterPicker({
   }, [query, stageIndex]);
 
   const checkColumnSelected = () => false;
+
+  if (column) {
+    return <div>✨ Filter editor ✨</div>;
+  }
 
   return (
     <QueryColumnPicker
@@ -31,7 +34,22 @@ export function FilterPicker({
       color="filter"
       checkIsColumnSelected={checkColumnSelected}
       onSelect={setColumn}
-      onClose={onClose}
     />
   );
+}
+
+function getInitialColumn(
+  query: Lib.Query,
+  stageIndex: number,
+  filter?: Lib.FilterClause,
+) {
+  if (filter) {
+    const {
+      args: [maybeColumn],
+    } = Lib.expressionParts(query, stageIndex, filter);
+
+    return Lib.isColumnMetadata(maybeColumn) ? maybeColumn : null;
+  }
+
+  return null;
 }

--- a/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
@@ -1,0 +1,37 @@
+import { useMemo, useState } from "react";
+import * as Lib from "metabase-lib";
+import { QueryColumnPicker } from "../QueryColumnPicker";
+
+export interface FilterPickerProps {
+  query: Lib.Query;
+  stageIndex: number;
+  onSelect: (filter: Lib.FilterClause) => void;
+  onClose?: () => void;
+}
+
+export function FilterPicker({
+  query,
+  stageIndex,
+  onClose,
+}: FilterPickerProps) {
+  const [, setColumn] = useState<Lib.ColumnMetadata | null>(null);
+
+  const columnGroups = useMemo(() => {
+    const columns = Lib.filterableColumns(query, stageIndex);
+    return Lib.groupColumns(columns);
+  }, [query, stageIndex]);
+
+  const checkColumnSelected = () => false;
+
+  return (
+    <QueryColumnPicker
+      query={query}
+      stageIndex={stageIndex}
+      columnGroups={columnGroups}
+      color="filter"
+      checkIsColumnSelected={checkColumnSelected}
+      onSelect={setColumn}
+      onClose={onClose}
+    />
+  );
+}

--- a/frontend/src/metabase/common/components/FilterPicker/FilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterPicker.unit.spec.tsx
@@ -1,0 +1,55 @@
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "__support__/ui";
+import * as Lib from "metabase-lib";
+import { createQuery, columnFinder } from "metabase-lib/test-helpers";
+import { FilterPicker } from "./FilterPicker";
+
+function createQueryWithFilter() {
+  const initialQuery = createQuery();
+  const columns = Lib.filterableColumns(initialQuery, 0);
+  const findColumn = columnFinder(initialQuery, columns);
+  const totalColumn = findColumn("ORDERS", "TOTAL");
+  const clause = Lib.expressionClause(">", [totalColumn, 20], null);
+  const query = Lib.filter(initialQuery, 0, clause);
+  const [filter] = Lib.filters(query, 0);
+  return { query, filter };
+}
+
+type SetupOpts = {
+  query?: Lib.Query;
+  filter?: Lib.FilterClause;
+};
+
+function setup({ query = createQuery(), filter }: SetupOpts = {}) {
+  const onSelect = jest.fn();
+
+  render(
+    <FilterPicker
+      query={query}
+      stageIndex={0}
+      filter={filter}
+      onSelect={onSelect}
+    />,
+  );
+}
+
+describe("FilterPicker", () => {
+  describe("without a filter", () => {
+    it("should list filterable columns", () => {
+      setup();
+
+      expect(screen.getByText("Order")).toBeInTheDocument();
+      expect(screen.getByText("Discount")).toBeInTheDocument();
+
+      userEvent.click(screen.getByText("Product"));
+      expect(screen.getByText("Category")).toBeInTheDocument();
+    });
+  });
+
+  describe("with a filter", () => {
+    it("should show the filter editor", () => {
+      setup(createQueryWithFilter());
+      expect(screen.getByText(/filter editor/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/metabase/common/components/FilterPicker/index.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/index.ts
@@ -1,0 +1,1 @@
+export * from "./FilterPicker";

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -13,7 +13,7 @@ import { StyledAccordionList } from "./QueryColumnPicker.styled";
 
 const DEFAULT_MAX_HEIGHT = 610;
 
-type ColumnListItem = Lib.ColumnDisplayInfo & {
+export type ColumnListItem = Lib.ColumnDisplayInfo & {
   column: Lib.ColumnMetadata;
 };
 

--- a/frontend/src/metabase/common/components/QueryColumnPicker/index.ts
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/index.ts
@@ -1,1 +1,1 @@
-export { QueryColumnPicker } from "./QueryColumnPicker";
+export * from "./QueryColumnPicker";

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/steps.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/steps.ts
@@ -7,7 +7,7 @@ import type { IconName } from "metabase/core/components/Icon";
 import { DataStep } from "../steps/DataStep";
 import { JoinStep } from "../steps/JoinStep";
 import ExpressionStep from "../steps/ExpressionStep";
-import FilterStep from "../steps/FilterStep";
+import { FilterStep } from "../steps/FilterStep";
 import { AggregateStep } from "../steps/AggregateStep";
 import BreakoutStep from "../steps/BreakoutStep";
 import SummarizeStep from "../steps/SummarizeStep";

--- a/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep/FilterStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep/FilterStep.tsx
@@ -2,8 +2,8 @@ import { t } from "ttag";
 
 import { FilterPopover } from "metabase/query_builder/components/filters/FilterPopover";
 
-import type { NotebookStepUiComponentProps } from "../types";
-import ClauseStep from "./ClauseStep";
+import type { NotebookStepUiComponentProps } from "../../types";
+import ClauseStep from "../ClauseStep";
 
 function FilterStep({
   query,

--- a/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep/FilterStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep/FilterStep.tsx
@@ -1,37 +1,74 @@
+import { useMemo } from "react";
 import { t } from "ttag";
-
-import { FilterPopover } from "metabase/query_builder/components/filters/FilterPopover";
-
+import { FilterPicker } from "metabase/common/components/FilterPicker";
+import * as Lib from "metabase-lib";
 import type { NotebookStepUiComponentProps } from "../../types";
 import ClauseStep from "../ClauseStep";
 
 export function FilterStep({
-  query,
+  topLevelQuery,
+  step,
   color,
   isLastOpened,
   readOnly,
   updateQuery,
 }: NotebookStepUiComponentProps) {
+  const { stageIndex } = step;
+
+  const filters = useMemo(
+    () => Lib.filters(topLevelQuery, stageIndex),
+    [topLevelQuery, stageIndex],
+  );
+
+  const handleAddFilter = (filter: Lib.FilterClause) => {
+    const nextQuery = Lib.filter(topLevelQuery, stageIndex, filter);
+    updateQuery(nextQuery);
+  };
+
+  const handleUpdateFilter = (
+    filter: Lib.FilterClause,
+    nextFilter: Lib.FilterClause,
+  ) => {
+    const nextQuery = Lib.replaceClause(
+      topLevelQuery,
+      stageIndex,
+      filter,
+      nextFilter,
+    );
+    updateQuery(nextQuery);
+  };
+
+  const handleRemoveFilter = (filter: Lib.FilterClause) => {
+    const nextQuery = Lib.removeClause(topLevelQuery, stageIndex, filter);
+    updateQuery(nextQuery);
+  };
+
+  const renderFilterName = (filter: Lib.FilterClause) =>
+    Lib.displayInfo(topLevelQuery, stageIndex, filter).longDisplayName;
+
   return (
     <ClauseStep
-      color={color}
+      items={filters}
       initialAddText={t`Add filters to narrow your answer`}
-      items={query.filters()}
-      renderName={item => item.displayName()}
       readOnly={readOnly}
+      color={color}
+      isLastOpened={isLastOpened}
+      renderName={renderFilterName}
       renderPopover={filter => (
-        <FilterPopover
-          query={query}
+        <FilterPicker
+          query={topLevelQuery}
+          stageIndex={stageIndex}
           filter={filter}
-          onChangeFilter={newFilter =>
-            filter
-              ? updateQuery(filter.replace(newFilter))
-              : updateQuery(query.filter(newFilter))
-          }
+          onSelect={nextFilter => {
+            if (filter) {
+              handleUpdateFilter(filter, nextFilter);
+            } else {
+              handleAddFilter(nextFilter);
+            }
+          }}
         />
       )}
-      isLastOpened={isLastOpened}
-      onRemove={filter => updateQuery(filter.remove())}
+      onRemove={handleRemoveFilter}
     />
   );
 }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep/FilterStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep/FilterStep.tsx
@@ -5,7 +5,7 @@ import { FilterPopover } from "metabase/query_builder/components/filters/FilterP
 import type { NotebookStepUiComponentProps } from "../../types";
 import ClauseStep from "../ClauseStep";
 
-function FilterStep({
+export function FilterStep({
   query,
   color,
   isLastOpened,
@@ -35,6 +35,3 @@ function FilterStep({
     />
   );
 }
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default FilterStep;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep/FilterStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep/FilterStep.unit.spec.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "__support__/ui";
+import * as Lib from "metabase-lib";
+import { createQuery, columnFinder } from "metabase-lib/test-helpers";
+import { createMockNotebookStep } from "../../test-utils";
+import { FilterStep } from "./FilterStep";
+
+function createQueryWithFilter() {
+  const initialQuery = createQuery();
+  const columns = Lib.filterableColumns(initialQuery, 0);
+  const findColumn = columnFinder(initialQuery, columns);
+  const totalColumn = findColumn("ORDERS", "TOTAL");
+  const clause = Lib.expressionClause(">", [totalColumn, 20], null);
+  const query = Lib.filter(initialQuery, 0, clause);
+  const [filter] = Lib.filters(query, 0);
+  return { query, filter };
+}
+
+function setup(step = createMockNotebookStep()) {
+  const updateQuery = jest.fn();
+
+  render(
+    <FilterStep
+      step={step}
+      query={step.query}
+      topLevelQuery={step.topLevelQuery}
+      color="filter"
+      isLastOpened={false}
+      reportTimezone="UTC"
+      updateQuery={updateQuery}
+    />,
+  );
+}
+
+describe("FilterStep", () => {
+  it("should render without filters", () => {
+    setup();
+    expect(
+      screen.getByText("Add filters to narrow your answer"),
+    ).toBeInTheDocument();
+  });
+
+  it("should render filters", () => {
+    const { query } = createQueryWithFilter();
+    setup(createMockNotebookStep({ topLevelQuery: query }));
+    expect(screen.getByText("Total is greater than 20")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep/index.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./FilterStep";
+export * from "./FilterStep";

--- a/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep/index.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/no-default-export -- deprecated usage
+export { default } from "./FilterStep";


### PR DESCRIPTION
Closes #34130, epic #34112

Adds very basic MLv2-based `FilterPicker` and `FilterStep` components. So far, they both only allow selecting a column to filter on. Once a column is selected, it displays a filter editor placeholder