### PR TITLE
34618 splitting breakouts

### DIFF
--- a/e2e/test/scenarios/visualizations/bar_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/bar_chart.cy.spec.js
@@ -413,6 +413,7 @@ describe("scenarios > visualizations > bar chart", () => {
     cy.get(".value-labels").should("contain", "13");
     cy.get(".value-labels").should("contain", "19");
 
+    cy.log("Should not produce a split axis graph (#34618)");
     cy.get(".axis.yr").should("not.exist");
   });
 });

--- a/e2e/test/scenarios/visualizations/bar_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/bar_chart.cy.spec.js
@@ -5,6 +5,8 @@ import {
   getDraggableElements,
   moveColumnDown,
   popover,
+  visitDashboard,
+  cypressWaitAll,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
@@ -358,62 +360,157 @@ describe("scenarios > visualizations > bar chart", () => {
   });
 
   it("should support showing data points with > 10 series (#33725)", () => {
-    visitQuestionAdhoc({
-      display: "bar",
-      dataset_query: {
-        database: SAMPLE_DB_ID,
-        type: "query",
-        query: {
-          "source-table": ORDERS_ID,
-          aggregation: [["count"]],
-          filter: [
-            "and",
-            [
-              "time-interval",
-              [
-                "field",
-                ORDERS.CREATED_AT,
-                {
-                  "base-type": "type/DateTime",
-                },
-              ],
-              -1,
-              "month",
-              {},
-            ],
-            [
-              "=",
-              ["field", PEOPLE.STATE, {}],
-              "AK",
-              "AL",
-              "AR",
-              "AZ",
-              "CA",
-              "CO",
-              "CT",
-              "FL",
-              "GA",
-              "IA",
-            ],
-          ],
-          breakout: [
-            ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
-            ["field", PEOPLE.STATE, { "source-field": ORDERS.USER_ID }],
-          ],
+    cy.signInAsAdmin();
+    const stateFilter = [
+      "=",
+      ["field", PEOPLE.STATE, {}],
+      "AK",
+      "AL",
+      "AR",
+      "AZ",
+      "CA",
+      "CO",
+      "CT",
+      "FL",
+      "GA",
+      "IA",
+    ];
+
+    const dateFilter = [
+      "between",
+      [
+        "field",
+        ORDERS.CREATED_AT,
+        {
+          "base-type": "type/DateTime",
         },
+      ],
+      "2023-09-01",
+      "2023-09-30",
+    ];
+
+    const avgTotalByMonth = {
+      name: "Average Total by Month",
+      type: "query",
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["avg", ["field", ORDERS.TOTAL]]],
+        breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }]],
       },
+      display: "line",
+    };
+
+    const sumTotalByMonth = {
+      name: "Sum Total by Month",
+      type: "query",
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["sum", ["field", ORDERS.TOTAL]]],
+        breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }]],
+      },
+      display: "line",
+    };
+
+    const multiMetric = {
+      name: "Should split",
+      type: "query",
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [
+          ["avg", ["field", ORDERS.TAX]],
+          ["sum", ["field", ORDERS.TAX]],
+          ["min", ["field", ORDERS.TAX]],
+          ["max", ["field", ORDERS.TAX]],
+          ["avg", ["field", ORDERS.SUBTOTAL]],
+          ["sum", ["field", ORDERS.SUBTOTAL]],
+          ["min", ["field", ORDERS.SUBTOTAL]],
+          ["max", ["field", ORDERS.SUBTOTAL]],
+          ["avg", ["field", ORDERS.TOTAL]],
+          ["sum", ["field", ORDERS.TOTAL]],
+          ["min", ["field", ORDERS.TOTAL]],
+          ["max", ["field", ORDERS.TOTAL]],
+        ],
+        breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }]],
+        filter: dateFilter,
+      },
+      display: "bar",
+      visualization_settings: {
+        "graph.show_values": true,
+      },
+    };
+
+    const breakoutQuestion = {
+      name: "Should not Split",
+      type: "query",
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["count"]],
+        breakout: [
+          ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+          ["field", PEOPLE.STATE, { "source-field": ORDERS.USER_ID }],
+        ],
+        filter: ["and", stateFilter, dateFilter],
+      },
+      display: "bar",
       visualization_settings: {
         "graph.dimensions": ["CREATED_AT", "STATE"],
         "graph.metrics": ["count"],
         "graph.show_values": true,
       },
+    };
+
+    cy.createDashboardWithQuestions({
+      dashboardName: "Split Test Dashboard",
+      questions: [multiMetric],
+    }).then(({ dashboard }) => {
+      cy.createQuestion(sumTotalByMonth, { wrapId: true }).then(() => {
+        cy.get("@questionId").then(questionId => {
+          cypressWaitAll([
+            cy.createQuestionAndAddToDashboard(avgTotalByMonth, dashboard.id, {
+              series: [
+                {
+                  id: questionId,
+                },
+              ],
+              col: 12,
+              row: 0,
+              visualization_settings: {
+                "card.title": "Multi Series",
+              },
+            }),
+            cy.createQuestionAndAddToDashboard(breakoutQuestion, dashboard.id, {
+              col: 0,
+              row: 9,
+              size_x: 15,
+            }),
+          ]).then(() => {
+            visitDashboard(dashboard.id);
+          });
+        });
+      });
     });
 
-    cy.get(".value-labels").should("contain", "6");
-    cy.get(".value-labels").should("contain", "13");
-    cy.get(".value-labels").should("contain", "19");
+    //This card is testing #33725 now, as the changes made for #34618 would cause "Should not Split" to no longer split and error
+    cy.findAllByTestId("dashcard")
+      .contains("[data-testid=dashcard]", "Should split")
+      .within(() => {
+        cy.get(".axis.yr").should("exist");
+      });
+
+    cy.findAllByTestId("dashcard")
+      .contains("[data-testid=dashcard]", "Multi Series")
+      .within(() => {
+        cy.get(".axis.yr").should("exist");
+      });
 
     cy.log("Should not produce a split axis graph (#34618)");
-    cy.get(".axis.yr").should("not.exist");
+    cy.findAllByTestId("dashcard")
+      .contains("[data-testid=dashcard]", "Should not Split")
+      .within(() => {
+        cy.get(".value-labels").should("contain", "6");
+        cy.get(".value-labels").should("contain", "13");
+        cy.get(".value-labels").should("contain", "19");
+        cy.get(".axis.yr").should("not.exist");
+      });
   });
 });

--- a/e2e/test/scenarios/visualizations/bar_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/bar_chart.cy.spec.js
@@ -412,5 +412,7 @@ describe("scenarios > visualizations > bar chart", () => {
     cy.get(".value-labels").should("contain", "6");
     cy.get(".value-labels").should("contain", "13");
     cy.get(".value-labels").should("contain", "19");
+
+    cy.get(".axis.yr").should("not.exist");
   });
 });

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -355,6 +355,17 @@ export function xValueForWaterfallTotal({ settings, series }) {
 
 const uniqueCards = series => _.uniq(series.map(({ card }) => card.id)).length;
 
+const aggregateColumns = series => {
+  return _.uniq(
+    series
+      .map(({ data: { cols } }) => {
+        return cols.filter(col => col.source === "aggregation");
+      })
+      .flat()
+      .map(({ name }) => name),
+  ).length;
+};
+
 export function shouldSplitYAxis(
   { settings, chartType, isScalarSeries, series },
   datas,
@@ -364,7 +375,7 @@ export function shouldSplitYAxis(
     isScalarSeries ||
     chartType === "scatter" ||
     settings["graph.y_axis.auto_split"] === false ||
-    uniqueCards(series) < 2 ||
+    (uniqueCards(series) < 2 && aggregateColumns(series) < 2) ||
     isStacked(settings, datas)
   ) {
     return false;

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -362,6 +362,7 @@ export function shouldSplitYAxis(
     isScalarSeries ||
     chartType === "scatter" ||
     settings["graph.y_axis.auto_split"] === false ||
+    settings["graph.metrics"]?.length < 2 ||
     isStacked(settings, datas)
   ) {
     return false;

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -353,6 +353,8 @@ export function xValueForWaterfallTotal({ settings, series }) {
   return TOTAL_ORDINAL_VALUE;
 }
 
+const uniqueCards = series => _.uniq(series.map(({ card }) => card.id)).length;
+
 export function shouldSplitYAxis(
   { settings, chartType, isScalarSeries, series },
   datas,
@@ -362,7 +364,7 @@ export function shouldSplitYAxis(
     isScalarSeries ||
     chartType === "scatter" ||
     settings["graph.y_axis.auto_split"] === false ||
-    settings["graph.metrics"]?.length < 2 ||
+    uniqueCards(series) < 2 ||
     isStacked(settings, datas)
   ) {
     return false;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/34618

### Description
Depending on the number of series in your breakout, it's possible to have a single card want to split the Y axis even though there is only 1 metric being. The change here will have `shouldSplitYAxis` return false if a series is only made up of 1 card, and has 1 metric. This covers the case where you have a question that is a breakout with many series, but means that questions with multiple metrics, or series that have been added together can still split.

### How to verify
The linked issue gives an example of a question that has multiple dimensions, but would split even though there is only 1 metric. This change fixes that case, but should leave the other cases mentioned above untouched.

### Demo
This is a screenshot of a dashboard containing the examples of:
- A card with an added series (should split if appropriate)
- A card with a question that has multiple aggregations (should split if appropriate)
- A card with a breakout (should not split)
- A card with a breakout, and an added series with a breakout (should split if appropriate)

**Before**

![Screenshot 2023-10-17 at 10.11.50 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/2c73573f-8629-4c93-a365-2e170d38e109/Screenshot%202023-10-17%20at%2010.11.50%20AM.png)

**After**

![Screenshot 2023-10-17 at 10.13.15 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/9aaf541b-6d43-42ea-ad88-5565f32b2835/Screenshot%202023-10-17%20at%2010.13.15%20AM.png)

The bottom left card (single series breakout) is now split, which we want.

The last case is splitting, but the split it's coming up with isn't very ideal :/

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
