### PR TITLE
Invalid params reporting

### DIFF
--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -272,7 +272,7 @@
   [{:keys [method route fn-name docstr args body arg->schema]}]
   {:pre [(or (string? route) (vector? route))]}
   (let [method-kw       (method-symbol->keyword method)
-        allowed-params  (keys arg->schema)
+        allowed-params  (mapv keyword (keys arg->schema))
         prep-route      #'compojure/prepare-route
         multipart?      (get (meta method) :multipart false)
         handler-wrapper (if multipart? mp/wrap-multipart-params identity)]

--- a/test/metabase/api/common/internal_test.clj
+++ b/test/metabase/api/common/internal_test.clj
@@ -140,7 +140,7 @@
                                         :lonlat [0.0 0.0]}}))))
         (is (some (fn [{message :msg, :as entry}]
                     (when (str/includes? (str message)
-                                         (str "Unexpected parameters at [:post \"/post/test-address\"]: [:tags :address :id]\n"
+                                         (str "Unexpected parameters at [:post \"/post/test-address\"]: [:tags :id]\n"
                                               "Please add them to the schema or remove them from the API client"))
                       entry))
                   (mb.logger/messages))))


### PR DESCRIPTION
It's two commits, but both really small (second one is literally just a documentation change).

So the problem is that `(:body request)` is coming in with keys being keywords, so `allowed-params` should contain keywords to meaningfully compare with the body. Right now it just complains about everything in the logs.