### PR TITLE
[Move dashcard to tab] permissions e2e + helper e2e methods

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.js
+++ b/e2e/support/helpers/e2e-dashboard-helpers.js
@@ -167,6 +167,10 @@ export function deleteTab(tabName) {
   });
 }
 
+export function goToTab(tabName) {
+  cy.findByRole("tab", { name: tabName }).click();
+}
+
 export function visitDashboardAndCreateTab({ dashboardId, save = true }) {
   visitDashboard(dashboardId);
   editDashboard();

--- a/e2e/support/helpers/e2e-dashboard-helpers.js
+++ b/e2e/support/helpers/e2e-dashboard-helpers.js
@@ -1,5 +1,5 @@
 import { visitDashboard } from "./e2e-misc-helpers";
-import { popover } from "./e2e-ui-elements-helpers";
+import { menu, popover } from "./e2e-ui-elements-helpers";
 
 // Metabase utility functions for commonly-used patterns
 export function selectDashboardFilter(selection, filterName) {
@@ -169,6 +169,11 @@ export function deleteTab(tabName) {
 
 export function goToTab(tabName) {
   cy.findByRole("tab", { name: tabName }).click();
+}
+
+export function moveDashCardToTab({ dashcardIndex = 0, tabName }) {
+  getDashboardCard(dashcardIndex).realHover().icon("move_card").click();
+  menu().findByText(tabName).click();
 }
 
 export function visitDashboardAndCreateTab({ dashboardId, save = true }) {

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -18,13 +18,13 @@ import {
   visitCollection,
   main,
   getDashboardCard,
-  menu,
   getDashboardCards,
   getTextCardDetails,
   getHeadingCardDetails,
   getLinkCardDetails,
   updateDashboardCards,
   goToTab,
+  moveDashCardToTab,
 } from "e2e/support/helpers";
 
 import {
@@ -111,9 +111,7 @@ describe("scenarios > dashboard > tabs", () => {
 
     cy.log("move card to second tab");
 
-    getDashboardCard().realHover();
-    cy.icon("move_card").click();
-    menu().findByText("Tab 2").click();
+    moveDashCardToTab({ tabName: "Tab 2" });
 
     getDashboardCards().should("have.length", 0);
 
@@ -163,10 +161,7 @@ describe("scenarios > dashboard > tabs", () => {
       cy.log("moving dashcards to second tab");
 
       cards.forEach(() => {
-        getDashboardCard(0).realHover();
-        cy.icon("move_card").eq(0).click();
-
-        menu().findByText("Tab 2").click();
+        moveDashCardToTab({ tabName: "Tab 2" });
       });
 
       getDashboardCards().should("have.length", 0);
@@ -199,10 +194,7 @@ describe("scenarios > dashboard > tabs", () => {
 
     goToTab("Tab 1");
 
-    // TODO: create moveDashcardToTab helper
-    getDashboardCard(0).realHover();
-    cy.icon("move_card").eq(0).click();
-    menu().findByText("Tab 2").click();
+    moveDashCardToTab({ tabName: "Tab 2" });
 
     saveDashboard();
 

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -194,6 +194,10 @@ describe("scenarios > dashboard > tabs", () => {
 
     goToTab("Tab 1");
 
+    getDashboardCard()
+      .findByText(/you don't have permission/)
+      .should("exist");
+
     moveDashCardToTab({ tabName: "Tab 2" });
 
     saveDashboard();

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -31,6 +31,8 @@ import {
   ORDERS_DASHBOARD_DASHCARD_ID,
   ORDERS_QUESTION_ID,
   ORDERS_COUNT_QUESTION_ID,
+  ADMIN_PERSONAL_COLLECTION_ID,
+  NORMAL_PERSONAL_COLLECTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
 
 describe("scenarios > dashboard > tabs", () => {
@@ -173,6 +175,39 @@ describe("scenarios > dashboard > tabs", () => {
       getDashboardCards().should("have.length", cards.length);
     },
   );
+
+  it("should allow moving dashcard even if we don't have permission on that underlying query", () => {
+    const questionDetails = {
+      native: {
+        query: "select 42",
+      },
+      collection_id: ADMIN_PERSONAL_COLLECTION_ID,
+    };
+    cy.createNativeQuestionAndDashboard({
+      questionDetails,
+      dashboardDetails: {
+        collection_id: NORMAL_PERSONAL_COLLECTION_ID,
+      },
+    }).then(({ body: { dashboard_id } }) => {
+      cy.signInAsNormalUser();
+      visitDashboard(dashboard_id);
+    });
+
+    editDashboard();
+    createNewTab();
+
+    // TODO: create navigateToTab helper
+    cy.findByRole("tab", { name: "Tab 1" }).click();
+
+    // TODO: create moveDashcardToTab helper
+    getDashboardCard(0).realHover();
+    cy.icon("move_card").eq(0).click();
+    menu().findByText("Tab 2").click();
+
+    saveDashboard();
+
+    getDashboardCards().should("have.length", 0);
+  });
 
   it("should leave dashboard if navigating back after initial load", () => {
     visitDashboardAndCreateTab({ dashboardId: ORDERS_DASHBOARD_ID });

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -24,6 +24,7 @@ import {
   getHeadingCardDetails,
   getLinkCardDetails,
   updateDashboardCards,
+  goToTab,
 } from "e2e/support/helpers";
 
 import {
@@ -63,7 +64,7 @@ describe("scenarios > dashboard > tabs", () => {
     cy.url().should("include", "2-tab-2");
 
     // Go back to first tab
-    cy.findByRole("tab", { name: "Tab 1" }).click();
+    goToTab("Tab 1");
     dashboardCards().within(() => {
       cy.findByText("Orders, count").should("not.exist");
     });
@@ -84,7 +85,7 @@ describe("scenarios > dashboard > tabs", () => {
 
     // Undo then go back to first tab
     undo();
-    cy.findByRole("tab", { name: "Tab 1" }).click();
+    goToTab("Tab 1");
     dashboardCards().within(() => {
       cy.findByText("Orders").should("be.visible");
     });
@@ -96,7 +97,7 @@ describe("scenarios > dashboard > tabs", () => {
       save: false,
     });
 
-    cy.findByRole("tab", { name: "Tab 1" }).click();
+    goToTab("Tab 1");
 
     cy.log("should stay on the same tab");
     cy.findByRole("tab", { selected: true }).should("have.text", "Tab 1");
@@ -116,7 +117,7 @@ describe("scenarios > dashboard > tabs", () => {
 
     getDashboardCards().should("have.length", 0);
 
-    cy.findByRole("tab", { name: "Tab 2" }).click();
+    goToTab("Tab 2");
 
     getDashboardCards().should("have.length", 1);
 
@@ -157,7 +158,7 @@ describe("scenarios > dashboard > tabs", () => {
 
       editDashboard();
       createNewTab();
-      cy.findByRole("tab", { name: "Tab 1" }).click();
+      goToTab("Tab 1");
 
       cy.log("moving dashcards to second tab");
 
@@ -170,7 +171,7 @@ describe("scenarios > dashboard > tabs", () => {
 
       getDashboardCards().should("have.length", 0);
 
-      cy.findByRole("tab", { name: "Tab 2" }).click();
+      goToTab("Tab 2");
 
       getDashboardCards().should("have.length", cards.length);
     },
@@ -196,8 +197,7 @@ describe("scenarios > dashboard > tabs", () => {
     editDashboard();
     createNewTab();
 
-    // TODO: create navigateToTab helper
-    cy.findByRole("tab", { name: "Tab 1" }).click();
+    goToTab("Tab 1");
 
     // TODO: create moveDashcardToTab helper
     getDashboardCard(0).realHover();
@@ -262,12 +262,12 @@ describe("scenarios > dashboard > tabs", () => {
     cy.get("@secondTabQuery").should("not.have.been.called");
 
     // Visit second tab and confirm only second card was queried
-    cy.findByRole("tab", { name: "Tab 2" }).click();
+    goToTab("Tab 2");
     cy.get("@firstTabQuery").should("have.been.calledOnce");
     cy.get("@secondTabQuery").should("have.been.calledOnce");
 
     // Go back to first tab, expect no additional queries
-    cy.findByRole("tab", { name: "Tab 1" }).click();
+    goToTab("Tab 1");
     cy.get("@firstTabQuery").should("have.been.calledOnce");
     cy.get("@secondTabQuery").should("have.been.calledOnce");
 
@@ -298,7 +298,7 @@ describe("scenarios > dashboard > tabs", () => {
     cy.get("@publicSecondTabQuery").should("not.have.been.called");
 
     // Visit second tab and confirm only second card was queried
-    cy.findByRole("tab", { name: "Tab 2" }).click();
+    goToTab("Tab 2");
     cy.get("@publicFirstTabQuery").should("have.been.calledOnce");
     cy.get("@publicSecondTabQuery").should("have.been.calledOnce");
   });


### PR DESCRIPTION
epic: https://github.com/metabase/metabase/issues/34367

### Description

- https://github.com/metabase/metabase/commit/8462081fe679786ba234ca067e3f51e0d631c950 adds a e2e to check for the permissions edge case, in which you don't have access to the card but should be able to move the dashcard if you have edit permissions in the dashboard
- https://github.com/metabase/metabase/commit/01b5e992dc05fcde824c3c90824fc5a906121d14 adds a goToTab helper
- https://github.com/metabase/metabase/commit/1b03cf013c9a01e35c7129af7b206f02945ce2f2 adds a helper to move a dashcard to another tab


Note: e2e are probably failing because of https://metaboat.slack.com/archives/C5XHN8GLW/p1697729886291229

