### PR TITLE
Disable model metadata editor animation in Cypress

### DIFF
--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
@@ -12,6 +12,7 @@ import { t } from "ttag";
 import _ from "underscore";
 import { usePrevious } from "react-use";
 
+import { isCypressActive } from "metabase/env";
 import Radio from "metabase/core/components/Radio";
 
 import {
@@ -319,7 +320,7 @@ function DatasetFieldMetadataSidebar({
   return (
     <SidebarContent>
       <AnimatableContent
-        animated={shouldAnimateFieldChange}
+        animated={shouldAnimateFieldChange && !isCypressActive}
         onAnimationEnd={onFieldChangeAnimationEnd}
       >
         <RootForm


### PR DESCRIPTION
As @nemanjaglumac pointed out, the "in" transition of the model metadata editor sidebar is causing flakes and there's no easy workaround. This PR disables the animation in E2E tests

### To Verify

1. Open `/model/:modelId/metadata` in your browser, click through a few columns
2. Ensure the sidebar animates when a column changes
3. Repeat the same thing in any E2E test
4. Ensure there's no animation

(backporting so the release branch can get less flaky as well)