### PR TITLE
Move some pre-release checks to build job from test job

### DIFF
--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -36,8 +36,8 @@ jobs:
       uses: actions/github-script@v6
       id: canonical_version
       with:
-        script: |
-          const { isValidVersionString, getCanonicalVersion } = require('${{ github.workspace }}/release/dist/index.cjs');
+        script: | # js
+          const { isValidVersionString, getCanonicalVersion, hasBeenReleased } = require('${{ github.workspace }}/release/dist/index.cjs');
 
           const version = '${{ inputs.version }}';
 
@@ -45,10 +45,60 @@ jobs:
             throw new Error("The version format is invalid! It must start with either 'v0.' or 'v1.'.");
           }
 
-          return {
+          const versions = {
             ee: getCanonicalVersion(version, 'ee'),
             oss: getCanonicalVersion(version, 'oss'),
           };
+
+          const ossReleased = await hasBeenReleased({
+            github,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            version: versions.oss,
+          });
+
+          const eeReleased = await hasBeenReleased({
+            github,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            version: versions.ee,
+          });
+
+          if (ossReleased || eeReleased) {
+            throw new Error("This version has already been released!", version);
+          }
+
+          return versions;
+
+  check-commit:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+    - name: Check out the code to verify the release branch
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0  # IMPORTANT! to get all the branches
+    - name: Ensure that the specified commit exists in the latest release branch
+      env:
+        COMMIT: ${{ inputs.commit }}
+      run: |
+        echo "Checking if the specified commit is in a release branch..."
+
+        git branch -a --contains $COMMIT > branches.txt
+        if [[ $(grep -c master branches.txt) =~ 1 ]]; then
+          echo "Found in master branch. ABORT!"
+          exit -1
+        fi
+        if [[ $(grep -c 'release-x' branches.txt) =~ 1 ]]; then
+          echo "Found the commit $COMMIT in:"
+          git branch -a --contains $COMMIT
+          echo "Proceeding to the next step..."
+          exit 0
+        else
+          echo "Commit $COMMIT is not found in a single release branch"
+          echo "ABORT!."
+          exit -1
+        fi
 
   build-uberjar-for-release:
     needs: check-version

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -80,69 +80,8 @@ jobs:
             ./COMMIT-ID
             ./SHA256.sum
 
-  check-commit:
-    needs: release-artifact
-    runs-on: ubuntu-22.04
-    timeout-minutes: 10
-    steps:
-    - name: Get the version
-      run: |
-        if [[ "${{ matrix.edition }}" == "ee" ]]; then
-          echo "VERSION=${{ needs.release-artifact.outputs.ee_version }}" >> $GITHUB_ENV
-        else
-          echo "VERSION=${{ needs.release-artifact.outputs.oss_version }}" >> $GITHUB_ENV
-        fi
-    - name: Ensure that the intended version ($VERSION) was never released before
-      run: |
-        echo "Checking if $VERSION conflicts with a past release..."
-
-        CANONICAL_REFS=https://github.com/metabase/metabase/archive/refs
-        URL=${CANONICAL_REFS}/tags/$VERSION.zip
-        HTTP_CODE=$(curl -s -L -o /dev/null --head -w "%{HTTP_CODE}" ${URL})
-        if [[ $HTTP_CODE =~ "200" ]]; then
-          echo "ERROR: that version was already released in the past."
-          echo "ABORT!"
-          exit -1
-        else
-          if [[ $HTTP_CODE =~ "404" ]]; then
-            echo "That version has not been released yet."
-            echo "Proceeding to the next step..."
-            exit 0
-          else
-            echo "ERROR: Unhandled case of HTTP $HTTP_CODE while checking ${URL}"
-            echo "ABORT!"
-            exit -1
-          fi
-        fi
-
-    - name: Check out the code to verify the release branch
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0  # IMPORTANT! to get all the branches
-    - name: Ensure that the specified commit exists in the latest release branch
-      run: |
-        echo "Checking if the specified commit is in a release branch..."
-
-        git branch -a --contains $COMMIT > branches.txt
-        if [[ $(grep -c master branches.txt) =~ 1 ]]; then
-          echo "Found in master branch. ABORT!"
-          exit -1
-        fi
-        if [[ $(grep -c 'release-x' branches.txt) =~ 1 ]]; then
-          echo "Found the commit $COMMIT in:"
-          git branch -a --contains $COMMIT
-          echo "Proceeding to the next step..."
-          exit 0
-        else
-          echo "Commit $COMMIT is not found in a single release branch"
-          echo "ABORT!."
-          exit -1
-        fi
-      env:
-        COMMIT: ${{ needs.release-artifact.outputs.commit }}
-
   check-uberjar-health:
-    needs: [release-artifact, check-commit]
+    needs: [release-artifact]
     runs-on: ubuntu-22.04
     name: Is ${{ matrix.edition }} (java ${{ matrix.java-version }}) healthy?
     timeout-minutes: 10


### PR DESCRIPTION
Moves two checks to the build job from the test job:
- check that this commit is in a release branch
- check that this version hasn't been released already (we do this again in the publish job because there can be a time gap between them)

Tests:
- [x] tested in fork: happy path [build job](https://github.com/iethree/metabase/actions/runs/6437025680) [test job](https://github.com/iethree/metabase/actions/runs/6437136496)
- [x] tested in fork: [already released version](https://github.com/iethree/metabase/actions/runs/6459551673)
- [x] tested in fork: [commit not in release branch](https://github.com/iethree/metabase/actions/runs/6459575986)