### PR TITLE
Add custom warning message when leaving creating a model

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -336,9 +336,7 @@ describe("scenarios > dashboard", () => {
         cy.log("Should revert the title change if editing is cancelled");
         cy.findByTestId("dashboard-name-heading").clear().type(newTitle).blur();
         cy.findByTestId("edit-bar").button("Cancel").click();
-        modal().within(() => {
-          cy.button("Leave anyway").click();
-        });
+        modal().button("Leave anyway").click();
         cy.findByTestId("edit-bar").should("not.exist");
         cy.get("@updateDashboardSpy").should("not.have.been.called");
         cy.findByDisplayValue(originalDashboardName);

--- a/e2e/test/scenarios/models/create.cy.spec.js
+++ b/e2e/test/scenarios/models/create.cy.spec.js
@@ -17,10 +17,10 @@ describe("scenarios > models > create", () => {
     navigateToNewModelPage();
 
     // Cancel creation with confirmation modal
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Cancel").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Discard").click();
+    cy.findByTestId("dataset-edit-bar").button("Cancel").click();
+    modal().within(() => {
+      cy.button("Leave anyway").click();
+    });
 
     // Now we will create a model
     navigateToNewModelPage();

--- a/e2e/test/scenarios/models/create.cy.spec.js
+++ b/e2e/test/scenarios/models/create.cy.spec.js
@@ -18,9 +18,7 @@ describe("scenarios > models > create", () => {
 
     // Cancel creation with confirmation modal
     cy.findByTestId("dataset-edit-bar").button("Cancel").click();
-    modal().within(() => {
-      cy.button("Leave anyway").click();
-    });
+    modal().button("Leave anyway").click();
 
     // Now we will create a model
     navigateToNewModelPage();

--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -82,9 +82,7 @@ describe("scenarios > models metadata", () => {
       setColumnType("No special type", "Cost");
 
       cy.button("Cancel").click();
-      modal().within(() => {
-        cy.button("Leave anyway").click();
-      });
+      modal().button("Leave anyway").click();
 
       cy.findByTestId("TableInteractive-root").findByText("Subtotal");
     });

--- a/e2e/test/scenarios/models/models-query-editor.cy.spec.js
+++ b/e2e/test/scenarios/models/models-query-editor.cy.spec.js
@@ -90,9 +90,7 @@ describe("scenarios > models query editor", () => {
         .and("not.contain", "109.22");
 
       cy.button("Cancel").click();
-      modal().within(() => {
-        cy.button("Leave anyway").click();
-      });
+      modal().button("Leave anyway").click();
       cy.wait("@cardQuery");
 
       cy.url()
@@ -191,9 +189,7 @@ describe("scenarios > models query editor", () => {
         .and("not.contain", "109.22");
 
       cy.button("Cancel").click();
-      modal().within(() => {
-        cy.button("Leave anyway").click();
-      });
+      modal().button("Leave anyway").click();
       cy.wait("@cardQuery");
 
       cy.get(".cellData").should("contain", "37.65").and("contain", "109.22");

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -117,9 +117,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
       // Switching to data permissions page again
       cy.get("label").contains("Data").click();
 
-      modal().within(() => {
-        cy.button("Leave anyway").click();
-      });
+      modal().button("Leave anyway").click();
 
       cy.url().should("include", "/admin/permissions/data/group");
     });
@@ -319,9 +317,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
       // Switching to collection permissions page again
       cy.get("label").contains("Collection").click();
 
-      modal().within(() => {
-        cy.button("Leave anyway").click();
-      });
+      modal().button("Leave anyway").click();
 
       cy.url().should("include", "/admin/permissions/collections");
     });

--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -428,9 +428,7 @@ describe("scenarios > question > settings", () => {
       cy.contains("Orders in a dashboard").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Cancel").click();
-      modal().within(() => {
-        cy.button("Leave anyway").click();
-      });
+      modal().button("Leave anyway").click();
 
       // create a new question to see if the "add to a dashboard" modal is still there
       openNavigationSidebar();

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -9,9 +9,6 @@ import { usePrevious } from "react-use";
 import ActionButton from "metabase/components/ActionButton";
 import Button from "metabase/core/components/Button";
 import DebouncedFrame from "metabase/components/DebouncedFrame";
-import Confirm from "metabase/components/Confirm";
-import { LeaveConfirmationModalContent } from "metabase/components/LeaveConfirmationModal";
-import Modal from "metabase/components/Modal";
 
 import QueryVisualization from "metabase/query_builder/components/QueryVisualization";
 import ViewSidebar from "metabase/query_builder/components/view/ViewSidebar";
@@ -203,7 +200,6 @@ function DatasetEditor(props) {
   } = props;
 
   const isDirty = isModelQueryDirty || isMetadataDirty;
-  const [showCancelEditWarning, setShowCancelEditWarning] = useState(false);
   const fields = useMemo(
     () => getSortedModelFields(dataset, resultsMetadata?.columns),
     [dataset, resultsMetadata],
@@ -303,20 +299,12 @@ function DatasetEditor(props) {
     [initialEditorHeight, setDatasetEditorTab],
   );
 
-  const handleCancelEdit = () => {
-    onCancelDatasetChanges();
-    setQueryBuilderMode("view");
-  };
-
-  const handleCancelEditWarningClose = () => {
-    setShowCancelEditWarning(false);
-  };
-
-  const handleRequestCancelEdit = () => {
-    if (isDirty) {
-      setShowCancelEditWarning(true);
+  const handleCancelClick = () => {
+    if (dataset.isSaved()) {
+      onCancelDatasetChanges();
+      setQueryBuilderMode("view");
     } else {
-      handleCancelEdit();
+      onCancelCreateNewModel();
     }
   };
 
@@ -441,23 +429,11 @@ function DatasetEditor(props) {
           />
         }
         buttons={[
-          dataset.isSaved() ? (
-            <Button
-              key="cancel"
-              small
-              onClick={handleRequestCancelEdit}
-            >{t`Cancel`}</Button>
-          ) : (
-            <Confirm
-              key="cancel"
-              action={onCancelCreateNewModel}
-              title={t`Discard changes?`}
-              message={t`Your model won't be created.`}
-              confirmButtonText={t`Discard`}
-            >
-              <Button small>{t`Cancel`}</Button>
-            </Confirm>
-          ),
+          <Button
+            key="cancel"
+            small
+            onClick={handleCancelClick}
+          >{t`Cancel`}</Button>,
           <ActionButton
             key="save"
             disabled={!canSaveChanges}
@@ -515,13 +491,6 @@ function DatasetEditor(props) {
           {sidebar}
         </ViewSidebar>
       </Root>
-
-      <Modal isOpen={showCancelEditWarning}>
-        <LeaveConfirmationModalContent
-          onAction={handleCancelEdit}
-          onClose={handleCancelEditWarningClose}
-        />
-      </Modal>
     </>
   );
 }

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -9,6 +9,8 @@ import { usePrevious } from "react-use";
 import ActionButton from "metabase/components/ActionButton";
 import Button from "metabase/core/components/Button";
 import DebouncedFrame from "metabase/components/DebouncedFrame";
+import { LeaveConfirmationModalContent } from "metabase/components/LeaveConfirmationModal";
+import Modal from "metabase/components/Modal";
 
 import QueryVisualization from "metabase/query_builder/components/QueryVisualization";
 import ViewSidebar from "metabase/query_builder/components/view/ViewSidebar";
@@ -200,6 +202,7 @@ function DatasetEditor(props) {
   } = props;
 
   const isDirty = isModelQueryDirty || isMetadataDirty;
+  const [showCancelEditWarning, setShowCancelEditWarning] = useState(false);
   const fields = useMemo(
     () => getSortedModelFields(dataset, resultsMetadata?.columns),
     [dataset, resultsMetadata],
@@ -299,10 +302,23 @@ function DatasetEditor(props) {
     [initialEditorHeight, setDatasetEditorTab],
   );
 
+  const handleCancelEdit = () => {
+    setShowCancelEditWarning(false);
+    onCancelDatasetChanges();
+    setQueryBuilderMode("view");
+  };
+
+  const handleCancelEditWarningClose = () => {
+    setShowCancelEditWarning(false);
+  };
+
   const handleCancelClick = () => {
     if (dataset.isSaved()) {
-      onCancelDatasetChanges();
-      setQueryBuilderMode("view");
+      if (isDirty) {
+        setShowCancelEditWarning(true);
+      } else {
+        handleCancelEdit();
+      }
     } else {
       onCancelCreateNewModel();
     }
@@ -491,6 +507,13 @@ function DatasetEditor(props) {
           {sidebar}
         </ViewSidebar>
       </Root>
+
+      <Modal isOpen={showCancelEditWarning}>
+        <LeaveConfirmationModalContent
+          onAction={handleCancelEdit}
+          onClose={handleCancelEditWarningClose}
+        />
+      </Modal>
     </>
   );
 }

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -237,7 +237,7 @@ const setup = async ({
 
   const { history } = renderWithProviders(
     <Route>
-      <Route path="/home" component={TestHome} />
+      <Route path="/" component={TestHome} />
       <Route path="/model">
         <Route path="new" component={NewModelOptions} />
         <Route path="query" component={TestQueryBuilder} />
@@ -548,7 +548,7 @@ describe("QueryBuilder", () => {
       it("shows custom warning modal when leaving via Cancel button", async () => {
         await setup({
           card: null,
-          initialRoute: `/model/new`,
+          initialRoute: "/model/new",
         });
 
         await startNewNotebookModel();
@@ -564,7 +564,7 @@ describe("QueryBuilder", () => {
         it("shows custom warning modal when leaving edited query via SPA navigation", async () => {
           const { history } = await setup({
             card: TEST_MODEL_CARD,
-            initialRoute: "/home",
+            initialRoute: "/",
           });
 
           history.push(`/model/${TEST_MODEL_CARD.id}/query`);
@@ -580,7 +580,7 @@ describe("QueryBuilder", () => {
         it("does not show custom warning modal when leaving unedited query via SPA navigation", async () => {
           const { history } = await setup({
             card: TEST_MODEL_CARD,
-            initialRoute: "/home",
+            initialRoute: "/",
           });
 
           history.push(`/model/${TEST_MODEL_CARD.id}/query`);
@@ -652,7 +652,7 @@ describe("QueryBuilder", () => {
           const { history } = await setup({
             card: TEST_MODEL_CARD,
             dataset: TEST_MODEL_DATASET,
-            initialRoute: "/home",
+            initialRoute: "/",
           });
 
           history.push(`/model/${TEST_MODEL_CARD.id}/metadata`);
@@ -669,7 +669,7 @@ describe("QueryBuilder", () => {
           const { history } = await setup({
             card: TEST_MODEL_CARD,
             dataset: TEST_MODEL_DATASET,
-            initialRoute: "/home",
+            initialRoute: "/",
           });
 
           history.push(`/model/${TEST_MODEL_CARD.id}/metadata`);
@@ -772,7 +772,7 @@ describe("QueryBuilder", () => {
       it("shows custom warning modal when leaving edited question via SPA navigation", async () => {
         const { history } = await setup({
           card: TEST_NATIVE_CARD,
-          initialRoute: "/home",
+          initialRoute: "/",
         });
 
         history.push(`/question/${TEST_NATIVE_CARD.id}`);
@@ -787,7 +787,7 @@ describe("QueryBuilder", () => {
       it("does not show custom warning modal leaving with no changes via SPA navigation", async () => {
         const { history } = await setup({
           card: TEST_NATIVE_CARD,
-          initialRoute: "/home",
+          initialRoute: "/",
         });
 
         history.push(`/question/${TEST_NATIVE_CARD.id}`);
@@ -827,7 +827,7 @@ describe("QueryBuilder", () => {
       it("does not show custom warning modal when saving edited question", async () => {
         const { history } = await setup({
           card: TEST_NATIVE_CARD,
-          initialRoute: "/home",
+          initialRoute: "/",
         });
 
         history.push(`/question/${TEST_NATIVE_CARD.id}`);
@@ -857,7 +857,7 @@ describe("QueryBuilder", () => {
       it("does not show custom warning modal when saving edited question as a new one", async () => {
         const { history } = await setup({
           card: TEST_NATIVE_CARD,
-          initialRoute: "/home",
+          initialRoute: "/",
         });
 
         history.push(`/question/${TEST_NATIVE_CARD.id}`);

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -544,6 +544,19 @@ describe("QueryBuilder", () => {
 
         expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
       });
+
+      it("shows custom warning modal when leaving via Cancel button", async () => {
+        await setup({
+          card: null,
+          initialRoute: `/model/new`,
+        });
+
+        await startNewNotebookModel();
+
+        userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+        expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
+      });
     });
 
     describe("editing models", () => {

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -208,18 +208,18 @@ function isSavedCard(card: Card | UnsavedCard | null): card is Card {
 }
 
 interface SetupOpts {
-  card?: Card | UnsavedCard | null;
+  card: Card | UnsavedCard | null;
   dataset?: Dataset;
   initialRoute?: string;
 }
 
 const setup = async ({
-  card = TEST_CARD,
+  card,
   dataset = createMockDataset(),
   initialRoute = `/question${
     isSavedCard(card) ? `/${card.id}` : `#${serializeCardForUrl(card)}`
   }`,
-}: SetupOpts = {}) => {
+}: SetupOpts) => {
   setupDatabasesEndpoints([TEST_DB]);
   setupCardDataset(dataset);
   setupSearchEndpoints([]);
@@ -274,13 +274,14 @@ describe("QueryBuilder", () => {
   describe("rendering", () => {
     describe("renders structured queries", () => {
       it("renders a structured question in the simple mode", async () => {
-        await setup();
+        await setup({ card: TEST_CARD });
 
         expect(screen.getByDisplayValue(TEST_CARD.name)).toBeInTheDocument();
       });
 
       it("renders a structured question in the notebook mode", async () => {
         await setup({
+          card: TEST_CARD,
           initialRoute: `/question/${TEST_CARD.id}/notebook`,
         });
 

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -404,7 +404,7 @@ describe("QueryBuilder", () => {
       });
     });
 
-    describe("native queries", () => {
+    describe("editing native questions", () => {
       afterEach(() => {
         jest.restoreAllMocks();
       });
@@ -448,7 +448,7 @@ describe("QueryBuilder", () => {
       });
     });
 
-    describe("structured queries", () => {
+    describe("editing notebook questions", () => {
       afterEach(() => {
         jest.restoreAllMocks();
       });
@@ -711,7 +711,7 @@ describe("QueryBuilder", () => {
       });
     });
 
-    describe("native queries", () => {
+    describe("editing native questions", () => {
       it("shows custom warning modal when leaving edited question via SPA navigation", async () => {
         const { history } = await setup({
           card: TEST_NATIVE_CARD,

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -349,6 +349,22 @@ describe("QueryBuilder", () => {
   });
 
   describe("beforeunload events", () => {
+    describe("creating models", () => {
+      it("shows custom warning modal when leaving via SPA navigation", async () => {
+        const { mockEventListener } = await setup({
+          card: null,
+          initialRoute: "/model/new",
+        });
+
+        await startNewNotebookModel();
+
+        const mockEvent = callMockEvent(mockEventListener, "beforeunload");
+
+        expect(mockEvent.preventDefault).toHaveBeenCalled();
+        expect(mockEvent.returnValue).toBe(BEFORE_UNLOAD_UNSAVED_MESSAGE);
+      });
+    });
+
     describe("editing models", () => {
       describe("editing queries", () => {
         afterEach(() => {
@@ -522,21 +538,7 @@ describe("QueryBuilder", () => {
         history.push("/model/new");
         await waitForLoaderToBeRemoved();
 
-        userEvent.click(screen.getByText("Use the notebook editor"));
-        await waitForLoaderToBeRemoved();
-
-        userEvent.click(screen.getByText("Pick your starting data"));
-        const popover = screen.getByTestId("popover");
-        userEvent.click(within(popover).getByText("Sample Database"));
-        await waitForLoaderToBeRemoved();
-        userEvent.click(within(popover).getByText("Orders"));
-        userEvent.click(
-          within(screen.getByTestId("popover")).getByText("Orders"),
-        );
-
-        expect(
-          screen.getByRole("button", { name: "Get Answer" }),
-        ).toBeEnabled();
+        await startNewNotebookModel();
 
         history.goBack();
 
@@ -946,6 +948,20 @@ describe("QueryBuilder", () => {
     });
   });
 });
+
+const startNewNotebookModel = async () => {
+  userEvent.click(screen.getByText("Use the notebook editor"));
+  await waitForLoaderToBeRemoved();
+
+  userEvent.click(screen.getByText("Pick your starting data"));
+  const popover = screen.getByTestId("popover");
+  userEvent.click(within(popover).getByText("Sample Database"));
+  await waitForLoaderToBeRemoved();
+  userEvent.click(within(popover).getByText("Orders"));
+  userEvent.click(within(screen.getByTestId("popover")).getByText("Orders"));
+
+  expect(screen.getByRole("button", { name: "Get Answer" })).toBeEnabled();
+};
 
 const triggerNativeQueryChange = async () => {
   await waitFor(() => {

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -7,6 +7,7 @@ import {
   createMockCard,
   createMockColumn,
   createMockDataset,
+  createMockModelIndex,
   createMockNativeDatasetQuery,
   createMockNativeQuery,
   createMockStructuredDatasetQuery,
@@ -225,6 +226,11 @@ const setup = async ({
     setupCardQueryEndpoints(card, dataset);
     setupAlertsEndpoints(card, []);
     setupModelIndexEndpoints(card.id, []);
+  }
+
+  // this workaround can be removed when metabase#34523 is fixed
+  if (card === null) {
+    fetchMock.get("path:/api/model-index", [createMockModelIndex()]);
   }
 
   const mockEventListener = jest.spyOn(window, "addEventListener");

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -506,6 +506,38 @@ describe("QueryBuilder", () => {
   });
 
   describe("unsaved changes warning", () => {
+    describe("creating models", () => {
+      it("shows custom warning modal when leaving via SPA navigation", async () => {
+        const { history } = await setup({
+          card: null,
+          initialRoute: "/",
+        });
+
+        history.push("/model/new");
+        await waitForLoaderToBeRemoved();
+
+        userEvent.click(screen.getByText("Use the notebook editor"));
+        await waitForLoaderToBeRemoved();
+
+        userEvent.click(screen.getByText("Pick your starting data"));
+        const popover = screen.getByTestId("popover");
+        userEvent.click(within(popover).getByText("Sample Database"));
+        await waitForLoaderToBeRemoved();
+        userEvent.click(within(popover).getByText("Orders"));
+        userEvent.click(
+          within(screen.getByTestId("popover")).getByText("Orders"),
+        );
+
+        expect(
+          screen.getByRole("button", { name: "Get Answer" }),
+        ).toBeEnabled();
+
+        history.goBack();
+
+        expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
+      });
+    });
+
     describe("editing models", () => {
       describe("editing queries", () => {
         it("shows custom warning modal when leaving edited query via SPA navigation", async () => {

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -198,12 +198,12 @@ const TestQueryBuilder = (
 
 const TestHome = () => <div />;
 
-function isSavedCard(card: Card | UnsavedCard): card is Card {
-  return "id" in card;
+function isSavedCard(card: Card | UnsavedCard | null): card is Card {
+  return card !== null && "id" in card;
 }
 
 interface SetupOpts {
-  card?: Card | UnsavedCard;
+  card?: Card | UnsavedCard | null;
   dataset?: Dataset;
   initialRoute?: string;
 }

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -43,6 +43,7 @@ import {
 import { callMockEvent } from "__support__/events";
 import { BEFORE_UNLOAD_UNSAVED_MESSAGE } from "metabase/hooks/use-before-unload";
 import { serializeCardForUrl } from "metabase/lib/card";
+import NewModelOptions from "metabase/models/containers/NewModelOptions";
 import QueryBuilder from "./QueryBuilder";
 
 registerVisualizations();
@@ -232,6 +233,9 @@ const setup = async ({
     <Route>
       <Route path="/home" component={TestHome} />
       <Route path="/model">
+        <Route path="new" component={NewModelOptions} />
+        <Route path="query" component={TestQueryBuilder} />
+        <Route path="metadata" component={TestQueryBuilder} />
         <Route path=":slug/query" component={TestQueryBuilder} />
         <Route path=":slug/metadata" component={TestQueryBuilder} />
       </Route>

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -11,7 +11,6 @@ import {
   createMockModelIndex,
   createMockNativeDatasetQuery,
   createMockNativeQuery,
-  createMockResultsMetadata,
   createMockStructuredDatasetQuery,
   createMockStructuredQuery,
   createMockUnsavedCard,
@@ -35,6 +34,9 @@ import {
   setupSearchEndpoints,
   setupTimelinesEndpoints,
   setupModelIndexEndpoints,
+  setupCollectionsEndpointsByIds,
+  setupCardCreateEndpoint,
+  setupCardQueryMetadataEndpoint,
 } from "__support__/server-mocks";
 import {
   renderWithProviders,
@@ -569,13 +571,9 @@ describe("QueryBuilder", () => {
           card: null,
           initialRoute: "/model/new",
         });
-
-        fetchMock.get("path:/api/collection/1", [createMockCollection()]);
-        fetchMock.get(
-          "path:/api/table/card__1/query_metadata",
-          createMockResultsMetadata(),
-        );
-        fetchMock.post("path:/api/card", TEST_MODEL_CARD);
+        setupCollectionsEndpointsByIds([createMockCollection()]);
+        setupCardCreateEndpoint();
+        setupCardQueryMetadataEndpoint(TEST_NATIVE_CARD);
 
         await startNewNotebookModel();
 

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -34,9 +34,9 @@ import {
   setupSearchEndpoints,
   setupTimelinesEndpoints,
   setupModelIndexEndpoints,
-  setupCollectionsEndpointsByIds,
   setupCardCreateEndpoint,
   setupCardQueryMetadataEndpoint,
+  setupCollectionByIdEndpoint,
 } from "__support__/server-mocks";
 import {
   renderWithProviders,
@@ -571,7 +571,7 @@ describe("QueryBuilder", () => {
           card: null,
           initialRoute: "/model/new",
         });
-        setupCollectionsEndpointsByIds([createMockCollection()]);
+        setupCollectionByIdEndpoint({ collections: [createMockCollection()] });
         setupCardCreateEndpoint();
         setupCardQueryMetadataEndpoint(TEST_NATIVE_CARD);
 

--- a/frontend/src/metabase/query_builder/utils.ts
+++ b/frontend/src/metabase/query_builder/utils.ts
@@ -85,12 +85,19 @@ export const isNavigationAllowed = ({
   const { hash, pathname } = destination;
 
   if (question.isDataset()) {
+    const isGoingToNewModelTab =
+      pathname === "/model/query" || pathname === "/model/metadata";
     const isGoingToQueryTab =
       pathname.startsWith("/model/") && pathname.endsWith("/query");
     const isGoingToMetadataTab =
       pathname.startsWith("/model/") && pathname.endsWith("/metadata");
+    const isGoingToModelEditorTab = isGoingToQueryTab || isGoingToMetadataTab;
 
-    return isGoingToQueryTab || isGoingToMetadataTab;
+    if (isNewQuestion) {
+      return isGoingToModelEditorTab && isGoingToNewModelTab;
+    }
+
+    return isGoingToModelEditorTab && !isGoingToNewModelTab;
   }
 
   if (isExistingQuestion && question.isNative()) {

--- a/frontend/src/metabase/query_builder/utils.ts
+++ b/frontend/src/metabase/query_builder/utils.ts
@@ -85,19 +85,14 @@ export const isNavigationAllowed = ({
   const { hash, pathname } = destination;
 
   if (question.isDataset()) {
-    const isGoingToNewModelTab =
-      pathname === "/model/query" || pathname === "/model/metadata";
-    const isGoingToQueryTab =
-      pathname.startsWith("/model/") && pathname.endsWith("/query");
-    const isGoingToMetadataTab =
-      pathname.startsWith("/model/") && pathname.endsWith("/metadata");
-    const isGoingToModelEditorTab = isGoingToQueryTab || isGoingToMetadataTab;
-
     if (isNewQuestion) {
-      return isGoingToModelEditorTab && isGoingToNewModelTab;
+      return pathname === "/model/query" || pathname === "/model/metadata";
     }
 
-    return isGoingToModelEditorTab && !isGoingToNewModelTab;
+    return Boolean(
+      pathname.match(/^\/model\/.+\/query$/) ||
+        pathname.match(/^\/model\/.+\/metadata$/),
+    );
   }
 
   if (isExistingQuestion && question.isNative()) {

--- a/frontend/src/metabase/query_builder/utils.ts
+++ b/frontend/src/metabase/query_builder/utils.ts
@@ -81,7 +81,6 @@ export const isNavigationAllowed = ({
     return true;
   }
 
-  const isExistingQuestion = !isNewQuestion;
   const { hash, pathname } = destination;
 
   if (question.isDataset()) {
@@ -96,7 +95,7 @@ export const isNavigationAllowed = ({
     return isQueryTab || isMetadataTab;
   }
 
-  if (isExistingQuestion && question.isNative()) {
+  if (!isNewQuestion && question.isNative()) {
     const isRunningQuestion = pathname === "/question" && hash.length > 0;
     return isRunningQuestion;
   }

--- a/frontend/src/metabase/query_builder/utils.ts
+++ b/frontend/src/metabase/query_builder/utils.ts
@@ -73,9 +73,6 @@ export const isNavigationAllowed = ({
    * If there is no "question" there is no reason to prevent navigation.
    * If there is no "destination" then it's beforeunload event, which is
    * handled by useBeforeUnload hook - no reason to duplicate its work.
-   *
-   * If it's a new question, we're going to deal with it later as part of the epic:
-   * https://github.com/metabase/metabase/issues/33749
    */
   if (!question || !destination) {
     return true;
@@ -95,6 +92,10 @@ export const isNavigationAllowed = ({
     return isQueryTab || isMetadataTab;
   }
 
+  /**
+   * If it's a new question, we're going to deal with it later as part of the epic:
+   * https://github.com/metabase/metabase/issues/33749
+   */
   if (!isNewQuestion && question.isNative()) {
     const isRunningQuestion = pathname === "/question" && hash.length > 0;
     return isRunningQuestion;

--- a/frontend/src/metabase/query_builder/utils.ts
+++ b/frontend/src/metabase/query_builder/utils.ts
@@ -86,18 +86,18 @@ export const isNavigationAllowed = ({
 
   if (question.isDataset()) {
     if (isNewQuestion) {
-      return pathname === "/model/query" || pathname === "/model/metadata";
+      const isQueryTab = pathname === "/model/query";
+      const isMetadataTab = pathname === "/model/metadata";
+      return isQueryTab || isMetadataTab;
     }
 
-    return Boolean(
-      pathname.match(/^\/model\/.+\/query$/) ||
-        pathname.match(/^\/model\/.+\/metadata$/),
-    );
+    const isQueryTab = pathname.match(/^\/model\/.+\/query$/) !== null;
+    const isMetadataTab = pathname.match(/^\/model\/.+\/metadata$/) !== null;
+    return isQueryTab || isMetadataTab;
   }
 
   if (isExistingQuestion && question.isNative()) {
     const isRunningQuestion = pathname === "/question" && hash.length > 0;
-
     return isRunningQuestion;
   }
 

--- a/frontend/src/metabase/query_builder/utils.ts
+++ b/frontend/src/metabase/query_builder/utils.ts
@@ -77,10 +77,11 @@ export const isNavigationAllowed = ({
    * If it's a new question, we're going to deal with it later as part of the epic:
    * https://github.com/metabase/metabase/issues/33749
    */
-  if (!question || !destination || isNewQuestion) {
+  if (!question || !destination) {
     return true;
   }
 
+  const isExistingQuestion = !isNewQuestion;
   const { hash, pathname } = destination;
 
   if (question.isDataset()) {
@@ -92,7 +93,7 @@ export const isNavigationAllowed = ({
     return isGoingToQueryTab || isGoingToMetadataTab;
   }
 
-  if (question.isNative()) {
+  if (isExistingQuestion && question.isNative()) {
     const isRunningQuestion = pathname === "/question" && hash.length > 0;
 
     return isRunningQuestion;

--- a/frontend/src/metabase/query_builder/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.ts
@@ -168,7 +168,7 @@ describe("isNavigationAllowed", () => {
     const question = mockModelQuestion;
 
     it("does not allow navigating away from creating new model", () => {
-      const destinations = [...mockLocations, undefined];
+      const destinations = [...mockLocations];
 
       for (const destination of destinations) {
         expect(

--- a/frontend/src/metabase/query_builder/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.ts
@@ -146,14 +146,11 @@ describe("isNavigationAllowed", () => {
   describe("when editing notebook question", () => {
     const isNewQuestion = false;
     const question = notebookQuestion;
-    const destinations = [...locations, undefined];
 
-    it("always allows navigating away from editing notebook question", () => {
-      for (const destination of destinations) {
-        expect(
-          isNavigationAllowed({ destination, question, isNewQuestion }),
-        ).toBe(true);
-      }
+    it.each(locations)("allows navigating away to `$pathname`", destination => {
+      expect(
+        isNavigationAllowed({ destination, question, isNewQuestion }),
+      ).toBe(true);
     });
   });
 
@@ -169,12 +166,15 @@ describe("isNavigationAllowed", () => {
       ).toBe(true);
     });
 
-    it("disallows all other navigation", () => {
-      const destination = anyLocation;
-
-      expect(
-        isNavigationAllowed({ destination, question, isNewQuestion }),
-      ).toBe(false);
+    describe("disallows all other navigation", () => {
+      it.each([anyLocation, modelQueryTabLocation, modelMetadataTabLocation])(
+        "to `$pathname`",
+        destination => {
+          expect(
+            isNavigationAllowed({ destination, question, isNewQuestion }),
+          ).toBe(false);
+        },
+      );
     });
   });
 

--- a/frontend/src/metabase/query_builder/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.ts
@@ -9,7 +9,7 @@ import { checkNotNull } from "metabase/core/utils/types";
 
 import { isNavigationAllowed } from "./utils";
 
-const mockCard = createMockCard({
+const mockNotebookCard = createMockCard({
   id: getNextId(),
 });
 
@@ -18,7 +18,7 @@ const mockNativeCard = createMockCard({
   dataset_query: createMockNativeDatasetQuery(),
 });
 
-const mockModelCard = createMockCard({
+const mockNotebookModelCard = createMockCard({
   id: getNextId(),
   dataset: true,
 });
@@ -30,28 +30,32 @@ const mockNativeModelCard = createMockCard({
 });
 
 const mockCards = [
-  mockCard,
+  mockNotebookCard,
   mockNativeCard,
-  mockModelCard,
+  mockNotebookModelCard,
   mockNativeModelCard,
 ];
 
 const metadata = createMockMetadata({ questions: mockCards });
 
-const mockQuestion = checkNotNull(metadata.question(mockCard.id));
+const mockNotebookQuestion = checkNotNull(
+  metadata.question(mockNotebookCard.id),
+);
 
 const mockNativeQuestion = checkNotNull(metadata.question(mockNativeCard.id));
 
-const mockModelQuestion = checkNotNull(metadata.question(mockModelCard.id));
+const mockNotebookModelQuestion = checkNotNull(
+  metadata.question(mockNotebookModelCard.id),
+);
 
 const mockNativeModelQuestion = checkNotNull(
   metadata.question(mockNativeModelCard.id),
 );
 
 const mockQuestions = [
-  mockQuestion,
+  mockNotebookQuestion,
   mockNativeQuestion,
-  mockModelQuestion,
+  mockNotebookModelQuestion,
   mockNativeModelQuestion,
 ];
 
@@ -66,11 +70,11 @@ const mockNewModelMetadataTabLocation = createMockLocation({
 });
 
 const mockModelQueryTabLocation = createMockLocation({
-  pathname: `/model/${mockModelCard.id}/query`,
+  pathname: `/model/${mockNotebookModelCard.id}/query`,
 });
 
 const mockModelMetadataTabLocation = createMockLocation({
-  pathname: `/model/${mockModelCard.id}/metadata`,
+  pathname: `/model/${mockNotebookModelCard.id}/metadata`,
 });
 
 const mockRunQuestionLocation = createMockLocation({
@@ -115,7 +119,7 @@ describe("isNavigationAllowed", () => {
     const isNewQuestion = true;
 
     it("always allows navigating away from creating new question", () => {
-      const questions = [mockQuestion, mockNativeQuestion, undefined];
+      const questions = [mockNotebookQuestion, mockNativeQuestion, undefined];
       const destinations = [...mockLocations, undefined];
 
       for (const question of questions) {
@@ -130,7 +134,7 @@ describe("isNavigationAllowed", () => {
 
   describe("when editing notebook question", () => {
     const isNewQuestion = false;
-    const question = mockQuestion;
+    const question = mockNotebookQuestion;
     const destinations = [...mockLocations, undefined];
 
     it("always allows navigating away from editing notebook question", () => {
@@ -165,7 +169,7 @@ describe("isNavigationAllowed", () => {
 
   describe("when creating new model", () => {
     const isNewQuestion = true;
-    const question = mockModelQuestion;
+    const question = mockNotebookModelQuestion;
 
     it("does not allow navigating away from creating new model", () => {
       const destinations = [...mockLocations];
@@ -193,7 +197,7 @@ describe("isNavigationAllowed", () => {
 
   describe("when editing notebook model", () => {
     const isNewQuestion = false;
-    const question = mockModelQuestion;
+    const question = mockNotebookModelQuestion;
 
     it("allows navigating between model query & metadata tabs", () => {
       const destinations = [

--- a/frontend/src/metabase/query_builder/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.ts
@@ -54,14 +54,16 @@ const questions = [
   nativeModelQuestion,
 ];
 
-const anyLocation = createMockLocation();
+const anyLocation = createMockLocation({
+  pathname: "/",
+});
 
 const newModelQueryTabLocation = createMockLocation({
-  pathname: `/model/query`,
+  pathname: "/model/query",
 });
 
 const newModelMetadataTabLocation = createMockLocation({
-  pathname: `/model/metadata`,
+  pathname: "/model/metadata",
 });
 
 const modelQueryTabLocation = createMockLocation({
@@ -89,7 +91,7 @@ describe("isNavigationAllowed", () => {
     const destination = undefined;
 
     it.each(questions)(
-      "allows navigating away from creating new $_card.name",
+      "allows navigating away from creating new `$_card.name`",
       question => {
         const isNewQuestion = true;
 
@@ -100,7 +102,7 @@ describe("isNavigationAllowed", () => {
     );
 
     it.each(questions)(
-      "allows navigating away from editing $_card.name",
+      "allows navigating away from editing `$_card.name`",
       question => {
         const isNewQuestion = false;
 
@@ -112,36 +114,32 @@ describe("isNavigationAllowed", () => {
   });
 
   describe("when there is no question", () => {
-    const destinations = [...locations, undefined];
     const question = undefined;
 
-    it.each(destinations)(
-      "allows navigating away from $pathname",
-      destination => {
-        expect(
-          isNavigationAllowed({ destination, question, isNewQuestion: true }),
-        ).toBe(true);
-        expect(
-          isNavigationAllowed({ destination, question, isNewQuestion: false }),
-        ).toBe(true);
-      },
-    );
+    it.each(locations)("allows navigating away to `$pathname`", destination => {
+      expect(
+        isNavigationAllowed({ destination, question, isNewQuestion: true }),
+      ).toBe(true);
+      expect(
+        isNavigationAllowed({ destination, question, isNewQuestion: false }),
+      ).toBe(true);
+    });
   });
 
   describe("when creating new question", () => {
     const isNewQuestion = true;
 
-    it("always allows navigating away from creating new question", () => {
-      const questions = [notebookQuestion, nativeQuestion, undefined];
-      const destinations = [...locations, undefined];
-
-      for (const question of questions) {
-        for (const destination of destinations) {
-          expect(
-            isNavigationAllowed({ destination, question, isNewQuestion }),
-          ).toBe(true);
-        }
-      }
+    describe("allows navigating away", () => {
+      describe.each(locations)("to `$pathname`", destination => {
+        it.each([notebookQuestion, nativeQuestion])(
+          "from creating new `$_card.name`",
+          question => {
+            expect(
+              isNavigationAllowed({ destination, question, isNewQuestion }),
+            ).toBe(true);
+          },
+        );
+      });
     });
   });
 

--- a/frontend/src/metabase/query_builder/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.ts
@@ -9,95 +9,86 @@ import { checkNotNull } from "metabase/core/utils/types";
 
 import { isNavigationAllowed } from "./utils";
 
-const mockNotebookCard = createMockCard({
+const notebookCard = createMockCard({
   id: getNextId(),
 });
 
-const mockNativeCard = createMockCard({
+const nativeCard = createMockCard({
   id: getNextId(),
   dataset_query: createMockNativeDatasetQuery(),
 });
 
-const mockNotebookModelCard = createMockCard({
+const notebookModelCard = createMockCard({
   id: getNextId(),
   dataset: true,
 });
 
-const mockNativeModelCard = createMockCard({
+const nativeModelCard = createMockCard({
   id: getNextId(),
   dataset: true,
   dataset_query: createMockNativeDatasetQuery(),
 });
 
-const mockCards = [
-  mockNotebookCard,
-  mockNativeCard,
-  mockNotebookModelCard,
-  mockNativeModelCard,
-];
+const cards = [notebookCard, nativeCard, notebookModelCard, nativeModelCard];
 
-const metadata = createMockMetadata({ questions: mockCards });
+const metadata = createMockMetadata({ questions: cards });
 
-const mockNotebookQuestion = checkNotNull(
-  metadata.question(mockNotebookCard.id),
+const notebookQuestion = checkNotNull(metadata.question(notebookCard.id));
+
+const nativeQuestion = checkNotNull(metadata.question(nativeCard.id));
+
+const notebookModelQuestion = checkNotNull(
+  metadata.question(notebookModelCard.id),
 );
 
-const mockNativeQuestion = checkNotNull(metadata.question(mockNativeCard.id));
+const nativeModelQuestion = checkNotNull(metadata.question(nativeModelCard.id));
 
-const mockNotebookModelQuestion = checkNotNull(
-  metadata.question(mockNotebookModelCard.id),
-);
-
-const mockNativeModelQuestion = checkNotNull(
-  metadata.question(mockNativeModelCard.id),
-);
-
-const mockQuestions = [
-  mockNotebookQuestion,
-  mockNativeQuestion,
-  mockNotebookModelQuestion,
-  mockNativeModelQuestion,
+const questions = [
+  notebookQuestion,
+  nativeQuestion,
+  notebookModelQuestion,
+  nativeModelQuestion,
 ];
 
 const anyLocation = createMockLocation();
 
-const mockNewModelQueryTabLocation = createMockLocation({
+const newModelQueryTabLocation = createMockLocation({
   pathname: `/model/query`,
 });
 
-const mockNewModelMetadataTabLocation = createMockLocation({
+const newModelMetadataTabLocation = createMockLocation({
   pathname: `/model/metadata`,
 });
 
-const mockModelQueryTabLocation = createMockLocation({
-  pathname: `/model/${mockNotebookModelCard.id}/query`,
+const modelQueryTabLocation = createMockLocation({
+  pathname: `/model/${notebookModelCard.id}/query`,
 });
 
-const mockModelMetadataTabLocation = createMockLocation({
-  pathname: `/model/${mockNotebookModelCard.id}/metadata`,
+const modelMetadataTabLocation = createMockLocation({
+  pathname: `/model/${notebookModelCard.id}/metadata`,
 });
 
-const mockRunQuestionLocation = createMockLocation({
+const runQuestionLocation = createMockLocation({
   pathname: "/question",
-  hash: `#${window.btoa(JSON.stringify(mockNativeCard))}`,
+  hash: `#${window.btoa(JSON.stringify(nativeCard))}`,
 });
 
-const mockLocations = [
+const locations = [
   anyLocation,
-  mockModelQueryTabLocation,
-  mockModelMetadataTabLocation,
-  mockRunQuestionLocation,
+  modelQueryTabLocation,
+  modelMetadataTabLocation,
+  runQuestionLocation,
 ];
 
 describe("isNavigationAllowed", () => {
   describe("when there is no destination (i.e. it's a beforeunload event)", () => {
     const destination = undefined;
-    const questions = [...mockQuestions, undefined];
+    const testQuestions = [...questions, undefined];
 
     it("always allows navigating away from creating new question", () => {
       const isNewQuestion = true;
 
-      for (const question of questions) {
+      for (const question of testQuestions) {
         expect(
           isNavigationAllowed({ destination, question, isNewQuestion }),
         ).toBe(true);
@@ -119,8 +110,8 @@ describe("isNavigationAllowed", () => {
     const isNewQuestion = true;
 
     it("always allows navigating away from creating new question", () => {
-      const questions = [mockNotebookQuestion, mockNativeQuestion, undefined];
-      const destinations = [...mockLocations, undefined];
+      const questions = [notebookQuestion, nativeQuestion, undefined];
+      const destinations = [...locations, undefined];
 
       for (const question of questions) {
         for (const destination of destinations) {
@@ -134,8 +125,8 @@ describe("isNavigationAllowed", () => {
 
   describe("when editing notebook question", () => {
     const isNewQuestion = false;
-    const question = mockNotebookQuestion;
-    const destinations = [...mockLocations, undefined];
+    const question = notebookQuestion;
+    const destinations = [...locations, undefined];
 
     it("always allows navigating away from editing notebook question", () => {
       for (const destination of destinations) {
@@ -148,10 +139,10 @@ describe("isNavigationAllowed", () => {
 
   describe("when editing native question", () => {
     const isNewQuestion = false;
-    const question = mockNativeQuestion;
+    const question = nativeQuestion;
 
     it("allows to run the question", () => {
-      const destination = mockRunQuestionLocation;
+      const destination = runQuestionLocation;
 
       expect(
         isNavigationAllowed({ destination, question, isNewQuestion }),
@@ -169,10 +160,10 @@ describe("isNavigationAllowed", () => {
 
   describe("when creating new model", () => {
     const isNewQuestion = true;
-    const question = mockNotebookModelQuestion;
+    const question = notebookModelQuestion;
 
     it("does not allow navigating away from creating new model", () => {
-      const destinations = [...mockLocations];
+      const destinations = [...locations];
 
       for (const destination of destinations) {
         expect(
@@ -183,8 +174,8 @@ describe("isNavigationAllowed", () => {
 
     it("allows navigating between model query & metadata tabs", () => {
       const destinations = [
-        mockNewModelQueryTabLocation,
-        mockNewModelMetadataTabLocation,
+        newModelQueryTabLocation,
+        newModelMetadataTabLocation,
       ];
 
       for (const destination of destinations) {
@@ -197,13 +188,10 @@ describe("isNavigationAllowed", () => {
 
   describe("when editing notebook model", () => {
     const isNewQuestion = false;
-    const question = mockNotebookModelQuestion;
+    const question = notebookModelQuestion;
 
     it("allows navigating between model query & metadata tabs", () => {
-      const destinations = [
-        mockModelQueryTabLocation,
-        mockModelMetadataTabLocation,
-      ];
+      const destinations = [modelQueryTabLocation, modelMetadataTabLocation];
 
       for (const destination of destinations) {
         expect(
@@ -223,13 +211,10 @@ describe("isNavigationAllowed", () => {
 
   describe("when editing native-query model", () => {
     const isNewQuestion = false;
-    const question = mockNativeModelQuestion;
+    const question = nativeModelQuestion;
 
     it("allows navigating between model query & metadata tabs", () => {
-      const destinations = [
-        mockModelQueryTabLocation,
-        mockModelMetadataTabLocation,
-      ];
+      const destinations = [modelQueryTabLocation, modelMetadataTabLocation];
 
       for (const destination of destinations) {
         expect(

--- a/frontend/src/metabase/query_builder/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.ts
@@ -182,27 +182,23 @@ describe("isNavigationAllowed", () => {
     const isNewQuestion = true;
     const question = notebookModelQuestion;
 
-    it("does not allow navigating away from creating new model", () => {
-      const destinations = [...locations];
-
-      for (const destination of destinations) {
+    describe("does not allow navigating away from creating new model", () => {
+      it.each(locations)("to `$pathname`", destination => {
         expect(
           isNavigationAllowed({ destination, question, isNewQuestion }),
         ).toBe(false);
-      }
+      });
     });
 
-    it("allows navigating between model query & metadata tabs", () => {
-      const destinations = [
-        newModelQueryTabLocation,
-        newModelMetadataTabLocation,
-      ];
-
-      for (const destination of destinations) {
-        expect(
-          isNavigationAllowed({ destination, question, isNewQuestion }),
-        ).toBe(true);
-      }
+    describe("allows navigating between model query & metadata tabs", () => {
+      it.each([newModelQueryTabLocation, newModelMetadataTabLocation])(
+        "to `$pathname`",
+        destination => {
+          expect(
+            isNavigationAllowed({ destination, question, isNewQuestion }),
+          ).toBe(true);
+        },
+      );
     });
   });
 

--- a/frontend/src/metabase/query_builder/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.ts
@@ -256,22 +256,27 @@ describe("isNavigationAllowed", () => {
     const isNewQuestion = false;
     const question = nativeModelQuestion;
 
-    it("allows navigating between model query & metadata tabs", () => {
-      const destinations = [modelQueryTabLocation, modelMetadataTabLocation];
-
-      for (const destination of destinations) {
-        expect(
-          isNavigationAllowed({ destination, question, isNewQuestion }),
-        ).toBe(true);
-      }
+    describe("allows navigating between model query & metadata tabs", () => {
+      it.each([modelQueryTabLocation, modelMetadataTabLocation])(
+        "to `$pathname`",
+        destination => {
+          expect(
+            isNavigationAllowed({ destination, question, isNewQuestion }),
+          ).toBe(true);
+        },
+      );
     });
 
-    it("disallows all other navigation", () => {
-      const destination = anyLocation;
-
-      expect(
-        isNavigationAllowed({ destination, question, isNewQuestion }),
-      ).toBe(false);
+    describe("disallows all other navigation", () => {
+      it.each([
+        anyLocation,
+        newModelMetadataTabLocation,
+        newModelQueryTabLocation,
+      ])("to `$pathname`", destination => {
+        expect(
+          isNavigationAllowed({ destination, question, isNewQuestion }),
+        ).toBe(false);
+      });
     });
   });
 });

--- a/frontend/src/metabase/query_builder/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.ts
@@ -115,7 +115,7 @@ describe("isNavigationAllowed", () => {
     const isNewQuestion = true;
 
     it("always allows navigating away from creating new question", () => {
-      const questions = [...mockQuestions, undefined];
+      const questions = [mockQuestion, mockNativeQuestion, undefined];
       const destinations = [...mockLocations, undefined];
 
       for (const question of questions) {

--- a/frontend/src/metabase/query_builder/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.ts
@@ -57,6 +57,14 @@ const mockQuestions = [
 
 const anyLocation = createMockLocation();
 
+const mockNewModelQueryTabLocation = createMockLocation({
+  pathname: `/model/query`,
+});
+
+const mockNewModelMetadataTabLocation = createMockLocation({
+  pathname: `/model/metadata`,
+});
+
 const mockModelQueryTabLocation = createMockLocation({
   pathname: `/model/${mockModelCard.id}/query`,
 });
@@ -152,6 +160,34 @@ describe("isNavigationAllowed", () => {
       expect(
         isNavigationAllowed({ destination, question, isNewQuestion }),
       ).toBe(false);
+    });
+  });
+
+  describe("when creating new model", () => {
+    const isNewQuestion = true;
+    const question = mockModelQuestion;
+
+    it("does not allow navigating away from creating new model", () => {
+      const destinations = [...mockLocations, undefined];
+
+      for (const destination of destinations) {
+        expect(
+          isNavigationAllowed({ destination, question, isNewQuestion }),
+        ).toBe(false);
+      }
+    });
+
+    it("allows navigating between model query & metadata tabs", () => {
+      const destinations = [
+        mockNewModelQueryTabLocation,
+        mockNewModelMetadataTabLocation,
+      ];
+
+      for (const destination of destinations) {
+        expect(
+          isNavigationAllowed({ destination, question, isNewQuestion }),
+        ).toBe(true);
+      }
     });
   });
 

--- a/frontend/src/metabase/query_builder/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.ts
@@ -79,13 +79,6 @@ const runQuestionLocation = createMockLocation({
   hash: `#${window.btoa(JSON.stringify(nativeCard))}`,
 });
 
-const locations = [
-  anyLocation,
-  modelQueryTabLocation,
-  modelMetadataTabLocation,
-  runQuestionLocation,
-];
-
 describe("isNavigationAllowed", () => {
   describe("when there is no destination (i.e. it's a beforeunload event)", () => {
     const destination = undefined;
@@ -116,7 +109,14 @@ describe("isNavigationAllowed", () => {
   describe("when there is no question", () => {
     const question = undefined;
 
-    it.each(locations)("allows navigating away to `$pathname`", destination => {
+    it.each([
+      anyLocation,
+      modelQueryTabLocation,
+      modelMetadataTabLocation,
+      newModelQueryTabLocation,
+      newModelMetadataTabLocation,
+      runQuestionLocation,
+    ])("allows navigating away to `$pathname`", destination => {
       expect(
         isNavigationAllowed({ destination, question, isNewQuestion: true }),
       ).toBe(true);
@@ -130,7 +130,14 @@ describe("isNavigationAllowed", () => {
     const isNewQuestion = true;
 
     describe("allows navigating away", () => {
-      describe.each(locations)("to `$pathname`", destination => {
+      describe.each([
+        anyLocation,
+        modelQueryTabLocation,
+        modelMetadataTabLocation,
+        newModelQueryTabLocation,
+        newModelMetadataTabLocation,
+        runQuestionLocation,
+      ])("to `$pathname`", destination => {
         it.each([notebookQuestion, nativeQuestion])(
           "from creating new `$_card.name`",
           question => {
@@ -147,7 +154,14 @@ describe("isNavigationAllowed", () => {
     const isNewQuestion = false;
     const question = notebookQuestion;
 
-    it.each(locations)("allows navigating away to `$pathname`", destination => {
+    it.each([
+      anyLocation,
+      modelQueryTabLocation,
+      modelMetadataTabLocation,
+      newModelQueryTabLocation,
+      newModelMetadataTabLocation,
+      runQuestionLocation,
+    ])("allows navigating away to `$pathname`", destination => {
       expect(
         isNavigationAllowed({ destination, question, isNewQuestion }),
       ).toBe(true);
@@ -167,28 +181,23 @@ describe("isNavigationAllowed", () => {
     });
 
     describe("disallows all other navigation", () => {
-      it.each([anyLocation, modelQueryTabLocation, modelMetadataTabLocation])(
-        "to `$pathname`",
-        destination => {
-          expect(
-            isNavigationAllowed({ destination, question, isNewQuestion }),
-          ).toBe(false);
-        },
-      );
+      it.each([
+        anyLocation,
+        modelQueryTabLocation,
+        modelMetadataTabLocation,
+        newModelQueryTabLocation,
+        newModelMetadataTabLocation,
+      ])("to `$pathname`", destination => {
+        expect(
+          isNavigationAllowed({ destination, question, isNewQuestion }),
+        ).toBe(false);
+      });
     });
   });
 
   describe("when creating new model", () => {
     const isNewQuestion = true;
     const question = notebookModelQuestion;
-
-    describe("does not allow navigating away from creating new model", () => {
-      it.each(locations)("to `$pathname`", destination => {
-        expect(
-          isNavigationAllowed({ destination, question, isNewQuestion }),
-        ).toBe(false);
-      });
-    });
 
     describe("allows navigating between model query & metadata tabs", () => {
       it.each([newModelQueryTabLocation, newModelMetadataTabLocation])(
@@ -200,28 +209,46 @@ describe("isNavigationAllowed", () => {
         },
       );
     });
+
+    describe("disallows all other navigation", () => {
+      it.each([
+        anyLocation,
+        modelQueryTabLocation,
+        modelMetadataTabLocation,
+        runQuestionLocation,
+      ])("to `$pathname`", destination => {
+        expect(
+          isNavigationAllowed({ destination, question, isNewQuestion }),
+        ).toBe(false);
+      });
+    });
   });
 
   describe("when editing notebook model", () => {
     const isNewQuestion = false;
     const question = notebookModelQuestion;
 
-    it("allows navigating between model query & metadata tabs", () => {
-      const destinations = [modelQueryTabLocation, modelMetadataTabLocation];
-
-      for (const destination of destinations) {
-        expect(
-          isNavigationAllowed({ destination, question, isNewQuestion }),
-        ).toBe(true);
-      }
+    describe("allows navigating between model query & metadata tabs", () => {
+      it.each([modelQueryTabLocation, modelMetadataTabLocation])(
+        "to `$pathname`",
+        destination => {
+          expect(
+            isNavigationAllowed({ destination, question, isNewQuestion }),
+          ).toBe(true);
+        },
+      );
     });
 
-    it("disallows all other navigation", () => {
-      const destination = anyLocation;
-
-      expect(
-        isNavigationAllowed({ destination, question, isNewQuestion }),
-      ).toBe(false);
+    describe("disallows all other navigation", () => {
+      it.each([
+        anyLocation,
+        newModelMetadataTabLocation,
+        newModelQueryTabLocation,
+      ])("to `$pathname`", destination => {
+        expect(
+          isNavigationAllowed({ destination, question, isNewQuestion }),
+        ).toBe(false);
+      });
     });
   });
 

--- a/frontend/src/metabase/query_builder/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.ts
@@ -11,20 +11,24 @@ import { isNavigationAllowed } from "./utils";
 
 const notebookCard = createMockCard({
   id: getNextId(),
+  name: "notebook question",
 });
 
 const nativeCard = createMockCard({
   id: getNextId(),
+  name: "native question",
   dataset_query: createMockNativeDatasetQuery(),
 });
 
 const notebookModelCard = createMockCard({
   id: getNextId(),
+  name: "notebook model",
   dataset: true,
 });
 
 const nativeModelCard = createMockCard({
   id: getNextId(),
+  name: "native model",
   dataset: true,
   dataset_query: createMockNativeDatasetQuery(),
 });
@@ -83,27 +87,45 @@ const locations = [
 describe("isNavigationAllowed", () => {
   describe("when there is no destination (i.e. it's a beforeunload event)", () => {
     const destination = undefined;
-    const testQuestions = [...questions, undefined];
 
-    it("always allows navigating away from creating new question", () => {
-      const isNewQuestion = true;
+    it.each(questions)(
+      "allows navigating away from creating new $_card.name",
+      question => {
+        const isNewQuestion = true;
 
-      for (const question of testQuestions) {
         expect(
           isNavigationAllowed({ destination, question, isNewQuestion }),
         ).toBe(true);
-      }
-    });
+      },
+    );
 
-    it("always allows navigating away from editing question", () => {
-      const isNewQuestion = false;
+    it.each(questions)(
+      "allows navigating away from editing $_card.name",
+      question => {
+        const isNewQuestion = false;
 
-      for (const question of questions) {
         expect(
           isNavigationAllowed({ destination, question, isNewQuestion }),
         ).toBe(true);
-      }
-    });
+      },
+    );
+  });
+
+  describe("when there is no question", () => {
+    const destinations = [...locations, undefined];
+    const question = undefined;
+
+    it.each(destinations)(
+      "allows navigating away from $pathname",
+      destination => {
+        expect(
+          isNavigationAllowed({ destination, question, isNewQuestion: true }),
+        ).toBe(true);
+        expect(
+          isNavigationAllowed({ destination, question, isNewQuestion: false }),
+        ).toBe(true);
+      },
+    );
   });
 
   describe("when creating new question", () => {

--- a/frontend/test/__support__/server-mocks/card.ts
+++ b/frontend/test/__support__/server-mocks/card.ts
@@ -13,7 +13,11 @@ export function setupCardEndpoints(card: Card) {
     const lastCall = fetchMock.lastCall(url);
     return createMockCard(await lastCall?.request?.json());
   });
+  setupCardQueryMetadataEndpoint(card);
+  fetchMock.get(`path:/api/card/${card.id}/series`, []);
+}
 
+export function setupCardQueryMetadataEndpoint(card: Card) {
   const virtualTableId = getQuestionVirtualTableId(card.id);
   fetchMock.get(`path:/api/table/${virtualTableId}/query_metadata`, {
     ...convertSavedQuestionToVirtualTable(card),
@@ -23,17 +27,19 @@ export function setupCardEndpoints(card: Card) {
     })),
     dimension_options: {},
   });
-
-  fetchMock.get(`path:/api/card/${card.id}/series`, []);
 }
 
 export function setupCardsEndpoints(cards: Card[]) {
   fetchMock.get({ url: "path:/api/card", overwriteRoutes: false }, cards);
+  setupCardCreateEndpoint();
+  cards.forEach(card => setupCardEndpoints(card));
+}
+
+export function setupCardCreateEndpoint() {
   fetchMock.post("path:/api/card", async url => {
     const lastCall = fetchMock.lastCall(url);
     return createMockCard(await lastCall?.request?.json());
   });
-  cards.forEach(card => setupCardEndpoints(card));
 }
 
 export function setupUnauthorizedCardEndpoints(card: Card) {

--- a/frontend/test/__support__/server-mocks/collection.ts
+++ b/frontend/test/__support__/server-mocks/collection.ts
@@ -47,12 +47,6 @@ export function setupCollectionsEndpoints({
   );
 }
 
-export function setupCollectionsEndpointsByIds(collections: Collection[]) {
-  for (const collection of collections) {
-    fetchMock.get(`path:/api/collection/${collection.id}`, [collection]);
-  }
-}
-
 function getCollectionVirtualSchemaURLs(collection: Collection) {
   const db = SAVED_QUESTIONS_VIRTUAL_DB_ID;
   const schemaName = getCollectionVirtualSchemaName(collection);

--- a/frontend/test/__support__/server-mocks/collection.ts
+++ b/frontend/test/__support__/server-mocks/collection.ts
@@ -47,6 +47,12 @@ export function setupCollectionsEndpoints({
   );
 }
 
+export function setupCollectionsEndpointsByIds(collections: Collection[]) {
+  for (const collection of collections) {
+    fetchMock.get(`path:/api/collection/${collection.id}`, [collection]);
+  }
+}
+
 function getCollectionVirtualSchemaURLs(collection: Collection) {
   const db = SAVED_QUESTIONS_VIRTUAL_DB_ID;
   const schemaName = getCollectionVirtualSchemaName(collection);


### PR DESCRIPTION
Closes #34430

### Description

- New models are always considered dirty, that's why warning will be displayed even if user does not make any changes to an "empty" model
- There used to be a "Discard changes?" warning when clicking "Cancel" while creating a model - it's been replaced with "Changes are not saved" warning, see [Slack](https://metaboat.slack.com/archives/C057T1QTB3L/p1696930999213629) - consistency and easier implementation.

### How to verify

**1. Navigating away from creating a new model**

1. Click "+ New"
2. Choose "Model"
3. Choose "Use the notebook editor" (or "Use a native query")
4. (optional) Choose data source, do some changes in the definition/metadata
    - if you do this, you might encounter an existing issue: #34514 
    - there are more existing issues with back button navigation in Query Builder (#33709, #33708)
5. Click back button in your browser

Expected result: "Changes are not saved" modal is displayed

**2. Cancelling creating a new model**

1. Click "+ New"
2. Choose "Model"
3. Choose "Use the notebook editor" (or "Use a native query")
4. (optional) Choose data source, do some changes in the definition/metadata
5. Click "Cancel"

Expected result: "Changes are not saved" modal is displayed

**3. Saving a new model**

1. Click "+ New"
2. Choose "Model"
3. Choose "Use the notebook editor" (or "Use a native query")
4. Choose data source, do some changes in the definition/metadata
5. Click "Save", modal will open
6. Click "Save"
7. Wait for model to be created

Expected result: "Changes are not saved" modal is **not displayed**

### Demo

https://github.com/metabase/metabase/assets/6830683/ae58551d-c9a8-4a6b-850a-d5e7d1084cbb

