### PR TITLE
Fix more auditv2 backend tests

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15426,6 +15426,19 @@ databaseChangeLog:
                     nullable: false
                   defaultValue: '#31698A'
 
+  - changeSet:
+      id: v48.00-020
+      author: noahmoss
+      comment: Added 0.48.0 - Create recent_views.user_id index
+      changes:
+        - createIndex:
+            indexName: idx_recent_views_user_id
+            tableName: recent_views
+            columns:
+              - column:
+                  name: user_id
+      rollback: # not needed, it will be removed with the table
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/models/recent_views.clj
+++ b/src/metabase/models/recent_views.clj
@@ -55,8 +55,8 @@
       (t2/insert! :model/RecentViews {:user_id  user-id
                                       :model    (name model)
                                       :model_id model-id})
-      (let [current-views  (t2/select :model/RecentViews :user_id user-id {:order-by [[:timestamp :desc]]})
-            ids-to-prune (view-ids-to-prune current-views *recent-views-stored-per-user*)]
+      (let [current-views (t2/select :model/RecentViews :user_id user-id {:order-by [[:id :desc]]})
+            ids-to-prune  (view-ids-to-prune current-views *recent-views-stored-per-user*)]
         (when (seq ids-to-prune)
          (t2/delete! :model/RecentViews :id [:in ids-to-prune]))))))
 

--- a/test/metabase/events/recent_views_test.clj
+++ b/test/metabase/events/recent_views_test.clj
@@ -11,7 +11,7 @@
   [user-id]
   (t2/select-one [:model/RecentViews :user_id :model :model_id]
                  :user_id user-id
-                 {:order-by [[:timestamp :desc] [:id :desc]]}))
+                 {:order-by [[:id :desc]]}))
 
 (deftest card-query-test
   (mt/with-temp [Card card {:creator_id (mt/user->id :rasta)}]

--- a/test/metabase/events/recent_views_test.clj
+++ b/test/metabase/events/recent_views_test.clj
@@ -11,7 +11,7 @@
   [user-id]
   (t2/select-one [:model/RecentViews :user_id :model :model_id]
                  :user_id user-id
-                 {:order-by [[:timestamp :desc]]}))
+                 {:order-by [[:timestamp :desc] [:id :desc]]}))
 
 (deftest card-query-test
   (mt/with-temp [Card card {:creator_id (mt/user->id :rasta)}]


### PR DESCRIPTION
Fixes for two more tests that had slipped by before:
* Fixes event ordering in mysql in another test
* Adds an index on `recent_views.user_id` since all FK fields need to be indexed in postgres