### PR TITLE
Fix recent_views ordering on MySQL

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -88,7 +88,9 @@
                                (collection/visible-collection-ids->honeysql-filter-clause
                                 :id
                                 (collection/permissions-set->visible-collection-ids @api/*current-user-permissions-set*))]
-                    :order-by [[:type :asc] [:%lower.name :asc]]}) collections
+                              ;; Order NULL collection types first so that audit collections are last
+                    :order-by [[[[:case [:= :type nil] 0 :else 1]] :asc]
+                               [:%lower.name :asc]]}) collections
     ;; Remove other users' personal collections
     (if exclude-other-user-collections
       (remove-other-users-personal-collections api/*current-user-id* collections)

--- a/src/metabase/models/recent_views.clj
+++ b/src/metabase/models/recent_views.clj
@@ -70,7 +70,7 @@
                [:= :user_id user-id]
                [:= :model (h2x/literal "dashboard")]
                [:> :timestamp (t/minus (t/zoned-date-time) (t/days 1))]]
-    :order-by [[:timestamp :desc]]}))
+    :order-by [[:id :desc]]}))
 
 (defn user-recent-views
   "Returns the most recent `n` unique views for a given user."
@@ -81,7 +81,7 @@
    (let [all-user-views (t2/select-fn-vec #(select-keys % [:model :model_id])
                                           :model/RecentViews
                                           :user_id user-id
-                                          {:order-by [[:timestamp :desc]]
+                                          {:order-by [[:id :desc]]
                                            :limit    *recent-views-stored-per-user*})]
      (->> (distinct all-user-views)
           (take n)


### PR DESCRIPTION
Unlike H2 and Postgres, MySQL doesn't guarantee a specific order of equal rows when using `ORDER BY` on a non-unique column. Since I was using the `timestamp` field for comparing recent_views, the tests ended up having elements with equal timestamps, causing the tests to fail due to this non-determinism.

I've switched it to just use the ID for ordering instead, which bypasses this issue entirely.

Also fixed the ordering of collections so that the audit collection is always last on both Postgres and MySQL, even though they sort NULLs differently by default. Did this using a case statement that converts NULL types to 0 and non-NULLs to 1, and sorting on the integers instead.