### PR TITLE
Fix quick-filter drill returning extra operators (#34445)

### DIFF
--- a/frontend/src/metabase-lib/drills.unit.spec.ts
+++ b/frontend/src/metabase-lib/drills.unit.spec.ts
@@ -1092,18 +1092,17 @@ describe("availableDrillThrus", () => {
         operators: ["<", ">", "=", "≠"],
       },
     },
-    // FIXME: quick-filter returns extra "<", ">" operators for cell with no value (metabase#34445)
-    // {
-    //   drillType: "drill-thru/quick-filter",
-    //   clickType: "cell",
-    //   queryType: "aggregated",
-    //   columnName: "max",
-    //   expectedParameters: {
-    //     type: "drill-thru/quick-filter",
-    //     operators: ["=", "≠"],
-    //   },
-    // },
-    // endregion
+    // quick-filter returns extra "<", ">" operators for cell with no value (metabase#34445)
+    {
+      drillType: "drill-thru/quick-filter",
+      clickType: "cell",
+      queryType: "aggregated",
+      columnName: "max",
+      expectedParameters: {
+        type: "drill-thru/quick-filter",
+        operators: ["=", "≠"],
+      },
+    },
 
     // region --- drill-thru/underlying-records
     {

--- a/src/metabase/lib/drill_thru/sort.cljc
+++ b/src/metabase/lib/drill_thru/sort.cljc
@@ -5,6 +5,7 @@
    [metabase.lib.equality :as lib.equality]
    [metabase.lib.order-by :as lib.order-by]
    [metabase.lib.ref :as lib.ref]
+   [metabase.lib.remove-replace :as lib.remove-replace]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
    [metabase.lib.schema.order-by :as lib.schema.order-by]
@@ -66,7 +67,7 @@
    ;; changing it to the opposite direction, so we can safely assume we want to change the direction and
    ;; use [[lib.order-by/change-direction]] here.
    (if-let [existing-clause (existing-order-by-clause query stage-number column)]
-     (lib.order-by/change-direction query existing-clause)
+     (lib.remove-replace/replace-clause query existing-clause (lib.order-by/order-by-clause column (keyword direction)))
      (lib.order-by/order-by query stage-number column (keyword direction)))))
 
 (defmethod lib.drill-thru.common/drill-thru-info-method :drill-thru/sort

--- a/src/metabase/lib/schema/drill_thru.cljc
+++ b/src/metabase/lib/schema/drill_thru.cljc
@@ -17,9 +17,16 @@
 (mr/def ::pivot-types
   [:enum :category :location :time])
 
+(mr/def ::drill-thru.type
+  [:fn
+   {:error/message "valid drill-thru :type keyword"}
+   (fn [k]
+     (and (qualified-keyword? k)
+          (= (namespace k) "drill-thru")))])
+
 (mr/def ::drill-thru.common
   [:map
-   [:type     keyword?]
+   [:type     ::drill-thru.type]
    [:lib/type [:= :metabase.lib.drill-thru/drill-thru]]])
 
 (mr/def ::drill-thru.object-details

--- a/test/metabase/lib/drill_thru/column_filter_test.cljc
+++ b/test/metabase/lib/drill_thru/column_filter_test.cljc
@@ -1,0 +1,94 @@
+(ns metabase.lib.drill-thru.column-filter-test
+  (:require
+   [clojure.test :refer [deftest]]
+   [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]))
+
+(deftest ^:parallel returns-column-filter-test-1
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/column-filter
+    :click-type  :header
+    :query-type  :unaggregated
+    :column-name "ID"
+    :expected    {:type :drill-thru/column-filter, :initial-op {:short :=}}}))
+
+(deftest ^:parallel returns-column-filter-test-2
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/column-filter
+    :click-type  :header
+    :query-type  :unaggregated
+    :column-name "USER_ID"
+    :expected    {:type :drill-thru/column-filter, :initial-op {:short :=}}}))
+
+(deftest ^:parallel returns-column-filter-test-3
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/column-filter
+    :click-type  :header
+    :query-type  :unaggregated
+    :column-name "TAX"
+    :expected    {:type :drill-thru/column-filter, :initial-op {:short :=}}}))
+
+(deftest ^:parallel returns-column-filter-test-4
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/column-filter
+    :click-type  :header
+    :query-type  :unaggregated
+    :column-name "DISCOUNT"
+    :expected    {:type :drill-thru/column-filter, :initial-op {:short :=}}}))
+
+(deftest ^:parallel returns-column-filter-test-5
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/column-filter
+    :click-type  :header
+    :query-type  :unaggregated
+    :column-name "CREATED_AT"
+    :expected    {:type :drill-thru/column-filter, :initial-op nil}}))
+
+(deftest ^:parallel returns-column-filter-test-6
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/column-filter
+    :click-type  :header
+    :query-type  :unaggregated
+    :column-name "QUANTITY"
+    :expected    {:type :drill-thru/column-filter, :initial-op {:short :=}}}))
+
+(deftest ^:parallel returns-column-filter-test-7
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/column-filter
+    :click-type  :header
+    :query-type  :aggregated
+    :column-name "PRODUCT_ID"
+    :expected    {:type :drill-thru/column-filter, :initial-op {:short :=}}}))
+
+(deftest ^:parallel returns-column-filter-test-8
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/column-filter
+    :click-type  :header
+    :query-type  :aggregated
+    :column-name "PRODUCT_ID"
+    :expected    {:type :drill-thru/column-filter, :initial-op {:short :=}}}))
+
+(deftest ^:parallel returns-column-filter-test-9
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/column-filter
+    :click-type  :header
+    :query-type  :aggregated
+    :column-name "CREATED_AT"
+    :expected    {:type :drill-thru/column-filter, :initial-op nil}}))
+
+;;; FIXME column-filter should be available for aggregated query metric column (#34223)
+(deftest ^:parallel returns-column-filter-test-10
+  #_(lib.drill-thru.tu/test-returns-drill
+     {:drill-type  :drill-thru/column-filter
+      :click-type  :header
+      :query-type  :aggregated
+      :column-name "count"
+      :expected    {:type :drill-thru/column-filter, :initial-op {:short :=}}}))
+
+;;; FIXME column-filter should be available for aggregated query metric column (#34223)
+(deftest ^:parallel returns-column-filter-test-11
+  #_(lib.drill-thru.tu/test-returns-drill
+     {:drill-type  :drill-thru/column-filter
+      :click-type  :header
+      :query-type  :aggregated
+      :column-name "max"
+      :expected    {:type :drill-thru/column-filter, :initial-op {:short :=}}}))

--- a/test/metabase/lib/drill_thru/distribution_test.cljc
+++ b/test/metabase/lib/drill_thru/distribution_test.cljc
@@ -4,6 +4,7 @@
    [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.drill-thru.distribution :as lib.drill-thru.distribution]
+   [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
    [metabase.lib.test-metadata :as meta]
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))))
 
@@ -21,3 +22,43 @@
                      :value  nil}]
       (is (some? count-col))
       (is (nil? (lib.drill-thru.distribution/distribution-drill query -1 context))))))
+
+(deftest ^:parallel returns-distribution-test-1
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/distribution
+    :click-type  :header
+    :query-type  :unaggregated
+    :column-name "USER_ID"
+    :expected    {:type :drill-thru/distribution}}))
+
+(deftest ^:parallel returns-distribution-test-2
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/distribution
+    :click-type  :header
+    :query-type  :unaggregated
+    :column-name "TAX"
+    :expected    {:type :drill-thru/distribution}}))
+
+(deftest ^:parallel returns-distribution-test-3
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/distribution
+    :click-type  :header
+    :query-type  :unaggregated
+    :column-name "QUANTITY"
+    :expected    {:type :drill-thru/distribution}}))
+
+(deftest ^:parallel returns-distribution-test-4
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/distribution
+    :click-type  :header
+    :query-type  :aggregated
+    :column-name "PRODUCT_ID"
+    :expected    {:type :drill-thru/distribution}}))
+
+(deftest ^:parallel returns-distribution-test-5
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/distribution
+    :click-type  :header
+    :query-type  :aggregated
+    :column-name "CREATED_AT"
+    :expected    {:type :drill-thru/distribution}}))

--- a/test/metabase/lib/drill_thru/fk_details_test.cljc
+++ b/test/metabase/lib/drill_thru/fk_details_test.cljc
@@ -1,0 +1,24 @@
+(ns metabase.lib.drill-thru.fk-details-test
+  (:require
+   [clojure.test :refer [deftest]]
+   [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]))
+
+(deftest ^:parallel returns-fk-details-test-1
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/fk-details
+    :click-type  :cell
+    :query-type  :unaggregated
+    :column-name "PRODUCT_ID"
+    :expected    {:type      :drill-thru/fk-details
+                  :object-id (get-in lib.drill-thru.tu/test-queries ["ORDERS" :unaggregated :row "PRODUCT_ID"])
+                  :many-pks? false}}))
+
+(deftest ^:parallel returns-fk-details-test-2
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/fk-details
+    :click-type  :cell
+    :query-type  :unaggregated
+    :column-name "USER_ID"
+    :expected    {:type      :drill-thru/fk-details
+                  :object-id (get-in lib.drill-thru.tu/test-queries ["ORDERS" :unaggregated :row "USER_ID"])
+                  :many-pks? false}}))

--- a/test/metabase/lib/drill_thru/foreign_key_test.cljc
+++ b/test/metabase/lib/drill_thru/foreign_key_test.cljc
@@ -1,0 +1,29 @@
+(ns metabase.lib.drill-thru.foreign-key-test
+  (:require
+   [clojure.test :refer [deftest]]
+   [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]))
+
+(deftest ^:parallel returns-fk-filter-test-1
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/fk-filter
+    :click-type  :cell
+    :query-type  :unaggregated
+    :column-name "USER_ID"
+    :expected    {:type :drill-thru/fk-filter}}))
+
+(deftest ^:parallel returns-fk-filter-test-2
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/fk-filter
+    :click-type  :cell
+    :query-type  :unaggregated
+    :column-name "PRODUCT_ID"
+    :expected    {:type :drill-thru/fk-filter}}))
+
+;;; FIXME `fk-filter` doesn't get returned for fk column that was used as breakout (#34440)
+(deftest ^:parallel returns-fk-filter-test-3
+  #_(lib.drill-thru.tu/test-returns-drill
+     {:drill-type  :drill-thru/fk-filter
+      :click-type  :cell
+      :query-type  :aggregated
+      :column-name "PRODUCT_ID"
+      :expected    {:type :drill-thru/fk-filter}}))

--- a/test/metabase/lib/drill_thru/pivot_test.cljc
+++ b/test/metabase/lib/drill_thru/pivot_test.cljc
@@ -1,0 +1,13 @@
+(ns metabase.lib.drill-thru.pivot-test
+  (:require
+   [clojure.test :refer [deftest]]))
+
+;;; FIXME pivot is not implemented yet (#33559)
+(deftest ^:parallel returns-drill-thru-test-61
+  #_(lib.drill-thru.tu/test-returns-drill
+     {:drill-type  :drill-thru/pivot
+      :click-type  :cell
+      :query-type  :aggregated
+      :query-table "PRODUCTS"
+      :column-name "count"
+      :expected    {:type :drill-thru/pivot}}))

--- a/test/metabase/lib/drill_thru/quick_filter_test.cljc
+++ b/test/metabase/lib/drill_thru/quick_filter_test.cljc
@@ -1,0 +1,90 @@
+(ns metabase.lib.drill-thru.quick-filter-test
+  (:require
+   [clojure.test :refer [deftest testing]]
+   [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]))
+
+(deftest ^:parallel returns-quick-filter-test-1
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/quick-filter
+    :click-type  :cell
+    :query-type  :unaggregated
+    :column-name "SUBTOTAL"
+    :expected    {:type :drill-thru/quick-filter, :operators [{:name "<"}
+                                                              {:name ">"}
+                                                              {:name "="}
+                                                              {:name "≠"}]}}))
+
+(deftest ^:parallel returns-quick-filter-test-2
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/quick-filter
+    :click-type  :cell
+    :query-type  :unaggregated
+    :column-name "DISCOUNT"
+    :expected    {:type :drill-thru/quick-filter, :operators [{:name "="}
+                                                              {:name "≠"}]}}))
+
+(deftest ^:parallel returns-quick-filter-test-3
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/quick-filter
+    :click-type  :cell
+    :query-type  :unaggregated
+    :column-name "CREATED_AT"
+    :expected    {:type :drill-thru/quick-filter, :operators [{:name "<"}
+                                                              {:name ">"}
+                                                              {:name "="}
+                                                              {:name "≠"}]}}))
+
+(deftest ^:parallel returns-quick-filter-test-4
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/quick-filter
+    :click-type  :cell
+    :query-type  :unaggregated
+    :column-name "QUANTITY"
+    :expected    {:type :drill-thru/quick-filter, :operators [{:name "<"}
+                                                              {:name ">"}
+                                                              {:name "="}
+                                                              {:name "≠"}]}}))
+
+;;; FIXME quick-filter doesn't get returned for CREATED_AT column in aggregated query (#34443)
+(deftest ^:parallel returns-quick-filter-test-5
+  #_(lib.drill-thru.tu/test-returns-drill
+     {:drill-type  :drill-thru/quick-filter
+      :click-type  :cell
+      :query-type  :aggregated
+      :column-name "CREATED_AT"
+      :expected    {:type :drill-thru/quick-filter, :operators [{:name "<"}
+                                                                {:name ">"}
+                                                                {:name "="}
+                                                                {:name "≠"}]}}))
+
+(deftest ^:parallel returns-quick-filter-test-6
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/quick-filter
+    :click-type  :cell
+    :query-type  :aggregated
+    :column-name "count"
+    :expected    {:type :drill-thru/quick-filter, :operators [{:name "<"}
+                                                              {:name ">"}
+                                                              {:name "="}
+                                                              {:name "≠"}]}}))
+
+(deftest ^:parallel returns-quick-filter-test-7
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/quick-filter
+    :click-type  :cell
+    :query-type  :aggregated
+    :column-name "sum"
+    :expected    {:type :drill-thru/quick-filter, :operators [{:name "<"}
+                                                              {:name ">"}
+                                                              {:name "="}
+                                                              {:name "≠"}]}}))
+
+(deftest ^:parallel returns-quick-filter-test-8
+  (testing "quick-filter should not return < or > for cell with no value (#34445)"
+    (lib.drill-thru.tu/test-returns-drill
+     {:drill-type  :drill-thru/quick-filter
+      :click-type  :cell
+      :query-type  :aggregated
+      :column-name "max"
+      :expected    {:type :drill-thru/quick-filter, :operators [{:name "="}
+                                                                {:name "≠"}]}})))

--- a/test/metabase/lib/drill_thru/sort_test.cljc
+++ b/test/metabase/lib/drill_thru/sort_test.cljc
@@ -5,6 +5,7 @@
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.drill-thru.sort :as lib.drill-thru.sort]
+   [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
    [metabase.lib.test-metadata :as meta]
    #?@(:clj ([metabase.util.malli.fn :as mu.fn])
        :cljs ([metabase.test-runner.assert-exprs.approximately-equal]))))
@@ -95,3 +96,108 @@
                  [{:order-by [[:desc {} [:field {} (meta/id :orders :user-id)]]
                               [:asc {} [:field {} (meta/id :orders :id)]]]}]}
                 (lib/drill-thru query -1 drill :desc)))))))
+
+(deftest ^:parallel returns-sort-test-1
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/sort
+    :click-type  :header
+    :query-type  :unaggregated
+    :column-name "ID"
+    :expected    {:type :drill-thru/sort, :sort-directions [:asc :desc]}}))
+
+(deftest ^:parallel returns-sort-test-2
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/sort
+    :click-type  :header
+    :query-type  :unaggregated
+    :column-name "USER_ID"
+    :expected    {:type :drill-thru/sort, :sort-directions [:asc :desc]}}))
+
+(deftest ^:parallel returns-sort-test-3
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/sort
+    :click-type  :header
+    :query-type  :unaggregated
+    :column-name "TOTAL"
+    :expected    {:type :drill-thru/sort, :sort-directions [:asc :desc]}}))
+
+(deftest ^:parallel returns-sort-test-4
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type   :drill-thru/sort
+    :click-type   :header
+    :query-type   :unaggregated
+    :column-name  "TOTAL"
+    :custom-query (-> (get-in lib.drill-thru.tu/test-queries ["ORDERS" :unaggregated :query])
+                      (lib/order-by (meta/field-metadata :orders :total) :desc))
+    :expected     {:type :drill-thru/sort, :sort-directions [:asc]}}))
+
+(deftest ^:parallel returns-sort-test-5
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/sort
+    :click-type  :header
+    :query-type  :unaggregated
+    :column-name "CREATED_AT"
+    :expected    {:type :drill-thru/sort, :sort-directions [:asc :desc]}}))
+
+(deftest ^:parallel returns-sort-test-6
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type   :drill-thru/sort
+    :click-type   :header
+    :query-type   :unaggregated
+    :column-name  "CREATED_AT"
+    :custom-query (-> (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :query])
+                      (lib/order-by (meta/field-metadata :orders :created-at) :asc))
+    :expected     {:type :drill-thru/sort, :sort-directions [:desc]}}))
+
+(deftest ^:parallel returns-sort-test-7
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/sort
+    :click-type  :header
+    :query-type  :aggregated
+    :column-name "CREATED_AT"
+    :expected    {:type :drill-thru/sort, :sort-directions [:asc :desc]}}))
+
+(deftest ^:parallel returns-sort-test-8
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/sort
+    :click-type  :header
+    :query-type  :aggregated
+    :column-name "PRODUCT_ID"
+    :expected    {:type :drill-thru/sort, :sort-directions [:asc :desc]}}))
+
+(deftest ^:parallel returns-sort-test-9
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/sort
+    :click-type  :header
+    :query-type  :aggregated
+    :column-name "count"
+    :expected    {:type :drill-thru/sort, :sort-directions [:asc :desc]}}))
+
+(deftest ^:parallel returns-sort-test-10
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type   :drill-thru/sort
+    :click-type   :header
+    :query-type   :aggregated
+    :column-name  "count"
+    :custom-query (-> (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :query])
+                      (lib/order-by (meta/field-metadata :orders :created-at) :asc))
+    :expected     {:type :drill-thru/sort, :sort-directions [:asc :desc]}}))
+
+(deftest ^:parallel returns-sort-test-11
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/sort
+    :click-type  :header
+    :query-type  :aggregated
+    :column-name "max"
+    :expected    {:type :drill-thru/sort, :sort-directions [:asc :desc]}}))
+
+(deftest ^:parallel returns-sort-test-12
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type   :drill-thru/sort
+    :click-type   :header
+    :query-type   :aggregated
+    :column-name  "CREATED_AT"
+    :custom-query (->
+                   (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :query])
+                   (lib/order-by (meta/field-metadata :orders :created-at) :asc))
+    :expected     {:type :drill-thru/sort, :sort-directions [:desc]}}))

--- a/test/metabase/lib/drill_thru/summarize_column_by_time_test.cljc
+++ b/test/metabase/lib/drill_thru/summarize_column_by_time_test.cljc
@@ -3,7 +3,9 @@
    [clojure.test :refer [deftest is testing]]
    [medley.core :as m]
    [metabase.lib.core :as lib]
-   [metabase.lib.drill-thru.summarize-column-by-time :as lib.drill-thru.summarize-column-by-time]
+   [metabase.lib.drill-thru.summarize-column-by-time
+    :as lib.drill-thru.summarize-column-by-time]
+   [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
    [metabase.lib.test-metadata :as meta]
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))))
 
@@ -21,3 +23,27 @@
                      :value  nil}]
       (is (some? count-col))
       (is (nil? (lib.drill-thru.summarize-column-by-time/summarize-column-by-time-drill query -1 context))))))
+
+(deftest ^:parallel returns-summarize-column-by-time-test-1
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/summarize-column-by-time
+    :click-type  :header
+    :query-type  :unaggregated
+    :column-name "SUBTOTAL"
+    :expected    {:type :drill-thru/summarize-column-by-time}}))
+
+(deftest ^:parallel returns-summarize-column-by-time-test-2
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/summarize-column-by-time
+    :click-type  :header
+    :query-type  :unaggregated
+    :column-name "DISCOUNT"
+    :expected    {:type :drill-thru/summarize-column-by-time}}))
+
+(deftest ^:parallel returns-summarize-column-by-time-test-3
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/summarize-column-by-time
+    :click-type  :header
+    :query-type  :unaggregated
+    :column-name "QUANTITY"
+    :expected    {:type :drill-thru/summarize-column-by-time}}))

--- a/test/metabase/lib/drill_thru/summarize_column_test.cljc
+++ b/test/metabase/lib/drill_thru/summarize_column_test.cljc
@@ -1,0 +1,44 @@
+(ns metabase.lib.drill-thru.summarize-column-test
+  (:require
+   [clojure.test :refer [deftest]]
+   [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]))
+
+(deftest ^:parallel returns-summarize-column-test-1
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/summarize-column
+    :click-type  :header
+    :query-type  :unaggregated
+    :column-name "ID"
+    :expected    {:type :drill-thru/summarize-column, :aggregations [:distinct]}}))
+
+(deftest ^:parallel returns-summarize-column-test-2
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/summarize-column
+    :click-type  :header
+    :query-type  :unaggregated
+    :column-name "USER_ID"
+    :expected    {:type :drill-thru/summarize-column, :aggregations [:distinct]}}))
+
+(deftest ^:parallel returns-summarize-column-test-3
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/summarize-column
+    :click-type  :header
+    :query-type  :unaggregated
+    :column-name "SUBTOTAL"
+    :expected    {:type :drill-thru/summarize-column, :aggregations [:distinct :sum :avg]}}))
+
+(deftest ^:parallel returns-summarize-column-test-4
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/summarize-column
+    :click-type  :header
+    :query-type  :unaggregated
+    :column-name "CREATED_AT"
+    :expected    {:type :drill-thru/summarize-column, :aggregations [:distinct]}}))
+
+(deftest ^:parallel returns-summarize-column-test-5
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/summarize-column
+    :click-type  :header
+    :query-type  :unaggregated
+    :column-name "QUANTITY"
+    :expected    {:type :drill-thru/summarize-column, :aggregations [:distinct :sum :avg]}}))

--- a/test/metabase/lib/drill_thru/test_util.cljc
+++ b/test/metabase/lib/drill_thru/test_util.cljc
@@ -1,0 +1,155 @@
+(ns metabase.lib.drill-thru.test-util
+  "Adapted from frontend/src/metabase-lib/drills.unit.spec.ts"
+  (:require
+   [clojure.test :refer [is testing]]
+   [medley.core :as m]
+   [metabase.lib.core :as lib]
+   [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
+   [metabase.lib.test-metadata :as meta]
+   [metabase.lib.util :as lib.util]
+   [metabase.util :as u]
+   [metabase.util.malli :as mu]
+   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))))
+
+#?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
+
+(def test-queries
+  {"ORDERS"
+   {:unaggregated
+    {:query (lib/query meta/metadata-provider (meta/table-metadata :orders))
+     :row   {"ID"         "3"
+             "USER_ID"    "1"
+             "PRODUCT_ID" "105"
+             "SUBTOTAL"   52.723521442619514
+             "TAX"        2.9
+             "TOTAL"      49.206842233769756
+             "DISCOUNT"   nil
+             "CREATED_AT" "2025-12-06T22:22:48.544+02:00"
+             "QUANTITY"   2}}
+
+    :aggregated
+    {:query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                (lib/aggregate (lib/count))
+                (lib/aggregate (lib/sum (meta/field-metadata :orders :tax)))
+                (lib/aggregate (lib/max (meta/field-metadata :orders :discount)))
+                (lib/breakout (meta/field-metadata :orders :product-id))
+                (lib/breakout (-> (meta/field-metadata :orders :created-at)
+                                  (lib/with-temporal-bucket :month))))
+     :row   {"PRODUCT_ID" 3
+             "CREATED_AT" "2022-12-01T00:00:00+02:00"
+             "count"      77
+             "sum"        1
+             "max"        nil}}}
+
+   "PRODUCTS"
+   {:unaggregated
+    {:query (lib/query meta/metadata-provider (meta/table-metadata :products))
+     :row   {"ID"         "3"
+             "EAN"        "4966277046676"
+             "TITLE"      "Synergistic Granite Chair"
+             "CATEGORY"   "Doohickey"
+             "VENDOR"     "Murray, Watsica and Wunsch"
+             "PRICE"      35.38
+             "RATING"     4
+             "CREATED_AT" "2024-09-08T22:03:20.239+03:00"}}}})
+
+(def ^:private TestCase
+  [:map
+   [:click-type      [:enum :cell :header]]
+   [:query-type      [:enum :aggregated :unaggregated]]
+   [:column-name     :string]
+   ;; defaults to "ORDERS"
+   [:query-table  {:optional true} [:enum "ORDERS" #_"PRODUCTS"]]
+   [:custom-query {:optional true} ::lib.schema/query]])
+
+(def ^:private Row
+  [:map-of :string :any])
+
+(mu/defn ^:private query-and-row-for-test-case :- [:map
+                                                   [:query ::lib.schema/query]
+                                                   [:row   Row]]
+  [{:keys [query-table query-type]
+    :or   {query-table "ORDERS"}
+    :as   test-case} :- TestCase]
+  (or (get-in test-queries [query-table query-type])
+      (throw (ex-info "Invalid query-table/query-:type no matching test query" {:test-case test-case}))))
+
+(mu/defn ^:private test-case-context :- ::lib.schema.drill-thru/context
+  [query     :- ::lib.schema/query
+   row       :- Row
+   {:keys [column-name click-type query-type], :as _test-case} :- TestCase]
+  (let [cols       (lib/returned-columns query -1 (lib.util/query-stage query -1))
+        col        (m/find-first (fn [col]
+                                   (= (:name col) column-name))
+                                 cols)
+        _          (assert col (lib.util/format "No column found named %s; found: %s"
+                                                (pr-str column-name)
+                                                (pr-str (map :name cols))))
+        value      (let [v (get row column-name ::not-found)]
+                     (when-not (= v ::not-found)
+                       (if (some? v) v :null)))
+        dimensions (when (= query-type :aggregated)
+                     (for [col   cols
+                           :when (and (= (:lib/source col) :source/breakouts)
+                                      (not= (:name col) column-name))]
+                       {:column-name (:name col), :value (get row (:name col))}))]
+    (merge
+     {:column col
+      :value  nil}
+     (when (= click-type :cell)
+       {:value      value
+        :row        (for [[column-name value] row]
+                      {:column-name column-name, :value value})
+        :dimensions dimensions}))))
+
+(def ^:private AvailableDrillsTestCase
+  [:merge
+   TestCase
+   [:map
+    [:expected [:sequential [:map
+                             [:type ::lib.schema.drill-thru/drill-thru.type]]]]]])
+
+(mu/defn test-available-drill-thrus
+  [{:keys [column-name click-type query-type query-table expected]
+    :or   {query-table "ORDERS"}
+    :as   test-case} :- AvailableDrillsTestCase]
+  (testing (lib.util/format "should return correct drills for %s.%s %s in %s query"
+                            query-table column-name (name click-type) (name query-type))
+    (let [{:keys [query row]} (query-and-row-for-test-case test-case)
+          context             (test-case-context query row test-case)]
+      (testing (str "\nQuery = \n"   (u/pprint-to-str query)
+                    "\nContext =\n" (u/pprint-to-str context))
+        (is (=? expected
+                (lib/available-drill-thrus query -1 context)))))))
+
+(def ^:private ReturnsDrillTestCase
+  [:merge
+   TestCase
+   [:map
+    [:drill-type ::lib.schema.drill-thru/drill-thru.type]
+    [:expected   [:map
+                  [:type ::lib.schema.drill-thru/drill-thru.type]]]]])
+
+(mu/defn test-returns-drill
+  "Test that a certain drill gets returned."
+  [{:keys [drill-type query-table column-name click-type query-type custom-query expected]
+    :or   {query-table "ORDERS"}
+    :as   test-case} :- ReturnsDrillTestCase]
+  (testing (lib.util/format "should return %s drill config for %s.%s %s in %s query"
+                            drill-type
+                            query-table
+                            column-name
+                            (name click-type)
+                            (name query-type))
+    (let [{:keys [query row]} (query-and-row-for-test-case test-case)
+          query               (or custom-query query)
+          context             (test-case-context query row test-case)]
+      (testing (str "\nQuery =\n"   (u/pprint-to-str query)
+                    "\nContext =\n" (u/pprint-to-str context))
+        (let [drills (lib/available-drill-thrus query -1 context)]
+          (testing (str "\nAvailable Drills =\n" (u/pprint-to-str (into #{} (map :type) drills)))
+            (is (=? expected
+                    (m/find-first (fn [drill]
+                                    (= (:type drill) drill-type))
+                                  drills)))))))))

--- a/test/metabase/lib/drill_thru/underlying_records_test.cljc
+++ b/test/metabase/lib/drill_thru/underlying_records_test.cljc
@@ -1,30 +1,28 @@
-(ns metabase.lib.drill-thru.underlying-records-test)
+(ns metabase.lib.drill-thru.underlying-records-test
+  (:require
+   [clojure.test :refer [deftest]]
+   [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]))
 
-;; (let [metadata-provider (metabase.lib.metadata.jvm/application-database-metadata-provider 1)
-;;         orders            2
-;;         orders-id         11
-;;         created-at        14
-;;         subtotal          17
-;;         people            5
-;;         state             39
-;;         query             (as-> (metabase.lib.metadata/table metadata-provider people) <>
-;;                             (lib/query metadata-provider <>)
-;;                             (lib/aggregate <> (lib/count))
-;;                             (lib/breakout  <> (metabase.lib.options/ensure-uuid [:field {} state]))
-;;                               )
-;;         [state-col count-col] (metabase.lib.metadata.calculation/returned-columns query -1 query)
-;;         ]
-;;     #_(#'metabase.lib.drill-thru/underlying-records-drill
-;;       query -1
-;;       {:column     count-col
-;;        :value      87
-;;        :row        [{:column-name "STATE" :value "Wisconsin"}
-;;                     {:column-name "count" :value 87}]
-;;        :dimensions [{:column-name "STATE" :value "WI"}]})
-;;     (#'metabase.lib.drill-thru/next-breakouts query -1 [{:column-name "STATE" :value "WI"}])
+(deftest ^:parallel returns-underlying-records-test-1
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/underlying-records
+    :click-type  :cell
+    :query-type  :aggregated
+    :column-name "count"
+    :expected    {:type :drill-thru/underlying-records, :row-count 3, :table-name "Orders"}}))
 
-;;     #_(->> (lib/available-drill-thrus query -1 {:column (metabase.lib.metadata/field metadata-provider subtotal)
-;;                                               :value nil
-;;                                               #_#_:value  "2018-05-15T08:04:04.58Z"})
-;;            (map #(metabase.lib.metadata.calculation/display-info query -1 %))))
-;; (lib.order-by/order-bys query stage-number)
+(deftest ^:parallel returns-underlying-records-test-2
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/underlying-records
+    :click-type  :cell
+    :query-type  :aggregated
+    :column-name "sum"
+    :expected    {:type :drill-thru/underlying-records, :row-count 3, :table-name "Orders"}}))
+
+(deftest ^:parallel returns-underlying-records-test-3
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/underlying-records
+    :click-type  :cell
+    :query-type  :aggregated
+    :column-name "max"
+    :expected    {:type :drill-thru/underlying-records, :row-count 3, :table-name "Orders"}}))

--- a/test/metabase/lib/drill_thru/zoom_in_timeseries_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_in_timeseries_test.cljc
@@ -3,8 +3,7 @@
    [clojure.test :refer [deftest is]]
    [medley.core :as m]
    [metabase.lib.core :as lib]
-   [metabase.lib.drill-thru.zoom-in-timeseries
-    :as lib.drill-thru.zoom-in-timeseries]
+   [metabase.lib.drill-thru.zoom-in-timeseries :as lib.drill-thru.zoom-in-timeseries]
    [metabase.lib.temporal-bucket :as lib.temporal-bucket]
    [metabase.lib.test-metadata :as meta]
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))))
@@ -79,3 +78,30 @@
                                               [:field {:temporal-unit :quarter} (meta/id :orders :created-at)]
                                               "2022-04-01T00:00:00"]]}]}
                     query''))))))))
+
+;;; FIXME zoom-in.timeseries should be returned for aggregated query metric click (#33811)
+(deftest ^:parallel returns-zoom-in-timeseries-test-1
+  #_(lib.drill-thru.tu/test-returns-drill
+     {:drill-type  :drill-thru/zoom-in.timeseries
+      :click-type  :header
+      :query-type  :aggregated
+      :column-name "count"
+      :expected    {:type :drill-thru/zoom-in.timeseries}}))
+
+;;; FIXME zoom-in.timeseries should be returned for aggregated query metric click (#33811)
+(deftest ^:parallel returns-zoom-in-timeseries-test-2
+  #_(lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/zoom-in.timeseries
+    :click-type  :header
+    :query-type  :aggregated
+    :column-name "max"
+    :expected    {:type :drill-thru/zoom-in.timeseries}}))
+
+;;; FIXME zoom-in.timeseries should be returned for aggregated query metric click (#33811)
+(deftest ^:parallel returns-zoom-in-timeseries-test-3
+  #_(lib.drill-thru.tu/test-returns-drill
+     {:drill-type  :drill-thru/zoom-in.timeseries
+      :click-type  :header
+      :query-type  :aggregated
+      :column-name "sum"
+      :expected    {:type :drill-thru/zoom-in.timeseries}}))

--- a/test/metabase/lib/drill_thru/zoom_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_test.cljc
@@ -1,0 +1,54 @@
+(ns metabase.lib.drill-thru.zoom-test
+  (:require
+   [clojure.test :refer [deftest]]
+   [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]))
+
+(deftest ^:parallel returns-zoom-test-1
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/zoom
+    :click-type  :cell
+    :query-type  :unaggregated
+    :column-name "ID"
+    :expected    {:type      :drill-thru/zoom
+                  :object-id (get-in lib.drill-thru.tu/test-queries ["ORDERS" :unaggregated :row "ID"])
+                  :many-pks? false}}))
+
+(deftest ^:parallel returns-zoom-test-2
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/zoom
+    :click-type  :cell
+    :query-type  :unaggregated
+    :column-name "TAX"
+    :expected    {:type      :drill-thru/zoom
+                  :object-id (get-in lib.drill-thru.tu/test-queries ["ORDERS" :unaggregated :row "ID"])
+                  :many-pks? false}}))
+
+(deftest ^:parallel returns-zoom-test-3
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/zoom
+    :click-type  :cell
+    :query-type  :unaggregated
+    :column-name "DISCOUNT"
+    :expected    {:type      :drill-thru/zoom
+                  :object-id (get-in lib.drill-thru.tu/test-queries ["ORDERS" :unaggregated :row "ID"])
+                  :many-pks? false}}))
+
+(deftest ^:parallel returns-zoom-test-4
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/zoom
+    :click-type  :cell
+    :query-type  :unaggregated
+    :column-name "CREATED_AT"
+    :expected    {:type      :drill-thru/zoom
+                  :object-id (get-in lib.drill-thru.tu/test-queries ["ORDERS" :unaggregated :row "ID"])
+                  :many-pks? false}}))
+
+(deftest ^:parallel returns-zoom-test-5
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/zoom
+    :click-type  :cell
+    :query-type  :unaggregated
+    :column-name "QUANTITY"
+    :expected    {:type      :drill-thru/zoom
+                  :object-id (get-in lib.drill-thru.tu/test-queries ["ORDERS" :unaggregated :row "ID"])
+                  :many-pks? false}}))

--- a/test/metabase/lib/drill_thru_test.cljc
+++ b/test/metabase/lib/drill_thru_test.cljc
@@ -5,6 +5,7 @@
    [malli.error :as me]
    [medley.core :as m]
    [metabase.lib.core :as lib]
+   [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.test-metadata :as meta]
    [metabase.util :as u]
@@ -522,3 +523,179 @@
                                                      :value      87
                                                      :row        row
                                                      :dimensions [{:column-name "STATE" :value "WI"}]})))))))
+
+
+
+
+;;;
+;;; The tests below are adapted from frontend/src/metabase-lib/drills.unit.spec.ts
+;;;
+
+(deftest ^:parallel available-drill-thrus-test-1
+  (lib.drill-thru.tu/test-available-drill-thrus
+   {:click-type  :cell
+    :query-type  :unaggregated
+    :column-name "ID"
+    :expected    [{:type      :drill-thru/zoom
+                   :object-id (get-in lib.drill-thru.tu/test-queries ["ORDERS" :unaggregated :row "ID"])
+                   :many-pks? false}]}))
+
+(deftest ^:parallel available-drill-thrus-test-2
+  (lib.drill-thru.tu/test-available-drill-thrus
+   {:click-type  :cell
+    :query-type  :unaggregated
+    :column-name "USER_ID"
+    :expected    [{:type :drill-thru/fk-filter}
+                  {:type      :drill-thru/fk-details
+                   :object-id (get-in lib.drill-thru.tu/test-queries ["ORDERS" :unaggregated :row "USER_ID"])
+                   :many-pks? false}]}))
+
+(deftest ^:parallel available-drill-thrus-test-3
+  (lib.drill-thru.tu/test-available-drill-thrus
+   {:click-type  :cell
+    :query-type  :unaggregated
+    :column-name "SUBTOTAL"
+    :expected    [{:type      :drill-thru/zoom
+                   :object-id (get-in lib.drill-thru.tu/test-queries ["ORDERS" :unaggregated :row "ID"])
+                   :many-pks? false}
+                  {:type :drill-thru/quick-filter, :operators [{:name "<"}
+                                                               {:name ">"}
+                                                               {:name "="}
+                                                               {:name "≠"}]}]}))
+
+(deftest ^:parallel available-drill-thrus-test-4
+  (lib.drill-thru.tu/test-available-drill-thrus
+   {:click-type  :cell
+    :query-type  :unaggregated
+    :column-name "CREATED_AT"
+    :expected    [{:type      :drill-thru/zoom
+                   :object-id (get-in lib.drill-thru.tu/test-queries ["ORDERS" :unaggregated :row "ID"])
+                   :many-pks? false}
+                  {:type :drill-thru/quick-filter, :operators [{:name "<"}
+                                                               {:name ">"}
+                                                               {:name "="}
+                                                               {:name "≠"}]}]}))
+
+(deftest ^:parallel available-drill-thrus-test-5
+  (lib.drill-thru.tu/test-available-drill-thrus
+   {:click-type  :header
+    :query-type  :unaggregated
+    :column-name "ID"
+    :expected    [{:type :drill-thru/column-filter, :initial-op {:short :=}}
+                  {:type :drill-thru/sort, :sort-directions [:asc :desc]}
+                  {:type :drill-thru/summarize-column, :aggregations [:distinct]}]}))
+
+(deftest ^:parallel available-drill-thrus-test-6
+  (lib.drill-thru.tu/test-available-drill-thrus
+   {:click-type  :header
+    :query-type  :unaggregated
+    :column-name "PRODUCT_ID"
+    :expected    [{:type :drill-thru/distribution}
+                  {:type :drill-thru/column-filter, :initial-op {:short :=}}
+                  {:type :drill-thru/sort, :sort-directions [:asc :desc]}
+                  {:type :drill-thru/summarize-column, :aggregations [:distinct]}]}))
+
+(deftest ^:parallel available-drill-thrus-test-7
+  (lib.drill-thru.tu/test-available-drill-thrus
+   {:click-type  :header
+    :query-type  :unaggregated
+    :column-name "SUBTOTAL"
+    :expected    [{:type :drill-thru/distribution}
+                  {:type :drill-thru/column-filter, :initial-op {:short :=}}
+                  {:type :drill-thru/sort, :sort-directions [:asc :desc]}
+                  {:type :drill-thru/summarize-column, :aggregations [:distinct :sum :avg]}
+                  {:type :drill-thru/summarize-column-by-time}]}))
+
+(deftest ^:parallel available-drill-thrus-test-8
+  (lib.drill-thru.tu/test-available-drill-thrus
+   {:click-type  :header
+    :query-type  :unaggregated
+    :column-name "CREATED_AT"
+    :expected    [{:type :drill-thru/distribution}
+                  {:type :drill-thru/column-filter, :initial-op nil}
+                  {:type :drill-thru/sort, :sort-directions [:asc :desc]}
+                  {:type :drill-thru/summarize-column, :aggregations [:distinct]}]}))
+
+;; FIXME: fk-filter gets returned for non-fk column (#34440), fk-details gets returned for non-fk
+;; column (#34441), underlying-records drill gets shown two times for aggregated query (#34439)
+(deftest ^:parallel available-drill-thrus-test-9
+  #_(lib.drill-thru.tu/test-available-drill-thrus
+     {:click-type  :cell
+      :query-type  :aggregated
+      :column-name "count"
+      :expected    [{:type      :drill-thru/quick-filter
+                     :operators [{:name "<"}
+                                 {:name ">"}
+                                 {:name "="}
+                                 {:name "≠"}]}
+                    {:type       :drill-thru/underlying-records
+                     :row-count  2
+                     :table-name "Orders"}
+                    {:display-name "See this month by week"
+                     :type         :drill-thru/zoom-in.timeseries}]}))
+
+;; FIXME: fk-filter gets returned for non-fk column (#34440), fk-details gets returned for non-fk
+;; column (#34441), underlying-records drill gets shown two times for aggregated query (#34439)
+(deftest ^:parallel available-drill-thrus-test-10
+  #_(lib.drill-thru.tu/test-available-drill-thrus
+     {:click-type  :cell
+      :query-type  :aggregated
+      :column-name "max"
+      :expected    [{:type :drill-thru/quick-filter, :operators [{:name "="}
+                                                                 {:name "≠"}]}
+                    {:type :drill-thru/underlying-records, :row-count 2, :table-name "Orders"}
+                    {:type :drill-thru/zoom-in.timeseries, :display-name "See this month by week"}]}))
+
+;; FIXME: quick-filter gets returned for non-metric column (#34443)
+(deftest ^:parallel available-drill-thrus-test-11
+  #_(lib.drill-thru.tu/test-available-drill-thrus
+     {:click-type  :cell
+      :query-type  :aggregated
+      :column-name "PRODUCT_ID"
+      :expected    [{:type :drill-thru/fk-filter}
+                    {:type :drill-thru/fk-details, :object-id 3, :many-pks? false}
+                    {:row-count 2, :table-name "Orders", :type :drill-thru/underlying-records}]}))
+
+;; FIXME: quick-filter gets returned for non-metric column (#34443)
+(deftest ^:parallel available-drill-thrus-test-12
+  #_(lib.drill-thru.tu/test-available-drill-thrus
+     {:click-type  :cell
+      :query-type  :aggregated
+      :column-name "CREATED_AT"
+      :expected    [{:type :drill-thru/quick-filter, :operators [{:name "<"}
+                                                                 {:name ">"}
+                                                                 {:name "="}
+                                                                 {:name "≠"}]}
+                    {:row-count 3, :table-name "Orders", :type :drill-thru/underlying-records}]}))
+
+;; FIXME: for some reason the results for aggregated query are not correct (#34223, #34341)
+(deftest ^:parallel available-drill-thrus-test-13
+  (testing "We expect column-filter and sort drills, but get distribution and summarize-column"
+    #_(lib.drill-thru.tu/test-available-drill-thrus
+       {:click-type  :header
+        :query-type  :aggregated
+        :column-name "count"
+        :expected    [{:initial-op {:short :=}, :type :drill-thru/column-filter}
+                      {:sort-directions [:asc :desc], :type :drill-thru/sort}]})))
+
+;; FIXME: for some reason the results for aggregated query are not correct (#34223, #34341)
+(deftest ^:parallel available-drill-thrus-test-14
+  (testing "We expect column-filter and sort drills, but get distribution and summarize-column"
+    #_(lib.drill-thru.tu/test-available-drill-thrus
+       {:click-type  :header
+        :query-type  :aggregated
+        :column-name "PRODUCT_ID"
+        :expected    [{:initial-op {:short :=}, :type :drill-thru/column-filter}
+                      {:sort-directions [:asc :desc], :type :drill-thru/sort}]})))
+
+;; FIXME: for some reason the results for aggregated query are not correct (#34223, #34341)
+(deftest ^:parallel available-drill-thrus-test-15
+  (testing "We expect column-filter and sort drills, but get distribution and summarize-column"
+    #_(lib.drill-thru.tu/test-available-drill-thrus
+       {:click-type  :header
+        :query-type  :aggregated
+        :column-name "CREATED_AT"
+        :expected    [{:type       :drill-thru/column-filter
+                       :initial-op {:short :=}}
+                      {:type            :drill-thru/sort
+                       :sort-directions [:asc :desc]}]})))


### PR DESCRIPTION
Fixes #34445

As part of this I got tired of trying of the super slow feedback loop trying to run tests in `frontend/src/metabase-lib/drills.unit.spec.ts` so I just adapted the `availableDrillThrus` test case there to Clojure(Script). Now when fixing all of the other open drill bugs we already have a test case ready to go in Clojure