### PR TITLE
Fix `FilterPicker` for numeric PK and FK columns

### DIFF
--- a/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
@@ -98,11 +98,11 @@ function getFilterWidget(column: Lib.ColumnMetadata) {
   if (Lib.isCoordinate(column)) {
     return CoordinateFilterPicker;
   }
-  if (Lib.isNumber(column)) {
-    return NumberFilterPicker;
-  }
   if (Lib.isString(column)) {
     return StringFilterPicker;
+  }
+  if (Lib.isNumeric(column)) {
+    return NumberFilterPicker;
   }
   return NotImplementedPicker;
 }


### PR DESCRIPTION
Turns out, the new `FilterPicker` couldn't open numeric PK and FK columns because `isNumber` returns `false` for them. Fixed by switching to `isNumeric`

### To Verify

1. New > Question > Raw Data > Sample Database > Orders
2. Click Filter
3. Select ID and Product ID
4. Ensure you can see a numeric filter widget