### PR TITLE
[Dashboard] Do not lose filters state on navigating back from Question

### DIFF
--- a/e2e/test/scenarios/dashboard/reproductions/34382-dashboard-back-navigation-preserve-filters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/34382-dashboard-back-navigation-preserve-filters.cy.spec.js
@@ -23,7 +23,7 @@ describe("issue 34382", () => {
     createDashboardWithCards();
     cy.get("@dashboardId").then(visitDashboard);
 
-    setFilterValue("Gizmo");
+    addFilterValue("Gizmo");
     applyFilter();
 
     cy.log("Navigate to Products question");
@@ -103,7 +103,7 @@ const createDashboardWithCards = () => {
   );
 };
 
-function setFilterValue(value) {
+function addFilterValue(value) {
   filterWidget().click();
   popover().within(() => {
     cy.findByText(value).click();

--- a/e2e/test/scenarios/dashboard/reproductions/34382-dashboard-back-navigation-preserve-filters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/34382-dashboard-back-navigation-preserve-filters.cy.spec.js
@@ -1,0 +1,120 @@
+import {
+  dashboardParametersContainer,
+  getDashboardCard,
+  restore,
+  visitDashboard,
+  filterWidget,
+  queryBuilderHeader,
+  popover,
+} from "e2e/support/helpers";
+import { PRODUCTS, PRODUCTS_ID } from "metabase-types/api/mocks/presets";
+
+describe("issue 34382", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
+      "dashcardQuery",
+    );
+  });
+
+  it("should preserve filter value when navigating between the dashboard and the query builder with auto-apply disabled (metabase#34382)", () => {
+    createDashboardWithCards();
+    cy.get("@dashboardId").then(visitDashboard);
+
+    setFilterValue("Gizmo");
+    applyFilter();
+
+    cy.log("Navigate to Products question");
+    getDashboardCard().findByText("Products").click();
+
+    cy.log("Navigate back to dashboard");
+    queryBuilderHeader()
+      .findByLabelText("Back to Products in a dashboard")
+      .click();
+
+    cy.location("search").should("eq", "?category=Gizmo");
+    filterWidget().contains("Gizmo");
+
+    getDashboardCard().within(() => {
+      // only products with category "Gizmo" are filtered
+      cy.findAllByTestId("table-row").should("have.length", 8);
+      cy.findAllByText("Gizmo").should("have.length", 8);
+    });
+  });
+});
+
+const createDashboardWithCards = () => {
+  const getParameterMapping = ({ card_id }, parameters) => ({
+    parameter_mappings: parameters.map(parameter => ({
+      card_id,
+      parameter_id: parameter.id,
+      target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
+    })),
+  });
+
+  const questionDetails = {
+    name: "Products",
+    query: { "source-table": PRODUCTS_ID },
+  };
+
+  const questionDashcardDetails = {
+    row: 0,
+    col: 0,
+    size_x: 8,
+    size_y: 8,
+    visualization_settings: {},
+  };
+  const filterDetails = {
+    name: "Product Category",
+    slug: "category",
+    id: "96917421",
+    type: "category",
+  };
+
+  const dashboardDetails = {
+    name: "Products in a dashboard",
+    auto_apply_filters: false,
+    parameters: [filterDetails],
+  };
+
+  cy.createDashboard(dashboardDetails).then(
+    ({ body: { id: dashboard_id } }) => {
+      cy.createQuestion(questionDetails).then(
+        ({ body: { id: question_id } }) => {
+          cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
+            cards: [
+              {
+                id: -1,
+                card_id: question_id,
+                ...questionDashcardDetails,
+                ...getParameterMapping({ card_id: question_id }, [
+                  filterDetails,
+                ]),
+              },
+            ],
+          });
+        },
+      );
+
+      cy.wrap(dashboard_id).as("dashboardId");
+    },
+  );
+};
+
+function setFilterValue(value) {
+  filterWidget().click();
+  popover().within(() => {
+    cy.findByText(value).click();
+    cy.findByRole("button", { name: "Add filter" }).click();
+  });
+}
+
+function applyFilter() {
+  dashboardParametersContainer()
+    .findByRole("button", { name: "Apply" })
+    .click();
+
+  cy.wait("@dashcardQuery");
+}

--- a/frontend/src/metabase/dashboard/actions/data-fetching.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.js
@@ -268,7 +268,7 @@ export const fetchCardData = createThunkAction(
         },
       });
 
-      // If the dataset_query was filtered then we don't have permisison to view this card, so
+      // If the dataset_query was filtered then we don't have permission to view this card, so
       // shortcircuit and return a fake 403
       if (!card.dataset_query) {
         return {

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -7,7 +7,7 @@ import { getMainElement } from "metabase/lib/dom";
 
 import DashboardHeader from "metabase/dashboard/containers/DashboardHeader";
 import SyncedParametersList from "metabase/parameters/components/SyncedParametersList/SyncedParametersList";
-import FilterApplyButton from "metabase/parameters/components/FilterApplyButton";
+import { FilterApplyButton } from "metabase/parameters/components/FilterApplyButton";
 import { getVisibleParameters } from "metabase/parameters/utils/ui";
 import DashboardControls from "metabase/dashboard/hoc/DashboardControls";
 import { getValuePopulatedParameters } from "metabase-lib/parameters/utils/parameter-values";

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -304,7 +304,6 @@ class Dashboard extends Component {
       isHeaderVisible,
       embedOptions,
       isAutoApplyFilters,
-      isNavigatingBackToDashboard,
     } = this.props;
 
     const { error, isParametersWidgetSticky } = this.state;
@@ -317,9 +316,7 @@ class Dashboard extends Component {
       <SyncedParametersList
         parameters={getValuePopulatedParameters(
           parameters,
-          isAutoApplyFilters || isNavigatingBackToDashboard
-            ? parameterValues
-            : draftParameterValues,
+          isAutoApplyFilters ? parameterValues : draftParameterValues,
         )}
         editingParameter={editingParameter}
         dashboard={dashboard}

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -304,6 +304,7 @@ class Dashboard extends Component {
       isHeaderVisible,
       embedOptions,
       isAutoApplyFilters,
+      isNavigatingBackToDashboard,
     } = this.props;
 
     const { error, isParametersWidgetSticky } = this.state;
@@ -316,7 +317,9 @@ class Dashboard extends Component {
       <SyncedParametersList
         parameters={getValuePopulatedParameters(
           parameters,
-          isAutoApplyFilters ? parameterValues : draftParameterValues,
+          isAutoApplyFilters || isNavigatingBackToDashboard
+            ? parameterValues
+            : draftParameterValues,
         )}
         editingParameter={editingParameter}
         dashboard={dashboard}

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.jsx
@@ -61,7 +61,7 @@ import {
   getSlowCards,
   getIsAutoApplyFilters,
   getSelectedTabId,
-  getisNavigatingBackToDashboard,
+  getIsNavigatingBackToDashboard,
 } from "../../selectors";
 import { DASHBOARD_SLOW_TIMEOUT } from "../../constants";
 
@@ -106,7 +106,7 @@ const mapStateToProps = state => {
     embedOptions: getEmbedOptions(state),
     selectedTabId: getSelectedTabId(state),
     isAutoApplyFilters: getIsAutoApplyFilters(state),
-    isNavigatingBackToDashboard: getisNavigatingBackToDashboard(state),
+    isNavigatingBackToDashboard: getIsNavigatingBackToDashboard(state),
   };
 };
 

--- a/frontend/src/metabase/dashboard/hoc/DashboardData.jsx
+++ b/frontend/src/metabase/dashboard/hoc/DashboardData.jsx
@@ -12,7 +12,7 @@ import {
   getSlowCards,
   getParameters,
   getParameterValues,
-  getisNavigatingBackToDashboard,
+  getIsNavigatingBackToDashboard,
   getSelectedTabId,
 } from "metabase/dashboard/selectors";
 
@@ -26,7 +26,7 @@ const mapStateToProps = (state, props) => {
     slowCards: getSlowCards(state, props),
     parameters: getParameters(state, props),
     parameterValues: getParameterValues(state, props),
-    isNavigatingBackToDashboard: getisNavigatingBackToDashboard(state),
+    isNavigatingBackToDashboard: getIsNavigatingBackToDashboard(state),
   };
 };
 

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -338,7 +338,11 @@ const parameterValues = handleActions(
 
 const draftParameterValues = handleActions(
   {
-    [INITIALIZE]: { next: () => ({}) },
+    [INITIALIZE]: {
+      next: (state, { payload: { clearCache = true } = {} }) => {
+        return clearCache ? {} : state;
+      },
+    },
     [FETCH_DASHBOARD]: {
       next: (
         state,
@@ -358,7 +362,6 @@ const draftParameterValues = handleActions(
     [REMOVE_PARAMETER]: {
       next: (state, { payload: { id } }) => dissoc(state, id),
     },
-    [RESET]: { next: () => ({}) },
   },
   {},
 );

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.js
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.js
@@ -102,10 +102,50 @@ describe("dashboard reducers", () => {
         ),
       ).toEqual({ ...initState, isEditing: null });
     });
+
+    it("should return unchanged state if `clearCache: false` passed", () => {
+      expect(
+        reducer(
+          {
+            ...initState,
+            draftParameterValues: {
+              "60bca071": ["Gadget", "Doohickey", "Gizmo"],
+            },
+          },
+          {
+            type: INITIALIZE,
+            payload: {
+              clearCache: false,
+            },
+          },
+        ),
+      ).toEqual({
+        ...initState,
+        draftParameterValues: {
+          "60bca071": ["Gadget", "Doohickey", "Gizmo"],
+        },
+      });
+    });
+
+    it("should reset state if `clearCache`: false` is not passed", () => {
+      expect(
+        reducer(
+          {
+            ...initState,
+            draftParameterValues: {
+              "60bca071": ["Gadget", "Doohickey", "Gizmo"],
+            },
+          },
+          {
+            type: INITIALIZE,
+          },
+        ),
+      ).toEqual(initState);
+    });
   });
 
   describe("SET_EDITING_DASHBOARD", () => {
-    it("should clear sideabr state when entering edit mode", () => {
+    it("should clear sidebar state when entering edit mode", () => {
       const state = {
         ...initState,
         sidebar: { name: "foo", props: { abc: 123 } },
@@ -118,7 +158,7 @@ describe("dashboard reducers", () => {
       ).toEqual({ ...state, isEditing: true, sidebar: { props: {} } });
     });
 
-    it("should clear sideabr state when leaving edit mode", () => {
+    it("should clear sidebar state when leaving edit mode", () => {
       const state = {
         ...initState,
         sidebar: { name: "foo", props: { abc: 123 } },

--- a/frontend/src/metabase/dashboard/selectors/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors/selectors.js
@@ -201,7 +201,7 @@ export const getCanShowAutoApplyFiltersToast = createSelector(
 export const getDocumentTitle = state =>
   state.dashboard.loadingControls.documentTitle;
 
-export const getisNavigatingBackToDashboard = state =>
+export const getIsNavigatingBackToDashboard = state =>
   state.dashboard.isNavigatingBackToDashboard;
 
 export const getIsBookmarked = (state, props) =>

--- a/frontend/src/metabase/parameters/components/FilterApplyButton/FilterApplyButton.tsx
+++ b/frontend/src/metabase/parameters/components/FilterApplyButton/FilterApplyButton.tsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from "metabase/lib/redux";
 import {
   getHasUnappliedParameterValues,
   getIsAutoApplyFilters,
+  getIsNavigatingBackToDashboard,
 } from "metabase/dashboard/selectors";
 import { applyDraftParameterValues } from "metabase/dashboard/actions";
 import { ApplyButton } from "./FilterApplyButton.styled";
@@ -11,6 +12,9 @@ import { ApplyButton } from "./FilterApplyButton.styled";
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default function FilterApplyButton() {
   const isAutoApplyFilters = useSelector(getIsAutoApplyFilters);
+  const isNavigatingBackToDashboard = useSelector(
+    getIsNavigatingBackToDashboard,
+  );
   const hasUnappliedParameterValues = useSelector(
     getHasUnappliedParameterValues,
   );
@@ -20,7 +24,11 @@ export default function FilterApplyButton() {
     dispatch(applyDraftParameterValues());
   }, [dispatch]);
 
-  if (isAutoApplyFilters || !hasUnappliedParameterValues) {
+  if (
+    isAutoApplyFilters ||
+    !hasUnappliedParameterValues ||
+    isNavigatingBackToDashboard
+  ) {
     return null;
   }
 

--- a/frontend/src/metabase/parameters/components/FilterApplyButton/FilterApplyButton.tsx
+++ b/frontend/src/metabase/parameters/components/FilterApplyButton/FilterApplyButton.tsx
@@ -9,8 +9,7 @@ import {
 import { applyDraftParameterValues } from "metabase/dashboard/actions";
 import { ApplyButton } from "./FilterApplyButton.styled";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default function FilterApplyButton() {
+export function FilterApplyButton() {
   const isAutoApplyFilters = useSelector(getIsAutoApplyFilters);
   const isNavigatingBackToDashboard = useSelector(
     getIsNavigatingBackToDashboard,

--- a/frontend/src/metabase/parameters/components/FilterApplyButton/FilterApplyButton.tsx
+++ b/frontend/src/metabase/parameters/components/FilterApplyButton/FilterApplyButton.tsx
@@ -4,16 +4,12 @@ import { useDispatch, useSelector } from "metabase/lib/redux";
 import {
   getHasUnappliedParameterValues,
   getIsAutoApplyFilters,
-  getIsNavigatingBackToDashboard,
 } from "metabase/dashboard/selectors";
 import { applyDraftParameterValues } from "metabase/dashboard/actions";
 import { ApplyButton } from "./FilterApplyButton.styled";
 
 export function FilterApplyButton() {
   const isAutoApplyFilters = useSelector(getIsAutoApplyFilters);
-  const isNavigatingBackToDashboard = useSelector(
-    getIsNavigatingBackToDashboard,
-  );
   const hasUnappliedParameterValues = useSelector(
     getHasUnappliedParameterValues,
   );
@@ -23,11 +19,7 @@ export function FilterApplyButton() {
     dispatch(applyDraftParameterValues());
   }, [dispatch]);
 
-  if (
-    isAutoApplyFilters ||
-    !hasUnappliedParameterValues ||
-    isNavigatingBackToDashboard
-  ) {
+  if (isAutoApplyFilters || !hasUnappliedParameterValues) {
     return null;
   }
 

--- a/frontend/src/metabase/parameters/components/FilterApplyButton/index.ts
+++ b/frontend/src/metabase/parameters/components/FilterApplyButton/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./FilterApplyButton";
+export { FilterApplyButton } from "./FilterApplyButton";

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -14,7 +14,7 @@ import { isWithinIframe, initializeIframeResizer } from "metabase/lib/dom";
 import { parseHashOptions } from "metabase/lib/browser";
 
 import SyncedParametersList from "metabase/parameters/components/SyncedParametersList/SyncedParametersList";
-import FilterApplyButton from "metabase/parameters/components/FilterApplyButton";
+import { FilterApplyButton } from "metabase/parameters/components/FilterApplyButton";
 
 import type {
   Dashboard,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/34382

### Description

We need to preserve filter values not only when auto-apply is enabled for filters, but on navigating back to the dashboard from question

### How to verify

1. Create a saved question (e.g. select Products from the sample database), save it and add it to a dashboard.
2. Add a dashboard filter and connect it to the question (e.g. add Category).
3. Turn Apply filter values off for the dasboard.
4. Set a value for the filter, and apply it.
5. Open the card from the dashboard, notice that the filter values remain in effect.
6. Click the blue left arrow button to return to the dashboard (the Metabase one, not the browser back button).
7. (!) The filter values are kept in the dashboard filters.
8. (!) Reload the page keeps card filtered


### Demo

https://www.loom.com/share/11bf1d7700fd41dbadee91fcfcff0e47

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
