### PR TITLE
Fix load-to-h2 by requiring conn impersonation model when running EE jar

### DIFF
--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -25,6 +25,9 @@
 
 (set! *warn-on-reflection* true)
 
+(when config/ee-available?
+ (classloader/require 'metabase-enterprise.advanced-permissions.models.connection-impersonation))
+
 (defn- log-ok []
   (log/info (u/colorize 'green "[OK]")))
 


### PR DESCRIPTION
`load-to-h2` is using `connectionimpersonation` as the table name when it should be using `connection_impersonations`. The Connection Impersonation model implements `t2/table-name`, but [the error](https://metaboat.slack.com/archives/C04DN5VRQM6/p1696859523307469?thread_ts=1696616156.729289&cid=C04DN5VRQM6) is implying that the script is using the default implementation of `t2/table-name` instead.

The root cause seems to be that the model namespace isn't being required when running this code from the command line, so the custom implementation of `t2/table-name` isn't being loaded. Requiring the namespace explicitly fixes this.

Tests didn't catch this either. I think we need a check in CI that does the dump/load process using the jar, if possible. Or some other way to test this in Clojure that would have caught this issue, but not sure what it is.