### PR TITLE
Optimize changed files check for the backend.yml workflow

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -47,7 +47,7 @@ jobs:
         uses: ./.github/actions/prepare-backend
         with:
           m2-cache-key: "files-changed"
-      - name: Build static viz frontend
+      - name: Build static-viz frontend
         run: yarn build-static-viz
       - name: Upload Static Viz Bundle Artifact
         uses: actions/upload-artifact@v3
@@ -221,12 +221,18 @@ jobs:
         uses: ./.github/actions/prepare-backend
         with:
           m2-cache-key: be-tests
-
+      # Depending on which files changed, we might either have to build static-viz
+      # from scratch or download the previously built artifact
+      - name: Build static-viz frontend
+        if: needs.files-changed.outputs.backend_all == 'true'
+        run: yarn build-static-viz
       - name: Download Static Viz Bundle Artifact
+        if: needs.static-viz-files-changed.outputs.static_viz == 'true'
         uses: actions/download-artifact@v3
         with:
           name: static-viz-bundle-${{ github.sha }}
           path: resources/frontend_client/app/dist
+
       - name: Run tests
         run: clojure -X:dev:ci:test:${{ matrix.edition }}:${{ matrix.edition }}-dev
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -19,9 +19,25 @@ jobs:
   files-changed:
     name: Check which files changed
     runs-on: ubuntu-22.04
-    timeout-minutes: 6
+    timeout-minutes: 5
     outputs:
-      backend_all: ${{ steps.changes.outputs.backend_all }}
+      static_viz: ${{ steps.static_viz.outputs.static_viz }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Test which files changed
+        uses: dorny/paths-filter@v2.11.1
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-paths.yaml
+
+  static-viz-files-changed:
+    needs: files-changed
+    if: needs.files-changed.outputs.backend_all != 'true'
+    name: Check whether static-viz files changed
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    outputs:
       static_viz: ${{ steps.static_viz.outputs.static_viz }}
     steps:
       - uses: actions/checkout@v3
@@ -38,12 +54,7 @@ jobs:
         with:
           name: static-viz-bundle-${{ github.sha }}
           path: resources/frontend_client/app/dist
-      - name: Test which files changed
-        uses: dorny/paths-filter@v2.11.1
-        id: changes
-        with:
-          token: ${{ github.token }}
-          filters: .github/file-paths.yaml
+
       - name: Check for static viz changes
         uses: dorny/paths-filter@v2.11.1
         id: static_viz
@@ -73,8 +84,8 @@ jobs:
           flags: back-end
 
   be-linter-clj-kondo:
-    needs: files-changed
-    if: needs.files-changed.outputs.backend_all == 'true' || needs.files-changed.outputs.static_viz == 'true'
+    needs: [files-changed, static-viz-files-changed]
+    if: needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     env:
@@ -131,8 +142,8 @@ jobs:
           ./modules/drivers/vertica/test
 
   be-linter-eastwood:
-    needs: files-changed
-    if: github.event.pull_request.draft == false && (needs.files-changed.outputs.backend_all == 'true' || needs.files-changed.outputs.static_viz == 'true')
+    needs: [files-changed, static-viz-files-changed]
+    if: github.event.pull_request.draft == false && (needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true')
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
@@ -148,8 +159,8 @@ jobs:
   # we have to extract that job manually here. Backend developers have requested that this
   # test runs at all times to give them an early warning sign is something is broken.
   be-tests-java-11-ee-pre-check:
-    needs: files-changed
-    if: github.event.pull_request.draft == true && (needs.files-changed.outputs.backend_all == 'true' || needs.files-changed.outputs.static_viz == 'true')
+    needs: [files-changed, static-viz-files-changed]
+    if: github.event.pull_request.draft == true && (needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true')
     runs-on: ubuntu-22.04
     name: be-tests-java-11-ee-pre-check
     timeout-minutes: 60
@@ -181,8 +192,8 @@ jobs:
           fail-on-error: false
 
   be-tests:
-    needs: files-changed
-    if: github.event.pull_request.draft == false && (needs.files-changed.outputs.backend_all == 'true' || needs.files-changed.outputs.static_viz == 'true')
+    needs: [files-changed, static-viz-files-changed]
+    if: github.event.pull_request.draft == false && (needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true')
     runs-on: ubuntu-22.04
     name: be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}
     timeout-minutes: 60
@@ -220,11 +231,11 @@ jobs:
           fail-on-error: false
 
   be-tests-stub:
-    needs: files-changed
+    needs: [files-changed, static-viz-files-changed]
     if: |
       always() &&
       github.event.pull_request.draft == false &&
-      (needs.files-changed.outputs.backend_all == 'false' && needs.files-changed.outputs.static_viz == 'false')
+      (needs.files-changed.outputs.backend_all == 'false' && needs.static-viz-files-changed.outputs.static_viz == 'false')
     runs-on: ubuntu-22.04
     name: be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}
     timeout-minutes: 5
@@ -240,8 +251,8 @@ jobs:
   # checks that all the namespaces we actually ship can be compiled, without any dependencies that we don't ship (such
   # as `:dev` dependencies). See #27009 for more context.
   be-check:
-    needs: files-changed
-    if: github.event.pull_request.draft == false && (needs.files-changed.outputs.backend_all == 'true' || needs.files-changed.outputs.static_viz == 'true')
+    needs: [files-changed, static-viz-files-changed]
+    if: github.event.pull_request.draft == false && (needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true')
     runs-on: ubuntu-22.04
     name: be-check-java-${{ matrix.java-version }}
     timeout-minutes: 10
@@ -258,11 +269,11 @@ jobs:
         run: clojure -M:ee:drivers:check
 
   be-check-stub:
-    needs: files-changed
+    needs: [files-changed, static-viz-files-changed]
     if: |
       always() &&
       github.event.pull_request.draft == false &&
-      (needs.files-changed.outputs.backend_all == 'false' && needs.files-changed.outputs.static_viz == 'false')
+      (needs.files-changed.outputs.backend_all == 'false' && needs.static-viz-files-changed.outputs.static_viz == 'false')
     runs-on: ubuntu-22.04
     name: be-check-java-${{ matrix.java-version }}
     timeout-minutes: 10

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -85,7 +85,9 @@ jobs:
 
   be-linter-clj-kondo:
     needs: [files-changed, static-viz-files-changed]
-    if: needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true'
+    if: |
+      !cancelled() &&
+      (needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true')
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     env:
@@ -143,7 +145,10 @@ jobs:
 
   be-linter-eastwood:
     needs: [files-changed, static-viz-files-changed]
-    if: github.event.pull_request.draft == false && (needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true')
+    if: |
+      !cancelled() &&
+      github.event.pull_request.draft == false &&
+      (needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true')
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
@@ -160,7 +165,10 @@ jobs:
   # test runs at all times to give them an early warning sign is something is broken.
   be-tests-java-11-ee-pre-check:
     needs: [files-changed, static-viz-files-changed]
-    if: github.event.pull_request.draft == true && (needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true')
+    if: |
+      !cancelled() &&
+      github.event.pull_request.draft == true &&
+      (needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true')
     runs-on: ubuntu-22.04
     name: be-tests-java-11-ee-pre-check
     timeout-minutes: 60
@@ -193,7 +201,10 @@ jobs:
 
   be-tests:
     needs: [files-changed, static-viz-files-changed]
-    if: github.event.pull_request.draft == false && (needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true')
+    if: |
+      !cancelled() &&
+      github.event.pull_request.draft == false &&
+      (needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true')
     runs-on: ubuntu-22.04
     name: be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}
     timeout-minutes: 60
@@ -252,7 +263,10 @@ jobs:
   # as `:dev` dependencies). See #27009 for more context.
   be-check:
     needs: [files-changed, static-viz-files-changed]
-    if: github.event.pull_request.draft == false && (needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true')
+    if: |
+      !cancelled() &&
+      github.event.pull_request.draft == false &&
+      (needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true')
     runs-on: ubuntu-22.04
     name: be-check-java-${{ matrix.java-version }}
     timeout-minutes: 10

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     outputs:
-      static_viz: ${{ steps.static_viz.outputs.static_viz }}
+      backend_all: ${{ steps.changes.outputs.backend_all }}
     steps:
       - uses: actions/checkout@v3
       - name: Test which files changed


### PR DESCRIPTION
New static viz check is GREAT!
But to get the output is expensive, as it requires to prepare both FE and BE, **and** to build static-viz bundle.

I think we can slightly improve this check.

### Before
1. prepare-frontend
2. prepare-backend
3. build-static-viz
4. files-changed-check
5. static-viz-files-changed-check

So, we're doing all these expensive operations before the step 4, even though they might not even be necessary.
If files changed already outputs `backend_all`, this means we have to run these tests whether or not there were static-viz changes.

### After
1. test which files changed
    - if `backend_all` output -> skip static-viz-bundle and start running tests straight away
    - else if there are no direct backend changes, have an additional check for static-viz
2. static-viz-files-changed
    - if true -> run tests
    - else -> skip tests