### PR TITLE
[MLv2] Coordinate Filter Picker

### DIFF
--- a/frontend/src/metabase-lib/filter.ts
+++ b/frontend/src/metabase-lib/filter.ts
@@ -478,6 +478,7 @@ export function filterParts(
   return (
     stringFilterParts(query, stageIndex, filterClause) ??
     numberFilterParts(query, stageIndex, filterClause) ??
+    coordinateFilterParts(query, stageIndex, filterClause) ??
     booleanFilterParts(query, stageIndex, filterClause) ??
     specificDateFilterParts(query, stageIndex, filterClause) ??
     relativeDateFilterParts(query, stageIndex, filterClause) ??

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -200,7 +200,8 @@ export type FilterOperatorName =
   | NumberFilterOperatorName
   | BooleanFilterOperatorName
   | SpecificDateFilterOperatorName
-  | ExcludeDateFilterOperatorName;
+  | ExcludeDateFilterOperatorName
+  | CoordinateFilterOperatorName;
 
 export type StringFilterOperatorName = typeof STRING_FILTER_OPERATORS[number];
 
@@ -237,7 +238,8 @@ export type FilterParts =
   | SpecificDateFilterParts
   | RelativeDateFilterParts
   | ExcludeDateFilterParts
-  | TimeFilterParts;
+  | TimeFilterParts
+  | CoordinateFilterParts;
 
 export type DateParts = {
   year: number;

--- a/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/CoordinateColumnSelect.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/CoordinateColumnSelect.tsx
@@ -1,0 +1,69 @@
+import { t } from "ttag";
+import * as Lib from "metabase-lib";
+
+import { Stack, Select } from "metabase/ui";
+
+import {
+  getColumnOptions,
+  getColumnIdentifier,
+  findLatitudeColumns,
+  findLongitudeColumns,
+} from "./utils";
+
+export function CoordinateColumnSelect({
+  query,
+  stageIndex,
+  column,
+  value,
+  onChange,
+}: {
+  query: Lib.Query;
+  stageIndex: number;
+  column: Lib.ColumnMetadata;
+  value: Lib.ColumnMetadata | null;
+  onChange: (column: Lib.ColumnMetadata) => void;
+}) {
+  const latitudeColumns = findLatitudeColumns(query, stageIndex);
+  const longitudeColumns = findLongitudeColumns(query, stageIndex);
+
+  const columnDirection = Lib.isLatitude(column) ? "latitude" : "longitude";
+
+  if (columnDirection === "latitude" && longitudeColumns.length === 1) {
+    return null;
+  }
+
+  if (columnDirection === "longitude" && latitudeColumns.length === 1) {
+    return null;
+  }
+
+  const selectLabel =
+    columnDirection === "latitude"
+      ? t`Select longitude column`
+      : t`Select latitude column`;
+
+  const options = (
+    columnDirection === "latitude"
+      ? () => getColumnOptions({ query, stageIndex, columns: longitudeColumns })
+      : () => getColumnOptions({ query, stageIndex, columns: latitudeColumns })
+  )();
+
+  const handleChange = (newValue: string) => {
+    const selectedOption = options.find(option => option.value === newValue);
+
+    if (selectedOption) {
+      onChange(selectedOption.column);
+    }
+  };
+
+  return (
+    <Stack p="md" spacing="sm">
+      <Select
+        label={selectLabel}
+        data={options}
+        value={getColumnIdentifier(query, stageIndex, value)}
+        onChange={handleChange}
+        withinPortal={false}
+      />
+    </Stack>
+  );
+}

--- a/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
@@ -3,7 +3,6 @@ import { useState, useMemo } from "react";
 import { Box, Button, Flex, Text, NumberInput, Stack } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
-import Select from "metabase/core/components/Select";
 import FieldValuesWidget from "metabase/components/FieldValuesWidget";
 import Field from "metabase-lib/metadata/Field";
 import type { FilterPickerWidgetProps } from "../types";
@@ -14,15 +13,11 @@ import { Footer } from "../Footer";
 import { FilterOperatorPicker } from "../FilterOperatorPicker";
 import { FlexWithScroll } from "../FilterPicker.styled";
 
-import {
-  findSecondColumn,
-  isCoordinateFilterValid,
-  getColumnOptions,
-  findLatitudeColumns,
-  findLongitudeColumns,
-} from "./utils";
+import { CoordinateColumnSelect } from "./CoordinateColumnSelect";
 
-import { coordinateFilterValueCountMap, insideLabels } from "./constants";
+import { findSecondColumn, isCoordinateFilterValid } from "./utils";
+
+import { coordinateFilterValueCountMap } from "./constants";
 import type { CoordinateFilterValueCount } from "./types";
 
 export function CoordinateFilterPicker({
@@ -207,101 +202,43 @@ function CoordinateValueInput({
       return (
         <Stack align="center" justify="center" spacing="sm" p="md">
           <NumberInput
+            label={t`Upper latitude`}
             value={values[0]}
             onChange={(newValue: number) =>
               onChange([newValue, values[1], values[2], values[3]])
             }
-            placeholder={insideLabels[0]}
+            placeholder="90"
             autoFocus
           />
           <Flex align="center" justify="center" gap="sm">
             <NumberInput
+              label={t`Left longitude`}
               value={values[1]}
               onChange={(newValue: number) =>
                 onChange([values[0], newValue, values[2], values[3]])
               }
-              placeholder={insideLabels[1]}
+              placeholder="-180"
             />
             <NumberInput
+              label={t`Right longitude`}
               value={values[3]}
               onChange={(newValue: number) =>
                 onChange([values[0], values[1], values[2], newValue])
               }
-              placeholder={insideLabels[2]}
+              placeholder="180"
             />
           </Flex>
           <NumberInput
+            label={t`Lower latitude`}
             value={values[2]}
             onChange={(newValue: number) =>
               onChange([values[0], values[1], newValue, values[3]])
             }
-            placeholder={insideLabels[3]}
+            placeholder="-90"
           />
         </Stack>
       );
     default:
       return null;
   }
-}
-
-function CoordinateColumnSelect({
-  query,
-  stageIndex,
-  column,
-  value,
-  onChange,
-}: {
-  query: Lib.Query;
-  stageIndex: number;
-  column: Lib.ColumnMetadata;
-  value: Lib.ColumnMetadata | null;
-  onChange: (column: Lib.ColumnMetadata) => void;
-}) {
-  const latitudeColumns = findLatitudeColumns(query, stageIndex);
-  const longitudeColumns = findLongitudeColumns(query, stageIndex);
-
-  const columnDirection = Lib.isLatitude(column) ? "latitude" : "longitude";
-
-  if (columnDirection === "latitude" && longitudeColumns.length === 1) {
-    return null;
-  }
-
-  if (columnDirection === "longitude" && latitudeColumns.length === 1) {
-    return null;
-  }
-
-  const selectLabel =
-    columnDirection === "latitude"
-      ? t`Select longitude column`
-      : t`Select latitude column`;
-
-  const options = (
-    columnDirection === "latitude"
-      ? () => getColumnOptions({ query, stageIndex, columns: longitudeColumns })
-      : () => getColumnOptions({ query, stageIndex, columns: latitudeColumns })
-  )();
-
-  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const selectedOption = options.find(
-      option => option.value === e.target.value,
-    );
-
-    if (selectedOption) {
-      onChange(selectedOption.column);
-    }
-  };
-
-  return (
-    <Stack p="md" spacing="sm">
-      <label>
-        <strong>{selectLabel}</strong>
-      </label>
-      <Select
-        label={selectLabel}
-        options={options}
-        value={value ? Lib.displayInfo(query, stageIndex, value).name : ""}
-        onChange={handleChange}
-      />
-    </Stack>
-  );
 }

--- a/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
@@ -1,0 +1,307 @@
+import { t } from "ttag";
+import { useState, useMemo } from "react";
+import { Box, Button, Flex, Text, NumberInput, Stack } from "metabase/ui";
+import * as Lib from "metabase-lib";
+
+import Select from "metabase/core/components/Select";
+import FieldValuesWidget from "metabase/components/FieldValuesWidget";
+import Field from "metabase-lib/metadata/Field";
+import type { FilterPickerWidgetProps } from "../types";
+import { BackButton } from "../BackButton";
+import { Header } from "../Header";
+import { Footer } from "../Footer";
+
+import { FilterOperatorPicker } from "../FilterOperatorPicker";
+import { FlexWithScroll } from "../FilterPicker.styled";
+
+import {
+  findSecondColumn,
+  isCoordinateFilterValid,
+  getColumnOptions,
+  findLatitudeColumns,
+  findLongitudeColumns,
+} from "./utils";
+
+import { coordinateFilterValueCountMap, insideLabels } from "./constants";
+import type { CoordinateFilterValueCount } from "./types";
+
+export function CoordinateFilterPicker({
+  query,
+  stageIndex,
+  column,
+  filter,
+  onBack,
+  onChange,
+}: FilterPickerWidgetProps) {
+  const columnName = Lib.displayInfo(query, stageIndex, column).longDisplayName;
+  const filterParts = filter
+    ? Lib.coordinateFilterParts(query, stageIndex, filter)
+    : null;
+
+  const [operatorName, setOperatorName] =
+    useState<Lib.CoordinateFilterOperatorName>(
+      filterParts
+        ? filterParts.operator
+        : (Lib.defaultFilterOperatorName(
+            query,
+            stageIndex,
+            column,
+          ) as Lib.CoordinateFilterOperatorName),
+    );
+
+  const [values, setValues] = useState<number[]>(filterParts?.values ?? []);
+
+  const [column2, setColumn2] = useState<Lib.ColumnMetadata | null>(
+    findSecondColumn({ query, stageIndex, column, filter, operatorName }),
+  );
+
+  const handleOperatorChange = (
+    newOperatorName: Lib.CoordinateFilterOperatorName,
+  ) => {
+    setOperatorName(newOperatorName);
+    setValues([]);
+    setColumn2(
+      findSecondColumn({
+        query,
+        stageIndex,
+        column,
+        filter,
+        operatorName: newOperatorName,
+      }),
+    );
+  };
+
+  const handleFilterChange = () => {
+    if (operatorName && values.length) {
+      if (operatorName === "inside" && column2) {
+        const [latitudeColumn, longitudeColumn] = Lib.isLatitude(column)
+          ? [column, column2]
+          : [column2, column];
+
+        onChange(
+          Lib.coordinateFilterClause({
+            operator: operatorName,
+            column: latitudeColumn,
+            longitudeColumn,
+            values,
+          }),
+        );
+      } else {
+        onChange(
+          Lib.coordinateFilterClause({
+            operator: operatorName,
+            column,
+            values,
+          }),
+        );
+      }
+    }
+  };
+
+  const valueCount = coordinateFilterValueCountMap[operatorName];
+  const isFilterValid = isCoordinateFilterValid(operatorName, values);
+
+  return (
+    <>
+      <Header>
+        <BackButton onClick={onBack}>{columnName}</BackButton>
+        <FilterOperatorPicker
+          query={query}
+          stageIndex={stageIndex}
+          column={column}
+          value={operatorName}
+          onChange={newOperator =>
+            handleOperatorChange(
+              newOperator as Lib.CoordinateFilterOperatorName,
+            )
+          }
+        />
+      </Header>
+      {operatorName === "inside" && (
+        <CoordinateColumnSelect
+          query={query}
+          stageIndex={stageIndex}
+          column={column}
+          value={column2}
+          onChange={(newCol2: Lib.ColumnMetadata) => setColumn2(newCol2)}
+        />
+      )}
+      <CoordinateValueInput
+        values={values}
+        onChange={setValues}
+        valueCount={valueCount ?? 0}
+        column={column}
+      />
+      <Footer mt={valueCount === 0 ? -1 : undefined} /* to collapse borders */>
+        <Box />
+        <Button disabled={!isFilterValid} onClick={handleFilterChange}>
+          {filter ? t`Update filter` : t`Add filter`}
+        </Button>
+      </Footer>
+    </>
+  );
+}
+
+function CoordinateValueInput({
+  values,
+  onChange,
+  valueCount,
+  column,
+}: {
+  values: number[];
+  onChange: (values: number[]) => void;
+  valueCount: CoordinateFilterValueCount;
+  column: Lib.ColumnMetadata;
+}) {
+  const placeholder = t`Enter a number`;
+  const fieldId = useMemo(() => Lib._fieldId(column), [column]);
+
+  switch (valueCount) {
+    case "multiple":
+      return (
+        <FlexWithScroll p="md" mah={300}>
+          <FieldValuesWidget
+            fields={[new Field({ id: fieldId })]} // TODO adapt for MLv2
+            className="input"
+            value={values}
+            minWidth={"300px"}
+            onChange={onChange}
+            placeholder={placeholder}
+            disablePKRemappingForSearch
+            autoFocus
+            disableSearch
+            multi={valueCount === "multiple"}
+          />
+        </FlexWithScroll>
+      );
+    case 1:
+      return (
+        <Flex p="md">
+          <NumberInput
+            value={values[0]}
+            onChange={(newValue: number) => onChange([newValue])}
+            placeholder={placeholder}
+            autoFocus
+            w="100%"
+          />
+        </Flex>
+      );
+    case 2:
+      return (
+        <Flex align="center" justify="center" p="md">
+          <NumberInput
+            value={values[0]}
+            onChange={(newValue: number) => onChange([newValue, values[1]])}
+            placeholder={placeholder}
+            autoFocus
+          />
+          <Text mx="sm">{t`and`}</Text>
+          <NumberInput
+            value={values[1]}
+            onChange={(newValue: number) => onChange([values[0], newValue])}
+            placeholder={placeholder}
+          />
+        </Flex>
+      );
+    case 4:
+      return (
+        <Stack align="center" justify="center" spacing="sm" p="md">
+          <NumberInput
+            value={values[0]}
+            onChange={(newValue: number) =>
+              onChange([newValue, values[1], values[2], values[3]])
+            }
+            placeholder={insideLabels[0]}
+            autoFocus
+          />
+          <Flex align="center" justify="center" gap="sm">
+            <NumberInput
+              value={values[1]}
+              onChange={(newValue: number) =>
+                onChange([values[0], newValue, values[2], values[3]])
+              }
+              placeholder={insideLabels[1]}
+            />
+            <NumberInput
+              value={values[3]}
+              onChange={(newValue: number) =>
+                onChange([values[0], values[1], values[2], newValue])
+              }
+              placeholder={insideLabels[2]}
+            />
+          </Flex>
+          <NumberInput
+            value={values[2]}
+            onChange={(newValue: number) =>
+              onChange([values[0], values[1], newValue, values[3]])
+            }
+            placeholder={insideLabels[3]}
+          />
+        </Stack>
+      );
+    default:
+      return null;
+  }
+}
+
+function CoordinateColumnSelect({
+  query,
+  stageIndex,
+  column,
+  value,
+  onChange,
+}: {
+  query: Lib.Query;
+  stageIndex: number;
+  column: Lib.ColumnMetadata;
+  value: Lib.ColumnMetadata | null;
+  onChange: (column: Lib.ColumnMetadata) => void;
+}) {
+  const latitudeColumns = findLatitudeColumns(query, stageIndex);
+  const longitudeColumns = findLongitudeColumns(query, stageIndex);
+
+  const columnDirection = Lib.isLatitude(column) ? "latitude" : "longitude";
+
+  if (columnDirection === "latitude" && longitudeColumns.length === 1) {
+    return null;
+  }
+
+  if (columnDirection === "longitude" && latitudeColumns.length === 1) {
+    return null;
+  }
+
+  const selectLabel =
+    columnDirection === "latitude"
+      ? t`Select longitude column`
+      : t`Select latitude column`;
+
+  const options = (
+    columnDirection === "latitude"
+      ? () => getColumnOptions({ query, stageIndex, columns: longitudeColumns })
+      : () => getColumnOptions({ query, stageIndex, columns: latitudeColumns })
+  )();
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const selectedOption = options.find(
+      option => option.value === e.target.value,
+    );
+
+    if (selectedOption) {
+      onChange(selectedOption.column);
+    }
+  };
+
+  return (
+    <Stack p="md" spacing="sm">
+      <label>
+        <strong>{selectLabel}</strong>
+      </label>
+      <Select
+        label={selectLabel}
+        options={options}
+        value={value ? Lib.displayInfo(query, stageIndex, value).name : ""}
+        onChange={handleChange}
+      />
+    </Stack>
+  );
+}

--- a/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/constants.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/constants.ts
@@ -1,0 +1,21 @@
+import { t } from "ttag";
+import type { CoordinateFilterValueCountMap } from "./types";
+
+// why doesn't mbql recognize is-null not-null for coordinates?
+export const coordinateFilterValueCountMap: CoordinateFilterValueCountMap = {
+  ">": 1,
+  ">=": 1,
+  "<": 1,
+  "<=": 1,
+  between: 2,
+  inside: 4,
+  "=": "multiple",
+  "!=": "multiple",
+};
+
+export const insideLabels = [
+  t`Upper latitude`,
+  t`Left longitude`,
+  t`Right longitude`,
+  t`Lower latitude`,
+];

--- a/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/constants.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/constants.ts
@@ -1,4 +1,3 @@
-import { t } from "ttag";
 import type { CoordinateFilterValueCountMap } from "./types";
 
 // why doesn't mbql recognize is-null not-null for coordinates?
@@ -12,10 +11,3 @@ export const coordinateFilterValueCountMap: CoordinateFilterValueCountMap = {
   "=": "multiple",
   "!=": "multiple",
 };
-
-export const insideLabels = [
-  t`Upper latitude`,
-  t`Left longitude`,
-  t`Right longitude`,
-  t`Lower latitude`,
-];

--- a/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/index.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/index.ts
@@ -1,0 +1,1 @@
+export * from "./CoordinateFilterPicker";

--- a/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/types.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/types.ts
@@ -1,0 +1,7 @@
+import type { CoordinateFilterOperatorName } from "metabase-lib";
+
+export type CoordinateFilterValueCount = 0 | 1 | 2 | 4 | "multiple";
+export type CoordinateFilterValueCountMap = Record<
+  CoordinateFilterOperatorName,
+  CoordinateFilterValueCount
+>;

--- a/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/utils.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/utils.ts
@@ -1,0 +1,91 @@
+import * as Lib from "metabase-lib";
+import type { CoordinateFilterOperatorName } from "metabase-lib";
+
+import { coordinateFilterValueCountMap } from "./constants";
+
+export function isCoordinateFilterValid(
+  operatorName: CoordinateFilterOperatorName | null,
+  values: number[],
+): boolean {
+  if (!operatorName) {
+    return false;
+  }
+
+  const valueCount = coordinateFilterValueCountMap[operatorName];
+
+  if (valueCount === "multiple") {
+    return values.length >= 1;
+  }
+
+  return values.length === valueCount;
+}
+
+export function findLatitudeColumns(query: Lib.Query, stageIndex: number) {
+  const filterableColumns = Lib.filterableColumns(query, stageIndex);
+
+  return filterableColumns.filter(column => Lib.isLatitude(column));
+}
+
+export function findLongitudeColumns(query: Lib.Query, stageIndex: number) {
+  const filterableColumns = Lib.filterableColumns(query, stageIndex);
+
+  return filterableColumns.filter(column => Lib.isLongitude(column));
+}
+
+/**
+ * For "inside" filters, we may start with just one column, and need to find a second column
+ */
+export const findSecondColumn = ({
+  query,
+  stageIndex,
+  column,
+  filter,
+  operatorName,
+}: {
+  query: Lib.Query;
+  stageIndex: number;
+  column: Lib.ColumnMetadata;
+  filter?: Lib.FilterClause;
+  operatorName: CoordinateFilterOperatorName;
+}): Lib.ColumnMetadata | null => {
+  if (operatorName !== "inside") {
+    return null;
+  }
+
+  if (filter) {
+    const filterParts = Lib.coordinateFilterParts(query, stageIndex, filter);
+    if (filterParts?.longitudeColumn) {
+      return filterParts.longitudeColumn;
+    }
+  }
+
+  if (Lib.isLatitude(column)) {
+    return findLongitudeColumns(query, stageIndex)[0] ?? null;
+  }
+
+  if (Lib.isLongitude(column)) {
+    return findLatitudeColumns(query, stageIndex)[0] ?? null;
+  }
+
+  return null;
+};
+
+export const getColumnOptions = ({
+  query,
+  stageIndex,
+  columns,
+}: {
+  query: Lib.Query;
+  stageIndex: number;
+  columns: Lib.ColumnMetadata[];
+}) => {
+  return columns.map(column => {
+    const columnInfo = Lib.displayInfo(query, stageIndex, column);
+
+    return {
+      name: columnInfo.displayName,
+      value: columnInfo.name, // duplicate names?
+      column,
+    };
+  });
+};

--- a/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/utils.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/utils.ts
@@ -83,9 +83,22 @@ export const getColumnOptions = ({
     const columnInfo = Lib.displayInfo(query, stageIndex, column);
 
     return {
-      name: columnInfo.displayName,
-      value: columnInfo.name, // duplicate names?
+      label: columnInfo.displayName,
+      value: getColumnIdentifier(query, stageIndex, column),
       column,
     };
   });
+};
+
+export const getColumnIdentifier = (
+  query: Lib.Query,
+  stageIndex: number,
+  column: Lib.ColumnMetadata | null,
+) => {
+  if (!column) {
+    return "";
+  }
+  const columnInfo = Lib.displayInfo(query, stageIndex, column);
+
+  return `${columnInfo?.table?.name ?? "computed"}_${columnInfo.name}`;
 };

--- a/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
@@ -5,6 +5,7 @@ import { QueryColumnPicker } from "../QueryColumnPicker";
 import { BooleanFilterPicker } from "./BooleanFilterPicker";
 import { DateFilterPicker } from "./DateFilterPicker";
 import { NumberFilterPicker } from "./NumberFilterPicker";
+import { CoordinateFilterPicker } from "./CoordinateFilterPicker";
 import { StringFilterPicker } from "./StringFilterPicker";
 
 export interface FilterPickerProps {
@@ -93,6 +94,9 @@ function getFilterWidget(column: Lib.ColumnMetadata) {
   }
   if (Lib.isDate(column)) {
     return DateFilterPicker;
+  }
+  if (Lib.isCoordinate(column)) {
+    return CoordinateFilterPicker;
   }
   if (Lib.isNumber(column)) {
     return NumberFilterPicker;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/34378

### Description

Adds CoordinateFilterPicker. Behaves almost exactly the same as NumberFilterPicker except for `inside` filters.

### Inside Filters

Inside filters were kinda broken in MLv1. 

. | .
--- | ---
If you selected a latitude field and it found multiple longitude fields, it would let you select one like this: | ![Screen Shot 2023-10-06 at 1 34 56 PM](https://github.com/metabase/metabase/assets/30528226/410e5c73-20c2-4d23-bd16-b93ed4797b75)
But if you chose a longitude field... it would still present you with options to select another longitude field? | ![Screen Shot 2023-10-06 at 1 35 15 PM](https://github.com/metabase/metabase/assets/30528226/72c34967-89f1-47c7-8abe-6d24fff87f04)

I revamped this so that:

. | .
--- | ---
If you select a latitude field and there are multiple longitude fields, you get to select a longitude field | ![Screen Shot 2023-10-06 at 1 37 29 PM](https://github.com/metabase/metabase/assets/30528226/050ea133-3524-4744-a14d-2b1d538e1e37)
And if you select a longitude field and there are mutliple latitude fields, you get to select a latitude field | ![Screen Shot 2023-10-06 at 1 37 19 PM](https://github.com/metabase/metabase/assets/30528226/927c4573-c4fe-47cf-8484-1a3985ffeaab)
If you select a latitude field, and there's only one longitude field, we just select if for you | ![Screen Shot 2023-10-06 at 1 38 07 PM](https://github.com/metabase/metabase/assets/30528226/09f592d8-89ca-4308-ae1f-bfb28a154c6f)
If you select a longitude field, and there's only one latitude field, we just select it for you |  ![Screen Shot 2023-10-06 at 1 38 19 PM](https://github.com/metabase/metabase/assets/30528226/7b0a412d-daa3-4a08-8f1e-6b28a9513247)






