### PR TITLE
X-ray dashcards break with semantic type of Category and base type of Boolean

### DIFF
--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -405,7 +405,7 @@
                    (cond
                      link               [:field id {:source-field link}]
                      fk_target_field_id [:field fk_target_field_id {:source-field id}]
-                     id                 [:field id nil]
+                     id                 [:field id {:base-type base_type}]
                      :else              [:field name {:base-type base_type}]))]
     (cond
       (isa? base_type :type/Temporal)
@@ -664,8 +664,9 @@
  (walk/postwalk
    (fn [subform]
      (if (dashboard-templates/dimension-form? subform)
-       (let [[_ identifier opts] subform]
-         (->reference :mbql (-> identifier bindings (merge opts))))
+       (let [[_ identifier opts] subform
+             binding (-> identifier bindings (merge opts))]
+         (->reference :mbql binding))
        subform))
    {:type     :query
     :database (-> root :database)

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -67,8 +67,10 @@
 ;;; ------------------- `->reference` -------------------
 
 (deftest ^:parallel ->reference-test
-  (is (= [:field 1 nil]
-         (->> (assoc (mi/instance Field) :id 1)
+  (is (= [:field 1 {:base-type :type/Float}]
+         (->> (assoc (mi/instance Field)
+                :id 1
+                :base_type :type/Float)
               (#'magic/->reference :mbql))))
 
   (is (= [:field 2 {:source-field 1}]
@@ -2052,7 +2054,8 @@
                           :dataset_query {:type     :query
                                           :database (mt/id)
                                           :query    {:source-table (format "card__%s" card-id)
-                                                     :breakout     [[:field (mt/id :people :latitude) nil]]
+                                                     :breakout     [[:field (mt/id :people :latitude)
+                                                                     {:base-type :type/Float}]]
                                                      :aggregation  [["count"]]}}}]
                         (#'magic/card-candidates
                           base-context


### PR DESCRIPTION
X-ray dashcards with semantic type of Category and base type of Boolean were creating unparseable mbql queries.

Here is an x-ray of Accounts demonstrating this behavior:
<img width="629" alt="image" src="https://github.com/metabase/metabase/assets/8381441/016e5815-4d52-4e51-b653-6df1ac018f18">

And here is the fixed behavior:
<img width="629" alt="image" src="https://github.com/metabase/metabase/assets/8381441/016bf78c-8608-4344-8875-efd07b425ccb">

This is an example of a query generated previous to the fix:

```clojure
; Source table is Accounts, field 8 is LEGACY_PLAN
(qp/process-query
  {:type :query,
   :database 1,
   :query
   {:source-table 7,
    :breakout     [[:field 8 nil]],
    :aggregation  [["count"]]}})
```
This results in the following error:

Execution error (ExceptionInfo) at metabase.util.malli.fn/validate (fn.clj:150). Invalid output: {:stages [{:order-by [nil [nil nil ["an expression that can be compared with :> or :<" "an expression that can be compared with :> or :<"]]], :source-card ["missing required key"]}]}

The fix is simply to ensure that the base type of the field is present in the field attributes if the field is of the form `[:field id attributes]`.

Here is the fixed query, which works:

```clojure
(qp/process-query
  {:type :query,
   :database 1,
   :query
   {:source-table 7,
    :breakout     [[:field 8 {:base-type :type/Boolean}]],
    :aggregation  [["count"]]}})
```
