### PR TITLE
Update Trend chart design and fix copy

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/reproductions/31628-responsive-scalars.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/reproductions/31628-responsive-scalars.cy.spec.js
@@ -245,9 +245,8 @@ describe("issue 31628", () => {
 
   describe("display: smartscalar", () => {
     const descendantsSelector = [
+      "[data-testid='legend-caption']",
       "[data-testid='scalar-container']",
-      "[data-testid='scalar-title']",
-      "[data-testid='scalar-description']",
       "[data-testid='scalar-previous-value']",
     ].join(",");
 
@@ -295,9 +294,14 @@ describe("issue 31628", () => {
         cy.findByRole("tooltip").should("not.exist");
 
         /**
+         * it should not display period because the card height is too small to fit it
+         */
+        cy.findByTestId("scalar-period").should("not.exist");
+
+        /**
          * it should truncate title and show title tooltip on hover
          */
-        const scalarTitle = cy.findByTestId("scalar-title");
+        const scalarTitle = cy.findByTestId("legend-caption-title");
 
         scalarTitle.then($element => assertIsEllipsified($element[0]));
         scalarTitle.realHover();
@@ -305,21 +309,13 @@ describe("issue 31628", () => {
         popover().findByText(SMART_SCALAR_QUESTION.name).should("exist");
 
         /**
-         * it should show description tooltip on hover
-         */
-        cy.findByTestId("scalar-description").realHover();
-
-        popover().findByText(SMART_SCALAR_QUESTION.description).should("exist");
-
-        cy.findByTestId("scalar-description").trigger("mouseleave"); // allow tooltip to hide
-        /**
          * it should show previous value tooltip on hover
          */
         cy.findByTestId("scalar-previous-value").realHover();
 
         popover().within(() => {
           cy.contains("34.72%").should("exist");
-          cy.contains("• was 527 last month").should("exist");
+          cy.contains("• vs. previous month: 527").should("exist");
         });
 
         /**
@@ -329,7 +325,7 @@ describe("issue 31628", () => {
 
         previousValue.within(() => {
           cy.contains("34.72%").should("exist");
-          cy.contains("• was 527 last month").should("not.exist");
+          cy.contains("• vs. previous month: 527").should("not.exist");
           previousValue.then($element => assertIsNotEllipsified($element[0]));
         });
       });
@@ -342,7 +338,7 @@ describe("issue 31628", () => {
         previousValue.within(() => {
           cy.contains("34.7%").should("exist");
           cy.contains("34.72%").should("not.exist");
-          cy.contains("• was 527 last month").should("not.exist");
+          cy.contains("• vs. previous month: 527").should("not.exist");
           previousValue.then($element => assertIsNotEllipsified($element[0]));
         });
       });
@@ -355,7 +351,7 @@ describe("issue 31628", () => {
         previousValue.within(() => {
           cy.contains("35%").should("exist");
           cy.contains("34.72%").should("not.exist");
-          cy.contains("• was 527 last month").should("not.exist");
+          cy.contains("• vs. previous month: 527").should("not.exist");
           previousValue.then($element => assertIsNotEllipsified($element[0]));
         });
       });
@@ -392,9 +388,14 @@ describe("issue 31628", () => {
         cy.findByRole("tooltip").should("not.exist");
 
         /**
+         * it should display the period
+         */
+        cy.findByTestId("scalar-period").should("have.text", "Apr 2026");
+
+        /**
          * should truncate title and show title tooltip on hover
          */
-        scalarContainer = cy.findByTestId("scalar-title");
+        scalarContainer = cy.findByTestId("legend-caption-title");
 
         scalarContainer.then($element => assertIsEllipsified($element[0]));
         scalarContainer.realHover();
@@ -404,7 +405,7 @@ describe("issue 31628", () => {
         /**
          * should show description tooltip on hover
          */
-        cy.findByTestId("scalar-description").realHover();
+        cy.findByTestId("legend-caption").icon("info").realHover();
 
         popover().findByText(SMART_SCALAR_QUESTION.description).should("exist");
 
@@ -415,7 +416,7 @@ describe("issue 31628", () => {
 
         previousValue.within(() => {
           cy.contains("34.72%").should("exist");
-          cy.contains("• was 527 last month").should("exist");
+          cy.contains("• vs. previous month: 527").should("exist");
           previousValue.then($element => assertIsNotEllipsified($element[0]));
         });
 
@@ -449,19 +450,24 @@ describe("issue 31628", () => {
         cy.findByRole("tooltip").should("not.exist");
 
         /**
-         * should not truncate title and should not show title tooltip on hover
+         * it should display the period
          */
-        scalarContainer = cy.findByTestId("scalar-title");
+        cy.findByTestId("scalar-period").should("have.text", "Apr 2026");
 
-        scalarContainer.then($element => assertIsNotEllipsified($element[0]));
+        /**
+         * should truncate title and show title tooltip on hover
+         */
+        scalarContainer = cy.findByTestId("legend-caption-title");
+
+        scalarContainer.then($element => assertIsEllipsified($element[0]));
         scalarContainer.realHover();
 
-        cy.findByRole("tooltip").should("not.exist");
+        popover().findByText(SMART_SCALAR_QUESTION.name).should("exist");
 
         /**
          * should show description tooltip on hover
          */
-        cy.findByTestId("scalar-description").realHover();
+        cy.findByTestId("legend-caption").icon("info").realHover();
 
         popover().findByText(SMART_SCALAR_QUESTION.description).should("exist");
 
@@ -472,7 +478,7 @@ describe("issue 31628", () => {
 
         previousValue.within(() => {
           cy.contains("34.72%").should("exist");
-          cy.contains("• was 527 last month").should("exist");
+          cy.contains("• vs. previous month: 527").should("exist");
           previousValue.then($element => assertIsNotEllipsified($element[0]));
         });
 

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption.jsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption.jsx
@@ -43,7 +43,7 @@ const LegendCaption = ({
         className="fullscreen-normal-text fullscreen-night-text"
         onClick={onSelectTitle}
       >
-        <Ellipsified>{title}</Ellipsified>
+        <Ellipsified data-testid="legend-caption-title">{title}</Ellipsified>
       </LegendLabel>
       <LegendRightContent>
         {description && !shouldHideDescription(width) && (

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.styled.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 import { Ellipsified } from "metabase/core/components/Ellipsified";
 import { Icon } from "metabase/core/components/Icon";
 import { color } from "metabase/lib/colors";
-import { breakpointMaxMedium, space } from "metabase/styled-components/theme";
+import { space } from "metabase/styled-components/theme";
 
 export const Variation = styled.div`
   color: ${props => props.color};
@@ -42,15 +42,10 @@ export const PreviousValueContainer = styled.div`
   margin: ${space(0)} ${space(1)};
   gap: ${space(0)};
   line-height: 1.2rem;
-
-  ${breakpointMaxMedium} {
-    margin: ${space(1)};
-    flex-direction: column;
-  }
 `;
 
 export const PreviousValue = styled.h4`
-  color: ${color("text-light")};
+  color: ${color("text-medium")};
 `;
 
 export const Separator = styled.span`
@@ -60,8 +55,13 @@ export const Separator = styled.span`
 
 export const PreviousValueSeparator = styled(Separator)`
   color: ${color("text-light")};
-
-  ${breakpointMaxMedium} {
-    display: none;
-  }
+`;
+export const PreviousValueLabel = styled.span`
+  color: ${color("text-light")};
+`;
+export const ScalarPeriodContent = styled.h3`
+  text-align: center;
+  overflow: hidden;
+  cursor: ${props => props.onClick && "pointer"};
+  font-size: 0.875rem;
 `;

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.unit.spec.js
@@ -32,7 +32,7 @@ describe("SmartScalar", () => {
   describe("field selection", () => {
     const rows = [
       ["2019-10-01T00:00:00", 100, 200],
-      [("2019-11-01T00:00:00", 120, 220)],
+      ["2019-11-01T00:00:00", 120, 220],
     ];
     const insights = [
       {
@@ -53,30 +53,39 @@ describe("SmartScalar", () => {
     it("should use first non-date column (Count) by default", () => {
       setup(series({ rows, insights }));
       expect(screen.getByText("120")).toBeInTheDocument();
-      const previousValue = screen.getByText("20%");
-      expect(previousValue).toBeInTheDocument();
-      userEvent.hover(previousValue);
-      expect(screen.getByText("was 100 last month")).toBeInTheDocument();
+      expect(screen.getByText("Nov 2019")).toBeInTheDocument();
+      const lastChange = screen.getByText("20%");
+      expect(lastChange).toBeInTheDocument();
+      userEvent.hover(lastChange);
+      expect(screen.getByText("vs. previous month:")).toBeInTheDocument();
+      expect(screen.getByText("100")).toBeInTheDocument();
     });
     it("should use Count when selected", () => {
       setup(series({ rows, insights, field: "Count" }));
       expect(screen.getByText("120")).toBeInTheDocument();
-      const previousValue = screen.getByText("20%");
-      expect(previousValue).toBeInTheDocument();
-      userEvent.hover(previousValue);
-      expect(screen.getByText("was 100 last month")).toBeInTheDocument();
+      expect(screen.getByText("Nov 2019")).toBeInTheDocument();
+      const lastChange = screen.getByText("20%");
+      expect(lastChange).toBeInTheDocument();
+      userEvent.hover(lastChange);
+      expect(screen.getByText("vs. previous month:")).toBeInTheDocument();
+      expect(screen.getByText("100")).toBeInTheDocument();
     });
     it("should use Sum when selected", () => {
       setup(series({ rows, insights, field: "Sum" }));
       expect(screen.getByText("220")).toBeInTheDocument();
-      const previousValue = screen.getByText("10%");
-      expect(previousValue).toBeInTheDocument();
-      userEvent.hover(previousValue);
-      expect(screen.getByText("was 200 last month")).toBeInTheDocument();
+      expect(screen.getByText("Nov 2019")).toBeInTheDocument();
+      const lastChange = screen.getByText("10%");
+      expect(lastChange).toBeInTheDocument();
+      userEvent.hover(lastChange);
+      expect(screen.getByText("vs. previous month:")).toBeInTheDocument();
+      expect(screen.getByText("200")).toBeInTheDocument();
     });
   });
   it("should show 20% increase", () => {
-    const rows = [["2019-10-01T00:00:00", 100], [("2019-11-01T00:00:00", 120)]];
+    const rows = [
+      ["2019-10-01T00:00:00", 100],
+      ["2019-11-01T00:00:00", 120],
+    ];
     const insights = [
       {
         "last-value": 120,
@@ -90,16 +99,21 @@ describe("SmartScalar", () => {
     setup(series({ rows, insights }));
 
     expect(screen.getByText("120")).toBeInTheDocument();
+    expect(screen.getByText("Nov 2019")).toBeInTheDocument();
 
-    const previousValue = screen.getByText("20%");
-    expect(previousValue).toBeInTheDocument();
+    const lastChange = screen.getByText("20%");
+    expect(lastChange).toBeInTheDocument();
 
-    userEvent.hover(previousValue);
-    expect(screen.getByText("was 100 last month")).toBeInTheDocument();
+    userEvent.hover(lastChange);
+    expect(screen.getByText("vs. previous month:")).toBeInTheDocument();
+    expect(screen.getByText("100")).toBeInTheDocument();
   });
 
   it("should show 20% decrease", () => {
-    const rows = [["2019-10-01T00:00:00", 100], [("2019-11-01T00:00:00", 80)]];
+    const rows = [
+      ["2019-10-01T00:00:00", 100],
+      ["2019-11-01T00:00:00", 80],
+    ];
     const insights = [
       {
         "last-value": 80,
@@ -113,16 +127,21 @@ describe("SmartScalar", () => {
     setup(series({ rows, insights }));
 
     expect(screen.getByText("80")).toBeInTheDocument();
+    expect(screen.getByText("Nov 2019")).toBeInTheDocument();
 
-    const previousValue = screen.getByText("20%");
-    expect(previousValue).toBeInTheDocument();
+    const lastChange = screen.getByText("20%");
+    expect(lastChange).toBeInTheDocument();
 
-    userEvent.hover(previousValue);
-    expect(screen.getByText("was 100 last month")).toBeInTheDocument();
+    userEvent.hover(lastChange);
+    expect(screen.getByText("vs. previous month:")).toBeInTheDocument();
+    expect(screen.getByText("100")).toBeInTheDocument();
   });
 
   it("should show 0% change", () => {
-    const rows = [["2019-10-01T00:00:00", 100], [("2019-11-01T00:00:00", 100)]];
+    const rows = [
+      ["2019-10-01T00:00:00", 100],
+      ["2019-11-01T00:00:00", 100],
+    ];
     const insights = [
       {
         "last-value": 100,
@@ -136,6 +155,7 @@ describe("SmartScalar", () => {
     setup(series({ rows, insights }));
 
     expect(screen.getByText("100")).toBeInTheDocument();
+    expect(screen.getByText("Nov 2019")).toBeInTheDocument();
     expect(screen.getByText("No change from last month")).toBeInTheDocument();
   });
 
@@ -169,7 +189,7 @@ describe("SmartScalar", () => {
     const width = 200;
     const rows = [
       ["2019-10-01T00:00:00", 100],
-      [("2019-11-01T00:00:00", 81005)],
+      ["2019-11-01T00:00:00", 81005],
     ];
     const insights = [
       {
@@ -190,7 +210,7 @@ describe("SmartScalar", () => {
     const width = 200;
     const rows = [
       ["2019-10-01T00:00:00", 100],
-      [("2019-11-01T00:00:00", 810750.54)],
+      ["2019-11-01T00:00:00", 810750.54],
     ];
     const insights = [
       {

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/constants.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/constants.ts
@@ -8,8 +8,8 @@ export const ICON_MARGIN_RIGHT = SPACING;
 
 export const SCALAR_TITLE_LINE_HEIGHT = 23;
 
-export const MIN_PREVIOUS_VALUE_SIZE = 27;
+export const PREVIOUS_VALUE_SIZE = 27;
 
-export const MAX_PREVIOUS_VALUE_SIZE = 42;
+export const PERIOD_HIDE_HEIGHT_THRESHOLD = 70; // determined empirically
 
-export const TITLE_2_LINES_HEIGHT_THRESHOLD = 150; // determined empirically
+export const DASHCARD_HEADER_HEIGHT = 33;

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.unit.spec.ts
@@ -1,12 +1,10 @@
 import * as measureText from "metabase/lib/measure-text";
 import type { FontStyle } from "metabase/visualizations/shared/types/measure-text";
 
-import { TITLE_2_LINES_HEIGHT_THRESHOLD } from "./constants";
 import {
   formatChange,
   formatChangeAutoPrecision,
   getChangeWidth,
-  getValueHeight,
   getValueWidth,
 } from "./utils";
 
@@ -23,38 +21,6 @@ const getAutoPrecisionOptions = (width: number) => {
 };
 
 describe("SmartScalar > utils", () => {
-  describe("getValueHeight", () => {
-    const titleHeight2Lines = TITLE_2_LINES_HEIGHT_THRESHOLD + 1;
-    const titleHeight1Line = TITLE_2_LINES_HEIGHT_THRESHOLD - 1;
-
-    const height2LinesNoPreviousValue = getValueHeight(
-      titleHeight2Lines,
-      false,
-    );
-    const height2LinesPreviousValue = getValueHeight(titleHeight2Lines, true);
-    const height1LineNoPreviousValue = getValueHeight(titleHeight1Line, false);
-    const height1LinePreviousValue = getValueHeight(titleHeight1Line, true);
-
-    it("should give greater height there is no previous value", () => {
-      expect(height2LinesNoPreviousValue).toBeGreaterThan(
-        height2LinesPreviousValue,
-      );
-      expect(height1LineNoPreviousValue).toBeGreaterThan(
-        height1LinePreviousValue,
-      );
-    });
-
-    it("should not return negative values", () => {
-      expect(height2LinesNoPreviousValue).toBeGreaterThanOrEqual(0);
-      expect(height2LinesPreviousValue).toBeGreaterThanOrEqual(0);
-      expect(height1LineNoPreviousValue).toBeGreaterThanOrEqual(0);
-      expect(height1LinePreviousValue).toBeGreaterThanOrEqual(0);
-
-      expect(getValueHeight(1, false)).toBeGreaterThanOrEqual(0);
-      expect(getValueHeight(1, true)).toBeGreaterThanOrEqual(0);
-    });
-  });
-
   describe("getValueWidth", () => {
     it("should not return negative values", () => {
       expect(getValueWidth(1)).toBeGreaterThanOrEqual(0);

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "react-draggable": "^3.3.2",
     "react-dropzone": "^14.2.3",
     "react-grid-layout": "^1.2.5",
+    "react-innertext": "^1.1.5",
     "react-is": "^17.0.2",
     "react-markdown": "^8.0.4",
     "react-motion": "0.5.2",

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -915,8 +915,9 @@
               previous        (format-cell timezone-id previous-value metric-col viz-settings)
               adj             (if (pos? last-change) (tru "Up") (tru "Down"))
               delta-statement (if (= last-value previous-value)
-                                "No change."
-                                (str adj " " (percentage last-change) "."))]
+                                "No change"
+                                (str adj " " (percentage last-change)))
+              comparison-statement (str " vs. previous " (format-unit unit) ": " previous)]
           {:attachments nil
            :content     [:div
                          [:div {:style (style/style (style/scalar-style))}
@@ -926,10 +927,10 @@
                                                    :font-weight   700
                                                    :padding-right :16px})}
                           delta-statement
-                          " Was " previous " last " (format-unit unit)]]
+                          comparison-statement]]
            :render/text (str value "\n"
                              delta-statement
-                             " Was " previous " last " (format-unit unit))})
+                             comparison-statement)})
         ;; In other words, defaults to plain scalar if we don't have actual changes
         {:attachments nil
          :content     [:div

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -332,15 +332,15 @@
                                  :last-change nil
                                  :col "value"
                                  :last-value 20.0}]}]
-        (is (= "40\nUp 133.33%. Was 30 last month"
+        (is (= "40\nUp 133.33% vs. previous month: 30"
                (:render/text (body/render :smartscalar nil pacific-tz nil nil results))))
-        (is (= "40\nNo change. Was 40 last month"
+        (is (= "40\nNo change vs. previous month: 40"
                (:render/text (body/render :smartscalar nil pacific-tz nil nil sameres))))
         (is (= "20\nNothing to compare to."
                (:render/text (body/render :smartscalar nil pacific-tz nil nil dumbres))))
         (is (schema= {:attachments (s/eq nil)
                       :content     (s/pred vector? "hiccup vector")
-                      :render/text (s/eq "40\nUp 133.33%. Was 30 last month")}
+                      :render/text (s/eq "40\nUp 133.33% vs. previous month: 30")}
                      (body/render :smartscalar nil pacific-tz nil nil results)))))))
 
 (defn- replace-style-maps [hiccup-map]

--- a/yarn.lock
+++ b/yarn.lock
@@ -21179,6 +21179,11 @@ react-grid-layout@^1.2.5:
     react-draggable "^4.0.0"
     react-resizable "^3.0.1"
 
+react-innertext@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/react-innertext/-/react-innertext-1.1.5.tgz#8147ac54db3f7067d95f49e2d2c05a720d27d8d0"
+  integrity sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q==
+
 react-inspector@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-5.1.1.tgz#58476c78fde05d5055646ed8ec02030af42953c8"


### PR DESCRIPTION
Part of trend chart improvements epic: https://github.com/metabase/metabase/issues/33411

This PR changes the layout and corrects the copy for our trend chart.  We can release this independently in 48.

(In the next PRs for this epic, we will add same fixes to static viz trend chart, then add for support multiple comparisons.)

## Changes
1. Remove question title and description tooltip, and enable the Dashcard header to display them instead.
3. Add period label, but hide it when card is too short to display it.
4. Progressively shorten comparison text based on card width.
5. Remove comparison wrapping via media query breakpoint since new design will always keep comparison on a single line.

## Reviewing
Hide whitespace.

## Manual testing
1. Create a trend chart grouped by different time units to see if the new period label works.
2. See if it looks good at multiple card sizes.
3. Make sure tooltips show up when anything is truncated.

https://github.com/metabase/metabase/assets/116838/a600db32-2cd9-4721-9a92-dd5afa902a9e

https://github.com/metabase/metabase/assets/116838/5e0ea77c-1d35-4600-93a8-992c449a7a3c