### PR TITLE
[E2E] Set the `TERM` env at the job level

### DIFF
--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -28,6 +28,7 @@ jobs:
       CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.E2E_STARTER_TOKEN }}
       MB_SNOWPLOW_AVAILABLE: true
       MB_SNOWPLOW_URL: "http://localhost:9090" # Snowplow micro
+      TERM: xterm
       TZ: US/Pacific # to make node match the instance tz
     steps:
       - uses: actions/checkout@v3
@@ -72,6 +73,7 @@ jobs:
         run: |
           jar xf target/uberjar/metabase.jar version.properties
           mv version.properties resources/
+
       - name: Stress-test ${{ github.event.inputs.spec }} ${{ github.event.inputs.burn_in }} times
         run: |
           yarn run test-cypress-run \
@@ -79,8 +81,7 @@ jobs:
           --env burn=${{ github.event.inputs.burn_in }} \
           --config-file e2e/support/cypress-stress-test.config.js
           --browser ${{ steps.cypress-prep.outputs.chrome-path }}
-        env:
-          TERM: xterm
+
       - name: Upload Cypress Artifacts upon failure
         uses: actions/upload-artifact@v3
         if: failure()

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -182,6 +182,7 @@ jobs:
       MB_SNOWPLOW_AVAILABLE: true
       MB_SNOWPLOW_URL: "http://localhost:9090" # Snowplow micro
       ELECTRON_EXTRA_LAUNCH_ARGS: "--remote-debugging-port=40500" # deploysentinel
+      TERM: xterm
       TZ: US/Pacific # to make node match the instance tz
     strategy:
       fail-fast: false
@@ -256,8 +257,6 @@ jobs:
           --env grepTags=@OSS,grepOmitFiltered=true \
           --spec './e2e/test/scenarios/**/*.cy.spec.js' \
           --browser ${{ steps.cypress-prep.outputs.chrome-path }}
-        env:
-          TERM: xterm
 
       - name: Run slow and resource-intensive Cypress tests
         if: matrix.name == 'slow' && github.event_name != 'schedule'
@@ -266,8 +265,6 @@ jobs:
           --env grepTags="@slow",grepOmitFiltered=true \
           --spec './e2e/test/scenarios/**/*.cy.spec.js' \
           --browser ${{ steps.cypress-prep.outputs.chrome-path }}
-        env:
-          TERM: xterm
 
       - name: Run EE Cypress tests on ${{ matrix.name }}
         if: matrix.context == 'folder' && github.event_name != 'schedule'
@@ -276,8 +273,6 @@ jobs:
           --env grepTags="-@slow+-@mongo --@quarantine",grepOmitFiltered=true \
           --folder ${{ matrix.name }} \
           --browser ${{ steps.cypress-prep.outputs.chrome-path }}
-        env:
-          TERM: xterm
 
       - name: Run E2E tests that depend on Mongo
         if: matrix.name == 'mongo'
@@ -301,8 +296,6 @@ jobs:
           --env grepTags=@OSS,grepOmitFiltered=true \
           --spec './e2e/test/scenarios/**/*.cy.spec.js' \
           --browser "replay-chromium"
-        env:
-          TERM: xterm
           CYPRESS_REPLAYIO_ENABLED: 1
           RECORD_REPLAY_METADATA_FILE: /tmp/replay-metadata.json
           RECORD_REPLAY_METADATA_TEST_RUN_ID: ${{ needs.test-run-id.outputs.testRunId }}
@@ -314,8 +307,6 @@ jobs:
           --env grepTags="-@slow+-@mongo --@quarantine,grepOmitFiltered=true" \
           --folder ${{ matrix.name }} \
           --browser "replay-chromium"
-        env:
-          TERM: xterm
           CYPRESS_REPLAYIO_ENABLED: 1
           RECORD_REPLAY_METADATA_FILE: /tmp/replay-metadata.json
           RECORD_REPLAY_METADATA_TEST_RUN_ID: ${{ needs.test-run-id.outputs.testRunId }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -120,6 +120,7 @@ jobs:
       CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.E2E_STARTER_TOKEN }}
       MB_SNOWPLOW_AVAILABLE: true
       MB_SNOWPLOW_URL: "http://localhost:9090" # Snowplow micro
+      TERM: xterm
     services:
       maildev:
         image: maildev/maildev:2.0.5
@@ -157,8 +158,7 @@ jobs:
       run: |
         mkdir -p ./target/uberjar && cp metabase.jar ./target/uberjar/metabase.jar
         yarn test-cypress-run --folder onboarding
-      env:
-        TERM: xterm
+
     - name: Upload Cypress Artifacts upon failure
       uses: actions/upload-artifact@v3
       if: failure()


### PR DESCRIPTION
No need to repeat the same line for every single **step** when all steps can read from the **job** context.