### PR TITLE
BE: Remove linked filters from dashboard if values source type is not "From connected fields"

### DIFF
--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -127,19 +127,23 @@
   [dashboard]
   (update-dashboard-subscription-pulses! dashboard))
 
+(defn- migrate-parameter [p]
+  (cond-> p
+    ;; It was previously possible for parameters to have empty strings for :name and
+    ;; :slug, but these are now required to be non-blank strings. (metabase#24500)
+    (or (= (:name p) "")
+        (= (:slug p) ""))
+    (assoc :name "unnamed" :slug "unnamed")
+    ;; We don't support linked filters for parameters with :values_source_type of anything except nil,
+    ;; but it was previously possible to set :values_source_type to "static-list" or "card" and still
+    ;; have linked filters. (metabase#33892)
+    (some? (:values_source_type p))
+    (dissoc :filteringParameters)))
+
 (defn- migrate-parameters-list
   "Update the `:parameters` list of a dashboard from legacy formats."
   [dashboard]
-  (cond-> dashboard
-    (:parameters dashboard)
-    (update :parameters (fn [params]
-                          (for [p params]
-                            (cond-> p
-                              ;; It was previously possible for parameters to have empty strings for :name and
-                              ;; :slug, but these are now required to be non-blank strings.
-                              (or (= (:name p) "")
-                                  (= (:slug p) ""))
-                              (assoc :name "unnamed" :slug "unnamed")))))))
+  (m/update-existing dashboard :parameters #(map migrate-parameter %)))
 
 (t2/define-after-select :model/Dashboard
   [dashboard]

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -648,13 +648,36 @@
           (is (= nil
                  (:public_uuid dashboard))))))))
 
-(deftest migrate-parameters-list-test
+(def default-parameter
+  {:id   "_CATEGORY_NAME_"
+   :type "category"
+   :name "Category Name"
+   :slug "category_name"})
+
+(deftest migrate-parameters-with-linked-filters-and-values-source-type-test
+  (testing "test that a Dashboard's :parameters filterParameters are cleared if the :values_source_type is not nil"
+    (doseq [[values_source_type
+             keep-filtering-parameters?] {"card"        false
+                                          "static-list" false
+                                          nil           true}]
+      (testing (format "\nvalues_source_type=%s" values_source_type)
+       (mt/with-temp [:model/Dashboard dashboard {:parameters [(merge
+                                                                default-parameter
+                                                                {:filteringParameters ["other-param-id"]
+                                                                 :values_source_type  values_source_type})]}]
+         (let [parameter (first (:parameters dashboard))]
+           (if keep-filtering-parameters?
+             (is (= ["other-param-id"]
+                    (:filteringParameters parameter)))
+             (is (not (contains? parameter :filteringParameters))))))))))
+
+(deftest migrate-parameters-empty-name-test
   (testing "test that a Dashboard's :parameters is selected with a non-nil name and slug"
     (doseq [[name slug] [["" ""] ["" "slug"] ["name" ""]]]
-      (mt/with-temp [:model/Dashboard dashboard {:parameters [{:id   "_CATEGORY_NAME_"
-                                                               :type "category"
-                                                               :name name
-                                                               :slug slug}]}]
+      (mt/with-temp [:model/Dashboard dashboard {:parameters [(merge
+                                                               default-parameter
+                                                               {:name name
+                                                                :slug slug})]}]
         (is (=? {:name "unnamed"
                  :slug "unnamed"}
                 (first (:parameters dashboard))))))))
@@ -684,42 +707,38 @@
         (is (not (nil? (t2/select-one PulseCard :card_id new-card-id))))))))
 
 (deftest parameter-card-test
-  (let [default-params {:name       "Category Name"
-                        :slug       "category_name"
-                        :id         "_CATEGORY_NAME_"
-                        :type       "category"}]
-    (testing "A new dashboard creates a new ParameterCard"
-      (t2.with-temp/with-temp [Card      {card-id :id}      {}
-                               Dashboard {dashboard-id :id} {:parameters [(merge default-params
-                                                                                 {:values_source_type    "card"
-                                                                                  :values_source_config {:card_id card-id}})]}]
-        (is (=? {:card_id                   card-id
-                 :parameterized_object_type :dashboard
-                 :parameterized_object_id   dashboard-id
-                 :parameter_id              "_CATEGORY_NAME_"}
-                (t2/select-one 'ParameterCard :card_id card-id)))))
+  (testing "A new dashboard creates a new ParameterCard"
+    (t2.with-temp/with-temp [Card      {card-id :id}      {}
+                             Dashboard {dashboard-id :id} {:parameters [(merge default-parameter
+                                                                               {:values_source_type    "card"
+                                                                                :values_source_config {:card_id card-id}})]}]
+      (is (=? {:card_id                   card-id
+               :parameterized_object_type :dashboard
+               :parameterized_object_id   dashboard-id
+               :parameter_id              "_CATEGORY_NAME_"}
+              (t2/select-one 'ParameterCard :card_id card-id)))))
 
-    (testing "Adding a card_id creates a new ParameterCard"
-      (t2.with-temp/with-temp [Card      {card-id :id}      {}
-                               Dashboard {dashboard-id :id} {:parameters [default-params]}]
-        (is (nil? (t2/select-one 'ParameterCard :card_id card-id)))
-        (t2/update! Dashboard dashboard-id {:parameters [(merge default-params
-                                                                {:values_source_type    "card"
-                                                                 :values_source_config {:card_id card-id}})]})
-        (is (=? {:card_id                   card-id
-                 :parameterized_object_type :dashboard
-                 :parameterized_object_id   dashboard-id
-                 :parameter_id              "_CATEGORY_NAME_"}
-                (t2/select-one 'ParameterCard :card_id card-id)))))
+  (testing "Adding a card_id creates a new ParameterCard"
+    (t2.with-temp/with-temp [Card      {card-id :id}      {}
+                             Dashboard {dashboard-id :id} {:parameters [default-parameter]}]
+      (is (nil? (t2/select-one 'ParameterCard :card_id card-id)))
+      (t2/update! Dashboard dashboard-id {:parameters [(merge default-parameter
+                                                              {:values_source_type    "card"
+                                                               :values_source_config {:card_id card-id}})]})
+      (is (=? {:card_id                   card-id
+               :parameterized_object_type :dashboard
+               :parameterized_object_id   dashboard-id
+               :parameter_id              "_CATEGORY_NAME_"}
+              (t2/select-one 'ParameterCard :card_id card-id)))))
 
-    (testing "Removing a card_id deletes old ParameterCards"
-      (t2.with-temp/with-temp [Card      {card-id :id}      {}
-                               Dashboard {dashboard-id :id} {:parameters [(merge default-params
-                                                                                 {:values_source_type    "card"
-                                                                                  :values_source_config {:card_id card-id}})]}]
+  (testing "Removing a card_id deletes old ParameterCards"
+    (t2.with-temp/with-temp [Card      {card-id :id}      {}
+                             Dashboard {dashboard-id :id} {:parameters [(merge default-parameter
+                                                                               {:values_source_type    "card"
+                                                                                :values_source_config {:card_id card-id}})]}]
         ;; same setup as earlier test, we know the ParameterCard exists right now
-        (t2/delete! Dashboard :id dashboard-id)
-        (is (nil? (t2/select-one 'ParameterCard :card_id card-id)))))))
+      (t2/delete! Dashboard :id dashboard-id)
+      (is (nil? (t2/select-one 'ParameterCard :card_id card-id))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                         Collections Permissions Tests                                          |


### PR DESCRIPTION
BE part of #33892. Read [this comment](https://github.com/metabase/metabase/issues/33892#issuecomment-1752488489) to understand why this change is needed. 

Effectively migrates dashboard parameters on demand as they come out of the database.

In English the migration does the following:

IF the parameter has a "linked filter" (aka "filtering param" in the code) and "Where values should come from" is not "From connected fields" (in the code, values_source_config is not nil):

THEN remove the linked filters from the parameter.
