### PR TITLE
Clarify stacktraces from malli validation errors

### DIFF
--- a/src/metabase/util/malli/fn.clj
+++ b/src/metabase/util/malli/fn.clj
@@ -2,12 +2,15 @@
   (:refer-clojure :exclude [fn])
   (:require
    [clojure.core :as core]
+   [clojure.string :as str]
    [malli.core :as mc]
    [malli.destructure :as md]
    [malli.error :as me]
    [metabase.shared.util.i18n :as i18n]
    [metabase.util.malli.humanize :as mu.humanize]
    [metabase.util.malli.registry :as mr]))
+
+(set! *warn-on-reflection* true)
 
 (defn- add-default-schemas
   "Malli normally generates wacky default schemas when you use destructuring in an argslist; this never seems to work
@@ -143,20 +146,36 @@
   use [[metabase.util.malli/disable-enforcement]] to bind this only in Clojure code."
   true)
 
+(defn- fixup-stacktrace
+  "This function removes stack trace elements that came from this namespace. When we throw validation errors, they
+  shouldn't originate from *this* namespace, they should appear to be thrown from the instrumented function itself."
+  [^Exception e]
+  (let [trace (.getStackTrace e)
+        fixed-trace (into-array StackTraceElement
+                                (drop-while
+                                 #(str/starts-with? (.getClassName %)
+                                                    ;; this is... hacky, but it works.
+                                                    (namespace ::x))
+                                            trace))]
+    (.setStackTrace e fixed-trace)))
+
 (defn- validate [error-context schema value error-type]
   (when *enforce*
     (when-let [error (mr/explain schema value)]
       (let [humanized (me/humanize error)]
-        (throw (ex-info (case error-type
-                          ::invalid-input  (i18n/tru "Invalid input: {0}" (pr-str humanized))
-                          ::invalid-output (i18n/tru "Invalid output: {0}" (pr-str humanized)))
-                        (merge
-                         {:type      error-type
-                          :error     error
-                          :humanized humanized
-                          :schema    schema
-                          :value     value}
-                         error-context)))))))
+        (throw
+         (doto (ex-info
+                (case error-type
+                  ::invalid-input  (i18n/tru "Invalid input: {0}" (pr-str humanized))
+                  ::invalid-output (i18n/tru "Invalid output: {0}" (pr-str humanized)))
+                (merge
+                 {:type      error-type
+                  :error     error
+                  :humanized humanized
+                  :schema    schema
+                  :value     value}
+                 error-context))
+           fixup-stacktrace))))))
 
 (defn validate-input
   "Impl for [[metabase.util.malli.fn/fn]]; validates an input argument with `value` against `schema` using a cached
@@ -212,19 +231,19 @@
               schemas)
          (filter some?))))
 
-(defn- input-schema->application-form [input-schema]
+(defn- input-schema->application-form [input-schema deparameterized-fn]
   (let [arg-names (input-schema-arg-names input-schema)]
     (if (varargs-schema? input-schema)
-      (list* `apply '&f arg-names)
-      (list* '&f arg-names))))
+      (list* `apply deparameterized-fn arg-names)
+      (list* deparameterized-fn arg-names))))
 
-(defn- instrumented-arity [error-context [_=> input-schema output-schema]]
+(defn- instrumented-arity [error-context [_=> input-schema output-schema] deparameterized-fn]
   (let [input-schema           (if (= input-schema :cat)
                                  [:cat]
                                  input-schema)
         arglist                (input-schema->arglist input-schema)
         input-validation-forms (input-schema->validation-forms error-context input-schema)
-        result-form            (input-schema->application-form input-schema)
+        result-form            (input-schema->application-form input-schema deparameterized-fn)
         result-form            (if (and output-schema
                                         (not= output-schema :any))
                                  `(->> ~result-form
@@ -232,15 +251,17 @@
                                  result-form)]
     `(~arglist ~@input-validation-forms ~result-form)))
 
-(defn- instrumented-fn-tail [error-context [schema-type :as schema]]
+(defn- instrumented-fn-tail [error-context
+                             [schema-type :as schema]
+                             deparameterized-fn]
   (case schema-type
     :=>
-    [(instrumented-arity error-context schema)]
+    [(instrumented-arity error-context schema deparameterized-fn)]
 
     :function
     (let [[_function & schemas] schema]
       (for [schema schemas]
-        (instrumented-arity error-context schema)))))
+        (instrumented-arity error-context schema deparameterized-fn)))))
 
 (defn instrumented-fn-form
   "Given a `fn-tail` like
@@ -254,8 +275,9 @@
     (mc/-instrument {:schema [:=> [:cat :int :any] :any]}
                     (fn [x y] (+ 1 2)))"
   [error-context parsed]
-  `(let [~'&f ~(deparameterized-fn-form parsed)]
-     (core/fn ~@(instrumented-fn-tail error-context (fn-schema parsed)))))
+  `(core/fn ~@(instrumented-fn-tail error-context
+                                    (fn-schema parsed)
+                                    (deparameterized-fn-form parsed))))
 
 (defmacro fn
   "Malli version of [[schema.core/fn]]. A form like

--- a/src/metabase/util/malli/fn.clj
+++ b/src/metabase/util/malli/fn.clj
@@ -153,7 +153,7 @@
   (let [trace (.getStackTrace e)
         fixed-trace (into-array StackTraceElement
                                 (drop-while
-                                 #(str/starts-with? (.getClassName %)
+                                 #(str/starts-with? (.getClassName ^StackTraceElement %)
                                                     ;; this is... hacky, but it works.
                                                     (namespace ::x))
                                             trace))]


### PR DESCRIPTION
## The problem

In `metabase.util.malli.fn`, we have a macro, `defn`, that allows defining a function with input and output validation.

In pseudocode, the macro works by translating something like this:

```clojure
(mu/defn foo :- string
 [x :- int]
 (str x))
```

into something like this:

```clojure

(defn validate! [arg schema]
 ;; do some validation
 (when-not (valid? arg schema)
  (throw (ex-info "not valid" {}))))

(def foo
 (fn [x]
  (validate! x :int)
  (let [output (str x)]
    (validate! output :string)
    output)))
```

This works quite well. One issue is stacktraces. As you'd expect from looking at the toy macroexpansion above, if we call `foo` with an invalid argument, or if it results in an invalid output, we end up with a stacktrace that looks like:

```
Execution error (ExceptionInfo) at metabase.util.malli.fn/validate (fn.clj:150).
```

This makes sense, because the exception is being thrown from `validate!`, not from `foo` itself. But this is confusing - our schema validation namespace isn't really the place you should start looking for the bug.

## Solution

This change does two things: **first**, we manually edit the stacktrace of the exception when we throw it in `validate`, removing any starting entries that have a class name starting with `metabase.util.malli.fn`.

Of course, there is a potential disadvantage of this change - if we have a bug in our validation logic itself, the stacktrace will be *less* clear about the cause. I _think_ that in this case we're reasonably confident in the quality of our validation that this change is on-net good, but I'm open to the possibility that I might be wrong here - input welcome.

**Second**, instead of rewriting `mu/fn` bodies like so:

```
(let [f& ...] (fn [args] (do-validation) (f& args)))
```

Rewrite them like this:

```
(fn [args] (do-validation) ((fn [args'] ...) args))
```

As @dpsutton points out, if we have something like:

```
(def my-var (fn [x] ...))
```

stacktraces are correct (they point to `my-var`), while something like:

```
(def my-var (let [&f (fn [x] ...)] (fn [x] (&f x)))
```

results in stacktraces pointing to an anonymous function (`metabase.pulse/fn--190883/fn--190886 `).

## Performance Note

I wasn't entirely sure that this second change wouldn't have a negative performance impact, so I tested it with these toy examples:

```
(def option-1
  (let [f (fn [x] (+ x 10))]
    (fn [x]
      (f x))))

(def option-2
  (fn [x]
    ((fn [x'] (+ x 10)) x)))
```

I evaluated each option with Criterium to benchmark.

The first option (our current behavior) looked like this:

```
Evaluation count : 10184236800 in 60 samples of 169737280 calls.
      Execution time sample mean : 4.117003 ns
             Execution time mean : 4.117119 ns
Execution time sample std-deviation : 0.017140 ns
    Execution time std-deviation : 0.017686 ns
   Execution time lower quantile : 4.100963 ns ( 2.5%)
   Execution time upper quantile : 4.149603 ns (97.5%)
                   Overhead used : 1.783065 ns
```

The second option (the new behavior) looked like this:

```
Evaluation count : 13861192260 in 60 samples of 231019871 calls.
      Execution time sample mean : 2.553532 ns
             Execution time mean : 2.553510 ns
Execution time sample std-deviation : 0.019674 ns
    Execution time std-deviation : 0.019824 ns
   Execution time lower quantile : 2.524266 ns ( 2.5%)
   Execution time upper quantile : 2.599826 ns (97.5%)
                   Overhead used : 1.783065 ns
```

So overall the performance does not look to be worse and may actually be slightly better.