### PR TITLE
re-initialize qb when navigating back

### DIFF
--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -8,9 +8,14 @@ import {
   filter,
   filterField,
   visitCollection,
+  popover,
 } from "e2e/support/helpers";
 
-import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import {
+  SAMPLE_DB_ID,
+  USER_GROUPS,
+  WRITABLE_DB_ID,
+} from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { THIRD_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data";
 
@@ -312,6 +317,65 @@ describe("scenarios > question > native", () => {
     runQuery();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 1 row").should("be.visible");
+  });
+
+  describe("no native access", () => {
+    beforeEach(() => {
+      restore("postgres-12");
+      cy.signInAsAdmin();
+      cy.intercept("/api/database?saved=true").as("database");
+      cy.updatePermissionsGraph({
+        [USER_GROUPS.ALL_USERS_GROUP]: {
+          [WRITABLE_DB_ID]: { data: { schemas: "none", native: "none" } },
+        },
+        [USER_GROUPS.NOSQL_GROUP]: {
+          [SAMPLE_DB_ID]: { data: { schemas: "all", native: "write" } },
+          [WRITABLE_DB_ID]: { data: { schemas: "all", native: "none" } },
+        },
+      });
+
+      cy.updateCollectionGraph({
+        [USER_GROUPS.NOSQL_GROUP]: { root: "write" },
+      });
+
+      cy.createNativeQuestion(
+        {
+          name: "Secret Orders",
+          native: {
+            query: "SELECT * FROM ORDERS",
+          },
+          database: WRITABLE_DB_ID,
+        },
+        {
+          wrapId: true,
+        },
+      );
+
+      cy.signIn("nosql");
+    });
+
+    it("should not display the query when you do not have native access to the data source", () => {
+      cy.get("@questionId").then(questionId =>
+        cy.visit(`/question/${questionId}`),
+      );
+
+      cy.findByTestId("native-query-top-bar").within(() => {
+        cy.findByText("This question is written in SQL.").should("be.visible");
+        cy.findByTestId("visibility-toggler").should("not.exist");
+      });
+
+      cy.log("#32387");
+      cy.findByRole("button", { name: /New/ }).click();
+      popover().findByText("SQL query").click();
+
+      cy.wait("@database");
+      cy.go("back");
+
+      cy.findByTestId("native-query-top-bar").within(() => {
+        cy.findByText("This question is written in SQL.").should("be.visible");
+        cy.findByTestId("visibility-toggler").should("not.exist");
+      });
+    });
   });
 
   describe("prompts", () => {

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -319,65 +319,6 @@ describe("scenarios > question > native", () => {
     cy.findByText("Showing 1 row").should("be.visible");
   });
 
-  describe("no native access", () => {
-    beforeEach(() => {
-      restore("postgres-12");
-      cy.signInAsAdmin();
-      cy.intercept("/api/database?saved=true").as("database");
-      cy.updatePermissionsGraph({
-        [USER_GROUPS.ALL_USERS_GROUP]: {
-          [WRITABLE_DB_ID]: { data: { schemas: "none", native: "none" } },
-        },
-        [USER_GROUPS.NOSQL_GROUP]: {
-          [SAMPLE_DB_ID]: { data: { schemas: "all", native: "write" } },
-          [WRITABLE_DB_ID]: { data: { schemas: "all", native: "none" } },
-        },
-      });
-
-      cy.updateCollectionGraph({
-        [USER_GROUPS.NOSQL_GROUP]: { root: "write" },
-      });
-
-      cy.createNativeQuestion(
-        {
-          name: "Secret Orders",
-          native: {
-            query: "SELECT * FROM ORDERS",
-          },
-          database: WRITABLE_DB_ID,
-        },
-        {
-          wrapId: true,
-        },
-      );
-
-      cy.signIn("nosql");
-    });
-
-    it("should not display the query when you do not have native access to the data source", () => {
-      cy.get("@questionId").then(questionId =>
-        cy.visit(`/question/${questionId}`),
-      );
-
-      cy.findByTestId("native-query-top-bar").within(() => {
-        cy.findByText("This question is written in SQL.").should("be.visible");
-        cy.findByTestId("visibility-toggler").should("not.exist");
-      });
-
-      cy.log("#32387");
-      cy.findByRole("button", { name: /New/ }).click();
-      popover().findByText("SQL query").click();
-
-      cy.wait("@database");
-      cy.go("back");
-
-      cy.findByTestId("native-query-top-bar").within(() => {
-        cy.findByText("This question is written in SQL.").should("be.visible");
-        cy.findByTestId("visibility-toggler").should("not.exist");
-      });
-    });
-  });
-
   describe("prompts", () => {
     const PROMPT = "orders count";
     const PROMPT_RESPONSE = { sql: "select count(*) from orders" };
@@ -454,6 +395,65 @@ describe("scenarios > question > native", () => {
       runQuery();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("18,760");
+    });
+  });
+});
+
+describe("no native access", () => {
+  beforeEach(() => {
+    restore("postgres-12");
+    cy.signInAsAdmin();
+    cy.intercept("/api/database?saved=true").as("database");
+    cy.updatePermissionsGraph({
+      [USER_GROUPS.ALL_USERS_GROUP]: {
+        [WRITABLE_DB_ID]: { data: { schemas: "none", native: "none" } },
+      },
+      [USER_GROUPS.NOSQL_GROUP]: {
+        [SAMPLE_DB_ID]: { data: { schemas: "all", native: "write" } },
+        [WRITABLE_DB_ID]: { data: { schemas: "all", native: "none" } },
+      },
+    });
+
+    cy.updateCollectionGraph({
+      [USER_GROUPS.NOSQL_GROUP]: { root: "write" },
+    });
+
+    cy.createNativeQuestion(
+      {
+        name: "Secret Orders",
+        native: {
+          query: "SELECT * FROM ORDERS",
+        },
+        database: WRITABLE_DB_ID,
+      },
+      {
+        wrapId: true,
+      },
+    );
+
+    cy.signIn("nosql");
+  });
+
+  it("should not display the query when you do not have native access to the data source", () => {
+    cy.get("@questionId").then(questionId =>
+      cy.visit(`/question/${questionId}`),
+    );
+
+    cy.findByTestId("native-query-top-bar").within(() => {
+      cy.findByText("This question is written in SQL.").should("be.visible");
+      cy.findByTestId("visibility-toggler").should("not.exist");
+    });
+
+    cy.log("#32387");
+    cy.findByRole("button", { name: /New/ }).click();
+    popover().findByText("SQL query").click();
+
+    cy.wait("@database");
+    cy.go("back");
+
+    cy.findByTestId("native-query-top-bar").within(() => {
+      cy.findByText("This question is written in SQL.").should("be.visible");
+      cy.findByTestId("visibility-toggler").should("not.exist");
     });
   });
 });

--- a/frontend/src/metabase/query_builder/actions/navigation.js
+++ b/frontend/src/metabase/query_builder/actions/navigation.js
@@ -26,7 +26,7 @@ import {
 import { initializeQB, setCardAndRun } from "./core";
 import { zoomInRow, resetRowZoom } from "./object-detail";
 import { cancelQuery } from "./querying";
-import { setQueryBuilderMode } from "./ui";
+import { resetUIControls, setQueryBuilderMode } from "./ui";
 
 export const SET_CURRENT_STATE = "metabase/qb/SET_CURRENT_STATE";
 const setCurrentState = createAction(SET_CURRENT_STATE);
@@ -60,6 +60,7 @@ export const popState = createThunkAction(
         const shouldRefreshUrl = location.state.card.dataset;
         await dispatch(setCardAndRun(location.state.card, shouldRefreshUrl));
         await dispatch(setCurrentState(location.state));
+        await dispatch(resetUIControls());
       }
     }
 
@@ -95,6 +96,7 @@ export const locationChanged =
           getURL(location, { includeMode: true })
         ) {
           // the browser forward/back button was pressed
+
           dispatch(popState(nextLocation));
         }
       } else if (

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -295,6 +295,10 @@ function QueryBuilder(props) {
   });
 
   useEffect(() => {
+    initializeQB(location, params);
+  }, [initializeQB, location, params]);
+
+  useEffect(() => {
     window.addEventListener("resize", forceUpdateDebounced);
     return () => window.removeEventListener("resize", forceUpdateDebounced);
   });

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -295,10 +295,6 @@ function QueryBuilder(props) {
   });
 
   useEffect(() => {
-    initializeQB(location, params);
-  }, [initializeQB, location, params]);
-
-  useEffect(() => {
     window.addEventListener("resize", forceUpdateDebounced);
     return () => window.removeEventListener("resize", forceUpdateDebounced);
   });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/32387

### Description
The Query builder will display the native query when it shouldn't if you navigate to a question you can only view, to a blank native question, and then back again. This is because the QB does not re-initialize on the way back, so the UI controls are not recalculated. This PR causes the QB to re-initialize if the location or params changes 

### How to verify

1. Create a user that has read SQL access to one DB, and full sql access on another.
2. Create a question a native question that points to the first DB and save it
3. Log in as the restricted user, and navigate to the created question. You should not be able to see the SQL behind the question
4. click New -> SQL query, then click the back button on the browser. The SQL should still be hidden.

### Demo
![chrome_q1RxMxADgF](https://github.com/metabase/metabase/assets/1328979/8f010939-3899-4df9-ab96-dbbb7263648a)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
