### PR TITLE
Persist search filters across searches

### DIFF
--- a/e2e/test/scenarios/onboarding/search/search.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search.cy.spec.js
@@ -167,7 +167,6 @@ describe("scenarios > search", () => {
       });
     });
   });
-
   describe("applying search filters", () => {
     describe("no filters", () => {
       it("hydrating search from URL", () => {
@@ -506,6 +505,48 @@ describe("scenarios > search", () => {
           });
       });
     });
+
+    it("should persist filters when the user changes the text query", () => {
+      cy.visit("/search?q=orders");
+
+      // add created_by filter
+      cy.findByTestId("created_by-search-filter").click();
+      popover().within(() => {
+        cy.findByText("Bobby Tables").click();
+        cy.findByText("Apply filters").click();
+      });
+
+      // add last_edited_by filter
+      cy.findByTestId("last_edited_by-search-filter").click();
+      popover().within(() => {
+        cy.findByText("Bobby Tables").click();
+        cy.findByText("Apply filters").click();
+      });
+
+      // add type filter
+      cy.findByTestId("type-search-filter").click();
+      popover().within(() => {
+        cy.findByText("Question").click();
+        cy.findByText("Apply filters").click();
+      });
+
+      expectSearchResultItemNameContent({
+        itemNames: [
+          "Orders",
+          "Orders, Count",
+          "Orders, Count, Grouped by Created At (year)",
+        ],
+      });
+
+      getSearchBar().clear().type("count{enter}");
+
+      expectSearchResultItemNameContent({
+        itemNames: [
+          "Orders, Count",
+          "Orders, Count, Grouped by Created At (year)",
+        ],
+      });
+    });
   });
 });
 
@@ -541,4 +582,15 @@ function getProductsSearchResults() {
 
 function getSearchBar() {
   return cy.findByPlaceholderText("Search…");
+}
+
+function expectSearchResultItemNameContent({ itemNames }) {
+  cy.findAllByTestId("search-result-item-name").then($searchResultLabel => {
+    const searchResultLabelList = $searchResultLabel
+      .toArray()
+      .map(el => el.textContent);
+
+    expect(searchResultLabelList).to.have.length(itemNames.length);
+    expect(searchResultLabelList).to.include.members(itemNames);
+  });
 }

--- a/e2e/test/scenarios/onboarding/search/search.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search.cy.spec.js
@@ -590,7 +590,6 @@ function expectSearchResultItemNameContent({ itemNames }) {
       .toArray()
       .map(el => el.textContent);
 
-    expect(searchResultLabelList).to.have.length(itemNames.length);
-    expect(searchResultLabelList).to.include.members(itemNames);
+    expect(searchResultLabelList).to.deep.eq(itemNames);
   });
 }

--- a/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.unit.spec.tsx
@@ -158,4 +158,34 @@ describe("SearchBar", () => {
       expect(getSearchBar()).toHaveValue("");
     });
   });
+
+  describe("persisting search filters", () => {
+    it("should keep URL search filters when changing the text query", () => {
+      const { history } = setup({
+        initialRoute: "/search?q=foo&type=card",
+      });
+
+      userEvent.clear(getSearchBar());
+      userEvent.type(getSearchBar(), "bar{enter}");
+
+      const location = history.getCurrentLocation();
+
+      expect(location.pathname).toEqual("search");
+      expect(location.search).toEqual("?q=bar&type=card");
+    });
+
+    it("should not keep URL search filters when not in the search app", () => {
+      const { history } = setup({
+        initialRoute: "/collection/root?q=foo&type=card&type=dashboard",
+      });
+
+      userEvent.clear(getSearchBar());
+      userEvent.type(getSearchBar(), "bar{enter}");
+
+      const location = history.getCurrentLocation();
+
+      expect(location.pathname).toEqual("search");
+      expect(location.search).toEqual("?q=bar");
+    });
+  });
 });

--- a/frontend/src/metabase/search/utils/search-location/search-location.ts
+++ b/frontend/src/metabase/search/utils/search-location/search-location.ts
@@ -7,12 +7,7 @@ import type {
 import { SearchFilterKeys } from "metabase/search/constants";
 
 export function isSearchPageLocation(location?: SearchAwareLocation): boolean {
-  if (!location) {
-    return false;
-  }
-
-  const components = location.pathname.split("/");
-  return components[components.length - 1] === "search";
+  return location ? location.pathname === "/search" : false;
 }
 
 export function getSearchTextFromLocation(

--- a/frontend/src/metabase/search/utils/search-location/search-location.ts
+++ b/frontend/src/metabase/search/utils/search-location/search-location.ts
@@ -7,7 +7,7 @@ import type {
 import { SearchFilterKeys } from "metabase/search/constants";
 
 export function isSearchPageLocation(location?: SearchAwareLocation): boolean {
-  return location ? location.pathname === "/search" : false;
+  return location ? /^\/?search$/.test(location.pathname) : false;
 }
 
 export function getSearchTextFromLocation(

--- a/frontend/src/metabase/search/utils/search-location/search-location.ts
+++ b/frontend/src/metabase/search/utils/search-location/search-location.ts
@@ -7,11 +7,12 @@ import type {
 import { SearchFilterKeys } from "metabase/search/constants";
 
 export function isSearchPageLocation(location?: SearchAwareLocation): boolean {
-  if (location) {
-    const components = location.pathname.split("/");
-    return components[components.length - 1] === "search";
+  if (!location) {
+    return false;
   }
-  return false;
+
+  const components = location.pathname.split("/");
+  return components[components.length - 1] === "search";
 }
 
 export function getSearchTextFromLocation(

--- a/frontend/src/metabase/search/utils/search-location/search-location.ts
+++ b/frontend/src/metabase/search/utils/search-location/search-location.ts
@@ -6,9 +6,12 @@ import type {
 } from "metabase/search/types";
 import { SearchFilterKeys } from "metabase/search/constants";
 
-export function isSearchPageLocation(location: SearchAwareLocation): boolean {
-  const components = location.pathname.split("/");
-  return components[components.length - 1] === "search";
+export function isSearchPageLocation(location?: SearchAwareLocation): boolean {
+  if (location) {
+    const components = location.pathname.split("/");
+    return components[components.length - 1] === "search";
+  }
+  return false;
 }
 
 export function getSearchTextFromLocation(

--- a/frontend/src/metabase/search/utils/search-location/search-location.unit.spec.ts
+++ b/frontend/src/metabase/search/utils/search-location/search-location.unit.spec.ts
@@ -8,20 +8,28 @@ import type { SearchAwareLocation } from "metabase/search/types";
 import { SearchFilterKeys } from "metabase/search/constants";
 
 describe("isSearchPageLocation", () => {
-  it('should return true when the last component of pathname is "search"', () => {
-    const location = {
-      pathname: "/search",
-      query: {},
-    };
-    expect(isSearchPageLocation(location as SearchAwareLocation)).toBe(true);
+  it("should return true for a search page location", () => {
+    const location = { pathname: "/search" };
+    const result = isSearchPageLocation(location as SearchAwareLocation);
+    expect(result).toBe(true);
   });
 
-  it('should return false when the last component of pathname is not "search"', () => {
-    const location = {
-      pathname: "/collection/root",
-      query: {},
-    };
-    expect(isSearchPageLocation(location as SearchAwareLocation)).toBe(false);
+  it("should return true for a search page location with query params", () => {
+    const location = { pathname: "/search", search: "?q=test" };
+    const result = isSearchPageLocation(location as SearchAwareLocation);
+    expect(result).toBe(true);
+  });
+
+  it('should return false for non-search location that might have "search" in the path', () => {
+    const location = { pathname: "/collection/1-search" };
+    const result = isSearchPageLocation(location as SearchAwareLocation);
+    expect(result).toBe(false);
+  });
+
+  it("should return false for non-search location", () => {
+    const location = { pathname: "/some-page" };
+    const result = isSearchPageLocation(location as SearchAwareLocation);
+    expect(result).toBe(false);
   });
 });
 


### PR DESCRIPTION
### Description

Persists search filters when the user is in the search app, so filters aren't lost when the user changes a search query.

### How to verify
Go to the search app, and add some filters. Now change the search query and your filters won't be lost.

### Tests

- [X] Tests have been added for all components