### PR TITLE
E2E isolate mongo

### DIFF
--- a/.github/actions/build-e2e-matrix/action.yml
+++ b/.github/actions/build-e2e-matrix/action.yml
@@ -49,6 +49,7 @@ runs:
             ["visualizations", {} ],
             ["oss-subset", { edition: 'oss', context: "special" } ],
             ["slow", { runner: beefierRunner, context: "special" } ],
+            ["mongo", { context: "qa-database" } ],
           ];
 
           const config = testSets.map(([name, specialOptions]) => {

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -201,13 +201,6 @@ jobs:
         credentials:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      mongo-sample:
-        image: metabase/qa-databases:mongo-sample-4.4
-        ports:
-          - 27004:27017
-        credentials:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       mysql-sample:
         image: metabase/qa-databases:mysql-sample-8
         ports:
@@ -304,6 +297,23 @@ jobs:
           --browser ${{ steps.setup-chrome.outputs.chrome-path }}
         env:
           TERM: xterm
+
+      # Mongo
+      - name: Start Mongo server
+        if: matrix.name == 'mongo'
+        run: docker run -d -p 27004:27017 --name e2e-mongo metabase/qa-databases:mongo-sample-4.4
+      - name: Wait until the port 27004 is ready
+        run: while ! nc -z localhost 27004; do sleep 1; done
+        timeout-minutes: 3
+      - name: Run E2E tests that depend on Mongo
+        if: matrix.name == 'mongo'
+        run: |
+          yarn run test-cypress-run \
+          --env grepTags="@mongo --@quarantine",grepOmitFiltered=true \
+          --spec './e2e/test/scenarios/**/*.cy.spec.js' \
+          --browser ${{ steps.setup-chrome.outputs.chrome-path }}
+        env:
+          CYPRESS_QA_DB_MONGO: true
 
       # REPLAY.IO specific jobs
       - name: Install Replay.io browser

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -292,7 +292,7 @@ jobs:
         if: matrix.context == 'folder' && github.event_name != 'schedule'
         run: |
           yarn run test-cypress-run \
-          --env grepTags="-@slow --@quarantine",grepOmitFiltered=true \
+          --env grepTags="-@slow+-@mongo --@quarantine",grepOmitFiltered=true \
           --folder ${{ matrix.name }} \
           --browser ${{ steps.setup-chrome.outputs.chrome-path }}
         env:
@@ -338,7 +338,7 @@ jobs:
         if: matrix.context == 'folder' && github.event_name == 'schedule'
         run: |
           yarn run test-cypress-run \
-          --env grepTags="-@slow --@quarantine,grepOmitFiltered=true \
+          --env grepTags="-@slow+-@mongo --@quarantine,grepOmitFiltered=true \
           --folder ${{ matrix.name }} \
           --browser "replay-chromium"
         env:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -303,6 +303,7 @@ jobs:
         if: matrix.name == 'mongo'
         run: docker run -d -p 27004:27017 --name e2e-mongo metabase/qa-databases:mongo-sample-4.4
       - name: Wait until the port 27004 is ready
+        if: matrix.name == 'mongo'
         run: while ! nc -z localhost 27004; do sleep 1; done
         timeout-minutes: 3
       - name: Run E2E tests that depend on Mongo

--- a/e2e/snapshot-creators/qa-db.cy.snap.js
+++ b/e2e/snapshot-creators/qa-db.cy.snap.js
@@ -37,6 +37,8 @@ describe("qa databases snapshots", { tags: "@external" }, () => {
     snapshot("mysql-writable");
     deleteDatabase("mysqlID");
 
+    restoreAndAuthenticate();
+
     if (Cypress.env("QA_DB_MONGO") === true) {
       addMongoDatabase();
       snapshot("mongo-4");

--- a/e2e/snapshot-creators/qa-db.cy.snap.js
+++ b/e2e/snapshot-creators/qa-db.cy.snap.js
@@ -19,15 +19,16 @@ describe("qa databases snapshots", { tags: "@external" }, () => {
 
     restoreAndAuthenticate();
 
-    addMySQLDatabase();
-    snapshot("mysql-8");
-    deleteDatabase("mysqlID");
+    setupWritableDB("postgres");
+    addPostgresDatabase("Writable Postgres12", true);
+    snapshot("postgres-writable");
+    deleteDatabase("postgresID");
 
     restoreAndAuthenticate();
 
-    addMongoDatabase();
-    snapshot("mongo-4");
-    deleteDatabase("mongoID");
+    addMySQLDatabase();
+    snapshot("mysql-8");
+    deleteDatabase("mysqlID");
 
     restoreAndAuthenticate();
 
@@ -36,12 +37,13 @@ describe("qa databases snapshots", { tags: "@external" }, () => {
     snapshot("mysql-writable");
     deleteDatabase("mysqlID");
 
-    restoreAndAuthenticate();
+    if (Cypress.env("QA_DB_MONGO") === true) {
+      addMongoDatabase();
+      snapshot("mongo-4");
+      deleteDatabase("mongoID");
 
-    setupWritableDB("postgres");
-    addPostgresDatabase("Writable Postgres12", true);
-    snapshot("postgres-writable");
-    deleteDatabase("postgresID");
+      restoreAndAuthenticate();
+    }
 
     restore("blank");
   });

--- a/e2e/support/helpers/e2e-setup-helpers.js
+++ b/e2e/support/helpers/e2e-setup-helpers.js
@@ -3,6 +3,8 @@ export function snapshot(name) {
 }
 
 export function restore(name = "default") {
+  cy.skipOn(name.includes("mongo") && Cypress.env("QA_DB_MONGO") !== true);
+
   cy.log("Restore Data Set");
   cy.request("POST", `/api/testing/restore/${name}`);
 }

--- a/e2e/test/scenarios/admin/databases/add-new-database.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/add-new-database.cy.spec.js
@@ -151,96 +151,108 @@ describe("admin > database > add", () => {
       );
     });
 
-    it("should add Mongo database and redirect to listing", () => {
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("MongoDB").click({ force: true });
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Show advanced options").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("Additional connection string options");
+    it(
+      "should add Mongo database and redirect to listing",
+      { tags: "@mongo" },
+      () => {
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+        cy.contains("MongoDB").click({ force: true });
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+        cy.findByText("Show advanced options").click();
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+        cy.contains("Additional connection string options");
 
-      typeAndBlurUsingLabel("Display name", "QA Mongo4");
-      typeAndBlurUsingLabel("Host", "localhost");
-      typeAndBlurUsingLabel("Port", QA_MONGO_PORT);
-      typeAndBlurUsingLabel("Database name", "sample");
-      typeAndBlurUsingLabel("Username", "metabase");
-      typeAndBlurUsingLabel("Password", "metasample123");
-      typeAndBlurUsingLabel("Authentication database (optional)", "admin");
-
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Save").should("not.be.disabled").click();
-
-      cy.wait("@createDatabase");
-
-      cy.url().should("match", /\/admin\/databases\?created=true$/);
-
-      cy.findByRole("dialog").within(() => {
-        cy.findByText("We're taking a look at your database!");
-        cy.findByLabelText("close icon").click();
-      });
-
-      cy.findByRole("table").within(() => {
-        cy.findByText("QA Mongo4");
-      });
-
-      cy.findByRole("status").within(() => {
-        cy.findByText("Syncing…");
-        cy.findByText("Done!");
-      });
-    });
-
-    it("should add Mongo database via the connection string", () => {
-      const badDBString = `mongodb://metabase:metasample123@localhost:${QA_MONGO_PORT}`;
-      const badPasswordString = `mongodb://metabase:wrongPassword@localhost:${QA_MONGO_PORT}/sample?authSource=admin`;
-      const validConnectionString = `mongodb://metabase:metasample123@localhost:${QA_MONGO_PORT}/sample?authSource=admin`;
-
-      popover().findByText("MongoDB").click({ force: true });
-
-      cy.findByTestId("database-form").within(() => {
-        cy.findByText("Paste a connection string").click();
         typeAndBlurUsingLabel("Display name", "QA Mongo4");
-        cy.findByLabelText("Port").should("not.exist");
-        cy.findByLabelText("Paste your connection string").type(badDBString, {
-          delay: 0,
+        typeAndBlurUsingLabel("Host", "localhost");
+        typeAndBlurUsingLabel("Port", QA_MONGO_PORT);
+        typeAndBlurUsingLabel("Database name", "sample");
+        typeAndBlurUsingLabel("Username", "metabase");
+        typeAndBlurUsingLabel("Password", "metasample123");
+        typeAndBlurUsingLabel("Authentication database (optional)", "admin");
+
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+        cy.findByText("Save").should("not.be.disabled").click();
+
+        cy.wait("@createDatabase");
+
+        cy.url().should("match", /\/admin\/databases\?created=true$/);
+
+        cy.findByRole("dialog").within(() => {
+          cy.findByText("We're taking a look at your database!");
+          cy.findByLabelText("close icon").click();
         });
 
-        cy.button("Save").should("not.be.disabled").click();
-        cy.findByText(/No database name specified/);
-        cy.button("Failed");
+        cy.findByRole("table").within(() => {
+          cy.findByText("QA Mongo4");
+        });
 
-        cy.findByLabelText("Paste your connection string")
-          .clear()
-          .type(badPasswordString);
+        cy.findByRole("status").within(() => {
+          cy.findByText("Syncing…");
+          cy.findByText("Done!");
+        });
+      },
+    );
 
-        cy.button("Save", { timeout: 7000 }).should("not.be.disabled").click();
-        cy.findByText(/Exception authenticating MongoCredential/);
-        cy.button("Failed");
+    it(
+      "should add Mongo database via the connection string",
+      { tags: "@mongo" },
+      () => {
+        const badDBString = `mongodb://metabase:metasample123@localhost:${QA_MONGO_PORT}`;
+        const badPasswordString = `mongodb://metabase:wrongPassword@localhost:${QA_MONGO_PORT}/sample?authSource=admin`;
+        const validConnectionString = `mongodb://metabase:metasample123@localhost:${QA_MONGO_PORT}/sample?authSource=admin`;
 
-        cy.findByLabelText("Paste your connection string")
-          .clear()
-          .type(validConnectionString);
+        popover().findByText("MongoDB").click({ force: true });
 
-        cy.button("Save", { timeout: 7000 }).should("not.be.disabled").click();
-      });
+        cy.findByTestId("database-form").within(() => {
+          cy.findByText("Paste a connection string").click();
+          typeAndBlurUsingLabel("Display name", "QA Mongo4");
+          cy.findByLabelText("Port").should("not.exist");
+          cy.findByLabelText("Paste your connection string").type(badDBString, {
+            delay: 0,
+          });
 
-      cy.wait("@createDatabase");
+          cy.button("Save").should("not.be.disabled").click();
+          cy.findByText(/No database name specified/);
+          cy.button("Failed");
 
-      cy.url().should("match", /\/admin\/databases\?created=true$/);
+          cy.findByLabelText("Paste your connection string")
+            .clear()
+            .type(badPasswordString);
 
-      cy.findByRole("dialog").within(() => {
-        cy.findByText("We're taking a look at your database!");
-        cy.findByLabelText("close icon").click();
-      });
+          cy.button("Save", { timeout: 7000 })
+            .should("not.be.disabled")
+            .click();
+          cy.findByText(/Exception authenticating MongoCredential/);
+          cy.button("Failed");
 
-      cy.findByRole("table").within(() => {
-        cy.findByText("QA Mongo4");
-      });
+          cy.findByLabelText("Paste your connection string")
+            .clear()
+            .type(validConnectionString);
 
-      cy.findByRole("status").within(() => {
-        cy.findByText("Syncing…");
-        cy.findByText("Done!");
-      });
-    });
+          cy.button("Save", { timeout: 7000 })
+            .should("not.be.disabled")
+            .click();
+        });
+
+        cy.wait("@createDatabase");
+
+        cy.url().should("match", /\/admin\/databases\?created=true$/);
+
+        cy.findByRole("dialog").within(() => {
+          cy.findByText("We're taking a look at your database!");
+          cy.findByLabelText("close icon").click();
+        });
+
+        cy.findByRole("table").within(() => {
+          cy.findByText("QA Mongo4");
+        });
+
+        cy.findByRole("status").within(() => {
+          cy.findByText("Syncing…");
+          cy.findByText("Done!");
+        });
+      },
+    );
 
     it("should add MySQL database and redirect to listing", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/native/native-mongo.cy.spec.js
+++ b/e2e/test/scenarios/native/native-mongo.cy.spec.js
@@ -2,7 +2,7 @@ import { restore, modal } from "e2e/support/helpers";
 
 const MONGO_DB_NAME = "QA Mongo4";
 
-describe("scenarios > question > native > mongo", { tags: "@external" }, () => {
+describe("scenarios > question > native > mongo", { tags: "@mongo" }, () => {
   before(() => {
     cy.intercept("POST", "/api/card").as("createQuestion");
     cy.intercept("POST", "/api/dataset").as("dataset");

--- a/e2e/test/scenarios/native/reproductions/15946-mongo-pre-select-table.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/15946-mongo-pre-select-table.cy.spec.js
@@ -2,7 +2,7 @@ import { popover, restore, startNewQuestion } from "e2e/support/helpers";
 
 const MONGO_DB_NAME = "QA Mongo4";
 
-describe("issue 15946", { tags: "@external" }, () => {
+describe("issue 15946", { tags: "@mongo" }, () => {
   before(() => {
     restore("mongo-4");
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/native/reproductions/32121-sql-source-query-can-explore-results.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/32121-sql-source-query-can-explore-results.cy.spec.js
@@ -37,7 +37,7 @@ describe("issue 32121", () => {
     });
   });
 
-  describe("on native Mongo questions", { tags: "@external" }, () => {
+  describe("on native Mongo questions", { tags: "@mongo" }, () => {
     before(() => {
       restore("mongo-4");
       cy.signInAsAdmin();

--- a/e2e/test/scenarios/question/reproductions/13097-mongo-apply-distinct-count-multiple-columns.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/13097-mongo-apply-distinct-count-multiple-columns.cy.spec.js
@@ -8,7 +8,7 @@ import {
 
 const MONGO_DB_ID = 2;
 
-describe("issue 13097", { tags: "@external" }, () => {
+describe("issue 13097", { tags: "@mongo" }, () => {
   beforeEach(() => {
     restore("mongo-4");
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.cy.spec.js
@@ -1,7 +1,7 @@
 import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { restore, popover, visualize, openTable } from "e2e/support/helpers";
 
-describe("issue 17963", { tags: "@external" }, () => {
+describe("issue 17963", { tags: "@mongo" }, () => {
   beforeEach(() => {
     restore("mongo-4");
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/visualizations/reproductions/16170-line-mongo-replace-missing-values.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/16170-line-mongo-replace-missing-values.cy.spec.js
@@ -7,7 +7,7 @@ import {
 
 const externalDatabaseId = 2;
 
-describe("issue 16170", { tags: "@external" }, () => {
+describe("issue 16170", { tags: "@mongo" }, () => {
   beforeEach(() => {
     restore("mongo-4");
     cy.signInAsAdmin();


### PR DESCRIPTION
This PR isolates Mongo related E2E tests and runs them in a separate process.

This helps ease the load on the CI runner by not having to spin up unneeded [service container](https://docs.github.com/en/actions/using-containerized-services/about-service-containers).