### PR TITLE
Change audit_log to use timestamp with timezone, and expand length of `model` field

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15341,13 +15341,13 @@ databaseChangeLog:
                     nullable: false
               - column:
                   name: timestamp
-                  type: DATETIME
+                  type: ${timestamp_type}
                   remarks: The time an event was recorded
                   constraints:
                     nullable: false
               - column:
                   name: end_timestamp
-                  type: DATETIME
+                  type: ${timestamp_type}
                   remarks: The time an event ended, if applicable
                   constraints:
                     nullable: true
@@ -15359,7 +15359,7 @@ databaseChangeLog:
                     nullable: true
               - column:
                   name: model
-                  type: varchar(16)
+                  type: varchar(32)
                   remarks: The name of the model this event applies to (e.g. Card, Dashboard), if applicable
                   constraints:
                     nullable: true


### PR DESCRIPTION
* Change `audit_log` to use timestamp with timezone, consistent with audit v1 tables
* Expand length of `model` field - 16 chars was probably too conservative

Doing these in-place since we haven't merged anything to master yet. 