### PR TITLE
Make implicit fields coming from source query expressions use string id

### DIFF
--- a/test/metabase/query_processor/middleware/add_implicit_clauses_test.clj
+++ b/test/metabase/query_processor/middleware/add_implicit_clauses_test.clj
@@ -152,6 +152,18 @@
                          {:source-query    source-query
                           :source-metadata source-metadata}))))))))
 
+(deftest ^:parrallel expression-with-only-field-in-source-query-test
+  (testing "Field coming from expression in source query should have string id"
+    (let [{{source-query :query} :dataset_query
+           source-metadata       :result_metadata}
+          (qp.test-util/card-with-source-metadata-for-query
+           (mt/mbql-query venues {:expressions {"ccprice" $price}}))]
+      (is (some #(when (= % [:field "ccprice" {:base-type :type/Integer}]) %)
+                (-> (lib.tu.macros/mbql-query checkins
+                                              {:source-query    source-query
+                                               :source-metadata source-metadata})
+                    :query add-implicit-fields :fields))))))
+
 (deftest ^:parallel joined-field-test
   (testing "When adding implicit `:fields` clauses, should include `join-alias` clauses for joined fields (#14745)"
     (doseq [field-ref (lib.tu.macros/$ids


### PR DESCRIPTION
Closes #28451

### Description

When implicit fields are generated for a source query and that query contains expression that is just field, field in question is generated twice and later result is discarded. To overcome this, field generated from expression is in string id form.

### How to verify

Run the new test or try reproduction steps from the issue in question.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
