### PR TITLE
Upgrade Jetty

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -136,7 +136,7 @@
   org.clojure/tools.namespace               {:mvn/version "1.4.4"}
   org.clojure/tools.reader                  {:mvn/version "1.3.6"}
   org.clojure/tools.trace                   {:mvn/version "0.7.11"}             ; function tracing
-  org.eclipse.jetty/jetty-server            {:mvn/version "11.0.15"}            ; web server
+  org.eclipse.jetty/jetty-server            {:mvn/version "11.0.17"}            ; web server
   org.flatland/ordered                      {:mvn/version "1.15.11"}            ; ordered maps & sets
   org.graalvm.js/js                         {:mvn/version "22.3.3"}             ; JavaScript engine
   org.liquibase/liquibase-core              {:mvn/version "4.21.1"              ; migration management (Java lib)


### PR DESCRIPTION
Upgrading to prevent the new http2 attacks that were disclosed the last couple of days