### PR TITLE
Audit add user events (fixed commits w/ cherry-pick)

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -85,7 +85,6 @@
                   :last_name        last-name
                   :email            email
                   :sso_source       :saml
-                  :groups           group-names
                   :login_attributes user-attributes}]
     (when-let [user (or (sso-utils/fetch-and-update-login-attributes! new-user)
                         (sso-utils/create-new-sso-user! new-user))]

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -85,6 +85,7 @@
                   :last_name        last-name
                   :email            email
                   :sso_source       :saml
+                  :groups           group-names
                   :login_attributes user-attributes}]
     (when-let [user (or (sso-utils/fetch-and-update-login-attributes! new-user)
                         (sso-utils/create-new-sso-user! new-user))]

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
@@ -53,7 +53,8 @@
   This call is a no-op if the mentioned key values are equal."
   [{:keys [email] :as user-from-sso}]
   (when-let [{:keys [id] :as user} (t2/select-one User :%lower.email (u/lower-case-en email))]
-    (let [user-keys (keys user-from-sso)
+    (let [user-from-sso (dissoc user-from-sso :groups)
+          user-keys (keys user-from-sso)
           ;; remove keys with `nil` values
           user-data (into {} (filter second user-from-sso))]
       (if (= (select-keys user user-keys) user-data)

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
@@ -25,7 +25,7 @@
    [:last_name        [:maybe ms/NonBlankString]]
    [:email            ms/Email]
    [:sso_source       (into [:enum] (keys (dissoc (methods sso.interface/sso-get) :default)))]
-   [:groups           seqable?]
+   [:groups {:optional true} [:maybe seqable?]]
    [:login_attributes [:maybe :map]]])
 
 (mu/defn create-new-sso-user!

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.sso.integrations.sso-utils
   "Functions shared by the various SSO implementations"
   (:require
-   [metabase-enterprise.sso.api.interface :as sso.interface]
    [metabase.api.common :as api]
    [metabase.email.messages :as messages]
    [metabase.events :as events]
@@ -24,7 +23,9 @@
    [:first_name       [:maybe ms/NonBlankString]]
    [:last_name        [:maybe ms/NonBlankString]]
    [:email            ms/Email]
-   [:sso_source       (into [:enum] (keys (dissoc (methods sso.interface/sso-get) :default)))]
+   ;; TODO - we should avoid hardcoding this to make it easier to add new integrations. Maybe look at something like
+   ;; the keys of `(methods sso/sso-get)`
+   [:sso_source       [:enum :saml :jwt]]
    [:groups {:optional true} [:maybe seqable?]]
    [:login_attributes [:maybe :map]]])
 

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -202,6 +202,9 @@
                        :common_name  "New User"}]
                      (->> (mt/boolean-ids-and-timestamps (t2/select User :email "newuser@metabase.com"))
                           (map #(dissoc % :last_login))))))
+            (testing "User Invite Event is logged."
+              (is (= "newuser@metabase.com"
+                     (get-in (t2/select-one :model/AuditLog :topic :user-invited) [:details :email]))))
             (testing "attributes"
               (is (= {"more" "stuff"
                       "for"  "the new user"}

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -460,7 +460,10 @@
                           (map #(dissoc % :last_login)))))
               (testing "attributes"
                 (is (= (some-saml-attributes "newuser")
-                       (saml-login-attributes "newuser@metabase.com")))))
+                       (saml-login-attributes "newuser@metabase.com"))))
+              (testing "User Invite Event is logged."
+                (is (= "newuser@metabase.com"
+                       (get-in (t2/select-one :model/AuditLog :topic :user-invited) [:details :email])))))
             (finally
               (t2/delete! User :%lower.email "newuser@metabase.com"))))))))
 

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -4,6 +4,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]
+   [metabase.events.audit-log-test :as audit-log-test]
    [metabase.http-client :as client]
    [metabase.models.permissions-group :refer [PermissionsGroup]]
    [metabase.models.permissions-group-membership
@@ -447,23 +448,31 @@
             (is (not (t2/exists? User :%lower.email "newuser@metabase.com")))
             (let [req-options (saml-post-request-options (new-user-saml-test-response)
                                                          (saml/str->base64 default-redirect-uri))]
-              (is (successful-login? (client-full-response :post 302 "/auth/sso" req-options)))
-              (is (= [{:email        "newuser@metabase.com"
-                       :first_name   "New"
-                       :is_qbnewb    true
-                       :is_superuser false
-                       :id           true
-                       :last_name    "User"
-                       :date_joined  true
-                       :common_name  "New User"}]
-                     (->> (mt/boolean-ids-and-timestamps (t2/select User :email "newuser@metabase.com"))
-                          (map #(dissoc % :last_login)))))
-              (testing "attributes"
-                (is (= (some-saml-attributes "newuser")
-                       (saml-login-attributes "newuser@metabase.com"))))
+              (is (successful-login? (client-full-response :post 302 "/auth/sso" req-options))))
+            (let [new-user (t2/select-one User :email "newuser@metabase.com")]
+              (is (= {:email        "newuser@metabase.com"
+                      :first_name   "New"
+                      :is_qbnewb    true
+                      :is_superuser false
+                      :id           true
+                      :last_name    "User"
+                      :date_joined  true
+                      :common_name  "New User"}
+                     (-> (mt/boolean-ids-and-timestamps new-user)
+                         (dissoc :last_login))))
               (testing "User Invite Event is logged."
-                (is (= "newuser@metabase.com"
-                       (get-in (t2/select-one :model/AuditLog :topic :user-invited) [:details :email])))))
+                (is (= {:details  {:email      "newuser@metabase.com"
+                                   :first_name "New"
+                                   :last_name  "User"
+                                   :sso_source "saml"}
+                        :model    "User"
+                        :model_id (:id new-user)
+                        :topic    :user-invited
+                        :user_id  nil}
+                       (audit-log-test/event :user-invited (:id new-user))))))
+            (testing "attributes"
+              (is (= (some-saml-attributes "newuser")
+                     (saml-login-attributes "newuser@metabase.com"))))
             (finally
               (t2/delete! User :%lower.email "newuser@metabase.com"))))))))
 

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -464,6 +464,7 @@
                 (is (= {:details  {:email      "newuser@metabase.com"
                                    :first_name "New"
                                    :last_name  "User"
+                                   :user_group_memberships [{:id 1}]
                                    :sso_source "saml"}
                         :model    "User"
                         :model_id (:id new-user)

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -231,11 +231,11 @@
         (let [reset-token        (user/set-password-reset-token! user-id)
               password-reset-url (str (public-settings/site-url) "/auth/reset_password/" reset-token)]
           (log/info password-reset-url)
-          (messages/send-password-reset-email! email nil password-reset-url is-active?)
-          (events/publish-event! :event/password-reset-initiated
-                                 {:user-id api/*current-user-id*
-                                  ;; Fetch hashed value of reset token as identifer
-                                  :details {:token (t2/select-one-fn :reset_token :model/User :id user-id)}}))))))
+          (messages/send-password-reset-email! email nil password-reset-url is-active?)))
+      (events/publish-event! :event/password-reset-initiated
+                             {:user-id api/*current-user-id*
+                              ;; Fetch hashed value of reset token as identifer
+                              :details {:token (t2/select-one-fn :reset_token User :id user-id)}}))))
 
 (api/defendpoint POST "/forgot_password"
   "Send a reset email when user has forgotten their password."

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -231,7 +231,11 @@
         (let [reset-token        (user/set-password-reset-token! user-id)
               password-reset-url (str (public-settings/site-url) "/auth/reset_password/" reset-token)]
           (log/info password-reset-url)
-          (messages/send-password-reset-email! email nil password-reset-url is-active?))))))
+          (messages/send-password-reset-email! email nil password-reset-url is-active?)
+          (events/publish-event! :event/password-reset-initiated
+                                 {:user-id api/*current-user-id*
+                                  ;; Fetch hashed value of reset token as identifer
+                                  :details {:token (t2/select-one-fn :reset_token :model/User :id user-id)}}))))))
 
 (api/defendpoint POST "/forgot_password"
   "Send a reset email when user has forgotten their password."

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -82,6 +82,12 @@
       (log/error (trs "Could not invite user because email is not configured."))
       (u/prog1 (user/create-and-invite-user! user invitor true)
         (user/set-permissions-groups! <> [(perms-group/all-users) (perms-group/admin)])
+        (let [details (-> (into {} <>)
+                          (dissoc :last_login :is_qbnewb :is_superuser :date_joined :common_name :invitor)
+                          (merge {:invitor       invitor
+                                  :invite_method "email"}))]
+          (events/publish-event! :event/user-invited {:user-id api/*current-user-id*
+                                                      :details details}))
         (snowplow/track-event! ::snowplow/invite-sent api/*current-user-id* {:invited-user-id (u/the-id <>)
                                                                              :source          "setup"})))))
 

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -82,10 +82,7 @@
       (log/error (trs "Could not invite user because email is not configured."))
       (u/prog1 (user/create-and-invite-user! user invitor true)
         (user/set-permissions-groups! <> [(perms-group/all-users) (perms-group/admin)])
-        (events/publish-event! :event/user-invited
-                               (assoc <>
-                                      :groups [(perms-group/all-users) (perms-group/admin)]
-                                      :invite_method "email"))
+        (events/publish-event! :event/user-invited (assoc <> :invite_method "email"))
         (snowplow/track-event! ::snowplow/invite-sent api/*current-user-id* {:invited-user-id (u/the-id <>)
                                                                              :source          "setup"})))))
 

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -85,7 +85,8 @@
         (let [details (-> (into {} <>)
                           (dissoc :last_login :is_qbnewb :is_superuser :date_joined :common_name :invitor)
                           (merge {:invitor       invitor
-                                  :invite_method "email"}))]
+                                  :invite_method "email"
+                                  :groups [(perms-group/all-users) (perms-group/admin)]}))]
           (events/publish-event! :event/user-invited {:user-id api/*current-user-id*
                                                       :details details}))
         (snowplow/track-event! ::snowplow/invite-sent api/*current-user-id* {:invited-user-id (u/the-id <>)

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -450,8 +450,7 @@
                               :non-nil (cond-> #{:email}
                                          api/*is-superuser?* (conj :is_superuser))))]
           (t2/update! User id changes)
-          (events/publish-event! :event/user-update {:user-id api/*current-user-id*
-                                                     :details (assoc changes :id id)}))
+          (events/publish-event! :event/user-update (assoc (t2/select-one User :id id) :changes changes)))
         (maybe-update-user-personal-collection-name! user-before-update body))
       (maybe-set-user-group-memberships! id user_group_memberships is_superuser)))
   (-> (fetch-user :id id)
@@ -485,9 +484,7 @@
     ;; Can only reactivate inactive users
     (api/check (not (:is_active user))
       [400 {:message (tru "Not able to reactivate an active user")}])
-    (events/publish-event! :event/user-reactivated
-                           {:user-id api/*current-user-id*
-                            :details (dissoc user [:is_active :sso_source])})
+    (events/publish-event! :event/user-reactivated user)
     (reactivate-user! (dissoc user [:email :first_name :last_name]))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -528,9 +525,7 @@
   (check-not-internal-user id)
   (api/check-500
    (when (pos? (t2/update! User id {:is_active false}))
-     (events/publish-event! :event/user-deactivated
-                            {:user-id api/*current-user-id*
-                             :details (t2/select-one [:model/User :email :first_name :last_name :id] :id id)})))
+     (events/publish-event! :event/user-deactivated (t2/select-one User :id id))))
   {:success true})
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -117,6 +117,7 @@
 (derive :event/user-update ::user-event)
 (derive :event/user-deactivated ::user-event)
 (derive :event/user-reactivated ::user-event)
+(derive :event/password-reset-initiated ::user-event)
 
 (methodical/defmethod events/publish-event! ::user-event
   [topic object]

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -113,6 +113,7 @@
   (audit-log/record-event! topic segment))
 
 (derive ::user-event ::event)
+(derive :event/user-joined ::user-event)
 (derive :event/user-invited ::user-event)
 (derive :event/user-update ::user-event)
 (derive :event/user-deactivated ::user-event)
@@ -125,17 +126,7 @@
   {:pre [(let [id (:user-id object)]
            (or (nil? id)
                (pos-int? id)))]}
-  (let [{:keys [user-id details]} object]
-    (audit-log/record-event! topic details user-id :model/User (:id details))))
-
-(derive ::user-joined-event ::event)
-(derive :event/user-joined ::user-joined-event)
-
-(methodical/defmethod events/publish-event! ::user-joined-event
-  [topic object]
-  {:pre [(pos-int? (:user-id object))]}
-  (let [user-id (:user-id object)]
-   (audit-log/record-event! topic {} user-id :model/User user-id)))
+  (audit-log/record-event! topic object))
 
 (derive ::install-event ::event)
 (derive :event/install ::install-event)

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -135,9 +135,9 @@
 
 (methodical/defmethod events/publish-event! ::user-deactivated-event
   [topic object]
-  {:pre [(pos-int? (:updater object))]}
-  (let [{:keys [updater deactivated-user]} object]
-   (audit-log/record-event! topic object updater :model/User (:id deactivated-user))))
+  {:pre [(pos-int? (:deactivator object))]}
+  (let [{:keys [deactivator deactivated-user]} object]
+   (audit-log/record-event! topic object deactivator :model/User (:id deactivated-user))))
 
 (derive ::install-event ::event)
 (derive :event/install ::install-event)

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -121,6 +121,24 @@
   (let [user-id (:user-id object)]
    (audit-log/record-event! topic {} user-id :model/User user-id)))
 
+(derive ::user-update-event :metabase/event)
+(derive :event/user-update ::user-update-event)
+
+(methodical/defmethod events/publish-event! ::user-update-event
+  [topic object]
+  {:pre [(pos-int? (:updater object))]}
+  (let [{:keys [updater changes]} object]
+   (audit-log/record-event! topic object updater :model/User (:id changes))))
+
+(derive ::user-deactivated-event :metabase/event)
+(derive :event/user-deactivated ::user-deactivated-event)
+
+(methodical/defmethod events/publish-event! ::user-deactivated-event
+  [topic object]
+  {:pre [(pos-int? (:updater object))]}
+  (let [{:keys [updater deactivated-user]} object]
+   (audit-log/record-event! topic object updater :model/User (:id deactivated-user))))
+
 (derive ::install-event ::event)
 (derive :event/install ::install-event)
 

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -112,6 +112,17 @@
   [topic segment]
   (audit-log/record-event! topic segment))
 
+(derive ::user-event ::event)
+(derive :event/user-update ::user-event)
+(derive :event/user-deactivated ::user-event)
+(derive :event/user-reactivated ::user-event)
+
+(methodical/defmethod events/publish-event! ::user-event
+  [topic object]
+  {:pre [(pos-int? (:user-id object))]}
+  (let [{:keys [user-id details]} object]
+   (audit-log/record-event! topic details user-id :model/User (:id details))))
+
 (derive ::user-joined-event ::event)
 (derive :event/user-joined ::user-joined-event)
 
@@ -120,24 +131,6 @@
   {:pre [(pos-int? (:user-id object))]}
   (let [user-id (:user-id object)]
    (audit-log/record-event! topic {} user-id :model/User user-id)))
-
-(derive ::user-update-event :metabase/event)
-(derive :event/user-update ::user-update-event)
-
-(methodical/defmethod events/publish-event! ::user-update-event
-  [topic object]
-  {:pre [(pos-int? (:updater object))]}
-  (let [{:keys [updater changes]} object]
-   (audit-log/record-event! topic object updater :model/User (:id changes))))
-
-(derive ::user-deactivated-event :metabase/event)
-(derive :event/user-deactivated ::user-deactivated-event)
-
-(methodical/defmethod events/publish-event! ::user-deactivated-event
-  [topic object]
-  {:pre [(pos-int? (:deactivator object))]}
-  (let [{:keys [deactivator deactivated-user]} object]
-   (audit-log/record-event! topic object deactivator :model/User (:id deactivated-user))))
 
 (derive ::install-event ::event)
 (derive :event/install ::install-event)

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -118,6 +118,7 @@
 (derive :event/user-deactivated ::user-event)
 (derive :event/user-reactivated ::user-event)
 (derive :event/password-reset-initiated ::user-event)
+(derive :event/password-reset-successful ::user-event)
 
 (methodical/defmethod events/publish-event! ::user-event
   [topic object]

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -113,15 +113,18 @@
   (audit-log/record-event! topic segment))
 
 (derive ::user-event ::event)
+(derive :event/user-invited ::user-event)
 (derive :event/user-update ::user-event)
 (derive :event/user-deactivated ::user-event)
 (derive :event/user-reactivated ::user-event)
 
 (methodical/defmethod events/publish-event! ::user-event
   [topic object]
-  {:pre [(pos-int? (:user-id object))]}
+  {:pre [(let [id (:user-id object)]
+           (or (nil? id)
+               (pos-int? id)))]}
   (let [{:keys [user-id details]} object]
-   (audit-log/record-event! topic details user-id :model/User (:id details))))
+    (audit-log/record-event! topic details user-id :model/User (:id details))))
 
 (derive ::user-joined-event ::event)
 (derive :event/user-joined ::user-joined-event)

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -7,6 +7,7 @@
    [metabase.db.query :as mdb.query]
    [metabase.events :as events]
    [metabase.integrations.common :as integrations.common]
+   [metabase.models.audit-log :as audit-log]
    [metabase.models.collection :as collection]
    [metabase.models.interface :as mi]
    [metabase.models.permissions :as perms]
@@ -426,3 +427,17 @@
   (deferred-tru "The last version for which a user dismissed the 'What's new?' modal.")
   :user-local :only
   :type :string)
+
+;;; ## ------------------------------------------ AUDIT LOG ------------------------------------------
+
+(defmethod audit-log/model-details :model/User
+  [entity event-type]
+  (case event-type
+    :user-update               (:changes entity)
+    :user-invited              (select-keys (t2/hydrate entity :user_group_memberships)
+                                            [:groups :first_name :last_name :email
+                                             :invite_method :sso_source
+                                             :user_group_memberships])
+    :password-reset-initiated  (select-keys entity [:token])
+    :password-reset-successful (select-keys entity [:token])
+    {}))

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -5,6 +5,7 @@
    [metabase.api.common :as api]
    [metabase.config :as config]
    [metabase.db.query :as mdb.query]
+   [metabase.events :as events]
    [metabase.integrations.common :as integrations.common]
    [metabase.models.collection :as collection]
    [metabase.models.interface :as mi]
@@ -341,6 +342,9 @@
   [new-user :- NewUser invitor :- Invitor setup? :- :boolean]
   ;; create the new user
   (u/prog1 (insert-new-user! new-user)
+    (events/publish-event! :event/user-invited (assoc <>
+                                                      :invite_method "email"
+                                                      :sso_source (:sso_source new-user)))
     (send-welcome-email! <> invitor setup?)))
 
 (mu/defn create-new-google-auth-user!

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -275,8 +275,7 @@
                   :user_id  rasta-id
                   :model_id rasta-id
                   :model    "User"
-                  :details  {:id    rasta-id
-                             :token (t2/select-one-fn :reset_token :model/User :id rasta-id)}}
+                  :details  {:token (t2/select-one-fn :reset_token :model/User :id rasta-id)}}
                  (audit-log-test/event :password-reset-initiated rasta-id))))))))
 
 (deftest forgot-password-throttling-test
@@ -345,11 +344,10 @@
               (mt/client :post 200 "session/reset_password" {:token    token
                                                              :password (:new password)})
               (is (= {:topic    :password-reset-successful
-                      :user_id  id
+                      :user_id  nil
                       :model    "User"
                       :model_id id
-                      :details  {:id    id
-                                 :token reset-token}}
+                      :details  {:token reset-token}}
                      (audit-log-test/event :password-reset-successful id))))))))))
 
 (deftest reset-password-validation-test

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -270,12 +270,14 @@
       (testing "Test that forgot password event is logged."
         (mt/user-http-request :rasta :post 204 "session/forgot_password"
                               {:email (:username (mt/user->credentials :rasta))})
-        (is (= {:topic    :password-reset-initiated
-                :user_id  (mt/user->id :rasta)
-                :model    "User"
-                :model_id nil
-                :details  {:token (t2/select-one-fn :reset_token :model/User :id (mt/user->id :rasta))}}
-               (audit-log-test/event :password-reset-initiated)))))))
+        (let [rasta-id (mt/user->id :rasta)]
+          (is (= {:topic    :password-reset-initiated
+                  :user_id  rasta-id
+                  :model_id rasta-id
+                  :model    "User"
+                  :details  {:id    rasta-id
+                             :token (t2/select-one-fn :reset_token :model/User :id rasta-id)}}
+                 (audit-log-test/event :password-reset-initiated rasta-id))))))))
 
 (deftest forgot-password-throttling-test
   (reset-throttlers!)

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -331,6 +331,27 @@
                         :reset_triggered nil}
                        (mt/derecordize (t2/select-one [User :reset_token :reset_triggered], :id id))))))))))))
 
+(deftest reset-password-successful-event-test
+  (reset-throttlers!)
+  (testing "Test that a successful password reset creates the correct event"
+    (mt/with-model-cleanup [:model/Activity :model/AuditLog :model/User]
+      (mt/with-fake-inbox
+        (let [password {:old "password"
+                        :new "whateverUP12!!"}]
+          (t2.with-temp/with-temp [User {:keys [id]} {:password (:old password), :reset_triggered (System/currentTimeMillis)}]
+            (let [token       (u/prog1 (str id "_" (random-uuid))
+                                       (t2/update! User id {:reset_token <> :last_login :%now}))
+                  reset-token (t2/select-one-fn :reset_token :model/User :id id)]
+              (mt/client :post 200 "session/reset_password" {:token    token
+                                                             :password (:new password)})
+              (is (= {:topic    :password-reset-successful
+                      :user_id  id
+                      :model    "User"
+                      :model_id id
+                      :details  {:id    id
+                                 :token reset-token}}
+                     (audit-log-test/event :password-reset-successful id))))))))))
+
 (deftest reset-password-validation-test
   (reset-throttlers!)
   (testing "POST /api/session/reset_password"

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -261,6 +261,19 @@
         (is (= nil
                (mt/client :post 204 "session/forgot_password" {:email "not-found@metabase.com"})))))))
 
+(deftest forgot-password-event-test
+  (reset-throttlers!)
+  (mt/with-model-cleanup [:model/Activity :model/AuditLog]
+    (testing "Test that forgot password event is logged."
+      (mt/user-http-request :rasta :post 204 "session/forgot_password"
+                            {:email (:username (mt/user->credentials :rasta))})
+      (is (= {:topic    :password-reset-initiated
+              :user_id  (mt/user->id :rasta)
+              :model    "User"
+              :model_id nil
+              :details  {:token (t2/select-one-fn :reset_token :model/User :id (mt/user->id :rasta))}}
+             (audit-log-test/event :password-reset-initiated))))))
+
 (deftest forgot-password-throttling-test
   (reset-throttlers!)
   (testing "Test that email based throttling kicks in after the login failure threshold (10) has been reached"

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -129,11 +129,11 @@
                             :user_id  nil
                             :model    "User"
                             :model_id (u/the-id (t2/select-one User :email email))
-                            :details  {:invite_method "email"
-                                       :first_name    first-name
-                                       :last_name     last-name
-                                       :email         email
-                                       :groups        [{:id 1, :name "All Users"} {:id 2, :name "Administrators"}]}}
+                            :details  {:invite_method          "email"
+                                       :first_name             first-name
+                                       :last_name              last-name
+                                       :email                  email
+                                       :user_group_memberships [{:id 1} {:id 2}]}}
                            logged-event))))))))))))
 
 (deftest invite-user-test-2

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -134,13 +134,13 @@
                      (re-pattern (str invitor-first-name " could use your help setting up Metabase.*"))))
                 (testing "The audit-log :user-invited event is recorded"
                   (let [audit-log (event :user-invited (u/the-id (t2/select-one User :email email)))]
-                    (is (partial= {:topic    :user-invited
-                                   :user_id  nil
-                                   :model    "User"
-                                   :model_id (u/the-id (t2/select-one User :email email))
-                                   :details  {}}
-                                  audit-log))
-                    (is (= #{:id :invitor :email :first_name :last_name :groups :user_attributes :invite_method}
+                    (is (=? {:topic    :user-invited
+                             :user_id  nil
+                             :model    "User"
+                             :model_id (u/the-id (t2/select-one User :email email))
+                             :details  {}}
+                            audit-log))
+                    (is (= #{:id :invitor :email :first_name :last_name :groups :invite_method}
                            (set (keys (:details audit-log)))))))))))))))
 
 (deftest invite-user-test-2

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -97,19 +97,29 @@
                        :model         "User"}
                       (t2/select-one :model/AuditLog :topic "user-joined", :user_id user-id))))))))))
 
+(defn- event
+  ([topic]
+   (event topic nil))
+
+  ([topic model-id]
+   (t2/select-one [:model/AuditLog :topic :user_id :model :model_id :details]
+                  :topic    topic
+                  :model_id model-id
+                  {:order-by [[:id :desc]]})))
+
 (deftest invite-user-test
   (testing "POST /api/setup"
     (testing "Check that a second admin can be created during setup, and that an invite email is sent successfully and
              a Snowplow analytics event is sent"
       (mt/with-fake-inbox
         (snowplow-test/with-fake-snowplow-collector
-          (let [email (mt/random-email)
-                first-name (mt/random-name)
-                last-name (mt/random-name)
+          (let [email              (mt/random-email)
+                first-name         (mt/random-name)
+                last-name          (mt/random-name)
                 invitor-first-name (mt/random-name)]
             (with-setup! {:invite {:email email, :first_name first-name, :last_name last-name}
-                          :user {:first_name invitor-first-name}
-                          :site_name "Metabase"}
+                          :user   {:first_name invitor-first-name}
+                          :prefs  {:site_name "Metabase"}}
               (let [invited-user (t2/select-one User :email email)]
                 (is (= (:first_name invited-user) first-name))
                 (is (= (:last_name invited-user) last-name))
@@ -121,7 +131,17 @@
                                       (snowplow-test/pop-event-data-and-user-id!))))
                 (is (mt/received-email-body?
                      email
-                     (re-pattern (str invitor-first-name " could use your help setting up Metabase.*"))))))))))))
+                     (re-pattern (str invitor-first-name " could use your help setting up Metabase.*"))))
+                (testing "The audit-log :user-invited event is recorded"
+                  (let [audit-log (event :user-invited (u/the-id (t2/select-one User :email email)))]
+                    (is (partial= {:topic    :user-invited
+                                   :user_id  nil
+                                   :model    "User"
+                                   :model_id (u/the-id (t2/select-one User :email email))
+                                   :details  {}}
+                                  audit-log))
+                    (is (= #{:id :invitor :email :first_name :last_name :groups :user_attributes :invite_method}
+                           (set (keys (:details audit-log)))))))))))))))
 
 (deftest invite-user-test-2
   (testing "POST /api/setup"

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -1238,6 +1238,27 @@
                   :model_id model-id
                   {:order-by [[:id :desc]]})))
 
+(deftest user-activate-deactivate-event-test
+  (testing "User Deactivate/Reactivate events via the API are recorded in the audit log"
+    (mt/with-model-cleanup [:model/Activity :model/AuditLog]
+      (t2.with-temp/with-temp [User {:keys [id]} {:first_name "John"
+                                                  :last_name  "Cena"}]
+          (testing "DELETE /api/user/:id and PUT /api/user/:id/reactivate"
+            (mt/user-http-request :crowberto :delete 200 (format "user/%s" id))
+            (mt/user-http-request :crowberto :put 200 (format "user/%s/reactivate" id))
+            (is (= [{:topic    :user-deactivated
+                     :user_id  (mt/user->id :crowberto)
+                     :model    "User"
+                     :model_id id
+                     :details  {}}
+                    {:topic    :user-reactivated
+                     :user_id  (mt/user->id :crowberto)
+                     :model    "User"
+                     :model_id id
+                     :details  {}}]
+                   [(event :user-deactivated id)
+                    (event :user-reactivated id)])))))))
+
 (deftest user-update-event-test
   (testing "User Updates via the API are recorded in the audit log"
     (mt/with-model-cleanup [:model/Activity :model/AuditLog]

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer :all]
    [metabase.api.user :as api.user]
    [metabase.config :as config]
+   [metabase.events.audit-log-test :as audit-log-test]
    [metabase.http-client :as client]
    [metabase.models
     :refer [Card Collection Dashboard LoginHistory PermissionsGroup
@@ -1228,16 +1229,6 @@
       (is (= "You don't have permissions to do that."
              (mt/user-http-request :rasta :post 403 (format "user/%d/send_invite" (mt/user->id :crowberto))))))))
 
-(defn- event
-  ([topic]
-   (event topic nil))
-
-  ([topic model-id]
-   (t2/select-one [:model/AuditLog :topic :user_id :model :model_id :details]
-                  :topic    topic
-                  :model_id model-id
-                  {:order-by [[:id :desc]]})))
-
 (deftest user-activate-deactivate-event-test
   (testing "User Deactivate/Reactivate events via the API are recorded in the audit log"
     (mt/with-model-cleanup [:model/Activity :model/AuditLog]
@@ -1256,8 +1247,8 @@
                      :model    "User"
                      :model_id id
                      :details  {}}]
-                   [(event :user-deactivated id)
-                    (event :user-reactivated id)])))))))
+                   [(audit-log-test/event :user-deactivated id)
+                    (audit-log-test/event :user-reactivated id)])))))))
 
 (deftest user-update-event-test
   (testing "User Updates via the API are recorded in the audit log"
@@ -1275,4 +1266,4 @@
                                :changes {:first_name "Johnny"
                                          :last_name "Appleseed"
                                          :id id}}}
-                   (event :user-update id))))))))
+                   (audit-log-test/event :user-update id))))))))

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -1263,6 +1263,5 @@
                     :model    "User"
                     :model_id id
                     :details  {:first_name "Johnny"
-                               :last_name "Appleseed"
-                               :id id}}
+                               :last_name "Appleseed"}}
                    (audit-log-test/event :user-update id))))))))

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -1262,8 +1262,7 @@
                     :user_id  (mt/user->id :crowberto)
                     :model    "User"
                     :model_id id
-                    :details  {:updater (mt/user->id :crowberto)
-                               :changes {:first_name "Johnny"
-                                         :last_name "Appleseed"
-                                         :id id}}}
+                    :details  {:first_name "Johnny"
+                               :last_name "Appleseed"
+                               :id id}}
                    (audit-log-test/event :user-update id))))))))

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -468,20 +468,33 @@
               :details     {}}
              (event "user-joined" (mt/user->id :rasta)))))))
 
+(deftest user-invited-event-test
+  (testing :event/user-invited
+    (mt/with-model-cleanup [Activity]
+      (let [event {:user-id (mt/user->id :rasta)
+                   :details {}}]
+        (is (= event (events/publish-event! :event/user-invited event))))
+      (is (= {:model_id nil
+              :user_id  (mt/user->id :rasta)
+              :details  {}
+              :topic    :user-invited
+              :model    "User"}
+             (event :user-invited (mt/user->id :lucky)))))))
+
 (deftest user-update-event-test
- (testing :event/user-update
-  (mt/with-model-cleanup [Activity]
-    (let [event {:user-id (mt/user->id :rasta)
-                 :details {:id        (mt/user->id :lucky)
-                           :last_name "Charms"}}]
-      (is (= event (events/publish-event! :event/user-update event))))
-    (is (= {:model_id (mt/user->id :lucky)
-            :user_id  (mt/user->id :rasta)
-            :details  {:id        (mt/user->id :lucky)
-                       :last_name "Charms"}
-            :topic    :user-update
-            :model    "User"}
-     (event :user-update (mt/user->id :lucky)))))))
+  (testing :event/user-update
+    (mt/with-model-cleanup [Activity]
+      (let [event {:user-id (mt/user->id :rasta)
+                   :details {:id        (mt/user->id :lucky)
+                             :last_name "Charms"}}]
+        (is (= event (events/publish-event! :event/user-update event))))
+      (is (= {:model_id (mt/user->id :lucky)
+              :user_id  (mt/user->id :rasta)
+              :details  {:id        (mt/user->id :lucky)
+                         :last_name "Charms"}
+              :topic    :user-update
+              :model    "User"}
+             (event :user-update (mt/user->id :lucky)))))))
 
 (deftest user-deactivated-event-test
  (testing :event/user-deactivated
@@ -502,7 +515,7 @@
      (event :user-deactivated (mt/user->id :lucky)))))))
 
 (deftest user-reactivated-event-test
- (testing :event/user-deactivated
+ (testing :event/user-reactivated
   (mt/with-model-cleanup [Activity]
     (let [event {:user-id (mt/user->id :rasta)
                  :details {:id         (mt/user->id :lucky)

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -476,7 +476,8 @@
           (is (= new-user (events/publish-event! :event/user-invited new-user)))
           (is (= {:model_id id
                   :user_id  (mt/user->id :rasta)
-                  :details  (select-keys new-user [:first_name :last_name :email])
+                  :details  (assoc (select-keys new-user [:first_name :last_name :email])
+                                   :user_group_memberships [{:id 1}])
                   :topic    :user-invited
                   :model    "User"}
                  (event :user-invited id))))))))

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -546,3 +546,16 @@
               :topic    :password-reset-initiated
               :model    "User"}
              (event :password-reset-initiated (mt/user->id :rasta)))))))
+
+(deftest password-reset-successful-event-test
+  (testing :event/password-reset-successful
+    (mt/with-model-cleanup [:model/AuditLog]
+      (let [event {:user-id (mt/user->id :rasta)
+                   :details {:token "hash"}}]
+        (is (= event (events/publish-event! :event/password-reset-successful event))))
+      (is (= {:model_id nil
+              :user_id  (mt/user->id :rasta)
+              :details  {:token "hash"}
+              :topic    :password-reset-successful
+              :model    "User"}
+             (event :password-reset-successful))))))

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -470,7 +470,7 @@
 
 (deftest user-invited-event-test
   (testing :event/user-invited
-    (mt/with-model-cleanup [Activity]
+    (mt/with-model-cleanup [:model/AuditLog]
       (let [event {:user-id (mt/user->id :rasta)
                    :details {}}]
         (is (= event (events/publish-event! :event/user-invited event))))
@@ -483,7 +483,7 @@
 
 (deftest user-update-event-test
   (testing :event/user-update
-    (mt/with-model-cleanup [Activity]
+    (mt/with-model-cleanup [:model/AuditLog]
       (let [event {:user-id (mt/user->id :rasta)
                    :details {:id        (mt/user->id :lucky)
                              :last_name "Charms"}}]
@@ -498,7 +498,7 @@
 
 (deftest user-deactivated-event-test
  (testing :event/user-deactivated
-  (mt/with-model-cleanup [Activity]
+  (mt/with-model-cleanup [:model/AuditLog]
     (let [event {:user-id (mt/user->id :rasta)
                  :details {:id         (mt/user->id :lucky)
                            :first_name "Lucky"
@@ -516,7 +516,7 @@
 
 (deftest user-reactivated-event-test
  (testing :event/user-reactivated
-  (mt/with-model-cleanup [Activity]
+  (mt/with-model-cleanup [:model/AuditLog]
     (let [event {:user-id (mt/user->id :rasta)
                  :details {:id         (mt/user->id :lucky)
                            :first_name "Lucky"

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -479,7 +479,7 @@
               :details  {}
               :topic    :user-invited
               :model    "User"}
-             (event :user-invited (mt/user->id :lucky)))))))
+             (event :user-invited))))))
 
 (deftest user-update-event-test
   (testing :event/user-update

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -467,3 +467,37 @@
               :model_id    (mt/user->id :rasta)
               :details     {}}
              (event "user-joined" (mt/user->id :rasta)))))))
+
+(deftest user-update-event-test
+ (testing :event/user-update
+  (mt/with-model-cleanup [Activity]
+    (let [event {:updater (mt/user->id :rasta)
+                 :changes {:id        (mt/user->id :lucky)
+                           :last_name "Charms"}}]
+      (is (= event (events/publish-event! :event/user-update event))))
+    (is (= {:model_id (mt/user->id :lucky)
+            :user_id  (mt/user->id :rasta)
+            :details  {:updater (mt/user->id :rasta) :changes {:id        (mt/user->id :lucky)
+                                                               :last_name "Charms"}}
+            :topic    :user-update
+            :model    "User"}
+     (event :user-update (mt/user->id :lucky)))))))
+
+(deftest user-deactivated-event-test
+ (testing :event/user-deactivated
+  (mt/with-model-cleanup [Activity]
+    (let [event {:deactivator      (mt/user->id :rasta)
+                 :deactivated-user {:id         (mt/user->id :lucky)
+                                    :first_name "Lucky"
+                                    :last_name  "Toucan"}}]
+    (is (= event (events/publish-event! :event/user-deactivated event))))
+    (is (= {:model_id (mt/user->id :lucky)
+            :user_id  (mt/user->id :rasta)
+            :details
+            {:deactivator      (mt/user->id :rasta)
+             :deactivated-user {:id (mt/user->id :lucky)
+                                :first_name "Lucky"
+                                :last_name "Toucan"}}
+            :topic    :user-deactivated
+            :model    "User"}
+     (event :user-deactivated (mt/user->id :lucky)))))))

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -536,11 +536,13 @@
   (testing :event/password-reset-initiated
     (mt/with-model-cleanup [:model/AuditLog]
       (let [event {:user-id (mt/user->id :rasta)
-                   :details {:token "hash"}}]
+                   :details {:id    (mt/user->id :rasta)
+                             :token "hash"}}]
         (is (= event (events/publish-event! :event/password-reset-initiated event))))
-      (is (= {:model_id (mt/user->id :lucky)
+      (is (= {:model_id (mt/user->id :rasta)
               :user_id  (mt/user->id :rasta)
-              :details  {:token "hash"}
+              :details  {:id    (mt/user->id :rasta)
+                         :token "hash"}
               :topic    :password-reset-initiated
               :model    "User"}
-             (event :password-reset-initiated))))))
+             (event :password-reset-initiated (mt/user->id :rasta)))))))

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -457,16 +457,16 @@
 (deftest user-joined-event-test
   (testing :user-joined
     ;; TODO - what's the difference between `user-login` / `user-joined`?
-    (mt/with-model-cleanup [:model/AuditLog]
-      (let [event {:user-id (mt/user->id :rasta)}]
-        (is (= event
-               (events/publish-event! :event/user-joined event))))
-      (is (= {:topic       :user-joined
-              :user_id     (mt/user->id :rasta)
-              :model       "User"
-              :model_id    (mt/user->id :rasta)
-              :details     {}}
-             (event "user-joined" (mt/user->id :rasta)))))))
+    (mt/with-current-user (mt/user->id :rasta)
+      (mt/with-model-cleanup [:model/AuditLog]
+        (let [event (mt/fetch-user :rasta)]
+          (is (= event (events/publish-event! :event/user-joined event))))
+        (is (= {:topic       :user-joined
+                :user_id     (mt/user->id :rasta)
+                :model       "User"
+                :model_id    (mt/user->id :rasta)
+                :details     {}}
+               (event :user-joined (mt/user->id :rasta))))))))
 
 (deftest user-invited-event-test
   (testing :event/user-invited
@@ -476,7 +476,7 @@
           (is (= new-user (events/publish-event! :event/user-invited new-user)))
           (is (= {:model_id id
                   :user_id  (mt/user->id :rasta)
-                  :details  {}
+                  :details  (select-keys new-user [:first_name :last_name :email])
                   :topic    :user-invited
                   :model    "User"}
                  (event :user-invited id))))))))

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -531,3 +531,16 @@
             :topic    :user-reactivated
             :model    "User"}
      (event :user-reactivated (mt/user->id :lucky)))))))
+
+(deftest password-reset-initiated-event-test
+  (testing :event/password-reset-initiated
+    (mt/with-model-cleanup [:model/AuditLog]
+      (let [event {:user-id (mt/user->id :rasta)
+                   :details {:token "hash"}}]
+        (is (= event (events/publish-event! :event/password-reset-initiated event))))
+      (is (= {:model_id (mt/user->id :lucky)
+              :user_id  (mt/user->id :rasta)
+              :details  {:token "hash"}
+              :topic    :password-reset-initiated
+              :model    "User"}
+             (event :password-reset-initiated))))))

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -471,14 +471,14 @@
 (deftest user-update-event-test
  (testing :event/user-update
   (mt/with-model-cleanup [Activity]
-    (let [event {:updater (mt/user->id :rasta)
-                 :changes {:id        (mt/user->id :lucky)
+    (let [event {:user-id (mt/user->id :rasta)
+                 :details {:id        (mt/user->id :lucky)
                            :last_name "Charms"}}]
       (is (= event (events/publish-event! :event/user-update event))))
     (is (= {:model_id (mt/user->id :lucky)
             :user_id  (mt/user->id :rasta)
-            :details  {:updater (mt/user->id :rasta) :changes {:id        (mt/user->id :lucky)
-                                                               :last_name "Charms"}}
+            :details  {:id        (mt/user->id :lucky)
+                       :last_name "Charms"}
             :topic    :user-update
             :model    "User"}
      (event :user-update (mt/user->id :lucky)))))))
@@ -486,18 +486,35 @@
 (deftest user-deactivated-event-test
  (testing :event/user-deactivated
   (mt/with-model-cleanup [Activity]
-    (let [event {:deactivator      (mt/user->id :rasta)
-                 :deactivated-user {:id         (mt/user->id :lucky)
-                                    :first_name "Lucky"
-                                    :last_name  "Toucan"}}]
+    (let [event {:user-id (mt/user->id :rasta)
+                 :details {:id         (mt/user->id :lucky)
+                           :first_name "Lucky"
+                           :last_name  "Toucan"}}]
     (is (= event (events/publish-event! :event/user-deactivated event))))
     (is (= {:model_id (mt/user->id :lucky)
             :user_id  (mt/user->id :rasta)
             :details
-            {:deactivator      (mt/user->id :rasta)
-             :deactivated-user {:id (mt/user->id :lucky)
-                                :first_name "Lucky"
-                                :last_name "Toucan"}}
+            {:id         (mt/user->id :lucky)
+             :first_name "Lucky"
+             :last_name  "Toucan"}
             :topic    :user-deactivated
             :model    "User"}
      (event :user-deactivated (mt/user->id :lucky)))))))
+
+(deftest user-reactivated-event-test
+ (testing :event/user-deactivated
+  (mt/with-model-cleanup [Activity]
+    (let [event {:user-id (mt/user->id :rasta)
+                 :details {:id         (mt/user->id :lucky)
+                           :first_name "Lucky"
+                           :last_name  "Toucan"}}]
+    (is (= event (events/publish-event! :event/user-reactivated event))))
+    (is (= {:model_id (mt/user->id :lucky)
+            :user_id  (mt/user->id :rasta)
+            :details
+            {:id         (mt/user->id :lucky)
+             :first_name "Lucky"
+             :last_name  "Toucan"}
+            :topic    :user-reactivated
+            :model    "User"}
+     (event :user-reactivated (mt/user->id :lucky)))))))


### PR DESCRIPTION
Closes: #34102
This cherry-picked branch replaces: https://github.com/metabase/metabase/pull/34188 (oops!)

- [x] topic: user_invited
  - details: email, first_name, last_name, groups (list), user_attributes (list), invite_method: sso_method, email
  - this should be triggered both by manual invites and SSO

 - [x] topic: user_deactivated
   - model: User
   - model_id: deactivated user id
   - details: email, first_name, last_name
   - when we start to deactivate users by SSO, this should track it as well

 - [x] topic: user_update
   - details: what changed
   - this should be triggered both by manual edits and SSO

 - [x] topic: password_reset_initiated
   - user_id: id of the user that initiated the reset (if it was initiated by an admin on /admin/people)
   - model: User
   - model_id: id of the user whom the pw was reset
   - details: token?

 - [x] topic: password_reset_successful
   - details: something that links to the previous event (token?)

---- maybe
 
 - [x] topic: user_reactivated
   - model: User
   - model_id: reactivated user id
   - details: email, first_name, last_name
   - can SSO reactivate users? If so, this should track that