### PR TITLE
Increase E2E tests running on Replayio frequency

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -349,7 +349,7 @@ jobs:
 
       - name: Upload Replay.io recordings
         if: github.event_name == 'schedule' && !cancelled()
-        uses: replayio/action-upload@v0.4.7
+        uses: replayio/action-upload@v0.5.1
         with:
           api-key: rwk_gXbvYctIcR6RZyEzUvby3gtkO4esrB2L321lkY8FSuQ
           public: true

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,7 +3,7 @@ name: E2E Tests
 on:
   # We'll record runs using Replay.io and their browser on a schedule as an experiment
   schedule:
-    - cron: '0 22 * * 0'
+    - cron: '0 22 * * *'
   push:
     branches:
       - "master"


### PR DESCRIPTION
Run daily instead of weekly.

This PR also bumps the related replayio upload action to its latest version.

> **Note**
> `no-backport` label because I'll bundle this with https://github.com/metabase/metabase/pull/34552 and will backport them together.