### PR TITLE
Remove eclipse.org/dev links from docs

### DIFF
--- a/docs/configuring-metabase/customizing-jetty-webserver.md
+++ b/docs/configuring-metabase/customizing-jetty-webserver.md
@@ -38,4 +38,4 @@ If you have an SSL certificate and would prefer to have Metabase run over HTTPS 
 
 Be sure to replace `path/to/keystore.jks` and `storepass` with the correct path to and password for your [Java KeyStore](https://www.digitalocean.com/community/tutorials/java-keytool-essentials-working-with-java-keystores). With the above settings applied you will be running Metabase on port 8443 over HTTPS using the supplied certificate.
 
-No idea how to generate a Java KeyStore yourself? This is sort of an advanced topic, but if you're feeling froggy you can read more about how to configure SSL in Jetty [in their own documentation](https://www.eclipse.org/jetty/documentation/jetty-9/index.html#configuring-ssl). Otherwise, you'll probably find it easiest to handle SSL termination outside of Metabase.
+No idea how to generate a Java KeyStore yourself? This is sort of an advanced topic, but if you're feeling froggy you can read more about how to configure SSL in Jetty in their own documentation. Otherwise, you'll probably find it easiest to handle SSL termination outside of Metabase.

--- a/docs/installation-and-operation/monitoring-metabase.md
+++ b/docs/installation-and-operation/monitoring-metabase.md
@@ -109,7 +109,7 @@ When running into memory related issues, typically the first question
 we want to know is what is consuming extra memory? A heap dump will
 take a snapshot of everything in memory at that specific point of
 time. That memory snapshot can be analyzed later by tools like the
-[Eclipse Memory Analyzer Tool](https://www.eclipse.org/mat/). Create a
+Eclipse Memory Analyzer Tool. Create a
 heap dump from the "Monitor" tab:
 
 ![heapdump](images/HeapDump.png)

--- a/docs/troubleshooting-guide/running.md
+++ b/docs/troubleshooting-guide/running.md
@@ -12,9 +12,9 @@ Make sure you're using a Java version of 11 or higher. For more info, see [Java 
 
 ## WARNING: sun.reflect.Reflection.getCallerClass is not supported
 
-Don't worry about it. 
+Don't worry about it.
 
-``` 
+```
 WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
 ```
 
@@ -50,10 +50,8 @@ If the Metabase instance starts and runs for a significant amount of time before
 java -Xmx2g -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/path/to/a/directory -jar metabase-jar
 ```
 
-The `-XX:HeapDumpPath` flag specifies where to put the dump---the current directory is the default. When an `OutOfMemoryError` occurs, it will dump an `hprof` file to the directory specified. These can be very large (i.e., the size of the `-Xmx` argument) so ensure your disk has enough space. These `hprof` files can be read with many different tools, such as `jhat` (which is included with the JDK) or the [Eclipse Memory Analyzer Tool][eclipse-memory-analyzer].
+The `-XX:HeapDumpPath` flag specifies where to put the dump---the current directory is the default. When an `OutOfMemoryError` occurs, it will dump an `hprof` file to the directory specified. These can be very large (i.e., the size of the `-Xmx` argument) so ensure your disk has enough space. These `hprof` files can be read with many different tools, such as `jhat` (which is included with the JDK) or the Eclipse Memory Analyzer Tool.
 
 ## Metabase cannot read or write from a file or folder (IOError)
 
 If you see an error regarding file permissions, like Metabase being unable to read a SQLite database or a custom GeoJSON map file, check out the section "Metabase can't read to/from a file or directory" in our [Docker troubleshooting guide](./docker.md).
-
-[eclipse-memory-analyzer]: https://www.eclipse.org/mat/

--- a/docs/troubleshooting-guide/timeout.md
+++ b/docs/troubleshooting-guide/timeout.md
@@ -16,7 +16,6 @@ If your queries are hanging or timing out, the problem could be coming from your
 
 Fixes for timeout problems will depend on your specific setup. These resources may help:
 
-- [Configuring Jetty connectors][configuring-jetty]
 - [EC2 Troubleshooting][ec2-troubleshooting]
 - [Elastic Load Balancing Connection Timeout Management][elb-timeout]
 - [App Engine: Dealing with DeadlineExceededErrors][app-engine-timeout]
@@ -29,7 +28,6 @@ If you can’t solve your problem using the troubleshooting guides:
 - Search for [known bugs or limitations][known-issues].
 
 [app-engine-timeout]: https://cloud.google.com/appengine/articles/deadlineexceedederrors
-[configuring-jetty]: https://www.eclipse.org/jetty/documentation/current/#configuring-connectors
 [discourse]: https://discourse.metabase.com/
 [ec2-troubleshooting]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/TroubleshootingInstancesConnecting.html
 [elb-timeout]: https://aws.amazon.com/blogs/aws/elb-idle-timeout-control/


### PR DESCRIPTION
This PR temporarily removes links to https://eclipse.dev and https://eclipse.org because its SSL/TLS certificate expired on the 15th of October. This is causing the markdown-link-check action to fail, e.g. https://github.com/metabase/metabase/actions/runs/6510485967/job/17727898702?pr=34663#step:4:786

If eclipse.dev updates their certificate we can restore this link, but until then we should not link to broken websites from our docs.

If this merges I will set up a weekly reminder to check the eclipse website and hope that we can eventually revert this.