### PR TITLE
Add new audit views as migrations

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15938,8 +15938,6 @@ databaseChangeLog:
                   updated_at,
                   size_x,
                   size_y,
-                  "row",
-                  col,
                   visualization_settings,
                   parameter_mappings
               from report_dashboardcard

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15453,6 +15453,585 @@ databaseChangeLog:
                   name: user_id
       rollback: # not needed, it will be removed with the table
 
+  - changeSet:
+      id: v48.00-028
+      author: noahmoss
+      comment: Added 0.48.0 - new view v_audit_log
+      changes:
+        - sql:
+            dbms: postgresql,h2
+            sql: >-
+              create or replace view v_audit_log as
+              (
+              select row_number() over (order by timestamp) as id, source.*
+              from (select case
+                               when model = 'card' then 'question-view'
+                               when model = 'table' then 'table-view'
+                               when model = 'dashboard' then 'dashboard-view'
+                               end  as topic,
+                           timestamp,
+                           null     as end_timestamp,
+                           user_id,
+                           model,
+                           case
+                               when model = 'card' then concat('question_', cast(model_id as text))
+                               when model = 'table' then concat('table_', cast(model_id as text))
+                               when model = 'dashboard' then concat('dashboard_', cast(model_id as text))
+                               else cast(model_id as text)
+                               end  as model_id,
+                           metadata as details
+                    from view_log
+                    union
+                    select case
+                               when topic = 'card-create' then 'question-create'
+                               when topic = 'card-delete' then 'question-delete'
+                               when topic = 'card-update' then 'question-update'
+                               when topic = 'pulse-create' then 'subscription-create'
+                               when topic = 'pulse-delete' then 'subscription-delete'
+                               else topic
+                               end as topic,
+                           timestamp,
+                           null    as end_timestamp,
+                           user_id,
+                           model,
+                           case
+                               when model = 'dataset' then concat('model_', cast(model_id as text))
+                               when model = 'card' then concat('question_', cast(model_id as text))
+                               when model = 'pulse' then concat('subscription_', cast(model_id as text))
+                               else concat(model, '_', model_id)
+                               end as model_id,
+                           details
+                    from activity) AS source
+                );
+        - sql:
+            dbms: mysql,mariadb
+            sql: >-
+              create or replace view v_audit_log as
+              (
+              select uuid() as id, source.*
+              from (select case
+                               when model = 'card' then 'question-view'
+                               when model = 'table' then 'table-view'
+                               when model = 'dashboard' then 'dashboard-view'
+                               end  as topic,
+                           timestamp,
+                           null     as end_timestamp,
+                           user_id,
+                           model,
+                           case
+                               when model = 'card' then concat('question_', cast(model_id as char)) collate utf8mb4_unicode_ci
+                               when model = 'table' then concat('table_', cast(model_id as char)) collate utf8mb4_unicode_ci
+                               when model = 'dashboard' then concat('dashboard_', cast(model_id as char)) collate utf8mb4_unicode_ci
+                               else cast(model_id as char) collate utf8mb4_unicode_ci
+                               end  as model_id,
+                           metadata as details
+                    from view_log
+                    union
+                    select case
+                               when topic = 'card-create' then 'question-create'
+                               when topic = 'card-delete' then 'question-delete'
+                               when topic = 'card-update' then 'question-update'
+                               when topic = 'pulse-create' then 'subscription-create'
+                               when topic = 'pulse-delete' then 'subscription-delete'
+                               else topic
+                               end as topic,
+                           timestamp,
+                           null    as end_timestamp,
+                           user_id,
+                           model,
+                           case
+                               when model = 'dataset' then concat('model_', cast(model_id as char)) collate utf8mb4_unicode_ci
+                               when model = 'card' then concat('question_', cast(model_id as char)) collate utf8mb4_unicode_ci
+                               when model = 'pulse' then concat('subscription_', cast(model_id as char)) collate utf8mb4_unicode_ci
+                               else concat(model, '_', model_id) collate utf8mb4_unicode_ci
+                               end as model_id,
+                           details
+                    from activity) AS source
+                  );
+      rollback:
+        - sql:
+            sql: drop view if exists v_audit_log;
+
+  - changeSet:
+      id: v48.00-029
+      author: noahmoss
+      comment: Added 0.48.0 - new view v_content
+      changes:
+        - sql:
+            dbms: postgresql
+            sql: >-
+              create or replace view v_content as
+              select
+                  concat('action_', id) as id,
+                  'action' as entity_type,
+                  created_at,
+                  updated_at,
+                  creator_id,
+                  name,
+                  description,
+                  cast(null as int) as collection_id,
+                  made_public_by_id as made_public_by_user,
+                  cast(null as boolean) as is_embedding_enabled,
+                  archived,
+                  type as action_type,
+                  model_id as action_model_id,
+                  null as collection_is_official,
+                  null as collection_is_personal,
+                  null as question_viz_type,
+                  null as question_database_id,
+                  cast(null as boolean) as question_is_native,
+                  cast(null as timestamp) as event_timestamp
+                  from action
+              union
+              select
+                  concat('collection_', id) as id,
+                  'collection' as entity_type,
+                  created_at,
+                  null as updated_at,
+                  null as creator_id,
+                  name,
+                  description,
+                  null as collection_id,
+                  null as made_public_by_user,
+                  null as is_embedding_enabled,
+                  archived,
+                  null as action_type,
+                  null as action_model_id,
+                  case when authority_level='official' then true else false end as collection_is_official,
+                  case when personal_owner_id is not null then true else false end as collection_is_personal,
+                  null as question_viz_type,
+                  null as question_database_id,
+                  null as question_is_native,
+                  null as event_timestamp
+                  from collection
+              union
+              select
+                  concat(
+                      case when dataset
+                          then 'model_'
+                          else 'question_'
+                      end, id) as id,
+                  case when dataset then 'model' else 'question' end as entity_type,
+                  created_at,
+                  updated_at,
+                  creator_id,
+                  name,
+                  description,
+                  collection_id as collection_id,
+                  made_public_by_id as made_public_by_user,
+                  enable_embedding as is_embedding_enabled,
+                  archived,
+                  null as action_type,
+                  null as action_model_id,
+                  null as collection_is_official,
+                  null as collection_is_personal,
+                  display as question_viz_type,
+                  concat('database_', database_id) as question_database_id,
+                  case when query_type='native' then true else false end as question_is_native,
+                  null as event_timestamp
+                  from report_card
+              union
+              select
+                  concat('dashboard_', id) as id,
+                  'dashboard' as entity_type,
+                  created_at,
+                  updated_at,
+                  creator_id,
+                  name,
+                  description,
+                  collection_id as collection_id,
+                  made_public_by_id as made_public_by_user,
+                  enable_embedding as is_embedding_enabled,
+                  archived,
+                  null as action_type,
+                  null as action_model_id,
+                  null as collection_is_official,
+                  null as collection_is_personal,
+                  null as question_viz_type,
+                  null as question_database_id,
+                  null as question_is_native,
+                  null as event_timestamp
+                  from report_dashboard
+              union
+              select
+                  concat('event_', event.id) as id,
+                  'event' as entity_type,
+                  event.created_at,
+                  event.updated_at,
+                  event.creator_id,
+                  event.name,
+                  event.description,
+                  timeline.collection_id,
+                  null as made_public_by_user,
+                  null as is_embedding_enabled,
+                  event.archived,
+                  null as action_type,
+                  null as action_model_id,
+                  null as collection_is_official,
+                  null as collection_is_personal,
+                  null as question_viz_type,
+                  null as question_database_id,
+                  null as question_is_native,
+                  timestamp as event_timestamp
+                  from timeline_event event
+                      left join timeline on event.timeline_id = timeline.id
+        - sql:
+            dbms: mysql,mariadb
+            sql: >-
+              create or replace view v_content as
+              select
+                  concat('action_', id) as id,
+                  'action' as entity_type,
+                  created_at,
+                  updated_at,
+                  creator_id,
+                  name,
+                  description,
+                  null as collection_id,
+                  made_public_by_id as made_public_by_user,
+                  null as is_embedding_enabled,
+                  archived,
+                  type as action_type,
+                  model_id as action_model_id,
+                  null as collection_is_official,
+                  null as collection_is_personal,
+                  null as question_viz_type,
+                  null as question_database_id,
+                  null as question_is_native,
+                  null as event_timestamp
+                  from action
+              union
+              select
+                  concat('collection_', id) as id,
+                  'collection' as entity_type,
+                  created_at,
+                  null as updated_at,
+                  null as creator_id,
+                  name,
+                  description,
+                  null as collection_id,
+                  null as made_public_by_user,
+                  null as is_embedding_enabled,
+                  archived,
+                  null as action_type,
+                  null as action_model_id,
+                  case when authority_level='official' then true else false end as collection_is_official,
+                  case when personal_owner_id is not null then true else false end as collection_is_personal,
+                  null as question_viz_type,
+                  null as question_database_id,
+                  null as question_is_native,
+                  null as event_timestamp
+                  from collection
+              union
+              select
+                  concat(
+                      case when dataset
+                          then 'model_'
+                          else 'question_'
+                      end, id) as id,
+                  case when dataset then 'model' else 'question' end as entity_type,
+                  created_at,
+                  updated_at,
+                  creator_id,
+                  name,
+                  description,
+                  collection_id as collection_id,
+                  made_public_by_id as made_public_by_user,
+                  enable_embedding as is_embedding_enabled,
+                  archived,
+                  null as action_type,
+                  null as action_model_id,
+                  null as collection_is_official,
+                  null as collection_is_personal,
+                  display as question_viz_type,
+                  concat('database_', database_id) as question_database_id,
+                  case when query_type='native' then true else false end as question_is_native,
+                  null as event_timestamp
+                  from report_card
+              union
+              select
+                  concat('dashboard_', id) as id,
+                  'dashboard' as entity_type,
+                  created_at,
+                  updated_at,
+                  creator_id,
+                  name,
+                  description,
+                  collection_id as collection_id,
+                  made_public_by_id as made_public_by_user,
+                  enable_embedding as is_embedding_enabled,
+                  archived,
+                  null as action_type,
+                  null as action_model_id,
+                  null as collection_is_official,
+                  null as collection_is_personal,
+                  null as question_viz_type,
+                  null as question_database_id,
+                  null as question_is_native,
+                  null as event_timestamp
+                  from report_dashboard
+              union
+              select
+                  concat('event_', event.id) as id,
+                  'event' as entity_type,
+                  event.created_at,
+                  event.updated_at,
+                  event.creator_id,
+                  event.name,
+                  event.description,
+                  timeline.collection_id,
+                  null as made_public_by_user,
+                  null as is_embedding_enabled,
+                  event.archived,
+                  null as action_type,
+                  null as action_model_id,
+                  null as collection_is_official,
+                  null as collection_is_personal,
+                  null as question_viz_type,
+                  null as question_database_id,
+                  null as question_is_native,
+                  timestamp as event_timestamp
+                  from timeline_event event
+                      left join timeline on event.timeline_id = timeline.id
+        - sql:
+            dbms: h2
+            sql: >-
+              create or replace view v_content as
+              select
+                  concat('action_', id) as id,
+                  'action' as entity_type,
+                  created_at,
+                  updated_at,
+                  creator_id,
+                  name,
+                  description,
+                  cast(null as int) as collection_id,
+                  made_public_by_id as made_public_by_user,
+                  cast(null as boolean) as is_embedding_enabled,
+                  archived,
+                  type as action_type,
+                  model_id as action_model_id,
+                  null as collection_is_official,
+                  null as collection_is_personal,
+                  null as question_viz_type,
+                  null as question_database_id,
+                  cast(null as boolean) as question_is_native,
+                  cast(null as timestamp) as event_timestamp
+                  from action
+              union
+              select
+                  concat('collection_', id) as id,
+                  'collection' as entity_type,
+                  created_at,
+                  null as updated_at,
+                  null as creator_id,
+                  name,
+                  description,
+                  null as collection_id,
+                  null as made_public_by_user,
+                  null as is_embedding_enabled,
+                  archived,
+                  null as action_type,
+                  null as action_model_id,
+                  case when authority_level='official' then true else false end as collection_is_official,
+                  case when personal_owner_id is not null then true else false end as collection_is_personal,
+                  null as question_viz_type,
+                  null as question_database_id,
+                  null as question_is_native,
+                  null as event_timestamp
+                  from collection
+              union
+              select
+                  concat(
+                      case when dataset
+                          then 'model_'
+                          else 'question_'
+                      end, id) as id,
+                  case when dataset then 'model' else 'question' end as entity_type,
+                  created_at,
+                  updated_at,
+                  creator_id,
+                  name,
+                  description,
+                  collection_id as collection_id,
+                  made_public_by_id as made_public_by_user,
+                  enable_embedding as is_embedding_enabled,
+                  archived,
+                  null as action_type,
+                  null as action_model_id,
+                  null as collection_is_official,
+                  null as collection_is_personal,
+                  display as question_viz_type,
+                  concat('database_', database_id) as question_database_id,
+                  case when query_type='native' then true else false end as question_is_native,
+                  null as event_timestamp
+                  from report_card
+              union
+              select
+                  concat('dashboard_', id) as id,
+                  'dashboard' as entity_type,
+                  created_at,
+                  updated_at,
+                  creator_id,
+                  name,
+                  description,
+                  collection_id as collection_id,
+                  made_public_by_id as made_public_by_user,
+                  enable_embedding as is_embedding_enabled,
+                  archived,
+                  null as action_type,
+                  null as action_model_id,
+                  null as collection_is_official,
+                  null as collection_is_personal,
+                  null as question_viz_type,
+                  null as question_database_id,
+                  null as question_is_native,
+                  null as event_timestamp
+                  from report_dashboard
+              union
+              select
+                  concat('event_', event.id) as id,
+                  'event' as entity_type,
+                  event.created_at,
+                  event.updated_at,
+                  event.creator_id,
+                  event.name,
+                  event.description,
+                  timeline.collection_id,
+                  null as made_public_by_user,
+                  null as is_embedding_enabled,
+                  event.archived,
+                  null as action_type,
+                  null as action_model_id,
+                  null as collection_is_official,
+                  null as collection_is_personal,
+                  null as question_viz_type,
+                  null as question_database_id,
+                  null as question_is_native,
+                  timestamp as event_timestamp
+                  from timeline_event event
+                      left join timeline on event.timeline_id = timeline.id
+      rollback:
+        - sql:
+            sql: drop view if exists v_content;
+
+  - changeSet:
+      id: v48.00-030
+      author: noahmoss
+      comment: Added 0.48.0 - new view v_dashboardcard
+      changes:
+        - sql:
+            sql: >-
+              create or replace view v_dashboardcard AS
+              select
+                  concat('dashboardcard_', id) as id,
+                  concat('dashboard_', dashboard_id) as dashboard_id,
+                  case
+                      when dashboard_tab_id is not null
+                      then concat('dashboardtab_', dashboard_tab_id)
+                      end as dashboardtab_id,
+                  case
+                      when card_id is not null
+                      then concat('question_', card_id)
+                      end as question_id,
+                  created_at,
+                  updated_at,
+                  size_x,
+                  size_y,
+                  row,
+                  col,
+                  visualization_settings,
+                  parameter_mappings
+              from report_dashboardcard
+              order by dashboard_id
+      rollback:
+        - sql:
+            sql: drop view if exists v_dashboardcard;
+
+  - changeSet:
+      id: v48.00-031
+      author: noahmoss
+      comment: Added 0.48.0 - new view v_group_members
+      changes:
+        - sql:
+            sql: >-
+              create or replace view v_group_members as
+              select
+                  user_id,
+                  permissions_group.id as group_id,
+                  permissions_group.name as group_name
+                  from permissions_group_membership
+                      left join permissions_group on permissions_group_membership.group_id = permissions_group.id
+      rollback:
+        - sql:
+            sql: drop view if exists v_group_members;
+
+  - changeSet:
+      id: v48.00-032
+      author: noahmoss
+      comment: Added 0.48.0 - new view v_alerts_subscriptions
+      changes:
+        - sql:
+            sql: >-
+              create or replace view v_alerts_subscriptions as
+              select
+                  concat(
+                      case when dashboard_id is not null
+                          then 'subscription_'
+                          else 'alert_'
+                      end, pulse.id) as id,
+                  case when dashboard_id is not null then 'subscription' else 'alert' end entity_type,
+                  pulse.created_at,
+                  pulse.updated_at as updated_at,
+                  creator_id as creator_id,
+                  name,
+                  null as description,
+                  concat('collection_', collection_id) as collection_id,
+                  null as made_public_by_user,
+                  archived,
+                  null as is_official,
+                  null as action_type,
+                  null as action_model_id,
+                  null as collection_is_personal,
+                  concat('dashboard_', dashboard_id) as subscription_dashboard_id,
+                  card_id as alert_question_id,
+                  channel_type as recipient_type,
+                  details as recipient_external
+                  from pulse
+                      left join pulse_card on pulse.id = pulse_card.pulse_id
+                      left join pulse_channel on pulse.id = pulse_channel.pulse_id
+                  where pulse_card.dashboard_card_id is null
+      rollback:
+        - sql:
+            sql: drop view if exists v_alerts_subscriptions;
+
+  - changeSet:
+      id: v48.00-033
+      author: noahmoss
+      comment: Added 0.48.0 - new view v_users
+      changes:
+        - sql:
+            sql: >-
+              create or replace view v_users as
+              select
+                  id as user_id,
+                  email,
+                  first_name,
+                  last_name,
+                  concat(first_name, ' ', last_name) as full_name,
+                  date_joined,
+                  last_login,
+                  updated_at,
+                  is_superuser as is_admin,
+                  is_active,
+                  sso_source,
+                  locale
+                  from core_user
+      rollback:
+        - sql:
+            sql: drop view if exists v_users;
+
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15938,7 +15938,7 @@ databaseChangeLog:
                   updated_at,
                   size_x,
                   size_y,
-                  row,
+                  "row",
                   col,
                   visualization_settings,
                   parameter_mappings


### PR DESCRIPTION
Adds the [views for audit v2 content](https://github.com/metabase/metabase/tree/auditv2-main/resources/instance_analytics_views) to the app DB using SQL migrations