### PR TITLE
replace github_env with github_output because env is not available in…

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -57,7 +57,7 @@ jobs:
           BACKPORT_PR_URL=$(gh pr create --base "${TARGET_BRANCH}" --head "${BACKPORT_BRANCH}" --label "was-backported" --assignee "${GITHUB_ACTOR}" --title "🤖 backported \"${ORIGINAL_TITLE}\"" --body "#${ORIGINAL_PULL_REQUEST_NUMBER}")
           BACKPORT_PR_NUMBER=${BACKPORT_PR_URL##*/}
 
-          echo "backport_pr_number=$BACKPORT_PR_NUMBER" >> $GITHUB_ENV
+          echo "backport_pr_number=$BACKPORT_PR_NUMBER" >> $GITHUB_OUTPUT
           echo "New PR has been created"
         env:
           TARGET_BRANCH: ${{ steps.get_latest_release_branch.outputs.branch-name }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -114,7 +114,7 @@ jobs:
               BACKPORT_PR_URL=$(gh pr create --base "${TARGET_BRANCH}" --head "${BACKPORT_BRANCH}" --label "was-backported" --assignee "${GITHUB_ACTOR}" --title "🤖 backported \"${ORIGINAL_TITLE}\"" --body "#${ORIGINAL_PULL_REQUEST_NUMBER}")
               BACKPORT_PR_NUMBER=${BACKPORT_PR_URL##*/}
 
-              echo "backport_pr_number=$BACKPORT_PR_NUMBER" >> $GITHUB_ENV
+              echo "backport_pr_number=$BACKPORT_PR_NUMBER" >> $GITHUB_OUTPUT
               echo "New PR has been created"
           fi
         env:


### PR DESCRIPTION
Backports got fixed by https://github.com/metabase/metabase/pull/34624 but I accidentally changed `$GITHUB_OUTPUT` to `$GITHUB_ENV` when copied the script I tested so the workflow wrongly posts errors but still creates backports