### PR TITLE
Hardcode Vertica DB default timezone to UTC, don't use session timezone

### DIFF
--- a/modules/drivers/vertica/src/metabase/driver/vertica.clj
+++ b/modules/drivers/vertica/src/metabase/driver/vertica.clj
@@ -252,14 +252,11 @@
       (update :tables set/union (materialized-views database))))
 
 (defmethod driver/db-default-timezone :vertica
-  [driver database]
-  (sql-jdbc.execute/do-with-connection-with-options
-   driver database nil
-   (fn [^java.sql.Connection conn]
-     (with-open [stmt (.prepareStatement conn "show timezone;")
-                 rset (.executeQuery stmt)]
-       (when (.next rset)
-         (.getString rset "setting"))))))
+  [_driver _database]
+  ;; There is no Database default timezone in Vertica, you can change the SESSION timezone with `SET TIME ZONE TO ...`,
+  ;; but TIMESTAMP WITH TIMEZONEs are all stored in UTC. See
+  ;; https://www.vertica.com/docs/9.0.x/HTML/index.htm#Authoring/InstallationGuide/AppendixTimeZones/UsingTimeZonesWithHPVertica.htm
+  "UTC")
 
 (defmethod sql-jdbc.execute/set-timezone-sql :vertica [_] "SET TIME ZONE TO %s;")
 

--- a/modules/drivers/vertica/test/metabase/driver/vertica_test.clj
+++ b/modules/drivers/vertica/test/metabase/driver/vertica_test.clj
@@ -12,10 +12,8 @@
 
 (deftest db-timezone-test
   (mt/test-driver :vertica
-    ;; not 100% sure why sometimes we get one or the other, I think it has to do with our Vertica Docker image? We
-    ;; mostly just want to make sure the impl returns SOMETHING
-    (is (#{"America/Los_Angeles" "UTC"}
-         (driver/db-default-timezone :vertica (mt/db))))))
+    (is (= "UTC"
+           (driver/db-default-timezone :vertica (mt/db))))))
 
 (deftest ^:parallel additional-connection-string-options-test
   (testing "Make sure you can add additional connection string options (#6651)"


### PR DESCRIPTION
The implementation for `driver/db-default-timezone` was returning the session timezone, which is not only wrong but also leads to flaky tests, since it can change between test runs. 

It turns out that there is no Database default timezone in Vertica, you can change the session timezone with `SET TIME ZONE TO ...`, but TIMESTAMP WITH TIMEZONEs are all stored in UTC. See https://www.vertica.com/docs/9.0.x/HTML/index.htm#Authoring/InstallationGuide/AppendixTimeZones/UsingTimeZonesWithHPVertica.htm

So UTC is the right answer here. 