### PR TITLE
Bump Postgres version in drivers tests in CI to 12

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -468,15 +468,16 @@ jobs:
       MB_POSTGRESQL_TEST_USER: circle_test
     services:
       postgres:
-        image: circleci/postgres:9.6-alpine
+        image: postgres:12-alpine
         ports:
           - "5432:5432"
         env:
           POSTGRES_USER: circle_test
           POSTGRES_DB: circle_test
+          POSTGRES_HOST_AUTH_METHOD: trust
     steps:
     - uses: actions/checkout@v3
-    - name: Test Postgres driver (9.6)
+    - name: Test Postgres driver (12)
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-postgres-ee'

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -463,17 +463,17 @@ jobs:
       MB_DB_TYPE: postgres
       MB_DB_PORT: 5432
       MB_DB_HOST: localhost
-      MB_DB_DBNAME: circle_test
-      MB_DB_USER: circle_test
-      MB_POSTGRESQL_TEST_USER: circle_test
+      MB_DB_DBNAME: pg_test
+      MB_DB_USER: pg_test
+      MB_POSTGRESQL_TEST_USER: pg_test
     services:
       postgres:
         image: postgres:12-alpine
         ports:
           - "5432:5432"
         env:
-          POSTGRES_USER: circle_test
-          POSTGRES_DB: circle_test
+          POSTGRES_USER: pg_test
+          POSTGRES_DB: pg_test
           POSTGRES_HOST_AUTH_METHOD: trust
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -465,6 +465,7 @@ jobs:
       MB_DB_HOST: localhost
       MB_DB_DBNAME: pg_test
       MB_DB_USER: pg_test
+      MB_DB_PASS: pg_test
       MB_POSTGRESQL_TEST_USER: pg_test
     services:
       postgres:
@@ -474,7 +475,7 @@ jobs:
         env:
           POSTGRES_USER: pg_test
           POSTGRES_DB: pg_test
-          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_PASSWORD: pg_test
     steps:
     - uses: actions/checkout@v3
     - name: Test Postgres driver (12)

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -463,19 +463,18 @@ jobs:
       MB_DB_TYPE: postgres
       MB_DB_PORT: 5432
       MB_DB_HOST: localhost
-      MB_DB_DBNAME: pg_test
-      MB_DB_USER: pg_test
-      MB_DB_PASS: pg_test
-      MB_POSTGRESQL_TEST_USER: pg_test
+      MB_DB_DBNAME: mb_test
+      MB_DB_USER: mb_test
+      MB_POSTGRESQL_TEST_USER: mb_test
     services:
       postgres:
         image: postgres:12-alpine
         ports:
           - "5432:5432"
         env:
-          POSTGRES_USER: pg_test
-          POSTGRES_DB: pg_test
-          POSTGRES_PASSWORD: pg_test
+          POSTGRES_USER: mb_test
+          POSTGRES_DB: mb_test
+          POSTGRES_HOST_AUTH_METHOD: trust
     steps:
     - uses: actions/checkout@v3
     - name: Test Postgres driver (12)


### PR DESCRIPTION
The final release for 9.6 was November 11, 2021
The oldest currently supported version is v11, but its end date is now in November 2023, so I bumped this straight to v12, which will give us some time.
https://www.postgresql.org/support/versioning/

We've been using `circleci/postgres:9.6-alpine` image.
This PR changes the source to the official Postgres image.

Slack thread: https://metaboat.slack.com/archives/C04DN5VRQM6/p1696229415457619

