### PR TITLE
Use env vars for user-controlled strings

### DIFF
--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-22.04
     # Do not re-run scheduled workflow runs. That's only Replay.io E2E tests for now.
     if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event != 'schedule'
+    env:
+      BRANCH_NAME: ${{ github.event.workflow_run.head_branch }}
+      AUTHOR_NAME: ${{ github.event.workflow_run.head_commit.author.name }}
     steps:
       - name: Generate job summary
         run: |
@@ -30,11 +33,11 @@ jobs:
           script: | # js
             const MAX_ATTEMPTS = 2;
             const ATTEMPT = "${{ github.event.workflow_run.run_attempt }}";
-            const BRANCH = "${{ github.event.workflow_run.head_branch }}";
             const FAILED_RUN_URL = "${{ github.event.workflow_run.html_url }}";
             const FAILED_RUN_NAME = "${{ github.event.workflow_run.name }}";
-            const AUTHOR = "${{ github.event.workflow_run.head_commit.author.name }}";
             const BREAKING_COMMIT = "${{ github.event.workflow_run.head_sha }}";
+            const AUTHOR = process.env.AUTHOR_NAME;
+            const BRANCH = process.env.BRANCH_NAME;
 
             if (ATTEMPT <= MAX_ATTEMPTS) {
               github.rest.actions.reRunWorkflowFailedJobs({


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/34748

### Description

Uses environment variables for user-controlled strings to prevent code injection on third party PRs.


