### PR TITLE
Add Kondo rule to prevent dynamic vars from taking over

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -658,6 +658,8 @@
    :name    printable-namespaces}
   {:pattern "^metabase\\.lib\\.*"
    :name    metabase-lib}
+  {:pattern "^metabase\\.(?!(api|query-processor|server)).*$"
+   :name    non-api-namespaces}
   ;; Basically everything except `metabase.driver.` or `metabase.test-data.` except for the drivers explicitly called
   ;; out below. Remove these drivers from the regex once we switch to Honey SQL 2.
   ;;
@@ -744,6 +746,15 @@
      toucan.models    {:message "Don't use application database inside MLv2 code"}
      toucan.util.test {:message "Don't use application database inside MLv2 code"}
      toucan2.core     {:message "Don't use application database inside MLv2 code"}}}}
+
+  non-api-namespaces
+  {:linters
+   {:discouraged-var
+    {metabase.api.common/*current-user*                 {:message "Only use API-related dynamic variables in the API namespaces"}
+     metabase.api.common/*current-user-id*              {:message "Only use API-related dynamic variables in the API namespaces"}
+     metabase.api.common/*current-user-permissions-set* {:message "Only use API-related dynamic variables in the API namespaces"}
+     metabase.api.common/*is-superuser?*                {:message "Only use API-related dynamic variables in the API namespaces"}
+     metabase.api.common/*is-group-manager?*            {:message "Only use API-related dynamic variables in the API namespaces"}}}}
 
   qp-and-driver-source-namespaces
   {:linters

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -382,11 +382,12 @@
       (mt/with-env-keys-renamed-by #(str/replace-first % "mb-oracle-ssl-test" "mb-oracle-test")
         ;; need to get a fresh instance of details to pick up env key changes
         (let [ssl-details  (#'oracle.tx/connection-details)
-              orig-user-id api/*current-user-id*]
+              orig-user-id #_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-id*]
           (testing "Oracle can-connect? with SSL connection"
             (is (driver/can-connect? :oracle ssl-details)))
           (testing "Sync works with SSL connection"
             (binding [sync-util/*log-exceptions-and-continue?* false
+                      #_{:clj-kondo/ignore [:discouraged-var]}
                       api/*current-user-id* (mt/user->id :crowberto)]
               (doseq [[details variant] [[ssl-details "SSL with Truststore Path"]
                                          ;; in the file upload scenario, the truststore bytes are base64 encoded
@@ -410,7 +411,7 @@
                         (sync/sync-database! database {:scan :schema})
                         ;; should be four tables from test-data
                         (is (= 4 (t2/count Table :db_id (u/the-id database) :name [:like "test_data%"])))
-                        (binding [api/*current-user-id* orig-user-id ; restore original user-id to avoid perm errors
+                        (binding [#_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-id* orig-user-id ; restore original user-id to avoid perm errors
                                   ;; we also need to rebind this dynamic var so that we can pretend "test-data" is
                                   ;; actually the name of the database, and not some variation on the :name specified
                                   ;; above, so that the table names resolve correctly in the generated query we can't

--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -193,10 +193,11 @@
   (let [dashcard (api/check-404 (t2/select-one DashboardCard
                                                :id dashcard-id
                                                :dashboard_id dashboard-id))
-        action (api/check-404 (action/select-action :id (:action_id dashcard)))]
-    (snowplow/track-event! ::snowplow/action-executed api/*current-user-id* {:source    :dashboard
-                                                                             :type      (:type action)
-                                                                             :action_id (:id action)})
+        action   (api/check-404 (action/select-action :id (:action_id dashcard)))]
+    (snowplow/track-event! ::snowplow/action-executed #_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-id*
+                           {:source    :dashboard
+                            :type      (:type action)
+                            :action_id (:id action)})
     (execute-action! action request-parameters)))
 
 (defn- fetch-implicit-action-values
@@ -206,7 +207,7 @@
              (tru "Values can only be fetched for actions that require a Primary Key."))
   (let [implicit-action (keyword (:kind action))
         {:keys [prefetch-parameters]} (build-implicit-query action implicit-action request-parameters)
-        info {:executed-by api/*current-user-id*
+        info {:executed-by #_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-id*
               :context     :action
               :action-id   (:id action)}
         card (t2/select-one Card :id (:model_id action))

--- a/src/metabase/automagic_dashboards/comparison.clj
+++ b/src/metabase/automagic_dashboards/comparison.clj
@@ -42,7 +42,7 @@
   (-> card
       (select-keys [:dataset_query :description :display :name :result_metadata
                     :visualization_settings])
-      (assoc :creator_id    api/*current-user-id*
+      (assoc :creator_id    #_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-id*
              :collection_id nil
              :id            (gensym))))
 
@@ -284,7 +284,7 @@
                               :description       (tru "Automatically generated comparison dashboard comparing {0} and {1}"
                                                       (comparison-name left)
                                                       (comparison-name right))
-                              :creator_id        api/*current-user-id*
+                              :creator_id        #_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-id*
                               :parameters        []
                               :related           (update-related (:related dashboard) left right)}
                              (add-title-row left right))))

--- a/src/metabase/automagic_dashboards/populate.clj
+++ b/src/metabase/automagic_dashboards/populate.clj
@@ -136,7 +136,7 @@
 (defn- add-card
   "Add a card to dashboard `dashboard` at position [`x`, `y`]."
   [dashboard {:keys [title description dataset_query width height id] :as card} [x y]]
-  (let [card (-> {:creator_id    api/*current-user-id*
+  (let [card (-> {:creator_id    #_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-id*
                   :dataset_query dataset_query
                   :description   description
                   :name          title
@@ -159,7 +159,7 @@
   [dashboard {:keys [text width height visualization-settings]} [x y]]
   (update dashboard :ordered_cards conj
           (merge (card-defaults)
-                 {:creator_id             api/*current-user-id*
+                 {:creator_id             #_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-id*
                   :visualization_settings (merge
                                             {:text         text
                                              :virtual_card {:name                   nil
@@ -285,7 +285,7 @@
          dashboard     {:name           title
                         :transient_name (or transient_title title)
                         :description    description
-                        :creator_id     api/*current-user-id*
+                        :creator_id     #_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-id*
                         :parameters     []}
          cards         (shown-cards n cards)
          [dashboard _] (->> cards

--- a/src/metabase/metabot/feedback.clj
+++ b/src/metabase/metabot/feedback.clj
@@ -30,6 +30,6 @@
   [feedback]
   (let [snowplow-feedback (select-keys feedback snowplow-keys)]
     (snowplow/track-event!
-     ::snowplow/metabot-feedback-received api/*current-user-id*
+     ::snowplow/metabot-feedback-received #_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-id*
      snowplow-feedback)
     (store-detailed-feedback feedback)))

--- a/src/metabase/models/activity.clj
+++ b/src/metabase/models/activity.clj
@@ -32,6 +32,7 @@
 ;; the future we might want to change this and come up with some sort of system where we can determine which users get
 ;; to see other users -- perhaps if they are in a group together other than 'All Users'
 (defmethod can-? :user-joined [_ _]
+  #_{:clj-kondo/ignore [:discouraged-var]}
   api/*is-superuser?*)
 
 ;; For every other activity topic we'll look at the read/write perms for the object the activty is about (e.g. a Card

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -9,7 +9,8 @@
    [clojure.string :as str]
    [metabase.api.common
     :as api
-    :refer [*current-user-id* *current-user-permissions-set*]]
+    :refer [#_{:clj-kondo/ignore [:discouraged-var]} *current-user-id*
+            #_{:clj-kondo/ignore [:discouraged-var]} *current-user-permissions-set*]]
    [metabase.db.connection :as mdb.connection]
    [metabase.models.collection.root :as collection.root]
    [metabase.models.interface :as mi]
@@ -330,7 +331,8 @@
    (if (collection.root/is-root-collection? collection)
      nil
      (effective-location-path* (:location collection)
-                               (permissions-set->visible-collection-ids @*current-user-permissions-set*))))
+                               (permissions-set->visible-collection-ids
+                                #_{:clj-kondo/ignore [:discouraged-var]} @*current-user-permissions-set*))))
 
   ([real-location-path     :- LocationPath
     allowed-collection-ids :- VisibleCollections]
@@ -459,7 +461,8 @@
                                                    ;; cluttered with Personal Collections belonging to randos
                                                    [:or
                                                     [:= :personal_owner_id nil]
-                                                    [:= :personal_owner_id *current-user-id*]]
+                                                    [:= :personal_owner_id
+                                                     #_{:clj-kondo/ignore [:discouraged-var]} *current-user-id*]]
                                                    additional-honeysql-where-clauses)}))
         ;; Next, build a function to add children to a given `coll`. This function will recursively call itself to add
         ;; children to each child
@@ -479,7 +482,8 @@
 
 (mu/defn ^:private effective-children-where-clause
   [collection & additional-honeysql-where-clauses]
-  (let [visible-collection-ids (permissions-set->visible-collection-ids @*current-user-permissions-set*)]
+  (let [visible-collection-ids (permissions-set->visible-collection-ids
+                                #_{:clj-kondo/ignore [:discouraged-var]} @*current-user-permissions-set*)]
     ;; Collection B is an effective child of Collection A if...
     (into
       [:and
@@ -1003,7 +1007,7 @@
   "Check that we have write permissions for Collection with `collection-id`, or throw a 403 Exception. If
   `collection-id` is `nil`, this check is done for the Root Collection."
   [collection-or-id-or-nil]
-  (let [actual-perms   @*current-user-permissions-set*
+  (let [actual-perms   #_{:clj-kondo/ignore [:discouraged-var]} @*current-user-permissions-set*
         required-perms (perms/collection-readwrite-path (if collection-or-id-or-nil
                                                           collection-or-id-or-nil
                                                           root-collection))]

--- a/src/metabase/models/native_query_snippet/permissions.clj
+++ b/src/metabase/models/native_query_snippet/permissions.clj
@@ -9,7 +9,8 @@
 (defn has-any-native-permissions?
   "Checks whether the current user has native query permissions for any database."
   []
-  (perms/set-has-any-native-query-permissions? @api/*current-user-permissions-set*))
+  (perms/set-has-any-native-query-permissions?
+   #_{:clj-kondo/ignore [:discouraged-var]} @api/*current-user-permissions-set*))
 
 (defenterprise can-read?
   "Can the current User read this `snippet`?"

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -173,7 +173,7 @@
    [clojure.walk :as walk]
    [malli.core :as mc]
    [medley.core :as m]
-   [metabase.api.common :refer [*current-user-id*]]
+   [metabase.api.common :refer [#_{:clj-kondo/ignore [:discouraged-var]} *current-user-id*]]
    [metabase.api.permission-graph :as api.permission-graph]
    [metabase.config :as config]
    [metabase.models.interface :as mi]
@@ -1412,14 +1412,14 @@
   *  `before`  -- the graph before the changes
   *  `changes` -- set of changes applied in this revision."
   [model current-revision before changes]
-  (when *current-user-id*
+  (when #_{:clj-kondo/ignore [:discouraged-var]} *current-user-id*
     (first (t2/insert-returning-instances! model
                                            ;; manually specify ID here so if one was somehow inserted in the meantime in the fraction of a second since we
                                            ;; called `check-revision-numbers` the PK constraint will fail and the transaction will abort
                                            :id      (inc current-revision)
                                            :before  before
                                            :after   changes
-                                           :user_id *current-user-id*))))
+                                           :user_id #_{:clj-kondo/ignore [:discouraged-var]} *current-user-id*))))
 
 (defn log-permissions-changes
   "Log changes to the permissions graph."

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -135,22 +135,24 @@
 
 (defn- current-user-is-creator?
   [notification]
-  (= api/*current-user-id* (:creator_id notification)))
+  (= #_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-id*
+     (:creator_id notification)))
 
 (defn- current-user-is-recipient?
   [notification]
-  (let [channels (:channels (t2/hydrate notification [:channels :recipients]))
-        recipient-ids (for [{recipients :recipients} channels
-                            recipient recipients]
-                        (:id recipient))]
+  (let [channels            (:channels (t2/hydrate notification [:channels :recipients]))
+        recipient-ids       (for [{recipients :recipients} channels
+                                  recipient recipients]
+                              (:id recipient))
+        is-current-user-id? #{#_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-id*}]
     (boolean
-     (some #{api/*current-user-id*} recipient-ids))))
+     (some is-current-user-id? recipient-ids))))
 
 (defmethod mi/can-read? Pulse
   [notification]
   (if (is-alert? notification)
    (mi/current-user-has-full-permissions? :read notification)
-   (or api/*is-superuser?*
+   (or #_{:clj-kondo/ignore [:discouraged-var]} api/*is-superuser?*
        (or (current-user-is-creator? notification)
            (current-user-is-recipient? notification)))))
 
@@ -160,7 +162,7 @@
   [notification]
   (if (is-alert? notification)
     (mi/current-user-has-full-permissions? :write notification)
-    (or api/*is-superuser?*
+    (or #_{:clj-kondo/ignore [:discouraged-var]} api/*is-superuser?*
         (and (mi/current-user-has-full-permissions? :read notification)
              (current-user-is-creator? notification)))))
 

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -133,7 +133,7 @@
   ;; ignore the current user for the purposes of calculating the permissions required to run the query. Don't want the
   ;; preprocessing to fail because current user doesn't have permissions to run it when we're not trying to run it at
   ;; all
-  (binding [api/*current-user-id* nil]
+  (binding [#_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-id* nil]
     ((resolve 'metabase.query-processor/preprocess) query)))
 
 (mu/defn ^:private mbql-permissions-path-set :- [:set perms/PathSchema]
@@ -194,7 +194,7 @@
   "Return `true` if the current-user has sufficient permissions to run `query`. Handles checking for full table
   permissions and segmented table permissions"
   [query]
-  (let [user-perms @api/*current-user-permissions-set*]
+  (let [user-perms #_{:clj-kondo/ignore [:discouraged-var]} @api/*current-user-permissions-set*]
     (or (perms/set-has-full-permissions-for-set? user-perms (perms-set query))
         (perms/set-has-full-permissions-for-set? user-perms (segmented-perms-set query)))))
 

--- a/src/metabase/models/secret.clj
+++ b/src/metabase/models/secret.clj
@@ -241,14 +241,16 @@
   {:added "0.42.0"}
   [existing-id nm kind src value]
   (let [insert-new     (fn [id v]
-                         (let [inserted (first (t2/insert-returning-instances! Secret (cond-> {:version    v
-                                                                                               :name       nm
-                                                                                               :kind       kind
-                                                                                               :source     src
-                                                                                               :value      value
-                                                                                               :creator_id api/*current-user-id*}
-                                                                                        id
-                                                                                        (assoc :id id))))]
+                         (let [inserted (first (t2/insert-returning-instances!
+                                                Secret
+                                                (cond-> {:version    v
+                                                         :name       nm
+                                                         :kind       kind
+                                                         :source     src
+                                                         :value      value
+                                                         :creator_id #_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-id*}
+                                                  id
+                                                  (assoc :id id))))]
                            ;; Toucan doesn't support composite primary keys, so adding a new record with incremented
                            ;; version for an existing ID won't return a result from t2/insert!, hence we may need to
                            ;; manually select it here
@@ -257,7 +259,7 @@
     (if latest-version
       (if (= (select-keys latest-version bump-version-keys) [kind src value])
         (pos? (t2/update! Secret {:id existing-id :version (:version latest-version)}
-                        {:name nm}))
+                          {:name nm}))
         (insert-new (u/the-id latest-version) (inc (:version latest-version))))
       (insert-new nil 1))))
 

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -406,7 +406,7 @@
     ;; Update the atom in *user-local-values* with the new value before writing to the DB. This ensures that
     ;; subsequent setting updates within the same API request will not overwrite this value.
     (swap! @*user-local-values* u/assoc-dissoc setting-name value)
-    (t2/update! 'User api/*current-user-id* {:settings (json/generate-string @@*user-local-values*)})))
+    (t2/update! 'User #_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-id* {:settings (json/generate-string @@*user-local-values*)})))
 
 (def ^:dynamic *enforce-setting-access-checks*
   "A dynamic var that controls whether we should enforce checks on setting access. Defaults to false; should be
@@ -424,7 +424,7 @@
   "If `advanced-permissions` is enabled, check if current user has permissions to edit `setting`.
   Return `false` for all non-admins when `advanced-permissions` is disabled. Return `true` for all admins."
   []
-  (or api/*is-superuser?*
+  (or #_{:clj-kondo/ignore [:discouraged-var]} api/*is-superuser?*
       (do
         (when config/ee-available?
           (classloader/require 'metabase-enterprise.advanced-permissions.common
@@ -443,11 +443,12 @@
   accessed directly via the API, but not in most other places on the backend."
   [setting]
   (or (not *enforce-setting-access-checks*)
-      (nil? api/*current-user-id*)
+      (nil? #_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-id*)
+      #_{:clj-kondo/ignore [:discouraged-var]}
       api/*is-superuser?*
       (and
        ;; Non-admin setting managers can only access settings that are not marked as admin-only
-       (not api/*is-superuser?*)
+       (not #_{:clj-kondo/ignore [:discouraged-var]} api/*is-superuser?*)
        (has-advanced-setting-access?)
        (not= (:visibility setting) :admin))
       (and
@@ -1180,11 +1181,11 @@
   "Returns a set of setting visibilities that the current user has read access to."
   []
   (set (concat [:public]
-               (when @api/*current-user*
+               (when #_{:clj-kondo/ignore [:discouraged-var]} @api/*current-user*
                  [:authenticated])
                (when (has-advanced-setting-access?)
                  [:settings-manager])
-               (when api/*is-superuser?*
+               (when #_{:clj-kondo/ignore [:discouraged-var]} api/*is-superuser?*
                  [:admin]))))
 
 (defn current-user-writable-visibilities
@@ -1193,7 +1194,7 @@
   (set (concat []
                (when (has-advanced-setting-access?)
                  [:settings-manager :authenticated :public])
-               (when api/*is-superuser?*
+               (when #_{:clj-kondo/ignore [:discouraged-var]} api/*is-superuser?*
                  [:admin]))))
 
 (defn writable-settings

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -105,7 +105,8 @@
     (let [current-version (:tag config/mb-version-info)]
       (log/info (trs "Setting User {0}''s last_acknowledged_version to {1}, the current version" user-id current-version))
       ;; Can't use mw.session/with-current-user due to circular require
-      (binding [api/*current-user-id*       user-id
+      (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+                api/*current-user-id*       user-id
                 setting/*user-local-values* (delay (atom (user-local-settings user)))]
         (setting/set! :last-acknowledged-version current-version)))
     ;; add the newly created user to the magic perms groups.

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -658,7 +658,7 @@
 
 (defn- not-handling-api-request?
   []
-  (nil? @api/*current-user*))
+  (nil? #_{:clj-kondo/ignore [:discouraged-var]} @api/*current-user*))
 
 (defn set-uploads-database-id!
   "Sets the :uploads-database-id setting, with an appropriate permission check."

--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -578,7 +578,7 @@
   error if [[api/*current-user-id*]] is not bound."
   metabase-enterprise.sandbox.api.util
   []
-  (when-not api/*current-user-id*
+  (when-not #_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-id*
     ;; If no *current-user-id* is bound we can't check for sandboxes, so we should throw in this case to avoid
     ;; returning `false` for users who should actually be sandboxes.
     (throw (ex-info (str (tru "No current user found"))
@@ -592,7 +592,7 @@
   Will throw an error if [[api/*current-user-id*]] is not bound."
   metabase-enterprise.advanced-permissions.api.util
   []
-  (when-not api/*current-user-id*
+  (when-not #_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-id*
     ;; If no *current-user-id* is bound we can't check for impersonations, so we should throw in this case to avoid
     ;; returning `false` for users who should actually be using impersonations.
     (throw (ex-info (str (tru "No current user found"))

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -68,7 +68,7 @@
 
   This function should be executed under pulse's creator permissions."
   [dashboard dashcard card-or-id parameters]
-  (assert api/*current-user-id* "Makes sure you wrapped this with a `with-current-user`.")
+  (assert #_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-id* "Makes sure you wrapped this with a `with-current-user`.")
   (try
     (let [card-id (u/the-id card-or-id)
           card    (t2/select-one Card :id card-id)
@@ -127,7 +127,7 @@
 
   This function should be executed under pulse's creator permissions."
   [dashcard]
-  (assert api/*current-user-id* "Makes sure you wrapped this with a `with-current-user`.")
+  (assert #_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-id* "Makes sure you wrapped this with a `with-current-user`.")
   (let [link-card (get-in dashcard [:visualization_settings :link])]
     (cond
       (some? (:url link-card))
@@ -154,7 +154,7 @@
 
   The result will follow the pulse's creator permissions."
   [dashcard pulse dashboard]
-  (assert api/*current-user-id* "Makes sure you wrapped this with a `with-current-user`.")
+  (assert #_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-id* "Makes sure you wrapped this with a `with-current-user`.")
   (cond
     (:card_id dashcard)
     (let [parameters (merge-default-values (params/parameters pulse dashboard))]

--- a/src/metabase/related.clj
+++ b/src/metabase/related.clj
@@ -175,7 +175,7 @@
   []
   (when-let [dashboard-ids (not-empty (t2/select-fn-set :model_id 'Revision
                                                         :model     "Dashboard"
-                                                        :user_id   api/*current-user-id*
+                                                        :user_id   #_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-id*
                                                         {:order-by [[:timestamp :desc]]}))]
     (->> (t2/select Dashboard :id [:in dashboard-ids])
          filter-visible

--- a/src/metabase/transforms/dashboard.clj
+++ b/src/metabase/transforms/dashboard.clj
@@ -37,7 +37,7 @@
 (defn- card-for-source-table
   [table]
   {:pre [(map? table)]}
-  {:creator_id             api/*current-user-id*
+  {:creator_id             #_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-id*
    :dataset_query          {:type     :query
                             :query    {:source-table (u/the-id table)}
                             :database (:db_id table)}

--- a/src/metabase/transforms/materialize.clj
+++ b/src/metabase/transforms/materialize.clj
@@ -52,7 +52,7 @@
 (defn make-card-for-step!
   "Make and save a card for a given transform step and query."
   [{:keys [name transform description]} query]
-  (->> {:creator_id             api/*current-user-id*
+  (->> {:creator_id             #_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-id*
         :dataset_query          query
         :description            description
         :name                   name

--- a/test/metabase/actions_test.clj
+++ b/test/metabase/actions_test.clj
@@ -3,7 +3,7 @@
    [clojure.test :refer :all]
    [metabase.actions :as actions]
    [metabase.actions.execution :as actions.execution]
-   [metabase.api.common :refer [*current-user-permissions-set*]]
+   [metabase.api.common :refer [#_{:clj-kondo/ignore [:discouraged-var]} *current-user-permissions-set*]]
    [metabase.driver :as driver]
    [metabase.models :refer [Database Table]]
    [metabase.models.action :as action]
@@ -19,6 +19,7 @@
 
 (set! *warn-on-reflection* true)
 
+#_{:clj-kondo/ignore [:discouraged-var]}
 (defmacro with-actions-test-data-and-actions-permissively-enabled
   "Combines [[mt/with-actions-test-data-and-actions-enabled]] with full permissions."
   {:style/indent 0}
@@ -138,7 +139,7 @@
   (doseq [{:keys [action request-body]} (mock-requests)]
     (testing action
       (mt/with-temp-vals-in-db Database (mt/id) {:settings {:database-enable-actions false}}
-        (binding [*current-user-permissions-set* (delay #{"/"})]
+        (binding [#_{:clj-kondo/ignore [:discouraged-var]} *current-user-permissions-set* (delay #{"/"})]
           (testing "Should return a 400 if Database feature flag is disabled."
             (is (partial= ["Actions are not enabled." {:database-id (mt/id)}]
                           (try
@@ -185,7 +186,7 @@
 (deftest row-update-action-gives-400-when-matching-more-than-one
   (mt/test-drivers (mt/normal-drivers-with-feature :actions)
     (mt/with-actions-enabled
-      (binding [*current-user-permissions-set* (delay #{"/"})]
+      (binding [#_{:clj-kondo/ignore [:discouraged-var]} *current-user-permissions-set* (delay #{"/"})]
         (let [query-that-returns-more-than-one (assoc (mt/mbql-query users {:filter [:>= $id 1]})
                                                       :update_row {(format-field-name :name) "new-name"})
               query-that-returns-zero-row      (assoc (mt/mbql-query users {:filter [:= $id Integer/MAX_VALUE]})
@@ -202,7 +203,7 @@
 (deftest row-delete-action-gives-400-when-matching-more-than-one
   (mt/test-drivers (mt/normal-drivers-with-feature :actions)
     (mt/with-actions-enabled
-      (binding [*current-user-permissions-set* (delay #{"/"})]
+      (binding [#_{:clj-kondo/ignore [:discouraged-var]} *current-user-permissions-set* (delay #{"/"})]
         (let [query-that-returns-more-than-one (assoc (mt/mbql-query checkins {:filter [:>= $id 1]})
                                                       :update_row {(format-field-name :name) "new-name"})
               query-that-returns-zero-row      (assoc (mt/mbql-query checkins {:filter [:= $id Integer/MAX_VALUE]})

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -1027,6 +1027,7 @@
                  Field    _ {:table_id table-id}]
     (mt/with-test-user :rasta
       ;; make sure the current user permissions set is already fetched so it's not included in the DB call count below
+      #_{:clj-kondo/ignore [:discouraged-var]}
       @api/*current-user-permissions-set*
       (automagic-dashboards.test/with-dashboard-cleanup
         (let [database (t2/select-one Database :id db-id)]

--- a/test/metabase/driver/sql_jdbc/actions_test.clj
+++ b/test/metabase/driver/sql_jdbc/actions_test.clj
@@ -5,7 +5,7 @@
    [clojure.test :refer :all]
    [metabase.actions :as actions]
    [metabase.actions.error :as actions.error]
-   [metabase.api.common :refer [*current-user-permissions-set*]]
+   [metabase.api.common :refer [#_{:clj-kondo/ignore [:discouraged-var]} *current-user-permissions-set*]]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.actions :as sql-jdbc.actions]
    [metabase.models :refer [Field]]
@@ -53,7 +53,7 @@
           (reset! parse-sql-error-called? false)
           ;; attempting to delete the `Pizza` category should fail because there are several rows in `venues` that have
           ;; this `category_id` -- it's an FK constraint violation.
-          (binding [*current-user-permissions-set* (delay #{"/"})]
+          (binding [#_{:clj-kondo/ignore [:discouraged-var]} *current-user-permissions-set* (delay #{"/"})]
             (is (thrown-with-msg? Exception #"Referential integrity constraint violation:.*"
                                             (actions/perform-action! :row/delete (mt/mbql-query categories {:filter [:= $id 58]})))))
           (testing "Make sure our impl was actually called."

--- a/test/metabase/models/collection/graph_test.clj
+++ b/test/metabase/models/collection/graph_test.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.test :refer :all]
    [medley.core :as m]
-   [metabase.api.common :refer [*current-user-id*]]
    [metabase.models :refer [User]]
    [metabase.models.collection :as collection :refer [Collection]]
    [metabase.models.collection-permission-graph-revision
@@ -150,7 +149,7 @@
     ;; need to bind *current-user-id* or the Revision won't get updated
     (clear-graph-revisions!)
     (mt/with-non-admin-groups-no-root-collection-perms
-      (binding [*current-user-id* (mt/user->id :crowberto)]
+      (mt/with-current-user (mt/user->id :crowberto)
         (graph/update-graph! (graph :clear-revisions? true))
         (is (= {:revision 0
                 :groups   {(u/the-id (perms-group/all-users)) {:root :none}
@@ -163,7 +162,7 @@
     (clear-graph-revisions!)
     (mt/with-non-admin-groups-no-root-collection-perms
       (t2.with-temp/with-temp [Collection collection]
-        (binding [*current-user-id* (mt/user->id :crowberto)]
+        (mt/with-current-user (mt/user->id :crowberto)
           (graph/update-graph! (assoc-in (graph :clear-revisions? true)
                                          [:groups (u/the-id (perms-group/all-users)) (u/the-id collection)]
                                          :read))
@@ -175,7 +174,7 @@
   (testing "can we give them *write* perms?"
     (mt/with-non-admin-groups-no-root-collection-perms
       (t2.with-temp/with-temp [Collection collection]
-        (binding [*current-user-id* (mt/user->id :crowberto)]
+        (mt/with-current-user (mt/user->id :crowberto)
           (graph/update-graph! (assoc-in (graph :clear-revisions? true)
                                          [:groups (u/the-id (perms-group/all-users)) (u/the-id collection)]
                                          :write))
@@ -189,7 +188,7 @@
     (clear-graph-revisions!)
     (mt/with-non-admin-groups-no-root-collection-perms
       (t2.with-temp/with-temp [Collection collection]
-        (binding [*current-user-id* (mt/user->id :crowberto)]
+        (mt/with-current-user (mt/user->id :crowberto)
           (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
           (graph/update-graph! (assoc-in (graph :clear-revisions? true)
                                          [:groups (u/the-id (perms-group/all-users)) (u/the-id collection)]
@@ -204,7 +203,7 @@
     (t2.with-temp/with-temp [PermissionsGroup new-group]
       (clear-graph-revisions!)
       (mt/with-non-admin-groups-no-root-collection-perms
-        (binding [*current-user-id* (mt/user->id :crowberto)]
+        (mt/with-current-user (mt/user->id :crowberto)
           (graph/update-graph! (assoc-in (graph :clear-revisions? true)
                                          [:groups (u/the-id new-group) :root]
                                          :read))
@@ -218,7 +217,7 @@
     (t2.with-temp/with-temp [PermissionsGroup new-group]
       (clear-graph-revisions!)
       (mt/with-non-admin-groups-no-root-collection-perms
-        (binding [*current-user-id* (mt/user->id :crowberto)]
+        (mt/with-current-user (mt/user->id :crowberto)
           (graph/update-graph! (assoc-in (graph :clear-revisions? true)
                                          [:groups (u/the-id new-group) :root]
                                          :write))
@@ -233,7 +232,7 @@
     (t2.with-temp/with-temp [PermissionsGroup new-group]
       (clear-graph-revisions!)
       (mt/with-non-admin-groups-no-root-collection-perms
-        (binding [*current-user-id* (mt/user->id :crowberto)]
+        (mt/with-current-user (mt/user->id :crowberto)
           (perms/grant-collection-readwrite-permissions! new-group collection/root-collection)
           (graph/update-graph! (assoc-in (graph :clear-revisions? true)
                                          [:groups (u/the-id new-group) :root]

--- a/test/metabase/models/collection/root_test.clj
+++ b/test/metabase/models/collection/root_test.clj
@@ -12,6 +12,6 @@
                             #{"/collection/root/"} true}
           f                [#'mi/can-read? #'mi/can-write?]]
     (testing (format "%s with perms %s" f (pr-str perms))
-      (binding [api/*current-user-permissions-set* (atom perms)]
+      (binding [#_{:clj-kondo/ignore [:discouraged-var]} api/*current-user-permissions-set* (atom perms)]
         (is (= expected
                (f collection.root/root-collection)))))))

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -5,7 +5,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [clojure.walk :as walk]
-   [metabase.api.common :refer [*current-user-permissions-set*]]
+   [metabase.api.common :refer [#_{:clj-kondo/ignore [:discouraged-var]} *current-user-permissions-set*]]
    [metabase.models
     :refer [Card
             Collection
@@ -162,6 +162,7 @@
   [[collections-binding options] & body]
   `(do-with-collection-hierarchy ~options (fn [~collections-binding] ~@body)))
 
+#_{:clj-kondo/ignore [:discouraged-var]}
 (defmacro with-current-user-perms-for-collections
   "Run `body` with the current User permissions for `collections-or-ids`.
 
@@ -323,27 +324,32 @@
 
   (testing "Does the function also work if we call the single-arity version that powers hydration?"
     (testing "mix of full and read perms"
-      (binding [*current-user-permissions-set* (atom #{"/collection/10/" "/collection/20/read/"})]
+      (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+                *current-user-permissions-set* (atom #{"/collection/10/" "/collection/20/read/"})]
         (is (= "/10/20/"
                (collection/effective-location-path {:location "/10/20/30/"})))))
 
     (testing "missing some perms"
-      (binding [*current-user-permissions-set* (atom #{"/collection/10/read/" "/collection/30/read/"})]
+      (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+                *current-user-permissions-set* (atom #{"/collection/10/read/" "/collection/30/read/"})]
         (is (= "/10/30/"
                (collection/effective-location-path {:location "/10/20/30/"})))))
 
     (testing "no perms"
-      (binding [*current-user-permissions-set* (atom #{})]
+      (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+                *current-user-permissions-set* (atom #{})]
         (is (= "/"
                (collection/effective-location-path {:location "/10/20/30/"})))))
 
     (testing "read perms for all"
-      (binding [*current-user-permissions-set* (atom #{"/collection/10/" "/collection/20/read/" "/collection/30/read/"})]
+      (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+                *current-user-permissions-set* (atom #{"/collection/10/" "/collection/20/read/" "/collection/30/read/"})]
         (is (= "/10/20/30/"
                (collection/effective-location-path {:location "/10/20/30/"})))))
 
     (testing "root perms"
-      (binding [*current-user-permissions-set* (atom #{"/"})]
+      (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+                *current-user-permissions-set* (atom #{"/"})]
         (is (= "/10/20/30/"
                (collection/effective-location-path {:location "/10/20/30/"})))))))
 

--- a/test/metabase/models/dashboard_tab_test.clj
+++ b/test/metabase/models/dashboard_tab_test.clj
@@ -43,13 +43,15 @@
 
     (testing (str "Check that if a Dashtab of a Dashboard is in a Collection, someone who would not be able to see it under the old "
                   "artifact-permissions regime will be able to see it if they have permissions for that Collection")
-      (binding [api/*current-user-permissions-set* (delay #{(perms/collection-read-path collection)})]
+      (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+                api/*current-user-permissions-set* (delay #{(perms/collection-read-path collection)})]
         (mi/perms-objects-set dashtab :read)
         (is (= true (mi/can-read? dashtab)))
         (is (= false (mi/can-write? dashtab)))))
 
     (testing "Do we have *write* Permissions for a dashtab if we have *write* Permissions for the Collection it's in?"
-      (binding [api/*current-user-permissions-set* (delay #{(perms/collection-readwrite-path collection)})]
+      (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+                api/*current-user-permissions-set* (delay #{(perms/collection-readwrite-path collection)})]
         (is (= true (mi/can-read? dashtab)))
         (is (= true (mi/can-write? dashtab)))))
 

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -3,7 +3,6 @@
    [cheshire.core :refer [decode encode]]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [metabase.api.common :as api]
    [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
    [metabase.lib.test-util :as lib.tu]
@@ -233,7 +232,7 @@
 (deftest secret-db-details-integration-test
   (testing "manipulating secret values in db-details works correctly"
     (mt/with-driver :secret-test-driver
-      (binding [api/*current-user-id* (mt/user->id :crowberto)]
+      (mt/with-current-user (mt/user->id :crowberto)
         (let [secret-ids  (atom #{})    ; keep track of all secret IDs created with the temp database
               check-db-fn (fn [{:keys [details] :as _database} exp-secret]
                             (when (not= :file-path (:source exp-secret))

--- a/test/metabase/models/pulse_test.clj
+++ b/test/metabase/models/pulse_test.clj
@@ -435,12 +435,14 @@
 (deftest dashboard-subscription-permissions-test
   (with-dashboard-subscription-in-collection [_ collection dashboard subscription]
     (testing "An admin has read and write access to any dashboard subscription"
-      (binding [api/*is-superuser?* true]
+      (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+                api/*is-superuser?* true]
         (is (mi/can-read? subscription))
         (is (mi/can-write? subscription))))
 
     (mt/with-current-user (mt/user->id :rasta)
-      (binding [api/*current-user-permissions-set* (delay #{(perms/collection-read-path collection)})]
+      (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+                api/*current-user-permissions-set* (delay #{(perms/collection-read-path collection)})]
         (testing "A non-admin has read and write access to a subscription they created"
             (is (mi/can-read? subscription))
             (is (mi/can-write? subscription)))

--- a/test/metabase/models/query/permissions_test.clj
+++ b/test/metabase/models/query/permissions_test.clj
@@ -2,7 +2,8 @@
   (:require
    [clojure.test :refer :all]
    [metabase.api.common
-    :refer [*current-user-id* *current-user-permissions-set*]]
+    :refer [#_{:clj-kondo/ignore [:discouraged-var]} *current-user-id*
+            #_{:clj-kondo/ignore [:discouraged-var]} *current-user-permissions-set*]]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.models.card :as card :refer [Card]]
    [metabase.models.collection :refer [Collection]]
@@ -31,67 +32,79 @@
   (t2.with-temp/with-temp [Collection collection]
     (testing "Shouldn't be able to read a Card not in Collection without permissions"
       (t2.with-temp/with-temp [Card card (card)]
-        (binding [*current-user-permissions-set* (delay #{})]
+        (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+                  *current-user-permissions-set* (delay #{})]
           (is (= false
                  (mi/can-read? card)))))
 
       (testing "...or one in a Collection either!"
         (t2.with-temp/with-temp [Card card (card-in-collection collection)]
-          (binding [*current-user-permissions-set* (delay #{})]
+          (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+                    *current-user-permissions-set* (delay #{})]
             (is (= false
                    (mi/can-read? card)))))))
 
     (testing "*should* be allowed to read a Card not in a Collection if you have Root collection perms"
       (t2.with-temp/with-temp [Card card (card)]
-        (binding [*current-user-permissions-set* (delay #{"/collection/root/read/"})]
+        (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+                  *current-user-permissions-set* (delay #{"/collection/root/read/"})]
           (is (= true
                  (mi/can-read? card))))
 
         (testing "...but not if you have perms for some other Collection"
-          (binding [*current-user-permissions-set* (delay #{"/collection/1337/read/"})]
+          (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+                    *current-user-permissions-set* (delay #{"/collection/1337/read/"})]
             (is (= false
                    (mi/can-read? card)))))))
 
     (testing "should be allowed to *read* a Card in a Collection if you have read perms for that Collection"
       (t2.with-temp/with-temp [Card card (card-in-collection collection)]
-        (binding [*current-user-permissions-set* (delay #{(perms/collection-read-path collection)})]
+        (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+                  *current-user-permissions-set* (delay #{(perms/collection-read-path collection)})]
           (is (= true
                  (mi/can-read? card))))
 
         (testing "...but not if you only have Root Collection perms"
-          (binding [*current-user-permissions-set* (delay #{"/collection/root/read/"})]
+          (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+                    *current-user-permissions-set* (delay #{"/collection/root/read/"})]
             (is (= false
                    (mi/can-read? card)))))))
 
     (testing "to *write* a Card not in a Collection you need Root Collection Write Perms"
       (t2.with-temp/with-temp [Card card (card)]
-        (binding [*current-user-permissions-set* (delay #{"/collection/root/"})]
+        (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+                  *current-user-permissions-set* (delay #{"/collection/root/"})]
           (is (= true
                  (mi/can-write? card))))
 
         (testing "...root Collection Read Perms shouldn't work"
-          (binding [*current-user-permissions-set* (delay #{"/collection/root/read/"})]
+          (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+                    *current-user-permissions-set* (delay #{"/collection/root/read/"})]
             (is (= false
                    (mi/can-write? card))))
 
           (testing "...nor should write perms for another collection"
-            (binding [*current-user-permissions-set* (delay #{"/collection/1337/"})]
+            (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+                      *current-user-permissions-set* (delay #{"/collection/1337/"})]
               (is (= false
                      (mi/can-write? card))))))))
 
     (testing "to *write* a Card *in* a Collection you need Collection Write Perms"
       (t2.with-temp/with-temp [Card card (card-in-collection collection)]
-        (binding [*current-user-permissions-set* (delay #{(perms/collection-readwrite-path collection)})]
+        (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+                  *current-user-permissions-set* (delay #{(perms/collection-readwrite-path collection)})]
           (is (= true
                  (mi/can-write? card))))
 
         (testing "...Collection read perms shouldn't work"
-          (binding [*current-user-permissions-set* (delay #{(perms/collection-read-path collection)})]
+          (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+                    *current-user-permissions-set* (delay #{(perms/collection-read-path collection)})]
             (is (= false
                    (mi/can-write? card))))
 
           (testing "...nor should write perms for the Root Collection"
-            (binding [*current-user-permissions-set* (delay #{"/collection/root/"})]
+            (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+                      *current-user-permissions-set* (delay #{"/collection/root/"})]
               (is (= false
                      (mi/can-write? card))))))))))
 
@@ -129,7 +142,9 @@
                    Table    table {:db_id (u/the-id db) :schema nil}
                    Field    _     {:table_id (u/the-id table)}]
       (perms/revoke-data-perms! (perms-group/all-users) db)
-      (binding [*current-user-permissions-set* (atom nil)
+      (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+                *current-user-permissions-set* (atom nil)
+                #_{:clj-kondo/ignore [:discouraged-var]}
                 *current-user-id*              (mt/user->id :rasta)]
         (is (= #{(perms/table-query-path db nil table)}
                (query-perms/perms-set

--- a/test/metabase/models/secret/keystore_test.clj
+++ b/test/metabase/models/secret/keystore_test.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.java.io :as io]
    [clojure.test :refer :all]
-   [metabase.api.common :as api]
    [metabase.models :refer [Database Secret]]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
@@ -60,7 +59,7 @@
 
 (deftest secret-keystore-type-test
   (testing "A secret with :type :keystore can be saved and loaded properly"
-    (binding [api/*current-user-id* (mt/user->id :crowberto)]
+    (mt/with-current-user (mt/user->id :crowberto)
       (with-open [baos (ByteArrayOutputStream.)]
         (let [key-alias "my-secret-key"
               key-value "cromulent"

--- a/test/metabase/related_test.clj
+++ b/test/metabase/related_test.clj
@@ -205,7 +205,9 @@
                                                         :object   {}}
                            DashboardCard _             {:card_id (:id card-1), :dashboard_id dash-id}
                            DashboardCard _             {:card_id (:id card-2), :dashboard_id dash-id}]
-    (binding [api/*current-user-id*              (mt/user->id :rasta)
+    (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+              api/*current-user-id*              (mt/user->id :rasta)
+              #_{:clj-kondo/ignore [:discouraged-var]}
               api/*current-user-permissions-set* (atom #{"/"})]
       (is (=? [{:id dash-id}]
               (#'related/recommended-dashboards [card-1 card-2 card-3]))))))

--- a/test/metabase/test/data/impl/get_or_create.clj
+++ b/test/metabase/test/data/impl/get_or_create.clj
@@ -163,7 +163,9 @@
 
 (defn- create-database-with-bound-settings! [driver dbdef]
   (letfn [(thunk []
-            (binding [api/*current-user-id*              nil
+            (binding [#_{:clj-kondo/ignore [:discouraged-var]}
+                      api/*current-user-id*              nil
+                      #_{:clj-kondo/ignore [:discouraged-var]}
                       api/*current-user-permissions-set* nil]
               (create-database! driver dbdef)))]
     ;; make sure report timezone isn't set, possibly causing weird things to happen when data is loaded -- this


### PR DESCRIPTION
See also: #34030

Rather than undertake a huge refactor right now, I thought it'd be wiser to add a Kondo rule to prevent the problem from getting worse, then gradually refactor out the exceptions (as Bryan started to do in #34030).

I'm open to pushback about exactly which namespaces are or are not included, but this set seemed like a sensible place to start.
