### PR TITLE
implement show total pie setting

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/pie/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/model/index.ts
@@ -105,7 +105,7 @@ export function getPieChartModel(
   // Only add "other" slice if there are slices below threshold with non-zero total
   const otherTotal = others.reduce((currTotal, o) => currTotal + o.value, 0);
   if (otherTotal === 0) {
-    return { slices, total };
+    return { slices, total, colDescs };
   }
 
   const otherSlice: PieSlice = {
@@ -123,5 +123,6 @@ export function getPieChartModel(
   return {
     slices: [...slices, otherSlice],
     total,
+    colDescs,
   };
 }

--- a/frontend/src/metabase/visualizations/echarts/pie/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/model/types.ts
@@ -16,4 +16,5 @@ export interface PieSlice {
 export interface PieChartModel {
   slices: PieSlice[];
   total: number;
+  colDescs: PieColumnDescriptors;
 }

--- a/frontend/src/metabase/visualizations/echarts/pie/option/constants.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/option/constants.ts
@@ -1,6 +1,7 @@
 import type { RegisteredSeriesOption } from "echarts";
+import { t } from "ttag";
 
-export const SUNBURST_SERIES_OPTIONS: RegisteredSeriesOption["sunburst"] = {
+export const SUNBURST_SERIES_OPTION: RegisteredSeriesOption["sunburst"] = {
   type: "sunburst",
   sort: undefined,
   label: {
@@ -11,4 +12,35 @@ export const SUNBURST_SERIES_OPTIONS: RegisteredSeriesOption["sunburst"] = {
     color: "white", // TODO select color dynamically based on contrast with slice color
   },
   radius: ["60%", "90%"], // TODO compute this dynamically based on side length like in PieChart.jsx
+};
+
+export const TOTAL_GRAPHIC_OPTION = {
+  type: "group",
+  top: "center",
+  left: "center",
+  children: [
+    {
+      type: "text",
+      cursor: "text",
+      style: {
+        fontSize: "22px",
+        fontWeight: "700",
+        textAlign: "center",
+        // placeholder values to keep typescript happy
+        fontFamily: "",
+        fill: "",
+      },
+    },
+    {
+      type: "text",
+      cursor: "text",
+      top: 25, // TODO confirm this and other style values later
+      style: {
+        fontSize: "14px",
+        fontWeight: "700",
+        textAlign: "center",
+        text: t`Total`.toUpperCase(),
+      },
+    },
+  ],
 };

--- a/frontend/src/metabase/visualizations/echarts/pie/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/option/index.ts
@@ -9,23 +9,24 @@ import type {
 import type { PieChartModel } from "../model/types";
 import { SUNBURST_SERIES_OPTION, TOTAL_GRAPHIC_OPTION } from "./constants";
 
-function getTotalGraphic(
+function getTotalGraphicOption(
   total: number,
   formatMetric: Formatter,
   renderingContext: RenderingContext,
 ) {
-  const graphic = { ...TOTAL_GRAPHIC_OPTION };
+  const graphicOption = { ...TOTAL_GRAPHIC_OPTION };
 
-  graphic.children.forEach(child => {
+  graphicOption.children.forEach(child => {
     child.style.fontFamily = renderingContext.fontFamily;
   });
 
-  graphic.children[0].style.text = formatMetric(Math.round(total));
-  graphic.children[0].style.fill = renderingContext.getColor("text-dark");
+  graphicOption.children[0].style.text = formatMetric(Math.round(total));
+  graphicOption.children[0].style.fill = renderingContext.getColor("text-dark");
 
-  graphic.children[1].style.fill = renderingContext.getColor("text-light");
+  graphicOption.children[1].style.fill =
+    renderingContext.getColor("text-light");
 
-  return graphic;
+  return graphicOption;
 }
 
 export function getPieChartOption(
@@ -48,7 +49,7 @@ export function getPieChartOption(
       fontFamily: renderingContext.fontFamily,
     },
     graphic: settings["pie.show_total"]
-      ? getTotalGraphic(chartModel.total, formatMetric, renderingContext)
+      ? getTotalGraphicOption(chartModel.total, formatMetric, renderingContext)
       : undefined,
     series: {
       ...SUNBURST_SERIES_OPTION,

--- a/frontend/src/metabase/visualizations/echarts/pie/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/option/index.ts
@@ -1,5 +1,4 @@
 import type { EChartsOption } from "echarts";
-import { t } from "ttag";
 
 import type {
   ComputedVisualizationSettings,
@@ -8,47 +7,25 @@ import type {
 } from "metabase/visualizations/types";
 
 import type { PieChartModel } from "../model/types";
-import { SUNBURST_SERIES_OPTIONS } from "./constants";
+import { SUNBURST_SERIES_OPTION, TOTAL_GRAPHIC_OPTION } from "./constants";
 
-export function getTotalGraphic(
+function getTotalGraphic(
   total: number,
   formatMetric: Formatter,
   renderingContext: RenderingContext,
 ) {
-  const formattedTotal = formatMetric(Math.round(total));
+  const graphic = { ...TOTAL_GRAPHIC_OPTION };
 
-  return {
-    type: "group",
-    top: "center",
-    left: "center",
-    children: [
-      {
-        type: "text",
-        cursor: "text",
-        style: {
-          fill: renderingContext.getColor("text-dark"),
-          fontSize: "22px",
-          fontFamily: "Lato, sans-serif",
-          fontWeight: "700",
-          textAlign: "center",
-          text: formattedTotal,
-        },
-      },
-      {
-        type: "text",
-        cursor: "text",
-        top: 25, // TODO confirm this and other style values later
-        style: {
-          fill: renderingContext.getColor("text-light"),
-          fontSize: "14px",
-          fontFamily: renderingContext.fontFamily,
-          fontWeight: "700",
-          textAlign: "center",
-          text: t`Total`.toUpperCase(),
-        },
-      },
-    ],
-  };
+  graphic.children.forEach(child => {
+    child.style.fontFamily = renderingContext.fontFamily;
+  });
+
+  graphic.children[0].style.text = formatMetric(Math.round(total));
+  graphic.children[0].style.fill = renderingContext.getColor("text-dark");
+
+  graphic.children[1].style.fill = renderingContext.getColor("text-light");
+
+  return graphic;
 }
 
 export function getPieChartOption(
@@ -74,7 +51,7 @@ export function getPieChartOption(
       ? getTotalGraphic(chartModel.total, formatMetric, renderingContext)
       : undefined,
     series: {
-      ...SUNBURST_SERIES_OPTIONS,
+      ...SUNBURST_SERIES_OPTION,
       data: chartModel.slices.map(s => ({
         value: s.value,
         name: s.key,

--- a/frontend/src/metabase/visualizations/echarts/pie/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/option/index.ts
@@ -1,22 +1,78 @@
 import type { EChartsOption } from "echarts";
+import { t } from "ttag";
 
 import type {
   ComputedVisualizationSettings,
+  Formatter,
   RenderingContext,
 } from "metabase/visualizations/types";
 
 import type { PieChartModel } from "../model/types";
 import { SUNBURST_SERIES_OPTIONS } from "./constants";
 
+export function getTotalGraphic(
+  total: number,
+  formatMetric: Formatter,
+  renderingContext: RenderingContext,
+) {
+  const formattedTotal = formatMetric(Math.round(total));
+
+  return {
+    type: "group",
+    top: "center",
+    left: "center",
+    children: [
+      {
+        type: "text",
+        cursor: "text",
+        style: {
+          fill: renderingContext.getColor("text-dark"),
+          fontSize: "22px",
+          fontFamily: "Lato, sans-serif",
+          fontWeight: "700",
+          textAlign: "center",
+          text: formattedTotal,
+        },
+      },
+      {
+        type: "text",
+        cursor: "text",
+        top: 25, // TODO confirm this and other style values later
+        style: {
+          fill: renderingContext.getColor("text-light"),
+          fontSize: "14px",
+          fontFamily: renderingContext.fontFamily,
+          fontWeight: "700",
+          textAlign: "center",
+          text: t`Total`.toUpperCase(),
+        },
+      },
+    ],
+  };
+}
+
 export function getPieChartOption(
   chartModel: PieChartModel,
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
 ): EChartsOption {
+  const { column: getColumnSettings } = settings;
+  if (!getColumnSettings) {
+    throw Error(`"settings.column" is undefined`);
+  }
+
+  const formatMetric = (value: unknown) =>
+    renderingContext.formatValue(value, {
+      ...getColumnSettings(chartModel.colDescs.metricDesc.column),
+    });
+
   return {
     textStyle: {
       fontFamily: renderingContext.fontFamily,
     },
+    graphic: settings["pie.show_total"]
+      ? getTotalGraphic(chartModel.total, formatMetric, renderingContext)
+      : undefined,
     series: {
       ...SUNBURST_SERIES_OPTIONS,
       data: chartModel.slices.map(s => ({

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -18,6 +18,8 @@ import type { RemappingHydratedDatasetColumn } from "./columns";
 
 export type ColorGetter = (colorName: string) => string;
 
+export type Formatter = (value: unknown) => string;
+
 export interface RenderingContext {
   getColor: ColorGetter;
   formatValue: (value: unknown, options: StaticFormattingOptions) => string;


### PR DESCRIPTION
Part of https://github.com/metabase/metabase/issues/33281

### Description

Implements the "show total" setting on the pie chart.

Note that our [static viz formatter](https://github.com/metabase/metabase/blob/6e669a90e0a94652d004596b155cb7c153442eeb/frontend/src/metabase/static-viz/lib/format.ts#L60) function has an incomplete implementation, so many settings like currency will not appear. We will fix this in a later PR.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a question
2. Set visualization type to `Pie 2`
3. Enable "show total" setting
4. Add to a dashboard
5. Send in an email subscription
6. Confirm total appears, with some of the formatting settings applied

### Demo

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/67871d54-ddee-4119-b92b-a591077b143a/image.png)


### Checklist

- [] Tests have been added/updated to cover changes in this PR

_Will be covered later in percy tests._