### PR TITLE
combo static chart foundation with echarts

### DIFF
--- a/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
+++ b/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
@@ -1,7 +1,7 @@
 import { init } from "echarts";
 import type { IsomorphicChartProps } from "metabase/static-viz/containers/StaticChart/types";
 import { getCartesianChartModel } from "metabase/visualizations/echarts/cartesian/model";
-import { buildCartesianChartOption } from "metabase/visualizations/echarts/cartesian/option";
+import { getCartesianChartOption } from "metabase/visualizations/echarts/cartesian/option";
 import { sanitizeSvgForBatik } from "metabase/static-viz/lib/svg";
 import { computeStaticComboChartSettings } from "./settings";
 
@@ -29,7 +29,7 @@ export const ComboChart = ({
     computedVisualizationSettings,
   );
 
-  const option = buildCartesianChartOption(
+  const option = getCartesianChartOption(
     chartModel,
     computedVisualizationSettings,
     renderingContext,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
@@ -34,6 +34,8 @@ export const groupDataset = (
 
   for (const row of rows) {
     const dimensionValue = row[dimensionIndex];
+
+    // Get the existing datum by the dimension value if exists
     const datum = groupedData.get(dimensionValue) ?? {
       [dimensionColumn.name]: dimensionValue,
     };
@@ -46,9 +48,11 @@ export const groupDataset = (
       const rowValue = row[columnIndex];
       const seriesKey = getDatasetSeriesKey(column);
 
+      // Aggregate values of metric columns, simply, ones with summable numbers
       if (isMetric(column)) {
         datum[seriesKey] = sumMetric(datum[seriesKey], rowValue);
 
+        // If breakout is defined, create an additional series key for each breakout
         if (breakoutIndex != null) {
           const breakoutSeriesKey = getDatasetSeriesKey(
             column,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
@@ -48,8 +48,8 @@ export const getXAxisType = (settings: ComputedVisualizationSettings) => {
 
 export const buildDimensionAxis = (
   settings: ComputedVisualizationSettings,
-  renderingContext: RenderingContext,
   column: RemappingHydratedDatasetColumn,
+  renderingContext: RenderingContext,
 ): CartesianAxisOption => {
   const { getColor } = renderingContext;
   const axisType = getXAxisType(settings);
@@ -99,8 +99,8 @@ export const buildDimensionAxis = (
 
 const buildMetricsAxes = (
   settings: ComputedVisualizationSettings,
-  renderingContext: RenderingContext,
   column: RemappingHydratedDatasetColumn,
+  renderingContext: RenderingContext,
 ): CartesianAxisOption[] => {
   const { getColor } = renderingContext;
   const formatter = (value: unknown) => {
@@ -111,7 +111,6 @@ const buildMetricsAxes = (
   };
 
   // TODO: support Y-axis split
-
   return [
     {
       ...getAxisNameDefaultOption(
@@ -127,9 +126,7 @@ const buildMetricsAxes = (
       },
       axisLabel: {
         ...getTicksDefaultOption(renderingContext),
-        // TODO: figure out EChart types
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
+        // @ts-expect-error TODO: figure out EChart types
         formatter: (value: string) => {
           return formatter(value);
         },
@@ -146,13 +143,13 @@ export const buildAxes = (
   return {
     xAxis: buildDimensionAxis(
       settings,
-      renderingContext,
       cardSeriesModel.dimension.column,
+      renderingContext,
     ),
     yAxis: buildMetricsAxes(
       settings,
-      renderingContext,
       cardSeriesModel.metrics[0].column,
+      renderingContext,
     ),
   };
 };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -7,18 +7,18 @@ import type {
 } from "metabase/visualizations/types";
 import { buildAxes } from "metabase/visualizations/echarts/cartesian/option/axis";
 
-export const buildCartesianChartOption = (
+export const getCartesianChartOption = (
   chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
 ): EChartsOption => {
-  const series = buildOptionMultipleSeries(
+  const echartsSeries = buildOptionMultipleSeries(
     chartModel.flatMap(cardModel => cardModel.series),
     settings,
     renderingContext,
   );
 
-  const dataset = chartModel.map(cardModel => {
+  const echartsDataset = chartModel.map(cardModel => {
     const dimensions = [
       cardModel.series.dimension.dataKey,
       ...cardModel.series.metrics.map(s => s.dataKey),
@@ -30,8 +30,8 @@ export const buildCartesianChartOption = (
   const mainCard = chartModel[0];
 
   return {
-    dataset,
-    series,
+    dataset: echartsDataset,
+    series: echartsSeries,
     ...buildAxes(mainCard.series, settings, renderingContext),
   } as EChartsOption;
 };

--- a/frontend/src/metabase/visualizations/visualizations/ComboChartPlayground/ComboChartPlayground.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/ComboChartPlayground/ComboChartPlayground.tsx
@@ -17,7 +17,7 @@ import { GRAPH_GOAL_SETTINGS } from "metabase/visualizations/lib/settings/goal";
 import LineAreaBarChart from "metabase/visualizations/components/LineAreaBarChart";
 import { EChartsRenderer } from "metabase/visualizations/components/EChartsRenderer";
 import { getCartesianChartModel } from "metabase/visualizations/echarts/cartesian/model";
-import { buildCartesianChartOption } from "metabase/visualizations/echarts/cartesian/option";
+import { getCartesianChartOption } from "metabase/visualizations/echarts/cartesian/option";
 
 Object.assign(ComboChartPlayground, {
   uiName: "Combo EChart",
@@ -81,7 +81,7 @@ export function ComboChartPlayground({
 
   const option = useMemo(
     () =>
-      buildCartesianChartOption(chartModel, settings, renderingContext as any),
+      getCartesianChartOption(chartModel, settings, renderingContext as any),
     [chartModel, settings, renderingContext],
   );
 


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/34672

### Description

This PR polishes the initial combo chart prototype. It uses ECharts only for the static combo chart so far. There are many non-working features for now. Supported ones:
- Multiple series
- Categorical, timeseries, numeric x-axis
- Custom series colors
- Show values on chart
- Specify series display type: line/area/bar

### How to verify

1. Create a combo chart question, specify series `display` manually (defaults are not implemented)
2. Add it on a dashboard
4. Send in an email subscription
5. Confirm the chart renders

### Demo

<img width="1725" alt="Screenshot 2023-10-16 at 7 49 50 PM" src="https://github.com/metabase/metabase/assets/14301985/96ed378c-a696-44f9-a8e4-ee9c914ef357">

<img width="636" alt="Screenshot 2023-10-16 at 8 04 35 PM" src="https://github.com/metabase/metabase/assets/14301985/5e8346c1-d377-4b51-a4da-39a18b1c2cab">
