### PR TITLE
Improve E2E matrix generation and simplify job conditionals

### DIFF
--- a/.github/actions/build-e2e-matrix/action.yml
+++ b/.github/actions/build-e2e-matrix/action.yml
@@ -18,57 +18,46 @@ runs:
           const defaultRunner = "ubuntu-22.04";
           const beefierRunner = "buildjet-2vcpu-ubuntu-2204";
 
-          const folderContext = [
-            "actions",
-            "admin",
-            "admin-2",
-            "binning",
-            "collections",
-            "custom-column",
-            "dashboard",
-            "dashboard-cards",
-            "dashboard-filters",
-            "embedding",
-            "filters",
-            "joins",
-            "models",
-            "native",
-            "native-filters",
-            "onboarding",
-            "organization",
-            "permissions",
-            "question",
-            "sharing",
-            "visualizations",
+          const defaultOptions = {
+            "java-version": java,
+            runner: defaultRunner,
+            edition: "ee",
+            context: "folder"
+          };
+
+          const testSets = [
+            ["actions", {} ],
+            ["admin", {} ],
+            ["admin-2", {} ],
+            ["binning", {} ],
+            ["collections", {} ],
+            ["custom-column", {} ],
+            ["dashboard", {} ],
+            ["dashboard-cards", {} ],
+            ["dashboard-filters", {} ],
+            ["embedding", {} ],
+            ["filters", {} ],
+            ["joins", {} ],
+            ["models", {} ],
+            ["native", {} ],
+            ["native-filters", {} ],
+            ["onboarding", {} ],
+            ["organization", {} ],
+            ["permissions", {} ],
+            ["question", {} ],
+            ["sharing", {} ],
+            ["visualizations", {} ],
+            ["oss-subset", { edition: 'oss', context: "special" } ],
+            ["slow", { runner: beefierRunner, context: "special" } ],
           ];
 
-          const specialContext = ["oss-subset", "slow"];
-
-          const defaultConfig = folderContext.map(folder => {
+          const config = testSets.map(([name, specialOptions]) => {
             return {
-              "java-version": java,
-              folder,
-              runner: defaultRunner,
-              edition: "ee",
-            };
+              ...defaultOptions,
+              ...specialOptions,
+              name,
+            }
           });
 
-          const extraConfig = specialContext.map(s => {
-            return {
-              "java-version": java,
-              context: s,
-              runner: getRunner(s),
-              edition: getEdition(s),
-            };
-          });
-
-          function getRunner(context) {
-            return context === "slow" ? beefierRunner : defaultRunner;
-          }
-
-          function getEdition(context) {
-            return context === "oss-subset" ? "oss" : "ee";
-          }
-
-          const matrix = { include: [...defaultConfig, ...extraConfig] };
+          const matrix = { include: config };
           return matrix;

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -295,12 +295,12 @@ jobs:
         env:
           TERM: xterm
 
-      - name: Run EE Cypress tests on ${{ matrix.folder }}
+      - name: Run EE Cypress tests on ${{ matrix.name }}
         if: matrix.context == 'folder' && github.event_name != 'schedule'
         run: |
           yarn run test-cypress-run \
           --env grepTags="-@slow --@quarantine",grepOmitFiltered=true \
-          --folder ${{ matrix.folder }} \
+          --folder ${{ matrix.name }} \
           --browser ${{ steps.setup-chrome.outputs.chrome-path }}
         env:
           TERM: xterm
@@ -323,12 +323,12 @@ jobs:
           RECORD_REPLAY_METADATA_FILE: /tmp/replay-metadata.json
           RECORD_REPLAY_METADATA_TEST_RUN_ID: ${{ needs.test-run-id.outputs.testRunId }}
 
-      - name: Run EE Cypress tests on ${{ matrix.folder }} using Replay.io browser
+      - name: Run EE Cypress tests on ${{ matrix.name }} using Replay.io browser
         if: matrix.context == 'folder' && github.event_name == 'schedule'
         run: |
           yarn run test-cypress-run \
           --env grepTags="-@slow --@quarantine,grepOmitFiltered=true \
-          --folder ${{ matrix.folder }} \
+          --folder ${{ matrix.name }} \
           --browser "replay-chromium"
         env:
           TERM: xterm
@@ -347,7 +347,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: cypress-recording-${{ matrix.folder }}${{ matrix.context }}-${{ matrix.edition }}
+          name: cypress-recording-${{ matrix.name }}-${{ matrix.edition }}
           path: |
             ./cypress
             ./logs/test.log

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -156,7 +156,7 @@ jobs:
       (needs.download_uberjar.result == 'success' || needs.build.result == 'success')
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
-    name: e2e-tests-${{ matrix.folder }}${{ matrix.context }}-${{ matrix.edition }}
+    name: e2e-tests-${{ matrix.name }}-${{ matrix.edition }}
     env:
       MB_EDITION: ${{ matrix.edition }}
       DISPLAY: ""
@@ -286,7 +286,7 @@ jobs:
           TERM: xterm
 
       - name: Run slow and resource-intensive Cypress tests
-        if: matrix.context == 'slow' && github.event_name != 'schedule'
+        if: matrix.name == 'slow' && github.event_name != 'schedule'
         run: |
           yarn run test-cypress-run \
           --env grepTags="@slow",grepOmitFiltered=true \
@@ -296,7 +296,7 @@ jobs:
           TERM: xterm
 
       - name: Run EE Cypress tests on ${{ matrix.folder }}
-        if: matrix.edition == 'ee' && github.event_name != 'schedule' && matrix.context != 'slow'
+        if: matrix.context == 'folder' && github.event_name != 'schedule'
         run: |
           yarn run test-cypress-run \
           --env grepTags="-@slow --@quarantine",grepOmitFiltered=true \
@@ -324,7 +324,7 @@ jobs:
           RECORD_REPLAY_METADATA_TEST_RUN_ID: ${{ needs.test-run-id.outputs.testRunId }}
 
       - name: Run EE Cypress tests on ${{ matrix.folder }} using Replay.io browser
-        if: matrix.edition == 'ee' && github.event_name == 'schedule' && matrix.context != 'slow'
+        if: matrix.context == 'folder' && github.event_name == 'schedule'
         run: |
           yarn run test-cypress-run \
           --env grepTags="-@slow --@quarantine,grepOmitFiltered=true \
@@ -362,7 +362,7 @@ jobs:
       needs.download_uberjar.result == 'skipped'
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 5
-    name: e2e-tests-${{ matrix.folder }}${{ matrix.context }}-${{ matrix.edition }}
+    name: e2e-tests-${{ matrix.name }}-${{ matrix.edition }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.e2e-matrix-builder.outputs.matrix) }}


### PR DESCRIPTION
This PR is basically @iethree 's suggestion from the previous PR
https://github.com/metabase/metabase/pull/34431#discussion_r1348790394

I had to slightly change the keys and the logic to accommodate for:
- job names logic
- conditional step logic within a single job

The resulting matrix now looks like:
```js
{
    "include": [
        {
            "java-version": 11,
            "runner": "ubuntu-22.04",
            "edition": "ee",
            "context": "folder",
            "name": "actions"
        },
        {
            "java-version": 11,
            "runner": "ubuntu-22.04",
            "edition": "ee",
            "context": "folder",
            "name": "admin"
        },
        { ... },
        {
            "java-version": 11,
            "runner": "ubuntu-22.04",
            "edition": "ee",
            "context": "folder",
            "name": "sharing"
        },
        {
            "java-version": 11,
            "runner": "ubuntu-22.04",
            "edition": "ee",
            "context": "folder",
            "name": "visualizations"
        },
        {
            "java-version": 11,
            "runner": "ubuntu-22.04",
            "edition": "oss",
            "context": "special",
            "name": "oss-subset"
        },
        {
            "java-version": 11,
            "runner": "buildjet-2vcpu-ubuntu-2204",
            "edition": "ee",
            "context": "special",
            "name": "slow"
        }
    ]
}
```

Which allows us to generate a job name like this:
```diff
-  name: e2e-tests-${{ matrix.folder }}${{ matrix.context }}-${{ matrix.edition }}
+  name: e2e-tests-${{ matrix.name }}-${{ matrix.edition }}
```

And to simplify conditional step execution like this:
```diff
-  if: matrix.edition == 'ee' && github.event_name != 'schedule' && matrix.context != 'slow'
+  if: matrix.context == 'folder' && github.event_name != 'schedule'
```

AND

It will unblock https://github.com/metabase/metabase/pull/34423

---

> **Note**
> I will backport a few related PRs together. Hence, why `no-backport` label.