### PR TITLE
[E2E] Fix broken Replay runs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -331,7 +331,7 @@ jobs:
         if: matrix.context == 'folder' && github.event_name == 'schedule'
         run: |
           yarn run test-cypress-run \
-          --env grepTags="-@slow+-@mongo --@quarantine,grepOmitFiltered=true \
+          --env grepTags="-@slow+-@mongo --@quarantine,grepOmitFiltered=true" \
           --folder ${{ matrix.name }} \
           --browser "replay-chromium"
         env:


### PR DESCRIPTION
This was causing scheduled runs to fail due to a missing closing quotes in a string.