### PR TITLE
Adding check for column before getting friendly name

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -41,7 +41,7 @@ const HISTOGRAM_DATE_EXTRACTS = new Set([
 ]);
 
 export function getDefaultDimensionLabel(multipleSeries) {
-  return multipleSeries.length > 0
+  return multipleSeries.length > 0 && multipleSeries[0].data.cols[0]
     ? getFriendlyName(multipleSeries[0].data.cols[0])
     : null;
 }

--- a/frontend/src/metabase/visualizations/visualizations/BarChart.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/BarChart.unit.spec.tsx
@@ -1,0 +1,72 @@
+import { createMockMetadata } from "__support__/metadata";
+import { renderWithProviders, screen } from "__support__/ui";
+import {
+  createSampleDatabase,
+  ORDERS_ID,
+  SAMPLE_DB_ID,
+} from "metabase-types/api/mocks/presets";
+import registerVisualizations from "metabase/visualizations/register";
+import ChartSettings from "metabase/visualizations/components/ChartSettings";
+import { createMockColumn } from "metabase-types/api/mocks";
+import Question from "metabase-lib/Question";
+
+registerVisualizations();
+
+const metadata = createMockMetadata({
+  databases: [createSampleDatabase()],
+});
+
+const setup = () => {
+  const question = new Question(
+    {
+      dataset_query: {
+        type: "query",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregrations: [["count"]],
+        },
+        database: SAMPLE_DB_ID,
+      },
+      display: "bar",
+      visualization_settings: {},
+    },
+    metadata,
+  );
+
+  const series = [
+    {
+      card: question.card(),
+      data: {
+        rows: [[1000]],
+        cols: [
+          createMockColumn({
+            source: "aggregation",
+            field_ref: ["aggregation", 0],
+            name: "count",
+            display_name: "Count",
+            base_type: "type/BigInteger",
+          }),
+        ],
+      },
+    },
+  ];
+
+  renderWithProviders(
+    <ChartSettings
+      series={series}
+      quesiton={question}
+      initial={{ section: "Data" }}
+      noPreview
+    />,
+  );
+};
+
+describe("barchart", () => {
+  it("should not error when rendering for a question with new breakouts", () => {
+    setup();
+
+    expect(screen.getByText("X-axis")).toBeInTheDocument();
+    expect(screen.getByText("No valid fields")).toBeInTheDocument();
+    expect(screen.getByText("Count")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/33936

### Description
Simple check for the presence of a column before attempting to grab it's friendly name

### How to verify
1. New -> Question -> Orders
2. Summarize by count, and set the viz type to bar chart
3. Open viz settings. You should see that Count is set for the y-axis, but no valid fields are present for the x-axis.

### Demo
![image](https://github.com/metabase/metabase/assets/1328979/7af597c7-e6f4-4d67-8a19-72c9e76cce30)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
