### PR TITLE
fix: Collection move UI filters out Parent and all its subchildren

### DIFF
--- a/frontend/src/metabase/collections/components/BulkActions.jsx
+++ b/frontend/src/metabase/collections/components/BulkActions.jsx
@@ -96,6 +96,7 @@ function BulkActions({
                 ? t`Move ${selectedItems.length} items?`
                 : t`Move "${selectedItems[0].getName()}"?`
             }
+            collectionsToMove={selectedItems}
             onClose={onCloseModal}
             onMove={onMove}
           />

--- a/frontend/src/metabase/collections/components/MoveCollectionModal/MoveCollectionModal.tsx
+++ b/frontend/src/metabase/collections/components/MoveCollectionModal/MoveCollectionModal.tsx
@@ -28,6 +28,7 @@ const MoveCollectionModal = ({
       initialCollectionId={collection.id}
       onMove={handleMove}
       onClose={onClose}
+      collectionsToMove={[collection]}
     />
   );
 };

--- a/frontend/src/metabase/containers/CollectionMoveModal.tsx
+++ b/frontend/src/metabase/containers/CollectionMoveModal.tsx
@@ -15,6 +15,7 @@ interface CollectionMoveModalProps {
   onClose: () => void;
   onMove: (collection: any) => void;
   initialCollectionId?: number | string | null;
+  collectionsToMove?: Array<Collection>;
 }
 
 export const CollectionMoveModal = ({
@@ -22,6 +23,7 @@ export const CollectionMoveModal = ({
   onClose,
   onMove,
   initialCollectionId,
+  collectionsToMove,
 }: CollectionMoveModalProps) => {
   const [selectedCollectionId, setSelectedCollectionId] =
     useState(initialCollectionId);
@@ -48,6 +50,7 @@ export const CollectionMoveModal = ({
         onOpenCollectionChange={setOpenCollectionId}
         value={selectedCollectionId}
         onChange={setSelectedCollectionId}
+        collectionsToFilter={collectionsToMove}
       />
       <ButtonContainer>
         <Button light icon="add" onClick={() => setCreatingCollection(true)}>


### PR DESCRIPTION
Closes #33026

### Description

Filtering the collectionItems variable in `frontend/src/metabase/containers/ItemPicker/ItemPicker.tsx` according the selected collections which should be moved. Along with that also modified the checkCollectionMaybeHasChildren in `frontend/src/metabase/containers/ItemPicker/ItemPicker.tsx` to send false if all the children are filtered collections.  

The issue was mostly visual as there are checks in backend to not allow invalid collection moves. 

### How to verify

1. Create a Parent collection
1. Create a nested Child collection within the Parent
1. Go to the Parent and try to move it to the Child collection
1. The UI should filter out Parent and all its subchildren

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR (TBD)
