### PR TITLE
Start running the `fuzzing` workflow on related changes

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -2,10 +2,17 @@ name: Fuzzing
 
 on:
   workflow_dispatch:
-
+  push:
+    branches:
+      - 'master'
+      - 'release-**'
+    paths:
+      - 'frontend/src/metabase-lib/expressions/**'
+  pull_request:
+    paths:
+      - 'frontend/src/metabase-lib/expressions/**'
 
 jobs:
-
   fe-fuzz-tokenizer:
     runs-on: ubuntu-22.04
     timeout-minutes: 15


### PR DESCRIPTION
As @kulyk suggested internally, we can/should run this workflow on related changes.