### PR TITLE
Global search:  adding creator name and last editor name to search results

### DIFF
--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -38,54 +38,7 @@
 ;;; |                                            Columns for each Entity                                             |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(def ^:private all-search-columns
-  "All columns that will appear in the search results, and the types of those columns. The generated search query is a
-  `UNION ALL` of the queries for each different entity; it looks something like:
 
-    SELECT 'card' AS model, id, cast(NULL AS integer) AS table_id, ...
-    FROM report_card
-    UNION ALL
-    SELECT 'metric' as model, id, table_id, ...
-    FROM metric
-
-  Columns that aren't used in any individual query are replaced with `SELECT cast(NULL AS <type>)` statements. (These
-  are cast to the appropriate type because Postgres will assume `SELECT NULL` is `TEXT` by default and will refuse to
-  `UNION` two columns of two different types.)"
-  (ordered-map/ordered-map
-   ;; returned for all models. Important to be first for changing model for dataset
-   :model               :text
-   :id                  :integer
-   :name                :text
-   :display_name        :text
-   :description         :text
-   :archived            :boolean
-   ;; returned for Card, Dashboard, and Collection
-   :collection_id       :integer
-   :collection_name     :text
-   :collection_authority_level :text
-   ;; returned for Card and Dashboard
-   :collection_position :integer
-   :bookmark            :boolean
-   ;; returned for everything except Collection
-   :updated_at          :timestamp
-   ;; returned for Card only
-   :dashboardcard_count :integer
-   :moderated_status    :text
-   ;; returned for Metric and Segment
-   :table_id            :integer
-   :table_schema        :text
-   :table_name          :text
-   :table_description   :text
-   ;; returned for Metric, Segment, and Action
-   :database_id         :integer
-   ;; returned for Database and Table
-   :initial_sync_status :text
-   ;; returned for Action
-   :model_id            :integer
-   :model_name          :text
-   ;; returned for indexed-entity
-   :pk_ref              :text
-   :model_index_id      :integer))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                               Shared Query Logic                                               |
@@ -104,7 +57,7 @@
   prefixed with the `model` name so that it can be used in criteria. Projects a `nil` for columns the `model` doesn't
   have and doesn't modify aliases."
   [model :- SearchableModel, col-alias->honeysql-clause :- [:map-of :keyword HoneySQLColumn]]
-  (for [[search-col col-type] all-search-columns
+  (for [[search-col col-type] search.config/all-search-columns
         :let                  [maybe-aliased-col (get col-alias->honeysql-clause search-col)]]
     (cond
       (= search-col :model)
@@ -132,7 +85,7 @@
 (mu/defn ^:private select-clause-for-model :- [:sequential HoneySQLColumn]
   "The search query uses a `union-all` which requires that there be the same number of columns in each of the segments
   of the query. This function will take the columns for `model` and will inject constant `nil` values for any column
-  missing from `entity-columns` but found in `all-search-columns`."
+  missing from `entity-columns` but found in `search.config/all-search-columns`."
   [model :- SearchableModel]
   (let [entity-columns                (search.config/columns-for-model model)
         column-alias->honeysql-clause (m/index-by ->column-alias entity-columns)
@@ -192,6 +145,50 @@
     (sql.helpers/where query [:= id :database_id])
     query))
 
+(mu/defn ^:private replace-select :- :map
+  "Replace a select from query that has alias is `target-alias` with the `with` column, throw an error if
+  can't find the target select.
+
+  This works with the assumption that `query` contains a list of select from [[select-clause-for-model]],
+  and some of them are dummy column casted to the correct type.
+
+  This function then will replace the dummy column with alias is `target-alias` with the `with` column."
+  [query        :- :map
+   target-alias :- :keyword
+   with         :- [:or :keyword [:sequential :any]]]
+  (let [selects (:select query)
+        idx     (first (keep-indexed (fn [index item]
+                                       (when (and (coll? item)
+                                                  (= (last item) target-alias))
+                                         index))
+                                     selects))]
+    (if (some? idx)
+      (assoc query :select (m/replace-nth idx with selects))
+      (throw (ex-info "Failed to replace selector" {:status-code  400
+                                                    :target-alias target-alias
+                                                    :with         with})))))
+(defn- with-last-editing-info
+  [query model]
+  (cond
+   (#{"dashboard" "card" "dataset" "metric"} model)
+   (-> query
+       (replace-select :last_editor_id [:r.user_id :last_editor_id])
+       (replace-select :last_edited_at [:r.timestamp :last_edited_at])
+       (sql.helpers/left-join [:revision :r]
+                              [:and [:= :r.model_id (search.config/column-with-model-alias model :id)]
+                               [:= :r.most_recent true]
+                               [:= :r.model (search.filter/search-model->revision-model model)]]))))
+
+(defn- with-moderated-status
+  [query model]
+  (-> query
+      (replace-select :moderated_status [:mr.status])
+      (sql.helpers/left-join [:moderation_review :mr]
+                             [:and
+                              [:= :mr.moderated_item_type "card"]
+                              [:= :mr.moderated_item_id (search.config/column-with-model-alias model :id)]
+                              [:= :mr.most_recent true]])))
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                      Search Queries for each Toucan Model                                      |
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -201,15 +198,18 @@
   (fn [model _] model))
 
 (mu/defn ^:private shared-card-impl
-  [dataset? :- :boolean search-ctx :- SearchContext]
+  [model      :- [:enum "card" "dataset"]
+   search-ctx :- SearchContext]
   (-> (base-query-for-model "card" search-ctx)
-      (update :where (fn [where] [:and [:= :card.dataset dataset?] where]))
+      (update :where (fn [where] [:and [:= :card.dataset (= "dataset" model)] where]))
       (sql.helpers/left-join [:card_bookmark :bookmark]
                              [:and
                               [:= :bookmark.card_id :card.id]
                               [:= :bookmark.user_id api/*current-user-id*]])
       (add-collection-join-and-where-clauses :card.collection_id search-ctx)
-      (add-card-db-id-clause (:table-db-id search-ctx))))
+      (add-card-db-id-clause (:table-db-id search-ctx))
+      (with-last-editing-info model)
+      (with-moderated-status model)))
 
 (defmethod search-query-for-model "action"
   [model search-ctx]
@@ -220,13 +220,14 @@
                              [:= :query_action.action_id :action.id])
       (add-collection-join-and-where-clauses :model.collection_id search-ctx)))
 
+
 (defmethod search-query-for-model "card"
   [_model search-ctx]
-  (shared-card-impl false search-ctx))
+  (shared-card-impl "card"search-ctx))
 
 (defmethod search-query-for-model "dataset"
   [_model search-ctx]
-  (-> (shared-card-impl true search-ctx)
+  (-> (shared-card-impl "dataset" search-ctx)
       (update :select (fn [columns]
                         (cons [(h2x/literal "dataset") :model] (rest columns))))))
 
@@ -250,12 +251,14 @@
                              [:and
                               [:= :bookmark.dashboard_id :dashboard.id]
                               [:= :bookmark.user_id api/*current-user-id*]])
-      (add-collection-join-and-where-clauses :dashboard.collection_id search-ctx)))
+      (add-collection-join-and-where-clauses :dashboard.collection_id search-ctx)
+      (with-last-editing-info model)))
 
 (defmethod search-query-for-model "metric"
   [model search-ctx]
   (-> (base-query-for-model model search-ctx)
-      (sql.helpers/left-join [:metabase_table :table] [:= :metric.table_id :table.id])))
+      (sql.helpers/left-join [:metabase_table :table] [:= :metric.table_id :table.id])
+      (with-last-editing-info model)))
 
 (defmethod search-query-for-model "indexed-entity"
   [model search-ctx]
@@ -302,7 +305,7 @@
   "CASE expression that lets the results be ordered by whether they're an exact (non-fuzzy) match or not"
   [query]
   (let [match             (search.util/wildcard-match (search.util/normalize query))
-        columns-to-search (->> all-search-columns
+        columns-to-search (->> search.config/all-search-columns
                                (filter (fn [[_k v]] (= v :text)))
                                (map first)
                                (remove #{:collection_authority_level :moderated_status
@@ -369,6 +372,18 @@
                                      query))} :alias_is_required_by_sql_but_not_needed_here]]
       :order-by order-clause})))
 
+(defn- hydrate-user-metadata
+  "Hydrate common-name for last_edited_by and created_by from result."
+  [results]
+  (let [user-ids             (set (flatten (for [result results]
+                                             (remove nil? ((juxt :last_editor_id :creator_id) result)))))
+        user-id->common-name (t2/select-pk->fn :common_name [:model/User :id :first_name :last_name :email] :id [:in user-ids])]
+    (mapv (fn [{:keys [creator_id last_editor_id] :as result}]
+            (assoc result
+                   :creator_common_name (get user-id->common-name creator_id)
+                   :last_editor_common_name (get user-id->common-name last_editor_id)))
+          results)))
+
 (mu/defn ^:private search
   "Builds a search query that includes all the searchable entities and runs it"
   [search-ctx :- SearchContext]
@@ -391,7 +406,7 @@
                             (map #(update % :pk_ref json/parse-string))
                             (map (partial scoring/score-and-result (:search-string search-ctx)))
                             (filter #(pos? (:score %))))
-        total-results      (scoring/top-results reducible-results search.config/max-filtered-results xf)]
+        total-results      (hydrate-user-metadata (scoring/top-results reducible-results search.config/max-filtered-results xf))]
     ;; We get to do this slicing and dicing with the result data because
     ;; the pagination of search is for UI improvement, not for performance.
     ;; We intend for the cardinality of the search results to be below the default max before this slicing occurs

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -176,7 +176,7 @@
        (sql.helpers/left-join [:revision :r]
                               [:and [:= :r.model_id (search.config/column-with-model-alias model :id)]
                                [:= :r.most_recent true]
-                               [:= :r.model (search.filter/search-model->revision-model model)]])))
+                               [:= :r.model (search.config/search-model->revision-model model)]])))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                      Search Queries for each Toucan Model                                      |

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -1,5 +1,6 @@
 (ns metabase.search.config
   (:require
+   [flatland.ordered.map :as ordered-map]
    [malli.core :as mc]
    [metabase.models.permissions :as perms]
    [metabase.models.setting :refer [defsetting]]
@@ -100,6 +101,59 @@
     ;; nil will return all items
     [:verified           {:optional true} [:maybe true?]]]))
 
+(def all-search-columns
+  "All columns that will appear in the search results, and the types of those columns. The generated search query is a
+  `UNION ALL` of the queries for each different entity; it looks something like:
+
+    SELECT 'card' AS model, id, cast(NULL AS integer) AS table_id, ...
+    FROM report_card
+    UNION ALL
+    SELECT 'metric' as model, id, table_id, ...
+    FROM metric
+
+  Columns that aren't used in any individual query are replaced with `SELECT cast(NULL AS <type>)` statements. (These
+  are cast to the appropriate type because Postgres will assume `SELECT NULL` is `TEXT` by default and will refuse to
+  `UNION` two columns of two different types.)"
+  (ordered-map/ordered-map
+   ;; returned for all models. Important to be first for changing model for dataset
+   :model               :text
+   :id                  :integer
+   :name                :text
+   :display_name        :text
+   :description         :text
+   :archived            :boolean
+   ;; returned for Card, Dashboard, and Collection
+   :collection_id       :integer
+   :collection_name     :text
+   :collection_authority_level :text
+   ;; returned for Card and Dashboard
+   :collection_position :integer
+   :creator_id          :integer
+   :created_at          :timestamp
+   :bookmark            :boolean
+   ;; returned for everything except Collection
+   :updated_at          :timestamp
+   ;; returned for Card only, used for scoring
+   :dashboardcard_count :integer
+   :last_edited_at      :timestamp
+   :last_editor_id      :integer
+   :moderated_status    :text
+   ;; returned for Metric and Segment
+   :table_id            :integer
+   :table_schema        :text
+   :table_name          :text
+   :table_description   :text
+   ;; returned for Metric, Segment, and Action
+   :database_id         :integer
+   ;; returned for Database and Table
+   :initial_sync_status :text
+   ;; returned for Action
+   :model_id            :integer
+   :model_name          :text
+   ;; returned for indexed-entity
+   :pk_ref              :text
+   :model_index_id      :integer))
+
 (def ^:const displayed-columns
   "All of the result components that by default are displayed by the frontend."
   #{:name :display_name :collection_name :description})
@@ -153,7 +207,7 @@
 
 (def ^:private default-columns
   "Columns returned for all models."
-  [:id :name :description :archived :updated_at])
+  [:id :name :description :archived :created_at :updated_at])
 
 (def ^:private bookmark-col
   "Case statement to return boolean values of `:bookmark` for Card, Collection and Dashboard."
@@ -182,6 +236,7 @@
 (defmethod columns-for-model "action"
   [_]
   (conj default-columns :model_id
+        :creator_id
         [:model.collection_id        :collection_id]
         [:model.id                   :model_id]
         [:model.name                 :model_name]
@@ -189,20 +244,20 @@
 
 (defmethod columns-for-model "card"
   [_]
-  (conj default-columns :collection_id :collection_position
+  (conj default-columns :collection_id :collection_position :creator_id
         [:collection.name :collection_name]
         [:collection.authority_level :collection_authority_level]
-        [{:select   [:status]
-          :from     [:moderation_review]
-          :where    [:and
-                     [:= :moderated_item_type "card"]
-                     [:= :moderated_item_id :card.id]
-                     [:= :most_recent true]]
-          ;; order by and limit just in case a bug violates the invariant of only one most_recent. We don't want to
-          ;; error in this query
-          :order-by [[:id :desc]]
-          :limit    1}
-         :moderated_status]
+        #_[{:select   [:status]
+            :from     [:moderation_review]
+            :where    [:and
+                       [:= :moderated_item_type "card"]
+                       [:= :moderated_item_id :card.id]
+                       [:= :most_recent true]]
+            ;; order by and limit just in case a bug violates the invariant of only one most_recent. We don't want to
+            ;; error in this query
+            :order-by [[:id :desc]]
+            :limit    1}
+           :moderated_status]
         bookmark-col dashboardcard-count-col))
 
 (defmethod columns-for-model "indexed-entity" [_]
@@ -219,7 +274,7 @@
 
 (defmethod columns-for-model "dashboard"
   [_]
-  (conj default-columns :collection_id :collection_position bookmark-col
+  (conj default-columns :collection_id :collection_position :creator_id bookmark-col
         [:collection.name :collection_name]
         [:collection.authority_level :collection_authority_level]))
 
@@ -237,11 +292,11 @@
 
 (defmethod columns-for-model "segment"
   [_]
-  (into default-columns table-columns))
+  (concat default-columns table-columns [:creator_id]))
 
 (defmethod columns-for-model "metric"
   [_]
-  (into default-columns table-columns))
+  (concat default-columns table-columns [:creator_id]))
 
 (defmethod columns-for-model "table"
   [_]

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -223,6 +223,7 @@
 (def ^:private table-columns
   "Columns containing information about the Table this model references. Returned for Metrics and Segments."
   [:table_id
+   :created_at
    [:table.db_id       :database_id]
    [:table.schema      :table_schema]
    [:table.name        :table_name]
@@ -247,17 +248,17 @@
   (conj default-columns :collection_id :collection_position :creator_id
         [:collection.name :collection_name]
         [:collection.authority_level :collection_authority_level]
-        #_[{:select   [:status]
-            :from     [:moderation_review]
-            :where    [:and
-                       [:= :moderated_item_type "card"]
-                       [:= :moderated_item_id :card.id]
-                       [:= :most_recent true]]
-            ;; order by and limit just in case a bug violates the invariant of only one most_recent. We don't want to
-            ;; error in this query
-            :order-by [[:id :desc]]
-            :limit    1}
-           :moderated_status]
+        [{:select   [:status]
+          :from     [:moderation_review]
+          :where    [:and
+                     [:= :moderated_item_type "card"]
+                     [:= :moderated_item_id :card.id]
+                     [:= :most_recent true]]
+          ;; order by and limit just in case a bug violates the invariant of only one most_recent. We don't want to
+          ;; error in this query
+          :order-by [[:id :desc]]
+          :limit    1}
+         :moderated_status]
         bookmark-col dashboardcard-count-col))
 
 (defmethod columns-for-model "indexed-entity" [_]
@@ -280,7 +281,7 @@
 
 (defmethod columns-for-model "database"
   [_]
-  [:id :name :description :updated_at :initial_sync_status])
+  [:id :name :description :created_at :updated_at :initial_sync_status])
 
 (defmethod columns-for-model "collection"
   [_]
@@ -302,6 +303,7 @@
   [_]
   [:id
    :name
+   :created_at
    :display_name
    :description
    :updated_at

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -66,6 +66,13 @@
 
 (assert (= all-models (set models-search-order)) "The models search order has to include all models")
 
+(defn search-model->revision-model
+  "Return the apporpriate revision model given a search model."
+  [model]
+  (case model
+    "dataset" (recur "card")
+    (str/capitalize model)))
+
 (defn model->alias
   "Given a model string returns the model alias"
   [model]
@@ -323,12 +330,3 @@
 (defmethod column->string :default
   [value _ _]
   value)
-
-;;; ----------------------------------------- Helper Fns -----------------------------------------
-
-(defn search-model->revision-model
-  "Return the apporpriate revision model given a search model."
-  [model]
-  (case model
-    "dataset" (recur "card")
-    (str/capitalize model)))

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -1,5 +1,6 @@
 (ns metabase.search.config
   (:require
+   [clojure.string :as str]
    [flatland.ordered.map :as ordered-map]
    [malli.core :as mc]
    [metabase.models.permissions :as perms]
@@ -322,3 +323,12 @@
 (defmethod column->string :default
   [value _ _]
   value)
+
+;;; ----------------------------------------- Helper Fns -----------------------------------------
+
+(defn search-model->revision-model
+  "Return the apporpriate revision model given a search model."
+  [model]
+  (case model
+    "dataset" (recur "card")
+    (str/capitalize model)))

--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -162,24 +162,24 @@
                               (search.config/column-with-model-alias model :created_at)
                               created-at))))
 
-
 ;; Last edited by filter
 
 (defn- joined-with-table?
   "Check if  the query have a join with `table`.
-  Note: this does a very shallow check by only checking the join-clause is already the same.
+  Note: this does a very shallow check by only checking if the join-clause is the same.
   Using the same table with a different alias will return false.
 
     (-> (sql.helpers/select :*)
-    (sql.helpers/from [:a])
-    (sql.helpers/join :b [:= :a.id :b.id])
-    (joined-with-table? :join :b))
+        (sql.helpers/from [:a])
+        (sql.helpers/join :b [:= :a.id :b.id])
+        (joined-with-table? :join :b))
 
     ;; => true"
   [query join-type table]
   (->> (get query join-type) (partition 2) (map first) (some #(= % table)) boolean))
 
-(defn- search-model->revision-model
+(defn search-model->revision-model
+  "a"
   [model]
   (case model
     "dataset" (recur "card")
@@ -189,7 +189,7 @@
   (defmethod build-optional-filter-query [:last-edited-by model]
     [_filter model query editor-ids]
     (cond-> query
-      ;; both last-edited-by and last-edited at join with revision, so we should be careful not to join twice
+      ;; both last-edited-by and last-edited-at join with revision, so we should be careful not to join twice
       (not (joined-with-table? query :join :revision))
       (-> (sql.helpers/join :revision [:= :revision.model_id (search.config/column-with-model-alias model :id)])
           (sql.helpers/where [:= :revision.most_recent true]
@@ -204,7 +204,7 @@
   (defmethod build-optional-filter-query [:last-edited-at model]
     [_filter model query last-edited-at]
     (cond-> query
-      ;; both last-edited-by and last-edited at join with revision, so we should be careful not to join twice
+      ;; both last-edited-by and last-edited-at join with revision, so we should be careful not to join twice
       (not (joined-with-table? query :join :revision))
       (-> (sql.helpers/join :revision [:= :revision.model_id (search.config/column-with-model-alias model :id)])
           (sql.helpers/where [:= :revision.most_recent true]

--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -178,13 +178,6 @@
   [query join-type table]
   (->> (get query join-type) (partition 2) (map first) (some #(= % table)) boolean))
 
-(defn search-model->revision-model
-  "Return the apporpriate revision model given a search model."
-  [model]
-  (case model
-    "dataset" (recur "card")
-    (str/capitalize model)))
-
 (doseq [model ["dashboard" "card" "dataset" "metric"]]
   (defmethod build-optional-filter-query [:last-edited-by model]
     [_filter model query editor-ids]
@@ -193,7 +186,7 @@
       (not (joined-with-table? query :join :revision))
       (-> (sql.helpers/join :revision [:= :revision.model_id (search.config/column-with-model-alias model :id)])
           (sql.helpers/where [:= :revision.most_recent true]
-                             [:= :revision.model (search-model->revision-model model)]))
+                             [:= :revision.model (search.config/search-model->revision-model model)]))
       (= 1 (count editor-ids))
       (sql.helpers/where [:= :revision.user_id (first editor-ids)])
 
@@ -208,7 +201,7 @@
       (not (joined-with-table? query :join :revision))
       (-> (sql.helpers/join :revision [:= :revision.model_id (search.config/column-with-model-alias model :id)])
           (sql.helpers/where [:= :revision.most_recent true]
-                             [:= :revision.model (search-model->revision-model model)]))
+                             [:= :revision.model (search.config/search-model->revision-model model)]))
       true
       ;; on UI we showed the the last edit info from revision.timestamp
       ;; not the model.updated_at column

--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -179,7 +179,7 @@
   (->> (get query join-type) (partition 2) (map first) (some #(= % table)) boolean))
 
 (defn search-model->revision-model
-  "a"
+  "Return the apporpriate revision model given a search model."
   [model]
   (case model
     "dataset" (recur "card")

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -45,6 +45,9 @@
    :collection_authority_level nil
    :collection_position        nil
    :context                    nil
+   :created_at                 true
+   :creator_common_name        nil
+   :creator_id                 false
    :dashboardcard_count        nil
    :database_id                false
    :description                nil
@@ -53,6 +56,9 @@
    :model_id                   false
    :model_name                 nil
    :moderated_status           nil
+   :last_editor_common_name    nil
+   :last_editor_id             false
+   :last_edited_at             false
    :pk_ref                     nil
    :model_index_id             false ;; columns ending in _id get booleaned
    :table_description          nil
@@ -95,16 +101,16 @@
 
 (defn- default-search-results []
   (sorted-results
-   [(make-result "dashboard test dashboard", :model "dashboard", :bookmark false)
+   [(make-result "dashboard test dashboard", :model "dashboard", :bookmark false :creator_id true :creator_common_name "Rasta Toucan")
     test-collection
-    (make-result "card test card", :model "card", :bookmark false, :dashboardcard_count 0)
-    (make-result "dataset test dataset", :model "dataset", :bookmark false, :dashboardcard_count 0)
-    (make-result "action test action", :model "action", :model_name (:name action-model-params), :model_id true, :database_id true)
+    (make-result "card test card", :model "card", :bookmark false, :dashboardcard_count 0 :creator_id true :creator_common_name "Rasta Toucan")
+    (make-result "dataset test dataset", :model "dataset", :bookmark false, :dashboardcard_count 0 :creator_id true :creator_common_name "Rasta Toucan")
+    (make-result "action test action", :model "action", :model_name (:name action-model-params), :model_id true, :database_id true :creator_id true :creator_common_name "Rasta Toucan")
     (merge
-     (make-result "metric test metric", :model "metric", :description "Lookin' for a blueberry")
+     (make-result "metric test metric", :model "metric", :description "Lookin' for a blueberry" :creator_id true :creator_common_name "Rasta Toucan")
      (table-search-results))
     (merge
-     (make-result "segment test segment", :model "segment", :description "Lookin' for a blueberry")
+     (make-result "segment test segment", :model "segment", :description "Lookin' for a blueberry" :creator_id true :creator_common_name "Rasta Toucan")
      (table-search-results))]))
 
 (defn- default-metric-segment-results []
@@ -334,7 +340,7 @@
 (def ^:private dashboard-count-results
   (letfn [(make-card [dashboard-count]
             (make-result (str "dashboard-count " dashboard-count) :dashboardcard_count dashboard-count,
-                         :model "card", :bookmark false))]
+                         :model "card", :bookmark false :creator_id true :creator_common_name "Rasta Toucan"))]
     (set [(make-card 5)
           (make-card 3)
           (make-card 0)])))
@@ -385,8 +391,10 @@
                              (into
                               (default-results-with-collection)
                               (map #(merge default-search-row % (table-search-results))
-                                   [{:name "metric test2 metric", :description "Lookin' for a blueberry", :model "metric"}
-                                    {:name "segment test2 segment", :description "Lookin' for a blueberry", :model "segment"}]))))
+                                   [{:name "metric test2 metric", :description "Lookin' for a blueberry",
+                                     :model "metric" :creator_id true :creator_common_name "Rasta Toucan"}
+                                    {:name "segment test2 segment", :description "Lookin' for a blueberry",
+                                     :model "segment" :creator_id true :creator_common_name "Rasta Toucan"}]))))
                    (search-request-data :rasta :q "test"))))))))
 
   (testing (str "Users with root collection permissions should be able to search root collection data long with "
@@ -434,8 +442,10 @@
                     (into
                      (default-results-with-collection)
                      (map #(merge default-search-row % (table-search-results))
-                          [{:name "metric test2 metric" :description "Lookin' for a blueberry" :model "metric"}
-                           {:name "segment test2 segment" :description "Lookin' for a blueberry" :model "segment"}]))))
+                          [{:name "metric test2 metric" :description "Lookin' for a blueberry"
+                            :model "metric" :creator_id true :creator_common_name "Rasta Toucan"}
+                           {:name "segment test2 segment" :description "Lookin' for a blueberry" :model "segment"
+                            :creator_id true :creator_common_name "Rasta Toucan"}]))))
                   (search-request-data :rasta :q "test"))))))))
 
  (testing "Metrics on tables for which the user does not have access to should not show up in results"
@@ -638,8 +648,8 @@
 
 (deftest table-test
   (testing "You should see Tables in the search results!\n"
-    (t2.with-temp/with-temp [Table _ {:name "RoundTable"}]
-      (do-test-users [user [:crowberto :rasta]]
+    (mt/with-temp [Table _ {:name "RoundTable"}]
+      (do-test-users [user [:crowberto :crowberto]]
         (is (= [(default-table-search-row "RoundTable")]
                (search-request-data user :q "RoundTable"))))))
   (testing "You should not see hidden tables"
@@ -650,25 +660,25 @@
                (search-request-data user :q "Foo"))))))
   (testing "You should be able to search by their display name"
     (let [lancelot "Lancelot's Favorite Furniture"]
-      (t2.with-temp/with-temp [Table _ {:name "RoundTable" :display_name lancelot}]
+      (mt/with-temp [Table _ {:name "RoundTable" :display_name lancelot}]
         (do-test-users [user [:crowberto :rasta]]
           (is (= [(assoc (default-table-search-row "RoundTable") :name lancelot)]
                  (search-request-data user :q "Lancelot")))))))
   (testing "You should be able to search by their description"
     (let [lancelot "Lancelot's Favorite Furniture"]
-      (t2.with-temp/with-temp [Table _ {:name "RoundTable" :description lancelot}]
+      (mt/with-temp [Table _ {:name "RoundTable" :description lancelot}]
         (do-test-users [user [:crowberto :rasta]]
           (is (= [(assoc (default-table-search-row "RoundTable") :description lancelot :table_description lancelot)]
                  (search-request-data user :q "Lancelot")))))))
   (testing "When searching with ?archived=true, normal Tables should not show up in the results"
     (let [table-name (mt/random-name)]
-      (t2.with-temp/with-temp [Table _ {:name table-name}]
+      (mt/with-temp [Table _ {:name table-name}]
         (do-test-users [user [:crowberto :rasta]]
           (is (= []
                  (search-request-data user :q table-name :archived true)))))))
   (testing "*archived* tables should not appear in search results"
     (let [table-name (mt/random-name)]
-      (t2.with-temp/with-temp [Table _ {:name table-name, :active false}]
+      (mt/with-temp [Table _ {:name table-name, :active false}]
         (do-test-users [user [:crowberto :rasta]]
           (is (= []
                  (search-request-data user :q table-name)))))))
@@ -770,7 +780,7 @@
         ;; the call count number here are expected to change if we change the search api
         ;; we have this test here just to keep tracks this number to remind us to put effort
         ;; into keep this number as low as we can
-        (is (= 10 (call-count)))))))
+        (is (= 11 (call-count)))))))
 
 (deftest snowplow-new-search-query-event-test
   (testing "Send a snowplow event when a new global search query is made"

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -1084,8 +1084,6 @@
         (is (= "Failed to parse datetime value: today~"
                (mt/user-http-request :crowberto :get 400 "search" :q search-term :last_edited_at "today~" :creator_id (mt/user->id :rasta))))))))
 
-#_(mt/user-http-request :crowberto :get 200 "search" :q "a" :models "card" :last_edited_by (mt/user->id :crowberto))
-
 (deftest created-at-correctness-test
   (let [search-term "created-at-filtering"
         new          #t "2023-05-04T10:00Z[UTC]"
@@ -1307,4 +1305,4 @@
                (->> (mt/user-http-request :crowberto :get 200 "search" :q search-term)
                     :data
                     (map (juxt :model :id :creator_common_name :last_editor_common_name))
-                    set)))["card" card-id-1 "Ngoc Khuat" "Ngoc Khuat"]))))
+                    set)))))))


### PR DESCRIPTION
Per this [thread](https://metaboat.slack.com/archives/C057T1QTB3L/p1696309226264209?thread_ts=1696244653.276719&cid=C057T1QTB3L)

we want the search result to includes `creator_id, creator_common_name, last_editor_id, last_editor_name` for the ones that has it.

Part of https://github.com/metabase/metabase/issues/27982