### PR TITLE
Remove unused collection `color` column

### DIFF
--- a/dev/test/dev/model_tracking_test.clj
+++ b/dev/test/dev/model_tracking_test.clj
@@ -16,27 +16,27 @@
     (model-tracking/track! 'Collection)
 
     (testing "insert"
-      (t2/insert! Collection {:name "Test tracking" :color "#000000"})
+      (t2/insert! Collection {:name "Test tracking" :description "My awesome collection"})
       (testing "should be tracked"
         (is (=? [{:name  "Test tracking"
-                  :color "#000000"}]
+                  :description "My awesome collection"}]
                 (get-in (model-tracking/changes) [:collection :insert]))))
       (testing "should take affects"
         (is (= 1 (t2/count Collection :name "Test tracking")))))
 
     (testing "update"
-      (t2/update! Collection {:name "Test tracking"} {:color "#ffffff"})
+      (t2/update! Collection {:name "Test tracking"} {:description "Amazing collection"})
       (testing "changes should be tracked"
-        (is (= [{:color "#ffffff"}]
+        (is (= [{:description "Amazing collection"}]
                (get-in (model-tracking/changes) [:collection :update]))))
       (testing "should take affects"
-        (is (= "#ffffff" (t2/select-one-fn :color Collection :name "Test tracking")))))
+        (is (= "Amazing collection" (t2/select-one-fn :description Collection :name "Test tracking")))))
 
     (testing "delete"
       (let [coll-id (t2/select-one-pk Collection :name "Test tracking")]
         (t2/delete! Collection coll-id)
         (testing "should be tracked"
-          (is (=? [{:color "#ffffff"
+          (is (=? [{:description "Amazing collection"
                     :name  "Test tracking",
                     :id    coll-id}]
                   (get-in (model-tracking/changes) [:collection :delete]))))
@@ -46,18 +46,18 @@
     (testing "untrack should stop all tracking for"
       (model-tracking/untrack-all!)
       (testing "insert"
-        (t2/insert! Collection {:name "Test tracking" :color "#000000"})
+        (t2/insert! Collection {:name "Test tracking" :description "My awesome collection"})
         (testing "changes not should be tracked"
           (is (empty? (model-tracking/changes))))
         (testing "should take affects"
           (is (= 1 (t2/count Collection :name "Test tracking")))))
 
       (testing "update"
-        (t2/update! Collection {:name "Test tracking"} {:color "#ffffff"})
+        (t2/update! Collection {:name "Test tracking"} {:description "Amazing collection"})
         (testing "changes not should be tracked"
           (is (empty? (model-tracking/changes))))
         (testing "should take affects"
-          (is (= "#ffffff" (t2/select-one-fn :color Collection :name "Test tracking")))))
+          (is (= "Amazing collection" (t2/select-one-fn :description Collection :name "Test tracking")))))
 
       (testing "delete"
         (let [coll-id (t2/select-one-pk Collection :name "Test tracking")]

--- a/e2e/snapshot-creators/default.cy.snap.js
+++ b/e2e/snapshot-creators/default.cy.snap.js
@@ -160,7 +160,6 @@ describe("snapshots", () => {
     function postCollection(name, parent_id, callback) {
       cy.request("POST", "/api/collection", {
         name,
-        color: "#509ee3",
         description: `Collection ${name}`,
         parent_id,
       }).then(({ body }) => callback && callback(body));

--- a/e2e/support/commands/api/collection.js
+++ b/e2e/support/commands/api/collection.js
@@ -4,7 +4,6 @@ Cypress.Commands.add(
     name,
     description = null,
     parent_id = null,
-    color = "#509EE3",
     authority_level = null,
   } = {}) => {
     cy.log(`Create a collection: ${name}`);
@@ -12,7 +11,6 @@ Cypress.Commands.add(
       name,
       description,
       parent_id,
-      color,
       authority_level,
     });
   },

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -41,7 +41,6 @@ describe("scenarios > collection defaults", () => {
       _.times(COLLECTIONS_COUNT, index => {
         cy.request("POST", "/api/collection", {
           name: `Collection ${index + 1}`,
-          color: "#509EE3",
           parent_id: null,
         });
       });
@@ -137,7 +136,6 @@ describe("scenarios > collection defaults", () => {
           cy.request("POST", "/api/collection", {
             name: collection,
             parent_id: THIRD_COLLECTION_ID + index,
-            color: "#509ee3",
           });
         },
       );
@@ -310,13 +308,11 @@ describe("scenarios > collection defaults", () => {
         // Create Parent collection within `Our analytics`
         cy.request("POST", "/api/collection", {
           name: "Parent",
-          color: "#509EE3",
           parent_id: null,
         }).then(({ body: { id: PARENT_COLLECTION_ID } }) => {
           // Create Child collection within Parent collection
           cy.request("POST", "/api/collection", {
             name: "Child",
-            color: "#509EE3",
             parent_id: PARENT_COLLECTION_ID,
           }).then(({ body: { id: CHILD_COLLECTION_ID } }) => {
             // Fetch collection permission graph

--- a/e2e/test/scenarios/collections/personal-collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/personal-collections.cy.spec.js
@@ -81,7 +81,6 @@ describe("personal collections", () => {
       // Let's use the API to create a sub-collection "Foo" in admin's personal collection
       cy.request("POST", "/api/collection", {
         name: "Foo",
-        color: "#ff9a9a",
         parent_id: ADMIN_PERSONAL_COLLECTION_ID,
       });
 

--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -58,7 +58,6 @@ describeWithSnowplow(
 
       cy.request("POST", "/api/collection", {
         name: `Uploads Collection`,
-        color: "#000000", // shockingly, this unused field is required
         parent_id: null,
       }).then(({ body: { id: collectionId } }) => {
         cy.wrap(collectionId).as("collectionId");
@@ -107,7 +106,6 @@ describeWithSnowplow(
 
           cy.request("POST", "/api/collection", {
             name: `Uploads Collection`,
-            color: "#000000", // shockingly, this unused field is required
             parent_id: null,
           }).then(({ body: { id: collectionId } }) => {
             cy.wrap(collectionId).as("collectionId");

--- a/e2e/test/scenarios/dashboard/permissions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/permissions.cy.spec.js
@@ -21,7 +21,6 @@ describe("scenarios > dashboard > permissions", () => {
 
     cy.request("POST", "/api/collection", {
       name: "locked down collection",
-      color: "#509EE3",
       parent_id: null,
     }).then(({ body: { id: collection_id } }) => {
       cy.request("GET", "/api/collection/graph").then(

--- a/e2e/test/scenarios/native/snippets/snippet-permissions.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets/snippet-permissions.cy.spec.js
@@ -151,7 +151,6 @@ describeEE("scenarios > question > snippets (EE)", () => {
       cy.request("POST", "/api/collection", {
         name: "Snippet Folder",
         description: null,
-        color: "#509EE3",
         parent_id: null,
         namespace: "snippets",
       });
@@ -222,7 +221,6 @@ function createNestedSnippet() {
   cy.request("POST", "/api/collection", {
     name: "Snippet Folder",
     description: null,
-    color: "#509EE3",
     parent_id: null,
     namespace: "snippets",
   }).then(({ body: { id } }) => {

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -221,13 +221,11 @@ describe("scenarios > home > custom homepage", () => {
     it("should give you the option to set a custom home page using home page CTA", () => {
       cy.request("POST", "/api/collection", {
         name: "Personal nested Collection",
-        color: "#509ee3",
         description: `nested 1 level`,
         parent_id: ADMIN_PERSONAL_COLLECTION_ID,
       }).then(({ body }) => {
         cy.request("POST", "/api/collection", {
           name: "Personal nested nested Collection",
-          color: "#509ee3",
           description: `nested 2 levels`,
           parent_id: body.id,
         }).then(({ body }) => {

--- a/e2e/test/scenarios/organization/official-collections.cy.spec.js
+++ b/e2e/test/scenarios/organization/official-collections.cy.spec.js
@@ -39,7 +39,6 @@ describeEE("official collections", () => {
         failOnStatusCode: false,
         body: {
           name: "Wannabe Official Collection",
-          color: "#000000",
           authority_level: "official",
         },
       }).then(({ body, status, statusText }) => {

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -135,7 +135,6 @@ describe("scenarios > question > new", () => {
     it("should suggest questions saved in collections with colon in their name (metabase#14287)", () => {
       cy.request("POST", "/api/collection", {
         name: "foo:bar",
-        color: "#509EE3",
         parent_id: null,
       }).then(({ body: { id: COLLECTION_ID } }) => {
         // Move question #1 ("Orders") to newly created collection

--- a/enterprise/backend/test/metabase_enterprise/content_management/api/collection_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_management/api/collection_test.clj
@@ -15,13 +15,11 @@
         (testing "Admins can add an official collection"
           (mt/with-model-cleanup [:model/Collection]
             (let [resp (mt/user-http-request :crowberto :post 200 "collection" {:name            "An official collection"
-                                                                                :color           "#000000"
                                                                                 :authority_level "official"})]
               (is (malli= [:map
                            [:description       :nil]
                            [:archived          [:= false]]
                            [:slug              [:= "an_official_collection"]]
-                           [:color             [:= "#000000"]]
                            [:name              [:= "An official collection"]]
                            [:personal_owner_id :nil]
                            [:authority_level   [:= "official"]]
@@ -38,19 +36,17 @@
 
           (testing "but the type has to be valid"
             (mt/user-http-request :crowberto :post 400 "collection"
-                                  {:name "foo" :color "#f38630" :authority_level "invalid-type"})))
+                                  {:name "foo" :authority_level "invalid-type"})))
 
         (testing "non-admins get 403"
           (is (= "You don't have permissions to do that."
                  (mt/user-http-request :rasta :post 403 "collection" {:name            "An official collection"
-                                                                      :color           "#000000"
                                                                       :authority_level "official"}))))))
 
     (testing "fails to add an official collection if doesn't have any premium features"
       (premium-features-test/with-premium-features #{}
         (is (= "Official Collections is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
                (mt/user-http-request :crowberto :post 402 "collection" {:name            "An official collection"
-                                                                        :color           "#000000"
                                                                         :authority_level "official"})))))))
 
 (deftest update-collection-authority-happy-path-test

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/seed_entity_ids_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/seed_entity_ids_test.clj
@@ -19,8 +19,7 @@
     (let [now (LocalDateTime/of 2022 9 1 12 34 56)]
       (t2.with-temp/with-temp [Collection c {:name       "No Entity ID Collection"
                                              :slug       "no_entity_id_collection"
-                                             :created_at now
-                                             :color      "#FF0000"}]
+                                             :created_at now}]
         (t2/update! Collection (:id c) {:entity_id nil})
         (letfn [(entity-id []
                   (some-> (t2/select-one-fn :entity_id Collection :id (:id c)) str/trim))]
@@ -34,8 +33,7 @@
         (testing "Error: duplicate entity IDs"
           (t2.with-temp/with-temp [Collection c2 {:name       "No Entity ID Collection"
                                                   :slug       "no_entity_id_collection"
-                                                  :created_at now
-                                                  :color      "#FF0000"}]
+                                                  :created_at now}]
             (t2/update! Collection (:id c2) {:entity_id nil})
             (letfn [(entity-id []
                       (some-> (t2/select-one-fn :entity_id Collection :id (:id c2)) str/trim))]

--- a/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionForm.tsx
@@ -38,7 +38,7 @@ const SNIPPET_COLLECTION_SCHEMA = Yup.object({
 
 type SnippetCollectionFormValues = Pick<
   Collection,
-  "name" | "description" | "color" | "parent_id"
+  "name" | "description" | "parent_id"
 >;
 
 type UpdateSnippetCollectionFormValues = Partial<SnippetCollectionFormValues> &

--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -24,7 +24,6 @@ export interface Collection {
   name: string;
   description: string | null;
   can_write: boolean;
-  color?: string;
   archived: boolean;
   children?: Collection[];
   authority_level?: "official" | null;

--- a/frontend/src/metabase/containers/SaveQuestionModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.unit.spec.tsx
@@ -47,7 +47,6 @@ const TEST_COLLECTIONS = [
   {
     archived: false,
     can_write: true,
-    color: "#31698A",
     description: null,
     id: 1,
     location: "/",

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15303,6 +15303,24 @@ databaseChangeLog:
             columnName: slug
             newDataType: varchar(254)
 
+  - changeSet:
+      id: v48.00-017
+      author: nemanjaglumac
+      comment: 'Collection color is removed in 0.48.0'
+      changes:
+        - dropColumn:
+            tableName: collection
+            columnName: color
+      rollback:
+        - addColumn:
+            tableName: collection
+            columns:
+              - column:
+                  name: color
+                  type: char(7)
+                  remarks: 'Seven-character hex color for this Collection, including the preceding hash sign.'
+                  constraints:
+                    nullable: false
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15320,7 +15320,7 @@ databaseChangeLog:
                   type: char(7)
                   remarks: 'Seven-character hex color for this Collection, including the preceding hash sign.'
                   constraints:
-                    nullable: false
+                    nullable: true
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15304,7 +15304,7 @@ databaseChangeLog:
             newDataType: varchar(254)
 
   - changeSet:
-      id: v48.00-017
+      id: v48.00-019
       author: nemanjaglumac
       comment: 'Collection color is removed in 0.48.0'
       changes:

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15320,7 +15320,8 @@ databaseChangeLog:
                   type: char(7)
                   remarks: 'Seven-character hex color for this Collection, including the preceding hash sign.'
                   constraints:
-                    nullable: true
+                    nullable: false
+                  defaultValue: '#31698A'
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -819,7 +819,7 @@
 
 (defn create-collection!
   "Create a new collection."
-  [{:keys [name color description parent_id namespace authority_level]}]
+  [{:keys [name description parent_id namespace authority_level]}]
   ;; To create a new collection, you need write perms for the location you are going to be putting it in...
   (write-check-collection-or-root-collection parent_id namespace)
   (when (some? authority_level)
@@ -832,7 +832,6 @@
       Collection
       (merge
         {:name        name
-         :color       color
          :description description
          :authority_level authority_level
          :namespace   namespace}
@@ -841,9 +840,8 @@
 
 (api/defendpoint POST "/"
   "Create a new Collection."
-  [:as {{:keys [name color description parent_id namespace authority_level] :as body} :body}]
+  [:as {{:keys [name description parent_id namespace authority_level] :as body} :body}]
   {name            ms/NonBlankString
-   color           [:maybe [:re collection/hex-color-regex]]
    description     [:maybe ms/NonBlankString]
    parent_id       [:maybe ms/PositiveInt]
    namespace       [:maybe ms/NonBlankString]
@@ -899,10 +897,9 @@
 
 (api/defendpoint PUT "/:id"
   "Modify an existing Collection, including archiving or unarchiving it, or moving it."
-  [id, :as {{:keys [name color description archived parent_id authority_level], :as collection-updates} :body}]
+  [id, :as {{:keys [name description archived parent_id authority_level], :as collection-updates} :body}]
   {id              ms/PositiveInt
    name            [:maybe ms/NonBlankString]
-   color           [:maybe [:re collection/hex-color-regex]]
    description     [:maybe ms/NonBlankString]
    archived        [:maybe ms/BooleanValue]
    parent_id       [:maybe ms/PositiveInt]
@@ -922,7 +919,7 @@
                           (not (collection/is-personal-collection-or-descendant-of-one? collection-before-update)))))
     ;; ok, go ahead and update it! Only update keys that were specified in the `body`. But not `parent_id` since
     ;; that's not actually a property of Collection, and since we handle moving a Collection separately below.
-    (let [updates (u/select-keys-when collection-updates :present [:name :color :description :archived :authority_level])]
+    (let [updates (u/select-keys-when collection-updates :present [:name :description :archived :authority_level])]
       (when (seq updates)
         (t2/update! Collection id updates)))
     ;; if we're trying to *move* the Collection (instead or as well) go ahead and do that

--- a/src/metabase/automagic_dashboards/populate.clj
+++ b/src/metabase/automagic_dashboards/populate.clj
@@ -48,7 +48,7 @@
       (create-collection! "Automatically Generated Dashboards" nil nil)))
 
 (defn colors
-  "A vector of colors used for coloring charts and collections. Uses [[public-settings/application-colors]] for user choices."
+  "A vector of colors used for coloring charts. Uses [[public-settings/application-colors]] for user choices."
   []
   (let [order [:brand :accent1 :accent2 :accent3 :accent4 :accent5 :accent6 :accent7]
         colors-map (merge {:brand   "#509EE3"

--- a/src/metabase/automagic_dashboards/populate.clj
+++ b/src/metabase/automagic_dashboards/populate.clj
@@ -29,12 +29,11 @@
 
 (defn create-collection!
   "Create and return a new collection."
-  [title color description parent-collection-id]
+  [title description parent-collection-id]
   (first (t2/insert-returning-instances!
            'Collection
            (merge
              {:name        title
-              :color       color
               :description description}
              (when parent-collection-id
                {:location (collection/children-location (t2/select-one ['Collection :location :id]
@@ -46,7 +45,7 @@
   (or (t2/select-one 'Collection
         :name     "Automatically Generated Dashboards"
         :location "/")
-      (create-collection! "Automatically Generated Dashboards" "#509EE3" nil nil)))
+      (create-collection! "Automatically Generated Dashboards" nil nil)))
 
 (defn colors
   "A vector of colors used for coloring charts and collections. Uses [[public-settings/application-colors]] for user choices."

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -429,7 +429,6 @@
          :keys          [description] :as dashboard} (i18n/localized-strings->strings dashboard)
         collection (populate/create-collection!
                     (ensure-unique-collection-name dashboard-name parent-collection-id)
-                    (rand-nth (populate/colors))
                     "Automatically generated cards."
                     parent-collection-id)
         dashboard  (first (t2/insert-returning-instances!

--- a/src/metabase/transforms/materialize.clj
+++ b/src/metabase/transforms/materialize.clj
@@ -25,12 +25,11 @@
      :location location)))
 
 (defn- create-collection!
-  ([collection-name color description]
-   (create-collection! collection-name color description (root-container-location)))
-  ([collection-name color description location]
+  ([collection-name description]
+   (create-collection! collection-name description (root-container-location)))
+  ([collection-name description location]
    (first (t2/insert-returning-pks! Collection
                                     {:name        collection-name
-                                     :color       color
                                      :description description
                                      :location    location}))))
 
@@ -40,7 +39,7 @@
   (let [location "/"
         name     "Automatically Generated Transforms"]
     (or (get-collection name location)
-        (create-collection! name "#509EE3" nil location))))
+        (create-collection! name nil location))))
 
 (defn fresh-collection-for-transform!
   "Create a new collection for all the artefacts belonging to transform, or reset it if it already
@@ -48,7 +47,7 @@
   [{:keys [name description]}]
   (if-let [collection-id (get-collection name)]
     (t2/delete! Card :collection_id collection-id)
-    (create-collection! name "#509EE3" description)))
+    (create-collection! name description)))
 
 (defn make-card-for-step!
   "Make and save a card for a given transform step and query."

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -264,7 +264,6 @@
                            :archived          false
                            :entity_id         (:entity_id personal-collection)
                            :slug              "rasta_toucan_s_personal_collection"
-                           :color             "#31698A"
                            :name              "Rasta Toucan's Personal Collection"
                            :personal_owner_id (mt/user->id :rasta)
                            :id                (:id (collection/user->personal-collection (mt/user->id :rasta)))
@@ -341,7 +340,6 @@
                        :archived          false
                        :entity_id         (:entity_id collection)
                        :slug              "collection_personnelle_de_taco_bell"
-                       :color             "#ABCDEF"
                        :name              "Collection personnelle de Taco Bell"
                        :personal_owner_id (:id user)
                        :id                (:id collection)
@@ -898,7 +896,6 @@
   (merge
    (mt/object-defaults Collection)
    {:slug                "lucky_pigeon_s_personal_collection"
-    :color               "#31698A"
     :can_write           true
     :name                "Lucky Pigeon's Personal Collection"
     :personal_owner_id   (mt/user->id :lucky)
@@ -1432,12 +1429,11 @@
                        (mt/object-defaults Collection)
                        {:name              "Stamp Collection"
                         :slug              "stamp_collection"
-                        :color             "#123456"
                         :archived          false
                         :location          "/"
                         :personal_owner_id nil})
                       (-> (mt/user-http-request :crowberto :post 200 "collection"
-                                                {:name "Stamp Collection", :color "#123456"})
+                                                {:name "Stamp Collection"})
                           (dissoc :id :entity_id))))))))
 
 (deftest non-admin-create-collection-in-root-perms-test
@@ -1446,7 +1442,7 @@
       (mt/with-non-admin-groups-no-root-collection-perms
         (is (= "You don't have permissions to do that."
                (mt/user-http-request :rasta :post 403 "collection"
-                                     {:name "Stamp Collection", :color "#123456"})))))
+                                     {:name "Stamp Collection"})))))
     (testing "\nCan a non-admin user with Root Collection perms add a new collection to the Root Collection? (#8949)"
       (mt/with-model-cleanup [Collection]
         (mt/with-non-admin-groups-no-root-collection-perms
@@ -1456,11 +1452,10 @@
             (is (partial= (merge
                            (mt/object-defaults Collection)
                            {:name     "Stamp Collection"
-                            :color    "#123456"
                             :location "/"
                             :slug     "stamp_collection"})
                           (dissoc (mt/user-http-request :rasta :post 200 "collection"
-                                                        {:name "Stamp Collection", :color "#123456"})
+                                                        {:name "Stamp Collection"})
                                   :id :entity_id)))))))))
 
 (deftest create-child-collection-test
@@ -1475,11 +1470,9 @@
                           :name        "Trading Card Collection"
                           :slug        "trading_card_collection"
                           :description "Collection of basketball cards including limited-edition holographic Draymond Green"
-                          :color       "#ABCDEF"
                           :location    "/A/C/D/"})
                         (-> (mt/user-http-request :crowberto :post 200 "collection"
                                                   {:name        "Trading Card Collection"
-                                                   :color       "#ABCDEF"
                                                    :description "Collection of basketball cards including limited-edition holographic Draymond Green"
                                                    :parent_id   (u/the-id d)})
                             (update :location collection-test/location-path-ids->names)
@@ -1496,7 +1489,6 @@
                         s/Keyword  s/Any}
                        (mt/user-http-request :crowberto :post 200 "collection"
                                              {:name       collection-name
-                                              :color      "#f38630"
                                               :descrption "My SQL Snippets"
                                               :namespace  "snippets"})))
           (finally
@@ -1516,7 +1508,6 @@
                         :name            "My Beautiful Collection"
                         :slug            "my_beautiful_collection"
                         :entity_id       (:entity_id collection)
-                        :color           "#ABCDEF"
                         :location        "/"
                         :effective_ancestors [{:metabase.models.collection.root/is-root? true
                                                :name                                     "Our analytics"
@@ -1527,13 +1518,13 @@
 
                         :parent_id       nil})
                       (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id collection))
-                                            {:name "My Beautiful Collection" :color "#ABCDEF"})))))
+                                            {:name "My Beautiful Collection"})))))
     (testing "check that users without write perms aren't allowed to update a Collection"
       (mt/with-non-admin-groups-no-root-collection-perms
         (t2.with-temp/with-temp [Collection collection]
           (is (= "You don't have permissions to do that."
                  (mt/user-http-request :rasta :put 403 (str "collection/" (u/the-id collection))
-                                       {:name "My Beautiful Collection", :color "#ABCDEF"}))))))))
+                                       {:name "My Beautiful Collection"}))))))))
 
 (deftest archive-collection-test
   (testing "PUT /api/collection/:id"
@@ -1555,7 +1546,7 @@
         (mt/with-fake-inbox
           (mt/with-expected-messages 2
             (mt/user-http-request :crowberto :put 200 (str "collection/" collection-id)
-                                  {:name "My Beautiful Collection", :color "#ABCDEF", :archived true}))
+                                  {:name "My Beautiful Collection", :archived true}))
           (testing "emails"
             (is (= (merge (mt/email-to :crowberto {:subject "One of your alerts has stopped working",
                                                    :body    {"the question was archived by Crowberto Corv" true}})
@@ -1595,7 +1586,6 @@
                         :entity_id true
                         :name      "E"
                         :slug      "e"
-                        :color     "#ABCDEF"
                         :location  "/A/B/"
                         :parent_id (u/the-id b)})
                       (-> (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id e))

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -1139,8 +1139,8 @@
                      column_name;"))))))
 
 (deftest remove-collection-color-test
-  (testing "Migration v48.00-017"
-    (impl/test-migrations ["v48.00-017"] [migrate!]
+  (testing "Migration v48.00-019"
+    (impl/test-migrations ["v48.00-019"] [migrate!]
       (let [{:keys [db-type ^javax.sql.DataSource data-source]} mdb.connection/*application-db*
             collection-id (first (t2/insert-returning-pks! (t2/table-name Collection) {:name "Amazing collection"
                                                                                        :slug "amazing_collection"

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -1140,9 +1140,9 @@
 
 (deftest remove-collection-color-test
   (testing "Migration v48.00-017"
-    (impl/test-migrations ["v48.00-017"] [_]
+    (impl/test-migrations ["v48.00-017"] [migrate!]
       (let [{:keys [db-type ^javax.sql.DataSource data-source]} mdb.connection/*application-db*
-            migrate!      (partial db.setup/migrate! db-type data-source)
+            custom-migrate!      (partial db.setup/migrate! db-type data-source)
             collection-id (first (t2/insert-returning-pks! (t2/table-name Collection) {:name "Amazing collection"
                                                                                        :slug "amazing_collection"
                                                                                        :color "#509EE3"}))
@@ -1150,10 +1150,10 @@
                                               :from   [:collection]
                                               :where  [:= :id collection-id]})]
 
-        (migrate! :up)
+        (migrate!)
         (testing "should drop the existing color column"
           (is (true? (not (contains? (into {} test-collection) :color)))))
 
-        (migrate! :down)
+        (custom-migrate! :down)
         (testing "Rollback to the previous version should restore the column column and set the default value"
           (is (= "#31698A" (:color test-collection))))))))

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -1146,10 +1146,13 @@
                                                                                        :slug "amazing_collection"
                                                                                        :color "#509EE3"}))]
 
+        (testing "Collection should exist and have the color set by the user prior to migration"
+          (is (= "#509EE3" (:color (t2/select-one :model/Collection :id collection-id)))))
+
         (migrate!)
         (testing "should drop the existing color column"
           (is (true? (not (contains? (t2/select-one :model/Collection :id collection-id) :color)))))
 
         (db.setup/migrate! db-type data-source :down)
-        (testing "Rollback to the previous version should restore the column column, and give it the default color value"
+        (testing "Rollback to the previous version should restore the column column, and set the default color value"
           (is (= "#31698A" (:color (t2/select-one :model/Collection :id collection-id)))))))))

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -1151,7 +1151,7 @@
 
         (migrate!)
         (testing "should drop the existing color column"
-          (is (true? (not (contains? (t2/select-one :model/Collection :id collection-id) :color)))))
+          (is (not (contains? (t2/select-one :model/Collection :id collection-id) :color))))
 
         (db.setup/migrate! db-type data-source :down)
         (testing "Rollback to the previous version should restore the column column, and set the default color value"

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -1145,9 +1145,7 @@
             collection-id (first (t2/insert-returning-pks! (t2/table-name Collection) {:name "Amazing collection"
                                                                                        :slug "amazing_collection"
                                                                                        :color "#509EE3"}))
-            test-collection (mdb.query/query {:select [:*]
-                                              :from   [:collection]
-                                              :where  [:= :id collection-id]})]
+            test-collection (t2/select :model/Collection :id collection-id)]
 
         (migrate!)
         (testing "should drop the existing color column"

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -1142,7 +1142,6 @@
   (testing "Migration v48.00-017"
     (impl/test-migrations ["v48.00-017"] [migrate!]
       (let [{:keys [db-type ^javax.sql.DataSource data-source]} mdb.connection/*application-db*
-            custom-migrate!      (partial db.setup/migrate! db-type data-source)
             collection-id (first (t2/insert-returning-pks! (t2/table-name Collection) {:name "Amazing collection"
                                                                                        :slug "amazing_collection"
                                                                                        :color "#509EE3"}))
@@ -1154,6 +1153,6 @@
         (testing "should drop the existing color column"
           (is (true? (not (contains? (into {} test-collection) :color)))))
 
-        (custom-migrate! :down)
+        (db.setup/migrate! db-type data-source :down)
         (testing "Rollback to the previous version should restore the column column and set the default value"
           (is (= "#31698A" (:color test-collection))))))))

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -1153,6 +1153,6 @@
         (testing "should drop the existing color column"
           (is (not (contains? (t2/select-one :model/Collection :id collection-id) :color))))
 
-        (db.setup/migrate! db-type data-source :down)
+        (db.setup/migrate! db-type data-source :down 47)
         (testing "Rollback to the previous version should restore the column column, and set the default color value"
           (is (= "#31698A" (:color (t2/select-one :model/Collection :id collection-id)))))))))

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -1144,13 +1144,12 @@
       (let [{:keys [db-type ^javax.sql.DataSource data-source]} mdb.connection/*application-db*
             collection-id (first (t2/insert-returning-pks! (t2/table-name Collection) {:name "Amazing collection"
                                                                                        :slug "amazing_collection"
-                                                                                       :color "#509EE3"}))
-            test-collection (t2/select-one :model/Collection :id collection-id)]
+                                                                                       :color "#509EE3"}))]
 
         (migrate!)
         (testing "should drop the existing color column"
-          (is (true? (not (contains? test-collection :color)))))
+          (is (true? (not (contains? (t2/select-one :model/Collection :id collection-id) :color)))))
 
         (db.setup/migrate! db-type data-source :down)
-        (testing "Rollback to the previous version should restore the column column and set the default value"
-          (is (= "#31698A" (:color test-collection))))))))
+        (testing "Rollback to the previous version should restore the column column, and give it the default color value"
+          (is (= "#31698A" (:color (t2/select-one :model/Collection :id collection-id)))))))))

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -1144,7 +1144,7 @@
       (let [{:keys [db-type ^javax.sql.DataSource data-source]} mdb.connection/*application-db*
             migrate!      (partial db.setup/migrate! db-type data-source)
             collection-id (first (t2/insert-returning-pks! (t2/table-name Collection) {:name "Amazing collection"
-                                                                                       :slug "amazing-collection"
+                                                                                       :slug "amazing_collection"
                                                                                        :color "#509EE3"}))
             test-collection (mdb.query/query {:select [:*]
                                               :from   [:collection]

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -1152,7 +1152,7 @@
 
         (migrate! :up)
         (testing "should drop the existing color column"
-          (is (not (contains? (into {} test-collection) :color))))
+          (is (true? (not (contains? (into {} test-collection) :color)))))
 
         (migrate! :down)
         (testing "Rollback to the previous version should restore the column column and set the default value"

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -1151,8 +1151,8 @@
                                               :where  [:= :id collection-id]})]
 
         (migrate! :up)
-        (testing "should drop the existing color column")
-        (is (not (contains? (into {} test-collection) :color)))
+        (testing "should drop the existing color column"
+          (is (not (contains? (into {} test-collection) :color))))
 
         (migrate! :down)
         (testing "Rollback to the previous version should restore the column column and set the default value"

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -1143,7 +1143,9 @@
     (impl/test-migrations ["v48.00-017"] [_]
       (let [{:keys [db-type ^javax.sql.DataSource data-source]} mdb.connection/*application-db*
             migrate!      (partial db.setup/migrate! db-type data-source)
-            collection-id (first (t2/insert-returning-pks! (t2/table-name Collection) {:name  "Amazing collection" :color "#509EE3"}))
+            collection-id (first (t2/insert-returning-pks! (t2/table-name Collection) {:name "Amazing collection"
+                                                                                       :slug "amazing-collection"
+                                                                                       :color "#509EE3"}))
             test-collection (mdb.query/query {:select [:*]
                                               :from   [:collection]
                                               :where  [:= :id collection-id]})]

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -1145,11 +1145,11 @@
             collection-id (first (t2/insert-returning-pks! (t2/table-name Collection) {:name "Amazing collection"
                                                                                        :slug "amazing_collection"
                                                                                        :color "#509EE3"}))
-            test-collection (t2/select :model/Collection :id collection-id)]
+            test-collection (t2/select-one :model/Collection :id collection-id)]
 
         (migrate!)
         (testing "should drop the existing color column"
-          (is (true? (not (contains? (into {} test-collection) :color)))))
+          (is (true? (not (contains? test-collection :color)))))
 
         (db.setup/migrate! db-type data-source :down)
         (testing "Rollback to the previous version should restore the column column and set the default value"

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -52,29 +52,16 @@
 
 (deftest create-collection-test
   (testing "test that we can create a new Collection with valid inputs"
-    (t2.with-temp/with-temp [Collection collection {:name "My Favorite Cards", :color "#ABCDEF"}]
+    (t2.with-temp/with-temp [Collection collection {:name "My Favorite Cards"}]
       (is (partial= (merge
                      (mt/object-defaults Collection)
                      {:name              "My Favorite Cards"
                       :slug              "my_favorite_cards"
                       :description       nil
-                      :color             "#ABCDEF"
                       :archived          false
                       :location          "/"
                       :personal_owner_id nil})
                     collection)))))
-
-(deftest color-validation-test
-  (testing "Collection colors should be validated when inserted into the DB"
-    (doseq [[input msg] {nil        "Missing color"
-                         "#ABC"     "Too short"
-                         "#BCDEFG"  "Invalid chars"
-                         "#ABCDEFF" "Too long"
-                         "ABCDEF"   "Missing hash prefix"}]
-      (testing msg
-        (is (thrown?
-             Exception
-             (t2/insert! Collection {:name "My Favorite Cards", :color input})))))))
 
 (deftest with-temp-defaults-test
   (testing "double-check that `with-temp-defaults` are working correctly for Collection"
@@ -367,7 +354,7 @@
 (defmacro ^:private with-collection-in-location [[collection-binding location] & body]
   `(let [name# (mt/random-name)]
      (try
-       (let [~collection-binding (first (t2/insert-returning-instances! Collection :name name#, :color "#ABCDEF", :location ~location))]
+       (let [~collection-binding (first (t2/insert-returning-instances! Collection :name name#, :location ~location))]
          ~@body)
        (finally
          (t2/delete! Collection :name name#)))))
@@ -1439,7 +1426,6 @@
              #"Collection must be in the same namespace as its parent"
              (t2/insert! Collection
                          {:location  (format "/%d/" (:id parent-collection))
-                          :color     "#F38630"
                           :name      "Child Collection"
                           :namespace child-namespace}))))
 
@@ -1465,8 +1451,7 @@
            clojure.lang.ExceptionInfo
            #"Personal Collections must be in the default namespace"
            (t2/insert! Collection
-                       {:color             "#F38630"
-                        :name              "Personal Collection"
+                       {:name              "Personal Collection"
                         :namespace         "x"
                         :personal_owner_id user-id}))))))
 

--- a/test/metabase/test/generate.clj
+++ b/test/metabase/test/generate.clj
@@ -44,7 +44,6 @@
 (s/def ::not-empty-string (s/and string? not-empty #(< (count %) 10)))
 
 (s/def ::database (s/keys :req-un [::id ::engine ::name ::details]))
-(s/def ::color #{"#A00000" "#FFFFFF"})
 (s/def ::password ::not-empty-string)
 (s/def ::str? (s/or :nil nil? :string string?))
 (s/def ::topic ::not-empty-string)
@@ -150,7 +149,7 @@
 (s/def ::http-action (s/keys :req-un [::template]))
 
 (s/def ::core-user (s/keys :req-un [::id ::first_name ::last_name ::email ::password]))
-(s/def ::collection (s/keys :req-un [::id ::name ::color]))
+(s/def ::collection (s/keys :req-un [::id ::name]))
 (s/def ::activity (s/keys :req-un [::id ::topic ::details ::timestamp]))
 (s/def ::pulse (s/keys :req-un [::id ::name]))
 (s/def ::permissions-group (s/keys :req-un [::id ::name]))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -110,8 +110,7 @@
             :visualization_settings {}})
 
    Collection
-   (fn [_] {:name  (tu.random/random-name)
-            :color "#ABCDEF"})
+   (fn [_] {:name  (tu.random/random-name)})
 
    :model/Dashboard
    (fn [_] {:creator_id (rasta-id)

--- a/test_resources/instance_analytics_skip/collections/Lq6nt9JfsdTZXXz6cj1mX_a_a_a_a_a_a_s_personal_collection/Lq6nt9JfsdTZXXz6cj1mX_a_a_a_a_a_a_s_personal_collection.yaml
+++ b/test_resources/instance_analytics_skip/collections/Lq6nt9JfsdTZXXz6cj1mX_a_a_a_a_a_a_s_personal_collection/Lq6nt9JfsdTZXXz6cj1mX_a_a_a_a_a_a_s_personal_collection.yaml
@@ -2,7 +2,6 @@ authority_level: null
 description: null
 archived: false
 slug: a_a_a_a_a_a_s_personal_collection
-color: '#31698A'
 name: a@a.a a@a.a's Personal Collection
 personal_owner_id: a@a.a
 type: null

--- a/test_resources/instance_analytics_skip/collections/tYhkn_-pFTWcCTSwhgCBP_instance_analytics/tYhkn_-pFTWcCTSwhgCBP_instance_analytics.yaml
+++ b/test_resources/instance_analytics_skip/collections/tYhkn_-pFTWcCTSwhgCBP_instance_analytics/tYhkn_-pFTWcCTSwhgCBP_instance_analytics.yaml
@@ -2,7 +2,6 @@ authority_level: null
 description: null
 archived: false
 slug: instance_analytics
-color: '#509EE3'
 name: Instance Analytics
 personal_owner_id: null
 type: null


### PR DESCRIPTION
The `color` key hasn't been used for collections in over five years.
This PR removes it and resolves https://github.com/metabase/metabase/issues/23663

### What else does this PR accomplish?
- Adds a migration
- Adds a migration test
    - up: makes sure that the color column is dropped
    - down: makes sure we restore the color column, and we set the default value (since the field has been marked as non-nullable for so long)[^1]
- Removes `color` from FE Collection type/interface
- Removes `color` from FE unit and E2E tests, and their helpers

### Notes
- Running `./bin/lint-migrations-file.sh` locally gave me
```
Check Liquibase migrations file...
Ok.
```
- The alternative and possibly safer approach would've been to only migrate to `nullable` column type first, but this has not been used in such a long time that I went for a complete removal
- Historical context - see how Metabase collections looked and why this key was used back in `v0.22`
https://www.metabase.com/releases/2017-01-03-Metabase-0.22 

[^1]: My original intent was to rollback to a nullable color column. It would most likely be safe, but @calherries correctly noted that we should strive to return the system to its exact previous state to avoid unexpected bugs in other parts of the code base.