### PR TITLE
Dynamic X-Ray Entities

### DIFF
--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -1220,7 +1220,7 @@
                                           (fn [{:keys [dimension-name semantic_type] :as field}]
                                             {dimension-name {:field_type [semantic_type] :score 100}})
                                           fields)]]
-             {:metrics    [{metric-name
+             {:metrics    [{card-metric-name
                             {:name   metric-name
                              :metric (mapv (fn [{:keys [dimension-name]}]
                                              [:dimension dimension-name]) fields)
@@ -1230,7 +1230,7 @@
                             {:title (deferred-tru "A look at the {0} metric" metric-name)
                              :score         100
                              :dimensions    (mapv (fn [dim] (update-vals dim empty)) dimensions)
-                             :metrics       [metric-name]
+                             :metrics       [card-metric-name]
                              :query-literal definition
                              :height 8
                              :width 8

--- a/src/metabase/automagic_dashboards/schema.clj
+++ b/src/metabase/automagic_dashboards/schema.clj
@@ -111,10 +111,10 @@
   "A specification for the basic keys in a dashboard template."
   (mc/schema
     [:map
-     [:dimensions {:optional true} [:vector dimension-template]]
-     [:metrics {:optional true} [:vector metric-template]]
-     [:filters {:optional true} [:vector filter-template]]
-     [:cards {:optional true} [:vector card-template]]]))
+     [:dimensions {:optional true} [:sequential dimension-template]]
+     [:metrics {:optional true} [:sequential metric-template]]
+     [:filters {:optional true} [:sequential filter-template]]
+     [:cards {:optional true} [:sequential card-template]]]))
 
 ;; Available values schema -- These are items for which fields have been successfully bound
 
@@ -138,9 +138,9 @@
    set of dimensions which, when satisfied, enable this affinity object."
   (mc/schema
     [:map
-     [:dimensions {:optional true} [:vector string?]]
-     [:metrics {:optional true} [:vector string?]]
-     [:filters {:optional true} [:vector string?]]
+     [:dimensions {:optional true} [:sequential string?]]
+     [:metrics {:optional true} [:sequential string?]]
+     [:filters {:optional true} [:sequential string?]]
      [:score {:optional true} nat-int?]
      [:affinity-name string?]
      [:base-dims dimension-set]]))


### PR DESCRIPTION
Create a newly designed pipeline within `metabase.automagic-dashboards.core` that generates cards for metrics without hackery and proves the simplicity and extensibility of the new design.

The key elements of this design are:
- Start with grounded dimensions (a map of dimension names to matching fields). This is the same as the old bind-dimensions.
- Create ground-metrics in which we treat metrics as a first class citizen, whether generated from a template or user-provided.
- Expand these metrics with "interest" by assigning interesting combinations of dimensions to them. For templatized metrics, this comes from the card templates. For user-defined metrics, this comes from a massaged version of the card templates in which we consider only dimensions and visualizations, but this can be expanded upon as we evolve.