### PR TITLE
Use Mantine Switch instead of Toggle in Dashboard Sidebar

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
@@ -52,10 +52,12 @@ function createDashboardDetails({ parameters }) {
   };
 }
 
-const TOAST_TIMEOUT = 20000;
+const TOAST_TIMEOUT = 16000;
 
 const TOAST_MESSAGE =
   "You can make this dashboard snappier by turning off auto-applying filters.";
+
+const filterToggleLabel = "Auto-apply filters";
 
 describe(
   "scenarios > dashboards > filters > auto apply",
@@ -98,9 +100,9 @@ describe(
         );
         toggleDashboardInfoSidebar();
         rightSidebar().within(() => {
-          cy.findByLabelText("Auto-apply filters").click();
+          cy.findByText(filterToggleLabel).click();
           cy.wait("@updateDashboard");
-          cy.findByLabelText("Auto-apply filters").should("not.be.checked");
+          cy.findByLabelText(filterToggleLabel).should("not.be.checked");
         });
         filterWidget().findByText("Gadget").should("be.visible");
         getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
@@ -130,9 +132,9 @@ describe(
         filterWidget().findByText("Widget").should("be.visible");
         dashboardParametersContainer().button("Apply").should("be.visible");
         rightSidebar().within(() => {
-          cy.findByLabelText("Auto-apply filters").click();
+          cy.findByText(filterToggleLabel).click();
           cy.wait("@updateDashboard");
-          cy.findByLabelText("Auto-apply filters").should("be.checked");
+          cy.findByLabelText(filterToggleLabel).should("be.checked");
         });
         filterWidget().findByText("Widget").should("be.visible");
         getDashboardCard().findByText("Rows 1-4 of 54").should("be.visible");
@@ -147,9 +149,9 @@ describe(
           cy.button("Update filter").click();
         });
         rightSidebar().within(() => {
-          cy.findByLabelText("Auto-apply filters").click();
+          cy.findByText(filterToggleLabel).click();
           cy.wait("@updateDashboard");
-          cy.findByLabelText("Auto-apply filters").should("not.be.checked");
+          cy.findByLabelText(filterToggleLabel).should("not.be.checked");
         });
         filterWidget().findByText("2 selections").should("be.visible");
         cy.get("@cardQuery.all").should("have.length", 5);
@@ -230,9 +232,10 @@ describe(
           "parameter with default value should still be applied after turning auto-apply filter off",
         );
         rightSidebar().within(() => {
-          cy.findByLabelText("Auto-apply filters").should("be.checked").click();
+          cy.findByLabelText(filterToggleLabel).should("be.checked");
+          cy.findByText(filterToggleLabel).click();
           cy.wait("@updateDashboard");
-          cy.findByLabelText("Auto-apply filters").should("not.be.checked");
+          cy.findByLabelText(filterToggleLabel).should("not.be.checked");
         });
 
         getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
@@ -252,11 +255,10 @@ describe(
           "should not use the default parameter after turning auto-apply filter on again since the parameter was manually updated",
         );
         rightSidebar().within(() => {
-          cy.findByLabelText("Auto-apply filters")
-            .should("not.be.checked")
-            .click();
+          cy.findByLabelText(filterToggleLabel).should("not.be.checked");
+          cy.findAllByText(filterToggleLabel).click();
           cy.wait("@updateDashboard");
-          cy.findByLabelText("Auto-apply filters").should("be.checked");
+          cy.findByLabelText(filterToggleLabel).should("be.checked");
         });
 
         getDashboardCard().findByText("Rows 1-4 of 200").should("be.visible");
@@ -276,7 +278,7 @@ describe(
 
         toggleDashboardInfoSidebar();
         rightSidebar()
-          .findByLabelText("Auto-apply filters")
+          .findByLabelText(filterToggleLabel)
           .should("not.be.checked");
         // Gadget
         const filterDefaultValue = FILTER_WITH_DEFAULT_VALUE.default[0];
@@ -311,7 +313,7 @@ describe(
 
         toggleDashboardInfoSidebar();
         rightSidebar()
-          .findByLabelText("Auto-apply filters")
+          .findByLabelText(filterToggleLabel)
           .should("not.be.checked");
         filterWidget().findByText("Gadget").should("be.visible");
         getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
@@ -389,9 +391,7 @@ describe(
         cy.wait("@cardQuery");
 
         toggleDashboardInfoSidebar();
-        rightSidebar()
-          .findByLabelText("Auto-apply filters")
-          .should("be.disabled");
+        rightSidebar().findByLabelText(filterToggleLabel).should("be.disabled");
       });
 
       it("should not display a toast even when a dashboard takes longer than 15s to load", () => {
@@ -553,7 +553,7 @@ describe(
 
           toggleDashboardInfoSidebar();
           rightSidebar()
-            .findByLabelText("Auto-apply filters")
+            .findByLabelText(filterToggleLabel)
             .should("not.be.checked");
           filterWidget().findByText("Gadget").should("be.visible");
 
@@ -627,9 +627,9 @@ describeWithSnowplow("scenarios > dashboards > filters > auto apply", () => {
       expectGoodSnowplowEvents(
         NUMBERS_OF_GOOD_SNOWPLOW_EVENTS_BEFORE_DISABLING_AUTO_APPLY_FILTERS,
       );
-      cy.findByLabelText("Auto-apply filters").click();
+      cy.findByLabelText(filterToggleLabel).click();
       cy.wait("@updateDashboard");
-      cy.findByLabelText("Auto-apply filters").should("not.be.checked");
+      cy.findByLabelText(filterToggleLabel).should("not.be.checked");
       expectGoodSnowplowEvents(
         NUMBERS_OF_GOOD_SNOWPLOW_EVENTS_BEFORE_DISABLING_AUTO_APPLY_FILTERS + 1,
       );
@@ -646,9 +646,9 @@ describeWithSnowplow("scenarios > dashboards > filters > auto apply", () => {
       expectGoodSnowplowEvents(
         NUMBERS_OF_GOOD_SNOWPLOW_EVENTS_BEFORE_DISABLING_AUTO_APPLY_FILTERS,
       );
-      cy.findByLabelText("Auto-apply filters").click();
+      cy.findByLabelText(filterToggleLabel).click();
       cy.wait("@updateDashboard");
-      cy.findByLabelText("Auto-apply filters").should("be.checked");
+      cy.findByLabelText(filterToggleLabel).should("be.checked");
       expectGoodSnowplowEvents(
         NUMBERS_OF_GOOD_SNOWPLOW_EVENTS_BEFORE_DISABLING_AUTO_APPLY_FILTERS,
       );

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
@@ -627,7 +627,7 @@ describeWithSnowplow("scenarios > dashboards > filters > auto apply", () => {
       expectGoodSnowplowEvents(
         NUMBERS_OF_GOOD_SNOWPLOW_EVENTS_BEFORE_DISABLING_AUTO_APPLY_FILTERS,
       );
-      cy.findByLabelText(filterToggleLabel).click();
+      cy.findByText(filterToggleLabel).click();
       cy.wait("@updateDashboard");
       cy.findByLabelText(filterToggleLabel).should("not.be.checked");
       expectGoodSnowplowEvents(
@@ -646,7 +646,7 @@ describeWithSnowplow("scenarios > dashboards > filters > auto apply", () => {
       expectGoodSnowplowEvents(
         NUMBERS_OF_GOOD_SNOWPLOW_EVENTS_BEFORE_DISABLING_AUTO_APPLY_FILTERS,
       );
-      cy.findByLabelText(filterToggleLabel).click();
+      cy.findByText(filterToggleLabel).click();
       cy.wait("@updateDashboard");
       cy.findByLabelText(filterToggleLabel).should("be.checked");
       expectGoodSnowplowEvents(

--- a/e2e/test/scenarios/dashboard/reproductions/16559-show-recent-dashboard-revision.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/16559-show-recent-dashboard-revision.cy.spec.js
@@ -6,6 +6,7 @@ import {
   popover,
   restore,
   sidebar,
+  rightSidebar,
   toggleDashboardInfoSidebar,
   visitDashboard,
 } from "e2e/support/helpers";
@@ -70,7 +71,7 @@ describe("issue 16559", () => {
       .should("be.visible");
 
     cy.log("Toggle auto-apply filters");
-    cy.findByLabelText("Auto-apply filters").click();
+    rightSidebar().findByText("Auto-apply filters").click();
     cy.findByTestId("dashboard-history-list")
       .findAllByRole("listitem")
       .eq(0)

--- a/frontend/src/metabase/core/components/Toggle/Toggle.tsx
+++ b/frontend/src/metabase/core/components/Toggle/Toggle.tsx
@@ -11,6 +11,7 @@ export interface ToggleProps
   onChange?: (value: boolean) => void;
 }
 
+/** @deprecated use metabase/ui Switch instead */
 const Toggle = forwardRef(function Toggle(
   { className, value, small, color, onChange, ...rest }: ToggleProps,
   ref: Ref<HTMLInputElement>,

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.styled.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 
+import { Switch } from "metabase/ui";
 import { breakpointMaxSmall } from "metabase/styled-components/theme";
 
 import { color } from "metabase/lib/colors";
@@ -58,4 +59,12 @@ export const ContentSection = styled.div`
 
 export const DescriptionHeader = styled.h3`
   margin-bottom: 0.5rem;
+`;
+
+export const SpaceBetweenSwitch = styled(Switch)`
+  > div {
+    // target the inner div one level down only
+    display: flex;
+    justify-content: space-between;
+  }
 `;

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.styled.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
 
-import { Switch } from "metabase/ui";
 import { breakpointMaxSmall } from "metabase/styled-components/theme";
 
 import { color } from "metabase/lib/colors";
@@ -59,12 +58,4 @@ export const ContentSection = styled.div`
 
 export const DescriptionHeader = styled.h3`
   margin-bottom: 0.5rem;
-`;
-
-export const SpaceBetweenSwitch = styled(Switch)`
-  > div {
-    // target the inner div one level down only
-    display: flex;
-    justify-content: space-between;
-  }
 `;

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.tsx
@@ -4,6 +4,7 @@ import { t } from "ttag";
 import { PLUGIN_CACHING } from "metabase/plugins";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import MetabaseSettings from "metabase/lib/settings";
+import { Switch } from "metabase/ui";
 
 import { Timeline } from "metabase/common/components/Timeline";
 import EditableText from "metabase/core/components/EditableText";
@@ -25,7 +26,6 @@ import {
   HistoryHeader,
   ContentSection,
   DescriptionHeader,
-  SpaceBetweenSwitch,
 } from "./DashboardInfoSidebar.styled";
 
 type DashboardAttributeType = string | number | null | boolean;
@@ -92,10 +92,11 @@ export function DashboardInfoSidebar({
       </ContentSection>
 
       <ContentSection>
-        <SpaceBetweenSwitch
+        <Switch
           disabled={!canWrite}
           label={t`Auto-apply filters`}
           labelPosition="left"
+          variant="stretch"
           size="sm"
           id={autoApplyFilterToggleId}
           checked={dashboard.auto_apply_filters}

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.tsx
@@ -17,8 +17,6 @@ import {
   toggleAutoApplyFilters,
 } from "metabase/dashboard/actions";
 
-import Toggle from "metabase/core/components/Toggle";
-import FormField from "metabase/core/components/FormField";
 import { useUniqueId } from "metabase/hooks/use-unique-id";
 import { getTimelineEvents } from "metabase/common/components/Timeline/utils";
 import { useRevisionListQuery } from "metabase/common/hooks/use-revision-list-query";
@@ -27,6 +25,7 @@ import {
   HistoryHeader,
   ContentSection,
   DescriptionHeader,
+  SpaceBetweenSwitch,
 } from "./DashboardInfoSidebar.styled";
 
 type DashboardAttributeType = string | number | null | boolean;
@@ -93,18 +92,15 @@ export function DashboardInfoSidebar({
       </ContentSection>
 
       <ContentSection>
-        <FormField
-          title={t`Auto-apply filters`}
-          orientation="horizontal"
-          htmlFor={autoApplyFilterToggleId}
-        >
-          <Toggle
-            disabled={!canWrite}
-            id={autoApplyFilterToggleId}
-            value={dashboard.auto_apply_filters}
-            onChange={handleToggleAutoApplyFilters}
-          />
-        </FormField>
+        <SpaceBetweenSwitch
+          disabled={!canWrite}
+          label={t`Auto-apply filters`}
+          labelPosition="left"
+          size="sm"
+          id={autoApplyFilterToggleId}
+          checked={dashboard.auto_apply_filters}
+          onChange={e => handleToggleAutoApplyFilters(e.target.checked)}
+        />
       </ContentSection>
       {showCaching && (
         <ContentSection>

--- a/frontend/src/metabase/ui/components/inputs/Switch/Switch.stories.mdx
+++ b/frontend/src/metabase/ui/components/inputs/Switch/Switch.stories.mdx
@@ -15,6 +15,10 @@ export const argTypes = {
     control: { type: "inline-radio" },
     options: ["left", "right"],
   },
+  variant: {
+    control: { type: "inline-radio" },
+    options: ["default", "stretch"],
+  },
   label: {
     control: { type: "text" },
   },

--- a/frontend/src/metabase/ui/components/inputs/Switch/Switch.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Switch/Switch.styled.tsx
@@ -116,5 +116,13 @@ export const getSwitchOverrides = (): MantineThemeOverride["components"] => ({
         },
       };
     },
+    variants: {
+      stretch: () => ({
+        body: {
+          display: "flex",
+          justifyContent: "space-between",
+        },
+      }),
+    },
   },
 });


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/pull/34771
[slack discussion:](https://metaboat.slack.com/archives/C02H619CJ8K/p1697586616727759) 

### Description

Mostly I want a switch with a disabled state. Instead of tweaking the deprecated component, we're just replacing it with the shiny new mantine one.

The styling is a bit different because I used the included label (which also gets a disabled state) so would appreciate design eyes on this, but the disabled state is lovely.

Old Toggle | New Switch
---|---
![beforetoggle](https://github.com/metabase/metabase/assets/30528226/34e9c015-2f11-43fc-8fa5-50441a37fcd4) | ![afterSwtich](https://github.com/metabase/metabase/assets/30528226/6966bcb2-1e3d-48c1-8a28-1dba78feb80d)

Disabled state:

![Screen Shot 2023-10-18 at 4 38 42 PM](https://github.com/metabase/metabase/assets/30528226/d0341350-1032-44f6-b16d-9d973f2d8de9)

