### PR TITLE
Support string PKs in CSV files

### DIFF
--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -578,6 +578,7 @@
     ::upload/int                      [:bigint]
     ::upload/int-pk                   [:bigint :primary-key]
     ::upload/auto-incrementing-int-pk [:bigint :generated-always :as :identity :primary-key]
+    ::upload/string-pk                [:varchar :primary-key]
     ::upload/float                    [(keyword "DOUBLE PRECISION")]
     ::upload/boolean                  [:boolean]
     ::upload/date                     [:date]

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -613,6 +613,7 @@
     ::upload/int                      [:bigint]
     ::upload/int-pk                   [:bigint :primary-key]
     ::upload/auto-incrementing-int-pk [:bigint :not-null :auto-increment :primary-key]
+    ::upload/string-pk                [[:varchar 255] :primary-key]
     ::upload/float                    [:double]
     ::upload/boolean                  [:boolean]
     ::upload/date                     [:date]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -757,6 +757,7 @@
     ::upload/int                      [:bigint]
     ::upload/int-pk                   [:bigint :primary-key]
     ::upload/auto-incrementing-int-pk [:bigserial]
+    ::upload/string-pk                [[:varchar 255] :primary-key]
     ::upload/float                    [:float]
     ::upload/boolean                  [:boolean]
     ::upload/date                     [:date]


### PR DESCRIPTION
[Fixes #34592]

Don't merge until #34173 gets merged.

All the hard work was in #34173; not much to say about this.

@cdeweyx FYI I expanded the allowable column names to `id` `pk` `uuid` and `guid` (case-insensitive).