### PR TITLE
fix nested a to avoid warning

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionButtons/ChartSettingsButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionButtons/ChartSettingsButton.tsx
@@ -32,6 +32,7 @@ function ChartSettingsButton({
       tall
       triggerElement={
         <DashCardActionButton
+          as="span"
           tooltip={t`Visualization options`}
           aria-label={t`Show visualization options`}
         >

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionButtons/ChartSettingsButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionButtons/ChartSettingsButton.tsx
@@ -33,6 +33,7 @@ function ChartSettingsButton({
       triggerElement={
         <DashCardActionButton
           as="span"
+          role="button"
           tooltip={t`Visualization options`}
           aria-label={t`Show visualization options`}
         >

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionButtons/DashCardActionButton/DashCardActionButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionButtons/DashCardActionButton/DashCardActionButton.tsx
@@ -11,6 +11,7 @@ import {
 interface Props extends React.HTMLAttributes<HTMLAnchorElement> {
   tooltip: string;
   analyticsEvent?: string;
+  as?: React.ElementType;
 }
 
 function DashActionButton({


### PR DESCRIPTION
### Description

This removes this warning we get in the console
<img width="838" alt="image" src="https://github.com/metabase/metabase/assets/1914270/21ed1476-08a1-4601-942b-ae83897fb636">

I think this only shows up in dev mode but it's still some noise in the terminal

### How to verify

1. Open a dashboard with at least a card that has the chart settings button
2. Go in edit mode
3. After this PR the error should not be there

