### PR TITLE
Fix pivot table e2e test on master

### DIFF
--- a/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -1161,7 +1161,9 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
     cy.findByTestId("qb-header-action-panel").findByText("Save").click();
     modal().button("Save").click();
     cy.wait("@createCard");
+    cy.intercept("POST", "/api/card/pivot/*/query").as("cardPivotQuery");
     cy.reload();
+    cy.wait("@cardPivotQuery");
 
     cy.findByTestId("question-row-count").should(
       "have.text",

--- a/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -1152,7 +1152,6 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
         },
       },
     });
-    cy.wait("@pivotDataset");
 
     cy.findByTestId("question-row-count").should(
       "have.text",


### PR DESCRIPTION
Apparently `visitQuestionAdhoc` already waits on the pivot table request to complete, so this line was redundant and resulted in a timeout.

I had added it in [this PR](https://github.com/metabase/metabase/pull/34583) which then auto-merged since `e2e-tests-slow-ee` apparently isn't merge-blocking.