### PR TITLE
Add more E2E tests around joins

### DIFF
--- a/e2e/test/scenarios/joins/joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins.cy.spec.js
@@ -47,6 +47,23 @@ describe("scenarios > question > joined questions", () => {
       rhsSampleColumn: "Reviews - Product → ID",
     });
 
+    openNotebook();
+    getNotebookStep("join").icon("chevrondown").click();
+    popover().within(() => {
+      cy.findByText("Product ID").click();
+      cy.findByText("Body").click();
+      cy.findByText("Created At").click();
+    });
+    visualize();
+
+    assertJoinValid({
+      lhsTable: "Orders",
+      rhsTable: "Reviews",
+      lhsSampleColumn: "Product ID",
+      rhsSampleColumn: "Reviews - Product → Reviewer",
+    });
+    queryBuilderMain().findByText("Body").should("not.exist");
+
     // Post-join filters on the joined table (metabase#12221, metabase#15570)
     openNotebook();
     filter({ mode: "notebook" });
@@ -81,13 +98,13 @@ describe("scenarios > question > joined questions", () => {
   it("should join a native question", () => {
     cy.createNativeQuestion({
       name: "question a",
-      native: { query: "select 'foo' as a_column" },
+      native: { query: "select ID, PRODUCT_ID, TOTAL from orders" },
     });
 
     cy.createNativeQuestion(
       {
         name: "question b",
-        native: { query: "select 'foo' as b_column" },
+        native: { query: "select * from products" },
       },
       {
         wrapId: true,
@@ -97,8 +114,8 @@ describe("scenarios > question > joined questions", () => {
 
     startNewQuestion();
     selectSavedQuestionsToJoin("question a", "question b");
-    popover().findByText("A_COLUMN").click();
-    popover().findByText("B_COLUMN").click();
+    popover().findByText("PRODUCT_ID").click();
+    popover().findByText("ID").click();
 
     visualize();
 
@@ -106,34 +123,53 @@ describe("scenarios > question > joined questions", () => {
       assertJoinValid({
         lhsTable: "question a",
         rhsTable: "question b",
-        lhsSampleColumn: "A_COLUMN",
-        rhsSampleColumn: `Question ${joinedQuestionId} → B Column`,
+        lhsSampleColumn: "TOTAL",
+        rhsSampleColumn: `Question ${joinedQuestionId} → ID`,
       });
     });
-    assertQueryBuilderRowCount(1);
+
+    openNotebook();
+    getNotebookStep("join").icon("chevrondown").click();
+    popover().within(() => {
+      cy.findByText("EAN").click();
+      cy.findByText("VENDOR").click();
+      cy.findByText("PRICE").click();
+      cy.findByText("CATEGORY").click();
+      cy.findByText("CREATED_AT").click();
+    });
+    visualize();
+    cy.get("@joinedQuestionId").then(joinedQuestionId => {
+      assertJoinValid({
+        lhsTable: "question a",
+        rhsTable: "question b",
+        lhsSampleColumn: "TOTAL",
+        rhsSampleColumn: `Question ${joinedQuestionId} → Rating`,
+      });
+    });
+    queryBuilderMain().findByText("EAN").should("not.exist");
 
     openNotebook();
     cy.get("@joinedQuestionId").then(joinedQuestionId => {
       filter({ mode: "notebook" });
       popover().within(() => {
         cy.findByText(`Question ${joinedQuestionId}`).click();
-        cy.findByText("B_COLUMN").click();
-        cy.findByPlaceholderText("Enter some text").type("foo");
+        cy.findByText("CATEGORY").click();
+        cy.findByPlaceholderText("Enter some text").type("Gadget");
         cy.button("Add filter").click();
       });
 
       summarize({ mode: "notebook" });
       addSummaryGroupingField({
         table: `Question ${joinedQuestionId}`,
-        field: "B_COLUMN",
+        field: "CATEGORY",
       });
     });
     visualize();
 
     cy.findByTestId("qb-filters-panel")
-      .findByText("B_COLUMN is foo")
+      .findByText("CATEGORY is Gadget")
       .should("be.visible");
-    cy.get(".ScalarValue").contains("foo").should("be.visible");
+    cy.get(".ScalarValue").contains("Gadget").should("be.visible");
   });
 
   it("should join structured questions (metabase#13000, metabase#13649, metabase#13744)", () => {
@@ -185,7 +221,23 @@ describe("scenarios > question > joined questions", () => {
     });
 
     openNotebook();
+    getNotebookStep("join").icon("chevrondown").click();
+    popover().findByText("ID").click();
+    visualize();
 
+    cy.get("@joinedQuestionId").then(joinedQuestionId => {
+      assertJoinValid({
+        lhsTable: "Q1",
+        rhsTable: "Q2",
+        lhsSampleColumn: "Product ID",
+        rhsSampleColumn: `Question ${joinedQuestionId} → Sum of Total`,
+      });
+      queryBuilderMain()
+        .findByText(`Question ${joinedQuestionId} → ID`)
+        .should("not.exist");
+    });
+
+    openNotebook();
     cy.get("@joinedQuestionId").then(joinedQuestionId => {
       // add a custom column on top of the steps from the #13000 repro which was simply asserting
       // that a question could be made by joining two previously saved questions

--- a/e2e/test/scenarios/joins/joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins.cy.spec.js
@@ -210,6 +210,27 @@ describe("scenarios > question > joined questions", () => {
       .should("be.visible");
   });
 
+  it("should handle joins on different stages", () => {
+    openOrdersTable({ mode: "notebook" });
+
+    join();
+    joinTable("Products");
+
+    summarize({ mode: "notebook" });
+    addSummaryField({ metric: "Count of rows" });
+    addSummaryGroupingField({ table: "Product", field: "ID" });
+
+    join();
+    joinTable("Reviews", "ID", "Product ID");
+    visualize();
+
+    assertJoinValid({
+      lhsSampleColumn: "Count",
+      rhsSampleColumn: "Reviews → ID",
+    });
+    assertQueryBuilderRowCount(1136);
+  });
+
   it("should allow joins with multiple conditions", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
     openOrdersTable({ mode: "notebook" });

--- a/e2e/test/scenarios/joins/joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins.cy.spec.js
@@ -274,7 +274,7 @@ describe("scenarios > question > joined questions", () => {
     addSummaryField({ metric: "Count of rows" });
     addSummaryGroupingField({ table: "Product", field: "ID" });
 
-    join();
+    cy.findAllByTestId("action-buttons").last().button("Join data").click();
     joinTable("Reviews", "ID", "Product ID");
     visualize();
 

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -441,6 +441,8 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
   });
 
   it("should prompt to join with a model if the question is based on a model", () => {
+    cy.intercept("GET", "/api/table/*/query_metadata").as("loadMetadata");
+
     cy.createQuestion({
       name: "Products model",
       query: { "source-table": PRODUCTS_ID },
@@ -458,6 +460,8 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     startNewQuestion();
     popover().findByText("Models").click();
     popover().findByText("Products model").click();
+    cy.wait("@loadMetadata");
+
     join();
     popover().findByText("Orders model").click();
     popover().findByText("ID").click();

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -7,6 +7,7 @@ import {
   filterField,
   getNotebookStep,
   join,
+  openNotebook,
   openOrdersTable,
   openProductsTable,
   openTable,
@@ -450,17 +451,17 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       display: "table",
     });
 
-    cy.createQuestion({
-      name: "Orders model",
-      query: { "source-table": ORDERS_ID },
-      dataset: true,
-      display: "table",
-    });
+    cy.createQuestion(
+      {
+        name: "Orders model",
+        query: { "source-table": ORDERS_ID },
+        dataset: true,
+        display: "table",
+      },
+      { visitQuestion: true },
+    );
 
-    startNewQuestion();
-    popover().findByText("Models").click();
-    popover().findByText("Products model").click();
-    cy.wait("@loadMetadata");
+    openNotebook();
 
     join();
     popover().findByText("Orders model").click();


### PR DESCRIPTION
Extends the joins E2E test suite to cover the following scenarios:

* using columns from a joined table or card (structured or native) in other clauses (filters, breakouts, etc.)
* selecting a subset of columns from the RHS join table or card (structured or native)
* building multi-stage joins
* cleaning up joins after a source table change

**To verify:** CI should be green