### PR TITLE
FE: Prevent setting linked filters if filter widget is input box

### DIFF
--- a/frontend/src/metabase/parameters/components/ParameterLinkedFilters/ParameterLinkedFilters.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterLinkedFilters/ParameterLinkedFilters.tsx
@@ -77,6 +77,9 @@ function Content({
   if (parameter.values_source_type != null) {
     return <ParametersFromOtherSource />;
   }
+  if (parameter.values_query_type === "none") {
+    return <ParameterIsInputBoxType />;
+  }
   return (
     <UsableParameters
       parameter={parameter}
@@ -104,6 +107,14 @@ function NoUsableParameters({
         )}.`}
       </SectionMessage>
     </div>
+  );
+}
+
+function ParameterIsInputBoxType(): JSX.Element {
+  return (
+    <SectionMessage>
+      {t`This filter can't be limited by another dashboard filter because its widget type is an input box.`}
+    </SectionMessage>
   );
 }
 

--- a/frontend/src/metabase/parameters/components/ParameterLinkedFilters/ParameterLinkedFilters.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterLinkedFilters/ParameterLinkedFilters.unit.spec.tsx
@@ -74,4 +74,30 @@ describe("ParameterLinkedFilters", () => {
       expect(screen.queryByRole("switch")).not.toBeInTheDocument();
     },
   );
+
+  it("should not show linked filter options if the parameter has values_query_type = 'none'", () => {
+    setup({
+      parameter: createMockUiParameter({
+        id: "p1",
+        name: "P1",
+        values_query_type: "none",
+        values_source_config: {
+          values: ["foo", "bar"],
+        },
+      }),
+      otherParameters: [
+        createMockUiParameter({
+          id: "p2",
+          name: "P2",
+        }),
+      ],
+    });
+
+    expect(
+      screen.getByText(
+        "This filter can't be limited by another dashboard filter because its widget type is an input box.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/34604

This is the FE part of #34657

The BE part is https://github.com/metabase/metabase/pull/34660

If Input box is chosen:
![image](https://github.com/metabase/metabase/assets/39073188/b1fc0df1-4088-4267-935b-dfadc215305d)

We now hide the linked filter switches:
![image](https://github.com/metabase/metabase/assets/39073188/0860cd73-6a77-4340-b434-85e479883007)
