### PR TITLE
fix arabic number inconsistency

### DIFF
--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -706,16 +706,18 @@ function replaceDateFormatNames(format: string, options: OptionsType) {
 }
 
 function formatDateTimeWithFormats(
-  value: number,
+  value: number | Moment,
   dateFormat: string,
   timeFormat: string,
   options: OptionsType,
 ) {
-  const m = parseTimestamp(
-    value,
-    options.column && options.column.unit,
-    options.local,
-  );
+  const m = moment.isMoment(value)
+    ? value
+    : parseTimestamp(
+        value,
+        options.column && options.column.unit,
+        options.local,
+      );
   if (!m.isValid()) {
     return String(value);
   }

--- a/frontend/src/metabase/lib/i18n.js
+++ b/frontend/src/metabase/lib/i18n.js
@@ -7,6 +7,17 @@ import updateLocalePlugin from "dayjs/plugin/updateLocale";
 import MetabaseSettings from "metabase/lib/settings";
 import { DAY_OF_WEEK_OPTIONS } from "metabase/lib/date-time";
 
+(function preserveLatinNumbersInArabic() {
+  ["ar", "ar-sa"].map(l =>
+    moment.updateLocale(l, {
+      // Preserve latin numbers, but still replace commas.
+      // See https://github.com/moment/moment/blob/000ac1800e620f770f4eb31b5ae908f6167b0ab2/locale/ar.js#L185
+      postformat: string =>
+        string.replace(/\d/g, match => match).replace(/,/g, "،"),
+    }),
+  );
+})();
+
 // note this won't refresh strings that are evaluated at load time
 export async function loadLocalization(locale) {
   // we need to be sure to set the initial localization before loading any files

--- a/frontend/src/metabase/lib/i18n.js
+++ b/frontend/src/metabase/lib/i18n.js
@@ -61,7 +61,7 @@ function setLanguage(translationsObject) {
 
 const ARABIC_LOCALES = ["ar", "ar-sa"];
 
-function setLocalization(translationsObject) {
+export function setLocalization(translationsObject) {
   const language = translationsObject.headers.language;
   setLanguage(translationsObject);
   updateMomentLocale(language);
@@ -89,7 +89,7 @@ function updateMomentLocale(language) {
 }
 
 /**
- * Ensures that we consistently use latin numbers, even in Arabic locales.
+ * Ensures that we consistently use latin numbers in Arabic locales.
  * See https://github.com/metabase/metabase/issues/34271
  */
 function preverseLatinNumbersInMomentLocale(locale) {

--- a/frontend/src/metabase/lib/i18n.unit.spec.ts
+++ b/frontend/src/metabase/lib/i18n.unit.spec.ts
@@ -1,0 +1,26 @@
+import moment from "moment-timezone";
+
+import "./i18n";
+
+describe("preserveLatinNumbersInArabic", () => {
+  it("should preserve latin numbers when formatting dates in 'ar' locale", () => {
+    moment.locale("ar");
+    const m = moment("2023-10-12T21:07:33.476Z");
+
+    expect(m.format("MMMM D, YYYY, h:mm A")).toBe("أكتوبر 12، 2023، 2:07 م");
+  });
+
+  it("should preserve latin numbers when formatting dates in 'ar-sa' locale", () => {
+    moment.locale("ar-sa");
+    const m = moment("2023-10-12T21:07:33.476Z");
+
+    expect(m.format("MMMM D, YYYY, h:mm A")).toBe("أكتوبر 12، 2023، 2:07 م");
+  });
+
+  it("should preserve latin number in the 'en' locale", () => {
+    moment.locale("en");
+    const m = moment("2023-10-12T21:07:33.476Z");
+
+    expect(m.format("MMMM D, YYYY, h:mm A")).toBe("October 12, 2023, 2:07 PM");
+  });
+});

--- a/frontend/src/metabase/lib/i18n.unit.spec.ts
+++ b/frontend/src/metabase/lib/i18n.unit.spec.ts
@@ -1,27 +1,34 @@
 // eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
-import "./i18n";
+import { setLocalization } from "./i18n";
 
-describe("preserveLatinNumbersInArabic", () => {
+function setup(language: string) {
+  setLocalization({
+    headers: { language, "plural-forms": "nplurals=2; plural=(n != 1);" },
+    translations: { "": {} },
+  });
+}
+
+describe("setLocalization", () => {
   it("should preserve latin numbers when formatting dates in 'ar' locale", () => {
-    moment.locale("ar");
-    const m = moment("2023-10-12T21:07:33.476Z");
+    setup("ar");
+    const m = moment.utc("2023-10-12T21:07:33.476Z");
 
-    expect(m.format("MMMM D, YYYY, h:mm A")).toBe("أكتوبر 12، 2023، 2:07 م");
+    expect(m.format("MMMM D, YYYY, h:mm A")).toBe("أكتوبر 12، 2023، 9:07 م");
   });
 
   it("should preserve latin numbers when formatting dates in 'ar-sa' locale", () => {
-    moment.locale("ar-sa");
-    const m = moment("2023-10-12T21:07:33.476Z");
+    setup("ar-sa");
+    const m = moment.utc("2023-10-12T21:07:33.476Z");
 
-    expect(m.format("MMMM D, YYYY, h:mm A")).toBe("أكتوبر 12، 2023، 2:07 م");
+    expect(m.format("MMMM D, YYYY, h:mm A")).toBe("أكتوبر 12، 2023، 9:07 م");
   });
 
-  it("should preserve latin number in the 'en' locale", () => {
-    moment.locale("en");
-    const m = moment("2023-10-12T21:07:33.476Z");
+  it("should preserve latin numbers in the 'en' locale", () => {
+    setup("en");
+    const m = moment.utc("2023-10-12T21:07:33.476Z");
 
-    expect(m.format("MMMM D, YYYY, h:mm A")).toBe("October 12, 2023, 2:07 PM");
+    expect(m.format("MMMM D, YYYY, h:mm A")).toBe("October 12, 2023, 9:07 PM");
   });
 });

--- a/frontend/src/metabase/lib/i18n.unit.spec.ts
+++ b/frontend/src/metabase/lib/i18n.unit.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 import "./i18n";


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/34271

### Description

In Arabic locales (`ar` and `ar-sa`), we were displaying Arabic numerals for translated dates, but in the rest of the app we used Western numerals. This PR makes it so that for  dates we also use Western numerals.

Ideally we would have an option for which kind of numeral to use, but it's a sufficient solution to always use Western numerals. Even in Arabic-speaking countries where Arabic numerals are widely used, Western numerals are commonly seen on digital interfaces, so users should not be bothered by it.

### How to verify

1. Go to the Products model.
2. See "Created At" field in English.
3. Go to account settings, change language to "Arabic", then go back to Products model.
4. "Created At" field should now be translated, but using Western numerals.
5. Repeat the same for "Arabic (Saudi Arabia)" locale, and using admin site locale setting.
6. Go back to English, in Products model should see English dates again.

### Demo

https://github.com/metabase/metabase/assets/37751258/826375a2-1f85-4a3d-9abf-fab2e26dd0c0

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
