### PR TITLE
Brief branch away from metric-x-rays

### DIFF
--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -1310,25 +1310,29 @@
         template-with-user-groups   (update dashboard-template
                                             :groups into (user-defined-groups user-defined-metrics))
         empty-dashboard             (make-dashboard root template-with-user-groups)]
-    (-> (assoc empty-dashboard
-          ;; Adds the filters that show at the top of the dashboard
-          ;; Why do we need (or do we) the last remove form?
-          :filters (->> dashboard_filters
-                        (mapcat (comp :matches grounded-dimensions))
-                        (remove (comp (singular-cell-dimensions root) id-or-name)))
-          :cards dashcards)
-        (populate/create-dashboard :all)
-        (assoc
-          :related (related
-                     root grounded-dimensions
-                     dashboard-template)
-          ;     :more (when (and (not= show :all)
-          ;                      (-> dashboard :cards count (> show)))
-          ;             (format "%s#show=all" url))
-          ;     :transient_filters query-filter
-          ;     :param_fields (filter-referenced-fields root query-filter)
-          :auto_apply_filters true
-          ))))
+    (with-meta
+      (-> (assoc empty-dashboard
+            ;; Adds the filters that show at the top of the dashboard
+            ;; Why do we need (or do we) the last remove form?
+            :filters (->> dashboard_filters
+                          (mapcat (comp :matches grounded-dimensions))
+                          (remove (comp (singular-cell-dimensions root) id-or-name)))
+            :cards dashcards)
+          (populate/create-dashboard :all)
+          (assoc
+            :related (related
+                       root grounded-dimensions
+                       dashboard-template)
+            ;; This just adds extra cards
+            ;     :more (when (and (not= show :all)
+            ;                      (-> dashboard :cards count (> show)))
+            ;             (format "%s#show=all" url))
+            ;; This comes from root
+            ;     :transient_filters query-filter
+            ;     :param_fields (filter-referenced-fields root query-filter)
+            :auto_apply_filters true
+            ))
+      {:available-dimensions grounded-dimensions})))
 
 (defn- filter-referenced-fields
   "Return a map of fields referenced in filter clause."
@@ -1347,12 +1351,13 @@
   (let [base-context (make-base-context root)]
     (or (when dashboard-template
           (apply-dashboard-template base-context (dashboard-templates/get-dashboard-template dashboard-template)))
-        (some
-          (fn [dashboard-template]
-            (apply-dashboard-template base-context dashboard-template))
-          (matching-dashboard-templates
-            (dashboard-templates/get-dashboard-templates dashboard-templates-prefix)
-            root))
+        (let [[template] (matching-dashboard-templates
+                           (dashboard-templates/get-dashboard-templates dashboard-templates-prefix)
+                           root)
+              dashboard (generate-dashboard (make-base-context root) template)]
+          [dashboard
+           template
+           (meta dashboard)])
         (throw (ex-info (trs "Can''t create dashboard for {0}" (pr-str full-name))
                         (let [templates (->> (or (some-> dashboard-template dashboard-templates/get-dashboard-template vector)
                                                  (dashboard-templates/get-dashboard-templates dashboard-templates-prefix))

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -1355,9 +1355,11 @@
                            (dashboard-templates/get-dashboard-templates dashboard-templates-prefix)
                            root)
               dashboard (generate-dashboard (make-base-context root) template)]
+          (tap> dashboard)
+          (tap>  (meta dashboard))
           [dashboard
            template
-           (meta dashboard)])
+           {}])
         (throw (ex-info (trs "Can''t create dashboard for {0}" (pr-str full-name))
                         (let [templates (->> (or (some-> dashboard-template dashboard-templates/get-dashboard-template vector)
                                                  (dashboard-templates/get-dashboard-templates dashboard-templates-prefix))
@@ -1367,30 +1369,15 @@
 
 (defn- automagic-dashboard
   "Create dashboards for table `root` using the best matching heuristics."
-  [{:keys [show full-name query-filter url] :as root}]
-  (let [[dashboard
-         {:keys [dashboard-template-name] :as dashboard-template}
-         {:keys [available-dimensions
-                 available-metrics
-                 available-filters]}] (find-first-match-dashboard-template root)
-        show (or show max-cards)]
-    (log/debug (trs "Applying heuristic {0} to {1}." dashboard-template-name full-name))
-    (log/debug (trs "Dimensions bindings:\n{0}"
-                    (->> available-dimensions
-                         (m/map-vals #(update % :matches (partial map :name)))
-                         u/pprint-to-str)))
-    (log/debug (trs "Using definitions:\nMetrics:\n{0}\nFilters:\n{1}"
-                    (->> available-metrics (m/map-vals :metric) u/pprint-to-str)
-                    (-> available-filters u/pprint-to-str)))
-    (-> dashboard
-        (populate/create-dashboard show)
-        (assoc :related (related root available-dimensions dashboard-template)
-               :more (when (and (not= show :all)
-                                (-> dashboard :cards count (> show)))
-                       (format "%s#show=all" url))
-               :transient_filters query-filter
-               :param_fields (filter-referenced-fields root query-filter)
-               :auto_apply_filters true))))
+  [{:keys [dashboard-template dashboard-templates-prefix] :as root}]
+  (let [base-context (make-base-context root)]
+    ;; Note that once we verify this works, we can maybe just feed this template into generate-dashboard
+    (if dashboard-template
+      (apply-dashboard-template base-context (dashboard-templates/get-dashboard-template dashboard-template))
+      (let [template (first (matching-dashboard-templates
+                              (dashboard-templates/get-dashboard-templates dashboard-templates-prefix)
+                              root))]
+        (generate-dashboard base-context template)))))
 
 (defmulti automagic-analysis
   "Create a transient dashboard analyzing given entity."


### PR DESCRIPTION
Replacing apply-dashboard-template in `find-first-match-dashboard-template` with our new `generate-dashboard` function and returning what we expect to be the available-values data in meta.

If we can get the tests working here, we may have a replacement for the old code.