### PR TITLE
show banner and log error when token format is invalid

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -6,6 +6,7 @@
   ;; prefer keeping source width about ~118, GitHub seems to cut off stuff at either 119 or 120 and it's nicer
   ;; to look at code in GH when you don't have to scroll back and forth
   (fill-column . 118)
+  (whitespace-line-column . 118)
   ;; tell find-things-fast to always use this directory as project root regardless of presence of other
   ;; deps.edn files
   (ftf-project-finders . (ftf-get-top-git-dir)))

--- a/docs/api/premium-features.md
+++ b/docs/api/premium-features.md
@@ -11,7 +11,7 @@ API endpoints for Premium features.
 ## `GET /api/premium-features/token/status`
 
 Fetch info about the current Premium-Features premium features token including whether it is `valid`, a `trial` token, its
-  `features`, when it is `valid_thru`, and the `status` of the account.
+  `features`, when it is `valid-thru`, and the `status` of the account.
 
 ---
 

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -123,12 +123,13 @@ export type LoadingMessage =
   | "running-query"
   | "loading-results";
 
-export type TokenStatusStatus = "unpaid" | "past-due" | string;
+export type TokenStatusStatus = "unpaid" | "past-due" | "invalid" | string;
 
 export interface TokenStatus {
   status?: TokenStatusStatus;
   valid: boolean;
   "valid-thru"?: string;
+  "error-details"?: string;
   trial: boolean;
 }
 

--- a/frontend/src/metabase-types/api/store.ts
+++ b/frontend/src/metabase-types/api/store.ts
@@ -1,4 +1,5 @@
 export interface StoreTokenStatus {
+  status?: string;
   valid: boolean;
   trial: boolean;
 }

--- a/frontend/src/metabase/admin/settings/containers/PremiumEmbeddingLicensePage/PremiumEmbeddingLicensePage.tsx
+++ b/frontend/src/metabase/admin/settings/containers/PremiumEmbeddingLicensePage/PremiumEmbeddingLicensePage.tsx
@@ -20,16 +20,12 @@ import {
   PremiumEmbeddingLicensePageContent,
 } from "./PremiumEmbeddingLicensePage.styled";
 
-const getDescription = (
-  upgradeUrl: string,
-  tokenStatus?: TokenStatus,
-  hasToken?: boolean,
-) => {
-  if (!hasToken) {
+const getDescription = (upgradeUrl: string, tokenStatus?: TokenStatus) => {
+  if (!tokenStatus?.status) {
     return t`Our Premium Embedding product has been discontinued, but if you already have a license you can activate it here. You’ll continue to receive support for the duration of your license.`;
   }
 
-  if (!tokenStatus || !tokenStatus.isValid) {
+  if (!tokenStatus.isValid) {
     return (
       <>
         {jt`Your Premium Embedding license isn’t valid anymore. ${(
@@ -71,7 +67,6 @@ const PremiumEmbeddingLicensePage = ({
   const tokenSetting = settings.find(
     setting => setting.key === "premium-embedding-token",
   );
-  const token = tokenSetting?.value;
 
   const { isLoading, error, tokenStatus, updateToken, isUpdating } =
     useLicense();
@@ -103,18 +98,19 @@ const PremiumEmbeddingLicensePage = ({
       <PremiumEmbeddingLicensePageContent>
         <PremiumEmbeddingHeading>{t`Premium embedding`}</PremiumEmbeddingHeading>
         <PremiumEmbeddingDescription>
-          {getDescription(upgradeUrl, tokenStatus, !!token)}
+          {getDescription(upgradeUrl, tokenStatus)}
         </PremiumEmbeddingDescription>
         {!tokenStatus?.isValid && (
           <LicenseInputTitle>
             {t`Enter the token you bought from the Metabase Store below.`}
           </LicenseInputTitle>
         )}
+        {/* backend does not return token value */}
         <LicenseInput
           disabled={tokenSetting?.is_env_setting}
           error={error}
           loading={isUpdating}
-          token={token ? String(token) : undefined}
+          token={undefined}
           onUpdate={updateToken}
           invalid={isInvalid}
           placeholder={placeholder}

--- a/frontend/src/metabase/admin/settings/containers/PremiumEmbeddingLicensePage/PremiumEmbeddingLicensePage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/containers/PremiumEmbeddingLicensePage/PremiumEmbeddingLicensePage.unit.spec.tsx
@@ -29,7 +29,6 @@ const setup = async ({
   setupSettingsEndpoints([
     createMockSettingDefinition({
       key: "premium-embedding-token",
-      value: token,
     }),
   ]);
   setupStoreTokenEndpoints(tokenStatus);
@@ -52,7 +51,7 @@ describe("PremiumEmbeddingLicensePage", () => {
   it("should display a link to upgrade the license when the token is invalid", async () => {
     await setup({
       token: "ABC",
-      tokenStatus: createMockStoreTokenStatus({ valid: false }),
+      tokenStatus: createMockStoreTokenStatus({ status: "invalid" }),
     });
 
     const link = screen.getByRole("link", {

--- a/frontend/src/metabase/admin/settings/hooks/use-license.ts
+++ b/frontend/src/metabase/admin/settings/hooks/use-license.ts
@@ -12,6 +12,7 @@ export type TokenStatus = {
   isValid: boolean;
   isTrial: boolean;
   features: string[];
+  status: string;
 };
 
 export const useLicense = (onActivated?: () => void) => {
@@ -58,6 +59,7 @@ export const useLicense = (onActivated?: () => void) => {
           isValid: response.valid,
           isTrial: response.trial,
           features: response.features,
+          status: response.status,
         });
       } catch (e) {
         if ((e as any).status !== 404) {

--- a/frontend/src/metabase/components/AppBanner/AppBanner.tsx
+++ b/frontend/src/metabase/components/AppBanner/AppBanner.tsx
@@ -15,13 +15,9 @@ interface AppBannerProps {
 
 export const AppBanner = ({ location }: AppBannerProps) => {
   const isAdmin = useSelector(getUserIsAdmin);
-  const tokenStatusStatus = useSelector(
-    state => getSetting(state, "token-status")?.status,
-  );
-  if (shouldRenderPaymentBanner({ isAdmin, tokenStatusStatus })) {
-    return (
-      <PaymentBanner isAdmin={isAdmin} tokenStatusStatus={tokenStatusStatus} />
-    );
+  const tokenStatus = useSelector(state => getSetting(state, "token-status"));
+  if (tokenStatus && shouldRenderPaymentBanner({ isAdmin, tokenStatus })) {
+    return <PaymentBanner isAdmin={isAdmin} tokenStatus={tokenStatus} />;
   }
 
   return <DatabasePromptBanner location={location} />;

--- a/frontend/src/metabase/nav/components/PaymentBanner/PaymentBanner.tsx
+++ b/frontend/src/metabase/nav/components/PaymentBanner/PaymentBanner.tsx
@@ -1,18 +1,18 @@
 import { jt, t } from "ttag";
+
+import type { TokenStatus } from "metabase-types/api";
+
 import Banner from "metabase/components/Banner";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import MetabaseSettings from "metabase/lib/settings";
 
 interface PaymentBannerProps {
   isAdmin: boolean;
-  tokenStatusStatus: string | undefined;
+  tokenStatus: TokenStatus;
 }
 
-export const PaymentBanner = ({
-  isAdmin,
-  tokenStatusStatus,
-}: PaymentBannerProps) => {
-  if (isAdmin && tokenStatusStatus === "past-due") {
+export const PaymentBanner = ({ isAdmin, tokenStatus }: PaymentBannerProps) => {
+  if (isAdmin && tokenStatus.status === "past-due") {
     return (
       <Banner>
         {jt`⚠️ We couldn't process payment for your account. Please ${(
@@ -26,7 +26,7 @@ export const PaymentBanner = ({
         )} to avoid service interruptions.`}
       </Banner>
     );
-  } else if (isAdmin && tokenStatusStatus === "unpaid") {
+  } else if (isAdmin && tokenStatus.status === "unpaid") {
     return (
       <Banner>
         {jt`⚠️ Pro features won’t work right now due to lack of payment. ${(
@@ -40,6 +40,12 @@ export const PaymentBanner = ({
         )} to restore Pro functionality.`}
       </Banner>
     );
+  } else if (isAdmin && tokenStatus.status === "invalid") {
+    return (
+      <Banner>
+        {jt`⚠️ Pro features error. ` + (tokenStatus["error-details"] || "")}
+      </Banner>
+    );
   }
 
   return null;
@@ -47,8 +53,12 @@ export const PaymentBanner = ({
 
 export function shouldRenderPaymentBanner({
   isAdmin,
-  tokenStatusStatus,
+  tokenStatus,
 }: PaymentBannerProps) {
-  const shouldRenderStatuses: (string | undefined)[] = ["past-due", "unpaid"];
-  return isAdmin && shouldRenderStatuses.includes(tokenStatusStatus);
+  const shouldRenderStatuses: (string | undefined)[] = [
+    "past-due",
+    "unpaid",
+    "invalid",
+  ];
+  return isAdmin && shouldRenderStatuses.includes(tokenStatus?.status);
 }

--- a/frontend/src/metabase/nav/components/PaymentBanner/PaymentBanner.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/PaymentBanner/PaymentBanner.unit.spec.tsx
@@ -1,19 +1,17 @@
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectBannerToBeHidden"] }] */
 import { render, screen } from "__support__/ui";
 
-import type { TokenStatusStatus } from "metabase-types/api";
+import type { TokenStatus } from "metabase-types/api";
 
 import { PaymentBanner, shouldRenderPaymentBanner } from "./PaymentBanner";
 
 interface SetupOpts {
   isAdmin: boolean;
-  tokenStatusStatus: TokenStatusStatus;
+  tokenStatus: TokenStatus;
 }
 
-function setup({ isAdmin, tokenStatusStatus }: SetupOpts) {
-  render(
-    <PaymentBanner isAdmin={isAdmin} tokenStatusStatus={tokenStatusStatus} />,
-  );
+function setup({ isAdmin, tokenStatus }: SetupOpts) {
+  render(<PaymentBanner isAdmin={isAdmin} tokenStatus={tokenStatus} />);
 }
 
 const PAST_DUE_BANNER_REGEX =
@@ -27,7 +25,7 @@ describe("PaymentBanner", () => {
     it("should render past-due banner when token status status is `past-due`", () => {
       setup({
         isAdmin: true,
-        tokenStatusStatus: "past-due",
+        tokenStatus: { status: "past-due", valid: false, trial: false },
       });
 
       expect(screen.getByText(PAST_DUE_BANNER_REGEX)).toBeInTheDocument();
@@ -36,16 +34,30 @@ describe("PaymentBanner", () => {
     it("should render unpaid banner when token status status is `unpaid`", () => {
       setup({
         isAdmin: true,
-        tokenStatusStatus: "unpaid",
+        tokenStatus: { status: "unpaid", valid: false, trial: false },
       });
 
       expect(screen.getByText(UNPAID_BANNER_REGEX)).toBeInTheDocument();
     });
 
+    it("should render an error with details when the token is `invalid`", () => {
+      setup({
+        isAdmin: true,
+        tokenStatus: {
+          status: "invalid",
+          valid: false,
+          trial: false,
+          "error-details": "This is critical damage.",
+        },
+      });
+
+      expect(screen.getByText(/This is critical damage\./)).toBeInTheDocument();
+    });
+
     it("should not render any banner when token status status is not `past-due` or `unpaid`", () => {
       setup({
         isAdmin: true,
-        tokenStatusStatus: "something-else",
+        tokenStatus: { status: "something-else", valid: false, trial: false },
       });
 
       expectBannerToBeHidden();
@@ -55,18 +67,18 @@ describe("PaymentBanner", () => {
   describe("non-admin users", () => {
     it.each([
       {
-        tokenStatusStatus: "past-due",
+        tokenStatus: { status: "past-due", valid: false, trial: false },
       },
       {
-        tokenStatusStatus: "unpaid",
+        tokenStatus: { status: "unpaid", valid: false, trial: false },
       },
       {
-        tokenStatusStatus: "something-else",
+        tokenStatus: { status: "something-else", valid: false, trial: false },
       },
     ])(
-      "should not render any banner when tokenStatusStatus is `$tokenStatusStatus`",
-      ({ tokenStatusStatus }) => {
-        setup({ isAdmin: false, tokenStatusStatus });
+      "should not render any banner when tokenStatus.status is `${tokenStatus.status}`",
+      ({ tokenStatus }) => {
+        setup({ isAdmin: false, tokenStatus });
 
         expectBannerToBeHidden();
       },
@@ -77,40 +89,50 @@ describe("PaymentBanner", () => {
     it.each([
       {
         isAdmin: true,
-        tokenStatusStatus: "past-due",
+        tokenStatus: { status: "past-due", valid: false, trial: false },
         hasBanner: true,
       },
       {
         isAdmin: true,
-        tokenStatusStatus: "unpaid",
+        tokenStatus: { status: "unpaid", valid: false, trial: false },
         hasBanner: true,
       },
       {
         isAdmin: true,
-        tokenStatusStatus: "something-else",
+        tokenStatus: { status: "invalid", valid: false, trial: false },
+        hasBanner: true,
+      },
+      {
+        isAdmin: true,
+        tokenStatus: { status: "something-else", valid: false, trial: false },
         hasBanner: false,
       },
       {
         isAdmin: false,
-        tokenStatusStatus: "past-due",
+        tokenStatus: { status: "past-due", valid: false, trial: false },
         hasBanner: false,
       },
       {
         isAdmin: false,
-        tokenStatusStatus: "unpaid",
+        tokenStatus: { status: "unpaid", valid: false, trial: false },
         hasBanner: false,
       },
       {
         isAdmin: false,
-        tokenStatusStatus: "something-else",
+        tokenStatus: { status: "invalid", valid: false, trial: false },
+        hasBanner: false,
+      },
+      {
+        isAdmin: false,
+        tokenStatus: { status: "something-else", valid: false, trial: false },
         hasBanner: false,
       },
     ])(
-      "should return `${shouldRenderPaymentBanner} when isAdmin: $isAdmin, and tokenStatusStatus: $tokenStatusStatus`",
-      ({ isAdmin, tokenStatusStatus, hasBanner }) => {
-        expect(
-          shouldRenderPaymentBanner({ isAdmin, tokenStatusStatus }),
-        ).toEqual(hasBanner);
+      "should return `${shouldRenderPaymentBanner} when isAdmin: $isAdmin, and tokenStatus.status: ${tokenStatus.status}`",
+      ({ isAdmin, tokenStatus, hasBanner }) => {
+        expect(shouldRenderPaymentBanner({ isAdmin, tokenStatus })).toEqual(
+          hasBanner,
+        );
       },
     );
   });

--- a/src/metabase/api/premium_features.clj
+++ b/src/metabase/api/premium_features.clj
@@ -6,7 +6,7 @@
 
 (api/defendpoint GET "/token/status"
   "Fetch info about the current Premium-Features premium features token including whether it is `valid`, a `trial` token, its
-  `features`, when it is `valid_thru`, and the `status` of the account."
+  `features`, when it is `valid-thru`, and the `status` of the account."
   []
   (premium-features/fetch-token-status (api/check-404 (premium-features/premium-embedding-token))))
 

--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -13,7 +13,8 @@
    [metabase.util.i18n :refer [deferred-tru trs tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.schema :as ms]))
+   [metabase.util.malli.schema :as ms]
+   [metabase.util.string :as u.str]))
 
 (set! *warn-on-reflection* true)
 
@@ -31,10 +32,8 @@
         "This should be used for all new Slack integrations starting in Metabase v0.42.0."))
   :visibility :settings-manager
   :getter (fn []
-            (let [token (setting/get-value-of-type :string :slack-app-token)]
-              (when (string? token)
-                ;; Truncate middle of token so that the full value isn't visibile in the UI
-                (str (subs token 0 9) "..." (subs token (- (count token) 4)))))))
+            (-> (setting/get-value-of-type :string :slack-app-token)
+                (u.str/mask 9))))
 
 (defn- unobfuscated-slack-app-token
   []

--- a/src/metabase/util/string.clj
+++ b/src/metabase/util/string.clj
@@ -4,7 +4,6 @@
    [clojure.string :as str]
    [metabase.util.i18n :refer [deferred-tru]]))
 
-
 (defn build-sentence
   "Join parts of a sentence together to build a compound one.
 
@@ -31,18 +30,21 @@
        (= (count parts) 2) (str (first parts) " " (deferred-tru "and")  " " (second parts) (when stop? \.))
        :else               (str (first parts) ", " (build-sentence (rest parts) options))))))
 
-
 (defn mask
   "Mask string value behind 'start...end' representation.
 
   First four and last four symbols are shown. Even less if string is shorter
   than 8 chars."
-  [s]
-  (if (str/blank? s)
-    s
-    (let [cnt (count s)]
-      (str
-       (subs s 0 (max 1 (min 4 (- cnt 2))))
-       "..."
-       (when (< 8 cnt)
-         (subs s (- cnt 4) cnt))))))
+  ([s]
+   (mask s 4))
+  ([s start-limit]
+   (mask s start-limit 4))
+  ([s start-limit end-limit]
+   (if (str/blank? s)
+     s
+     (let [cnt (count s)]
+       (str
+        (subs s 0 (max 1 (min start-limit (- cnt 2))))
+        "..."
+        (when (< (+ end-limit start-limit) cnt)
+          (subs s (- cnt end-limit) cnt)))))))

--- a/src/metabase/util/string.clj
+++ b/src/metabase/util/string.clj
@@ -1,6 +1,7 @@
 (ns metabase.util.string
   "Util for building strings"
   (:require
+   [clojure.string :as str]
    [metabase.util.i18n :refer [deferred-tru]]))
 
 
@@ -29,3 +30,19 @@
        (= (count parts) 1) (str (first parts) (when stop? \.))
        (= (count parts) 2) (str (first parts) " " (deferred-tru "and")  " " (second parts) (when stop? \.))
        :else               (str (first parts) ", " (build-sentence (rest parts) options))))))
+
+
+(defn mask
+  "Mask string value behind 'start...end' representation.
+
+  First four and last four symbols are shown. Even less if string is shorter
+  than 8 chars."
+  [s]
+  (if (str/blank? s)
+    s
+    (let [cnt (count s)]
+      (str
+       (subs s 0 (max 1 (min 4 (- cnt 2))))
+       "..."
+       (when (< 8 cnt)
+         (subs s (- cnt 4) cnt))))))

--- a/test/metabase/api/premium_features_test.clj
+++ b/test/metabase/api/premium_features_test.clj
@@ -23,4 +23,13 @@
 
         (testing "requires superusers"
           (is (= "You don't have permissions to do that."
-                 (mt/user-http-request :rasta :get 403 "premium-features/token/status"))))))))
+                 (mt/user-http-request :rasta :get 403 "premium-features/token/status")))))))
+
+  (testing "Invalid token format"
+    ;; with-temporary-setting-values triggers error in premium-embedding-token :setter
+    (with-redefs [premium-features/premium-embedding-token (constantly "qwertyuiop")]
+      (testing "returns an error"
+        (is (= {:valid         false
+                :status        "invalid"
+                :error-details "Token should be 64 hexadecimal characters."}
+               (mt/user-http-request :crowberto :get 200 "premium-features/token/status")))))))

--- a/test/metabase/util/string_test.clj
+++ b/test/metabase/util/string_test.clj
@@ -1,0 +1,22 @@
+(ns metabase.util.string-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.util.string :as u.str]))
+
+
+(deftest mask-test
+  (testing "mask works correctly in general case"
+    (is (= "qwer...uiop"
+           (u.str/mask "qwertyuiop"))))
+
+  (testing "mask works correctly with short strings"
+    (is (= "qw..."
+           (u.str/mask "qwer")))
+    (is (= "q..."
+           (u.str/mask "q"))))
+
+  (testing "mask does not throw errors for empty values"
+    (is (= ""
+           (u.str/mask "")))
+    (is (= nil
+           (u.str/mask nil)))))

--- a/test/metabase/util/string_test.clj
+++ b/test/metabase/util/string_test.clj
@@ -3,20 +3,28 @@
    [clojure.test :refer :all]
    [metabase.util.string :as u.str]))
 
-
 (deftest mask-test
-  (testing "mask works correctly in general case"
-    (is (= "qwer...uiop"
-           (u.str/mask "qwertyuiop"))))
+  (testing "mask"
+    (testing "works correctly in general case"
+      (is (= "qwer...uiop"
+             (u.str/mask "qwertyuiop"))))
 
-  (testing "mask works correctly with short strings"
-    (is (= "qw..."
-           (u.str/mask "qwer")))
-    (is (= "q..."
-           (u.str/mask "q"))))
+    (testing "works correctly with short strings"
+      (is (= "qw..."
+             (u.str/mask "qwer")))
+      (is (= "q..."
+             (u.str/mask "q"))))
 
-  (testing "mask does not throw errors for empty values"
-    (is (= ""
-           (u.str/mask "")))
-    (is (= nil
-           (u.str/mask nil)))))
+    (testing "does not throw errors for empty values"
+      (is (= ""
+             (u.str/mask "")))
+      (is (= nil
+             (u.str/mask nil))))
+
+    (testing "works with custom start-limit"
+      (is (= "abcd-efgh...-end"
+             (u.str/mask "abcd-efgh-ijkl-end" 9))))
+
+    (testing "works with custom end-limit"
+      (is (= "ab...ra"
+            (u.str/mask "abracadabra" 2 2))))))


### PR DESCRIPTION
Makes `/api/properties` and `/api/premium-features/token/status` return valid structures with information about invalid token, plus logs the error about token being invalid in logs. Also this information is used to show a `PaymentBanner` on top of the screen so that admins can understand what is going on.

<img width="470" alt="image" src="https://github.com/metabase/metabase/assets/6553/bbc27334-cedf-4af4-8b3a-5045bf038c3d">

Plus `PremiumEmbeddingLicensePage` got a bit of an update — it relied on `value`, which is not returned from the backend (anymore?), so now it looks for `status`.

Resolves #33858.