### PR TITLE
Auditv2 main more audit log events

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/dump.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/dump.clj
@@ -17,6 +17,7 @@
    [metabase.models.setting :as setting]
    [metabase.models.table :refer [Table]]
    [metabase.models.user :refer [User]]
+   [metabase.util :as u]
    [metabase.util.i18n :as i18n :refer [trs]]
    [metabase.util.log :as log]
    [metabase.util.yaml :as yaml]
@@ -25,10 +26,13 @@
 (set! *warn-on-reflection* true)
 
 (defn spit-yaml
-  "Writes obj to filename and creates parent directories if necessary"
+  "Writes obj to filename and creates parent directories if necessary.
+
+  Writes (even nested) yaml keys in a deterministic fashion."
   [filename obj]
   (io/make-parents filename)
-  (spit filename (yaml/generate-string obj :dumper-options {:flow-style :block, :split-lines false})))
+  (spit filename (yaml/generate-string (u/deep-sort-map obj)
+                                       {:dumper-options {:flow-style :block :split-lines false}})))
 
 (defn- as-file?
   [instance]

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -511,10 +511,10 @@
 
       (testing "An audit log entry is generated when a manually triggered re-scan occurs"
         (mt/with-model-cleanup [:model/AuditLog :model/Activity]
-          (do (with-all-users-data-perms {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id :all}}}}}
-              (mt/user-http-request :rasta :post 200 (format "table/%d/rescan_values" table-id)))
-            (is (= table-id (:model_id (mt/latest-audit-log-entry))))
-            (is (= table-id (-> (mt/latest-audit-log-entry) :details :id)))))))
+          (with-all-users-data-perms {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id :all}}}}}
+            (mt/user-http-request :rasta :post 200 (format "table/%d/rescan_values" table-id)))
+          (is (= table-id (:model_id (mt/latest-audit-log-entry))))
+          (is (= table-id (-> (mt/latest-audit-log-entry) :details :id))))))
 
     (testing "POST /api/table/:id/discard_values"
       (testing "A non-admin can discard field values if they have data model perms for the table"

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -507,7 +507,14 @@
           (with-all-users-data-perms {(mt/id) {:data       {:schemas :block :native :none}
                                                :data-model {:schemas {"PUBLIC" {(mt/id :venues) :all}}}}}
             (mt/user-http-request :rasta :post 200 (format "table/%d/rescan_values" (mt/id :venues)))))
-        (is (= [1 2 3 4] (t2/select-one-fn :values FieldValues, :field_id (mt/id :venues :price))))))
+        (is (= [1 2 3 4] (t2/select-one-fn :values FieldValues, :field_id (mt/id :venues :price)))))
+
+      (testing "An audit log entry is generated when a manually triggered re-scan occurs"
+        (mt/with-model-cleanup [:model/AuditLog :model/Activity]
+          (do (with-all-users-data-perms {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id :all}}}}}
+              (mt/user-http-request :rasta :post 200 (format "table/%d/rescan_values" table-id)))
+            (is (= table-id (:model_id (mt/latest-audit-log-entry))))
+            (is (= table-id (-> (mt/latest-audit-log-entry) :details :id)))))))
 
     (testing "POST /api/table/:id/discard_values"
       (testing "A non-admin can discard field values if they have data model perms for the table"

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -950,7 +950,7 @@
           (t2/update! Database id {:cache_ttl cache_ttl}))
 
         (let [db (t2/select-one Database :id id)]
-          (events/publish-event! :event/database-update {:previous existing-database :new db})
+          (events/publish-event! :event/database-update (assoc db :audit-log/previous existing-database))
           ;; return the DB with the expanded schedules back in place
           (add-expanded-schedules db))))))
 

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -950,7 +950,7 @@
           (t2/update! Database id {:cache_ttl cache_ttl}))
 
         (let [db (t2/select-one Database :id id)]
-          (events/publish-event! :event/database-update {:old existing-database :new db})
+          (events/publish-event! :event/database-update {:previous existing-database :new db})
           ;; return the DB with the expanded schedules back in place
           (add-expanded-schedules db))))))
 

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -977,6 +977,7 @@
   {id ms/PositiveInt}
   ;; just wrap this in a future so it happens async
   (let [db (api/write-check (t2/select-one Database :id id))]
+    (events/publish-event! :event/database-manual-sync db)
     (future
       (sync-metadata/sync-db-metadata! db)
       (analyze/analyze-db! db)))
@@ -1012,6 +1013,7 @@
   {id ms/PositiveInt}
   ;; just wrap this is a future so it happens async
   (let [db (api/write-check (t2/select-one Database :id id))]
+    (events/publish-event! :event/database-manual-scan db)
     ;; Override *current-user-permissions-set* so that permission checks pass during sync. If a user has DB detail perms
     ;; but no data perms, they should stll be able to trigger a sync of field values. This is fine because we don't
     ;; return any actual field values from this API. (#21764)
@@ -1040,7 +1042,9 @@
   "Discards all saved field values for this `Database`."
   [id]
   {id ms/PositiveInt}
-  (delete-all-field-values-for-database! (api/write-check (t2/select-one Database :id id)))
+  (let [db (api/write-check (t2/select-one Database :id id))]
+    (events/publish-event! :event/database-discard-field-values db)
+    (delete-all-field-values-for-database! db))
   {:status :ok})
 
 

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -950,7 +950,7 @@
           (t2/update! Database id {:cache_ttl cache_ttl}))
 
         (let [db (t2/select-one Database :id id)]
-          (events/publish-event! :event/database-update db)
+          (events/publish-event! :event/database-update {:old existing-database :new db})
           ;; return the DB with the expanded schedules back in place
           (add-expanded-schedules db))))))
 

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -8,6 +8,7 @@
    [metabase.driver :as driver]
    [metabase.driver.h2 :as h2]
    [metabase.driver.util :as driver.u]
+   [metabase.events :as events]
    [metabase.models.card :refer [Card]]
    [metabase.models.database :refer [Database]]
    [metabase.models.field :refer [Field]]
@@ -466,6 +467,7 @@
   [id]
   {id ms/PositiveInt}
   (let [table (api/write-check (t2/select-one Table :id id))]
+    (events/publish-event! :event/table-manual-scan table)
     ;; Override *current-user-permissions-set* so that permission checks pass during sync. If a user has DB detail perms
     ;; but no data perms, they should stll be able to trigger a sync of field values. This is fine because we don't
     ;; return any actual field values from this API. (#21764)

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -8,7 +8,6 @@
    [metabase.driver :as driver]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]
-   [metabase.models.database :refer [Database]]
    [metabase.models.interface :as mi]
    [metabase.models.setting :as setting]
    [metabase.query-processor.context.default :as context.default]
@@ -242,7 +241,7 @@
     (u/id db-or-id-or-spec)
     (let [database-id (u/the-id db-or-id-or-spec)
           ;; we need the Database instance no matter what (in order to compare details hash with cached value)
-          db          (or (when (mi/instance-of? Database db-or-id-or-spec)
+          db          (or (when (mi/instance-of? :model/Database db-or-id-or-spec)
                             (lib.metadata.jvm/instance->metadata db-or-id-or-spec :metadata/database))
                           (when (= (:lib/type db-or-id-or-spec) :metadata/database)
                             db-or-id-or-spec)
@@ -267,7 +266,7 @@
                                 ;; the hash didn't match, but it's possible that a stale instance of `DatabaseInstance`
                                 ;; was passed in (ex: from a long-running sync operation); fetch the latest one from
                                 ;; our app DB, and see if it STILL doesn't match
-                                (not= curr-hash (-> (t2/select-one [Database :id :engine :details] :id database-id)
+                                (not= curr-hash (-> (t2/select-one [:model/Database :id :engine :details] :id database-id)
                                                     jdbc-spec-hash))))
                             (when log-invalidation?
                               (log-jdbc-spec-hash-change-msg! db-id))

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -5,7 +5,6 @@
    [metabase.api.common :as api]
    [metabase.events :as events]
    [metabase.models.audit-log :as audit-log]
-   [metabase.util.malli :as mu]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -140,6 +140,9 @@
 (derive :event/database-create ::database-event)
 (derive :event/database-update ::database-event)
 (derive :event/database-delete ::database-event)
+(derive :event/database-manual-sync ::database-event)
+(derive :event/database-manual-scan ::database-event)
+(derive :event/database-discard-field-values ::database-event)
 
 (methodical/defmethod events/publish-event! ::database-event
   [topic database]

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -155,7 +155,7 @@
 (methodical/defmethod events/publish-event! ::database-update-event
   [topic {:keys [previous new]}]
   (let [[previous-only new-only _both] (data/diff previous new)
-        updated-keys (into #{} (concat (keys previous-only) (keys new-only)))]
+        updated-keys (distinct (concat (keys previous-only) (keys new-only)))]
     (audit-log/record-event!
      topic
      {:previous_value (select-keys previous updated-keys)

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -63,10 +63,11 @@
   [topic dashboard]
   (audit-log/record-event! topic dashboard))
 
-(derive ::table-read-event ::event)
-(derive :event/table-read ::table-read-event)
+(derive ::table-event ::event)
+(derive :event/table-read ::table-event)
+(derive :event/table-manual-scan ::table-event)
 
-(methodical/defmethod events/publish-event! ::table-read-event
+(methodical/defmethod events/publish-event! ::table-event
   [topic table]
   (audit-log/record-event! topic table))
 

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -135,3 +135,12 @@
   [topic _event]
   (when-not (t2/exists? :model/AuditLog :topic "install")
     (audit-log/record-event! topic {})))
+
+(derive ::database-event ::event)
+(derive :event/database-create ::database-event)
+(derive :event/database-update ::database-event)
+(derive :event/database-delete ::database-event)
+
+(methodical/defmethod events/publish-event! ::database-event
+  [topic database]
+  (audit-log/record-event! topic database))

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -17,8 +17,8 @@
 
   If `:audit-db/previous` is missing, this is a noop."
   [event]
-  (if-let [previous (:audit-db/previous event)]
-    (let [new (dissoc event :audit-db/previous)
+  (if-let [previous (:audit-log/previous event)]
+    (let [new (dissoc event :audit-log/previous)
           [previous-only new-only _both] (data/diff previous new)
           updated-keys (distinct (concat (keys previous-only) (keys new-only)))]
       {:previous (select-keys previous updated-keys)
@@ -169,7 +169,6 @@
 
 (methodical/defmethod events/publish-event! ::database-update-event
   [topic event]
-  (def event event)
   (audit-log/record-event! topic
                            (maybe-prepare-update-event-data event)
                            api/*current-user-id*

--- a/src/metabase/models/audit_log.clj
+++ b/src/metabase/models/audit_log.clj
@@ -30,22 +30,6 @@
   [_entity _event-type]
   {})
 
-;; This is in this namespace instead of `metabase.models.card` to avoid circular dependencies with
-;; `metabase.query-processor`
-(defmethod model-details :model/Card
-  [{query :dataset_query, dataset? :dataset :as card} _event-type]
-  (let [query (when (seq query)
-                (try (qp/preprocess query)
-                     (catch Throwable e
-                       (log/error e (tru "Error preprocessing query:")))))
-        database-id (some-> query :database u/the-id)
-        table-id    (mbql.u/query->source-table-id query)]
-    (merge (select-keys card [:name :description])
-           {:database_id database-id
-            :table_id    table-id
-            ;; Use `model` instead of `dataset` to mirror product terminology
-            :model?      dataset?})))
-
 (defn model-name
   "Given a keyword identifier for a model, returns the name to store in the database"
   [model]

--- a/src/metabase/models/audit_log.clj
+++ b/src/metabase/models/audit_log.clj
@@ -46,10 +46,6 @@
             ;; Use `model` instead of `dataset` to mirror product terminology
             :model?      dataset?})))
 
-#_(defmethod model-details :model/Database
-  [database _event-type]
-  (select-keys database [:id :name :engine]))
-
 (defn model-name
   "Given a keyword identifier for a model, returns the name to store in the database"
   [model]

--- a/src/metabase/models/audit_log.clj
+++ b/src/metabase/models/audit_log.clj
@@ -59,9 +59,10 @@
   ([topic object user-id model model-id]
    (let [unqualified-topic (keyword (name topic))
          model-name        (model-name model)
-         details           (if (t2/model object)
-                             (model-details object unqualified-topic)
-                             (or object {}))]
+         details           (cond
+                             (:raw? object) (dissoc object :raw?)
+                             (t2/model object) (model-details object unqualified-topic)
+                             :else (or object {}))]
      (t2/insert! :model/AuditLog
                  :topic    unqualified-topic
                  :details  details

--- a/src/metabase/models/audit_log.clj
+++ b/src/metabase/models/audit_log.clj
@@ -5,8 +5,6 @@
   (:require
    [metabase.api.common :as api]
    [metabase.models.activity :as activity]
-   [metabase.models.card :refer [Card]]
-   [metabase.models.database :refer [Database]]
    [metabase.models.interface :as mi]
    [metabase.util :as u]
    [methodical.core :as m]
@@ -34,7 +32,7 @@
 
 ;; This is in this namespace instead of `metabase.models.card` to avoid circular dependencies with
 ;; `metabase.query-processor`
-(defmethod model-details Card
+(defmethod model-details :model/Card
   [{query :dataset_query, dataset? :dataset :as card} _event-type]
   (let [query (when (seq query)
                 (try (qp/preprocess query)
@@ -48,9 +46,8 @@
             ;; Use `model` instead of `dataset` to mirror product terminology
             :model?      dataset?})))
 
-;; This is in this namespace instead of `metabase.models.database` to avoid circular dependencies with
-;; `/metabase/driver/sql_jdbc/connection`
-(defmethod model-details Database [database _event-type]
+#_(defmethod model-details :model/Database
+  [database _event-type]
   (select-keys database [:id :name :engine]))
 
 (defn model-name

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -5,6 +5,7 @@
    [metabase.driver :as driver]
    [metabase.driver.impl :as driver.impl]
    [metabase.driver.util :as driver.u]
+   [metabase.models.audit-log :as audit-log]
    [metabase.models.interface :as mi]
    [metabase.models.permissions :as perms]
    [metabase.models.permissions-group :as perms-group]
@@ -382,3 +383,7 @@
 (defmethod serdes/storage-path "Database" [{:keys [name]} _]
   ;; ["databases" "db_name" "db_name"] directory for the database with same-named file inside.
   ["databases" name name])
+
+(defmethod audit-log/model-details Database
+  [database _event-type]
+  (select-keys database [:id :name :engine]))

--- a/src/metabase/models/persisted_info.clj
+++ b/src/metabase/models/persisted_info.clj
@@ -4,7 +4,6 @@
    [clojure.string :as str]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
-   [metabase.models.card :refer [Card]]
    [metabase.models.interface :as mi]
    [metabase.public-settings.premium-features :as premium-features :refer [defenterprise]]
    [metabase.query-processor.util :as qp.util]
@@ -137,12 +136,13 @@
 (defn ready-unpersisted-models!
   "Looks for all new models in database and creates a persisted-info ready to be synced."
   [database-id]
-  (let [cards (t2/select Card {:where [:and
-                                       [:= :database_id database-id]
-                                       [:= :dataset true]
-                                       [:not [:exists {:select [1]
-                                                       :from [:persisted_info]
-                                                       :where [:= :persisted_info.card_id :report_card.id]}]]]})]
+  (let [cards (t2/select :model/Card
+                         {:where [:and
+                                  [:= :database_id database-id]
+                                  [:= :dataset true]
+                                  [:not [:exists {:select [1]
+                                                  :from [:persisted_info]
+                                                  :where [:= :persisted_info.card_id :report_card.id]}]]]})]
     (t2/insert! PersistedInfo (map #(create-row nil %) cards))))
 
 (defn turn-on-model!

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -10,7 +10,6 @@
    [metabase.mbql.util :as mbql.u]
    [metabase.models.interface :as mi]
    [metabase.models.permissions :as perms]
-   [metabase.models.table :refer [Table]]
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.util :as qp.util]
    [metabase.util :as u]
@@ -81,7 +80,7 @@
             (map (fn [table-id]
                    ((juxt :id :schema) (lib.metadata/table (qp.store/metadata-provider) table-id))))
             table-ids)
-      (t2/select-pk->fn :schema Table :id [:in table-ids]))))
+      (t2/select-pk->fn :schema :model/Table :id [:in table-ids]))))
 
 (mu/defn tables->permissions-path-set :- [:set perms/PathSchema]
   "Given a sequence of `tables-or-ids` referenced by a query, return a set of required permissions. A truthy value for

--- a/src/metabase/models/segment.clj
+++ b/src/metabase/models/segment.clj
@@ -172,7 +172,7 @@
         (concat ["segments" (serdes/storage-leaf-file-name id label)]))))
 
 
-;;; ------------------------------------------------ Audit Log --------------------------------------------------------
+;;; ---------------------------------------------- Audit Log Table ----------------------------------------------------
 
 (defmethod audit-log/model-details :model/Segment
   [metric _event-type]

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -3,6 +3,7 @@
    [metabase.db.connection :as mdb.connection]
    [metabase.db.util :as mdb.u]
    [metabase.driver :as driver]
+   [metabase.models.audit-log :as audit-log]
    [metabase.models.database :refer [Database]]
    [metabase.models.field :refer [Field]]
    [metabase.models.field-values :refer [FieldValues]]
@@ -251,3 +252,9 @@
 (defmethod serdes/storage-path "Table" [table _ctx]
   (concat (serdes/storage-table-path-prefix (serdes/path table))
           [(:name table)]))
+
+;;; -------------------------------------------------- Audit Log Table -------------------------------------------------
+
+(defmethod audit-log/model-details Table
+  [table _event-type]
+  (select-keys table [:id :name :db_id]))

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -7,7 +7,6 @@
    [java-time :as t]
    [metabase.api.common :as api]
    [metabase.config :as config]
-   [metabase.models.database :refer [Database]]
    [metabase.models.interface :as mi]
    [metabase.models.setting :as setting :refer [defsetting]]
    [metabase.plugins.classloader :as classloader]
@@ -570,7 +569,7 @@
   "Whether this instance has a Sample Database database"
   :visibility :authenticated
   :setter     :none
-  :getter     (fn [] (t2/exists? 'Database, :is_sample true))
+  :getter     (fn [] (t2/exists? :model/Database, :is_sample true))
   :doc        false)
 
 (defsetting password-complexity
@@ -693,7 +692,7 @@
   :getter     (fn []
                 (let [v (setting/get-value-of-type :boolean :show-database-syncing-modal)]
                   (if (nil? v)
-                    (not (t2/exists? 'Database
+                    (not (t2/exists? :model/Database
                                      :is_sample false
                                      :is_audit false
                                      :initial_sync_status "complete"))
@@ -715,7 +714,7 @@
   "Sets the :uploads-database-id setting, with an appropriate permission check."
   [new-id]
   (if (or (not-handling-api-request?)
-          (mi/can-write? Database new-id))
+          (mi/can-write? :model/Database new-id))
     (setting/set-value-of-type! :integer :uploads-database-id new-id)
     (api/throw-403)))
 

--- a/src/metabase/sync/util.clj
+++ b/src/metabase/sync/util.clj
@@ -9,10 +9,8 @@
    [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
    [metabase.events :as events]
-   [metabase.models.database :refer [Database]]
    [metabase.models.field :refer [Field]]
    [metabase.models.interface :as mi]
-   [metabase.models.table :refer [Table]]
    [metabase.models.task-history :refer [TaskHistory]]
    [metabase.query-processor.interface :as qp.i]
    [metabase.sync.interface :as i]
@@ -304,19 +302,19 @@
   "Marks initial sync as complete for this table so that it becomes usable in the UI, if not already set"
   [table]
   (when (not= (:initial_sync_status table) "complete")
-    (t2/update! Table (u/the-id table) {:initial_sync_status "complete"})))
+    (t2/update! :model/Table (u/the-id table) {:initial_sync_status "complete"})))
 
 (defn set-initial-database-sync-complete!
   "Marks initial sync as complete for this database so that this is reflected in the UI, if not already set"
   [database]
   (when (not= (:initial_sync_status database) "complete")
-    (t2/update! Database (u/the-id database) {:initial_sync_status "complete"})))
+    (t2/update! :model/Database (u/the-id database) {:initial_sync_status "complete"})))
 
 (defn set-initial-database-sync-aborted!
   "Marks initial sync as aborted for this database so that an error can be displayed on the UI"
   [database]
   (when (not= (:initial_sync_status database) "complete")
-    (t2/update! Database (u/the-id database) {:initial_sync_status "aborted"})))
+    (t2/update! :model/Database (u/the-id database) {:initial_sync_status "aborted"})))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          OTHER SYNC UTILITY FUNCTIONS                                          |
@@ -325,7 +323,7 @@
 (defn db->sync-tables
   "Return all the Tables that should go through the sync processes for `database-or-id`."
   [database-or-id]
-  (t2/select Table, :db_id (u/the-id database-or-id), :active true, :visibility_type nil))
+  (t2/select :model/Table, :db_id (u/the-id database-or-id), :active true, :visibility_type nil))
 
 (defmulti name-for-logging
   "Return an appropriate string for logging an object in sync logging messages. Should be something like
@@ -337,11 +335,11 @@
   {:arglists '([instance])}
   mi/model)
 
-(defmethod name-for-logging Database
+(defmethod name-for-logging :model/Database
   [{database-name :name, id :id, engine :engine,}]
   (trs "{0} Database {1} ''{2}''" (name engine) (str (or id "")) database-name))
 
-(defmethod name-for-logging Table [{schema :schema, id :id, table-name :name}]
+(defmethod name-for-logging :model/Table [{schema :schema, id :id, table-name :name}]
   (trs "Table {0} ''{1}''" (or id "") (str (when (seq schema) (str schema ".")) table-name)))
 
 (defmethod name-for-logging Field [{field-name :name, id :id}]

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -843,3 +843,12 @@
   [xs]
   (or (empty? xs)
       (apply distinct? xs)))
+
+(defn deep-sort-map
+  "Converts a map (with potentially nested maps as values) into a sorted map of sorted maps."
+  [m]
+  (into (sorted-map)
+        (zipmap
+         (keys m)
+         (map (fn [val] (if (map? val) (deep-sort-map val) val))
+              (vals m)))))

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -848,7 +848,4 @@
   "Converts a map (with potentially nested maps as values) into a sorted map of sorted maps."
   [m]
   (into (sorted-map)
-        (zipmap
-         (keys m)
-         (map (fn [val] (if (map? val) (deep-sort-map val) val))
-              (vals m)))))
+        (update-vals m (fn [val] (cond-> val (map? val) deep-sort-map)))))

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -1117,9 +1117,7 @@
 (deftest discard-db-fieldvalues-audit-log-test
   (testing "Can we DISCARD all the FieldValues for a DB?"
     (mt/with-model-cleanup [:model/AuditLog :model/Activity]
-      (mt/with-temp [Database    db       {:engine "h2", :details (:details (mt/db))}
-                     Table       table  {:db_id (u/the-id db)}
-                     Field       field  {:table_id (u/the-id table)}]
+      (mt/with-temp [Database db    {:engine "h2", :details (:details (mt/db))}]
         (is (= {:status "ok"} (mt/user-http-request :crowberto :post 200 (format "database/%d/discard_values" (u/the-id db)))))
         (is (= (:id db) (:model_id (mt/latest-audit-log-entry))))))))
 

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -1119,8 +1119,7 @@
     (mt/with-model-cleanup [:model/AuditLog :model/Activity]
       (mt/with-temp [Database    db       {:engine "h2", :details (:details (mt/db))}
                      Table       table  {:db_id (u/the-id db)}
-                     Field       field  {:table_id (u/the-id table)}
-                     FieldValues values {:field_id (u/the-id field), :values [1 2 3 4]}]
+                     Field       field  {:table_id (u/the-id table)}]
         (is (= {:status "ok"} (mt/user-http-request :crowberto :post 200 (format "database/%d/discard_values" (u/the-id db)))))
         (is (= (:id db) (:model_id (mt/latest-audit-log-entry))))))))
 

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -447,12 +447,10 @@
             "A db update occured")
         (let [audit-log-entry (mt/latest-audit-log-entry)]
           (is (=?
-               {:previous_value
-                {:name "Cam's Awesome multimethod Database"
-                 :updated_at #hawk/malli :string},
-                :new_value
-                {:name "Sam's Awesome multimethod Database"
-                 :updated_at #hawk/malli :string}}
+               {:previous {:name "Cam's Awesome multimethod Database"
+                           :updated_at #hawk/malli :string},
+                :new {:name "Sam's Awesome multimethod Database"
+                      :updated_at #hawk/malli :string}}
                (:details audit-log-entry)))
           (is (= (get-in audit-log-entry [:details :previous_value :name])
                  "Cam's Awesome multimethod Database"))

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -1086,7 +1086,10 @@
                                                             (deliver update-field-values-called? :sync-called)))]
           (mt/user-http-request :crowberto :post 200 (format "database/%d/rescan_values" (u/the-id db)))
           (is (= :sync-called
-                 (deref update-field-values-called? long-timeout :sync-never-called))))))))
+                 (deref update-field-values-called? long-timeout :sync-never-called)))
+          (is (= (:id db) (:model_id (mt/latest-audit-log-entry "database-manual-scan"))))
+          (is (= (:id db) (-> (mt/latest-audit-log-entry "database-manual-scan")
+                              :details :id))))))))
 
 (deftest nonadmins-cant-trigger-rescan
   (testing "Non-admins should not be allowed to trigger re-scan"

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -441,21 +441,17 @@
   (testing "Check that we get audit log entries that match the db when updating a Database"
     (t2.with-temp/with-temp [Database {db-id :id}]
       (with-redefs [driver/can-connect? (constantly true)]
-        (is (= "Cam's Awesome multimethod Database" (:name (api-update-database! 200 db-id {:name "Cam's Awesome multimethod Database"})))
+        (is (= "Original Database Name" (:name (api-update-database! 200 db-id {:name "Original Database Name"})))
             "A db update occured")
-        (is (= "Sam's Awesome multimethod Database" (:name (api-update-database! 200 db-id {:name "Sam's Awesome multimethod Database"})))
+        (is (= "Updated Database Name" (:name (api-update-database! 200 db-id {:name "Updated Database Name"})))
             "A db update occured")
         (let [audit-log-entry (mt/latest-audit-log-entry)]
           (is (=?
-               {:previous {:name "Cam's Awesome multimethod Database"
+               {:previous {:name "Original Database Name"
                            :updated_at #hawk/malli :string},
-                :new {:name "Sam's Awesome multimethod Database"
+                :new {:name "Updated Database Name"
                       :updated_at #hawk/malli :string}}
-               (:details audit-log-entry)))
-          (is (= (get-in audit-log-entry [:details :previous_value :name])
-                 "Cam's Awesome multimethod Database"))
-          (is (= (get-in audit-log-entry [:details :new_value :name])
-                 "Sam's Awesome multimethod Database")))))))
+               (:details audit-log-entry))))))))
 
 (deftest disallow-updating-h2-database-details-test
   (testing "PUT /api/database/:id"

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -1039,7 +1039,7 @@
     (let [sync-called?    (promise)
           analyze-called? (promise)]
       (mt/with-model-cleanup [:model/AuditLog :model/Activity]
-        (t2.with-temp/with-temp [Database {{db-id :id} :as _db} {:engine "h2", :details (:details (mt/db))}]
+        (t2.with-temp/with-temp [Database {db-id :id :as db} {:engine "h2", :details (:details (mt/db))}]
           (with-redefs [sync-metadata/sync-db-metadata! (deliver-when-db sync-called? db)
                         analyze/analyze-db!             (deliver-when-db analyze-called? db)]
             (mt/user-http-request :crowberto :post 200 (format "database/%d/sync_schema" (u/the-id db)))

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -1116,12 +1116,13 @@
 
 (deftest discard-db-fieldvalues-audit-log-test
   (testing "Can we DISCARD all the FieldValues for a DB?"
-    (mt/with-temp [Database    db       {:engine "h2", :details (:details (mt/db))}
-                   Table       table  {:db_id (u/the-id db)}
-                   Field       field  {:table_id (u/the-id table)}
-                   FieldValues values {:field_id (u/the-id field), :values [1 2 3 4]}]
-      (is (= {:status "ok"} (mt/user-http-request :crowberto :post 200 (format "database/%d/discard_values" (u/the-id db)))))
-      (is (= (:id db) (:model_id (mt/latest-audit-log-entry)))))))
+    (mt/with-model-cleanup [:model/AuditLog :model/Activity]
+      (mt/with-temp [Database    db       {:engine "h2", :details (:details (mt/db))}
+                     Table       table  {:db_id (u/the-id db)}
+                     Field       field  {:table_id (u/the-id table)}
+                     FieldValues values {:field_id (u/the-id field), :values [1 2 3 4]}]
+        (is (= {:status "ok"} (mt/user-http-request :crowberto :post 200 (format "database/%d/discard_values" (u/the-id db)))))
+        (is (= (:id db) (:model_id (mt/latest-audit-log-entry))))))))
 
 (deftest nonadmins-cant-discard-all-fieldvalues
   (testing "Non-admins should not be allowed to discard all FieldValues"

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -1114,6 +1114,15 @@
         (is (= false
                (t2/exists? FieldValues :id (u/the-id values-2))))))))
 
+(deftest discard-db-fieldvalues-audit-log-test
+  (testing "Can we DISCARD all the FieldValues for a DB?"
+    (mt/with-temp [Database    db       {:engine "h2", :details (:details (mt/db))}
+                   Table       table  {:db_id (u/the-id db)}
+                   Field       field  {:table_id (u/the-id table)}
+                   FieldValues values {:field_id (u/the-id field), :values [1 2 3 4]}]
+      (is (= {:status "ok"} (mt/user-http-request :crowberto :post 200 (format "database/%d/discard_values" (u/the-id db)))))
+      (is (= (:id db) (:model_id (mt/latest-audit-log-entry)))))))
+
 (deftest nonadmins-cant-discard-all-fieldvalues
   (testing "Non-admins should not be allowed to discard all FieldValues"
     (is (= "You don't have permissions to do that."

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -1153,7 +1153,7 @@
                           :new-value      "GETTER VALUE"}}
                (last-audit-event-fn)))))
 
-    (testing "Sensative settings have their values obfuscated automatically"
+    (testing "Sensitive settings have their values obfuscated automatically"
       (mt/with-temporary-setting-values [test-sensitive-setting-audit nil]
         (test-sensitive-setting-audit! "old password")
         (test-sensitive-setting-audit! "new password")

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -216,6 +216,7 @@
   doall-recursive
   file->bytes
   is-uuid-string?
+  latest-audit-log-entry
   let-url
   obj->json->obj
   postwalk-pred

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -1241,3 +1241,10 @@
       (if (neg? @a)
         (apply f args)
         (throw (ex-info "Not yet" {:remaining @a}))))))
+
+(defn latest-audit-log-entry
+  "Returns the latest audit log entry, optionally filters on `topic`."
+  ([]
+   (t2/select-one :model/AuditLog {:order-by [[:id :desc]]}))
+  ([topic]
+   (t2/select-one :model/AuditLog {:order-by [[:id :desc]] :where [:= :topic topic]})))

--- a/test/metabase/util_test.cljc
+++ b/test/metabase/util_test.cljc
@@ -435,3 +435,14 @@
     #{1}    true
     [1 2]   true
     [1 2 1] false))
+
+(deftest ^:parallel deep-sort-map-test
+  (is (= (into [] (u/deep-sort-map {:c 3 :a 1 :b 2}))
+         [[:a 1] [:b 2] [:c 3]])
+      "top level map should be sorted.")
+
+  (let [m {:d {:d.c 3 :d.a 1 :d.b 2} :c 3 :a 1 :b 2}
+        deeply-sorted (u/deep-sort-map m)]
+    (is (= (keys deeply-sorted) [:a :b :c :d]) "top level map should be sorted.")
+    (is (= (sort [[:d.c 3] [:d.a 1] [:d.b 2]]) (into [] (:d deeply-sorted)))
+        "submaps should be sorted.")))


### PR DESCRIPTION
Resolves #34099

Populates the audit log for the following events:

- [x] ~database-add~ `database-create`
Details: ~db_name~, ~db_id~, name, id, engine
    - [x] test

- [x] `database-update`
Details: ~db_name~, ~db_id~, name, id, engine
    - [x] test

- [x] `database-delete`
Details: ~db_name~, ~db_id~, name, id, engine
    - [x] test

- [x] `database-manual-sync`
Details: ~db_name~, ~db_id~, name, id, engine
    - [x] test

- [x] `database-manual-scan`
Details: ~db_name~, ~db_id~, name, id, engine
    - [x] test

- [x] `database-discard-field-values`
Details: ~db_name~, ~db_id~, name, id, engine
    - [x] test

- [x] `table-manual-scan`
Details: ~table_name~, ~table_id~, name, id, db_id
    - [x] test