### PR TITLE
Use Mantine popover in `FilterStep`

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -1,5 +1,6 @@
 // various Metabase-specific "scoping" functions like inside popover/modal/navbar/main/sidebar content area
-export const POPOVER_ELEMENT = ".popover[data-state~='visible']";
+export const POPOVER_ELEMENT =
+  ".popover[data-state~='visible'],[role='dialog']";
 
 export function popover() {
   cy.get(POPOVER_ELEMENT).should("be.visible");

--- a/frontend/src/metabase/common/components/FilterPicker/FilterOperatorPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterOperatorPicker.tsx
@@ -20,5 +20,5 @@ export function FilterOperatorPicker({
     }));
   }, [options]);
 
-  return <Select data={data} {...props} withinPortal={false} />;
+  return <Select data={data} {...props} />;
 }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
@@ -4,7 +4,7 @@ import { AggregationPicker } from "metabase/common/components/AggregationPicker"
 import * as Lib from "metabase-lib";
 import type StructuredQuery from "metabase-lib/queries/StructuredQuery";
 import type { NotebookStepUiComponentProps } from "../../types";
-import ClauseStep from "../ClauseStep";
+import { ClauseStep } from "../ClauseStep";
 
 const aggTetherOptions = {
   attachment: "top left",

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
@@ -82,6 +82,7 @@ export function AggregateStep({
       )}
       onRemove={handleRemoveAggregation}
       data-testid="aggregate-step"
+      withLegacyPopover
     />
   );
 }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
@@ -68,7 +68,7 @@ export function AggregateStep({
       isLastOpened={isLastOpened}
       tetherOptions={aggTetherOptions}
       renderName={renderAggregationName}
-      renderPopover={(aggregation, index) => (
+      renderPopover={({ item: aggregation, index }) => (
         <AggregationPopover
           query={topLevelQuery}
           stageIndex={stageIndex}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.tsx
@@ -66,12 +66,12 @@ function BreakoutStep({
       isLastOpened={isLastOpened}
       tetherOptions={breakoutTetherOptions}
       renderName={renderBreakoutName}
-      renderPopover={(breakout, breakoutIndex) => (
+      renderPopover={({ item: breakout, index }) => (
         <BreakoutPopover
           query={topLevelQuery}
           stageIndex={stageIndex}
           breakout={breakout}
-          breakoutIndex={breakoutIndex}
+          breakoutIndex={index}
           onAddBreakout={handleAddBreakout}
           onUpdateBreakoutColumn={handleUpdateBreakoutColumn}
         />

--- a/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 import { QueryColumnPicker } from "metabase/common/components/QueryColumnPicker";
 import * as Lib from "metabase-lib";
 import type { NotebookStepUiComponentProps } from "../../types";
-import ClauseStep from "../ClauseStep";
+import { ClauseStep } from "../ClauseStep";
 
 const breakoutTetherOptions = {
   attachment: "top left",

--- a/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.tsx
@@ -78,6 +78,7 @@ function BreakoutStep({
       )}
       onRemove={handleRemoveBreakout}
       data-testid="breakout-step"
+      withLegacyPopover
     />
   );
 }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/ClausePopover.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/ClausePopover.tsx
@@ -1,0 +1,33 @@
+import { useCallback, useState } from "react";
+import type { PopoverBaseProps } from "metabase/ui";
+import { Popover } from "metabase/ui";
+
+interface ClausePopoverProps extends PopoverBaseProps {
+  isInitiallyOpen?: boolean;
+  renderItem: (open: () => void) => JSX.Element | string;
+  renderPopover: (close: () => void) => JSX.Element | null;
+}
+
+export function ClausePopover({
+  isInitiallyOpen = false,
+  renderItem,
+  renderPopover,
+  ...props
+}: ClausePopoverProps) {
+  const [isOpen, setIsOpen] = useState(isInitiallyOpen);
+
+  const handleOpen = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  return (
+    <Popover trapFocus {...props} opened={isOpen} onClose={handleClose}>
+      <Popover.Target>{renderItem(handleOpen)}</Popover.Target>
+      <Popover.Dropdown>{renderPopover(handleClose)}</Popover.Dropdown>
+    </Popover>
+  );
+}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/ClauseStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/ClauseStep.tsx
@@ -5,7 +5,7 @@ import {
   NotebookCell,
   NotebookCellAdd,
   NotebookCellItem,
-} from "../NotebookCell";
+} from "../../NotebookCell";
 
 interface ClauseStepProps<T> {
   color: string;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/ClauseStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/ClauseStep.tsx
@@ -1,4 +1,6 @@
 import type Tether from "tether";
+import type { PopoverBaseProps } from "metabase/ui";
+import { Popover } from "metabase/ui";
 import { Icon } from "metabase/core/components/Icon";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 import {
@@ -13,7 +15,9 @@ export interface ClauseStepProps<T> {
   isLastOpened?: boolean;
   initialAddText?: string | null;
   tetherOptions?: Tether.ITetherOptions | null;
+  popoverProps?: PopoverBaseProps;
   readOnly?: boolean;
+  withLegacyPopover?: boolean;
   renderName: (item: T, index: number) => JSX.Element | string;
   renderPopover: (item?: T, index?: number) => JSX.Element | null;
   canRemove?: (item: T) => boolean;
@@ -27,7 +31,9 @@ export const ClauseStep = <T,>({
   isLastOpened = false,
   initialAddText = null,
   tetherOptions = null,
+  popoverProps = {},
   readOnly,
+  withLegacyPopover = false,
   renderName,
   renderPopover,
   canRemove,
@@ -57,27 +63,46 @@ export const ClauseStep = <T,>({
     </NotebookCellItem>
   );
 
+  if (withLegacyPopover) {
+    return (
+      <NotebookCell color={color} data-testid={props["data-testid"]}>
+        {items.map((item, index) => (
+          <PopoverWithTrigger
+            key={index}
+            triggerElement={renderItem(item, index)}
+            tetherOptions={tetherOptions}
+            sizeToFit
+          >
+            {renderPopover(item, index)}
+          </PopoverWithTrigger>
+        ))}
+        {!readOnly && (
+          <PopoverWithTrigger
+            isInitiallyOpen={isLastOpened}
+            triggerElement={addItemElement}
+            tetherOptions={tetherOptions}
+            sizeToFit
+          >
+            {renderPopover()}
+          </PopoverWithTrigger>
+        )}
+      </NotebookCell>
+    );
+  }
+
   return (
     <NotebookCell color={color} data-testid={props["data-testid"]}>
       {items.map((item, index) => (
-        <PopoverWithTrigger
-          key={index}
-          triggerElement={renderItem(item, index)}
-          tetherOptions={tetherOptions}
-          sizeToFit
-        >
-          {renderPopover(item, index)}
-        </PopoverWithTrigger>
+        <Popover key={index} trapFocus {...popoverProps}>
+          <Popover.Target>{renderItem(item, index)}</Popover.Target>
+          <Popover.Dropdown>{renderPopover(item, index)}</Popover.Dropdown>
+        </Popover>
       ))}
       {!readOnly && (
-        <PopoverWithTrigger
-          isInitiallyOpen={isLastOpened}
-          triggerElement={addItemElement}
-          tetherOptions={tetherOptions}
-          sizeToFit
-        >
-          {renderPopover()}
-        </PopoverWithTrigger>
+        <Popover defaultOpened={isLastOpened} trapFocus {...popoverProps}>
+          <Popover.Target>{addItemElement}</Popover.Target>
+          <Popover.Dropdown>{renderPopover()}</Popover.Dropdown>
+        </Popover>
       )}
     </NotebookCell>
   );

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/ClauseStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/ClauseStep.tsx
@@ -7,54 +7,63 @@ import {
   NotebookCellItem,
 } from "../../NotebookCell";
 
-interface ClauseStepProps<T> {
+export interface ClauseStepProps<T> {
   color: string;
   items: T[];
-  renderName: (item: T, index: number) => JSX.Element | string;
-  renderPopover: (item?: T, index?: number) => JSX.Element | null;
-  canRemove?: (item: T) => boolean;
   isLastOpened?: boolean;
-  onRemove?: ((item: T, index: number) => void) | null;
   initialAddText?: string | null;
   tetherOptions?: Tether.ITetherOptions | null;
   readOnly?: boolean;
+  renderName: (item: T, index: number) => JSX.Element | string;
+  renderPopover: (item?: T, index?: number) => JSX.Element | null;
+  canRemove?: (item: T) => boolean;
+  onRemove?: ((item: T, index: number) => void) | null;
   "data-testid"?: string;
 }
 
 export const ClauseStep = <T,>({
   color,
   items,
-  renderName,
-  renderPopover,
-  canRemove,
-  onRemove = null,
   isLastOpened = false,
   initialAddText = null,
   tetherOptions = null,
   readOnly,
+  renderName,
+  renderPopover,
+  canRemove,
+  onRemove = null,
   ...props
 }: ClauseStepProps<T>): JSX.Element => {
+  const addItemElement = (
+    <NotebookCellAdd
+      color={color}
+      initialAddText={items.length === 0 && initialAddText}
+    />
+  );
+
+  const renderItem = (item: T, index: number) => (
+    <NotebookCellItem color={color} readOnly={readOnly}>
+      {renderName(item, index)}
+      {!readOnly && onRemove && (!canRemove || canRemove(item)) && (
+        <Icon
+          className="ml1"
+          name="close"
+          onClick={e => {
+            e.stopPropagation();
+            onRemove(item, index);
+          }}
+        />
+      )}
+    </NotebookCellItem>
+  );
+
   return (
     <NotebookCell color={color} data-testid={props["data-testid"]}>
       {items.map((item, index) => (
         <PopoverWithTrigger
-          tetherOptions={tetherOptions}
           key={index}
-          triggerElement={
-            <NotebookCellItem color={color} readOnly={readOnly}>
-              {renderName(item, index)}
-              {!readOnly && onRemove && (!canRemove || canRemove(item)) && (
-                <Icon
-                  className="ml1"
-                  name="close"
-                  onClick={e => {
-                    e.stopPropagation();
-                    onRemove(item, index);
-                  }}
-                />
-              )}
-            </NotebookCellItem>
-          }
+          triggerElement={renderItem(item, index)}
+          tetherOptions={tetherOptions}
           sizeToFit
         >
           {renderPopover(item, index)}
@@ -62,15 +71,10 @@ export const ClauseStep = <T,>({
       ))}
       {!readOnly && (
         <PopoverWithTrigger
-          triggerElement={
-            <NotebookCellAdd
-              color={color}
-              initialAddText={items.length === 0 && initialAddText}
-            />
-          }
+          isInitiallyOpen={isLastOpened}
+          triggerElement={addItemElement}
           tetherOptions={tetherOptions}
           sizeToFit
-          isInitiallyOpen={isLastOpened}
         >
           {renderPopover()}
         </PopoverWithTrigger>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/ClauseStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/ClauseStep.tsx
@@ -21,7 +21,7 @@ interface ClauseStepProps<T> {
   "data-testid"?: string;
 }
 
-const ClauseStep = <T,>({
+export const ClauseStep = <T,>({
   color,
   items,
   renderName,
@@ -78,6 +78,3 @@ const ClauseStep = <T,>({
     </NotebookCell>
   );
 };
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default ClauseStep;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/index.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/no-default-export
+export { default } from "./ClauseStep";

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/index.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export
-export { default } from "./ClauseStep";
+export * from "./ClauseStep";

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.tsx
@@ -21,7 +21,7 @@ const ExpressionStep = ({
       items={items}
       renderName={({ name }) => name}
       readOnly={readOnly}
-      renderPopover={item => (
+      renderPopover={({ item }) => (
         <ExpressionWidget
           query={query}
           name={item?.name}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.tsx
@@ -39,6 +39,7 @@ const ExpressionStep = ({
       )}
       isLastOpened={isLastOpened}
       onRemove={({ name }) => updateQuery(query.removeExpression(name))}
+      withLegacyPopover
     />
   );
 };

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.tsx
@@ -1,7 +1,7 @@
 import { ExpressionWidget } from "metabase/query_builder/components/expressions/ExpressionWidget";
 
 import type { NotebookStepUiComponentProps } from "../types";
-import ClauseStep from "./ClauseStep";
+import { ClauseStep } from "./ClauseStep";
 
 const ExpressionStep = ({
   color,

--- a/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep/FilterStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep/FilterStep.tsx
@@ -65,7 +65,7 @@ export function FilterStep({
         isLastOpened={isLastOpened}
         popoverProps={POPOVER_PROPS}
         renderName={renderFilterName}
-        renderPopover={(filter, index) => (
+        renderPopover={({ item: filter, index, onClose }) => (
           <FilterPopover
             query={topLevelQuery}
             stageIndex={stageIndex}
@@ -79,6 +79,7 @@ export function FilterStep({
             onAddFilter={handleAddFilter}
             onUpdateFilter={handleUpdateFilter}
             onLegacyQueryChange={updateQuery}
+            onClose={onClose}
           />
         )}
         onRemove={handleRemoveFilter}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep/FilterStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep/FilterStep.tsx
@@ -1,12 +1,17 @@
 import { useMemo } from "react";
 import { t } from "ttag";
 import ErrorBoundary from "metabase/ErrorBoundary";
+import type { PopoverBaseProps } from "metabase/ui";
 import { FilterPicker } from "metabase/common/components/FilterPicker";
 import * as Lib from "metabase-lib";
 import type LegacyQuery from "metabase-lib/queries/StructuredQuery";
 import type LegacyFilter from "metabase-lib/queries/structured/Filter";
 import type { NotebookStepUiComponentProps } from "../../types";
 import { ClauseStep } from "../ClauseStep";
+
+const POPOVER_PROPS: PopoverBaseProps = {
+  offset: { crossAxis: 32, mainAxis: 4 },
+};
 
 export function FilterStep({
   query: legacyQuery,
@@ -58,6 +63,7 @@ export function FilterStep({
         readOnly={readOnly}
         color={color}
         isLastOpened={isLastOpened}
+        popoverProps={POPOVER_PROPS}
         renderName={renderFilterName}
         renderPopover={(filter, index) => (
           <FilterPopover

--- a/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep/FilterStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep/FilterStep.tsx
@@ -6,7 +6,7 @@ import * as Lib from "metabase-lib";
 import type LegacyQuery from "metabase-lib/queries/StructuredQuery";
 import type LegacyFilter from "metabase-lib/queries/structured/Filter";
 import type { NotebookStepUiComponentProps } from "../../types";
-import ClauseStep from "../ClauseStep";
+import { ClauseStep } from "../ClauseStep";
 
 export function FilterStep({
   query: legacyQuery,

--- a/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.tsx
@@ -73,6 +73,7 @@ function SortStep({
         />
       )}
       onRemove={handleRemoveOrderBy}
+      withLegacyPopover
     />
   );
 }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.tsx
@@ -4,7 +4,7 @@ import { Icon } from "metabase/core/components/Icon";
 import { QueryColumnPicker } from "metabase/common/components/QueryColumnPicker";
 import * as Lib from "metabase-lib";
 import type { NotebookStepUiComponentProps } from "../../types";
-import ClauseStep from "../ClauseStep";
+import { ClauseStep } from "../ClauseStep";
 import { SortDirectionButton } from "./SortStep.styled";
 
 function SortStep({

--- a/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.tsx
@@ -62,12 +62,12 @@ function SortStep({
           onToggleSortDirection={() => handleToggleOrderByDirection(clause)}
         />
       )}
-      renderPopover={(orderBy, orderByIndex) => (
+      renderPopover={({ item: orderBy, index }) => (
         <SortPopover
           query={topLevelQuery}
           stageIndex={stageIndex}
           orderBy={orderBy}
-          orderByIndex={orderByIndex}
+          orderByIndex={index}
           onAddOrderBy={handleAddOrderBy}
           onUpdateOrderByColumn={handleUpdateOrderByColumn}
         />

--- a/frontend/src/metabase/ui/components/overlays/Popover/Popover.styled.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Popover/Popover.styled.tsx
@@ -3,7 +3,14 @@ import type { MantineThemeOverride } from "@mantine/core";
 export const getPopoverOverrides = (): MantineThemeOverride["components"] => ({
   Popover: {
     defaultProps: {
+      radius: "sm",
+      shadow: "md",
       withinPortal: true,
     },
+    styles: theme => ({
+      dropdown: {
+        padding: 0,
+      },
+    }),
   },
 });

--- a/frontend/src/metabase/ui/components/overlays/Popover/index.ts
+++ b/frontend/src/metabase/ui/components/overlays/Popover/index.ts
@@ -1,1 +1,3 @@
+export { Popover } from "@mantine/core";
+export type { PopoverBaseProps, PopoverProps } from "@mantine/core";
 export { getPopoverOverrides } from "./Popover.styled";


### PR DESCRIPTION
Closes #34691

Having a Mantine `Select` inside tether-driven popover doesn't work well with Cypress: when trying to click a `Select` item, Cypress believes the element is hidden. This PR adds Mantine `Popover` and makes the `FilterStep` use it, which happens to fix the problem.

Here's how it's expected to change a filter operator now:

```js
openOrdersTable();

filter({ mode: "notebook" });
popover().within(() => {
  cy.findByText("Discount").click();

  // Finds the `Select` element by the name of the current operator
  cy.findByDisplayValue("Equal to").click();
});

cy.findByRole("listbox").findByText("Greater than");
```