### PR TITLE
Add `:audit` flag to most settings, and obfuscate sensitive settings automatically

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
@@ -14,8 +14,9 @@
   "Whether to sync newly created Databases during config-from-file initialization. By default, true, but you can disable
   this behavior if you want to sync it manually or use SerDes to populate its data model."
   :visibility :internal
-  :type :boolean
-  :default true)
+  :type       :boolean
+  :default    true
+  :audit      :getter)
 
 (s/def :metabase-enterprise.advanced-config.file.databases.config-file-spec/name
   string?)

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/models/pulse_channel.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/models/pulse_channel.clj
@@ -12,7 +12,8 @@
   :feature    :email-allow-list
   ;; this is a comma-separated string but we're not using `:csv` because it gets serialized to an array which makes it
   ;; inconvenient to use on the frontend.
-  :type       :string)
+  :type       :string
+  :audit      :getter)
 
 (defn- allowed-domains-set
   "Parse [[subscription-allowed-domains]] into a set. `nil` if the Setting is not set or empty."

--- a/enterprise/backend/src/metabase_enterprise/enhancements/integrations/ldap.clj
+++ b/enterprise/backend/src/metabase_enterprise/enhancements/integrations/ldap.clj
@@ -22,17 +22,20 @@
 (defsetting ldap-sync-user-attributes
   (deferred-tru "Should we sync user attributes when someone logs in via LDAP?")
   :type    :boolean
-  :default true)
+  :default true
+  :audit   :getter)
 
 ;; TODO - maybe we want to add a csv setting type?
 (defsetting ldap-sync-user-attributes-blacklist
   (deferred-tru "Comma-separated list of user attributes to skip syncing for LDAP users.")
   :default "userPassword,dn,distinguishedName"
-  :type    :csv)
+  :type    :csv
+  :audit   :getter)
 
 (defsetting ldap-group-membership-filter
   (deferred-tru "Group membership lookup filter. The placeholders '{dn}' and '{uid}' will be replaced by the user''s Distinguished Name and UID, respectively.")
-  :default "(member={dn})")
+  :default "(member={dn})"
+  :audit   :getter)
 
 (defn- syncable-user-attributes [m]
   (when (ldap-sync-user-attributes)

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_settings.clj
@@ -26,7 +26,8 @@
 (defsetting saml-identity-provider-uri
   (deferred-tru "This is the URL where your users go to log in to your identity provider. Depending on which IdP you''re
 using, this usually looks like https://your-org-name.example.com or https://example.com/app/my_saml_app/abc123/sso/saml")
-  :feature :sso-saml)
+  :feature :sso-saml
+  :audit   :getter)
 
 (s/defn ^:private validate-saml-idp-cert
   "Validate that an encoded identity provider certificate is valid, or throw an Exception."
@@ -42,6 +43,7 @@ using, this usually looks like https://your-org-name.example.com or https://exam
   (deferred-tru "Encoded certificate for the identity provider. Depending on your IdP, you might need to download this,
 open it in a text editor, then copy and paste the certificate's contents here.")
   :feature :sso-saml
+  :audit   :no-value
   :setter  (fn [new-value]
             ;; when setting the idp cert validate that it's something we
              (when new-value
@@ -51,54 +53,64 @@ open it in a text editor, then copy and paste the certificate's contents here.")
 (defsetting saml-identity-provider-issuer
   (deferred-tru "This is a unique identifier for the IdP. Often referred to as Entity ID or simply 'Issuer'. Depending
 on your IdP, this usually looks something like http://www.example.com/141xkex604w0Q5PN724v")
-  :feature :sso-saml)
+  :feature :sso-saml
+  :audit   :getter)
 
 (defsetting saml-application-name
   (deferred-tru "This application name will be used for requests to the Identity Provider")
   :default "Metabase"
-  :feature :sso-saml)
+  :feature :sso-saml
+  :audit   :getter)
 
 (defsetting saml-keystore-path
   (deferred-tru "Absolute path to the Keystore file to use for signing SAML requests")
-  :feature :sso-saml)
+  :feature :sso-saml
+  :audit   :getter)
 
 (defsetting saml-keystore-password
   (deferred-tru "Password for opening the keystore")
   :default    "changeit"
   :sensitive? true
-  :feature    :sso-saml)
+  :feature    :sso-saml
+  :audit      :getter)
 
 (defsetting saml-keystore-alias
   (deferred-tru "Alias for the key that {0} should use for signing SAML requests"
                 (public-settings/application-name-for-setting-descriptions))
   :default "metabase"
-  :feature :sso-saml)
+  :feature :sso-saml
+  :audit   :getter)
 
 (defsetting saml-attribute-email
   (deferred-tru "SAML attribute for the user''s email address")
   :default "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
-  :feature :sso-saml)
+  :feature :sso-saml
+  :audit   :getter)
 
 (defsetting saml-attribute-firstname
   (deferred-tru "SAML attribute for the user''s first name")
   :default "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname"
-  :feature :sso-saml)
+  :feature :sso-saml
+  :audit   :getter)
 
 (defsetting saml-attribute-lastname
   (deferred-tru "SAML attribute for the user''s last name")
   :default "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname"
-  :feature :sso-saml)
+  :feature :sso-saml
+  :audit   :getter)
 
 (defsetting saml-group-sync
   (deferred-tru "Enable group membership synchronization with SAML.")
   :type    :boolean
   :default false
-  :feature :sso-saml)
+  :feature :sso-saml
+  :audit   :getter)
 
 (defsetting saml-attribute-group
   (deferred-tru "SAML attribute for group syncing")
   :default "member_of"
-  :feature :sso-saml)
+  :feature :sso-saml
+  :audit   :getter)
 
 (defsetting saml-group-mappings
   ;; Should be in the form: {"groupName": [1, 2, 3]} where keys are SAML groups and values are lists of MB groups IDs
@@ -108,6 +120,7 @@ on your IdP, this usually looks something like http://www.example.com/141xkex604
   :cache?  false
   :default {}
   :feature :sso-saml
+  :audit   :getter
   :setter  (comp (partial setting/set-value-of-type! :json :saml-group-mappings)
                  (partial mu/validate-throw validate-group-mappings)))
 
@@ -126,6 +139,7 @@ on your IdP, this usually looks something like http://www.example.com/141xkex604
   :type    :boolean
   :default false
   :feature :sso-saml
+  :audit   :getter
   :getter  (fn []
              (if (saml-configured)
                (setting/get-value-of-type :boolean :saml-enabled)
@@ -133,40 +147,47 @@ on your IdP, this usually looks something like http://www.example.com/141xkex604
 
 (defsetting jwt-identity-provider-uri
   (deferred-tru "URL of JWT based login page")
-  :feature :sso-jwt)
+  :feature :sso-jwt
+  :audit   :getter)
 
 (defsetting jwt-shared-secret
   (deferred-tru (str "String used to seed the private key used to validate JWT messages."
                      " "
                      "A hexadecimal-encoded 256-bit key (i.e., a 64-character string) is strongly recommended."))
   :type    :string
-  :feature :sso-jwt)
+  :feature :sso-jwt
+  :audit   :no-value)
 
 (defsetting jwt-attribute-email
   (deferred-tru "Key to retrieve the JWT user's email address")
   :default "email"
-  :feature :sso-jwt)
+  :feature :sso-jwt
+  :audit   :getter)
 
 (defsetting jwt-attribute-firstname
   (deferred-tru "Key to retrieve the JWT user's first name")
   :default "first_name"
-  :feature :sso-jwt)
+  :feature :sso-jwt
+  :audit   :getter)
 
 (defsetting jwt-attribute-lastname
   (deferred-tru "Key to retrieve the JWT user's last name")
   :default "last_name"
-  :feature :sso-jwt)
+  :feature :sso-jwt
+  :audit   :getter)
 
 (defsetting jwt-attribute-groups
   (deferred-tru "Key to retrieve the JWT user's groups")
   :default "groups"
-  :feature :sso-jwt)
+  :feature :sso-jwt
+  :audit   :getter)
 
 (defsetting jwt-group-sync
   (deferred-tru "Enable group membership synchronization with JWT.")
   :type    :boolean
   :default false
-  :feature :sso-jwt)
+  :feature :sso-jwt
+  :audit   :getter)
 
 (defsetting jwt-group-mappings
   ;; Should be in the form: {"groupName": [1, 2, 3]} where keys are JWT groups and values are lists of MB groups IDs
@@ -176,6 +197,7 @@ on your IdP, this usually looks something like http://www.example.com/141xkex604
   :cache?  false
   :default {}
   :feature :sso-jwt
+  :audit   :getter
   :setter  (comp (partial setting/set-value-of-type! :json :jwt-group-mappings)
                  (partial mu/validate-throw validate-group-mappings)))
 
@@ -194,6 +216,7 @@ on your IdP, this usually looks something like http://www.example.com/141xkex604
   :type    :boolean
   :default false
   :feature :sso-jwt
+  :audit   :getter
   :getter  (fn []
              (if (jwt-configured)
                (setting/get-value-of-type :boolean :jwt-enabled)

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -40,16 +40,17 @@
   :type       :boolean
   :visibility :public
   :default    config/is-prod?
-  :doc        false)
+  :doc        false
+  :audit      :never)
 
 (defsetting snowplow-enabled
   (deferred-tru
    (str "Boolean indicating whether analytics events are being sent to Snowplow. "
         "True if anonymous tracking is enabled for this instance, and a Snowplow collector is available."))
-  :type   :boolean
-  :setter :none
-  :getter (fn [] (and (snowplow-available)
-                      (public-settings/anon-tracking-enabled)))
+  :type       :boolean
+  :setter     :none
+  :getter     (fn [] (and (snowplow-available)
+                          (public-settings/anon-tracking-enabled)))
   :visibility :public
   :doc        false)
 
@@ -60,6 +61,7 @@
                 ;; See the iglu-schema-registry repo for instructions on how to run Snowplow Micro locally for development
                 "http://localhost:9090")
   :visibility :public
+  :audit      :never
   :doc        false)
 
 (defn- first-user-creation

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -591,6 +591,7 @@
   :visibility :public
   :type       :keyword
   :default    :substring
+  :audit      :raw-value
   :setter     (fn [v]
                 (let [v (cond-> v (string? v) keyword)]
                   (if (autocomplete-matching-options v)

--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -23,7 +23,8 @@
   :visibility :admin
   :type       :boolean
   :setter     :none
-  :default    true)
+  :default    true
+  :audit      :getter)
 
 (def ^:private CustomGeoJSON
   [:map-of :keyword [:map {:closed true}
@@ -106,7 +107,8 @@
                (when new-value
                  (validate-geojson new-value))
                (setting/set-value-of-type! :json :custom-geojson new-value)))
-  :visibility :public)
+  :visibility :public
+  :audit      :raw-value)
 
 (def ^:private connection-timeout-ms 8000)
 

--- a/src/metabase/api/ldap.clj
+++ b/src/metabase/api/ldap.clj
@@ -87,7 +87,8 @@
                         (throw (ex-info (tru "Unable to connect to LDAP server with current settings")
                                         (humanize-error-messages result))))))
                   (setting/set-value-of-type! :boolean :ldap-enabled new-value)))
-  :default    false)
+  :default    false
+  :audit      :getter)
 
 (defn- update-password-if-needed
   "Do not update password if `new-password` is an obfuscated value of the current password."

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -244,12 +244,12 @@
   (forgot-password-impl email)
   api/generic-204-no-content)
 
-
 (defsetting reset-token-ttl-hours
   (deferred-tru "Number of hours a password reset is considered valid.")
   :visibility :internal
   :type       :integer
-  :default    48)
+  :default    48
+  :audit      :getter)
 
 (defn reset-token-ttl-ms
   "number of milliseconds a password reset is considered valid."
@@ -359,8 +359,8 @@
         (throw (ex-info (tru "Email for pulse-id doesn't exist.")
                         {:type        type
                          :status-code 400}))))
-      (events/publish-event! :event/subscription-unsubscribe {:details {:email email}})
-      {:status :success :title (:name (pulse/retrieve-notification pulse-id :archived false))}))
+    (events/publish-event! :event/subscription-unsubscribe {:details {:email email}})
+    {:status :success :title (:name (pulse/retrieve-notification pulse-id :archived false))}))
 
 (api/defendpoint POST "/pulse/unsubscribe/undo"
   "Allow non-users to undo an unsubscribe from pulses/subscriptions, with the hash given through email."

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -31,19 +31,20 @@
    [metabase.util.password :as u.password]
    [toucan2.core :as t2]))
 
-(defsetting user-visibility
-  (deferred-tru "Note: Sandboxed users will never see suggestions.")
-  :visibility   :authenticated
-  :feature      :email-restrict-recipients
-  :type         :keyword
-  :default      :all)
-
 (set! *warn-on-reflection* true)
 
 (when config/ee-available?
   (classloader/require 'metabase-enterprise.sandbox.api.util
                        'metabase-enterprise.advanced-permissions.common
                        'metabase-enterprise.advanced-permissions.models.permissions.group-manager))
+
+(defsetting user-visibility
+  (deferred-tru "Note: Sandboxed users will never see suggestions.")
+  :visibility   :authenticated
+  :feature      :email-restrict-recipients
+  :type         :keyword
+  :default      :all
+  :audit        :raw-value)
 
 (defn check-self-or-superuser
   "Check that `user-id` is *current-user-id*` or that `*current-user*` is a superuser, or throw a 403."

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -54,6 +54,7 @@
 (defsetting report-timezone
   (deferred-tru "Connection timezone to use when executing queries. Defaults to system timezone.")
   :visibility :settings-manager
+  :audit      :getter
   :setter
   (fn [new-value]
     (setting/set-value-of-type! :string :report-timezone new-value)

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -83,8 +83,9 @@
 (setting/defsetting jdbc-data-warehouse-max-connection-pool-size
   "Maximum size of the c3p0 connection pool."
   :visibility :internal
-  :type :integer
-  :default 15)
+  :type       :integer
+  :default    15
+  :audit      :getter)
 
 (setting/defsetting jdbc-data-warehouse-unreturned-connection-timeout-seconds
   "Kill connections if they are unreturned after this amount of time. In theory this should not be needed because the QP

--- a/src/metabase/email.clj
+++ b/src/metabase/email.clj
@@ -23,11 +23,13 @@
 (defsetting email-from-address
   (deferred-tru "The email address you want to use for the sender of emails.")
   :default    "notifications@metabase.com"
-  :visibility :settings-manager)
+  :visibility :settings-manager
+  :audit      :getter)
 
 (defsetting email-from-name
   (deferred-tru "The name you want to use for the sender of emails.")
-  :visibility :settings-manager)
+  :visibility :settings-manager
+  :audit      :getter)
 
 (def ^:private ReplyToAddresses
   [:maybe [:sequential ms/Email]])
@@ -37,40 +39,48 @@
 
 (defsetting email-reply-to
   (deferred-tru "The email address you want the replies to go to, if different from the from address.")
-  :type :json
+  :type       :json
   :visibility :settings-manager
-  :setter (fn [new-value]
-           (if (validate-reply-to-addresses new-value)
-             (setting/set-value-of-type! :json :email-reply-to new-value)
-             (throw (ex-info "Invalid reply-to address" {:value new-value})))))
+  :audit      :getter
+  :setter     (fn [new-value]
+               (if (validate-reply-to-addresses new-value)
+                 (setting/set-value-of-type! :json :email-reply-to new-value)
+                 (throw (ex-info "Invalid reply-to address" {:value new-value})))))
 
 (defsetting email-smtp-host
   (deferred-tru "The address of the SMTP server that handles your emails.")
-  :visibility :settings-manager)
+  :visibility :settings-manager
+  :audit      :getter)
 
 (defsetting email-smtp-username
   (deferred-tru "SMTP username.")
-  :visibility :settings-manager)
+  :visibility :settings-manager
+  :audit      :getter)
 
 (defsetting email-smtp-password
   (deferred-tru "SMTP password.")
   :visibility :settings-manager
-  :sensitive? true)
+  :sensitive? true
+  :audit      :getter)
+
+(email-smtp-password! "hi there")
 
 (defsetting email-smtp-port
   (deferred-tru "The port your SMTP server uses for outgoing emails.")
   :type       :integer
-  :visibility :settings-manager)
+  :visibility :settings-manager
+  :audit      :getter)
 
 (defsetting email-smtp-security
   (deferred-tru "SMTP secure connection protocol. (tls, ssl, starttls, or none)")
   :type       :keyword
   :default    :none
   :visibility :settings-manager
-  :setter  (fn [new-value]
-             (when (some? new-value)
-               (assert (#{:tls :ssl :none :starttls} (keyword new-value))))
-             (setting/set-value-of-type! :keyword :email-smtp-security new-value)))
+  :audit      :raw-value
+  :setter     (fn [new-value]
+                (when (some? new-value)
+                  (assert (#{:tls :ssl :none :starttls} (keyword new-value))))
+                (setting/set-value-of-type! :keyword :email-smtp-security new-value)))
 
 ;; ## PUBLIC INTERFACE
 

--- a/src/metabase/email.clj
+++ b/src/metabase/email.clj
@@ -63,8 +63,6 @@
   :sensitive? true
   :audit      :getter)
 
-(email-smtp-password! "hi there")
-
 (defsetting email-smtp-port
   (deferred-tru "The port your SMTP server uses for outgoing emails.")
   :type       :integer

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -9,5 +9,6 @@
   (deferred-tru "Toggle which is true after a user has dismissed the custom dashboard toast.")
   :user-local :only
   :visibility :authenticated
-  :type :boolean
-  :default false)
+  :type       :boolean
+  :default    false
+  :audit      :never)

--- a/src/metabase/integrations/google.clj
+++ b/src/metabase/integrations/google.clj
@@ -28,6 +28,7 @@
 (defsetting google-auth-client-id
   (deferred-tru "Client ID for Google Sign-In.")
   :visibility :public
+  :audit      :getter
   :setter     (fn [client-id]
                 (if (seq client-id)
                   (let [trimmed-client-id (str/trim client-id)]
@@ -49,6 +50,7 @@
   (deferred-tru "Is Google Sign-in currently enabled?")
   :visibility :public
   :type       :boolean
+  :audit      :getter
   :getter     (fn []
                 (if-some [value (setting/get-value-of-type :boolean :google-auth-enabled)]
                   value

--- a/src/metabase/integrations/ldap.clj
+++ b/src/metabase/integrations/ldap.clj
@@ -22,58 +22,70 @@
   (classloader/require 'metabase-enterprise.enhancements.integrations.ldap))
 
 (defsetting ldap-host
-  (deferred-tru "Server hostname."))
+  (deferred-tru "Server hostname.")
+  :audit :getter)
 
 (defsetting ldap-port
   (deferred-tru "Server port, usually 389 or 636 if SSL is used.")
-  :type :integer
-  :default 389)
+  :type    :integer
+  :default 389
+  :audit   :getter)
 
 (defsetting ldap-security
   (deferred-tru "Use SSL, TLS or plain text.")
   :type    :keyword
   :default :none
+  :audit   :raw-value
   :setter  (fn [new-value]
              (when (some? new-value)
                (assert (#{:none :ssl :starttls} (keyword new-value))))
              (setting/set-value-of-type! :keyword :ldap-security new-value)))
 
 (defsetting ldap-bind-dn
-  (deferred-tru "The Distinguished Name to bind as (if any), this user will be used to lookup information about other users."))
+  (deferred-tru "The Distinguished Name to bind as (if any), this user will be used to lookup information about other users.")
+  :audit :getter)
 
 (defsetting ldap-password
   (deferred-tru "The password to bind with for the lookup user.")
-  :sensitive? true)
+  :sensitive? true
+  :audit     :getter)
 
 (defsetting ldap-user-base
-  (deferred-tru "Search base for users. (Will be searched recursively)"))
+  (deferred-tru "Search base for users. (Will be searched recursively)")
+  :audit :getter)
 
 (defsetting ldap-user-filter
   (deferred-tru "User lookup filter. The placeholder '{login}' will be replaced by the user supplied login.")
-  :default "(&(objectClass=inetOrgPerson)(|(uid={login})(mail={login})))")
+  :default "(&(objectClass=inetOrgPerson)(|(uid={login})(mail={login})))"
+  :audit   :getter)
 
 (defsetting ldap-attribute-email
   (deferred-tru "Attribute to use for the user''s email. (usually ''mail'', ''email'' or ''userPrincipalName'')")
   :default "mail"
-  :getter (fn [] (u/lower-case-en (setting/get-value-of-type :string :ldap-attribute-email))))
+  :getter  (fn [] (u/lower-case-en (setting/get-value-of-type :string :ldap-attribute-email)))
+  :audit   :getter)
 
 (defsetting ldap-attribute-firstname
   (deferred-tru "Attribute to use for the user''s first name. (usually ''givenName'')")
   :default "givenName"
-  :getter (fn [] (u/lower-case-en (setting/get-value-of-type :string :ldap-attribute-firstname))))
+  :getter  (fn [] (u/lower-case-en (setting/get-value-of-type :string :ldap-attribute-firstname)))
+  :audit   :getter)
 
 (defsetting ldap-attribute-lastname
   (deferred-tru "Attribute to use for the user''s last name. (usually ''sn'')")
   :default "sn"
-  :getter (fn [] (u/lower-case-en (setting/get-value-of-type :string :ldap-attribute-lastname))))
+  :getter  (fn [] (u/lower-case-en (setting/get-value-of-type :string :ldap-attribute-lastname)))
+  :audit   :getter)
 
 (defsetting ldap-group-sync
   (deferred-tru "Enable group membership synchronization with LDAP.")
   :type    :boolean
-  :default false)
+  :default false
+  :audit   :getter)
 
 (defsetting ldap-group-base
-  (deferred-tru "Search base for groups. Not required for LDAP directories that provide a ''memberOf'' overlay, such as Active Directory. (Will be searched recursively)"))
+  (deferred-tru "Search base for groups. Not required for LDAP directories that provide a ''memberOf'' overlay, such as Active Directory. (Will be searched recursively)")
+  :audit   :getter)
 
 (defsetting ldap-group-mappings
   ;; Should be in the form: {"cn=Some Group,dc=...": [1, 2, 3]} where keys are LDAP group DNs and values are lists of
@@ -82,6 +94,7 @@
   :type    :json
   :cache?  false
   :default {}
+  :audit   :getter
   :getter  (fn []
              (json/parse-string (setting/get-value-of-type :string :ldap-group-mappings) #(DN. (str %))))
   :setter  (fn [new-value]

--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -23,7 +23,8 @@
          "Please use a new Slack app integration instead."))
   :deprecated "0.42.0"
   :visibility :settings-manager
-  :doc        false)
+  :doc        false
+  :audit      :never)
 
 (defsetting slack-app-token
   (deferred-tru
@@ -36,7 +37,8 @@
          "Set to 'false' if a Slack API request returns an auth error."))
   :type       :boolean
   :visibility :settings-manager
-  :doc        false)
+  :doc        false
+  :audit      :never)
 
 (defn process-files-channel-name
   "Converts empty strings to `nil`, and removes leading `#` from the channel name if present."
@@ -47,8 +49,9 @@
 (defsetting slack-cached-channels-and-usernames
   "A cache shared between instances for storing an instance's slack channels and users."
   :visibility :internal
-  :type :json
-  :doc  false)
+  :type       :json
+  :doc        false
+  :audit      :never)
 
 (def ^:private zoned-time-epoch (t/zoned-date-time 1970 1 1 0))
 
@@ -58,12 +61,14 @@
   :cache?     false
   :type       :timestamp
   :default    zoned-time-epoch
-  :doc        false)
+  :doc        false
+  :audit      :never)
 
 (defsetting slack-files-channel
   (deferred-tru "The name of the channel to which Metabase files should be initially uploaded")
   :default "metabase_files"
   :visibility :settings-manager
+  :audit      :getter
   :setter (fn [channel-name]
             (setting/set-value-of-type! :string :slack-files-channel (process-files-channel-name channel-name))))
 

--- a/src/metabase/models/humanization.clj
+++ b/src/metabase/models/humanization.clj
@@ -80,6 +80,7 @@
   :type       :keyword
   :default    :simple
   :visibility :settings-manager
+  :audit      :raw-value
   :getter     (fn []
                 (let [strategy (setting/get-value-of-type :keyword :humanization-strategy)]
                   ;; actual advanced method has been excised. Use `:simple` instead if someone had specified

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -30,6 +30,7 @@
   (deferred-tru "This will replace the word \"Metabase\" wherever it appears.")
   :visibility :public
   :type       :string
+  :audit      :getter
   :enabled?   premium-features/enable-whitelabeling?
   :default    "Metabase")
 
@@ -67,11 +68,13 @@
 (defsetting check-for-updates
   (deferred-tru "Identify when new versions of Metabase are available.")
   :type    :boolean
+  :audit   :getter
   :default true)
 
 (defsetting version-info
   (deferred-tru "Information about available versions of Metabase.")
   :type    :json
+  :audit   :getter
   :default {}
   :doc     false)
 
@@ -79,6 +82,7 @@
   (deferred-tru "Indicates when Metabase last checked for new versions.")
   :visibility :public
   :type       :timestamp
+  :audit      :never
   :default    nil
   :doc        false)
 
@@ -86,6 +90,7 @@
   (deferred-tru "The startup time in milliseconds")
   :visibility :public
   :type       :double
+  :audit      :never
   :default    0.0
   :doc        false)
 
@@ -93,12 +98,14 @@
   (deferred-tru "The name used for this instance of {0}."
                 (application-name-for-setting-descriptions))
   :default    "Metabase"
+  :audit      :getter
   :visibility :settings-manager)
 
 (defsetting custom-homepage
   (deferred-tru "Pick a dashboard to serve as the homepage. If people lack permissions to view the selected dashboard, Metabase will redirect them to the default homepage.")
   :default    false
   :type       :boolean
+  :audit      :getter
   :visibility :public)
 
 (defsetting custom-homepage-dashboard
@@ -123,6 +130,7 @@
   [_]
   `String)
 
+;; TODO test
 (defsetting site-uuid
   ;; Don't i18n this docstring because it's not user-facing! :)
   "Unique identifier used for this instance of {0}. This is set once and only once the first time it is fetched via
@@ -180,18 +188,19 @@
    (str "This URL is used for things like creating links in emails, auth redirects, and in some embedding scenarios, "
         "so changing it could break functionality or get you locked out of this instance."))
   :visibility :public
-  :getter (fn []
-            (try
-              (some-> (setting/get-value-of-type :string :site-url) normalize-site-url)
-              (catch clojure.lang.ExceptionInfo e
-                (log/error e (trs "site-url is invalid; returning nil for now. Will be reset on next request.")))))
-  :setter (fn [new-value]
-            (let [new-value (some-> new-value normalize-site-url)
-                  https?    (some-> new-value (str/starts-with?  "https:"))]
-              ;; if the site URL isn't HTTPS then disable force HTTPS redirects if set
-              (when-not https?
-                (redirect-all-requests-to-https! false))
-              (setting/set-value-of-type! :string :site-url new-value))))
+  :audit      :getter
+  :getter     (fn []
+                (try
+                  (some-> (setting/get-value-of-type :string :site-url) normalize-site-url)
+                  (catch clojure.lang.ExceptionInfo e
+                    (log/error e (trs "site-url is invalid; returning nil for now. Will be reset on next request.")))))
+  :setter     (fn [new-value]
+                (let [new-value (some-> new-value normalize-site-url)
+                      https?    (some-> new-value (str/starts-with?  "https:"))]
+                  ;; if the site URL isn't HTTPS then disable force HTTPS redirects if set
+                  (when-not https?
+                    (redirect-all-requests-to-https! false))
+                  (setting/set-value-of-type! :string :site-url new-value))))
 
 (defsetting site-locale
   (deferred-tru
@@ -200,6 +209,7 @@
     (application-name-for-setting-descriptions))
   :default    "en"
   :visibility :public
+  :audit      :getter
   :getter     (fn []
                 (let [value (setting/get-value-of-type :string :site-locale)]
                   (when (i18n/available-locale? value)
@@ -212,14 +222,16 @@
 
 (defsetting admin-email
   (deferred-tru "The email address users should be referred to if they encounter a problem.")
-  :visibility :authenticated)
+  :visibility :authenticated
+  :audit      :getter)
 
 (defsetting anon-tracking-enabled
   (deferred-tru "Enable the collection of anonymous usage data in order to help {0} improve."
                 (application-name-for-setting-descriptions))
   :type       :boolean
   :default    true
-  :visibility :public)
+  :visibility :public
+  :audit      :getter)
 
 (defsetting ga-code
   (deferred-tru "Google Analytics tracking code.")
@@ -233,60 +245,70 @@
   :setter     :none
   :getter     (fn [] (and config/is-prod? (anon-tracking-enabled)))
   :visibility :public
+  :audit      :never
   :doc        false)
 
 (defsetting map-tile-server-url
   (deferred-tru "The map tile server URL template used in map visualizations, for example from OpenStreetMaps or MapBox.")
   :default    "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-  :visibility :public)
+  :visibility :public
+  :audit      :getter)
 
 (defsetting landing-page
   (deferred-tru "Default page to show people when they log in.")
   :visibility :public
   :type       :string
-  :default    "")
+  :default    ""
+  :audit      :getter)
 
 (defsetting enable-public-sharing
   (deferred-tru "Enable admins to create publicly viewable links (and embeddable iframes) for Questions and Dashboards?")
   :type       :boolean
   :default    false
-  :visibility :authenticated)
+  :visibility :authenticated
+  :audit      :getter)
 
 (defsetting enable-embedding
   (deferred-tru "Allow admins to securely embed questions and dashboards within other applications?")
   :type       :boolean
   :default    false
-  :visibility :authenticated)
+  :visibility :authenticated
+  :audit      :getter)
 
 (defsetting embedding-app-origin
   (deferred-tru "Allow this origin to embed the full {0} application"
                 (application-name-for-setting-descriptions))
   :feature    :embedding
-  :visibility :public)
+  :visibility :public
+  :audit      :getter)
 
 (defsetting enable-nested-queries
   (deferred-tru "Allow using a saved question or Model as the source for other queries?")
   :type       :boolean
   :default    true
-  :visibility :authenticated)
+  :visibility :authenticated
+  :audit      :getter)
 
 (defsetting enable-query-caching
   (deferred-tru "Enabling caching will save the results of queries that take a long time to run.")
   :type       :boolean
   :default    false
-  :visibility :authenticated)
+  :visibility :authenticated
+  :audit      :getter)
 
 (defsetting persisted-models-enabled
   (deferred-tru "Allow persisting models into the source database.")
   :type       :boolean
   :default    false
-  :visibility :public)
+  :visibility :public
+  :audit      :getter)
 
 (defsetting persisted-model-refresh-cron-schedule
   (deferred-tru "cron syntax string to schedule refreshing persisted models.")
   :type       :string
   :default    "0 0 0/6 * * ? *"
-  :visibility :admin)
+  :visibility :admin
+  :audit      :getter)
 
 (def ^:private ^:const global-max-caching-kb
   "Although depending on the database, we can support much larger cached values (1GB for PG, 2GB for H2 and 4GB for
@@ -302,6 +324,7 @@
   ;; results, and doesn't consider whether the results are compressed, as the `:db` backend does.)
   :type    :integer
   :default 1000
+  :audit   :getter
   :setter  (fn [new-value]
              (when (and new-value
                         (> (cond-> new-value
@@ -318,14 +341,16 @@
 (defsetting query-caching-max-ttl
   (deferred-tru "The absolute maximum time to keep any cached query results, in seconds.")
   :type    :double
-  :default (* 60.0 60.0 24.0 100.0)) ; 100 days
+  :default (* 60.0 60.0 24.0 100.0) ; 100 days
+  :audit   :getter)
 
 ;; TODO -- this isn't really a TTL at all. Consider renaming to something like `-min-duration`
 (defsetting query-caching-min-ttl
   (deferred-tru "{0} will cache all saved questions with an average query execution time longer than this many seconds:"
                  (application-name-for-setting-descriptions))
   :type    :double
-  :default 60.0)
+  :default 60.0
+  :audit   :getter)
 
 (defsetting query-caching-ttl-ratio
   (deferred-tru
@@ -333,25 +358,29 @@
         "execution time and multiply that by whatever you input here. So if a query takes on average 2 minutes to run, "
         "and you input 10 for your multiplier, its cache entry will persist for 20 minutes."))
   :type    :integer
-  :default 10)
+  :default 10
+  :audit   :getter)
 
 (defsetting notification-link-base-url
   (deferred-tru "By default \"Site Url\" is used in notification links, but can be overridden.")
   :visibility :internal
   :type       :string
-  :enabled?   premium-features/hide-embed-branding?)
+  :enabled?   premium-features/hide-embed-branding?
+  :audit      :getter)
 
 (defsetting deprecation-notice-version
   (deferred-tru "Metabase version for which a notice about usage of deprecated features has been shown.")
   :visibility :admin
-  :doc        false)
+  :doc        false
+  :audit      :never)
 
 (defsetting loading-message
   (deferred-tru "Message to show while a query is running.")
   :visibility :public
   :enabled?   premium-features/enable-whitelabeling?
   :type       :keyword
-  :default    :doing-science)
+  :default    :doing-science
+  :audit      :getter)
 
 (defsetting application-colors
   (deferred-tru
@@ -361,7 +390,8 @@
   :visibility :public
   :type       :json
   :enabled?   premium-features/enable-whitelabeling?
-  :default    {})
+  :default    {}
+  :audit      :getter)
 
 (defsetting application-font
   (deferred-tru "This will replace “Lato” as the font family.")
@@ -369,16 +399,18 @@
   :type       :string
   :default    "Lato"
   :enabled?   premium-features/enable-whitelabeling?
-  :setter (fn [new-value]
-              (when new-value
-                (when-not (u.fonts/available-font? new-value)
-                  (throw (ex-info (tru "Invalid font {0}" (pr-str new-value)) {:status-code 400}))))
-              (setting/set-value-of-type! :string :application-font new-value)))
+  :audit      :getter
+  :setter     (fn [new-value]
+                  (when new-value
+                    (when-not (u.fonts/available-font? new-value)
+                      (throw (ex-info (tru "Invalid font {0}" (pr-str new-value)) {:status-code 400}))))
+                  (setting/set-value-of-type! :string :application-font new-value)))
 
 (defsetting application-font-files
   (deferred-tru "Tell us where to find the file for each font weight. You don’t need to include all of them, but it’ll look better if you do.")
   :visibility :public
   :type       :json
+  :audit      :getter
   :enabled?   premium-features/enable-whitelabeling?)
 
 (defn application-color
@@ -395,6 +427,7 @@
   (deferred-tru "For best results, use an SVG file with a transparent background.")
   :visibility :public
   :type       :string
+  :audit      :getter
   :enabled?   premium-features/enable-whitelabeling?
   :default    "app/assets/img/logo.svg")
 
@@ -402,6 +435,7 @@
   (deferred-tru "The url or image that you want to use as the favicon.")
   :visibility :public
   :type       :string
+  :audit      :getter
   :enabled?   premium-features/enable-whitelabeling?
   :default    "app/assets/img/favicon.ico")
 
@@ -409,6 +443,7 @@
   (deferred-tru "Enables Metabot character on the home page")
   :visibility :public
   :type       :boolean
+  :audit      :getter
   :enabled?   premium-features/enable-whitelabeling?
   :default    true)
 
@@ -416,6 +451,7 @@
   (deferred-tru "Display the lighthouse illustration on the home and login pages.")
   :visibility :public
   :type       :boolean
+  :audit      :getter
   :enabled?   premium-features/enable-whitelabeling?
   :default    true)
 
@@ -425,6 +461,7 @@
   :type       :boolean
   :default    true
   :feature    :disable-password-login
+  :audit      :raw-value
   :getter     (fn []
                 ;; if `:enable-password-login` has an *explict* (non-default) value, and SSO is configured, use that;
                 ;; otherwise this always returns true.
@@ -438,27 +475,31 @@
   (deferred-tru
     (str "When using the default binning strategy and a number of bins is not provided, "
          "this number will be used as the default."))
-  :type :integer
-  :default 8)
+  :type    :integer
+  :default 8
+  :audit   :getter)
 
 (defsetting breakout-bin-width
   (deferred-tru
    (str "When using the default binning strategy for a field of type Coordinate (such as Latitude and Longitude), "
         "this number will be used as the default bin width (in degrees)."))
-  :type :double
-  :default 10.0)
+  :type    :double
+  :default 10.0
+  :audit   :getter)
 
 (defsetting custom-formatting
   (deferred-tru "Object keyed by type, containing formatting settings")
   :type       :json
   :default    {}
-  :visibility :public)
+  :visibility :public
+  :audit      :getter)
 
 (defsetting enable-xrays
   (deferred-tru "Allow users to explore data using X-rays")
   :type       :boolean
   :default    true
-  :visibility :authenticated)
+  :visibility :authenticated
+  :audit      :getter)
 
 (defsetting show-homepage-data
   (deferred-tru
@@ -466,7 +507,8 @@
         "Admins might turn this off in order to direct users to better content than raw data"))
   :type       :boolean
   :default    true
-  :visibility :authenticated)
+  :visibility :authenticated
+  :audit      :getter)
 
 (defsetting show-homepage-xrays
   (deferred-tru
@@ -474,7 +516,8 @@
          "pinned. Admins might hide this to direct users to better content than raw data"))
   :type       :boolean
   :default    true
-  :visibility :authenticated)
+  :visibility :authenticated
+  :audit      :getter)
 
 (defsetting show-homepage-pin-message
   (deferred-tru
@@ -483,11 +526,13 @@
   :type       :boolean
   :default    true
   :visibility :authenticated
-  :doc        false)
+  :doc        false
+  :audit      :getter)
 
 (defsetting source-address-header
   (deferred-tru "Identify the source of HTTP requests by this header's value, instead of its remote address.")
   :default "X-Forwarded-For"
+  :audit   :getter
   :getter  (fn [] (some-> (setting/get-value-of-type :string :source-address-header)
                           u/lower-case-en)))
 
@@ -538,7 +583,8 @@
   (deferred-tru "When set, enforces the use of session cookies for all users which expire when the browser is closed.")
   :type       :boolean
   :visibility :public
-  :default    nil)
+  :default    nil
+  :audit      :getter)
 
 (defsetting version
   "Metabase's version info"
@@ -578,6 +624,7 @@
   :visibility :public
   :type       :boolean
   :default    false
+  :audit      :getter
   :setter     (fn [new-value]
                 ;; if we're trying to enable this setting, make sure `site-url` is actually an HTTPS URL.
                 (when (if (string? new-value)
@@ -595,6 +642,7 @@
   :visibility :public
   :type       :keyword
   :default    :sunday
+  :audit      :raw-value
   :getter     (fn []
                 ;; if something invalid is somehow in the DB just fall back to Sunday
                 (when-let [value (setting/get-value-of-type :keyword :start-of-week)]
@@ -641,6 +689,7 @@
          "Defaults to false if any non-default database has already finished syncing for this instance."))
   :visibility :admin
   :type       :boolean
+  :audit      :never
   :getter     (fn []
                 (let [v (setting/get-value-of-type :boolean :show-database-syncing-modal)]
                   (if (nil? v)
@@ -655,6 +704,7 @@
   (deferred-tru "Whether or not uploads are enabled")
   :visibility :authenticated
   :type       :boolean
+  :audit      :getter
   :default    false)
 
 (defn- not-handling-api-request?
@@ -673,14 +723,17 @@
   (deferred-tru "Database ID for uploads")
   :visibility :authenticated
   :type       :integer
+  :audit      :getter
   :setter     set-uploads-database-id!)
 
 (defsetting uploads-schema-name
   (deferred-tru "Schema name for uploads")
-  :visibility   :authenticated
-  :type         :string)
+  :visibility :authenticated
+  :type       :string
+  :audit      :getter)
 
 (defsetting uploads-table-prefix
   (deferred-tru "Prefix for upload table names")
-  :visibility   :authenticated
-  :type         :string)
+  :visibility :authenticated
+  :type       :string
+  :audit      :getter)

--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -73,6 +73,7 @@
   (deferred-tru "Cached number of active users. Refresh every 5 minutes.")
   :visibility :admin
   :type       :integer
+  :audit      :never
   :default    0
   :getter     (fn []
                 (if-not ((requiring-resolve 'metabase.db/db-is-set-up?))
@@ -187,6 +188,7 @@
   (deferred-tru "Cached token status for premium features. This is to avoid an API request on the the first page load.")
   :visibility :admin
   :type       :json
+  :audit      :never
   :setter     :none
   :getter     (fn [] (some-> (premium-embedding-token) (fetch-token-status))))
 
@@ -196,6 +198,7 @@
 
 (defsetting premium-embedding-token     ; TODO - rename this to premium-features-token?
   (deferred-tru "Token for premium features. Go to the MetaStore to get yours!")
+  :audit :never
   :setter
   (fn [new-value]
     ;; validate the new value if we're not unsetting it
@@ -277,6 +280,7 @@
   (let [options (merge {:type       :boolean
                         :visibility :public
                         :setter     :none
+                        :audit      :never
                         :getter     `(default-premium-feature-getter ~(some-> feature name))}
                        options)]
     `(do
@@ -383,6 +387,7 @@
   :type       :boolean
   :visibility :public
   :setter     :none
+  :audit      :never
   :getter     (fn [] (boolean ((token-features) "hosting")))
   :doc        false)
 

--- a/src/metabase/query_processor/middleware/constraints.clj
+++ b/src/metabase/query_processor/middleware/constraints.clj
@@ -14,7 +14,8 @@
   (deferred-tru "Maximum number of rows to return specifically on :rows type queries via the API.")
   :visibility     :authenticated
   :type           :integer
-  :database-local :allowed)
+  :database-local :allowed
+  :audit          :getter)
 
 (def ^:private max-results
   "General maximum number of rows to return from an API query."

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -12,7 +12,8 @@
                 (public-settings/application-name-for-setting-descriptions))
   :type       :boolean
   :default    true
-  :visibility :authenticated)
+  :visibility :authenticated
+  :audit      :getter)
 
 (def ^:dynamic *db-max-results*
   "Number of raw results to fetch from the database. This number is in place to prevent massive application DB load by

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -133,7 +133,8 @@
     (str "Base-64 encoded public key for this site''s SSL certificate. "
          "Specify this to enable HTTP Public Key Pinning. "
          "See {0} for more information.")
-    "http://mzl.la/1EnfqBf"))
+    "http://mzl.la/1EnfqBf")
+  :audit :getter)
 ;; TODO - it would be nice if we could make this a proper link in the UI; consider enabling markdown parsing
 
 (defn- first-embedding-app-origin

--- a/src/metabase/setup.clj
+++ b/src/metabase/setup.clj
@@ -13,7 +13,8 @@
   "A token used to signify that an instance has permissions to create the initial User. This is created upon the first
   launch of Metabase, by the first instance; once used, it is cleared out, never to be used again."
   :visibility :public
-  :setter     :none)
+  :setter     :none
+  :audit      :never)
 
 (defn token-match?
   "Function for checking if the supplied string matches our setup token.
@@ -63,4 +64,5 @@
                           (let [exists? (boolean (seq (t2/select :model/User {:where [:not= :id config/internal-mb-user-id]})))]
                             (swap! app-db-id->user-exists? assoc (mdb.connection/unique-identifier) exists?)
                             exists?))))))
-  :doc        false)
+  :doc        false
+  :audit      :never)

--- a/src/metabase/task/follow_up_emails.clj
+++ b/src/metabase/task/follow_up_emails.clj
@@ -26,7 +26,8 @@
   "Have we sent a follow up email to the instance admin?"
   :type       :boolean
   :default    false
-  :visibility :internal)
+  :visibility :internal
+  :audit      :never)
 
 (defn- send-follow-up-email!
   "Send an email to the instance admin following up on their experience with Metabase thus far."

--- a/src/metabase/util/embed.clj
+++ b/src/metabase/util/embed.clj
@@ -58,6 +58,7 @@
 (setting/defsetting embedding-secret-key
   (deferred-tru "Secret key used to sign JSON Web Tokens for requests to `/api/embed` endpoints.")
   :visibility :admin
+  :audit :no-value
   :setter (fn [new-value]
             (when (seq new-value)
               (assert (u/hexadecimal-string? new-value)

--- a/src/metabase/util/ssh.clj
+++ b/src/metabase/util/ssh.clj
@@ -30,7 +30,8 @@
   (deferred-tru "Controls how often the heartbeats are sent when an SSH tunnel is established (in seconds).")
   :visibility :public
   :type       :integer
-  :default    180)
+  :default    180
+  :audit      :getter)
 
 (set! *warn-on-reflection* true)
 


### PR DESCRIPTION
* Adds the `:audit` flag to most existing settings. Most of them use `:audit :getter` so that the full value is logged, as returned by their getter.
	* This is done even for settings that don't have a custom getter, mainly so that ints and booleans are logged as their respective types (i.e. the value returned by `get-value-of-type`) rather than the raw string in the database. I'm not in love with the naming here because it seems tied to custom getters...if anyone has a better suggestion I'd be happy to change it.
* Adds obfuscation for settings marked as `sensitive?` when we're writing them to the audit log. This was an oversight in the original PR so I've added it here.