### PR TITLE
use replace for programatic navigation in Table Metadata

### DIFF
--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataHeader/MetadataHeader.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataHeader/MetadataHeader.tsx
@@ -31,6 +31,7 @@ interface DispatchProps {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => ({
+  // When navigating programatically, use replace so that the browser back button works
   onSelectDatabase: (databaseId, { useReplace = false } = {}) =>
     dispatch(
       useReplace

--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataHeader/MetadataHeader.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataHeader/MetadataHeader.tsx
@@ -1,6 +1,6 @@
 import { useLayoutEffect } from "react";
 import { connect } from "react-redux";
-import { push } from "react-router-redux";
+import { push, replace } from "react-router-redux";
 import { t } from "ttag";
 import _ from "underscore";
 import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
@@ -24,12 +24,19 @@ interface DatabaseLoaderProps {
 }
 
 interface DispatchProps {
-  onSelectDatabase: (databaseId: DatabaseId) => void;
+  onSelectDatabase: (
+    databaseId: DatabaseId,
+    options: { useReplace?: boolean },
+  ) => void;
 }
 
 const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => ({
-  onSelectDatabase: databaseId =>
-    dispatch(push(Urls.dataModelDatabase(databaseId))),
+  onSelectDatabase: (databaseId, { useReplace = false } = {}) =>
+    dispatch(
+      useReplace
+        ? replace(Urls.dataModelDatabase(databaseId))
+        : push(Urls.dataModelDatabase(databaseId)),
+    ),
 });
 
 type MetadataHeaderProps = OwnProps & DatabaseLoaderProps & DispatchProps;
@@ -43,7 +50,7 @@ const MetadataHeader = ({
 }: MetadataHeaderProps) => {
   useLayoutEffect(() => {
     if (databases.length > 0 && selectedDatabaseId == null) {
-      onSelectDatabase(databases[0].id);
+      onSelectDatabase(databases[0].id, { useReplace: true });
     }
   }, [databases, selectedDatabaseId, onSelectDatabase]);
 

--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataSchemaList/MetadataSchemaList.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataSchemaList/MetadataSchemaList.tsx
@@ -32,6 +32,7 @@ interface DispatchProps {
 type MetadataSchemaListProps = OwnProps & SchemaLoaderProps & DispatchProps;
 
 const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => ({
+  // When navigating programatically, use replace so that the browser back button works
   onSelectSchema: (databaseId, schemaId, { useReplace = false } = {}) => {
     dispatch(
       useReplace

--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataSchemaList/MetadataSchemaList.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataSchemaList/MetadataSchemaList.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useLayoutEffect, useMemo, useState } from "react";
 import { connect } from "react-redux";
-import { push } from "react-router-redux";
+import { push, replace } from "react-router-redux";
 import cx from "classnames";
 import { msgid, ngettext, t } from "ttag";
 import _ from "underscore";
@@ -22,14 +22,23 @@ interface SchemaLoaderProps {
 }
 
 interface DispatchProps {
-  onSelectSchema: (databaseId: DatabaseId, schemaId: SchemaId) => void;
+  onSelectSchema: (
+    databaseId: DatabaseId,
+    schemaId: SchemaId,
+    options?: { useReplace?: boolean },
+  ) => void;
 }
 
 type MetadataSchemaListProps = OwnProps & SchemaLoaderProps & DispatchProps;
 
 const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => ({
-  onSelectSchema: (databaseId, schemaId) =>
-    dispatch(push(Urls.dataModelSchema(databaseId, schemaId))),
+  onSelectSchema: (databaseId, schemaId, { useReplace = false } = {}) => {
+    dispatch(
+      useReplace
+        ? replace(Urls.dataModelSchema(databaseId, schemaId))
+        : push(Urls.dataModelSchema(databaseId, schemaId)),
+    );
+  },
 });
 
 const MetadataSchemaList = ({
@@ -58,7 +67,9 @@ const MetadataSchemaList = ({
 
   useLayoutEffect(() => {
     if (allSchemas.length === 1 && selectedSchemaId == null) {
-      onSelectSchema(selectedDatabaseId, allSchemas[0].id);
+      onSelectSchema(selectedDatabaseId, allSchemas[0].id, {
+        useReplace: true,
+      });
     }
   }, [selectedDatabaseId, selectedSchemaId, allSchemas, onSelectSchema]);
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/33784

### Description
When clicking on the Table Metadata link in the header of the admin app, we redirect you to a state where you've chosen the first database and the first schema that is returned from the API. While doing those redirects, we were using a `push` rather than `replace`, resulting in you not being able to navigate backwards from that page (as you could go back to a state where we would redirect you again).

### How to verify
1. go to admin app
2. click "Table Metadata"
3. Hit the back button in your browser. You should go back to the page you were previously at.

### Demo
![5InIMOvU58](https://github.com/metabase/metabase/assets/1328979/c200ecf9-dc92-4c2e-8b71-202542fbe706)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
