### PR TITLE
Fix dayjs i18n init

### DIFF
--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -11,9 +11,6 @@ import "number-to-locale-string";
 // Should be imported before any other metabase import
 import "ee-overrides"; // eslint-disable-line import/no-duplicates
 
-// day.js plugins should be enabled before setting the locale
-import "metabase/lib/dayjs";
-
 // If enabled this monkeypatches `t` and `jt` to return blacked out
 // strings/elements to assist in finding untranslated strings.
 import "metabase/lib/i18n-debug";

--- a/frontend/src/metabase/lib/dayjs.ts
+++ b/frontend/src/metabase/lib/dayjs.ts
@@ -1,6 +1,0 @@
-import dayjs from "dayjs";
-import localeDataPlugin from "dayjs/plugin/localeData";
-import updateLocalePlugin from "dayjs/plugin/updateLocale";
-
-dayjs.extend(localeDataPlugin);
-dayjs.extend(updateLocalePlugin);

--- a/frontend/src/metabase/lib/i18n.js
+++ b/frontend/src/metabase/lib/i18n.js
@@ -1,6 +1,7 @@
 import { addLocale, useLocale } from "ttag";
 import moment from "moment-timezone";
 import dayjs from "dayjs";
+import updateLocalePlugin from "dayjs/plugin/updateLocale";
 
 import MetabaseSettings from "metabase/lib/settings";
 import { DAY_OF_WEEK_OPTIONS } from "metabase/lib/date-time";
@@ -39,7 +40,8 @@ export function updateMomentStartOfWeek() {
 export function updateDayjsStartOfWeek() {
   const startOfWeekDay = getStartOfWeekDay();
   if (startOfWeekDay != null) {
-    dayjs.updateLocale(dayjs.locale(), { week: { dow: startOfWeekDay } });
+    dayjs.extend(updateLocalePlugin);
+    dayjs.updateLocale(dayjs.locale(), { weekStart: startOfWeekDay });
   }
 }
 

--- a/frontend/src/metabase/ui/components/theme/DatesProvider/DatesProvider.tsx
+++ b/frontend/src/metabase/ui/components/theme/DatesProvider/DatesProvider.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import dayjs from "dayjs";
-import { DatesProvider as MantineDatesProvider } from "@mantine/dates";
 import type { DatesProviderSettings, DayOfWeek } from "@mantine/dates";
+import { DatesProvider as MantineDatesProvider } from "@mantine/dates";
 
 interface DatesProviderProps {
   children?: ReactNode;
@@ -9,8 +9,8 @@ interface DatesProviderProps {
 
 export function DatesProvider({ children }: DatesProviderProps) {
   const settings: DatesProviderSettings = {
-    locale: dayjs.locale(),
-    firstDayOfWeek: dayjs.localeData().firstDayOfWeek() as DayOfWeek,
+    locale: dayjs().locale(),
+    firstDayOfWeek: dayjs().startOf("week").day() as DayOfWeek,
   };
 
   return (

--- a/frontend/test/jest-setup.js
+++ b/frontend/test/jest-setup.js
@@ -3,7 +3,6 @@ import "cross-fetch/polyfill";
 import "raf/polyfill";
 import "jest-localstorage-mock";
 import "jest-canvas-mock";
-import "metabase/lib/dayjs";
 import "__support__/mocks";
 
 // NOTE: this is needed because sometimes asynchronous code tries to access


### PR DESCRIPTION
How to verify:
- `yarn dev`
- Open http://localhost:3000/admin/settings/localization
- Set different days for start of week and debug `DatesProvider` initialization. `firstDayOfWeek` should be set correctly, e.g. 0 - Sunday, 1 - Monday etc

<img width="892" alt="Screenshot 2023-10-20 at 14 46 26" src="https://github.com/metabase/metabase/assets/8542534/38ba971d-77cd-4b52-9fa0-24f5c52f59e7">
