### PR TITLE
Small consistency changes to x-ray code

### DIFF
--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -742,7 +742,7 @@
     (str (u/upper-case-en (subs s 0 1)) (subs s 1))))
 
 (defn- instantiate-metadata
-  [x context {:keys [available-metrics]} bindings]
+  [x context available-metrics bindings]
   (-> (walk/postwalk
        (fn [form]
          (if (i18n/localized-string? form)
@@ -781,8 +781,6 @@
   bindings are provided. E.g. if X is mapped over Y and multiple fields are candidates for dimension Y, you will end
   up with a dashcard for each potential valid X and Y combination."
   [context
-   ;; TODO - Is this needed or can we just use satisfied-dimensions?
-   {:keys [available-dimensions] :as available-values}
    {card-dimensions :dimensions
     card-query      :query
     card-score      :score
@@ -792,69 +790,84 @@
    bindings]
   (let [score          (if card-query
                          card-score
-                         (* (or (->> card-dimensions
-                                     (map (partial get available-dimensions))
-                                     (concat satisfied-filters satisfied-metrics)
+                         (* (or (->> (concat (vals satisfied-filters)
+                                             (vals satisfied-metrics)
+                                             (vals satisfied-dimensions))
                                      (transduce (keep :score) stats/mean))
                                 dashboard-templates/max-score)
                             (/ card-score dashboard-templates/max-score)))
-        metrics        (for [metric satisfied-metrics]
+        metrics        (for [metric (vals satisfied-metrics)]
                          {:name   ((some-fn :name (comp metric-name :metric)) metric)
                           :metric (:metric metric)
                           :op     (-> metric :metric metric-op)})
         dashcard       (visualization/expand-visualization
                          card-template
-                         (map (comp bindings second) satisfied-dimensions)
+                         (vals bindings)
                          metrics)
         dashcard-query (if card-query
                          (build-native-query context bindings card-query)
                          (build-mbql-query context
                                            bindings
-                                           satisfied-filters
+                                           (vals satisfied-filters)
                                            metrics
-                                           satisfied-dimensions
+                                           (map (comp #(into [:dimension] %) first) card-dimensions)
                                            limit
                                            (build-order-by dashcard)))]
     (-> dashcard
-        (instantiate-metadata context available-values (->> (map :name metrics)
+        (instantiate-metadata context satisfied-metrics (->> (map :name metrics)
                                                             (zipmap (:metrics dashcard))
                                                             (merge bindings)))
         (assoc :dataset_query dashcard-query
                :metrics metrics
-               :dimensions (map (comp :name bindings second) satisfied-dimensions)
+               :dimensions (map :name (vals bindings))
                :score score))))
 
 (defn- valid-bindings? [{:keys [root]} satisfied-dimensions bindings]
   (let [cell-dimension? (singular-cell-dimensions root)]
     (->> satisfied-dimensions
-         (map (fn [[_ identifier opts]]
+         (map first)
+         (map (fn [[identifier opts]]
                 (merge (bindings identifier) opts)))
          (every? (every-pred valid-breakout-dimension?
                              (complement (comp cell-dimension? id-or-name)))))))
 
-(defn- card-candidates
+(mu/defn card-candidates
   "Generate all potential cards given a card definition and bindings for
    dimensions, metrics, and filters."
-  [{:keys [query-filter] :as context}
-   satisfied-bindings
-   {:keys [available-metrics available-filters] :as available-values}
-   {required-dimensions :dimensions
-    required-metrics    :metrics
-    required-filters    :filters
+  [{:keys [query-filter] :as context} :- ads/context
+   satisfied-bindings :- [:map-of ads/dimension-set ads/dimension-maps]
+   {:keys [available-dimensions available-metrics available-filters]} :- ads/available-values
+   {card-dimensions :dimensions
+    card-metrics    :metrics
+    card-filters    :filters
     :as                 card-template}]
-  (let [satisfied-metrics    (map available-metrics required-metrics)
-        satisfied-filters    (cond-> (map available-filters required-filters)
+  (let [satisfied-metrics    (zipmap
+                               card-metrics
+                               (map available-metrics card-metrics))
+        satisfied-filters    (cond-> (zipmap
+                                       card-filters
+                                       (map available-filters card-filters))
                                query-filter
-                               (conj {:filter query-filter}))
-        satisfied-dimensions (map (comp (partial into [:dimension]) first) required-dimensions)
+                               (assoc "query-filter" {:filter query-filter}))
+        satisfied-dimensions (zipmap
+                               card-dimensions
+                               (map
+                                 (fn [card-dimension]
+                                   (-> card-dimension
+                                       ffirst
+                                       available-dimensions
+                                       (dissoc :matches)))
+                                 card-dimensions))
         satisfied-values     {:satisfied-dimensions satisfied-dimensions
                               :satisfied-metrics    satisfied-metrics
                               :satisfied-filters    satisfied-filters}
-        dimension-locations  [satisfied-dimensions satisfied-metrics satisfied-filters]
-        used-dimensions      (set (dashboard-templates/collect-dimensions dimension-locations))]
+        dimension-locations  [satisfied-metrics satisfied-filters]
+        used-dimensions      (set (into
+                                    (map ffirst card-dimensions)
+                                    (dashboard-templates/collect-dimensions dimension-locations)))]
     (->> (satisfied-bindings (set used-dimensions))
-         (filter (partial valid-bindings? context satisfied-dimensions))
-         (map (partial build-dashcard context available-values card-template satisfied-values)))))
+         (filter (partial valid-bindings? context card-dimensions))
+         (map (partial build-dashcard context card-template satisfied-values)))))
 
 (defn- matching-dashboard-templates
   "Return matching dashboard templates ordered by specificity.
@@ -1096,14 +1109,14 @@
 (defn- make-dashboard
   ([root dashboard-template]
    (make-dashboard root dashboard-template {:tables [(:source root)] :root root} nil))
-  ([root dashboard-template context available-values]
+  ([root dashboard-template context {:keys [available-metrics]}]
    (-> dashboard-template
        (select-keys [:title :description :transient_title :groups])
        (cond->
          (:comparison? root)
          (update :groups (partial m/map-vals (fn [{:keys [title comparison_title] :as group}]
                                                (assoc group :title (or comparison_title title))))))
-       (instantiate-metadata context available-values {}))))
+       (instantiate-metadata context available-metrics {}))))
 
 (defn- enriched-field-with-sources [{:keys [tables source]} field]
   (assoc field

--- a/src/metabase/automagic_dashboards/schema.clj
+++ b/src/metabase/automagic_dashboards/schema.clj
@@ -124,7 +124,7 @@
     [:map
      [:available-dimensions [:map-of [:string {:min 1}] any?]]
      [:available-metrics [:map-of [:string {:min 1}] any?]]
-     [:available-filters [:map-of [:string {:min 1}] any?]]]))
+     [:available-filters {:optional true} [:map-of [:string {:min 1}] any?]]]))
 
 ;; Schemas for "affinity" functions as these can be particularly confusing
 

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -2110,7 +2110,7 @@
   (testing "Cases in which the bindings are valid."
     (is (true?
          (let [context           nil
-               common-dimensions [[:dimension "Date" {}]]
+               common-dimensions [{"Date" {}}]
                bindings          {"Date"     {:name "SALES_DATE"}
                                   "Discount" {:name "Price Discount"}
                                   "Income"   {:name "Income"}}]
@@ -2128,13 +2128,13 @@
     (is (false?
          (let [context           {:root {:cell-query
                                          [:= [:field 123 {:base-type :type/Integer}]]}}
-               common-dimensions [[:dimension "ID" {}]]
+               common-dimensions [{"ID" {}}]
                bindings          {"ID" {:id 123}}]
            (#'magic/valid-bindings? context common-dimensions bindings))))
     (is (false?
          (let [context           {:root {:cell-query
                                          [:= [:field "X" {:base-type :type/Integer}]]}}
-               common-dimensions [[:dimension "X" {}]]
+               common-dimensions [{"X" {}}]
                bindings          {"X" {:name "X"}}]
            (#'magic/valid-bindings? context common-dimensions bindings))))))
 


### PR DESCRIPTION
This is a small set of changes pulled from another [PR](https://github.com/metabase/metabase/pull/34155) whose contents probably won't be merged. The intent of these changes is to be explicit in what is passed into each of the card creation functions, ensure consistency of types, and eliminate redundant or non-required arguments.

`build-dashcard` was the target of this simplification. The `available-values` argument is no longer necessary as that data is sourced from other arguments. the `satisfied-*` arguments are no longer seqs of satisfied filter, metric, and dimension definitions, but maps of names of those items to the definitions. This is only needed because satisfied metrics needs metrics names when adding metadata. However, all values were modified into a consistent shape.

In other areas, if an aggregate object with several keys is passed to a function that uses only one element of the object, only the inner element is passed.

In card-candidates, `:matches` is dissoced from `satisfied-dimensions` to remove the extra payload that isn't needed in that argument. This makes it clear that satisfied field values are passed into card creation functions via the `satisfied-bindings` and not cruft from earlier stage.

As an aside, one potential fix that would substantially improve the readibility of this entire codebase would be to move the element names in the one key to value maps as is done for dimensions, metrics, filters, and cards into the elements as a named key. Carrying that shape forward from the yaml files requires a ton of first this or zipmap that to recover the names into whatever the current context is.