### PR TITLE
Automatically manage milestones in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -571,3 +571,36 @@ jobs:
         aws cloudfront create-invalidation \
         --distribution-id ${{ vars.AWS_CLOUDFRONT_STATIC_ID }} \
         --paths "/version-info.json" "/version-info-ee.json"
+
+  manage-issues:
+    permissions: write-all
+    runs-on: ubuntu-22.04
+    needs: [publish-version-info, draft-release-notes]
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        sparse-checkout: release
+    - name: Prepare build scripts
+      run: cd ${{ github.workspace }}/release && yarn && yarn build
+    - name: Update milestones
+      uses: actions/github-script@v6
+      with:
+        script: | # js
+          const { closeMilestone, openNextMilestones } = require('${{ github.workspace }}/release/dist/index.cjs');
+
+          const version = '${{ inputs.version }}';
+
+          await closeMilestone({
+            github,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            version,
+          });
+
+          await openNextMilestones({
+            github,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            version,
+          });

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -99,3 +99,41 @@ export const isLatestVersion = (thisVersion: string, allVersions: string[]) => {
 
   return compareVersions(String(coerce(thisVersion.replace(/(v1|v0)\./, ''))), lastVersion) > -1;
 };
+
+export const getNextVersions = (versionString: string): string[] => {
+  if (!isValidVersionString(versionString)) {
+    throw new Error(`Invalid version string: ${versionString}`);
+  }
+
+  const versionType = getVersionType(versionString);
+
+  if (versionType === 'rc' || versionType === 'patch') {
+    return [];
+  }
+
+  const editionString = isEnterpriseVersion(versionString)
+    ? 'v1.'
+    : 'v0.';
+
+  // minor releases -> next minor release
+  const [major, minor] = versionString
+    .replace(/(v1|v0)\./, '')
+    .replace(/.0$/, "")
+    .split('.')
+    .map(Number);
+
+  if (versionType === 'minor') {
+    return [editionString + [major, minor + 1].join('.')];
+  }
+
+
+  // major releases -> x.1 minor release AND next .0 major release
+  if (versionType === 'major') {
+    return [
+      editionString + [major, 1].join('.'),
+      editionString + [major + 1, 0].join('.'),
+    ];
+  }
+
+  return [];
+};

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -7,6 +7,7 @@ import {
   getVersionType,
   getReleaseBranch,
   isLatestVersion,
+  getNextVersions,
 } from "./version-helpers";
 
 describe("version-helpers", () => {
@@ -277,4 +278,69 @@ describe("version-helpers", () => {
       });
     });
   });
+
+  describe('getNextVersions', () => {
+    it('should get next versions for a major release', () => {
+      const testCases: [string, string[]][] = [
+        ['v0.75.0', ['v0.75.1', 'v0.76.0']],
+        ['v0.99.0', ['v0.99.1', 'v0.100.0']],
+      ];
+
+      testCases.forEach(([input, expected]) => {
+        expect(getNextVersions(input)).toEqual(expected);
+      });
+    });
+
+    it('should handle ee and oss versions', () => {
+      const testCases: [string, string[]][] = [
+        ['v0.75.1', ['v0.75.2']],
+        ['v1.75.1', ['v1.75.2']],
+      ];
+
+      testCases.forEach(([input, expected]) => {
+        expect(getNextVersions(input)).toEqual(expected);
+      });
+    });
+
+    it('should get next versions for a minor release', () => {
+      const testCases: [string, string[]][] = [
+        ['v0.75.1', ['v0.75.2']],
+        ['v0.75.1.0', ['v0.75.2']], // disregards extra .0
+        ['v0.79.99', ['v0.79.100']],
+        ['v0.79.99.0', ['v0.79.100']],
+      ];
+
+      testCases.forEach(([input, expected]) => {
+        expect(getNextVersions(input)).toEqual(expected);
+      });
+    });
+
+    it('should not get next versions for a patch release', () => {
+      const testCases: [string, string[]][] = [
+        ['v0.75.1.1', []],
+        ['v0.79.99.3', []],
+      ];
+
+      testCases.forEach(([input, expected]) => {
+        expect(getNextVersions(input)).toEqual(expected);
+      });
+    });
+
+    it('should not get next versions for an RC release', () => {
+      const testCases: [string, string[]][] = [
+        ['v0.75.0-RC2', []],
+        ['v0.79.0-rc99', []],
+      ];
+
+      testCases.forEach(([input, expected]) => {
+        expect(getNextVersions(input)).toEqual(expected);
+      });
+    });
+
+    it('should throw an error for an invalid version string', () => {
+      expect(() => getNextVersions('foo')).toThrow();
+      expect(() => getNextVersions('v2.75')).toThrow();
+      expect(() => getNextVersions('v0.75-RC2')).toThrow();
+    });
+  })
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase-private/issues/173

### Description

- Automatically closes the milestone that just got released (if any).
- Opens new milestone based on the release type
  - minor releases open the next minor release milestone
  - major releases open the next minor and next major release milestones
  - patch and RC releases don't open any new milestones

Tested in fork:
- [x] [major release](https://github.com/iethree/metabase/actions/runs/6488336875)
- [x] [minor release](https://github.com/iethree/metabase/actions/runs/6475238760/job/17581870906)
- [x] [patch release](https://github.com/iethree/metabase/actions/runs/6475800493)
- [x] [rc release](https://github.com/iethree/metabase/actions/runs/6475792793/job/17583438794)



✅  Created minor milestone:

![Screen Shot 2023-10-10 at 3 58 56 PM](https://github.com/metabase/metabase/assets/30528226/c3fb527b-5d72-488d-abc7-a4629e5aaee0)

✅  Created major and minor milestones:
![Screen Shot 2023-10-11 at 3 45 38 PM](https://github.com/metabase/metabase/assets/30528226/f47eef5b-86d4-4888-b067-6466182fbba3)
