### PR TITLE
[MLv2] Add the expression editor to `FilterPicker`

### DIFF
--- a/frontend/src/metabase-lib/filter.ts
+++ b/frontend/src/metabase-lib/filter.ts
@@ -476,6 +476,14 @@ export function filterParts(
   );
 }
 
+export function isCustomFilter(
+  query: Query,
+  stageIndex: number,
+  filter: FilterClause,
+) {
+  return !filterParts(query, stageIndex, filter);
+}
+
 function findTemporalBucket(
   query: Query,
   stageIndex: number,

--- a/frontend/src/metabase/common/components/FilterPicker/FilterPicker.styled.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterPicker.styled.tsx
@@ -1,6 +1,12 @@
 import styled from "@emotion/styled";
+import AccordionList from "metabase/core/components/AccordionList";
+import { color } from "metabase/lib/colors";
 import { Flex } from "metabase/ui";
 
 export const FlexWithScroll = styled(Flex)`
   overflow-y: auto;
+`;
+
+export const StyledAccordionList = styled(AccordionList)`
+  color: ${color("filter")};
 `;

--- a/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
@@ -1,39 +1,103 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
+import { t } from "ttag";
+
 import { Box } from "metabase/ui";
+import { getColumnIcon } from "metabase/common/utils/columns";
+import {
+  getColumnGroupIcon,
+  getColumnGroupName,
+} from "metabase/common/utils/column-groups";
+import { useToggle } from "metabase/hooks/use-toggle";
+
+import { Icon } from "metabase/core/components/Icon";
+import type { IconName } from "metabase/core/components/Icon";
+import { ExpressionWidget } from "metabase/query_builder/components/expressions/ExpressionWidget";
+import { ExpressionWidgetHeader } from "metabase/query_builder/components/expressions/ExpressionWidgetHeader";
+
+import type { Expression as LegacyExpressionClause } from "metabase-types/api";
 import * as Lib from "metabase-lib";
-import { QueryColumnPicker } from "../QueryColumnPicker";
+
+import { isExpression as isLegacyExpression } from "metabase-lib/expressions";
+import LegacyFilter from "metabase-lib/queries/structured/Filter";
+import type LegacyQuery from "metabase-lib/queries/StructuredQuery";
+
 import { BooleanFilterPicker } from "./BooleanFilterPicker";
 import { DateFilterPicker } from "./DateFilterPicker";
 import { NumberFilterPicker } from "./NumberFilterPicker";
 import { CoordinateFilterPicker } from "./CoordinateFilterPicker";
 import { StringFilterPicker } from "./StringFilterPicker";
 import { TimeFilterPicker } from "./TimeFilterPicker";
+import { StyledAccordionList } from "./FilterPicker.styled";
 
 export interface FilterPickerProps {
   query: Lib.Query;
   stageIndex: number;
   filter?: Lib.FilterClause;
+
+  legacyQuery: LegacyQuery;
+  legacyFilter?: LegacyFilter;
+  onSelectLegacy: (legacyFilter: LegacyFilter) => void;
+
   onSelect: (filter: Lib.ExpressionClause) => void;
   onClose?: () => void;
 }
 
+type Section = {
+  key?: string;
+  name: string;
+  items: Lib.ColumnMetadata[];
+  icon?: IconName;
+};
+
 const MIN_WIDTH = 300;
 const MAX_WIDTH = 410;
+
+const CUSTOM_EXPRESSION_SECTION: Section = {
+  key: "custom-expression",
+  name: t`Custom Expression`,
+  items: [],
+  icon: "filter",
+};
 
 export function FilterPicker({
   query,
   stageIndex,
   filter,
+  legacyQuery,
+  legacyFilter,
   onSelect,
+  onSelectLegacy,
   onClose,
 }: FilterPickerProps) {
+  const [
+    isEditingExpression,
+    { turnOn: openExpressionEditor, turnOff: closeExpressionEditor },
+  ] = useToggle(filter && Lib.isCustomFilter(query, stageIndex, filter));
+
   const [column, setColumn] = useState<Lib.ColumnMetadata | undefined>(
     getInitialColumn(query, stageIndex, filter),
   );
 
-  const columnGroups = useMemo(() => {
+  const renderItemName = useCallback(
+    (column: Lib.ColumnMetadata) =>
+      Lib.displayInfo(query, stageIndex, column).displayName,
+    [query, stageIndex],
+  );
+
+  const sections = useMemo(() => {
     const columns = Lib.filterableColumns(query, stageIndex);
-    return Lib.groupColumns(columns);
+    const columnGroups = Lib.groupColumns(columns);
+
+    const sections = columnGroups.map(group => {
+      const groupInfo = Lib.displayInfo(query, stageIndex, group);
+      return {
+        name: getColumnGroupName(groupInfo),
+        icon: getColumnGroupIcon(groupInfo),
+        items: Lib.getColumnsFromColumnGroup(group),
+      };
+    });
+
+    return [...sections, CUSTOM_EXPRESSION_SECTION];
   }, [query, stageIndex]);
 
   const checkColumnSelected = () => false;
@@ -43,16 +107,55 @@ export function FilterPicker({
     onClose?.();
   };
 
+  const handleSectionChange = useCallback(
+    (section: Section) => {
+      if (section.key === "custom-expression") {
+        openExpressionEditor();
+      }
+    },
+    [openExpressionEditor],
+  );
+
+  const handleExpressionChange = useCallback(
+    (name: string, expression: LegacyExpressionClause) => {
+      if (Array.isArray(expression) && isLegacyExpression(expression)) {
+        const baseFilter =
+          legacyFilter || new LegacyFilter([], null, legacyQuery);
+        const nextFilter = baseFilter.set(expression);
+        onSelectLegacy(nextFilter);
+        onClose?.();
+      }
+    },
+    [legacyQuery, legacyFilter, onSelectLegacy, onClose],
+  );
+
+  if (isEditingExpression) {
+    return (
+      <ExpressionWidget
+        query={legacyQuery}
+        expression={legacyFilter?.raw() as LegacyExpressionClause}
+        startRule="boolean"
+        header={<ExpressionWidgetHeader onBack={closeExpressionEditor} />}
+        onChangeExpression={handleExpressionChange}
+        onClose={closeExpressionEditor}
+      />
+    );
+  }
+
   const renderContent = () => {
     if (!column) {
       return (
-        <QueryColumnPicker
-          query={query}
-          stageIndex={stageIndex}
-          columnGroups={columnGroups}
-          color="filter"
-          checkIsColumnSelected={checkColumnSelected}
-          onSelect={setColumn}
+        <StyledAccordionList
+          sections={sections}
+          onChange={setColumn}
+          onChangeSection={handleSectionChange}
+          itemIsSelected={checkColumnSelected}
+          renderItemName={renderItemName}
+          renderItemDescription={omitItemDescription}
+          renderItemIcon={renderItemIcon}
+          // Compat with E2E tests around MLv1-based components
+          // Prefer using a11y role selectors
+          itemTestId="dimension-list-item"
         />
       );
     }
@@ -85,6 +188,14 @@ function getInitialColumn(
   return filter
     ? Lib.filterParts(query, stageIndex, filter)?.column
     : undefined;
+}
+
+function omitItemDescription() {
+  return null;
+}
+
+function renderItemIcon(column: Lib.ColumnMetadata) {
+  return <Icon name={getColumnIcon(column)} size={18} />;
 }
 
 const NotImplementedPicker = () => <div />;

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -1,9 +1,12 @@
 import { useCallback, useMemo } from "react";
 
 import { getColumnIcon } from "metabase/common/utils/columns";
+import {
+  getColumnGroupIcon,
+  getColumnGroupName,
+} from "metabase/common/utils/column-groups";
 import type { IconName } from "metabase/core/components/Icon";
 import { Icon } from "metabase/core/components/Icon";
-import { singularize } from "metabase/lib/formatting";
 import type { ColorName } from "metabase/lib/colors/types";
 
 import * as Lib from "metabase-lib";
@@ -63,8 +66,8 @@ export function QueryColumnPicker({
         }));
 
         return {
-          name: getGroupName(groupInfo),
-          icon: getGroupIcon(groupInfo),
+          name: getColumnGroupName(groupInfo),
+          icon: getColumnGroupIcon(groupInfo),
           items,
         };
       }),
@@ -180,23 +183,4 @@ function omitItemDescription() {
 
 function renderItemIcon(item: ColumnListItem) {
   return <Icon name={getColumnIcon(item.column)} size={18} />;
-}
-
-function getGroupName(groupInfo: Lib.ColumnDisplayInfo | Lib.TableDisplayInfo) {
-  const columnInfo = groupInfo as Lib.ColumnDisplayInfo;
-  const tableInfo = groupInfo as Lib.TableDisplayInfo;
-  return columnInfo.fkReferenceName || singularize(tableInfo.displayName);
-}
-
-function getGroupIcon(groupInfo: Lib.ColumnDisplayInfo | Lib.TableDisplayInfo) {
-  if ((groupInfo as Lib.TableDisplayInfo).isSourceTable) {
-    return "table";
-  }
-  if (groupInfo.isFromJoin) {
-    return "join_left_outer";
-  }
-  if (groupInfo.isImplicitlyJoinable) {
-    return "connections";
-  }
-  return;
 }

--- a/frontend/src/metabase/common/utils/column-groups.ts
+++ b/frontend/src/metabase/common/utils/column-groups.ts
@@ -1,0 +1,26 @@
+import { singularize } from "metabase/lib/formatting";
+import type { IconName } from "metabase/core/components/Icon";
+import type { ColumnDisplayInfo, TableDisplayInfo } from "metabase-lib/types";
+
+export function getColumnGroupName(
+  groupInfo: ColumnDisplayInfo | TableDisplayInfo,
+) {
+  const columnInfo = groupInfo as ColumnDisplayInfo;
+  const tableInfo = groupInfo as TableDisplayInfo;
+  return columnInfo.fkReferenceName || singularize(tableInfo.displayName);
+}
+
+export function getColumnGroupIcon(
+  groupInfo: ColumnDisplayInfo | TableDisplayInfo,
+): IconName | undefined {
+  if ((groupInfo as TableDisplayInfo).isSourceTable) {
+    return "table";
+  }
+  if (groupInfo.isFromJoin) {
+    return "join_left_outer";
+  }
+  if (groupInfo.isImplicitlyJoinable) {
+    return "connections";
+  }
+  return;
+}


### PR DESCRIPTION
Closes #34496

Adds the custom expression editor to the `FilterPicker`. Custom expressions themselves are not yet ported to MLv2, so for now we're using MLv1 to work with them. This PR is very similar to what we've done to aggregations in #31529

### To Verify

1. New > Question > Raw Data > Sample Database > Orders
2. Add a standard filter (e.g. Total > 100)
3. Click the filter, scroll down, and click "Custom Expression"
4. Ensure the editor opened with `Total > 100` formula inside
5. Change the formula to something else, click "Done"
6. Click the filter, ensure you can see the original formula

### Demo

https://github.com/metabase/metabase/assets/17258145/2bc0e9a4-21a9-49a3-bcaf-9519da1ae627

