### PR TITLE
`drill-thru-method` for sort drill thrus should handle string directions

### DIFF
--- a/src/metabase/lib/drill_thru/sort.cljc
+++ b/src/metabase/lib/drill_thru/sort.cljc
@@ -42,7 +42,7 @@
     stage-number                 :- :int
     {:keys [column], :as _drill} :- ::lib.schema.drill-thru/drill-thru.sort
     direction                    :- [:enum :asc :desc]]
-   (lib.order-by/order-by query stage-number column direction)))
+   (lib.order-by/order-by query stage-number column (keyword direction))))
 
 (defmethod lib.drill-thru.common/drill-thru-info-method :drill-thru/sort
   [_query _stage-number {directions :sort-directions}]

--- a/test/metabase/lib/drill_thru/sort_test.cljc
+++ b/test/metabase/lib/drill_thru/sort_test.cljc
@@ -5,8 +5,8 @@
    [metabase.lib.core :as lib]
    [metabase.lib.drill-thru.sort :as lib.drill-thru.sort]
    [metabase.lib.test-metadata :as meta]
-   [metabase.util.malli.fn :as mu.fn]
-   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))))
+   #?@(:clj ([metabase.util.malli.fn :as mu.fn])
+       :cljs ([metabase.test-runner.assert-exprs.approximately-equal]))))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
@@ -31,10 +31,10 @@
       (lib/drill-thru query drill)
       (lib/drill-thru query -1 drill)
       (lib/drill-thru query -1 drill :asc)
-      (binding [mu.fn/*enforce* false]
+      (binding #?(:clj [mu.fn/*enforce* false] :cljs [])
         (lib/drill-thru query -1 drill "asc")))
     (testing "Handle JS input correctly (#34342)"
-      (binding [mu.fn/*enforce* false]
+      (binding #?(:clj [mu.fn/*enforce* false] :cljs [])
         (is (=? {:query {:source-table (meta/id :orders)
                          :order-by     [[:asc
                                          [:field


### PR DESCRIPTION
Fixes #34342

The problem was the FE was passing in `"asc"` instead of `:asc` and the function did something wacky in this case since we have Malli schema enforcement disabled in JS for now. 

Verified the fix by running the unit test.

