### PR TITLE
Exclude `team.json` from CI triggers in file paths

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -3,7 +3,7 @@ default: &default
   - "bin/**"
 
 ci: &ci
-  - ".github/**/!(*.md)"
+  - ".github/**/!(*.md|team.json)"
 
 shared_sources: &shared_sources
   - "shared/src/**"


### PR DESCRIPTION
Check results in [this test tool](https://www.digitalocean.com/community/tools/glob?comments=true&glob=.github%2F%2A%2A%2F%21%28%2A.md%7Cteam.json%29&matches=false&tests=.github%2Fteam.json&tests=.github%2Ffoo%2Fteam.json&tests=.github%2Ffoo%2Fpotato.json&tests=.github%2Ffoo%2Fbar.md&tests=.github%2Ffoo.md&tests=.github%2Fworkflow.yml&tests=.github%2Ffoo%2Fworkflow.yml) that confirm the glob used here is correct.