### PR TITLE
Fix unable to start dev mode with a fresh DB

### DIFF
--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -87,11 +87,11 @@
 (defn start!
   []
   (server/start-web-server! #'handler/app)
+  (when-not @initialized?
+    (init!))
   (when config/is-dev?
     (prune-deleted-inmem-databases!)
-    (with-out-str (malli-dev/start!)))
-  (when-not @initialized?
-    (init!)))
+    (with-out-str (malli-dev/start!))))
 
 (defn stop!
   []


### PR DESCRIPTION
We added a prune job when starting metabase in dev mode in https://github.com/metabase/metabase/pull/34579

but we should run this after DB is initialized, otherwise, it'll fail to start.

error

```
Execution error (PSQLException) at org.postgresql.core.v3.QueryExecutorImpl/receiveErrorResponse (QueryExecutorImpl.java:2713).
ERROR: relation "metabase_database" does not exist
```