### PR TITLE
Fix Select CSP errors

### DIFF
--- a/frontend/src/metabase/ui/components/inputs/Select/Select.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.styled.tsx
@@ -6,6 +6,7 @@ export const getSelectOverrides = (): MantineThemeOverride["components"] => ({
   Select: {
     defaultProps: {
       withinPortal: true,
+      dropdownComponent: "div",
       itemComponent: SelectItem,
       maxDropdownHeight: 512,
     },


### PR DESCRIPTION
Uses native scrollbars to avoid CSP errors with `ScrollArea` which is based on `radix`. As you see on the screenshot it inserts inline styles. "div" solution is described in the docs https://v6.mantine.dev/core/select/#native-scrollbars

<img width="1728" alt="Screenshot 2023-10-04 at 16 44 40" src="https://github.com/metabase/metabase/assets/8542534/bed9a387-e3ae-43bb-8ecd-95c3dbf61a54">
