### PR TITLE
compute pie chart settings

### DIFF
--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -95,6 +95,16 @@ export type TableColumnOrderSetting = {
   field_ref?: FieldReference;
 };
 
+export type PieChartSettings = {
+  "pie.dimension": string;
+  "pie.metric": string;
+  "pie.show_legend": boolean;
+  "pie.show_total": boolean;
+  "pie.percent_visibility": "off" | "legend" | "inside";
+  "pie.slice_threshold": number;
+  "pie.colors": Record<string, string>;
+};
+
 export type VisualizationSettings = {
   "graph.show_values"?: boolean;
   "stackable.stack_type"?: "stacked" | "normalized" | null;
@@ -133,7 +143,7 @@ export type VisualizationSettings = {
   "pivot_table.collapsed_rows"?: PivotTableCollapsedRowsSetting;
 
   [key: string]: any;
-};
+} & Partial<PieChartSettings>;
 
 export interface ModerationReview {
   moderator_id: number;

--- a/frontend/src/metabase/static-viz/components/PieChart/PieChart.tsx
+++ b/frontend/src/metabase/static-viz/components/PieChart/PieChart.tsx
@@ -2,16 +2,26 @@ import { init } from "echarts";
 import type { IsomorphicStaticChartProps } from "metabase/static-viz/containers/IsomorphicStaticChart/types";
 import { sanitizeSvgForBatik } from "metabase/static-viz/lib/svg";
 
+import { computeStaticPieChartSettings } from "./setttings";
+
 const WIDTH = 540;
 const HEIGHT = 360;
 
-export function PieChart(props: IsomorphicStaticChartProps) {
+export function PieChart({
+  rawSeries,
+  renderingContext,
+}: IsomorphicStaticChartProps) {
+  const computedVizSettings = computeStaticPieChartSettings(rawSeries);
+  //eslint-disable-next-line no-console
+  console.log("computedVizSettings", JSON.stringify(computedVizSettings));
+
   const chart = init(null, null, {
     renderer: "svg",
     ssr: true,
     width: WIDTH,
     height: HEIGHT,
   });
+
   chart.setOption({
     // Mock data, will be replaced
     series: {
@@ -22,6 +32,7 @@ export function PieChart(props: IsomorphicStaticChartProps) {
       ],
     },
   });
+
   const svg = sanitizeSvgForBatik(chart.renderToSVGString());
 
   return (

--- a/frontend/src/metabase/static-viz/components/PieChart/PieChart.tsx
+++ b/frontend/src/metabase/static-viz/components/PieChart/PieChart.tsx
@@ -9,9 +9,13 @@ const HEIGHT = 360;
 
 export function PieChart({
   rawSeries,
+  dashcardSettings,
   renderingContext,
 }: IsomorphicStaticChartProps) {
-  const computedVizSettings = computeStaticPieChartSettings(rawSeries);
+  const computedVizSettings = computeStaticPieChartSettings(
+    rawSeries,
+    dashcardSettings,
+  );
   //eslint-disable-next-line no-console
   console.log("computedVizSettings", JSON.stringify(computedVizSettings));
 

--- a/frontend/src/metabase/static-viz/components/PieChart/constants.ts
+++ b/frontend/src/metabase/static-viz/components/PieChart/constants.ts
@@ -10,5 +10,3 @@ export const PIE_CHART_DEFAULT_OPTIONS = {
     cronut: "#DDECFA",
   },
 };
-
-export const SLICE_THRESHOLD = 0.025; // approx 1 degree in percentage

--- a/frontend/src/metabase/static-viz/components/PieChart/constants.ts
+++ b/frontend/src/metabase/static-viz/components/PieChart/constants.ts
@@ -10,3 +10,5 @@ export const PIE_CHART_DEFAULT_OPTIONS = {
     cronut: "#DDECFA",
   },
 };
+
+export const SLICE_THRESHOLD = 0.025; // approx 1 degree in percentage

--- a/frontend/src/metabase/static-viz/components/PieChart/settings.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/components/PieChart/settings.unit.spec.ts
@@ -1,0 +1,89 @@
+import { createMockCard } from "metabase-types/api/mocks";
+import type { RawSeries } from "metabase-types/api";
+import { computeStaticPieChartSettings } from "./setttings";
+
+const MOCK_COLS = [
+  {
+    name: "CATEGORY",
+    source: "breakout",
+    display_name: "Category",
+  },
+  {
+    name: "count",
+    display_name: "Count",
+    source: "aggregation",
+    effective_type: "type/BigInteger",
+  },
+];
+
+const MOCK_ROWS = [
+  ["Doohickey", 42],
+  ["Gadget", 53],
+  ["Gizmo", 51],
+  ["Widget", 54],
+];
+
+const MOCK_RAW_SERIES: RawSeries = [
+  {
+    card: createMockCard(),
+    data: {
+      cols: MOCK_COLS,
+      rows: MOCK_ROWS,
+      rows_truncated: 0,
+      results_metadata: {
+        columns: MOCK_COLS,
+      },
+    },
+  },
+];
+
+const DEFAULT_SETTINGS = {
+  "pie.dimension": "CATEGORY",
+  "pie.metric": "count",
+  "pie.show_legend": true,
+  "pie.show_total": true,
+  "pie.percent_visibility": "legend",
+  "pie.slice_threshold": 2.5,
+  "pie.colors": {
+    Doohickey: "#88BF4D",
+    Gadget: "#F9D45C",
+    Gizmo: "#A989C5",
+    Widget: "#F2A86F",
+  },
+};
+
+const STORED_SETTINGS = {
+  "pie.dimension": "DIMENSION",
+  "pie.metric": "metric",
+  "pie.show_legend": false,
+  "pie.show_total": false,
+  "pie.percent_visibility": "off" as const,
+  "pie.slice_threshold": 5,
+  "pie.colors": {
+    Doohickey: "#e68a76",
+    Gadget: "#76e696",
+    Gizmo: "#525de1",
+    Widget: "#dc52e1",
+  },
+};
+
+describe("computeStaticPieChartSettings", () => {
+  it("should replace empty values in stored settings with defaults", () => {
+    const { column, ...computedSettings } =
+      computeStaticPieChartSettings(MOCK_RAW_SERIES);
+
+    expect(typeof column).toBe("function");
+    expect(computedSettings).toStrictEqual(DEFAULT_SETTINGS);
+  });
+
+  it("should not replace non-empty values in stored settings", () => {
+    const rawSeries = [{ ...MOCK_RAW_SERIES[0] }];
+    rawSeries[0].card.visualization_settings = { ...STORED_SETTINGS };
+
+    const { column, ...computedSettings } =
+      computeStaticPieChartSettings(rawSeries);
+
+    expect(typeof column).toBe("function");
+    expect(computedSettings).toStrictEqual(STORED_SETTINGS);
+  });
+});

--- a/frontend/src/metabase/static-viz/components/PieChart/settings.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/components/PieChart/settings.unit.spec.ts
@@ -1,56 +1,8 @@
-import { createMockCard } from "metabase-types/api/mocks";
-import type { RawSeries } from "metabase-types/api";
+import {
+  DEFAULT_SETTINGS,
+  MOCK_RAW_SERIES,
+} from "metabase/visualizations/echarts/pie/test";
 import { computeStaticPieChartSettings } from "./setttings";
-
-const MOCK_COLS = [
-  {
-    name: "CATEGORY",
-    source: "breakout",
-    display_name: "Category",
-  },
-  {
-    name: "count",
-    display_name: "Count",
-    source: "aggregation",
-    effective_type: "type/BigInteger",
-  },
-];
-
-const MOCK_ROWS = [
-  ["Doohickey", 42],
-  ["Gadget", 53],
-  ["Gizmo", 51],
-  ["Widget", 54],
-];
-
-const MOCK_RAW_SERIES: RawSeries = [
-  {
-    card: createMockCard(),
-    data: {
-      cols: MOCK_COLS,
-      rows: MOCK_ROWS,
-      rows_truncated: 0,
-      results_metadata: {
-        columns: MOCK_COLS,
-      },
-    },
-  },
-];
-
-const DEFAULT_SETTINGS = {
-  "pie.dimension": "CATEGORY",
-  "pie.metric": "count",
-  "pie.show_legend": true,
-  "pie.show_total": true,
-  "pie.percent_visibility": "legend",
-  "pie.slice_threshold": 2.5,
-  "pie.colors": {
-    Doohickey: "#88BF4D",
-    Gadget: "#F9D45C",
-    Gizmo: "#A989C5",
-    Widget: "#F2A86F",
-  },
-};
 
 const STORED_SETTINGS = {
   "pie.dimension": "DIMENSION",

--- a/frontend/src/metabase/static-viz/components/PieChart/settings.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/components/PieChart/settings.unit.spec.ts
@@ -21,8 +21,10 @@ const STORED_SETTINGS = {
 
 describe("computeStaticPieChartSettings", () => {
   it("should replace empty values in stored settings with defaults", () => {
-    const { column, ...computedSettings } =
-      computeStaticPieChartSettings(MOCK_RAW_SERIES);
+    const { column, ...computedSettings } = computeStaticPieChartSettings(
+      MOCK_RAW_SERIES,
+      {},
+    );
 
     expect(typeof column).toBe("function");
     expect(computedSettings).toStrictEqual(DEFAULT_SETTINGS);
@@ -32,8 +34,10 @@ describe("computeStaticPieChartSettings", () => {
     const rawSeries = [{ ...MOCK_RAW_SERIES[0] }];
     rawSeries[0].card.visualization_settings = { ...STORED_SETTINGS };
 
-    const { column, ...computedSettings } =
-      computeStaticPieChartSettings(rawSeries);
+    const { column, ...computedSettings } = computeStaticPieChartSettings(
+      rawSeries,
+      {},
+    );
 
     expect(typeof column).toBe("function");
     expect(computedSettings).toStrictEqual(STORED_SETTINGS);

--- a/frontend/src/metabase/static-viz/components/PieChart/setttings.ts
+++ b/frontend/src/metabase/static-viz/components/PieChart/setttings.ts
@@ -1,33 +1,9 @@
-import type {
-  ComputedVisualizationSettings,
-  RemappingHydratedDatasetColumn,
-} from "metabase/visualizations/types";
-import type {
-  DatasetColumn,
-  PieChartSettings,
-  RawSeries,
-  VisualizationSettings,
-} from "metabase-types/api";
+import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
+import type { PieChartSettings, RawSeries } from "metabase-types/api";
 import { getDefaultDimensionAndMetric } from "metabase/visualizations/lib/utils";
 import { getColorsForValues } from "metabase/lib/colors/charts";
 import { SLICE_THRESHOLD } from "metabase/visualizations/echarts/pie/constants";
-import { normalize } from "metabase-lib/queries/utils/normalize";
-import { getColumnKey } from "metabase-lib/queries/utils/get-column-key";
-
-// TODO move this to base branch in shared location
-const getColumnSettings = (
-  column: DatasetColumn,
-  settings: VisualizationSettings,
-) => {
-  const columnKey = Object.keys(settings.column_settings ?? {}).find(
-    possiblyDenormalizedFieldRef =>
-      normalize(possiblyDenormalizedFieldRef) === getColumnKey(column),
-  );
-  if (!columnKey) {
-    return null;
-  }
-  return settings.column_settings?.[columnKey];
-};
+import { getCommonStaticVizSettings } from "metabase/static-viz/lib/settings";
 
 function getPieChartColors(
   rawSeries: RawSeries,
@@ -50,9 +26,7 @@ function getPieChartColors(
 export function computeStaticPieChartSettings(
   rawSeries: RawSeries,
 ): ComputedVisualizationSettings {
-  const settings: ComputedVisualizationSettings = {
-    ...rawSeries[0].card.visualization_settings,
-  };
+  const settings = getCommonStaticVizSettings(rawSeries);
 
   if (!settings["pie.dimension"] || !settings["pie.metric"]) {
     const defaults = getDefaultDimensionAndMetric(rawSeries);
@@ -65,9 +39,6 @@ export function computeStaticPieChartSettings(
   settings["pie.percent_visibility"] ??= "legend";
   settings["pie.slice_threshold"] ??= SLICE_THRESHOLD * 100;
   settings["pie.colors"] ??= getPieChartColors(rawSeries, settings);
-
-  settings.column = (column: RemappingHydratedDatasetColumn) =>
-    getColumnSettings(column, settings);
 
   return settings;
 }

--- a/frontend/src/metabase/static-viz/components/PieChart/setttings.ts
+++ b/frontend/src/metabase/static-viz/components/PieChart/setttings.ts
@@ -1,0 +1,74 @@
+import type {
+  ComputedVisualizationSettings,
+  RemappingHydratedDatasetColumn,
+} from "metabase/visualizations/types";
+import type {
+  DatasetColumn,
+  PieChartSettings,
+  RawSeries,
+  VisualizationSettings,
+} from "metabase-types/api";
+import { getDefaultDimensionAndMetric } from "metabase/visualizations/lib/utils";
+import { getColorsForValues } from "metabase/lib/colors/charts";
+import { normalize } from "metabase-lib/queries/utils/normalize";
+import { getColumnKey } from "metabase-lib/queries/utils/get-column-key";
+
+import { SLICE_THRESHOLD } from "./constants";
+
+// TODO move this to base branch in shared location
+const getColumnSettings = (
+  column: DatasetColumn,
+  settings: VisualizationSettings,
+) => {
+  const columnKey = Object.keys(settings.column_settings ?? {}).find(
+    possiblyDenormalizedFieldRef =>
+      normalize(possiblyDenormalizedFieldRef) === getColumnKey(column),
+  );
+  if (!columnKey) {
+    return null;
+  }
+  return settings.column_settings?.[columnKey];
+};
+
+function getPieChartColors(
+  rawSeries: RawSeries,
+  currentSettings: Partial<PieChartSettings>,
+): PieChartSettings["pie.colors"] {
+  const [
+    {
+      data: { rows, cols },
+    },
+  ] = rawSeries;
+
+  const dimensionIndex = cols.findIndex(
+    col => col.name === currentSettings["pie.dimension"],
+  );
+  const dimensionValues = rows.map(r => String(r[dimensionIndex]));
+
+  return getColorsForValues(dimensionValues, currentSettings["pie.colors"]);
+}
+
+export function computeStaticPieChartSettings(
+  rawSeries: RawSeries,
+): ComputedVisualizationSettings {
+  const settings: ComputedVisualizationSettings = {
+    ...rawSeries[0].card.visualization_settings,
+  };
+
+  if (!settings["pie.dimension"] || !settings["pie.metric"]) {
+    const defaults = getDefaultDimensionAndMetric(rawSeries);
+    settings["pie.dimension"] ??= defaults.dimension;
+    settings["pie.metric"] ??= defaults.metric;
+  }
+
+  settings["pie.show_legend"] ??= true;
+  settings["pie.show_total"] ??= true;
+  settings["pie.percent_visibility"] ??= "legend";
+  settings["pie.slice_threshold"] ??= SLICE_THRESHOLD * 100;
+  settings["pie.colors"] ??= getPieChartColors(rawSeries, settings);
+
+  settings.column = (column: RemappingHydratedDatasetColumn) =>
+    getColumnSettings(column, settings);
+
+  return settings;
+}

--- a/frontend/src/metabase/static-viz/components/PieChart/setttings.ts
+++ b/frontend/src/metabase/static-viz/components/PieChart/setttings.ts
@@ -10,10 +10,9 @@ import type {
 } from "metabase-types/api";
 import { getDefaultDimensionAndMetric } from "metabase/visualizations/lib/utils";
 import { getColorsForValues } from "metabase/lib/colors/charts";
+import { SLICE_THRESHOLD } from "metabase/visualizations/echarts/pie/constants";
 import { normalize } from "metabase-lib/queries/utils/normalize";
 import { getColumnKey } from "metabase-lib/queries/utils/get-column-key";
-
-import { SLICE_THRESHOLD } from "./constants";
 
 // TODO move this to base branch in shared location
 const getColumnSettings = (

--- a/frontend/src/metabase/static-viz/components/PieChart/setttings.ts
+++ b/frontend/src/metabase/static-viz/components/PieChart/setttings.ts
@@ -1,5 +1,9 @@
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
-import type { PieChartSettings, RawSeries } from "metabase-types/api";
+import type {
+  PieChartSettings,
+  RawSeries,
+  VisualizationSettings,
+} from "metabase-types/api";
 import { getDefaultDimensionAndMetric } from "metabase/visualizations/lib/utils";
 import { getColorsForValues } from "metabase/lib/colors/charts";
 import { SLICE_THRESHOLD } from "metabase/visualizations/echarts/pie/constants";
@@ -25,8 +29,9 @@ function getPieChartColors(
 
 export function computeStaticPieChartSettings(
   rawSeries: RawSeries,
+  dashcardSettings: VisualizationSettings,
 ): ComputedVisualizationSettings {
-  const settings = getCommonStaticVizSettings(rawSeries);
+  const settings = getCommonStaticVizSettings(rawSeries, dashcardSettings);
 
   if (!settings["pie.dimension"] || !settings["pie.metric"]) {
     const defaults = getDefaultDimensionAndMetric(rawSeries);

--- a/frontend/src/metabase/visualizations/echarts/pie/constants.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/constants.ts
@@ -1,0 +1,1 @@
+export const SLICE_THRESHOLD = 0.025; // approx 1 degree in percentage

--- a/frontend/src/metabase/visualizations/echarts/pie/test.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/test.ts
@@ -42,7 +42,7 @@ export const DEFAULT_SETTINGS = {
   "pie.metric": "count",
   "pie.show_legend": true,
   "pie.show_total": true,
-  "pie.percent_visibility": "legend",
+  "pie.percent_visibility": "legend" as const,
   "pie.slice_threshold": 2.5,
   "pie.colors": {
     Doohickey: "#88BF4D",

--- a/frontend/src/metabase/visualizations/echarts/pie/test.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/test.ts
@@ -1,0 +1,53 @@
+/* istanbul ignore file */
+import { createMockCard } from "metabase-types/api/mocks";
+import type { RawSeries } from "metabase-types/api";
+
+const MOCK_COLS = [
+  {
+    name: "CATEGORY",
+    source: "breakout",
+    display_name: "Category",
+  },
+  {
+    name: "count",
+    display_name: "Count",
+    source: "aggregation",
+    effective_type: "type/BigInteger",
+  },
+];
+
+const MOCK_ROWS = [
+  ["Doohickey", 42],
+  ["Gadget", 53],
+  ["Gizmo", 51],
+  ["Widget", 54],
+];
+
+export const MOCK_RAW_SERIES: RawSeries = [
+  {
+    card: createMockCard(),
+    data: {
+      cols: MOCK_COLS,
+      rows: MOCK_ROWS,
+      rows_truncated: 0,
+      results_metadata: {
+        columns: MOCK_COLS,
+      },
+    },
+  },
+];
+
+export const DEFAULT_SETTINGS = {
+  "pie.dimension": "CATEGORY",
+  "pie.metric": "count",
+  "pie.show_legend": true,
+  "pie.show_total": true,
+  "pie.percent_visibility": "legend",
+  "pie.slice_threshold": 2.5,
+  "pie.colors": {
+    Doohickey: "#88BF4D",
+    Gadget: "#F9D45C",
+    Gizmo: "#A989C5",
+    Widget: "#F2A86F",
+  },
+};


### PR DESCRIPTION
Part of https://github.com/metabase/metabase/issues/33281

### Description

Computes the viz settings object, which will we later need to compute the chart model and echarts' option object.

### How to verify

1. Create a question
2. Set visualization type to `Pie 2`
3. Add to a dashboard
4. Send in an email subscription
5. Check backend logs, should show reasonable values for the computed settings object.

### Demo

```json
{
  "pie.show_total": false,
  "pie.percent_visibility": "inside",
  "graph.dimensions": [
    "CATEGORY"
  ],
  "graph.metrics": [
    "count"
  ],
  "pie.dimension": "CATEGORY",
  "pie.metric": "count",
  "pie.show_legend": true,
  "pie.slice_threshold": 2.5,
  "pie.colors": {
    "Doohickey": "#88BF4D",
    "Gadget": "#F9D45C",
    "Gizmo": "#A989C5",
    "Widget": "#F2A86F"
  }
}
```

Example output

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
