### PR TITLE
create pie chart model

### DIFF
--- a/frontend/src/metabase/lib/arrays.ts
+++ b/frontend/src/metabase/lib/arrays.ts
@@ -6,3 +6,19 @@ export function moveElement<T>(array: T[], oldIndex: number, newIndex: number) {
 
 export const sumArray = (values: number[]) =>
   values.reduce((acc, value) => acc + value, 0);
+
+export const findWithIndex = <T>(
+  arr: T[],
+  predicate: (value: T, index: number, arr: T[]) => boolean,
+) => {
+  for (let i = 0; i < arr.length; i++) {
+    const item = arr[i];
+    if (predicate(item, i, arr)) {
+      return { item, index: i };
+    }
+  }
+  return {
+    index: -1,
+    item: undefined,
+  };
+};

--- a/frontend/src/metabase/static-viz/components/PieChart/PieChart.tsx
+++ b/frontend/src/metabase/static-viz/components/PieChart/PieChart.tsx
@@ -2,6 +2,7 @@ import { init } from "echarts";
 import type { IsomorphicStaticChartProps } from "metabase/static-viz/containers/IsomorphicStaticChart/types";
 import { sanitizeSvgForBatik } from "metabase/static-viz/lib/svg";
 
+import { getPieChartModel } from "metabase/visualizations/echarts/pie/model";
 import { computeStaticPieChartSettings } from "./setttings";
 
 const WIDTH = 540;
@@ -16,8 +17,13 @@ export function PieChart({
     rawSeries,
     dashcardSettings,
   );
+  const model = getPieChartModel(
+    rawSeries,
+    computedVizSettings,
+    renderingContext,
+  );
   //eslint-disable-next-line no-console
-  console.log("computedVizSettings", JSON.stringify(computedVizSettings));
+  console.log("model", JSON.stringify(model));
 
   const chart = init(null, null, {
     renderer: "svg",

--- a/frontend/src/metabase/visualizations/echarts/pie/constants.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/constants.ts
@@ -1,1 +1,3 @@
 export const SLICE_THRESHOLD = 0.025; // approx 1 degree in percentage
+
+export const OTHER_SLICE_MIN_PERCENTAGE = 0.003;

--- a/frontend/src/metabase/visualizations/echarts/pie/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/model/index.ts
@@ -1,0 +1,142 @@
+import _ from "underscore";
+import { t } from "ttag";
+
+import type { RawSeries, RowValue } from "metabase-types/api";
+import type {
+  ComputedVisualizationSettings,
+  RenderingContext,
+} from "metabase/visualizations/types";
+import { NULL_DISPLAY_VALUE } from "metabase/lib/constants";
+
+import { OTHER_SLICE_MIN_PERCENTAGE } from "../constants";
+import type { PieColumnDescriptors, PieChartModel, PieSlice } from "./types";
+
+export const findWithIndex = <T>(
+  arr: T[],
+  predicate: (value: T, index: number, arr: T[]) => boolean,
+) => {
+  for (let i = 0; i < arr.length; i++) {
+    const item = arr[i];
+    if (predicate(item, i, arr)) {
+      return { item, index: i };
+    }
+  }
+  return {
+    index: -1,
+    item: undefined,
+  };
+};
+
+function getColDescs(
+  rawSeries: RawSeries,
+  settings: ComputedVisualizationSettings,
+): PieColumnDescriptors {
+  const [
+    {
+      data: { cols },
+    },
+  ] = rawSeries;
+
+  const dimension = findWithIndex(
+    cols,
+    c => c.name === settings["pie.dimension"],
+  );
+  const metric = findWithIndex(cols, c => c.name === settings["pie.metric"]);
+
+  if (!dimension.item || !metric.item) {
+    throw new Error(
+      `Could not find columns based on "pie.dimension" (${settings["pie.dimension"]}) and "pie.metric" (${settings["pie.metric"]}) settings.`,
+    );
+  }
+
+  return {
+    dimensionDesc: {
+      index: dimension.index,
+      column: dimension.item,
+    },
+    metricDesc: {
+      index: metric.index,
+      column: metric.item,
+    },
+  };
+}
+
+export function getRowValues(row: RowValue[], colDescs: PieColumnDescriptors) {
+  const { dimensionDesc, metricDesc } = colDescs;
+
+  // dimension val needs to be string to use as key for objects, such as "pie.colors" setting
+  const dimensionValue = String(row[dimensionDesc.index] ?? NULL_DISPLAY_VALUE);
+
+  const metricValue = row[metricDesc.index] ?? 0;
+  if (typeof metricValue !== "number") {
+    throw new Error(
+      `Pie chart metric value (${metricValue}) should be a number`,
+    );
+  }
+
+  return { dimensionValue, metricValue };
+}
+
+export function getPieChartModel(
+  rawSeries: RawSeries,
+  settings: ComputedVisualizationSettings,
+  renderingContext: RenderingContext,
+): PieChartModel {
+  const [
+    {
+      data: { rows },
+    },
+  ] = rawSeries;
+  const colDescs = getColDescs(rawSeries, settings);
+
+  const total = rows.reduce(
+    (currTotal, row) => currTotal + getRowValues(row, colDescs).metricValue,
+    0,
+  );
+
+  const [slices, others] = _.chain(rows)
+    .map((row, index): PieSlice => {
+      const { dimensionValue, metricValue } = getRowValues(row, colDescs);
+
+      if (!settings["pie.colors"]) {
+        throw Error(`"pie.colors" setting is not defined`);
+      }
+
+      return {
+        key: dimensionValue,
+        value: metricValue,
+        normalizedPercentage: metricValue / total, // slice percentage values are normalized to 0-1 scale
+        rowIndex: index,
+        color: settings["pie.colors"][dimensionValue],
+      };
+    })
+    .partition(
+      slice =>
+        slice.normalizedPercentage >=
+        (settings["pie.slice_threshold"] ?? 0) / 100, // stored setting for "pie.slice_threshold" is on 0-100 scale to match user input
+    )
+    .value();
+
+  // Only add "other" slice if there are slices below threshold with non-zero total
+  const otherTotal = others.reduce((currTotal, o) => currTotal + o.value, 0);
+  if (otherTotal === 0) {
+    return { slices, total };
+  }
+
+  const otherSlice: PieSlice = {
+    key: t`Other`,
+    value: otherTotal,
+    normalizedPercentage: otherTotal / total,
+    color: renderingContext.getColor("text-light"),
+  };
+
+  // Increase "other" slice so it's barely visible
+  if (otherSlice.normalizedPercentage < OTHER_SLICE_MIN_PERCENTAGE) {
+    otherSlice.value = total * OTHER_SLICE_MIN_PERCENTAGE;
+  }
+
+  return {
+    slices: [...slices, otherSlice],
+    total,
+  };
+}

--- a/frontend/src/metabase/visualizations/echarts/pie/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/model/index.ts
@@ -7,25 +7,10 @@ import type {
   RenderingContext,
 } from "metabase/visualizations/types";
 import { NULL_DISPLAY_VALUE } from "metabase/lib/constants";
+import { findWithIndex } from "metabase/core/utils/arrays";
 
 import { OTHER_SLICE_MIN_PERCENTAGE } from "../constants";
 import type { PieColumnDescriptors, PieChartModel, PieSlice } from "./types";
-
-export const findWithIndex = <T>(
-  arr: T[],
-  predicate: (value: T, index: number, arr: T[]) => boolean,
-) => {
-  for (let i = 0; i < arr.length; i++) {
-    const item = arr[i];
-    if (predicate(item, i, arr)) {
-      return { item, index: i };
-    }
-  }
-  return {
-    index: -1,
-    item: undefined,
-  };
-};
 
 function getColDescs(
   rawSeries: RawSeries,

--- a/frontend/src/metabase/visualizations/echarts/pie/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/model/index.ts
@@ -7,7 +7,7 @@ import type {
   RenderingContext,
 } from "metabase/visualizations/types";
 import { NULL_DISPLAY_VALUE } from "metabase/lib/constants";
-import { findWithIndex } from "metabase/core/utils/arrays";
+import { findWithIndex } from "metabase/lib/arrays";
 
 import { OTHER_SLICE_MIN_PERCENTAGE } from "../constants";
 import type { PieColumnDescriptors, PieChartModel, PieSlice } from "./types";

--- a/frontend/src/metabase/visualizations/echarts/pie/model/index.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/model/index.unit.spec.ts
@@ -1,0 +1,55 @@
+import { color } from "metabase/lib/colors";
+
+import { DEFAULT_SETTINGS, MOCK_RAW_SERIES } from "../test";
+import { getPieChartModel } from ".";
+
+const MOCK_RENDERING_CONTEXT = {
+  getColor: color,
+  measureText: () => 0,
+  formatValue: (_: any, _2: any) => "",
+  fontFamily: "",
+};
+
+describe("getPieChartModel", () => {
+  it("should return the correct model object given valid 'rawSeries' and 'settings'", () => {
+    const model = getPieChartModel(
+      MOCK_RAW_SERIES,
+      DEFAULT_SETTINGS,
+      MOCK_RENDERING_CONTEXT,
+    );
+
+    expect(model).toStrictEqual({
+      slices: [
+        {
+          color: "#88BF4D",
+          key: "Doohickey",
+          normalizedPercentage: 0.21,
+          rowIndex: 0,
+          value: 42,
+        },
+        {
+          color: "#F9D45C",
+          key: "Gadget",
+          normalizedPercentage: 0.265,
+          rowIndex: 1,
+          value: 53,
+        },
+        {
+          color: "#A989C5",
+          key: "Gizmo",
+          normalizedPercentage: 0.255,
+          rowIndex: 2,
+          value: 51,
+        },
+        {
+          color: "#F2A86F",
+          key: "Widget",
+          normalizedPercentage: 0.27,
+          rowIndex: 3,
+          value: 54,
+        },
+      ],
+      total: 200,
+    });
+  });
+});

--- a/frontend/src/metabase/visualizations/echarts/pie/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/model/types.ts
@@ -5,11 +5,6 @@ export interface PieColumnDescriptors {
   dimensionDesc: ColumnDescriptor;
 }
 
-export interface PieLegendItem {
-  title: string[];
-  color: string;
-}
-
 export interface PieSlice {
   key: string;
   value: number;

--- a/frontend/src/metabase/visualizations/echarts/pie/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/model/types.ts
@@ -11,7 +11,7 @@ export interface PieLegendItem {
 }
 
 export interface PieSlice {
-  key: string | number | boolean;
+  key: string;
   value: number;
   normalizedPercentage: number;
   rowIndex?: number;

--- a/frontend/src/metabase/visualizations/echarts/pie/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/model/types.ts
@@ -1,0 +1,24 @@
+import type { ColumnDescriptor } from "metabase/visualizations/lib/graph/columns";
+
+export interface PieColumnDescriptors {
+  metricDesc: ColumnDescriptor;
+  dimensionDesc: ColumnDescriptor;
+}
+
+export interface PieLegendItem {
+  title: string[];
+  color: string;
+}
+
+export interface PieSlice {
+  key: string | number | boolean;
+  value: number;
+  normalizedPercentage: number;
+  rowIndex?: number;
+  color: string;
+}
+
+export interface PieChartModel {
+  slices: PieSlice[];
+  total: number;
+}

--- a/frontend/src/metabase/visualizations/visualizations/PieChart2/PieChart2.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart2/PieChart2.tsx
@@ -1,15 +1,32 @@
 import type { VisualizationProps } from "metabase/visualizations/types";
 import { EChartsRenderer } from "metabase/visualizations/components/EChartsRenderer";
+import { getPieChartModel } from "metabase/visualizations/echarts/pie/model";
+import { measureTextWidth } from "metabase/lib/measure-text";
+import { formatValue } from "metabase/lib/formatting/value";
+import { color } from "metabase/lib/colors";
+import type { OptionsType } from "metabase/lib/formatting/types";
+import PieChart from "../PieChart/PieChart";
 
 Object.assign(PieChart2, {
   uiName: "Pie 2",
   identifier: "pie2",
   iconName: "pie",
+  settings: PieChart.settings,
 });
 
-// Only using this for testing, wiull
+// Only using this for testing, will
 // remove from this branch before merging
 export function PieChart2(props: VisualizationProps) {
+  const model = getPieChartModel(props.rawSeries, props.settings, {
+    getColor: color,
+    formatValue: (value, options) =>
+      formatValue(value, options as OptionsType) as string,
+    measureText: measureTextWidth,
+    fontFamily: props.fontFamily,
+  });
+  //eslint-disable-next-line
+  console.log("model", model);
+
   return (
     <EChartsRenderer
       option={{


### PR DESCRIPTION
Part of https://github.com/metabase/metabase/issues/33281

### Description

Computes the chart model object, which will then be used in the next PR to create the echarts option object and render the chart.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a question
2. Set visualization type to `Pie 2`
3. Add to a dashboard
4. Send in an email subscription
5. Check backend logs, should show reasonable values for the model object.

### Demo

![Screenshot 2023-10-18 at 12.38.00 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/7080d6d5-9cc6-44a4-88de-8f73604bbf59/Screenshot%202023-10-18%20at%2012.38.00%20PM.png)

Rendered this question using `Pie 2` chart.

```json
{
  "slices": [
    {
      "key": "Doohickey",
      "value": 42,
      "normalizedPercentage": 0.21,
      "rowIndex": 0,
      "color": "#88BF4D"
    },
    {
      "key": "Gadget",
      "value": 53,
      "normalizedPercentage": 0.265,
      "rowIndex": 1,
      "color": "#F9D45C"
    },
    {
      "key": "Gizmo",
      "value": 51,
      "normalizedPercentage": 0.255,
      "rowIndex": 2,
      "color": "#A989C5"
    },
    {
      "key": "Widget",
      "value": 54,
      "normalizedPercentage": 0.27,
      "rowIndex": 3,
      "color": "#F2A86F"
    }
  ],
  "total": 200
}
```
This was the resultant model object (no settings were changed).

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
