### PR TITLE
[Auditv2] Misc UI fixes

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.tsx
@@ -2,6 +2,8 @@ import { withRouter } from "react-router";
 import type { Location } from "history";
 import type { Collection, CollectionId } from "metabase-types/api";
 
+import { isInstanceAnalyticsCollection } from "metabase/collections/utils";
+
 import { CollectionMenu } from "../CollectionMenu";
 import { CollectionCaption } from "./CollectionCaption";
 import CollectionBookmark from "./CollectionBookmark";
@@ -9,6 +11,7 @@ import CollectionTimeline from "./CollectionTimeline";
 import { CollectionUpload } from "./CollectionUpload";
 
 import { HeaderActions, HeaderRoot } from "./CollectionHeader.styled";
+import { CollectionPermissions } from "./CollectionPermissions";
 
 export interface CollectionHeaderProps {
   collection: Collection;
@@ -39,6 +42,7 @@ const CollectionHeader = ({
 }: CollectionHeaderProps): JSX.Element => {
   const showUploadButton =
     collection.can_write && (canUpload || !uploadsEnabled);
+  const isInstanceAnalytics = isInstanceAnalyticsCollection(collection);
 
   return (
     <HeaderRoot>
@@ -55,19 +59,24 @@ const CollectionHeader = ({
             onUpload={onUpload}
           />
         )}
-        <CollectionTimeline collection={collection} />
+        {!isInstanceAnalytics && <CollectionTimeline collection={collection} />}
+        {isInstanceAnalytics && (
+          <CollectionPermissions collection={collection} />
+        )}
         <CollectionBookmark
           collection={collection}
           isBookmarked={isBookmarked}
           onCreateBookmark={onCreateBookmark}
           onDeleteBookmark={onDeleteBookmark}
         />
-        <CollectionMenu
-          collection={collection}
-          isAdmin={isAdmin}
-          isPersonalCollectionChild={isPersonalCollectionChild}
-          onUpdateCollection={onUpdateCollection}
-        />
+        {!isInstanceAnalytics && (
+          <CollectionMenu
+            collection={collection}
+            isAdmin={isAdmin}
+            isPersonalCollectionChild={isPersonalCollectionChild}
+            onUpdateCollection={onUpdateCollection}
+          />
+        )}
       </HeaderActions>
     </HeaderRoot>
   );

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionPermissions.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionPermissions.tsx
@@ -1,0 +1,24 @@
+import { t } from "ttag";
+import * as Urls from "metabase/lib/urls";
+import Link from "metabase/core/components/Link/Link";
+import Tooltip from "metabase/core/components/Tooltip";
+import type { Collection } from "metabase-types/api";
+import { CollectionHeaderButton } from "./CollectionHeader.styled";
+
+interface CollectionPermissionsProps {
+  collection: Collection;
+}
+
+export const CollectionPermissions = ({
+  collection,
+}: CollectionPermissionsProps) => {
+  const url = `${Urls.collection(collection)}/permissions`;
+
+  return (
+    <Tooltip tooltip={t`Edit permissions`} placement="bottom">
+      <div>
+        <CollectionHeaderButton as={Link} to={url} icon="lock" />
+      </div>
+    </Tooltip>
+  );
+};

--- a/frontend/src/metabase/collections/components/CollectionHeader/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/tests/enterprise.unit.spec.tsx
@@ -1,0 +1,109 @@
+import userEvent from "@testing-library/user-event";
+import { getIcon, queryIcon, screen } from "__support__/ui";
+import type { CollectionType } from "metabase-types/api";
+import { setup } from "./setup";
+
+describe("Instance Analytics Collection Header", () => {
+  const defaultOptions = {
+    collection: {
+      name: "Instance Analytics",
+      type: "instance-analytics" as CollectionType,
+      can_write: false,
+    },
+    hasEnterprisePlugins: true,
+    // 😬 this test needs the official_collections feature flag so that it
+    // doesn't cause the following test block to fail
+    tokenFeatures: { audit_app: true, official_collections: true },
+  };
+
+  it("should show an audit icon for instance analytics collections", () => {
+    setup(defaultOptions);
+    expect(getIcon("audit")).toBeInTheDocument();
+  });
+
+  it("should not show an audit icon for regular collections", () => {
+    setup({
+      ...defaultOptions,
+      collection: {
+        name: "Rock Collection",
+        type: null,
+      },
+    });
+    expect(queryIcon("audit")).not.toBeInTheDocument();
+  });
+
+  it("should show bookmark icon for instance analytics", () => {
+    setup(defaultOptions);
+    expect(getIcon("bookmark")).toBeInTheDocument();
+  });
+
+  it("should show permissions icon for instance analytics", () => {
+    setup(defaultOptions);
+    expect(getIcon("lock")).toBeInTheDocument();
+  });
+
+  it("should not show upload icon for instance analytics", () => {
+    setup(defaultOptions);
+    expect(queryIcon("upload")).not.toBeInTheDocument();
+  });
+
+  it("should not show timeline events icon for instance analytics", () => {
+    setup(defaultOptions);
+    expect(queryIcon("calendar")).not.toBeInTheDocument();
+  });
+
+  it("should not show rest ... menu for instance analytics", () => {
+    setup(defaultOptions);
+    expect(queryIcon("ellipsis")).not.toBeInTheDocument();
+  });
+});
+
+describe("Official Collections Header", () => {
+  const officialCollectionOptions = {
+    collection: {
+      id: 144,
+      name: "Rock Collection",
+      can_write: true,
+    },
+    hasEnterprisePlugins: true,
+
+    tokenFeatures: { official_collections: true },
+    isAdmin: true,
+  };
+
+  it("should allow admin users to designate official collections", async () => {
+    setup(officialCollectionOptions);
+    userEvent.click(getIcon("ellipsis"));
+    expect(
+      await screen.findByText("Make collection official"),
+    ).toBeInTheDocument();
+    expect(await getIcon("badge")).toBeInTheDocument();
+  });
+
+  it("should not allow non-admin users to designate official collections", async () => {
+    setup({
+      ...officialCollectionOptions,
+      isAdmin: false,
+    });
+    userEvent.click(getIcon("ellipsis"));
+    expect(
+      screen.queryByText("Make collection official"),
+    ).not.toBeInTheDocument();
+    expect(await queryIcon("badge")).not.toBeInTheDocument();
+  });
+
+  it("should not allow admin users to designate read-only collections as official", async () => {
+    setup({
+      ...officialCollectionOptions,
+      collection: {
+        ...officialCollectionOptions.collection,
+        can_write: false,
+      },
+    });
+    userEvent.click(getIcon("ellipsis"));
+    expect(
+      screen.queryByText("Make collection official"),
+    ).not.toBeInTheDocument();
+    expect(await queryIcon("badge")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/collections/components/CollectionHeader/tests/setup.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/tests/setup.tsx
@@ -1,0 +1,67 @@
+import { renderWithProviders } from "__support__/ui";
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import {
+  createMockCollection,
+  createMockTokenFeatures,
+} from "metabase-types/api/mocks";
+import { mockSettings } from "__support__/settings";
+import { createMockState } from "metabase-types/store/mocks";
+import type { Collection, TokenFeatures } from "metabase-types/api";
+import type { CollectionHeaderProps } from "../CollectionHeader";
+import CollectionHeader from "../CollectionHeader";
+
+const getProps = (
+  opts?: Partial<CollectionHeaderProps>,
+): CollectionHeaderProps => ({
+  collection: createMockCollection(),
+  isAdmin: false,
+  isBookmarked: false,
+  canUpload: false,
+  uploadsEnabled: true,
+  isPersonalCollectionChild: false,
+  onUpdateCollection: jest.fn(),
+  onCreateBookmark: jest.fn(),
+  onUpload: jest.fn(),
+  onDeleteBookmark: jest.fn(),
+  location: {
+    pathname: `/collection/1`,
+    search: "",
+    query: {},
+    hash: "",
+    state: {},
+    action: "PUSH",
+    key: "1",
+  },
+  ...opts,
+});
+
+export const setup = ({
+  collection,
+  hasEnterprisePlugins = false,
+  tokenFeatures,
+  ...otherProps
+}: {
+  collection?: Partial<Collection>;
+  hasEnterprisePlugins?: boolean;
+  tokenFeatures?: Partial<TokenFeatures>;
+} & Partial<Omit<CollectionHeaderProps, "collection">> = {}) => {
+  const props = getProps({
+    collection: createMockCollection(collection),
+    ...otherProps,
+  });
+
+  const settings = mockSettings({
+    "token-features": createMockTokenFeatures(tokenFeatures),
+  });
+  const state = createMockState({ settings });
+
+  if (hasEnterprisePlugins) {
+    setupEnterprisePlugins();
+  }
+
+  renderWithProviders(<CollectionHeader {...props} />, {
+    storeInitialState: state,
+  });
+
+  return props;
+};

--- a/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
@@ -29,7 +29,13 @@ export const CollectionMenu = ({
   const isPersonal = isPersonalCollection(collection);
   const canWrite = collection.can_write;
 
-  if (isAdmin && !isRoot && !isPersonal && !isPersonalCollectionChild) {
+  if (
+    isAdmin &&
+    !isRoot &&
+    !isPersonal &&
+    !isPersonalCollectionChild &&
+    canWrite
+  ) {
     items.push(
       ...PLUGIN_COLLECTIONS.getAuthorityLevelMenuItems(
         collection,

--- a/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
@@ -7,7 +7,6 @@ import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 import {
   isPersonalCollection,
   isRootCollection,
-  isInstanceAnalyticsCollection,
 } from "metabase/collections/utils";
 import type { Collection } from "metabase-types/api";
 
@@ -28,16 +27,9 @@ export const CollectionMenu = ({
   const url = Urls.collection(collection);
   const isRoot = isRootCollection(collection);
   const isPersonal = isPersonalCollection(collection);
-  const isInstanceAnalytics = isInstanceAnalyticsCollection(collection);
   const canWrite = collection.can_write;
 
-  if (
-    isAdmin &&
-    !isRoot &&
-    !isPersonal &&
-    !isPersonalCollectionChild &&
-    !isInstanceAnalytics
-  ) {
+  if (isAdmin && !isRoot && !isPersonal && !isPersonalCollectionChild) {
     items.push(
       ...PLUGIN_COLLECTIONS.getAuthorityLevelMenuItems(
         collection,

--- a/frontend/src/metabase/query_builder/components/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.tsx
@@ -70,7 +70,7 @@ const QuestionActions = ({
   const isMetabotEnabled = useSelector(state =>
     getSetting(state, "is-metabot-enabled"),
   );
-  const isModerator = useSelector(getUserIsAdmin);
+  const isModerator = useSelector(getUserIsAdmin) && question.canWrite?.();
 
   const dispatch = useDispatch();
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/34746

### Description

Fixes a few little UI issues with Auditv2

Audit collection should not have the timeline events button, and the permissions button shouldn't be in the `...` menu
. | .
--- | ---
Before | ![Screen Shot 2023-10-17 at 4 17 14 PM](https://github.com/metabase/metabase/assets/30528226/72bc825e-9631-4647-bd52-494bb1e0c64e)
After | ![Screen Shot 2023-10-17 at 4 16 50 PM](https://github.com/metabase/metabase/assets/30528226/48ff04c9-8000-4999-9cee-281213b8c39a) 


Audit collections and questions and models should not be able to be made "official"

Before | After
---|---
![Screen Shot 2023-10-17 at 5 42 20 PM](https://github.com/metabase/metabase/assets/30528226/6a6bbe88-1348-4d0d-b538-b6e29bbd2597) | ![Screen Shot 2023-10-17 at 5 41 52 PM](https://github.com/metabase/metabase/assets/30528226/13a08845-b1a6-4d68-86ba-fc0e96bff711)

~~The auto-apply filters toggle is disabled on read-only questions, it should look disabled now with faded opacity and a "not-allowed" cursor.~~
Removed in favor of using the mantine component in a separate PR in master


### How to verify

Describe the steps to verify that the changes are working as expected.

1. Load up an instance with auditv2 enabled (need an enterprise token)
2. check out your audit collection, dashboards, and models to see the above ☝️ 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
