### PR TITLE
[MLv2] TimeFilterPicker

### DIFF
--- a/frontend/src/metabase-lib/constants.ts
+++ b/frontend/src/metabase-lib/constants.ts
@@ -49,7 +49,13 @@ export const EXCLUDE_DATE_FILTER_OPERATORS = [
   "not-null",
 ] as const;
 
-export const TIME_FILTER_OPERATORS = [">", "<", "between"] as const;
+export const TIME_FILTER_OPERATORS = [
+  ">",
+  "<",
+  "between",
+  "is-null",
+  "not-null",
+] as const;
 
 export const RELATIVE_DATE_BUCKETS = [
   "minute",

--- a/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
@@ -7,6 +7,7 @@ import { DateFilterPicker } from "./DateFilterPicker";
 import { NumberFilterPicker } from "./NumberFilterPicker";
 import { CoordinateFilterPicker } from "./CoordinateFilterPicker";
 import { StringFilterPicker } from "./StringFilterPicker";
+import { TimeFilterPicker } from "./TimeFilterPicker";
 
 export interface FilterPickerProps {
   query: Lib.Query;
@@ -91,6 +92,9 @@ const NotImplementedPicker = () => <div />;
 function getFilterWidget(column: Lib.ColumnMetadata) {
   if (Lib.isBoolean(column)) {
     return BooleanFilterPicker;
+  }
+  if (Lib.isTime(column)) {
+    return TimeFilterPicker;
   }
   if (Lib.isDate(column)) {
     return DateFilterPicker;

--- a/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/FilterTimeInput.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/FilterTimeInput.tsx
@@ -1,0 +1,32 @@
+import type { ChangeEvent } from "react";
+import { useCallback } from "react";
+import moment from "moment";
+
+import type { TimeInputProps } from "metabase/ui";
+import { TimeInput } from "metabase/ui";
+
+interface FilterTimeInputProps
+  extends Omit<TimeInputProps, "value" | "onChange"> {
+  value: Date;
+  onChange: (value: Date) => void;
+}
+
+const TIME_FORMAT = "HH:mm";
+
+export function FilterTimeInput({
+  value,
+  onChange,
+  ...props
+}: FilterTimeInputProps) {
+  const inputValue = moment(value).format(TIME_FORMAT);
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const date = moment(event.target.value, TIME_FORMAT, true).toDate();
+      onChange(date);
+    },
+    [onChange],
+  );
+
+  return <TimeInput {...props} value={inputValue} onChange={handleChange} />;
+}

--- a/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
@@ -1,0 +1,145 @@
+import { useMemo, useState } from "react";
+import { t } from "ttag";
+
+import { Box, Button, Flex, Text } from "metabase/ui";
+
+import * as Lib from "metabase-lib";
+
+import type { FilterPickerWidgetProps } from "../types";
+import { getAvailableOperatorOptions } from "../utils";
+import { BackButton } from "../BackButton";
+import { Header } from "../Header";
+import { Footer } from "../Footer";
+import { FilterOperatorPicker } from "../FilterOperatorPicker";
+
+import { DEFAULT_VALUE, OPERATOR_OPTIONS } from "./constants";
+import { getDefaultValuesForOperator, isFilterValid } from "./utils";
+import { FilterTimeInput } from "./FilterTimeInput";
+
+export function TimeFilterPicker({
+  query,
+  stageIndex,
+  column,
+  filter,
+  onChange,
+  onBack,
+}: FilterPickerWidgetProps) {
+  const columnName = Lib.displayInfo(query, stageIndex, column).longDisplayName;
+
+  const filterParts = filter
+    ? Lib.timeFilterParts(query, stageIndex, filter)
+    : null;
+
+  const availableOperators = useMemo(
+    () =>
+      getAvailableOperatorOptions(query, stageIndex, column, OPERATOR_OPTIONS),
+    [query, stageIndex, column],
+  );
+
+  const [operatorName, setOperatorName] = useState(
+    filterParts?.operator ?? "<",
+  );
+
+  const [values, setValues] = useState(
+    filterParts?.values ?? getDefaultValuesForOperator(operatorName),
+  );
+
+  const valueCount = useMemo(() => {
+    const option = availableOperators.find(
+      option => option.operator === operatorName,
+    );
+    return option?.valueCount ?? 0;
+  }, [availableOperators, operatorName]);
+
+  const isValid = useMemo(
+    () => isFilterValid(operatorName, values),
+    [operatorName, values],
+  );
+
+  const handleOperatorChange = (
+    newOperatorName: Lib.TimeFilterOperatorName,
+  ) => {
+    setOperatorName(newOperatorName);
+    setValues(getDefaultValuesForOperator(newOperatorName));
+  };
+
+  const handleFilterChange = () => {
+    onChange(
+      Lib.timeFilterClause({
+        operator: operatorName,
+        column,
+        values,
+      }),
+    );
+  };
+
+  return (
+    <>
+      <Header>
+        <BackButton onClick={onBack}>{columnName}</BackButton>
+        <FilterOperatorPicker
+          value={operatorName}
+          options={availableOperators}
+          onChange={handleOperatorChange}
+        />
+      </Header>
+      {valueCount > 0 && (
+        <Flex p="md">
+          <ValuesInput
+            values={values}
+            valueCount={valueCount}
+            onChange={setValues}
+          />
+        </Flex>
+      )}
+      <Footer mt={valueCount === 0 ? -1 : undefined} /* to collapse borders */>
+        <Box />
+        <Button disabled={!isValid} onClick={handleFilterChange}>
+          {filter ? t`Update filter` : t`Add filter`}
+        </Button>
+      </Footer>
+    </>
+  );
+}
+
+function ValuesInput({
+  values,
+  valueCount,
+  onChange,
+}: {
+  values: Date[];
+  valueCount: number;
+  onChange: (values: Date[]) => void;
+}) {
+  if (valueCount === 1) {
+    const [value = DEFAULT_VALUE] = values;
+    return (
+      <FilterTimeInput
+        value={value}
+        onChange={newValue => onChange([newValue])}
+        w="100%"
+      />
+    );
+  }
+
+  if (valueCount === 2) {
+    const [value1 = DEFAULT_VALUE, value2 = DEFAULT_VALUE] = values;
+    return (
+      <Flex direction="row" align="center" gap="sm" w="100%">
+        <FilterTimeInput
+          value={value1}
+          onChange={newValue1 => onChange([newValue1, value2])}
+          w="100%"
+        />
+        <Text>{t`and`}</Text>
+        <FilterTimeInput
+          value={value2}
+          onChange={newValue2 => onChange([value1, newValue2])}
+          w="100%"
+        />
+      </Flex>
+    );
+  }
+
+  return null;
+}

--- a/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/constants.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/constants.ts
@@ -1,0 +1,27 @@
+import moment from "moment";
+import type { OperatorOption } from "./types";
+
+export const DEFAULT_VALUE = moment().startOf("day").toDate(); // 00:00:00
+
+export const OPERATOR_OPTIONS: OperatorOption[] = [
+  {
+    operator: "<",
+    valueCount: 1,
+  },
+  {
+    operator: ">",
+    valueCount: 1,
+  },
+  {
+    operator: "between",
+    valueCount: 2,
+  },
+  {
+    operator: "is-null",
+    valueCount: 0,
+  },
+  {
+    operator: "not-null",
+    valueCount: 0,
+  },
+];

--- a/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/index.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/index.ts
@@ -1,0 +1,1 @@
+export * from "./TimeFilterPicker";

--- a/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/types.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/types.ts
@@ -1,0 +1,8 @@
+import type { PickerOperatorOption } from "../types";
+
+type TimePickerOperator = ">" | "<" | "between" | "is-null" | "not-null";
+
+export interface OperatorOption
+  extends PickerOperatorOption<TimePickerOperator> {
+  valueCount: number;
+}

--- a/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/utils.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/utils.ts
@@ -1,0 +1,33 @@
+import type { TimeFilterOperatorName } from "metabase-lib";
+import { DEFAULT_VALUE, OPERATOR_OPTIONS } from "./constants";
+
+export function getDefaultValuesForOperator(
+  operatorName: TimeFilterOperatorName,
+): Date[] {
+  const option = OPERATOR_OPTIONS.find(
+    option => option.operator === operatorName,
+  );
+  if (!option) {
+    return [];
+  }
+  return Array(option.valueCount).fill(DEFAULT_VALUE);
+}
+
+export function isFilterValid(
+  operatorName: TimeFilterOperatorName,
+  values: Date[],
+) {
+  const option = OPERATOR_OPTIONS.find(
+    option => option.operator === operatorName,
+  );
+  if (!option) {
+    return false;
+  }
+
+  const { valueCount } = option;
+  const filledValues = values.filter(value => value instanceof Date);
+
+  return Number.isFinite(valueCount)
+    ? filledValues.length === valueCount
+    : filledValues.length >= 1;
+}

--- a/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.stories.mdx
+++ b/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.stories.mdx
@@ -1,0 +1,265 @@
+import { Canvas, Story, Meta } from "@storybook/addon-docs";
+import { Stack, TimeInput } from "metabase/ui";
+
+export const args = {
+  variant: "default",
+  soze: "md",
+  label: "Label",
+  description: undefined,
+  error: undefined,
+  placeholder: "Placeholder",
+  disabled: false,
+  readOnly: false,
+  withAsterisk: false,
+  onChange: event => {
+    console.log(event.target.value);
+  },
+};
+
+export const sampleArgs = {
+  value: "20:40",
+  label: "Time of day",
+  description: "The time you've this page",
+  placholder: "HH:MM",
+  error: "required",
+};
+
+export const argTypes = {
+  variant: {
+    options: ["default", "unstyled"],
+    control: { type: "inline-radio" },
+  },
+  size: {
+    options: ["xs", "md"],
+    control: { type: "inline-radio" },
+  },
+  label: {
+    control: { type: "text" },
+  },
+  description: {
+    control: { type: "text" },
+  },
+  placeholder: {
+    control: { type: "text" },
+  },
+  error: {
+    control: { type: "text" },
+  },
+  disabled: {
+    control: { type: "boolean" },
+  },
+  readOnly: {
+    control: { type: "boolean" },
+  },
+  withAsterisk: {
+    control: { type: "boolean" },
+  },
+};
+
+<Meta title="Inputs/TimeInput" component={TimeInput} args={args} />
+
+# Textarea
+
+Our themed wrapper around [Mantine TimeInput](https://v6.mantine.dev/dates/time-input/).
+
+## Docs
+
+- [Mantine TimeInput Docs](https://v6.mantine.dev/dates/time-input/)
+- [HTML Time Input Docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time)
+
+# Exxamples
+
+export const DefaultTemplate = args => <TimeInput {...args} />;
+
+export const VariantTemplate = args => (
+  <Stack>
+    <TimeInput {...args} variant="default" />
+    <TimeInput {...args} variant="unstyled" />
+  </Stack>
+);
+
+export const Default = DefaultTemplate.bind({});
+
+<Canvas>
+  <Story name="Default">{Default}</Story>
+</Canvas>
+
+### Size - md
+
+export const EmptyMd = VariantTemplate.bind({});
+EmptyMd.args = {
+  label: sampleArgs.label,
+  placeholder: sampleArgs.placeholder,
+};
+
+<Canvas>
+  <Story name="Empty, md">{EmptyMd}</Story>
+</Canvas>
+
+#### Filled
+
+export const FilledMd = VariantTemplate.bind({});
+FilledMd.args = {
+  defaultValue: sampleArgs.value,
+  label: sampleArgs.label,
+  placeholder: sampleArgs.placeholder,
+};
+
+<Canvas>
+  <Story name="Filled, md">{FilledMd}</Story>
+</Canvas>
+
+#### Asterisk
+
+export const AsteriskMd = VariantTemplate.bind({});
+AsteriskMd.args = {
+  label: sampleArgs.label,
+  placeholder: sampleArgs.placeholder,
+  withAsterisk: true,
+};
+
+<Canvas>
+  <Story name="Asterisk, md">{AsteriskMd}</Story>
+</Canvas>
+
+#### Description
+
+export const DescriptionMd = VariantTemplate.bind({});
+DescriptionMd.args = {
+  label: sampleArgs.label,
+  description: sampleArgs.description,
+  placeholder: sampleArgs.placeholder,
+};
+
+<Canvas>
+  <Story name="Description, md">{DescriptionMd}</Story>
+</Canvas>
+
+#### Disabled
+
+export const DisabledMd = VariantTemplate.bind({});
+DisabledMd.args = {
+  label: sampleArgs.label,
+  description: sampleArgs.description,
+  placeholder: sampleArgs.placeholder,
+  disabled: true,
+  withAsterisk: true,
+};
+
+<Canvas>
+  <Story name="Disabled, md">{DisabledMd}</Story>
+</Canvas>
+
+#### Error
+
+export const ErrorMd = VariantTemplate.bind({});
+ErrorMd.args = {
+  label: sampleArgs.label,
+  description: sampleArgs.description,
+  placeholder: sampleArgs.placeholder,
+  error: sampleArgs.error,
+  withAsterisk: true,
+};
+
+<Canvas>
+  <Story name="Error, md">{ErrorMd}</Story>
+</Canvas>
+
+#### Read only
+
+export const ReadOnlyMd = VariantTemplate.bind({});
+ReadOnlyMd.args = {
+  defaultValue: sampleArgs.value,
+  label: sampleArgs.label,
+  description: sampleArgs.description,
+  placeholder: sampleArgs.placeholder,
+  readOnly: true,
+};
+
+<Canvas>
+  <Story name="Read only, md">{ReadOnlyMd}</Story>
+</Canvas>
+
+### Size - xs
+
+export const EmptyXs = VariantTemplate.bind({});
+EmptyXs.args = {
+  ...EmptyMd.args,
+  size: "xs",
+};
+
+<Canvas>
+  <Story name="Empty, xs">{EmptyXs}</Story>
+</Canvas>
+
+#### Filled
+
+export const FilledXs = VariantTemplate.bind({});
+FilledXs.args = {
+  ...FilledMd.args,
+  size: "xs",
+};
+
+<Canvas>
+  <Story name="Filled, xs">{FilledXs}</Story>
+</Canvas>
+
+#### Asterisk
+
+export const AsteriskXs = VariantTemplate.bind({});
+AsteriskXs.args = {
+  ...AsteriskMd.args,
+  size: "xs",
+};
+
+<Canvas>
+  <Story name="Asterisk, xs">{AsteriskXs}</Story>
+</Canvas>
+
+#### Description
+
+export const DescriptionXs = VariantTemplate.bind({});
+DescriptionXs.args = {
+  ...DescriptionMd.args,
+  size: "xs",
+};
+
+<Canvas>
+  <Story name="Description, xs">{DescriptionXs}</Story>
+</Canvas>
+
+#### Disabled
+
+export const DisabledXs = VariantTemplate.bind({});
+DisabledXs.args = {
+  ...DisabledMd.args,
+  size: "xs",
+};
+
+<Canvas>
+  <Story name="Disabled, xs">{DisabledXs}</Story>
+</Canvas>
+
+#### Error
+
+export const ErrorXs = VariantTemplate.bind({});
+ErrorXs.args = {
+  ...ErrorMd.args,
+  size: "xs",
+};
+
+<Canvas>
+  <Story name="Error, xs">{ErrorXs}</Story>
+</Canvas>
+
+#### Read only
+
+export const ReadOnlyXs = VariantTemplate.bind({});
+ReadOnlyXs.args = {
+  ...ReadOnlyMd.args,
+  size: "xs",
+};
+
+<Canvas>
+  <Story name="Read only, xs">{ReadOnlyXs}</Story>
+</Canvas>

--- a/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.styled.tsx
@@ -1,0 +1,17 @@
+import type { MantineThemeOverride } from "@mantine/core";
+
+export const getTimeInputOverrides =
+  (): MantineThemeOverride["components"] => ({
+    TimeInput: {
+      defaultProps: {
+        size: "md",
+      },
+      styles: theme => ({
+        wrapper: {
+          "&:not(:only-child)": {
+            marginTop: theme.spacing.xs,
+          },
+        },
+      }),
+    },
+  });

--- a/frontend/src/metabase/ui/components/inputs/TimeInput/index.ts
+++ b/frontend/src/metabase/ui/components/inputs/TimeInput/index.ts
@@ -1,0 +1,3 @@
+export { TimeInput } from "@mantine/dates";
+export type { TimeInputProps } from "@mantine/dates";
+export { getTimeInputOverrides } from "./TimeInput.styled";

--- a/frontend/src/metabase/ui/components/inputs/index.ts
+++ b/frontend/src/metabase/ui/components/inputs/index.ts
@@ -7,3 +7,4 @@ export * from "./Select";
 export * from "./Textarea";
 export * from "./Switch";
 export * from "./TextInput";
+export * from "./TimeInput";

--- a/frontend/src/metabase/ui/theme.ts
+++ b/frontend/src/metabase/ui/theme.ts
@@ -19,6 +19,7 @@ import {
   getTextareaOverrides,
   getSwitchOverrides,
   getTextInputOverrides,
+  getTimeInputOverrides,
   getTextOverrides,
   getTitleOverrides,
 } from "./components";
@@ -122,6 +123,7 @@ export const getThemeOverrides = (): MantineThemeOverride => ({
     ...getTextareaOverrides(),
     ...getSwitchOverrides(),
     ...getTextInputOverrides(),
+    ...getTimeInputOverrides(),
     ...getTextOverrides(),
     ...getTitleOverrides(),
   },


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/34379

Adds MLv2-powered `TimeFilterPicker` using Mantine's `TimeInput`

### To Verify

1. New > Native query > `select '14:02:13'::time "time"` > Save
2. Click "Explore results", open the notebook editor
3. Filter the "Time" column to see the picker