### PR TITLE
Add sql-formatter-dialect multimethod

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -9,12 +9,12 @@ title: Driver interface changelog
 - The MBQL schema in `metabase.mbql.schema` now uses [Malli](https://github.com/metosin/malli) instead of
   [Schema](https://github.com/plumatic/schema). If you were using this namespace in combination with Schema, you'll
   want to update your code to use Malli instead.
-  
+
 - Another driver feature has been added: `:table-privileges`. This feature signals whether we can store
   the table-level privileges for the database on database sync.
-  
-- The multimethod `metabase.driver/current-user-table-privileges` has been added. This method is used to get 
-  the set of privileges the database connection's current user has. It needs to be implemented if the database 
+
+- The multimethod `metabase.driver/current-user-table-privileges` has been added. This method is used to get
+  the set of privileges the database connection's current user has. It needs to be implemented if the database
   supports the `:table-privileges` feature.
 
 - The following functions in `metabase.query-processor.store` (`qp.store`) are now deprecated
@@ -69,6 +69,10 @@ title: Driver interface changelog
   `metabase.driver/db-default-timezone` implementations for JDBC-based drivers, has been deprecated, and will be
   removed in 0.51.0 or later. You can easily implement `metabase.driver/db-default-timezone` directly, and use
   `metabase.driver.sql-jdbc.execute/do-with-connection-with-options` to get a `java.sql.Connection` for a Database.
+
+- Added a new multimethod `metabase.db.query/sql-formatter-dialect`, which allows to switch
+  the SQL dialect used for pretty printing SQL queries. By default, it uses `:standardsql`.
+  See `metabase.db.query/sql-dialects` for available values.
 
 ## Metabase 0.47.0
 

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -5,6 +5,7 @@
    [clojure.string :as str]
    [medley.core :as m]
    [metabase.db.metadata-queries :as metadata-queries]
+   [metabase.db.query :as mdb.query]
    [metabase.driver :as driver]
    [metabase.driver.bigquery-cloud-sdk.common :as bigquery.common]
    [metabase.driver.bigquery-cloud-sdk.params :as bigquery.params]
@@ -445,3 +446,5 @@
     (when-not (str/blank? dataset-id)
       (convert-dataset-id-to-filters! database dataset-id))
     database))
+
+(defmethod mdb.query/sql-formatter-dialect :bigquery-cloud-sdk [_] :mysql)

--- a/modules/drivers/oracle/src/metabase/driver/oracle.clj
+++ b/modules/drivers/oracle/src/metabase/driver/oracle.clj
@@ -5,6 +5,7 @@
    [honey.sql :as sql]
    [java-time.api :as t]
    [metabase.config :as config]
+   [metabase.db.query :as mdb.query]
    [metabase.driver :as driver]
    [metabase.driver.common :as driver.common]
    [metabase.driver.impl :as driver.impl]
@@ -637,3 +638,5 @@
 (defmethod driver.sql/->prepared-substitution [:oracle Boolean]
   [driver bool]
   (driver.sql/->prepared-substitution driver (if bool 1 0)))
+
+(defmethod mdb.query/sql-formatter-dialect :oracle [_] :plsql)

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -4,6 +4,7 @@
    [cheshire.core :as json]
    [clojure.java.jdbc :as jdbc]
    [java-time.api :as t]
+   [metabase.db.query :as mdb.query]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.common :as sql-jdbc.common]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
@@ -367,3 +368,5 @@
 (defmethod sql-jdbc.execute/set-parameter [:redshift java.time.ZonedDateTime]
   [driver ps i t]
   (sql-jdbc.execute/set-parameter driver ps i (t/sql-timestamp (t/with-zone-same-instant t (t/zone-id "UTC")))))
+
+(defmethod mdb.query/sql-formatter-dialect :redshift [_] :redshift)

--- a/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
@@ -6,6 +6,7 @@
    [honey.sql.helpers :as sql.helpers]
    [medley.core :as m]
    [metabase.connection-pool :as connection-pool]
+   [metabase.db.query :as mdb.query]
    [metabase.driver :as driver]
    [metabase.driver.hive-like :as hive-like]
    [metabase.driver.hive-like.fixed-hive-connection
@@ -222,3 +223,5 @@
 (defmethod sql.qp/quote-style :sparksql
   [_driver]
   :mysql)
+
+(defmethod mdb.query/sql-formatter-dialect :sparksql [_] :sparksql)

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -7,6 +7,7 @@
    [honeysql.helpers :as hh]
    [java-time.api :as t]
    [metabase.config :as config]
+   [metabase.db.query :as mdb.query]
    [metabase.driver :as driver]
    [metabase.driver.sql :as driver.sql]
    [metabase.driver.sql-jdbc.common :as sql-jdbc.common]
@@ -657,3 +658,5 @@
     (-> (update database :details #(dissoc % :rowcount-override))
         (update :settings #(assoc % :max-results-bare-rows rowcount-override)))
     database))
+
+(defmethod mdb.query/sql-formatter-dialect :sqlserver [_] :tsql)

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -10,6 +10,7 @@
    [java-time.api :as t]
    [medley.core :as m]
    [metabase.config :as config]
+   [metabase.db.query :as mdb.query]
    [metabase.db.spec :as mdb.spec]
    [metabase.driver :as driver]
    [metabase.driver.common :as driver.common]
@@ -505,6 +506,7 @@
   #{"INFORMATION_SCHEMA"})
 
 (defmethod sql.qp/quote-style :mysql [_] :mysql)
+(defmethod mdb.query/sql-formatter-dialect :mysql [_] :mysql)
 
 ;; If this fails you need to load the timezone definitions from your system into MySQL; run the command
 ;;

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -8,6 +8,7 @@
    [clojure.walk :as walk]
    [honey.sql :as sql]
    [java-time.api :as t]
+   [metabase.db.query :as mdb.query]
    [metabase.db.spec :as mdb.spec]
    [metabase.driver :as driver]
    [metabase.driver.common :as driver.common]
@@ -78,12 +79,6 @@
     [driver _feat _db]
     ;; only supported for Postgres for right now. Not supported for child drivers like Redshift or whatever.
     (= driver :postgres)))
-
-;;; +----------------------------------------------------------------------------------------------------------------+
-;;; |                                             metabase.driver impls                                              |
-;;; +----------------------------------------------------------------------------------------------------------------+
-
-(defmethod driver/display-name :postgres [_] "PostgreSQL")
 
 (defmethod driver/humanize-connection-error-message :postgres
   [_ message]
@@ -846,6 +841,8 @@
        "select t.*"
        "from table_privileges t"
        "where t.select or t.update or t.insert or t.delete"]))))
+
+(defmethod mdb.query/sql-formatter-dialect :postgres [_] :postgresql)
 
 ;;; ------------------------------------------------- User Impersonation --------------------------------------------------
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/34235
See https://github.com/ClickHouse/metabase-clickhouse-driver/issues/195

### Description

As of 0.47.x, all custom drivers defaulted to `Dialect/StandardSql` as the branching in the SQL format implementation was for the core drivers only. This PR adds a multimethod to override the chosen dialect for third-party drivers.

NB: this bit for some reason was repeated twice in `postgres.clj`, so it was removed.

```clojure
;;; +----------------------------------------------------------------------------------------------------------------+
;;; |                                             metabase.driver impls                                              |
;;; +----------------------------------------------------------------------------------------------------------------+

(defmethod driver/display-name :postgres [_] "PostgreSQL")
```


### How to verify

Shouldn't require additional verification as there is a default implementation + driver overrides that should behave the same as before.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - should rely on the existing tests.
