### PR TITLE
Fix `yarn dev-ee` with new CLJS setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -290,7 +290,7 @@
   "scripts": {
     "concurrently": "yarn && concurrently --kill-others -p name",
     "dev": "yarn && yarn clean:cljs && concurrently -n 'backend,frontend,cljs,static-viz' -c 'blue,green,yellow,magenta,red' 'clojure -M:run' 'yarn build-hot:js-wait' 'yarn build-hot:cljs' 'yarn build-static-viz:watch-wait'",
-    "dev-ee": "yarn && yarn clean:cljs && concurrently -n 'backend,frontend,cljs,static-viz' -c 'blue,green,yellow,magenta,red' 'clojure -M:run:ee' 'MB_EDITION=ee yarn build-hot:js' 'MB_EDITION=ee yarn build-hot:cljs' 'yarn build-static-viz:watch-wait'",
+    "dev-ee": "yarn && yarn clean:cljs && concurrently -n 'backend,frontend,cljs,static-viz' -c 'blue,green,yellow,magenta,red' 'clojure -M:run:ee' 'MB_EDITION=ee yarn build-hot:js-wait' 'MB_EDITION=ee yarn build-hot:cljs' 'yarn build-static-viz:watch-wait'",
     "type-check": "yarn clean:cljs && yarn build:cljs && tsc --noEmit",
     "remove-webpack-cache": "rm -rf ./node_modules/.cache",
     "lint": "yarn lint-eslint && yarn lint-prettier && yarn lint-docs-links && yarn lint-yaml && yarn type-check",


### PR DESCRIPTION
`yarn dev` had been adjusted to use `build-hot:js-wait` (which waits for the first CLJS compilation to be done), but `yarn dev-ee` had not been changed, so its JS compilation ran too early, failed, and never re-ran.

We actually had this broken behavior (JS build runs too early, CLJS build completes, JS build fails, JS build notices new inputs and re-runs) for a long time. But since it fixed itself when the JS build re-ran, it didn't cause any issues. Now that the JS build no longer watches the CLJS output for changes, the CLJS output needs to be there for the first JS build.