### PR TITLE
Prevent table for pivoting if all columns have high cardinality

### DIFF
--- a/frontend/src/metabase/visualizations/lib/utils.js
+++ b/frontend/src/metabase/visualizations/lib/utils.js
@@ -3,6 +3,7 @@ import d3 from "d3";
 import { t } from "ttag";
 import crossfilter from "crossfilter";
 
+import { isNotNull } from "metabase/core/utils/types";
 import { isDimension, isMetric, isDate } from "metabase-lib/types/utils/isa";
 
 export const MAX_SERIES = 100;
@@ -399,3 +400,27 @@ export const preserveExistingColumnsOrder = (prevColumns, newColumns) => {
 export function getCardKey(cardId) {
   return `${cardId ?? "unsaved"}`;
 }
+
+const PIVOT_SENSIBLE_MAX_CARDINALITY = 16;
+
+export const getDefaultPivotColumn = (cols, rows) => {
+  const columnsWithCardinality = cols
+    .map((column, index) => {
+      if (!isDimension(column)) {
+        return null;
+      }
+
+      const cardinality = getColumnCardinality(cols, rows, index);
+      if (cardinality > PIVOT_SENSIBLE_MAX_CARDINALITY) {
+        return null;
+      }
+
+      return { column, cardinality };
+    })
+    .filter(isNotNull);
+
+  return (
+    _.min(columnsWithCardinality, ({ cardinality }) => cardinality)?.column ??
+    null
+  );
+};

--- a/frontend/src/metabase/visualizations/lib/utils.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/utils.unit.spec.js
@@ -8,7 +8,9 @@ import {
   getDefaultDimensionsAndMetrics,
   preserveExistingColumnsOrder,
   computeSplit,
+  getDefaultPivotColumn,
 } from "metabase/visualizations/lib/utils";
+import { createMockColumn } from "metabase-types/api/mocks";
 
 // TODO Atte Keinänen 5/31/17 Rewrite tests using metabase-lib methods instead of a raw format
 
@@ -359,6 +361,66 @@ describe("metabase/visualization/lib/utils", () => {
 
     it("should return the same number of series as given", () => {
       expect(computeSplit(extents).flat()).toHaveLength(extents.length);
+    });
+  });
+
+  describe("getDefaultPivotColumn", () => {
+    const lowestCardinalityColumn = createMockColumn({
+      name: "lowest_cardinality",
+    });
+    const lowCardinalityColumn = createMockColumn({ name: "low_cardinality" });
+    const highCardinalityColumn = createMockColumn({
+      name: "high_cardinality",
+    });
+    const highestCardinalityColumn = createMockColumn({
+      name: "highest_cardinality",
+    });
+
+    const lowestCardinality = 5;
+    const lowCardinality = 16;
+    const highCardinality = 17;
+    const highestCardinality = 50;
+
+    it("returns null if all columns has cardinality > 16", () => {
+      const cols = [highestCardinalityColumn, highCardinalityColumn];
+      const rows = _.range(highestCardinality).map(n => [
+        n,
+        n % highCardinality,
+      ]);
+
+      expect(getDefaultPivotColumn(cols, rows)).toBeNull();
+    });
+
+    it("returns lowest cardinality column from ones where it is <= 16", () => {
+      const cols = [
+        highestCardinalityColumn,
+        highCardinalityColumn,
+        lowCardinalityColumn,
+        lowestCardinalityColumn,
+      ];
+      const rows = _.range(highestCardinality).map(n => [
+        n,
+        n % highCardinality,
+        n % lowCardinality,
+        n % lowestCardinality,
+      ]);
+
+      expect(getDefaultPivotColumn(cols, rows)).toEqual(
+        lowestCardinalityColumn,
+      );
+    });
+
+    it("ignores low cardinality non-dimension columns", () => {
+      const cols = [
+        lowCardinalityColumn,
+        createMockColumn({
+          name: "lowest_cardinality_aggregation",
+          source: "aggregation",
+        }),
+      ];
+      const rows = _.range(lowCardinality).map(n => [n, 1]);
+
+      expect(getDefaultPivotColumn(cols, rows)).toEqual(lowCardinalityColumn);
     });
   });
 });

--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -7,7 +7,6 @@ import cx from "classnames";
 import { getIn } from "icepick";
 import * as DataGrid from "metabase/lib/data_grid";
 import { getOptionFromColumn } from "metabase/visualizations/lib/settings/utils";
-import { getColumnCardinality } from "metabase/visualizations/lib/utils";
 import { formatColumn } from "metabase/lib/formatting";
 
 import ChartSettingLinkUrlInput from "metabase/visualizations/components/settings/ChartSettingLinkUrlInput";
@@ -27,6 +26,7 @@ import {
   getDefaultSize,
   getMinSize,
 } from "metabase/visualizations/shared/utils/sizes";
+import { getDefaultPivotColumn } from "metabase/visualizations/lib/utils";
 import {
   isMetric,
   isDimension,
@@ -77,29 +77,30 @@ export default class Table extends Component {
       widget: "toggle",
       inline: true,
       getHidden: ([{ card, data }]) => data && data.cols.length !== 3,
-      getDefault: ([{ card, data }]) =>
-        data &&
-        data.cols.length === 3 &&
-        Q_DEPRECATED.isStructured(card.dataset_query) &&
-        data.cols.filter(isMetric).length === 1 &&
-        data.cols.filter(isDimension).length === 2,
+      getDefault: ([{ card, data }]) => {
+        if (
+          !data ||
+          data.cols.length !== 3 ||
+          !Q_DEPRECATED.isStructured(card.dataset_query) ||
+          data.cols.filter(isMetric).length !== 1 ||
+          data.cols.filter(isDimension).length !== 2
+        ) {
+          return false;
+        }
+
+        return getDefaultPivotColumn(data.cols, data.rows) != null;
+      },
     },
     "table.pivot_column": {
       section: t`Columns`,
       title: t`Pivot column`,
       widget: "field",
-      getDefault: (
-        [
-          {
-            data: { cols, rows },
-          },
-        ],
-        settings,
-      ) => {
-        const col = _.min(cols.filter(isDimension), col =>
-          getColumnCardinality(cols, rows, cols.indexOf(col)),
-        );
-        return col && col.name;
+      getDefault: ([
+        {
+          data: { cols, rows },
+        },
+      ]) => {
+        return getDefaultPivotColumn(cols, rows)?.name;
       },
       getProps: (
         [


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/34677

### Description

Do not auto pivot the Table visualization on dimensions with cardinality > 16. This is about the pivot functionality of our regular table, not pivot table.

### How to verify

1. New question -> Sample Dataset -> Orders
2. Summarize by [Discount: Auto binned] and [Total: Auto binned]
3. Ensure it shows the table which was automatically pivoted
4. New question -> Sample Dataset -> Orders 
5. Summarize by [Id] and [Product Id]
6. Ensure it shows the table which is not automatically pivoted

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
