### PR TITLE
Store E2E uberjar artifact with a SHA1 in its name

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -146,6 +146,21 @@ jobs:
       - name: Build uberjar with ./bin/build.sh
         run: ./bin/build.sh
 
+      - name: Mark with the commit hash
+        run: echo ${{ github.sha }} > COMMIT-ID
+        shell: bash
+      - name: Calculate SHA256 checksum
+        run: sha256sum ./target/uberjar/metabase.jar > SHA256.sum
+        shell: bash
+      - name: Upload JARs as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: metabase-${{ matrix.edition }}-${{ github.sha }}-uberjar
+          path: |
+            ./target/uberjar/metabase.jar
+            ./COMMIT-ID
+            ./SHA256.sum
+
       - name: Prepare uberjar artifact
         uses: ./.github/actions/prepare-uberjar-artifact
 
@@ -215,7 +230,7 @@ jobs:
         if: needs.build.result == 'success'
         name: Retrieve uberjar artifact for ${{ matrix.edition }}
         with:
-          name: metabase-${{ matrix.edition }}-uberjar
+          name: metabase-${{ matrix.edition }}-${{ github.sha }}-uberjar
 
       - name: Get the version info
         run: |
@@ -385,7 +400,7 @@ jobs:
         if: needs.build.result == 'success'
         name: Retrieve uberjar artifact for ee
         with:
-          name: metabase-ee-uberjar
+          name: metabase-ee-${{ github.sha }}-uberjar
 
       - name: Get the version info
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -161,9 +161,6 @@ jobs:
             ./COMMIT-ID
             ./SHA256.sum
 
-      - name: Prepare uberjar artifact
-        uses: ./.github/actions/prepare-uberjar-artifact
-
   e2e-tests:
     needs: [build, files-changed, test-run-id, download_uberjar, e2e-matrix-builder]
     if: |


### PR DESCRIPTION
This is only the first step in achieving https://github.com/metabase/metabase/issues/34778

And it's also a prerequisite for greatly simplifying and unblocking the work in https://github.com/metabase/metabase/pull/34647.