### PR TITLE
Fix `load-from-h2` logic to loads entire system before running from uberjar

### DIFF
--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -4,10 +4,7 @@
   data from an application database to any empty application database for all combinations of supported application
   database types."
   (:require
-   [clojure.java.classpath :as classpath]
    [clojure.java.jdbc :as jdbc]
-   [clojure.string :as str]
-   [clojure.tools.namespace.find :as ns.find]
    [honey.sql :as sql]
    [metabase.config :as config]
    [metabase.db.connection :as mdb.connection]
@@ -375,7 +372,6 @@
                                         table-name table-name)]]
         (jdbc/execute! target-db-conn sql)))))
 
-
 (s/defn copy!
   "Copy data from a source application database into an empty destination application database."
   [source-db-type     :- (s/enum :h2 :postgres :mysql)
@@ -383,9 +379,7 @@
    target-db-type     :- (s/enum :h2 :postgres :mysql)
    target-data-source :- javax.sql.DataSource]
   ;; make sure the entire system is loaded before running this test, to make sure we account for all the models.
-  (doseq [ns-symb (ns.find/find-namespaces (classpath/system-classpath))
-          :when   (and (str/starts-with? ns-symb "metabase")
-                       (not (str/includes? ns-symb "test")))]
+  (doseq [ns-symb u/metabase-namespace-symbols]
     (classloader/require ns-symb))
   ;; make sure the source database is up-do-date
   (step (trs "Set up {0} source database and run migrations..." (name source-db-type))

--- a/src/metabase/util/jvm.clj
+++ b/src/metabase/util/jvm.clj
@@ -268,11 +268,11 @@
 ;; This is made `^:const` so it will get calculated when the uberjar is compiled. `find-namespaces` won't work if
 ;; source is excluded; either way this takes a few seconds, so doing it at compile time speeds up launch as well.
 (defonce ^:const ^{:doc "Vector of symbols of all Metabase namespaces, excluding test namespaces. This is intended
-                        for use by various routines that load related namespaces, such as task and events
-                        initialization."}
- metabase-namespace-symbols
+  for use by various routines that load related namespaces, such as task and events
+  initialization."}
+  metabase-namespace-symbols
   (vec (sort (for [ns-symb (ns.find/find-namespaces (classpath/system-classpath))
-                   :when   (and (str/starts-with? ns-symb "metabase.")
+                   :when   (and (str/starts-with? ns-symb "metabase")
                                 (not (str/includes? ns-symb "test")))]
                ns-symb))))
 


### PR DESCRIPTION
There was a bug in the code that should have fixed #34505, it only discovered and loaded namespaces when running locally from source, not from the uberjar.

The `tools.namespace.find` logic does not work inside an uberjar, but we already have a vector that contains all the metabase namespaces that we generate at compile time that can work for this purpose. It previously filtered out `metabase-enterprise` namespaces, but there was no good reason for it to do so, so I fixed that

Fixes #34505