### PR TITLE
Let them eat cake

### DIFF
--- a/docs/api/timeline-event.md
+++ b/docs/api/timeline-event.md
@@ -48,7 +48,7 @@ Create a new [[TimelineEvent]].
 
 *  **`source`** value may be nil, or if non-nil, value must be one of: `collections`, `question`.
 
-*  **`icon`** value may be nil, or if non-nil, value must be one of: `balloons`, `bell`, `cloud`, `mail`, `star`, `warning`.
+*  **`icon`** value may be nil, or if non-nil, value must be one of: `cake`, `bell`, `cloud`, `mail`, `star`, `warning`.
 
 ## `PUT /api/timeline-event/:id`
 
@@ -70,7 +70,7 @@ Update a [[TimelineEvent]].
 
 *  **`timeline_id`** value may be nil, or if non-nil, value must be an integer greater than zero.
 
-*  **`icon`** value may be nil, or if non-nil, value must be one of: `balloons`, `bell`, `cloud`, `mail`, `star`, `warning`.
+*  **`icon`** value may be nil, or if non-nil, value must be one of: `cake`, `bell`, `cloud`, `mail`, `star`, `warning`.
 
 *  **`id`** 
 

--- a/docs/api/timeline.md
+++ b/docs/api/timeline.md
@@ -55,7 +55,7 @@ Create a new [[Timeline]].
 
 *  **`description`** value may be nil, or if non-nil, value must be a string.
 
-*  **`icon`** value may be nil, or if non-nil, value must be one of: `balloons`, `bell`, `cloud`, `mail`, `star`, `warning`.
+*  **`icon`** value may be nil, or if non-nil, value must be one of: `cake`, `bell`, `cloud`, `mail`, `star`, `warning`.
 
 *  **`collection_id`** value may be nil, or if non-nil, value must be an integer greater than zero.
 
@@ -76,7 +76,7 @@ Update the [[Timeline]] with `id`. Returns the timeline without events. Archivin
 
 *  **`description`** value may be nil, or if non-nil, value must be a string.
 
-*  **`icon`** value may be nil, or if non-nil, value must be one of: `balloons`, `bell`, `cloud`, `mail`, `star`, `warning`.
+*  **`icon`** value may be nil, or if non-nil, value must be one of: `cake`, `bell`, `cloud`, `mail`, `star`, `warning`.
 
 *  **`collection_id`** value may be nil, or if non-nil, value must be an integer greater than zero.
 

--- a/e2e/test/scenarios/organization/timelines-collection.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-collection.cy.spec.js
@@ -54,7 +54,7 @@ describe("scenarios > organization > timelines > collection", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Star").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Balloons").click();
+      cy.findByText("Cake").click();
       cy.button("Create").click();
       cy.wait("@createEvent");
 
@@ -62,7 +62,7 @@ describe("scenarios > organization > timelines > collection", () => {
       cy.findByText("RC2").should("be.visible");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("May 12, 2027").should("be.visible");
-      cy.icon("balloons").should("be.visible");
+      cy.icon("cake").should("be.visible");
     });
 
     it("should create an event in a personal collection", () => {

--- a/frontend/src/metabase/core/components/Icon/icons/index.ts
+++ b/frontend/src/metabase/core/components/Icon/icons/index.ts
@@ -1055,7 +1055,7 @@ export const Icons = {
     component: number_component,
     source: number_source,
   },
-  balloons: {
+  cake: {
     component: birthday_component,
     source: birthday_source,
   },

--- a/frontend/src/metabase/lib/timelines.ts
+++ b/frontend/src/metabase/lib/timelines.ts
@@ -12,7 +12,7 @@ export const getTimelineName = (timeline: Timeline) => {
 export const getTimelineIcons = () => {
   return [
     { name: t`Star`, value: "star", icon: "star" },
-    { name: t`Balloons`, value: "balloons", icon: "balloons" },
+    { name: t`Cake`, value: "cake", icon: "cake" },
     { name: t`Mail`, value: "mail", icon: "mail" },
     { name: t`Warning`, value: "warning", icon: "warning" },
     { name: t`Bell`, value: "bell", icon: "bell" },

--- a/src/metabase/models/timeline.clj
+++ b/src/metabase/models/timeline.clj
@@ -26,7 +26,7 @@
 
 (def Icons
   "Timeline and TimelineEvent icon string Schema"
- [:enum "star" "balloons" "mail" "warning" "bell" "cloud"])
+ [:enum "star" "cake" "mail" "warning" "bell" "cloud"])
 
 (def DefaultIcon
   "Timeline default icon"


### PR DESCRIPTION
Fixes #34581 by correctly labeling the cake icon as `Cake`. If we want to add back a balloon icon later, we can do that.

<img width="341" alt="image" src="https://github.com/metabase/metabase/assets/2223916/9c6c5396-0153-41e6-887e-16190bce7dac">
