### PR TITLE
Improve release commit check

### DIFF
--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -78,29 +78,28 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0  # IMPORTANT! to get all the branches
+        sparse-checkout: release
     - name: Prepare build scripts
       run: cd ${{ github.workspace }}/release && yarn && yarn build
-    - name: Get Release Version
+    - name: Get Release Branch
       uses: actions/github-script@v6
       id: release_branch
       with:
         result_encoding: string
         script: | # js
           const { getReleaseBranch } = require('${{ github.workspace }}/release/dist/index.cjs');
-
           const version = '${{ inputs.version }}';
-
           const releaseBranch = getReleaseBranch(version);
           return releaseBranch;
-
     - name: Ensure that the specified commit exists in the ${{ steps.release_branch.outputs.result }} release branch
       run: |
+        git checkout ${{ steps.release_branch.outputs.result }}
         git branch --contains ${{ inputs.commit }} | grep -q ${{ steps.release_branch.outputs.result }} \
           && echo "Commit found in correct release branch" \
           || (echo "Commit not found in correct release branch" && exit 1)
 
   build-uberjar-for-release:
-    needs: check-version
+    needs: [check-version, check-commit]
     runs-on: ubuntu-22.04
     timeout-minutes: 50
     strategy:

--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -93,8 +93,9 @@ jobs:
           return releaseBranch;
     - name: Ensure that the specified commit exists in the ${{ steps.release_branch.outputs.result }} release branch
       run: |
-        git checkout ${{ steps.release_branch.outputs.result }}
-        git branch --contains ${{ inputs.commit }} | grep -q ${{ steps.release_branch.outputs.result }} \
+        RELEASE_BRANCH=${{ steps.release_branch.outputs.result }}
+        git checkout $RELEASE_BRANCH
+        git branch --contains ${{ inputs.commit }} | grep -q $RELEASE_BRANCH \
           && echo "Commit found in correct release branch" \
           || (echo "Commit not found in correct release branch" && exit 1)
 

--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -78,27 +78,26 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0  # IMPORTANT! to get all the branches
-    - name: Ensure that the specified commit exists in the latest release branch
-      env:
-        COMMIT: ${{ inputs.commit }}
-      run: |
-        echo "Checking if the specified commit is in a release branch..."
+    - name: Prepare build scripts
+      run: cd ${{ github.workspace }}/release && yarn && yarn build
+    - name: Get Release Version
+      uses: actions/github-script@v6
+      id: release_branch
+      with:
+        result_encoding: string
+        script: | # js
+          const { getReleaseBranch } = require('${{ github.workspace }}/release/dist/index.cjs');
 
-        git branch -a --contains $COMMIT > branches.txt
-        if [[ $(grep -c master branches.txt) =~ 1 ]]; then
-          echo "Found in master branch. ABORT!"
-          exit -1
-        fi
-        if [[ $(grep -c 'release-x' branches.txt) =~ 1 ]]; then
-          echo "Found the commit $COMMIT in:"
-          git branch -a --contains $COMMIT
-          echo "Proceeding to the next step..."
-          exit 0
-        else
-          echo "Commit $COMMIT is not found in a single release branch"
-          echo "ABORT!."
-          exit -1
-        fi
+          const version = '${{ inputs.version }}';
+
+          const releaseBranch = getReleaseBranch(version);
+          return releaseBranch;
+
+    - name: Ensure that the specified commit exists in the ${{ steps.release_branch.outputs.result }} release branch
+      run: |
+        git branch --contains ${{ inputs.commit }} | grep -q ${{ steps.release_branch.outputs.result }} \
+          && echo "Commit found in correct release branch" \
+          || (echo "Commit not found in correct release branch" && exit 1)
 
   build-uberjar-for-release:
     needs: check-version


### PR DESCRIPTION
### Description

Currently we run a check to determine whether the commit we are releasing is in any release branch, so we could easily accidentlly release a commit from the `release-x.46.x` branch as version 49.5. 😱 

This updates the check to first find the correct release branch for the given version number, then verifies that the given commit is in that specific release branch.

## Tests (in fork)
- [x] [release a 44 build from a 44 commit](https://github.com/iethree/metabase/actions/runs/6488567754/job/17621253837)
- [x] [try to release a 44 build from a 47 commit](https://github.com/iethree/metabase/actions/runs/6488603635/job/17621351216)
