### PR TITLE
Fix entities fetch caching

### DIFF
--- a/frontend/src/metabase/common/hooks/use-entity-list-query/use-entity-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-entity-list-query/use-entity-list-query.unit.spec.tsx
@@ -102,9 +102,9 @@ const TestInnerComponent = () => {
   );
 };
 
-const setup = ({ databases = [TEST_DB], tables = [TEST_TABLE] } = {}) => {
-  setupDatabasesEndpoints(databases);
-  setupTablesEndpoints(tables);
+const setup = () => {
+  setupDatabasesEndpoints([TEST_DB]);
+  setupTablesEndpoints([TEST_TABLE]);
   return renderWithProviders(<TestComponent />);
 };
 
@@ -179,10 +179,11 @@ describe("useEntityListQuery", () => {
   });
 
   it("should not remove loader in case second api call is cached", async () => {
-    const dbsResponse = [TEST_DB];
     fetchMock.get(
       "path:/api/database",
-      delay(100).then(() => dbsResponse),
+      delay(100).then(() => {
+        return [TEST_DB];
+      }),
       { overwriteRoutes: true },
     );
 
@@ -204,12 +205,9 @@ describe("useEntityListQuery", () => {
       within(screen.getByTestId("test2")).getByTestId("loading-spinner"),
     ).toBeInTheDocument();
 
-    await delay(100);
+    await delay(100); // trigger fetch request to be resolved
 
-    expect(fetchMock.calls("path:/api/database")).toHaveLength(1);
-    expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
-
-    await delay(0); // trigger delay to make sure state has been updated
+    await delay(0); // trigger extra event loop to make sure React state has been updated
 
     expect(fetchMock.calls("path:/api/database")).toHaveLength(1);
     expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();

--- a/frontend/src/metabase/common/hooks/use-entity-list-query/use-entity-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-entity-list-query/use-entity-list-query.unit.spec.tsx
@@ -1,5 +1,6 @@
 import fetchMock from "fetch-mock";
 import userEvent from "@testing-library/user-event";
+import { within } from "@testing-library/react";
 import { useDispatch } from "metabase/lib/redux";
 import Databases from "metabase/entities/databases";
 import Tables from "metabase/entities/tables";
@@ -16,6 +17,7 @@ import {
   waitFor,
   waitForLoaderToBeRemoved,
 } from "__support__/ui";
+import { delay } from "metabase/lib/promise";
 import type Database from "metabase-lib/metadata/Database";
 import type Table from "metabase-lib/metadata/Table";
 import { useEntityListQuery } from "./use-entity-list-query";
@@ -23,7 +25,7 @@ import { useEntityListQuery } from "./use-entity-list-query";
 const TEST_DB = createMockDatabase();
 const TEST_TABLE = createMockTable();
 
-const TestComponent = () => {
+const TestComponent = ({ testId }: { testId?: string }) => {
   const {
     data = [],
     isLoading,
@@ -44,11 +46,17 @@ const TestComponent = () => {
   const handleInvalidate = () => dispatch(Databases.actions.invalidateLists());
 
   if (isLoading || error) {
-    return <LoadingAndErrorWrapper loading={isLoading} error={error} />;
+    return (
+      <LoadingAndErrorWrapper
+        loading={isLoading}
+        error={error}
+        data-testid={testId}
+      />
+    );
   }
 
   return (
-    <div>
+    <div data-testid={testId}>
       <button onClick={handleInvalidate}>Invalidate databases</button>
       {data.map(database => (
         <div key={database.id}>{database.name}</div>
@@ -94,9 +102,9 @@ const TestInnerComponent = () => {
   );
 };
 
-const setup = () => {
-  setupDatabasesEndpoints([TEST_DB]);
-  setupTablesEndpoints([TEST_TABLE]);
+const setup = ({ databases = [TEST_DB], tables = [TEST_TABLE] } = {}) => {
+  setupDatabasesEndpoints(databases);
+  setupTablesEndpoints(tables);
   return renderWithProviders(<TestComponent />);
 };
 
@@ -168,5 +176,42 @@ describe("useEntityListQuery", () => {
     await waitForLoaderToBeRemoved();
 
     expect(screen.getByText(TEST_TABLE.name)).toBeInTheDocument();
+  });
+
+  it("should not remove loader in case second api call is cached", async () => {
+    const dbsResponse = [TEST_DB];
+    fetchMock.get(
+      "path:/api/database",
+      delay(100).then(() => dbsResponse),
+      { overwriteRoutes: true },
+    );
+
+    const { rerender } = setup();
+
+    expect(fetchMock.calls("path:/api/database")).toHaveLength(1);
+
+    rerender(
+      <>
+        <TestComponent />
+        <TestComponent testId="test2" />
+      </>,
+    );
+
+    // second component should not create extra request, make sure that caching works as expected
+    expect(fetchMock.calls("path:/api/database")).toHaveLength(1);
+
+    expect(
+      within(screen.getByTestId("test2")).getByTestId("loading-spinner"),
+    ).toBeInTheDocument();
+
+    await delay(100);
+
+    expect(fetchMock.calls("path:/api/database")).toHaveLength(1);
+    expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
+
+    await delay(0); // trigger delay to make sure state has been updated
+
+    expect(fetchMock.calls("path:/api/database")).toHaveLength(1);
+    expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/components/LoadingAndErrorWrapper/LoadingAndErrorWrapper.jsx
+++ b/frontend/src/metabase/components/LoadingAndErrorWrapper/LoadingAndErrorWrapper.jsx
@@ -25,6 +25,7 @@ export default class LoadingAndErrorWrapper extends Component {
     messageInterval: PropTypes.number,
     loadingScenes: PropTypes.array,
     renderError: PropTypes.func,
+    "data-testid": PropTypes.string,
   };
 
   static defaultProps = {
@@ -116,6 +117,7 @@ export default class LoadingAndErrorWrapper extends Component {
       showSpinner,
       loadingMessages,
       loadingScenes,
+      "data-testid": testId,
     } = this.props;
 
     const { messageIndex, sceneIndex } = this.state;
@@ -134,7 +136,11 @@ export default class LoadingAndErrorWrapper extends Component {
       return Children.only(children);
     }
     return (
-      <div className={this.props.className} style={this.props.style}>
+      <div
+        className={this.props.className}
+        style={this.props.style}
+        data-testid={testId}
+      >
         {error ? (
           this.renderError(contentClassName)
         ) : loading ? (

--- a/frontend/src/metabase/components/LoadingAndErrorWrapper/LoadingAndErrorWrapper.jsx
+++ b/frontend/src/metabase/components/LoadingAndErrorWrapper/LoadingAndErrorWrapper.jsx
@@ -117,6 +117,8 @@ export default class LoadingAndErrorWrapper extends Component {
       showSpinner,
       loadingMessages,
       loadingScenes,
+      style,
+      className,
       "data-testid": testId,
     } = this.props;
 
@@ -136,11 +138,7 @@ export default class LoadingAndErrorWrapper extends Component {
       return Children.only(children);
     }
     return (
-      <div
-        className={this.props.className}
-        style={this.props.style}
-        data-testid={testId}
-      >
+      <div className={className} style={style} data-testid={testId}>
         {error ? (
           this.renderError(contentClassName)
         ) : loading ? (

--- a/frontend/src/metabase/lib/redux/utils.js
+++ b/frontend/src/metabase/lib/redux/utils.js
@@ -284,64 +284,62 @@ function withCachedData(
   // thunk decorator:
   return thunkCreator =>
     // thunk creator:
-    (...args) => {
-      async function thunk(dispatch, getState) {
-        const options = args[args.length - 1] || {};
-        const { useCachedForbiddenError, reload, properties } = options;
+    (...args) =>
+    // thunk:
+    async (dispatch, getState) => {
+      const options = args[args.length - 1] || {};
+      const { useCachedForbiddenError, reload, properties } = options;
 
-        const existingStatePath = getExistingStatePath(...args);
-        const requestStatePath = ["requests", ...getRequestStatePath(...args)];
-        const newQueryKey = getQueryKey && getQueryKey(...args);
-        const existingData = getIn(getState(), existingStatePath);
-        const { loading, loaded, queryKey, error } =
-          getIn(getState(), requestStatePath) || {};
+      const existingStatePath = getExistingStatePath(...args);
+      const requestStatePath = ["requests", ...getRequestStatePath(...args)];
+      const newQueryKey = getQueryKey && getQueryKey(...args);
+      const existingData = getIn(getState(), existingStatePath);
+      const { loading, loaded, queryKey, error } =
+        getIn(getState(), requestStatePath) || {};
 
-        // Avoid requesting data with permanently forbidden access
-        if (useCachedForbiddenError && error?.status === 403) {
-          throw error;
-        }
-
-        const hasRequestedProperties =
-          properties &&
-          existingData &&
-          _.all(properties, p => existingData[p] !== undefined);
-
-        // return existing data if
-        if (
-          // we don't want to reload
-          // the check is a workaround for EntityListLoader passing reload function to children
-          reload !== true &&
-          // reload if the query used to load an entity has changed even if it's already loaded
-          newQueryKey === queryKey
-        ) {
-          // and we have a non-error request state or have a list of properties that all exist on the object
-          if (loaded || hasRequestedProperties) {
-            return existingData;
-          } else if (loading) {
-            const queryPromise = getIn(
-              getState(),
-              requestStatePath,
-            )?.queryPromise;
-
-            if (queryPromise) {
-              // wait for current loading request to be resolved
-              await queryPromise;
-
-              // need to wait for next tick to allow loaded request data to be processed and avoid loops
-              await delay(10);
-
-              // retry this function after waited request gets resolved
-              return thunk(dispatch, getState);
-            }
-
-            return existingData;
-          }
-        }
-
-        return thunkCreator(...args)(dispatch, getState);
+      // Avoid requesting data with permanently forbidden access
+      if (useCachedForbiddenError && error?.status === 403) {
+        throw error;
       }
 
-      return thunk;
+      const hasRequestedProperties =
+        properties &&
+        existingData &&
+        _.all(properties, p => existingData[p] !== undefined);
+
+      // return existing data if
+      if (
+        // we don't want to reload
+        // the check is a workaround for EntityListLoader passing reload function to children
+        reload !== true &&
+        // reload if the query used to load an entity has changed even if it's already loaded
+        newQueryKey === queryKey
+      ) {
+        // and we have a non-error request state or have a list of properties that all exist on the object
+        if (loaded || hasRequestedProperties) {
+          return existingData;
+        } else if (loading) {
+          const queryPromise = getIn(
+            getState(),
+            requestStatePath,
+          )?.queryPromise;
+
+          if (queryPromise) {
+            // wait for current loading request to be resolved
+            await queryPromise;
+
+            // need to wait for next tick to allow loaded request data to be processed and avoid loops
+            await delay(0);
+
+            // retry this function after waited request gets resolved
+            return thunkCreator(...args)(dispatch, getState);
+          }
+
+          return existingData;
+        }
+      }
+
+      return thunkCreator(...args)(dispatch, getState);
     };
 }
 


### PR DESCRIPTION
Relates to https://github.com/metabase/metabase/issues/31905

### Description

This is additional fix for https://github.com/metabase/metabase/pull/33898 
More context - https://metaboat.slack.com/archives/C057T1QTB3L/p1697183111294489

There is a race condition: 
Let's say we have two fetch requests to load entities list (e.g. databases), 
The second request waits for the first one to be loaded, 
and then for the second request we waited extra 10ms to make sure state gets recalculated.

https://github.com/metabase/metabase/blob/ed00657b6807960b31c386175426bcfad5fb456f/frontend/src/metabase/lib/redux/utils.js#L327-L333

But as soon as first request get loaded, it updates request state to be "loaded"

https://github.com/metabase/metabase/blob/ed00657b6807960b31c386175426bcfad5fb456f/frontend/src/metabase/lib/redux/utils.js#L246-L253

For this 10ms period we are in the incorrect state due to different request states.

### How to verify

1. Create a new question or model, save it.
2. Refresh the page.
3. You should not see 2 same api requests to load your question/model.
4. You should see a collection where your question/model is saved to as selected in the left menu.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
