### PR TITLE
Handle mismatching date parameters in dashboard -> native question drills

### DIFF
--- a/e2e/test/scenarios/native-filters/reproductions/34129.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/reproductions/34129.cy.spec.js
@@ -1,0 +1,81 @@
+import {
+  filterWidget,
+  getDashboardCard,
+  popover,
+  restore,
+  visitDashboard,
+} from "e2e/support/helpers";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { ORDERS } = SAMPLE_DATABASE;
+
+const parameter = {
+  name: "Relative Date",
+  slug: "relative_date",
+  id: "3952592",
+  type: "date/relative",
+  sectionId: "date",
+};
+
+const templateTag = {
+  type: "dimension",
+  name: "time",
+  id: "301a329f-5a83-40df-898b-236078025cbe",
+  "display-name": "Time",
+  dimension: ["field", ORDERS.CREATED_AT, null],
+  "widget-type": "date/month-year",
+};
+
+const questionDetails = {
+  name: "issue 34129",
+  native: {
+    query:
+      "select min(CREATED_AT), max(CREATED_AT), count(*) from ORDERS where {{ time }}",
+    "template-tags": {
+      [templateTag.name]: templateTag,
+    },
+  },
+};
+
+const dashboardDetails = {
+  parameters: [parameter],
+};
+
+const getParameterMapping = (cardId, parameterId) => ({
+  card_id: cardId,
+  parameter_id: parameterId,
+  target: ["dimension", ["template-tag", templateTag.name]],
+});
+
+describe("issue 34129", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+    cy.intercept("/api/card/*/query").as("cardQuery");
+    cy.intercept("/api/dashboard/*/dashcard/*/card/*/query").as(
+      "dashcardQuery",
+    );
+  });
+
+  it("should support mismatching date filter parameter values when navigating from a dashboard (metabase#34129)", () => {
+    cy.createNativeQuestionAndDashboard({
+      questionDetails,
+      dashboardDetails,
+    }).then(({ body: card }) => {
+      const { card_id, dashboard_id } = card;
+      const mapping = getParameterMapping(card_id, parameter.id);
+      cy.editDashboardCard(card, { parameter_mappings: [mapping] });
+      visitDashboard(dashboard_id);
+      cy.wait("@dashcardQuery");
+    });
+
+    filterWidget().click();
+    popover().findByText("Today").click();
+    cy.wait("@dashcardQuery");
+
+    getDashboardCard().findByText(questionDetails.name).click();
+    cy.wait("@cardQuery");
+
+    filterWidget().findByText("Today").should("exist");
+  });
+});

--- a/frontend/src/metabase/parameters/utils/date-formatting.ts
+++ b/frontend/src/metabase/parameters/utils/date-formatting.ts
@@ -5,7 +5,10 @@ import moment from "moment-timezone";
 import { DATE_OPERATORS } from "metabase/query_builder/components/filters/pickers/DatePicker/DatePicker";
 import { EXCLUDE_OPERATORS } from "metabase/query_builder/components/filters/pickers/DatePicker/ExcludeDatePicker";
 import { dateParameterValueToMBQL } from "metabase-lib/parameters/utils/mbql";
-import { DATE_MBQL_FILTER_MAPPING } from "metabase-lib/parameters/constants";
+import {
+  DATE_MBQL_FILTER_MAPPING,
+  PARAMETER_OPERATOR_TYPES,
+} from "metabase-lib/parameters/constants";
 import {
   generateTimeFilterValuesDescriptions,
   getRelativeDatetimeInterval,
@@ -111,52 +114,68 @@ function getFilterTitle(filter: any[]) {
   return prefix + desc;
 }
 
-export function formatAllOptionsWidget(urlEncoded: string) {
+export function formatAllOptionsWidget(urlEncoded: string): string | null {
   if (urlEncoded == null) {
     return null;
   }
   const filter = dateParameterValueToMBQL(urlEncoded, noopRef);
-
   return filter ? getFilterTitle(filter) : null;
 }
 
 function parseDateRangeValue(value: string) {
   const [start, end] = (value || "").split(RANGE_SEPARATOR);
-  return { start, end };
+  return { start: moment(start), end: moment(end) };
 }
 
-export function formatRangeWidget(value: string) {
+export function formatRangeWidget(value: string): string | null {
   const { start, end } = parseDateRangeValue(value);
-  return start && end
-    ? moment(start).format("MMMM D, YYYY") +
-        " - " +
-        moment(end).format("MMMM D, YYYY")
-    : "";
+  return start.isValid() && end.isValid()
+    ? start.format("MMMM D, YYYY") + " - " + end.format("MMMM D, YYYY")
+    : null;
 }
 
-export function formatSingleWidget(value: string) {
-  return value ? moment(value).format("MMMM D, YYYY") : "";
+function formatSingleWidget(value: string): string | null {
+  const m = moment(value);
+  return m.isValid() ? m.format("MMMM D, YYYY") : null;
 }
 
-export function formatMonthYearWidget(value: string) {
+function formatMonthYearWidget(value: string): string | null {
   const m = moment(value, "YYYY-MM");
-  return m.isValid() ? m.format("MMMM YYYY") : "";
+  return m.isValid() ? m.format("MMMM YYYY") : null;
 }
 
-export function formatQuarterYearWidget(value: string) {
+function formatQuarterYearWidget(value: string): string | null {
   const m = moment(value, "[Q]Q-YYYY");
-  return m.isValid() ? m.format("[Q]Q YYYY") : "";
+  return m.isValid() ? m.format("[Q]Q YYYY") : null;
 }
 
-export function formatRelativeWidget(value: string) {
+function formatRelativeWidget(value: string): string | null {
   return DATE_MBQL_FILTER_MAPPING[value]
     ? DATE_MBQL_FILTER_MAPPING[value].name
-    : "";
+    : null;
+}
+
+export function formatDateValue(
+  value: string,
+  parameter: UiParameter,
+): string | null {
+  // the value can be from a mismatching parameter, so we need to test every date parameter type
+  const types = [
+    parameter.type,
+    ...PARAMETER_OPERATOR_TYPES.date.map(({ type }) => type),
+  ];
+
+  return types.reduce((result: string | null, type) => {
+    return result ?? formatDateValueForType(value, type);
+  }, null);
 }
 
 // This should miror the logic in `metabase.shared.parameters.parameters`
-export function formatDateValue(value: string, parameter: UiParameter) {
-  switch (parameter.type) {
+export function formatDateValueForType(
+  value: string,
+  type: string,
+): string | null {
+  switch (type) {
     case "date/range":
       return formatRangeWidget(value);
     case "date/single":

--- a/frontend/src/metabase/parameters/utils/date-formatting.ts
+++ b/frontend/src/metabase/parameters/utils/date-formatting.ts
@@ -124,7 +124,7 @@ export function formatAllOptionsWidget(urlEncoded: string): string | null {
 
 function parseDateRangeValue(value: string) {
   const [start, end] = (value || "").split(RANGE_SEPARATOR);
-  return { start: moment(start), end: moment(end) };
+  return { start: moment(start, true), end: moment(end, true) };
 }
 
 export function formatRangeWidget(value: string): string | null {
@@ -135,17 +135,17 @@ export function formatRangeWidget(value: string): string | null {
 }
 
 function formatSingleWidget(value: string): string | null {
-  const m = moment(value);
+  const m = moment(value, true);
   return m.isValid() ? m.format("MMMM D, YYYY") : null;
 }
 
 function formatMonthYearWidget(value: string): string | null {
-  const m = moment(value, "YYYY-MM");
+  const m = moment(value, "YYYY-MM", true);
   return m.isValid() ? m.format("MMMM YYYY") : null;
 }
 
 function formatQuarterYearWidget(value: string): string | null {
-  const m = moment(value, "[Q]Q-YYYY");
+  const m = moment(value, "[Q]Q-YYYY", true);
   return m.isValid() ? m.format("[Q]Q YYYY") : null;
 }
 

--- a/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
+++ b/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
@@ -81,6 +81,11 @@ describe("metabase/parameters/utils/formatting", () => {
         expected: "Last Week",
       },
       {
+        type: "date/month-year",
+        value: "2023-10-02~2023-10-24",
+        expected: "October 2, 2023 - October 24, 2023",
+      },
+      {
         type: "number/=",
         value: 123456789,
         expected: "123,456,789",

--- a/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
+++ b/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
@@ -61,6 +61,11 @@ describe("metabase/parameters/utils/formatting", () => {
         expected: "Past 30 Days",
       },
       {
+        type: "date/month-year",
+        value: "thisday",
+        expected: "Today",
+      },
+      {
         type: "number/=",
         value: 123456789,
         expected: "123,456,789",

--- a/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
+++ b/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
@@ -47,23 +47,23 @@ describe("metabase/parameters/utils/formatting", () => {
       },
       {
         type: "date/month-year",
-        value: "2018-01",
-        expected: "January 2018",
-      },
-      {
-        type: "date/quarter-year",
-        value: "Q1-2018",
-        expected: "Q1 2018",
-      },
-      {
-        type: "date/relative",
-        value: "past30days",
-        expected: "Past 30 Days",
+        value: "thisday",
+        expected: "Today",
       },
       {
         type: "date/month-year",
-        value: "thisday",
-        expected: "Today",
+        value: "thisweek",
+        expected: "This Week",
+      },
+      {
+        type: "date/month-year",
+        value: "past1days",
+        expected: "Yesterday",
+      },
+      {
+        type: "date/month-year",
+        value: "past1weeks",
+        expected: "Last Week",
       },
       {
         type: "number/=",

--- a/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
+++ b/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
@@ -47,6 +47,21 @@ describe("metabase/parameters/utils/formatting", () => {
       },
       {
         type: "date/month-year",
+        value: "2018-01",
+        expected: "January 2018",
+      },
+      {
+        type: "date/quarter-year",
+        value: "Q1-2018",
+        expected: "Q1 2018",
+      },
+      {
+        type: "date/relative",
+        value: "past30days",
+        expected: "Past 30 Days",
+      },
+      {
+        type: "date/month-year",
         value: "thisday",
         expected: "Today",
       },

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -114,9 +114,7 @@ async function fetchAndPrepareSavedQuestionCards(
 
   // for showing the "started from" lineage correctly when adding filters/breakouts and when going back and forth
   // in browser history, the original_card_id has to be set for the current card (simply the id of card itself for now)
-  card.original_card_id = card.id;
-
-  return { card, originalCard };
+  return { card: { ...card, original_card_id: card.id }, originalCard };
 }
 
 async function fetchAndPrepareAdHocQuestionCards(


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/34129

How to verify:
- Follow the steps from the issue or run the new cypress test
- Try all dashboard time widget types with different native date parameter widget types. 

<img width="902" alt="Screenshot 2023-10-02 at 12 11 52" src="https://github.com/metabase/metabase/assets/8542534/f2b0ab80-94b2-4836-a4a7-19320ef3fabc">
