### PR TITLE
MLv2 Joins — Disable RHS table changes

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/NotebookCell/NotebookCell.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookCell/NotebookCell.styled.tsx
@@ -20,6 +20,7 @@ export const NotebookCellItemContainer = styled.div<{
   color: string;
   inactive?: boolean;
   readOnly?: boolean;
+  disabled?: boolean;
 }>`
   display: flex;
   align-items: center;
@@ -32,7 +33,7 @@ export const NotebookCellItemContainer = styled.div<{
     props.inactive ? alpha(props.color, 0.25) : "transparent"};
 
   cursor: ${props =>
-    !props.inactive && !props.readOnly && !!props.onClick
+    !props.inactive && !props.readOnly && !props.disabled && !!props.onClick
       ? "pointer"
       : "default"};
 
@@ -51,6 +52,7 @@ export const NotebookCellItemContentContainer = styled.div<{
   color: string;
   inactive?: boolean;
   readOnly?: boolean;
+  disabled?: boolean;
   border?: BorderSide;
   roundedCorners: BorderSide[];
 }>`
@@ -59,9 +61,14 @@ export const NotebookCellItemContentContainer = styled.div<{
   padding: ${CONTAINER_PADDING};
   background-color: ${props => (props.inactive ? "transparent" : props.color)};
 
+  pointer-events: ${props => (props.disabled ? "none" : "auto")};
+
   &:hover {
     background-color: ${props =>
-      !props.inactive && !props.readOnly && alpha(props.color, 0.8)};
+      !props.inactive &&
+      !props.readOnly &&
+      !props.disabled &&
+      alpha(props.color, 0.8)};
   }
 
   ${props =>
@@ -86,7 +93,3 @@ export const NotebookCellItemContentContainer = styled.div<{
 
   transition: background 300ms linear;
 `;
-
-export const NotebookCellRightSideContainer = styled(
-  NotebookCellItemContentContainer,
-)``;

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookCell/NotebookCell.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookCell/NotebookCell.styled.tsx
@@ -50,6 +50,7 @@ export const NotebookCellItemContainer = styled.div<{
 export const NotebookCellItemContentContainer = styled.div<{
   color: string;
   inactive?: boolean;
+  readOnly?: boolean;
   border?: BorderSide;
   roundedCorners: BorderSide[];
 }>`
@@ -59,7 +60,8 @@ export const NotebookCellItemContentContainer = styled.div<{
   background-color: ${props => (props.inactive ? "transparent" : props.color)};
 
   &:hover {
-    background-color: ${props => !props.inactive && alpha(props.color, 0.8)};
+    background-color: ${props =>
+      !props.inactive && !props.readOnly && alpha(props.color, 0.8)};
   }
 
   ${props =>
@@ -84,3 +86,7 @@ export const NotebookCellItemContentContainer = styled.div<{
 
   transition: background 300ms linear;
 `;
+
+export const NotebookCellRightSideContainer = styled(
+  NotebookCellItemContentContainer,
+)``;

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookCell/NotebookCell.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookCell/NotebookCell.tsx
@@ -5,7 +5,6 @@ import {
   NotebookCell as _NotebookCell,
   NotebookCellItemContainer,
   NotebookCellItemContentContainer,
-  NotebookCellRightSideContainer,
   CONTAINER_PADDING,
 } from "./NotebookCell.styled";
 
@@ -18,6 +17,7 @@ interface NotebookCellItemProps {
   color: string;
   inactive?: boolean;
   readOnly?: boolean;
+  disabled?: boolean;
   right?: React.ReactNode;
   containerStyle?: React.CSSProperties;
   rightContainerStyle?: React.CSSProperties;
@@ -27,62 +27,60 @@ interface NotebookCellItemProps {
   ref?: React.Ref<HTMLDivElement>;
 }
 
-const _NotebookCellItem = forwardRef<HTMLDivElement, NotebookCellItemProps>(
-  function NotebookCellItem(
-    {
-      inactive,
-      color,
-      containerStyle,
-      right,
-      rightContainerStyle,
-      children,
-      readOnly,
-      ...restProps
-    },
-    ref,
-  ) {
-    const hasRightSide = isValidElement(right) && !readOnly;
-    const mainContentRoundedCorners: BorderSide[] = ["left"];
-    if (!hasRightSide) {
-      mainContentRoundedCorners.push("right");
-    }
-    return (
-      <NotebookCellItemContainer
+export const NotebookCellItem = forwardRef<
+  HTMLDivElement,
+  NotebookCellItemProps
+>(function NotebookCellItem(
+  {
+    inactive,
+    disabled,
+    color,
+    containerStyle,
+    right,
+    rightContainerStyle,
+    children,
+    readOnly,
+    ...restProps
+  },
+  ref,
+) {
+  const hasRightSide = isValidElement(right) && !readOnly;
+  const mainContentRoundedCorners: BorderSide[] = ["left"];
+  if (!hasRightSide) {
+    mainContentRoundedCorners.push("right");
+  }
+  return (
+    <NotebookCellItemContainer
+      inactive={inactive}
+      readOnly={readOnly}
+      color={color}
+      {...restProps}
+      data-testid={restProps["data-testid"] ?? "notebook-cell-item"}
+      ref={ref}
+    >
+      <NotebookCellItemContentContainer
         inactive={inactive}
+        disabled={disabled}
         readOnly={readOnly}
         color={color}
-        {...restProps}
-        data-testid={restProps["data-testid"] ?? "notebook-cell-item"}
-        ref={ref}
+        roundedCorners={mainContentRoundedCorners}
+        style={containerStyle}
       >
+        {children}
+      </NotebookCellItemContentContainer>
+      {hasRightSide && (
         <NotebookCellItemContentContainer
           inactive={inactive}
-          readOnly={readOnly}
           color={color}
-          roundedCorners={mainContentRoundedCorners}
-          style={containerStyle}
+          border="left"
+          roundedCorners={["right"]}
+          style={rightContainerStyle}
         >
-          {children}
+          {right}
         </NotebookCellItemContentContainer>
-        {hasRightSide && (
-          <NotebookCellRightSideContainer
-            inactive={inactive}
-            color={color}
-            border="left"
-            roundedCorners={["right"]}
-            style={rightContainerStyle}
-          >
-            {right}
-          </NotebookCellRightSideContainer>
-        )}
-      </NotebookCellItemContainer>
-    );
-  },
-);
-
-export const NotebookCellItem = Object.assign(_NotebookCellItem, {
-  displayName: "NotebookCellItem",
-  Content: NotebookCellItemContentContainer,
+      )}
+    </NotebookCellItemContainer>
+  );
 });
 
 interface NotebookCellAddProps extends NotebookCellItemProps {

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookCell/NotebookCell.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookCell/NotebookCell.tsx
@@ -5,6 +5,7 @@ import {
   NotebookCell as _NotebookCell,
   NotebookCellItemContainer,
   NotebookCellItemContentContainer,
+  NotebookCellRightSideContainer,
   CONTAINER_PADDING,
 } from "./NotebookCell.styled";
 
@@ -26,57 +27,62 @@ interface NotebookCellItemProps {
   ref?: React.Ref<HTMLDivElement>;
 }
 
-export const NotebookCellItem = forwardRef<
-  HTMLDivElement,
-  NotebookCellItemProps
->(function NotebookCellItem(
-  {
-    inactive,
-    color,
-    containerStyle,
-    right,
-    rightContainerStyle,
-    children,
-    readOnly,
-    ...restProps
-  },
-  ref,
-) {
-  const hasRightSide = isValidElement(right) && !readOnly;
-  const mainContentRoundedCorners: BorderSide[] = ["left"];
-  if (!hasRightSide) {
-    mainContentRoundedCorners.push("right");
-  }
-  return (
-    <NotebookCellItemContainer
-      inactive={inactive}
-      readOnly={readOnly}
-      color={color}
-      {...restProps}
-      data-testid={restProps["data-testid"] ?? "notebook-cell-item"}
-      ref={ref}
-    >
-      <NotebookCellItemContentContainer
+const _NotebookCellItem = forwardRef<HTMLDivElement, NotebookCellItemProps>(
+  function NotebookCellItem(
+    {
+      inactive,
+      color,
+      containerStyle,
+      right,
+      rightContainerStyle,
+      children,
+      readOnly,
+      ...restProps
+    },
+    ref,
+  ) {
+    const hasRightSide = isValidElement(right) && !readOnly;
+    const mainContentRoundedCorners: BorderSide[] = ["left"];
+    if (!hasRightSide) {
+      mainContentRoundedCorners.push("right");
+    }
+    return (
+      <NotebookCellItemContainer
         inactive={inactive}
+        readOnly={readOnly}
         color={color}
-        roundedCorners={mainContentRoundedCorners}
-        style={containerStyle}
+        {...restProps}
+        data-testid={restProps["data-testid"] ?? "notebook-cell-item"}
+        ref={ref}
       >
-        {children}
-      </NotebookCellItemContentContainer>
-      {hasRightSide && (
         <NotebookCellItemContentContainer
           inactive={inactive}
+          readOnly={readOnly}
           color={color}
-          border="left"
-          roundedCorners={["right"]}
-          style={rightContainerStyle}
+          roundedCorners={mainContentRoundedCorners}
+          style={containerStyle}
         >
-          {right}
+          {children}
         </NotebookCellItemContentContainer>
-      )}
-    </NotebookCellItemContainer>
-  );
+        {hasRightSide && (
+          <NotebookCellRightSideContainer
+            inactive={inactive}
+            color={color}
+            border="left"
+            roundedCorners={["right"]}
+            style={rightContainerStyle}
+          >
+            {right}
+          </NotebookCellRightSideContainer>
+        )}
+      </NotebookCellItemContainer>
+    );
+  },
+);
+
+export const NotebookCellItem = Object.assign(_NotebookCellItem, {
+  displayName: "NotebookCellItem",
+  Content: NotebookCellItemContentContainer,
 });
 
 interface NotebookCellAddProps extends NotebookCellItemProps {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
@@ -187,7 +187,7 @@ export function JoinStep({
     <Flex miw="100%" gap="1rem">
       <TablesNotebookCell color={color}>
         <Flex direction="row" gap={6}>
-          <NotebookCellItem color={color} readOnly aria-label={t`Left table`}>
+          <NotebookCellItem color={color} disabled aria-label={t`Left table`}>
             {lhsDisplayName}
           </NotebookCellItem>
           <JoinStrategyPicker

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
@@ -187,7 +187,7 @@ export function JoinStep({
     <Flex miw="100%" gap="1rem">
       <TablesNotebookCell color={color}>
         <Flex direction="row" gap={6}>
-          <NotebookCellItem color={color} aria-label={t`Left table`}>
+          <NotebookCellItem color={color} readOnly aria-label={t`Left table`}>
             {lhsDisplayName}
           </NotebookCellItem>
           <JoinStrategyPicker

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -251,6 +251,15 @@ describe("Notebook Editor > Join Step", () => {
     expect(within(rhsColumnPicker).getByText("Body")).toBeInTheDocument();
   });
 
+  it("shouldn't let changing the RHS table", () => {
+    setup(createMockNotebookStep({ topLevelQuery: getJoinedQuery() }));
+
+    const rhsTablePicker = screen.getByLabelText("Right table");
+    const pickerButton = within(rhsTablePicker).getByText("Products");
+
+    expect(pickerButton).toBeDisabled();
+  });
+
   it("should highlight selected LHS column", async () => {
     setup(createMockNotebookStep({ topLevelQuery: getJoinedQuery() }));
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.styled.tsx
@@ -1,8 +1,7 @@
 import styled from "@emotion/styled";
-import { css } from "@emotion/react";
 import IconButtonWrapper from "metabase/components/IconButtonWrapper/IconButtonWrapper";
 import { color } from "metabase/lib/colors";
-import { NotebookCell, NotebookCellItem } from "../../../NotebookCell";
+import { NotebookCell } from "../../../NotebookCell";
 
 export const PickerButton = styled.button`
   color: inherit;
@@ -14,22 +13,4 @@ export const ColumnPickerButton = styled(IconButtonWrapper)`
   padding: ${NotebookCell.CONTAINER_PADDING};
   opacity: 0.5;
   color: ${color("white")};
-`;
-
-export const PickerNotebookCellItem = styled(NotebookCellItem)<{
-  canChangeTable?: boolean;
-}>`
-  ${NotebookCellItem.Content} {
-    pointer-events: ${props => (props.canChangeTable ? "auto" : "none")};
-  }
-
-  ${props =>
-    !props.inactive &&
-    css`
-      &:hover {
-        ${NotebookCellItem.Content} {
-          background-color: ${props.color};
-        }
-      }
-    `}
 `;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.styled.tsx
@@ -6,7 +6,7 @@ import { NotebookCell } from "../../../NotebookCell";
 export const PickerButton = styled.button`
   color: inherit;
   font-weight: inherit;
-  cursor: pointer;
+  cursor: ${props => (props.disabled ? "auto" : "pointer")};
 `;
 
 export const ColumnPickerButton = styled(IconButtonWrapper)`

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.styled.tsx
@@ -1,7 +1,8 @@
 import styled from "@emotion/styled";
+import { css } from "@emotion/react";
 import IconButtonWrapper from "metabase/components/IconButtonWrapper/IconButtonWrapper";
 import { color } from "metabase/lib/colors";
-import { NotebookCell } from "../../../NotebookCell";
+import { NotebookCell, NotebookCellItem } from "../../../NotebookCell";
 
 export const PickerButton = styled.button`
   color: inherit;
@@ -13,4 +14,22 @@ export const ColumnPickerButton = styled(IconButtonWrapper)`
   padding: ${NotebookCell.CONTAINER_PADDING};
   opacity: 0.5;
   color: ${color("white")};
+`;
+
+export const PickerNotebookCellItem = styled(NotebookCellItem)<{
+  canChangeTable?: boolean;
+}>`
+  ${NotebookCellItem.Content} {
+    pointer-events: ${props => (props.canChangeTable ? "auto" : "none")};
+  }
+
+  ${props =>
+    !props.inactive &&
+    css`
+      &:hover {
+        ${NotebookCellItem.Content} {
+          background-color: ${props.color};
+        }
+      }
+    `}
 `;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
@@ -16,12 +16,9 @@ import type { TableId } from "metabase-types/api";
 import * as Lib from "metabase-lib";
 import type Table from "metabase-lib/metadata/Table";
 
+import { NotebookCellItem } from "../../../NotebookCell";
 import { FIELDS_PICKER_STYLES } from "../../../FieldsPickerIcon";
-import {
-  PickerButton,
-  PickerNotebookCellItem,
-  ColumnPickerButton,
-} from "./JoinTablePicker.styled";
+import { PickerButton, ColumnPickerButton } from "./JoinTablePicker.styled";
 
 interface JoinTablePickerProps {
   query: Lib.Query;
@@ -82,10 +79,10 @@ export function JoinTablePicker({
   const tableFilter = (table: Table) => !tableId || table.db_id === databaseId;
 
   return (
-    <PickerNotebookCellItem
+    <NotebookCellItem
       inactive={!table}
       readOnly={readOnly}
-      canChangeTable={canChangeTable}
+      disabled={!canChangeTable}
       color={color}
       aria-label={t`Right table`}
       right={
@@ -117,7 +114,7 @@ export function JoinTablePicker({
           </PickerButton>
         }
       />
-    </PickerNotebookCellItem>
+    </NotebookCellItem>
   );
 }
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
@@ -16,9 +16,12 @@ import type { TableId } from "metabase-types/api";
 import * as Lib from "metabase-lib";
 import type Table from "metabase-lib/metadata/Table";
 
-import { NotebookCellItem } from "../../../NotebookCell";
 import { FIELDS_PICKER_STYLES } from "../../../FieldsPickerIcon";
-import { PickerButton, ColumnPickerButton } from "./JoinTablePicker.styled";
+import {
+  PickerButton,
+  PickerNotebookCellItem,
+  ColumnPickerButton,
+} from "./JoinTablePicker.styled";
 
 interface JoinTablePickerProps {
   query: Lib.Query;
@@ -54,6 +57,8 @@ export function JoinTablePicker({
   const databaseId = pickerInfo?.databaseId || Lib.databaseID(query);
   const tableId = pickerInfo?.tableId || pickerInfo?.cardId;
 
+  const canChangeTable = !readOnly && !table;
+
   const databases = useMemo(() => {
     const database = metadata.database(databaseId);
     return [database, metadata.savedQuestionsDatabase()].filter(Boolean);
@@ -77,9 +82,10 @@ export function JoinTablePicker({
   const tableFilter = (table: Table) => !tableId || table.db_id === databaseId;
 
   return (
-    <NotebookCellItem
+    <PickerNotebookCellItem
       inactive={!table}
       readOnly={readOnly}
+      canChangeTable={canChangeTable}
       color={color}
       aria-label={t`Right table`}
       right={
@@ -106,12 +112,12 @@ export function JoinTablePicker({
         selectedTableId={tableId}
         setSourceTableFn={handleTableChange}
         triggerElement={
-          <PickerButton disabled={!!table || readOnly}>
+          <PickerButton disabled={!canChangeTable}>
             {tableInfo?.displayName || t`Pick data…`}
           </PickerButton>
         }
       />
-    </NotebookCellItem>
+    </PickerNotebookCellItem>
   );
 }
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
@@ -106,7 +106,7 @@ export function JoinTablePicker({
         selectedTableId={tableId}
         setSourceTableFn={handleTableChange}
         triggerElement={
-          <PickerButton disabled={readOnly}>
+          <PickerButton disabled={!!table || readOnly}>
             {tableInfo?.displayName || t`Pick data…`}
           </PickerButton>
         }


### PR DESCRIPTION
Epic #30514

Addresses the same issue #32911 was supposed to fix. It turned out to be a can of worms, mostly because it requires some arbitrary notebook state, and keeping it in sync with an actual query is very error-prone and hard to get right. This PR disables the right column picker once a table is selected (it's expected to remove a join and create a new one instead). This makes it impossible to make a join invalid from the UI, so we don't have to worry about that problem at all now.

FWIW, it should be possible to restore and improve the previous behavior once we port the notebook's top-level components to MLv2 as well (mostly parts slicing a query down into steps and rendering them)

### To Verify

1. New > Question > Raw Data > Sample Database > Orders
2. Join the Products table
3. Click the "Products" table cell in the join section
4. Ensure the table picker doesn't open