### PR TITLE
[MLv2] Prototope: fix notebook + joins state issue

### DIFF
--- a/frontend/src/metabase-lib/join.ts
+++ b/frontend/src/metabase-lib/join.ts
@@ -67,6 +67,14 @@ export function withJoinStrategy(join: Join, strategy: JoinStrategy): Join {
   return ML.with_join_strategy(join, strategy);
 }
 
+export function joinAlias(
+  query: Query,
+  stageIndex: number,
+  join: Join,
+): string {
+  return displayInfo(query, stageIndex, join).name;
+}
+
 export function joinConditions(join: Join): JoinCondition[] {
   return ML.join_conditions(join);
 }

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -20,6 +20,8 @@ import type {
   ColumnMetadata,
   DrillThru,
   DrillThruDisplayInfo,
+  Join,
+  JoinDisplayInfo,
   JoinConditionOperator,
   JoinConditionOperatorDisplayInfo,
   JoinStrategy,
@@ -105,6 +107,11 @@ declare function DisplayInfoFn(
   stageIndex: number,
   metric: MetricMetadata,
 ): MetricDisplayInfo;
+declare function DisplayInfoFn(
+  query: Query,
+  stageIndex: number,
+  join: Join,
+): JoinDisplayInfo;
 declare function DisplayInfoFn(
   query: Query,
   stageIndex: number,

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -229,6 +229,11 @@ export type RelativeDateFilterOptions = {
   "include-current"?: boolean;
 };
 
+export type JoinDisplayInfo = {
+  name: string;
+  displayName: string;
+};
+
 export type JoinConditionOperatorDisplayInfo = {
   displayName: string;
   shortName: string;

--- a/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
@@ -119,6 +119,7 @@ const Notebook = ({ className, ...props }: NotebookProps) => {
     if (isResultDirty) {
       await runQuestionQuery();
     }
+    setJoinsToRemove([]);
   }
 
   return (

--- a/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
@@ -84,11 +84,7 @@ const Notebook = ({ className, ...props }: NotebookProps) => {
       joinsToRemove.forEach(({ alias }) => {
         const join = joinByAlias[alias];
         if (join) {
-          try {
-            query = Lib.removeClause(query, stageIndex, join);
-          } catch (e) {
-            // ignore
-          }
+          query = Lib.removeClause(query, stageIndex, join);
         }
       });
     });

--- a/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 import Button from "metabase/core/components/Button";
@@ -10,6 +11,7 @@ import {
   getQuestionIdFromVirtualTableId,
   isVirtualCardId,
 } from "metabase-lib/metadata/utils/saved-questions";
+import type { JoinToRemove } from "./types";
 import NotebookSteps from "./NotebookSteps";
 import { NotebookRoot } from "./Notebook.styled";
 
@@ -45,6 +47,23 @@ const Notebook = ({ className, ...props }: NotebookProps) => {
     setQueryBuilderMode,
   } = props;
 
+  const [, setJoinsToRemove] = useState<JoinToRemove[]>([]);
+
+  const addJoinToRemove = (joinToRemove: JoinToRemove) => {
+    setJoinsToRemove(joins => [...joins, joinToRemove]);
+  };
+
+  const removeJoinToRemove = (joinToRemove: JoinToRemove) => {
+    setJoinsToRemove(joins =>
+      joins.filter(join => {
+        const isTargetJoin =
+          joinToRemove.stageIndex === join.stageIndex &&
+          joinToRemove.alias === join.alias;
+        return !isTargetJoin;
+      }),
+    );
+  };
+
   async function cleanupQuestion() {
     // Converting a query to MLv2 and back performs a clean-up
     let cleanQuestion = question.setDatasetQuery(
@@ -78,7 +97,11 @@ const Notebook = ({ className, ...props }: NotebookProps) => {
 
   return (
     <NotebookRoot className={className}>
-      <NotebookSteps {...props} />
+      <NotebookSteps
+        {...props}
+        addJoinToRemove={addJoinToRemove}
+        removeJoinToRemove={removeJoinToRemove}
+      />
       {hasVisualizeButton && isRunnable && (
         <Button medium primary style={{ minWidth: 220 }} onClick={visualize}>
           {t`Visualize`}

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
@@ -14,6 +14,7 @@ import type Question from "metabase-lib/Question";
 import type StructuredQuery from "metabase-lib/queries/StructuredQuery";
 
 import type {
+  NotebookStepUiComponentProps,
   NotebookStep as INotebookStep,
   NotebookStepAction,
 } from "../types";
@@ -35,7 +36,11 @@ function hasLargeButton(action: NotebookStepAction) {
   return !STEP_UI[action.type].compact;
 }
 
-interface NotebookStepProps {
+interface NotebookStepProps
+  extends Pick<
+    NotebookStepUiComponentProps,
+    "addJoinToRemove" | "removeJoinToRemove"
+  > {
   step: INotebookStep;
   sourceQuestion?: Question;
   isLastStep: boolean;
@@ -54,6 +59,8 @@ function NotebookStep({
   reportTimezone,
   openStep,
   updateQuery,
+  addJoinToRemove,
+  removeJoinToRemove,
   readOnly = false,
 }: NotebookStepProps) {
   const [isPreviewOpen, { turnOn: openPreview, turnOff: closePreview }] =
@@ -144,6 +151,8 @@ function NotebookStep({
                 query={step.query}
                 sourceQuestion={sourceQuestion}
                 updateQuery={updateQuery}
+                addJoinToRemove={addJoinToRemove}
+                removeJoinToRemove={removeJoinToRemove}
                 isLastOpened={isLastOpened}
                 reportTimezone={reportTimezone}
                 readOnly={readOnly}

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookSteps/NotebookSteps.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookSteps/NotebookSteps.tsx
@@ -6,11 +6,7 @@ import StructuredQuery from "metabase-lib/queries/StructuredQuery";
 import type { Query } from "metabase-lib/types";
 import type Question from "metabase-lib/Question";
 
-import type {
-  NotebookStep as INotebookStep,
-  OpenSteps,
-  UpdateQueryOpts,
-} from "../types";
+import type { NotebookStep as INotebookStep, OpenSteps } from "../types";
 import { getQuestionSteps } from "../lib/steps";
 import NotebookStep from "../NotebookStep";
 import { Container } from "./NotebookSteps.styled";
@@ -34,15 +30,7 @@ function getInitialOpenSteps(question: Question, readOnly: boolean): OpenSteps {
     };
   }
 
-  // We need to keep join steps open at all time for MLv1-MLv2 compat
-  // This should be reworked once all notebook clauses are using MLv2
-  // Learn more: https://github.com/metabase/metabase/pull/32911
-
-  const steps = getQuestionSteps(question, {});
-  const joinSteps = steps.filter(step => step.type === "join");
-  const openStepsEntries = joinSteps.map(step => [step.id, true]);
-
-  return Object.fromEntries(openStepsEntries);
+  return {};
 }
 
 function NotebookSteps({
@@ -78,11 +66,7 @@ function NotebookSteps({
   }, []);
 
   const handleQueryChange = useCallback(
-    async (
-      step: INotebookStep,
-      query: StructuredQuery | Query,
-      { closeStep = true }: UpdateQueryOpts = {},
-    ) => {
+    async (step: INotebookStep, query: StructuredQuery | Query) => {
       // Performs a query update with either metabase-lib v1 or v2
       // The StructuredQuery block is temporary and will be removed
       // once all the notebook steps are using metabase-lib v2
@@ -98,11 +82,9 @@ function NotebookSteps({
         await updateQuestion(cleanQuestion);
       }
 
-      if (closeStep) {
-        // mark the step as "closed" since we can assume
-        // it's been added or removed by the updateQuery
-        handleStepClose(step.id);
-      }
+      // mark the step as "closed" since we can assume
+      // it's been added or removed by the updateQuery
+      handleStepClose(step.id);
     },
     [question, updateQuestion, handleStepClose],
   );
@@ -116,10 +98,8 @@ function NotebookSteps({
       {steps.map((step, index) => {
         const isLast = index === steps.length - 1;
         const isLastOpened = lastOpenedStep === step.id;
-        const onChange = (
-          query: StructuredQuery | Query,
-          opts?: UpdateQueryOpts,
-        ) => handleQueryChange(step, query, opts);
+        const onChange = (query: StructuredQuery | Query) =>
+          handleQueryChange(step, query);
 
         return (
           <NotebookStep

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookSteps/NotebookSteps.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookSteps/NotebookSteps.tsx
@@ -6,7 +6,11 @@ import StructuredQuery from "metabase-lib/queries/StructuredQuery";
 import type { Query } from "metabase-lib/types";
 import type Question from "metabase-lib/Question";
 
-import type { NotebookStep as INotebookStep, OpenSteps } from "../types";
+import type {
+  NotebookStep as INotebookStep,
+  OpenSteps,
+  JoinToRemove,
+} from "../types";
 import { getQuestionSteps } from "../lib/steps";
 import NotebookStep from "../NotebookStep";
 import { Container } from "./NotebookSteps.styled";
@@ -16,8 +20,10 @@ interface NotebookStepsProps {
   question: Question;
   sourceQuestion?: Question;
   reportTimezone: string;
-  updateQuestion: (question: Question) => Promise<void>;
   readOnly?: boolean;
+  addJoinToRemove: (join: JoinToRemove) => void;
+  removeJoinToRemove: (join: JoinToRemove) => void;
+  updateQuestion: (question: Question) => Promise<void>;
 }
 
 function getInitialOpenSteps(question: Question, readOnly: boolean): OpenSteps {
@@ -38,8 +44,10 @@ function NotebookSteps({
   question,
   sourceQuestion,
   reportTimezone,
-  updateQuestion,
   readOnly = false,
+  addJoinToRemove,
+  removeJoinToRemove,
+  updateQuestion,
 }: NotebookStepsProps) {
   const [openSteps, setOpenSteps] = useState<OpenSteps>(
     getInitialOpenSteps(question, readOnly),
@@ -109,9 +117,11 @@ function NotebookSteps({
             isLastStep={isLast}
             isLastOpened={isLastOpened}
             reportTimezone={reportTimezone}
+            readOnly={readOnly}
             updateQuery={onChange}
             openStep={handleStepOpen}
-            readOnly={readOnly}
+            addJoinToRemove={addJoinToRemove}
+            removeJoinToRemove={removeJoinToRemove}
           />
         );
       })}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { t } from "ttag";
 
 import { Box, Flex, Text } from "metabase/ui";
@@ -31,17 +31,12 @@ export function JoinStep({
   color,
   readOnly,
   sourceQuestion,
-  updateQuery: _updateQuery,
+  updateQuery,
 }: NotebookStepUiComponentProps) {
   const { stageIndex, itemIndex } = step;
 
   const joins = Lib.joins(query, stageIndex);
   const join = typeof itemIndex === "number" ? joins[itemIndex] : undefined;
-
-  const updateQuery = useCallback(
-    (nextQuery: Lib.Query) => _updateQuery(nextQuery, { closeStep: false }),
-    [_updateQuery],
-  );
 
   const {
     strategy,

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
@@ -32,6 +32,8 @@ export function JoinStep({
   readOnly,
   sourceQuestion,
   updateQuery,
+  addJoinToRemove,
+  removeJoinToRemove,
 }: NotebookStepUiComponentProps) {
   const { stageIndex, itemIndex } = step;
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
@@ -45,6 +45,7 @@ export function JoinStep({
     table,
     columns,
     conditions,
+    isMarkedForRemoval,
     setStrategy,
     setTable,
     addCondition,
@@ -52,7 +53,7 @@ export function JoinStep({
     removeCondition,
     isColumnSelected,
     setSelectedColumns,
-  } = useJoin(query, stageIndex, join);
+  } = useJoin(query, stageIndex, join, addJoinToRemove, removeJoinToRemove);
 
   const [isAddingNewCondition, setIsAddingNewCondition] = useState(false);
 
@@ -152,6 +153,7 @@ export function JoinStep({
           join={join}
           table={table}
           readOnly={readOnly}
+          isMarkedForRemoval={isMarkedForRemoval}
           canRemove={!isSingleCondition}
           onChange={nextCondition => {
             if (isComplete) {
@@ -263,6 +265,7 @@ interface JoinConditionProps {
   table: Lib.Joinable;
   readOnly?: boolean;
   canRemove: boolean;
+  isMarkedForRemoval: boolean;
   onChange: (condition: Lib.JoinCondition) => void;
   onChangeLHSColumn: (column: Lib.ColumnMetadata) => void;
   onRemove: () => void;
@@ -276,6 +279,7 @@ function JoinCondition({
   table,
   readOnly,
   canRemove,
+  isMarkedForRemoval,
   onChange,
   onChangeLHSColumn,
   onRemove,
@@ -290,7 +294,13 @@ function JoinCondition({
     setOperator,
     setLHSColumn,
     setRHSColumn,
-  } = useJoinCondition(query, stageIndex, table, join, condition);
+  } = useJoinCondition(
+    query,
+    stageIndex,
+    table,
+    isMarkedForRemoval ? undefined : join,
+    condition,
+  );
 
   const rhsColumnPicker = useRef<JoinConditionColumnPickerRef>(null);
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/use-join.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/use-join.ts
@@ -1,8 +1,21 @@
 import { useEffect, useCallback, useState, useMemo } from "react";
 import { usePrevious } from "react-use";
 import * as Lib from "metabase-lib";
+import type { JoinToRemove } from "../../types";
 
-export function useJoin(query: Lib.Query, stageIndex: number, join?: Lib.Join) {
+export function useJoin(
+  query: Lib.Query,
+  stageIndex: number,
+  join: Lib.Join | undefined,
+  addJoinToRemove: (joinToRemove: JoinToRemove) => void,
+  removeJoinToRemove: (joinToRemove: JoinToRemove) => void,
+) {
+  const [isMarkedForRemovalAs, setIsMarkedForRemovalAs] = useState<
+    string | null
+  >(null);
+
+  const isMarkedForRemoval = !!isMarkedForRemovalAs;
+
   const previousQuery = usePrevious(query);
   const previousJoin = usePrevious(join);
 
@@ -25,16 +38,20 @@ export function useJoin(query: Lib.Query, stageIndex: number, join?: Lib.Join) {
   );
 
   const columns = useMemo(() => {
-    if (join) {
+    if (join && !isMarkedForRemoval) {
       return Lib.joinableColumns(query, stageIndex, join);
     }
     if (table) {
       return Lib.joinableColumns(query, stageIndex, table);
     }
     return [];
-  }, [query, stageIndex, join, table]);
+  }, [query, stageIndex, join, table, isMarkedForRemoval]);
 
   useEffect(() => {
+    if (isMarkedForRemoval) {
+      return;
+    }
+
     if (join && previousJoin !== join) {
       _setStrategy(Lib.joinStrategy(join));
       _setTable(Lib.joinedThing(query, join));
@@ -46,10 +63,17 @@ export function useJoin(query: Lib.Query, stageIndex: number, join?: Lib.Join) {
     if (!previousJoin && join) {
       _setSelectedColumns([]);
     }
-  }, [query, previousQuery, stageIndex, join, previousJoin]);
+  }, [
+    query,
+    previousQuery,
+    stageIndex,
+    join,
+    previousJoin,
+    isMarkedForRemoval,
+  ]);
 
   const isColumnSelected = (column: Lib.ColumnMetadata) => {
-    if (join) {
+    if (join && !isMarkedForRemoval) {
       return !!Lib.displayInfo(query, stageIndex, column).selected;
     }
     if (selectedColumns === "all") {
@@ -62,7 +86,7 @@ export function useJoin(query: Lib.Query, stageIndex: number, join?: Lib.Join) {
   };
 
   const setSelectedColumns = (nextSelectedColumns: Lib.JoinFields) => {
-    if (join) {
+    if (join && !isMarkedForRemoval) {
       const nextJoin = Lib.withJoinFields(join, nextSelectedColumns);
       const nextQuery = Lib.replaceClause(query, stageIndex, join, nextJoin);
       return nextQuery;
@@ -84,12 +108,12 @@ export function useJoin(query: Lib.Query, stageIndex: number, join?: Lib.Join) {
   const setStrategy = useCallback(
     (nextStrategy: Lib.JoinStrategy) => {
       _setStrategy(nextStrategy);
-      if (join) {
+      if (join && !isMarkedForRemoval) {
         const nextJoin = Lib.withJoinStrategy(join, nextStrategy);
         return Lib.replaceClause(query, stageIndex, join, nextJoin);
       }
     },
-    [query, stageIndex, join],
+    [query, stageIndex, join, isMarkedForRemoval],
   );
 
   const setTable = useCallback(
@@ -112,29 +136,53 @@ export function useJoin(query: Lib.Query, stageIndex: number, join?: Lib.Join) {
           ? Lib.replaceClause(query, stageIndex, join, nextJoin)
           : Lib.join(query, stageIndex, nextJoin);
 
+        if (isMarkedForRemoval && join) {
+          removeJoinToRemove({ stageIndex, alias: isMarkedForRemovalAs });
+          setIsMarkedForRemovalAs(null);
+        }
+
         return { nextQuery, hasConditions: true };
+      }
+
+      if (join) {
+        const alias = Lib.joinAlias(query, stageIndex, join);
+        setIsMarkedForRemovalAs(alias);
+        addJoinToRemove({ stageIndex, alias });
       }
 
       _setTable(nextTable);
       _setSelectedColumns("all");
       _setConditions([]);
 
-      // With a new table and no suggested condition,
-      // the existing join in no longer valid, so we remove it
-      if (join) {
-        const nextQuery = Lib.removeClause(query, stageIndex, join);
-        return { nextQuery, hasConditions: false };
-      }
-
       return { nextQuery: null, hasConditions: false };
     },
-    [query, stageIndex, join, strategy],
+    [
+      query,
+      stageIndex,
+      join,
+      strategy,
+      isMarkedForRemoval,
+      isMarkedForRemovalAs,
+      addJoinToRemove,
+      removeJoinToRemove,
+    ],
   );
 
   const addCondition = useCallback(
     (condition: Lib.JoinCondition) => {
       const nextConditions = [...conditions, condition];
       _setConditions(nextConditions);
+
+      if (join && table && isMarkedForRemoval) {
+        let nextJoin = Lib.joinClause(table, nextConditions);
+        nextJoin = Lib.withJoinFields(nextJoin, selectedColumns);
+        nextJoin = Lib.withJoinStrategy(nextJoin, strategy);
+
+        removeJoinToRemove({ stageIndex, alias: isMarkedForRemovalAs });
+        setIsMarkedForRemovalAs(null);
+
+        return Lib.replaceClause(query, stageIndex, join, nextJoin);
+      }
 
       if (join) {
         const nextJoin = Lib.withJoinConditions(join, nextConditions);
@@ -146,7 +194,18 @@ export function useJoin(query: Lib.Query, stageIndex: number, join?: Lib.Join) {
         return Lib.join(query, stageIndex, nextJoin);
       }
     },
-    [query, stageIndex, join, table, strategy, selectedColumns, conditions],
+    [
+      query,
+      stageIndex,
+      join,
+      table,
+      strategy,
+      selectedColumns,
+      conditions,
+      isMarkedForRemoval,
+      isMarkedForRemovalAs,
+      removeJoinToRemove,
+    ],
   );
 
   const updateCondition = useCallback(
@@ -180,7 +239,8 @@ export function useJoin(query: Lib.Query, stageIndex: number, join?: Lib.Join) {
     strategy,
     table,
     columns,
-    conditions,
+    conditions: isMarkedForRemoval ? [] : conditions,
+    isMarkedForRemoval,
     setStrategy,
     setTable,
     addCondition,

--- a/frontend/src/metabase/query_builder/components/notebook/types.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/types.ts
@@ -49,6 +49,11 @@ export interface NotebookStepAction {
   }) => void;
 }
 
+export type JoinToRemove = {
+  stageIndex: number;
+  alias: string;
+};
+
 export interface NotebookStepUiComponentProps {
   step: NotebookStep;
   topLevelQuery: Query;
@@ -59,6 +64,8 @@ export interface NotebookStepUiComponentProps {
   reportTimezone: string;
   readOnly?: boolean;
   updateQuery: (query: StructuredQuery | Query) => Promise<void>;
+  addJoinToRemove: (join: JoinToRemove) => void;
+  removeJoinToRemove: (join: JoinToRemove) => void;
 }
 
 export type OpenSteps = Record<NotebookStep["id"], boolean>;

--- a/frontend/src/metabase/query_builder/components/notebook/types.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/types.ts
@@ -49,10 +49,6 @@ export interface NotebookStepAction {
   }) => void;
 }
 
-export type UpdateQueryOpts = {
-  closeStep?: boolean;
-};
-
 export interface NotebookStepUiComponentProps {
   step: NotebookStep;
   topLevelQuery: Query;
@@ -62,10 +58,7 @@ export interface NotebookStepUiComponentProps {
   isLastOpened: boolean;
   reportTimezone: string;
   readOnly?: boolean;
-  updateQuery: (
-    query: StructuredQuery | Query,
-    opts?: UpdateQueryOpts,
-  ) => Promise<void>;
+  updateQuery: (query: StructuredQuery | Query) => Promise<void>;
 }
 
 export type OpenSteps = Record<NotebookStep["id"], boolean>;


### PR DESCRIPTION
Attempts to fix the same issue as #32911 — that fix ended up incomplete and fragile (reverted at #34407, the base branch for this PR)

**High-level approach**

1. Adding the `joinsToRemove` state to the top-level `Notebook` component. It's a list of records like `{ stageIndex, alias }` which should uniquely identify a join at any point in time (as opposed to e.g. notebook step IDs that have to be recomputed every time a step is removed)
2. Once we put a previously valid join to an invalid state (when we select a new table, but there's no suggested condition), we add this join to the `joinsToRemove` list
3. If we complete that join before we click Visualize, we remove it from the `joinsToRemove`
4. If the join remains incomplete once Visualize is clicked, we'll go through `joinsToRemove` and remove every join that is still out there