### PR TITLE
[CI] Make `Chromatic` workflow 3rd party friendly

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -34,7 +34,7 @@ jobs:
         uses: dorny/paths-filter@v2.11.1
         id: changes
         with:
-          token: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           filters: .github/file-paths.yaml
 
   fe-chromatic:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - "master"
-  pull_request:
+  pull_request_target:
     types: [synchronize, labeled, unlabeled]
 
 concurrency:
@@ -12,8 +12,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  authorize:
+    environment:
+      ${{ github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      'external' || 'internal' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - run: echo "true"
+
   files-changed:
     name: Check which files changed
+    needs: [authorize]
     runs-on: ubuntu-22.04
     timeout-minutes: 3
     outputs:
@@ -29,7 +39,7 @@ jobs:
           filters: .github/file-paths.yaml
 
   fe-chromatic:
-    needs: files-changed
+    needs: [authorize, files-changed]
     if: contains(github.event.pull_request.labels.*.name, 'chromatic') || (github.ref_name == 'master' && needs.files-changed.outputs.frontend_all == 'true')
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -39,7 +39,7 @@ jobs:
 
   fe-chromatic:
     needs: [authorize, files-changed]
-    if: contains(github.event.pull_request.labels.*.name, 'chromatic') || (github.ref_name == 'master' && needs.files-changed.outputs.frontend_all == 'true')
+    if: contains(github.event.pull_request_target.labels.*.name, 'chromatic') || (github.ref_name == 'master' && needs.files-changed.outputs.frontend_all == 'true')
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -28,7 +28,6 @@ jobs:
     timeout-minutes: 3
     outputs:
       frontend_all: ${{ steps.changes.outputs.frontend_all }}
-      e2e_specs: ${{ steps.changes.outputs.e2e_specs }}
     steps:
       - uses: actions/checkout@v3
       - name: Test which files changed

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -34,7 +34,7 @@ jobs:
         uses: dorny/paths-filter@v2.11.1
         id: changes
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           filters: .github/file-paths.yaml
 
   fe-chromatic:


### PR DESCRIPTION
This is the first step in accomplishing #34724.
It's also the safest one to start exploring the approach for safe 3rd party (external) contributions running in our CI with access to secrets.
Read about it here: https://iterative.ai/blog/testing-external-contributions-using-github-actions-secrets

tl;dr
> The authorize job checks if the workflow was triggered from a fork pull request. In that case, the external environment will prevent the job from running until it’s approved. Otherwise (i.e. when pull requests belong to the main repository), the job will run without requiring explicit approval.