### PR TITLE
Automatically audit setting updates

### DIFF
--- a/src/metabase/models/audit_log.clj
+++ b/src/metabase/models/audit_log.clj
@@ -4,14 +4,9 @@
   used for in-app functionality, such as the recently-viewed items displayed on the homepage."
   (:require
    [metabase.api.common :as api]
-   [metabase.mbql.util :as mbql.u]
    [metabase.models.activity :as activity]
-   [metabase.models.card :refer [Card]]
    [metabase.models.interface :as mi]
-   [metabase.query-processor :as qp]
    [metabase.util :as u]
-   [metabase.util.i18n :refer [tru]]
-   [metabase.util.log :as log]
    [methodical.core :as m]
    [toucan2.core :as t2]))
 
@@ -37,19 +32,13 @@
 
 ;; This is in this namespace instead of `metabase.models.card` to avoid circular dependencies with
 ;; `metabase.query-processor`
-(defmethod model-details Card
-  [{query :dataset_query, dataset? :dataset :as card} _event-type]
-  (let [query (when (seq query)
-                (try (qp/preprocess query)
-                     (catch Throwable e
-                       (log/error e (tru "Error preprocessing query:")))))
-        database-id (some-> query :database u/the-id)
-        table-id    (mbql.u/query->source-table-id query)]
-    (merge (select-keys card [:name :description])
-           {:database_id database-id
-            :table_id    table-id
-            ;; Use `model` instead of `dataset` to mirror product terminology
-            :model?      dataset?})))
+(defmethod model-details :model/Card
+  [{dataset? :dataset, database-id :database-id, table-id :table-id, :as card} _event-type]
+  (merge (select-keys card [:name :description])
+         {:database_id database-id
+          :table_id    table-id
+          ;; Use `model` instead of `dataset` to mirror product terminology
+          :model?      dataset?}))
 
 (defn model-name
   "Given a keyword identifier for a model, returns the name to store in the database"

--- a/src/metabase/models/audit_log.clj
+++ b/src/metabase/models/audit_log.clj
@@ -90,7 +90,7 @@
                  :model_id model-id
                  :user_id  user-id)
      ;; TODO: temporarily double-writing to the `activity` table, delete this in Metabase v48
-     (when-not (#{:card-read :dashboard-read :table-read :card-query} unqualified-topic)
+     (when-not (#{:card-read :dashboard-read :table-read :card-query :setting-update} unqualified-topic)
       (activity/record-activity!
        :topic      topic
        :object     object

--- a/src/metabase/models/audit_log.clj
+++ b/src/metabase/models/audit_log.clj
@@ -30,16 +30,6 @@
   [_entity _event-type]
   {})
 
-;; This is in this namespace instead of `metabase.models.card` to avoid circular dependencies with
-;; `metabase.query-processor`
-(defmethod model-details :model/Card
-  [{dataset? :dataset, database-id :database-id, table-id :table-id, :as card} _event-type]
-  (merge (select-keys card [:name :description])
-         {:database_id database-id
-          :table_id    table-id
-          ;; Use `model` instead of `dataset` to mirror product terminology
-          :model?      dataset?}))
-
 (defn model-name
   "Given a keyword identifier for a model, returns the name to store in the database"
   [model]

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -577,4 +577,4 @@
   [{dataset? :dataset :as card} _event-type]
   (merge (select-keys card [:name :description :database_id :table_id])
           ;; Use `model` instead of `dataset` to mirror product terminology
-         {:model?      dataset?}))
+         {:model? dataset?}))

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -7,10 +7,13 @@
    [medley.core :as m]
    [metabase.db.query :as mdb.query]
    [metabase.mbql.normalize :as mbql.normalize]
+   [metabase.models.audit-log :as audit-log]
    [metabase.models.collection :as collection]
    [metabase.models.field-values :as field-values]
    [metabase.models.interface :as mi]
-   [metabase.models.parameter-card :as parameter-card :refer [ParameterCard]]
+   [metabase.models.parameter-card
+    :as parameter-card
+    :refer [ParameterCard]]
    [metabase.models.params :as params]
    [metabase.models.permissions :as perms]
    [metabase.models.query :as query]
@@ -19,7 +22,9 @@
    [metabase.moderation :as moderation]
    [metabase.plugins.classloader :as classloader]
    [metabase.public-settings :as public-settings]
-   [metabase.public-settings.premium-features :as premium-features :refer [defenterprise]]
+   [metabase.public-settings.premium-features
+    :as premium-features
+    :refer [defenterprise]]
    [metabase.query-processor.util :as qp.util]
    [metabase.server.middleware.session :as mw.session]
    [metabase.util :as u]
@@ -27,8 +32,7 @@
    [metabase.util.log :as log]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
-   [toucan2.tools.hydrate :as t2.hydrate]
-   [metabase.models.audit-log :as audit-log]))
+   [toucan2.tools.hydrate :as t2.hydrate]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -27,7 +27,8 @@
    [metabase.util.log :as log]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
-   [toucan2.tools.hydrate :as t2.hydrate]))
+   [toucan2.tools.hydrate :as t2.hydrate]
+   [metabase.models.audit-log :as audit-log]))
 
 (set! *warn-on-reflection* true)
 
@@ -564,3 +565,12 @@
       (when (seq snippets)
         (set (for [snippet-id snippets]
                ["NativeQuerySnippet" snippet-id]))))))
+
+
+;;; ------------------------------------------------ Audit Log --------------------------------------------------------
+
+(defmethod audit-log/model-details :model/Card
+  [{dataset? :dataset :as card} _event-type]
+  (merge (select-keys card [:name :description :database_id :table_id])
+          ;; Use `model` instead of `dataset` to mirror product terminology
+         {:model?      dataset?}))

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -82,6 +82,7 @@
    [medley.core :as m]
    [metabase.api.common :as api]
    [metabase.config :as config]
+   [metabase.models.audit-log :as audit-log]
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
    [metabase.models.setting.cache :as setting.cache]
@@ -309,7 +310,11 @@
 
    ;; Function which returns true if the setting should be enabled. If it returns false, the setting will throw an
    ;; exception when it is attempted to be set, and will return its default value when read. Defaults to always enabled.
-   :enabled?    (s/maybe clojure.lang.IFn)})
+   :enabled?    (s/maybe clojure.lang.IFn)
+
+   ;; Keyword that determines what kind of audit log entry should be created when this setting is written. Options are
+   ;; `:never`, `:no-value`, `:raw-value`, and `:getter`. (default: `:no-value`)
+   :audit       (s/maybe (s/enum :never :no-value :raw-value :getter))})
 
 (defonce ^{:doc "Map of loaded defsettings"}
   registered-settings
@@ -804,6 +809,28 @@
 (defn- default-setter-for-type [setting-type]
   (partial set-value-of-type! (keyword setting-type)))
 
+(defn- audit-setting-change!
+  [name audit previous-value new-value]
+  (audit-log/record-event! :setting-update
+                                 (merge
+                                  {:key name}
+                                  (when (not= audit :no-value)
+                                    {:previous-value previous-value
+                                     :new-value      new-value}))
+                                 api/*current-user-id*
+                                 :model/Setting))
+(defn- set-with-audit-logging!
+  [{:keys [name setter getter audit] :as setting} new-value]
+  (if (= audit :never)
+    (setter new-value)
+    (let [value-fn       #(condp = audit
+                            :no-value  nil
+                            :raw-value (get-raw-value setting)
+                            :getter    (getter))
+          previous-value (value-fn)]
+      (setter new-value)
+      (audit-setting-change! name audit previous-value (value-fn)))))
+
 (defn set!
   "Set the value of `setting-definition-or-name`. What this means depends on the Setting's `:setter`; by default, this
   just updates the Settings cache and writes its value to the DB.
@@ -815,7 +842,7 @@
     (mandrill-api-key \"xyz123\")"
   [setting-definition-or-name new-value]
   (let [{:keys [setter cache? enabled? feature] :as setting} (resolve-setting setting-definition-or-name)
-        name                                                  (setting-name setting)]
+        name                                                 (setting-name setting)]
     (when (and feature (not (has-feature? feature)))
       (throw (ex-info (tru "Setting {0} is not enabled because feature {1} is not available" name feature) setting)))
     (when (and enabled? (not (enabled?)))
@@ -825,7 +852,7 @@
     (when (= setter :none)
       (throw (UnsupportedOperationException. (tru "You cannot set {0}; it is a read-only setting." name))))
     (binding [*disable-cache* (not cache?)]
-      (setter new-value))))
+      (set-with-audit-logging! setting new-value))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -857,7 +884,8 @@
                  :database-local :never
                  :user-local     :never
                  :deprecated     nil
-                 :enabled?       nil}
+                 :enabled?       nil
+                 :audit          :never}
                 (dissoc setting :name :type :default)))
       (s/validate SettingDefinition <>)
       (validate-default-value-for-type <>)
@@ -1065,7 +1093,12 @@
 
   ###### `enabled?`
   Function which returns true if the setting should be enabled. If it returns false, the setting will throw an
-  exception when it is attempted to be set, and will return its default value when read. Defaults to always enabled."
+  exception when it is attempted to be set, and will return its default value when read. Defaults to always enabled.
+
+  ###### `audit`
+  Keyword that determines what kind of audit log entry should be created when this setting is written. Options are
+  `:never`, `:no-value`, `:raw-value`, and `:getter` (logs the value from the custom getter, if applicable).
+  (Default: `:no-value`)"
   {:style/indent 1}
   [setting-symbol description & {:as options}]
   {:pre [(symbol? setting-symbol)

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -829,8 +829,7 @@
 (defn- should-audit?
   "Returns true if the setting change should be written to the `audit_log`."
   [setting]
-  (and (not= (:audit setting) :never)
-       (site-wide-only? setting)))
+  (not= (:audit setting) :never))
 
 (defn- set-with-audit-logging!
   "Calls the setting's setter with `new-value`, and then writes the change to the `audit_log` table if necessary."

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -811,16 +811,17 @@
 
 (defn- audit-setting-change!
   [name audit previous-value new-value]
-  (audit-log/record-event! :setting-update
-                                 (merge
-                                  {:key name}
-                                  (when (not= audit :no-value)
-                                    {:previous-value previous-value
-                                     :new-value      new-value}))
-                                 api/*current-user-id*
-                                 :model/Setting))
+  (audit-log/record-event!
+   :setting-update
+   (merge {:key name}
+          (when (not= audit :no-value)
+            {:previous-value previous-value
+             :new-value      new-value}))
+   api/*current-user-id*
+   :model/Setting))
 
 (defn- set-with-audit-logging!
+  "Calls the setting's setter with `new-value`, and then writes the change to the `audit_log` table if necessary."
   [{:keys [name setter getter audit] :as setting} new-value]
   (if (= audit :never)
     (setter new-value)
@@ -830,7 +831,7 @@
                             :getter    (getter))
           previous-value (audit-value-fn)]
       (u/prog1 (setter new-value)
-       (audit-setting-change! name audit previous-value (audit-value-fn))))))
+        (audit-setting-change! name audit previous-value (audit-value-fn))))))
 
 (defn set!
   "Set the value of `setting-definition-or-name`. What this means depends on the Setting's `:setter`; by default, this

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -104,7 +104,8 @@
 (defsetting custom-homepage-dashboard
   (deferred-tru "ID of dashboard to use as a homepage")
   :type       :integer
-  :visibility :public)
+  :visibility :public
+  :audit      :getter)
 
 ;; `::uuid-nonce` is a Setting that sets a site-wide random UUID value the first time it is fetched.
 (defmethod setting/get-value-of-type ::uuid-nonce

--- a/test/metabase/api/setting_test.clj
+++ b/test/metabase/api/setting_test.clj
@@ -287,6 +287,12 @@
                :env_name "MB_TEST_USER_LOCAL_ALLOWED_SETTING",
                :description "test Setting",
                :default nil}
+              {:key "test-user-local-only-audited-setting",
+               :value nil,
+               :is_env_setting false,
+               :env_name "MB_TEST_USER_LOCAL_ONLY_AUDITED_SETTING",
+               :description "Audited user-local setting",
+               :default nil}
               {:key "test-user-local-only-setting",
                :value "ABC" ,
                :is_env_setting false,
@@ -364,6 +370,12 @@
                :is_env_setting false,
                :env_name "MB_TEST_USER_LOCAL_ALLOWED_SETTING",
                :description "test Setting",
+               :default nil}
+              {:key "test-user-local-only-audited-setting",
+               :value nil,
+               :is_env_setting false,
+               :env_name "MB_TEST_USER_LOCAL_ONLY_AUDITED_SETTING",
+               :description "Audited user-local setting",
                :default nil}
               {:key "test-user-local-only-setting",
                :value "ABC" ,

--- a/test/metabase/api/setting_test.clj
+++ b/test/metabase/api/setting_test.clj
@@ -362,86 +362,18 @@
       (is (= "ABC" (models.setting-test/test-setting-1))))))
 
 (deftest user-local-settings-underscored-test
-  (testing "GET /api/setting/"
-    (testing "admins can list all settings and see user-local values included"
-      (set-initial-user-local-values)
-      (is (= [{:key "test-user-local-allowed-setting"
-               :value "ABC" ,
-               :is_env_setting false,
-               :env_name "MB_TEST_USER_LOCAL_ALLOWED_SETTING",
-               :description "test Setting",
-               :default nil}
-              {:key "test-user-local-only-audited-setting",
-               :value nil,
-               :is_env_setting false,
-               :env_name "MB_TEST_USER_LOCAL_ONLY_AUDITED_SETTING",
-               :description "Audited user-local setting",
-               :default nil}
-              {:key "test-user-local-only-setting",
-               :value "ABC" ,
-               :is_env_setting false,
-               :env_name "MB_TEST_USER_LOCAL_ONLY_SETTING",
-               :description "test Setting",
-               :default nil}]
-             (fetch-user-local-test-settings :crowberto)))
-      (clear-user-local-values)))
+  (mt/with-temporary-setting-values [test-setting-1 nil
+                                     test-setting-2 nil]
+    (testing "setting names can use snake case instead of kebab case: "
+      (testing "GET /api/setting/:key"
+        (models.setting-test/test-setting-1! "ABC")
+        (is (= "ABC" (mt/user-http-request :crowberto :get 200 "setting/test_setting_1"))))
 
-  (testing "GET /api/setting/:key"
-    (testing "should return the user-local value of a user-local setting"
-      (set-initial-user-local-values)
-      (is (= "ABC"
-             (mt/user-http-request :crowberto :get 200 "setting/test_user_local_only_setting")))
-      (is (= "ABC"
-             (mt/user-http-request :crowberto :get 200 "setting/test_user_local_allowed_setting")))
+      (testing "PUT /api/setting/:key"
+        (mt/user-http-request :crowberto :put 204 "setting/test_setting_1" {:value "DEF"})
+        (is (= "DEF" (mt/user-http-request :crowberto :get 200 "setting/test_setting_1"))))
 
-      (is (= "DEF"
-             (mt/user-http-request :rasta :get 200 "setting/test_user_local_only_setting")))
-      (is (= "DEF"
-             (mt/user-http-request :rasta :get 200 "setting/test_user_local_allowed_setting")))
-      (clear-user-local-values)))
-
-  (testing "PUT /api/setting/:key"
-    (testing "should update the user-local value of a user-local setting"
-      (set-initial-user-local-values)
-      (mt/user-http-request :crowberto :put 204 "setting/test_user_local_only_setting" {:value "GHI"})
-      (is (= "GHI"
-             (mt/user-http-request :crowberto :get 200 "setting/test_user_local_only_setting")))
-      (mt/user-http-request :crowberto :put 204 "setting/test_user_local_allowed_setting" {:value "JKL"})
-      (is (= "JKL"
-             (mt/user-http-request :crowberto :get 200 "setting/test_user_local_allowed_setting")))
-
-      (mt/user-http-request :rasta :put 204 "setting/test_user_local_only_setting" {:value "MNO"})
-      (is (= "MNO"
-             (mt/user-http-request :rasta :get 200 "setting/test_user_local_only_setting")))
-      (mt/user-http-request :rasta :put 204 "setting/test_user_local_allowed_setting" {:value "PQR"})
-      (is (= "PQR"
-             (mt/user-http-request :rasta :get 200 "setting/test_user_local_allowed_setting")))
-      (clear-user-local-values)))
-
-  (testing "PUT /api/setting"
-    (testing "can update multiple user-local settings at once"
-      (set-initial-user-local-values)
-      (mt/user-http-request :crowberto :put 204 "setting" {:test_user_local_only_setting    "GHI"
-                                                           :test_user_local_allowed_setting "JKL"})
-
-      (is (= (mt/user-http-request :crowberto :get 200 "setting/test-user-local-only-setting")
-             (mt/user-http-request :crowberto :get 200 "setting/test_user_local_only_setting")))
-      (is (= (mt/user-http-request :crowberto :get 200 "setting/test-user-local-allowed-setting")
-             (mt/user-http-request :crowberto :get 200 "setting/test_user_local_allowed_setting")))
-
-      (mt/user-http-request :rasta :put 204 "setting" {:test_user_local_only_setting    "MNO"
-                                                       :test_user_local_allowed_setting "PQR"})
-      (is (= "MNO"
-             (mt/user-http-request :rasta :get 200 "setting/test_user_local_only_setting")))
-      (is (= "PQR"
-             (mt/user-http-request :rasta :get 200 "setting/test_user_local_allowed_setting")))
-      (clear-user-local-values))
-
-    (testing "if a non-admin tries to set multiple settings and any aren't user-local, none are updated"
-      (set-initial-user-local-values)
-      (models.setting-test/test-setting-1! "ABC")
-      (mt/user-http-request :rasta :put 403 "setting" {:test_user_local_only_setting "MNO"
-                                                       :test_setting_1               "PQR"})
-      (is (= "DEF" (mt/with-current-user (mt/user->id :rasta)
-                     (models.setting-test/test-user-local-only-setting))))
-      (is (= "ABC" (models.setting-test/test-setting-1))))))
+      (testing "PUT /api/setting"
+        (mt/user-http-request :crowberto :put 204 "setting" {:test_setting_1 "GHI", :test_setting_2 "JKL"})
+        (is (= "GHI" (mt/user-http-request :crowberto :get 200 "setting/test_setting_1")))
+        (is (= "JKL" (mt/user-http-request :crowberto :get 200 "setting/test_setting_2")))))))

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -87,7 +87,7 @@
                    :details  (cond-> {:name        "My Cool Card"
                                       :description nil
                                       :table_id    nil
-                                      :database_id 8}
+                                      :database_id (mt/id)}
                                dataset? (assoc :model? true))}
                   (event "card-update" (:id card)))))))))))
 

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -41,7 +41,7 @@
                 :user_id  (mt/user->id :rasta)
                 :model    "Card"
                 :model_id (:id card)
-                :details  {:name "My Cool Card", :description nil, :database_id nil, :table_id nil}}
+                :details  {:name "My Cool Card", :description nil, :database_id (mt/id) :table_id nil}}
                (event "card-create" (:id card)))))))))
 
 (deftest card-create-nested-query-test
@@ -87,7 +87,7 @@
                    :details  (cond-> {:name        "My Cool Card"
                                       :description nil
                                       :table_id    nil
-                                      :database_id nil}
+                                      :database_id 8}
                                dataset? (assoc :model? true))}
                   (event "card-update" (:id card)))))))))))
 


### PR DESCRIPTION
Updates the settings framework to add a new `audit` keyword option which dictates the type of automatic audit logging we do for updates to the setting's value. Options are `:none`, `:no-value`, `:raw-value` and `getter`. 

Pursuant to https://github.com/metabase/metabase/issues/34100 but there will be a follow-up PR which adds this to option many existing settings. 

See https://metaboat.slack.com/archives/C056QEW4KNF/p1697464465009129 for relevant discussion.

Also includes some refactor of `model-details` for cards to untangle a circular dependency (we don't need to pre-process a card's query to get the DB and table ID since they're on the card itself already).