### PR TITLE
Use private ReplayIO API key

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -351,8 +351,8 @@ jobs:
         if: github.event_name == 'schedule' && !cancelled()
         uses: replayio/action-upload@v0.4.7
         with:
-          api-key: rwk_gXbvYctIcR6RZyEzUvby3gtkO4esrB2L321lkY8FSuQ
-          public: true
+          api-key: ${{ secrets.REPLAY_IO_TOKEN }}
+          public: false
 
       - name: Upload Cypress Artifacts upon failure
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Forks are pushing replays to this repo/prganization.
In the beginning it didn't really matter that this API key was public, but it's time to change it.