### PR TITLE
Update test `expression-with-only-field-in-source-query-test`

### DIFF
--- a/test/metabase/query_processor/middleware/add_implicit_clauses_test.clj
+++ b/test/metabase/query_processor/middleware/add_implicit_clauses_test.clj
@@ -152,14 +152,14 @@
                          {:source-query    source-query
                           :source-metadata source-metadata}))))))))
 
-(deftest ^:parrallel expression-with-only-field-in-source-query-test
+(deftest ^:parallel expression-with-only-field-in-source-query-test
   (testing "Field coming from expression in source query should have string id"
     (let [{{source-query :query} :dataset_query
            source-metadata       :result_metadata}
           (qp.test-util/card-with-source-metadata-for-query
            (mt/mbql-query venues {:expressions {"ccprice" $price}}))]
       (is (some #(when (= % [:field "ccprice" {:base-type :type/Integer}]) %)
-                (-> (lib.tu.macros/mbql-query checkins
+                (-> (lib.tu.macros/mbql-query nil
                                               {:source-query    source-query
                                                :source-metadata source-metadata})
                     :query add-implicit-fields :fields))))))


### PR DESCRIPTION
While backporting #34568, I've realized there is one typo and misleading use of `checkins` in test. This PR addresses that in master.

Explanation of changing `checkins` to `nil`: Use of `mbql-query` was copied from other test. I forgot to change value of it's first argument. As it is using precomputed values for `:source-query` and `:source-metadata` in its second argument, it makes no sense to leave `checkins` in there, as it could lead to potential confusion regarding my intent. Hence I've changed the first arg value to `nil`.