### PR TITLE
replace `java-time` namespace with `java-time.api`

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/common.clj
@@ -6,7 +6,7 @@
    [clojure.walk :as walk]
    [honey.sql :as sql]
    [honey.sql.helpers :as sql.helpers]
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase-enterprise.audit-app.query-processor.middleware.handle-audit-queries
     :as qp.middleware.audit]

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -3,7 +3,7 @@
   (:require
    [buddy.sign.jwt :as jwt]
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase-enterprise.sso.api.interface :as sso.i]
    [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]
    [metabase-enterprise.sso.integrations.sso-utils :as sso-utils]

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -19,7 +19,7 @@
   (:require
    [buddy.core.codecs :as codecs]
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase-enterprise.sso.api.interface :as sso.i]
    [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/api/logs_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/api/logs_test.clj
@@ -2,7 +2,7 @@
   "Tests for /api/ee/logs endpoints"
   (:require
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase-enterprise.advanced-config.api.logs :as ee.api.logs]
    [metabase.models.query-execution :refer [QueryExecution]]
    [metabase.public-settings.premium-features-test :as premium-features.test]

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/caching_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/caching_test.clj
@@ -1,7 +1,7 @@
 (ns metabase-enterprise.advanced-config.caching-test
   (:require
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.models :refer [Card Dashboard Database PersistedInfo TaskHistory]]
    [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features-test

--- a/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
@@ -5,7 +5,7 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase-enterprise.search.scoring :as ee-scoring]
    [metabase.public-settings.premium-features-test :as premium-features-test]
    [metabase.search.scoring :as scoring]))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.set :as set]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase-enterprise.serialization.test-util :as ts]
    [metabase-enterprise.serialization.v2.extract :as extract]
    [metabase.models

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1,7 +1,7 @@
 (ns ^:mb/once metabase-enterprise.serialization.v2.load-test
   (:require
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase-enterprise.serialization.test-util :as ts]
    [metabase-enterprise.serialization.v2.extract :as serdes.extract]
    [metabase-enterprise.serialization.v2.ingest :as serdes.ingest]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/storage_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/storage_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.java.io :as io]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase-enterprise.serialization.test-util :as ts]
    [metabase-enterprise.serialization.v2.extract :as extract]
    [metabase-enterprise.serialization.v2.storage :as storage]

--- a/modules/drivers/athena/src/metabase/driver/athena.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena.clj
@@ -5,7 +5,7 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [honey.sql :as sql]
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.driver :as driver]
    [metabase.driver.athena.schema-parser :as athena.schema-parser]

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/params.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/params.clj
@@ -1,6 +1,6 @@
 (ns metabase.driver.bigquery-cloud-sdk.params
   (:require
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.util.date-2 :as u.date]
    [metabase.util.log :as log])
   (:import

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.string :as str]
    [honeysql.format :as hformat]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.driver.bigquery-cloud-sdk.common :as bigquery.common]
    [metabase.driver.common :as driver.common]

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -4,7 +4,7 @@
    [clojure.test :refer :all]
    [honeysql.core :as hsql]
    [honeysql.format :as hformat]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.driver.bigquery-cloud-sdk :as bigquery]
    [metabase.driver.bigquery-cloud-sdk.query-processor :as bigquery.qp]

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.string :as str]
    [flatland.ordered.map :as ordered-map]
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.config :as config]
    [metabase.driver :as driver]

--- a/modules/drivers/druid/src/metabase/driver/druid/execute.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/execute.clj
@@ -2,7 +2,7 @@
   (:require
    [cheshire.core :as json]
    [clojure.math.numeric-tower :as math]
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.driver.druid.query-processor :as druid.qp]
    [metabase.lib.metadata :as lib.metadata]

--- a/modules/drivers/druid/test/metabase/driver/druid/query_processor_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/query_processor_test.clj
@@ -4,7 +4,7 @@
    [cheshire.core :as json]
    [clojure.test :refer :all]
    [clojure.tools.macro :as tools.macro]
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.db.metadata-queries :as metadata-queries]
    [metabase.driver :as driver]

--- a/modules/drivers/googleanalytics/src/metabase/driver/googleanalytics/execute.clj
+++ b/modules/drivers/googleanalytics/src/metabase/driver/googleanalytics/execute.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.tools.reader.edn :as edn]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver.googleanalytics.metadata :as ga.metadata]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor.store :as qp.store]

--- a/modules/drivers/googleanalytics/src/metabase/driver/googleanalytics/query_processor.clj
+++ b/modules/drivers/googleanalytics/src/metabase/driver/googleanalytics/query_processor.clj
@@ -3,7 +3,7 @@
   See https://developers.google.com/analytics/devguides/reporting/core/v3"
   (:require
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.mbql.util :as mbql.u]

--- a/modules/drivers/googleanalytics/test/metabase/driver/googleanalytics/query_processor_test.clj
+++ b/modules/drivers/googleanalytics/test/metabase/driver/googleanalytics/query_processor_test.clj
@@ -1,6 +1,6 @@
 (ns metabase.driver.googleanalytics.query-processor-test
   (:require [clojure.test :refer :all]
-            [java-time :as t]
+            [java-time.api :as t]
             [metabase.driver.googleanalytics-test :as ga.test]
             [metabase.driver.googleanalytics.query-processor :as ga.qp]
             [metabase.test :as mt]

--- a/modules/drivers/googleanalytics/test/metabase/driver/googleanalytics_test.clj
+++ b/modules/drivers/googleanalytics/test/metabase/driver/googleanalytics_test.clj
@@ -2,7 +2,7 @@
   "Tests for the Google Analytics driver and query processor."
   (:require
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.driver :as driver]
    [metabase.driver.googleanalytics]

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -5,7 +5,7 @@
    [cheshire.generate :as json.generate]
    [clojure.string :as str]
    [flatland.ordered.map :as ordered-map]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.db.metadata-queries :as metadata-queries]
    [metabase.driver :as driver]
    [metabase.driver.common :as driver.common]

--- a/modules/drivers/mongo/src/metabase/driver/mongo/parameters.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/parameters.clj
@@ -3,7 +3,7 @@
    [cheshire.core :as json]
    [clojure.string :as str]
    [clojure.walk :as walk]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver.common.parameters :as params]
    [metabase.driver.common.parameters.dates :as params.dates]
    [metabase.driver.common.parameters.operators :as params.ops]

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -6,7 +6,7 @@
    [clojure.string :as str]
    [clojure.walk :as walk]
    [flatland.ordered.map :as ordered-map]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.driver.common :as driver.common]
    [metabase.driver.util :as driver.u]

--- a/modules/drivers/mongo/test/metabase/driver/mongo/parameters_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/parameters_test.clj
@@ -5,7 +5,7 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver.common.parameters :as params]
    [metabase.driver.mongo.parameters :as mongo.params]
    [metabase.models :refer [NativeQuerySnippet]]

--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.set :as set]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.driver.mongo.query-processor :as mongo.qp]
    [metabase.models :refer [Field Table]]

--- a/modules/drivers/oracle/src/metabase/driver/oracle.clj
+++ b/modules/drivers/oracle/src/metabase/driver/oracle.clj
@@ -3,7 +3,7 @@
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [honey.sql :as sql]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.config :as config]
    [metabase.driver :as driver]
    [metabase.driver.common :as driver.common]

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -4,7 +4,7 @@
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.api.common :as api]
    [metabase.db.query :as mdb.query]
    [metabase.driver :as driver]

--- a/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
+++ b/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
@@ -8,7 +8,7 @@
    [honeysql.core :as hsql]
    [honeysql.format :as hformat]
    [honeysql.helpers :as hh]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.db.spec :as mdb.spec]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.common :as sql-jdbc.common]

--- a/modules/drivers/presto-jdbc/test/metabase/driver/presto_jdbc_test.clj
+++ b/modules/drivers/presto-jdbc/test/metabase/driver/presto_jdbc_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [honeysql.format :as hformat]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.api.database :as api.database]
    [metabase.db.metadata-queries :as metadata-queries]
    [metabase.driver :as driver]

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -3,7 +3,7 @@
   (:require
    [cheshire.core :as json]
    [clojure.java.jdbc :as jdbc]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.common :as sql-jdbc.common]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]

--- a/modules/drivers/redshift/test/metabase/test/data/redshift.clj
+++ b/modules/drivers/redshift/test/metabase/test/data/redshift.clj
@@ -1,7 +1,7 @@
 (ns metabase.test.data.redshift
   (:require
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -4,7 +4,7 @@
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.driver :as driver]
    [metabase.driver.common :as driver.common]

--- a/modules/drivers/sparksql/src/metabase/driver/hive_like.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/hive_like.clj
@@ -3,7 +3,7 @@
    [buddy.core.codecs :as codecs]
    [clojure.string :as str]
    [honey.sql :as sql]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]

--- a/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
+++ b/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.config :as config]
    [metabase.driver :as driver]
    [metabase.driver.sql :as driver.sql]

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -5,7 +5,7 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [honeysql.helpers :as hh]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.config :as config]
    [metabase.driver :as driver]
    [metabase.driver.sql :as driver.sql]

--- a/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
+++ b/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
@@ -4,7 +4,7 @@
    [clojure.test :refer :all]
    [colorize.core :as colorize]
    [honeysql.core :as hsql]
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.config :as config]
    [metabase.driver :as driver]

--- a/modules/drivers/vertica/test/metabase/test/data/vertica.clj
+++ b/modules/drivers/vertica/test/metabase/test/data/vertica.clj
@@ -5,7 +5,7 @@
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]

--- a/shared/src/metabase/shared/util/internal/time.clj
+++ b/shared/src/metabase/shared/util/internal/time.clj
@@ -1,6 +1,6 @@
 (ns metabase.shared.util.internal.time
   (:require
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.public-settings :as public-settings]
    [metabase.shared.util.internal.time-common :as common])
   (:import

--- a/shared/test/metabase/shared/util/time_test.cljc
+++ b/shared/test/metabase/shared/util/time_test.cljc
@@ -4,7 +4,7 @@
    [metabase.shared.util.internal.time :as internal]
    [metabase.shared.util.time :as shared.ut]
    #?@(:cljs [["moment" :as moment]]
-       :clj  [[java-time :as t]]))
+       :clj  [[java-time.api :as t]]))
   #?(:clj (:import java.util.Locale)))
 
 (defn- from [time-str]

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -2,7 +2,7 @@
   "Functions for sending Snowplow analytics events"
   (:require
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.config :as config]
    [metabase.models.setting :as setting :refer [defsetting Setting]]

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -4,7 +4,7 @@
    [cheshire.core :as json]
    [clj-http.client :as http]
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.analytics.snowplow :as snowplow]
    [metabase.config :as config]

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -2,7 +2,7 @@
   "/api/session endpoints"
   (:require
    [compojure.core :refer [DELETE GET POST]]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.analytics.snowplow :as snowplow]
    [metabase.api.common :as api]
    [metabase.api.ldap :as api.ldap]

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -1,7 +1,7 @@
 (ns metabase.api.setup
   (:require
    [compojure.core :refer [GET POST]]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.analytics.snowplow :as snowplow]
    [metabase.api.common :as api]
    [metabase.api.common.validation :as validation]

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -3,7 +3,7 @@
   (:require
    [compojure.core :refer [DELETE GET POST PUT]]
    [honey.sql.helpers :as sql.helpers]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.analytics.snowplow :as snowplow]
    [metabase.api.common :as api]
    [metabase.api.common.validation :as validation]

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -89,8 +89,7 @@
     [clojure.walk :as walk]
     [clojure.zip :as zip]
     [flatland.ordered.map :refer [ordered-map]]
-    #_{:clj-kondo/ignore [:deprecated-namespace]}
-    [java-time :as t]
+    [java-time.api :as t]
     [kixi.stats.core :as stats]
     [kixi.stats.math :as math]
     [medley.core :as m]

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.tools.trace :as trace]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.analytics.prometheus :as prometheus]
    [metabase.config :as config]
    [metabase.core.config-from-file :as config-from-file]

--- a/src/metabase/db/connection_pool_setup.clj
+++ b/src/metabase/db/connection_pool_setup.clj
@@ -1,7 +1,7 @@
 (ns metabase.db.connection-pool-setup
   "Code for creating the connection pool for the application DB and setting it as the default Toucan connection."
   (:require
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.config :as config]
    [metabase.connection-pool :as connection-pool]
    [schema.core :as s])

--- a/src/metabase/db/jdbc_protocols.clj
+++ b/src/metabase/db/jdbc_protocols.clj
@@ -5,7 +5,7 @@
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.db.connection :as mdb.connection]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -9,7 +9,7 @@
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver.impl :as driver.impl]
    [metabase.models.setting :as setting :refer [defsetting]]
    [metabase.plugins.classloader :as classloader]

--- a/src/metabase/driver/common/parameters/dates.clj
+++ b/src/metabase/driver/common/parameters/dates.clj
@@ -2,7 +2,7 @@
   "Shared code for handling datetime parameters, used by both MBQL and native params implementations."
   (:require
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.lib.schema.parameter :as lib.schema.parameter]
    [metabase.mbql.schema :as mbql.s]

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.math.combinatorics :as math.combo]
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.config :as config]
    [metabase.db.jdbc-protocols :as mdb.jdbc-protocols]
    [metabase.db.spec :as mdb.spec]

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -7,7 +7,7 @@
    [clojure.string :as str]
    [clojure.walk :as walk]
    [honey.sql :as sql]
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.config :as config]
    [metabase.db.spec :as mdb.spec]

--- a/src/metabase/driver/mysql/ddl.clj
+++ b/src/metabase/driver/mysql/ddl.clj
@@ -3,7 +3,7 @@
    [clojure.core.async :as a]
    [clojure.string :as str]
    [honey.sql :as sql]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver.ddl.interface :as ddl.i]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -7,7 +7,7 @@
    [clojure.string :as str]
    [clojure.walk :as walk]
    [honey.sql :as sql]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.db.spec :as mdb.spec]
    [metabase.driver :as driver]
    [metabase.driver.common :as driver.common]

--- a/src/metabase/driver/postgres/ddl.clj
+++ b/src/metabase/driver/postgres/ddl.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.java.jdbc :as jdbc]
    [honey.sql :as sql]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver.ddl.interface :as ddl.i]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql.ddl :as sql.ddl]

--- a/src/metabase/driver/sql/util/unprepare.clj
+++ b/src/metabase/driver/sql/util/unprepare.clj
@@ -6,7 +6,7 @@
   methods from here) let's rename this `metabase.driver.sql.unprepare` when we get a chance."
   (:require
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.driver.sql.util :as sql.u]
    [metabase.util :as u]

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -8,7 +8,7 @@
    [clojure.core.async :as a]
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.db.query :as mdb.query]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]

--- a/src/metabase/driver/sql_jdbc/execute/legacy_impl.clj
+++ b/src/metabase/driver/sql_jdbc/execute/legacy_impl.clj
@@ -3,7 +3,7 @@
   don't fully support the new JSR-310 `java.time` classes. Drivers with `::use-legacy-classes-for-read-and-set` as a
   parent will use these implementations instead of the defaults."
   (:require
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.util.date-2 :as u.date]

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -7,7 +7,7 @@
    [clojure.core.cache :as cache]
    [clojure.java.io :as io]
    [hiccup.core :refer [html]]
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.config :as config]
    [metabase.db.query :as mdb.query]

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -1,6 +1,6 @@
 (ns metabase.events.view-log
   (:require
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.events :as events]
    [metabase.models.setting :as setting :refer [defsetting]]
    [metabase.models.view-log :refer [ViewLog]]

--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -4,7 +4,7 @@
    [clj-http.client :as http]
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.email.messages :as messages]
    [metabase.models.setting :as setting :refer [defsetting]]

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -19,7 +19,7 @@
     Normally these FieldValues will be deleted after [[advanced-field-values-max-age]] days by the scanning process.
     But they will also be automatically deleted when the Full FieldValues of the same Field got updated."
   (:require
-   [java-time :as t]
+   [java-time.api :as t]
    [malli.core :as mc]
    [medley.core :as m]
    [metabase.models.interface :as mi]

--- a/src/metabase/models/login_history.clj
+++ b/src/metabase/models/login_history.clj
@@ -1,6 +1,6 @@
 (ns metabase.models.login-history
   (:require
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.email.messages :as messages]
    [metabase.models.setting :refer [defsetting]]
    [metabase.server.request.util :as request.u]

--- a/src/metabase/models/secret.clj
+++ b/src/metabase/models/secret.clj
@@ -3,7 +3,7 @@
    [clojure.core.memoize :as memoize]
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.api.common :as api]
    [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]

--- a/src/metabase/models/task_history.clj
+++ b/src/metabase/models/task_history.clj
@@ -1,7 +1,7 @@
 (ns metabase.models.task-history
   (:require
    [cheshire.generate :refer [add-encoder encode-map]]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.models.interface :as mi]
    [metabase.models.permissions :as perms]
    [metabase.public-settings.premium-features :as premium-features]

--- a/src/metabase/models/timeline.clj
+++ b/src/metabase/models/timeline.clj
@@ -1,6 +1,6 @@
 (ns metabase.models.timeline
   (:require
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.models.collection.root :as collection.root]
    [metabase.models.permissions :as perms]
    [metabase.models.serialization :as serdes]

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -4,7 +4,7 @@
    [clj-http.client :as http]
    [clojure.core.memoize :as memoize]
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.api.common :as api]
    [metabase.config :as config]
    [metabase.models.database :refer [Database]]

--- a/src/metabase/pulse/render/datetime.clj
+++ b/src/metabase/pulse/render/datetime.clj
@@ -2,7 +2,7 @@
   "Logic for rendering datetimes inside Pulses."
   (:require
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.public-settings :as public-settings]
    [metabase.shared.models.visualization-settings :as mb.viz]
    [metabase.util.date-2 :as u.date]

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -11,7 +11,7 @@
   `MB_QP_CACHE_BACKEND`. Refer to [[metabase.query-processor.middleware.cache-backend.interface]] for more details
   about how the cache backends themselves."
   (:require
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.config :as config]
    [metabase.public-settings :as public-settings]

--- a/src/metabase/query_processor/middleware/cache_backend/db.clj
+++ b/src/metabase/query_processor/middleware/cache_backend/db.clj
@@ -1,6 +1,6 @@
 (ns metabase.query-processor.middleware.cache-backend.db
   (:require
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.db :as mdb]
    [metabase.db.query :as mdb.query]
    [metabase.models.query-cache :refer [QueryCache]]

--- a/src/metabase/query_processor/middleware/format_rows.clj
+++ b/src/metabase/query_processor/middleware/format_rows.clj
@@ -2,7 +2,7 @@
   "Middleware that formats the results of a query.
    Currently, the only thing this does is convert datetime types to ISO-8601 strings in the appropriate timezone."
   (:require
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.util.date-2 :as u.date]
    [metabase.util.i18n :refer [tru]]

--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -3,7 +3,7 @@
   to queries ran internally e.g. as part of the sync process).
   These include things like saving QueryExecutions and adding query ViewLogs, storing exceptions and formatting the results."
   (:require
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.events :as events]
    [metabase.models.query :as query]
    [metabase.models.query-execution

--- a/src/metabase/query_processor/streaming/common.clj
+++ b/src/metabase/query_processor/streaming/common.clj
@@ -1,7 +1,7 @@
 (ns metabase.query-processor.streaming.common
   "Shared util fns for various export (download) streaming formats."
   (:require
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.util.date-2 :as u.date])

--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -1,7 +1,7 @@
 (ns metabase.query-processor.streaming.csv
   (:require
    [clojure.data.csv :as csv]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.query-processor.streaming.common :as common]
    [metabase.query-processor.streaming.interface :as qp.si]
    [metabase.util.date-2 :as u.date])

--- a/src/metabase/query_processor/streaming/json.clj
+++ b/src/metabase/query_processor/streaming/json.clj
@@ -3,7 +3,7 @@
   response with all the metadata for `:api`."
   (:require
    [cheshire.core :as json]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.query-processor.streaming.common :as common]
    [metabase.query-processor.streaming.interface :as qp.si]
    [metabase.util.date-2 :as u.date])

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -3,7 +3,7 @@
    [cheshire.core :as json]
    [clojure.string :as str]
    [dk.ative.docjure.spreadsheet :as spreadsheet]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.lib.schema.temporal-bucketing
     :as lib.schema.temporal-bucketing]
    [metabase.public-settings :as public-settings]

--- a/src/metabase/query_processor/timezone.clj
+++ b/src/metabase/query_processor/timezone.clj
@@ -1,7 +1,7 @@
 (ns metabase.query-processor.timezone
   "Functions for fetching the timezone for the current query."
   (:require
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.config :as config]
    [metabase.driver :as driver]
    [metabase.lib.metadata :as lib.metadata]

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -1,7 +1,7 @@
 (ns metabase.search.scoring
   (:require
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.search.config :as search-config]
    [metabase.search.util :as search-util]

--- a/src/metabase/server/middleware/browser_cookie.clj
+++ b/src/metabase/server/middleware/browser_cookie.clj
@@ -4,7 +4,7 @@
   cookie is deleted, it's fine; the user will just get an email saying they logged in from a new device next time
   they log in."
   (:require
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.server.request.util :as request.u]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -3,7 +3,7 @@
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.analytics.snowplow :as snowplow]
    [metabase.config :as config]
    [metabase.models.setting :refer [defsetting]]

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -2,7 +2,7 @@
   "Ring middleware related to session (binding current user and permissions)."
   (:require
    [honey.sql.helpers :as sql.helpers]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.api.common
     :as api
     :refer [*current-user*

--- a/src/metabase/server/request/util.clj
+++ b/src/metabase/server/request/util.clj
@@ -4,7 +4,7 @@
    [cheshire.core :as json]
    [clj-http.client :as http]
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.config :as config]
    [metabase.public-settings :as public-settings]
    [metabase.util :as u]

--- a/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+++ b/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
@@ -2,7 +2,7 @@
   "Non-identifying fingerprinters for various field types."
   (:require
    [bigml.histogram.core :as hist]
-   [java-time :as t]
+   [java-time.api :as t]
    [kixi.stats.core :as stats]
    [kixi.stats.math :as math]
    [medley.core :as m]

--- a/src/metabase/sync/analyze/fingerprint/insights.clj
+++ b/src/metabase/sync/analyze/fingerprint/insights.clj
@@ -1,7 +1,7 @@
 (ns metabase.sync.analyze.fingerprint.insights
   "Deeper statistical analysis of results."
   (:require
-   [java-time :as t]
+   [java-time.api :as t]
    [kixi.stats.core :as stats]
    [kixi.stats.math :as math]
    [kixi.stats.protocols :as p]

--- a/src/metabase/sync/field_values.clj
+++ b/src/metabase/sync/field_values.clj
@@ -1,7 +1,7 @@
 (ns metabase.sync.field-values
   "Logic for updating FieldValues for fields in a database."
   (:require
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.db :as mdb]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.models.field :refer [Field]]

--- a/src/metabase/sync/sync_metadata/sync_timezone.clj
+++ b/src/metabase/sync/sync_metadata/sync_timezone.clj
@@ -1,6 +1,6 @@
 (ns metabase.sync.sync-metadata.sync-timezone
   (:require
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
    [metabase.lib.schema.expression.temporal

--- a/src/metabase/sync/util.clj
+++ b/src/metabase/sync/util.clj
@@ -4,7 +4,7 @@
   (:require
    [clojure.math.numeric-tower :as math]
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]

--- a/src/metabase/task/follow_up_emails.clj
+++ b/src/metabase/task/follow_up_emails.clj
@@ -4,7 +4,7 @@
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.schedule.cron :as cron]
    [clojurewerkz.quartzite.triggers :as triggers]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.email :as email]
    [metabase.email.messages :as messages]
    [metabase.models.setting :as setting]

--- a/src/metabase/task/persist_refresh.clj
+++ b/src/metabase/task/persist_refresh.clj
@@ -5,7 +5,7 @@
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.schedule.cron :as cron]
    [clojurewerkz.quartzite.triggers :as triggers]
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.db :as mdb]
    [metabase.driver :as driver]

--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -8,7 +8,7 @@
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.schedule.cron :as cron]
    [clojurewerkz.quartzite.triggers :as triggers]
-   [java-time :as t]
+   [java-time.api :as t]
    [malli.core :as mc]
    [metabase.db.query :as mdb.query]
    [metabase.lib.schema.id :as lib.schema.id]

--- a/src/metabase/task/truncate_audit_log.clj
+++ b/src/metabase/task/truncate_audit_log.clj
@@ -4,7 +4,7 @@
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.schedule.cron :as cron]
    [clojurewerkz.quartzite.triggers :as triggers]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.config :as config]
    [metabase.models.query-execution :refer [QueryExecution]]
    [metabase.models.setting :as setting]

--- a/src/metabase/task/upgrade_checks.clj
+++ b/src/metabase/task/upgrade_checks.clj
@@ -6,7 +6,7 @@
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.schedule.cron :as cron]
    [clojurewerkz.quartzite.triggers :as triggers]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.config :as config]
    [metabase.public-settings :as public-settings]
    [metabase.task :as task]

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -7,7 +7,7 @@
    [clojure.string :as str]
    [flatland.ordered.map :as ordered-map]
    [flatland.ordered.set :as ordered-set]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.mbql.util :as mbql.u]
    [metabase.public-settings :as public-settings]

--- a/src/metabase/util/date_2.clj
+++ b/src/metabase/util/date_2.clj
@@ -4,7 +4,7 @@
   (:refer-clojure :exclude [format range])
   (:require
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [java-time.core :as t.core]
    [metabase.util.date-2.common :as u.date.common]
    [metabase.util.date-2.parse :as u.date.parse]

--- a/src/metabase/util/date_2/common.clj
+++ b/src/metabase/util/date_2/common.clj
@@ -1,7 +1,7 @@
 (ns metabase.util.date-2.common
   (:require
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.util :as u])
   (:import
    (java.time ZoneId ZoneOffset)

--- a/src/metabase/util/date_2/parse.clj
+++ b/src/metabase/util/date_2/parse.clj
@@ -1,7 +1,7 @@
 (ns metabase.util.date-2.parse
   (:require
    [clojure.string :as str]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.util.date-2.common :as u.date.common]
    [metabase.util.date-2.parse.builder :as b]
    [metabase.util.i18n :refer [tru]]

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.analytics.stats-test
   (:require
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.analytics.stats :as stats :refer [anonymous-usage-stats]]
    [metabase.email :as email]
    [metabase.integrations.slack :as slack]

--- a/test/metabase/api/activity_test.clj
+++ b/test/metabase/api/activity_test.clj
@@ -2,7 +2,7 @@
   "Tests for /api/activity endpoints."
   (:require
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.events :as events]
    [metabase.models.card :refer [Card]]
    [metabase.models.dashboard :refer [Dashboard]]

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -9,7 +9,7 @@
    [clojure.tools.macro :as tools.macro]
    [clojurewerkz.quartzite.scheduler :as qs]
    [dk.ative.docjure.spreadsheet :as spreadsheet]
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.analytics.snowplow-test :as snowplow-test]
    [metabase.api.card :as api.card]

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -2,7 +2,7 @@
   "Tests for /api/pulse endpoints."
   (:require
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.api.card-test :as api.card-test]
    [metabase.api.pulse :as api.pulse]
    [metabase.http-client :as client]

--- a/test/metabase/api/slack_test.clj
+++ b/test/metabase/api/slack_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.config :as config]
    [metabase.integrations.slack :as slack]
    [metabase.test :as mt]))

--- a/test/metabase/api/task_test.clj
+++ b/test/metabase/api/task_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.api.task-test
   (:require
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.models.task-history :refer [TaskHistory]]
    [metabase.test :as mt]
    [metabase.util :as u]

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -6,7 +6,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [flatland.ordered.map :refer [ordered-map]]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.api.common :as api]
    [metabase.automagic-dashboards.core :as magic]
    [metabase.automagic-dashboards.dashboard-templates :as dashboard-templates]

--- a/test/metabase/db/connection_pool_setup_test.clj
+++ b/test/metabase/db/connection_pool_setup_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.connection-pool :as connection-pool]
    [metabase.db.connection-pool-setup :as mdb.connection-pool-setup]
    [metabase.db.data-source :as mdb.data-source]

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -13,7 +13,7 @@
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.db.connection :as mdb.connection]
    [metabase.db.custom-migrations-test :as custom-migrations-test]
    [metabase.db.query :as mdb.query]

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -3,7 +3,7 @@
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.actions.error :as actions.error]
    [metabase.config :as config]
    [metabase.core :as mbc]

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -4,7 +4,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [honey.sql :as sql]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.actions.error :as actions.error]
    [metabase.config :as config]
    [metabase.db.metadata-queries :as metadata-queries]

--- a/test/metabase/driver/sql/parameters/substitute_test.clj
+++ b/test/metabase/driver/sql/parameters/substitute_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.db.query :as mdb.query]
    [metabase.driver :as driver]
    [metabase.driver.common.parameters :as params]

--- a/test/metabase/driver/sql/test_util/unique_prefix.clj
+++ b/test/metabase/driver/sql/test_util/unique_prefix.clj
@@ -26,7 +26,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.public-settings :as public-settings]
    [metabase.util.date-2 :as u.date]))
 

--- a/test/metabase/driver/sql/util/unprepare_test.clj
+++ b/test/metabase/driver/sql/util/unprepare_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.driver.sql.util.unprepare :as unprepare]
    [metabase.util.date-2 :as u.date])

--- a/test/metabase/events/view_log_test.clj
+++ b/test/metabase/events/view_log_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.events.view-log-test
   (:require
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.events :as events]
    [metabase.events.view-log :as view-log]
    [metabase.models :refer [Card Dashboard Table User ViewLog]]

--- a/test/metabase/http_client.clj
+++ b/test/metabase/http_client.clj
@@ -8,7 +8,7 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [malli.core :as mc]
    [medley.core :as m]
    [metabase.config :as config]

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -5,7 +5,7 @@
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.db.metadata-queries :as metadata-queries]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.models.database :refer [Database]]

--- a/test/metabase/models/interface_test.clj
+++ b/test/metabase/models/interface_test.clj
@@ -2,7 +2,7 @@
   (:require
    [cheshire.core :as json]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.db.connection :as mdb.connection]
    [metabase.mbql.normalize :as mbql.normalize]
    [metabase.models.field :refer [Field]]

--- a/test/metabase/models/login_history_test.clj
+++ b/test/metabase/models/login_history_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.models :refer [LoginHistory User]]
    [metabase.models.login-history :as login-history]
    [metabase.public-settings :as public-settings]

--- a/test/metabase/models/task_history_test.clj
+++ b/test/metabase/models/task_history_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.models.task-history-test
   (:require
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.models :refer [TaskHistory]]
    [metabase.models.task-history :as task-history]
    [metabase.test :as mt]

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -5,7 +5,7 @@
    [clojure.core.async :as a]
    [clojure.data.csv :as csv]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.models.permissions :as perms]

--- a/test/metabase/query_processor/middleware/format_rows_test.clj
+++ b/test/metabase/query_processor/middleware/format_rows_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.query-processor.middleware.format-rows-test
   (:require
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.query-processor.middleware.format-rows :as format-rows]
    [metabase.query-processor.test-util :as qp.test-util]

--- a/test/metabase/query_processor/middleware/optimize_temporal_filters_test.clj
+++ b/test/metabase/query_processor/middleware/optimize_temporal_filters_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.query-processor :as qp]
    [metabase.query-processor.middleware.optimize-temporal-filters

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -3,7 +3,7 @@
    [buddy.core.codecs :as codecs]
    [clojure.core.async :as a]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.events :as events]
    [metabase.query-processor.context :as qp.context]
    [metabase.query-processor.error-type :as qp.error-type]

--- a/test/metabase/query_processor/middleware/wrap_value_literals_test.clj
+++ b/test/metabase/query_processor/middleware/wrap_value_literals_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.query-processor.middleware.wrap-value-literals-test
   (:require
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]

--- a/test/metabase/query_processor_test/alternative_date_test.clj
+++ b/test/metabase/query_processor_test/alternative_date_test.clj
@@ -3,7 +3,7 @@
   related types."
   (:require
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.test-util :as sql-jdbc.tu]
    [metabase.driver.sql.query-processor :as sql.qp]

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -17,7 +17,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql.query-processor :as sql.qp]

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.models :refer [Card]]
    [metabase.query-processor :as qp]

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -2,7 +2,7 @@
   "Tests for expressions (calculated columns)."
   (:require
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.driver :as driver]
    [metabase.models.field :refer [Field]]

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -5,7 +5,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [honey.sql :as sql]
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.db.query :as mdb.query]
    [metabase.driver :as driver]

--- a/test/metabase/query_processor_test/parameters_test.clj
+++ b/test/metabase/query_processor_test/parameters_test.clj
@@ -4,7 +4,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.driver :as driver]
    [metabase.lib.native :as lib-native]

--- a/test/metabase/query_processor_test/timezones_test.clj
+++ b/test/metabase/query_processor_test/timezones_test.clj
@@ -3,7 +3,7 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.models :refer [Field Table]]

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.search.scoring-test
   (:require
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.search.config :as search-config]
    [metabase.search.scoring :as scoring]))
 

--- a/test/metabase/server/middleware/auth_test.clj
+++ b/test/metabase/server/middleware/auth_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.server.middleware.auth-test
   (:require
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.models.session :refer [Session]]
    [metabase.server.middleware.auth :as mw.auth]
    [metabase.server.middleware.session :as mw.session]

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -4,7 +4,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [environ.core :as env]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.api.common :as api :refer [*current-user* *current-user-id*]]
    [metabase.config :as config]
    [metabase.core.initialization-status :as init-status]

--- a/test/metabase/server/request/util_test.clj
+++ b/test/metabase/server/request/util_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [clojure.tools.reader.edn :as edn]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.server.request.util :as request.u]
    [metabase.test :as mt]
    [ring.mock.request :as ring.mock]

--- a/test/metabase/sync/field_values_test.clj
+++ b/test/metabase/sync/field_values_test.clj
@@ -3,7 +3,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.db.metadata-queries :as metadata-queries]
    [metabase.models :refer [Field FieldValues Table]]
    [metabase.models.field-values :as field-values]

--- a/test/metabase/sync/sync_metadata/sync_timezone_test.clj
+++ b/test/metabase/sync/sync_metadata/sync_timezone_test.clj
@@ -3,7 +3,7 @@
    [clj-time.core :as time]
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.driver.mysql-test :as mysql-test]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]

--- a/test/metabase/sync/util_test.clj
+++ b/test/metabase/sync/util_test.clj
@@ -4,7 +4,7 @@
    [clojure.core.async :as a]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.models.database :as database :refer [Database]]
    [metabase.models.interface :as mi]

--- a/test/metabase/task/persist_refresh_test.clj
+++ b/test/metabase/task/persist_refresh_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [clojurewerkz.quartzite.conversion :as qc]
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.models :refer [Card Database PersistedInfo TaskHistory]]
    [metabase.query-processor.timezone :as qp.timezone]

--- a/test/metabase/task/sync_databases_test.clj
+++ b/test/metabase/task/sync_databases_test.clj
@@ -6,7 +6,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [clojurewerkz.quartzite.conversion :as qc]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.models.database :refer [Database]]
    [metabase.sync.schedules :as sync.schedules]
    [metabase.task.sync-databases :as task.sync-databases]

--- a/test/metabase/task/task_history_cleanup_test.clj
+++ b/test/metabase/task/task_history_cleanup_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.set :as set]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.models.task-history :refer [TaskHistory]]
    [metabase.models.task-history-test :as tht]
    [metabase.task.task-history-cleanup :as cleanup-task]

--- a/test/metabase/task/truncate_audit_log_test.clj
+++ b/test/metabase/task/truncate_audit_log_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.task.truncate-audit-log-test
   (:require
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.models.query-execution :refer [QueryExecution]]
    [metabase.models.setting :as setting]
    [metabase.public-settings.premium-features :as premium-features]

--- a/test/metabase/test/data/dataset_definitions.clj
+++ b/test/metabase/test/data/dataset_definitions.clj
@@ -1,7 +1,7 @@
 (ns metabase.test.data.dataset-definitions
   "Definitions of various datasets for use in tests with `data/dataset` and the like."
   (:require
-   [java-time :as t]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.test.data.interface :as tx]
    [metabase.util.date-2 :as u.date])

--- a/test/metabase/test/generate.clj
+++ b/test/metabase/test/generate.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.spec.alpha :as s]
    [clojure.test.check.generators :as gen]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.mbql.util :as mbql.u]
    [metabase.models :refer [Action Activity Card Collection Dashboard
                             DashboardCard DashboardCardSeries Database Dimension Field

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -10,7 +10,7 @@
    [clojurewerkz.quartzite.scheduler :as qs]
    [colorize.core :as colorize]
    [environ.core :as env]
-   [java-time :as t]
+   [java-time.api :as t]
    [mb.hawk.parallel]
    [metabase.db.query :as mdb.query]
    [metabase.db.util :as mdb.u]

--- a/test/metabase/test/util/misc.clj
+++ b/test/metabase/test/util/misc.clj
@@ -4,7 +4,7 @@
    [clojure.data :as data]
    [clojure.test :refer :all]
    [environ.core :as env]
-   [java-time :as t]
+   [java-time.api :as t]
    [mb.hawk.init]
    [mb.hawk.parallel]
    [medley.core :as m]

--- a/test/metabase/util/date_2_test.clj
+++ b/test/metabase/util/date_2_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
    [metabase.test :as mt]
    [metabase.test.util.timezone :as test.tz]
    [metabase.util.date-2 :as u.date]


### PR DESCRIPTION
This namespace was deprecated and replaced with `java-time.api`.

Closes https://github.com/metabase/metabase/issues/34506

### Description

The bare `java-time` was deprecated and replaced with `java-time.api` because single-segment namespaces don't work well with GraalVM. We can migrate over to the new namespace with no effects - I have verified that the namespaces are identical except for the deprecation notice.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR (the existing tests should cover this comfortably)
