### PR TITLE
render pie chart legend

### DIFF
--- a/frontend/src/metabase/static-viz/components/PieChart/PieChart.tsx
+++ b/frontend/src/metabase/static-viz/components/PieChart/PieChart.tsx
@@ -1,11 +1,18 @@
 import { init } from "echarts";
+import { Group } from "@visx/group";
+
 import type { IsomorphicStaticChartProps } from "metabase/static-viz/containers/IsomorphicStaticChart/types";
 import { sanitizeSvgForBatik } from "metabase/static-viz/lib/svg";
 
 import { getPieChartModel } from "metabase/visualizations/echarts/pie/model";
 import { getPieChartOption } from "metabase/visualizations/echarts/pie/option";
+
+import { getPieChartFormatters } from "metabase/visualizations/echarts/pie/format";
+import { calculateLegendRows } from "../Legend/utils";
+import { Legend } from "../Legend";
 import { computeStaticPieChartSettings } from "./setttings";
 
+const PADDING_TOP = 16; // TODO confirm with design
 const WIDTH = 540;
 const HEIGHT = 360;
 
@@ -23,11 +30,32 @@ export function PieChart({
     computedVizSettings,
     renderingContext,
   );
-  const option = getPieChartOption(
+  const formatters = getPieChartFormatters(
     chartModel,
     computedVizSettings,
     renderingContext,
   );
+  const option = getPieChartOption(
+    chartModel,
+    formatters,
+    computedVizSettings,
+    renderingContext,
+  );
+
+  const legendRows = calculateLegendRows(
+    chartModel.slices.map(s => ({
+      name: `${s.key} - ${formatters.formatPercent(s.normalizedPercentage)}`,
+      color: s.color,
+    })),
+    WIDTH,
+    24,
+    18,
+    400,
+  );
+  if (!legendRows) {
+    throw Error("Error calculating legend rows");
+  }
+  const { height: legendHeight, items } = legendRows;
 
   const chart = init(null, null, {
     renderer: "svg",
@@ -41,8 +69,14 @@ export function PieChart({
   const svg = sanitizeSvgForBatik(chart.renderToSVGString());
 
   return (
-    <svg width={WIDTH} height={HEIGHT}>
-      <g dangerouslySetInnerHTML={{ __html: svg }}></g>
+    <svg width={WIDTH} height={PADDING_TOP + HEIGHT + legendHeight}>
+      <Group top={PADDING_TOP}>
+        <Legend fontSize={18} fontWeight={400} items={items} />
+      </Group>
+      <Group
+        top={PADDING_TOP + legendHeight}
+        dangerouslySetInnerHTML={{ __html: svg }}
+      ></Group>
     </svg>
   );
 }

--- a/frontend/src/metabase/static-viz/components/PieChart/PieChart.tsx
+++ b/frontend/src/metabase/static-viz/components/PieChart/PieChart.tsx
@@ -3,14 +3,12 @@ import { Group } from "@visx/group";
 
 import type { IsomorphicStaticChartProps } from "metabase/static-viz/containers/IsomorphicStaticChart/types";
 import { sanitizeSvgForBatik } from "metabase/static-viz/lib/svg";
-
 import { getPieChartModel } from "metabase/visualizations/echarts/pie/model";
 import { getPieChartOption } from "metabase/visualizations/echarts/pie/option";
-
 import { getPieChartFormatters } from "metabase/visualizations/echarts/pie/format";
-import { calculateLegendRows } from "../Legend/utils";
-import { Legend } from "../Legend";
+
 import { computeStaticPieChartSettings } from "./setttings";
+import { getPieChartLegend } from "./legend";
 
 const PADDING_TOP = 16; // TODO confirm with design
 const WIDTH = 540;
@@ -41,21 +39,13 @@ export function PieChart({
     computedVizSettings,
     renderingContext,
   );
-
-  const legendRows = calculateLegendRows(
-    chartModel.slices.map(s => ({
-      name: `${s.key} - ${formatters.formatPercent(s.normalizedPercentage)}`,
-      color: s.color,
-    })),
+  const { legendHeight, Legend } = getPieChartLegend(
+    chartModel,
+    formatters,
+    computedVizSettings,
     WIDTH,
-    24,
-    18,
-    400,
+    PADDING_TOP,
   );
-  if (!legendRows) {
-    throw Error("Error calculating legend rows");
-  }
-  const { height: legendHeight, items } = legendRows;
 
   const chart = init(null, null, {
     renderer: "svg",
@@ -66,16 +56,14 @@ export function PieChart({
 
   chart.setOption(option);
 
-  const svg = sanitizeSvgForBatik(chart.renderToSVGString());
+  const chartSvg = sanitizeSvgForBatik(chart.renderToSVGString());
 
   return (
     <svg width={WIDTH} height={PADDING_TOP + HEIGHT + legendHeight}>
-      <Group top={PADDING_TOP}>
-        <Legend fontSize={18} fontWeight={400} items={items} />
-      </Group>
+      <Legend />
       <Group
         top={PADDING_TOP + legendHeight}
-        dangerouslySetInnerHTML={{ __html: svg }}
+        dangerouslySetInnerHTML={{ __html: chartSvg }}
       ></Group>
     </svg>
   );

--- a/frontend/src/metabase/static-viz/components/PieChart/legend.tsx
+++ b/frontend/src/metabase/static-viz/components/PieChart/legend.tsx
@@ -1,0 +1,44 @@
+import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
+import type { PieChartFormatters } from "metabase/visualizations/echarts/pie/format";
+import type { PieChartModel } from "metabase/visualizations/echarts/pie/model/types";
+
+import { calculateLegendRows } from "../Legend/utils";
+import { Legend } from "../Legend";
+
+export function getPieChartLegend(
+  chartModel: PieChartModel,
+  formatters: PieChartFormatters,
+  settings: ComputedVisualizationSettings,
+  width: number,
+  top: number,
+) {
+  if (!settings["pie.show_legend"]) {
+    return { legendHeight: 0, Legend: () => null };
+  }
+
+  const legendRows = calculateLegendRows(
+    chartModel.slices.map(s => ({
+      name:
+        settings["pie.percent_visibility"] === "legend"
+          ? `${s.key} - ${formatters.formatPercent(s.normalizedPercentage)}`
+          : s.key,
+      color: s.color,
+    })),
+    width,
+    24,
+    18,
+    400,
+  );
+  if (!legendRows) {
+    throw Error("Error calculating legend rows");
+  }
+
+  const { height: legendHeight, items } = legendRows;
+
+  return {
+    legendHeight,
+    Legend: () => (
+      <Legend items={items} top={top} fontSize={18} fontWeight={400} />
+    ),
+  };
+}

--- a/frontend/src/metabase/static-viz/components/PieChart/legend.tsx
+++ b/frontend/src/metabase/static-viz/components/PieChart/legend.tsx
@@ -12,7 +12,7 @@ export function getPieChartLegend(
   width: number,
   top: number,
 ) {
-  if (!settings["pie.show_legend"]) {
+  if (!settings["pie.show_legend"] || chartModel.slices.length <= 1) {
     return { legendHeight: 0, Legend: () => null };
   }
 

--- a/frontend/src/metabase/visualizations/echarts/pie/format.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/format.ts
@@ -1,0 +1,47 @@
+import type {
+  ComputedVisualizationSettings,
+  RenderingContext,
+} from "metabase/visualizations/types";
+import { computeMaxDecimalsForValues } from "metabase/visualizations/lib/utils";
+
+import type { PieChartModel } from "./model/types";
+
+export interface PieChartFormatters {
+  formatMetric: (value: unknown) => string;
+  formatPercent: (value: unknown) => string;
+}
+
+export function getPieChartFormatters(
+  chartModel: PieChartModel,
+  settings: ComputedVisualizationSettings,
+  renderingContext: RenderingContext,
+): PieChartFormatters {
+  const { column: getColumnSettings } = settings;
+  if (!getColumnSettings) {
+    throw Error(`"settings.column" is undefined`);
+  }
+  const metricColSettings = getColumnSettings(
+    chartModel.colDescs.metricDesc.column,
+  );
+
+  const formatMetric = (value: unknown) =>
+    renderingContext.formatValue(value, {
+      ...metricColSettings,
+    });
+
+  const formatPercent = (value: unknown) =>
+    renderingContext.formatValue(value, {
+      column: metricColSettings.column,
+      number_separators: metricColSettings.number_separators,
+      number_style: "percent",
+      decimals: computeMaxDecimalsForValues(
+        chartModel.slices.map(s => s.normalizedPercentage),
+        {
+          style: "percent",
+          maximumSignificantDigits: 2,
+        },
+      ),
+    });
+
+  return { formatMetric, formatPercent };
+}

--- a/frontend/src/metabase/visualizations/echarts/pie/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/option/index.ts
@@ -6,9 +6,9 @@ import type {
   Formatter,
   RenderingContext,
 } from "metabase/visualizations/types";
-import { computeMaxDecimalsForValues } from "metabase/visualizations/lib/utils";
 
 import type { PieChartModel, PieSlice } from "../model/types";
+import type { PieChartFormatters } from "../format";
 import { SUNBURST_SERIES_OPTION, TOTAL_GRAPHIC_OPTION } from "./constants";
 
 function getSliceByKey(key: string, slices: PieSlice[]) {
@@ -46,42 +46,20 @@ function getTotalGraphicOption(
 
 export function getPieChartOption(
   chartModel: PieChartModel,
+  formatters: PieChartFormatters,
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
 ): EChartsOption {
-  const { column: getColumnSettings } = settings;
-  if (!getColumnSettings) {
-    throw Error(`"settings.column" is undefined`);
-  }
-  const metricColSettings = getColumnSettings(
-    chartModel.colDescs.metricDesc.column,
-  );
-
   // "Show total" setting
-  const formatMetric = (value: unknown) =>
-    renderingContext.formatValue(value, {
-      ...metricColSettings,
-    });
-
   const graphicOption = settings["pie.show_total"]
-    ? getTotalGraphicOption(chartModel.total, formatMetric, renderingContext)
+    ? getTotalGraphicOption(
+        chartModel.total,
+        formatters.formatMetric,
+        renderingContext,
+      )
     : undefined;
 
   // "Show percentages: On the chart" setting
-  const formatPercent = (value: unknown) =>
-    renderingContext.formatValue(value, {
-      column: metricColSettings.column,
-      number_separators: metricColSettings.number_separators,
-      number_style: "percent",
-      decimals: computeMaxDecimalsForValues(
-        chartModel.slices.map(s => s.normalizedPercentage),
-        {
-          style: "percent",
-          maximumSignificantDigits: 2,
-        },
-      ),
-    });
-
   const seriesOption = cloneDeep(SUNBURST_SERIES_OPTION); // deep clone to avoid sharing label.formatter will other instances
   if (!seriesOption.label) {
     throw Error(`"seriesOption.label" is undefined`);
@@ -91,7 +69,7 @@ export function getPieChartOption(
       return " ";
     }
 
-    return formatPercent(
+    return formatters.formatPercent(
       getSliceByKey(name, chartModel.slices).normalizedPercentage,
     );
   };

--- a/frontend/src/metabase/visualizations/visualizations/PieChart2/PieChart2.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart2/PieChart2.tsx
@@ -9,6 +9,7 @@ import { formatValue } from "metabase/lib/formatting/value";
 import { color } from "metabase/lib/colors";
 import type { OptionsType } from "metabase/lib/formatting/types";
 import { getPieChartOption } from "metabase/visualizations/echarts/pie/option";
+import { getPieChartFormatters } from "metabase/visualizations/echarts/pie/format";
 import PieChart from "../PieChart/PieChart";
 
 Object.assign(PieChart2, {
@@ -34,8 +35,14 @@ export function PieChart2(props: VisualizationProps) {
     props.settings,
     renderingContext,
   );
+  const formatters = getPieChartFormatters(
+    chartModel,
+    props.settings,
+    renderingContext,
+  );
   const option = getPieChartOption(
     chartModel,
+    formatters,
     props.settings,
     renderingContext,
   );


### PR DESCRIPTION
Part of https://github.com/metabase/metabase/issues/33281

Closes https://github.com/metabase/metabase/issues/35790

### Description

Renders the legend with the show percent setting as well.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a question
2. Set visualization type to `Pie 2`
3. Set "show percentages" setting to "in legend"
4. Add to a dashboard
5. Send in an email subscription
6. Confirm legend appears in chart, with percentages

### Demo

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/abeeadb4-3aa8-453e-802f-970bfe79147b.png)

Without percentages

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/0beb2575-5cf0-4f33-98d6-55b610279c87.png)

With percentages

### Checklist

- [] Tests have been added/updated to cover changes in this PR

_Will be covered later in percy tests._