### PR TITLE
Modify SearchResult to fit new search payload

### DIFF
--- a/frontend/src/metabase-types/api/mocks/search.ts
+++ b/frontend/src/metabase-types/api/mocks/search.ts
@@ -36,6 +36,12 @@ export const createMockSearchResult = (
     dashboard_count: null,
     context: null,
     scores: [createMockSearchScore()],
+    created_at: "2022-01-01T00:00:00.000Z",
+    creator_common_name: "Testy Tableton",
+    creator_id: 2,
+    last_edited_at: "2023-01-01T00:00:00.000Z",
+    last_editor_common_name: "Bobby Tables",
+    last_editor_id: 1,
     ...options,
   };
 };

--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -1,3 +1,4 @@
+import type { UserId } from "metabase-types/api/user";
 import type { CardId } from "./card";
 import type { Collection } from "./collection";
 import type { DatabaseId, InitialSyncStatus } from "./database";
@@ -71,6 +72,12 @@ export interface SearchResult {
   dashboard_count: number | null;
   context: any; // this might be a dead property
   scores: SearchScore[];
+  last_edited_at: string | null;
+  last_editor_id: UserId | null;
+  last_editor_common_name: string | null;
+  creator_id: UserId | null;
+  creator_common_name: string | null;
+  created_at: string | null;
 }
 
 export interface SearchListQuery {


### PR DESCRIPTION
Adds `created_at`, `creator_common_name`, `creator_id`, `last_edited_at`, `last_editor_common_name`, and `last_editor_id` to the `SearchResult` frontend model.

This code was originally in [Search Results Facelift](https://github.com/metabase/metabase/pull/34410) but split out to separate data from styling for reviews


This should match the new payload provided by [Global search: adding creator name and last editor name to search results
](https://github.com/metabase/metabase/pull/34312)