### PR TITLE
Add public setting to opt-in to CC recipients

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/sandbox/pulse_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/pulse_test.clj
@@ -6,11 +6,11 @@
    [medley.core :as m]
    [metabase-enterprise.test :as met]
    [metabase.api.alert :as api.alert]
+   [metabase.email :as email]
    [metabase.email.messages :as messages]
    [metabase.models
     :refer [Card Pulse PulseCard PulseChannel PulseChannelRecipient]]
    [metabase.models.pulse :as pulse]
-   [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.pulse]
    [metabase.pulse.test-util :as pulse.tu]
@@ -74,7 +74,7 @@
         (mt/with-fake-inbox
           (with-redefs [messages/render-pulse-email  (fn [_ _ _ [{:keys [result]}] _]
                                                        [{:result result}])
-                        public-settings/bcc-enabled? (constantly false)]
+                        email/bcc-enabled? (constantly false)]
             (mt/with-test-user nil
               (metabase.pulse/send-pulse! pulse)))
           (let [results @mt/inbox]

--- a/src/metabase/email.clj
+++ b/src/metabase/email.clj
@@ -29,6 +29,12 @@
   (deferred-tru "The name you want to use for the sender of emails.")
   :visibility :settings-manager)
 
+(defsetting bcc-enabled?
+  (deferred-tru "Whether or not bcc emails are enabled, default behavior is that it is")
+  :visibility :settings-manager
+  :type       :boolean
+  :default    true)
+
 (def ^:private ReplyToAddresses
   [:maybe [:sequential ms/Email]])
 

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -683,9 +683,3 @@
   (deferred-tru "Prefix for upload table names")
   :visibility   :authenticated
   :type         :string)
-
-(defsetting bcc-enabled?
-  (deferred-tru "Whether or not bcc emails are enabled, default behavior is that it is")
-  :visibility :authenticated
-  :type       :boolean
-  :default    true)

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -683,3 +683,9 @@
   (deferred-tru "Prefix for upload table names")
   :visibility   :authenticated
   :type         :string)
+
+(defsetting bcc-enabled?
+  (deferred-tru "Whether or not bcc emails are enabled, default behavior is that it is")
+  :visibility :authenticated
+  :type       :boolean
+  :default    true)

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -536,7 +536,7 @@
                                      :recipients   recipients
                                      :message-type message-type
                                      :message      message
-                                     :bcc?         (public-settings/bcc-enabled?)})
+                                     :bcc?         (email/bcc-enabled?)})
       (catch ExceptionInfo e
         (when (not= :smtp-host-not-set (:cause (ex-data e)))
           (throw e))))))

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -536,7 +536,7 @@
                                      :recipients   recipients
                                      :message-type message-type
                                      :message      message
-                                     :bcc?         true})
+                                     :bcc?         (public-settings/bcc-enabled?)})
       (catch ExceptionInfo e
         (when (not= :smtp-host-not-set (:cause (ex-data e)))
           (throw e))))))


### PR DESCRIPTION
For https://github.com/metabase/metabase/issues/34293

### Description

Adds a public setting for whether or not bcc is enabled.

### How to verify

1. Change the public setting to false
2. Send a pulse
3. See the email send `to:` :) 