### PR TITLE
Fix `codeql` conditional run check

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,6 +24,7 @@ jobs:
           filters: .github/file-paths.yaml
   analyze:
     needs: files-changed
+    if: needs.files-changed.outputs.codeql == 'true'
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository


### PR DESCRIPTION
This workflow was always running, even though we had a files-check step all along.

🤦 