### PR TITLE
Fix docs update trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -459,7 +459,7 @@ jobs:
               repo: '${{ secrets.DOCS_REPO }}',
               event_type: 'trigger-docs-update',
               client_payload: {
-                version: '${{ github.ref_name }}'
+                version: '${{ inputs.version }}'
               }
             });
 


### PR DESCRIPTION
### Description

Since this job used to trigger off of a tag push, the `ref_name` used to be the version number. Now we can just use the input version number.
