### PR TITLE
Update join condition transformation for mongo

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -909,7 +909,7 @@
         ;; Map the own fields to a fresh alias and to its rvalue.
         mapping (map (fn [f] (let [alias (-> (format "let_%s_" (->lvalue f))
                                             ;; ~ in let aliases provokes a parse error in Mongo
-                                            (str/replace "~" "_")
+                                            (str/replace #"~|\." "_")
                                             gensym
                                             name)]
                               {:field f, :rvalue (->rvalue f), :alias alias}))

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -908,7 +908,8 @@
                      [:field _ (_ :guard #(not= (:join-alias %) alias))])
         ;; Map the own fields to a fresh alias and to its rvalue.
         mapping (map (fn [f] (let [alias (-> (format "let_%s_" (->lvalue f))
-                                            ;; ~ in let aliases provokes a parse error in Mongo
+                                            ;; ~ in let aliases provokes a parse error in Mongo. For correct function,
+                                            ;; aliases should also contain no . characters (#32182).
                                             (str/replace #"~|\." "_")
                                             gensym
                                             name)]

--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -251,14 +251,15 @@
               ;; at least one child field selected as a projection, which is not allowed as of MongoDB 4.4
               ;; see docstring on mongo.qp/remove-parent-fields for full details
               (is (empty? (set/intersection projections #{"source" "url" "venue"})))))
-          (testing "Nested fields in join condition are transformed to use `_` instead of a `.` (#32182)"
+          (testing "Nested fields in join condition aliases are transformed to use `_` instead of a `.` (#32182)"
             (let [query (mt/mbql-query tips
                           {:joins [{:alias "Tips"
                                     :source-table $$tips
                                     :condition [:= $tips.source.categories &Tips.$tips.source.categories]}]})
                   compiled (mongo.qp/mbql->native query)
                   let-lhs (-> compiled (get-in [:query 0 "$lookup" :let]) keys first)]
-                 (is (str/includes? let-lhs "source_categories")))))))))
+                 (is (and (not (str/includes? let-lhs "."))
+                          (str/includes? let-lhs "source_categories"))))))))))
 
 (deftest ^:parallel multiple-distinct-count-test
   (mt/test-driver :mongo

--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.driver.mongo.query-processor-test
   (:require
    [clojure.set :as set]
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.driver :as driver]
@@ -249,7 +250,15 @@
               ;; the "source", "url", and "venue" fields should NOT have been chosen as projections, since they have
               ;; at least one child field selected as a projection, which is not allowed as of MongoDB 4.4
               ;; see docstring on mongo.qp/remove-parent-fields for full details
-              (is (empty? (set/intersection projections #{"source" "url" "venue"}))))))))))
+              (is (empty? (set/intersection projections #{"source" "url" "venue"})))))
+          (testing "Nested fields in join condition are transformed to use `_` instead of a `.` (#32182)"
+            (let [query (mt/mbql-query tips
+                          {:joins [{:alias "Tips"
+                                    :source-table $$tips
+                                    :condition [:= $tips.source.categories &Tips.$tips.source.categories]}]})
+                  compiled (mongo.qp/mbql->native query)
+                  let-lhs (-> compiled (get-in [:query 0 "$lookup" :let]) keys first)]
+                 (is (str/includes? let-lhs "source_categories")))))))))
 
 (deftest ^:parallel multiple-distinct-count-test
   (mt/test-driver :mongo


### PR DESCRIPTION
Closes #32182

### Description

LHS of let in lookup must contain identifier with no dots. This commit updates identifier generation to conform that.

### How to verify

See the new test or follow reproduction steps from linked issue.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
