### PR TITLE
[MLv2] Add underlying-records drill and `top-level-query` machinery

### DIFF
--- a/frontend/src/metabase-lib/drills.unit.spec.ts
+++ b/frontend/src/metabase-lib/drills.unit.spec.ts
@@ -1088,7 +1088,7 @@ describe("availableDrillThrus", () => {
       columnName: "count",
       expectedParameters: {
         type: "drill-thru/underlying-records",
-        rowCount: 77, // FIXME: (metabase#32108) this should return real count of rows
+        rowCount: 77,
         tableName: "Orders",
       },
     },
@@ -1099,7 +1099,7 @@ describe("availableDrillThrus", () => {
       columnName: "sum",
       expectedParameters: {
         type: "drill-thru/underlying-records",
-        rowCount: 1, // FIXME: (metabase#32108) this should return real count of rows
+        rowCount: 1, // This is not really a row count, rather the sum value.
         tableName: "Orders",
       },
     },
@@ -1110,7 +1110,7 @@ describe("availableDrillThrus", () => {
       columnName: "max",
       expectedParameters: {
         type: "drill-thru/underlying-records",
-        rowCount: 2, // FIXME: (metabase#32108) this should return real count of rows
+        rowCount: 2, // max is null in the AGGREGATED_ORDERS_ROW_VALUES; that defaults to 2.
         tableName: "Orders",
       },
     },

--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -1,11 +1,17 @@
 (ns metabase.lib.drill-thru.underlying-records
   (:require
+   [medley.core :as m]
+   [metabase.lib.aggregation :as lib.aggregation]
+   [metabase.lib.convert :as lib.convert]
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
+   [metabase.lib.filter :as lib.filter]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
+   [metabase.lib.options :as lib.options]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
    [metabase.lib.types.isa :as lib.types.isa]
+   [metabase.lib.underlying :as lib.underlying]
    [metabase.lib.util :as lib.util]
    [metabase.util.malli :as mu]))
 
@@ -13,15 +19,15 @@
   "When clicking on a particular broken-out group, offer a look at the details of all the rows that went into this
   bucket. Eg. distribution of People by State, then click New York and see the table of all People filtered by
   `STATE = 'New York'`."
-  [query                             :- ::lib.schema/query
-   stage-number                      :- :int
-   {:keys [column dimensions value]} :- ::lib.schema.drill-thru/context]
+  [query                                        :- ::lib.schema/query
+   stage-number                                 :- :int
+   {:keys [column column-ref dimensions value]} :- ::lib.schema.drill-thru/context]
   ;; Clicking on breakouts is weird. Clicking on Count(People) by State: Minnesota yields a FE `clicked` with:
   ;; - column is COUNT
   ;; - row[0] has col: STATE, value: "Minnesota"
   ;; - row[1] has col: count (source: "aggregation")
   ;; - dimensions which is [{column: STATE, value: "MN"}]
-  ;; - value: the count.
+  ;; - value: the aggregated value (the count, the sum, etc.)
   ;; So dimensions is exactly what we want.
   ;; It returns the table name and row count, since that's used for pluralization of the name.
   (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
@@ -36,7 +42,9 @@
      :row-count  (if (number? value) value 2)
      :table-name (some->> (lib.util/source-table-id query)
                           (lib.metadata/table query)
-                          (lib.metadata.calculation/display-name query stage-number))}))
+                          (lib.metadata.calculation/display-name query stage-number))
+     :dimensions dimensions
+     :column-ref column-ref}))
 
 (defmethod lib.drill-thru.common/drill-thru-info-method :drill-thru/underlying-records
   [_query _stage-number {:keys [row-count table-name]}]
@@ -44,7 +52,52 @@
    :row-count  row-count
    :table-name table-name})
 
+(mu/defn ^:private drill-filter :- ::lib.schema/query
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   column       :- lib.metadata/ColumnMetadata
+   value        :- :any]
+  (lib.filter/filter query stage-number (lib.filter/= column value)))
+
 (defmethod lib.drill-thru.common/drill-thru-method :drill-thru/underlying-records
-  [_query _stage-number _drill-thru & _]
-  (throw (ex-info "Not implemented" {}))
-  #_(lib.filter/filter query stage-number (lib.options/ensure-uuid [(keyword filter-op) {} (lib.ref/ref column) value])))
+  [query _stage-number {:keys [column-ref dimensions]} & _]
+  (let [top-query   (lib.underlying/top-level-query query)
+        ;; Drop all aggregations, breakouts, sort orders, etc. to get the underlying records.
+        ;; Note that the input _stage-number is deliberately ignored. The top-level query may have fewer stages than the
+        ;; input query; all operations are performed on the final stage of the top-level query.
+        base-query  (lib.util/update-query-stage top-query -1
+                                                 dissoc :aggregation :breakout :order-by :limit :fields)
+        ;; Turn any non-aggregation dimensions into filters.
+        ;; eg. if we drilled into a temporal bucket, add a filter for the [:= breakout-column that-month].
+        filtered    (reduce (fn [q {:keys [column value]}]
+                              (drill-filter q -1 column value))
+                            base-query
+                            (for [dimension dimensions
+                                  :let [top (update dimension :column #(lib.underlying/top-level-column query %))]
+                                  :when (-> top :column :lib/source (not= :source/aggregations))]
+                              top))
+        ;; The column-ref should be an aggregation ref - look up the full aggregation.
+        aggregation (when-let [agg-uuid (last column-ref)]
+                      (m/find-first #(= (lib.options/uuid %) agg-uuid)
+                                    (lib.aggregation/aggregations top-query -1)))]
+    ;; Apply the filters derived from the aggregation.
+    (reduce #(lib.filter/filter %1 -1 %2)
+            filtered
+            ;; If we found an aggregation, check if it implies further filtering.
+            ;; Simple aggregations like :sum don't add more filters; metrics or fancy aggregations like :sum-where do.
+            (when aggregation
+              (case (first aggregation)
+                ;; Fancy aggregations that filter the input - the filter is the last part of the aggregation.
+                (:sum-where :count-where :share)
+                [(last aggregation)]
+
+                ;; Metrics are standard filter + aggregation units; if the column is a metric get its filters.
+                :metric
+                (-> (lib.metadata/metric query (last aggregation))
+                    :definition
+                    lib.convert/js-legacy-inner-query->pMBQL
+                    (assoc :database (:database query))
+                    (lib.filter/filters -1))
+
+                ;; Default: no filters to add.
+                nil)))))

--- a/src/metabase/lib/underlying.cljc
+++ b/src/metabase/lib/underlying.cljc
@@ -1,0 +1,61 @@
+(ns metabase.lib.underlying
+  "Helpers for getting at \"underlying\" or \"top-level\" queries and columns.
+  This logic is shared by a handful of things like drill-thrus."
+  (:require
+   [metabase.lib.aggregation :as lib.aggregation]
+   [metabase.lib.breakout :as lib.breakout]
+   [metabase.lib.equality :as lib.equality]
+   [metabase.lib.field :as lib.field]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.metadata.calculation :as lib.metadata.calculation]
+   [metabase.lib.ref :as lib.ref]
+   [metabase.lib.schema :as lib.schema]
+   [metabase.lib.util :as lib.util]
+   [metabase.util.malli :as mu]))
+
+(mu/defn ^:private pop-until-aggregation-or-breakout :- [:maybe ::lib.schema/query]
+  "Strips off any trailing stages that do not contain aggregations.
+
+  If there are no such stages, returns nil."
+  [query :- ::lib.schema/query]
+  (if (and (empty? (lib.aggregation/aggregations query -1))
+           (empty? (lib.breakout/breakouts query -1)))
+    ;; No aggregations or breakouts in the last stage, so pop it off and recur.
+    (let [popped (update query :stages pop)]
+      (when (seq (:stages popped))
+        (recur popped)))
+    query))
+
+(mu/defn top-level-query :- ::lib.schema/query
+  "Returns the \"top-level\" query for the given query.
+
+  That means dropping any trailing filters, fields, etc. to get back to the last stage that has an aggregation. If there
+  are no stages with aggregations, the original query is returned.
+
+  If the database does not support nested queries, this also returns the original."
+  [query :- ::lib.schema/query]
+  (or (when ((-> query lib.metadata/database :features) :nested-queries)
+        (pop-until-aggregation-or-breakout query))
+      query))
+
+(mu/defn top-level-column :- lib.metadata/ColumnMetadata
+  "Given a column, returns the \"top-level\" equivalent.
+
+  Top-level means to find the corresponding column in the [[top-level-query]], which requires walking back through the
+  stages finding the equivalent column at each one.
+
+  Returns nil if the column can't be traced back to the top-level query."
+  [query  :- ::lib.schema/query
+   column :- lib.metadata/ColumnMetadata]
+  (let [top-query (top-level-query query)]
+    (if (= query top-query)
+      column ;; Unchanged if this is already a top-level query. That includes keeping the "superfluous" options!
+      (loop [query  query
+             column column]
+        (if (= query top-query)
+          ;; Once we've found it, drop any superfluous options.
+          (dissoc column ::lib.field/temporal-unit ::lib.field/binning)
+          (let [prev-cols (lib.metadata.calculation/returned-columns query -2 (lib.util/previous-stage query -1))
+                prev-col  (lib.equality/find-matching-column query -2 (lib.ref/ref column) prev-cols)]
+            (when prev-col
+              (recur (update query :stages pop) prev-col))))))))

--- a/test/metabase/lib/drill_thru/underlying_records_test.cljc
+++ b/test/metabase/lib/drill_thru/underlying_records_test.cljc
@@ -1,9 +1,16 @@
 (ns metabase.lib.drill-thru.underlying-records-test
   (:require
    [clojure.test :refer [deftest is testing]]
+   [medley.core :as m]
    [metabase.lib.core :as lib]
+   [metabase.lib.drill-thru :as lib.drill-thru]
    [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
-   [metabase.util :as u]))
+   [metabase.lib.options :as lib.options]
+   [metabase.lib.test-metadata :as meta]
+   [metabase.lib.test-util.metadata-providers.mock :as providers.mock]
+   [metabase.util :as u]
+   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal])
+       :clj  ([java-time.api :as jt]))))
 
 (deftest ^:parallel returns-underlying-records-test-1
   (lib.drill-thru.tu/test-returns-drill
@@ -43,3 +50,142 @@
             (is (= 1
                    (count (filter #(= (:type %) :drill-thru/underlying-records)
                                   drills))))))))))
+
+
+#?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
+
+(def last-month
+  #?(:cljs (let [now    (js/Date.)
+                 year   (.getFullYear now)
+                 month  (.getMonth now)]
+             (-> (js/Date.UTC year (dec month))
+                 (js/Date.)
+                 (.toISOString)))
+     :clj  (let [last-month (-> (jt/zoned-date-time (jt/year) (jt/month))
+                                (jt/minus (jt/months 1)))]
+             (jt/format :iso-offset-date-time last-month))))
+
+(defn- underlying-state [query agg-index agg-value breakout-values exp-filters-fn]
+  (let [columns                         (lib/returned-columns query)
+        {aggs      :source/aggregations
+         breakouts :source/breakouts}   (group-by :lib/source columns)
+        agg-column                      (nth aggs agg-index)
+        agg-dim                         {:column     agg-column
+                                         :column-ref (lib/ref agg-column)
+                                         :value      agg-value}]
+    (is (= (count breakouts)
+           (count breakout-values)))
+    (let [breakout-dims (for [[breakout value] (map vector breakouts breakout-values)]
+                          {:column     breakout
+                           :column-ref (lib/ref breakout)
+                           :value      value})
+          context       (merge agg-dim
+                               {:row        (cons agg-dim breakout-dims)
+                                :dimensions breakout-dims})]
+      (is (=? {:lib/type :mbql/query
+               :stages [{:filters     (exp-filters-fn agg-dim breakout-dims)
+                         :aggregation (symbol "nil #_\"key is not present.\"")
+                         :breakout    (symbol "nil #_\"key is not present.\"")
+                         :fields      (symbol "nil #_\"key is not present.\"")}]}
+              (->> (lib.drill-thru/available-drill-thrus query context)
+                   (m/find-first #(= (:type %) :drill-thru/underlying-records))
+                   (lib.drill-thru/drill-thru query -1)))))))
+
+(deftest ^:parallel underlying-records-apply-test
+  (testing "sum(subtotal) over time"
+    (underlying-state (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                          (lib/aggregate (lib/sum (meta/field-metadata :orders :subtotal)))
+                          (lib/breakout (lib/with-temporal-bucket
+                                          (meta/field-metadata :orders :created-at)
+                                          :month)))
+                      0 #_agg-index
+                      42295.12
+                      [last-month]
+                      (fn [_agg-dim [breakout-dim]]
+                        [[:= {}
+                          (-> (:column-ref breakout-dim)
+                              (lib.options/with-options {:temporal-unit :month}))
+                          last-month]])))
+  (testing "sum_where(subtotal, products.category = \"Doohickey\") over time"
+    (underlying-state (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                          (lib/aggregate (lib/sum-where
+                                           (meta/field-metadata :orders :subtotal)
+                                           (lib/= (meta/field-metadata :products :category)
+                                                  "Doohickey")))
+                          (lib/breakout (lib/with-temporal-bucket
+                                          (meta/field-metadata :orders :created-at)
+                                          :month)))
+                      0 #_agg-index
+                      6572.12
+                      [last-month]
+                      (fn [_agg-dim [breakout-dim]]
+                        [[:= {}
+                          (-> (:column-ref breakout-dim)
+                              (lib.options/with-options {:temporal-unit :month}))
+                          last-month]
+                         [:= {} (-> (meta/field-metadata :products :category)
+                                    lib/ref
+                                    (lib.options/with-options {}))
+                          "Doohickey"]])))
+
+  (testing "metric over time"
+    (let [metric   {:description "Orders with a subtotal of $100 or more."
+                    :archived false
+                    :updated-at "2023-10-04T20:11:34.029582"
+                    :lib/type :metadata/metric
+                    :definition
+                    {"source-table" (meta/id :orders)
+                     "aggregation" [["count"]]
+                     "filter" [">=" ["field" (meta/id :orders :subtotal) nil] 100]}
+                    :table-id (meta/id :orders)
+                    :name "Large orders"
+                    :caveats nil
+                    :entity-id "NWMNcv_yhhZIT7winoIdi"
+                    :how-is-this-calculated nil
+                    :show-in-getting-started false
+                    :id 1
+                    :database (meta/id)
+                    :points-of-interest nil
+                    :creator-id 1
+                    :created-at "2023-10-04T20:11:34.029582"}
+          provider (lib/composed-metadata-provider
+                     meta/metadata-provider
+                     (providers.mock/mock-metadata-provider {:metrics [metric]}))]
+      (underlying-state (-> (lib/query provider (meta/table-metadata :orders))
+                            (lib/aggregate metric)
+                            (lib/breakout (lib/with-temporal-bucket
+                                            (meta/field-metadata :orders :created-at)
+                                            :month)))
+                        0 #_agg-index
+                        6572.12
+                        [last-month]
+                        (fn [_agg-dim [breakout-dim]]
+                          (let [monthly-breakout (-> (:column-ref breakout-dim)
+                                                     (lib.options/with-options {:temporal-unit :month}))
+                                subtotal         (-> (meta/field-metadata :orders :subtotal)
+                                                     lib/ref
+                                                     (lib.options/with-options {}))]
+                            [[:=  {} monthly-breakout last-month]
+                             [:>= {} subtotal 100]]))))))
+
+(deftest ^:parallel multiple-aggregations-multiple-breakouts-test
+  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                  (lib/aggregate (lib/count))
+                  (lib/aggregate (lib/sum (meta/field-metadata :orders :tax)))
+                  (lib/aggregate (lib/max (meta/field-metadata :orders :discount)))
+                  (lib/breakout  (meta/field-metadata :orders :product-id))
+                  (lib/breakout  (lib/with-temporal-bucket (meta/field-metadata :orders :created-at) :month)))]
+    (doseq [[agg-index agg-value] [[0 77]
+                                   [1 1]
+                                   [2 :null]]]
+      (underlying-state query agg-index agg-value
+                        [120 last-month]
+                        (fn [_agg-dim [product-id-dim created-at-dim]]
+                          [[:= {}
+                            (-> (:column-ref product-id-dim)
+                                (lib.options/update-options dissoc :lib/uuid))
+                            120]
+                           [:= {}
+                            (-> (:column-ref created-at-dim)
+                                (lib.options/with-options {:temporal-unit :month}))
+                            last-month]])))))

--- a/test/metabase/lib/drill_thru/zoom_in_timeseries_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_in_timeseries_test.cljc
@@ -14,10 +14,10 @@
 (deftest ^:parallel zoom-in-timeseries-e2e-test
   (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
                   (lib/aggregate (lib/count))
-                  (lib/breakout (lib/with-temporal-bucket (meta/field-metadata :orders :created-at) :day))
+                  (lib/breakout (meta/field-metadata :products :category))
                   (lib/breakout (lib/with-temporal-bucket (meta/field-metadata :orders :created-at) :year)))]
     (is (=? {:stages [{:aggregation [[:count {}]]
-                       :breakout    [[:field {:temporal-unit :day} (meta/id :orders :created-at)]
+                       :breakout    [[:field {} (meta/id :products :category)]
                                      [:field {:temporal-unit :year} (meta/id :orders :created-at)]]}]}
             query))
     (let [columns    (lib/returned-columns query)
@@ -47,7 +47,7 @@
               (lib/display-info query -1 drill)))
       (let [query' (lib/drill-thru query drill)]
         (is (=? {:stages [{:aggregation [[:count {}]]
-                           :breakout    [[:field {:temporal-unit :day} (meta/id :orders :created-at)]
+                           :breakout    [[:field {} (meta/id :products :category)]
                                          [:field {:temporal-unit :quarter} (meta/id :orders :created-at)]]
                            :filters     [[:=
                                           {}
@@ -79,7 +79,7 @@
                   (lib/display-info query' -1 drill)))
           (let [query'' (lib/drill-thru query' drill)]
             (is (=? {:stages [{:aggregation [[:count {}]]
-                               :breakout    [[:field {:temporal-unit :day} (meta/id :orders :created-at)]
+                               :breakout    [[:field {} (meta/id :products :category)]
                                              [:field {:temporal-unit :month} (meta/id :orders :created-at)]]
                                ;; if we were SMART we could remove the first filter clause since it's not adding any
                                ;; value, but it won't hurt anything other than performance to keep it there. QP can

--- a/test/metabase/lib/drill_thru_test.cljc
+++ b/test/metabase/lib/drill_thru_test.cljc
@@ -458,7 +458,7 @@
         (let [context {:column     count-col
                        :column-ref (lib/ref count-col)
                        :value      nil}]
-          (is (=? [{:type :drill-thru/column-filter
+          (is (=? [{:type   :drill-thru/column-filter
                     :column {:name "count"}
                     :initial-op {:display-name-variant :equal-to
                                  :short :=}}
@@ -474,7 +474,7 @@
         (let [context {:column     max-of-discount-col
                        :column-ref (lib/ref max-of-discount-col)
                        :value      nil}]
-          (is (=? [{:type :drill-thru/column-filter,
+          (is (=? [{:type   :drill-thru/column-filter,
                     :column {:display-name "Max of Discount"}
                     :initial-op {:display-name-variant :equal-to
                                  :short :=}}
@@ -515,12 +515,12 @@
                               {:name "≠"}]}
                  {:lib/type   :metabase.lib.drill-thru/drill-thru
                   :type       :drill-thru/underlying-records
-                  #_#_:row-count  (:value sum-dim)
-                  #_#_:dimensions [breakout-dim]
-                  #_#_:column-ref (:column-ref sum-dim)}
+                  :row-count  (:value sum-dim)
+                  :dimensions [breakout-dim]
+                  :column-ref (:column-ref sum-dim)}
                  {:lib/type   :metabase.lib.drill-thru/drill-thru
                   :type       :drill-thru/zoom-in.timeseries
-                  :dimension  {:column breakout}}]
+                  :dimension  breakout-dim}]
                 (lib/available-drill-thrus query -1 context)))
         (test-drill-applications query context)))))
 

--- a/test/metabase/lib/underlying_test.cljc
+++ b/test/metabase/lib/underlying_test.cljc
@@ -1,0 +1,73 @@
+(ns metabase.lib.underlying-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [metabase.lib.core :as lib]
+   [metabase.lib.test-metadata :as meta]
+   [metabase.lib.underlying :as lib.underlying]
+   [metabase.lib.util :as lib.util]))
+
+(deftest ^:parallel top-level-query-test
+  (testing `lib.underlying/top-level-query
+    (testing "returns the same query"
+     (testing "if the last stage has aggregations"
+       (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                       (lib/aggregate (lib/count)))]
+         (is (identical? query
+                         (lib.underlying/top-level-query query)))))
+     (testing "if there are no aggregations in any stage"
+       (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                       (lib/append-stage)
+                       (lib/filter (lib/= (meta/field-metadata :orders :product-id)
+                                          100)))]
+         (is (identical? query
+                         (lib.underlying/top-level-query query))))))
+
+    (testing "returns the last stage with an aggregation"
+      (let [agg-0 (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                      (lib/aggregate (lib/count))
+                      (lib/append-stage)
+                      (lib/filter (lib/= (meta/field-metadata :orders :product-id)
+                                         100)))
+
+            agg-1 (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                      (lib/append-stage)
+                      (lib/aggregate (lib/count))
+                      (lib/filter (lib/= (meta/field-metadata :orders :product-id)
+                                         100)))]
+        (is (identical? agg-1
+                        (lib.underlying/top-level-query agg-1)))
+        (is (= (update agg-0 :stages pop)
+               (lib.underlying/top-level-query agg-0)))))
+
+    (testing "returns the last stage with a breakout"
+      (let [brk-0 (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                      (lib/breakout (meta/field-metadata :orders :product-id))
+                      (lib/append-stage)
+                      (lib/filter (lib/= (meta/field-metadata :orders :product-id)
+                                         100)))
+
+            brk-1 (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                      (lib/append-stage)
+                      (lib/breakout (meta/field-metadata :orders :product-id))
+                      (lib/filter (lib/= (meta/field-metadata :orders :product-id)
+                                         100)))]
+        (is (identical? brk-1
+                        (lib.underlying/top-level-query brk-1)))
+        (is (= (update brk-0 :stages pop)
+               (lib.underlying/top-level-query brk-0)))))))
+
+(deftest ^:parallel top-level-column-test
+  (testing `lib.underlying/top-level-column
+    (testing "returns the same column if not nested"
+      (let [query (lib/query meta/metadata-provider (meta/table-metadata :orders))]
+        (doseq [column (lib/returned-columns query)]
+          (is (= column (lib.underlying/top-level-column query column))))))
+
+    (testing "returns the column in the top-level query"
+      (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                      (lib/aggregate (lib/sum (meta/field-metadata :orders :subtotal)))
+                      (lib/breakout (meta/field-metadata :orders :created-at))
+                      (lib/append-stage))
+            cols  (lib/returned-columns query)]
+        (is (= (lib/returned-columns query 0 (lib.util/query-stage query 0))
+               (map #(lib.underlying/top-level-column query %) cols)))))))


### PR DESCRIPTION
This adds the `underlying-records` drill, the one that allows you to click an aggregation (possibly with a breakout)
and see the raw table rows with appropriate filtering.

Removes some hacks in how dimensions are handled by drill-thru, and
fixes up some tests accordingly. This changed the format of
`zoom-in.timeseries` drills somewhat.

Also adds `dev.fe-helpers` for inspecting the current query in the CLJS
REPL.

Resolves https://github.com/metabase/metabase/issues/34233

