### PR TITLE
fix scrolling while dragging column items

### DIFF
--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -72,7 +72,7 @@ describe("scenarios > question > settings", () => {
       cy.get("@table").contains("Total").should("not.exist");
     });
 
-    it("should allow you to re-order columns even when one has been removed (metabase2#9287)", () => {
+    it("should allow you to re-order columns even when one has been removed (metabase #14238, #29287)", () => {
       cy.viewport(1600, 800);
 
       visitQuestionAdhoc({

--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -75,7 +75,28 @@ describe("scenarios > question > settings", () => {
     it("should allow you to re-order columns even when one has been removed (metabase2#9287)", () => {
       cy.viewport(1600, 800);
 
-      openOrdersTable();
+      visitQuestionAdhoc({
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          query: {
+            "source-table": ORDERS_ID,
+            joins: [
+              {
+                fields: "all",
+                alias: "Products",
+                "source-table": PRODUCTS_ID,
+                strategy: "left-join",
+                condition: [
+                  "=",
+                  ["field", ORDERS.PRODUCT_ID, {}],
+                  ["field", PRODUCTS.ID, { "join-alias": "Products" }],
+                ],
+              },
+            ],
+          },
+          type: "query",
+        },
+      });
       cy.findByTestId("viz-settings-button").click();
 
       cy.findByTestId("Subtotal-hide-button").click();
@@ -86,6 +107,27 @@ describe("scenarios > question > settings", () => {
       moveColumnDown(cy.get("@total"), -2);
 
       getSidebarColumns().eq("1").should("contain.text", "Total");
+
+      getVisibleSidebarColumns()
+        .eq("9")
+        .as("title")
+        .should("have.text", "Products → Title");
+
+      cy.findByTestId("chartsettings-sidebar").scrollTo("top");
+      cy.findByTestId("chartsettings-sidebar").should(([$el]) => {
+        expect($el.scrollTop).to.eql(0);
+      });
+
+      cy.get("@title")
+        .trigger("mousedown", 0, 0, { force: true })
+        .trigger("mousemove", 5, 5, { force: true })
+        .trigger("mousemove", 0, 15, { force: true });
+      cy.wait(2000);
+      cy.get("@title").trigger("mouseup", 0, 15, { force: true });
+
+      cy.findByTestId("chartsettings-sidebar").should(([$el]) => {
+        expect($el.scrollTop).to.be.greaterThan(0);
+      });
     });
 
     it("should preserve correct order of columns after column removal via sidebar (metabase#13455)", () => {

--- a/frontend/src/metabase/visualizations/components/ChartSettings.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.styled.tsx
@@ -44,18 +44,18 @@ export const SectionWarnings = styled(Warnings)`
 export const ChartSettingsRoot = styled.div`
   display: flex;
   flex-grow: 1;
-  overflow-y: auto;
+  height: 100%;
 `;
 
 export const ChartSettingsMenu = styled.div`
   flex: 1 0 0;
   display: flex;
   flex-direction: column;
+  overflow-y: auto;
 `;
 
 export const ChartSettingsListContainer = styled.div`
   position: relative;
-  overflow-y: auto;
   padding: 2rem 0;
 `;
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/14238

### Description
The `react-sortable-hoc` library supports scrolling while dragging by default, but it was calculating the wrong container due to too many parents having `overflow-y: auto` set. Removed unneeded styling and verified that viz settings on dashcards still worked as intended

### How to verify

1. New question -> Sample Dataset -> Orders
2. Join Products -> Visualize
3. Open settings and drag columns. The list should be larger than the panel, and dragging an item towards the bottom of the list should cause the panel to scroll.

### Demo
![chrome_EdfCTanCnz](https://github.com/metabase/metabase/assets/1328979/a610c7bc-64b1-4abf-9b1f-539570f4fd14)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
