### PR TITLE
limit tab name length to 75 chars

### DIFF
--- a/frontend/src/metabase/core/components/TabButton/TabButton.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.tsx
@@ -133,6 +133,7 @@ const _TabButton = forwardRef(function TabButton<T>(
           {label}
         </TabButtonInputResizer>
         <TabButtonInput
+          maxLength={75}
           type="text"
           value={label}
           isSelected={isSelected}

--- a/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
@@ -85,4 +85,21 @@ describe("TabButton", () => {
     expect(onRename).toHaveBeenCalledWith(newLabel);
     expect(await screen.findByDisplayValue(newLabel)).toBeInTheDocument();
   });
+
+  it("should limit the length to 75chars", async () => {
+    const { onRename } = setup();
+
+    userEvent.click(getIcon("chevrondown"));
+    (await screen.findByRole("option", { name: "Rename" })).click();
+
+    const newLabel = Array.from({ length: 100 }).fill("a").join("");
+    const expectedLabel = newLabel.slice(0, 75);
+
+    const inputEl = screen.getByRole("textbox");
+    userEvent.type(inputEl, newLabel);
+    fireEvent.keyPress(inputEl, { key: "Enter", charCode: 13 });
+
+    expect(onRename).toHaveBeenCalledWith(expectedLabel);
+    expect(await screen.findByDisplayValue(expectedLabel)).toBeInTheDocument();
+  });
 });

--- a/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
@@ -61,7 +61,7 @@ describe("TabButton", () => {
     const { onRename } = setup();
 
     userEvent.click(getIcon("chevrondown"));
-    (await screen.findByRole("option", { name: "Rename" })).click();
+    (await renameOption()).click();
 
     const newLabel = "A new label";
     const inputEl = screen.getByRole("textbox");
@@ -90,16 +90,18 @@ describe("TabButton", () => {
     const { onRename } = setup();
 
     userEvent.click(getIcon("chevrondown"));
-    (await screen.findByRole("option", { name: "Rename" })).click();
+    (await renameOption()).click();
 
     const newLabel = "a".repeat(100);
     const expectedLabel = newLabel.slice(0, 75);
 
     const inputEl = screen.getByRole("textbox");
     userEvent.type(inputEl, newLabel);
-    userEvent.type(inputEl, '{enter}');
+    userEvent.type(inputEl, "{enter}");
 
     expect(onRename).toHaveBeenCalledWith(expectedLabel);
     expect(await screen.findByDisplayValue(expectedLabel)).toBeInTheDocument();
   });
 });
+
+const renameOption = () => screen.findByRole("option", { name: "Rename" });

--- a/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
@@ -86,18 +86,18 @@ describe("TabButton", () => {
     expect(await screen.findByDisplayValue(newLabel)).toBeInTheDocument();
   });
 
-  it("should limit the length to 75chars", async () => {
+  it("should limit the length to 75 chars", async () => {
     const { onRename } = setup();
 
     userEvent.click(getIcon("chevrondown"));
     (await screen.findByRole("option", { name: "Rename" })).click();
 
-    const newLabel = Array.from({ length: 100 }).fill("a").join("");
+    const newLabel = "a".repeat(100);
     const expectedLabel = newLabel.slice(0, 75);
 
     const inputEl = screen.getByRole("textbox");
     userEvent.type(inputEl, newLabel);
-    fireEvent.keyPress(inputEl, { key: "Enter", charCode: 13 });
+    userEvent.type(inputEl, '{enter}');
 
     expect(onRename).toHaveBeenCalledWith(expectedLabel);
     expect(await screen.findByDisplayValue(expectedLabel)).toBeInTheDocument();


### PR DESCRIPTION
### Description

Discussion on slack: https://metaboat.slack.com/archives/C057T1QTB3L/p1697561471253979?thread_ts=1697550130.556539&cid=C057T1QTB3L

We decided to hard limit the tab name length to 75 as longer names just create problems and don't really make sense

### How to verify

1. Go to a dashboard in edit mode
2. Double click a tab name
3. Type more than 75 chars


