### PR TITLE
remove % typo from docs

### DIFF
--- a/docs/dashboards/introduction.md
+++ b/docs/dashboards/introduction.md
@@ -79,7 +79,7 @@ To learn more, see [Fun with Markdown in your dashboards](https://www.metabase.c
 
 ### Including variables in text cards
 
-You can include a variable in a text card, then wire that variable up to a dashboard filter. All you need to do to create a variable is to wrap a word in double braces,% `{% raw %}{{{% endraw %}` and `{% raw %}}}{%endraw%}` (the variable can't contain any spaces). For example, you could add a text card with the following text:
+You can include a variable in a text card, then wire that variable up to a dashboard filter. All you need to do to create a variable is to wrap a word in double braces, `{% raw %}{{{% endraw %}` and `{% raw %}}}{%endraw%}` (the variable can't contain any spaces). For example, you could add a text card with the following text:
 
 ```
 {% raw %}


### PR DESCRIPTION
### Description

Found this wild `%` while reading the docs, I'm assuming it's a typo?
<img width="847" alt="image" src="https://github.com/metabase/metabase/assets/1914270/804ae992-ddf4-4c12-a921-74564a492ba6">


