### PR TITLE
Mantine TimeInput

### DIFF
--- a/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.stories.mdx
+++ b/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.stories.mdx
@@ -1,0 +1,265 @@
+import { Canvas, Story, Meta } from "@storybook/addon-docs";
+import { Stack, TimeInput } from "metabase/ui";
+
+export const args = {
+  variant: "default",
+  soze: "md",
+  label: "Label",
+  description: undefined,
+  error: undefined,
+  placeholder: "Placeholder",
+  disabled: false,
+  readOnly: false,
+  withAsterisk: false,
+  onChange: event => {
+    console.log(event.target.value);
+  },
+};
+
+export const sampleArgs = {
+  value: new Date(0, 0, 1, 20, 40),
+  label: "Time of day",
+  description: "The time you've this page",
+  placholder: "HH:MM",
+  error: "required",
+};
+
+export const argTypes = {
+  variant: {
+    options: ["default", "unstyled"],
+    control: { type: "inline-radio" },
+  },
+  size: {
+    options: ["xs", "md"],
+    control: { type: "inline-radio" },
+  },
+  label: {
+    control: { type: "text" },
+  },
+  description: {
+    control: { type: "text" },
+  },
+  placeholder: {
+    control: { type: "text" },
+  },
+  error: {
+    control: { type: "text" },
+  },
+  disabled: {
+    control: { type: "boolean" },
+  },
+  readOnly: {
+    control: { type: "boolean" },
+  },
+  withAsterisk: {
+    control: { type: "boolean" },
+  },
+};
+
+<Meta title="Inputs/TimeInput" component={TimeInput} args={args} />
+
+# Textarea
+
+Our themed wrapper around [Mantine TimeInput](https://v6.mantine.dev/dates/time-input/).
+
+## Docs
+
+- [Mantine TimeInput Docs](https://v6.mantine.dev/dates/time-input/)
+- [HTML Time Input Docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time)
+
+# Exxamples
+
+export const DefaultTemplate = args => <TimeInput {...args} />;
+
+export const VariantTemplate = args => (
+  <Stack>
+    <TimeInput {...args} variant="default" />
+    <TimeInput {...args} variant="unstyled" />
+  </Stack>
+);
+
+export const Default = DefaultTemplate.bind({});
+
+<Canvas>
+  <Story name="Default">{Default}</Story>
+</Canvas>
+
+### Size - md
+
+export const EmptyMd = VariantTemplate.bind({});
+EmptyMd.args = {
+  label: sampleArgs.label,
+  placeholder: sampleArgs.placeholder,
+};
+
+<Canvas>
+  <Story name="Empty, md">{EmptyMd}</Story>
+</Canvas>
+
+#### Filled
+
+export const FilledMd = VariantTemplate.bind({});
+FilledMd.args = {
+  defaultValue: sampleArgs.value,
+  label: sampleArgs.label,
+  placeholder: sampleArgs.placeholder,
+};
+
+<Canvas>
+  <Story name="Filled, md">{FilledMd}</Story>
+</Canvas>
+
+#### Asterisk
+
+export const AsteriskMd = VariantTemplate.bind({});
+AsteriskMd.args = {
+  label: sampleArgs.label,
+  placeholder: sampleArgs.placeholder,
+  withAsterisk: true,
+};
+
+<Canvas>
+  <Story name="Asterisk, md">{AsteriskMd}</Story>
+</Canvas>
+
+#### Description
+
+export const DescriptionMd = VariantTemplate.bind({});
+DescriptionMd.args = {
+  label: sampleArgs.label,
+  description: sampleArgs.description,
+  placeholder: sampleArgs.placeholder,
+};
+
+<Canvas>
+  <Story name="Description, md">{DescriptionMd}</Story>
+</Canvas>
+
+#### Disabled
+
+export const DisabledMd = VariantTemplate.bind({});
+DisabledMd.args = {
+  label: sampleArgs.label,
+  description: sampleArgs.description,
+  placeholder: sampleArgs.placeholder,
+  disabled: true,
+  withAsterisk: true,
+};
+
+<Canvas>
+  <Story name="Disabled, md">{DisabledMd}</Story>
+</Canvas>
+
+#### Error
+
+export const ErrorMd = VariantTemplate.bind({});
+ErrorMd.args = {
+  label: sampleArgs.label,
+  description: sampleArgs.description,
+  placeholder: sampleArgs.placeholder,
+  error: sampleArgs.error,
+  withAsterisk: true,
+};
+
+<Canvas>
+  <Story name="Error, md">{ErrorMd}</Story>
+</Canvas>
+
+#### Read only
+
+export const ReadOnlyMd = VariantTemplate.bind({});
+ReadOnlyMd.args = {
+  defaultValue: sampleArgs.value,
+  label: sampleArgs.label,
+  description: sampleArgs.description,
+  placeholder: sampleArgs.placeholder,
+  readOnly: true,
+};
+
+<Canvas>
+  <Story name="Read only, md">{ReadOnlyMd}</Story>
+</Canvas>
+
+### Size - xs
+
+export const EmptyXs = VariantTemplate.bind({});
+EmptyXs.args = {
+  ...EmptyMd.args,
+  size: "xs",
+};
+
+<Canvas>
+  <Story name="Empty, xs">{EmptyXs}</Story>
+</Canvas>
+
+#### Filled
+
+export const FilledXs = VariantTemplate.bind({});
+FilledXs.args = {
+  ...FilledMd.args,
+  size: "xs",
+};
+
+<Canvas>
+  <Story name="Filled, xs">{FilledXs}</Story>
+</Canvas>
+
+#### Asterisk
+
+export const AsteriskXs = VariantTemplate.bind({});
+AsteriskXs.args = {
+  ...AsteriskMd.args,
+  size: "xs",
+};
+
+<Canvas>
+  <Story name="Asterisk, xs">{AsteriskXs}</Story>
+</Canvas>
+
+#### Description
+
+export const DescriptionXs = VariantTemplate.bind({});
+DescriptionXs.args = {
+  ...DescriptionMd.args,
+  size: "xs",
+};
+
+<Canvas>
+  <Story name="Description, xs">{DescriptionXs}</Story>
+</Canvas>
+
+#### Disabled
+
+export const DisabledXs = VariantTemplate.bind({});
+DisabledXs.args = {
+  ...DisabledMd.args,
+  size: "xs",
+};
+
+<Canvas>
+  <Story name="Disabled, xs">{DisabledXs}</Story>
+</Canvas>
+
+#### Error
+
+export const ErrorXs = VariantTemplate.bind({});
+ErrorXs.args = {
+  ...ErrorMd.args,
+  size: "xs",
+};
+
+<Canvas>
+  <Story name="Error, xs">{ErrorXs}</Story>
+</Canvas>
+
+#### Read only
+
+export const ReadOnlyXs = VariantTemplate.bind({});
+ReadOnlyXs.args = {
+  ...ReadOnlyMd.args,
+  size: "xs",
+};
+
+<Canvas>
+  <Story name="Read only, xs">{ReadOnlyXs}</Story>
+</Canvas>

--- a/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.stories.mdx
+++ b/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.stories.mdx
@@ -58,7 +58,7 @@ export const argTypes = {
 
 <Meta title="Inputs/TimeInput" component={TimeInput} args={args} />
 
-# Textarea
+# TimeInput
 
 Our themed wrapper around [Mantine TimeInput](https://v6.mantine.dev/dates/time-input/).
 

--- a/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.stories.mdx
+++ b/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.stories.mdx
@@ -67,7 +67,7 @@ Our themed wrapper around [Mantine TimeInput](https://v6.mantine.dev/dates/time-
 - [Mantine TimeInput Docs](https://v6.mantine.dev/dates/time-input/)
 - [HTML Time Input Docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time)
 
-# Exxamples
+# Examples
 
 export const DefaultTemplate = args => <TimeInput {...args} />;
 

--- a/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.styled.tsx
@@ -1,0 +1,17 @@
+import type { MantineThemeOverride } from "@mantine/core";
+
+export const getTimeInputOverrides =
+  (): MantineThemeOverride["components"] => ({
+    TimeInput: {
+      defaultProps: {
+        size: "md",
+      },
+      styles: theme => ({
+        wrapper: {
+          "&:not(:only-child)": {
+            marginTop: theme.spacing.xs,
+          },
+        },
+      }),
+    },
+  });

--- a/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.tsx
+++ b/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.tsx
@@ -1,0 +1,61 @@
+import { useLayoutEffect, useState } from "react";
+import type { ChangeEvent } from "react";
+import moment from "moment-timezone";
+import { TimeInput as MantineTimeInput } from "@mantine/dates";
+import type { TimeInputProps as MantineTimeInputProps } from "@mantine/dates";
+
+const TIME_FORMAT = "HH:mm";
+
+export type TimeInputProps = Omit<
+  MantineTimeInputProps,
+  "value" | "defaultValue" | "onChange"
+> & {
+  value?: Date | null;
+  defaultValue?: Date | null;
+  onChange?: (value: Date) => void;
+};
+
+export function TimeInput({
+  value,
+  defaultValue = value,
+  onChange,
+  ...props
+}: TimeInputProps) {
+  const [inputValue, setInputValue] = useState(
+    defaultValue ? formatTime(defaultValue) : "",
+  );
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const newInputValue = event.target.value;
+    setInputValue(newInputValue);
+
+    const newTime = parseTime(newInputValue);
+    newTime && onChange?.(newTime);
+  };
+
+  const handleBlur = () => {
+    value && setInputValue(formatTime(value));
+  };
+
+  useLayoutEffect(() => {
+    value && setInputValue(formatTime(value));
+  }, [value]);
+
+  return (
+    <MantineTimeInput
+      {...props}
+      value={inputValue}
+      onChange={handleChange}
+      onBlur={handleBlur}
+    />
+  );
+}
+
+function formatTime(time: Date) {
+  return moment(time).format(TIME_FORMAT);
+}
+
+function parseTime(value: string) {
+  const time = moment(value, TIME_FORMAT, true);
+  return time.isValid() ? time.toDate() : undefined;
+}

--- a/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.unit.spec.tsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "__support__/ui";
+import { TimeInput } from "./TimeInput";
+
+interface SetupOpts {
+  defaultValue?: Date;
+}
+
+function setup({ defaultValue }: SetupOpts = {}) {
+  const onChange = jest.fn();
+
+  render(<TestInput defaultValue={defaultValue} onChange={onChange} />);
+
+  return { onChange };
+}
+
+interface TestInputProps {
+  defaultValue?: Date;
+  onChange?: (date: Date) => void;
+}
+
+function TestInput({ defaultValue, onChange }: TestInputProps) {
+  const [value, setValue] = useState(defaultValue);
+
+  const handleChange = (value: Date) => {
+    setValue(value);
+    onChange?.(value);
+  };
+
+  return <TimeInput label="Time" value={value} onChange={handleChange} />;
+}
+
+describe("TimeInput", () => {
+  it("should show the default value", () => {
+    setup({ defaultValue: new Date(0, 0, 1, 12, 30) });
+
+    const input = screen.getByLabelText("Time");
+    expect(input).toHaveValue("12:30");
+  });
+
+  it("should allow to enter a time value", () => {
+    const { onChange } = setup();
+
+    const input = screen.getByLabelText("Time");
+    userEvent.type(input, "10:20");
+
+    const time = onChange.mock.lastCall[0] as Date;
+    expect(time.getHours()).toBe(10);
+    expect(time.getMinutes()).toBe(20);
+  });
+
+  it("should reset to the last correct value on blur", () => {
+    const { onChange } = setup();
+
+    const input = screen.getByLabelText("Time");
+    userEvent.type(input, "10:20");
+    userEvent.clear(input);
+    userEvent.type(input, "12:");
+    userEvent.tab();
+
+    const time = onChange.mock.lastCall[0] as Date;
+    expect(time.getHours()).toBe(10);
+    expect(time.getMinutes()).toBe(20);
+    expect(input).toHaveValue("10:20");
+  });
+});

--- a/frontend/src/metabase/ui/components/inputs/TimeInput/index.ts
+++ b/frontend/src/metabase/ui/components/inputs/TimeInput/index.ts
@@ -1,0 +1,2 @@
+export * from "./TimeInput";
+export { getTimeInputOverrides } from "./TimeInput.styled";

--- a/frontend/src/metabase/ui/components/inputs/index.ts
+++ b/frontend/src/metabase/ui/components/inputs/index.ts
@@ -7,3 +7,4 @@ export * from "./Select";
 export * from "./Textarea";
 export * from "./Switch";
 export * from "./TextInput";
+export * from "./TimeInput";

--- a/frontend/src/metabase/ui/theme.ts
+++ b/frontend/src/metabase/ui/theme.ts
@@ -17,6 +17,7 @@ import {
   getSelectOverrides,
   getTabsOverrides,
   getTextareaOverrides,
+  getTimeInputOverrides,
   getSwitchOverrides,
   getTextInputOverrides,
   getTextOverrides,
@@ -123,6 +124,7 @@ export const getThemeOverrides = (): MantineThemeOverride => ({
     ...getSwitchOverrides(),
     ...getTextInputOverrides(),
     ...getTextOverrides(),
+    ...getTimeInputOverrides(),
     ...getTitleOverrides(),
   },
 });

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@mantine/core": "^6.0.13",
+    "@mantine/dates": "^6.0.13",
     "@mantine/hooks": "^6.0.13",
     "@react-oauth/google": "^0.11.1",
     "@reduxjs/toolkit": "^1.9.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4956,6 +4956,13 @@
     react-remove-scroll "^2.5.5"
     react-textarea-autosize "8.3.4"
 
+"@mantine/dates@^6.0.13":
+  version "6.0.21"
+  resolved "https://registry.yarnpkg.com/@mantine/dates/-/dates-6.0.21.tgz#a140da22bd4188aff446ddb5d3bcf37b658b0608"
+  integrity sha512-nSX7MxNkHyyDJqEJOT7Wg930jBfgWz+3pnoWo601cYDvFjh5GgcRz66v36rnMJFK1/56k5G9rWzUOzuM94j6hg==
+  dependencies:
+    "@mantine/utils" "6.0.21"
+
 "@mantine/hooks@^6.0.13":
   version "6.0.13"
   resolved "https://registry.yarnpkg.com/@mantine/hooks/-/hooks-6.0.13.tgz#d90fa315ee30a900e0d9a460c6bb00c9a65f18e0"
@@ -4973,6 +4980,11 @@
   version "6.0.13"
   resolved "https://registry.yarnpkg.com/@mantine/utils/-/utils-6.0.13.tgz#a7adc128a2e7c07031c7221c1533800d0c80279a"
   integrity sha512-iqIU9wurqAeccVbWjM0yr1JGne5VP+ob55M03QAXOEN4+ck93VDTjCkZJR2RFhDcs5q0twQFoOmU/gULR8aKIA==
+
+"@mantine/utils@6.0.21":
+  version "6.0.21"
+  resolved "https://registry.yarnpkg.com/@mantine/utils/-/utils-6.0.21.tgz#6185506e91cba3e308aaa8ea9ababc8e767995d6"
+  integrity sha512-33RVDRop5jiWFao3HKd3Yp7A9mEq4HAJxJPTuYm1NkdqX6aTKOQK7wT8v8itVodBp+sb4cJK6ZVdD1UurK/txQ==
 
 "@mdx-js/mdx@^1.6.22":
   version "1.6.22"


### PR DESCRIPTION
Follow the same approach used by the mantine's `DateInput`:
- Allows controlled and uncontrolled usage
- Accepts and return a `Date`
- Resets the input value on blur

`TextInput` is used internally so no custom styles are needed.

How to test:
- `yarn storybook`
- Open http://localhost:6006/?path=/docs/inputs-timeinput--default-story
- To test AM/PM, change your Clock settings in the OS settings, and re-open the browser


<img width="1273" alt="Screenshot 2023-10-13 at 14 29 53" src="https://github.com/metabase/metabase/assets/8542534/9f590b0a-f5a5-4af8-a20b-6eef18667df8">
<img width="435" alt="Screenshot 2023-10-18 at 3 39 45 PM" src="https://github.com/metabase/metabase/assets/8542534/6e9ca97d-7279-4b0c-9999-c9169c60bcd3">
<img width="443" alt="Screenshot 2023-10-18 at 3 39 55 PM" src="https://github.com/metabase/metabase/assets/8542534/bb4c4df8-4715-4d8b-8028-ce33f14fdc0b">
