### PR TITLE
BE: Remove filterParameters from parameter if values_query_type=none

### DIFF
--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -131,10 +131,15 @@
     (or (= (:name p) "")
         (= (:slug p) ""))
     (assoc :name "unnamed" :slug "unnamed")
-    ;; We don't support linked filters for parameters with :values_source_type of anything except nil,
-    ;; but it was previously possible to set :values_source_type to "static-list" or "card" and still
-    ;; have linked filters. (metabase#33892)
-    (some? (:values_source_type p))
+    (or
+     ;; we don't support linked filters for parameters with :values_source_type of anything except nil,
+     ;; but it was previously possible to set :values_source_type to "static-list" or "card" and still
+     ;; have linked filters. (metabase#33892)
+     (some? (:values_source_type p))
+     (= (:values_query_type p) "none"))
+     ;; linked filters don't do anything when parameters have values_query_type="none" (aka "Input box"),
+     ;; but it was previously possible to set :values_query_type to "none" and still have linked filters.
+     ;; (metabase#34657)
     (dissoc :filteringParameters)))
 
 (defn- migrate-parameters-list

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -670,6 +670,22 @@
                     (:filteringParameters parameter)))
              (is (not (contains? parameter :filteringParameters))))))))))
 
+(deftest migrate-parameters-with-linked-filters-and-values-query-type-test
+  (testing "test that a Dashboard's :parameters filterParameters are cleared if the :values_query_type is 'none'"
+    (doseq [[values_query_type
+             keep-filtering-parameters?] {"none" false
+                                          "list" true}]
+      (testing (format "\nvalues_query_type=%s" values_query_type)
+       (mt/with-temp [:model/Dashboard dashboard {:parameters [(merge
+                                                                default-parameter
+                                                                {:filteringParameters ["other-param-id"]
+                                                                 :values_query_type   values_query_type})]}]
+         (let [parameter (first (:parameters dashboard))]
+           (if keep-filtering-parameters?
+             (is (= ["other-param-id"]
+                    (:filteringParameters parameter)))
+             (is (not (contains? parameter :filteringParameters))))))))))
+
 (deftest migrate-parameters-empty-name-test
   (testing "test that a Dashboard's :parameters is selected with a non-nil name and slug"
     (doseq [[name slug] [["" ""] ["" "slug"] ["name" ""]]]


### PR DESCRIPTION
Epic: #34604

Part 1 of 2 for #34657

Linked filters don't work if the widget type for a filter is "Input box", because an input box doesn't have any values for the user to choose from.. "Input box" corresponds to `values_query_type="none"` in the code.

This PR changes the parameters as they are selected out of the database so that previously saved filters with values_query_type="none" will have their linked filters removed.

This is similar to #34660, where we removed linked filters if the values source type was not "From connected fields".