### PR TITLE
[MLv2] Add the expression editor to `FilterPicker`

### DIFF
--- a/frontend/src/metabase-lib/filter.ts
+++ b/frontend/src/metabase-lib/filter.ts
@@ -476,6 +476,14 @@ export function filterParts(
   );
 }
 
+export function isCustomFilter(
+  query: Query,
+  stageIndex: number,
+  filter: FilterClause,
+) {
+  return !filterParts(query, stageIndex, filter);
+}
+
 function findTemporalBucket(
   query: Query,
   stageIndex: number,

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -17,7 +17,7 @@ export type ColumnListItem = Lib.ColumnDisplayInfo & {
   column: Lib.ColumnMetadata;
 };
 
-type Section<T = ColumnListItem> = {
+export type Section<T = ColumnListItem> = {
   key?: string;
   name: string;
   items: T[];


### PR DESCRIPTION
Closes #34496

Adds the custom expression editor to the `FilterPicker`. Custom expressions themselves are not yet ported to MLv2, so for now we're using MLv1 to work with them. This PR is very similar to what we've done to aggregations in #31529

### To Verify

1. New > Question > Raw Data > Sample Database > Orders
2. Add a standard filter (e.g. Total > 100)
3. Click the filter, scroll down, and click "Custom Expression"
4. Ensure the editor opened with `Total > 100` formula inside
5. Change the formula to something else, click "Done"
6. Click the filter, ensure you can see the original formula

### Demo

https://github.com/metabase/metabase/assets/17258145/2bc0e9a4-21a9-49a3-bcaf-9519da1ae627

