### PR TITLE
Add date input to set dates and date ranges

### DIFF
--- a/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.tsx
@@ -26,7 +26,6 @@ export function DateRangePicker({
 }: DateRangePickerProps) {
   const [startDate, setStartDate] = useState<DateValue>(initialStartDate);
   const [endDate, setEndDate] = useState<DateValue>(initialEndDate);
-  const [openedDate, setOpenedDate] = useState(initialEndDate);
   const isValid = startDate != null && endDate != null;
 
   const handleRangeChange = ([newStartDate, newEndDate]: DatesRangeValue) => {
@@ -57,19 +56,16 @@ export function DateRangePicker({
           <Text>{t`and`}</Text>
           <DateInput
             value={endDate}
-            date={openedDate}
             popoverProps={{ opened: false }}
             onChange={handleEndDateChange}
-            onDateChange={setOpenedDate}
           />
         </Group>
         <DatePicker
           type="range"
           value={[startDate, endDate]}
-          date={openedDate}
+          defaultDate={initialEndDate}
           allowSingleDateInRange
           onChange={handleRangeChange}
-          onDateChange={setOpenedDate}
         />
       </Stack>
       <Divider />

--- a/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.tsx
@@ -1,46 +1,71 @@
 import { useState } from "react";
 import { t } from "ttag";
-import { Box, Button, DatePicker, Divider, Group } from "metabase/ui";
-import type { DatesRangeValue } from "metabase/ui";
-import type { SpecificDatePickerValue } from "../../types";
+import {
+  Button,
+  DateInput,
+  DatePicker,
+  Divider,
+  Group,
+  Stack,
+  Text,
+} from "metabase/ui";
+import type { DateValue, DatesRangeValue } from "metabase/ui";
 
 interface DateRangePickerProps {
-  value: SpecificDatePickerValue;
+  value: [Date, Date];
   isNew: boolean;
-  onChange: (value: SpecificDatePickerValue) => void;
+  onChange: (value: [Date, Date]) => void;
   onSubmit: () => void;
 }
 
 export function DateRangePicker({
-  value,
+  value: initialValue,
   isNew,
   onChange,
   onSubmit,
 }: DateRangePickerProps) {
-  const [dateRange, setDateRange] = useState<DatesRangeValue>([
-    value.values[0],
-    value.values[1],
-  ]);
-  const [startDate, endDate] = dateRange;
-  const isValid = startDate != null && endDate != null;
+  const [[startDate, endDate], setValue] =
+    useState<DatesRangeValue>(initialValue);
+  const isValid = true;
 
-  const handleChange = ([startDate, endDate]: DatesRangeValue) => {
-    setDateRange([startDate, endDate]);
-    if (startDate != null && endDate != null) {
-      onChange({ ...value, values: [startDate, endDate] });
+  const handleRangeChange = ([newStartDate, newEndDate]: DatesRangeValue) => {
+    setValue([newStartDate, newEndDate]);
+    if (newStartDate != null && newEndDate != null) {
+      onChange([newStartDate, newEndDate]);
     }
+  };
+
+  const handleStartDateChange = (newStartDate: DateValue) => {
+    handleRangeChange([newStartDate, endDate]);
+  };
+
+  const handleEndDateChange = (newEndDate: DateValue) => {
+    handleRangeChange([startDate, newEndDate]);
   };
 
   return (
     <div>
-      <Box p="md">
+      <Stack p="md">
+        <Group>
+          <DateInput
+            value={startDate}
+            popoverProps={{ opened: false }}
+            onChange={handleStartDateChange}
+          />
+          <Text>{t`and`}</Text>
+          <DateInput
+            value={endDate}
+            popoverProps={{ opened: false }}
+            onChange={handleEndDateChange}
+          />
+        </Group>
         <DatePicker
           type="range"
-          value={dateRange}
+          value={[startDate, endDate]}
           allowSingleDateInRange
-          onChange={handleChange}
+          onChange={handleRangeChange}
         />
-      </Box>
+      </Stack>
       <Divider />
       <Group p="sm" position="right">
         <Button variant="filled" disabled={!isValid} onClick={onSubmit}>

--- a/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.tsx
@@ -46,7 +46,7 @@ export function DateRangePicker({
 
   return (
     <div>
-      <Stack p="md">
+      <Stack p="md" align="center">
         <Group align="center">
           <DateInput
             value={startDate}

--- a/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.tsx
@@ -19,17 +19,19 @@ interface DateRangePickerProps {
 }
 
 export function DateRangePicker({
-  value: initialValue,
+  value: [initialStartDate, initialEndDate],
   isNew,
   onChange,
   onSubmit,
 }: DateRangePickerProps) {
-  const [[startDate, endDate], setValue] =
-    useState<DatesRangeValue>(initialValue);
-  const isValid = true;
+  const [startDate, setStartDate] = useState<DateValue>(initialStartDate);
+  const [endDate, setEndDate] = useState<DateValue>(initialEndDate);
+  const [openedDate, setOpenedDate] = useState(initialEndDate);
+  const isValid = startDate != null && endDate != null;
 
   const handleRangeChange = ([newStartDate, newEndDate]: DatesRangeValue) => {
-    setValue([newStartDate, newEndDate]);
+    setStartDate(newStartDate);
+    setEndDate(newEndDate);
     if (newStartDate != null && newEndDate != null) {
       onChange([newStartDate, newEndDate]);
     }
@@ -45,8 +47,8 @@ export function DateRangePicker({
 
   return (
     <div>
-      <Stack p="md">
-        <Group>
+      <Stack p="md" align="center">
+        <Group align="center">
           <DateInput
             value={startDate}
             popoverProps={{ opened: false }}
@@ -55,15 +57,19 @@ export function DateRangePicker({
           <Text>{t`and`}</Text>
           <DateInput
             value={endDate}
+            date={openedDate}
             popoverProps={{ opened: false }}
             onChange={handleEndDateChange}
+            onDateChange={setOpenedDate}
           />
         </Group>
         <DatePicker
           type="range"
           value={[startDate, endDate]}
+          date={openedDate}
           allowSingleDateInRange
           onChange={handleRangeChange}
+          onDateChange={setOpenedDate}
         />
       </Stack>
       <Divider />

--- a/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.tsx
@@ -46,7 +46,7 @@ export function DateRangePicker({
 
   return (
     <div>
-      <Stack p="md" align="center">
+      <Stack p="md">
         <Group align="center">
           <DateInput
             value={startDate}

--- a/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.tsx
@@ -1,37 +1,57 @@
 import { useState } from "react";
 import { t } from "ttag";
-import { Box, Button, DatePicker, Divider, Group } from "metabase/ui";
+import {
+  Button,
+  DateInput,
+  DatePicker,
+  Divider,
+  Group,
+  Stack,
+} from "metabase/ui";
 import type { DateValue } from "metabase/ui";
-import type { SpecificDatePickerValue } from "../../types";
 
 interface SingleDatePickerProps {
-  value: SpecificDatePickerValue;
+  value: Date;
   isNew: boolean;
-  onChange: (value: SpecificDatePickerValue) => void;
+  onChange: (value: Date) => void;
   onSubmit: () => void;
 }
 
 export function SingleDatePicker({
-  value,
+  value: initialValue,
   isNew,
   onChange,
   onSubmit,
 }: SingleDatePickerProps) {
-  const [date, setDate] = useState<DateValue>(value.values[0]);
-  const isValid = date != null;
+  const [value, setValue] = useState<DateValue>(initialValue);
+  const [date, setDate] = useState<Date>(initialValue);
+  const isValid = value != null;
 
-  const handleChange = (date: DateValue) => {
-    setDate(date);
-    if (date) {
-      onChange({ ...value, values: [date] });
+  const handleChange = (value: DateValue) => {
+    setValue(value);
+
+    if (value) {
+      onChange(value);
     }
   };
 
   return (
     <div>
-      <Box p="md">
-        <DatePicker value={date} onChange={handleChange} />
-      </Box>
+      <Stack p="md">
+        <DateInput
+          value={value}
+          date={date}
+          popoverProps={{ opened: false }}
+          onChange={handleChange}
+          onDateChange={setDate}
+        />
+        <DatePicker
+          value={value}
+          date={date}
+          onChange={handleChange}
+          onDateChange={setDate}
+        />
+      </Stack>
       <Divider />
       <Group p="sm" position="right">
         <Button variant="filled" disabled={!isValid} onClick={onSubmit}>

--- a/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.tsx
@@ -24,14 +24,13 @@ export function SingleDatePicker({
   onSubmit,
 }: SingleDatePickerProps) {
   const [value, setValue] = useState<DateValue>(initialValue);
-  const [date, setDate] = useState<Date>(initialValue);
+  const [openedDate, setOpenedDate] = useState<Date>(initialValue);
   const isValid = value != null;
 
-  const handleChange = (value: DateValue) => {
-    setValue(value);
-
-    if (value) {
-      onChange(value);
+  const handleChange = (newDate: DateValue) => {
+    setValue(newDate);
+    if (newDate != null) {
+      onChange(newDate);
     }
   };
 
@@ -40,16 +39,16 @@ export function SingleDatePicker({
       <Stack p="md">
         <DateInput
           value={value}
-          date={date}
+          date={openedDate}
           popoverProps={{ opened: false }}
           onChange={handleChange}
-          onDateChange={setDate}
+          onDateChange={setOpenedDate}
         />
         <DatePicker
           value={value}
-          date={date}
+          date={openedDate}
           onChange={handleChange}
-          onDateChange={setDate}
+          onDateChange={setOpenedDate}
         />
       </Stack>
       <Divider />

--- a/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.tsx
@@ -36,11 +36,12 @@ export function SingleDatePicker({
 
   return (
     <div>
-      <Stack p="md">
+      <Stack p="md" align="center">
         <DateInput
           value={value}
           date={openedDate}
           popoverProps={{ opened: false }}
+          w="100%"
           onChange={handleChange}
           onDateChange={setOpenedDate}
         />

--- a/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/SpecificDatePicker.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/SpecificDatePicker.tsx
@@ -63,7 +63,7 @@ export function SpecificDatePicker({
       <Divider />
       {tabs.map(tab => (
         <Tabs.Panel key={tab.operator} value={tab.operator}>
-          {isDateRange(value) ? null : (
+          {isDateRange(value.values) ? null : (
             <SingleDatePicker
               value={getDate(value)}
               isNew={isNew}

--- a/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/SpecificDatePicker.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/SpecificDatePicker.tsx
@@ -3,8 +3,14 @@ import { Divider, Flex, Tabs } from "metabase/ui";
 import { BackButton } from "../BackButton";
 import type { DatePickerOperator, SpecificDatePickerValue } from "../types";
 import { SingleDatePicker } from "./SingleDatePicker";
-import { DateRangePicker } from "./DateRangePicker";
-import { getDefaultValue, getTabs, isDateRange, setOperator } from "./utils";
+import {
+  getDate,
+  getDefaultValue,
+  getTabs,
+  isDateRange,
+  setDate,
+  setOperator,
+} from "./utils";
 import { TabList } from "./SpecificDatePicker.styled";
 
 export interface SpecificDatePickerProps {
@@ -34,6 +40,10 @@ export function SpecificDatePicker({
     }
   };
 
+  const handleDateChange = (date: Date) => {
+    setValue(setDate(value, date));
+  };
+
   const handleSubmit = () => {
     onChange(value);
   };
@@ -53,18 +63,11 @@ export function SpecificDatePicker({
       <Divider />
       {tabs.map(tab => (
         <Tabs.Panel key={tab.operator} value={tab.operator}>
-          {isDateRange(value) ? (
-            <DateRangePicker
-              value={value}
-              isNew={isNew}
-              onChange={setValue}
-              onSubmit={handleSubmit}
-            />
-          ) : (
+          {isDateRange(value) ? null : (
             <SingleDatePicker
-              value={value}
+              value={getDate(value)}
               isNew={isNew}
-              onChange={setValue}
+              onChange={handleDateChange}
               onSubmit={handleSubmit}
             />
           )}

--- a/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/SpecificDatePicker.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/SpecificDatePicker.tsx
@@ -3,12 +3,14 @@ import { Divider, Flex, Tabs } from "metabase/ui";
 import { BackButton } from "../BackButton";
 import type { DatePickerOperator, SpecificDatePickerValue } from "../types";
 import { SingleDatePicker } from "./SingleDatePicker";
+import { DateRangePicker } from "./DateRangePicker";
 import {
   getDate,
   getDefaultValue,
   getTabs,
   isDateRange,
   setDate,
+  setDateRange,
   setOperator,
 } from "./utils";
 import { TabList } from "./SpecificDatePicker.styled";
@@ -44,6 +46,10 @@ export function SpecificDatePicker({
     setValue(setDate(value, date));
   };
 
+  const handleDateRangeChange = (dates: [Date, Date]) => {
+    setValue(setDateRange(value, dates));
+  };
+
   const handleSubmit = () => {
     onChange(value);
   };
@@ -63,7 +69,14 @@ export function SpecificDatePicker({
       <Divider />
       {tabs.map(tab => (
         <Tabs.Panel key={tab.operator} value={tab.operator}>
-          {isDateRange(value.values) ? null : (
+          {isDateRange(value.values) ? (
+            <DateRangePicker
+              value={value.values}
+              isNew={isNew}
+              onChange={handleDateRangeChange}
+              onSubmit={handleSubmit}
+            />
+          ) : (
             <SingleDatePicker
               value={getDate(value)}
               isNew={isNew}

--- a/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/utils.ts
+++ b/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/utils.ts
@@ -40,6 +40,14 @@ export function setOperator(
   }
 }
 
+export function getDate(value: SpecificDatePickerValue) {
+  return value.values[0];
+}
+
+export function setDate(value: SpecificDatePickerValue, date: Date) {
+  return { ...value, values: [date] };
+}
+
 export function isDateRange(value: SpecificDatePickerValue) {
   return value.operator === "between";
 }

--- a/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/utils.ts
+++ b/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/utils.ts
@@ -48,6 +48,6 @@ export function setDate(value: SpecificDatePickerValue, date: Date) {
   return { ...value, values: [date] };
 }
 
-export function isDateRange(value: SpecificDatePickerValue) {
-  return value.operator === "between";
+export function isDateRange(value: Date[]): value is [Date, Date] {
+  return value.length === 2;
 }

--- a/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/utils.ts
+++ b/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/utils.ts
@@ -48,6 +48,13 @@ export function setDate(value: SpecificDatePickerValue, date: Date) {
   return { ...value, values: [date] };
 }
 
+export function setDateRange(
+  value: SpecificDatePickerValue,
+  dates: [Date, Date],
+) {
+  return { ...value, values: dates };
+}
+
 export function isDateRange(value: Date[]): value is [Date, Date] {
   return value.length === 2;
 }

--- a/frontend/src/metabase/ui/components/dates/DateInput/index.ts
+++ b/frontend/src/metabase/ui/components/dates/DateInput/index.ts
@@ -1,0 +1,2 @@
+export { DateInput } from "@mantine/dates";
+export type { DateInputProps } from "@mantine/dates";

--- a/frontend/src/metabase/ui/components/dates/index.ts
+++ b/frontend/src/metabase/ui/components/dates/index.ts
@@ -1,1 +1,2 @@
+export * from "./DateInput";
 export * from "./DatePicker";


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/34112

It should be possible to set dates via the input and calendar. Ignore broken calendar styles.

<img width="541" alt="Screenshot 2023-10-12 at 16 38 15" src="https://github.com/metabase/metabase/assets/8542534/921347ce-56a4-4e31-aed9-9693a7c2b3ca">
<img width="527" alt="Screenshot 2023-10-12 at 16 38 06" src="https://github.com/metabase/metabase/assets/8542534/a55ba4e6-5eb2-4341-a9fb-d1f29ca023ff">
