### PR TITLE
Ensure that field picker icon does not get smushed

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
@@ -33,15 +33,14 @@ export const ChartSettingFieldPickerRoot = styled.div<ChartSettingFieldPickerRoo
     margin-left: 0;
     color: ${color("text-dark")};
     height: 0.625rem;
-
     ${props => props.disabled && "display: none;"}
+    flex-shrink: 0;
   }
 
   ${SelectButton.Content} {
     font-size: 0.875rem;
     line-height: 1rem;
     margin-right: 0.25rem;
-    text-overflow: ellipsis;
     max-width: 100%;
     overflow-wrap: anywhere;
     text-align: left;

--- a/frontend/src/metabase/visualizations/visualizations/BarChart.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/BarChart.unit.spec.tsx
@@ -3,16 +3,12 @@ import { renderWithProviders, screen } from "__support__/ui";
 import {
   createSampleDatabase,
   ORDERS_ID,
-  ORDERS,
   SAMPLE_DB_ID,
 } from "metabase-types/api/mocks/presets";
-import registerVisualizations from "metabase/visualizations/register";
 import ChartSettings from "metabase/visualizations/components/ChartSettings";
 import { createMockColumn, createMockDataset } from "metabase-types/api/mocks";
 import type { Series } from "metabase-types/api";
 import Question from "metabase-lib/Question";
-
-registerVisualizations();
 
 const metadata = createMockMetadata({
   databases: [createSampleDatabase()],
@@ -60,7 +56,7 @@ describe("barchart", () => {
             cols: [
               createMockColumn({
                 source: "aggregation",
-                field_ref: ["aggregation", 0],
+                field_ref: ["aggregation", 0, null],
                 name: "count",
                 display_name: "Count",
                 base_type: "type/BigInteger",
@@ -75,62 +71,5 @@ describe("barchart", () => {
     expect(screen.getByText("X-axis")).toBeInTheDocument();
     expect(screen.getByText("No valid fields")).toBeInTheDocument();
     expect(screen.getByText("Count")).toBeInTheDocument();
-  });
-
-  it("should not ellipsify really long field names", () => {
-    const longColumnName =
-      "COLUMN THAT WILL BE BIG BIG BIG VERY BIG IN ORDER TO ACCOMMODAT";
-    const question = new Question(
-      {
-        dataset_query: {
-          type: "query",
-          query: {
-            "source-table": ORDERS_ID,
-            aggregration: [["count"]],
-            breakout: [["expression", longColumnName]],
-            expressions: {
-              longColumnName: [
-                "get-month",
-                ["field", ORDERS.CREATED_AT, { "base-type": "type/DateTime" }],
-              ],
-            },
-          },
-          database: SAMPLE_DB_ID,
-        },
-        display: "bar",
-        visualization_settings: {},
-      },
-      metadata,
-    );
-
-    const series = [
-      {
-        card: question.card(),
-        ...createMockDataset({
-          data: {
-            cols: [
-              createMockColumn({
-                source: "aggregation",
-                field_ref: ["aggregation", 0],
-                name: "count",
-                display_name: "Count",
-                base_type: "type/BigInteger",
-              }),
-              createMockColumn({
-                source: "breakout",
-                field_ref: ["expression", longColumnName],
-                name: longColumnName,
-                display_name: longColumnName,
-                expression_name: longColumnName,
-                base_type: "type/Integer",
-              }),
-            ],
-          },
-        }),
-      },
-    ];
-    setup({ question, series });
-
-    expect(screen.getByText(longColumnName)).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/visualizations/visualizations/BarChart.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/BarChart.unit.spec.tsx
@@ -3,11 +3,13 @@ import { renderWithProviders, screen } from "__support__/ui";
 import {
   createSampleDatabase,
   ORDERS_ID,
+  ORDERS,
   SAMPLE_DB_ID,
 } from "metabase-types/api/mocks/presets";
 import registerVisualizations from "metabase/visualizations/register";
 import ChartSettings from "metabase/visualizations/components/ChartSettings";
-import { createMockColumn } from "metabase-types/api/mocks";
+import { createMockColumn, createMockDataset } from "metabase-types/api/mocks";
+import type { Series } from "metabase-types/api";
 import Question from "metabase-lib/Question";
 
 registerVisualizations();
@@ -16,41 +18,12 @@ const metadata = createMockMetadata({
   databases: [createSampleDatabase()],
 });
 
-const setup = () => {
-  const question = new Question(
-    {
-      dataset_query: {
-        type: "query",
-        query: {
-          "source-table": ORDERS_ID,
-          aggregrations: [["count"]],
-        },
-        database: SAMPLE_DB_ID,
-      },
-      display: "bar",
-      visualization_settings: {},
-    },
-    metadata,
-  );
+interface SetupProps {
+  question: Question;
+  series: Series;
+}
 
-  const series = [
-    {
-      card: question.card(),
-      data: {
-        rows: [[1000]],
-        cols: [
-          createMockColumn({
-            source: "aggregation",
-            field_ref: ["aggregation", 0],
-            name: "count",
-            display_name: "Count",
-            base_type: "type/BigInteger",
-          }),
-        ],
-      },
-    },
-  ];
-
+const setup = ({ series, question }: SetupProps) => {
   renderWithProviders(
     <ChartSettings
       series={series}
@@ -63,10 +36,101 @@ const setup = () => {
 
 describe("barchart", () => {
   it("should not error when rendering for a question with new breakouts", () => {
-    setup();
+    const question = new Question(
+      {
+        dataset_query: {
+          type: "query",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregrations: [["count"]],
+          },
+          database: SAMPLE_DB_ID,
+        },
+        display: "bar",
+        visualization_settings: {},
+      },
+      metadata,
+    );
+
+    const series = [
+      {
+        card: question.card(),
+        ...createMockDataset({
+          data: {
+            cols: [
+              createMockColumn({
+                source: "aggregation",
+                field_ref: ["aggregation", 0],
+                name: "count",
+                display_name: "Count",
+                base_type: "type/BigInteger",
+              }),
+            ],
+          },
+        }),
+      },
+    ];
+    setup({ question, series });
 
     expect(screen.getByText("X-axis")).toBeInTheDocument();
     expect(screen.getByText("No valid fields")).toBeInTheDocument();
     expect(screen.getByText("Count")).toBeInTheDocument();
+  });
+
+  it("should not ellipsify really long field names", () => {
+    const longColumnName =
+      "COLUMN THAT WILL BE BIG BIG BIG VERY BIG IN ORDER TO ACCOMMODAT";
+    const question = new Question(
+      {
+        dataset_query: {
+          type: "query",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregration: [["count"]],
+            breakout: [["expression", longColumnName]],
+            expressions: {
+              longColumnName: [
+                "get-month",
+                ["field", ORDERS.CREATED_AT, { "base-type": "type/DateTime" }],
+              ],
+            },
+          },
+          database: SAMPLE_DB_ID,
+        },
+        display: "bar",
+        visualization_settings: {},
+      },
+      metadata,
+    );
+
+    const series = [
+      {
+        card: question.card(),
+        ...createMockDataset({
+          data: {
+            cols: [
+              createMockColumn({
+                source: "aggregation",
+                field_ref: ["aggregation", 0],
+                name: "count",
+                display_name: "Count",
+                base_type: "type/BigInteger",
+              }),
+              createMockColumn({
+                source: "breakout",
+                field_ref: ["expression", longColumnName],
+                name: longColumnName,
+                display_name: longColumnName,
+                expression_name: longColumnName,
+                base_type: "type/Integer",
+              }),
+            ],
+          },
+        }),
+      },
+    ];
+    setup({ question, series });
+
+    expect(screen.getByText(longColumnName)).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/visualizations/visualizations/BarChart.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/BarChart.unit.spec.tsx
@@ -6,9 +6,12 @@ import {
   SAMPLE_DB_ID,
 } from "metabase-types/api/mocks/presets";
 import ChartSettings from "metabase/visualizations/components/ChartSettings";
+import registerVisualizations from "metabase/visualizations/register";
 import { createMockColumn, createMockDataset } from "metabase-types/api/mocks";
 import type { Series } from "metabase-types/api";
 import Question from "metabase-lib/Question";
+
+registerVisualizations();
 
 const metadata = createMockMetadata({
   databases: [createSampleDatabase()],


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31086

### Description
Long names actually already wrap in both the field picker and column item components. This PR just helps the field picker icon not get squished, and adds a test to verify that that long names are rendered in full in the future (this test may not actually be necessary, since Jest looks at the DOM and generally speaking ellipsis is a style sheet thing).

### How to verify
1. New -> Question -> Orders
2. Create a custom column that is month([Created At]), and give it a very long name
3. Count, and group by the custom column
4. Examine the viz settings for the field picker (bar chart) and Column Item (table view)

### Demo
![image](https://github.com/metabase/metabase/assets/1328979/d6167037-ef35-49a7-91e0-c49ad7b9399b)
![image](https://github.com/metabase/metabase/assets/1328979/636819f2-2cba-41fb-9f9a-584d6117dbae)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR (Kinda... it was really already working)
