### PR TITLE
defendpoint without redefine routes

### DIFF
--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -331,9 +331,9 @@
 (defn- namespace->api-route-fns
   "Return a sequence of all API endpoint functions defined by `defendpoint` in a namespace."
   [nmspace]
-  (for [[symb varr] (ns-publics nmspace)
+  (for [[_symb varr] (ns-publics nmspace)
         :when       (:is-endpoint? (meta varr))]
-    symb))
+    varr))
 
 (defn- api-routes-docstring [nmspace route-fns middleware]
   (str


### PR DESCRIPTION
Are you annoyed with having to eval `(api/define-routes)` every time you change a `defendpoint`? Rest assured, it will no longer be the case with this change!

Resolves https://github.com/metabase/metabase/issues/34393