### PR TITLE
Add filter operators API

### DIFF
--- a/frontend/src/metabase-lib/expression.ts
+++ b/frontend/src/metabase-lib/expression.ts
@@ -44,7 +44,7 @@ export function expressionParts(
 
 export function expressionClause(
   operator: ExpressionOperatorName,
-  args: ExpressionArg[],
+  args: (ExpressionArg | ExpressionClause)[],
   options: ExpressionOptions | null = null,
 ): ExpressionClause {
   return ML.expression_clause(operator, args, options);

--- a/frontend/src/metabase-lib/expression.ts
+++ b/frontend/src/metabase-lib/expression.ts
@@ -3,7 +3,7 @@ import type {
   ColumnMetadata,
   ExpressionArg,
   ExpressionClause,
-  ExpressionOperator,
+  ExpressionOperatorName,
   ExpressionOptions,
   ExpressionParts,
   FilterClause,
@@ -43,8 +43,8 @@ export function expressionParts(
 }
 
 export function expressionClause(
-  operator: ExpressionOperator,
-  args: (ExpressionArg | ExpressionClause)[],
+  operator: ExpressionOperatorName,
+  args: ExpressionArg[],
   options: ExpressionOptions | null = null,
 ): ExpressionClause {
   return ML.expression_clause(operator, args, options);

--- a/frontend/src/metabase-lib/filter.ts
+++ b/frontend/src/metabase-lib/filter.ts
@@ -14,6 +14,7 @@ import type {
   FilterParts,
   NumberFilterParts,
   Query,
+  RelativeDateFilterParts,
   SpecificDateFilterParts,
   StringFilterParts,
 } from "./types";
@@ -240,6 +241,36 @@ export function isSpecificDateFilter(
   filterClause: FilterClause,
 ): boolean {
   return specificDateFilterParts(query, stageIndex, filterClause) != null;
+}
+
+export function relativeDateFilterClause({
+  column,
+  value,
+  bucket,
+  offsetValue,
+  offsetBucket,
+  options,
+}: RelativeDateFilterParts): ExpressionClause {
+  if (offsetValue == null || offsetBucket == null) {
+    return expressionClause("time-interval", [column, value, bucket], options);
+  }
+
+  return expressionClause("between", [
+    expressionClause("+", [
+      column,
+      expressionClause("interval", [-offsetValue, offsetBucket]),
+    ]),
+    expressionClause("relative-datetime", [value < 0 ? value : 0, bucket]),
+    expressionClause("relative-datetime", [value > 0 ? value : 0, bucket]),
+  ]);
+}
+
+export function relativeDateFilterParts(
+  query: Query,
+  stageIndex: number,
+  filterClause: FilterClause,
+): RelativeDateFilterParts | null {
+  return null;
 }
 
 export function excludeDateFilterClause({

--- a/frontend/src/metabase-lib/filter.ts
+++ b/frontend/src/metabase-lib/filter.ts
@@ -308,6 +308,7 @@ export function filterParts(
     numberFilterParts(query, stageIndex, filterClause) ??
     booleanFilterParts(query, stageIndex, filterClause) ??
     specificDateFilterParts(query, stageIndex, filterClause) ??
+    relativeDateFilterParts(query, stageIndex, filterClause) ??
     excludeDateFilterParts(query, stageIndex, filterClause)
   );
 }

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -31,6 +31,8 @@ import type {
   TableDisplayInfo,
   TableMetadata,
   Query,
+  FilterOperator,
+  FilterOperatorDisplayInfo,
 } from "./types";
 
 export function metadataProvider(
@@ -97,13 +99,18 @@ declare function DisplayInfoFn(
 declare function DisplayInfoFn(
   query: Query,
   stageIndex: number,
-  filterOperator: JoinConditionOperator,
+  joinOperator: JoinConditionOperator,
 ): JoinConditionOperatorDisplayInfo;
 declare function DisplayInfoFn(
   query: Query,
   stageIndex: number,
   drillThru: DrillThru,
 ): DrillThruDisplayInfo;
+declare function DisplayInfoFn(
+  query: Query,
+  stageIndex: number,
+  filterOperator: FilterOperator,
+): FilterOperatorDisplayInfo;
 
 // x can be any sort of opaque object, e.g. a clause or metadata map. Values returned depend on what you pass in, but it
 // should always have display_name... see :metabase.lib.metadata.calculation/display-info schema

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -99,7 +99,7 @@ declare function DisplayInfoFn(
 declare function DisplayInfoFn(
   query: Query,
   stageIndex: number,
-  joinOperator: JoinConditionOperator,
+  joinConditionOperator: JoinConditionOperator,
 ): JoinConditionOperatorDisplayInfo;
 declare function DisplayInfoFn(
   query: Query,

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -130,7 +130,7 @@ export type OrderByClauseDisplayInfo = ClauseDisplayInfo & {
   direction: OrderByDirection;
 };
 
-export type ExpressionOperator =
+export type ExpressionOperatorName =
   | "+"
   | "="
   | "!="
@@ -151,11 +151,17 @@ export type ExpressionOperator =
   | "time-interval"
   | "relative-datetime";
 
-export type ExpressionArg = null | boolean | number | string | ColumnMetadata;
+export type ExpressionArg =
+  | null
+  | boolean
+  | number
+  | string
+  | ColumnMetadata
+  | ExpressionClause;
 
 export type ExpressionParts = {
-  operator: ExpressionOperator;
-  args: (ExpressionArg | ExpressionParts)[];
+  operator: ExpressionOperatorName;
+  args: ExpressionArg[];
   options: ExpressionOptions;
 };
 
@@ -164,10 +170,21 @@ export type ExpressionOptions = {
   "include-current"?: boolean;
 };
 
-export type StringFilterOperator = Extract<
-  ExpressionOperator,
+export type ExpressionOperatorDisplayInfo = {
+  shortName: ExpressionOperatorName;
+};
+
+declare const FilterOperator: unique symbol;
+export type FilterOperator = unknown & { _opaque: typeof FilterOperator };
+
+export type FilterOperatorName =
   | "="
   | "!="
+  | ">"
+  | "<"
+  | "between"
+  | ">="
+  | "<="
   | "contains"
   | "does-not-contain"
   | "is-null"
@@ -175,35 +192,15 @@ export type StringFilterOperator = Extract<
   | "is-empty"
   | "not-empty"
   | "starts-with"
-  | "ends-with"
->;
+  | "ends-with";
 
-export type NumberFilterOperator = Extract<
-  ExpressionOperator,
-  "=" | "!=" | ">" | "<" | "between" | ">=" | "<=" | "is-null" | "not-null"
->;
+export type FilterOperatorDisplayInfo = {
+  shortName: FilterOperatorName;
+  displayName: string;
+  default?: boolean;
+};
 
-export type BooleanFilterOperator = Extract<
-  ExpressionOperator,
-  "=" | "is-null" | "not-null"
->;
-
-export type SpecificDateFilterOperator = Extract<
-  ExpressionOperator,
-  "=" | "<" | ">" | "between"
->;
-
-export type ExcludeDateFilterOperator = Extract<
-  ExpressionOperator,
-  "!=" | "is-null" | "not-null"
->;
-
-export type TimeFilterOperator = Extract<
-  ExpressionOperator,
-  "<" | ">" | "between"
->;
-
-export type TemporalUnit =
+export type BucketName =
   | "minute"
   | "hour"
   | "day"
@@ -216,18 +213,8 @@ export type TemporalUnit =
   | "quarter-of-year"
   | "hour-of-day";
 
-export type RelativeTemporalUnit = Extract<
-  TemporalUnit,
-  "minute" | "hour" | "day" | "week" | "quarter" | "month" | "year"
->;
-
-export type ExcludeTemporalUnit = Extract<
-  TemporalUnit,
-  "day-of-week" | "month-of-year" | "quarter-of-year" | "hour-of-day"
->;
-
 export type StringFilterParts = {
-  operator: StringFilterOperator;
+  operator: FilterOperator;
   column: ColumnMetadata;
   values: string[];
   options: StringFilterOptions;
@@ -238,34 +225,21 @@ export type StringFilterOptions = {
 };
 
 export type NumberFilterParts = {
-  operator: NumberFilterOperator;
+  operator: FilterOperator;
   column: ColumnMetadata;
   values: number[];
 };
 
 export type BooleanFilterParts = {
-  operator: BooleanFilterOperator;
+  operator: FilterOperator;
   column: ColumnMetadata;
   values: boolean[];
 };
 
 export type SpecificDateFilterParts = {
-  operator: SpecificDateFilterOperator;
+  operator: FilterOperator;
   column: ColumnMetadata;
   values: string[]; // yyyy-MM-dd or yyyy-MM-ddTHH:mm:ss
-};
-
-export type RelativeDateFilterParts = {
-  column: ColumnMetadata;
-  value: number | "current";
-  unit: RelativeTemporalUnit;
-  offsetValue?: number;
-  offsetUnit?: RelativeTemporalUnit;
-  options: RelativeDateFilterOptions;
-};
-
-export type RelativeDateFilterOptions = {
-  "include-current"?: boolean;
 };
 
 // values depend on the unit
@@ -275,14 +249,14 @@ export type RelativeDateFilterOptions = {
 // hour-of-day => 0-23
 
 export type ExcludeDateFilterParts = {
-  operator: ExcludeDateFilterOperator;
+  operator: FilterOperator;
   column: ColumnMetadata;
   values: number[];
-  unit: ExcludeTemporalUnit;
+  bucket: Bucket;
 };
 
 export type TimeFilterParts = {
-  operator: TimeFilterOperator;
+  operator: FilterOperator;
   column: ColumnMetadata;
   values: string[]; // HH:mm:ss
 };
@@ -293,7 +267,6 @@ export type FilterParts =
   | BooleanFilterParts
   | TimeFilterParts
   | SpecificDateFilterParts
-  | RelativeDateFilterParts
   | ExcludeDateFilterParts;
 
 declare const Join: unique symbol;

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -64,6 +64,25 @@ export type ColumnGroup = unknown & { _opaque: typeof ColumnGroup };
 declare const Bucket: unique symbol;
 export type Bucket = unknown & { _opaque: typeof Bucket };
 
+export type BucketName =
+  | "minute"
+  | "hour"
+  | "day"
+  | "week"
+  | "quarter"
+  | "month"
+  | "year"
+  | "day-of-week"
+  | "month-of-year"
+  | "quarter-of-year"
+  | "hour-of-day";
+
+export type BucketDisplayInfo = {
+  displayName: string;
+  default?: boolean;
+  selected?: boolean;
+};
+
 export type TableDisplayInfo = {
   name: string;
   displayName: string;
@@ -120,12 +139,6 @@ export type AggregationClauseDisplayInfo = ClauseDisplayInfo;
 
 export type BreakoutClauseDisplayInfo = ClauseDisplayInfo;
 
-export type BucketDisplayInfo = {
-  displayName: string;
-  default?: boolean;
-  selected?: boolean;
-};
-
 export type OrderByClauseDisplayInfo = ClauseDisplayInfo & {
   direction: OrderByDirection;
 };
@@ -170,10 +183,6 @@ export type ExpressionOptions = {
   "include-current"?: boolean;
 };
 
-export type ExpressionOperatorDisplayInfo = {
-  shortName: ExpressionOperatorName;
-};
-
 declare const FilterOperator: unique symbol;
 export type FilterOperator = unknown & { _opaque: typeof FilterOperator };
 
@@ -200,21 +209,8 @@ export type FilterOperatorDisplayInfo = {
   default?: boolean;
 };
 
-export type BucketName =
-  | "minute"
-  | "hour"
-  | "day"
-  | "week"
-  | "quarter"
-  | "month"
-  | "year"
-  | "day-of-week"
-  | "month-of-year"
-  | "quarter-of-year"
-  | "hour-of-day";
-
 export type StringFilterParts = {
-  operator: FilterOperator;
+  operator: FilterOperatorName;
   column: ColumnMetadata;
   values: string[];
   options: StringFilterOptions;
@@ -225,38 +221,38 @@ export type StringFilterOptions = {
 };
 
 export type NumberFilterParts = {
-  operator: FilterOperator;
+  operator: FilterOperatorName;
   column: ColumnMetadata;
   values: number[];
 };
 
 export type BooleanFilterParts = {
-  operator: FilterOperator;
+  operator: FilterOperatorName;
   column: ColumnMetadata;
   values: boolean[];
 };
 
 export type SpecificDateFilterParts = {
-  operator: FilterOperator;
+  operator: FilterOperatorName;
   column: ColumnMetadata;
   values: string[]; // yyyy-MM-dd or yyyy-MM-ddTHH:mm:ss
 };
 
-// values depend on the unit
+// values depend on the bucket
 // day-of-week => 1-7 (Monday-Sunday)
 // month-of-year => 0-11 (January-December)
 // quarter-of-year => 1-4
 // hour-of-day => 0-23
 
 export type ExcludeDateFilterParts = {
-  operator: FilterOperator;
+  operator: FilterOperatorName;
   column: ColumnMetadata;
   values: number[];
-  bucket: Bucket;
+  bucket: BucketName;
 };
 
 export type TimeFilterParts = {
-  operator: FilterOperator;
+  operator: FilterOperatorName;
   column: ColumnMetadata;
   values: string[]; // HH:mm:ss
 };

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -238,6 +238,19 @@ export type SpecificDateFilterParts = {
   values: string[]; // yyyy-MM-dd or yyyy-MM-ddTHH:mm:ss
 };
 
+export type RelativeDateFilterParts = {
+  column: ColumnMetadata;
+  value: number | "current";
+  bucket: BucketName;
+  offsetValue?: number;
+  offsetBucket?: BucketName;
+  options: RelativeDateFilterOptions;
+};
+
+export type RelativeDateFilterOptions = {
+  "include-current"?: boolean;
+};
+
 // values depend on the bucket
 // day-of-week => 1-7 (Monday-Sunday)
 // month-of-year => 0-11 (January-December)
@@ -263,6 +276,7 @@ export type FilterParts =
   | BooleanFilterParts
   | TimeFilterParts
   | SpecificDateFilterParts
+  | RelativeDateFilterParts
   | ExcludeDateFilterParts;
 
 declare const Join: unique symbol;

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -78,6 +78,7 @@ export type BucketName =
   | "hour-of-day";
 
 export type BucketDisplayInfo = {
+  shortName: BucketName;
   displayName: string;
   default?: boolean;
   selected?: boolean;
@@ -253,7 +254,7 @@ export type RelativeDateFilterOptions = {
 
 // values depend on the bucket
 // day-of-week => 1-7 (Monday-Sunday)
-// month-of-year => 0-11 (January-December)
+// month-of-year => 1-12 (January-December)
 // quarter-of-year => 1-4
 // hour-of-day => 0-23
 

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -165,17 +165,11 @@ export type ExpressionOperatorName =
   | "time-interval"
   | "relative-datetime";
 
-export type ExpressionArg =
-  | null
-  | boolean
-  | number
-  | string
-  | ColumnMetadata
-  | ExpressionClause;
+export type ExpressionArg = null | boolean | number | string | ColumnMetadata;
 
 export type ExpressionParts = {
   operator: ExpressionOperatorName;
-  args: ExpressionArg[];
+  args: (ExpressionArg | ExpressionParts)[];
   options: ExpressionOptions;
 };
 

--- a/frontend/src/metabase/common/components/FilterPicker/BooleanFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/BooleanFilterPicker.tsx
@@ -1,12 +1,11 @@
 import { t } from "ttag";
 import { useMemo, useState } from "react";
-
 import { Box, Button, Radio, Stack } from "metabase/ui";
 import * as Lib from "metabase-lib";
-import type { FilterPickerWidgetProps } from "./types";
 import { BackButton } from "./BackButton";
 import { Header } from "./Header";
 import { Footer } from "./Footer";
+import type { FilterPickerWidgetProps } from "./types";
 
 type OptionType = "true" | "false" | "empty" | "not-empty";
 
@@ -70,7 +69,7 @@ export function BooleanFilterPicker({
     return isExpanded ? options : options.filter(option => option.isAdvanced);
   }, [options, isExpanded]);
 
-  const handleChange = (type: string) => {
+  const handleOptionChange = (type: string) => {
     setOptionType(type as OptionType);
   };
 
@@ -84,7 +83,7 @@ export function BooleanFilterPicker({
         <BackButton onClick={onBack}>{columnInfo.displayName}</BackButton>
       </Header>
       <Stack p="md">
-        <Radio.Group value={optionType} onChange={handleChange}>
+        <Radio.Group value={optionType} onChange={handleOptionChange}>
           {visibleOptions.map(option => (
             <Radio
               key={option.type}

--- a/frontend/src/metabase/common/components/FilterPicker/BooleanFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/BooleanFilterPicker.tsx
@@ -66,7 +66,7 @@ export function BooleanFilterPicker({
   );
 
   const visibleOptions = useMemo(() => {
-    return isExpanded ? options : options.filter(option => option.isAdvanced);
+    return isExpanded ? options : options.filter(option => !option.isAdvanced);
   }, [options, isExpanded]);
 
   const handleOptionChange = (type: string) => {

--- a/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
@@ -10,7 +10,7 @@ export interface FilterPickerProps {
   query: Lib.Query;
   stageIndex: number;
   filter?: Lib.FilterClause;
-  onSelect: (filter: Lib.FilterClause) => void;
+  onSelect: (filter: Lib.ExpressionClause) => void;
   onClose?: () => void;
 }
 

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
@@ -11,8 +11,11 @@ import {
 
 type NoBucket = null;
 
-export type BucketListItem = Lib.BucketDisplayInfo & {
+export type BucketListItem = {
+  displayName: string;
   bucket: Lib.Bucket | NoBucket;
+  default?: boolean;
+  selected?: boolean;
 };
 
 export interface BaseBucketPickerPopoverProps {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep/FilterStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep/FilterStep.tsx
@@ -20,14 +20,14 @@ export function FilterStep({
     [topLevelQuery, stageIndex],
   );
 
-  const handleAddFilter = (filter: Lib.FilterClause) => {
+  const handleAddFilter = (filter: Lib.ExpressionClause) => {
     const nextQuery = Lib.filter(topLevelQuery, stageIndex, filter);
     updateQuery(nextQuery);
   };
 
   const handleUpdateFilter = (
     filter: Lib.FilterClause,
-    nextFilter: Lib.FilterClause,
+    nextFilter: Lib.ExpressionClause,
   ) => {
     const nextQuery = Lib.replaceClause(
       topLevelQuery,


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/34190

Changes:
- Bring `filterableColumnOperators` back. Use the return value as a source of truth which operators are supported.  The thing is that computing a list of supported operators is a bit complex task because it's different if the column is a PK, for instance.
- Update `filterParts` functions to rely on `filterableColumnOperators` for operator checks.
- Update `BooleanFilterPicker` to use it.
- Remove date filters for now - the way we work with temporal buckets needs to be re-worked, TBD in next PRs

We should follow the following pattern with operators:
- `filterableColumnOperators` returns operators
- The component either intersects these operators with what it supports or has some default behavior for non-special operators
This is how `BooleanFilterPicker` works in this PR