### PR TITLE
Remove extra driver/execute-write-query! sql-jdbc implementation

### DIFF
--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -347,21 +347,6 @@
              successes]))))
      rows)))
 
-(defmethod driver/execute-write-query! :sql-jdbc
-  [driver {{sql :query, :keys [params]} :native}]
-  {:pre [(string? sql)]}
-  (try
-    (let [{db-id :id} (lib.metadata/database (qp.store/metadata-provider))]
-      (with-jdbc-transaction [conn db-id]
-        (with-open [stmt (sql-jdbc.execute/statement-or-prepared-statement driver conn sql params nil)]
-          {:rows-affected (if (instance? PreparedStatement stmt)
-                            (.executeUpdate ^PreparedStatement stmt)
-                            (.executeUpdate stmt sql))})))
-    (catch Throwable e
-      (throw (ex-info (tru "Error executing write query: {0}" (ex-message e))
-                      {:sql sql, :params params, :type qp.error-type/invalid-query}
-                      e)))))
-
 ;;;; `:bulk/create`
 
 (defmethod actions/perform-action!* [:sql-jdbc :bulk/create]

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -10,12 +10,10 @@
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.util :as driver.u]
-   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.query-processor :as qp]
-   [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
    #_{:clj-kondo/ignore [:deprecated-namespace]}
@@ -25,7 +23,7 @@
    [metabase.util.malli :as mu]
    [schema.core :as s])
   (:import
-   (java.sql Connection PreparedStatement SQLException)))
+   (java.sql Connection SQLException)))
 
 (set! *warn-on-reflection* true)
 

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -700,6 +700,7 @@
   (try
     (do-with-connection-with-options
      driver
+     (lib.metadata/database (qp.store/metadata-provider))
      {:session-timezone (qp.timezone/report-timezone-id-if-supported driver (lib.metadata/database (qp.store/metadata-provider)))}
      (fn [^Connection conn]
        (with-open [stmt (statement-or-prepared-statement driver conn sql params nil)]


### PR DESCRIPTION
There are two implementations of `metabase.driver/execute-write-query!` with a dispatch value of `:sql-jdbc`. This PR removes the older one, because I assume that when the newer one was created ([PR](https://github.com/metabase/metabase/pull/22166)) it was intentionally modified by copying the old one.

I also [modified the newer implementation](https://github.com/metabase/metabase/pull/34216/files#diff-885821240479a14087c2ec8e287386ca49888288728b8ef0f94dc66b77987569R703) because `do-with-connection-with-options` was missing an argument. This doesn't result in failures currently because its implementation is overwritten in the built jar, so it's never used (I checked master and the latest 47 release).