### PR TITLE
Refactor: Remove FieldValuesWidget forceTokenField prop

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.tsx
+++ b/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.tsx
@@ -102,7 +102,6 @@ export interface IFieldValuesWidgetProps {
   className?: string;
   prefix?: string;
   placeholder?: string;
-  forceTokenField?: boolean;
   checkedColor?: string;
 
   valueRenderer?: (value: string | number) => JSX.Element;
@@ -135,7 +134,6 @@ export function FieldValuesWidgetInner({
   className,
   prefix,
   placeholder,
-  forceTokenField = false,
   checkedColor,
   valueRenderer,
   optionRenderer,
@@ -411,8 +409,7 @@ export function FieldValuesWidgetInner({
   const isListMode =
     !disableList &&
     shouldList({ parameter, fields, disableSearch }) &&
-    valuesMode === "list" &&
-    !forceTokenField;
+    valuesMode === "list";
   const isLoading = loadingState === "LOADING";
   const hasListValues = hasList({
     parameter,

--- a/frontend/src/metabase/components/FormCategoryInput/CategoryFieldInput/CategoryFieldInput.tsx
+++ b/frontend/src/metabase/components/FormCategoryInput/CategoryFieldInput/CategoryFieldInput.tsx
@@ -51,7 +51,7 @@ function CategoryFieldInput({
         autoFocus={false}
         alwaysShowOptions={false}
         disableSearch={false}
-        forceTokenField
+        disableList
         layoutRenderer={DefaultTokenFieldLayout}
         valueRenderer={(val: string) => <span>{val}</span>}
         color="brand"


### PR DESCRIPTION
`forceTokenField` can be removed from `FieldValuesWidget` because the `disableList` prop works the same way, so we should just use it instead

related: https://github.com/metabase/metabase/pull/34910