### PR TITLE
Rename dashboard's ordered_tabs to tabs

### DIFF
--- a/docs/api/dashboard.md
+++ b/docs/api/dashboard.md
@@ -73,9 +73,9 @@ Fetch possible values of the parameter whose ID is `:param-key` that contain `:q
 
 *  **`id`** value must be an integer greater than zero.
 
-*  **`param-key`** 
+*  **`param-key`**
 
-*  **`query`** 
+*  **`query`**
 
 *  **`query-params`**
 
@@ -91,7 +91,7 @@ Fetch possible values of the parameter whose ID is `:param-key`. If the values c
 
 *  **`id`** value must be an integer greater than zero.
 
-*  **`param-key`** 
+*  **`param-key`**
 
 *  **`query-params`**
 
@@ -176,11 +176,11 @@ Run the query associated with a Saved Question (`Card`) in the context of a `Das
 
 ### PARAMS:
 
-*  **`dashboard-id`** 
+*  **`dashboard-id`**
 
-*  **`dashcard-id`** 
+*  **`dashcard-id`**
 
-*  **`card-id`** 
+*  **`card-id`**
 
 *  **`parameters`** value may be nil, or if non-nil, value must be an array. Each value must be a parameter map with an 'id' key
 
@@ -194,11 +194,11 @@ Run the query associated with a Saved Question (`Card`) in the context of a `Das
 
 ### PARAMS:
 
-*  **`dashboard-id`** 
+*  **`dashboard-id`**
 
-*  **`dashcard-id`** 
+*  **`dashcard-id`**
 
-*  **`card-id`** 
+*  **`card-id`**
 
 *  **`export-format`** value must be one of: `api`, `csv`, `json`, `xlsx`.
 
@@ -221,10 +221,10 @@ Execute the associated Action in the context of a `Dashboard` and `DashboardCard
 
 *  **`parameters`** value may be nil, or if non-nil, value must be a map with schema: (
   value must be a map with schema: (
-    p? : 
-    pred-name : 
+    p? :
+    pred-name :
   ) : value must be a map with schema: (
-    _ : 
+    _ :
   )
 )
 
@@ -278,11 +278,11 @@ Run a pivot table query for a specific DashCard.
 
 ### PARAMS:
 
-*  **`dashboard-id`** 
+*  **`dashboard-id`**
 
-*  **`dashcard-id`** 
+*  **`dashcard-id`**
 
-*  **`card-id`** 
+*  **`card-id`**
 
 *  **`parameters`** value may be nil, or if non-nil, value must be an array. Each value must be a parameter map with an 'id' key
 
@@ -330,7 +330,7 @@ Update a Dashboard.
 
 *  **`collection_id`** value may be nil, or if non-nil, value must be an integer greater than zero.
 
-*  **`dash-updates`** 
+*  **`dash-updates`**
 
 *  **`name`** value may be nil, or if non-nil, value must be a non-blank string.
 
@@ -340,7 +340,7 @@ Update a Dashboard.
 
 *  **`cache_ttl`** value may be nil, or if non-nil, value must be an integer greater than zero.
 
-*  **`id`** 
+*  **`id`**
 
 *  **`position`** value may be nil, or if non-nil, value must be an integer greater than zero.
 
@@ -357,7 +357,7 @@ Update `Cards` and `Tabs` on a Dashboard. Request body should have the form:
                      :series             [{:id 123
                                            ...}]}
                      ...]
-     :ordered_tabs [{:id       ... ; DashboardTab ID
+     :tabs [{:id       ... ; DashboardTab ID
                      :name     ...}]}.
 
 ### PARAMS:
@@ -366,7 +366,7 @@ Update `Cards` and `Tabs` on a Dashboard. Request body should have the form:
 
 *  **`cards`** value must be seq of maps in which ids are unique
 
-*  **`ordered_tabs`** nullable value must be seq of maps in which ids are unique
+*  **`tabs`** nullable value must be seq of maps in which ids are unique
 
 ---
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -670,7 +670,7 @@
                  (is (serdes/with-cache (serdes.load/load-metabase (ingest/ingest-yaml dump-dir)))
                      "successful"))
                (let [new-dashboard (-> (t2/select-one Dashboard :entity_id dashboard-eid)
-                                       (t2/hydrate :ordered_tabs :dashcards))
+                                       (t2/hydrate :tabs :dashcards))
                      new-tab-id-1  (t2/select-one-pk :model/DashboardTab :entity_id tab-eid-1)
                      new-tab-id-2  (t2/select-one-pk :model/DashboardTab :entity_id tab-eid-2)
                      new-card-id-1 (t2/select-one-pk Card :entity_id card-eid-1)
@@ -684,7 +684,7 @@
                            :dashboard_id (:id new-dashboard)
                            :name         "Tab 2"
                            :position     1}]
-                         (:ordered_tabs new-dashboard)))
+                         (:tabs new-dashboard)))
                  (is (=? [{:card_id          new-card-id-1
                            :dashboard_id     (:id new-dashboard)
                            :dashboard_tab_id new-tab-id-1}

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -19,7 +19,7 @@ export interface Dashboard {
   description: string | null;
   model?: string;
   dashcards: (DashboardCard | ActionDashboardCard)[];
-  ordered_tabs?: DashboardOrderedTab[];
+  tabs?: DashboardOrderedTab[];
   parameters?: Parameter[] | null;
   can_write: boolean;
   cache_ttl: number | null;

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -19,7 +19,7 @@ export interface Dashboard {
   description: string | null;
   model?: string;
   dashcards: (DashboardCard | ActionDashboardCard)[];
-  tabs?: DashboardOrderedTab[];
+  tabs?: DashboardTab[];
   parameters?: Parameter[] | null;
   can_write: boolean;
   cache_ttl: number | null;
@@ -70,7 +70,7 @@ export type DashboardCard = BaseDashboardCard & {
 
 export type DashboardTabId = number;
 
-export type DashboardOrderedTab = {
+export type DashboardTab = {
   id: DashboardTabId;
   dashboard_id: DashboardId;
   entity_id: string;

--- a/frontend/src/metabase-types/store/dashboard.ts
+++ b/frontend/src/metabase-types/store/dashboard.ts
@@ -6,7 +6,7 @@ import type {
   DashCardDataMap,
   ParameterId,
   ParameterValueOrArray,
-  DashboardOrderedTab,
+  DashboardTab,
   DashboardTabId,
 } from "metabase-types/api";
 
@@ -18,7 +18,7 @@ export type DashboardSidebarName =
   | "sharing"
   | "info";
 
-export type StoreDashboardTab = DashboardOrderedTab & {
+export type StoreDashboardTab = DashboardTab & {
   isRemoved?: boolean;
 };
 

--- a/frontend/src/metabase-types/store/dashboard.ts
+++ b/frontend/src/metabase-types/store/dashboard.ts
@@ -22,9 +22,9 @@ export type StoreDashboardTab = DashboardOrderedTab & {
   isRemoved?: boolean;
 };
 
-export type StoreDashboard = Omit<Dashboard, "dashcards" | "ordered_tabs"> & {
+export type StoreDashboard = Omit<Dashboard, "dashcards" | "tabs"> & {
   dashcards: DashCardId[];
-  ordered_tabs?: StoreDashboardTab[];
+  tabs?: StoreDashboardTab[];
 };
 
 export type StoreDashcard = DashboardCard & {

--- a/frontend/src/metabase/dashboard/actions/save.js
+++ b/frontend/src/metabase/dashboard/actions/save.js
@@ -110,7 +110,7 @@ export const updateDashboardAndCards = createThunkAction(
           visualization_settings: dc.visualization_settings,
           parameter_mappings: dc.parameter_mappings,
         })),
-        ordered_tabs: (dashboard.ordered_tabs ?? [])
+        tabs: (dashboard.tabs ?? [])
           .filter(tab => !tab.isRemoved)
           .map(({ id, name }) => ({
             id,

--- a/frontend/src/metabase/dashboard/actions/tabs.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.ts
@@ -31,7 +31,7 @@ type MoveTabPayload = {
 type SelectTabPayload = { tabId: DashboardTabId | null };
 type SaveCardsAndTabsPayload = {
   cards: DashboardCard[];
-  ordered_tabs: DashboardOrderedTab[];
+  tabs: DashboardOrderedTab[];
 };
 type InitTabsPayload = { slug: string | undefined };
 
@@ -86,8 +86,7 @@ function getPrevDashAndTabs({
   const dashId = state.dashboardId;
   const prevDash = dashId ? state.dashboards[dashId] : null;
   const prevTabs =
-    prevDash?.ordered_tabs?.filter(t => !filterRemovedTabs || !t.isRemoved) ??
-    [];
+    prevDash?.tabs?.filter(t => !filterRemovedTabs || !t.isRemoved) ?? [];
 
   return { dashId, prevDash, prevTabs };
 }
@@ -141,7 +140,7 @@ export const tabsReducer = createReducer<DashboardState>(
             dashId,
             name: t`Tab ${prevTabs.filter(t => !t.isRemoved).length + 1}`,
           });
-          prevDash.ordered_tabs = [...prevTabs, newTab];
+          prevDash.tabs = [...prevTabs, newTab];
 
           // 2. Select new tab
           state.selectedTabId = tabId;
@@ -157,7 +156,7 @@ export const tabsReducer = createReducer<DashboardState>(
           getDefaultTab({ tabId: firstTabId, dashId, name: t`Tab 1` }),
           getDefaultTab({ tabId: secondTabId, dashId, name: t`Tab 2` }),
         ];
-        prevDash.ordered_tabs = [...prevTabs, ...newTabs];
+        prevDash.tabs = [...prevTabs, ...newTabs];
 
         // 2. Select second tab
         state.selectedTabId = secondTabId;
@@ -267,11 +266,7 @@ export const tabsReducer = createReducer<DashboardState>(
           );
         }
 
-        prevDash.ordered_tabs = arrayMove(
-          prevTabs,
-          sourceTabIndex,
-          destTabIndex,
-        );
+        prevDash.tabs = arrayMove(prevTabs, sourceTabIndex, destTabIndex);
       },
     );
 
@@ -281,7 +276,7 @@ export const tabsReducer = createReducer<DashboardState>(
 
     builder.addCase(
       saveCardsAndTabs,
-      (state, { payload: { cards: newCards, ordered_tabs: newTabs } }) => {
+      (state, { payload: { cards: newCards, tabs: newTabs } }) => {
         const { prevDash, prevTabs } = getPrevDashAndTabs({
           state,
           filterRemovedTabs: true,

--- a/frontend/src/metabase/dashboard/actions/tabs.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.ts
@@ -7,7 +7,7 @@ import type {
   DashCardId,
   DashboardId,
   DashboardCard,
-  DashboardOrderedTab,
+  DashboardTab,
   DashboardTabId,
 } from "metabase-types/api";
 import type { DashboardState, TabDeletionId } from "metabase-types/store";
@@ -31,7 +31,7 @@ type MoveTabPayload = {
 type SelectTabPayload = { tabId: DashboardTabId | null };
 type SaveCardsAndTabsPayload = {
   cards: DashboardCard[];
-  tabs: DashboardOrderedTab[];
+  tabs: DashboardTab[];
 };
 type InitTabsPayload = { slug: string | undefined };
 

--- a/frontend/src/metabase/dashboard/actions/tabs.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.unit.spec.ts
@@ -11,9 +11,7 @@ describe("tabsReducer", () => {
       TEST_DASHBOARD_STATE,
       moveTab({ sourceTabId: 1, destTabId: 3 }),
     );
-    expect(newDashState.dashboards[1].ordered_tabs?.map(t => t.id)).toEqual([
-      2, 3, 1,
-    ]);
+    expect(newDashState.dashboards[1].tabs?.map(t => t.id)).toEqual([2, 3, 1]);
   });
 });
 

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -196,7 +196,7 @@ class Dashboard extends Component {
         addCardToDashboard({
           dashId: dashboardId,
           cardId: addCardOnLoad,
-          tabId: this.props.dashboard.ordered_tabs[0]?.id ?? null,
+          tabId: this.props.dashboard.tabs[0]?.id ?? null,
         });
       }
     } catch (error) {

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
@@ -29,7 +29,7 @@ function setup({
     dashboards: {
       1: {
         ...TEST_DASHBOARD_STATE.dashboards[1],
-        ordered_tabs: tabs ?? TEST_DASHBOARD_STATE.dashboards[1].ordered_tabs,
+        tabs: tabs ?? TEST_DASHBOARD_STATE.dashboards[1].tabs,
       },
     },
   };

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
@@ -4,7 +4,7 @@ import type { Location } from "history";
 
 import { renderWithProviders, screen } from "__support__/ui";
 import type { DashboardState, State } from "metabase-types/store";
-import type { DashboardOrderedTab } from "metabase-types/api";
+import type { DashboardTab } from "metabase-types/api";
 import { getDefaultTab, resetTempTabId } from "metabase/dashboard/actions";
 import { INPUT_WRAPPER_TEST_ID } from "metabase/core/components/TabButton";
 
@@ -20,7 +20,7 @@ function setup({
   slug = undefined,
   isEditing = true,
 }: {
-  tabs?: DashboardOrderedTab[];
+  tabs?: DashboardTab[];
   slug?: string | undefined;
   isEditing?: boolean;
 } = {}) {

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/test-utils.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/test-utils.ts
@@ -59,7 +59,7 @@ export const TEST_DASHBOARD_STATE: DashboardState = {
         timestamp: "",
       },
       dashcards: [1, 2],
-      ordered_tabs: [
+      tabs: [
         getDefaultTab({ tabId: 1, dashId: 1, name: "Tab 1" }),
         getDefaultTab({ tabId: 2, dashId: 1, name: "Tab 2" }),
         getDefaultTab({ tabId: 3, dashId: 1, name: "Tab 3" }),

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -436,9 +436,7 @@ class DashboardHeader extends Component {
 
       extraButtons.push({
         title:
-          dashboard.ordered_tabs?.length > 1
-            ? t`Export tab as PDF`
-            : t`Export as PDF`,
+          dashboard.tabs?.length > 1 ? t`Export tab as PDF` : t`Export as PDF`,
         icon: "document",
         testId: "dashboard-export-pdf-button",
         action: () => {

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.unit.spec.tsx
@@ -25,7 +25,7 @@ const TEST_DASHBOARD = createMockDashboard({
 });
 
 const TEST_DASHBOARD_WITH_TABS = createMockDashboard({
-  ordered_tabs: [
+  tabs: [
     getDefaultTab({ tabId: 1, dashId: 1, name: "Tab 1" }),
     getDefaultTab({
       tabId: 2,

--- a/frontend/src/metabase/dashboard/selectors/selectors-typed.ts
+++ b/frontend/src/metabase/dashboard/selectors/selectors-typed.ts
@@ -7,7 +7,7 @@ export function getDashboardId(state: State) {
 export function getTabs(state: State) {
   const dashboardId = getDashboardId(state);
   return dashboardId
-    ? state.dashboard.dashboards[dashboardId].ordered_tabs?.filter(
+    ? state.dashboard.dashboards[dashboardId].tabs?.filter(
         tab => !tab.isRemoved,
       ) ?? []
     : [];

--- a/frontend/src/metabase/public/containers/PublicDashboard.jsx
+++ b/frontend/src/metabase/public/containers/PublicDashboard.jsx
@@ -84,7 +84,7 @@ class PublicDashboard extends Component {
     initialize();
     try {
       await fetchDashboard(uuid || token, location.query);
-      if (this.props.dashboard.ordered_tabs.length === 0) {
+      if (this.props.dashboard.tabs.length === 0) {
         await fetchDashboardCardData({ reload: false, clearCache: true });
       }
     } catch (error) {

--- a/src/metabase/api/automagic_dashboards.clj
+++ b/src/metabase/api/automagic_dashboards.clj
@@ -222,11 +222,11 @@
              (reduce (fn [dashboard {:keys [tab dash-cards]}]
                        (-> dashboard
                            (update :dashcards into dash-cards)
-                           (update :ordered_tabs conj tab)))
+                           (update :tabs conj tab)))
                      (merge
                       seed-dashboard
                       {:dashcards []
-                       :ordered_tabs  []})))
+                       :tabs  []})))
         (update seed-dashboard
                 :dashcards (fn [cards] (add-source-model-link model cards)))))
     {:name      (format "Here's a look at \"%s\" from \"%s\"" indexed-entity-name model-name)

--- a/src/metabase/api/automagic_dashboards.clj
+++ b/src/metabase/api/automagic_dashboards.clj
@@ -226,7 +226,7 @@
                      (merge
                       seed-dashboard
                       {:dashcards []
-                       :tabs  []})))
+                       :tabs      []})))
         (update seed-dashboard
                 :dashcards (fn [cards] (add-source-model-link model cards)))))
     {:name      (format "Here's a look at \"%s\" from \"%s\"" indexed-entity-name model-name)

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -684,7 +684,7 @@
         (track-dashcard-and-tab-events!  id @changes-stats)
         true))
    {:cards        (t2/hydrate (dashboard/dashcards id) :series)
-    :ordered_tabs (dashboard/ordered-tabs id)}))
+    :ordered_tabs (dashboard/tabs id)}))
 
 (api/defendpoint GET "/:id/revisions"
   "Fetch `Revisions` for Dashboard with ID."

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -217,7 +217,7 @@
                    :series
                    :dashcard/action
                    :dashcard/linkcard-info]
-                  :ordered_tabs
+                  :tabs
                   :collection_authority_level
                   :can_write
                   :param_fields
@@ -364,7 +364,7 @@
                               (when is_deep_copy
                                 (duplicate-cards existing-dashboard collection_id))
 
-                              id->new-tab-id (when-let [existing-tabs (seq (:ordered_tabs existing-dashboard))]
+                              id->new-tab-id (when-let [existing-tabs (seq (:tabs existing-dashboard))]
                                                (duplicate-tabs dash existing-tabs))]
                           (reset! new-cards (vals id->new-card))
                           (when-let [dashcards (seq (update-cards-for-copy from-dashboard-id
@@ -641,19 +641,19 @@
                      :series             [{:id 123
                                            ...}]}
                      ...]
-     :ordered_tabs [{:id       ... ; DashboardTab ID
+     :tabs [{:id       ... ; DashboardTab ID
                      :name     ...}]}"
-  [id :as {{:keys [cards ordered_tabs]} :body}]
+  [id :as {{:keys [cards tabs]} :body}]
   {id           ms/PositiveInt
    cards        (ms/maps-with-unique-key [:sequential UpdatedDashboardCard] :id)
-   ;; ordered_tabs should be required in production, making it optional because lots of
+   ;; tabs should be required in production, making it optional because lots of
    ;; e2e tests curerntly doesn't include it
-   ordered_tabs [:maybe (ms/maps-with-unique-key [:sequential UpdatedDashboardTab] :id)]}
+   tabs [:maybe (ms/maps-with-unique-key [:sequential UpdatedDashboardTab] :id)]}
   (let [dashboard (-> (api/write-check Dashboard id)
                       api/check-not-archived
-                      (t2/hydrate [:dashcards :series :card] :ordered_tabs))
-        new-tabs  (map-indexed (fn [idx tab] (assoc tab :position idx)) ordered_tabs)]
-    (when (and (seq (:ordered_tabs dashboard))
+                      (t2/hydrate [:dashcards :series :card] :tabs))
+        new-tabs  (map-indexed (fn [idx tab] (assoc tab :position idx)) tabs)]
+    (when (and (seq (:tabs dashboard))
                (not (every? #(some? (:dashboard_tab_id %)) cards)))
       (throw (ex-info (tru "This dashboard has tab, makes sure every card has a tab")
                       {:status-code 400})))
@@ -662,7 +662,7 @@
         (t2/with-transaction [_conn]
           (let [{:keys [old->new-tab-id
                         deleted-tab-ids]
-                 :as tabs-changes-stats} (dashboard-tab/do-update-tabs! (:id dashboard) (:ordered_tabs dashboard) new-tabs)
+                 :as tabs-changes-stats} (dashboard-tab/do-update-tabs! (:id dashboard) (:tabs dashboard) new-tabs)
                 deleted-tab-ids          (set deleted-tab-ids)
                 current-cards            (cond->> (:dashcards dashboard)
                                            (seq deleted-tab-ids)
@@ -684,7 +684,7 @@
         (track-dashcard-and-tab-events!  id @changes-stats)
         true))
    {:cards        (t2/hydrate (dashboard/dashcards id) :series)
-    :ordered_tabs (dashboard/tabs id)}))
+    :tabs (dashboard/tabs id)}))
 
 (api/defendpoint GET "/:id/revisions"
   "Fetch `Revisions` for Dashboard with ID."

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -683,8 +683,8 @@
         ;; trigger events out of tx so rows are committed and visible from other threads
         (track-dashcard-and-tab-events!  id @changes-stats)
         true))
-   {:cards        (t2/hydrate (dashboard/dashcards id) :series)
-    :tabs (dashboard/tabs id)}))
+   {:cards (t2/hydrate (dashboard/dashcards id) :series)
+    :tabs  (dashboard/tabs id)}))
 
 (api/defendpoint GET "/:id/revisions"
   "Fetch `Revisions` for Dashboard with ID."

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -231,7 +231,7 @@
   {:pre [(even? (count conditions))]}
   (binding [params/*ignore-current-user-perms-and-return-all-field-values* true]
     (-> (api/check-404 (apply t2/select-one [Dashboard :name :description :id :parameters :auto_apply_filters], :archived false, conditions))
-        (t2/hydrate [:dashcards :card :series :dashcard/action] :ordered_tabs :param_values :param_fields)
+        (t2/hydrate [:dashcards :card :series :dashcard/action] :tabs :param_values :param_fields)
         api.dashboard/add-query-average-durations
         (update :dashcards (fn [dashcards]
                              (for [dashcard dashcards]

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -353,7 +353,7 @@
 
 (defn- update-card-row-on-downgrade-for-dashboard-tab
   [dashboard-id]
-  (let [ordered-tab+cards (->> (t2/query {:select    [:report_dashboardcard.* [:dashboard_tab.position :tab_position]]
+  (let [tab+cards (->> (t2/query {:select    [:report_dashboardcard.* [:dashboard_tab.position :tab_position]]
                                           :from      [:report_dashboardcard]
                                           :where     [:= :report_dashboardcard.dashboard_id dashboard-id]
                                           :left-join [:dashboard_tab [:= :dashboard_tab.id :report_dashboardcard.dashboard_tab_id]]})
@@ -361,7 +361,7 @@
                                ;; sort by tab position
                                (sort-by first))
         cards->max-height (fn [cards] (apply max (map #(+ (:row %) (:size_y %)) cards)))]
-    (loop [position+cards ordered-tab+cards
+    (loop [position+cards tab+cards
            next-tab-row   0]
       (when-let [[tab-pos cards] (first position+cards)]
         (if (zero? tab-pos)

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -354,9 +354,9 @@
 (defn- update-card-row-on-downgrade-for-dashboard-tab
   [dashboard-id]
   (let [tab+cards (->> (t2/query {:select    [:report_dashboardcard.* [:dashboard_tab.position :tab_position]]
-                                          :from      [:report_dashboardcard]
-                                          :where     [:= :report_dashboardcard.dashboard_id dashboard-id]
-                                          :left-join [:dashboard_tab [:= :dashboard_tab.id :report_dashboardcard.dashboard_tab_id]]})
+                                  :from      [:report_dashboardcard]
+                                  :where     [:= :report_dashboardcard.dashboard_id dashboard-id]
+                                  :left-join [:dashboard_tab [:= :dashboard_tab.id :report_dashboardcard.dashboard_tab_id]]})
                                (group-by :tab_position)
                                ;; sort by tab position
                                (sort-by first))

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -159,7 +159,7 @@
 
 ;;; --------------------------------------------------- Hydration ----------------------------------------------------
 
-(mi/define-simple-hydration-method ordered-tabs
+(mi/define-simple-hydration-method tabs
   :ordered_tabs
   "Return the ordered DashboardTabs associated with `dashboard-or-id`, sorted by tab position."
   [dashboard-or-id]
@@ -220,7 +220,7 @@
       (assoc :cards (vec (for [dashboard-card (dashcards dashboard)]
                            (-> (apply dissoc dashboard-card excluded-columns-for-dashcard-revision)
                                (assoc :series (mapv :id (dashboard-card/series dashboard-card)))))))
-      (assoc :tabs (map #(apply dissoc % excluded-columns-for-dashboard-tab-revision) (ordered-tabs dashboard)))))
+      (assoc :tabs (map #(apply dissoc % excluded-columns-for-dashboard-tab-revision) (tabs dashboard)))))
 
 (defn- revert-dashcards
   [dashboard-id serialized-cards]

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -549,7 +549,7 @@
                (t2/hydrate :tabs))]
     (-> (serdes/extract-one-basics "Dashboard" dash)
         (update :dashcards         #(mapv extract-dashcard %))
-        (update :tabs      #(mapv extract-dashtab %))
+        (update :tabs              #(mapv extract-dashtab %))
         (update :parameters        serdes/export-parameters)
         (update :collection_id     serdes/*export-fk* Collection)
         (update :creator_id        serdes/*export-user*)

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -160,7 +160,7 @@
 ;;; --------------------------------------------------- Hydration ----------------------------------------------------
 
 (mi/define-simple-hydration-method tabs
-  :ordered_tabs
+  :tabs
   "Return the ordered DashboardTabs associated with `dashboard-or-id`, sorted by tab position."
   [dashboard-or-id]
   (t2/select :model/DashboardTab :dashboard_id (u/the-id dashboard-or-id) {:order-by [[:position :asc]]}))
@@ -445,7 +445,7 @@
   "Save a denormalized description of `dashboard`."
   [dashboard parent-collection-id]
   (let [{dashcards      :dashcards
-         tabs           :ordered_tabs
+         tabs           :tabs
          dashboard-name :name
          :keys          [description] :as dashboard} (i18n/localized-strings->strings dashboard)
         collection (populate/create-collection!
@@ -455,7 +455,7 @@
         dashboard  (first (t2/insert-returning-instances!
                             :model/Dashboard
                             (-> dashboard
-                                (dissoc :dashcards :ordered_tabs :rule :related
+                                (dissoc :dashcards :tabs :rule :related
                                         :transient_name :transient_filters :param_fields :more)
                                 (assoc :description description
                                        :collection_id (:id collection)
@@ -545,11 +545,11 @@
   (let [dash (cond-> dash
                (nil? (:dashcards dash))
                (t2/hydrate :dashcards)
-               (nil? (:ordered_tabs dash))
-               (t2/hydrate :ordered_tabs))]
+               (nil? (:tabs dash))
+               (t2/hydrate :tabs))]
     (-> (serdes/extract-one-basics "Dashboard" dash)
         (update :dashcards         #(mapv extract-dashcard %))
-        (update :ordered_tabs      #(mapv extract-dashtab %))
+        (update :tabs      #(mapv extract-dashtab %))
         (update :parameters        serdes/export-parameters)
         (update :collection_id     serdes/*export-fk* Collection)
         (update :creator_id        serdes/*export-user*)
@@ -582,8 +582,8 @@
 
 ;; Call the default load-one! for the Dashboard, then for each DashboardCard.
 (defmethod serdes/load-one! "Dashboard" [ingested maybe-local]
-  (let [dashboard ((get-method serdes/load-one! :default) (dissoc ingested :dashcards :ordered_tabs) maybe-local)]
-    (doseq [tab (:ordered_tabs ingested)]
+  (let [dashboard ((get-method serdes/load-one! :default) (dissoc ingested :dashcards :tabs) maybe-local)]
+    (doseq [tab (:tabs ingested)]
       (serdes/load-one! (dashtab-for tab dashboard)
                         (t2/select-one :model/DashboardTab :entity_id (:entity_id tab))))
     (doseq [dashcard (:dashcards ingested)]

--- a/src/metabase/models/dashboard_tab.clj
+++ b/src/metabase/models/dashboard_tab.clj
@@ -38,7 +38,7 @@
         dashcards         (t2/select :model/DashboardCard :dashboard_id dashboard-id :dashboard_tab_id [:in tab-ids])
         tab-id->dashcards (-> (group-by :dashboard_tab_id dashcards)
                               (update-vals #(sort dashboard-card/dashcard-comparator %)))
-        tabs      (sort-by :position tabs)]
+        tabs              (sort-by :position tabs)]
     (for [{:keys [id] :as tab} tabs]
       (assoc tab :cards (get tab-id->dashcards id)))))
 

--- a/src/metabase/models/dashboard_tab.clj
+++ b/src/metabase/models/dashboard_tab.clj
@@ -29,7 +29,7 @@
   [_original-model _dest-key _hydrating-model]
   [:dashboard_tab_id])
 
-(methodical/defmethod t2.hydrate/batched-hydrate [:default :ordered-tab-cards]
+(methodical/defmethod t2.hydrate/batched-hydrate [:default :tab-cards]
   "Given a list of tabs, return a seq of ordered tabs, in which each tabs contain a seq of orderd cards."
   [_model _k tabs]
   (assert (= 1 (count (set (map :dashboard_id tabs)))), "All tabs must belong to the same dashboard")
@@ -38,8 +38,8 @@
         dashcards         (t2/select :model/DashboardCard :dashboard_id dashboard-id :dashboard_tab_id [:in tab-ids])
         tab-id->dashcards (-> (group-by :dashboard_tab_id dashcards)
                               (update-vals #(sort dashboard-card/dashcard-comparator %)))
-        ordered-tabs      (sort-by :position tabs)]
-    (for [{:keys [id] :as tab} ordered-tabs]
+        tabs      (sort-by :position tabs)]
+    (for [{:keys [id] :as tab} tabs]
       (assoc tab :cards (get tab-id->dashcards id)))))
 
 (defmethod mi/perms-objects-set :model/DashboardTab

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -199,8 +199,8 @@
   (let [dashboard-id      (u/the-id dashboard)]
     (mw.session/with-current-user pulse-creator-id
       (if (dashboard/has-tabs? dashboard)
-        (let [ordered-tabs-with-cards (t2/hydrate (t2/select :model/DashboardTab :dashboard_id dashboard-id) :ordered-tab-cards)]
-         (doall (flatten (for [{:keys [cards] :as tab} ordered-tabs-with-cards]
+        (let [tabs-with-cards (t2/hydrate (t2/select :model/DashboardTab :dashboard_id dashboard-id) :tab-cards)]
+         (doall (flatten (for [{:keys [cards] :as tab} tabs-with-cards]
                            (concat [(tab->part tab)] (dashcards->part cards pulse dashboard))))))
         (dashcards->part (t2/select DashboardCard :dashboard_id dashboard-id) pulse dashboard)))))
 

--- a/test/metabase/api/automagic_dashboards_test.clj
+++ b/test/metabase/api/automagic_dashboards_test.clj
@@ -368,10 +368,10 @@
                     :name "A look at Reviews" :position 0}
                    {:id   #hawk/malli Tab-Id-Schema
                     :name "A look at Orders" :position 1}]
-                  (:ordered_tabs dash)))
+                  (:tabs dash)))
           (testing "The first card for each tab is a linked model card to the source model"
             (is (=? (repeat
-                     (count (:ordered_tabs dash))
+                     (count (:tabs dash))
                      {:visualization_settings
                       {:virtual_card {:display "link", :archived false}
                        :link         {:entity {:id      (:id model)
@@ -438,7 +438,7 @@
                         :name "A look at Reviews" :position 0}
                        {:id   #hawk/malli Tab-Id-Schema
                         :name "A look at Orders" :position 1}]
-                      (:ordered_tabs dash)))
+                      (:tabs dash)))
               (testing "All query cards have the correct filters"
                 (let [pk-filters (expected-filters {:model             model
                                                     :model-index       model-index
@@ -461,7 +461,7 @@
           ;; FE has a bug where it doesn't fire off queries for cards if there's only a single tab. So we hack around
           ;; that by not creating tabs if there would only be one.
           (testing "Has no tabs"
-            (is (empty? (:ordered_tabs dash))))
+            (is (empty? (:tabs dash))))
           (testing "The first card for each tab is a linked model card to the source model"
             (is (=? {:visualization_settings
                      {:virtual_card {:display "link", :archived false}

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -349,7 +349,7 @@
                       :param_fields               nil
                       :param_values               nil
                       :last-edit-info             {:timestamp true :id true :first_name "Test" :last_name "User" :email "test@example.com"}
-                      :ordered_tabs               [{:name "Test Dashboard Tab" :position 0 :id dashtab-id :dashboard_id dashboard-id}]
+                      :tabs               [{:name "Test Dashboard Tab" :position 0 :id dashtab-id :dashboard_id dashboard-id}]
                       :dashcards              [{:size_x                     4
                                                 :size_y                     4
                                                 :col                        0
@@ -440,7 +440,7 @@
                                                                 :has_field_values "search"
                                                                 :name_field       nil
                                                                 :dimensions       []}}
-                         :ordered_tabs               []
+                         :tabs               []
                          :dashcards              [{:size_x                     4
                                                    :size_y                     4
                                                    :col                        0
@@ -1388,7 +1388,7 @@
                                                             :size_x             4
                                                             :size_y             4
                                                             :parameter_mappings mappings}]
-                                                   :ordered_tabs []}))
+                                                   :tabs []}))
             :dashcards    (fn [] (t2/select DashboardCard :dashboard_id dashboard-id))})))))
 
 (defn- dashcard-like-response
@@ -1422,12 +1422,12 @@
                                        (mt/user-http-request :rasta :put expected-status-code
                                                              (format "dashboard/%d/cards" dashboard-id)
                                                              {:cards        [(assoc dashcard-info :parameter_mappings new-mappings)]
-                                                              :ordered_tabs []}))
+                                                              :tabs []}))
              :update-size!           (fn []
                                        (mt/user-http-request :rasta :put 200
                                                              (format "dashboard/%d/cards" dashboard-id)
                                                              {:cards        [new-dashcard-info]
-                                                              :ordered_tabs []}))}))))))
+                                                              :tabs []}))}))))))
 
 (deftest e2e-update-cards-and-tabs-test
   (testing "PUT /api/dashboard/:id/cards with create/update/delete in a single req"
@@ -1443,7 +1443,7 @@
          DashboardCard           {dashcard-id-2 :id} {:dashboard_id dashboard-id, :card_id card-id-1, :dashboard_tab_id dashtab-id-2}
          DashboardCard           {dashcard-id-3 :id} {:dashboard_id dashboard-id, :card_id card-id-1, :dashboard_tab_id dashtab-id-2}]
         (let [resp (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
-                                         {:ordered_tabs  [{:id   dashtab-id-1
+                                         {:tabs  [{:id   dashtab-id-1
                                                            :name "Tab 1 edited"}
                                                           {:id   dashtab-id-2
                                                            :name "Tab 2"}
@@ -1485,7 +1485,7 @@
                       :dashboard_id dashboard-id
                       :name         "New tab"
                       :position     2}]
-                    (:ordered_tabs resp)))
+                    (:tabs resp)))
             (testing "dashtab 3 got deleted"
               (is (nil? (t2/select-one :model/DashboardTab :id dashtab-id-3)))))
 
@@ -1551,7 +1551,7 @@
                                                           :row    3
                                                           :card_id card-id-2
                                                           :series  [{:id series-id-1}]}]
-                                                 :ordered_tabs []}))
+                                                 :tabs []}))
             updated-card-1 {:id           dashcard-id-1
                             :card_id      card-id-1
                             :dashboard_id dashboard-id
@@ -1591,8 +1591,8 @@
       (with-dashboards-in-writeable-collection [dashboard-id]
         ;; send a request that update and create and delete some cards at the same time
         (is (some? (t2/select-one :model/DashboardTab :id dashtab-id-2)))
-        (let [tabs (:ordered_tabs (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
-                                                        {:ordered_tabs [{:name     "Tab new"
+        (let [tabs (:tabs (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
+                                                        {:tabs [{:name     "Tab new"
                                                                          :id       -1}
                                                                         {:name     "Tab 1 moved to second position"
                                                                          :id       dashtab-id-1}]
@@ -1621,7 +1621,7 @@
       ;; create 2 tabs, assign the existing dashcard to the 1st tab
       ;; create 2 new dashcards, 1 for each tab
       (let [resp (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
-                                  {:ordered_tabs  [{:id       -1
+                                  {:tabs  [{:id       -1
                                                     :name     "New Tab 1"}
                                                    {:id       -2
                                                     :name     "New Tab 2"}]
@@ -1660,7 +1660,7 @@
                           :card_id          card-id-2
                           :dashboard_id     dashboard-id
                           :dashboard_tab_id tab-2-id}]
-                 :ordered_tabs [{:id           tab-1-id
+                 :tabs [{:id           tab-1-id
                                  :dashboard_id dashboard-id
                                  :name         "New Tab 1"
                                  :position     0}
@@ -1683,7 +1683,7 @@
                                                        :size_y  4
                                                        :col     1
                                                        :row     1})
-                                      :ordered_tabs (dashboard/tabs dashboard-id)})))))))
+                                      :tabs (dashboard/tabs dashboard-id)})))))))
 
 (deftest update-tabs-track-snowplow-test
   (t2.with-temp/with-temp
@@ -1694,7 +1694,7 @@
     (testing "create and delete tabs events are tracked"
       (snowplow-test/with-fake-snowplow-collector
         (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
-                              {:ordered_tabs  [{:id   dashtab-id-1
+                              {:tabs  [{:id   dashtab-id-1
                                                 :name "Tab 1 edited"}
                                                {:id   dashtab-id-2
                                                 :name "Tab 2"}
@@ -1718,7 +1718,7 @@
     (testing "send nothing if tabs are unchanged"
       (snowplow-test/with-fake-snowplow-collector
         (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
-                              {:ordered_tabs  (dashboard/tabs dashboard-id)
+                              {:tabs  (dashboard/tabs dashboard-id)
                                :cards         []})
         (is (= 0 (count (snowplow-test/pop-event-data-and-user-id!))))))))
 
@@ -1741,7 +1741,7 @@
                                                                                             :hash "abc"
                                                                                             :target "foo"}]
                                                                   :visualization_settings {}}]
-                                                  :ordered_tabs []}))]
+                                                  :tabs []}))]
           ;; extra sure here because the dashcard we given has a negative id
           (testing "the inserted dashcards has ids auto-generated"
             (is (pos-int? (:id (first resp)))))
@@ -1785,7 +1785,7 @@
                                                                              :size_x  4
                                                                              :size_y  4
                                                                              :series [{:id series-id-1}]}]
-                                                             :ordered_tabs []}))]
+                                                             :tabs []}))]
           (is (=? [{:row                    4
                     :col                    4
                     :size_x                 4
@@ -1828,7 +1828,7 @@
                                                                            :card_id                nil
                                                                            :action_id              action-id
                                                                            :visualization_settings {:label "Update"}}]
-                                                           :ordered_tabs []}))))
+                                                           :tabs []}))))
               (is (partial= {:dashcards [{:action (cond-> {:visualization_settings {:hello true}
                                                            :type (name action-type)
                                                            :parameters [{:id "id"}]
@@ -1901,7 +1901,7 @@
                                                                                      :hash "abc"
                                                                                      :target "foo"}]
                                                            :visualization_settings {}}]
-                                            :ordered_tabs []}))))))
+                                            :tabs []}))))))
 
 ;;; -------------------------------------- Update dashcards only tests ---------------------------------------
 
@@ -1947,7 +1947,7 @@
                                                :size_y 1
                                                :col    1
                                                :row    3}]
-                               :ordered_tabs []})
+                               :tabs []})
         (is (= {:size_x                 4
                 :size_y                 2
                 :col                    0
@@ -2011,7 +2011,7 @@
           (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
                                        {:cards [(assoc action-card :card_id model-id-2)
                                                 (assoc question-card :card_id model-id-2)]
-                                        :ordered_tabs []})
+                                        :tabs []})
           ;; Only action card should change
           (is (partial= [{:card_id model-id-2}
                          {:card_id model-id}]
@@ -2024,8 +2024,8 @@
                 :name     "Tab 2"}
                {:id       dashtab-id-1
                 :name     "Tab 1 edited"}]
-              (:ordered_tabs (mt/user-http-request :crowberto :put 200 (format "dashboard/%d/cards" dashboard-id)
-                                                   {:ordered_tabs [{:id   dashtab-id-2
+              (:tabs (mt/user-http-request :crowberto :put 200 (format "dashboard/%d/cards" dashboard-id)
+                                                   {:tabs [{:id   dashtab-id-2
                                                                     :name "Tab 2"}
                                                                    {:id   dashtab-id-1
                                                                     :name "Tab 1 edited"}]
@@ -2052,10 +2052,10 @@
                  (count (t2/select-pks-set DashboardCard, :dashboard_id dashboard-id))))
           (is (=? {:cards [{:id     dashcard-id-3
                             :series [{:id series-id-1}]}]
-                   :ordered_tabs  []}
+                   :tabs  []}
                   (mt/user-http-request :rasta :put 200
                                         (format "dashboard/%d/cards" dashboard-id) {:cards [(dashcard-like-response dashcard-id-3)]
-                                                                                    :ordered_tabs []})))
+                                                                                    :tabs []})))
           (is (= 1
                  (count (t2/select-pks-set DashboardCard, :dashboard_id dashboard-id)))))))
     (testing "prune"
@@ -2066,10 +2066,10 @@
         (with-dashboards-in-writeable-collection [dashboard-id]
           (is (= 2
                  (count (t2/select-pks-set DashboardCard, :dashboard_id dashboard-id))))
-          (is (=? {:ordered_tabs []
+          (is (=? {:tabs []
                    :cards        []}
                   (mt/user-http-request :rasta :put 200
-                                        (format "dashboard/%d/cards" dashboard-id) {:cards [] :ordered_tabs []})))
+                                        (format "dashboard/%d/cards" dashboard-id) {:cards [] :tabs []})))
           (is (= 0
                  (count (t2/select-pks-set DashboardCard, :dashboard_id dashboard-id)))))))))
 
@@ -2082,10 +2082,10 @@
                  (t2/count DashboardCard, :dashboard_id dashboard-id)))
           (is (= 2
                  (t2/count :model/DashboardTab :dashboard_id dashboard-id))))
-        (is (=? {:ordered_tabs [{:id dashtab-id-1}]}
+        (is (=? {:tabs [{:id dashtab-id-1}]}
                 (mt/user-http-request :rasta :put 200
                                       (format "dashboard/%d/cards" dashboard-id)
-                                      {:ordered_tabs [(t2/select-one :model/DashboardTab :id dashtab-id-1)]
+                                      {:tabs [(t2/select-one :model/DashboardTab :id dashtab-id-1)]
                                        :cards (remove #(= (:dashboard_tab_id %) dashtab-id-2) (current-cards dashboard-id))})))
         (testing "deteted 1 tab, we should have"
           (testing "1 card left"
@@ -2101,11 +2101,11 @@
                  (t2/count DashboardCard, :dashboard_id dashboard-id)))
           (is (= 2
                  (t2/count :model/DashboardTab :dashboard_id dashboard-id))))
-        (is (=? {:ordered_tabs  []
+        (is (=? {:tabs  []
                  :cards []}
                 (mt/user-http-request :rasta :put 200
                                       (format "dashboard/%d/cards" dashboard-id)
-                                      {:ordered_tabs []
+                                      {:tabs []
                                        :cards        []})))
         (testing "dashboard should be empty"
           (testing "0 card left"

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1683,7 +1683,7 @@
                                                        :size_y  4
                                                        :col     1
                                                        :row     1})
-                                      :ordered_tabs (dashboard/ordered-tabs dashboard-id)})))))))
+                                      :ordered_tabs (dashboard/tabs dashboard-id)})))))))
 
 (deftest update-tabs-track-snowplow-test
   (t2.with-temp/with-temp
@@ -1718,7 +1718,7 @@
     (testing "send nothing if tabs are unchanged"
       (snowplow-test/with-fake-snowplow-collector
         (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
-                              {:ordered_tabs  (dashboard/ordered-tabs dashboard-id)
+                              {:ordered_tabs  (dashboard/tabs dashboard-id)
                                :cards         []})
         (is (= 0 (count (snowplow-test/pop-event-data-and-user-id!))))))))
 

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -349,27 +349,27 @@
                       :param_fields               nil
                       :param_values               nil
                       :last-edit-info             {:timestamp true :id true :first_name "Test" :last_name "User" :email "test@example.com"}
-                      :tabs               [{:name "Test Dashboard Tab" :position 0 :id dashtab-id :dashboard_id dashboard-id}]
-                      :dashcards              [{:size_x                     4
-                                                :size_y                     4
-                                                :col                        0
-                                                :row                        0
-                                                :collection_authority_level nil
-                                                :updated_at                 true
-                                                :created_at                 true
-                                                :entity_id                  (:entity_id dashcard)
-                                                :parameter_mappings         []
-                                                :visualization_settings     {}
-                                                :dashboard_tab_id           dashtab-id
-                                                :card                       (merge api.card-test/card-defaults-no-hydrate
-                                                                                   {:name                   "Dashboard Test Card"
-                                                                                    :creator_id             (mt/user->id :rasta)
-                                                                                    :collection_id          true
-                                                                                    :display                "table"
-                                                                                    :entity_id              (:entity_id card)
-                                                                                    :visualization_settings {}
-                                                                                    :result_metadata        nil})
-                                                :series                     []}]})
+                      :tabs                       [{:name "Test Dashboard Tab" :position 0 :id dashtab-id :dashboard_id dashboard-id}]
+                      :dashcards                  [{:size_x                     4
+                                                    :size_y                     4
+                                                    :col                        0
+                                                    :row                        0
+                                                    :collection_authority_level nil
+                                                    :updated_at                 true
+                                                    :created_at                 true
+                                                    :entity_id                  (:entity_id dashcard)
+                                                    :parameter_mappings         []
+                                                    :visualization_settings     {}
+                                                    :dashboard_tab_id           dashtab-id
+                                                    :card                       (merge api.card-test/card-defaults-no-hydrate
+                                                                                       {:name                   "Dashboard Test Card"
+                                                                                        :creator_id             (mt/user->id :rasta)
+                                                                                        :collection_id          true
+                                                                                        :display                "table"
+                                                                                        :entity_id              (:entity_id card)
+                                                                                        :visualization_settings {}
+                                                                                        :result_metadata        nil})
+                                                    :series                     []}]})
                     (dashboard-response (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-id)))))))))
 
     (testing "a dashboard that has link cards on it"
@@ -440,31 +440,31 @@
                                                                 :has_field_values "search"
                                                                 :name_field       nil
                                                                 :dimensions       []}}
-                         :tabs               []
-                         :dashcards              [{:size_x                     4
-                                                   :size_y                     4
-                                                   :col                        0
-                                                   :row                        0
-                                                   :updated_at                 true
-                                                   :created_at                 true
-                                                   :entity_id                  (:entity_id dashcard)
-                                                   :collection_authority_level nil
-                                                   :parameter_mappings         [{:card_id      1
-                                                                                 :parameter_id "foo"
-                                                                                 :target       ["dimension" ["field" field-id nil]]}]
-                                                   :visualization_settings     {}
-                                                   :dashboard_tab_id           nil
-                                                   :card                       (merge api.card-test/card-defaults-no-hydrate
-                                                                                      {:name                   "Dashboard Test Card"
-                                                                                       :creator_id             (mt/user->id :rasta)
-                                                                                       :collection_id          true
-                                                                                       :collection             false
-                                                                                       :entity_id              (:entity_id card)
-                                                                                       :display                "table"
-                                                                                       :query_type             nil
-                                                                                       :visualization_settings {}
-                                                                                       :result_metadata        nil})
-                                                   :series                     []}]})
+                         :tabs                       []
+                         :dashcards                  [{:size_x                     4
+                                                       :size_y                     4
+                                                       :col                        0
+                                                       :row                        0
+                                                       :updated_at                 true
+                                                       :created_at                 true
+                                                       :entity_id                  (:entity_id dashcard)
+                                                       :collection_authority_level nil
+                                                       :parameter_mappings         [{:card_id      1
+                                                                                     :parameter_id "foo"
+                                                                                     :target       ["dimension" ["field" field-id nil]]}]
+                                                       :visualization_settings     {}
+                                                       :dashboard_tab_id           nil
+                                                       :card                       (merge api.card-test/card-defaults-no-hydrate
+                                                                                          {:name                   "Dashboard Test Card"
+                                                                                           :creator_id             (mt/user->id :rasta)
+                                                                                           :collection_id          true
+                                                                                           :collection             false
+                                                                                           :entity_id              (:entity_id card)
+                                                                                           :display                "table"
+                                                                                           :query_type             nil
+                                                                                           :visualization_settings {}
+                                                                                           :result_metadata        nil})
+                                                       :series                     []}]})
                  (dashboard-response (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-id)))))))))
     (testing "fetch a dashboard from an official collection includes the collection type"
       (mt/with-temp [Dashboard     {dashboard-id :id} {:name "Test Dashboard"}
@@ -1388,7 +1388,7 @@
                                                             :size_x             4
                                                             :size_y             4
                                                             :parameter_mappings mappings}]
-                                                   :tabs []}))
+                                                   :tabs  []}))
             :dashcards    (fn [] (t2/select DashboardCard :dashboard_id dashboard-id))})))))
 
 (defn- dashcard-like-response
@@ -1421,13 +1421,13 @@
              :update-mappings!       (fn [expected-status-code]
                                        (mt/user-http-request :rasta :put expected-status-code
                                                              (format "dashboard/%d/cards" dashboard-id)
-                                                             {:cards        [(assoc dashcard-info :parameter_mappings new-mappings)]
-                                                              :tabs []}))
+                                                             {:cards [(assoc dashcard-info :parameter_mappings new-mappings)]
+                                                              :tabs  []}))
              :update-size!           (fn []
                                        (mt/user-http-request :rasta :put 200
                                                              (format "dashboard/%d/cards" dashboard-id)
-                                                             {:cards        [new-dashcard-info]
-                                                              :tabs []}))}))))))
+                                                             {:cards [new-dashcard-info]
+                                                              :tabs  []}))}))))))
 
 (deftest e2e-update-cards-and-tabs-test
   (testing "PUT /api/dashboard/:id/cards with create/update/delete in a single req"
@@ -1444,34 +1444,34 @@
          DashboardCard           {dashcard-id-3 :id} {:dashboard_id dashboard-id, :card_id card-id-1, :dashboard_tab_id dashtab-id-2}]
         (let [resp (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
                                          {:tabs  [{:id   dashtab-id-1
-                                                           :name "Tab 1 edited"}
-                                                          {:id   dashtab-id-2
-                                                           :name "Tab 2"}
-                                                          {:id   -1
-                                                           :name "New tab"}]
-                                          :cards [{:id     dashcard-id-1
-                                                   :size_x 4
-                                                   :size_y 4
-                                                   :col    1
-                                                   :row    1
+                                                   :name "Tab 1 edited"}
+                                                  {:id   dashtab-id-2
+                                                   :name "Tab 2"}
+                                                  {:id   -1
+                                                   :name "New tab"}]
+                                          :cards [{:id               dashcard-id-1
+                                                   :size_x           4
+                                                   :size_y           4
+                                                   :col              1
+                                                   :row              1
                                                    ;; initialy was in tab1, now in tab 2
                                                    :dashboard_tab_id dashtab-id-2
-                                                   :card_id card-id-1}
-                                                  {:id     dashcard-id-2
+                                                   :card_id          card-id-1}
+                                                  {:id               dashcard-id-2
                                                    :dashboard_tab_id dashtab-id-2
-                                                   :size_x 2
-                                                   :size_y 2
-                                                   :col    2
-                                                   :row    2}
+                                                   :size_x           2
+                                                   :size_y           2
+                                                   :col              2
+                                                   :row              2}
                                                   ;; remove the dashcard3 and create a new card using negative numbers
                                                   ;; and assign into the newly created dashcard
-                                                  {:id     -1
-                                                   :size_x 1
-                                                   :size_y 1
-                                                   :col    3
-                                                   :row    3
+                                                  {:id               -1
+                                                   :size_x           1
+                                                   :size_y           1
+                                                   :col              3
+                                                   :row              3
                                                    :dashboard_tab_id -1
-                                                   :card_id card-id-2}]})]
+                                                   :card_id          card-id-2}]})]
           (testing "tabs got updated correctly "
             (is (=? [{:id           dashtab-id-1
                       :dashboard_id dashboard-id
@@ -1530,11 +1530,11 @@
                                                 :position         0}]
       ;; send a request that update and create and delete some cards at the same time
       (let [cards (:cards (mt/user-http-request :crowberto :put 200 (format "dashboard/%d/cards" dashboard-id)
-                                                {:cards [{:id     dashcard-id-1
-                                                          :size_x 4
-                                                          :size_y 4
-                                                          :col    1
-                                                          :row    1
+                                                {:cards [{:id      dashcard-id-1
+                                                          :size_x  4
+                                                          :size_y  4
+                                                          :col     1
+                                                          :row     1
                                                           ;; update series for card 1
                                                           :series  [{:id series-id-2}]
                                                           :card_id card-id-1}
@@ -1544,14 +1544,14 @@
                                                           :col    2
                                                           :row    2}
                                                          ;; remove the dashcard3 and create a new card using negative numbers
-                                                         {:id     -1
-                                                          :size_x 1
-                                                          :size_y 1
-                                                          :col    3
-                                                          :row    3
+                                                         {:id      -1
+                                                          :size_x  1
+                                                          :size_y  1
+                                                          :col     3
+                                                          :row     3
                                                           :card_id card-id-2
                                                           :series  [{:id series-id-1}]}]
-                                                 :tabs []}))
+                                                 :tabs  []}))
             updated-card-1 {:id           dashcard-id-1
                             :card_id      card-id-1
                             :dashboard_id dashboard-id
@@ -1592,11 +1592,11 @@
         ;; send a request that update and create and delete some cards at the same time
         (is (some? (t2/select-one :model/DashboardTab :id dashtab-id-2)))
         (let [tabs (:tabs (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
-                                                        {:tabs [{:name     "Tab new"
-                                                                         :id       -1}
-                                                                        {:name     "Tab 1 moved to second position"
-                                                                         :id       dashtab-id-1}]
-                                                         :cards        []}))]
+                                                {:tabs  [{:name "Tab new"
+                                                          :id   -1}
+                                                         {:name "Tab 1 moved to second position"
+                                                          :id   dashtab-id-1}]
+                                                 :cards []}))]
 
           (is (=? [{:dashboard_id dashboard-id
                     :name         "Tab new"
@@ -1621,10 +1621,10 @@
       ;; create 2 tabs, assign the existing dashcard to the 1st tab
       ;; create 2 new dashcards, 1 for each tab
       (let [resp (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
-                                  {:tabs  [{:id       -1
-                                                    :name     "New Tab 1"}
-                                                   {:id       -2
-                                                    :name     "New Tab 2"}]
+                                  {:tabs  [{:id   -1
+                                            :name "New Tab 1"}
+                                           {:id   -2
+                                            :name "New Tab 2"}]
                                    :cards [{:id               dashcard-1-id
                                             :size_x           4
                                             :size_y           4
@@ -1660,14 +1660,14 @@
                           :card_id          card-id-2
                           :dashboard_id     dashboard-id
                           :dashboard_tab_id tab-2-id}]
-                 :tabs [{:id           tab-1-id
-                                 :dashboard_id dashboard-id
-                                 :name         "New Tab 1"
-                                 :position     0}
-                                {:id           tab-2-id
-                                 :dashboard_id dashboard-id
-                                 :name         "New Tab 2"
-                                 :position     1}]}
+                 :tabs  [{:id           tab-1-id
+                          :dashboard_id dashboard-id
+                          :name         "New Tab 1"
+                          :position     0}
+                         {:id           tab-2-id
+                          :dashboard_id dashboard-id
+                          :name         "New Tab 2"
+                          :position     1}]}
                 (update resp :cards #(sort dashboard-card/dashcard-comparator %))))))))
 
 (deftest update-cards-error-handling-test
@@ -1676,14 +1676,14 @@
       (testing "if a dashboard has tabs, check if all cards from the request has a tab_id"
         (is (= "This dashboard has tab, makes sure every card has a tab"
                (mt/user-http-request :crowberto :put 400 (format "dashboard/%d/cards" dashboard-id)
-                                     {:cards        (conj
-                                                      (current-cards dashboard-id)
-                                                      {:id      -1
-                                                       :size_x  4
-                                                       :size_y  4
-                                                       :col     1
-                                                       :row     1})
-                                      :tabs (dashboard/tabs dashboard-id)})))))))
+                                     {:cards (conj
+                                              (current-cards dashboard-id)
+                                              {:id     -1
+                                               :size_x 4
+                                               :size_y 4
+                                               :col    1
+                                               :row    1})
+                                      :tabs  (dashboard/tabs dashboard-id)})))))))
 
 (deftest update-tabs-track-snowplow-test
   (t2.with-temp/with-temp
@@ -1695,14 +1695,14 @@
       (snowplow-test/with-fake-snowplow-collector
         (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
                               {:tabs  [{:id   dashtab-id-1
-                                                :name "Tab 1 edited"}
-                                               {:id   dashtab-id-2
-                                                :name "Tab 2"}
-                                               {:id   -1
-                                                :name "New tab 1"}
-                                               {:id   -2
-                                                :name "New tab 2"}]
-                               :cards         []})
+                                        :name "Tab 1 edited"}
+                                       {:id   dashtab-id-2
+                                        :name "Tab 2"}
+                                       {:id   -1
+                                        :name "New tab 1"}
+                                       {:id   -2
+                                        :name "New tab 2"}]
+                               :cards []})
         (is (= [{:data {"dashboard_id"   dashboard-id
                         "num_tabs"       1
                         "total_num_tabs" 4
@@ -1719,7 +1719,7 @@
       (snowplow-test/with-fake-snowplow-collector
         (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
                               {:tabs  (dashboard/tabs dashboard-id)
-                               :cards         []})
+                               :cards []})
         (is (= 0 (count (snowplow-test/pop-event-data-and-user-id!))))))))
 
 ;;; -------------------------------------- Create dashcards tests ---------------------------------------
@@ -1730,18 +1730,18 @@
     (with-dashboards-in-writeable-collection [dashboard-id]
       (api.card-test/with-cards-in-readable-collection [card-id]
         (let [resp (:cards (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
-                                                 {:cards        [{:id                     -1
-                                                                  :card_id                card-id
-                                                                  :row                    4
-                                                                  :col                    4
-                                                                  :size_x                 4
-                                                                  :size_y                 4
-                                                                  :parameter_mappings     [{:parameter_id "abc"
-                                                                                            :card_id 123
-                                                                                            :hash "abc"
-                                                                                            :target "foo"}]
-                                                                  :visualization_settings {}}]
-                                                  :tabs []}))]
+                                                 {:cards [{:id                     -1
+                                                           :card_id                card-id
+                                                           :row                    4
+                                                           :col                    4
+                                                           :size_x                 4
+                                                           :size_y                 4
+                                                           :parameter_mappings     [{:parameter_id "abc"
+                                                                                     :card_id      123
+                                                                                     :hash         "abc"
+                                                                                     :target       "foo"}]
+                                                           :visualization_settings {}}]
+                                                  :tabs  []}))]
           ;; extra sure here because the dashcard we given has a negative id
           (testing "the inserted dashcards has ids auto-generated"
             (is (pos-int? (:id (first resp)))))
@@ -1778,14 +1778,14 @@
     (with-dashboards-in-writeable-collection [dashboard-id]
       (api.card-test/with-cards-in-readable-collection [card-id series-id-1]
         (let [dashboard-cards (:cards (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
-                                                            {:cards        [{:id      -1
-                                                                             :card_id card-id
-                                                                             :row     4
-                                                                             :col     4
-                                                                             :size_x  4
-                                                                             :size_y  4
-                                                                             :series [{:id series-id-1}]}]
-                                                             :tabs []}))]
+                                                            {:cards [{:id      -1
+                                                                      :card_id card-id
+                                                                      :row     4
+                                                                      :col     4
+                                                                      :size_x  4
+                                                                      :size_y  4
+                                                                      :series  [{:id series-id-1}]}]
+                                                             :tabs  []}))]
           (is (=? [{:row                    4
                     :col                    4
                     :size_x                 4
@@ -1820,15 +1820,15 @@
                               :action_id              action-id
                               :card_id                nil}]
                             (:cards (mt/user-http-request :crowberto :put 200 (format "dashboard/%s/cards" dashboard-id)
-                                                          {:cards        [{:id                     -1
-                                                                           :size_x                 1
-                                                                           :size_y                 1
-                                                                           :row                    1
-                                                                           :col                    1
-                                                                           :card_id                nil
-                                                                           :action_id              action-id
-                                                                           :visualization_settings {:label "Update"}}]
-                                                           :tabs []}))))
+                                                          {:cards [{:id                     -1
+                                                                    :size_x                 1
+                                                                    :size_y                 1
+                                                                    :row                    1
+                                                                    :col                    1
+                                                                    :card_id                nil
+                                                                    :action_id              action-id
+                                                                    :visualization_settings {:label "Update"}}]
+                                                           :tabs  []}))))
               (is (partial= {:dashcards [{:action (cond-> {:visualization_settings {:hello true}
                                                            :type (name action-type)
                                                            :parameters [{:id "id"}]
@@ -1890,18 +1890,18 @@
      Card      {card-id :id}      {:archived true}]
     (is (= "The object has been archived."
            (:message (mt/user-http-request :rasta :put 404 (format "dashboard/%d/cards" dashboard-id)
-                                           {:cards       [{:id                     -1
-                                                           :card_id                card-id
-                                                           :row                    4
-                                                           :col                    4
-                                                           :size_x                 4
-                                                           :size_y                 4
-                                                           :parameter_mappings     [{:parameter_id "abc"
-                                                                                     :card_id 123
-                                                                                     :hash "abc"
-                                                                                     :target "foo"}]
-                                                           :visualization_settings {}}]
-                                            :tabs []}))))))
+                                           {:cards [{:id                     -1
+                                                     :card_id                card-id
+                                                     :row                    4
+                                                     :col                    4
+                                                     :size_x                 4
+                                                     :size_y                 4
+                                                     :parameter_mappings     [{:parameter_id "abc"
+                                                                               :card_id      123
+                                                                               :hash         "abc"
+                                                                               :target       "foo"}]
+                                                     :visualization_settings {}}]
+                                            :tabs  []}))))))
 
 ;;; -------------------------------------- Update dashcards only tests ---------------------------------------
 
@@ -1936,18 +1936,18 @@
                (remove-ids-and-booleanize-timestamps (dashboard-card/retrieve-dashboard-card dashcard-id-2))))
         ;; TODO adds tests for return
         (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
-                              {:cards        [{:id     dashcard-id-1
-                                               :size_x 4
-                                               :size_y 2
-                                               :col    0
-                                               :row    0
-                                               :series [{:id series-id-1}]}
-                                              {:id     dashcard-id-2
-                                               :size_x 1
-                                               :size_y 1
-                                               :col    1
-                                               :row    3}]
-                               :tabs []})
+                              {:cards [{:id     dashcard-id-1
+                                        :size_x 4
+                                        :size_y 2
+                                        :col    0
+                                        :row    0
+                                        :series [{:id series-id-1}]}
+                                       {:id     dashcard-id-2
+                                        :size_x 1
+                                        :size_y 1
+                                        :col    1
+                                        :row    3}]
+                               :tabs  []})
         (is (= {:size_x                 4
                 :size_y                 2
                 :col                    0
@@ -2011,7 +2011,7 @@
           (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
                                        {:cards [(assoc action-card :card_id model-id-2)
                                                 (assoc question-card :card_id model-id-2)]
-                                        :tabs []})
+                                        :tabs  []})
           ;; Only action card should change
           (is (partial= [{:card_id model-id-2}
                          {:card_id model-id}]
@@ -2025,11 +2025,11 @@
                {:id       dashtab-id-1
                 :name     "Tab 1 edited"}]
               (:tabs (mt/user-http-request :crowberto :put 200 (format "dashboard/%d/cards" dashboard-id)
-                                                   {:tabs [{:id   dashtab-id-2
-                                                                    :name "Tab 2"}
-                                                                   {:id   dashtab-id-1
-                                                                    :name "Tab 1 edited"}]
-                                                    :cards (current-cards dashboard-id)})))))))
+                                           {:tabs  [{:id   dashtab-id-2
+                                                     :name "Tab 2"}
+                                                    {:id   dashtab-id-1
+                                                     :name "Tab 1 edited"}]
+                                            :cards (current-cards dashboard-id)})))))))
 
 ;;; -------------------------------------- Delete dashcards tests ---------------------------------------
 
@@ -2055,7 +2055,7 @@
                    :tabs  []}
                   (mt/user-http-request :rasta :put 200
                                         (format "dashboard/%d/cards" dashboard-id) {:cards [(dashcard-like-response dashcard-id-3)]
-                                                                                    :tabs []})))
+                                                                                    :tabs  []})))
           (is (= 1
                  (count (t2/select-pks-set DashboardCard, :dashboard_id dashboard-id)))))))
     (testing "prune"
@@ -2066,10 +2066,11 @@
         (with-dashboards-in-writeable-collection [dashboard-id]
           (is (= 2
                  (count (t2/select-pks-set DashboardCard, :dashboard_id dashboard-id))))
-          (is (=? {:tabs []
-                   :cards        []}
+          (is (=? {:tabs  []
+                   :cards []}
                   (mt/user-http-request :rasta :put 200
-                                        (format "dashboard/%d/cards" dashboard-id) {:cards [] :tabs []})))
+                                        (format "dashboard/%d/cards" dashboard-id) {:cards []
+                                                                                    :tabs  []})))
           (is (= 0
                  (count (t2/select-pks-set DashboardCard, :dashboard_id dashboard-id)))))))))
 
@@ -2085,7 +2086,7 @@
         (is (=? {:tabs [{:id dashtab-id-1}]}
                 (mt/user-http-request :rasta :put 200
                                       (format "dashboard/%d/cards" dashboard-id)
-                                      {:tabs [(t2/select-one :model/DashboardTab :id dashtab-id-1)]
+                                      {:tabs  [(t2/select-one :model/DashboardTab :id dashtab-id-1)]
                                        :cards (remove #(= (:dashboard_tab_id %) dashtab-id-2) (current-cards dashboard-id))})))
         (testing "deteted 1 tab, we should have"
           (testing "1 card left"
@@ -2105,8 +2106,8 @@
                  :cards []}
                 (mt/user-http-request :rasta :put 200
                                       (format "dashboard/%d/cards" dashboard-id)
-                                      {:tabs []
-                                       :cards        []})))
+                                      {:tabs  []
+                                       :cards []})))
         (testing "dashboard should be empty"
           (testing "0 card left"
             (is (= 0

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -152,7 +152,7 @@
    :param_fields           nil})
 
 (def successful-dashboard-info
-  {:auto_apply_filters true, :description nil, :parameters [], :dashcards [], :ordered_tabs [],
+  {:auto_apply_filters true, :description nil, :parameters [], :dashcards [], :tabs [],
    :param_values nil, :param_fields nil})
 
 (def ^:private yesterday (time/minus (time/now) (time/days 1)))

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -435,25 +435,25 @@
 
 (defn- fetch-public-dashboard [{uuid :public_uuid}]
   (-> (client/client :get 200 (str "public/dashboard/" uuid))
-      (select-keys [:name :dashcards :ordered_tabs])
+      (select-keys [:name :dashcards :tabs])
       (update :name boolean)
       (update :dashcards count)
-      (update :ordered_tabs count)))
+      (update :tabs count)))
 
 (deftest get-public-dashboard-test
   (testing "GET /api/public/dashboard/:uuid"
     (mt/with-temporary-setting-values [enable-public-sharing true]
       (with-temp-public-dashboard-and-card [dash card]
-        (is (= {:name true, :dashcards 1, :ordered_tabs 0}
+        (is (= {:name true, :dashcards 1, :tabs 0}
                (fetch-public-dashboard dash)))
         (testing "We shouldn't see Cards that have been archived"
           (t2/update! Card (u/the-id card) {:archived true})
-          (is (= {:name true, :dashcards 0, :ordered_tabs 0}
+          (is (= {:name true, :dashcards 0, :tabs 0}
                  (fetch-public-dashboard dash)))))
-      (testing "dashboard with tabs should return ordered_tabs"
+      (testing "dashboard with tabs should return tabs"
        (api.dashboard-test/with-simple-dashboard-with-tabs [{:keys [dashboard-id]}]
          (t2/update! :model/Dashboard :id dashboard-id (shared-obj))
-         (is (= {:name true, :dashcards 2, :ordered_tabs 2}
+         (is (= {:name true, :dashcards 2, :tabs 2}
                 (fetch-public-dashboard (t2/select-one :model/Dashboard :id dashboard-id)))))))))
 
 (deftest public-dashboard-with-implicit-action-only-expose-unhidden-fields

--- a/test/metabase/models/dashboard_tab_test.clj
+++ b/test/metabase/models/dashboard_tab_test.clj
@@ -88,7 +88,7 @@
                               {:id (:id dashtab-2) :position 1 :dashboard_id (:id dashboard)}]}
               (t2/hydrate dashboard :ordered_tabs))))))
 
-(deftest hydrate-ordered-tabs-card-test
+(deftest hydrate-tabs-card-test
   (t2.with-temp/with-temp
     [:model/Dashboard    {dashboard-id :id}    {}
      :model/DashboardTab {tab-2-id :id}        {:name         "Tab 2"
@@ -117,4 +117,4 @@
              {:id    tab-2-id
               :cards [{:id dash-1-tab2-id}
                       {:id dash-2-tab2-id}]}]
-            (t2/hydrate (t2/select :model/DashboardTab :dashboard_id dashboard-id) :ordered-tab-cards)))))
+            (t2/hydrate (t2/select :model/DashboardTab :dashboard_id dashboard-id) :tab-cards)))))

--- a/test/metabase/models/dashboard_tab_test.clj
+++ b/test/metabase/models/dashboard_tab_test.clj
@@ -84,8 +84,8 @@
        :model/DashboardTab dashtab-2 {:dashboard_id (:id dashboard) :position 1}
        DashboardCard   _         {:dashboard_id (:id dashboard) :card_id (:id card) :dashboard_tab_id (:id dashtab-1)}
        DashboardCard   _         {:dashboard_id (:id dashboard) :card_id (:id card) :dashboard_tab_id (:id dashtab-2)}]
-      (is (=? {:tabs [{:id (:id dashtab-1) :position 0 :dashboard_id (:id dashboard)}
-                              {:id (:id dashtab-2) :position 1 :dashboard_id (:id dashboard)}]}
+      (is (=? {:tabs [{:id (:id dashtab-1), :position 0, :dashboard_id (:id dashboard)}
+                      {:id (:id dashtab-2), :position 1, :dashboard_id (:id dashboard)}]}
               (t2/hydrate dashboard :tabs))))))
 
 (deftest hydrate-tabs-card-test

--- a/test/metabase/models/dashboard_tab_test.clj
+++ b/test/metabase/models/dashboard_tab_test.clj
@@ -84,9 +84,9 @@
        :model/DashboardTab dashtab-2 {:dashboard_id (:id dashboard) :position 1}
        DashboardCard   _         {:dashboard_id (:id dashboard) :card_id (:id card) :dashboard_tab_id (:id dashtab-1)}
        DashboardCard   _         {:dashboard_id (:id dashboard) :card_id (:id card) :dashboard_tab_id (:id dashtab-2)}]
-      (is (=? {:ordered_tabs [{:id (:id dashtab-1) :position 0 :dashboard_id (:id dashboard)}
+      (is (=? {:tabs [{:id (:id dashtab-1) :position 0 :dashboard_id (:id dashboard)}
                               {:id (:id dashtab-2) :position 1 :dashboard_id (:id dashboard)}]}
-              (t2/hydrate dashboard :ordered_tabs))))))
+              (t2/hydrate dashboard :tabs))))))
 
 (deftest hydrate-tabs-card-test
   (t2.with-temp/with-temp

--- a/test_resources/instance_analytics_skip/collections/tYhkn_-pFTWcCTSwhgCBP_instance_analytics/dashboards/WFmN9gRmW1LCfzHneB4QH_ia_dash.yaml
+++ b/test_resources/instance_analytics_skip/collections/tYhkn_-pFTWcCTSwhgCBP_instance_analytics/dashboards/WFmN9gRmW1LCfzHneB4QH_ia_dash.yaml
@@ -23,7 +23,7 @@ creator_id: a@a.a
 made_public_by_id: null
 embedding_params: null
 cache_ttl: null
-ordered_tabs: []
+tabs: []
 serdes/meta:
 - model: Dashboard
   id: WFmN9gRmW1LCfzHneB4QH


### PR DESCRIPTION
This PR renames the `ordered_tabs` key on Dashboard entities to just `tabs`. The key is hydrated onto dashboards so there is no need for a migration.

It is similar to https://github.com/metabase/metabase/pull/34792 which renames ordered_cards to dashcards.

In each commit in this PR I'm doing a simple automated search-and-replace. I assume that ordered_tab, OrderedTab and ordered-tab are only used in the codebase to refer to dashboard's `ordered_tabs` and not something else.

Note there's no `orderedTab` in the codebase, so there is no commit for that.