### PR TITLE
Prevent empty dashboard parameter labels

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -100,7 +100,7 @@ describe("scenarios > dashboard > parameters", () => {
     cy.get(".DashCard").last().should("contain", "4,939");
   });
 
-  it("should remove parameter name or the whole parameter (metabase#10829, metabase#17933)", () => {
+  it("should be able to remove parameter (metabase#17933)", () => {
     // Mirrored issue in metabase-enterprise#275
 
     const questionDetails = {
@@ -229,20 +229,11 @@ describe("scenarios > dashboard > parameters", () => {
     cy.findByText("Remove").click();
     cy.location("search").should("eq", `?${endsWith.slug}=zmo`);
 
-    // Remove filter name (metabase#10829)
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(endsWith.name).find(".Icon-gear").click();
-    cy.findByDisplayValue(endsWith.name).clear().blur();
-
-    cy.location("search").should("eq", "?unnamed=zmo");
-    cy.findByDisplayValue("unnamed");
-
     cy.button("Save").click();
 
-    cy.log("Filter name should be 'unnamed' and the value cleared");
-    filterWidget().contains(/unnamed/i);
-
-    cy.location("search").should("eq", "?unnamed=");
+    cy.log("There should only be one filter remaining and its value cleared");
+    filterWidget().contains(new RegExp(`${endsWith.name}`, "i"));
+    cy.location("search").should("eq", `?${endsWith.slug}=`);
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("37.65");

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -59,7 +59,7 @@ const ParameterSettings = ({
     [],
   );
 
-  const labelError = internalValue ? null : t`Required`;
+  const labelError = internalValue ? null : t`required`;
 
   const handleLabelBlur = useCallback(
     (event: { target: HTMLInputElement }) => {
@@ -83,13 +83,13 @@ const ParameterSettings = ({
   return (
     <SettingsRoot>
       <SettingSection>
-        <SettingLabel>{t`Label`}</SettingLabel>
         <TextInput
-          onChange={handleLabelChange}
+          label={t`Label`}
           value={internalValue}
-          onBlur={handleLabelBlur}
           error={labelError}
           aria-label={t`Label`}
+          onChange={handleLabelChange}
+          onBlur={handleLabelBlur}
         />
       </SettingSection>
       {canUseCustomSource(parameter) && (

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -59,7 +59,7 @@ const ParameterSettings = ({
     [],
   );
 
-  const labelError = internalValue ? null : t`required`;
+  const labelError = internalValue ? null : t`Required`;
 
   const handleLabelBlur = useCallback(
     (event: { target: HTMLInputElement }) => {
@@ -83,13 +83,13 @@ const ParameterSettings = ({
   return (
     <SettingsRoot>
       <SettingSection>
+        <SettingLabel>{t`Label`}</SettingLabel>
         <TextInput
-          label={t`Label`}
+          onChange={handleLabelChange}
           value={internalValue}
+          onBlur={handleLabelBlur}
           error={labelError}
           aria-label={t`Label`}
-          onChange={handleLabelChange}
-          onBlur={handleLabelBlur}
         />
       </SettingSection>
       {canUseCustomSource(parameter) && (

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useState } from "react";
+import { useCallback, useLayoutEffect, useMemo, useState } from "react";
 import { t } from "ttag";
 import Radio from "metabase/core/components/Radio";
 import type {
@@ -59,15 +59,22 @@ const ParameterSettings = ({
     [],
   );
 
+  const labelInputError = useMemo(() => {
+    if (internalValue === "") {
+      return t`Required`;
+    }
+    return null;
+  }, [internalValue]);
+
   const handleNameChange = useCallback(
     (event: { target: HTMLInputElement }) => {
-      if (event.target.value !== "") {
-        onChangeName(event.target.value);
-      } else {
+      if (labelInputError) {
         setInternalValue(parameter.name);
+      } else {
+        onChangeName(event.target.value);
       }
     },
-    [onChangeName, parameter.name],
+    [onChangeName, parameter.name, labelInputError],
   );
 
   const handleSourceSettingsChange = useCallback(
@@ -86,7 +93,7 @@ const ParameterSettings = ({
           onChange={handleChange}
           value={internalValue}
           onBlur={handleNameChange}
-          error={internalValue === "" && t`Required`}
+          error={labelInputError}
           aria-label={t`Label`}
         />
       </SettingSection>

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useMemo, useState } from "react";
+import { useCallback, useLayoutEffect, useState } from "react";
 import { t } from "ttag";
 import Radio from "metabase/core/components/Radio";
 import type {
@@ -52,29 +52,24 @@ const ParameterSettings = ({
     setInternalValue(parameter.name);
   }, [parameter.name]);
 
-  const handleChange = useCallback(
+  const handleLabelChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       setInternalValue(event.target.value);
     },
     [],
   );
 
-  const labelInputError = useMemo(() => {
-    if (internalValue === "") {
-      return t`Required`;
-    }
-    return null;
-  }, [internalValue]);
+  const labelError = internalValue ? null : t`Required`;
 
-  const handleNameChange = useCallback(
+  const handleLabelBlur = useCallback(
     (event: { target: HTMLInputElement }) => {
-      if (labelInputError) {
+      if (labelError) {
         setInternalValue(parameter.name);
       } else {
         onChangeName(event.target.value);
       }
     },
-    [onChangeName, parameter.name, labelInputError],
+    [onChangeName, parameter.name, labelError],
   );
 
   const handleSourceSettingsChange = useCallback(
@@ -90,10 +85,10 @@ const ParameterSettings = ({
       <SettingSection>
         <SettingLabel>{t`Label`}</SettingLabel>
         <TextInput
-          onChange={handleChange}
+          onChange={handleLabelChange}
           value={internalValue}
-          onBlur={handleNameChange}
-          error={labelInputError}
+          onBlur={handleLabelBlur}
+          error={labelError}
           aria-label={t`Label`}
         />
       </SettingSection>

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -1,6 +1,5 @@
-import { useCallback } from "react";
+import { useCallback, useLayoutEffect, useState } from "react";
 import { t } from "ttag";
-import InputBlurChange from "metabase/components/InputBlurChange";
 import Radio from "metabase/core/components/Radio";
 import type {
   Parameter,
@@ -8,6 +7,7 @@ import type {
   ValuesSourceConfig,
   ValuesSourceType,
 } from "metabase-types/api";
+import { TextInput } from "metabase/ui";
 import { canUseCustomSource } from "metabase-lib/parameters/utils/parameter-source";
 import { getIsMultiSelect } from "../../utils/dashboards";
 import { isSingleOrMultiSelectable } from "../../utils/parameter-type";
@@ -46,11 +46,28 @@ const ParameterSettings = ({
   onChangeSourceConfig,
   onRemoveParameter,
 }: ParameterSettingsProps): JSX.Element => {
+  const [internalValue, setInternalValue] = useState(parameter.name);
+
+  useLayoutEffect(() => {
+    setInternalValue(parameter.name);
+  }, [parameter.name]);
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setInternalValue(event.target.value);
+    },
+    [],
+  );
+
   const handleNameChange = useCallback(
     (event: { target: HTMLInputElement }) => {
-      onChangeName(event.target.value);
+      if (event.target.value !== "") {
+        onChangeName(event.target.value);
+      } else {
+        setInternalValue(parameter.name);
+      }
     },
-    [onChangeName],
+    [onChangeName, parameter.name],
   );
 
   const handleSourceSettingsChange = useCallback(
@@ -65,9 +82,12 @@ const ParameterSettings = ({
     <SettingsRoot>
       <SettingSection>
         <SettingLabel>{t`Label`}</SettingLabel>
-        <InputBlurChange
-          value={parameter.name}
-          onBlurChange={handleNameChange}
+        <TextInput
+          onChange={handleChange}
+          value={internalValue}
+          onBlur={handleNameChange}
+          error={internalValue === "" && t`Required`}
+          aria-label={t`Label`}
         />
       </SettingSection>
       {canUseCustomSource(parameter) && (

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.unit.spec.tsx
@@ -13,7 +13,6 @@ function fillValue(input: HTMLElement, value: string) {
   if (value.length) {
     userEvent.type(input, value);
   }
-  input.blur();
 }
 
 describe("ParameterSidebar", () => {
@@ -41,10 +40,18 @@ describe("ParameterSidebar", () => {
     const labelInput = screen.getByLabelText("Label");
     expect(labelInput).toHaveValue("foo");
     fillValue(labelInput, "");
+    // expect there to be an error message with the text "Required"
+    expect(screen.getByText(/required/i)).toBeInTheDocument();
+    labelInput.blur();
+    // when the input blurs, the value should have reverted to the original
     expect(onChangeName).not.toHaveBeenCalled();
     expect(labelInput).toHaveValue("foo");
+    // the error message should disappear
+    expect(screen.queryByText(/required/i)).not.toBeInTheDocument();
 
+    // sanity check with a non-blank value
     fillValue(labelInput, "bar");
+    labelInput.blur();
     expect(onChangeName).toHaveBeenCalledWith("bar");
     expect(labelInput).toHaveValue("bar");
   });

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.unit.spec.tsx
@@ -8,6 +8,14 @@ interface SetupOpts {
   parameter?: UiParameter;
 }
 
+function fillValue(input: HTMLElement, value: string) {
+  userEvent.clear(input);
+  if (value.length) {
+    userEvent.type(input, value);
+  }
+  input.blur();
+}
+
 describe("ParameterSidebar", () => {
   it("should allow to change source settings for string parameters", () => {
     const { onChangeQueryType } = setup({
@@ -20,6 +28,25 @@ describe("ParameterSidebar", () => {
     userEvent.click(screen.getByRole("radio", { name: "Search box" }));
 
     expect(onChangeQueryType).toHaveBeenCalledWith("search");
+  });
+
+  it("should not update the label if the input is blank", () => {
+    const { onChangeName } = setup({
+      parameter: createMockUiParameter({
+        name: "foo",
+        type: "string/=",
+        sectionId: "string",
+      }),
+    });
+    const labelInput = screen.getByLabelText("Label");
+    expect(labelInput).toHaveValue("foo");
+    fillValue(labelInput, "");
+    expect(onChangeName).not.toHaveBeenCalled();
+    expect(labelInput).toHaveValue("foo");
+
+    fillValue(labelInput, "bar");
+    expect(onChangeName).toHaveBeenCalledWith("bar");
+    expect(labelInput).toHaveValue("bar");
   });
 
   it("should allow to change source settings for location parameters", () => {
@@ -38,11 +65,12 @@ describe("ParameterSidebar", () => {
 
 const setup = ({ parameter = createMockUiParameter() }: SetupOpts = {}) => {
   const onChangeQueryType = jest.fn();
+  const onChangeName = jest.fn();
 
   renderWithProviders(
     <ParameterSettings
       parameter={parameter}
-      onChangeName={jest.fn()}
+      onChangeName={onChangeName}
       onChangeDefaultValue={jest.fn()}
       onChangeIsMultiSelect={jest.fn()}
       onChangeQueryType={onChangeQueryType}
@@ -52,5 +80,5 @@ const setup = ({ parameter = createMockUiParameter() }: SetupOpts = {}) => {
     />,
   );
 
-  return { onChangeQueryType };
+  return { onChangeQueryType, onChangeName };
 };

--- a/frontend/src/metabase/parameters/utils/dashboards.ts
+++ b/frontend/src/metabase/parameters/utils/dashboards.ts
@@ -53,11 +53,8 @@ export function createParameter(
 
 export function setParameterName(
   parameter: Parameter,
-  name?: string,
+  name: string,
 ): Parameter {
-  if (!name) {
-    name = "unnamed";
-  }
   const slug = slugify(name);
   return {
     ...parameter,

--- a/frontend/src/metabase/parameters/utils/dashboards.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/dashboards.unit.spec.js
@@ -98,10 +98,10 @@ describe("metabase/parameters/utils/dashboards", () => {
       });
     });
 
-    it("should default", () => {
+    it("should not default", () => {
       expect(setParameterName({}, "")).toEqual({
-        name: "unnamed",
-        slug: "unnamed",
+        name: "",
+        slug: "",
       });
     });
   });

--- a/frontend/src/metabase/ui/components/inputs/Input/Input.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Input/Input.styled.tsx
@@ -109,7 +109,7 @@ export const getInputOverrides = (): MantineThemeOverride["components"] => ({
   InputWrapper: {
     defaultProps: {
       size: "md",
-      inputWrapperOrder: ["label", "description", "error", "input"],
+      inputWrapperOrder: ["label", "error", "description", "input"],
     },
     styles: theme => ({
       label: {
@@ -124,8 +124,10 @@ export const getInputOverrides = (): MantineThemeOverride["components"] => ({
         lineHeight: theme.lineHeight,
       },
       error: {
+        display: "inline-block",
+        marginLeft: theme.spacing.xs,
         color: theme.colors.error[0],
-        fontSize: theme.fontSizes.xs,
+        fontSize: theme.fontSizes.sm,
         lineHeight: theme.lineHeight,
       },
       required: {

--- a/frontend/src/metabase/ui/components/inputs/Input/Input.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Input/Input.styled.tsx
@@ -109,7 +109,7 @@ export const getInputOverrides = (): MantineThemeOverride["components"] => ({
   InputWrapper: {
     defaultProps: {
       size: "md",
-      inputWrapperOrder: ["label", "error", "description", "input"],
+      inputWrapperOrder: ["label", "description", "error", "input"],
     },
     styles: theme => ({
       label: {
@@ -124,10 +124,8 @@ export const getInputOverrides = (): MantineThemeOverride["components"] => ({
         lineHeight: theme.lineHeight,
       },
       error: {
-        display: "inline-block",
-        marginLeft: theme.spacing.xs,
         color: theme.colors.error[0],
-        fontSize: theme.fontSizes.sm,
+        fontSize: theme.fontSizes.xs,
         lineHeight: theme.lineHeight,
       },
       required: {


### PR DESCRIPTION
Step 1 of fixing #27653 (see [this comment](https://github.com/metabase/metabase/issues/27653#issuecomment-1746565164) for the whole plan)

Prevents a dashboard parameter label from being set to an empty string.

If you’re editing the label field, then leave it blank, we show an error state with the message "Required". When you unfocus the input box in the error state, it reverts back to the label it had before.

![chrome-capture-2023-9-4](https://github.com/metabase/metabase/assets/39073188/9fff2cf2-e101-473c-ae93-004adcbb91a4)


