### PR TITLE
Fix dashboard filter label carrying over from previously edited label

### DIFF
--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useLayoutEffect, useState } from "react";
 import { t } from "ttag";
 import Radio from "metabase/core/components/Radio";
 import type {
@@ -53,6 +53,10 @@ const ParameterSettings = ({
     labelValue: tempLabelValue,
     isParameterSlugUsed,
   });
+
+  useLayoutEffect(() => {
+    setTempLabelValue(parameter.name);
+  }, [parameter.name]);
 
   const handleLabelChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setTempLabelValue(event.target.value);

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -49,14 +49,15 @@ const ParameterSettings = ({
   onRemoveParameter,
 }: ParameterSettingsProps): JSX.Element => {
   const [tempLabelValue, setTempLabelValue] = useState(parameter.name);
-  const labelError = getLabelError({
-    labelValue: tempLabelValue,
-    isParameterSlugUsed,
-  });
 
   useLayoutEffect(() => {
     setTempLabelValue(parameter.name);
   }, [parameter.name]);
+
+  const labelError = getLabelError({
+    labelValue: tempLabelValue,
+    isParameterSlugUsed,
+  });
 
   const handleLabelChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setTempLabelValue(event.target.value);

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.unit.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { renderWithProviders, screen } from "__support__/ui";

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.unit.spec.tsx
@@ -89,7 +89,7 @@ describe("ParameterSidebar", () => {
     expect(labelInput).toHaveValue("Bar");
   });
 
-  it("if the parameter updates, the label should update (metabase#34613)", () => {
+  it("if the parameter updates, the label should update (metabase#34611)", () => {
     const initialParameter = createMockUiParameter({
       id: "id1",
       name: "Foo",

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.unit.spec.tsx
@@ -12,43 +12,6 @@ interface SetupOpts {
   otherParameters: UiParameter[];
 }
 
-const TestWrapper = ({
-  initialParameter,
-  nextParameter,
-  otherParameters,
-}: SetupOpts) => {
-  const [parameter, setParameter] = useState(initialParameter);
-
-  const onChangeName = (_parameterId: string, name: string) => {
-    setParameter({ ...initialParameter, name });
-  };
-
-  return (
-    <div>
-      <button
-        data-testid="parameter-sidebar-test-change"
-        onClick={() => nextParameter && setParameter(nextParameter)}
-      >
-        Next Parameter Button
-      </button>
-      <ParameterSidebar
-        parameter={parameter}
-        otherParameters={otherParameters}
-        onChangeName={onChangeName}
-        onChangeDefaultValue={jest.fn()}
-        onChangeIsMultiSelect={jest.fn()}
-        onChangeQueryType={jest.fn()}
-        onChangeSourceType={jest.fn()}
-        onChangeSourceConfig={jest.fn()}
-        onChangeFilteringParameters={jest.fn()}
-        onRemoveParameter={jest.fn()}
-        onShowAddParameterPopover={jest.fn()}
-        onClose={jest.fn()}
-      />
-    </div>
-  );
-};
-
 const setup = ({
   initialParameter,
   nextParameter,
@@ -56,6 +19,45 @@ const setup = ({
 }: SetupOpts): {
   clickNextParameterButton: () => void;
 } => {
+  const NEXT_PARAMETER_BUTTON_ID = "parameter-sidebar-test-change";
+
+  const TestWrapper = ({
+    initialParameter,
+    nextParameter,
+    otherParameters,
+  }: SetupOpts) => {
+    const [parameter, setParameter] = useState(initialParameter);
+
+    const onChangeName = (_parameterId: string, name: string) => {
+      setParameter({ ...initialParameter, name });
+    };
+
+    return (
+      <div>
+        <button
+          data-testid={NEXT_PARAMETER_BUTTON_ID}
+          onClick={() => nextParameter && setParameter(nextParameter)}
+        >
+          Next Parameter Button
+        </button>
+        <ParameterSidebar
+          parameter={parameter}
+          otherParameters={otherParameters}
+          onChangeName={onChangeName}
+          onChangeDefaultValue={jest.fn()}
+          onChangeIsMultiSelect={jest.fn()}
+          onChangeQueryType={jest.fn()}
+          onChangeSourceType={jest.fn()}
+          onChangeSourceConfig={jest.fn()}
+          onChangeFilteringParameters={jest.fn()}
+          onRemoveParameter={jest.fn()}
+          onShowAddParameterPopover={jest.fn()}
+          onClose={jest.fn()}
+        />
+      </div>
+    );
+  };
+
   renderWithProviders(
     <TestWrapper
       initialParameter={initialParameter}
@@ -64,10 +66,9 @@ const setup = ({
     />,
   );
 
-  // clicking the next parameter button will update the parameter from initialParameter to nextParameter
   return {
     clickNextParameterButton: () =>
-      userEvent.click(screen.getByTestId("parameter-sidebar-test-change")),
+      userEvent.click(screen.getByTestId(NEXT_PARAMETER_BUTTON_ID)),
   };
 };
 


### PR DESCRIPTION
Fixes #34611

This regression happened in when I removed this code https://github.com/metabase/metabase/pull/34369/files#diff-7dadc4846cebae50d37bcfb4679d3373e3732401e5a9f0eb90d863f86ea88afdL51-L53. This PR restores those four lines that were removed and adds a test for it.