### PR TITLE
fix "between datetimes" filter

### DIFF
--- a/src/metabase/driver/common/parameters/dates.clj
+++ b/src/metabase/driver/common/parameters/dates.clj
@@ -238,6 +238,10 @@
 (defn- ->iso-8601-date [t]
   (t/format :iso-local-date t))
 
+(defn- ->iso-8601-date-time [t]
+  (t/format :iso-local-date-time t))
+
+
 ;; TODO - using `range->filter` so much below seems silly. Why can't we just bucket the field and use `:=` clauses?
 (defn- range->filter
   [{:keys [start end]} field-clause]
@@ -309,11 +313,19 @@
               (let [iso8601date (->iso-8601-date date)]
                 [:= (with-temporal-unit-if-field field-clause :day) iso8601date]))}
    ;; day range
-   {:parser (regex->parser #"([0-9-T:]+)~([0-9-T:]+)" [:date-1 :date-2])
+   {:parser (regex->parser #"([0-9-T]+)~([0-9-T]+)" [:date-1 :date-2])
     :range  (fn [{:keys [date-1 date-2]} _]
               {:start date-1, :end date-2})
     :filter (fn [{:keys [date-1 date-2]} field-clause]
               [:between (with-temporal-unit-if-field field-clause :day) (->iso-8601-date date-1) (->iso-8601-date date-2)])}
+   ;; datetime range
+   {:parser (regex->parser #"([0-9-T:]+)~([0-9-T:]+)" [:date-1 :date-2])
+    :range  (fn [{:keys [date-1 date-2]} _]
+              {:start date-1, :end date-2})
+    :filter (fn [{:keys [date-1 date-2]} field-clause]
+              [:between (with-temporal-unit-if-field field-clause :default)
+               (->iso-8601-date-time date-1)
+               (->iso-8601-date-time date-2)])}
    ;; before day
    {:parser (regex->parser #"~([0-9-T:]+)" [:date])
     :range  (fn [{:keys [date]} _]

--- a/test/metabase/driver/common/parameters/dates_test.clj
+++ b/test/metabase/driver/common/parameters/dates_test.clj
@@ -32,6 +32,12 @@
             "2019-04-01"
             "2019-04-03"]
            (params.dates/date-string->filter "2019-04-01~2019-04-03" [:field "field" {:base-type :type/DateTime}]))))
+  (testing "datetime range"
+    (is (= [:between
+            [:field "field" {:base-type :type/DateTime, :temporal-unit :default}]
+            "2019-04-01T12:30:00"
+            "2019-04-03T16:30:00"]
+           (params.dates/date-string->filter "2019-04-01T12:30~2019-04-03T16:30" [:field "field" {:base-type :type/DateTime}]))))
   (testing "after day"
     (is (= [:>
             [:field "field" {:base-type :type/DateTime, :temporal-unit :day}]


### PR DESCRIPTION
Date parsing code wasn't accounting for datetimes.

Resolves #34615 