### PR TITLE
Remove invalid test cases

### DIFF
--- a/test/metabase/lib/drill_thru/distribution_test.cljc
+++ b/test/metabase/lib/drill_thru/distribution_test.cljc
@@ -46,19 +46,3 @@
     :query-type  :unaggregated
     :column-name "QUANTITY"
     :expected    {:type :drill-thru/distribution}}))
-
-(deftest ^:parallel returns-distribution-test-4
-  (lib.drill-thru.tu/test-returns-drill
-   {:drill-type  :drill-thru/distribution
-    :click-type  :header
-    :query-type  :aggregated
-    :column-name "PRODUCT_ID"
-    :expected    {:type :drill-thru/distribution}}))
-
-(deftest ^:parallel returns-distribution-test-5
-  (lib.drill-thru.tu/test-returns-drill
-   {:drill-type  :drill-thru/distribution
-    :click-type  :header
-    :query-type  :aggregated
-    :column-name "CREATED_AT"
-    :expected    {:type :drill-thru/distribution}}))


### PR DESCRIPTION
The breaking test cases were ported from JS to CLJC while PR #34681 that removed the JS test cases was waiting for review. The test cases were removed because they contradict earlier (temporarily commented out) test cases.
