### PR TITLE
Fix adding filters in nested queries

### DIFF
--- a/e2e/test/scenarios/filters/reproductions/34279-filters-nested-query.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/34279-filters-nested-query.cy.spec.js
@@ -1,0 +1,51 @@
+import {
+  restore,
+  popover,
+  startNewQuestion,
+  getNotebookStep,
+  visualize,
+} from "e2e/support/helpers";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "Test Question",
+  query: {
+    "source-table": PRODUCTS_ID,
+    aggregations: [["count"]],
+    breakouts: [
+      ["field", PRODUCTS.CATEGORY, null],
+      ["field", PRODUCTS.CREATED_AT, { "temporal-unit": "year" }],
+    ],
+  },
+};
+
+describe("issue 34279", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should allow to add filters in nested queries (metabase#34279)", () => {
+    cy.createQuestion(questionDetails).then(({ body: card }) => {
+      startNewQuestion();
+      popover().within(() => {
+        cy.findByText("Saved Questions").click();
+        cy.findByText(questionDetails.name).click();
+      });
+      getNotebookStep("filter")
+        .findByText("Add filters to narrow your answer")
+        .click();
+      popover().within(() => {
+        cy.findByText("Category").click();
+        cy.findByText("Widget").click();
+        cy.button("Add filter").click();
+      });
+      visualize();
+      cy.findByTestId("qb-filters-panel")
+        .findByText("Category is Widget")
+        .should("be.visible");
+    });
+  });
+});

--- a/frontend/src/metabase-lib/Dimension.ts
+++ b/frontend/src/metabase-lib/Dimension.ts
@@ -262,8 +262,10 @@ export default class Dimension {
 
     const otherDimension: Dimension | null | undefined =
       other instanceof Dimension ? other : this.parseMBQL(other);
-    const baseDimensionA = this.baseDimension();
-    const baseDimensionB = otherDimension && otherDimension.baseDimension();
+    const baseDimensionA = this.getMLv1CompatibleDimension().baseDimension();
+    const baseDimensionB =
+      otherDimension &&
+      otherDimension.getMLv1CompatibleDimension().baseDimension();
     return (
       !!baseDimensionA &&
       !!baseDimensionB &&


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/34279
In master it's fixed by https://github.com/metabase/metabase/pull/32698, so we only need to cherry-pick the fix and add a test.

How to verify:
- Create a new question based on Products with aggregations and breakouts by Category
- Create another question based on the previous one and add a filter for Category
- It should be possible to add this filter and save the question