### PR TITLE
fix Arabic translations

### DIFF
--- a/locales/ar-SA.po
+++ b/locales/ar-SA.po
@@ -30108,7 +30108,7 @@ msgstr "كل القيم ({0})"
 
 #: frontend/src/metabase/visualizations/shared/utils/data.ts:129
 msgid "Other ({0})"
-msgstr "أخرى (0})"
+msgstr "أخرى ({0})"
 
 #: frontend/src/metabase/writeback/components/ActionCreator/FormCreator/constants.ts:20
 #: frontend/src/metabase/writeback/components/ActionCreator/FormCreator/constants.ts:74

--- a/locales/ar.po
+++ b/locales/ar.po
@@ -25622,7 +25622,7 @@ msgstr "كل القيم ({0})"
 
 #: frontend/src/metabase/visualizations/shared/utils/data.ts:129
 msgid "Other ({0})"
-msgstr "أخرى (0})"
+msgstr "أخرى ({0})"
 
 #: frontend/src/metabase/writeback/components/ActionCreator/FormCreator/constants.ts:20
 #: frontend/src/metabase/writeback/components/ActionCreator/FormCreator/constants.ts:74


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/34236

### Description

Due to incorrect translation string for `Other (n)` for Arabic locale it does not correctly rendered in the app.
I also fixed these two strings in the https://poeditor.com/ 

### How to verify

1. New question -> Sample Dataset -> Orders group by Created At: Month
2. Make it a row chart
3. Switch locale to Arabic
4. Ensure the `Other (n)` renders translated

### Demo

<img width="254" alt="Screenshot 2023-10-02 at 8 13 46 PM" src="https://github.com/metabase/metabase/assets/14301985/03eb21d0-5344-4005-8e94-de883c9005fc">

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR — we do not test every single l10n string for typos
