### PR TITLE
Rename dashboard's ordered_cards to dashcards

### DIFF
--- a/e2e/support/commands/api/composite/createQuestionAndAddToDashboard.js
+++ b/e2e/support/commands/api/composite/createQuestionAndAddToDashboard.js
@@ -7,11 +7,11 @@ Cypress.Commands.add(
     ).then(({ body: { id: card_id } }) =>
       cy
         .request(`/api/dashboard/${dashboardId}`)
-        .then(({ body: { ordered_cards } }) =>
+        .then(({ body: { dashcards } }) =>
           cy
             .request("PUT", `/api/dashboard/${dashboardId}/cards`, {
               cards: [
-                ...ordered_cards,
+                ...dashcards,
                 {
                   id: -1,
                   card_id,

--- a/e2e/support/cypress_sample_instance_data.js
+++ b/e2e/support/cypress_sample_instance_data.js
@@ -63,7 +63,7 @@ export const ORDERS_DASHBOARD_ID = _.findWhere(
 export const ORDERS_DASHBOARD_DASHCARD_ID = _.findWhere(
   SAMPLE_INSTANCE_DATA.dashboards,
   { name: "Orders in a dashboard" },
-).ordered_cards[0].id;
+).dashcards[0].id;
 
 export const ADMIN_USER_ID = _.findWhere(SAMPLE_INSTANCE_DATA.users, {
   email: "admin@metabase.test",

--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -163,14 +163,14 @@ export function visitDashboard(dashboard_id, { params = {} } = {}) {
     url: `/api/dashboard/${dashboard_id}`,
     // That's why we have to ignore failures
     failOnStatusCode: false,
-  }).then(({ status, body: { ordered_cards } }) => {
+  }).then(({ status, body: { dashcards } }) => {
     const dashboardAlias = "getDashboard" + dashboard_id;
 
     cy.intercept("GET", `/api/dashboard/${dashboard_id}`).as(dashboardAlias);
 
     const canViewDashboard = hasAccess(status);
 
-    let validQuestions = dashboardHasQuestions(ordered_cards);
+    let validQuestions = dashboardHasQuestions(dashcards);
     if (params.tab != null) {
       validQuestions = validQuestions.filter(
         card => card.dashboard_tab_id === params.tab,

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
@@ -222,7 +222,7 @@ describe("scenarios > dashboard card resizing", () => {
       saveDashboard();
 
       cy.request("GET", `/api/dashboard/${dashId}`).then(({ body }) => {
-        body.ordered_cards.forEach(({ card, size_x, size_y }) => {
+        body.dashcards.forEach(({ card, size_x, size_y }) => {
           const { height, width } = getDefaultSize(card.display);
           expect(size_x).to.equal(width);
           expect(size_y).to.equal(height);
@@ -253,7 +253,7 @@ describe("scenarios > dashboard card resizing", () => {
       editDashboard();
 
       cy.request("GET", `/api/dashboard/${dashId}`).then(({ body }) => {
-        const orderedCards = body.ordered_cards;
+        const orderedCards = body.dashcards;
         orderedCards.forEach(({ card }) => {
           const dashCard = cy.contains(".DashCard", card.name);
           resizeDashboardCard({
@@ -280,7 +280,7 @@ describe("scenarios > dashboard card resizing", () => {
         saveDashboard();
 
         cy.request("GET", `/api/dashboard/${dashId}`).then(({ body }) => {
-          body.ordered_cards.forEach(({ card, size_x, size_y }) => {
+          body.dashcards.forEach(({ card, size_x, size_y }) => {
             const { height, width } = getMinSize(card.display);
             expect(size_x).to.equal(width);
             expect(size_y).to.equal(height);

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
@@ -253,11 +253,11 @@ describe("scenarios > dashboard card resizing", () => {
       editDashboard();
 
       cy.request("GET", `/api/dashboard/${dashId}`).then(({ body }) => {
-        const orderedCards = body.dashcards;
-        orderedCards.forEach(({ card }) => {
-          const dashCard = cy.contains(".DashCard", card.name);
+        const dashcards = body.dashcards;
+        dashcards.forEach(({ card }) => {
+          const dashcard = cy.contains(".DashCard", card.name);
           resizeDashboardCard({
-            card: dashCard,
+            card: dashcard,
             x: getDefaultSize(card.display).width * 100,
             y: getDefaultSize(card.display).height * 100,
           });
@@ -266,11 +266,11 @@ describe("scenarios > dashboard card resizing", () => {
         saveDashboard();
         editDashboard();
 
-        orderedCards.forEach(({ card }) => {
-          const dashCard = cy.contains(".DashCard", card.name);
-          dashCard.within(() => {
+        dashcards.forEach(({ card }) => {
+          const dashcard = cy.contains(".DashCard", card.name);
+          dashcard.within(() => {
             resizeDashboardCard({
-              card: dashCard,
+              card: dashcard,
               x: -getDefaultSize(card.display).width * 200,
               y: -getDefaultSize(card.display).height * 200,
             });

--- a/e2e/test/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -445,7 +445,7 @@ const visitXrayDashboardUrl = urlOptions => {
 const addLinkClickBehavior = ({ dashboardId, linkTemplate }) => {
   cy.request("GET", `/api/dashboard/${dashboardId}`).then(({ body }) => {
     cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
-      cards: body.ordered_cards.map(card => ({
+      cards: body.dashcards.map(card => ({
         ...card,
         visualization_settings: {
           click_behavior: {

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -528,7 +528,7 @@
                                        :link         {:entity {:id    id
                                                                :model model}}})
               dashboard->link-cards (fn [dashboard]
-                                      (map #(get-in % [:visualization_settings :link :entity]) (:ordered_cards dashboard)))]
+                                      (map #(get-in % [:visualization_settings :link :entity]) (:dashcards dashboard)))]
           (t2.with-temp/with-temp
             [Collection    {coll-id   :id
                             coll-name :name
@@ -628,7 +628,7 @@
                             {:id new-card-id  :model "card"}
                             {:id new-model-id :model "dataset"}]
                            (-> (t2/select-one Dashboard :name dashboard-name)
-                               (t2/hydrate :ordered_cards)
+                               (t2/hydrate :dashcards)
                                dashboard->link-cards)))))))))))))
 
 (deftest dashboard-with-tabs-test
@@ -670,7 +670,7 @@
                  (is (serdes/with-cache (serdes.load/load-metabase (ingest/ingest-yaml dump-dir)))
                      "successful"))
                (let [new-dashboard (-> (t2/select-one Dashboard :entity_id dashboard-eid)
-                                       (t2/hydrate :ordered_tabs :ordered_cards))
+                                       (t2/hydrate :ordered_tabs :dashcards))
                      new-tab-id-1  (t2/select-one-pk :model/DashboardTab :entity_id tab-eid-1)
                      new-tab-id-2  (t2/select-one-pk :model/DashboardTab :entity_id tab-eid-2)
                      new-card-id-1 (t2/select-one-pk Card :entity_id card-eid-1)
@@ -697,7 +697,7 @@
                           {:card_id          new-card-id-2
                            :dashboard_id     (:id new-dashboard)
                            :dashboard_tab_id new-tab-id-2}]
-                         (:ordered_cards new-dashboard))))))))))))
+                         (:dashcards new-dashboard))))))))))))
 
 (deftest premium-features-test
   (testing "with :serialization enabled on the token"

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -404,7 +404,7 @@
         (let [ser (serdes/extract-one "Dashboard" {} (t2/select-one 'Dashboard :id other-dash-id))]
           (is (=? {:serdes/meta            [{:model "Dashboard" :id other-dash :label "dave_s_dash"}]
                    :entity_id              other-dash
-                   :ordered_cards
+                   :dashcards
                    [{:visualization_settings {:table.pivot_column "SOURCE"
                                               :table.cell_column "sum"
                                               :table.columns

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -506,7 +506,7 @@
                                                      :target       (s/eq [:dimension [:field ["my-db" nil "orders" "subtotal"]
                                                                                       {:source-field ["my-db" nil "orders" "invoice"]}]])}]
                                s/Keyword s/Any}]
-                       (:ordered_cards dash))))
+                       (:dashcards dash))))
 
               (testing "exported :visualization_settings are properly converted"
                 (let [expected {:table.pivot_column "SOURCE"
@@ -529,7 +529,7 @@
                   (is (= expected
                          (:visualization_settings card)))
                   (is (= expected
-                         (-> dash :ordered_cards first :visualization_settings))))))))
+                         (-> dash :dashcards first :visualization_settings))))))))
 
 
         (testing "deserializing adjusts the IDs properly"

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditDashboard.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditDashboard.jsx
@@ -16,7 +16,7 @@ const AuditDashboard = ({ cards, ...props }) => (
     style={{ backgroundColor: "transparent", padding: 0 }}
     // HACK: to get inline dashboards working quickly
     dashboardId={{
-      ordered_cards: cards.map(([{ x, y, w, h }, dc]) => ({
+      dashcards: cards.map(([{ x, y, w, h }, dc]) => ({
         col: x,
         row: y,
         size_x: w,

--- a/frontend/src/metabase-types/api/actions.ts
+++ b/frontend/src/metabase-types/api/actions.ts
@@ -1,10 +1,7 @@
 import type { Parameter, ParameterId, ParameterTarget } from "./parameters";
 import type { NativeDatasetQuery } from "./query";
 import type { ClickBehavior } from "./click-behavior";
-import type {
-  BaseDashboardOrderedCard,
-  DashboardParameterMapping,
-} from "./dashboard";
+import type { BaseDashboardCard, DashboardParameterMapping } from "./dashboard";
 import type { Card, CardId } from "./card";
 import type { DatabaseId } from "./database";
 import type { UserId, UserInfo } from "./user";
@@ -172,7 +169,7 @@ export type ActionParametersMapping = Pick<
 >;
 
 export interface ActionDashboardCard
-  extends Omit<BaseDashboardOrderedCard, "parameter_mappings"> {
+  extends Omit<BaseDashboardCard, "parameter_mappings"> {
   action?: WritebackAction;
   card_id?: CardId | null; // model card id for the associated action
   card?: Card;

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -18,7 +18,7 @@ export interface Dashboard {
   name: string;
   description: string | null;
   model?: string;
-  ordered_cards: (DashboardOrderedCard | ActionDashboardCard)[];
+  dashcards: (DashboardOrderedCard | ActionDashboardCard)[];
   ordered_tabs?: DashboardOrderedTab[];
   parameters?: Parameter[] | null;
   can_write: boolean;

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -18,7 +18,7 @@ export interface Dashboard {
   name: string;
   description: string | null;
   model?: string;
-  dashcards: (DashboardOrderedCard | ActionDashboardCard)[];
+  dashcards: (DashboardCard | ActionDashboardCard)[];
   ordered_tabs?: DashboardOrderedTab[];
   parameters?: Parameter[] | null;
   can_write: boolean;
@@ -36,7 +36,7 @@ export interface Dashboard {
 
 export type DashCardId = number;
 
-export type BaseDashboardOrderedCard = {
+export type BaseDashboardCard = {
   id: DashCardId;
   dashboard_id: DashboardId;
   dashboard_tab_id?: DashboardTabId;
@@ -61,7 +61,7 @@ export type VirtualCard = Partial<Card> & {
   display: VirtualCardDisplay;
 };
 
-export type DashboardOrderedCard = BaseDashboardOrderedCard & {
+export type DashboardCard = BaseDashboardCard & {
   card_id: CardId | null;
   card: Card;
   parameter_mappings?: DashboardParameterMapping[] | null;

--- a/frontend/src/metabase-types/api/mocks/dashboard.ts
+++ b/frontend/src/metabase-types/api/mocks/dashboard.ts
@@ -1,7 +1,7 @@
 import type {
   Card,
   Dashboard,
-  DashboardOrderedCard,
+  DashboardCard,
   VirtualCard,
   ActionDashboardCard,
 } from "metabase-types/api";
@@ -27,9 +27,9 @@ export const createMockDashboard = (opts?: Partial<Dashboard>): Dashboard => ({
   ...opts,
 });
 
-export const createMockDashboardOrderedCard = (
-  opts?: Partial<DashboardOrderedCard>,
-): DashboardOrderedCard => ({
+export const createMockDashboardCard = (
+  opts?: Partial<DashboardCard>,
+): DashboardCard => ({
   id: 1,
   dashboard_id: 1,
   col: 0,
@@ -50,7 +50,7 @@ export const createMockDashboardOrderedCard = (
 export const createMockActionDashboardCard = (
   opts?: Partial<ActionDashboardCard>,
 ): ActionDashboardCard => ({
-  ...createMockDashboardOrderedCard(),
+  ...createMockDashboardCard(),
   action: undefined,
   card: createMockCard({ display: "action" }),
   visualization_settings: {
@@ -63,8 +63,8 @@ export const createMockActionDashboardCard = (
 });
 
 export const createMockTextDashboardCard = (
-  opts?: Partial<DashboardOrderedCard> & { text?: string },
-): DashboardOrderedCard => ({
+  opts?: Partial<DashboardCard> & { text?: string },
+): DashboardCard => ({
   ...createMockDashboardCardWithVirtualCard({
     visualization_settings: {
       text: opts?.text ?? "Body Text",
@@ -81,8 +81,8 @@ export const createMockTextDashboardCard = (
 });
 
 export const createMockHeadingDashboardCard = (
-  opts?: Partial<DashboardOrderedCard> & { text?: string },
-): DashboardOrderedCard => ({
+  opts?: Partial<DashboardCard> & { text?: string },
+): DashboardCard => ({
   ...createMockDashboardCardWithVirtualCard({
     visualization_settings: {
       text: opts?.text ?? "Heading Text",
@@ -99,8 +99,8 @@ export const createMockHeadingDashboardCard = (
 });
 
 export const createMockLinkDashboardCard = (
-  opts?: Partial<DashboardOrderedCard> & { url?: string },
-): DashboardOrderedCard => ({
+  opts?: Partial<DashboardCard> & { url?: string },
+): DashboardCard => ({
   ...createMockDashboardCardWithVirtualCard({
     id: 1,
     visualization_settings: {
@@ -120,9 +120,9 @@ export const createMockLinkDashboardCard = (
 });
 
 export const createMockDashboardCardWithVirtualCard = (
-  opts?: Partial<DashboardOrderedCard>,
-): DashboardOrderedCard => ({
-  ...createMockDashboardOrderedCard(),
+  opts?: Partial<DashboardCard>,
+): DashboardCard => ({
+  ...createMockDashboardCard(),
   card: {
     query_average_duration: null,
     display: opts?.visualization_settings?.virtual_card?.display ?? "text",

--- a/frontend/src/metabase-types/api/mocks/dashboard.ts
+++ b/frontend/src/metabase-types/api/mocks/dashboard.ts
@@ -11,7 +11,7 @@ export const createMockDashboard = (opts?: Partial<Dashboard>): Dashboard => ({
   id: 1,
   collection_id: null,
   name: "Dashboard",
-  ordered_cards: [],
+  dashcards: [],
   can_write: true,
   description: "",
   cache_ttl: null,

--- a/frontend/src/metabase-types/store/dashboard.ts
+++ b/frontend/src/metabase-types/store/dashboard.ts
@@ -1,7 +1,7 @@
 import type {
   Dashboard,
   DashboardId,
-  DashboardOrderedCard,
+  DashboardCard,
   DashCardId,
   DashCardDataMap,
   ParameterId,
@@ -27,7 +27,7 @@ export type StoreDashboard = Omit<Dashboard, "dashcards" | "ordered_tabs"> & {
   ordered_tabs?: StoreDashboardTab[];
 };
 
-export type StoreDashcard = DashboardOrderedCard & {
+export type StoreDashcard = DashboardCard & {
   isDirty?: boolean;
   isRemoved?: boolean;
 };

--- a/frontend/src/metabase-types/store/dashboard.ts
+++ b/frontend/src/metabase-types/store/dashboard.ts
@@ -22,11 +22,8 @@ export type StoreDashboardTab = DashboardOrderedTab & {
   isRemoved?: boolean;
 };
 
-export type StoreDashboard = Omit<
-  Dashboard,
-  "ordered_cards" | "ordered_tabs"
-> & {
-  ordered_cards: DashCardId[];
+export type StoreDashboard = Omit<Dashboard, "dashcards" | "ordered_tabs"> & {
+  dashcards: DashCardId[];
   ordered_tabs?: StoreDashboardTab[];
 };
 

--- a/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.unit.spec.tsx
@@ -16,7 +16,7 @@ import {
 import {
   createMockDashboard,
   createMockActionDashboardCard,
-  createMockDashboardOrderedCard,
+  createMockDashboardCard,
   createMockQueryAction,
   createMockCard,
   createMockParameter,
@@ -67,7 +67,7 @@ const actions2 = [
 
 const implicitActions = createMockImplicitCUDActions(models[1].id, 123);
 
-const dashcard = createMockDashboardOrderedCard();
+const dashcard = createMockDashboardCard();
 const actionDashcard = createMockActionDashboardCard({ id: 2 });
 const actionDashcardWithAction = createMockActionDashboardCard({
   id: 3,

--- a/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.unit.spec.tsx
@@ -75,7 +75,7 @@ const actionDashcardWithAction = createMockActionDashboardCard({
 });
 
 const dashboard = createMockDashboard({
-  ordered_cards: [dashcard, actionDashcard, actionDashcardWithAction],
+  dashcards: [dashcard, actionDashcard, actionDashcardWithAction],
   parameters: [dashboardParameter],
 });
 

--- a/frontend/src/metabase/actions/utils.ts
+++ b/frontend/src/metabase/actions/utils.ts
@@ -7,7 +7,7 @@ import type {
   ActionDashboardCard,
   ActionFormOption,
   ActionFormSettings,
-  BaseDashboardOrderedCard,
+  BaseDashboardCard,
   Card,
   FieldType,
   FieldSettings,
@@ -152,7 +152,7 @@ export function isSavedAction(
 }
 
 export function isActionDashCard(
-  dashCard: BaseDashboardOrderedCard,
+  dashCard: BaseDashboardCard,
 ): dashCard is ActionDashboardCard {
   const virtualCard = dashCard?.visualization_settings?.virtual_card;
   return isActionCard(virtualCard as Card);

--- a/frontend/src/metabase/dashboard/actions/actions.unit.spec.js
+++ b/frontend/src/metabase/dashboard/actions/actions.unit.spec.js
@@ -159,7 +159,7 @@ describe("dashboard actions", () => {
         id: 1,
         name: "Foo",
         parameters: [],
-        ordered_cards: [
+        dashcards: [
           { id: 1, name: "Foo", card_id: 1 },
           { id: 2, name: "Bar", card_id: 2 },
         ],
@@ -172,12 +172,12 @@ describe("dashboard actions", () => {
           dashboards: {
             1: {
               ...dashboard,
-              ordered_cards: [1, 2],
+              dashcards: [1, 2],
             },
           },
           dashcards: {
-            1: dashboard.ordered_cards[0],
-            2: dashboard.ordered_cards[1],
+            1: dashboard.dashcards[0],
+            2: dashboard.dashcards[1],
           },
         },
       });

--- a/frontend/src/metabase/dashboard/actions/cards.js
+++ b/frontend/src/metabase/dashboard/actions/cards.js
@@ -32,7 +32,7 @@ function generateTemporaryDashcardId() {
 function getExistingDashCards(state, dashId, tabId) {
   const { dashboards, dashcards } = state.dashboard;
   const dashboard = dashboards[dashId];
-  return dashboard.ordered_cards
+  return dashboard.dashcards
     .map(id => dashcards[id])
     .filter(dc => {
       if (dc.isRemoved) {

--- a/frontend/src/metabase/dashboard/actions/data-fetching.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.js
@@ -52,7 +52,7 @@ import { loadMetadataForDashboard } from "./metadata";
 // normalizr schemas
 const dashcard = new schema.Entity("dashcard");
 const dashboard = new schema.Entity("dashboard", {
-  ordered_cards: [dashcard],
+  dashcards: [dashcard],
 });
 
 export const FETCH_DASHBOARD = "metabase/dashboard/FETCH_DASHBOARD";
@@ -155,7 +155,7 @@ export const fetchDashboard = createThunkAction(
         entities = {
           dashboard: { [dashId]: loadedDashboard },
           dashcard: Object.fromEntries(
-            loadedDashboard.ordered_cards.map(id => [
+            loadedDashboard.dashcards.map(id => [
               id,
               getDashCardById(getState(), id),
             ]),
@@ -167,7 +167,7 @@ export const fetchDashboard = createThunkAction(
         result = {
           ...result,
           id: dashId,
-          ordered_cards: result.ordered_cards.map(dc => ({
+          dashcards: result.dashcards.map(dc => ({
             ...dc,
             dashboard_id: dashId,
           })),
@@ -177,7 +177,7 @@ export const fetchDashboard = createThunkAction(
         result = {
           ...result,
           id: dashId,
-          ordered_cards: result.ordered_cards.map(dc => ({
+          dashcards: result.dashcards.map(dc => ({
             ...dc,
             dashboard_id: dashId,
           })),
@@ -188,7 +188,7 @@ export const fetchDashboard = createThunkAction(
         result = {
           ...result,
           id: dashId,
-          ordered_cards: result.ordered_cards.map(dc => ({
+          dashcards: result.dashcards.map(dc => ({
             ...dc,
             dashboard_id: dashId,
           })),
@@ -208,8 +208,8 @@ export const fetchDashboard = createThunkAction(
 
         const cards =
           selectedTabId === undefined
-            ? result.ordered_cards
-            : result.ordered_cards.filter(
+            ? result.dashcards
+            : result.dashcards.filter(
                 c => c.dashboard_tab_id === selectedTabId,
               );
 
@@ -219,7 +219,7 @@ export const fetchDashboard = createThunkAction(
       const isUsingCachedResults = entities != null;
       if (!isUsingCachedResults) {
         // copy over any virtual cards from the dashcard to the underlying card/question
-        result.ordered_cards.forEach(card => {
+        result.dashcards.forEach(card => {
           if (card.visualization_settings.virtual_card) {
             card.card = Object.assign(
               card.card || {},
@@ -494,7 +494,7 @@ export const fetchDashboardCardData =
 export const fetchDashboardCardMetadata = createThunkAction(
   FETCH_DASHBOARD_CARD_METADATA,
   () => async (dispatch, getState) => {
-    const allDashCards = getDashboardComplete(getState()).ordered_cards;
+    const allDashCards = getDashboardComplete(getState()).dashcards;
     const selectedTabId = getSelectedTabId(getState());
 
     const cards = allDashCards.filter(

--- a/frontend/src/metabase/dashboard/actions/save.js
+++ b/frontend/src/metabase/dashboard/actions/save.js
@@ -27,7 +27,7 @@ export const updateDashboardAndCards = createThunkAction(
       const { dashboards, dashcards, dashboardId } = state.dashboard;
       const dashboard = {
         ...dashboards[dashboardId],
-        ordered_cards: dashboards[dashboardId].ordered_cards.map(
+        dashcards: dashboards[dashboardId].dashcards.map(
           dashcardId => dashcards[dashcardId],
         ),
       };
@@ -41,8 +41,8 @@ export const updateDashboardAndCards = createThunkAction(
         );
 
         const cardsHaveChanged = haveDashboardCardsChanged(
-          dashboard.ordered_cards,
-          dashboardBeforeEditing.ordered_cards,
+          dashboard.dashcards,
+          dashboardBeforeEditing.dashcards,
         );
 
         if (!cardsHaveChanged && !dashboardHasChanged) {
@@ -55,10 +55,10 @@ export const updateDashboardAndCards = createThunkAction(
       // Invalid (partially complete) states are fine during editing,
       // but we should restore the previous value if saved while invalid.
       const clickBehaviorPath = ["visualization_settings", "click_behavior"];
-      dashboard.ordered_cards = dashboard.ordered_cards.map((card, index) => {
+      dashboard.dashcards = dashboard.dashcards.map((card, index) => {
         if (!clickBehaviorIsValid(getIn(card, clickBehaviorPath))) {
           const startingValue = getIn(dashboardBeforeEditing, [
-            "ordered_cards",
+            "dashcards",
             index,
             ...clickBehaviorPath,
           ]);
@@ -70,7 +70,7 @@ export const updateDashboardAndCards = createThunkAction(
       });
 
       // update parameter mappings
-      dashboard.ordered_cards = dashboard.ordered_cards.map(dc => ({
+      dashboard.dashcards = dashboard.dashcards.map(dc => ({
         ...dc,
         parameter_mappings: dc.parameter_mappings.filter(
           mapping =>
@@ -88,15 +88,13 @@ export const updateDashboardAndCards = createThunkAction(
 
       // update modified cards
       await Promise.all(
-        dashboard.ordered_cards
+        dashboard.dashcards
           .filter(dc => dc.card.isDirty)
           .map(async dc => CardApi.update(dc.card)),
       );
 
       // update the dashboard cards and tabs
-      const dashcardsToUpdate = dashboard.ordered_cards.filter(
-        dc => !dc.isRemoved,
-      );
+      const dashcardsToUpdate = dashboard.dashcards.filter(dc => !dc.isRemoved);
       const updatedCardsAndTabs = await DashboardApi.updateCardsAndTabs({
         dashId: dashboard.id,
         cards: dashcardsToUpdate.map(dc => ({

--- a/frontend/src/metabase/dashboard/actions/tabs.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.ts
@@ -163,7 +163,7 @@ export const tabsReducer = createReducer<DashboardState>(
         state.selectedTabId = secondTabId;
 
         // 3. Assign existing dashcards to first tab
-        prevDash.ordered_cards.forEach(id => {
+        prevDash.dashcards.forEach(id => {
           state.dashcards[id] = {
             ...state.dashcards[id],
             isDirty: true,
@@ -201,7 +201,7 @@ export const tabsReducer = createReducer<DashboardState>(
 
         // 3. Mark dashcards on removed tab as removed
         const removedDashCardIds: DashCardId[] = [];
-        prevDash.ordered_cards.forEach(id => {
+        prevDash.dashcards.forEach(id => {
           if (state.dashcards[id].dashboard_tab_id === tabToRemove.id) {
             state.dashcards[id].isRemoved = true;
             removedDashCardIds.push(id);
@@ -293,7 +293,7 @@ export const tabsReducer = createReducer<DashboardState>(
         }
 
         // 1. Replace temporary with real dashcard ids
-        const prevCards = prevDash.ordered_cards.filter(
+        const prevCards = prevDash.dashcards.filter(
           id => !state.dashcards[id].isRemoved,
         );
         prevCards.forEach((oldId, index) => {

--- a/frontend/src/metabase/dashboard/actions/tabs.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.ts
@@ -6,7 +6,7 @@ import { arrayMove } from "@dnd-kit/sortable";
 import type {
   DashCardId,
   DashboardId,
-  DashboardOrderedCard,
+  DashboardCard,
   DashboardOrderedTab,
   DashboardTabId,
 } from "metabase-types/api";
@@ -30,7 +30,7 @@ type MoveTabPayload = {
 };
 type SelectTabPayload = { tabId: DashboardTabId | null };
 type SaveCardsAndTabsPayload = {
-  cards: DashboardOrderedCard[];
+  cards: DashboardCard[];
   ordered_tabs: DashboardOrderedTab[];
 };
 type InitTabsPayload = { slug: string | undefined };

--- a/frontend/src/metabase/dashboard/actions/utils.ts
+++ b/frontend/src/metabase/dashboard/actions/utils.ts
@@ -1,6 +1,6 @@
 import _ from "underscore";
 
-import type { Dashboard, DashboardOrderedCard } from "metabase-types/api";
+import type { Dashboard, DashboardCard } from "metabase-types/api";
 
 export function hasDashboardChanged(
   dashboard: Dashboard,
@@ -18,8 +18,8 @@ export function hasDashboardChanged(
 // sometimes the cards objects change order but all the cards themselves are the same
 // this should not trigger a save
 export function haveDashboardCardsChanged(
-  newCards: DashboardOrderedCard[],
-  oldCards: DashboardOrderedCard[],
+  newCards: DashboardCard[],
+  oldCards: DashboardCard[],
 ) {
   return (
     !newCards.every(newCard =>

--- a/frontend/src/metabase/dashboard/actions/utils.ts
+++ b/frontend/src/metabase/dashboard/actions/utils.ts
@@ -7,10 +7,10 @@ export function hasDashboardChanged(
   dashboardBeforeEditing: Dashboard,
 ) {
   return !_.isEqual(
-    { ...dashboard, ordered_cards: dashboard.ordered_cards.length },
+    { ...dashboard, dashcards: dashboard.dashcards.length },
     {
       ...dashboardBeforeEditing,
-      ordered_cards: dashboardBeforeEditing.ordered_cards.length,
+      dashcards: dashboardBeforeEditing.dashcards.length,
     },
   );
 }

--- a/frontend/src/metabase/dashboard/actions/utils.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/utils.unit.spec.ts
@@ -55,7 +55,7 @@ describe("dashboard > actions > utils", () => {
       const oldDash = createMockDashboard({
         id: 1,
         name: "old name",
-        ordered_cards: [createMockDashboardOrderedCard()],
+        dashcards: [createMockDashboardOrderedCard()],
       });
       const newDash = createMockDashboard({ id: 1, name: "old name" });
 
@@ -66,12 +66,12 @@ describe("dashboard > actions > utils", () => {
       const oldDash = createMockDashboard({
         id: 1,
         name: "old name",
-        ordered_cards: [createMockDashboardOrderedCard({ id: 1 })],
+        dashcards: [createMockDashboardOrderedCard({ id: 1 })],
       });
       const newDash = createMockDashboard({
         id: 1,
         name: "old name",
-        ordered_cards: [createMockDashboardOrderedCard({ id: 2 })],
+        dashcards: [createMockDashboardOrderedCard({ id: 2 })],
       });
 
       expect(hasDashboardChanged(newDash, oldDash)).toBe(false);

--- a/frontend/src/metabase/dashboard/actions/utils.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/utils.unit.spec.ts
@@ -1,6 +1,6 @@
 import {
   createMockDashboard,
-  createMockDashboardOrderedCard,
+  createMockDashboardCard,
 } from "metabase-types/api/mocks";
 import { hasDashboardChanged, haveDashboardCardsChanged } from "./utils";
 
@@ -55,7 +55,7 @@ describe("dashboard > actions > utils", () => {
       const oldDash = createMockDashboard({
         id: 1,
         name: "old name",
-        dashcards: [createMockDashboardOrderedCard()],
+        dashcards: [createMockDashboardCard()],
       });
       const newDash = createMockDashboard({ id: 1, name: "old name" });
 
@@ -66,12 +66,12 @@ describe("dashboard > actions > utils", () => {
       const oldDash = createMockDashboard({
         id: 1,
         name: "old name",
-        dashcards: [createMockDashboardOrderedCard({ id: 1 })],
+        dashcards: [createMockDashboardCard({ id: 1 })],
       });
       const newDash = createMockDashboard({
         id: 1,
         name: "old name",
-        dashcards: [createMockDashboardOrderedCard({ id: 2 })],
+        dashcards: [createMockDashboardCard({ id: 2 })],
       });
 
       expect(hasDashboardChanged(newDash, oldDash)).toBe(false);
@@ -81,12 +81,12 @@ describe("dashboard > actions > utils", () => {
   describe("haveDashboardCardsChanged", () => {
     it("should return true if a card changed", () => {
       const oldCards = [
-        createMockDashboardOrderedCard({ id: 1 }),
-        createMockDashboardOrderedCard({ id: 2 }),
+        createMockDashboardCard({ id: 1 }),
+        createMockDashboardCard({ id: 2 }),
       ];
       const newCards = [
-        createMockDashboardOrderedCard({ id: 2 }),
-        createMockDashboardOrderedCard({ id: 3 }),
+        createMockDashboardCard({ id: 2 }),
+        createMockDashboardCard({ id: 3 }),
       ];
 
       expect(haveDashboardCardsChanged(newCards, oldCards)).toBe(true);
@@ -94,13 +94,13 @@ describe("dashboard > actions > utils", () => {
 
     it("should return true if a card was added", () => {
       const oldCards = [
-        createMockDashboardOrderedCard({ id: 1 }),
-        createMockDashboardOrderedCard({ id: 2 }),
+        createMockDashboardCard({ id: 1 }),
+        createMockDashboardCard({ id: 2 }),
       ];
       const newCards = [
-        createMockDashboardOrderedCard({ id: 1 }),
-        createMockDashboardOrderedCard({ id: 2 }),
-        createMockDashboardOrderedCard({ id: 3 }),
+        createMockDashboardCard({ id: 1 }),
+        createMockDashboardCard({ id: 2 }),
+        createMockDashboardCard({ id: 3 }),
       ];
 
       expect(haveDashboardCardsChanged(newCards, oldCards)).toBe(true);
@@ -108,14 +108,14 @@ describe("dashboard > actions > utils", () => {
 
     it("should return true if a card was added and deleted", () => {
       const oldCards = [
-        createMockDashboardOrderedCard({ id: 1 }),
-        createMockDashboardOrderedCard({ id: 2 }),
-        createMockDashboardOrderedCard({ id: 3 }),
+        createMockDashboardCard({ id: 1 }),
+        createMockDashboardCard({ id: 2 }),
+        createMockDashboardCard({ id: 3 }),
       ];
       const newCards = [
-        createMockDashboardOrderedCard({ id: 1 }),
-        createMockDashboardOrderedCard({ id: 2 }),
-        createMockDashboardOrderedCard({ id: 4 }),
+        createMockDashboardCard({ id: 1 }),
+        createMockDashboardCard({ id: 2 }),
+        createMockDashboardCard({ id: 4 }),
       ];
 
       expect(haveDashboardCardsChanged(newCards, oldCards)).toBe(true);
@@ -123,28 +123,28 @@ describe("dashboard > actions > utils", () => {
 
     it("should return true if a card was removed", () => {
       const oldCards = [
-        createMockDashboardOrderedCard({ id: 1 }),
-        createMockDashboardOrderedCard({ id: 2 }),
+        createMockDashboardCard({ id: 1 }),
+        createMockDashboardCard({ id: 2 }),
       ];
-      const newCards = [createMockDashboardOrderedCard({ id: 1 })];
+      const newCards = [createMockDashboardCard({ id: 1 })];
 
       expect(haveDashboardCardsChanged(newCards, oldCards)).toBe(true);
     });
 
     it("should return true if deeply nested properties change", () => {
       const oldCards = [
-        createMockDashboardOrderedCard({
+        createMockDashboardCard({
           id: 1,
           visualization_settings: { foo: { bar: { baz: 21 } } },
         }),
-        createMockDashboardOrderedCard({ id: 2 }),
+        createMockDashboardCard({ id: 2 }),
       ];
       const newCards = [
-        createMockDashboardOrderedCard({
+        createMockDashboardCard({
           id: 1,
           visualization_settings: { foo: { bar: { baz: 22 } } },
         }),
-        createMockDashboardOrderedCard({ id: 2 }),
+        createMockDashboardCard({ id: 2 }),
       ];
 
       expect(haveDashboardCardsChanged(newCards, oldCards)).toBe(true);
@@ -152,12 +152,12 @@ describe("dashboard > actions > utils", () => {
 
     it("should return false if the dashboard cards have not changed", () => {
       const oldCards = [
-        createMockDashboardOrderedCard({ id: 1 }),
-        createMockDashboardOrderedCard({ id: 2 }),
+        createMockDashboardCard({ id: 1 }),
+        createMockDashboardCard({ id: 2 }),
       ];
       const newCards = [
-        createMockDashboardOrderedCard({ id: 1 }),
-        createMockDashboardOrderedCard({ id: 2 }),
+        createMockDashboardCard({ id: 1 }),
+        createMockDashboardCard({ id: 2 }),
       ];
 
       expect(haveDashboardCardsChanged(newCards, oldCards)).toBe(false);
@@ -165,12 +165,12 @@ describe("dashboard > actions > utils", () => {
 
     it("should return false if the dashboard cards have only changed order", () => {
       const oldCards = [
-        createMockDashboardOrderedCard({ id: 1 }),
-        createMockDashboardOrderedCard({ id: 2 }),
+        createMockDashboardCard({ id: 1 }),
+        createMockDashboardCard({ id: 2 }),
       ];
       const newCards = [
-        createMockDashboardOrderedCard({ id: 2 }),
-        createMockDashboardOrderedCard({ id: 1 }),
+        createMockDashboardCard({ id: 2 }),
+        createMockDashboardCard({ id: 1 }),
       ];
 
       expect(haveDashboardCardsChanged(newCards, oldCards)).toBe(false);
@@ -180,7 +180,7 @@ describe("dashboard > actions > utils", () => {
       const oldCards = Array(1000)
         .fill("")
         .map(index =>
-          createMockDashboardOrderedCard({
+          createMockDashboardCard({
             id: index,
             visualization_settings: { foo: { bar: { baz: index * 10 } } },
           }),
@@ -188,7 +188,7 @@ describe("dashboard > actions > utils", () => {
       const newCards = Array(1000)
         .fill("")
         .map(index =>
-          createMockDashboardOrderedCard({
+          createMockDashboardCard({
             id: index,
             visualization_settings: { foo: { bar: { baz: index * 10 } } },
           }),

--- a/frontend/src/metabase/dashboard/components/ActionSidebar/ActionSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/ActionSidebar/ActionSidebar.tsx
@@ -58,10 +58,10 @@ export function ActionSidebarFn({
 
   const dashcard = useMemo(
     () =>
-      dashboard.ordered_cards.find(
+      dashboard.dashcards.find(
         dc => dc?.id === dashcardId && isActionDashCard(dc),
       ) as ActionDashboardCard | undefined,
-    [dashboard.ordered_cards, dashcardId],
+    [dashboard.dashcards, dashcardId],
   );
 
   if (!dashcard) {

--- a/frontend/src/metabase/dashboard/components/ActionSidebar/ActionSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/ActionSidebar/ActionSidebar.unit.spec.tsx
@@ -40,7 +40,7 @@ const actionsDatabase = createMockDatabase({
   settings: { "database-enable-actions": true },
 });
 const dashboard = createMockDashboard({
-  ordered_cards: [dashcard, actionDashcard, actionDashcardWithAction],
+  dashcards: [dashcard, actionDashcard, actionDashcardWithAction],
 });
 
 const setup = (

--- a/frontend/src/metabase/dashboard/components/ActionSidebar/ActionSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/ActionSidebar/ActionSidebar.unit.spec.tsx
@@ -10,7 +10,7 @@ import {
 import {
   createMockDashboard,
   createMockActionDashboardCard,
-  createMockDashboardOrderedCard,
+  createMockDashboardCard,
   createMockQueryAction,
   createMockCard,
   createMockDatabase,
@@ -25,7 +25,7 @@ import {
 } from "__support__/server-mocks";
 import { ActionSidebarFn } from "./ActionSidebar";
 
-const dashcard = createMockDashboardOrderedCard();
+const dashcard = createMockDashboardCard();
 const actionDashcard = createMockActionDashboardCard({ id: 2 });
 const actionDashcardWithAction = createMockActionDashboardCard({
   id: 3,

--- a/frontend/src/metabase/dashboard/components/AddSeriesModal/AddSeriesModal.tsx
+++ b/frontend/src/metabase/dashboard/components/AddSeriesModal/AddSeriesModal.tsx
@@ -6,7 +6,7 @@ import type {
   Card,
   CardId,
   DashCardId,
-  DashboardOrderedCard,
+  DashboardCard,
   Dataset,
 } from "metabase-types/api";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
@@ -23,11 +23,11 @@ import { QuestionList } from "./QuestionList";
 const CAN_REMOVE_SERIES = (seriesIndex: number) => seriesIndex > 0;
 
 export interface Props {
-  dashcard: DashboardOrderedCard;
+  dashcard: DashboardCard;
   dashcardData: Record<DashCardId, Record<CardId, Dataset>>;
   fetchCardData: (
     card: Card,
-    dashcard: DashboardOrderedCard,
+    dashcard: DashboardCard,
     options: {
       clearCache?: boolean;
       ignoreCache?: boolean;
@@ -36,7 +36,7 @@ export interface Props {
   ) => Promise<unknown>;
   setDashCardAttributes: (options: {
     id: DashCardId;
-    attributes: Partial<DashboardOrderedCard>;
+    attributes: Partial<DashboardCard>;
   }) => void;
   onClose: () => void;
 }
@@ -44,7 +44,7 @@ export interface Props {
 interface State {
   error: unknown;
   isLoading: boolean;
-  series: NonNullable<DashboardOrderedCard["series"]>;
+  series: NonNullable<DashboardCard["series"]>;
 }
 
 export class AddSeriesModal extends Component<Props, State> {

--- a/frontend/src/metabase/dashboard/components/AddSeriesModal/AddSeriesModal.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/AddSeriesModal/AddSeriesModal.unit.spec.tsx
@@ -4,7 +4,7 @@ import { getNextId } from "__support__/utils";
 import {
   createMockCard,
   createMockColumn,
-  createMockDashboardOrderedCard,
+  createMockDashboardCard,
   createMockDataset,
   createMockDatasetData,
 } from "metabase-types/api/mocks";
@@ -67,13 +67,13 @@ const dataset = createMockDataset({
   }),
 });
 
-const dashcard = createMockDashboardOrderedCard({
+const dashcard = createMockDashboardCard({
   id: getNextId(),
   card: baseCard,
   series: [firstCard, secondCard, incompleteCard],
 });
 
-const incompleteDashcard = createMockDashboardOrderedCard({
+const incompleteDashcard = createMockDashboardCard({
   id: getNextId(),
   card: baseCard,
   series: [incompleteCard],

--- a/frontend/src/metabase/dashboard/components/AddSeriesModal/QuestionList.tsx
+++ b/frontend/src/metabase/dashboard/components/AddSeriesModal/QuestionList.tsx
@@ -11,7 +11,7 @@ import { CardApi } from "metabase/services";
 import type {
   Card,
   CardId,
-  DashboardOrderedCard,
+  DashboardCard,
   GetCompatibleCardsPayload,
 } from "metabase-types/api";
 import {
@@ -30,7 +30,7 @@ const PAGE_SIZE = 50;
 interface QuestionListProps {
   enabledCards: Card[];
   onSelect: (card: Card, isChecked: boolean) => void;
-  dashcard: DashboardOrderedCard;
+  dashcard: DashboardCard;
 }
 
 export const QuestionList = memo(function QuestionList({

--- a/frontend/src/metabase/dashboard/components/AddSeriesModal/QuestionList.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/AddSeriesModal/QuestionList.unit.spec.tsx
@@ -4,7 +4,7 @@ import _ from "underscore";
 import userEvent from "@testing-library/user-event";
 import {
   createMockCard,
-  createMockDashboardOrderedCard,
+  createMockDashboardCard,
 } from "metabase-types/api/mocks";
 import type { Card, GetCompatibleCardsPayload } from "metabase-types/api";
 import { QuestionList } from "./QuestionList";
@@ -47,7 +47,7 @@ describe("QuestionList", () => {
     mockCompatibleCardsPage(compatibleCardsFirstPage);
 
     const onSelect = jest.fn();
-    const dashcard = createMockDashboardOrderedCard({ card_id: 1 });
+    const dashcard = createMockDashboardCard({ card_id: 1 });
 
     render(
       <QuestionList
@@ -81,7 +81,7 @@ describe("QuestionList", () => {
     mockCompatibleCardsPage(compatibleCardsFirstPage);
 
     const onSelect = jest.fn();
-    const dashcard = createMockDashboardOrderedCard({ card_id: 1 });
+    const dashcard = createMockDashboardCard({ card_id: 1 });
     const selectedCard = createMockCard({
       id: 500,
       name: "search text selected card",
@@ -120,7 +120,7 @@ describe("QuestionList", () => {
     mockCompatibleCardsPage([createMockCard({ id: 3, name: "fetched card" })]);
 
     const cards = [createMockCard({ id: 2, name: "added card" })];
-    const dashcard = createMockDashboardOrderedCard({ card_id: 1 });
+    const dashcard = createMockDashboardCard({ card_id: 1 });
 
     render(
       <QuestionList

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.tsx
@@ -7,7 +7,7 @@ import Sidebar from "metabase/dashboard/components/Sidebar";
 
 import type {
   Dashboard,
-  DashboardOrderedCard,
+  DashboardCard,
   DashCardId,
   CardId,
   ClickBehavior,
@@ -31,7 +31,7 @@ type VizSettings = Record<string, unknown>;
 
 interface Props {
   dashboard: Dashboard;
-  dashcard: DashboardOrderedCard;
+  dashcard: DashboardCard;
   dashcardData: Record<DashCardId, Record<CardId, DatasetData>>;
   parameters: UiParameter[];
   hideClickBehaviorSidebar: () => void;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarContent.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarContent.tsx
@@ -3,7 +3,7 @@ import { getIn } from "icepick";
 
 import type {
   Dashboard,
-  DashboardOrderedCard,
+  DashboardCard,
   DashCardId,
   CardId,
   ClickBehavior,
@@ -21,7 +21,7 @@ import { SidebarContent } from "./ClickBehaviorSidebar.styled";
 
 interface Props {
   dashboard: Dashboard;
-  dashcard: DashboardOrderedCard;
+  dashcard: DashboardCard;
   dashcardData: Record<DashCardId, Record<CardId, DatasetData>>;
   parameters: UiParameter[];
   clickBehavior?: ClickBehavior;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarHeader/ClickBehaviorSidebarHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarHeader/ClickBehaviorSidebarHeader.tsx
@@ -3,7 +3,7 @@ import { t, jt } from "ttag";
 
 import { Icon } from "metabase/core/components/Icon";
 
-import type { DashboardOrderedCard, DatasetColumn } from "metabase-types/api";
+import type { DashboardCard, DatasetColumn } from "metabase-types/api";
 
 import { isTableDisplay } from "metabase/lib/click-behavior";
 import { Heading, SidebarHeader } from "../ClickBehaviorSidebar.styled";
@@ -22,7 +22,7 @@ function DefaultHeader({ children }: { children: React.ReactNode }) {
 }
 
 interface Props {
-  dashcard: DashboardOrderedCard;
+  dashcard: DashboardCard;
   selectedColumn?: DatasetColumn | null;
   onUnsetColumn: () => void;
 }

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarMainView/ClickBehaviorSidebarMainView.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarMainView/ClickBehaviorSidebarMainView.tsx
@@ -1,6 +1,6 @@
 import type {
   Dashboard,
-  DashboardOrderedCard,
+  DashboardCard,
   ClickBehavior,
 } from "metabase-types/api";
 
@@ -18,7 +18,7 @@ import {
 interface ClickBehaviorOptionsProps {
   clickBehavior: ClickBehavior;
   dashboard: Dashboard;
-  dashcard: DashboardOrderedCard;
+  dashcard: DashboardCard;
   parameters: UiParameter[];
   updateSettings: (settings: Partial<ClickBehavior>) => void;
 }
@@ -56,7 +56,7 @@ function ClickBehaviorOptions({
 interface ClickBehaviorSidebarMainViewProps {
   clickBehavior: ClickBehavior;
   dashboard: Dashboard;
-  dashcard: DashboardOrderedCard;
+  dashcard: DashboardCard;
   parameters: UiParameter[];
   handleShowTypeSelector: () => void;
   updateSettings: (settings: Partial<ClickBehavior>) => void;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/CrossfilterOptions.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/CrossfilterOptions.tsx
@@ -5,14 +5,14 @@ import ClickMappings from "metabase/dashboard/components/ClickMappings";
 import type {
   ClickBehavior,
   Dashboard,
-  DashboardOrderedCard,
+  DashboardCard,
 } from "metabase-types/api";
 
 import { Heading, SidebarContent } from "./ClickBehaviorSidebar.styled";
 
 interface Props {
   dashboard: Dashboard;
-  dashcard: DashboardOrderedCard;
+  dashcard: DashboardCard;
   clickBehavior: ClickBehavior;
   updateSettings: (settings: ClickBehavior) => void;
 }

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/CustomURLPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/CustomURLPicker.tsx
@@ -8,7 +8,7 @@ import ModalWithTrigger from "metabase/components/ModalWithTrigger";
 import type {
   ArbitraryCustomDestinationClickBehavior,
   ClickBehavior,
-  DashboardOrderedCard,
+  DashboardCard,
 } from "metabase-types/api";
 import { isTableDisplay } from "metabase/lib/click-behavior";
 import type { UiParameter } from "metabase-lib/parameters/types";
@@ -26,7 +26,7 @@ import {
 } from "./CustomURLPicker.styled";
 
 interface Props {
-  dashcard: DashboardOrderedCard;
+  dashcard: DashboardCard;
   clickBehavior: ArbitraryCustomDestinationClickBehavior;
   parameters: UiParameter[];
   updateSettings: (settings: ClickBehavior) => void;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkOptions.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkOptions.tsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { t } from "ttag";
 
 import type {
-  DashboardOrderedCard,
+  DashboardCard,
   ArbitraryCustomDestinationClickBehavior,
   ClickBehavior,
   CustomDestinationClickBehavior,
@@ -51,7 +51,7 @@ function LinkTypeOptions({
 
 interface Props {
   clickBehavior: CustomDestinationClickBehavior;
-  dashcard: DashboardOrderedCard;
+  dashcard: DashboardCard;
   parameters: UiParameter[];
   updateSettings: (settings: Partial<ClickBehavior>) => void;
 }

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker.tsx
@@ -18,7 +18,7 @@ import ClickMappings, {
 import type {
   Dashboard,
   DashboardId,
-  DashboardOrderedCard,
+  DashboardCard,
   CardId,
   ClickBehavior,
   EntityCustomDestinationClickBehavior,
@@ -98,7 +98,7 @@ function TargetClickMappings({
 }: {
   isDash: boolean;
   clickBehavior: EntityCustomDestinationClickBehavior;
-  dashcard: DashboardOrderedCard;
+  dashcard: DashboardCard;
   updateSettings: (settings: Partial<ClickBehavior>) => void;
 }) {
   const Entity = isDash ? Dashboards : Questions;
@@ -125,7 +125,7 @@ function LinkedEntityPicker({
   clickBehavior,
   updateSettings,
 }: {
-  dashcard: DashboardOrderedCard;
+  dashcard: DashboardCard;
   clickBehavior: EntityCustomDestinationClickBehavior;
   updateSettings: (settings: Partial<ClickBehavior>) => void;
 }) {

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TableClickBehaviorView/TableClickBehaviorView.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TableClickBehaviorView/TableClickBehaviorView.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import type {
-  DashboardOrderedCard,
+  DashboardCard,
   ClickBehavior,
   ClickBehaviorType,
   DatasetColumn,
@@ -20,7 +20,7 @@ const COLUMN_SORTING_ORDER_BY_CLICK_BEHAVIOR_TYPE = [
 
 function explainClickBehaviorType(
   type: ClickBehaviorType,
-  dashcard: DashboardOrderedCard,
+  dashcard: DashboardCard,
 ) {
   return {
     action: t`Execute an action`,
@@ -34,7 +34,7 @@ function explainClickBehaviorType(
 
 interface Props {
   columns: DatasetColumn[];
-  dashcard: DashboardOrderedCard;
+  dashcard: DashboardCard;
   getClickBehaviorForColumn: (
     column: DatasetColumn,
   ) => ClickBehavior | undefined;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TypeSelector/TypeSelector.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TypeSelector/TypeSelector.tsx
@@ -4,7 +4,7 @@ import type { IconName } from "metabase/core/components/Icon";
 import { Icon } from "metabase/core/components/Icon";
 import { color } from "metabase/lib/colors";
 
-import type { DashboardOrderedCard, ClickBehavior } from "metabase-types/api";
+import type { DashboardCard, ClickBehavior } from "metabase-types/api";
 import type { UiParameter } from "metabase-lib/parameters/types";
 
 import { clickBehaviorOptions, getClickBehaviorOptionName } from "../utils";
@@ -51,7 +51,7 @@ export const BehaviorOption = ({
 );
 
 interface TypeSelectorProps {
-  dashcard: DashboardOrderedCard;
+  dashcard: DashboardCard;
   clickBehavior: ClickBehavior;
   parameters: UiParameter[];
   updateSettings: (settings?: ClickBehavior) => void;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/utils.ts
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/utils.ts
@@ -3,7 +3,7 @@ import { getIn } from "icepick";
 
 import type {
   ClickBehaviorType,
-  DashboardOrderedCard,
+  DashboardCard,
   DatasetColumn,
 } from "metabase-types/api";
 import { hasActionsMenu } from "metabase/lib/click-behavior";
@@ -23,7 +23,7 @@ export const clickBehaviorOptions: ClickBehaviorOption[] = [
 
 export function getClickBehaviorOptionName(
   value: ClickBehaviorType | "menu",
-  dashcard: DashboardOrderedCard,
+  dashcard: DashboardCard,
 ) {
   if (value === "menu") {
     return hasActionsMenu(dashcard)
@@ -42,7 +42,7 @@ export function getClickBehaviorOptionName(
   return t`Unknown`;
 }
 export function getClickBehaviorForColumn(
-  dashcard: DashboardOrderedCard,
+  dashcard: DashboardCard,
   column: DatasetColumn,
 ) {
   return getIn(dashcard, [

--- a/frontend/src/metabase/dashboard/components/DashCard/ClickBehaviorSidebarOverlay/ClickBehaviorSidebarOverlay.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/ClickBehaviorSidebarOverlay/ClickBehaviorSidebarOverlay.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 
 import { getClickBehaviorDescription } from "metabase/lib/click-behavior";
 
-import type { DashboardOrderedCard } from "metabase-types/api";
+import type { DashboardCard } from "metabase-types/api";
 
 import {
   Root,
@@ -14,11 +14,9 @@ import {
 } from "./ClickBehaviorSidebarOverlay.styled";
 
 interface Props {
-  dashcard: DashboardOrderedCard;
+  dashcard: DashboardCard;
   dashcardWidth: number;
-  showClickBehaviorSidebar: (
-    dashCardId: DashboardOrderedCard["id"] | null,
-  ) => void;
+  showClickBehaviorSidebar: (dashCardId: DashboardCard["id"] | null) => void;
   isShowingThisClickBehaviorSidebar: boolean;
 }
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -23,7 +23,7 @@ import type {
   Card,
   CardId,
   Dashboard,
-  DashboardOrderedCard,
+  DashboardCard,
   DashCardId,
   ParameterId,
   ParameterValueOrArray,
@@ -52,7 +52,7 @@ function preventDragging(event: React.SyntheticEvent) {
 
 export interface DashCardProps {
   dashboard: Dashboard;
-  dashcard: DashboardOrderedCard & { justAdded?: boolean };
+  dashcard: DashboardCard & { justAdded?: boolean };
   gridItemWidth: number;
   totalNumGridCols: number;
   dashcardData: Record<DashCardId, Record<CardId, Dataset>>;
@@ -61,7 +61,7 @@ export interface DashCardProps {
   metadata: Metadata;
   mode?: Mode;
 
-  clickBehaviorSidebarDashcard?: DashboardOrderedCard | null;
+  clickBehaviorSidebarDashcard?: DashboardCard | null;
 
   isEditing?: boolean;
   isEditingParameter?: boolean;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionButtons/ChartSettingsButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionButtons/ChartSettingsButton.tsx
@@ -6,7 +6,7 @@ import { ChartSettingsWithState } from "metabase/visualizations/components/Chart
 
 import type {
   Dashboard,
-  DashboardOrderedCard,
+  DashboardCard,
   Series,
   VisualizationSettings,
 } from "metabase-types/api";
@@ -16,7 +16,7 @@ import DashCardActionButton from "./DashCardActionButton";
 interface Props {
   series: Series;
   dashboard: Dashboard;
-  dashcard?: DashboardOrderedCard;
+  dashcard?: DashboardCard;
   onReplaceAllVisualizationSettings: (settings: VisualizationSettings) => void;
 }
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionButtons/DashCardActionButtons.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionButtons/DashCardActionButtons.tsx
@@ -6,7 +6,7 @@ import { getVisualizationRaw } from "metabase/visualizations";
 
 import type {
   Dashboard,
-  DashboardOrderedCard,
+  DashboardCard,
   Series,
   VisualizationSettings,
 } from "metabase-types/api";
@@ -26,7 +26,7 @@ import LinkCardEditButton from "./LinkCardEditButton";
 interface Props {
   series: Series;
   dashboard: Dashboard;
-  dashcard?: DashboardOrderedCard;
+  dashcard?: DashboardCard;
   isLoading: boolean;
   isVirtualDashCard: boolean;
   isPreviewing: boolean;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionButtons/LinkCardEditButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionButtons/LinkCardEditButton.tsx
@@ -1,15 +1,12 @@
 import { t } from "ttag";
 
-import type {
-  DashboardOrderedCard,
-  VisualizationSettings,
-} from "metabase-types/api";
+import type { DashboardCard, VisualizationSettings } from "metabase-types/api";
 import { isRestrictedLinkEntity } from "metabase-types/guards/dashboard";
 
 import DashCardActionButton from "./DashCardActionButton";
 
 interface Props {
-  dashcard: DashboardOrderedCard;
+  dashcard: DashboardCard;
   onUpdateVisualizationSettings: (
     settings: Partial<VisualizationSettings>,
   ) => void;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
@@ -3,7 +3,7 @@ import { getIcon } from "__support__/ui";
 
 import {
   createMockCard,
-  createMockDashboardOrderedCard,
+  createMockDashboardCard,
   createMockActionDashboardCard,
   createMockHeadingDashboardCard,
   createMockTextDashboardCard,
@@ -32,7 +32,7 @@ const setup = options => {
   render(
     <DashCardCardParameterMapper
       card={createMockCard()}
-      dashcard={createMockDashboardOrderedCard()}
+      dashcard={createMockDashboardCard()}
       editingParameter={{}}
       target={null}
       mappingOptions={[]}
@@ -67,7 +67,7 @@ describe("DashCardParameterMapper", () => {
     const linkCard = createMockCard({ dataset_query: {}, display: "link" });
     setup({
       card: linkCard,
-      dashcard: createMockDashboardOrderedCard({
+      dashcard: createMockDashboardCard({
         visualization_settings: {
           virtual_card: linkCard,
         },
@@ -112,7 +112,7 @@ describe("DashCardParameterMapper", () => {
     const textCard = createMockCard({ dataset_query: {}, display: "text" });
     setup({
       card: textCard,
-      dashcard: createMockDashboardOrderedCard({
+      dashcard: createMockDashboardCard({
         card: textCard,
         size_y: 3,
         visualization_settings: {
@@ -135,7 +135,7 @@ describe("DashCardParameterMapper", () => {
     });
     setup({
       card,
-      dashcard: createMockDashboardOrderedCard({
+      dashcard: createMockDashboardCard({
         card,
       }),
       mappingOptions: [["dimension", ["field", 1]]],
@@ -152,7 +152,7 @@ describe("DashCardParameterMapper", () => {
     });
     setup({
       card: numberCard,
-      dashcard: createMockDashboardOrderedCard({
+      dashcard: createMockDashboardCard({
         card: numberCard,
         size_y: 3,
       }),
@@ -168,7 +168,7 @@ describe("DashCardParameterMapper", () => {
     });
     setup({
       card: numberCard,
-      dashcard: createMockDashboardOrderedCard({
+      dashcard: createMockDashboardCard({
         card: numberCard,
         size_y: 2,
       }),
@@ -185,7 +185,7 @@ describe("DashCardParameterMapper", () => {
       });
       setup({
         card: numberCard,
-        dashcard: createMockDashboardOrderedCard({
+        dashcard: createMockDashboardCard({
           card: numberCard,
           size_y: 2,
         }),
@@ -199,7 +199,7 @@ describe("DashCardParameterMapper", () => {
       const textCard = createMockCard({ dataset_query: {}, display: "text" });
       setup({
         card: textCard,
-        dashcard: createMockDashboardOrderedCard({
+        dashcard: createMockDashboardCard({
           card: textCard,
           size_y: 3,
           visualization_settings: {

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -17,7 +17,7 @@ import {
 
 import type {
   Dashboard,
-  DashboardOrderedCard,
+  DashboardCard,
   DashCardId,
   Dataset,
   Series,
@@ -47,7 +47,7 @@ import { shouldShowParameterMapper } from "./utils";
 
 interface DashCardVisualizationProps {
   dashboard: Dashboard;
-  dashcard: DashboardOrderedCard;
+  dashcard: DashboardCard;
   series: Series;
   parameterValues: Record<ParameterId, ParameterValueOrArray>;
   parameterValuesBySlug: Record<string, ParameterValueOrArray>;

--- a/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
@@ -4,7 +4,7 @@ import registerVisualizations from "metabase/visualizations/register";
 import {
   createMockCard,
   createMockDashboard,
-  createMockDashboardOrderedCard,
+  createMockDashboardCard,
   createMockSettings,
   createMockDatasetData,
   createMockTextDashboardCard,
@@ -21,7 +21,7 @@ registerVisualizations();
 
 const dashboard = createMockDashboard();
 
-const tableDashcard = createMockDashboardOrderedCard({
+const tableDashcard = createMockDashboardCard({
   card: createMockCard({
     name: "My Card",
     display: "table",

--- a/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
@@ -101,7 +101,7 @@ describe("DashCard", () => {
     const textCard = createMockTextDashboardCard({ text: "Hello, world!" });
     const board = {
       ...dashboard,
-      ordered_cards: [textCard],
+      dashcards: [textCard],
     };
     setup({
       dashboard: board,
@@ -117,7 +117,7 @@ describe("DashCard", () => {
     });
     const board = {
       ...dashboard,
-      ordered_cards: [textCard],
+      dashcards: [textCard],
     };
     setup({
       dashboard: board,
@@ -133,7 +133,7 @@ describe("DashCard", () => {
     });
     const board = {
       ...dashboard,
-      ordered_cards: [linkCard],
+      dashcards: [linkCard],
     };
     setup({
       dashboard: board,
@@ -149,7 +149,7 @@ describe("DashCard", () => {
     });
     const board = {
       ...dashboard,
-      ordered_cards: [linkCard],
+      dashcards: [linkCard],
     };
     setup({
       dashboard: board,

--- a/frontend/src/metabase/dashboard/components/DashCard/types.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/types.ts
@@ -1,11 +1,11 @@
-import type { Card, DashboardOrderedCard } from "metabase-types/api";
+import type { Card, DashboardCard } from "metabase-types/api";
 
 export type CardSlownessStatus = "usually-fast" | "usually-slow" | boolean;
 
 export type NavigateToNewCardFromDashboardOpts = {
   nextCard: Card;
   previousCard: Card;
-  dashcard: DashboardOrderedCard;
+  dashcard: DashboardCard;
   objectId?: unknown;
 };
 

--- a/frontend/src/metabase/dashboard/components/DashCard/utils.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/utils.ts
@@ -1,11 +1,11 @@
-import type { DashboardOrderedCard } from "metabase-types/api";
+import type { DashboardCard } from "metabase-types/api";
 import { getVirtualCardType } from "metabase/dashboard/utils";
 
 export function shouldShowParameterMapper({
   dashcard,
   isEditingParameter,
 }: {
-  dashcard: DashboardOrderedCard;
+  dashcard: DashboardCard;
   isEditingParameter?: boolean;
 }) {
   return (

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -240,10 +240,10 @@ class Dashboard extends Component {
 
     const canWrite = dashboard?.can_write ?? false;
 
-    const dashboardHasCards = dashboard?.ordered_cards.length > 0 ?? false;
+    const dashboardHasCards = dashboard?.dashcards.length > 0 ?? false;
 
     const tabHasCards =
-      dashboard?.ordered_cards.filter(
+      dashboard?.dashcards.filter(
         c =>
           selectedTabId !== undefined && c.dashboard_tab_id === selectedTabId,
       ).length > 0 ?? false;

--- a/frontend/src/metabase/dashboard/components/DashboardActions.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardActions.jsx
@@ -39,12 +39,12 @@ export const getDashboardActions = (
   const buttons = [];
 
   const isLoaded = !!dashboard;
-  const hasCards = isLoaded && dashboard.ordered_cards.length > 0;
+  const hasCards = isLoaded && dashboard.dashcards.length > 0;
 
   // dashcardData only contains question cards, text ones don't appear here
   const hasDataCards =
     hasCards &&
-    dashboard.ordered_cards.some(
+    dashboard.dashcards.some(
       dashCard => !["text", "heading"].includes(dashCard.card.display),
     );
 

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -49,14 +49,14 @@ class DashboardGrid extends Component {
     super(props, context);
 
     const visibleCardIds = getVisibleCardIds(
-      props.dashboard.ordered_cards,
+      props.dashboard.dashcards,
       props.dashcardData,
     );
 
     this.state = {
       visibleCardIds,
-      initialCardSizes: this.getInitialCardSizes(props.dashboard.ordered_cards),
-      layouts: this.getLayouts(props.dashboard.ordered_cards),
+      initialCardSizes: this.getInitialCardSizes(props.dashboard.dashcards),
+      layouts: this.getLayouts(props.dashboard.dashcards),
       addSeriesModalDashCard: null,
       isDragging: false,
       isAnimationPaused: true,
@@ -107,14 +107,14 @@ class DashboardGrid extends Component {
 
     const visibleCardIds = !isEditing
       ? getVisibleCardIds(
-          dashboard.ordered_cards,
+          dashboard.dashcards,
           dashcardData,
           this.state.visibleCardIds,
         )
-      : new Set(dashboard.ordered_cards.map(card => card.id));
+      : new Set(dashboard.dashcards.map(card => card.id));
 
     const cards = this.getVisibleCards(
-      dashboard.ordered_cards,
+      dashboard.dashcards,
       visibleCardIds,
       isEditing,
       selectedTabId,
@@ -218,7 +218,7 @@ class DashboardGrid extends Component {
   };
 
   getVisibleCards = (
-    cards = this.props.dashboard.ordered_cards,
+    cards = this.props.dashboard.dashcards,
     visibleCardIds = this.state.visibleCardIds,
     isEditing = this.props.isEditing,
     selectedTabId = this.props.selectedTabId,

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/test-utils.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/test-utils.ts
@@ -58,7 +58,7 @@ export const TEST_DASHBOARD_STATE: DashboardState = {
         last_name: "",
         timestamp: "",
       },
-      ordered_cards: [1, 2],
+      dashcards: [1, 2],
       ordered_tabs: [
         getDefaultTab({ tabId: 1, dashId: 1, name: "Tab 1" }),
         getDefaultTab({ tabId: 2, dashId: 1, name: "Tab 2" }),

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.unit.spec.tsx
@@ -21,7 +21,7 @@ console.error = jest.fn();
 const DASHCARD = createMockDashboardOrderedCard();
 
 const TEST_DASHBOARD = createMockDashboard({
-  ordered_cards: [DASHCARD],
+  dashcards: [DASHCARD],
 });
 
 const TEST_DASHBOARD_WITH_TABS = createMockDashboard({
@@ -128,7 +128,7 @@ const setup = async ({
         dashboards: {
           [dashboard.id]: {
             ...dashboard,
-            ordered_cards: dashboard.ordered_cards.map(c => c.id),
+            dashcards: dashboard.dashcards.map(c => c.id),
           },
         },
         dashcards: {

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.unit.spec.tsx
@@ -8,7 +8,7 @@ import {
 } from "__support__/ui";
 import {
   createMockDashboard,
-  createMockDashboardOrderedCard,
+  createMockDashboardCard,
 } from "metabase-types/api/mocks";
 import { setupBookmarksEndpoints } from "__support__/server-mocks";
 import { createMockDashboardState } from "metabase-types/store/mocks";
@@ -18,7 +18,7 @@ import DashboardHeader from "./DashboardHeader";
 console.warn = jest.fn();
 console.error = jest.fn();
 
-const DASHCARD = createMockDashboardOrderedCard();
+const DASHCARD = createMockDashboardCard();
 
 const TEST_DASHBOARD = createMockDashboard({
   dashcards: [DASHCARD],

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -114,10 +114,7 @@ const dashboards = handleActions(
       ...state,
       [dashcard.dashboard_id]: {
         ...state[dashcard.dashboard_id],
-        ordered_cards: [
-          ...state[dashcard.dashboard_id].ordered_cards,
-          dashcard.id,
-        ],
+        dashcards: [...state[dashcard.dashboard_id].dashcards, dashcard.id],
       },
     }),
     [CREATE_PUBLIC_LINK]: {

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.js
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.js
@@ -193,7 +193,7 @@ describe("dashboard reducers", () => {
   describe("SET_DASHBOARD_ATTRIBUTES", () => {
     const emptyDashboard = {
       archived: false,
-      ordered_cards: [],
+      dashcards: [],
       can_write: true,
       enable_embedding: false,
       show_in_getting_started: false,

--- a/frontend/src/metabase/dashboard/selectors.unit.spec.js
+++ b/frontend/src/metabase/dashboard/selectors.unit.spec.js
@@ -18,7 +18,7 @@ const STATE = {
     dashboardId: 0,
     dashboards: {
       0: {
-        ordered_cards: [0, 1],
+        dashcards: [0, 1],
         parameters: [],
       },
     },
@@ -344,7 +344,7 @@ describe("dashboard/selectors", () => {
 
   describe("getDashboardComplete", () => {
     const multiCardState = chain(STATE)
-      .assocIn(["dashboard", "dashboards", 0, "ordered_cards"], [0, 1, 2])
+      .assocIn(["dashboard", "dashboards", 0, "dashcards"], [0, 1, 2])
       .assocIn(["dashboard", "dashcards", 2], {
         card: { id: 2, dataset_query: { type: "query", query: {} } },
         parameter_mappings: [],
@@ -369,7 +369,7 @@ describe("dashboard/selectors", () => {
         .assocIn(["dashboard", "dashcards", 2, "isRemoved"], true)
         .value();
 
-      expect(getDashboardComplete(state).ordered_cards).toEqual([
+      expect(getDashboardComplete(state).dashcards).toEqual([
         multiCardState.dashboard.dashcards[1],
       ]);
     });
@@ -381,7 +381,7 @@ describe("dashboard/selectors", () => {
         { row: 0, col: 2 },
       ]);
 
-      const cards = getDashboardComplete(state).ordered_cards;
+      const cards = getDashboardComplete(state).dashcards;
 
       expect(cards[2].card.id).toBe(0);
       expect(cards[1].card.id).toBe(1);
@@ -395,7 +395,7 @@ describe("dashboard/selectors", () => {
         { row: 0, col: 0 },
       ]);
 
-      const cards = getDashboardComplete(state).ordered_cards;
+      const cards = getDashboardComplete(state).dashcards;
 
       expect(cards[2].card.id).toBe(0);
       expect(cards[1].card.id).toBe(1);

--- a/frontend/src/metabase/dashboard/selectors/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors/selectors.js
@@ -120,7 +120,7 @@ export const getDashboardComplete = createSelector(
       return null;
     }
 
-    const ordered_cards = dashboard.ordered_cards
+    const orderedDashcards = dashboard.dashcards
       .map(id => dashcards[id])
       .filter(dc => !dc.isRemoved)
       .sort((a, b) => {
@@ -138,7 +138,7 @@ export const getDashboardComplete = createSelector(
     return (
       dashboard && {
         ...dashboard,
-        ordered_cards,
+        dashcards: orderedDashcards,
       }
     );
   },
@@ -217,7 +217,7 @@ export const getIsDirty = createSelector(
       dashboard &&
       (dashboard.isDirty ||
         _.some(
-          dashboard.ordered_cards,
+          dashboard.dashcards,
           id =>
             !(dashcards[id].isAdded && dashcards[id].isRemoved) &&
             (dashcards[id].isDirty ||

--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -54,7 +54,7 @@ export function expandInlineDashboard(dashboard: Partial<Dashboard>) {
     name: "",
     parameters: [],
     ...dashboard,
-    ordered_cards: dashboard.ordered_cards?.map(dashcard => ({
+    dashcards: dashboard.dashcards?.map(dashcard => ({
       visualization_settings: {},
       parameter_mappings: [],
       ...dashcard,
@@ -120,7 +120,7 @@ export function getNativeDashCardEmptyMappingText(parameter: Parameter) {
 export function getAllDashboardCards(dashboard: Dashboard) {
   const results = [];
   if (dashboard) {
-    for (const dashcard of dashboard.ordered_cards) {
+    for (const dashcard of dashboard.dashcards) {
       const cards = [dashcard.card].concat((dashcard as any).series || []);
       results.push(...cards.map(card => ({ card, dashcard })));
     }

--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -12,7 +12,7 @@ import type {
   CardId,
   DashCardId,
   Dashboard,
-  DashboardOrderedCard,
+  DashboardCard,
   Database,
   Dataset,
   NativeDatasetQuery,
@@ -76,26 +76,26 @@ export function expandInlineCard(card?: Card) {
   };
 }
 
-export function isVirtualDashCard(dashcard: DashboardOrderedCard) {
+export function isVirtualDashCard(dashcard: DashboardCard) {
   return _.isObject(dashcard?.visualization_settings?.virtual_card);
 }
 
-export function getVirtualCardType(dashcard: DashboardOrderedCard) {
+export function getVirtualCardType(dashcard: DashboardCard) {
   return dashcard?.visualization_settings?.virtual_card?.display;
 }
 
-export function isLinkDashCard(dashcard: DashboardOrderedCard) {
+export function isLinkDashCard(dashcard: DashboardCard) {
   return getVirtualCardType(dashcard) === "link";
 }
 
-export function isNativeDashCard(dashcard: DashboardOrderedCard) {
+export function isNativeDashCard(dashcard: DashboardCard) {
   return dashcard.card && new Question(dashcard.card).isNative();
 }
 
 // For a virtual (text) dashcard without any parameters, returns a boolean indicating whether we should display the
 // info text about parameter mapping in the card itself or as a tooltip.
 export function showVirtualDashCardInfoText(
-  dashcard: DashboardOrderedCard,
+  dashcard: DashboardCard,
   isMobile: boolean,
 ) {
   if (isVirtualDashCard(dashcard)) {
@@ -175,7 +175,7 @@ export function getDatasetQueryParams(
 }
 
 export function isDashcardLoading(
-  dashcard: DashboardOrderedCard,
+  dashcard: DashboardCard,
   dashcardsData: Record<DashCardId, Record<CardId, Dataset | null>>,
 ) {
   if (isVirtualDashCard(dashcard)) {
@@ -237,7 +237,7 @@ const hasRows = (dashcardData: Record<CardId, Dataset>) => {
 };
 
 const shouldHideCard = (
-  dashcard: DashboardOrderedCard,
+  dashcard: DashboardCard,
   dashcardData: Record<CardId, Dataset | null>,
   wasVisible: boolean,
 ) => {
@@ -260,7 +260,7 @@ const shouldHideCard = (
 };
 
 export const getVisibleCardIds = (
-  cards: DashboardOrderedCard[],
+  cards: DashboardCard[],
   dashcardsData: Record<DashCardId, Record<CardId, Dataset | null>>,
   prevVisibleCardIds = new Set<number>(),
 ) => {

--- a/frontend/src/metabase/dashboard/utils.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/utils.unit.spec.ts
@@ -10,7 +10,7 @@ import {
 import {
   createMockDashboard,
   createMockDashboardCardWithVirtualCard,
-  createMockDashboardOrderedCard,
+  createMockDashboardCard,
   createMockDatabase,
   createMockDataset,
   createMockDatasetData,
@@ -142,7 +142,7 @@ describe("Dashboard utils", () => {
 
     it("should return false for cards with loaded data", () => {
       expect(
-        isDashcardLoading(createMockDashboardOrderedCard({ id: 1 }), {
+        isDashcardLoading(createMockDashboardCard({ id: 1 }), {
           1: { 2: createMockDataset() },
         }),
       ).toBe(false);
@@ -150,7 +150,7 @@ describe("Dashboard utils", () => {
 
     it("should return true when the dash card data is missing", () => {
       expect(
-        isDashcardLoading(createMockDashboardOrderedCard({ id: 1 }), {
+        isDashcardLoading(createMockDashboardCard({ id: 1 }), {
           1: { 2: null, 3: createMockDataset() },
         }),
       ).toBe(true);
@@ -217,10 +217,10 @@ describe("Dashboard utils", () => {
     });
 
     const normalCardId = 2;
-    const normalCard = createMockDashboardOrderedCard({ id: normalCardId });
+    const normalCard = createMockDashboardCard({ id: normalCardId });
 
     const hidingWhenEmptyCardId = 3;
-    const hidingWhenEmptyCard = createMockDashboardOrderedCard({
+    const hidingWhenEmptyCard = createMockDashboardCard({
       id: hidingWhenEmptyCardId,
       visualization_settings: { "card.hide_empty": true },
     });
@@ -290,7 +290,7 @@ describe("Dashboard utils", () => {
   describe("getCurrentTabDashboardCards", () => {
     it("when selectedTabId=null returns cards with dashboard_tab_id=undefined", () => {
       const selectedTabId = null;
-      const dashcard = createMockDashboardOrderedCard({
+      const dashcard = createMockDashboardCard({
         dashboard_tab_id: undefined,
       });
       const dashboard = createMockDashboard({
@@ -309,10 +309,10 @@ describe("Dashboard utils", () => {
 
     it("returns cards from selected tab only", () => {
       const selectedTabId = 1;
-      const visibleDashcard = createMockDashboardOrderedCard({
+      const visibleDashcard = createMockDashboardCard({
         dashboard_tab_id: 1,
       });
-      const hiddenDashcard = createMockDashboardOrderedCard({
+      const hiddenDashcard = createMockDashboardCard({
         dashboard_tab_id: 2,
       });
 

--- a/frontend/src/metabase/dashboard/utils.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/utils.unit.spec.ts
@@ -294,7 +294,7 @@ describe("Dashboard utils", () => {
         dashboard_tab_id: undefined,
       });
       const dashboard = createMockDashboard({
-        ordered_cards: [dashcard],
+        dashcards: [dashcard],
       });
 
       expect(
@@ -317,7 +317,7 @@ describe("Dashboard utils", () => {
       });
 
       const dashboard = createMockDashboard({
-        ordered_cards: [visibleDashcard, hiddenDashcard],
+        dashcards: [visibleDashcard, hiddenDashcard],
       });
 
       expect(

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.unit.spec.tsx
@@ -115,7 +115,7 @@ async function setup({
     dashboardId = openDashboard.id;
     dashboardsForState[openDashboard.id] = {
       ...openDashboard,
-      ordered_cards: openDashboard.ordered_cards.map(c => c.id),
+      dashcards: openDashboard.dashcards.map(c => c.id),
     };
     dashboardsForEntities.push(openDashboard);
   }

--- a/frontend/src/metabase/parameters/utils/dashboards.ts
+++ b/frontend/src/metabase/parameters/utils/dashboards.ts
@@ -6,7 +6,7 @@ import type {
   Card,
   Dashboard,
   DashboardParameterMapping,
-  DashboardOrderedCard,
+  DashboardCard,
   Parameter,
   ParameterMappingOptions,
 } from "metabase-types/api";
@@ -91,7 +91,7 @@ export function isDashboardParameterWithoutMapping(
   return parameterExistsOnDashboard && !parameterHasMapping;
 }
 
-function getMappings(dashcards: DashboardOrderedCard[]): ExtendedMapping[] {
+function getMappings(dashcards: DashboardCard[]): ExtendedMapping[] {
   return dashcards.flatMap(dashcard => {
     const { parameter_mappings, card, series } = dashcard;
     const cards = [card, ...(series || [])];
@@ -115,7 +115,7 @@ export function getDashboardUiParameters(
   metadata: Metadata,
 ): UiParameter[] {
   const { parameters, dashcards } = dashboard;
-  const mappings = getMappings(dashcards as DashboardOrderedCard[]);
+  const mappings = getMappings(dashcards as DashboardCard[]);
   const uiParameters: UiParameter[] = (parameters || []).map(parameter => {
     if (isFieldFilterParameter(parameter)) {
       return buildFieldFilterUiParameter(parameter, mappings, metadata);
@@ -173,7 +173,7 @@ function buildFieldFilterUiParameter(
 
 export function getParametersMappedToDashcard(
   dashboard: Dashboard,
-  dashcard: DashboardOrderedCard,
+  dashcard: DashboardCard,
 ): ParameterWithTarget[] {
   const { parameters } = dashboard;
   const { parameter_mappings } = dashcard;
@@ -212,7 +212,7 @@ export function hasMatchingParameters({
     return false;
   }
 
-  const mappings = getMappings(dashboard.dashcards as DashboardOrderedCard[]);
+  const mappings = getMappings(dashboard.dashcards as DashboardCard[]);
   const mappingsForDashcard = mappings.filter(
     mapping => mapping.dashcard_id === dashcardId,
   );

--- a/frontend/src/metabase/parameters/utils/dashboards.ts
+++ b/frontend/src/metabase/parameters/utils/dashboards.ts
@@ -68,7 +68,7 @@ export function getIsMultiSelect(parameter: Parameter): boolean {
 }
 
 export function hasMapping(parameter: Parameter, dashboard: Dashboard) {
-  return dashboard.ordered_cards.some(ordered_card => {
+  return dashboard.dashcards.some(ordered_card => {
     return ordered_card?.parameter_mappings?.some(parameter_mapping => {
       return parameter_mapping.parameter_id === parameter.id;
     });
@@ -91,8 +91,8 @@ export function isDashboardParameterWithoutMapping(
   return parameterExistsOnDashboard && !parameterHasMapping;
 }
 
-function getMappings(ordered_cards: DashboardOrderedCard[]): ExtendedMapping[] {
-  return ordered_cards.flatMap(dashcard => {
+function getMappings(dashcards: DashboardOrderedCard[]): ExtendedMapping[] {
+  return dashcards.flatMap(dashcard => {
     const { parameter_mappings, card, series } = dashcard;
     const cards = [card, ...(series || [])];
     return (parameter_mappings || [])
@@ -114,8 +114,8 @@ export function getDashboardUiParameters(
   dashboard: Dashboard,
   metadata: Metadata,
 ): UiParameter[] {
-  const { parameters, ordered_cards } = dashboard;
-  const mappings = getMappings(ordered_cards as DashboardOrderedCard[]);
+  const { parameters, dashcards } = dashboard;
+  const mappings = getMappings(dashcards as DashboardOrderedCard[]);
   const uiParameters: UiParameter[] = (parameters || []).map(parameter => {
     if (isFieldFilterParameter(parameter)) {
       return buildFieldFilterUiParameter(parameter, mappings, metadata);
@@ -204,7 +204,7 @@ export function hasMatchingParameters({
   cardId: number;
   parameters: Parameter[];
 }) {
-  const dashcard = _.findWhere(dashboard.ordered_cards, {
+  const dashcard = _.findWhere(dashboard.dashcards, {
     id: dashcardId,
     card_id: cardId,
   });
@@ -212,9 +212,7 @@ export function hasMatchingParameters({
     return false;
   }
 
-  const mappings = getMappings(
-    dashboard.ordered_cards as DashboardOrderedCard[],
-  );
+  const mappings = getMappings(dashboard.dashcards as DashboardOrderedCard[]);
   const mappingsForDashcard = mappings.filter(
     mapping => mapping.dashcard_id === dashcardId,
   );

--- a/frontend/src/metabase/parameters/utils/dashboards.ts
+++ b/frontend/src/metabase/parameters/utils/dashboards.ts
@@ -68,8 +68,8 @@ export function getIsMultiSelect(parameter: Parameter): boolean {
 }
 
 export function hasMapping(parameter: Parameter, dashboard: Dashboard) {
-  return dashboard.dashcards.some(ordered_card => {
-    return ordered_card?.parameter_mappings?.some(parameter_mapping => {
+  return dashboard.dashcards.some(dashcard => {
+    return dashcard?.parameter_mappings?.some(parameter_mapping => {
       return parameter_mapping.parameter_id === parameter.id;
     });
   });

--- a/frontend/src/metabase/parameters/utils/dashboards.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/dashboards.unit.spec.js
@@ -111,14 +111,14 @@ describe("metabase/parameters/utils/dashboards", () => {
 
     it("should return false when there are no cards on the dashboard", () => {
       const dashboard = {
-        ordered_cards: [],
+        dashcards: [],
       };
       expect(hasMapping(parameter, dashboard)).toBe(false);
     });
 
     it("should return false when there are no cards with parameter mappings", () => {
       const dashboard = {
-        ordered_cards: [
+        dashcards: [
           {
             parameter_mappings: [],
           },
@@ -133,14 +133,14 @@ describe("metabase/parameters/utils/dashboards", () => {
 
     it("should return false when missing parameter mappings", () => {
       const dashboard = {
-        ordered_cards: [{ parameter_mappings: undefined }],
+        dashcards: [{ parameter_mappings: undefined }],
       };
       expect(hasMapping(parameter, dashboard)).toBe(false);
     });
 
     it("should return false when there are no matching parameter mapping parameter_ids", () => {
       const dashboard = {
-        ordered_cards: [
+        dashcards: [
           {
             parameter_mappings: [
               {
@@ -166,7 +166,7 @@ describe("metabase/parameters/utils/dashboards", () => {
 
     it("should return true when the given parameter's id is found in a parameter_mappings object", () => {
       const dashboard = {
-        ordered_cards: [
+        dashcards: [
           {
             parameter_mappings: [
               {
@@ -202,7 +202,7 @@ describe("metabase/parameters/utils/dashboards", () => {
 
     it("should return false when the given parameter is not found in the dashboard's parameters list", () => {
       const brokenDashboard = {
-        ordered_cards: [
+        dashcards: [
           {
             parameter_mappings: [
               {
@@ -230,7 +230,7 @@ describe("metabase/parameters/utils/dashboards", () => {
 
     it("should return false when the given parameter is both found in the dashboard's parameters and also mapped", () => {
       const dashboard = {
-        ordered_cards: [
+        dashcards: [
           {
             parameter_mappings: [
               {
@@ -257,7 +257,7 @@ describe("metabase/parameters/utils/dashboards", () => {
 
     it("should return true when the given parameter is found on the dashboard but is not mapped", () => {
       const dashboard = {
-        ordered_cards: [
+        dashcards: [
           {
             parameter_mappings: [
               {
@@ -342,7 +342,7 @@ describe("metabase/parameters/utils/dashboards", () => {
   describe("hasMatchingParameters", () => {
     it("should return false when the given card is not found on the dashboard", () => {
       const dashboard = {
-        ordered_cards: [
+        dashcards: [
           {
             id: 1,
             card_id: 123,
@@ -380,7 +380,7 @@ describe("metabase/parameters/utils/dashboards", () => {
 
     it("should return false when a given parameter is not found in the dashcard mappings", () => {
       const dashboard = {
-        ordered_cards: [
+        dashcards: [
           {
             id: 1,
             card_id: 123,
@@ -426,7 +426,7 @@ describe("metabase/parameters/utils/dashboards", () => {
 
     it("should return true when all given parameters are found mapped to the dashcard", () => {
       const dashboard = {
-        ordered_cards: [
+        dashcards: [
           {
             id: 1,
             card_id: 123,
@@ -527,7 +527,7 @@ describe("metabase/parameters/utils/dashboards", () => {
   describe("getDashboardUiParameters", () => {
     const dashboard = {
       id: 1,
-      ordered_cards: [
+      dashcards: [
         {
           id: 1,
           card_id: 123,

--- a/frontend/src/metabase/parameters/utils/fixtures/dashboard-with-boolean-parameter.json
+++ b/frontend/src/metabase/parameters/utils/fixtures/dashboard-with-boolean-parameter.json
@@ -2,7 +2,7 @@
   "description": null,
   "archived": false,
   "collection_position": null,
-  "ordered_cards": [
+  "dashcards": [
     {
       "size_x": 7,
       "series": [],

--- a/frontend/src/metabase/sharing/components/SharingSidebar/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar/SharingSidebar.jsx
@@ -55,7 +55,7 @@ const cardsFromDashboard = dashboard => {
     return [];
   }
 
-  return dashboard.ordered_cards.map(card => ({
+  return dashboard.dashcards.map(card => ({
     id: card.card.id,
     collection_id: card.card.collection_id,
     description: card.card.description,

--- a/frontend/src/metabase/sharing/components/SharingSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar/tests/setup.tsx
@@ -32,7 +32,7 @@ const linkDashcard = createMockActionDashboardCard({
 export const user = createMockUser();
 
 const dashboard = createMockDashboard({
-  ordered_cards: [dashcard, actionDashcard, linkDashcard],
+  dashcards: [dashcard, actionDashcard, linkDashcard],
   parameters: [
     {
       name: "ID",
@@ -140,7 +140,7 @@ export function setup(
           dashboards: {
             [dashboard.id]: {
               ...dashboard,
-              ordered_cards: [dashcard.id, actionDashcard.id, linkDashcard.id],
+              dashcards: [dashcard.id, actionDashcard.id, linkDashcard.id],
             },
           },
         } as DashboardState,

--- a/frontend/src/metabase/sharing/components/SharingSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar/tests/setup.tsx
@@ -9,7 +9,7 @@ import { setupEnterprisePlugins } from "__support__/enterprise";
 import {
   createMockDashboard,
   createMockActionDashboardCard,
-  createMockDashboardOrderedCard,
+  createMockDashboardCard,
   createMockUser,
   createMockCard,
   createMockTokenFeatures,
@@ -19,7 +19,7 @@ import type { DashboardState } from "metabase-types/store";
 
 import SharingSidebar from "../SharingSidebar";
 
-export const dashcard = createMockDashboardOrderedCard();
+export const dashcard = createMockDashboardCard();
 
 const actionDashcard = createMockActionDashboardCard({
   id: 2,

--- a/frontend/src/metabase/visualizations/components/ChartSettings.unit.spec.js
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.unit.spec.js
@@ -3,7 +3,7 @@ import registerVisualizations from "metabase/visualizations/register";
 import { renderWithProviders, fireEvent, screen } from "__support__/ui";
 import {
   createMockCard,
-  createMockDashboardOrderedCard,
+  createMockDashboardCard,
   createMockVisualizationSettings,
 } from "metabase-types/api/mocks";
 
@@ -144,7 +144,7 @@ describe("ChartSettings", () => {
     });
 
     setup({
-      dashcard: createMockDashboardOrderedCard({
+      dashcard: createMockDashboardCard({
         card: createMockCard({ visualization_settings: originalVizSettings }),
       }),
       settings: modifiedSettings,

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/types.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/types.ts
@@ -1,8 +1,4 @@
-import type {
-  Card,
-  DatasetData,
-  DashboardOrderedCard,
-} from "metabase-types/api";
+import type { Card, DatasetData, DashboardCard } from "metabase-types/api";
 
 import type Table from "metabase-lib/metadata/Table";
 import type ForeignKey from "metabase-lib/metadata/ForeignKey";
@@ -26,7 +22,7 @@ export interface ObjectDetailProps {
   data: DatasetData;
   question?: Question;
   card?: Card;
-  dashcard?: DashboardOrderedCard;
+  dashcard?: DashboardCard;
   isObjectDetail?: boolean; // whether this should be shown in a modal
   table?: Table | null;
   zoomedRow?: unknown[] | undefined;

--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.js
@@ -48,7 +48,7 @@ function isDashboardAddedSeries(series, seriesIndex, dashboard) {
   const { card: addedSeriesCard } = series[seriesIndex];
 
   // find the dashcard associated with the first series
-  const dashCard = dashboard.ordered_cards.find(
+  const dashCard = dashboard.dashcards.find(
     dashCard => dashCard.card_id === firstCardInSeries.id,
   );
 

--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.unit.spec.js
@@ -208,7 +208,7 @@ describe("getStackedTooltipModel", () => {
     series: () => null,
   };
   const dashboard = {
-    ordered_cards: [],
+    dashcards: [],
   };
   const cols = [StringColumn(), NumberColumn()];
   const getMockSeries = ({ card, rows, hasBreakout }) => {

--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
@@ -7,7 +7,7 @@ import { useToggle } from "metabase/hooks/use-toggle";
 import { isEmpty } from "metabase/lib/validate";
 import type {
   Dashboard,
-  DashboardOrderedCard,
+  DashboardCard,
   ParameterValueOrArray,
   VisualizationSettings,
 } from "metabase-types/api";
@@ -24,7 +24,7 @@ import {
 interface HeadingProps {
   isEditing: boolean;
   onUpdateVisualizationSettings: ({ text }: { text: string }) => void;
-  dashcard: DashboardOrderedCard;
+  dashcard: DashboardCard;
   settings: VisualizationSettings;
   dashboard: Dashboard;
   parameterValues: { [id: string]: ParameterValueOrArray };

--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.unit.spec.tsx
@@ -4,10 +4,10 @@ import { color } from "metabase/lib/colors";
 
 import {
   createMockDashboard,
-  createMockDashboardOrderedCard,
+  createMockDashboardCard,
 } from "metabase-types/api/mocks";
 import type {
-  DashboardOrderedCard,
+  DashboardCard,
   Dashboard,
   ParameterId,
   Parameter,
@@ -24,7 +24,7 @@ interface Settings {
 }
 
 interface Options {
-  dashcard?: DashboardOrderedCard;
+  dashcard?: DashboardCard;
   isEditing?: boolean;
   isEditingParameter?: boolean;
   onUpdateVisualizationSettings?: ({ text }: { text: string }) => void;
@@ -34,7 +34,7 @@ interface Options {
 }
 
 const defaultProps = {
-  dashcard: createMockDashboardOrderedCard(),
+  dashcard: createMockDashboardCard(),
   dashboard: createMockDashboard(),
   isEditing: false,
   isEditingParameter: false,
@@ -73,7 +73,7 @@ describe("Text", () => {
 
       const options = {
         settings: getSettingsWithText(text),
-        dashcard: createMockDashboardOrderedCard({ parameter_mappings }),
+        dashcard: createMockDashboardCard({ parameter_mappings }),
         dashboard: createMockDashboard({ parameters }),
         parameterValues: parameterValues,
       };
@@ -125,7 +125,7 @@ describe("Text", () => {
 
         const options = {
           settings: getSettingsWithText(text),
-          dashcard: createMockDashboardOrderedCard({ parameter_mappings }),
+          dashcard: createMockDashboardCard({ parameter_mappings }),
           dashboard: createMockDashboard({ parameters }),
           parameterValues: parameterValues,
           isEditing: true,
@@ -191,7 +191,7 @@ describe("Text", () => {
 
         const options = {
           settings: getSettingsWithText(text),
-          dashcard: createMockDashboardOrderedCard({ parameter_mappings }),
+          dashcard: createMockDashboardCard({ parameter_mappings }),
           dashboard: createMockDashboard({ parameters }),
           parameterValues: parameterValues,
           isEditing: true,

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
@@ -7,7 +7,7 @@ import { SearchResults } from "metabase/nav/components/search/SearchResults";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
 
 import type {
-  DashboardOrderedCard,
+  DashboardCard,
   LinkCardSettings,
   SearchModelType,
   UnrestrictedLinkEntity,
@@ -46,12 +46,12 @@ const MODELS_TO_SEARCH: SearchModelType[] = [
 ];
 
 export interface LinkVizProps {
-  dashcard: DashboardOrderedCard;
+  dashcard: DashboardCard;
   isEditing: boolean;
   onUpdateVisualizationSettings: (
-    newSettings: Partial<DashboardOrderedCard["visualization_settings"]>,
+    newSettings: Partial<DashboardCard["visualization_settings"]>,
   ) => void;
-  settings: DashboardOrderedCard["visualization_settings"] & {
+  settings: DashboardCard["visualization_settings"] & {
     link: LinkCardSettings;
   };
   isEditingParameter?: boolean;

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.unit.spec.tsx
@@ -14,10 +14,7 @@ import {
 import * as domUtils from "metabase/lib/dom";
 import registerVisualizations from "metabase/visualizations/register";
 
-import type {
-  DashboardOrderedCard,
-  LinkCardSettings,
-} from "metabase-types/api";
+import type { DashboardCard, LinkCardSettings } from "metabase-types/api";
 import {
   createMockDashboardCardWithVirtualCard,
   createMockCollectionItem,
@@ -32,7 +29,7 @@ import { LinkViz } from "./LinkViz";
 
 registerVisualizations();
 
-type LinkCardVizSettings = DashboardOrderedCard["visualization_settings"] & {
+type LinkCardVizSettings = DashboardCard["visualization_settings"] & {
   link: LinkCardSettings;
 };
 

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -438,7 +438,7 @@
     (testing "make sure x-rays don't use features that the driver doesn't support"
       (is (empty?
            (mbql.u/match-one (->> (magic/automagic-analysis (t2/select-one Field :id (mt/id :venues :price)) {})
-                                  :ordered_cards
+                                  :dashcards
                                   (mapcat (comp :breakout :query :dataset_query :card)))
              [:field _ (_ :guard :binning)]))))))
 

--- a/src/metabase/api/automagic_dashboards.clj
+++ b/src/metabase/api/automagic_dashboards.clj
@@ -209,7 +209,7 @@
                                        :transient_filters))]
       (if (second child-dashboards)
         (->> child-dashboards
-             (map-indexed (fn [idx {tab-name :name tab-cards :ordered_cards}]
+             (map-indexed (fn [idx {tab-name :name tab-cards :dashcards}]
                             ;; id starts at 0. want our temporary ids to start at -1, -2, ...
                             (let [tab-id (dec (- idx))]
                               {:tab {:id       tab-id
@@ -221,16 +221,16 @@
                                     (add-source-model-link model tab-cards))})))
              (reduce (fn [dashboard {:keys [tab dash-cards]}]
                        (-> dashboard
-                           (update :ordered_cards into dash-cards)
+                           (update :dashcards into dash-cards)
                            (update :ordered_tabs conj tab)))
                      (merge
                       seed-dashboard
-                      {:ordered_cards []
+                      {:dashcards []
                        :ordered_tabs  []})))
         (update seed-dashboard
-                :ordered_cards (fn [cards] (add-source-model-link model cards)))))
+                :dashcards (fn [cards] (add-source-model-link model cards)))))
     {:name          (format "Here's a look at \"%s\" from \"%s\"" indexed-entity-name model-name)
-     :ordered_cards (add-source-model-link
+     :dashcards (add-source-model-link
                      model
                      [{:row                    0
                        :col                    0

--- a/src/metabase/api/automagic_dashboards.clj
+++ b/src/metabase/api/automagic_dashboards.clj
@@ -229,7 +229,7 @@
                        :ordered_tabs  []})))
         (update seed-dashboard
                 :dashcards (fn [cards] (add-source-model-link model cards)))))
-    {:name          (format "Here's a look at \"%s\" from \"%s\"" indexed-entity-name model-name)
+    {:name      (format "Here's a look at \"%s\" from \"%s\"" indexed-entity-name model-name)
      :dashcards (add-source-model-link
                      model
                      [{:row                    0

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -115,10 +115,10 @@
   "Replace the `:card` and `:series` entries from dashcards that they user isn't allowed to read with empty objects."
   [dashboard]
   (update dashboard :dashcards (fn [dashcards]
-                                     (vec (for [dashcard dashcards]
-                                            (-> dashcard
-                                                (update :card hide-unreadable-card)
-                                                (update :series (partial mapv hide-unreadable-card))))))))
+                                 (vec (for [dashcard dashcards]
+                                        (-> dashcard
+                                            (update :card hide-unreadable-card)
+                                            (update :series (partial mapv hide-unreadable-card))))))))
 
 
 ;;; ------------------------------------------ Query Average Duration Info -------------------------------------------

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -139,7 +139,7 @@
   make these parameters visible at all to the frontend."
   [dashboard token-params]
   (let [params             (:parameters dashboard)
-        ordered-cards      (:ordered_cards dashboard)
+        ordered-cards      (:dashcards dashboard)
         params-with-values (reduce
                             (fn [acc param]
                              (if-let [value (get token-params (keyword (:slug param)))]
@@ -148,7 +148,7 @@
                             []
                             params)]
     (assoc dashboard
-           :ordered_cards
+           :dashcards
            (map
             (fn [card]
               (if (-> card :visualization_settings :virtual_card)

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -139,7 +139,7 @@
   make these parameters visible at all to the frontend."
   [dashboard token-params]
   (let [params             (:parameters dashboard)
-        ordered-cards      (:dashcards dashboard)
+        dashcards      (:dashcards dashboard)
         params-with-values (reduce
                             (fn [acc param]
                              (if-let [value (get token-params (keyword (:slug param)))]
@@ -154,7 +154,7 @@
               (if (-> card :visualization_settings :virtual_card)
                 (params/process-virtual-dashcard card params-with-values)
                 card))
-            ordered-cards))))
+            dashcards))))
 
 (mu/defn ^:private apply-slug->value :- [:maybe [:sequential
                                                  [:map

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -231,9 +231,9 @@
   {:pre [(even? (count conditions))]}
   (binding [params/*ignore-current-user-perms-and-return-all-field-values* true]
     (-> (api/check-404 (apply t2/select-one [Dashboard :name :description :id :parameters :auto_apply_filters], :archived false, conditions))
-        (t2/hydrate [:ordered_cards :card :series :dashcard/action] :ordered_tabs :param_values :param_fields)
+        (t2/hydrate [:dashcards :card :series :dashcard/action] :ordered_tabs :param_values :param_fields)
         api.dashboard/add-query-average-durations
-        (update :ordered_cards (fn [dashcards]
+        (update :dashcards (fn [dashcards]
                                  (for [dashcard dashcards]
                                    (-> (select-keys dashcard [:id :card :card_id :dashboard_id :series :col :row :size_x :dashboard_tab_id
                                                               :size_y :parameter_mappings :visualization_settings :action])
@@ -425,8 +425,8 @@
   [field-id dashboard-id]
   (let [dashboard       (-> (t2/select-one Dashboard :id dashboard-id)
                             api/check-404
-                            (t2/hydrate [:ordered_cards :card]))
-        param-field-ids (params/dashcards->param-field-ids (:ordered_cards dashboard))]
+                            (t2/hydrate [:dashcards :card]))
+        param-field-ids (params/dashcards->param-field-ids (:dashcards dashboard))]
     (api/check-404 (contains? param-field-ids field-id))))
 
 (defn card-and-field-id->values

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -234,14 +234,14 @@
         (t2/hydrate [:dashcards :card :series :dashcard/action] :ordered_tabs :param_values :param_fields)
         api.dashboard/add-query-average-durations
         (update :dashcards (fn [dashcards]
-                                 (for [dashcard dashcards]
-                                   (-> (select-keys dashcard [:id :card :card_id :dashboard_id :series :col :row :size_x :dashboard_tab_id
-                                                              :size_y :parameter_mappings :visualization_settings :action])
-                                       (update :card remove-card-non-public-columns)
-                                       (update :series (fn [series]
-                                                         (for [series series]
-                                                           (remove-card-non-public-columns series))))
-                                       (m/update-existing :action public-action))))))))
+                             (for [dashcard dashcards]
+                               (-> (select-keys dashcard [:id :card :card_id :dashboard_id :series :col :row :size_x :dashboard_tab_id
+                                                          :size_y :parameter_mappings :visualization_settings :action])
+                                   (update :card remove-card-non-public-columns)
+                                   (update :series (fn [series]
+                                                     (for [series series]
+                                                       (remove-card-non-public-columns series))))
+                                   (m/update-existing :action public-action))))))))
 
 (defn- dashboard-with-uuid [uuid] (public-dashboard :public_uuid uuid))
 

--- a/src/metabase/automagic_dashboards/comparison.clj
+++ b/src/metabase/automagic_dashboards/comparison.clj
@@ -28,7 +28,7 @@
 (defn- dashboard->cards
   [dashboard]
   (->> dashboard
-       :ordered_cards
+       :dashcards
        (map (fn [{:keys [size_y card col row series] :as dashcard}]
               (assoc card
                 :text     (-> dashcard :visualization_settings :text)
@@ -94,7 +94,7 @@
               series (-> card-right
                          (update :name #(format "%s (%s)" % (comparison-name right)))
                          vector)]
-          (update dashboard :ordered_cards conj (merge (populate/card-defaults)
+          (update dashboard :dashcards conj (merge (populate/card-defaults)
                                                        {:col                    0
                                                         :row                    row
                                                         :size_x                 populate/grid-width
@@ -114,7 +114,7 @@
                              (not (multiseries? card-right))
                              (assoc-in [:visualization_settings :graph.colors] [color-right]))]
           (-> dashboard
-              (update :ordered_cards conj (merge (populate/card-defaults)
+              (update :dashcards conj (merge (populate/card-defaults)
                                                  {:col                    0
                                                   :row                    row
                                                   :size_x                 width
@@ -123,7 +123,7 @@
                                                   :card_id                (:id card-left)
                                                   :series                 series-left
                                                   :visualization_settings {}}))
-              (update :ordered_cards conj (merge (populate/card-defaults)
+              (update :dashcards conj (merge (populate/card-defaults)
                                                  {:col                    width
                                                    :row                    row
                                                    :size_x                 width

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -1628,7 +1628,7 @@
   "Hack to shove back in joins when they get automagically stripped out by the question decomposition into metrics"
   [entity dashboard]
   (if-let [join-statement (get-in entity [:dataset_query :query :joins])]
-    (update dashboard :ordered_cards #(map (partial splice-in join-statement) %))
+    (update dashboard :dashcards #(map (partial splice-in join-statement) %))
     dashboard))
 
 (defn- query-based-analysis

--- a/src/metabase/automagic_dashboards/filters.clj
+++ b/src/metabase/automagic_dashboards/filters.clj
@@ -137,7 +137,7 @@
         (add-filters dashboard max-filters)))
   ([dashboard dimensions max-filters]
    (let [fks (when-let [table-ids (not-empty (set (keep (comp :table_id :card)
-                                                        (:ordered_cards dashboard))))]
+                                                        (:dashcards dashboard))))]
                (->> (t2/select Field :fk_target_field_id [:not= nil]
                                :table_id [:in table-ids])
                     field/with-targets))]
@@ -149,12 +149,12 @@
            (fn [dashboard candidate]
              (let [filter-id     (-> candidate ((juxt :id :name :unit)) hash str)
                    candidate     (assoc candidate :fk-map (build-fk-map fks candidate))
-                   dashcards     (:ordered_cards dashboard)
+                   dashcards     (:dashcards dashboard)
                    dashcards-new (keep #(add-filter % filter-id candidate) dashcards)]
                ;; Only add filters that apply to all cards.
                (if (= (count dashcards) (count dashcards-new))
                  (-> dashboard
-                     (assoc :ordered_cards dashcards-new)
+                     (assoc :dashcards dashcards-new)
                      (update :parameters conj {:id   filter-id
                                                :type (filter-type candidate)
                                                :name (:display_name candidate)

--- a/src/metabase/automagic_dashboards/populate.clj
+++ b/src/metabase/automagic_dashboards/populate.clj
@@ -144,7 +144,7 @@
                   :id            (or id (gensym))}
                  (merge (visualization-settings card))
                  card/populate-query-fields)]
-    (update dashboard :ordered_cards conj
+    (update dashboard :dashcards conj
             (merge (card-defaults)
              {:col                    y
               :row                    x
@@ -157,7 +157,7 @@
 (defn add-text-card
   "Add a text card to dashboard `dashboard` at position [`x`, `y`]."
   [dashboard {:keys [text width height visualization-settings]} [x y]]
-  (update dashboard :ordered_cards conj
+  (update dashboard :dashcards conj
           (merge (card-defaults)
                  {:creator_id             api/*current-user-id*
                   :visualization_settings (merge
@@ -317,14 +317,14 @@
 (defn- merge-filters
   [ds]
   (when (->> ds
-             (mapcat :ordered_cards)
+             (mapcat :dashcards)
              (keep (comp :table_id :card))
              distinct
              count
              (= 1))
    [(->> ds (mapcat :parameters) distinct)
     (->> ds
-         (mapcat :ordered_cards)
+         (mapcat :dashcards)
          (mapcat :parameter_mappings)
          (map #(dissoc % :card_id))
          distinct)]))
@@ -335,13 +335,13 @@
   ([target dashboard {:keys [skip-titles?]}]
    (let [[parameters parameter-mappings] (merge-filters [target dashboard])
          offset                         (->> target
-                                             :ordered_cards
+                                             :dashcards
                                              (map #(+ (:row %) (:size_y %)))
                                              (apply max -1) ; -1 so it neturalizes +1 for spacing
                                                             ; if the target dashboard is empty.
                                              inc)
          cards                        (->> dashboard
-                                           :ordered_cards
+                                           :dashcards
                                            (map #(-> %
                                                      (update :row + offset (if skip-titles?
                                                                              0
@@ -362,4 +362,4 @@
                            :visualization-settings {:dashcard.background false
                                                     :text.align_vertical :bottom}}
                           [offset 0]))
-         (update :ordered_cards concat cards)))))
+         (update :dashcards concat cards)))))

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -165,7 +165,7 @@
   [dashboard-or-id]
   (t2/select :model/DashboardTab :dashboard_id (u/the-id dashboard-or-id) {:order-by [[:position :asc]]}))
 
-(mi/define-simple-hydration-method ordered-cards
+(mi/define-simple-hydration-method dashcards
   :dashcards
   "Return the DashboardCards associated with `dashboard`, in the order they were created."
   [dashboard-or-id]
@@ -217,7 +217,7 @@
 (defmethod revision/serialize-instance :model/Dashboard
   [_model _id dashboard]
   (-> (apply dissoc dashboard excluded-columns-for-dashboard-revision)
-      (assoc :cards (vec (for [dashboard-card (ordered-cards dashboard)]
+      (assoc :cards (vec (for [dashboard-card (dashcards dashboard)]
                            (-> (apply dissoc dashboard-card excluded-columns-for-dashcard-revision)
                                (assoc :series (mapv :id (dashboard-card/series dashboard-card)))))))
       (assoc :tabs (map #(apply dissoc % excluded-columns-for-dashboard-tab-revision) (ordered-tabs dashboard)))))

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -548,7 +548,7 @@
                (nil? (:ordered_tabs dash))
                (t2/hydrate :ordered_tabs))]
     (-> (serdes/extract-one-basics "Dashboard" dash)
-        (update :dashcards     #(mapv extract-dashcard %))
+        (update :dashcards         #(mapv extract-dashcard %))
         (update :ordered_tabs      #(mapv extract-dashtab %))
         (update :parameters        serdes/export-parameters)
         (update :collection_id     serdes/*export-fk* Collection)

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -166,7 +166,7 @@
   (t2/select :model/DashboardTab :dashboard_id (u/the-id dashboard-or-id) {:order-by [[:position :asc]]}))
 
 (mi/define-simple-hydration-method ordered-cards
-  :ordered_cards
+  :dashcards
   "Return the DashboardCards associated with `dashboard`, in the order they were created."
   [dashboard-or-id]
   (t2/select DashboardCard
@@ -341,8 +341,8 @@
   "Get the set of Field IDs referenced by the parameters in this Dashboard."
   [dashboard-or-id]
   (let [dash (-> (t2/select-one Dashboard :id (u/the-id dashboard-or-id))
-                 (t2/hydrate [:ordered_cards :card]))]
-    (params/dashcards->param-field-ids (:ordered_cards dash))))
+                 (t2/hydrate [:dashcards :card]))]
+    (params/dashcards->param-field-ids (:dashcards dash))))
 
 (defn- update-field-values-for-on-demand-dbs!
   "If the parameters have changed since last time this Dashboard was saved, we need to update the FieldValues
@@ -374,7 +374,7 @@
 (def ^:private DashboardWithSeriesAndCard
   [:map
    [:id ms/PositiveInt]
-   [:ordered_cards [:sequential [:map
+   [:dashcards [:sequential [:map
                                  [:card_id {:optional true} [:maybe ms/PositiveInt]]
                                  [:card {:optional true} [:maybe [:map
                                                                   [:id ms/PositiveInt]]]]]]]])
@@ -387,7 +387,7 @@
   {:style/indent 1}
   [dashboard     :- DashboardWithSeriesAndCard
    new-dashcards :- [:sequential ms/Map]]
-  (let [old-dashcards    (:ordered_cards dashboard)
+  (let [old-dashcards    (:dashcards dashboard)
         id->old-dashcard (m/index-by :id old-dashcards)
         old-dashcard-ids (set (keys id->old-dashcard))
         new-dashcard-ids (set (map :id new-dashcards))
@@ -444,7 +444,7 @@
 (defn save-transient-dashboard!
   "Save a denormalized description of `dashboard`."
   [dashboard parent-collection-id]
-  (let [{dashcards      :ordered_cards
+  (let [{dashcards      :dashcards
          tabs           :ordered_tabs
          dashboard-name :name
          :keys          [description] :as dashboard} (i18n/localized-strings->strings dashboard)
@@ -455,7 +455,7 @@
         dashboard  (first (t2/insert-returning-instances!
                             :model/Dashboard
                             (-> dashboard
-                                (dissoc :ordered_cards :ordered_tabs :rule :related
+                                (dissoc :dashcards :ordered_tabs :rule :related
                                         :transient_name :transient_filters :param_fields :more)
                                 (assoc :description description
                                        :collection_id (:id collection)
@@ -486,10 +486,10 @@
 
 (mu/defn ^:private dashboard->resolved-params* :- [:map-of ms/NonBlankString ParamWithMapping]
   [dashboard :- [:map [:parameters [:maybe [:sequential :map]]]]]
-  (let [dashboard           (t2/hydrate dashboard [:ordered_cards :card])
+  (let [dashboard           (t2/hydrate dashboard [:dashcards :card])
         param-key->mappings (apply
                              merge-with set/union
-                             (for [dashcard (:ordered_cards dashboard)
+                             (for [dashcard (:dashcards dashboard)
                                    param    (:parameter_mappings dashcard)]
                                {(:parameter_id param) #{(assoc param :dashcard dashcard)}}))]
     (into {} (for [{param-key :id, :as param} (:parameters dashboard)]
@@ -523,7 +523,7 @@
 ;;; |                                               SERIALIZATION                                                    |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 (defmethod serdes/extract-query "Dashboard" [_ opts]
-  (eduction (map #(t2/hydrate % :ordered_cards))
+  (eduction (map #(t2/hydrate % :dashcards))
             (serdes/extract-query-collections Dashboard opts)))
 
 (defn- extract-dashcard
@@ -543,12 +543,12 @@
 (defmethod serdes/extract-one "Dashboard"
   [_model-name _opts dash]
   (let [dash (cond-> dash
-               (nil? (:ordered_cards dash))
-               (t2/hydrate :ordered_cards)
+               (nil? (:dashcards dash))
+               (t2/hydrate :dashcards)
                (nil? (:ordered_tabs dash))
                (t2/hydrate :ordered_tabs))]
     (-> (serdes/extract-one-basics "Dashboard" dash)
-        (update :ordered_cards     #(mapv extract-dashcard %))
+        (update :dashcards     #(mapv extract-dashcard %))
         (update :ordered_tabs      #(mapv extract-dashtab %))
         (update :parameters        serdes/export-parameters)
         (update :collection_id     serdes/*export-fk* Collection)
@@ -559,7 +559,7 @@
   [dash]
   (-> dash
       serdes/load-xform-basics
-      ;; Deliberately not doing anything to :ordered_cards - they get handled by load-insert! and load-update! below.
+      ;; Deliberately not doing anything to :dashcards - they get handled by load-insert! and load-update! below.
       (update :collection_id     serdes/*import-fk* Collection)
       (update :parameters        serdes/import-parameters)
       (update :creator_id        serdes/*import-user*)
@@ -582,11 +582,11 @@
 
 ;; Call the default load-one! for the Dashboard, then for each DashboardCard.
 (defmethod serdes/load-one! "Dashboard" [ingested maybe-local]
-  (let [dashboard ((get-method serdes/load-one! :default) (dissoc ingested :ordered_cards :ordered_tabs) maybe-local)]
+  (let [dashboard ((get-method serdes/load-one! :default) (dissoc ingested :dashcards :ordered_tabs) maybe-local)]
     (doseq [tab (:ordered_tabs ingested)]
       (serdes/load-one! (dashtab-for tab dashboard)
                         (t2/select-one :model/DashboardTab :entity_id (:entity_id tab))))
-    (doseq [dashcard (:ordered_cards ingested)]
+    (doseq [dashcard (:dashcards ingested)]
       (serdes/load-one! (dashcard-for dashcard dashboard)
                         (t2/select-one 'DashboardCard :entity_id (:entity_id dashcard))))))
 
@@ -599,8 +599,8 @@
        set))
 
 (defmethod serdes/dependencies "Dashboard"
-  [{:keys [collection_id ordered_cards parameters]}]
-  (->> (map serdes-deps-dashcard ordered_cards)
+  [{:keys [collection_id dashcards parameters]}]
+  (->> (map serdes-deps-dashcard dashcards)
        (reduce set/union #{})
        (set/union (when collection_id #{[{:model "Collection" :id collection_id}]}))
        (set/union (serdes/parameters-deps parameters))))

--- a/src/metabase/models/params.clj
+++ b/src/metabase/models/params.clj
@@ -256,14 +256,14 @@
   "Return a map of Field ID to FieldValues (if any) for any Fields referenced by Cards in `dashboard`,
    or `nil` if none are referenced or none of them have FieldValues."
   [dashboard]
-  (field-ids->param-field-values (dashcards->param-field-ids (:ordered_cards dashboard))))
+  (field-ids->param-field-values (dashcards->param-field-ids (:dashcards dashboard))))
 
 (defmethod param-values :model/Dashboard [dashboard]
   (dashboard->param-field-values dashboard))
 
 (defmethod param-fields :model/Dashboard [dashboard]
-  (-> (t2/hydrate dashboard [:ordered_cards :card])
-      :ordered_cards
+  (-> (t2/hydrate dashboard [:dashcards :card])
+      :dashcards
       dashcards->param-field-ids
       param-field-ids->fields))
 

--- a/src/metabase/moderation.clj
+++ b/src/metabase/moderation.clj
@@ -27,7 +27,7 @@
   cards. In the future could have dashboards here as well."
   [items]
   ;; no need to do work on empty items. Also, can have nil here due to text cards. I think this is a bug in toucan. To
-  ;; get here we are `(t2/hydrate dashboard [:ordered_cards [:card :moderation_reviews] :series] ...)` But ordered_cards
+  ;; get here we are `(t2/hydrate dashboard [:dashcards [:card :moderation_reviews] :series] ...)` But dashcards
   ;; dont have to have cards. but the hydration will pass the nil card id into here.  NOTE: it is important that each
   ;; item that comes into this comes out. The nested hydration is positional, not by an id so everything that comes in
   ;; must go out in the same order

--- a/test/metabase/api/automagic_dashboards_test.clj
+++ b/test/metabase/api/automagic_dashboards_test.clj
@@ -25,7 +25,7 @@
 
 (use-fixtures :once (fixtures/initialize :db :web-server :test-users :test-users-personal-collections))
 
-(defn- ordered-cards-schema-check
+(defn- dashcards-schema-check
   [dashcards]
   (testing "check if all cards in dashcards contain the required fields"
     (doseq [card dashcards]
@@ -51,7 +51,7 @@
      (with-dashboard-cleanup
        (let [api-endpoint (apply format (str "automagic-dashboards/" template) args)
              resp         (mt/user-http-request :rasta :get 200 api-endpoint)
-             _            (ordered-cards-schema-check (:dashcards resp))
+             _            (dashcards-schema-check (:dashcards resp))
              result       (validation-fn resp)]
          (when (and result
                     (try

--- a/test/metabase/api/automagic_dashboards_test.clj
+++ b/test/metabase/api/automagic_dashboards_test.clj
@@ -26,9 +26,9 @@
 (use-fixtures :once (fixtures/initialize :db :web-server :test-users :test-users-personal-collections))
 
 (defn- ordered-cards-schema-check
-  [ordered_cards]
-  (testing "check if all cards in ordered_cards contain the required fields"
-    (doseq [card ordered_cards]
+  [dashcards]
+  (testing "check if all cards in dashcards contain the required fields"
+    (doseq [card dashcards]
       (is (schema= {:id                     (s/cond-pre s/Str s/Int)
                     :dashboard_tab_id       (s/maybe s/Int)
                     :row                    s/Int
@@ -51,7 +51,7 @@
      (with-dashboard-cleanup
        (let [api-endpoint (apply format (str "automagic-dashboards/" template) args)
              resp         (mt/user-http-request :rasta :get 200 api-endpoint)
-             _            (ordered-cards-schema-check (:ordered_cards resp))
+             _            (ordered-cards-schema-check (:dashcards resp))
              result       (validation-fn resp)]
          (when (and result
                     (try
@@ -263,7 +263,7 @@
                                  (tf.materialize/get-collection "Test transform"))
                                (fn [dashboard]
                                  (->> dashboard
-                                      :ordered_cards
+                                      :dashcards
                                       (sort-by (juxt :row :col))
                                       last
                                       :card
@@ -337,7 +337,7 @@
 
 (deftest create-linked-dashboard-test-no-linked
   (testing "If there are no linked-tables, create a default view explaining the situation."
-    (is (=? {:ordered_cards [{:visualization_settings {:virtual_card {:display "link", :archived false}
+    (is (=? {:dashcards [{:visualization_settings {:virtual_card {:display "link", :archived false}
                                                        :link         {:entity {:model   "dataset"
                                                                                :display "table"}}}}
                              {:visualization_settings {:text                "# Unfortunately, there's not much else to show right now...",
@@ -378,7 +378,7 @@
                                                :name    (:name model)
                                                :model   "dataset"
                                                :display "table"}}}})
-                    (->> (:ordered_cards dash)
+                    (->> (:dashcards dash)
                          (group-by :dashboard_tab_id)
                          vals
                          (map first)))))
@@ -392,7 +392,7 @@
             (let [pk-filters (expected-filters {:model             model
                                                 :model-index       model-index
                                                 :model-index-value model-index-value})]
-              (cards-have-filters? (:ordered_cards dash) pk-filters))))))
+              (cards-have-filters? (:dashcards dash) pk-filters))))))
     (testing "X-ray a native model"
       (letfn [(lower [x] (u/lower-case-en x))
               (by-id [cols col-name] (or (some (fn [col]
@@ -443,7 +443,7 @@
                 (let [pk-filters (expected-filters {:model             model
                                                     :model-index       model-index
                                                     :model-index-value model-index-value})]
-                  (cards-have-filters? (:ordered_cards dash) pk-filters))))))))))
+                  (cards-have-filters? (:dashcards dash) pk-filters))))))))))
 
 (deftest create-linked-dashboard-test-single-link
   (mt/dataset sample-dataset
@@ -469,7 +469,7 @@
                                               :name    (:name model)
                                               :model   "dataset"
                                               :display "table"}}}}
-                    (->> dash :ordered_cards first))))
+                    (->> dash :dashcards first))))
           (testing "The generated dashboard has a meaningful name and description"
             (is (true?
                  (and
@@ -480,4 +480,4 @@
             (let [pk-filters (expected-filters {:model             model
                                                 :model-index       model-index
                                                 :model-index-value model-index-value})]
-              (cards-have-filters? (:ordered_cards dash) pk-filters))))))))
+              (cards-have-filters? (:dashcards dash) pk-filters))))))))

--- a/test/metabase/api/automagic_dashboards_test.clj
+++ b/test/metabase/api/automagic_dashboards_test.clj
@@ -338,12 +338,12 @@
 (deftest create-linked-dashboard-test-no-linked
   (testing "If there are no linked-tables, create a default view explaining the situation."
     (is (=? {:dashcards [{:visualization_settings {:virtual_card {:display "link", :archived false}
-                                                       :link         {:entity {:model   "dataset"
-                                                                               :display "table"}}}}
-                             {:visualization_settings {:text                "# Unfortunately, there's not much else to show right now...",
-                                                       :virtual_card        {:display :text},
-                                                       :dashcard.background false,
-                                                       :text.align_vertical :bottom}}]}
+                                                   :link         {:entity {:model   "dataset"
+                                                                           :display "table"}}}}
+                         {:visualization_settings {:text                "# Unfortunately, there's not much else to show right now...",
+                                                   :virtual_card        {:display :text},
+                                                   :dashcard.background false,
+                                                   :text.align_vertical :bottom}}]}
             (#'api.magic/create-linked-dashboard {:model             nil
                                                   :linked-tables     ()
                                                   :model-index       nil

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -90,7 +90,7 @@
                              (update :collection_id boolean)
                              (update :collection boolean)))))
 
-(defn- dashboard-response [{:keys [creator ordered_cards created_at updated_at] :as dashboard}]
+(defn- dashboard-response [{:keys [creator dashcards created_at updated_at] :as dashboard}]
   ;; todo: should be udpated to use mt/boolean-ids-and-timestamps
   (let [dash (-> (into {} dashboard)
                  (dissoc :id)
@@ -109,7 +109,7 @@
                                     (update :id boolean)
                                     (update :timestamp boolean))))
       creator       (update :creator #(into {} %))
-      ordered_cards (update :ordered_cards #(mapv dashcard-response %)))))
+      dashcards (update :dashcards #(mapv dashcard-response %)))))
 
 (defn- do-with-dashboards-in-a-collection [grant-collection-perms-fn! dashboards-or-ids f]
   (mt/with-non-admin-groups-no-root-collection-perms
@@ -350,7 +350,7 @@
                       :param_values               nil
                       :last-edit-info             {:timestamp true :id true :first_name "Test" :last_name "User" :email "test@example.com"}
                       :ordered_tabs               [{:name "Test Dashboard Tab" :position 0 :id dashtab-id :dashboard_id dashboard-id}]
-                      :ordered_cards              [{:size_x                     4
+                      :dashcards              [{:size_x                     4
                                                     :size_y                     4
                                                     :col                        0
                                                     :row                        0
@@ -376,7 +376,7 @@
       (let [link-card-info-from-resp
             (fn [resp]
               (->> resp
-                   :ordered_cards
+                   :dashcards
                    (map (fn [dashcard] (or (get-in dashcard [:visualization_settings :link :entity])
                                            ;; get for link card
                                            (get-in dashcard [:visualization_settings :link]))))))]
@@ -441,7 +441,7 @@
                                                                 :name_field       nil
                                                                 :dimensions       []}}
                          :ordered_tabs               []
-                         :ordered_cards              [{:size_x                     4
+                         :dashcards              [{:size_x                     4
                                                        :size_y                     4
                                                        :col                        0
                                                        :row                        0
@@ -1829,7 +1829,7 @@
                                                                            :action_id              action-id
                                                                            :visualization_settings {:label "Update"}}]
                                                            :ordered_tabs []}))))
-              (is (partial= {:ordered_cards [{:action (cond-> {:visualization_settings {:hello true}
+              (is (partial= {:dashcards [{:action (cond-> {:visualization_settings {:hello true}
                                                                :type (name action-type)
                                                                :parameters [{:id "id"}]
                                                                :database_enabled_actions true}
@@ -1848,7 +1848,7 @@
               (mt/with-actions [{:keys [action-id]} {:type :query :visualization_settings {:hello true}}]
                 (mt/with-temp [Dashboard     {dashboard-id :id} {}
                                DashboardCard _ {:action_id action-id, :dashboard_id dashboard-id}]
-                  (is (partial= {:ordered_cards [{:action {:database_enabled_actions enable-actions?}}]}
+                  (is (partial= {:dashcards [{:action {:database_enabled_actions enable-actions?}}]}
                                 (mt/user-http-request :crowberto :get 200 (format "dashboard/%s" dashboard-id)))))))))))))
 
 (deftest add-card-parameter-mapping-permissions-test
@@ -3617,7 +3617,7 @@
                                                           :action_id action-id
                                                           :card_id card-id}]
             (testing "Dashcard should only have id and name params"
-              (is (partial= {:ordered_cards [{:action {:parameters [{:id "id"} {:id "name"}]}}]}
+              (is (partial= {:dashcards [{:action {:parameters [{:id "id"} {:id "name"}]}}]}
                             (mt/user-http-request :crowberto :get 200 (format "dashboard/%s" dashboard-id)))))
             (let [execute-path (format "dashboard/%s/dashcard/%s/execute" dashboard-id dashcard-id)]
               (testing "Prefetch should limit to id and name"
@@ -3647,7 +3647,7 @@
                                                           :action_id action-id
                                                           :card_id card-id}]
             (testing "Dashcard should only have id and name params"
-              (is (partial= {:ordered_cards [{:action {:parameters [{:id "id"} {:id "name"}]}}]}
+              (is (partial= {:dashcards [{:action {:parameters [{:id "id"} {:id "name"}]}}]}
                             (mt/user-http-request :crowberto :get 200 (format "dashboard/%s" dashboard-id)))))
             (let [execute-path (format "dashboard/%s/dashcard/%s/execute" dashboard-id dashcard-id)]
               (testing "Prefetch should only return non-hidden fields"

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -351,25 +351,25 @@
                       :last-edit-info             {:timestamp true :id true :first_name "Test" :last_name "User" :email "test@example.com"}
                       :ordered_tabs               [{:name "Test Dashboard Tab" :position 0 :id dashtab-id :dashboard_id dashboard-id}]
                       :dashcards              [{:size_x                     4
-                                                    :size_y                     4
-                                                    :col                        0
-                                                    :row                        0
-                                                    :collection_authority_level nil
-                                                    :updated_at                 true
-                                                    :created_at                 true
-                                                    :entity_id                  (:entity_id dashcard)
-                                                    :parameter_mappings         []
-                                                    :visualization_settings     {}
-                                                    :dashboard_tab_id           dashtab-id
-                                                    :card                       (merge api.card-test/card-defaults-no-hydrate
-                                                                                       {:name                   "Dashboard Test Card"
-                                                                                        :creator_id             (mt/user->id :rasta)
-                                                                                        :collection_id          true
-                                                                                        :display                "table"
-                                                                                        :entity_id              (:entity_id card)
-                                                                                        :visualization_settings {}
-                                                                                        :result_metadata        nil})
-                                                    :series                     []}]})
+                                                :size_y                     4
+                                                :col                        0
+                                                :row                        0
+                                                :collection_authority_level nil
+                                                :updated_at                 true
+                                                :created_at                 true
+                                                :entity_id                  (:entity_id dashcard)
+                                                :parameter_mappings         []
+                                                :visualization_settings     {}
+                                                :dashboard_tab_id           dashtab-id
+                                                :card                       (merge api.card-test/card-defaults-no-hydrate
+                                                                                   {:name                   "Dashboard Test Card"
+                                                                                    :creator_id             (mt/user->id :rasta)
+                                                                                    :collection_id          true
+                                                                                    :display                "table"
+                                                                                    :entity_id              (:entity_id card)
+                                                                                    :visualization_settings {}
+                                                                                    :result_metadata        nil})
+                                                :series                     []}]})
                     (dashboard-response (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-id)))))))))
 
     (testing "a dashboard that has link cards on it"
@@ -442,29 +442,29 @@
                                                                 :dimensions       []}}
                          :ordered_tabs               []
                          :dashcards              [{:size_x                     4
-                                                       :size_y                     4
-                                                       :col                        0
-                                                       :row                        0
-                                                       :updated_at                 true
-                                                       :created_at                 true
-                                                       :entity_id                  (:entity_id dashcard)
-                                                       :collection_authority_level nil
-                                                       :parameter_mappings         [{:card_id      1
-                                                                                     :parameter_id "foo"
-                                                                                     :target       ["dimension" ["field" field-id nil]]}]
-                                                       :visualization_settings     {}
-                                                       :dashboard_tab_id           nil
-                                                       :card                       (merge api.card-test/card-defaults-no-hydrate
-                                                                                          {:name                   "Dashboard Test Card"
-                                                                                           :creator_id             (mt/user->id :rasta)
-                                                                                           :collection_id          true
-                                                                                           :collection             false
-                                                                                           :entity_id              (:entity_id card)
-                                                                                           :display                "table"
-                                                                                           :query_type             nil
-                                                                                           :visualization_settings {}
-                                                                                           :result_metadata        nil})
-                                                       :series                     []}]})
+                                                   :size_y                     4
+                                                   :col                        0
+                                                   :row                        0
+                                                   :updated_at                 true
+                                                   :created_at                 true
+                                                   :entity_id                  (:entity_id dashcard)
+                                                   :collection_authority_level nil
+                                                   :parameter_mappings         [{:card_id      1
+                                                                                 :parameter_id "foo"
+                                                                                 :target       ["dimension" ["field" field-id nil]]}]
+                                                   :visualization_settings     {}
+                                                   :dashboard_tab_id           nil
+                                                   :card                       (merge api.card-test/card-defaults-no-hydrate
+                                                                                      {:name                   "Dashboard Test Card"
+                                                                                       :creator_id             (mt/user->id :rasta)
+                                                                                       :collection_id          true
+                                                                                       :collection             false
+                                                                                       :entity_id              (:entity_id card)
+                                                                                       :display                "table"
+                                                                                       :query_type             nil
+                                                                                       :visualization_settings {}
+                                                                                       :result_metadata        nil})
+                                                   :series                     []}]})
                  (dashboard-response (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-id)))))))))
     (testing "fetch a dashboard from an official collection includes the collection type"
       (mt/with-temp [Dashboard     {dashboard-id :id} {:name "Test Dashboard"}
@@ -1830,11 +1830,11 @@
                                                                            :visualization_settings {:label "Update"}}]
                                                            :ordered_tabs []}))))
               (is (partial= {:dashcards [{:action (cond-> {:visualization_settings {:hello true}
-                                                               :type (name action-type)
-                                                               :parameters [{:id "id"}]
-                                                               :database_enabled_actions true}
-                                                              (#{:query :implicit} action-type)
-                                                              (assoc :database_id (mt/id)))}]}
+                                                           :type (name action-type)
+                                                           :parameters [{:id "id"}]
+                                                           :database_enabled_actions true}
+                                                    (#{:query :implicit} action-type)
+                                                    (assoc :database_id (mt/id)))}]}
                             (mt/user-http-request :crowberto :get 200 (format "dashboard/%s" dashboard-id)))))))))))
 
 (deftest dashcard-action-database-enabled-actions-test

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -152,7 +152,7 @@
    :param_fields           nil})
 
 (def successful-dashboard-info
-  {:auto_apply_filters true, :description nil, :parameters [], :ordered_cards [], :ordered_tabs [],
+  {:auto_apply_filters true, :description nil, :parameters [], :dashcards [], :ordered_tabs [],
    :param_values nil, :param_fields nil})
 
 (def ^:private yesterday (time/minus (time/now) (time/days 1)))
@@ -556,7 +556,7 @@
                                                                :text         "Text card with variable: {{foo}}"}}]
         (is (= "Text card with variable: bar"
                (-> (client/client :get 200 (dashboard-url dash {:params {:a "bar"}}))
-                   :ordered_cards
+                   :dashcards
                    first
                    :visualization_settings
                    :text)))))))

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -435,25 +435,25 @@
 
 (defn- fetch-public-dashboard [{uuid :public_uuid}]
   (-> (client/client :get 200 (str "public/dashboard/" uuid))
-      (select-keys [:name :ordered_cards :ordered_tabs])
+      (select-keys [:name :dashcards :ordered_tabs])
       (update :name boolean)
-      (update :ordered_cards count)
+      (update :dashcards count)
       (update :ordered_tabs count)))
 
 (deftest get-public-dashboard-test
   (testing "GET /api/public/dashboard/:uuid"
     (mt/with-temporary-setting-values [enable-public-sharing true]
       (with-temp-public-dashboard-and-card [dash card]
-        (is (= {:name true, :ordered_cards 1, :ordered_tabs 0}
+        (is (= {:name true, :dashcards 1, :ordered_tabs 0}
                (fetch-public-dashboard dash)))
         (testing "We shouldn't see Cards that have been archived"
           (t2/update! Card (u/the-id card) {:archived true})
-          (is (= {:name true, :ordered_cards 0, :ordered_tabs 0}
+          (is (= {:name true, :dashcards 0, :ordered_tabs 0}
                  (fetch-public-dashboard dash)))))
       (testing "dashboard with tabs should return ordered_tabs"
        (api.dashboard-test/with-simple-dashboard-with-tabs [{:keys [dashboard-id]}]
          (t2/update! :model/Dashboard :id dashboard-id (shared-obj))
-         (is (= {:name true, :ordered_cards 2, :ordered_tabs 2}
+         (is (= {:name true, :dashcards 2, :ordered_tabs 2}
                 (fetch-public-dashboard (t2/select-one :model/Dashboard :id dashboard-id)))))))))
 
 (deftest public-dashboard-with-implicit-action-only-expose-unhidden-fields
@@ -476,7 +476,7 @@
                                                      :action_id    action-id
                                                      :card_id      card-id}]
                 (testing "Dashcard should only have id and name params"
-                  (is (partial= {:ordered_cards [{:action {:parameters [{:id "id"} {:id "name"}]}}]}
+                  (is (partial= {:dashcards [{:action {:parameters [{:id "id"} {:id "name"}]}}]}
                                 (mt/user-http-request :crowberto :get 200 (format "public/dashboard/%s" dashboard-uuid)))))
                 (let [execute-path (format "public/dashboard/%s/dashcard/%s/execute" dashboard-uuid (:id dashcard))]
                   (testing "Prefetch should only return non-hidden fields"
@@ -501,7 +501,7 @@
                                             :action_id action-id
                                             :card_id model-id}]
               (let [public-action (-> (client/client :get 200 (format "public/dashboard/%s" (:public_uuid dash)))
-                                      :ordered_cards first :action)]
+                                      :dashcards first :action)]
                 (testing "hidden action fields should not be included in the response"
                   (is (partial= [:name] ; id is hidden
                                 (-> public-action :visualization_settings :fields keys))))

--- a/test/metabase/automagic_dashboards/comparison_test.clj
+++ b/test/metabase/automagic_dashboards/comparison_test.clj
@@ -20,7 +20,7 @@
   (-> left
       (magic/automagic-analysis {})
       (c/comparison-dashboard left right {})
-      :ordered_cards
+      :dashcards
       count
       pos?))
 

--- a/test/metabase/models/dashboard_card_test.clj
+++ b/test/metabase/models/dashboard_card_test.clj
@@ -214,7 +214,7 @@
                    DashboardCard dashcard-3 {:dashboard_id dashboard-id :card_id card-id}
                    Card          {series-id-1 :id} {:name "Series Card 1"}
                    Card          {series-id-2 :id} {:name "Series Card 2"}]
-      (let [dashboard (t2/hydrate dashboard [:ordered_cards :series :card])]
+      (let [dashboard (t2/hydrate dashboard [:dashcards :series :card])]
         (testing "Should have fewer DB calls if there are no changes to the dashcards"
           (t2/with-call-count [call-count]
             (dashboard/update-dashcards! dashboard [dashcard-1 dashcard-2 dashcard-3])

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -807,7 +807,7 @@
           (let [dashboard       (magic/automagic-analysis (t2/select-one Table :id (mt/id :venues)) {})
                 saved-dashboard (dashboard/save-transient-dashboard! dashboard (u/the-id rastas-personal-collection))]
             (is (= (t2/count DashboardCard :dashboard_id (u/the-id saved-dashboard))
-                   (-> dashboard :ordered_cards count)))))))))
+                   (-> dashboard :dashcards count)))))))))
 
 (deftest validate-collection-namespace-test
   (t2.with-temp/with-temp [Collection {collection-id :id} {:namespace "currency"}]

--- a/test/metabase/models/on_demand_test.clj
+++ b/test/metabase/models/on_demand_test.clj
@@ -218,7 +218,7 @@
                   ;; clear out the list of updated Field Names
                   (reset! updated-field-names #{})
                   ;; ok, now update the parameter mapping to the new field. The new Field should get new values
-                  (dashboard/update-dashcards! (t2/hydrate dash [:ordered_cards :series :card])
+                  (dashboard/update-dashcards! (t2/hydrate dash [:dashcards :series :card])
                     [(assoc dashcard :parameter_mappings (parameter-mappings-for-card-and-field card new-field))])))))))
 
     (testing "with newly added param referencing Field in non-On-Demand DB should *not* get updated FieldValues"
@@ -239,5 +239,5 @@
               {:db {:is_on_demand false}}
               (fn [{:keys [table card dash dashcard]}]
                 (t2.with-temp/with-temp [Field new-field {:table_id (u/the-id table), :has_field_values "list"}]
-                  (dashboard/update-dashcards! (t2/hydrate dash [:ordered_cards :series :card])
+                  (dashboard/update-dashcards! (t2/hydrate dash [:dashcards :series :card])
                     [(assoc dashcard :parameter_mappings (parameter-mappings-for-card-and-field card new-field))])))))))))

--- a/test/metabase/test/automagic_dashboards.clj
+++ b/test/metabase/test/automagic_dashboards.clj
@@ -51,11 +51,11 @@
       (testing "Dashboard should have a name"
         (is (some? (:name dashboard))))
       (testing "Cards should have correct cardinality"
-        (is (= cardinality (-> dashboard :ordered_cards count))))
+        (is (= cardinality (-> dashboard :dashcards count))))
       (testing "URLs should be valid"
         (test-urls-are-valid dashboard))
       (testing "Dashboard's cards should be valid"
-        (doseq [card (keep :card (:ordered_cards dashboard))]
+        (doseq [card (keep :card (:dashcards dashboard))]
           (test-card-is-valid card)))
       (testing "Dashboard should have `auto_apply_filters` set to true"
         (is (true? (:auto_apply_filters dashboard)))))))

--- a/test_resources/instance_analytics_skip/collections/tYhkn_-pFTWcCTSwhgCBP_instance_analytics/dashboards/WFmN9gRmW1LCfzHneB4QH_ia_dash.yaml
+++ b/test_resources/instance_analytics_skip/collections/tYhkn_-pFTWcCTSwhgCBP_instance_analytics/dashboards/WFmN9gRmW1LCfzHneB4QH_ia_dash.yaml
@@ -1,7 +1,7 @@
 description: null
 archived: false
 collection_position: null
-ordered_cards:
+dashcards:
 - size_x: 15
   dashboard_tab_id: null
   action_id: null


### PR DESCRIPTION
This PR renames the `ordered_cards` key on Dashboard entities to `dashcards`. The key is hydrated onto dashboards so there is no need for a migration.

In each commit in this PR I'm doing a simple automated search-and-replace. Except for
[Rename orderedCards to dashcards (manual)](https://github.com/metabase/metabase/pull/34792/commits/db7b0dc7729b8e3e2f1e64a511fc273c287aaaa8), which was manual. I assume that `ordered_cards`, `orderedCards`, `orderedCard`, and `ordered-cards` are only used in the codebase to refer to dashboard's "ordered_cards" and not something else.