### PR TITLE
Truncate slack token and make it visible to settings managers

### DIFF
--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -36,6 +36,10 @@
                 ;; Truncate middle of token so that the full value isn't visibile in the UI
                 (str (subs token 0 9) "..." (subs token (- (count token) 4)))))))
 
+(defn- unobfuscated-slack-app-token
+  []
+  (setting/get-value-of-type :string :slack-app-token))
+
 (defsetting slack-token-valid?
   (deferred-tru
     (str "Whether the current Slack app token, if set, is valid. "
@@ -121,7 +125,7 @@
 (defn- do-slack-request [request-fn endpoint request]
   (let [token (or (get-in request [:query-params :token])
                   (get-in request [:form-params :token])
-                  (slack-app-token)
+                  (unobfuscated-slack-app-token)
                   (slack-token))]
     (when token
       (let [url     (str "https://slack.com/api/" (name endpoint))

--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -27,8 +27,14 @@
 
 (defsetting slack-app-token
   (deferred-tru
-    (str "Bot user OAuth token for connecting the Metabase Slack app. "
-         "This should be used for all new Slack integrations starting in Metabase v0.42.0.")))
+   (str "Bot user OAuth token for connecting the Metabase Slack app. "
+        "This should be used for all new Slack integrations starting in Metabase v0.42.0."))
+  :visibility :settings-manager
+  :getter (fn []
+            (let [token (setting/get-value-of-type :string :slack-app-token)]
+              (when (string? token)
+                ;; Truncate middle of token so that the full value isn't visibile in the UI
+                (str (subs token 0 9) "..." (subs token (- (count token) 4)))))))
 
 (defsetting slack-token-valid?
   (deferred-tru

--- a/test/metabase/api/slack_test.clj
+++ b/test/metabase/api/slack_test.clj
@@ -18,7 +18,7 @@
         (mt/with-temporary-setting-values [slack-app-token nil
                                            slack-token     "fake-token"]
           (mt/user-http-request :crowberto :put 200 "slack/settings" {:slack-app-token "fake-token"})
-          (is (= "fake-token" (slack/slack-app-token)))
+          (is (= "fake-token" (#'slack/unobfuscated-slack-app-token)))
           (is (= nil (slack/slack-token))))))
 
     (testing "A 400 error is returned if the Slack app token is invalid"
@@ -70,7 +70,6 @@
         (is (= {:channels []}
                (slack/slack-cached-channels-and-usernames)))
         (is (= @#'slack/zoned-time-epoch (slack/slack-channels-and-usernames-last-updated)))))
-
 
     (testing "A non-admin cannot modify the Slack app token or files channel settings"
       (mt/user-http-request :rasta :put 403 "slack/settings"

--- a/test/metabase/integrations/slack_test.clj
+++ b/test/metabase/integrations/slack_test.clj
@@ -79,6 +79,12 @@
   (doseq [f [test-no-auth-token test-invalid-auth-token]]
     (f endpoint thunk)))
 
+(deftest slack-app-token-truncation-test
+  (testing "slack-app-token is truncated when fetched by the setting's custom getter"
+    (tu/with-temporary-setting-values [slack-app-token "xoxb-781236542736-2364535789652-GkwFDQoHqzXDVsC6GzqYUypD"]
+      (is (= "xoxb-7812...UypD"
+             (slack/slack-app-token))))))
+
 (deftest conversations-list-test
   (testing "conversations-list"
     (test-auth conversations-endpoint slack/conversations-list)


### PR DESCRIPTION
* Truncates Slack token to the first and last four characters when the setting is fetched. This adds a little more security to the Slack admin page, even though it's only visible to Metabase admins already.
* Adjusts visibility of the setting to also include setting managers. This was a bug I just discovered—setting managers can see the Slack config page but couldn't see if it was already enabled.

Resolves https://github.com/metabase/metabase/issues/34616