### PR TITLE
Fix tests wtih unmocked http requests

### DIFF
--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.unit.spec.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.unit.spec.tsx
@@ -42,10 +42,10 @@ function setup({
   });
   const metadata = getMetadata(state);
   setupDatabaseUsageInfo(database, {
-    question: 1,
-    dataset: 1,
-    metric: 1,
-    segment: 1,
+    question: 0,
+    dataset: 0,
+    metric: 0,
+    segment: 0,
   });
 
   // Using mockResolvedValue since `ActionButton` component

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.unit.spec.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.unit.spec.tsx
@@ -1,6 +1,5 @@
 import _ from "underscore";
 import userEvent from "@testing-library/user-event";
-import fetchMock from "fetch-mock";
 import { checkNotNull } from "metabase/core/utils/types";
 import { getMetadata } from "metabase/selectors/metadata";
 import type { Database, InitialSyncStatus } from "metabase-types/api";
@@ -9,6 +8,7 @@ import {
   COMMON_DATABASE_FEATURES,
 } from "metabase-types/api/mocks";
 import { createMockState } from "metabase-types/store/mocks";
+import { setupDatabaseUsageInfo } from "__support__/server-mocks/database";
 import { createMockEntitiesState } from "__support__/store";
 import {
   renderWithProviders,
@@ -41,7 +41,12 @@ function setup({
     }),
   });
   const metadata = getMetadata(state);
-  fetchMock.get(`path:/api/database/${database.id}/usage_info`, {});
+  setupDatabaseUsageInfo(database, {
+    question: 1,
+    dataset: 1,
+    metric: 1,
+    segment: 1,
+  });
 
   // Using mockResolvedValue since `ActionButton` component
   // the Sidebar is using is expecting these callbacks to be async

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.unit.spec.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.unit.spec.tsx
@@ -1,5 +1,6 @@
 import _ from "underscore";
 import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
 import { checkNotNull } from "metabase/core/utils/types";
 import { getMetadata } from "metabase/selectors/metadata";
 import type { Database, InitialSyncStatus } from "metabase-types/api";
@@ -40,6 +41,7 @@ function setup({
     }),
   });
   const metadata = getMetadata(state);
+  fetchMock.get(`path:/api/database/${database.id}/usage_info`, {});
 
   // Using mockResolvedValue since `ActionButton` component
   // the Sidebar is using is expecting these callbacks to be async

--- a/frontend/src/metabase/admin/datamodel/components/MetricForm/MetricForm.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/MetricForm/MetricForm.unit.spec.tsx
@@ -4,8 +4,15 @@ import MetricApp from "metabase/admin/datamodel/containers/MetricApp";
 import { Route } from "metabase/hoc/Title";
 import { callMockEvent } from "__support__/events";
 import { BEFORE_UNLOAD_UNSAVED_MESSAGE } from "metabase/hooks/use-before-unload";
+import {
+  setupDatabasesEndpoints,
+  setupSearchEndpoints,
+} from "__support__/server-mocks";
+import { createMockDatabase } from "metabase-types/api/mocks";
 
 const setup = () => {
+  setupDatabasesEndpoints([createMockDatabase()]);
+  setupSearchEndpoints([]);
   renderWithProviders(
     <Route path="/admin/datamodel/metric/create" component={MetricApp} />,
     {

--- a/frontend/src/metabase/admin/datamodel/components/SegmentForm/SegmentForm.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/SegmentForm/SegmentForm.unit.spec.tsx
@@ -4,6 +4,11 @@ import { Route } from "metabase/hoc/Title";
 import { callMockEvent } from "__support__/events";
 import { BEFORE_UNLOAD_UNSAVED_MESSAGE } from "metabase/hooks/use-before-unload";
 import SegmentApp from "metabase/admin/datamodel/containers/SegmentApp";
+import {
+  setupDatabasesEndpoints,
+  setupSearchEndpoints,
+} from "__support__/server-mocks";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets/sample_database";
 
 const setup = () => {
   renderWithProviders(
@@ -20,6 +25,11 @@ const setup = () => {
 };
 
 describe("SegmentForm", () => {
+  beforeEach(() => {
+    setupDatabasesEndpoints([createSampleDatabase()]);
+    setupSearchEndpoints([]);
+  });
+
   afterEach(() => {
     jest.restoreAllMocks();
   });

--- a/frontend/src/metabase/auth/components/PasswordPanel/PasswordPanel.unit.spec.tsx
+++ b/frontend/src/metabase/auth/components/PasswordPanel/PasswordPanel.unit.spec.tsx
@@ -5,8 +5,13 @@ import {
   createMockSettingsState,
   createMockState,
 } from "metabase-types/store/mocks";
-import { setupLoginEndpoint } from "__support__/server-mocks";
+import {
+  setupCurrentUserEndpoint,
+  setupLoginEndpoint,
+  setupPropertiesEndpoints,
+} from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { createMockSettings, createMockUser } from "metabase-types/api/mocks";
 import { PasswordPanel } from "./PasswordPanel";
 
 const TEST_EMAIL = "user@example.test";
@@ -26,6 +31,8 @@ const setup = ({ isGoogleAuthEnabled = false }: SetupOpts = {}) => {
   MetabaseSettings.set("google-auth-enabled", isGoogleAuthEnabled);
 
   setupLoginEndpoint();
+  setupCurrentUserEndpoint(createMockUser());
+  setupPropertiesEndpoints(createMockSettings());
   renderWithProviders(<PasswordPanel />, { storeInitialState: state });
 };
 

--- a/frontend/src/metabase/common/hooks/use-dashboard-query/use-dashboard-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-dashboard-query/use-dashboard-query.unit.spec.tsx
@@ -1,6 +1,8 @@
-import fetchMock from "fetch-mock";
 import { createMockDashboard } from "metabase-types/api/mocks";
-import { setupDashboardEndpoints } from "__support__/server-mocks";
+import {
+  setupDashboardEndpoints,
+  setupDashboardNotFoundEndpoint,
+} from "__support__/server-mocks";
 import {
   renderWithProviders,
   screen,
@@ -41,7 +43,7 @@ describe("useDatabaseQuery", () => {
     expect(screen.getByText(TEST_DASHBOARD.name)).toBeInTheDocument();
   });
   it("should return an error when it can't find a dashboard", async () => {
-    fetchMock.get(`path:/api/dashboard/${TEST_DASHBOARD.id}`, 404);
+    setupDashboardNotFoundEndpoint(TEST_DASHBOARD);
     renderWithProviders(<TestComponent />);
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(screen.getByText("Error")).toBeInTheDocument();

--- a/frontend/src/metabase/common/hooks/use-dashboard-query/use-dashboard-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-dashboard-query/use-dashboard-query.unit.spec.tsx
@@ -1,3 +1,4 @@
+import fetchMock from "fetch-mock";
 import { createMockDashboard } from "metabase-types/api/mocks";
 import { setupDashboardEndpoints } from "__support__/server-mocks";
 import {
@@ -40,6 +41,7 @@ describe("useDatabaseQuery", () => {
     expect(screen.getByText(TEST_DASHBOARD.name)).toBeInTheDocument();
   });
   it("should return an error when it can't find a dashboard", async () => {
+    fetchMock.get(`path:/api/dashboard/${TEST_DASHBOARD.id}`, 404);
     renderWithProviders(<TestComponent />);
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(screen.getByText("Error")).toBeInTheDocument();

--- a/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/CategoryFingerprint.unit.spec.js
+++ b/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/CategoryFingerprint.unit.spec.js
@@ -21,22 +21,24 @@ const categoryField = Dimension.parseMBQL(
   metadata,
 ).field();
 
-const mockFetchFieldValues = jest.fn();
 function setup({
   field,
   fieldValues,
   fingerprint,
-  fetchFieldValues = mockFetchFieldValues,
+  fetchFieldValues = jest.fn().mockResolvedValue([]),
 }) {
   categoryField.fingerprint = fingerprint;
-  mockFetchFieldValues.mockReset();
-  return render(
-    <CategoryFingerprint
-      field={field}
-      fieldValues={fieldValues}
-      fetchFieldValues={mockFetchFieldValues}
-    />,
-  );
+
+  return {
+    ...render(
+      <CategoryFingerprint
+        field={field}
+        fieldValues={fieldValues}
+        fetchFieldValues={fetchFieldValues}
+      />,
+    ),
+    mockFetchFieldValues: fetchFieldValues,
+  };
 }
 
 describe("CategoryFingerprint", () => {
@@ -46,9 +48,10 @@ describe("CategoryFingerprint", () => {
     });
 
     it("should not fetch field values when field values are empty", () => {
-      setup({
+      const { mockFetchFieldValues } = setup({
         field: categoryField,
       });
+
       expect(mockFetchFieldValues).not.toHaveBeenCalled();
     });
 
@@ -85,16 +88,17 @@ describe("CategoryFingerprint", () => {
     });
 
     it("should fetch field values when field values are empty", () => {
-      setup({
+      const { mockFetchFieldValues } = setup({
         field: categoryField,
       });
+
       expect(mockFetchFieldValues).toHaveBeenCalledWith({
         id: categoryField.id,
       });
     });
 
-    it("should not fetch field values when field values are presnet", () => {
-      setup({
+    it("should not fetch field values when field values are present", () => {
+      const { mockFetchFieldValues } = setup({
         field: categoryField,
         fieldValues: ["foo", "bar"],
       });
@@ -104,7 +108,6 @@ describe("CategoryFingerprint", () => {
     it("should show a loading state while fetching", () => {
       setup({
         field: categoryField,
-        fetchFieldValues: () => new Promise(),
       });
       expect(screen.getByText("Getting distinct values...")).toBeVisible();
     });

--- a/frontend/src/metabase/containers/QuestionResultLoader.unit.spec.js
+++ b/frontend/src/metabase/containers/QuestionResultLoader.unit.spec.js
@@ -1,6 +1,8 @@
 import { render } from "@testing-library/react";
 
 import { QuestionResultLoader } from "metabase/containers/QuestionResultLoader";
+import { setupCardQueryEndpoints } from "__support__/server-mocks";
+import { createMockDataset } from "metabase-types/api/mocks";
 import Question from "metabase-lib/Question";
 
 describe("QuestionResultLoader", () => {
@@ -8,6 +10,7 @@ describe("QuestionResultLoader", () => {
     const question = new Question({
       id: 1,
     });
+    setupCardQueryEndpoints(question.card(), createMockDataset());
 
     const loadSpy = jest.spyOn(QuestionResultLoader.prototype, "_loadResult");
 

--- a/frontend/src/metabase/dashboard/actions/save.js
+++ b/frontend/src/metabase/dashboard/actions/save.js
@@ -139,6 +139,11 @@ export const updateDashboard = createThunkAction(
       const { dashboards, dashboardId } = state.dashboard;
       const dashboard = dashboards[dashboardId];
 
+      if (!dashboard) {
+        console.warn(`no dashboard with id ${dashboardId} were found`);
+        return;
+      }
+
       if (attributeNames.length > 0) {
         const attributes = _.pick(dashboard, attributeNames);
 

--- a/frontend/src/metabase/dashboard/components/AddSeriesModal/AddSeriesModal.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/AddSeriesModal/AddSeriesModal.unit.spec.tsx
@@ -10,6 +10,7 @@ import {
 } from "metabase-types/api/mocks";
 import registerVisualizations from "metabase/visualizations/register";
 
+import { setupCardsEndpoints } from "__support__/server-mocks";
 import type { Props as AddSeriesModalProps } from "./AddSeriesModal";
 import { AddSeriesModal } from "./AddSeriesModal";
 
@@ -93,6 +94,7 @@ const defaultProps = {
 };
 
 const setup = (options?: Partial<AddSeriesModalProps>) => {
+  setupCardsEndpoints([baseCard, firstCard, secondCard]);
   return renderWithProviders(<AddSeriesModal {...defaultProps} {...options} />);
 };
 

--- a/frontend/src/metabase/entities/containers/EntityName.unit.spec.tsx
+++ b/frontend/src/metabase/entities/containers/EntityName.unit.spec.tsx
@@ -3,6 +3,10 @@ import { screen } from "@testing-library/react";
 import { renderWithProviders } from "__support__/ui";
 import { createMockEntitiesState } from "__support__/store";
 import { createMockCard, createMockUser } from "metabase-types/api/mocks";
+import {
+  setupCardEndpoints,
+  setupUserEndpoints,
+} from "__support__/server-mocks";
 import { EntityName } from "./EntityName";
 
 describe("EntityName", () => {
@@ -11,6 +15,8 @@ describe("EntityName", () => {
       const mockUser = createMockUser({
         common_name: "Testy Tableton",
       });
+      setupUserEndpoints(mockUser);
+
       renderWithProviders(
         <EntityName entityType="users" entityId={mockUser.id} />,
         {
@@ -29,6 +35,7 @@ describe("EntityName", () => {
     test("question with name (metabase#33192)", async () => {
       const expectedQuestionName = "Mock Products question";
       const mockCard = createMockCard({ name: expectedQuestionName });
+      setupCardEndpoints(mockCard);
 
       renderWithProviders(
         <EntityName entityType="questions" entityId={mockCard.id} />,

--- a/frontend/src/metabase/nav/components/WhatsNewNotification/WhatsNewNotification.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/WhatsNewNotification/WhatsNewNotification.unit.spec.tsx
@@ -1,6 +1,8 @@
 import fetchMock from "fetch-mock";
 import type { VersionInfoRecord } from "metabase-types/api";
 import {
+  createMockSettingDefinition,
+  createMockSettings,
   createMockVersion,
   createMockVersionInfo,
   createMockVersionInfoRecord as mockVersion,
@@ -11,6 +13,10 @@ import {
 } from "metabase-types/store/mocks";
 import * as domUtils from "metabase/lib/dom";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import {
+  setupPropertiesEndpoints,
+  setupSettingsEndpoints,
+} from "__support__/server-mocks";
 import { WhatsNewNotification } from "./WhatsNewNotification";
 
 const LAST_ACK_SETTINGS_URL = `path:/api/setting/last-acknowledged-version`;
@@ -46,6 +52,8 @@ const setup = ({
     "version-info": createMockVersionInfo({ latest, older }),
     "last-acknowledged-version": lastAcknowledged,
   });
+  setupPropertiesEndpoints(createMockSettings());
+  setupSettingsEndpoints([createMockSettingDefinition()]);
 
   return renderWithProviders(<WhatsNewNotification></WhatsNewNotification>, {
     storeInitialState: createMockState({ settings: mockSettings }),

--- a/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.unit.spec.tsx
@@ -2,6 +2,7 @@ import userEvent from "@testing-library/user-event";
 import type { Parameter, ValuesQueryType } from "metabase-types/api";
 import { createMockParameter } from "metabase-types/api/mocks";
 import { renderWithProviders, screen } from "__support__/ui";
+import { setupParameterValuesEndpoints } from "__support__/server-mocks";
 import ValuesSourceSettings from "./ValuesSourceSettings";
 
 interface SetupOpts {
@@ -11,6 +12,7 @@ interface SetupOpts {
 const setup = ({ parameter }: SetupOpts) => {
   const onChangeQueryType = jest.fn();
   const onChangeSourceSettings = jest.fn();
+  setupParameterValuesEndpoints({ values: [], has_more_values: false });
 
   renderWithProviders(
     <ValuesSourceSettings

--- a/frontend/src/metabase/pulse/components/RecipientPicker.unit.spec.js
+++ b/frontend/src/metabase/pulse/components/RecipientPicker.unit.spec.js
@@ -22,6 +22,7 @@ describe("recipient picker", () => {
           users={TEST_USERS}
           isNewPulse={true}
           onRecipientsChange={() => alert("why?")}
+          invalidRecipientText={() => {}}
         />,
       );
       // Popover with all names should be open on focus
@@ -35,6 +36,7 @@ describe("recipient picker", () => {
           users={TEST_USERS}
           isNewPulse={true}
           onRecipientsChange={() => alert("why?")}
+          invalidRecipientText={() => {}}
         />,
       );
       // Now only the recipient name should be visible

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.unit.spec.tsx
@@ -1,4 +1,3 @@
-import fetchMock from "fetch-mock";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMockMetadata } from "__support__/metadata";
@@ -10,6 +9,7 @@ import type { Field, FieldValue } from "metabase-types/api";
 import { createMockField } from "metabase-types/api/mocks";
 import { createAdHocCard } from "metabase-types/api/mocks/presets";
 
+import { setupFieldValuesGeneralEndpoint } from "__support__/server-mocks";
 import Question from "metabase-lib/Question";
 import Filter from "metabase-lib/queries/structured/Filter";
 import type StructuredQuery from "metabase-lib/queries/StructuredQuery";
@@ -92,7 +92,7 @@ describe("InlineCategoryPicker", () => {
 
   beforeEach(() => {
     // mock all requests to field values
-    fetchMock.get(/\/api\/field\/\d+\/values/, []);
+    setupFieldValuesGeneralEndpoint();
   });
 
   it("should render an inline category picker", () => {

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.unit.spec.tsx
@@ -91,7 +91,6 @@ describe("InlineCategoryPicker", () => {
   );
 
   beforeEach(() => {
-    // mock all requests to field values
     setupFieldValuesGeneralEndpoint();
   });
 

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.unit.spec.tsx
@@ -1,3 +1,4 @@
+import fetchMock from "fetch-mock";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMockMetadata } from "__support__/metadata";
@@ -88,6 +89,11 @@ describe("InlineCategoryPicker", () => {
   const remappedCategoryField = checkNotNull(
     metadata.field(REMAPPED_CATEGORY_FIELD),
   );
+
+  beforeEach(() => {
+    // mock all requests to field values
+    fetchMock.get(/\/api\/field\/\d+\/values/, []);
+  });
 
   it("should render an inline category picker", () => {
     const testFilter = new Filter(

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.unit.spec.tsx
@@ -1,6 +1,5 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import fetchMock from "fetch-mock";
 import { renderWithProviders } from "__support__/ui";
 import { createMockMetadata } from "__support__/metadata";
 
@@ -9,6 +8,7 @@ import { checkNotNull } from "metabase/core/utils/types";
 import { createMockField } from "metabase-types/api/mocks";
 import { createAdHocCard } from "metabase-types/api/mocks/presets";
 
+import { setupFieldValuesGeneralEndpoint } from "__support__/server-mocks";
 import Filter from "metabase-lib/queries/structured/Filter";
 import Question from "metabase-lib/Question";
 import type StructuredQuery from "metabase-lib/queries/StructuredQuery";
@@ -20,7 +20,7 @@ const TEXT_FIELD_ID = 2;
 
 describe("InlineValuePicker", () => {
   beforeEach(() => {
-    fetchMock.get(/\/api\/field\/\d+\/values/, []);
+    setupFieldValuesGeneralEndpoint();
   });
   const metadata = createMockMetadata({
     fields: [

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.unit.spec.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
 import { renderWithProviders } from "__support__/ui";
 import { createMockMetadata } from "__support__/metadata";
 
@@ -18,6 +19,9 @@ const PK_FIELD_ID = 1;
 const TEXT_FIELD_ID = 2;
 
 describe("InlineValuePicker", () => {
+  beforeEach(() => {
+    fetchMock.get(/\/api\/field\/\d+\/values/, []);
+  });
   const metadata = createMockMetadata({
     fields: [
       createMockField({

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.unit.spec.js
@@ -1,7 +1,10 @@
 /* eslint-disable react/display-name, react/prop-types */
 import { Component } from "react";
-import fetchMock from "fetch-mock";
-import { createMockDatabase, createMockTable } from "metabase-types/api/mocks";
+import {
+  createMockCard,
+  createMockDatabase,
+  createMockTable,
+} from "metabase-types/api/mocks";
 
 import {
   ORDERS_ID,
@@ -14,6 +17,7 @@ import {
   createSampleDatabase,
 } from "metabase-types/api/mocks/presets";
 import { createMockMetadata } from "__support__/metadata";
+import { setupCardEndpoints } from "__support__/server-mocks/card";
 import { renderWithProviders, screen } from "__support__/ui";
 import * as Urls from "metabase/lib/urls";
 import Question from "metabase-lib/Question";
@@ -274,9 +278,10 @@ class ErrorBoundary extends Component {
     return this.props.children;
   }
 }
+const SOURCE_CARD = createMockCard({ id: SOURCE_QUESTION_ID });
 
 function setup({ question, subHead = false, isObjectDetail = false } = {}) {
-  fetchMock.get(`path:/api/card/${SOURCE_QUESTION_ID}`, {});
+  setupCardEndpoints(SOURCE_CARD);
 
   const onError = jest.fn();
   renderWithProviders(

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.unit.spec.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/display-name, react/prop-types */
 import { Component } from "react";
+import fetchMock from "fetch-mock";
 import { createMockDatabase, createMockTable } from "metabase-types/api/mocks";
 
 import {
@@ -275,6 +276,8 @@ class ErrorBoundary extends Component {
 }
 
 function setup({ question, subHead = false, isObjectDetail = false } = {}) {
+  fetchMock.get(`path:/api/card/${SOURCE_QUESTION_ID}`, {});
+
   const onError = jest.fn();
   renderWithProviders(
     <ErrorBoundary onError={onError}>

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -540,7 +540,7 @@ describe("QueryBuilder", () => {
 
     it("should allow downloading results for a native query", async () => {
       const mockDownloadEndpoint = fetchMock.post(
-        `/api/card/${TEST_NATIVE_CARD.id}/query/csv`,
+        `path:/api/card/${TEST_NATIVE_CARD.id}/query/csv`,
         {},
       );
       await setup({

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization-object.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization-object.unit.spec.tsx
@@ -6,6 +6,11 @@ import {
 } from "metabase-types/api/mocks";
 import type { FieldVisibilityType } from "metabase-types/api";
 import registerVisualizations from "metabase/visualizations/register";
+import {
+  setupActionsEndpoints,
+  setupDatabasesEndpoints,
+} from "__support__/server-mocks";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
 registerVisualizations();
 
@@ -39,6 +44,9 @@ function setup({
       },
     ),
   ];
+
+  setupDatabasesEndpoints([createSampleDatabase()]);
+  setupActionsEndpoints([]);
 
   renderWithProviders(<Visualization rawSeries={series} />);
 }

--- a/frontend/test/__support__/server-mocks/card.ts
+++ b/frontend/test/__support__/server-mocks/card.ts
@@ -17,7 +17,7 @@ export function setupCardEndpoints(card: Card) {
   const virtualTableId = getQuestionVirtualTableId(card.id);
   fetchMock.get(`path:/api/table/${virtualTableId}/query_metadata`, {
     ...convertSavedQuestionToVirtualTable(card),
-    fields: card.result_metadata.map(field => ({
+    fields: card.result_metadata?.map(field => ({
       ...field,
       table_id: virtualTableId,
     })),

--- a/frontend/test/__support__/server-mocks/card.ts
+++ b/frontend/test/__support__/server-mocks/card.ts
@@ -23,6 +23,8 @@ export function setupCardEndpoints(card: Card) {
     })),
     dimension_options: {},
   });
+
+  fetchMock.get(`path:/api/card/${card.id}/series`, []);
 }
 
 export function setupCardsEndpoints(cards: Card[]) {

--- a/frontend/test/__support__/server-mocks/dashboard.ts
+++ b/frontend/test/__support__/server-mocks/dashboard.ts
@@ -14,3 +14,7 @@ export function setupDashboardsEndpoints(dashboards: Dashboard[]) {
   fetchMock.get("path:/api/dashboard", dashboards);
   dashboards.forEach(dashboard => setupDashboardEndpoints(dashboard));
 }
+
+export function setupDashboardNotFoundEndpoint(dashboard: Dashboard) {
+  fetchMock.get(`path:/api/dashboard/${dashboard.id}`, 404);
+}

--- a/frontend/test/__support__/server-mocks/database.ts
+++ b/frontend/test/__support__/server-mocks/database.ts
@@ -1,7 +1,7 @@
 import fetchMock from "fetch-mock";
 import _ from "underscore";
 import { SAVED_QUESTIONS_DATABASE } from "metabase/databases/constants";
-import type { Database } from "metabase-types/api";
+import type { Database, DatabaseUsageInfo } from "metabase-types/api";
 import { isTypeFK } from "metabase-lib/types/utils/isa";
 import { PERMISSION_ERROR } from "./constants";
 import { setupTableEndpoints } from "./table";
@@ -17,6 +17,13 @@ export function setupDatabaseEndpoints(db: Database) {
     const body = await call?.request?.json();
     return { ...db, ...body };
   });
+}
+
+export function setupDatabaseUsageInfo(
+  db: Database,
+  usageInfo: DatabaseUsageInfo,
+) {
+  fetchMock.get(`path:/api/database/${db.id}/usage_info`, usageInfo);
 }
 
 export function setupDatabasesEndpoints(

--- a/frontend/test/__support__/server-mocks/field.ts
+++ b/frontend/test/__support__/server-mocks/field.ts
@@ -12,6 +12,13 @@ export function setupFieldValuesEndpoints(fieldValues: FieldValuesResult) {
   fetchMock.get(`path:/api/field/${fieldValues.field_id}/values`, fieldValues);
 }
 
+export function setupFieldValuesGeneralEndpoint() {
+  fetchMock.get(
+    { url: /\/api\/field\/\d+\/values/, overwriteRoutes: false },
+    [],
+  );
+}
+
 export function setupUnauthorizedFieldValuesEndpoints(
   fieldValues: FieldValuesResult,
 ) {


### PR DESCRIPTION
## Description

We have several tests which make http requests under the hood without any mocking. 
It turned out, some components make such requests only after some internal change of the component is changed and it usually happens after the test is completed, but jest still complains about it and randomly marks tests as failed.

To address this issue I used the idea form @npretto and added `fetchMock.catch` for all the requests which were not covered by fetch-mock, unfortunately it led to the memory leak and jest tests started failing at CI or get stuck. 

Instead of catching all the requests I decided to find all the places our tests make http requests (using http sniffer) and fix all of existing problems. Unfortunately those errors can appear again later and we'll need to fix them again.

FYI: since it's an async problem, jest puts the error to the wrong test (which is usually next to the actually failing).

## How to verify

- make sure jest tests passed

## How to verify if your test actually makes http request

add the following code to `jest-setup-env` file:

```
beforeEach(() => {
  fetchMock.restore();
  fetchMock.catch((url, ...args) => {
    console.error("Caught unmocked request to url: ", url);
    console.warn(args);

    // consider all unmocked requests are broken
    return 500;
  });
});
```