### PR TITLE
Migrate notebook's data step to MLv2

### DIFF
--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -12,6 +12,7 @@ import type {
   Bucket,
   BucketDisplayInfo,
   CardMetadata,
+  CardDisplayInfo,
   Clause,
   ClauseDisplayInfo,
   ColumnDisplayInfo,

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -1,6 +1,6 @@
 import * as ML from "cljs/metabase.lib.js";
 import * as ML_MetadataCalculation from "cljs/metabase.lib.metadata.calculation";
-import type { DatabaseId, FieldReference } from "metabase-types/api";
+import type { DatabaseId, FieldReference, TableId } from "metabase-types/api";
 import type Metadata from "./metadata/Metadata";
 import type {
   AggregationClause,
@@ -155,7 +155,7 @@ export function describeRelativeDatetime(
 
 export function tableOrCardMetadata(
   queryOrMetadataProvider: Query | MetadataProvider,
-  tableID: number | string,
+  tableID: TableId,
 ): CardMetadata | TableMetadata {
   return ML.table_or_card_metadata(queryOrMetadataProvider, tableID);
 }

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -57,6 +57,16 @@ declare function DisplayInfoFn(
 declare function DisplayInfoFn(
   query: Query,
   stageIndex: number,
+  cardMetadata: CardMetadata,
+): CardDisplayInfo;
+declare function DisplayInfoFn(
+  query: Query,
+  stageIndex: number,
+  tableMetadata: TableMetadata,
+): TableDisplayInfo;
+declare function DisplayInfoFn(
+  query: Query,
+  stageIndex: number,
   aggregationClause: AggregationClause,
 ): AggregationClauseDisplayInfo;
 declare function DisplayInfoFn(

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -68,6 +68,11 @@ declare function DisplayInfoFn(
 declare function DisplayInfoFn(
   query: Query,
   stageIndex: number,
+  tableLike: CardMetadata | TableMetadata,
+): CardDisplayInfo | TableDisplayInfo;
+declare function DisplayInfoFn(
+  query: Query,
+  stageIndex: number,
   aggregationClause: AggregationClause,
 ): AggregationClauseDisplayInfo;
 declare function DisplayInfoFn(

--- a/frontend/src/metabase-lib/query.ts
+++ b/frontend/src/metabase-lib/query.ts
@@ -7,10 +7,11 @@ import type {
   MetricMetadata,
   Query,
 } from "./types";
+import type LegacyMetadata from "./metadata/Metadata";
 
 export function fromLegacyQuery(
   databaseId: DatabaseId,
-  metadata: MetadataProvider,
+  metadata: MetadataProvider | LegacyMetadata,
   datasetQuery: DatasetQuery,
 ): Query {
   return ML.query(databaseId, metadata, datasetQuery);

--- a/frontend/src/metabase-lib/query.ts
+++ b/frontend/src/metabase-lib/query.ts
@@ -1,5 +1,5 @@
 import * as ML from "cljs/metabase.lib.js";
-import type { DatabaseId, DatasetQuery } from "metabase-types/api";
+import type { DatabaseId, DatasetQuery, TableId } from "metabase-types/api";
 import type {
   Clause,
   ColumnMetadata,
@@ -18,6 +18,10 @@ export function fromLegacyQuery(
 
 export function toLegacyQuery(query: Query): DatasetQuery {
   return ML.legacy_query(query);
+}
+
+export function withDifferentTable(query: Query, tableId: TableId): Query {
+  return ML.with_different_table(query, tableId);
 }
 
 export function suggestedName(query: Query): string {

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -72,6 +72,8 @@ export type TableDisplayInfo = {
   isImplicitlyJoinable: boolean;
 };
 
+export type CardDisplayInfo = TableDisplayInfo;
+
 type TableInlineDisplayInfo = Pick<
   TableDisplayInfo,
   "name" | "displayName" | "isSourceTable"

--- a/frontend/src/metabase/query_builder/components/notebook/FieldsPickerIcon.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/FieldsPickerIcon.tsx
@@ -1,41 +1,36 @@
-import PropTypes from "prop-types";
 import styled from "@emotion/styled";
 import { t } from "ttag";
 
 import { Icon } from "metabase/core/components/Icon";
+import IconButtonWrapper from "metabase/components/IconButtonWrapper";
 import Tooltip from "metabase/core/components/Tooltip";
+import { color } from "metabase/lib/colors";
 import { NotebookCell } from "./NotebookCell";
 
-export const FieldPickerContentContainer = styled.div`
+const FieldPickerContentContainer = styled(IconButtonWrapper)`
+  color: ${color("white")};
   padding: ${NotebookCell.CONTAINER_PADDING};
-`;
-
-const StyledIcon = styled(Icon)`
   opacity: 0.5;
 `;
 
-const propTypes = {
-  isTriggeredComponentOpen: PropTypes.bool,
-};
+interface FieldsPickerIconProps {
+  isTriggeredComponentOpen?: boolean;
+}
 
 export function FieldsPickerIcon({
   isTriggeredComponentOpen,
-}: {
-  isTriggeredComponentOpen?: boolean;
-}) {
+}: FieldsPickerIconProps) {
   return (
-    <Tooltip
-      tooltip={<span>{t`Pick columns`}</span>}
-      isEnabled={!isTriggeredComponentOpen}
-    >
-      <FieldPickerContentContainer data-testid="fields-picker">
-        <StyledIcon name="chevrondown" />
+    <Tooltip tooltip={t`Pick columns`} isEnabled={!isTriggeredComponentOpen}>
+      <FieldPickerContentContainer
+        aria-label={t`Pick columns`}
+        data-testid="fields-picker"
+      >
+        <Icon name="chevrondown" />
       </FieldPickerContentContainer>
     </Tooltip>
   );
 }
-
-FieldsPickerIcon.propTypes = propTypes;
 
 export const FIELDS_PICKER_STYLES = {
   notebookItemContainer: {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.styled.tsx
@@ -1,0 +1,6 @@
+import styled from "@emotion/styled";
+import { NotebookCell } from "../../NotebookCell";
+
+export const DataStepCell = styled.div`
+  padding: ${NotebookCell.CONTAINER_PADDING};
+`;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
@@ -7,13 +7,11 @@ import { DataSourceSelector } from "metabase/query_builder/components/DataSelect
 
 import type { TableId } from "metabase-types/api";
 import * as Lib from "metabase-lib";
+
 import type { NotebookStepUiComponentProps } from "../../types";
 import { NotebookCell, NotebookCellItem } from "../../NotebookCell";
-import {
-  FieldPickerContentContainer,
-  FieldsPickerIcon,
-  FIELDS_PICKER_STYLES,
-} from "../../FieldsPickerIcon";
+import { FieldsPickerIcon, FIELDS_PICKER_STYLES } from "../../FieldsPickerIcon";
+import { DataStepCell } from "./DataStep.styled";
 
 export const DataStep = ({
   topLevelQuery,
@@ -56,9 +54,9 @@ export const DataStep = ({
           }
           isInitiallyOpen={!query.tableId()}
           triggerElement={
-            <FieldPickerContentContainer>
+            <DataStepCell>
               {table ? table.displayName() : t`Pick your starting data`}
-            </FieldPickerContentContainer>
+            </DataStepCell>
           }
         />
       </NotebookCellItem>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
@@ -24,6 +24,7 @@ export const DataStep = ({
   const { stageIndex } = step;
 
   const question = query.question();
+  const metadata = question.metadata();
   const collectionId = question.collectionId();
   const tableId = query.sourceTableId();
 
@@ -45,9 +46,32 @@ export const DataStep = ({
 
   const canSelectTableColumns = table && isRaw && !readOnly;
 
-  const onTableChange = (nextTableId: TableId) => {
+  const handleCreateQuery = (tableId: TableId) => {
+    const databaseId = metadata.table(tableId)?.db_id;
+    if (databaseId) {
+      const nextQuery = Lib.fromLegacyQuery(databaseId, metadata, {
+        type: "query",
+        database: databaseId,
+        query: {
+          "source-table": tableId,
+        },
+      });
+      updateQuery(nextQuery);
+    }
+  };
+
+  const handleChangeTable = (nextTableId: TableId) => {
     const nextQuery = Lib.withDifferentTable(topLevelQuery, nextTableId);
     updateQuery(nextQuery);
+  };
+
+  const handleTableSelect = (tableId: TableId) => {
+    const isNew = !databaseId;
+    if (isNew) {
+      handleCreateQuery(tableId);
+    } else {
+      handleChangeTable(tableId);
+    }
   };
 
   return (
@@ -74,7 +98,7 @@ export const DataStep = ({
           databaseQuery={{ saved: true }}
           selectedDatabaseId={databaseId}
           selectedTableId={tableId}
-          setSourceTableFn={onTableChange}
+          setSourceTableFn={handleTableSelect}
           isInitiallyOpen={!table}
           triggerElement={<DataStepCell>{pickerLabel}</DataStepCell>}
         />

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.unit.spec.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
-import { getIcon, renderWithProviders, screen } from "__support__/ui";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+import { renderWithProviders, screen } from "__support__/ui";
 import {
   setupDatabasesEndpoints,
   setupSearchEndpoints,
@@ -56,7 +56,7 @@ describe("DataStep", () => {
   describe("fields selection", () => {
     it("should render with all columns selected", async () => {
       await setup();
-      userEvent.click(getIcon("chevrondown"));
+      userEvent.click(screen.getByLabelText("Pick columns"));
 
       expect(screen.getByLabelText("Select none")).toBeChecked();
       expect(screen.getByLabelText("ID")).toBeChecked();
@@ -68,7 +68,7 @@ describe("DataStep", () => {
     it("should render with a single column selected", async () => {
       const query = createQueryWithFields(["ID"]);
       await setup(createMockNotebookStep({ topLevelQuery: query }));
-      userEvent.click(getIcon("chevrondown"));
+      userEvent.click(screen.getByLabelText("Pick columns"));
 
       expect(screen.getByLabelText("Select all")).not.toBeChecked();
       expect(screen.getByLabelText("ID")).toBeChecked();
@@ -80,7 +80,7 @@ describe("DataStep", () => {
     it("should render with multiple columns selected", async () => {
       const query = createQueryWithFields(["ID", "TOTAL"]);
       await setup(createMockNotebookStep({ topLevelQuery: query }));
-      userEvent.click(getIcon("chevrondown"));
+      userEvent.click(screen.getByLabelText("Pick columns"));
 
       expect(screen.getByLabelText("Select all")).not.toBeChecked();
       expect(screen.getByLabelText("ID")).toBeChecked();
@@ -96,7 +96,7 @@ describe("DataStep", () => {
       const step = createMockNotebookStep({ topLevelQuery: query });
       const { getNextColumn } = await setup(step);
 
-      userEvent.click(getIcon("chevrondown"));
+      userEvent.click(screen.getByLabelText("Pick columns"));
       userEvent.click(screen.getByLabelText("Tax"));
 
       expect(getNextColumn("ID").selected).toBeTruthy();
@@ -107,7 +107,7 @@ describe("DataStep", () => {
     it("should allow de-selecting a column", async () => {
       const { getNextColumn } = await setup();
 
-      userEvent.click(getIcon("chevrondown"));
+      userEvent.click(screen.getByLabelText("Pick columns"));
       userEvent.click(screen.getByLabelText("Tax"));
 
       expect(getNextColumn("ID").selected).toBeTruthy();
@@ -120,7 +120,7 @@ describe("DataStep", () => {
       const step = createMockNotebookStep({ topLevelQuery: query });
       const { getNextColumn } = await setup(step);
 
-      userEvent.click(getIcon("chevrondown"));
+      userEvent.click(screen.getByLabelText("Pick columns"));
       userEvent.click(screen.getByLabelText("Select all"));
 
       expect(getNextColumn("ID").selected).toBeTruthy();
@@ -131,7 +131,7 @@ describe("DataStep", () => {
     it("should leave one column when de-selecting all columns", async () => {
       const { getNextQuery } = await setup();
 
-      userEvent.click(getIcon("chevrondown"));
+      userEvent.click(screen.getByLabelText("Pick columns"));
       userEvent.click(screen.getByLabelText("Select none"));
 
       const nextQuery = getNextQuery();

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.unit.spec.tsx
@@ -1,11 +1,16 @@
 import userEvent from "@testing-library/user-event";
-import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 import { renderWithProviders, screen } from "__support__/ui";
+import {
+  createSampleDatabase,
+  SAMPLE_DB_ID,
+} from "metabase-types/api/mocks/presets";
 import {
   setupDatabasesEndpoints,
   setupSearchEndpoints,
 } from "__support__/server-mocks";
 import * as Lib from "metabase-lib";
+import Question from "metabase-lib/Question";
+import type StructuredQuery from "metabase-lib/queries/StructuredQuery";
 import { columnFinder, createQuery } from "metabase-lib/test-helpers";
 import { createMockNotebookStep } from "../../test-utils";
 import { DataStep } from "./DataStep";
@@ -17,7 +22,10 @@ const createQueryWithFields = (columnNames: string[]) => {
   return Lib.withFields(query, 0, columns);
 };
 
-const setup = async (step = createMockNotebookStep()) => {
+const setup = async (
+  step = createMockNotebookStep(),
+  { readOnly = false }: { readOnly?: boolean } = {},
+) => {
   const updateQuery = jest.fn();
   setupDatabasesEndpoints([createSampleDatabase()]);
   setupSearchEndpoints([]);
@@ -27,6 +35,7 @@ const setup = async (step = createMockNotebookStep()) => {
       step={step}
       topLevelQuery={step.topLevelQuery}
       query={step.query}
+      readOnly={readOnly}
       color="brand"
       isLastOpened={false}
       reportTimezone="UTC"
@@ -39,6 +48,12 @@ const setup = async (step = createMockNotebookStep()) => {
     return lastCall[0];
   };
 
+  const getNextTableName = () => {
+    const query = getNextQuery();
+    const [sampleColumn] = Lib.visibleColumns(query, 0);
+    return Lib.displayInfo(query, 0, sampleColumn).table?.displayName;
+  };
+
   const getNextColumn = (columnName: string) => {
     const nextQuery = getNextQuery();
     const nextFields = Lib.fieldableColumns(nextQuery, 0);
@@ -49,10 +64,40 @@ const setup = async (step = createMockNotebookStep()) => {
 
   await screen.findByText("Orders");
 
-  return { getNextQuery, getNextColumn };
+  return { getNextQuery, getNextTableName, getNextColumn };
 };
 
 describe("DataStep", () => {
+  it("should render without a table selected", async () => {
+    const question = Question.create({ databaseId: SAMPLE_DB_ID });
+    const legacyQuery = question.query() as StructuredQuery;
+    const query = question._getMLv2Query();
+    await setup(
+      createMockNotebookStep({ query: legacyQuery, topLevelQuery: query }),
+    );
+
+    expect(screen.getByText("Pick your starting data")).toBeInTheDocument();
+
+    // Ensure the table picker is not open
+    expect(screen.getByText("Sample Database")).toBeInTheDocument();
+    expect(screen.getByText("Orders")).toBeInTheDocument();
+    expect(screen.getByText("Products")).toBeInTheDocument();
+    expect(screen.getByText("People")).toBeInTheDocument();
+  });
+
+  it("should render with a selected table", async () => {
+    await setup();
+
+    expect(screen.getByText("Orders")).toBeInTheDocument();
+
+    expect(
+      screen.queryByText("Pick your starting data"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Sample Database")).not.toBeInTheDocument();
+    expect(screen.queryByText("Products")).not.toBeInTheDocument();
+    expect(screen.queryByText("People")).not.toBeInTheDocument();
+  });
+
   describe("fields selection", () => {
     it("should render with all columns selected", async () => {
       await setup();
@@ -136,6 +181,22 @@ describe("DataStep", () => {
 
       const nextQuery = getNextQuery();
       expect(Lib.fields(nextQuery, 0)).toHaveLength(1);
+    });
+
+    it("should not display fields picker in read-only mode", async () => {
+      await setup(createMockNotebookStep(), { readOnly: true });
+      expect(screen.queryByLabelText("Pick columns")).not.toBeInTheDocument();
+    });
+
+    it("should not display fields picker until a table is selected", async () => {
+      const question = Question.create({ databaseId: SAMPLE_DB_ID });
+      const legacyQuery = question.query() as StructuredQuery;
+      const query = question._getMLv2Query();
+      await setup(
+        createMockNotebookStep({ query: legacyQuery, topLevelQuery: query }),
+      );
+
+      expect(screen.queryByLabelText("Pick columns")).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.unit.spec.tsx
@@ -53,87 +53,89 @@ const setup = async (step = createMockNotebookStep()) => {
 };
 
 describe("DataStep", () => {
-  it("should render with all columns selected", async () => {
-    await setup();
-    userEvent.click(getIcon("chevrondown"));
+  describe("fields selection", () => {
+    it("should render with all columns selected", async () => {
+      await setup();
+      userEvent.click(getIcon("chevrondown"));
 
-    expect(screen.getByLabelText("Select none")).toBeChecked();
-    expect(screen.getByLabelText("ID")).toBeChecked();
-    expect(screen.getByLabelText("ID")).toBeEnabled();
-    expect(screen.getByLabelText("Tax")).toBeChecked();
-    expect(screen.getByLabelText("Tax")).toBeEnabled();
-  });
+      expect(screen.getByLabelText("Select none")).toBeChecked();
+      expect(screen.getByLabelText("ID")).toBeChecked();
+      expect(screen.getByLabelText("ID")).toBeEnabled();
+      expect(screen.getByLabelText("Tax")).toBeChecked();
+      expect(screen.getByLabelText("Tax")).toBeEnabled();
+    });
 
-  it("should render with a single column selected", async () => {
-    const query = createQueryWithFields(["ID"]);
-    await setup(createMockNotebookStep({ topLevelQuery: query }));
-    userEvent.click(getIcon("chevrondown"));
+    it("should render with a single column selected", async () => {
+      const query = createQueryWithFields(["ID"]);
+      await setup(createMockNotebookStep({ topLevelQuery: query }));
+      userEvent.click(getIcon("chevrondown"));
 
-    expect(screen.getByLabelText("Select all")).not.toBeChecked();
-    expect(screen.getByLabelText("ID")).toBeChecked();
-    expect(screen.getByLabelText("ID")).toBeDisabled();
-    expect(screen.getByLabelText("Tax")).not.toBeChecked();
-    expect(screen.getByLabelText("Tax")).toBeEnabled();
-  });
+      expect(screen.getByLabelText("Select all")).not.toBeChecked();
+      expect(screen.getByLabelText("ID")).toBeChecked();
+      expect(screen.getByLabelText("ID")).toBeDisabled();
+      expect(screen.getByLabelText("Tax")).not.toBeChecked();
+      expect(screen.getByLabelText("Tax")).toBeEnabled();
+    });
 
-  it("should render with multiple columns selected", async () => {
-    const query = createQueryWithFields(["ID", "TOTAL"]);
-    await setup(createMockNotebookStep({ topLevelQuery: query }));
-    userEvent.click(getIcon("chevrondown"));
+    it("should render with multiple columns selected", async () => {
+      const query = createQueryWithFields(["ID", "TOTAL"]);
+      await setup(createMockNotebookStep({ topLevelQuery: query }));
+      userEvent.click(getIcon("chevrondown"));
 
-    expect(screen.getByLabelText("Select all")).not.toBeChecked();
-    expect(screen.getByLabelText("ID")).toBeChecked();
-    expect(screen.getByLabelText("ID")).toBeEnabled();
-    expect(screen.getByLabelText("Tax")).not.toBeChecked();
-    expect(screen.getByLabelText("Tax")).toBeEnabled();
-    expect(screen.getByLabelText("Total")).toBeChecked();
-    expect(screen.getByLabelText("Total")).toBeEnabled();
-  });
+      expect(screen.getByLabelText("Select all")).not.toBeChecked();
+      expect(screen.getByLabelText("ID")).toBeChecked();
+      expect(screen.getByLabelText("ID")).toBeEnabled();
+      expect(screen.getByLabelText("Tax")).not.toBeChecked();
+      expect(screen.getByLabelText("Tax")).toBeEnabled();
+      expect(screen.getByLabelText("Total")).toBeChecked();
+      expect(screen.getByLabelText("Total")).toBeEnabled();
+    });
 
-  it("should allow selecting a column", async () => {
-    const query = createQueryWithFields(["ID"]);
-    const step = createMockNotebookStep({ topLevelQuery: query });
-    const { getNextColumn } = await setup(step);
+    it("should allow selecting a column", async () => {
+      const query = createQueryWithFields(["ID"]);
+      const step = createMockNotebookStep({ topLevelQuery: query });
+      const { getNextColumn } = await setup(step);
 
-    userEvent.click(getIcon("chevrondown"));
-    userEvent.click(screen.getByLabelText("Tax"));
+      userEvent.click(getIcon("chevrondown"));
+      userEvent.click(screen.getByLabelText("Tax"));
 
-    expect(getNextColumn("ID").selected).toBeTruthy();
-    expect(getNextColumn("TAX").selected).toBeTruthy();
-    expect(getNextColumn("TOTAL").selected).toBeFalsy();
-  });
+      expect(getNextColumn("ID").selected).toBeTruthy();
+      expect(getNextColumn("TAX").selected).toBeTruthy();
+      expect(getNextColumn("TOTAL").selected).toBeFalsy();
+    });
 
-  it("should allow de-selecting a column", async () => {
-    const { getNextColumn } = await setup();
+    it("should allow de-selecting a column", async () => {
+      const { getNextColumn } = await setup();
 
-    userEvent.click(getIcon("chevrondown"));
-    userEvent.click(screen.getByLabelText("Tax"));
+      userEvent.click(getIcon("chevrondown"));
+      userEvent.click(screen.getByLabelText("Tax"));
 
-    expect(getNextColumn("ID").selected).toBeTruthy();
-    expect(getNextColumn("TAX").selected).toBeFalsy();
-    expect(getNextColumn("TOTAL").selected).toBeTruthy();
-  });
+      expect(getNextColumn("ID").selected).toBeTruthy();
+      expect(getNextColumn("TAX").selected).toBeFalsy();
+      expect(getNextColumn("TOTAL").selected).toBeTruthy();
+    });
 
-  it("should allow selecting all columns", async () => {
-    const query = createQueryWithFields(["ID"]);
-    const step = createMockNotebookStep({ topLevelQuery: query });
-    const { getNextColumn } = await setup(step);
+    it("should allow selecting all columns", async () => {
+      const query = createQueryWithFields(["ID"]);
+      const step = createMockNotebookStep({ topLevelQuery: query });
+      const { getNextColumn } = await setup(step);
 
-    userEvent.click(getIcon("chevrondown"));
-    userEvent.click(screen.getByLabelText("Select all"));
+      userEvent.click(getIcon("chevrondown"));
+      userEvent.click(screen.getByLabelText("Select all"));
 
-    expect(getNextColumn("ID").selected).toBeTruthy();
-    expect(getNextColumn("TAX").selected).toBeTruthy();
-    expect(getNextColumn("TOTAL").selected).toBeTruthy();
-  });
+      expect(getNextColumn("ID").selected).toBeTruthy();
+      expect(getNextColumn("TAX").selected).toBeTruthy();
+      expect(getNextColumn("TOTAL").selected).toBeTruthy();
+    });
 
-  it("should leave one column when de-selecting all columns", async () => {
-    const { getNextQuery } = await setup();
+    it("should leave one column when de-selecting all columns", async () => {
+      const { getNextQuery } = await setup();
 
-    userEvent.click(getIcon("chevrondown"));
-    userEvent.click(screen.getByLabelText("Select none"));
+      userEvent.click(getIcon("chevrondown"));
+      userEvent.click(screen.getByLabelText("Select none"));
 
-    const nextQuery = getNextQuery();
-    expect(Lib.fields(nextQuery, 0)).toHaveLength(1);
+      const nextQuery = getNextQuery();
+      expect(Lib.fields(nextQuery, 0)).toHaveLength(1);
+    });
   });
 });

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.jsx
@@ -15,11 +15,7 @@ import Question from "metabase-lib/Question";
 import StructuredQuery from "metabase-lib/queries/StructuredQuery";
 
 import { NotebookCellAdd, NotebookCellItem } from "../../NotebookCell";
-import {
-  FieldPickerContentContainer,
-  FIELDS_PICKER_STYLES,
-  FieldsPickerIcon,
-} from "../../FieldsPickerIcon";
+import { FIELDS_PICKER_STYLES, FieldsPickerIcon } from "../../FieldsPickerIcon";
 import FieldsPicker from "../FieldsPicker";
 import {
   DimensionContainer,
@@ -42,6 +38,7 @@ import {
   RemoveJoinIcon,
   Row,
   SecondaryJoinCell,
+  TableCell,
 } from "./JoinStep.styled";
 
 const stepShape = {
@@ -486,9 +483,9 @@ function JoinTablePicker({
         setSourceTableFn={onChange}
         isInitiallyOpen={!hasSourceTable}
         triggerElement={
-          <FieldPickerContentContainer>
+          <TableCell>
             {joinedTable ? joinedTable.displayName() : t`Pick data…`}
-          </FieldPickerContentContainer>
+          </TableCell>
         }
       />
     </NotebookCellItem>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.styled.tsx
@@ -6,6 +6,10 @@ import { Icon } from "metabase/core/components/Icon";
 import Button from "metabase/core/components/Button";
 import { NotebookCell } from "../../NotebookCell";
 
+export const TableCell = styled.div`
+  padding: ${NotebookCell.CONTAINER_PADDING};
+`;
+
 export const Row = styled.div`
   display: flex;
   align-items: center;


### PR DESCRIPTION
Epic #28689

Migrates notebook editor's `DataStep` to MLv2. The main change is that we're not using MLv2's `withDifferentTable` method to change the source table. This will help to fix an issue on the MLv2 joins branch (#33078) when changing a source table wasn't cleaning up existing joins as expected.

### To Verify

1. New > Question > Select table/model/saved question
2. Build a query
3. Click the source table name at the very beginning of the notebook editor and make sure you can change the table