### PR TITLE
Refine CI triggers for E2E workflow

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -82,6 +82,15 @@ sources: &sources
   - *frontend_sources
   - *backend_sources
 
+e2e_ci: &e2e_ci
+  - ".github/actions/build-e2e-matrix"
+  - ".github/actions/prepare-frontend/**"
+  - ".github/actions/prepare-backend/**"
+  - ".github/actions/prepare-uberjar-artifact"
+  - ".github/actions/e2e-prepare-containers"
+  - ".github/actions/prepare-cypress"
+  - ".github/actions/run-snowplow-micro"
+
 e2e_specs: &e2e_specs
   - "**/*.cy.*.js"
   - "e2e/runner/**"
@@ -90,7 +99,7 @@ e2e_specs: &e2e_specs
 
 e2e_all:
   - *default
-  - *ci
+  - *e2e_ci
   - *sources
   - *e2e_specs
 


### PR DESCRIPTION
A part of https://github.com/metabase/metabase/issues/34880.

This PR only refines the CI part of E2E workflow triggers.
Before this, E2E tests were running on any change within the `.github/` folder, and now they run only on related changes.

But what are related changes?
Grep [`e2e-tests.yml`](https://github.com/metabase/metabase/blob/master/.github/workflows/e2e-tests.yml) for `./.github/` and you'll have the answer there. All these references mean that e2e workflow depend on those files. Therefore, they need to be included in `e2e_ci` triggers. You can see  them [here](https://github.com/metabase/metabase/pull/34892/files#diff-e1efa15d3b81fb0728ad28251d13e6e0791213aac383839fa74881fa18ed60aeR85-R92).
