### PR TITLE
FE: Do not show linked filter options if the parameter has values_source_type of "static-list" or "card"

### DIFF
--- a/frontend/src/metabase/parameters/components/ParameterLinkedFilters/ParameterLinkedFilters.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterLinkedFilters/ParameterLinkedFilters.tsx
@@ -68,31 +68,11 @@ const ParameterLinkedFilters = ({
     [],
   );
 
-  let disableReason = null;
-  if (usableParameters.length === 0) {
-    disableReason = (
-      <div>
-        <SectionMessage>
-          {t`If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one.`}
-        </SectionMessage>
-        <SectionMessage>
-          {jt`So first, ${(
-            <SectionMessageLink key="link" onClick={onShowAddParameterPopover}>
-              {t`add another dashboard filter`}
-            </SectionMessageLink>
-          )}.`}
-        </SectionMessage>
-      </div>
-    );
-  } else if (parameter.values_source_type != null) {
-    disableReason = (
-      <div>
-        <SectionMessage>
-          {t`If the filter has values that are from another question or model, or a custom list, then this filter can't be limited by another dashboard filter.`}
-        </SectionMessage>
-      </div>
-    );
-  }
+  const disableReason = getDisableReason({
+    usableParameters,
+    parameter,
+    onShowAddParameterPopover,
+  });
 
   return (
     <SectionRoot>
@@ -120,6 +100,42 @@ const ParameterLinkedFilters = ({
     </SectionRoot>
   );
 };
+
+function getDisableReason({
+  usableParameters,
+  parameter,
+  onShowAddParameterPopover,
+}: {
+  usableParameters: Parameter[];
+  parameter: Parameter;
+  onShowAddParameterPopover: () => void;
+}): JSX.Element | null {
+  if (usableParameters.length === 0) {
+    return (
+      <div>
+        <SectionMessage>
+          {t`If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one.`}
+        </SectionMessage>
+        <SectionMessage>
+          {jt`So first, ${(
+            <SectionMessageLink key="link" onClick={onShowAddParameterPopover}>
+              {t`add another dashboard filter`}
+            </SectionMessageLink>
+          )}.`}
+        </SectionMessage>
+      </div>
+    );
+  } else if (parameter.values_source_type != null) {
+    return (
+      <div>
+        <SectionMessage>
+          {t`If the filter has values that are from another question or model, or a custom list, then this filter can't be limited by another dashboard filter.`}
+        </SectionMessage>
+      </div>
+    );
+  }
+  return null;
+}
 
 interface LinkedParameterProps {
   parameter: Parameter;

--- a/frontend/src/metabase/parameters/components/ParameterLinkedFilters/ParameterLinkedFilters.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterLinkedFilters/ParameterLinkedFilters.tsx
@@ -68,26 +68,36 @@ const ParameterLinkedFilters = ({
     [],
   );
 
+  let disableReason = null;
+  if (usableParameters.length === 0) {
+    disableReason = (
+      <div>
+        <SectionMessage>
+          {t`If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one.`}
+        </SectionMessage>
+        <SectionMessage>
+          {jt`So first, ${(
+            <SectionMessageLink key="link" onClick={onShowAddParameterPopover}>
+              {t`add another dashboard filter`}
+            </SectionMessageLink>
+          )}.`}
+        </SectionMessage>
+      </div>
+    );
+  } else if (parameter.values_source_type != null) {
+    disableReason = (
+      <div>
+        <SectionMessage>
+          {t`If the filter has values that are from another question or model, or a custom list, then this filter can't be limited by another dashboard filter.`}
+        </SectionMessage>
+      </div>
+    );
+  }
+
   return (
     <SectionRoot>
       <SectionHeader>{t`Limit this filter's choices`}</SectionHeader>
-      {usableParameters.length === 0 ? (
-        <div>
-          <SectionMessage>
-            {t`If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one.`}
-          </SectionMessage>
-          <SectionMessage>
-            {jt`So first, ${(
-              <SectionMessageLink
-                key="link"
-                onClick={onShowAddParameterPopover}
-              >
-                {t`add another dashboard filter`}
-              </SectionMessageLink>
-            )}.`}
-          </SectionMessage>
-        </div>
-      ) : (
+      {disableReason || (
         <div>
           <SectionMessage>
             {jt`If you toggle on one of these dashboard filters, selecting a value for that filter will limit the available choices for ${(

--- a/frontend/src/metabase/parameters/components/ParameterLinkedFilters/ParameterLinkedFilters.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterLinkedFilters/ParameterLinkedFilters.tsx
@@ -38,27 +38,107 @@ const ParameterLinkedFilters = ({
   onChangeFilteringParameters,
   onShowAddParameterPopover,
 }: ParameterLinkedFiltersProps): JSX.Element => {
-  const [expandedParameterId, setExpandedParameterId] = useState<ParameterId>();
-
-  const filteringParameters = useMemo(
-    () => parameter.filteringParameters ?? [],
-    [parameter],
-  );
-
   const usableParameters = useMemo(
     () => otherParameters.filter(usableAsLinkedFilter),
     [otherParameters],
   );
 
+  return (
+    <SectionRoot>
+      <SectionHeader>{t`Limit this filter's choices`}</SectionHeader>
+      <Content
+        usableParameters={usableParameters}
+        parameter={parameter}
+        onChangeFilteringParameters={onChangeFilteringParameters}
+        onShowAddParameterPopover={onShowAddParameterPopover}
+      />
+    </SectionRoot>
+  );
+};
+
+function Content({
+  usableParameters,
+  parameter,
+  onChangeFilteringParameters,
+  onShowAddParameterPopover,
+}: {
+  usableParameters: Parameter[];
+  parameter: Parameter;
+  onChangeFilteringParameters: (filteringParameters: ParameterId[]) => void;
+  onShowAddParameterPopover: () => void;
+}) {
+  if (usableParameters.length === 0) {
+    return (
+      <NoUsableParameters
+        onShowAddParameterPopover={onShowAddParameterPopover}
+      />
+    );
+  }
+  if (parameter.values_source_type != null) {
+    return <ParametersFromOtherSource />;
+  }
+  return (
+    <UsableParameters
+      parameter={parameter}
+      usableParameters={usableParameters}
+      onChangeFilteringParameters={onChangeFilteringParameters}
+    />
+  );
+}
+
+function NoUsableParameters({
+  onShowAddParameterPopover,
+}: {
+  onShowAddParameterPopover: () => void;
+}): JSX.Element {
+  return (
+    <div>
+      <SectionMessage>
+        {t`If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one.`}
+      </SectionMessage>
+      <SectionMessage>
+        {jt`So first, ${(
+          <SectionMessageLink key="link" onClick={onShowAddParameterPopover}>
+            {t`add another dashboard filter`}
+          </SectionMessageLink>
+        )}.`}
+      </SectionMessage>
+    </div>
+  );
+}
+
+function ParametersFromOtherSource(): JSX.Element {
+  return (
+    <div>
+      <SectionMessage>
+        {t`If the filter has values that are from another question or model, or a custom list, then this filter can't be limited by another dashboard filter.`}
+      </SectionMessage>
+    </div>
+  );
+}
+
+function UsableParameters({
+  parameter,
+  usableParameters,
+  onChangeFilteringParameters,
+}: {
+  parameter: Parameter;
+  usableParameters: Parameter[];
+  onChangeFilteringParameters: (filteringParameters: ParameterId[]) => void;
+}): JSX.Element {
+  const [expandedParameterId, setExpandedParameterId] = useState<ParameterId>();
+
   const handleFilterChange = useCallback(
     (otherParameter: Parameter, isFiltered: boolean) => {
       const newParameters = isFiltered
-        ? filteringParameters.concat(otherParameter.id)
-        : filteringParameters.filter(id => id !== otherParameter.id);
+        ? (parameter.filteringParameters ?? []).concat(otherParameter.id)
+        : (parameter.filteringParameters ?? []).filter(
+            id => id !== otherParameter.id,
+          );
 
       onChangeFilteringParameters(newParameters);
     },
-    [filteringParameters, onChangeFilteringParameters],
+    [parameter.filteringParameters, onChangeFilteringParameters],
   );
 
   const handleExpandedChange = useCallback(
@@ -68,73 +148,28 @@ const ParameterLinkedFilters = ({
     [],
   );
 
-  const disableReason = getDisableReason({
-    usableParameters,
-    parameter,
-    onShowAddParameterPopover,
-  });
-
   return (
-    <SectionRoot>
-      <SectionHeader>{t`Limit this filter's choices`}</SectionHeader>
-      {disableReason || (
-        <div>
-          <SectionMessage>
-            {jt`If you toggle on one of these dashboard filters, selecting a value for that filter will limit the available choices for ${(
-              <em key="text">{t`this`}</em>
-            )} filter.`}
-          </SectionMessage>
-          {usableParameters.map(otherParameter => (
-            <LinkedParameter
-              key={otherParameter.id}
-              parameter={parameter}
-              otherParameter={otherParameter}
-              isFiltered={filteringParameters.includes(otherParameter.id)}
-              isExpanded={otherParameter.id === expandedParameterId}
-              onFilterChange={handleFilterChange}
-              onExpandedChange={handleExpandedChange}
-            />
-          ))}
-        </div>
-      )}
-    </SectionRoot>
+    <div>
+      <SectionMessage>
+        {jt`If you toggle on one of these dashboard filters, selecting a value for that filter will limit the available choices for ${(
+          <em key="text">{t`this`}</em>
+        )} filter.`}
+      </SectionMessage>
+      {usableParameters.map(otherParameter => (
+        <LinkedParameter
+          key={otherParameter.id}
+          parameter={parameter}
+          otherParameter={otherParameter}
+          isFiltered={
+            !!parameter.filteringParameters?.includes(otherParameter.id)
+          }
+          isExpanded={otherParameter.id === expandedParameterId}
+          onFilterChange={handleFilterChange}
+          onExpandedChange={handleExpandedChange}
+        />
+      ))}
+    </div>
   );
-};
-
-function getDisableReason({
-  usableParameters,
-  parameter,
-  onShowAddParameterPopover,
-}: {
-  usableParameters: Parameter[];
-  parameter: Parameter;
-  onShowAddParameterPopover: () => void;
-}): JSX.Element | null {
-  if (usableParameters.length === 0) {
-    return (
-      <div>
-        <SectionMessage>
-          {t`If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one.`}
-        </SectionMessage>
-        <SectionMessage>
-          {jt`So first, ${(
-            <SectionMessageLink key="link" onClick={onShowAddParameterPopover}>
-              {t`add another dashboard filter`}
-            </SectionMessageLink>
-          )}.`}
-        </SectionMessage>
-      </div>
-    );
-  } else if (parameter.values_source_type != null) {
-    return (
-      <div>
-        <SectionMessage>
-          {t`If the filter has values that are from another question or model, or a custom list, then this filter can't be limited by another dashboard filter.`}
-        </SectionMessage>
-      </div>
-    );
-  }
-  return null;
 }
 
 interface LinkedParameterProps {

--- a/frontend/src/metabase/parameters/components/ParameterLinkedFilters/ParameterLinkedFilters.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterLinkedFilters/ParameterLinkedFilters.unit.spec.tsx
@@ -44,4 +44,30 @@ describe("ParameterLinkedFilters", () => {
 
     expect(onChangeFilteringParameters).toHaveBeenCalledWith(["p2"]);
   });
+
+  it("should not show linked filter options if the parameter has a custom list source", () => {
+    setup({
+      parameter: createMockUiParameter({
+        id: "p1",
+        name: "P1",
+        values_source_type: "static-list",
+        values_source_config: {
+          values: ["foo", "bar"],
+        },
+      }),
+      otherParameters: [
+        createMockUiParameter({
+          id: "p2",
+          name: "P2",
+        }),
+      ],
+    });
+
+    expect(
+      screen.getByText(
+        "If the filter has values that are from another question or model, or a custom list, then this filter can't be limited by another dashboard filter.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/metabase/parameters/components/ParameterLinkedFilters/ParameterLinkedFilters.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterLinkedFilters/ParameterLinkedFilters.unit.spec.tsx
@@ -1,5 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders, screen } from "__support__/ui";
+import type { ValuesSourceType } from "metabase-types/api/parameters";
 import type { UiParameter } from "metabase-lib/parameters/types";
 import { createMockUiParameter } from "metabase-lib/parameters/mock";
 import ParameterLinkedFilters from "./ParameterLinkedFilters";
@@ -45,29 +46,32 @@ describe("ParameterLinkedFilters", () => {
     expect(onChangeFilteringParameters).toHaveBeenCalledWith(["p2"]);
   });
 
-  it("should not show linked filter options if the parameter has a custom list source", () => {
-    setup({
-      parameter: createMockUiParameter({
-        id: "p1",
-        name: "P1",
-        values_source_type: "static-list",
-        values_source_config: {
-          values: ["foo", "bar"],
-        },
-      }),
-      otherParameters: [
-        createMockUiParameter({
-          id: "p2",
-          name: "P2",
+  it.each(["static-list", "card"])(
+    "should not show linked filter options if the parameter has a %s source",
+    valuesSourceType => {
+      setup({
+        parameter: createMockUiParameter({
+          id: "p1",
+          name: "P1",
+          values_source_type: valuesSourceType as ValuesSourceType,
+          values_source_config: {
+            values: ["foo", "bar"],
+          },
         }),
-      ],
-    });
+        otherParameters: [
+          createMockUiParameter({
+            id: "p2",
+            name: "P2",
+          }),
+        ],
+      });
 
-    expect(
-      screen.getByText(
-        "If the filter has values that are from another question or model, or a custom list, then this filter can't be limited by another dashboard filter.",
-      ),
-    ).toBeInTheDocument();
-    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
-  });
+      expect(
+        screen.getByText(
+          "If the filter has values that are from another question or model, or a custom list, then this filter can't be limited by another dashboard filter.",
+        ),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+    },
+  );
 });


### PR DESCRIPTION
Part 2 out of 3 for #33892, see comment [here](https://github.com/metabase/metabase/issues/33892#issuecomment-1752488489) for the plan.

Part 1 is here and can be merged separately: #34424

This PR prevents users from linking dashboard filter's values to another filter if the filter's values source is not compatible with linked filters.

Linked filters only work if a filter has "From connected fields" selected under "Where values should come from" in the filter settings (this corresponds to `values_source_config != undefined` in the code).