### PR TITLE
Refine CI triggers for `backend` and `drivers` tests

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -42,6 +42,13 @@ frontend_all: &frontend_all
   - *frontend_sources
   - *frontend_specs
 
+backend_ci: &backend_ci
+  - ".github/actions/prepare-frontend/**"
+  - ".github/actions/prepare-backend/**"
+  - ".github/actions/test-driver/**"
+  - ".github/workflows/backend.yml"
+  - ".github/workflows/drivers.yml"
+
 backend_presto_kerberos:
   - "**/presto_jdbc/**"
   - "**/presto_jdbc.clj"
@@ -66,7 +73,7 @@ backend_specs: &backend_specs
 
 backend_all: &backend_all
   - *default
-  - *ci
+  - *backend_ci
   - *backend_sources
   - *backend_specs
 


### PR DESCRIPTION
This PR defines a set of specific workflows and/or actions that, when altered, should trigger backend and drivers tests in CI. It is a part of #34880

### How to test?
- Grep https://github.com/metabase/metabase/blob/master/.github/workflows/backend.yml and https://github.com/metabase/metabase/blob/master/.github/workflows/drivers.yml for mention of `./.github`. It should give you the sense of the files that these workflows depend on.
- Using this branch as the base, change any of the listed files and make sure that the both backend and drivers workflows are running
- Change any of the backend source or test files and make sure that the both workflows are running as before
- Change any of the unrelated (not listed here) workflows or actions and make sure that the both workflows are NOT running

## Tests

```[tasklist]
### Positive cases (changing the following files **should** trigger `drivers` and `backend` workflows)
- [x] `.github/actions/prepare-frontend/action.yml` (#34977)
- [x] `.github/actions/prepare-backend/action.yml` (#34978)
- [x] `.github/actions/test-driver/action.yml` (#34979)
- [x] `.github/workflows/drivers.yml` (#34980)
- [x] `.github/workflows/backend.yml` (#34981)
```

```[tasklist]
### Negative cases (changing the following files **should not** trigger the FE workflow)
- [x] `.github/workflows/e2e-tests.yml` (#34982)
```
