### PR TITLE
[MLv2] TimeFilterPicker

### DIFF
--- a/frontend/src/metabase-lib/constants.ts
+++ b/frontend/src/metabase-lib/constants.ts
@@ -49,7 +49,13 @@ export const EXCLUDE_DATE_FILTER_OPERATORS = [
   "not-null",
 ] as const;
 
-export const TIME_FILTER_OPERATORS = [">", "<", "between"] as const;
+export const TIME_FILTER_OPERATORS = [
+  ">",
+  "<",
+  "between",
+  "is-null",
+  "not-null",
+] as const;
 
 export const RELATIVE_DATE_BUCKETS = [
   "minute",

--- a/frontend/src/metabase-lib/filter.ts
+++ b/frontend/src/metabase-lib/filter.ts
@@ -52,6 +52,7 @@ import type {
   TimeFilterParts,
   TimeParts,
 } from "./types";
+import { isTime } from "./column_types";
 
 export function filterableColumns(
   query: Query,
@@ -71,7 +72,7 @@ export function defaultFilterOperatorName(
   stageIndex: number,
   column: ColumnMetadata,
 ): FilterOperatorName {
-  return "=";
+  return isTime(column) ? "<" : "=";
 }
 
 export function filter(

--- a/frontend/src/metabase/common/components/FilterPicker/FilterOperatorPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterOperatorPicker.tsx
@@ -13,6 +13,7 @@ type FilterOperatorPickerProps = {
   stageIndex: number;
   column: Lib.ColumnMetadata;
   value: Lib.FilterOperatorName | null;
+  supportedOperators?: ReadonlyArray<Lib.FilterOperatorName>;
   onChange: (operator: Lib.FilterOperatorName) => void;
 };
 
@@ -21,11 +22,12 @@ export function FilterOperatorPicker({
   stageIndex,
   column,
   value,
+  supportedOperators,
   onChange,
 }: FilterOperatorPickerProps) {
   const options: Option[] = useMemo(
-    () => getOptions(query, stageIndex, column),
-    [query, stageIndex, column],
+    () => getOptions(query, stageIndex, column, supportedOperators),
+    [query, stageIndex, column, supportedOperators],
   );
 
   return (
@@ -45,15 +47,21 @@ function getOptions(
   query: Lib.Query,
   stageIndex: number,
   column: Lib.ColumnMetadata,
+  supportedOperators?: ReadonlyArray<Lib.FilterOperatorName>,
 ): Option[] {
   const operators = Lib.filterableColumnOperators(column);
+  let operatorInfos = operators.map(operator =>
+    Lib.displayInfo(query, stageIndex, operator),
+  );
 
-  return operators.map(operator => {
-    const operatorInfo = Lib.displayInfo(query, stageIndex, operator);
+  if (Array.isArray(supportedOperators)) {
+    operatorInfos = operatorInfos.filter(operatorInfo =>
+      supportedOperators.includes(operatorInfo.shortName),
+    );
+  }
 
-    return {
-      name: operatorInfo.longDisplayName,
-      value: operatorInfo.shortName,
-    };
-  });
+  return operatorInfos.map(operatorInfo => ({
+    name: operatorInfo.longDisplayName,
+    value: operatorInfo.shortName,
+  }));
 }

--- a/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
@@ -6,6 +6,7 @@ import { BooleanFilterPicker } from "./BooleanFilterPicker";
 import { DateFilterPicker } from "./DateFilterPicker";
 import { NumberFilterPicker } from "./NumberFilterPicker";
 import { StringFilterPicker } from "./StringFilterPicker";
+import { TimeFilterPicker } from "./TimeFilterPicker";
 
 export interface FilterPickerProps {
   query: Lib.Query;
@@ -90,6 +91,9 @@ const NotImplementedPicker = () => <div />;
 function getFilterWidget(column: Lib.ColumnMetadata) {
   if (Lib.isBoolean(column)) {
     return BooleanFilterPicker;
+  }
+  if (Lib.isTime(column)) {
+    return TimeFilterPicker;
   }
   if (Lib.isDate(column)) {
     return DateFilterPicker;

--- a/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
@@ -1,0 +1,154 @@
+import { useState } from "react";
+import { t } from "ttag";
+
+import { Box, Button, Flex, Text } from "metabase/ui";
+import { TimeInput } from "metabase/common/components/TimeInput";
+
+import * as Lib from "metabase-lib";
+
+import type { FilterPickerWidgetProps } from "../types";
+import { BackButton } from "../BackButton";
+import { Header } from "../Header";
+import { Footer } from "../Footer";
+import { FilterOperatorPicker } from "../FilterOperatorPicker";
+
+export const defaultTimeValue = {
+  hour: 0,
+  minute: 0,
+};
+
+export const timeFilterValueCountMap = {
+  "is-null": 0,
+  "not-null": 0,
+  ">": 1,
+  "<": 1,
+  between: 2,
+};
+
+export const supportedOperators = [
+  "<",
+  ">",
+  "between",
+  "is-null",
+  "not-null",
+] as const;
+
+function getDefaultValuesForOperator(
+  operatorName: Lib.TimeFilterOperatorName,
+): Lib.TimeParts[] {
+  const valueCount = timeFilterValueCountMap[operatorName];
+  return valueCount > 0 ? Array(valueCount).fill(defaultTimeValue) : [];
+}
+
+export function TimeFilterPicker({
+  query,
+  stageIndex,
+  column,
+  filter,
+  onBack,
+  onChange,
+}: FilterPickerWidgetProps) {
+  const columnName = Lib.displayInfo(query, stageIndex, column).longDisplayName;
+
+  const filterParts = filter
+    ? Lib.timeFilterParts(query, stageIndex, filter)
+    : null;
+
+  const [operatorName, setOperatorName] = useState<Lib.TimeFilterOperatorName>(
+    filterParts ? filterParts.operator : "<",
+  );
+
+  const [values, setValues] = useState<Lib.TimeParts[]>(
+    filterParts?.values ?? getDefaultValuesForOperator(operatorName),
+  );
+
+  const valueCount = timeFilterValueCountMap[operatorName];
+  const hasValuesInput = valueCount > 0;
+  const isValid = values.length === valueCount;
+
+  const handleOperatorChange = (
+    newOperatorName: Lib.TimeFilterOperatorName,
+  ) => {
+    setOperatorName(newOperatorName);
+    setValues(getDefaultValuesForOperator(newOperatorName));
+  };
+
+  const handleFilterChange = () => {
+    if (isValid) {
+      onChange(
+        Lib.timeFilterClause({
+          operator: operatorName,
+          column,
+          values,
+        }),
+      );
+    }
+  };
+
+  return (
+    <>
+      <Header>
+        <BackButton onClick={onBack}>{columnName}</BackButton>
+        <FilterOperatorPicker
+          query={query}
+          stageIndex={stageIndex}
+          column={column}
+          value={operatorName}
+          supportedOperators={supportedOperators}
+          onChange={newOperatorName =>
+            handleOperatorChange(newOperatorName as Lib.TimeFilterOperatorName)
+          }
+        />
+      </Header>
+      {hasValuesInput && (
+        <Flex p="md">
+          <ValuesInput
+            values={values}
+            valueCount={valueCount}
+            onChange={setValues}
+          />
+        </Flex>
+      )}
+      <Footer mt={valueCount === 0 ? -1 : undefined} /* to collapse borders */>
+        <Box />
+        <Button disabled={!isValid} onClick={handleFilterChange}>
+          {filter ? t`Update filter` : t`Add filter`}
+        </Button>
+      </Footer>
+    </>
+  );
+}
+
+function ValuesInput({
+  values,
+  valueCount,
+  onChange,
+}: {
+  values: Lib.TimeParts[];
+  valueCount: number;
+  onChange: (values: Lib.TimeParts[]) => void;
+}) {
+  if (valueCount === 1) {
+    const [value = defaultTimeValue] = values;
+    return <TimeInput value={value} onChange={value => onChange([value])} />;
+  }
+
+  if (valueCount === 2) {
+    const [value1 = defaultTimeValue, value2 = defaultTimeValue] = values;
+    return (
+      <Flex direction="column" gap="sm">
+        <TimeInput
+          value={value1}
+          onChange={newValue1 => onChange([newValue1, value2])}
+        />
+        <Text>{t`and`}</Text>
+        <TimeInput
+          value={value2}
+          onChange={newValue2 => onChange([value1, newValue2])}
+        />
+      </Flex>
+    );
+  }
+
+  return null;
+}

--- a/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
@@ -33,20 +33,13 @@ export const supportedOperators = [
   "not-null",
 ] as const;
 
-function getDefaultValuesForOperator(
-  operatorName: Lib.TimeFilterOperatorName,
-): Lib.TimeParts[] {
-  const valueCount = timeFilterValueCountMap[operatorName];
-  return Array(valueCount).fill(defaultTimeValue);
-}
-
 export function TimeFilterPicker({
   query,
   stageIndex,
   column,
   filter,
-  onBack,
   onChange,
+  onBack,
 }: FilterPickerWidgetProps) {
   const columnName = Lib.displayInfo(query, stageIndex, column).longDisplayName;
 
@@ -54,8 +47,8 @@ export function TimeFilterPicker({
     ? Lib.timeFilterParts(query, stageIndex, filter)
     : null;
 
-  const [operatorName, setOperatorName] = useState<Lib.TimeFilterOperatorName>(
-    filterParts ? filterParts.operator : "<",
+  const [operatorName, setOperatorName] = useState(
+    getInitialOperatorName(query, stageIndex, column, filterParts),
   );
 
   const [values, setValues] = useState<Lib.TimeParts[]>(
@@ -117,6 +110,29 @@ export function TimeFilterPicker({
       </Footer>
     </>
   );
+}
+
+function getInitialOperatorName(
+  query: Lib.Query,
+  stageIndex: number,
+  column: Lib.ColumnMetadata,
+  filterParts: Lib.TimeFilterParts | null,
+): Lib.TimeFilterOperatorName {
+  if (filterParts) {
+    return filterParts.operator;
+  }
+  return Lib.defaultFilterOperatorName(
+    query,
+    stageIndex,
+    column,
+  ) as Lib.TimeFilterOperatorName;
+}
+
+function getDefaultValuesForOperator(
+  operatorName: Lib.TimeFilterOperatorName,
+): Lib.TimeParts[] {
+  const valueCount = timeFilterValueCountMap[operatorName];
+  return Array(valueCount).fill(defaultTimeValue);
 }
 
 function ValuesInput({

--- a/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
@@ -37,7 +37,7 @@ function getDefaultValuesForOperator(
   operatorName: Lib.TimeFilterOperatorName,
 ): Lib.TimeParts[] {
   const valueCount = timeFilterValueCountMap[operatorName];
-  return valueCount > 0 ? Array(valueCount).fill(defaultTimeValue) : [];
+  return Array(valueCount).fill(defaultTimeValue);
 }
 
 export function TimeFilterPicker({

--- a/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/index.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/index.ts
@@ -1,0 +1,1 @@
+export * from "./TimeFilterPicker";

--- a/frontend/src/metabase/common/components/TimeInput/TimeInput.tsx
+++ b/frontend/src/metabase/common/components/TimeInput/TimeInput.tsx
@@ -1,0 +1,35 @@
+import moment from "moment";
+import TimeInputView from "metabase/core/components/TimeInput";
+import { useSelector } from "metabase/lib/redux";
+import { getTimeFormat } from "metabase/selectors/settings";
+
+export type TimeInputValue = {
+  hour: number;
+  minute: number;
+};
+
+export interface TimeInputProps {
+  value: TimeInputValue;
+  onChange: (value: TimeInputValue) => void;
+}
+
+export function TimeInput({ value, onChange }: TimeInputProps) {
+  const momentValue = moment().hours(value.hour).minutes(value.minute);
+  const timeFormat = useSelector(getTimeFormat);
+
+  const handleChange = (nextMomentValue: moment.Moment) => {
+    onChange({
+      hour: nextMomentValue.hours(),
+      minute: nextMomentValue.minutes(),
+    });
+  };
+
+  return (
+    <TimeInputView
+      value={momentValue}
+      timeFormat={timeFormat}
+      hasClearButton={false}
+      onChange={handleChange}
+    />
+  );
+}

--- a/frontend/src/metabase/common/components/TimeInput/index.ts
+++ b/frontend/src/metabase/common/components/TimeInput/index.ts
@@ -1,0 +1,1 @@
+export * from "./TimeInput";

--- a/frontend/src/metabase/selectors/settings.ts
+++ b/frontend/src/metabase/selectors/settings.ts
@@ -24,6 +24,12 @@ export const getSetting = <T extends SettingKey>(
   key: T,
 ): Settings[T] => getSettings(state)[key];
 
+export const getTimeFormat = createSelector(
+  (state: State) => getSetting(state, "custom-formatting"),
+  formattingSettings =>
+    formattingSettings["type/Temporal"]?.time_style || "h:mm A",
+);
+
 export const getStoreUrl = (path = "") => {
   return `https://store.metabase.com/${path}`;
 };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/34379

Adds MLv2-powered `TimeFilterPicker`. Drafting this as I'm not sure about the UI components — rebuilding `TimePicker` as is really hurts, maybe we'd like to refresh its UI a little bit?

### To Verify

1. New > Native query > `select '14:02:13'::time "time"` > Save
2. Click "Explore results", open the notebook editor
3. Filter the "Time" column to see the picker