### PR TITLE
[E2E] Fix segment flake

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/metrics.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/metrics.cy.spec.js
@@ -323,17 +323,6 @@ describe("scenarios > admin > datamodel > metrics", () => {
   });
 });
 
-// Ugly hack to prevent failures that started after https://github.com/metabase/metabase/pull/24682 has been merged.
-// For unknon reasons, popover doesn't open with expanded list of all Sample Database tables. Rather. it shows
-// Sample Database (collapsed) only. We need to click on it to expand it.
-// This conditional mechanism prevents failures even if that popover opens expanded in the future.
 function selectTable(tableName) {
-  cy.findByText("Select a table").click();
-
-  cy.get(".List-section").then($list => {
-    if ($list.length !== 5) {
-      cy.findByText("Sample Database").click();
-    }
-    cy.findByText(tableName).click();
-  });
+  popover().findByText(tableName).click();
 }

--- a/e2e/test/scenarios/admin/datamodel/segments.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/segments.cy.spec.js
@@ -20,41 +20,25 @@ describe("scenarios > admin > datamodel > segments", () => {
   });
 
   describe("with no segments", () => {
-    it("should show no segments in UI", () => {
-      cy.visit("/admin/datamodel/segments");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Segments").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText(
-        "Create segments to add them to the Filter dropdown in the query builder",
-      );
-    });
-
     it("should have 'Custom expression' in a filter list (metabase#13069)", () => {
       cy.visit("/admin/datamodel/segments");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("New segment").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Select a table").click();
 
-      // Ugly hack to prevent failures that started after https://github.com/metabase/metabase/pull/24682 has been merged.
-      // For unknon reasons, popover doesn't open with expanded list of all Sample Database tables. Rather. it shows
-      // Sample Database (collapsed) only. We need to click on it to expand it.
-      // This conditional mechanism prevents failures even if that popover opens expanded in the future.
-      cy.get(".List-section").then($list => {
-        if ($list.length !== 5) {
-          cy.findByText("Sample Database").click();
-        }
-        cy.findByText("Orders").click();
-      });
+      cy.log("should initially show no segments in UI");
+      cy.get("main").findByText(
+        "Create segments to add them to the Filter dropdown in the query builder",
+      );
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Add filters to narrow your answer").click();
+      cy.button("New segment").click();
+
+      cy.get(".GuiBuilder").findByText("Select a table").click();
+      popover().findByText("Orders").click();
+
+      cy.get(".GuiBuilder")
+        .findByText("Add filters to narrow your answer")
+        .click();
 
       cy.log("Fails in v0.36.0 and v0.36.3. It exists in v0.35.4");
-      popover().within(() => {
-        cy.findByText("Custom Expression");
-      });
+      popover().findByText("Custom Expression");
     });
 
     it("should show no segments", () => {


### PR DESCRIPTION
This one has been pretty stubborn recently.
Example of a failed run: https://www.deploysentinel.com/ci/runs/651c372df97a9a2886dbd82a

I removed the hacky workaround (which seems to be the source of flakiness) and have tidied up a bit.

> **Note**
> This fix applies to both segments and metrics because they had the same hacky workaround

Ran the test 30x in CI and it was all green:
```
scenarios > admin > datamodel > segments
    with no segments
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 1 of 30 (8806ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 2 of 30 (6712ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 3 of 30 (6175ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 4 of 30 (6143ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 5 of 30 (6488ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 6 of 30 (5662ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 7 of 30 (5328ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 8 of 30 (5988ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 9 of 30 (6526ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 10 of 30 (6688ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 11 of 30 (5893ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 12 of 30 (5555ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 13 of 30 (5481ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 14 of 30 (6061ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 15 of 30 (5912ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 16 of 30 (5562ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 17 of 30 (5276ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 18 of 30 (5358ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 19 of 30 (5223ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 20 of 30 (5519ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 21 of 30 (5607ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 22 of 30 (5147ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 23 of 30 (6361ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 24 of 30 (5365ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 25 of 30 (5230ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 26 of 30 (5318ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 27 of 30 (5121ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 28 of 30 (5156ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 29 of 30 (5061ms)
      ✓ should have 'Custom expression' in a filter list (metabase#13069): burning 30 of 30 (5041ms)
      ```