### PR TITLE
Adding dropped series to split suggestions

### DIFF
--- a/e2e/test/scenarios/visualizations/bar_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/bar_chart.cy.spec.js
@@ -356,4 +356,61 @@ describe("scenarios > visualizations > bar chart", () => {
     );
     cy.get("[data-testid^=draggable-item]").should("have.length", 0);
   });
+
+  it("should support showing data points with > 10 series (#33725)", () => {
+    visitQuestionAdhoc({
+      display: "bar",
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        type: "query",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          filter: [
+            "and",
+            [
+              "time-interval",
+              [
+                "field",
+                ORDERS.CREATED_AT,
+                {
+                  "base-type": "type/DateTime",
+                },
+              ],
+              -1,
+              "month",
+              {},
+            ],
+            [
+              "=",
+              ["field", PEOPLE.STATE, {}],
+              "AK",
+              "AL",
+              "AR",
+              "AZ",
+              "CA",
+              "CO",
+              "CT",
+              "FL",
+              "GA",
+              "IA",
+            ],
+          ],
+          breakout: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+            ["field", PEOPLE.STATE, { "source-field": ORDERS.USER_ID }],
+          ],
+        },
+      },
+      visualization_settings: {
+        "graph.dimensions": ["CREATED_AT", "STATE"],
+        "graph.metrics": ["count"],
+        "graph.show_values": true,
+      },
+    });
+
+    cy.get(".value-labels").should("contain", "6");
+    cy.get(".value-labels").should("contain", "13");
+    cy.get(".value-labels").should("contain", "19");
+  });
 });

--- a/frontend/src/metabase/visualizations/lib/utils.js
+++ b/frontend/src/metabase/visualizations/lib/utils.js
@@ -62,8 +62,13 @@ export function getAvailableCanvasWidth(element) {
 
 function generateSplits(list, left = [], right = [], depth = 0) {
   // NOTE: currently generates all permutations, some of which are equivalent
-  if (list.length === 0 || depth > SPLIT_AXIS_MAX_DEPTH) {
+  if (list.length === 0) {
     return [[left, right]];
+  } else if (depth > SPLIT_AXIS_MAX_DEPTH) {
+    // If we reach our max depth, we need to ensure that any item that haven't been added either list are accounted for
+    return left.length < right.length
+      ? [[left.concat(list), right]]
+      : [[left, right.concat(list)]];
   } else {
     return [
       ...generateSplits(

--- a/frontend/src/metabase/visualizations/lib/utils.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/utils.unit.spec.js
@@ -7,6 +7,7 @@ import {
   getFriendlyName,
   getDefaultDimensionsAndMetrics,
   preserveExistingColumnsOrder,
+  computeSplit,
 } from "metabase/visualizations/lib/utils";
 
 // TODO Atte Keinänen 5/31/17 Rewrite tests using metabase-lib methods instead of a raw format
@@ -337,6 +338,27 @@ describe("metabase/visualization/lib/utils", () => {
       expect(
         preserveExistingColumnsOrder(["a", "b"], ["c", "d"]),
       ).toStrictEqual(["c", "d"]);
+    });
+  });
+
+  describe("computeSplit", () => {
+    const extents = [
+      [6, 8],
+      [9, 13],
+      [6, 7],
+      [1, 1],
+      [10, 13],
+      [15, 19],
+      [5, 6],
+      [5, 10],
+      [9, 13],
+      [2, 6],
+      [12, 15],
+      [1, 1],
+    ];
+
+    it("should return the same number of series as given", () => {
+      expect(computeSplit(extents).flat()).toHaveLength(extents.length);
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/33725

### Description
When determining potential splits, we only generated possibilities for a total of 8 series. This is being surfaced by a recent change to logic that decides if we should split the y axis or not. This changes ensures that no columns are dropped when generating split possibilities


### How to verify
1. New question -> Sample Dataset -> Orders
2. Count by User -> State, Orders ->Created At: Month
3. Filter by last month (just makes it easier to read)
4. Set the Viz to a bar chart, and enable `Show values on data points`
5. You should see a beautiful chart, and not an error message


### Demo
![image](https://github.com/metabase/metabase/assets/1328979/567a9866-d31e-43ac-8d2c-2e156f6e54c6)

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
