### PR TITLE
Use correct build dependencies for build-for-release job

### DIFF
--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -105,6 +105,7 @@ jobs:
     outputs:
       java_version: ${{ fromJson(steps.dependencies.outputs.result).java_version }}
       node_version: ${{ fromJson(steps.dependencies.outputs.result).node_version }}
+      build_process: ${{ fromJson(steps.dependencies.outputs.result).build_process }}
     steps:
     - uses: actions/checkout@v3
       with:
@@ -116,15 +117,18 @@ jobs:
       id: dependencies
       with:
         script: | # js
-          const { getBuildRequirements } = require('${{ github.workspace }}/release/dist/index.cjs');
+          const { getBuildRequirements, getMajorVersion } = require('${{ github.workspace }}/release/dist/index.cjs');
 
           const version = '${{ inputs.version }}';
 
           const requirements = getBuildRequirements(version);
+          const build_process = getMajorVersion(version) < 46 ? 'legacy' : 'new';
+          console.log('Build process:', build_process);
 
           return {
             java_version: requirements.java,
             node_version: requirements.node,
+            build_process,
           };
 
   build-uberjar-for-release:
@@ -137,6 +141,15 @@ jobs:
     env:
       INTERACTIVE: false
     steps:
+    - name: Get correct version number
+      run: | # bash
+        if [ '${{matrix.edition}}' == 'ee' ]; then
+          version='${{ needs.check-version.outputs.ee }}'
+        else
+          version='${{ needs.check-version.outputs.oss }}'
+        fi
+
+        echo "VERSION=$version" >> $GITHUB_ENV
     - name: Setup Java ${{ needs.get-build-requirements.outputs.java_version }}
       uses: actions/setup-java@v3
       with:
@@ -156,13 +169,13 @@ jobs:
     - name: Prepare back-end environment
       uses: ./.github/actions/prepare-backend
 
-    - name: Build Metabase ${{ needs.check-version.outputs.ee }}
-      if: ${{ matrix.edition == 'ee' }}
-      run: ./bin/build.sh :edition :${{ matrix.edition }} :version ${{ needs.check-version.outputs.ee }}
+    - name: Build Metabase
+      if: ${{ needs.get-build-requirements.outputs.build_process != 'legacy' }}
+      run: ./bin/build.sh :edition :${{ matrix.edition }} :version $VERSION
 
-    - name: Build Metabase ${{ needs.check-version.outputs.oss }}
-      if: ${{ matrix.edition == 'oss' }}
-      run: ./bin/build.sh :edition :${{ matrix.edition }} :version ${{ needs.check-version.outputs.oss }}
+    - name: Build Metabase (legacy)
+      if: ${{ needs.get-build-requirements.outputs.build_process == 'legacy' }}
+      run: cd ./bin/build-mb && clojure -X build/build! :edition :${{ matrix.edition }} :version $VERSION
 
     - name: Store commit's SHA-1 hash
       run:  echo ${{ inputs.commit }} > COMMIT-ID

--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -112,7 +112,7 @@ jobs:
         sparse-checkout: release
     - name: Prepare build scripts
       run: cd ${{ github.workspace }}/release && yarn && yarn build
-    - name: Get Release Version
+    - name: Get build dependencies
       uses: actions/github-script@v6
       id: dependencies
       with:

--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -99,8 +99,36 @@ jobs:
           && echo "Commit found in correct release branch" \
           || (echo "Commit not found in correct release branch" && exit 1)
 
+  get-build-requirements:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    outputs:
+      java_version: ${{ fromJson(steps.dependencies.outputs.result).java_version }}
+      node_version: ${{ fromJson(steps.dependencies.outputs.result).node_version }}
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        sparse-checkout: release
+    - name: Prepare build scripts
+      run: cd ${{ github.workspace }}/release && yarn && yarn build
+    - name: Get Release Version
+      uses: actions/github-script@v6
+      id: dependencies
+      with:
+        script: | # js
+          const { getBuildRequirements } = require('${{ github.workspace }}/release/dist/index.cjs');
+
+          const version = '${{ inputs.version }}';
+
+          const requirements = getBuildRequirements(version);
+
+          return {
+            java_version: requirements.node,
+            node_version: requirements.java,
+          };
+
   build-uberjar-for-release:
-    needs: [check-version, check-commit]
+    needs: [check-version, check-commit, get-build-requirements]
     runs-on: ubuntu-22.04
     timeout-minutes: 50
     strategy:
@@ -109,6 +137,15 @@ jobs:
     env:
       INTERACTIVE: false
     steps:
+    - name: Setup Java ${{ needs.get-build-requirements.outputs.java_version }}
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: ${{ needs.get-build-requirements.outputs.java_version }}
+    - name: Setup Node.js ${{ needs.get-build-requirements.outputs.node_version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ needs.get-build-requirements.outputs.node_version }}.x
     - name: Check out the code
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -123,8 +123,8 @@ jobs:
           const requirements = getBuildRequirements(version);
 
           return {
-            java_version: requirements.node,
-            node_version: requirements.java,
+            java_version: requirements.java,
+            node_version: requirements.node,
           };
 
   build-uberjar-for-release:

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -100,6 +100,29 @@ export const isLatestVersion = (thisVersion: string, allVersions: string[]) => {
   return compareVersions(String(coerce(thisVersion.replace(/(v1|v0)\./, ''))), lastVersion) > -1;
 };
 
+const versionRequirements: Record<number, { java: number, node: number }> = {
+  43: { java: 8, node: 14 },
+  44: { java: 11, node: 14 },
+  45: { java: 11, node: 14 },
+  46: { java: 11, node: 16 },
+  47: { java: 11, node: 18 },
+};
+
+export const getBuildRequirements = (version: string) => {
+  if (!isValidVersionString(version)) {
+    throw new Error(`Invalid version string: ${version}`);
+  }
+  const majorVersion = Number(getMajorVersion(version));
+
+  if (majorVersion in versionRequirements) {
+    return versionRequirements[majorVersion];
+  }
+
+  const lastKey = Object.keys(versionRequirements)[Object.keys(versionRequirements).length - 1];
+  console.warn(`No build requirements found for version ${version}, using latest: v${lastKey}`);
+  return versionRequirements[Number(lastKey)];
+}
+
 export const getNextVersions = (versionString: string): string[] => {
   if (!isValidVersionString(versionString)) {
     throw new Error(`Invalid version string: ${versionString}`);

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -319,6 +319,7 @@ describe("version-helpers", () => {
         node: 18,
         java: 11,
       });
+    });
   });
 
   describe('getNextVersions', () => {

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -7,6 +7,7 @@ import {
   getVersionType,
   getReleaseBranch,
   isLatestVersion,
+  getBuildRequirements,
   getNextVersions,
 } from "./version-helpers";
 
@@ -279,6 +280,47 @@ describe("version-helpers", () => {
     });
   });
 
+  describe("getBuildRequirements", () => {
+    it("should return the correct build requirements for provided ee version", () => {
+      expect(getBuildRequirements("v1.47.2.1")).toEqual({
+        node: 18,
+        java: 11,
+      });
+    });
+
+    it("should return the correct build requirements for provided oss version", () => {
+      expect(getBuildRequirements("v0.47.2.1")).toEqual({
+        node: 18,
+        java: 11,
+      });
+    });
+
+    it("should return the correct build requirements for a major version release", () => {
+      expect(getBuildRequirements("v0.47.0")).toEqual({
+        node: 18,
+        java: 11,
+      });
+    });
+
+    it("should return the correct build requirements for an RC release", () => {
+      expect(getBuildRequirements("v0.47.0-RC7")).toEqual({
+        node: 18,
+        java: 11,
+      });
+    });
+
+    it("should throw an error for invalid versions", () => {
+      expect(() => getBuildRequirements("foo")).toThrow();
+      expect(() => getBuildRequirements("v2.47.6")).toThrow();
+    });
+
+    it('should use the latest build requirements for a version that has not been released', () => {
+      expect(getBuildRequirements("v0.99.0")).toEqual({
+        node: 18,
+        java: 11,
+      });
+  });
+
   describe('getNextVersions', () => {
     it('should get next versions for a major release', () => {
       const testCases: [string, string[]][] = [
@@ -342,5 +384,5 @@ describe("version-helpers", () => {
       expect(() => getNextVersions('v2.75')).toThrow();
       expect(() => getNextVersions('v0.75-RC2')).toThrow();
     });
-  })
+  });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase-private/issues/172

### Description

- Adds a map of node and java versions required to build various metabase versions back to v43 and uses those versions in the build-for-release job so each version gets built correctly. 
- If we forget to add a new entry for a new major version, it will use the versions for the latest major version.
- [Testing older versions](https://github.com/iethree/metabase/actions/runs/6488706217) is a little broken because the e2e tests have assertions that aren't true of all versions, but we can deal with that in another PR.

**Tests in fork:**
- [x] tested [47 release in fork](https://github.com/iethree/metabase/actions/runs/6475050580)
- [x] tested [46 release in fork](https://github.com/iethree/metabase/actions/runs/6437023913)
- [x] tested [45 release in fork](https://github.com/iethree/metabase/actions/runs/6475049310)
- [x] tested [44 release in fork](https://github.com/iethree/metabase/actions/runs/6488567754)
- [x] tested [43 release in fork](https://github.com/iethree/metabase/actions/runs/6474904168)
- [x] tested [99 release in fork](https://github.com/iethree/metabase/actions/runs/6437042995)
