### PR TITLE
Add a couple tests for comma-separated numbers in a number field

### DIFF
--- a/test/metabase/query_processor_test/parameters_test.clj
+++ b/test/metabase/query_processor_test/parameters_test.clj
@@ -223,7 +223,39 @@
                :database   (mt/id)
                :parameters [{:type   :category
                              :target [:dimension [:template-tag "price"]]
-                             :value  [1 2]}]}))))))
+                             :value  [1 2]}]}))))
+    (testing "Comma-separated numbers in a number field"
+      ;; this is an undocumented feature but lots of people rely on it, so we want it to continue working.
+      (is (= {:query "SELECT * FROM VENUES WHERE price IN (1, 2, 3)"
+              :params []}
+             (qp/compile-and-splice-parameters
+              {:type :native
+               :native {:query "SELECT * FROM VENUES WHERE price IN ({{number_comma}})"
+                        :template-tags {"number_comma"
+                                        {:name "number_comma"
+                                         :display-name "Number Comma"
+                                         :type :number
+                                         :dimension [:field (mt/id :venues :price) nil]}}}
+               :database (mt/id)
+               :parameters [{:type "number/="
+                             :value ["1,2,3"]
+                             :target [:variable [:template-tag "number_comma"]]}]}))))
+    (testing "Trailing commas do not cause errors"
+      ;; this is an undocumented feature but lots of people rely on it, so we want it to continue working.
+      (is (= {:query "SELECT * FROM VENUES WHERE price IN (1, 2)"
+              :params []}
+             (qp/compile-and-splice-parameters
+              {:type :native
+               :native {:query "SELECT * FROM VENUES WHERE price IN ({{number_comma}})"
+                        :template-tags {"number_comma"
+                                        {:name "number_comma"
+                                         :display-name "Number Comma"
+                                         :type :number
+                                         :dimension [:field (mt/id :venues :price) nil]}}}
+               :database (mt/id)
+               :parameters [{:type "number/="
+                             :value ["1,2,"]
+                             :target [:variable [:template-tag "number_comma"]]}]}))))))
 
 (deftest ^:parallel params-in-comments-test
   (testing "Params in SQL comments are ignored"


### PR DESCRIPTION
We want to add some tests to verify that this (slightly hidden) feature continues working.

Fixes: https://github.com/metabase/metabase/issues/21163