### PR TITLE
Remove dependent joins from subsequent stages too

### DIFF
--- a/src/metabase/lib/remove_replace.cljc
+++ b/src/metabase/lib/remove_replace.cljc
@@ -338,9 +338,17 @@
   ([query        :- :metabase.lib.schema/query
     stage-number :- :int
     join-spec    :- [:or :metabase.lib.schema.join/join :string :int]]
-   (update-joins query stage-number join-spec (fn [joins join-alias]
-                                                (not-empty (filterv #(not (dependent-join? % join-alias))
-                                                                    joins))))))
+   (try
+     (update-joins query stage-number join-spec (fn [joins join-alias]
+                                                  (not-empty (filterv #(not (dependent-join? % join-alias))
+                                                                      joins))))
+     (catch #?(:clj Exception :cljs :default) e
+       (let [{:keys [error stage join]} (ex-data e)]
+         (if (= error ::lib.util/cannot-remove-final-join-condition)
+           (-> query
+               (remove-join (u/index-of #{stage} (:stages query)) join)
+               (remove-join stage-number join-spec))
+           (throw e)))))))
 
 (mu/defn replace-join :- :metabase.lib.schema/query
   "Replace the join specified by `join-spec` in `query` at `stage-number` with `new-join`.

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -112,7 +112,10 @@
 
         (= [:joins :conditions] [first-loc last-loc])
         (throw (ex-info (i18n/tru "Cannot remove the final join condition")
-                        {:conditions (get-in stage location)}))
+                        {:error ::cannot-remove-final-join-condition
+                         :conditions (get-in stage location)
+                         :join (get-in stage (pop location))
+                         :stage stage}))
 
         (= [:joins :fields] [first-loc last-loc])
         (update-in stage (pop location) dissoc last-loc)


### PR DESCRIPTION
Fixes #34404.

This is a quick and dirty hack to make sure any dependent joins get removed and unblock the FE work on joins.
