### PR TITLE
Revert `openSteps` notebook hack for MLv2 joins

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/NotebookSteps/NotebookSteps.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookSteps/NotebookSteps.tsx
@@ -6,11 +6,7 @@ import StructuredQuery from "metabase-lib/queries/StructuredQuery";
 import type { Query } from "metabase-lib/types";
 import type Question from "metabase-lib/Question";
 
-import type {
-  NotebookStep as INotebookStep,
-  OpenSteps,
-  UpdateQueryOpts,
-} from "../types";
+import type { NotebookStep as INotebookStep, OpenSteps } from "../types";
 import { getQuestionSteps } from "../lib/steps";
 import NotebookStep from "../NotebookStep";
 import { Container } from "./NotebookSteps.styled";
@@ -34,15 +30,7 @@ function getInitialOpenSteps(question: Question, readOnly: boolean): OpenSteps {
     };
   }
 
-  // We need to keep join steps open at all time for MLv1-MLv2 compat
-  // This should be reworked once all notebook clauses are using MLv2
-  // Learn more: https://github.com/metabase/metabase/pull/32911
-
-  const steps = getQuestionSteps(question, {});
-  const joinSteps = steps.filter(step => step.type === "join");
-  const openStepsEntries = joinSteps.map(step => [step.id, true]);
-
-  return Object.fromEntries(openStepsEntries);
+  return {};
 }
 
 function NotebookSteps({
@@ -78,11 +66,7 @@ function NotebookSteps({
   }, []);
 
   const handleQueryChange = useCallback(
-    async (
-      step: INotebookStep,
-      query: StructuredQuery | Query,
-      { closeStep = true }: UpdateQueryOpts = {},
-    ) => {
+    async (step: INotebookStep, query: StructuredQuery | Query) => {
       // Performs a query update with either metabase-lib v1 or v2
       // The StructuredQuery block is temporary and will be removed
       // once all the notebook steps are using metabase-lib v2
@@ -98,11 +82,9 @@ function NotebookSteps({
         await updateQuestion(cleanQuestion);
       }
 
-      if (closeStep) {
-        // mark the step as "closed" since we can assume
-        // it's been added or removed by the updateQuery
-        handleStepClose(step.id);
-      }
+      // mark the step as "closed" since we can assume
+      // it's been added or removed by the updateQuery
+      handleStepClose(step.id);
     },
     [question, updateQuestion, handleStepClose],
   );
@@ -116,10 +98,8 @@ function NotebookSteps({
       {steps.map((step, index) => {
         const isLast = index === steps.length - 1;
         const isLastOpened = lastOpenedStep === step.id;
-        const onChange = (
-          query: StructuredQuery | Query,
-          opts?: UpdateQueryOpts,
-        ) => handleQueryChange(step, query, opts);
+        const onChange = (query: StructuredQuery | Query) =>
+          handleQueryChange(step, query);
 
         return (
           <NotebookStep

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { t } from "ttag";
 
 import { Box, Flex, Text } from "metabase/ui";
@@ -31,17 +31,12 @@ export function JoinStep({
   color,
   readOnly,
   sourceQuestion,
-  updateQuery: _updateQuery,
+  updateQuery,
 }: NotebookStepUiComponentProps) {
   const { stageIndex, itemIndex } = step;
 
   const joins = Lib.joins(query, stageIndex);
   const join = typeof itemIndex === "number" ? joins[itemIndex] : undefined;
-
-  const updateQuery = useCallback(
-    (nextQuery: Lib.Query) => _updateQuery(nextQuery, { closeStep: false }),
-    [_updateQuery],
-  );
 
   const {
     strategy,

--- a/frontend/src/metabase/query_builder/components/notebook/types.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/types.ts
@@ -49,10 +49,6 @@ export interface NotebookStepAction {
   }) => void;
 }
 
-export type UpdateQueryOpts = {
-  closeStep?: boolean;
-};
-
 export interface NotebookStepUiComponentProps {
   step: NotebookStep;
   topLevelQuery: Query;
@@ -62,10 +58,7 @@ export interface NotebookStepUiComponentProps {
   isLastOpened: boolean;
   reportTimezone: string;
   readOnly?: boolean;
-  updateQuery: (
-    query: StructuredQuery | Query,
-    opts?: UpdateQueryOpts,
-  ) => Promise<void>;
+  updateQuery: (query: StructuredQuery | Query) => Promise<void>;
 }
 
 export type OpenSteps = Record<NotebookStep["id"], boolean>;


### PR DESCRIPTION
Reverts #32911, more details in #34501 that addresses the same problem