### PR TITLE
Fix flaky ActionViz unit tests

### DIFF
--- a/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
@@ -351,10 +351,11 @@ describe("Actions > ActionViz > Action", () => {
       userEvent.click(editActionEl);
 
       const editorModal = await screen.findByTestId("action-editor-modal");
+      const actionTitle = await within(editorModal).findByText(
+        "My Awesome Action",
+      );
 
-      expect(
-        within(editorModal).getByText("My Awesome Action"),
-      ).toBeInTheDocument();
+      expect(actionTitle).toBeInTheDocument();
 
       const cancelEditButton = within(editorModal).getByText("Cancel");
       expect(cancelEditButton).toBeInTheDocument();
@@ -393,7 +394,9 @@ describe("Actions > ActionViz > Action", () => {
       const editorModal = await screen.findByTestId("action-editor-modal");
 
       // edit action title
-      const actionTitleField = within(editorModal).getByTestId("editable-text");
+      const actionTitleField = await within(editorModal).findByTestId(
+        "editable-text",
+      );
       userEvent.type(actionTitleField, updatedTitle);
       userEvent.tab(); // blur field
 

--- a/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
@@ -351,11 +351,8 @@ describe("Actions > ActionViz > Action", () => {
       userEvent.click(editActionEl);
 
       const editorModal = await screen.findByTestId("action-editor-modal");
-      const actionTitle = await within(editorModal).findByText(
-        "My Awesome Action",
-      );
 
-      expect(actionTitle).toBeInTheDocument();
+      await within(editorModal).findByText("My Awesome Action");
 
       const cancelEditButton = within(editorModal).getByText("Cancel");
       expect(cancelEditButton).toBeInTheDocument();


### PR DESCRIPTION
Fixes flaky ActionViz unit tests.
More context in [slack 🧵 ](https://metaboat.slack.com/archives/C057T1QTB3L/p1695969979382479) .

### Description
The issue happened because internal model content is wrapped into EntityObjectLoader and we didn't await it's content to be loaded and ready.


### How to verify

Run jest tests without cache `yarn jest --maxWorkers=4 --no-cache`,
`should allow to edit underlying action if a user has edit permissions` and `should open action form after action editing` tests in `Action.unit.spec.tsx` should pass without errors.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
