### PR TITLE
Add custom warning message when leaving creating an SQL question

### DIFF
--- a/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -32,6 +32,27 @@ const TEST_CASES = [
   { case: "dashboard", subject: DASHBOARD_NAME },
 ];
 
+/**
+ * Our app registers beforeunload event listener e.g. when editing a native SQL question.
+ * Cypress does not automatically close the browser prompt and does not allow manually
+ * interacting with it (unlike with window.confirm). The test will hang forever with
+ * the prompt displayed and will eventually time out. We need to work around this by
+ * monkey-patching window.addEventListener to ignore beforeunload event handlers.
+ *
+ * @see https://github.com/cypress-io/cypress/issues/2118
+ */
+Cypress.on("window:load", window => {
+  const addEventListener = window.addEventListener;
+
+  window.addEventListener = function (event) {
+    if (event === "beforeunload") {
+      return;
+    }
+
+    return addEventListener.apply(this, arguments);
+  };
+});
+
 describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
   beforeEach(() => {
     restore();

--- a/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-QueryActions.unit.spec.ts
+++ b/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-QueryActions.unit.spec.ts
@@ -38,7 +38,9 @@ describe("ActionCreator > Query Actions", () => {
       userEvent.click(getIcon("reference"));
 
       expect(screen.getAllByText("Data Reference")).toHaveLength(2);
-      expect(screen.getByText("Database")).toBeInTheDocument();
+      expect(
+        within(screen.getByTestId("sidebar-content")).getByText("Database"),
+      ).toBeInTheDocument();
     });
 
     it("should show action settings button", async () => {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/__mocks__/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/__mocks__/NativeQueryEditor.jsx
@@ -1,14 +1,46 @@
 /* eslint-disable react/prop-types */
 import SyncedParametersList from "metabase/parameters/components/SyncedParametersList/SyncedParametersList";
 import { ACE_ELEMENT_ID } from "metabase/query_builder/components/NativeQueryEditor/constants";
+import DataSourceSelectors from "metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors";
 
-const MockNativeQueryEditor = ({ query, setParameterValue, ...props }) => {
+const MockNativeQueryEditor = ({
+  canChangeDatabase = true,
+  editorContext = "question",
+  isNativeEditorOpen,
+  query,
+  readOnly,
+  setDatasetQuery,
+  setParameterValue,
+}) => {
   const onChange = evt => {
-    props.setDatasetQuery(query.setQueryText(evt.target.value));
+    setDatasetQuery(query.setQueryText(evt.target.value));
+  };
+
+  const onDatabaseIdChange = databaseId => {
+    if (query.databaseId() !== databaseId) {
+      setDatasetQuery(query.setDatabaseId(databaseId).setDefaultCollection());
+    }
+  };
+
+  const onTableIdChange = tableId => {
+    const table = query.metadata().table(tableId);
+    if (table && table.name !== query.collection()) {
+      setDatasetQuery(query.setCollectionName(table.name));
+    }
   };
 
   return (
     <div data-testid="mock-native-query-editor" id={ACE_ELEMENT_ID}>
+      {canChangeDatabase && (
+        <DataSourceSelectors
+          isNativeEditorOpen={isNativeEditorOpen}
+          query={query}
+          readOnly={readOnly}
+          setDatabaseId={onDatabaseIdChange}
+          setTableId={onTableIdChange}
+          editorContext={editorContext}
+        />
+      )}
       {query.queryText && (
         <textarea value={query.queryText()} onChange={onChange} />
       )}

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -11,6 +11,7 @@ import {
   createMockModelIndex,
   createMockNativeDatasetQuery,
   createMockNativeQuery,
+  createMockResultsMetadata,
   createMockStructuredDatasetQuery,
   createMockStructuredQuery,
   createMockUnsavedCard,
@@ -534,6 +535,10 @@ describe("QueryBuilder", () => {
 
   describe("unsaved changes warning", () => {
     describe("creating models", () => {
+      afterEach(() => {
+        jest.clearAllMocks();
+      });
+
       it("shows custom warning modal when leaving via SPA navigation", async () => {
         const { history } = await setup({
           card: null,

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -605,6 +605,24 @@ describe("QueryBuilder", () => {
           screen.queryByTestId("leave-confirmation"),
         ).not.toBeInTheDocument();
       });
+
+      it("shows custom warning modal when user tries to leave an ad-hoc native query", async () => {
+        const { history } = await setup({
+          card: TEST_UNSAVED_NATIVE_CARD,
+          initialRoute: "/",
+        });
+
+        history.push(
+          `/question#${serializeCardForUrl(TEST_UNSAVED_NATIVE_CARD)}`,
+        );
+        await waitForLoaderToBeRemoved();
+
+        await triggerNativeQueryChange();
+
+        history.goBack();
+
+        expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
+      });
     });
 
     describe("editing models", () => {

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -830,6 +830,30 @@ describe("QueryBuilder", () => {
 
         expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
       });
+
+      it("does not show custom warning modal when running new question", async () => {
+        await setup({
+          card: null,
+          initialRoute: "/",
+        });
+
+        userEvent.click(screen.getByText("New"));
+        userEvent.click(
+          within(screen.getByTestId("popover")).getByText("SQL query"),
+        );
+
+        await waitForLoaderToBeRemoved();
+
+        userEvent.click(
+          within(screen.getByTestId("query-builder-main")).getByRole("button", {
+            name: "Refresh",
+          }),
+        );
+
+        expect(
+          screen.queryByTestId("leave-confirmation"),
+        ).not.toBeInTheDocument();
+      });
     });
 
     describe("editing native questions", () => {

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -38,7 +38,6 @@ import {
   setupCardCreateEndpoint,
   setupCardQueryMetadataEndpoint,
   setupCollectionByIdEndpoint,
-  setupCollectionsEndpoints,
 } from "__support__/server-mocks";
 import {
   renderWithProviders,
@@ -236,9 +235,7 @@ const setup = async ({
   setupSearchEndpoints([]);
   setupBookmarksEndpoints([]);
   setupTimelinesEndpoints([]);
-  setupCollectionsEndpoints({
-    collections: [TEST_COLLECTION],
-  });
+  setupCollectionByIdEndpoint({ collections: [TEST_COLLECTION] });
   if (isSavedCard(card)) {
     setupCardsEndpoints([card]);
     setupCardQueryEndpoints(card, dataset);

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -847,10 +847,31 @@ describe("QueryBuilder", () => {
         );
 
         await waitForLoaderToBeRemoved();
+        await triggerNativeQueryChange();
 
         history.goBack();
 
         expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
+      });
+
+      it("does not show custom warning modal when leaving creating empty question via SPA navigation", async () => {
+        const { history } = await setup({
+          card: null,
+          initialRoute: "/",
+        });
+
+        userEvent.click(screen.getByText("New"));
+        userEvent.click(
+          within(screen.getByTestId("popover")).getByText("SQL query"),
+        );
+
+        await waitForLoaderToBeRemoved();
+
+        history.goBack();
+
+        expect(
+          screen.queryByTestId("leave-confirmation"),
+        ).not.toBeInTheDocument();
       });
 
       it("does not show custom warning modal when running new question", async () => {

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -534,10 +534,6 @@ describe("QueryBuilder", () => {
 
   describe("unsaved changes warning", () => {
     describe("creating models", () => {
-      afterEach(() => {
-        jest.clearAllMocks();
-      });
-
       it("shows custom warning modal when leaving via SPA navigation", async () => {
         const { history } = await setup({
           card: null,

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -476,10 +476,6 @@ describe("QueryBuilder", () => {
     });
 
     describe("editing native questions", () => {
-      afterEach(() => {
-        jest.restoreAllMocks();
-      });
-
       it("should trigger beforeunload event when leaving edited question", async () => {
         const { mockEventListener } = await setup({
           card: TEST_NATIVE_CARD,
@@ -516,10 +512,6 @@ describe("QueryBuilder", () => {
     });
 
     describe("editing notebook questions", () => {
-      afterEach(() => {
-        jest.restoreAllMocks();
-      });
-
       it("should not trigger beforeunload event when leaving edited question which will turn the question ad-hoc", async () => {
         const { mockEventListener } = await setup({
           card: TEST_STRUCTURED_CARD,
@@ -564,10 +556,6 @@ describe("QueryBuilder", () => {
 
   describe("unsaved changes warning", () => {
     describe("creating models", () => {
-      afterEach(() => {
-        jest.clearAllMocks();
-      });
-
       it("shows custom warning modal when leaving via SPA navigation", async () => {
         const { history } = await setup({
           card: null,

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -207,11 +207,7 @@ const TestQueryBuilder = (
   );
 };
 
-const TestHome = () => (
-  <div>
-    <NewItemMenu trigger={<button>New</button>} />
-  </div>
-);
+const TestHome = () => <NewItemMenu trigger={<button>New</button>} />;
 
 function isSavedCard(card: Card | UnsavedCard | null): card is Card {
   return card !== null && "id" in card;

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -49,6 +49,7 @@ import { callMockEvent } from "__support__/events";
 import { BEFORE_UNLOAD_UNSAVED_MESSAGE } from "metabase/hooks/use-before-unload";
 import { serializeCardForUrl } from "metabase/lib/card";
 import NewModelOptions from "metabase/models/containers/NewModelOptions";
+import NewItemMenu from "metabase/containers/NewItemMenu";
 import QueryBuilder from "./QueryBuilder";
 
 registerVisualizations();
@@ -201,7 +202,11 @@ const TestQueryBuilder = (
   );
 };
 
-const TestHome = () => <div />;
+const TestHome = () => (
+  <div>
+    <NewItemMenu trigger={<button>New</button>} />
+  </div>
+);
 
 function isSavedCard(card: Card | UnsavedCard | null): card is Card {
   return card !== null && "id" in card;
@@ -804,6 +809,26 @@ describe("QueryBuilder", () => {
         expect(
           screen.queryByTestId("leave-confirmation"),
         ).not.toBeInTheDocument();
+      });
+    });
+
+    describe("creating native questions", () => {
+      it("shows custom warning modal when leaving creating question via SPA navigation", async () => {
+        const { history } = await setup({
+          card: null,
+          initialRoute: "/",
+        });
+
+        userEvent.click(screen.getByText("New"));
+        userEvent.click(
+          within(screen.getByTestId("popover")).getByText("SQL query"),
+        );
+
+        await waitForLoaderToBeRemoved();
+
+        history.goBack();
+
+        expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
       });
     });
 

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -590,7 +590,6 @@ describe("QueryBuilder", () => {
           card: null,
           initialRoute: "/model/new",
         });
-        setupCollectionByIdEndpoint({ collections: [createMockCollection()] });
         setupCardCreateEndpoint();
         setupCardQueryMetadataEndpoint(TEST_NATIVE_CARD);
 

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -375,7 +375,6 @@ describe("QueryBuilder", () => {
         await startNewNotebookModel();
 
         const mockEvent = callMockEvent(mockEventListener, "beforeunload");
-
         expect(mockEvent.preventDefault).toHaveBeenCalled();
         expect(mockEvent.returnValue).toBe(BEFORE_UNLOAD_UNSAVED_MESSAGE);
       });
@@ -392,7 +391,6 @@ describe("QueryBuilder", () => {
           await triggerNotebookQueryChange();
 
           const mockEvent = callMockEvent(mockEventListener, "beforeunload");
-
           expect(mockEvent.preventDefault).toHaveBeenCalled();
           expect(mockEvent.returnValue).toBe(BEFORE_UNLOAD_UNSAVED_MESSAGE);
         });
@@ -513,9 +511,7 @@ describe("QueryBuilder", () => {
 
         const mockEvent = callMockEvent(mockEventListener, "beforeunload");
         expect(mockEvent.preventDefault).not.toHaveBeenCalled();
-        expect(mockEvent.returnValue).not.toEqual(
-          BEFORE_UNLOAD_UNSAVED_MESSAGE,
-        );
+        expect(mockEvent.returnValue).toEqual(undefined);
       });
     });
 
@@ -536,9 +532,7 @@ describe("QueryBuilder", () => {
 
         const mockEvent = callMockEvent(mockEventListener, "beforeunload");
         expect(mockEvent.preventDefault).not.toHaveBeenCalled();
-        expect(mockEvent.returnValue).not.toEqual(
-          BEFORE_UNLOAD_UNSAVED_MESSAGE,
-        );
+        expect(mockEvent.returnValue).toEqual(undefined);
       });
 
       it("should not trigger beforeunload event when user tries to leave an ad-hoc structured query", async () => {
@@ -553,9 +547,7 @@ describe("QueryBuilder", () => {
 
         const mockEvent = callMockEvent(mockEventListener, "beforeunload");
         expect(mockEvent.preventDefault).not.toHaveBeenCalled();
-        expect(mockEvent.returnValue).not.toEqual(
-          BEFORE_UNLOAD_UNSAVED_MESSAGE,
-        );
+        expect(mockEvent.returnValue).toEqual(undefined);
       });
 
       it("should not trigger beforeunload event when query is unedited", async () => {
@@ -565,9 +557,7 @@ describe("QueryBuilder", () => {
 
         const mockEvent = callMockEvent(mockEventListener, "beforeunload");
         expect(mockEvent.preventDefault).not.toHaveBeenCalled();
-        expect(mockEvent.returnValue).not.toEqual(
-          BEFORE_UNLOAD_UNSAVED_MESSAGE,
-        );
+        expect(mockEvent.returnValue).toEqual(undefined);
       });
     });
   });

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -11,7 +11,6 @@ import {
   createMockModelIndex,
   createMockNativeDatasetQuery,
   createMockNativeQuery,
-  createMockResultsMetadata,
   createMockStructuredDatasetQuery,
   createMockStructuredQuery,
   createMockUnsavedCard,

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -616,6 +616,7 @@ export const getShouldShowUnsavedChangesWarning = createSelector(
     isResultsMetadataDirty,
     getQuestion,
     getIsSavedQuestionChanged,
+    getOriginalQuestion,
   ],
   (
     queryBuilderMode,
@@ -623,13 +624,17 @@ export const getShouldShowUnsavedChangesWarning = createSelector(
     isMetadataDirty,
     question,
     isSavedQuestionChanged,
+    originalQuestion,
   ) => {
     const isEditingModel = queryBuilderMode === "dataset";
+    const isNewQuestion = !originalQuestion;
 
     const shouldShowUnsavedChangesWarningForModels =
       isEditingModel && (isDirty || isMetadataDirty);
     const shouldShowUnsavedChangesWarningForSqlQuery =
-      question != null && question.isNative() && isSavedQuestionChanged;
+      question != null &&
+      question.isNative() &&
+      (isSavedQuestionChanged || isNewQuestion);
 
     return (
       shouldShowUnsavedChangesWarningForModels ||

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -631,10 +631,12 @@ export const getShouldShowUnsavedChangesWarning = createSelector(
 
     const shouldShowUnsavedChangesWarningForModels =
       isEditingModel && (isDirty || isMetadataDirty);
+    const isNewNonEmptyQuestion =
+      question && isNewQuestion && !question.isEmpty();
     const shouldShowUnsavedChangesWarningForSqlQuery =
       question != null &&
       question.isNative() &&
-      (isSavedQuestionChanged || isNewQuestion);
+      (isSavedQuestionChanged || isNewNonEmptyQuestion);
 
     return (
       shouldShowUnsavedChangesWarningForModels ||

--- a/frontend/src/metabase/query_builder/utils.ts
+++ b/frontend/src/metabase/query_builder/utils.ts
@@ -92,11 +92,7 @@ export const isNavigationAllowed = ({
     return isQueryTab || isMetadataTab;
   }
 
-  /**
-   * If it's a new question, we're going to deal with it later as part of the epic:
-   * https://github.com/metabase/metabase/issues/33749
-   */
-  if (!isNewQuestion && question.isNative()) {
+  if (question.isNative()) {
     const isRunningQuestion = pathname === "/question" && hash.length > 0;
     return isRunningQuestion;
   }

--- a/frontend/src/metabase/query_builder/utils.ts
+++ b/frontend/src/metabase/query_builder/utils.ts
@@ -78,6 +78,7 @@ export const isNavigationAllowed = ({
     return true;
   }
 
+  const isExistingQuestion = !isNewQuestion;
   const { hash, pathname } = destination;
 
   if (question.isDataset()) {
@@ -92,11 +93,7 @@ export const isNavigationAllowed = ({
     return isQueryTab || isMetadataTab;
   }
 
-  /**
-   * If it's a new question, we're going to deal with it later as part of the epic:
-   * https://github.com/metabase/metabase/issues/33749
-   */
-  if (!isNewQuestion && question.isNative()) {
+  if (isExistingQuestion && question.isNative()) {
     const isRunningQuestion = pathname === "/question" && hash.length > 0;
     return isRunningQuestion;
   }

--- a/frontend/src/metabase/query_builder/utils.ts
+++ b/frontend/src/metabase/query_builder/utils.ts
@@ -78,7 +78,6 @@ export const isNavigationAllowed = ({
     return true;
   }
 
-  const isExistingQuestion = !isNewQuestion;
   const { hash, pathname } = destination;
 
   if (question.isDataset()) {
@@ -93,7 +92,7 @@ export const isNavigationAllowed = ({
     return isQueryTab || isMetadataTab;
   }
 
-  if (isExistingQuestion && question.isNative()) {
+  if (!isNewQuestion && question.isNative()) {
     const isRunningQuestion = pathname === "/question" && hash.length > 0;
     return isRunningQuestion;
   }

--- a/frontend/src/metabase/query_builder/utils.ts
+++ b/frontend/src/metabase/query_builder/utils.ts
@@ -92,6 +92,10 @@ export const isNavigationAllowed = ({
     return isQueryTab || isMetadataTab;
   }
 
+  /**
+   * If it's a new question, we're going to deal with it later as part of the epic:
+   * https://github.com/metabase/metabase/issues/33749
+   */
   if (!isNewQuestion && question.isNative()) {
     const isRunningQuestion = pathname === "/question" && hash.length > 0;
     return isRunningQuestion;

--- a/frontend/src/metabase/query_builder/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.ts
@@ -6,6 +6,7 @@ import {
   createMockNativeDatasetQuery,
 } from "metabase-types/api/mocks";
 import { checkNotNull } from "metabase/core/utils/types";
+import { serializeCardForUrl } from "metabase/lib/card";
 
 import { isNavigationAllowed } from "./utils";
 
@@ -76,7 +77,7 @@ const modelMetadataTabLocation = createMockLocation({
 
 const runQuestionLocation = createMockLocation({
   pathname: "/question",
-  hash: `#${window.btoa(JSON.stringify(nativeCard))}`,
+  hash: `#${serializeCardForUrl(nativeCard)}`,
 });
 
 describe("isNavigationAllowed", () => {

--- a/frontend/src/metabase/query_builder/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.ts
@@ -126,11 +126,12 @@ describe("isNavigationAllowed", () => {
     });
   });
 
-  describe("when creating new question", () => {
+  describe("when creating new notebook question", () => {
     const isNewQuestion = true;
+    const question = notebookQuestion;
 
     describe("allows navigating away", () => {
-      describe.each([
+      it.each([
         anyLocation,
         modelQueryTabLocation,
         modelMetadataTabLocation,
@@ -138,14 +139,36 @@ describe("isNavigationAllowed", () => {
         newModelMetadataTabLocation,
         runQuestionLocation,
       ])("to `$pathname`", destination => {
-        it.each([notebookQuestion, nativeQuestion])(
-          "from creating new `$_card.name`",
-          question => {
-            expect(
-              isNavigationAllowed({ destination, question, isNewQuestion }),
-            ).toBe(true);
-          },
-        );
+        expect(
+          isNavigationAllowed({ destination, question, isNewQuestion }),
+        ).toBe(true);
+      });
+    });
+  });
+
+  describe("when creating new native question", () => {
+    const isNewQuestion = true;
+    const question = nativeQuestion;
+
+    it("allows to run the question", () => {
+      const destination = runQuestionLocation;
+
+      expect(
+        isNavigationAllowed({ destination, question, isNewQuestion }),
+      ).toBe(true);
+    });
+
+    describe("disallows all other navigation", () => {
+      it.each([
+        anyLocation,
+        modelQueryTabLocation,
+        modelMetadataTabLocation,
+        newModelQueryTabLocation,
+        newModelMetadataTabLocation,
+      ])("to `$pathname`", destination => {
+        expect(
+          isNavigationAllowed({ destination, question, isNewQuestion }),
+        ).toBe(false);
       });
     });
   });

--- a/frontend/test/__support__/server-mocks/collection.ts
+++ b/frontend/test/__support__/server-mocks/collection.ts
@@ -45,6 +45,12 @@ export function setupCollectionsEndpoints({
     { url: "path:/api/collection", overwriteRoutes: false },
     collections,
   );
+  for (const collection of collections) {
+    fetchMock.get(
+      { url: `path:/api/collection/${collection.id}`, overwriteRoutes: false },
+      collection,
+    );
+  }
 }
 
 function getCollectionVirtualSchemaURLs(collection: Collection) {

--- a/frontend/test/__support__/server-mocks/collection.ts
+++ b/frontend/test/__support__/server-mocks/collection.ts
@@ -47,12 +47,6 @@ export function setupCollectionsEndpoints({
   );
 }
 
-export function setupCollectionsEndpointsByIds(collections: Collection[]) {
-  for (const collection of collections) {
-    fetchMock.get(`path:/api/collection/${collection.id}`, [collection]);
-  }
-}
-
 function getCollectionVirtualSchemaURLs(collection: Collection) {
   const db = SAVED_QUESTIONS_VIRTUAL_DB_ID;
   const schemaName = getCollectionVirtualSchemaName(collection);

--- a/frontend/test/__support__/server-mocks/collection.ts
+++ b/frontend/test/__support__/server-mocks/collection.ts
@@ -45,12 +45,6 @@ export function setupCollectionsEndpoints({
     { url: "path:/api/collection", overwriteRoutes: false },
     collections,
   );
-  for (const collection of collections) {
-    fetchMock.get(
-      { url: `path:/api/collection/${collection.id}`, overwriteRoutes: false },
-      collection,
-    );
-  }
 }
 
 function getCollectionVirtualSchemaURLs(collection: Collection) {

--- a/frontend/test/__support__/server-mocks/collection.ts
+++ b/frontend/test/__support__/server-mocks/collection.ts
@@ -47,6 +47,12 @@ export function setupCollectionsEndpoints({
   );
 }
 
+export function setupCollectionsEndpointsByIds(collections: Collection[]) {
+  for (const collection of collections) {
+    fetchMock.get(`path:/api/collection/${collection.id}`, [collection]);
+  }
+}
+
 function getCollectionVirtualSchemaURLs(collection: Collection) {
   const db = SAVED_QUESTIONS_VIRTUAL_DB_ID;
   const schemaName = getCollectionVirtualSchemaName(collection);


### PR DESCRIPTION
Closes #34429



### Description

- Same as #34593, but it became closed by github after force-push and I can't reopen it anymore
- There should be no warning when SQL query is empty

### How to verify

**1. Navigating away from creating a new empty SQL question**

1. Click "+ New"
2. Choose "SQL query"
3. Click back button in your browser

Expected result: "Changes are not saved" modal is **not displayed**

**2. Navigating away from creating a new non-empty SQL question**

1. Click "+ New"
2. Choose "SQL query"
3. Type some SQL in the editor
4. Click back button in your browser

Expected result: "Changes are not saved" modal is **displayed**


### Demo



https://github.com/metabase/metabase/assets/6830683/63eea005-cb98-4354-926a-14d94a5e984c

