### PR TITLE
Updates hawk to include supports `#hawk/malli` reader within `=?`

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -210,7 +210,7 @@
     com.gfredericks/test.chuck   {:mvn/version "0.2.14"}                    ; generating strings from regexes (useful with malli)
     djblue/portal                {:mvn/version "0.46.0"}                    ; ui for inspecting values
     io.github.camsaul/humane-are {:mvn/version "1.0.2"}
-    io.github.metabase/hawk      {:sha "f1c10798f3230b976a1096cd0ff51daebe472fbb"}
+    io.github.metabase/hawk      {:sha "9c97bcb6d4de116325e651b40973fd0a75b7ae21"}
     jonase/eastwood              {:mvn/version "1.4.0"                      ; inspects namespaces and reports possible problems using tools.analyzer
                                   :exclusions
                                   [org.ow2.asm/asm-all]}
@@ -308,7 +308,7 @@
     cider/piggieback                   {:mvn/version "0.5.3"}
     cljs-bean/cljs-bean                {:mvn/version "1.9.0"}
     com.lambdaisland/glogi             {:mvn/version "1.3.169"}
-    io.github.metabase/hawk            {:sha "f1c10798f3230b976a1096cd0ff51daebe472fbb"}
+    io.github.metabase/hawk            {:sha "9c97bcb6d4de116325e651b40973fd0a75b7ae21"}
     org.clojars.mmb90/cljs-cache       {:mvn/version "0.1.4"}
     ;; Forcibly targeting a newer release than ships by default with shadow-cljs 2.20.20.
     ;; It fixes an issue where TypeScript can't parse the `cljs_env.js` output file.

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
@@ -247,12 +247,12 @@
                                                  :card_id              card-id-1
                                                  :attribute_remappings {"foo" 1}}]))
                   result (mt/user-http-request :crowberto :put 200 "permissions/graph" graph)]
-              (is (=? [{:id                   #hawk/schema s/Int
+              (is (=? [{:id                   #hawk/malli :int
                         :table_id             table-id-1
                         :group_id             group-id
                         :card_id              card-id-1
                         :attribute_remappings {:foo 1}
-                        :permission_id        #hawk/schema s/Int}]
+                        :permission_id        #hawk/malli :int}]
                       (:sandboxes result)))
               (is (t2/exists? GroupTableAccessPolicy :table_id table-id-1 :group_id group-id))))
 

--- a/test/metabase/api/automagic_dashboards_test.clj
+++ b/test/metabase/api/automagic_dashboards_test.clj
@@ -313,7 +313,7 @@
 
 (def Tab-Id-Schema
   "Schema for tab-ids. Must be integers for the front-end, but negative so we know they do not (yet) exist in the db."
-  (s/pred neg-int? 'ui-temp-id?))
+  [:fn neg-int?])
 
 (defn- expected-filters
   [{:keys [model-index-value] :as info}]
@@ -364,9 +364,9 @@
                                                    :linked-field-id %reviews.product_id}
                                                   {:linked-table-id $$orders
                                                    :linked-field-id %orders.product_id}])})]
-          (is (=? [{:id   #hawk/schema Tab-Id-Schema
+          (is (=? [{:id   #hawk/malli Tab-Id-Schema
                     :name "A look at Reviews" :position 0}
-                   {:id   #hawk/schema Tab-Id-Schema
+                   {:id   #hawk/malli Tab-Id-Schema
                     :name "A look at Orders" :position 1}]
                   (:ordered_tabs dash)))
           (testing "The first card for each tab is a linked model card to the source model"
@@ -434,9 +434,9 @@
                                                         :linked-field-id %reviews.product_id}
                                                        {:linked-table-id $$orders
                                                         :linked-field-id %orders.product_id}])})]
-              (is (=? [{:id   #hawk/schema Tab-Id-Schema
+              (is (=? [{:id   #hawk/malli Tab-Id-Schema
                         :name "A look at Reviews" :position 0}
-                       {:id   #hawk/schema Tab-Id-Schema
+                       {:id   #hawk/malli Tab-Id-Schema
                         :name "A look at Orders" :position 1}]
                       (:ordered_tabs dash)))
               (testing "All query cards have the correct filters"

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1479,7 +1479,7 @@
                       :dashboard_id dashboard-id
                       :name         "Tab 2"
                       :position 1}
-                     {:id           #hawk/schema (s/pred pos-int?)
+                     {:id           #hawk/malli [:fn pos-int?]
                       :dashboard_id dashboard-id
                       :name         "New tab"
                       :position     2}]
@@ -1502,7 +1502,7 @@
                         :size_y           2
                         :col              2
                         :row              2}
-                       {:id               #hawk/schema (s/pred pos-int?)
+                       {:id               #hawk/malli [:fn pos-int?]
                         :size_x           1
                         :size_y           1
                         :col              3
@@ -1650,11 +1650,11 @@
                           :card_id          card-id-1
                           :dashboard_id     dashboard-id
                           :dashboard_tab_id tab-1-id}
-                         {:id               #hawk/schema (s/pred pos-int?)
+                         {:id               #hawk/malli [:fn pos-int?]
                           :card_id          card-id-1
                           :dashboard_id     dashboard-id
                           :dashboard_tab_id tab-1-id}
-                         {:id               #hawk/schema (s/pred pos-int?)
+                         {:id               #hawk/malli [:fn pos-int?]
                           :card_id          card-id-2
                           :dashboard_id     dashboard-id
                           :dashboard_tab_id tab-2-id}]

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -19,7 +19,6 @@
    [metabase.search.scoring :as scoring]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [schema.core :as s]
    [toucan2.core :as t2]
    [toucan2.execute :as t2.execute]
    [toucan2.tools.with-temp :as t2.with-temp]))
@@ -503,16 +502,16 @@
                        (into #{} (comp relevant (map :name)) (search! "fort"))))))
 
             (let [normalize (fn [x] (-> x (update :pk_ref mbql.normalize/normalize)))]
-              (is (=? {"Rome"   {:pk_ref        (mt/$ids $municipality.id)
-                                 :name          "Rome"
-                                 :model_id      (:id model)
+              (is (=? {"Rome"   {:pk_ref         (mt/$ids $municipality.id)
+                                 :name           "Rome"
+                                 :model_id       (:id model)
                                  :model_name     (:name model)
-                                 :model_index_id #hawk/schema s/Int}
-                       "Tromsø" {:pk_ref        (mt/$ids $municipality.id)
-                                 :name          "Tromsø"
-                                 :model_id      (:id model)
+                                 :model_index_id #hawk/malli :int}
+                       "Tromsø" {:pk_ref         (mt/$ids $municipality.id)
+                                 :name           "Tromsø"
+                                 :model_id       (:id model)
                                  :model_name     (:name model)
-                                 :model_index_id #hawk/schema s/Int}}
+                                 :model_index_id #hawk/malli :int}}
                       (into {} (comp relevant (map (juxt :name normalize)))
                             (search! "rom"))))))))))
 
@@ -808,12 +807,12 @@
                      Action      _              (archived {:name     "test action"
                                                            :type     :query
                                                            :model_id model-id})]
-      (testing "`archived-string` is invalid"
-        (is (=? {:message "Invalid input: [\"value must be a valid boolean string ('true' or 'false').\"]"}
-                (mt/user-http-request :crowberto :get 500 "search/models" :archived-string 1))))
-      (testing "`archived-string` is 'false'"
-        (is (= #{"dashboard" "database" "segment" "collection" "action" "metric" "card" "dataset" "table"}
-               (set (mt/user-http-request :crowberto :get 200 "search/models" :archived-string "false")))))
-      (testing "`archived-string` is 'true'"
-        (is (= #{"action"}
-               (set (mt/user-http-request :crowberto :get 200 "search/models" :archived-string "true")))))))))
+       (testing "`archived-string` is invalid"
+         (is (=? {:message "Invalid input: [\"value must be a valid boolean string ('true' or 'false').\"]"}
+                 (mt/user-http-request :crowberto :get 500 "search/models" :archived-string 1))))
+       (testing "`archived-string` is 'false'"
+         (is (= #{"dashboard" "database" "segment" "collection" "action" "metric" "card" "dataset" "table"}
+                (set (mt/user-http-request :crowberto :get 200 "search/models" :archived-string "false")))))
+       (testing "`archived-string` is 'true'"
+         (is (= #{"action"}
+                (set (mt/user-http-request :crowberto :get 200 "search/models" :archived-string "true")))))))))

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -18,7 +18,6 @@
    [metabase.test.data.users :as test.users]
    [metabase.test.util :as tu]
    [metabase.util :as u]
-   [schema.core :as s]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp])
   (:import
@@ -542,7 +541,7 @@
                (t2/select :model/DashboardTab :dashboard_id dashboard-id {:order-by [[:position :asc]]})))
        ;; revert
        (revert-to-previous-revision Dashboard dashboard-id 2)
-       (is (=? [{:id #hawk/schema (s/pred pos-int?) :name "Tab 1" :position 0}
+       (is (=? [{:id #hawk/malli [:fn pos-int?] :name "Tab 1" :position 0}
                 {:id tab-2-id :name "Tab 2" :position 1}]
                (t2/select :model/DashboardTab :dashboard_id dashboard-id {:order-by [[:position :asc]]})))))))
 


### PR DESCRIPTION
PR that implements it https://github.com/metabase/hawk/pull/10