### PR TITLE
🍒 Manual Backport: Make implicit fields coming from source query expressions use string id

### DIFF
--- a/src/metabase/query_processor/middleware/add_implicit_clauses.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_clauses.clj
@@ -60,14 +60,16 @@
   "Get implicit Fields for a query with a `:source-query` that has `source-metadata`."
   [source-metadata :- (su/non-empty [mbql.s/SourceQueryMetadata])]
   (distinct
-   (for [{field-name :name, base-type :base_type, field-id :id, field-ref :field_ref} source-metadata]
+   (for [{field-name :name, base-type :base_type, field-id :id, [ref-type :as field-ref] :field_ref} source-metadata]
      ;; return field-ref directly if it's a `:field` clause already. It might include important info such as
      ;; `:join-alias` or `:source-field`. Remove binning/temporal bucketing info. The Field should already be getting
      ;; bucketed in the source query; don't need to apply bucketing again in the parent query.
      (or (some-> (mbql.u/match-one field-ref :field)
                  (mbql.u/update-field-options dissoc :binning :temporal-unit))
          ;; otherwise construct a field reference that can be used to refer to this Field.
-         (if field-id
+         ;; Force string id field if expression contains just field. See issue #28451.
+         (if (and (not= ref-type :expression)
+                  field-id)
            ;; If we have a Field ID, return a `:field` (id) clause
            [:field field-id nil]
            ;; otherwise return a `:field` (name) clause, e.g. for a Field that's the result of an aggregation or

--- a/test/metabase/query_processor/middleware/add_implicit_clauses_test.clj
+++ b/test/metabase/query_processor/middleware/add_implicit_clauses_test.clj
@@ -127,6 +127,18 @@
                               {:source-query    source-query
                                :source-metadata source-metadata}))))))))
 
+(deftest ^:parallel expression-with-only-field-in-source-query-test
+  (testing "Field coming from expression in source query should have string id"
+    (let [{{source-query :query} :dataset_query
+           source-metadata       :result_metadata}
+          (qp.test-util/card-with-source-metadata-for-query
+           (mt/mbql-query venues {:expressions {"ccprice" $price}}))]
+      (is (some #(when (= % [:field "ccprice" {:base-type :type/Integer}]) %)
+                (-> (mt/mbql-query nil
+                                   {:source-query    source-query
+                                    :source-metadata source-metadata})
+                    :query (#'qp.add-implicit-clauses/add-implicit-fields) :fields))))))
+
 (deftest joined-field-test
   (testing "When adding implicit `:fields` clauses, should include `join-alias` clauses for joined fields (#14745)"
     (doseq [field-ref (mt/$ids


### PR DESCRIPTION
Manual backport of #34568.
