### PR TITLE
Prune deleted in-memory databases on startup (in dev)

### DIFF
--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -2,6 +2,7 @@
   "Put everything needed for REPL development within easy reach"
   (:require
    [clojure.core.async :as a]
+   [clojure.string :as str]
    [dev.debug-qp :as debug-qp]
    [dev.model-tracking :as model-tracking]
    [honeysql.core :as hsql]
@@ -24,6 +25,7 @@
    [metabase.test :as mt]
    [metabase.test.data.impl :as data.impl]
    [metabase.util :as u]
+   [metabase.util.log :as log]
    [methodical.core :as methodical]
    [potemkin :as p]
    [toucan2.connection :as t2.connection]
@@ -58,10 +60,35 @@
   (mbc/init!)
   (reset! initialized? true))
 
+(defn deleted-inmem-databases
+  "Finds in-memory Databases for which the underlying in-mem h2 db no longer exists."
+  []
+  (let [h2-dbs (t2/select :model/Database :engine :h2)
+        in-memory? (fn [db] (some-> db :details :db (str/starts-with? "mem:")))
+        can-connect? (fn [db]
+                       (binding [metabase.driver.h2/*allow-testing-h2-connections* true]
+                         (try
+                           (driver/can-connect? :h2 (:details db))
+                           (catch org.h2.jdbc.JdbcSQLNonTransientConnectionException _
+                             false)
+                           (catch Exception e
+                             (log/error e "Error checking in-memory database for deletion")
+                             ;; we don't want to delete these, so just pretend we could connect
+                             true))))]
+    (remove can-connect? (filter in-memory? h2-dbs))))
+
+(defn prune-deleted-inmem-databases!
+  "Delete any in-memory Databases to which we can't connect (in order to trigger cleanup of their related tasks, which
+  will otherwise spam logs)."
+  []
+  (when-let [outdated-ids (seq (map :id (deleted-inmem-databases)))]
+    (t2/delete! :model/Database :id [:in outdated-ids])))
+
 (defn start!
   []
   (server/start-web-server! #'handler/app)
   (when config/is-dev?
+    (prune-deleted-inmem-databases!)
     (with-out-str (malli-dev/start!)))
   (when-not @initialized?
     (init!)))


### PR DESCRIPTION
### Description

Thanks to @dpsutton for the help here! I investigated an alternative approach of reusing the machinery that we use in tests to determine whether the database already exists, but that turned out to rely on a private atom that stored a list of databases created by the tests. I didn't want to muck around with those internals, and it turned out to be simpler than expected to make `can-connect?` work (although I did need to catch the exception thrown when we couldn't connect, which seems a little odd - I would have expected `can-connect?` to catch that and return `false`).

Fixes https://github.com/metabase/metabase/issues/9962

### How to verify

As this is development-only, I didn't add tests for the new behavior, but it's pretty simple. I did test it out in the REPL by verifying that the dangling in-memory databases I had were deleted after running `prune-deleted-inmem-databases!`.