### PR TITLE
add repro test for #26467 which has been already fixed with #28945

### DIFF
--- a/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -1053,14 +1053,14 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
     });
   });
 
-  it("should not have to wait for data to show fields in summarisation (#26467)", () => {
+  it("should not have to wait for data to show fields in summarisation (metabase#26467)", () => {
     createAndVisitTestQuestion();
 
     cy.intercept("POST", "api/card/pivot/*/query", req => {
       req.on("response", res => {
         res.setDelay(20_000);
       });
-    }).as("querySlowed");
+    });
 
     cy.reload();
 

--- a/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -8,6 +8,7 @@ import {
   visitIframe,
   dragField,
   leftSidebar,
+  main,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
@@ -1050,6 +1051,27 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
         });
       });
     });
+  });
+
+  it("should not have to wait for data to show fields in summarisation", () => {
+    createAndVisitTestQuestion();
+
+    cy.reload();
+
+    cy.intercept("POST", "api/card/pivot/*/query", req => {
+      req.on("response", res => {
+        res.setDelay(300000);
+      });
+    }).as("querySlowed");
+
+    // confirm that it's loading
+    main().findByText("Doing science...").should("be.visible");
+
+    cy.icon("notebook").click();
+
+    main().findByText("User → Source").click();
+
+    popover().findByText("Address").click();
   });
 });
 

--- a/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -1053,16 +1053,16 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
     });
   });
 
-  it("should not have to wait for data to show fields in summarisation", () => {
+  it("should not have to wait for data to show fields in summarisation (#26467)", () => {
     createAndVisitTestQuestion();
-
-    cy.reload();
 
     cy.intercept("POST", "api/card/pivot/*/query", req => {
       req.on("response", res => {
-        res.setDelay(300000);
+        res.setDelay(20_000);
       });
     }).as("querySlowed");
+
+    cy.reload();
 
     // confirm that it's loading
     main().findByText("Doing science...").should("be.visible");

--- a/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -1072,6 +1072,8 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
     main().findByText("User → Source").click();
 
     popover().findByText("Address").click();
+
+    main().findByText("User → Address").should("be.visible");
   });
 });
 


### PR DESCRIPTION
# Description
This adds a test for https://github.com/metabase/metabase/issues/26467 which was fixed with https://github.com/metabase/metabase/pull/28945/


# How to verify
See the steps in the linked issue, it should now work.
I tested this test in v0.45 and it failed. It needed some edits because some helpers were missing:
```ts
    createAndVisitTestQuestion();

    cy.reload();

    cy.intercept("POST", "api/card/pivot/*/query", req => {
      req.on("response", res => {
        res.setDelay(300000);
      });
    }).as("querySlowed");

    // confirm that it's loading
    cy.findByText("Doing science...").should("be.visible");

    cy.icon("notebook").click();

    cy.get("main").findAllByText("User → Source").first().click();

    popover().findByText("State").click();

    cy.get("main").findByText("User → State").should("be.visible");
