### PR TITLE
Install dependencies before `dev` and `dev-ee`

### DIFF
--- a/package.json
+++ b/package.json
@@ -289,7 +289,7 @@
   },
   "scripts": {
     "concurrently": "concurrently --kill-others -p name",
-    "dev": "yan && yarn clean:cljs && concurrently -n 'backend,frontend,cljs,static-viz' -c 'blue,green,yellow,magenta,red' 'clojure -M:run' 'yarn build-hot:js-wait' 'yarn build-hot:cljs' 'yarn build-static-viz:watch-wait'",
+    "dev": "yarn && yarn clean:cljs && concurrently -n 'backend,frontend,cljs,static-viz' -c 'blue,green,yellow,magenta,red' 'clojure -M:run' 'yarn build-hot:js-wait' 'yarn build-hot:cljs' 'yarn build-static-viz:watch-wait'",
     "dev-ee": "yarn && yarn clean:cljs && concurrently -n 'backend,frontend,cljs,static-viz' -c 'blue,green,yellow,magenta,red' 'clojure -M:run:ee' 'MB_EDITION=ee yarn build-hot:js-wait' 'MB_EDITION=ee yarn build-hot:cljs' 'yarn build-static-viz:watch-wait'",
     "type-check": "yarn clean:cljs && yarn build:cljs && yarn type-check-pure",
     "type-check-pure": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -289,8 +289,8 @@
   },
   "scripts": {
     "concurrently": "concurrently --kill-others -p name",
-    "dev": "yarn clean:cljs && concurrently -n 'backend,frontend,cljs,static-viz' -c 'blue,green,yellow,magenta,red' 'clojure -M:run' 'yarn build-hot:js-wait' 'yarn build-hot:cljs' 'yarn build-static-viz:watch-wait'",
-    "dev-ee": "yarn clean:cljs && concurrently -n 'backend,frontend,cljs,static-viz' -c 'blue,green,yellow,magenta,red' 'clojure -M:run:ee' 'MB_EDITION=ee yarn build-hot:js-wait' 'MB_EDITION=ee yarn build-hot:cljs' 'yarn build-static-viz:watch-wait'",
+    "dev": "yan && yarn clean:cljs && concurrently -n 'backend,frontend,cljs,static-viz' -c 'blue,green,yellow,magenta,red' 'clojure -M:run' 'yarn build-hot:js-wait' 'yarn build-hot:cljs' 'yarn build-static-viz:watch-wait'",
+    "dev-ee": "yarn && yarn clean:cljs && concurrently -n 'backend,frontend,cljs,static-viz' -c 'blue,green,yellow,magenta,red' 'clojure -M:run:ee' 'MB_EDITION=ee yarn build-hot:js-wait' 'MB_EDITION=ee yarn build-hot:cljs' 'yarn build-static-viz:watch-wait'",
     "type-check": "yarn clean:cljs && yarn build:cljs && yarn type-check-pure",
     "type-check-pure": "tsc --noEmit",
     "remove-webpack-cache": "rm -rf ./node_modules/.cache",


### PR DESCRIPTION
Follow up after #34553.

@metabase/frontend-developers said it would be helpful to auto-install potential new dependencies when we spin up dev environment.