### PR TITLE
Remove unused and deprecated `delete-file!` function

### DIFF
--- a/bin/build/src/metabuild_common/core.clj
+++ b/bin/build/src/metabuild_common/core.clj
@@ -40,7 +40,6 @@
   assert-file-exists
   copy-file!
   create-directory-unless-exists!
-  delete-file!
   delete-file-if-exists!
   download-file!
   file-exists?

--- a/bin/build/src/metabuild_common/files.clj
+++ b/bin/build/src/metabuild_common/files.clj
@@ -49,12 +49,6 @@
   ([file & more]
    (dorun (map delete-file-if-exists! (cons file more)))))
 
-(defn ^:deprecated delete-file!
-  "Alias for `delete-file-if-exists!`. Here for backwards compatibility. Prefer `delete-file-if-exists!` going
-  forward."
-  [& args]
-  (apply delete-file-if-exists! args))
-
 (defn copy-file!
   "Copy a `source` file (or directory, recursively) to `dest`."
   [^String source ^String dest]


### PR DESCRIPTION
It was deprecated and left in a codebase for backwards compatibility. But it seems we've migrated all references to the new method `delete-file-if-exists`.

The last time this was touched was three years ago. Should be safe to remove.