### PR TITLE
Fixed & symbol escaping for the bug-triage integration

### DIFF
--- a/.github/workflows/bugs-triage-slack-notification.yml
+++ b/.github/workflows/bugs-triage-slack-notification.yml
@@ -21,8 +21,9 @@ jobs:
       - name: Check for labels containing team name
         id: check_labels
         run: |
+          labels_json=$(sed 's/&/\$/g' <<< '${{ toJson(github.event.issue.labels) }}')
           echo "has_team_label=false" >> "$GITHUB_OUTPUT"
-          for label in "${{ toJson(github.event.issue.labels) }}"
+          for label in "$labels_json"
           do
             if [[ $label == *".Team"* ]]; then
               echo "Label contains the team name."


### PR DESCRIPTION
Script can't handle the & in the label name (e.g. Querying/Parameters & Variables)

Context: https://metaboat.slack.com/archives/C05NXACAG1G/p1695803002769909?thread_ts=1695735460.328409&cid=C05NXACAG1G