### PR TITLE
Determine `pivot-cols` and `pivot-rows` on the backend using viz settings

### DIFF
--- a/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -9,6 +9,7 @@ import {
   dragField,
   leftSidebar,
   main,
+  modal,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
@@ -59,6 +60,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
+    cy.intercept("POST", "/api/card").as("createCard");
   });
 
   it("should be created from an ad-hoc question", () => {
@@ -1150,6 +1152,21 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
         },
       },
     });
+
+    cy.findByTestId("question-row-count").should(
+      "have.text",
+      "Showing first 52,711 rows",
+    );
+
+    cy.findByTestId("qb-header-action-panel").findByText("Save").click();
+    modal().button("Save").click();
+    cy.wait("@createCard");
+    cy.reload();
+
+    cy.findByTestId("question-row-count").should(
+      "have.text",
+      "Showing first 52,711 rows",
+    );
   });
 });
 

--- a/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -1152,6 +1152,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
         },
       },
     });
+    cy.wait("@pivotDataset");
 
     cy.findByTestId("question-row-count").should(
       "have.text",

--- a/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -22,6 +22,8 @@ const {
   PEOPLE,
   REVIEWS,
   REVIEWS_ID,
+  ANALYTIC_EVENTS,
+  ANALYTIC_EVENTS_ID,
 } = SAMPLE_DATABASE;
 
 const QUESTION_NAME = "Cypress Pivot Table";
@@ -1097,6 +1099,57 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
     popover().findByText("Address").click();
 
     main().findByText("User → Address").should("be.visible");
+  });
+
+  it("should return the same number of rows when running as an ad-hoc query vs a saved card (metabase#34278)", () => {
+    const query = {
+      type: "query",
+      query: {
+        "source-table": ANALYTIC_EVENTS_ID,
+        aggregation: [["count"]],
+        breakout: [
+          ["field", ANALYTIC_EVENTS.BUTTON_LABEL, { "base-type": "type/Text" }],
+          ["field", ANALYTIC_EVENTS.PAGE_URL, { "base-type": "type/Text" }],
+          [
+            "field",
+            ANALYTIC_EVENTS.TIMESTAMP,
+            { "base-type": "type/DateTime", "temporal-unit": "day" },
+          ],
+          ["field", ANALYTIC_EVENTS.EVENT, { "base-type": "type/Text" }],
+          ["field", ANALYTIC_EVENTS.ACCOUNT_ID, { "base-type": "type/Text" }],
+          ["field", ANALYTIC_EVENTS.ID, { "base-type": "type/Text" }],
+        ],
+      },
+      database: SAMPLE_DB_ID,
+    };
+
+    visitQuestionAdhoc({
+      dataset_query: query,
+      display: "pivot",
+      visualization_settings: {
+        "pivot_table.column_split": {
+          rows: [
+            ["field", ANALYTIC_EVENTS.PAGE_URL, { "base-type": "type/Text" }],
+            [
+              "field",
+              ANALYTIC_EVENTS.BUTTON_LABEL,
+              { "base-type": "type/Text" },
+            ],
+            ["field", ANALYTIC_EVENTS.ACCOUNT_ID, { "base-type": "type/Text" }],
+            [
+              "field",
+              ANALYTIC_EVENTS.TIMESTAMP,
+              { "base-type": "type/DateTime", "temporal-unit": "day" },
+            ],
+            ["field", ANALYTIC_EVENTS.ID, { "base-type": "type/Text" }],
+          ],
+          columns: [
+            ["field", ANALYTIC_EVENTS.EVENT, { "base-type": "type/Text" }],
+          ],
+          values: [["aggregation", 0]],
+        },
+      },
+    });
   });
 });
 

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -182,7 +182,11 @@
   (let [info {:executed-by api/*current-user-id*
               :context     :ad-hoc}]
     (qp.streaming/streaming-response [context :api]
-      (qp.pivot/run-pivot-query (assoc query :async? true) info context))))
+      (qp.pivot/run-pivot-query (assoc query
+                                       :async? true
+                                       :constraints (qp.constraints/default-query-constraints))
+                                info
+                                context))))
 
 (defn- parameter-field-values
   [field-ids query]

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -203,19 +203,20 @@
                   (^:once fn* [query info]
                    (qp.streaming/streaming-response [context export-format (u/slugify (:card-name info))]
                                                     (qp-runner query info context))))
-        card  (api/read-check (t2/select-one [Card :id :name :dataset_query :database_id
-                                              :cache_ttl :collection_id :dataset :result_metadata]
+        card  (api/read-check (t2/select-one [Card :id :name :dataset_query :database_id :cache_ttl :collection_id
+                                              :dataset :result_metadata :visualization_settings]
                                              :id card-id))
         query (-> (assoc (query-for-card card parameters constraints middleware {:dashboard-id dashboard-id}) :async? true)
                   (update :middleware (fn [middleware]
                                         (merge
                                          {:js-int-to-string? true :ignore-cached-results? ignore_cache}
                                          middleware))))
-        info  (cond-> {:executed-by  api/*current-user-id*
-                       :context      context
-                       :card-id      card-id
-                       :card-name    (:name card)
-                       :dashboard-id dashboard-id}
+        info  (cond-> {:executed-by            api/*current-user-id*
+                       :context                context
+                       :card-id                card-id
+                       :card-name              (:name card)
+                       :dashboard-id           dashboard-id
+                       :visualization-settings (:visualization_settings card)}
                 (and (:dataset card) (seq (:result_metadata card)))
                 (assoc :metadata/dataset-metadata (:result_metadata card)))]
     (api/check-not-archived card)

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -196,17 +196,16 @@
       :or   {constraints (qp.constraints/default-query-constraints)
              context     :question
              qp-runner   qp/process-query-and-save-execution!}}]
-  {:pre [(u/maybe? sequential? parameters)]}
+  {:pre [(int? card-id) (u/maybe? sequential? parameters)]}
   (let [run   (or run
                   ;; param `run` can be used to control how the query is ran, e.g. if you need to
                   ;; customize the `context` passed to the QP
                   (^:once fn* [query info]
                    (qp.streaming/streaming-response [context export-format (u/slugify (:card-name info))]
                                                     (qp-runner query info context))))
-        card  (api/read-check
-               (t2/select-one [Card :id :name :dataset_query :database_id
-                               :cache_ttl :collection_id :dataset :result_metadata]
-                              :id card-id))
+        card  (api/read-check (t2/select-one [Card :id :name :dataset_query :database_id
+                                              :cache_ttl :collection_id :dataset :result_metadata]
+                                             :id card-id))
         query (-> (assoc (query-for-card card parameters constraints middleware {:dashboard-id dashboard-id}) :async? true)
                   (update :middleware (fn [middleware]
                                         (merge

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -196,16 +196,17 @@
       :or   {constraints (qp.constraints/default-query-constraints)
              context     :question
              qp-runner   qp/process-query-and-save-execution!}}]
-  {:pre [(int? card-id) (u/maybe? sequential? parameters)]}
+  {:pre [(u/maybe? sequential? parameters)]}
   (let [run   (or run
                   ;; param `run` can be used to control how the query is ran, e.g. if you need to
                   ;; customize the `context` passed to the QP
                   (^:once fn* [query info]
                    (qp.streaming/streaming-response [context export-format (u/slugify (:card-name info))]
                                                     (qp-runner query info context))))
-        card  (api/read-check (t2/select-one [Card :id :name :dataset_query :database_id
-                                              :cache_ttl :collection_id :dataset :result_metadata]
-                                             :id card-id))
+        card  (api/read-check
+               (t2/select-one [Card :id :name :dataset_query :database_id
+                               :cache_ttl :collection_id :dataset :result_metadata]
+                              :id card-id))
         query (-> (assoc (query-for-card card parameters constraints middleware {:dashboard-id dashboard-id}) :async? true)
                   (update :middleware (fn [middleware]
                                         (merge

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -14,9 +14,7 @@
    [metabase.query-processor.util :as qp.util]
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs tru]]
-   [metabase.util.log :as log]
-   #_{:clj-kondo/ignore [:discouraged-namespace]}
-   [toucan2.core :as t2]))
+   [metabase.util.log :as log]))
 
 (set! *warn-on-reflection* true)
 

--- a/test/metabase/api/pivots.clj
+++ b/test/metabase/api/pivots.clj
@@ -11,44 +11,63 @@
         ;; Disable on Redshift due to OutOfMemory issue (see #18834)
         :redshift))
 
+(def pivot-query-options
+  "Pivot rows and columns for `pivot-query`"
+  {:pivot_rows [1 0]
+   :pivot_cols [2]})
+
 (defn pivot-query
   "A basic pivot table query"
-  []
-  (mt/dataset sample-dataset
-    (-> (mt/mbql-query orders
-                       {:aggregation [[:count] [:sum $orders.quantity]]
-                        :breakout    [$orders.user_id->people.state
-                                      $orders.user_id->people.source
-                                      $orders.product_id->products.category]})
-        (assoc :pivot_rows [1 0]
-               :pivot_cols [2]))))
+  ([]
+   (pivot-query true))
+
+  ([include-pivot-options?]
+   (mt/dataset sample-dataset
+     (merge
+      (mt/mbql-query orders
+                     {:aggregation [[:count] [:sum $orders.quantity]]
+                      :breakout    [$orders.user_id->people.state
+                                    $orders.user_id->people.source
+                                    $orders.product_id->products.category]})
+      (when include-pivot-options?
+        pivot-query-options)))))
 
 (defn filters-query
   "A pivot table query with a filter applied"
-  []
-  (-> (mt/mbql-query orders
-        {:aggregation [[:count]]
-         :breakout    [$orders.user_id->people.state
-                       $orders.user_id->people.source]
-         :filter      [:and [:= $orders.user_id->people.source "Google" "Organic"]]})
-      (assoc :pivot_rows [0]
-             :pivot_cols [1])))
+  ([]
+   (filters-query true))
+
+  ([include-pivot-options?]
+   (merge
+    (mt/mbql-query orders
+                   {:aggregation [[:count]]
+                    :breakout    [$orders.user_id->people.state
+                                  $orders.user_id->people.source]
+                    :filter      [:and [:= $orders.user_id->people.source "Google" "Organic"]]})
+    (when include-pivot-options?
+      {:pivot_rows [0]
+       :pivot_cols [1]}))))
 
 (defn parameters-query
   "A pivot table query with parameters"
-  []
-  (-> (mt/mbql-query orders
-        {:aggregation [[:count]]
-         :breakout    [$orders.user_id->people.state
-                       $orders.user_id->people.source]
-         :filter      [:and [:= $orders.user_id->people.source "Google" "Organic"]]
-         :parameters  [{:type   "category"
-                        :target [:dimension $orders.product_id->products.category]
-                        :value  "Gadget"}]})
-      (assoc :pivot_rows [0]
-             :pivot_cols [1])))
+  ([]
+   (parameters-query true))
+
+  ([include-pivot-options?]
+   (merge
+    (mt/mbql-query orders
+       {:aggregation [[:count]]
+        :breakout    [$orders.user_id->people.state
+                      $orders.user_id->people.source]
+        :filter      [:and [:= $orders.user_id->people.source "Google" "Organic"]]
+        :parameters  [{:type   "category"
+                       :target [:dimension $orders.product_id->products.category]
+                       :value  "Gadget"}]})
+    (when include-pivot-options?
+      {:pivot_rows [0]
+       :pivot_cols [1]}))))
 
 (defn pivot-card
   "A dashboard card query with a pivot table"
   []
-  {:dataset_query (pivot-query)})
+  {:dataset_query (pivot-query false)})

--- a/test/metabase/api/pivots.clj
+++ b/test/metabase/api/pivots.clj
@@ -70,4 +70,10 @@
 (defn pivot-card
   "A dashboard card query with a pivot table"
   []
-  {:dataset_query (pivot-query false)})
+  (let [pivot-query (pivot-query false)
+        breakout    (-> pivot-query :query :breakout)]
+    {:dataset_query pivot-query
+     :visualization_settings
+     {:pivot_table.column_split
+      {:rows    [(get breakout 1) (get breakout 0)]
+       :columns [(get breakout 2)]}}}))

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -161,15 +161,9 @@
 
 (deftest pivot-options-test
   (testing "`pivot-options` correctly generates pivot-rows and pivot-cols from a card's viz settings"
-    (let [pivot-query (api.pivots/pivot-query false)
-          breakout    (-> pivot-query :query :breakout)]
-      (t2.with-temp/with-temp [:model/Card card {:dataset_query pivot-query
-                                                 :visualization_settings
-                                                 {:pivot_table.column_split
-                                                  {:rows    [(get breakout 1) (get breakout 0)]
-                                                   :columns [(get breakout 2)]}}}]
-        (is (= {:pivot-rows [1 0] :pivot-cols [2]}
-             (qp.pivot/pivot-options pivot-query (u/the-id card))))))))
+    (t2.with-temp/with-temp [:model/Card card (api.pivots/pivot-card)]
+      (is (= {:pivot-rows [1 0] :pivot-cols [2]}
+           (qp.pivot/pivot-options (api.pivots/pivot-query false) (u/the-id card)))))))
 
 (deftest dont-return-too-many-rows-test
   (testing "Make sure pivot queries don't return too many rows (#14329)"

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -13,7 +13,8 @@
    [metabase.query-processor.pivot :as qp.pivot]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [schema.core :as s]))
+   [schema.core :as s]
+   [toucan2.tools.with-temp :as t2.with-temp]))
 
 (set! *warn-on-reflection* true)
 
@@ -153,9 +154,22 @@
                                       :pivot-cols [2])
                                (assoc-in [:query :aggregation] [[:count] [:sum (mt/$ids $orders.quantity)]])
                                (assoc-in [:query :source-table] (mt/$ids $$orders))))
-                actual   (map (fn [actual-val] (dissoc actual-val :database)) (#'qp.pivot/generate-queries request))]
+                actual   (map (fn [actual-val] (dissoc actual-val :database))
+                              (#'qp.pivot/generate-queries request {:pivot-rows [1 0] :pivot-cols [2]}))]
             (is (= 6 (count actual)))
             (is (= expected actual))))))))
+
+(deftest pivot-options-test
+  (testing "`pivot-options` correctly generates pivot-rows and pivot-cols from a card's viz settings"
+    (let [pivot-query (api.pivots/pivot-query false)
+          breakout    (-> pivot-query :query :breakout)]
+      (t2.with-temp/with-temp [:model/Card card {:dataset_query pivot-query
+                                                 :visualization_settings
+                                                 {:pivot_table.column_split
+                                                  {:rows    [(get breakout 1) (get breakout 0)]
+                                                   :columns [(get breakout 2)]}}}]
+        (is (= {:pivot-rows [1 0] :pivot-cols [2]}
+             (qp.pivot/pivot-options pivot-query (u/the-id card))))))))
 
 (deftest dont-return-too-many-rows-test
   (testing "Make sure pivot queries don't return too many rows (#14329)"

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -13,8 +13,7 @@
    [metabase.query-processor.pivot :as qp.pivot]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [schema.core :as s]
-   [toucan2.tools.with-temp :as t2.with-temp]))
+   [schema.core :as s]))
 
 (set! *warn-on-reflection* true)
 

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -161,7 +161,7 @@
 (deftest pivot-options-test
   (testing "`pivot-options` correctly generates pivot-rows and pivot-cols from a card's viz settings"
     (is (= {:pivot-rows [1 0] :pivot-cols [2]}
-         (qp.pivot/pivot-options (api.pivots/pivot-query false) (:visualization_settings (api.pivots/pivot-card)))))))
+           (qp.pivot/pivot-options (api.pivots/pivot-query false) (:visualization_settings (api.pivots/pivot-card)))))))
 
 (deftest dont-return-too-many-rows-test
   (testing "Make sure pivot queries don't return too many rows (#14329)"

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -161,9 +161,8 @@
 
 (deftest pivot-options-test
   (testing "`pivot-options` correctly generates pivot-rows and pivot-cols from a card's viz settings"
-    (t2.with-temp/with-temp [:model/Card card (api.pivots/pivot-card)]
-      (is (= {:pivot-rows [1 0] :pivot-cols [2]}
-           (qp.pivot/pivot-options (api.pivots/pivot-query false) (u/the-id card)))))))
+    (is (= {:pivot-rows [1 0] :pivot-cols [2]}
+         (qp.pivot/pivot-options (api.pivots/pivot-query false) (:visualization_settings (api.pivots/pivot-card)))))))
 
 (deftest dont-return-too-many-rows-test
   (testing "Make sure pivot queries don't return too many rows (#14329)"


### PR DESCRIPTION
Pivot tables execution requires `pivot-cols` and `pivot-rows` vectors, which indicate the indices of the breakouts to use as cols and rows for the pivot table. These are used in `generate-queries` to determine which subqueries need to be run to assemble the pivot table with the appropriate subtotal & grand total values.

For ad-hoc queries, these values are passed in by the frontend as part of the query object itself. For saved cards, however, these values were not being passed consistently. In some cases (normal card execution, embeds) they were being passed in the API request body but not being looked at by the backend. For public cards, they weren't being passed at all. However: this info can also be determined by looking at `:pivot_table.column_split` in a card's viz settings, which the backend already has access to for all types of card execution.

This PR modifies the pivot table execution code to pull this information from card's viz settings if it's not already in the query itself. I've also applied the default constraints for row limits for ad-hoc queries, which were already being applied for saved cards. These changes together result in consistent pivot table results across all of the query processing entry points.

Resolves https://github.com/metabase/metabase/issues/34278