### PR TITLE
Do not run frontend workflow when label is added or removed

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,54 @@
+name: Chromatic Storybook deployment
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    types: [synchronize, labeled, unlabeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  files-changed:
+    name: Check which files changed
+    runs-on: ubuntu-22.04
+    timeout-minutes: 3
+    outputs:
+      frontend_all: ${{ steps.changes.outputs.frontend_all }}
+      e2e_specs: ${{ steps.changes.outputs.e2e_specs }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Test which files changed
+        uses: dorny/paths-filter@v2.11.1
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-paths.yaml
+
+  fe-chromatic:
+    needs: files-changed
+    if: contains(github.event.pull_request.labels.*.name, 'chromatic') || (github.ref_name == 'master' && needs.files-changed.outputs.frontend_all == 'true')
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Prepare front-end environment
+        uses: ./.github/actions/prepare-frontend
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+        with:
+          m2-cache-key: "cljs"
+      - name: Publish to Chromatic
+        uses: chromaui/action@v1
+        env:
+          PUBLISH_CHROMATIC: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          STORYBOOK_BUILD_TIMEOUT: 900000
+        if: env.PUBLISH_CHROMATIC != null
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -21,6 +21,10 @@ jobs:
       frontend_all: ${{ steps.changes.outputs.frontend_all }}
       e2e_specs: ${{ steps.changes.outputs.e2e_specs }}
     steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@v3
       - name: Test which files changed
         uses: dorny/paths-filter@v2.11.1

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   files-changed:
+    if: github.event.action != 'labeled' && github.event.action != 'unlabeled'
     name: Check which files changed
     runs-on: ubuntu-22.04
     timeout-minutes: 3

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -6,7 +6,7 @@ on:
       - "master"
       - "release-**"
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
@@ -14,7 +14,6 @@ concurrency:
 
 jobs:
   files-changed:
-    if: github.event.action != 'labeled' && github.event.action != 'unlabeled'
     name: Check which files changed
     runs-on: ubuntu-22.04
     timeout-minutes: 3
@@ -22,10 +21,6 @@ jobs:
       frontend_all: ${{ steps.changes.outputs.frontend_all }}
       e2e_specs: ${{ steps.changes.outputs.e2e_specs }}
     steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@v3
       - name: Test which files changed
         uses: dorny/paths-filter@v2.11.1
@@ -121,28 +116,3 @@ jobs:
           m2-cache-key: "cljs"
       - name: Run frontend timezones tests
         run: yarn run test-timezones
-
-  fe-chromatic:
-    needs: files-changed
-    if: contains(github.event.pull_request.labels.*.name, 'chromatic') || (github.ref_name == 'master' && needs.files-changed.outputs.frontend_all == 'true')
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Prepare front-end environment
-        uses: ./.github/actions/prepare-frontend
-      - name: Prepare back-end environment
-        uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "cljs"
-      - name: Publish to Chromatic
-        uses: chromaui/action@v1
-        env:
-          PUBLISH_CHROMATIC: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          STORYBOOK_BUILD_TIMEOUT: 900000
-        if: env.PUBLISH_CHROMATIC != null
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
### Description

Adding required label `backport` or `no-backport` led to another run of unit tests which could already pass to that moment.
As I got from the file, we listen for `labeled` and `unlabeled` pull_request types only for chromatic, so to me it looks reasonable to move chromatic to a separate workflow file and run it separately from main frontend.

### How to verify

- when frontend job is passed, add a label (backport/no-backport), then wait 10s, go to https://github.com/metabase/metabase/actions/workflows/frontend.yml and make sure no new run of frontend is pending 

### Demo

https://www.loom.com/share/a81f3bf228774711b0554252aa49b9c3

### Checklist

~- [ ] Tests have been added/updated to cover changes in this PR~
