### PR TITLE
FE: Disable invalid values source options if parameter has linked filters

### DIFF
--- a/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.tsx
@@ -92,7 +92,7 @@ const RadioLabel = ({
           isEnabled={!!isEditDisabled}
         >
           {/* This div is needed to make the tooltip work when the button is disabled */}
-          <div>
+          <div data-testid="values-source-settings-edit-btn">
             <Button
               onClick={onEditClick}
               disabled={!!isEditDisabled}

--- a/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.tsx
@@ -80,7 +80,7 @@ const RadioLabel = ({
   title,
   isSelected,
   onEditClick,
-  isEditDisabled,
+  isEditDisabled = false,
 }: RadioLabelProps): JSX.Element => {
   return (
     <RadioLabelRoot>
@@ -89,13 +89,13 @@ const RadioLabel = ({
         <Tooltip
           tooltip={t`You can’t customize selectable values for this filter because it is linked to another one.`}
           placement="top"
-          isEnabled={!!isEditDisabled}
+          isEnabled={isEditDisabled}
         >
           {/* This div is needed to make the tooltip work when the button is disabled */}
           <div data-testid="values-source-settings-edit-btn">
             <Button
               onClick={onEditClick}
-              disabled={!!isEditDisabled}
+              disabled={isEditDisabled}
               variant="subtle"
               p={0}
               compact={true}

--- a/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.tsx
@@ -35,7 +35,8 @@ const ValuesSourceSettings = ({
     return getRadioOptions({
       queryType: queryType,
       onEditClick: () => setIsModalOpened(true),
-      isEditDisabled: isOnlyConnectedFieldSourceAllowed(parameter),
+      // linked filters only work with connected field sources (metabase#33892)
+      isEditDisabled: hasLinkedFilters(parameter),
     });
   }, [queryType, parameter]);
 
@@ -64,9 +65,8 @@ const ValuesSourceSettings = ({
   );
 };
 
-function isOnlyConnectedFieldSourceAllowed(parameter: Parameter) {
-  // linked filters only work with connected field sources (metabase#33892)
-  return !!parameter.filteringParameters?.length;
+function hasLinkedFilters({ filteringParameters }: Parameter) {
+  return filteringParameters != null && filteringParameters.length > 0;
 }
 
 interface RadioLabelProps {

--- a/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.tsx
@@ -91,6 +91,7 @@ const RadioLabel = ({
           placement="top"
           isEnabled={!!isEditDisabled}
         >
+          {/* This div is needed to make the tooltip work when the button is disabled */}
           <div>
             <Button
               onClick={onEditClick}

--- a/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.unit.spec.tsx
@@ -49,7 +49,7 @@ describe("ValuesSourceSettings", () => {
     });
   });
 
-  it("Editing the values source should be disabled when the filter has linked filters", () => {
+  it("editing the values source should be disabled when the filter has linked filters", () => {
     setup({
       parameter: createMockParameter({
         filteringParameters: ["2"],

--- a/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.unit.spec.tsx
@@ -49,13 +49,9 @@ describe("ValuesSourceSettings", () => {
     });
   });
 
-  it("Edit button on should be disabled with field has linked filters enabled", () => {
+  it("Editing the values source should be disabled when the filter has linked filters", () => {
     setup({
       parameter: createMockParameter({
-        type: "category",
-        values_query_type: "list",
-        id: "1",
-        name: "Category",
         filteringParameters: ["2"],
       }),
     });
@@ -64,16 +60,34 @@ describe("ValuesSourceSettings", () => {
     expect(screen.getByRole("button", { name: "Edit" })).toBeDisabled();
     userEvent.click(screen.getByRole("radio", { name: "Search box" }));
     expect(screen.getByRole("button", { name: "Edit" })).toBeDisabled();
-    // Test that hovering over the button shows the tooltip
-    // calling .parentElement is needed because the button has pointer-events: none when disabled
-    // eslint-disable-next-line testing-library/no-node-access
-    userEvent.hover(
-      screen.getByRole("button", { name: "Edit" }).parentElement as HTMLElement,
-    );
+
+    // hovering over the button shows the tooltip"
+    userEvent.hover(screen.getByTestId("values-source-settings-edit-btn"));
     expect(
       screen.getByText(
         "You can’t customize selectable values for this filter because it is linked to another one.",
       ),
     ).toBeInTheDocument();
+  });
+
+  it("Editing the values source should be enabled when the filter has no linked filters", () => {
+    setup({
+      parameter: createMockParameter({
+        filteringParameters: [],
+      }),
+    });
+
+    userEvent.click(screen.getByRole("radio", { name: "Dropdown list Edit" }));
+    expect(screen.getByRole("button", { name: "Edit" })).toBeEnabled();
+    userEvent.click(screen.getByRole("radio", { name: "Search box" }));
+    expect(screen.getByRole("button", { name: "Edit" })).toBeEnabled();
+
+    // hovering over the button doesn't show the tooltip
+    userEvent.hover(screen.getByTestId("values-source-settings-edit-btn"));
+    expect(
+      screen.queryByText(
+        "You can’t customize selectable values for this filter because it is linked to another one.",
+      ),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.unit.spec.tsx
@@ -48,4 +48,32 @@ describe("ValuesSourceSettings", () => {
       values: ["A"],
     });
   });
+
+  it("Edit button on should be disabled with field has linked filters enabled", () => {
+    setup({
+      parameter: createMockParameter({
+        type: "category",
+        values_query_type: "list",
+        id: "1",
+        name: "Category",
+        filteringParameters: ["2"],
+      }),
+    });
+
+    userEvent.click(screen.getByRole("radio", { name: "Dropdown list Edit" }));
+    expect(screen.getByRole("button", { name: "Edit" })).toBeDisabled();
+    userEvent.click(screen.getByRole("radio", { name: "Search box" }));
+    expect(screen.getByRole("button", { name: "Edit" })).toBeDisabled();
+    // Test that hovering over the button shows the tooltip
+    // calling .parentElement is needed because the button has pointer-events: none when disabled
+    // eslint-disable-next-line testing-library/no-node-access
+    userEvent.hover(
+      screen.getByRole("button", { name: "Edit" }).parentElement as HTMLElement,
+    );
+    expect(
+      screen.getByText(
+        "You can’t customize selectable values for this filter because it is linked to another one.",
+      ),
+    ).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/34604

Part 3 out of 3 for #33892, see comment [here](https://github.com/metabase/metabase/issues/33892#issuecomment-1752488489) for the plan.

Part 1 is here: #34424
Part 2 is here: #34438

This PR prevents users from setting a filter's values source to anything other than "From connected fields" if the filter has any linked filters. It does so by disabling the "Edit" button here and showing an explanation in the tooltip:

![image](https://github.com/metabase/metabase/assets/39073188/0604e6eb-5294-4005-bb21-d2a8cf1b5971)