### PR TITLE
Add `:dataset` to the `POST /api/card` endpoint

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -559,9 +559,10 @@ saved later when it is ready."
 
 (api/defendpoint POST "/"
   "Create a new `Card`."
-  [:as {{:keys [collection_id collection_position dataset_query description display name
+  [:as {{:keys [collection_id collection_position dataset dataset_query description display name
                 parameters parameter_mappings result_metadata visualization_settings cache_ttl], :as body} :body}]
   {name                   ms/NonBlankString
+   dataset                [:maybe :boolean]
    dataset_query          ms/Map
    parameters             [:maybe [:sequential ms/Parameter]]
    parameter_mappings     [:maybe [:sequential ms/ParameterMapping]]


### PR DESCRIPTION
Depending on this key's value, we might either create a model when saving a card, or not.

It already exists in some tests and in the `create-card!` function but it was never explicitly defined in this endpoint. That is a shame because we generate API documentation based on these keys.