### PR TITLE
Clean up join E2E tests

### DIFF
--- a/e2e/support/helpers/e2e-bi-basics-helpers.js
+++ b/e2e/support/helpers/e2e-bi-basics-helpers.js
@@ -1,4 +1,4 @@
-import { popover } from "e2e/support/helpers";
+import { popover, queryBuilderMain } from "e2e/support/helpers";
 
 /**
  * Initiate Summarize action
@@ -112,4 +112,32 @@ function getIcon(actionType) {
 export function assertQueryBuilderRowCount(count) {
   const message = count === 1 ? "Showing 1 row" : `Showing ${count} rows`;
   cy.findByTestId("question-row-count").contains(message);
+}
+
+/**
+ * Assert a join is valid by checking query builder UI and query results.
+ * Expects a question to be visualized as a table.
+ *
+ * @param {string} lhsTable join's LHS table name
+ * @param {string} rhsTable join's RHS table name
+ * @param {string} lhsSampleColumn join's LHS sample column name
+ * @param {string} rhsSampleColumn join's RHS sample column name
+ */
+export function assertJoinValid({
+  lhsTable,
+  rhsTable,
+  lhsSampleColumn,
+  rhsSampleColumn,
+}) {
+  // Ensure the QB shows `${lhsTable} + ${rhsTable}` in the header
+  cy.findByTestId("question-table-badges").within(() => {
+    cy.findByText(lhsTable).should("be.visible");
+    cy.findByText(rhsTable).should("be.visible");
+  });
+
+  // Ensure the results have columns from both tables
+  queryBuilderMain().within(() => {
+    cy.findByText(lhsSampleColumn).should("be.visible");
+    cy.findByText(rhsSampleColumn).should("be.visible");
+  });
 }

--- a/e2e/support/helpers/e2e-bi-basics-helpers.js
+++ b/e2e/support/helpers/e2e-bi-basics-helpers.js
@@ -118,8 +118,8 @@ export function assertQueryBuilderRowCount(count) {
  * Assert a join is valid by checking query builder UI and query results.
  * Expects a question to be visualized as a table.
  *
- * @param {string} lhsTable join's LHS table name
- * @param {string} rhsTable join's RHS table name
+ * @param {string} [lhsTable] join's LHS table name
+ * @param {string} [rhsTable] join's RHS table name
  * @param {string} lhsSampleColumn join's LHS sample column name
  * @param {string} rhsSampleColumn join's RHS sample column name
  */
@@ -130,10 +130,13 @@ export function assertJoinValid({
   rhsSampleColumn,
 }) {
   // Ensure the QB shows `${lhsTable} + ${rhsTable}` in the header
-  cy.findByTestId("question-table-badges").within(() => {
-    cy.findByText(lhsTable).should("be.visible");
-    cy.findByText(rhsTable).should("be.visible");
-  });
+  // The check is optional for cases when a table name isn't clear (e.g. a multi-stage ad-hoc question)
+  if (lhsTable && rhsTable) {
+    cy.findByTestId("question-table-badges").within(() => {
+      cy.findByText(lhsTable).should("be.visible");
+      cy.findByText(rhsTable).should("be.visible");
+    });
+  }
 
   // Ensure the results have columns from both tables
   queryBuilderMain().within(() => {

--- a/e2e/support/helpers/e2e-bi-basics-helpers.js
+++ b/e2e/support/helpers/e2e-bi-basics-helpers.js
@@ -108,3 +108,8 @@ const ACTION_TYPE_TO_ICON_MAP = {
 function getIcon(actionType) {
   return ACTION_TYPE_TO_ICON_MAP[actionType];
 }
+
+export function assertQueryBuilderRowCount(count) {
+  const message = count === 1 ? "Showing 1 row" : `Showing ${count} rows`;
+  cy.findByTestId("question-row-count").contains(message);
+}

--- a/e2e/support/helpers/e2e-bi-basics-helpers.js
+++ b/e2e/support/helpers/e2e-bi-basics-helpers.js
@@ -14,7 +14,7 @@ export function filter({ mode } = {}) {
 }
 
 export function join() {
-  initiateAction("Join", "notebook");
+  cy.button("Join data").click();
 }
 
 export function addCustomColumn() {
@@ -95,7 +95,6 @@ function initiateAction(actionType, mode) {
 const ACTION_TYPE_TO_ICON_MAP = {
   Filter: "filter",
   Summarize: "sum",
-  Join: "join_left_outer",
   CustomColumn: "add_data",
 };
 

--- a/e2e/support/helpers/e2e-bi-basics-helpers.js
+++ b/e2e/support/helpers/e2e-bi-basics-helpers.js
@@ -109,7 +109,8 @@ function getIcon(actionType) {
 }
 
 export function assertQueryBuilderRowCount(count) {
-  const message = count === 1 ? "Showing 1 row" : `Showing ${count} rows`;
+  const message =
+    count === 1 ? "Showing 1 row" : `Showing ${count.toLocaleString()} rows`;
   cy.findByTestId("question-row-count").contains(message);
 }
 

--- a/e2e/support/helpers/e2e-dashboard-helpers.js
+++ b/e2e/support/helpers/e2e-dashboard-helpers.js
@@ -205,6 +205,10 @@ export const dashboardHeader = () => {
   return cy.findByTestId("dashboard-header");
 };
 
+export const dashboardGrid = () => {
+  return cy.findByTestId("dashboard-grid");
+};
+
 /**
  *
  * @param {number} dashboardId

--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -257,7 +257,9 @@ export function saveQuestion(
   cy.findByText("Save").click();
 
   modal().within(() => {
-    cy.findByLabelText("Name").clear().type(name);
+    if (name) {
+      cy.findByLabelText("Name").clear().type(name);
+    }
     cy.button("Save").click();
   });
 

--- a/e2e/support/helpers/e2e-notebook-helpers.js
+++ b/e2e/support/helpers/e2e-notebook-helpers.js
@@ -35,7 +35,13 @@ export function visualize(callback) {
   });
 }
 
-export function addSummaryField({ metric, field, stage = 0, index = 0 }) {
+export function addSummaryField({
+  metric,
+  table,
+  field,
+  stage = 0,
+  index = 0,
+}) {
   getNotebookStep("summarize", { stage, index })
     .findByTestId("aggregate-step")
     .findAllByTestId("notebook-cell-item")
@@ -44,13 +50,21 @@ export function addSummaryField({ metric, field, stage = 0, index = 0 }) {
 
   popover().within(() => {
     cy.findByText(metric).click();
+    if (table) {
+      cy.findByText(table).click();
+    }
     if (field) {
       cy.findByText(field).click();
     }
   });
 }
 
-export function addSummaryGroupingField({ field, stage = 0, index = 0 }) {
+export function addSummaryGroupingField({
+  table,
+  field,
+  stage = 0,
+  index = 0,
+}) {
   getNotebookStep("summarize", { stage, index })
     .findByTestId("breakout-step")
     .findAllByTestId("notebook-cell-item")
@@ -58,6 +72,9 @@ export function addSummaryGroupingField({ field, stage = 0, index = 0 }) {
     .click();
 
   popover().within(() => {
+    if (table) {
+      cy.findByText(table).click();
+    }
     cy.findByText(field).click();
   });
 }
@@ -68,6 +85,24 @@ export function removeSummaryGroupingField({ field, stage = 0, index = 0 }) {
     .findByText(field)
     .icon("close")
     .click();
+}
+
+/**
+ * Joins a raw table given a table and optional LHS and RHS column names
+ * (for cases when join condition can't be selected automatically)
+ *
+ * Expects a join popover to be open
+ *
+ * @param {string} tableName
+ * @param {string} [lhsColumnName]
+ * @param {string} [rhsColumnName]
+ */
+export function joinTable(tableName, lhsColumnName, rhsColumnName) {
+  popover().findByText(tableName).click();
+  if (lhsColumnName && rhsColumnName) {
+    popover().findByText(lhsColumnName).click();
+    popover().findByText(rhsColumnName).click();
+  }
 }
 
 export function selectSavedQuestionsToJoin(

--- a/e2e/test/scenarios/joins/joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins.cy.spec.js
@@ -46,24 +46,16 @@ describe("scenarios > question > joined questions", () => {
     });
 
     // Post-join filters on the joined table (metabase#12221, metabase#15570)
-    filter();
-    cy.get(".Modal").within(() => {
-      // Temporal compat between MLv1 and MLv2
-      // MLv2 does a better job naming joined tables,
-      // but simple mode filters UI still uses MLv1
-      // Once it's ported, we should just look for "Review"
-      const joinedTable = new RegExp(/Reviews? - Products?/);
-      cy.findByText(joinedTable).click();
-      cy.findByTestId("filter-field-Rating").contains("2").click();
-      cy.button("Apply Filters").click();
-      cy.wait("@dataset");
+    openNotebook();
+    filter({ mode: "notebook" });
+    popover().within(() => {
+      cy.findByText("Reviews - Product").click();
+      cy.findByText("Rating").click();
+      cy.findByLabelText("2").click();
+      cy.button("Add filter").click();
     });
 
-    cy.findByTestId("qb-filters-panel").findByText("Rating is equal to 2");
-
     // Post-join aggregation (metabase#11452):
-    openNotebook();
-
     summarize({ mode: "notebook" });
     addSummaryField({
       metric: "Average of ...",

--- a/e2e/test/scenarios/joins/joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins.cy.spec.js
@@ -31,7 +31,7 @@ describe("scenarios > question > joined questions", () => {
     cy.signInAsAdmin();
   });
 
-  it("should allow joins on tables (metabase#11452, metabase#12221, metabase#13468, metabase#15570)", () => {
+  it("should join raw tables (metabase#11452, metabase#12221, metabase#13468, metabase#15570)", () => {
     openOrdersTable({ mode: "notebook" });
 
     join();
@@ -84,7 +84,7 @@ describe("scenarios > question > joined questions", () => {
     assertQueryBuilderRowCount(89);
   });
 
-  it("should join on field literals", () => {
+  it("should join a native question", () => {
     cy.createNativeQuestion({
       name: "question a",
       native: { query: "select 'foo' as a_column" },
@@ -120,7 +120,7 @@ describe("scenarios > question > joined questions", () => {
     assertQueryBuilderRowCount(1);
   });
 
-  it("should allow joins based on saved questions (metabase#13000, metabase#13649, metabase#13744)", () => {
+  it("should join structured questions (metabase#13000, metabase#13649, metabase#13744)", () => {
     cy.intercept("GET", `/api/table/${PRODUCTS_ID}/query_metadata`).as(
       "metadata",
     );
@@ -186,7 +186,7 @@ describe("scenarios > question > joined questions", () => {
     queryBuilderMain().findByText("Sum Divide");
   });
 
-  it("should allow joins on multiple dimensions", () => {
+  it("should allow joins with multiple conditions", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
     openOrdersTable({ mode: "notebook" });
 
@@ -209,14 +209,14 @@ describe("scenarios > question > joined questions", () => {
     assertQueryBuilderRowCount(415);
   });
 
-  it("should allow joins on date-time fields", () => {
+  it("should sync join condition's date-time column units", () => {
     openOrdersTable({ mode: "notebook" });
 
     join();
     joinTable("Products");
     selectJoinStrategy("Inner join");
 
-    // Test join dimension infers parent dimension's temporal unit
+    // Test LHS column infers RHS column's temporal unit
 
     cy.findByTestId("parent-dimension").click();
     popover().findByText("by month").click({ force: true });
@@ -228,7 +228,7 @@ describe("scenarios > question > joined questions", () => {
     assertJoinColumnName("left", "Created At: Week");
     assertJoinColumnName("right", "Created At: Week");
 
-    // Test changing a temporal unit on one dimension would update a second one
+    // Test changing a temporal unit on one column would update a second one
 
     cy.findByTestId("join-dimension").click();
     popover().findByText("by week").click({ force: true });

--- a/e2e/test/scenarios/joins/joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins.cy.spec.js
@@ -289,7 +289,7 @@ describe("scenarios > question > joined questions", () => {
     openOrdersTable({ mode: "notebook" });
 
     joinTable("Products");
-    selectJoinType("Inner join");
+    selectJoinStrategy("Inner join");
 
     getNotebookStep("join").icon("add").click();
     popover().findByText("Created At").click();
@@ -310,58 +310,51 @@ describe("scenarios > question > joined questions", () => {
     openOrdersTable({ mode: "notebook" });
 
     joinTable("Products");
-    selectJoinType("Inner join");
+    selectJoinStrategy("Inner join");
 
     // Test join dimension infers parent dimension's temporal unit
 
     cy.findByTestId("parent-dimension").click();
-    selectFromDropdown("by month", { force: true });
-    selectFromDropdown("Week");
+    popover().findByText("by month").click({ force: true });
+    popover().last().findByText("Week").click();
 
     cy.findByTestId("join-dimension").click();
-    selectFromDropdown("Created At");
+    popover().findByText("Created At").click();
 
-    assertDimensionName("parent", "Created At: Week");
-    assertDimensionName("join", "Created At: Week");
+    assertJoinColumnName("left", "Created At: Week");
+    assertJoinColumnName("right", "Created At: Week");
 
     // Test changing a temporal unit on one dimension would update a second one
 
     cy.findByTestId("join-dimension").click();
-    selectFromDropdown("by week", { force: true });
-    selectFromDropdown("Day");
+    popover().findByText("by week").click({ force: true });
+    popover().last().findByText("Day").click();
 
-    assertDimensionName("parent", "Created At: Day");
-    assertDimensionName("join", "Created At: Day");
+    assertJoinColumnName("left", "Created At: Day");
+    assertJoinColumnName("right", "Created At: Day");
 
     summarize({ mode: "notebook" });
-    selectFromDropdown("Count of rows");
+    popover().findByText("Count of rows").click();
 
     visualize();
 
-    // 2087 rows mean the join is done correctly,
-    // (orders joined with products on the same day-month-year)
     cy.get(".ScalarValue").contains("2,087");
   });
 });
 
 function joinTable(table) {
-  cy.findByText("Join data").click();
+  cy.button("Join data").click();
   popover().findByText(table).click();
 }
 
-function selectJoinType(strategy) {
+function selectJoinStrategy(strategy) {
   cy.icon("join_left_outer").first().click();
   popover().findByText(strategy).click();
 }
 
-function selectFromDropdown(option, clickOpts) {
-  popover().last().findByText(option).click(clickOpts);
-}
-
-function assertDimensionName(type, name) {
-  cy.findByTestId(`${type}-dimension`).within(() => {
-    cy.findByText(name);
-  });
+function assertJoinColumnName(type, name) {
+  const testId = type === "left" ? "parent-dimension" : "join-dimension";
+  cy.findByTestId(testId).findByText(name).should("be.visible");
 }
 
 function assertJoinValid({

--- a/e2e/test/scenarios/joins/joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins.cy.spec.js
@@ -1,17 +1,17 @@
 import {
   addCustomColumn,
-  restore,
-  openOrdersTable,
-  openNotebook,
-  popover,
-  visualize,
-  summarize,
-  startNewQuestion,
-  filter,
   enterCustomColumnDetails,
-  selectSavedQuestionsToJoin,
-  queryBuilderMain,
+  filter,
   getNotebookStep,
+  openNotebook,
+  openOrdersTable,
+  popover,
+  queryBuilderMain,
+  restore,
+  selectSavedQuestionsToJoin,
+  startNewQuestion,
+  summarize,
+  visualize,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";

--- a/e2e/test/scenarios/joins/joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins.cy.spec.js
@@ -99,7 +99,6 @@ describe("scenarios > question > joined questions", () => {
   });
 
   it("should join on field literals", () => {
-    // create two native questions
     cy.createNativeQuestion({
       name: "question a",
       native: { query: "select 'foo' as a_column" },
@@ -112,36 +111,27 @@ describe("scenarios > question > joined questions", () => {
       },
       {
         wrapId: true,
+        idAlias: "joinedQuestionId",
       },
     );
 
-    // start a custom question with question a
     startNewQuestion();
     selectSavedQuestionsToJoin("question a", "question b");
-
-    // select the join columns
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    popover().within(() => cy.findByText("A_COLUMN").click());
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    popover().within(() => cy.findByText("B_COLUMN").click());
+    popover().findByText("A_COLUMN").click();
+    popover().findByText("B_COLUMN").click();
 
     visualize();
 
-    // check that query worked
-
-    cy.findByTestId("question-table-badges").within(() => {
-      cy.findByText("question a");
-      cy.findByText("question b");
-    });
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("A_COLUMN");
-
-    cy.get("@questionId").then(questionId => {
-      cy.findByText(`Question ${questionId} → B Column`);
+    cy.get("@joinedQuestionId").then(joinedQuestionId => {
+      assertJoinValid({
+        lhsTable: "question a",
+        rhsTable: "question b",
+        lhsSampleColumn: "A_COLUMN",
+        rhsSampleColumn: `Question ${joinedQuestionId} → B Column`,
+      });
     });
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Showing 1 row");
+    cy.findByTestId("question-row-count").contains("Showing 1 row");
   });
 
   it("should allow joins based on saved questions (metabase#13000, metabase#13649, metabase#13744)", () => {

--- a/e2e/test/scenarios/joins/joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins.cy.spec.js
@@ -369,26 +369,6 @@ describe("scenarios > question > joined questions", () => {
     // (orders joined with products on the same day-month-year)
     cy.get(".ScalarValue").contains("2,087");
   });
-
-  it("should show 'Previous results' instead of a table name for non-field dimensions (metabase#17968)", () => {
-    openOrdersTable({ mode: "notebook" });
-
-    summarize({ mode: "notebook" });
-    selectFromDropdown("Count of rows");
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Pick a column to group by").click();
-    selectFromDropdown("Created At");
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Join data").click();
-    selectFromDropdown("Products");
-    selectFromDropdown("Count");
-
-    cy.findByTestId("step-join-1-0")
-      .findByTestId("parent-dimension")
-      .findByText("Previous results");
-  });
 });
 
 function joinTable(table) {

--- a/e2e/test/scenarios/joins/joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins.cy.spec.js
@@ -291,19 +291,19 @@ describe("scenarios > question > joined questions", () => {
     joinTable("Products");
     selectJoinType("Inner join");
 
-    cy.findByTestId("step-join-0-0").within(() => {
-      cy.icon("add").click();
-    });
-
-    selectFromDropdown("Created At");
-    selectFromDropdown("Created At");
+    getNotebookStep("join").icon("add").click();
+    popover().findByText("Created At").click();
+    popover().findByText("Created At").click();
 
     visualize();
 
-    // 415 rows mean the join is done correctly,
-    // (join on product's FK + join on the same "created_at" field)
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Showing 415 rows");
+    assertJoinValid({
+      lhsTable: "Orders",
+      rhsTable: "Products",
+      lhsSampleColumn: "Product ID",
+      rhsSampleColumn: "Products → ID",
+    });
+    cy.findByTestId("question-row-count").contains("Showing 415 rows");
   });
 
   it("should allow joins on date-time fields", () => {

--- a/e2e/test/scenarios/joins/joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins.cy.spec.js
@@ -7,7 +7,6 @@ import {
   startNewQuestion,
   filter,
   enterCustomColumnDetails,
-  openProductsTable,
   selectSavedQuestionsToJoin,
   getNotebookStep,
 } from "e2e/support/helpers";
@@ -310,42 +309,6 @@ describe("scenarios > question > joined questions", () => {
 
     cy.findAllByText(/Products? → Category/).should("have.length", 1);
     cy.findAllByText(/Question \d+? → Category/).should("have.length", 1);
-  });
-
-  it("joining on a question with remapped values should work (metabase#15578)", () => {
-    cy.intercept("POST", "/api/dataset").as("dataset");
-    // Remap display value
-    cy.request("POST", `/api/field/${ORDERS.PRODUCT_ID}/dimension`, {
-      name: "Product ID",
-      type: "external",
-      human_readable_field_id: PRODUCTS.TITLE,
-    });
-
-    cy.createQuestion({
-      name: "15578",
-      query: { "source-table": ORDERS_ID },
-    });
-
-    openProductsTable({ mode: "notebook" });
-
-    cy.icon("join_left_outer").click();
-
-    popover().findByText("Sample Database").click();
-    popover().findByText("Raw Data").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Saved Questions").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("15578").click();
-
-    popover().findByText("ID").click();
-    popover()
-      // Implicit assertion - test will fail for multiple strings
-      .findByText("Product ID")
-      .click();
-
-    visualize(response => {
-      expect(response.body.error).to.not.exist;
-    });
   });
 
   it("should allow joins on multiple dimensions", () => {

--- a/e2e/test/scenarios/joins/reproductions/12928-joining-questions-with-joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/12928-joining-questions-with-joins.cy.spec.js
@@ -1,0 +1,113 @@
+import {
+  assertJoinValid,
+  assertQueryBuilderRowCount,
+  popover,
+  restore,
+  selectSavedQuestionsToJoin,
+  startNewQuestion,
+  visualize,
+} from "e2e/support/helpers";
+
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const {
+  ORDERS,
+  ORDERS_ID,
+  PRODUCTS,
+  PRODUCTS_ID,
+  PEOPLE,
+  PEOPLE_ID,
+  REVIEWS,
+  REVIEWS_ID,
+} = SAMPLE_DATABASE;
+
+const SOURCE_QUESTION_NAME = "12928_Q1";
+const JOINED_QUESTION_NAME = "12928_Q2";
+
+const SOURCE_QUESTION_DETAILS = {
+  name: SOURCE_QUESTION_NAME,
+  query: {
+    "source-table": ORDERS_ID,
+    aggregation: [["count"]],
+    breakout: [
+      ["field", PRODUCTS.CATEGORY, { "join-alias": "Products" }],
+      ["field", PEOPLE.SOURCE, { "join-alias": "People - User" }],
+    ],
+    joins: [
+      {
+        alias: "Products",
+        condition: [
+          "=",
+          ["field", ORDERS.PRODUCT_ID, null],
+          ["field", PRODUCTS.ID, { "join-alias": "Products" }],
+        ],
+        fields: "all",
+        "source-table": PRODUCTS_ID,
+      },
+      {
+        alias: "People - User",
+        condition: [
+          "=",
+          ["field", ORDERS.USER_ID, null],
+          ["field", PEOPLE.ID, { "join-alias": "People - User" }],
+        ],
+        fields: "all",
+        "source-table": PEOPLE_ID,
+      },
+    ],
+  },
+};
+
+const JOINED_QUESTION_DETAILS = {
+  name: JOINED_QUESTION_NAME,
+  query: {
+    "source-table": REVIEWS_ID,
+    aggregation: [["avg", ["field", REVIEWS.RATING, null]]],
+    breakout: [["field", PRODUCTS.CATEGORY, { "join-alias": "Products" }]],
+    joins: [
+      {
+        alias: "Products",
+        condition: [
+          "=",
+          ["field", REVIEWS.PRODUCT_ID, null],
+          ["field", PRODUCTS.ID, { "join-alias": "Products" }],
+        ],
+        fields: "all",
+        "source-table": PRODUCTS_ID,
+      },
+    ],
+  },
+};
+
+describe("issue 12928", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should join saved questions that themselves contain joins (metabase#12928)", () => {
+    cy.createQuestion(SOURCE_QUESTION_DETAILS);
+    cy.createQuestion(JOINED_QUESTION_DETAILS, {
+      wrapId: true,
+      idAlias: "joinedQuestionId",
+    });
+
+    startNewQuestion();
+    selectSavedQuestionsToJoin(SOURCE_QUESTION_NAME, JOINED_QUESTION_NAME);
+    popover().findByText("Products → Category").click();
+    popover().findByText("Products → Category").click();
+
+    visualize();
+
+    cy.get("@joinedQuestionId").then(joinedQuestionId => {
+      assertJoinValid({
+        lhsTable: SOURCE_QUESTION_NAME,
+        rhsTable: JOINED_QUESTION_NAME,
+        lhsSampleColumn: "Products → Category",
+        rhsSampleColumn: `Question ${joinedQuestionId} → Category`,
+      });
+    });
+
+    assertQueryBuilderRowCount(20);
+  });
+});

--- a/e2e/test/scenarios/joins/reproductions/14793-xrays-joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/14793-xrays-joins.cy.spec.js
@@ -1,0 +1,78 @@
+import _ from "underscore";
+import {
+  dashboardGrid,
+  getDashboardCards,
+  restore,
+  visitQuestionAdhoc,
+  popover,
+} from "e2e/support/helpers";
+
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { PRODUCTS, PRODUCTS_ID, REVIEWS, REVIEWS_ID } = SAMPLE_DATABASE;
+
+const XRAY_DATASETS = 11; // enough to load most questions
+
+const QUESTION_DETAILS = {
+  dataset_query: {
+    type: "query",
+    query: {
+      "source-table": REVIEWS_ID,
+      joins: [
+        {
+          fields: "all",
+          "source-table": PRODUCTS_ID,
+          condition: [
+            "=",
+            ["field", REVIEWS.PRODUCT_ID, null],
+            ["field", PRODUCTS.ID, { "join-alias": "Products" }],
+          ],
+          alias: "Products",
+        },
+      ],
+      aggregation: [
+        ["sum", ["field", PRODUCTS.PRICE, { "join-alias": "Products" }]],
+      ],
+      breakout: [["field", REVIEWS.CREATED_AT, { "temporal-unit": "year" }]],
+    },
+    database: SAMPLE_DB_ID,
+  },
+  display: "line",
+};
+
+describe("issue 14793", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.intercept("GET", "/api/automagic-dashboards/adhoc/**").as("xray");
+    cy.intercept("POST", "/api/dataset").as("postDataset");
+  });
+
+  it("x-rays should work on explicit joins when metric is for the joined table (metabase#14793)", () => {
+    visitQuestionAdhoc(QUESTION_DETAILS);
+
+    cy.get(".dot").eq(2).click({ force: true });
+
+    popover().findByText("Automatic insights…").click();
+    popover().findByText("X-ray").click();
+
+    cy.wait("@xray").then(xhr => {
+      _.times(XRAY_DATASETS, () => {
+        cy.wait("@postDataset");
+      });
+      expect(xhr.status).not.to.eq(500);
+      expect(xhr.response.body.cause).not.to.exist;
+    });
+
+    dashboardGrid()
+      .findByText("How this metric is distributed across different numbers")
+      .should("be.visible");
+
+    cy.findByTestId("automatic-dashboard-header")
+      .findByText(/^A closer look at/)
+      .should("be.visible");
+
+    getDashboardCards().should("have.length", 18);
+  });
+});

--- a/e2e/test/scenarios/joins/reproductions/14793-xrays-joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/14793-xrays-joins.cy.spec.js
@@ -1,4 +1,3 @@
-import _ from "underscore";
 import {
   dashboardGrid,
   getDashboardCards,
@@ -58,9 +57,9 @@ describe("issue 14793", () => {
     popover().findByText("X-ray").click();
 
     cy.wait("@xray").then(xhr => {
-      _.times(XRAY_DATASETS, () => {
+      for (let i = 0; i < XRAY_DATASETS; ++i) {
         cy.wait("@postDataset");
-      });
+      }
       expect(xhr.status).not.to.eq(500);
       expect(xhr.response.body.cause).not.to.exist;
     });

--- a/e2e/test/scenarios/joins/reproductions/15578-remapped-values-joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/15578-remapped-values-joins.cy.spec.js
@@ -1,0 +1,62 @@
+import {
+  restore,
+  popover,
+  visualize,
+  openProductsTable,
+  queryBuilderHeader,
+  queryBuilderMain,
+} from "e2e/support/helpers";
+
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
+
+const JOINED_QUESTION_NAME = "15578";
+
+describe("issue 15578", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    // Remap display value
+    cy.request("POST", `/api/field/${ORDERS.PRODUCT_ID}/dimension`, {
+      name: "Product ID",
+      type: "external",
+      human_readable_field_id: PRODUCTS.TITLE,
+    });
+
+    cy.createQuestion({
+      name: JOINED_QUESTION_NAME,
+      query: { "source-table": ORDERS_ID },
+    });
+  });
+
+  it("joining on a question with remapped values should work (metabase#15578)", () => {
+    openProductsTable({ mode: "notebook" });
+
+    cy.button("Join data").click();
+
+    popover().findByText("Sample Database").click();
+    popover().findByText("Raw Data").click();
+    popover().findByText("Saved Questions").click();
+    popover().findByText(JOINED_QUESTION_NAME).click();
+
+    popover().findByText("ID").click();
+    popover().findByText("Product ID").click();
+
+    visualize();
+
+    queryBuilderHeader()
+      .findByTestId("question-table-badges")
+      .within(() => {
+        cy.findByText("Products").should("be.visible");
+        cy.findByText(JOINED_QUESTION_NAME).should("be.visible");
+      });
+
+    queryBuilderMain().within(() => {
+      cy.findByText("Category").should("be.visible");
+      cy.findByText("Question 5 → ID").should("be.visible");
+    });
+  });
+});

--- a/e2e/test/scenarios/joins/reproductions/17968-notebook-join-table-names.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/17968-notebook-join-table-names.cy.spec.js
@@ -1,31 +1,34 @@
-import { restore, popover, openOrdersTable } from "e2e/support/helpers";
+import {
+  restore,
+  getNotebookStep,
+  openOrdersTable,
+  popover,
+  summarize,
+} from "e2e/support/helpers";
 
 describe("issue 17968", () => {
   beforeEach(() => {
-    cy.intercept("POST", "/api/dataset").as("dataset");
     restore();
     cy.signInAsAdmin();
   });
 
-  it("shows correct table names when joining many tables (metabase#17968)", () => {
+  it("should show 'Previous results' instead of a table name for non-field dimensions (metabase#17968)", () => {
     openOrdersTable({ mode: "notebook" });
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Join data").click();
+    summarize({ mode: "notebook" });
+    popover().findByText("Count of rows").click();
+
+    getNotebookStep("summarize")
+      .findByText("Pick a column to group by")
+      .click();
+    popover().findByText("Created At").click();
+
+    cy.button("Join data").click();
     popover().findByText("Products").click();
+    popover().findByText("Count").click();
 
-    cy.findByTestId("action-buttons").findByText("Join data").click();
-    popover().findByText("Reviews").click();
-
-    popover().within(() => {
-      cy.findByText("Products").click();
-      cy.findByText("ID").click();
-    });
-
-    popover().findByText("Product ID").click();
-
-    cy.findByTestId("step-join-0-1")
+    getNotebookStep("join", { stage: 1 })
       .findByTestId("parent-dimension")
-      .findByText("Products");
+      .findByText("Previous results");
   });
 });

--- a/e2e/test/scenarios/joins/reproductions/17968-notebook-join-table-names.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/17968-notebook-join-table-names.cy.spec.js
@@ -23,7 +23,7 @@ describe("issue 17968", () => {
       .click();
     popover().findByText("Created At").click();
 
-    cy.button("Join data").click();
+    cy.findAllByTestId("action-buttons").last().button("Join data").click();
     popover().findByText("Products").click();
     popover().findByText("Count").click();
 

--- a/e2e/test/scenarios/visualizations/reproductions/30058-32075-map-visualizations.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/30058-32075-map-visualizations.cy.spec.js
@@ -113,7 +113,7 @@ describe("issue 30058", () => {
 
 const addCountGreaterThan2Filter = () => {
   openNotebook();
-  cy.button("Filter").click();
+  cy.findAllByTestId("action-buttons").last().button("Filter").click();
   popover().within(() => {
     cy.findByText("Count").click();
     cy.icon("chevrondown").click();

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -451,7 +451,7 @@ class DashboardGrid extends Component {
   render() {
     const { width } = this.props;
     return (
-      <div className="flex layout-centered">
+      <div className="flex layout-centered" data-testid="dashboard-grid">
         {width > 0 ? this.renderGrid() : <div />}
         {this.renderAddSeriesModal()}
       </div>

--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
@@ -124,7 +124,10 @@ class AutomaticDashboardAppInner extends Component {
       >
         <div className="" style={{ marginRight: hasSidebar ? 346 : undefined }}>
           {isHeaderVisible && (
-            <div className="bg-white border-bottom">
+            <div
+              className="bg-white border-bottom"
+              data-testid="automatic-dashboard-header"
+            >
               <div className="wrapper flex align-center py2">
                 <XrayIcon name="bolt" size={24} />
                 <div>

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
@@ -76,6 +76,7 @@ function NotebookStep({
               color={stepUi.getColor()}
               large={hasLargeActionButtons}
               {...stepUi}
+              aria-label={stepUi.title}
               onClick={() => action.action({ query: step.query, openStep })}
             />
           ),


### PR DESCRIPTION
Cleans up the joins E2E test suite before adding more tests in #34252

* extracts a few repros to their own files, so the `joins.cy.spec` file contains common scenarios
* migrates the test suite to more high-level helpers
* introduces more high-level E2E helpers for joins (like `assertJoinValid` or `joinTable`)

**To verify:** CI should be green