### PR TITLE
store metabase version in cards and revisions (#28387, #29167)

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15337,6 +15337,32 @@ databaseChangeLog:
                     nullable: false
                   defaultValue: '#31698A'
 
+  - changeSet:
+      id: v48.00-021
+      author: piranha
+      comment: 'Cards store Metabase version used to create them'
+      changes:
+        - addColumn:
+            tableName: report_card
+            columns:
+              - column:
+                  name: metabase_version
+                  type: varchar(100)
+                  remarks: 'Metabase version used to create the card.'
+
+  - changeSet:
+      id: v48.00-025
+      author: piranha
+      comment: 'Revisions store Metabase version used to create them'
+      changes:
+        - addColumn:
+            tableName: revision
+            columns:
+              - column:
+                  name: metabase_version
+                  type: varchar(100)
+                  remarks: 'Metabase version used to create the revision.'
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -5,6 +5,7 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [medley.core :as m]
+   [metabase.config :as config]
    [metabase.db.query :as mdb.query]
    [metabase.mbql.normalize :as mbql.normalize]
    [metabase.models.collection :as collection]
@@ -106,7 +107,7 @@
 ;;; --------------------------------------------------- Revisions ----------------------------------------------------
 
 (def ^:private excluded-columns-for-card-revision
-  [:id :created_at :updated_at :entity_id :creator_id :public_uuid :made_public_by_id])
+  [:id :created_at :updated_at :entity_id :creator_id :public_uuid :made_public_by_id :metabase_version])
 
 (defmethod revision/serialize-instance :model/Card
   ([instance]
@@ -410,6 +411,7 @@
 (t2/define-before-insert :model/Card
   [card]
   (-> card
+      (assoc :metabase_version config/mb-version-string)
       maybe-normalize-query
       populate-result-metadata
       pre-insert

--- a/src/metabase/models/revision.clj
+++ b/src/metabase/models/revision.clj
@@ -2,6 +2,7 @@
   (:require
    [cheshire.core :as json]
    [clojure.data :as data]
+   [metabase.config :as config]
    [metabase.db.util :as mdb.u]
    [metabase.models.interface :as mi]
    [metabase.models.revision.diff :refer [diff-strings*]]
@@ -73,7 +74,7 @@
 
 (t2/define-before-insert :model/Revision
   [revision]
-  (assoc revision :timestamp :%now))
+  (assoc revision :timestamp :%now :metabase_version config/mb-version-string))
 
 (t2/define-before-update :model/Revision
   [_revision]

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -14,6 +14,7 @@
    [metabase.analytics.snowplow-test :as snowplow-test]
    [metabase.api.card :as api.card]
    [metabase.api.pivots :as api.pivots]
+   [metabase.config :as config]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
@@ -663,7 +664,8 @@
                                                  :is_superuser false
                                                  :last_name    "Toucan"
                                                  :first_name   "Rasta"
-                                                 :email        "rasta@metabase.com"})})
+                                                 :email        "rasta@metabase.com"})
+                       :metabase_version       config/mb-version-string})
                      (-> (mt/user-http-request :rasta :post 200 "card" card)
                          (dissoc :created_at :updated_at :id)
                          (update :table_id integer?)
@@ -1056,7 +1058,8 @@
                    :table_id               (mt/id :venues)
                    :collection_id          (u/the-id collection)
                    :collection             (into {} collection)
-                   :result_metadata        (mt/obj->json->obj (:result_metadata card))})
+                   :result_metadata        (mt/obj->json->obj (:result_metadata card))
+                   :metabase_version       config/mb-version-string})
                  (mt/user-http-request :rasta :get 200 (str "card/" (u/the-id card))))))
         (testing "Card should include last edit info if available"
           (mt/with-temp [User     {user-id :id} {:first_name "Test" :last_name "User" :email "user@test.com"}

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -370,7 +370,7 @@
                                                                                         :visualization_settings {}
                                                                                         :result_metadata        nil})
                                                     :series                     []}]})
-                   (dashboard-response (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-id)))))))))
+                    (dashboard-response (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-id)))))))))
 
     (testing "a dashboard that has link cards on it"
       (let [link-card-info-from-resp
@@ -402,12 +402,12 @@
                      :db_id nil   :collection_id     collection-id}
                     {:url "https://metabase.com"}]
                    (link-card-info-from-resp
-                     (mt/user-http-request :crowberto :get 200 (format "dashboard/%d" (:id dashboard))))))
+                    (mt/user-http-request :crowberto :get 200 (format "dashboard/%d" (:id dashboard))))))
 
-           (testing "should return restricted if user doesn't have permission to view the models"
-             (perms/revoke-data-perms! (perms-group/all-users) database-id)
-             (is (= #{{:restricted true} {:url "https://metabase.com"}}
-                    (set (link-card-info-from-resp
+            (testing "should return restricted if user doesn't have permission to view the models"
+              (perms/revoke-data-perms! (perms-group/all-users) database-id)
+              (is (= #{{:restricted true} {:url "https://metabase.com"}}
+                     (set (link-card-info-from-resp
                            (mt/user-http-request :lucky :get 200 (format "dashboard/%d" (:id dashboard))))))))))))
 
     (testing "fetch a dashboard with a param in it"
@@ -424,47 +424,48 @@
                                                                              :target       [:dimension [:field field-id nil]]}]}]
         (with-dashboards-in-readable-collection [dashboard-id]
           (api.card-test/with-cards-in-readable-collection [card-id]
-            (is (= (merge dashboard-defaults
-                          {:name                       "Test Dashboard"
-                           :creator_id                 (mt/user->id :rasta)
-                           :collection_id              true
-                           :collection_authority_level nil
-                           :can_write                  false
-                           :param_values               nil
-                           :param_fields               {field-id {:id               field-id
-                                                                  :table_id         table-id
-                                                                  :display_name     display-name
-                                                                  :base_type        "type/Text"
-                                                                  :semantic_type    nil
-                                                                  :has_field_values "search"
-                                                                  :name_field       nil
-                                                                  :dimensions       []}}
-                           :ordered_tabs               []
-                           :ordered_cards              [{:size_x                     4
-                                                         :size_y                     4
-                                                         :col                        0
-                                                         :row                        0
-                                                         :updated_at                 true
-                                                         :created_at                 true
-                                                         :entity_id                  (:entity_id dashcard)
-                                                         :collection_authority_level nil
-                                                         :parameter_mappings         [{:card_id      1
-                                                                                       :parameter_id "foo"
-                                                                                       :target       ["dimension" ["field" field-id nil]]}]
-                                                         :visualization_settings     {}
-                                                         :dashboard_tab_id           nil
-                                                         :card                       (merge api.card-test/card-defaults-no-hydrate
-                                                                                            {:name                   "Dashboard Test Card"
-                                                                                             :creator_id             (mt/user->id :rasta)
-                                                                                             :collection_id          true
-                                                                                             :collection             false
-                                                                                             :entity_id              (:entity_id card)
-                                                                                             :display                "table"
-                                                                                             :query_type             nil
-                                                                                             :visualization_settings {}
-                                                                                             :result_metadata        nil})
-                                                         :series                     []}]})
-                   (dashboard-response (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-id)))))))))
+            (is (=?
+                 (merge dashboard-defaults
+                        {:name                       "Test Dashboard"
+                         :creator_id                 (mt/user->id :rasta)
+                         :collection_id              true
+                         :collection_authority_level nil
+                         :can_write                  false
+                         :param_values               nil
+                         :param_fields               {field-id {:id               field-id
+                                                                :table_id         table-id
+                                                                :display_name     display-name
+                                                                :base_type        "type/Text"
+                                                                :semantic_type    nil
+                                                                :has_field_values "search"
+                                                                :name_field       nil
+                                                                :dimensions       []}}
+                         :ordered_tabs               []
+                         :ordered_cards              [{:size_x                     4
+                                                       :size_y                     4
+                                                       :col                        0
+                                                       :row                        0
+                                                       :updated_at                 true
+                                                       :created_at                 true
+                                                       :entity_id                  (:entity_id dashcard)
+                                                       :collection_authority_level nil
+                                                       :parameter_mappings         [{:card_id      1
+                                                                                     :parameter_id "foo"
+                                                                                     :target       ["dimension" ["field" field-id nil]]}]
+                                                       :visualization_settings     {}
+                                                       :dashboard_tab_id           nil
+                                                       :card                       (merge api.card-test/card-defaults-no-hydrate
+                                                                                          {:name                   "Dashboard Test Card"
+                                                                                           :creator_id             (mt/user->id :rasta)
+                                                                                           :collection_id          true
+                                                                                           :collection             false
+                                                                                           :entity_id              (:entity_id card)
+                                                                                           :display                "table"
+                                                                                           :query_type             nil
+                                                                                           :visualization_settings {}
+                                                                                           :result_metadata        nil})
+                                                       :series                     []}]})
+                 (dashboard-response (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-id)))))))))
     (testing "fetch a dashboard from an official collection includes the collection type"
       (mt/with-temp [Dashboard     {dashboard-id :id} {:name "Test Dashboard"}
                      Card          {card-id :id}      {:name "Dashboard Test Card"}
@@ -2150,6 +2151,7 @@
                :message               "updated"
                :user                  (-> (user-details (mt/fetch-user :crowberto))
                                           (dissoc :email :date_joined :last_login :is_superuser :is_qbnewb))
+               :metabase_version      config/mb-version-string
                :diff                  {:before {:name        "b"
                                                 :description nil
                                                 :cards       [{:series nil, :size_y 4, :size_x 4}]}
@@ -2161,6 +2163,7 @@
               {:is_reversion         false
                :is_creation          true
                :message              nil
+               :metabase_version     config/mb-version-string
                :user                 (-> (user-details (mt/fetch-user :rasta))
                                          (dissoc :email :date_joined :last_login :is_superuser :is_qbnewb))
                :diff                 nil
@@ -2200,6 +2203,7 @@
               :message              nil
               :user                 (-> (user-details (mt/fetch-user :crowberto))
                                         (dissoc :email :date_joined :last_login :is_superuser :is_qbnewb))
+              :metabase_version     config/mb-version-string
               :diff                 {:before {:name "b"}
                                      :after  {:name "a"}}
               :has_multiple_changes false
@@ -2213,6 +2217,7 @@
                :message              nil
                :user                 (-> (user-details (mt/fetch-user :crowberto))
                                          (dissoc :email :date_joined :last_login :is_superuser :is_qbnewb))
+               :metabase_version     config/mb-version-string
                :diff                 {:before {:name "b"}
                                       :after  {:name "a"}}
                :has_multiple_changes false
@@ -2220,6 +2225,7 @@
               {:is_reversion         false
                :is_creation          false
                :message              "updated"
+               :metabase_version     config/mb-version-string
                :user                 (-> (user-details (mt/fetch-user :crowberto))
                                          (dissoc :email :date_joined :last_login :is_superuser :is_qbnewb))
                :diff                 {:before {:name "a"}
@@ -2229,6 +2235,7 @@
               {:is_reversion         false
                :is_creation          true
                :message              nil
+               :metabase_version     config/mb-version-string
                :user                 (-> (user-details (mt/fetch-user :rasta))
                                          (dissoc :email :date_joined :last_login :is_superuser :is_qbnewb))
                :diff                 nil

--- a/test/metabase/api/revision_test.clj
+++ b/test/metabase/api/revision_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.api.revision-test
   (:require
    [clojure.test :refer :all]
+   [metabase.config :as config]
    [metabase.models.card :refer [Card]]
    [metabase.models.collection :refer [Collection]]
    [metabase.models.dashboard :refer [Dashboard]]
@@ -64,6 +65,7 @@
                :is_creation          true
                :message              nil
                :user                 @rasta-revision-info
+               :metabase_version     config/mb-version-string
                :diff                 nil
                :has_multiple_changes false
                :description          "created this."}]
@@ -112,6 +114,7 @@
                :is_creation          false
                :message              "because i wanted to"
                :user                 @rasta-revision-info
+               :metabase_version     config/mb-version-string
                :diff                 {:before {:name "something else"}
                                       :after  {:name name}}
                :description          "reverted to an earlier version."
@@ -120,6 +123,7 @@
                :is_creation          false
                :message              nil
                :user                 @rasta-revision-info
+               :metabase_version     config/mb-version-string
                :diff                 {:before {:name name}
                                       :after  {:name "something else"}}
                :description          (format "renamed this Card from \"%s\" to \"something else\"." name)
@@ -127,6 +131,7 @@
               {:is_reversion         false
                :is_creation          true
                :message              nil
+               :metabase_version     config/mb-version-string
                :user                 @rasta-revision-info
                :diff                 nil
                :description          "created this."
@@ -180,6 +185,7 @@
                :is_creation          false
                :message              nil
                :user                 @rasta-revision-info
+               :metabase_version     config/mb-version-string
                :diff                 {:before {:cards nil}
                                       :after  {:cards [(merge default-revision-card {:card_id card-id :dashboard_id id})]}}
                :has_multiple_changes false
@@ -188,6 +194,7 @@
                :is_creation          false
                :message              nil
                :user                 @rasta-revision-info
+               :metabase_version     config/mb-version-string
                :diff                 {:before {:cards [(merge default-revision-card {:card_id card-id :dashboard_id id})]}
                                       :after  {:cards nil}}
                :has_multiple_changes false
@@ -196,6 +203,7 @@
                :is_creation          false
                :message              nil
                :user                 @rasta-revision-info
+               :metabase_version     config/mb-version-string
                :diff                 {:before {:cards nil}
                                       :after  {:cards [(merge default-revision-card {:card_id card-id :dashboard_id id})]}}
                :has_multiple_changes false
@@ -204,6 +212,7 @@
                :is_creation          true
                :message              nil
                :user                 @rasta-revision-info
+               :metabase_version     config/mb-version-string
                :diff                 nil
                :has_multiple_changes false
                :description          "created this."}]

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -15,7 +15,7 @@
    [metabase.db.custom-migrations :as custom-migrations]
    [metabase.db.schema-migrations-test.impl :as impl]
    [metabase.db.setup :as db.setup]
-   [metabase.models :refer [Card Database Revision User]]
+   [metabase.models :refer [Database User]]
    [metabase.models.interface :as mi]
    [metabase.task :as task]
    [metabase.test.fixtures :as fixtures]
@@ -87,15 +87,16 @@
                                                             :created_at :%now
                                                             :updated_at :%now
                                                             :details    "{}"})
-            card-id     (t2/insert-returning-pks! Card {:name                   "My Saved Question"
-                                                        :created_at             :%now
-                                                        :updated_at             :%now
-                                                        :creator_id             user-id
-                                                        :display                "table"
-                                                        :dataset_query          "{}"
-                                                        :visualization_settings (json/generate-string visualization-settings)
-                                                        :database_id            database-id
-                                                        :collection_id          nil})]
+            card-id     (t2/insert-returning-pks! (t2/table-name :model/Card)
+                                                  {:name                   "My Saved Question"
+                                                   :created_at             :%now
+                                                   :updated_at             :%now
+                                                   :creator_id             user-id
+                                                   :display                "table"
+                                                   :dataset_query          "{}"
+                                                   :visualization_settings (json/generate-string visualization-settings)
+                                                   :database_id            database-id
+                                                   :collection_id          nil})]
         (migrate!)
         (testing "legacy column_settings are updated"
           (is (= expected
@@ -153,16 +154,17 @@
                                                             :created_at :%now
                                                             :updated_at :%now
                                                             :details    "{}"})
-            card-id     (t2/insert-returning-pks! Card {:name                   "My Saved Question"
-                                                        :created_at             :%now
-                                                        :updated_at             :%now
-                                                        :creator_id             user-id
-                                                        :display                "table"
-                                                        :dataset_query          "{}"
-                                                        :visualization_settings "{}"
-                                                        :result_metadata        (json/generate-string result_metadata)
-                                                        :database_id            database-id
-                                                        :collection_id          nil})]
+            card-id     (t2/insert-returning-pks! (t2/table-name :model/Card)
+                                                  {:name                   "My Saved Question"
+                                                   :created_at             :%now
+                                                   :updated_at             :%now
+                                                   :creator_id             user-id
+                                                   :display                "table"
+                                                   :dataset_query          "{}"
+                                                   :visualization_settings "{}"
+                                                   :result_metadata        (json/generate-string result_metadata)
+                                                   :database_id            database-id
+                                                   :collection_id          nil})]
         (migrate!)
         (let [migrated-result-metadata (:result_metadata (t2/query-one {:select [:result_metadata]
                                                                         :from   [:report_card]
@@ -226,16 +228,17 @@
                                                             :created_at :%now
                                                             :updated_at :%now
                                                             :details    "{}"})
-            card-id     (t2/insert-returning-pks! Card {:name                   "My Saved Question"
-                                                        :created_at             :%now
-                                                        :updated_at             :%now
-                                                        :creator_id             user-id
-                                                        :display                "table"
-                                                        :dataset_query          "{}"
-                                                        :result_metadata        (json/generate-string result_metadata)
-                                                        :visualization_settings (json/generate-string visualization-settings)
-                                                        :database_id            database-id
-                                                        :collection_id          nil})]
+            card-id     (t2/insert-returning-pks! (t2/table-name :model/Card)
+                                                  {:name                   "My Saved Question"
+                                                   :created_at             :%now
+                                                   :updated_at             :%now
+                                                   :creator_id             user-id
+                                                   :display                "table"
+                                                   :dataset_query          "{}"
+                                                   :result_metadata        (json/generate-string result_metadata)
+                                                   :visualization_settings (json/generate-string visualization-settings)
+                                                   :database_id            database-id
+                                                   :collection_id          nil})]
         (migrate!)
         (testing "After the migration, column_settings field refs are updated to include join-alias"
           (is (= expected
@@ -374,11 +377,12 @@
                         ;; it's to test an edge case to make sure downgrade from 24 -> 18 does not remove this card
                         {:row 36 :col 0  :size_x 17 :size_y 1}
                         {:row 36 :col 17 :size_x 1  :size_y 1}]
-          revision-id (first (t2/insert-returning-pks! 'Revision
-                                                        {:object   {:cards cards}
-                                                         :model    "Dashboard"
-                                                         :model_id 1
-                                                         :user_id  user-id}))]
+          revision-id (first (t2/insert-returning-pks! (t2/table-name :model/Revision)
+                                                       {:object    (json/generate-string {:cards cards})
+                                                        :model     "Dashboard"
+                                                        :model_id  1
+                                                        :user_id   user-id
+                                                        :timestamp :%now}))]
 
       (migrate!)
       (testing "forward migration migrate correclty"
@@ -395,10 +399,13 @@
                 {:row 0  :col 0  :size_x 24 :size_y 2}
                 {:row 36 :col 0  :size_x 23 :size_y 1}
                 {:row 36 :col 23 :size_x 1  :size_y 1}]
-               (t2/select-one-fn (comp :cards :object) :model/Revision :id revision-id))))
+               (-> (t2/select-one (t2/table-name :model/Revision) :id revision-id)
+                  :object (json/parse-string true) :cards))))
      (migrate-down! 46)
      (testing "downgrade works correctly"
-      (is (= cards (t2/select-one-fn (comp :cards :object) :model/Revision :id revision-id)))))))
+       (is (= cards
+              (-> (t2/select-one (t2/table-name :model/Revision) :id revision-id)
+                  :object (json/parse-string true) :cards)))))))
 
 (deftest migrate-dashboard-revision-grid-from-18-to-24-handle-faliure-test
   (impl/test-migrations ["v47.00-032" "v47.00-033"] [migrate!]
@@ -415,11 +422,12 @@
                         {:id 3 :row nil :col nil :size_x nil :size_y nil}  ; contains nil fields
                         {:id 4 :row "x" :col "x" :size_x "x" :size_y "x"}  ; string values need to be skipped
                         {:id 5 :row 0 :col 0 :size_x 4 :size_y 4 :series [1 2 3]}]  ; include keys other than size
-          revision-id (first (t2/insert-returning-pks! 'Revision
-                                                       {:object   {:cards cards}
-                                                        :model    "Dashboard"
-                                                        :model_id 1
-                                                        :user_id  user-id}))]
+          revision-id (first (t2/insert-returning-pks! (t2/table-name :model/Revision)
+                                                       {:object    (json/generate-string {:cards cards})
+                                                        :model     "Dashboard"
+                                                        :model_id  1
+                                                        :user_id   user-id
+                                                        :timestamp :%now}))]
 
       (migrate!)
       (testing "forward migration migrate correclty and ignore failures"
@@ -428,7 +436,8 @@
                 {:id 3 :row 0 :col 0 :size_x 5 :size_y 4}
                 {:id 4 :row "x" :col "x" :size_x "x" :size_y "x"}
                 {:id 5 :row 0 :col 0 :size_x 5 :size_y 4 :series [1 2 3]}]
-               (t2/select-one-fn (comp :cards :object) :model/Revision :id revision-id))))
+               (-> (t2/select-one (t2/table-name :model/Revision) :id revision-id)
+                   :object (json/parse-string true) :cards))))
       (migrate-down! 46)
 
       (testing "downgrade works correctly and ignore failures"
@@ -437,7 +446,8 @@
                 {:id 3 :size_y 4 :size_x 4 :col 0 :row 0}
                 {:id 4 :row "x" :col "x" :size_x "x" :size_y "x"}
                 {:id 5 :row 0 :col 0 :size_x 4 :size_y 4 :series [1 2 3]}]
-               (t2/select-one-fn (comp :cards :object) :model/Revision :id revision-id)))))))
+               (-> (t2/select-one (t2/table-name :model/Revision) :id revision-id)
+                   :object (json/parse-string true) :cards)))))))
 
 (defn two-cards-overlap? [box1 box2]
   (let [{col1    :col
@@ -541,10 +551,12 @@
                                                         :password    "superstrong"
                                                         :date_joined :%now})
             card        {:visualization_settings visualization-settings}
-            revision-id (t2/insert-returning-pks! Revision {:model    "Card"
-                                                            :model_id 1 ;; TODO: this could be a foreign key in the future
-                                                            :user_id  user-id
-                                                            :object   (json/generate-string card)})]
+            revision-id (t2/insert-returning-pks! (t2/table-name :model/Revision)
+                                                  {:model     "Card"
+                                                   :model_id  1 ;; TODO: this could be a foreign key in the future
+                                                   :user_id   user-id
+                                                   :object    (json/generate-string card)
+                                                   :timestamp :%now})]
         (migrate!)
         (testing "legacy column_settings are updated"
           (is (= expected
@@ -615,10 +627,12 @@
                                                         :email       "howard@aircraft.com"
                                                         :password    "superstrong"
                                                         :date_joined :%now})
-            revision-id (t2/insert-returning-pks! Revision {:model    "Card"
-                                                            :model_id 1 ;; TODO: this could be a foreign key in the future
-                                                            :user_id  user-id
-                                                            :object   (json/generate-string card)})]
+            revision-id (t2/insert-returning-pks! (t2/table-name :model/Revision)
+                                                  {:model     "Card"
+                                                   :model_id  1 ;; TODO: this could be a foreign key in the future
+                                                   :user_id   user-id
+                                                   :object    (json/generate-string card)
+                                                   :timestamp :%now})]
         (migrate!)
         (testing "column_settings field refs are updated"
           (is (= expected
@@ -668,15 +682,16 @@
                                                                    :created_at :%now
                                                                    :updated_at :%now
                                                                    :details    "{}"})
-            card-id     (t2/insert-returning-pks! :model/Card {:name                   "My Saved Question"
-                                                               :created_at             :%now
-                                                               :updated_at             :%now
-                                                               :creator_id             user-id
-                                                               :display                "table"
-                                                               :dataset_query          "{}"
-                                                               :visualization_settings "{}"
-                                                               :database_id            database-id
-                                                               :collection_id          nil})
+            card-id     (t2/insert-returning-pks! (t2/table-name :model/Card)
+                                                  {:name                   "My Saved Question"
+                                                   :created_at             :%now
+                                                   :updated_at             :%now
+                                                   :creator_id             user-id
+                                                   :display                "table"
+                                                   :dataset_query          "{}"
+                                                   :visualization_settings "{}"
+                                                   :database_id            database-id
+                                                   :collection_id          nil})
             dashboard-id (t2/insert-returning-pks! :model/Dashboard {:name                "My Dashboard"
                                                                      :creator_id          user-id
                                                                      :parameters          []})
@@ -757,16 +772,17 @@
                                                                    :created_at :%now
                                                                    :updated_at :%now
                                                                    :details    "{}"})
-            card-id     (t2/insert-returning-pks! :model/Card {:name                   "My Saved Question"
-                                                               :created_at             :%now
-                                                               :updated_at             :%now
-                                                               :creator_id             user-id
-                                                               :display                "table"
-                                                               :dataset_query          "{}"
-                                                               :result_metadata        (json/generate-string result_metadata)
-                                                               :visualization_settings "{}"
-                                                               :database_id            database-id
-                                                               :collection_id          nil})
+            card-id     (t2/insert-returning-pks! (t2/table-name :model/Card)
+                                                  {:name                   "My Saved Question"
+                                                   :created_at             :%now
+                                                   :updated_at             :%now
+                                                   :creator_id             user-id
+                                                   :display                "table"
+                                                   :dataset_query          "{}"
+                                                   :result_metadata        (json/generate-string result_metadata)
+                                                   :visualization_settings "{}"
+                                                   :database_id            database-id
+                                                   :collection_id          nil})
             dashboard-id (t2/insert-returning-pks! :model/Dashboard {:name                "My Dashboard"
                                                                      :creator_id          user-id
                                                                      :parameters          []})
@@ -819,10 +835,12 @@
                                                         :password    "superstrong"
                                                         :date_joined :%now})
             dashboard   {:cards [{:visualization_settings visualization-settings}]}
-            revision-id (t2/insert-returning-pks! :model/Revision {:model    "Dashboard"
-                                                                   :model_id 1
-                                                                   :user_id  user-id
-                                                                   :object   (json/generate-string dashboard)})]
+            revision-id (t2/insert-returning-pks! (t2/table-name :model/Revision)
+                                                  {:model     "Dashboard"
+                                                   :model_id  1
+                                                   :user_id   user-id
+                                                   :object    (json/generate-string dashboard)
+                                                   :timestamp :%now})]
         (migrate!)
         (testing "legacy column_settings are updated"
           (is (= expected
@@ -888,8 +906,7 @@
                                                                    :created_at :%now
                                                                    :updated_at :%now
                                                                    :details    "{}"})
-            [card-id]          (t2/insert-returning-pks!
-                                :model/Card
+            [card-id]          (t2/insert-returning-pks! (t2/table-name :model/Card)
                                 {:name                   "My Saved Question"
                                  :created_at             :%now
                                  :updated_at             :%now
@@ -910,10 +927,12 @@
                                  :collection_id          nil})
             dashboard   {:cards [{:card_id                card-id
                                   :visualization_settings visualization-settings}]}
-            revision-id (t2/insert-returning-pks! :model/Revision {:model    "Dashboard"
-                                                                   :model_id 1
-                                                                   :user_id  user-id
-                                                                   :object   (json/generate-string dashboard)})]
+            revision-id (t2/insert-returning-pks! (t2/table-name :model/Revision)
+                                                  {:model     "Dashboard"
+                                                   :model_id  1
+                                                   :user_id   user-id
+                                                   :object    (json/generate-string dashboard)
+                                                   :timestamp :%now})]
         (migrate!)
         (testing "column_settings field refs are updated"
           (is (= expected

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -3,6 +3,7 @@
    [cheshire.core :as json]
    [clojure.set :as set]
    [clojure.test :refer :all]
+   [metabase.config :as config]
    [metabase.models
     :refer [Collection Dashboard DashboardCard ParameterCard NativeQuerySnippet Revision]]
    [metabase.models.card :as card]
@@ -756,7 +757,7 @@
                                before
                                changes)))))))))))
 
- ;; test tracking result_metdata for models
+ ;; test tracking result_metadata for models
  (let [card-info (mt/card-with-source-metadata-for-query
                    (mt/mbql-query venues))]
    (t2.with-temp/with-temp
@@ -775,3 +776,15 @@
                         Dashboard
                         before
                         changes)))))))))
+
+(deftest storing-metabase-version
+  (testing "Newly created Card should know a Metabase version used to create it"
+    (t2.with-temp/with-temp [:model/Card card {}]
+      (is (= config/mb-version-string (:metabase_version card)))
+
+      (with-redefs [config/mb-version-string "blablabla"]
+        (t2/update! :model/Card :id (:id card) {:description "test"}))
+
+      ;; we store version of metabase which created the card
+      (is (= config/mb-version-string
+             (t2/select-one-fn :metabase_version :model/Card :id (:id card)))))))


### PR DESCRIPTION
Cards are getting version of Metabase they were created in. Ditto for revisions.

Resolves #28387 and #29167.