### PR TITLE
update the team label names in .github/team.json

### DIFF
--- a/.github/team.json
+++ b/.github/team.json
@@ -2,7 +2,7 @@
   "teams": [
     {
       "name": "Team 42",
-      "label": ".Team/42 :milky_way:",
+      "label": ".Team/42",
       "members": [
         "ranquild",
         "WiNloSt",
@@ -19,7 +19,7 @@
     },
     {
       "name": "Query Processor",
-      "label": ".Team/QueryProcessor :hammer_and_wrench:",
+      "label": ".Team/QueryProcessor",
       "members": [
         "camsaul",
         "kulyk",
@@ -32,7 +32,7 @@
     },
     {
       "name": "Pixel Police",
-      "label": ".Team/PixelPolice :police_officer:",
+      "label": ".Team/PixelPolice",
       "members": [
         "noahmoss",
         "escherize",


### PR DESCRIPTION
Remove the emojis from the team labels. With the emojis, the "auto-add to project" github automated workflow doesn't work, and we rely on it for the #bug-triage channel on slack. After several attempts of escaping the emojis, they've been removed from the labels, and now have to be removed here as well for the auto-assignment of PRs to continue working.
[ci skip]
