### PR TITLE
src-min-noconflict -> src-noconflict

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -163,7 +163,7 @@ const config = (module.exports = {
       __support__: TEST_SUPPORT_PATH,
       e2e: E2E_PATH,
       style: SRC_PATH + "/css/core/index",
-      ace: __dirname + "/node_modules/ace-builds/src-min-noconflict",
+      ace: __dirname + "/node_modules/ace-builds/src-noconflict",
       // NOTE @kdoh - 7/24/18
       // icepick 2.x is es6 by defalt, to maintain backwards compatability
       // with ie11 point to the minified version


### PR DESCRIPTION
We were pulling src-min-noconflict AND src-noconflict on ace-builds. As we can't yet transform completely to src-min-noconflict completely, I'm droping the src-min-noconflict to unify to just 1 package so we don't add it twice.

Previous discussion [here](https://github.com/metabase/metabase/pull/34534#discussion_r1356706040)