### PR TITLE
Translations: Removed duplicated translation keys "Conditional Formatting" vs "Conditional formatting"

### DIFF
--- a/docs/questions/sharing/visualizations/table.md
+++ b/docs/questions/sharing/visualizations/table.md
@@ -205,7 +205,7 @@ Lets you toggle between showing the currency label in the column heading or in e
 
 ## Conditional table formatting
 
-Sometimes it's helpful to highlight certain rows or columns in your tables when they meet a specific condition. You can set up conditional formatting rules by going to the visualization settings while looking at any table, then clicking on the **Conditional Formatting** tab.
+Sometimes it's helpful to highlight certain rows or columns in your tables when they meet a specific condition. You can set up conditional formatting rules by going to the visualization settings while looking at any table, then clicking on the **Conditional formatting** tab.
 
 ![Conditional formatting](../../images/conditional-formatting.png)
 

--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -253,7 +253,7 @@ describe("scenarios > question > settings", () => {
 
       cy.findByTestId("viz-settings-button").click(); // open settings sidebar
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Conditional Formatting"); // confirm it's open
+      cy.findByText("Conditional formatting"); // confirm it's open
 
       // cy.get(".test-TableInteractive").findByText("Subtotal").scrollIntoView();
       H.tableHeaderClick("Subtotal"); // open subtotal column header actions

--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -918,7 +918,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
 
     cy.findByTestId("viz-settings-button").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Conditional Formatting").click();
+    cy.findByText("Conditional formatting").click();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add a rule").click();

--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -390,7 +390,7 @@ describe("scenarios > visualizations > table > conditional formatting", () => {
       });
 
       cy.findByTestId("viz-settings-button").click();
-      H.sidebar().findByText("Conditional Formatting").click();
+      H.sidebar().findByText("Conditional formatting").click();
     });
 
     it("should be able to remove, add, and re-order rows", () => {
@@ -481,7 +481,7 @@ describe("scenarios > visualizations > table > conditional formatting", () => {
 
     it("should work with boolean columns", { tags: ["@external"] }, () => {
       cy.findByTestId("viz-settings-button").click();
-      H.leftSidebar().findByText("Conditional Formatting").click();
+      H.leftSidebar().findByText("Conditional formatting").click();
       cy.findByRole("button", { name: /add a rule/i }).click();
 
       H.popover().findByRole("option", { name: "Boolean" }).click();

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
@@ -155,7 +155,7 @@ export const settings = {
   },
   "pivot_table.column_widths": {},
   [COLUMN_FORMATTING_SETTING]: {
-    section: t`Conditional Formatting`,
+    section: t`Conditional formatting`,
     widget: ChartSettingsTableFormatting,
     default: [],
     getDefault: (

--- a/frontend/src/metabase/visualizations/visualizations/Table.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.tsx
@@ -155,7 +155,7 @@ class Table extends Component<TableProps, TableState> {
     ...tableColumnSettings,
     "table.column_widths": {},
     [DataGrid.COLUMN_FORMATTING_SETTING]: {
-      section: t`Conditional Formatting`,
+      section: t`Conditional formatting`,
       widget: ChartSettingsTableFormatting,
       default: [],
       getProps: (series: Series, settings: VisualizationSettings) => ({


### PR DESCRIPTION
While updating a couple of Swedish translations in POEditor I discovered a "duplication" of translation key. It is not technically a duplicate (`Conditional Formatting` vs `Conditional formatting`) but one of them should be enough.

### Description

Removed one of them (`Conditional Formatting`) in code so it can later be removed in the translations (via POEditor) as well.

### How to verify

1. Related tests: 
    *`e2e/test/scenarios/question/settings.cy.spec.js`
    *`e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js` 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
