### PR TITLE
[MLv2] RelativeDatePicker — Fix opening "Next" tab from "Current"

### DIFF
--- a/frontend/src/metabase/common/components/DatePicker/RelativeDatePicker/utils.ts
+++ b/frontend/src/metabase/common/components/DatePicker/RelativeDatePicker/utils.ts
@@ -41,11 +41,16 @@ export function setDirection(
   if (direction === "current") {
     return { type: "relative", value: "current", unit: "hour" };
   }
-  if (!isIntervalValue(value)) {
-    return DEFAULT_VALUE;
-  }
 
   const sign = direction === "last" ? -1 : 1;
+
+  if (!isIntervalValue(value)) {
+    return {
+      ...DEFAULT_VALUE,
+      value: Math.abs(DEFAULT_VALUE.value) * sign,
+    };
+  }
+
   return {
     ...value,
     value: Math.abs(value.value) * sign,


### PR DESCRIPTION
Fixes that clicking the "Next" tab while being on "Current" was opening the "Past" tab

The issue is that `setDirection` returns the `DEFAULT_VALUE` when the current `value` is "current" and the `DEFAULT_VALUE` has a hardcoded `-30` value. Fixed by taking the `sign` in mind