### PR TITLE
[MLv2] Update Boolean Picker Operator Options

### DIFF
--- a/frontend/src/metabase/common/components/FilterPicker/BooleanFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/BooleanFilterPicker.tsx
@@ -9,6 +9,8 @@ import type { FilterPickerWidgetProps } from "./types";
 
 type OptionType = Lib.FilterOperatorName | "true" | "false";
 
+const operatorsToShow = ["=", "is-null", "not-null"];
+
 type Option = {
   name: string;
   type: OptionType;
@@ -94,24 +96,27 @@ function getOptions(
   column: Lib.ColumnMetadata,
 ): Option[] {
   const operators = Lib.filterableColumnOperators(column);
-  return operators.flatMap((operator): Option[] => {
-    const operatorInfo = Lib.displayInfo(query, stageIndex, operator);
-    if (operatorInfo.shortName === "=") {
-      return [
-        { operator, name: t`True`, type: "true" },
-        { operator, name: t`False`, type: "false" },
-      ];
-    } else {
-      return [
-        {
-          operator,
-          name: operatorInfo.displayName,
-          type: operatorInfo.shortName,
-          isAdvanced: true,
-        },
-      ];
-    }
-  });
+  return operators
+    .flatMap((operator): Option[] => {
+      const operatorInfo = Lib.displayInfo(query, stageIndex, operator);
+      if (operatorInfo.shortName === "=") {
+        return [
+          { operator, name: t`True`, type: "true" },
+          { operator, name: t`False`, type: "false" },
+        ];
+      } else if (operatorsToShow.includes(operatorInfo.shortName)) {
+        return [
+          {
+            operator,
+            name: operatorInfo.displayName,
+            type: operatorInfo.shortName,
+            isAdvanced: true,
+          },
+        ];
+      }
+      return [];
+    })
+    .filter(Boolean);
 }
 
 function getOptionType(

--- a/frontend/src/metabase/common/components/FilterPicker/BooleanFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/BooleanFilterPicker.tsx
@@ -9,8 +9,6 @@ import type { FilterPickerWidgetProps } from "./types";
 
 type OptionType = Lib.FilterOperatorName | "true" | "false";
 
-const operatorsToShow = ["=", "is-null", "not-null"];
-
 type Option = {
   name: string;
   type: OptionType;
@@ -99,22 +97,19 @@ function getOptions(
   return operators
     .flatMap((operator): Option[] => {
       const operatorInfo = Lib.displayInfo(query, stageIndex, operator);
-      if (operatorInfo.shortName === "=") {
-        return [
-          { operator, name: t`True`, type: "true" },
-          { operator, name: t`False`, type: "false" },
-        ];
-      } else if (operatorsToShow.includes(operatorInfo.shortName)) {
-        return [
-          {
-            operator,
-            name: operatorInfo.displayName,
-            type: operatorInfo.shortName,
-            isAdvanced: true,
-          },
-        ];
+      switch (operatorInfo.shortName) {
+        case "=":
+          return [
+            { operator, name: t`True`, type: "true" },
+            { operator, name: t`False`, type: "false" },
+          ];
+        case "is-null":
+          return [{ operator, name: t`Empty`, type: "is-null" }];
+        case "not-null":
+          return [{ operator, name: t`Not empty`, type: "not-null" }];
+        default:
+          return [];
       }
-      return [];
     })
     .filter(Boolean);
 }


### PR DESCRIPTION

### Description

Updates the boolean picker to only show the operators that we want for the UI, not all possible operators. I think some of the possible operators given to us by the backend are wrong, but even so, the requirements of the UI here are such that we don't actually want to show all valid operators (like `!=`)

Before | After
--- | ---
![Screen Shot 2023-10-02 at 12 23 58 PM](https://github.com/metabase/metabase/assets/30528226/b1b67137-e161-4a27-a790-817caf34a8de) | ![Screen Shot 2023-10-02 at 12 35 08 PM](https://github.com/metabase/metabase/assets/30528226/4f8a3b2a-4f0e-49f1-a59e-bb4d77fa2c8a)


