### PR TITLE
Filters date defaults

### DIFF
--- a/frontend/src/metabase/common/components/DatePicker/RelativeDatePicker/DateIntervalPicker/constants.ts
+++ b/frontend/src/metabase/common/components/DatePicker/RelativeDatePicker/DateIntervalPicker/constants.ts
@@ -1,0 +1,11 @@
+import type { DatePickerTruncationUnit } from "metabase/common/components/DatePicker";
+
+export const DEFAULT_OFFSETS: Record<DatePickerTruncationUnit, number> = {
+  minute: 60,
+  hour: 24,
+  day: 7,
+  week: 4,
+  month: 3,
+  quarter: 4,
+  year: 1,
+};

--- a/frontend/src/metabase/common/components/DatePicker/RelativeDatePicker/DateIntervalPicker/utils.ts
+++ b/frontend/src/metabase/common/components/DatePicker/RelativeDatePicker/DateIntervalPicker/utils.ts
@@ -1,6 +1,7 @@
 import * as Lib from "metabase-lib";
 import type { DatePickerTruncationUnit } from "../../types";
 import type { DateIntervalValue } from "../types";
+import { DEFAULT_OFFSETS } from "./constants";
 
 export function setUnit(
   value: DateIntervalValue,
@@ -12,7 +13,7 @@ export function setUnit(
 export function setDefaultOffset(value: DateIntervalValue): DateIntervalValue {
   return {
     ...value,
-    offsetValue: Math.sign(value.value),
+    offsetValue: DEFAULT_OFFSETS[value.unit] * Math.sign(value.value),
     offsetUnit: value.unit,
     options: {},
   };

--- a/frontend/src/metabase/common/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx
@@ -106,7 +106,7 @@ export function DateOffsetIntervalPicker({
       </PickerGrid>
       <Divider />
       <Group px="md" py="sm" spacing="sm" position="apart">
-        <Group c="text.1">
+        <Group c="text.1" spacing="sm">
           <Icon name="calendar" />
           <Text c="inherit">{dateRangeText}</Text>
         </Group>

--- a/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.tsx
@@ -93,7 +93,7 @@ export function DateRangePicker({
         <DatePicker
           type="range"
           value={[startDate, hasEndDate ? endDate : null]}
-          defaultDate={endDate}
+          defaultDate={startDate}
           numberOfColumns={2}
           allowSingleDateInRange
           onChange={handleRangeChange}

--- a/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/utils.ts
+++ b/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/utils.ts
@@ -14,13 +14,13 @@ export function getTabs(
 }
 
 export function getDefaultValue(): SpecificDatePickerValue {
-  const today = moment().startOf("date");
-  const past30Days = today.subtract(30, "day");
+  const today = moment().startOf("date").toDate();
+  const past30Days = moment(today).subtract(30, "day").toDate();
 
   return {
     type: "specific",
     operator: "between",
-    values: [past30Days.toDate(), today.toDate()],
+    values: [past30Days, today],
   };
 }
 
@@ -28,16 +28,22 @@ export function setOperator(
   value: SpecificDatePickerValue,
   operator: SpecificDatePickerOperator,
 ): SpecificDatePickerValue {
+  const [date] = value.values;
+  const past30Days = moment(date).subtract(30, "day").toDate();
+  const next30Days = moment(date).add(30, "day").toDate();
+
   switch (operator) {
     case "=":
     case "<":
       return value.operator === "between"
         ? { ...value, operator, values: [value.values[1]] }
-        : { ...value, operator, values: [value.values[0]] };
+        : { ...value, operator, values: [date] };
     case ">":
-      return { ...value, operator, values: [value.values[0]] };
+      return { ...value, operator, values: [date] };
     case "between":
-      return { ...value, operator, values: [value.values[0], value.values[0]] };
+      return value.operator === ">"
+        ? { ...value, operator, values: [date, next30Days] }
+        : { ...value, operator, values: [past30Days, date] };
   }
 }
 

--- a/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/utils.ts
+++ b/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/utils.ts
@@ -14,12 +14,13 @@ export function getTabs(
 }
 
 export function getDefaultValue(): SpecificDatePickerValue {
-  const today = moment().startOf("date").toDate();
+  const today = moment().startOf("date");
+  const past30Days = today.subtract(30, "day");
 
   return {
     type: "specific",
     operator: "between",
-    values: [today, today],
+    values: [past30Days.toDate(), today.toDate()],
   };
 }
 


### PR DESCRIPTION
Adds default according to the existing behavior
- when switching between specific dates tabs
- when selecting "starting from" in relative date filters

It should work as in master.

<img width="651" alt="Screenshot 2023-10-19 at 19 53 59" src="https://github.com/metabase/metabase/assets/8542534/b02ebc77-3b96-4f6d-926f-ca5771319514">
<img width="548" alt="Screenshot 2023-10-19 at 19 18 23" src="https://github.com/metabase/metabase/assets/8542534/e59e48ee-b311-41f4-b73a-4479feca1597">
