### PR TITLE
remove padding on HeaderBadges to align title and last edit info

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardHeaderView.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeaderView.styled.tsx
@@ -56,7 +56,6 @@ export const HeaderCaption = styled(EditableText)`
 export const HeaderBadges = styled.div`
   display: flex;
   align-items: center;
-  padding-left: 0.5rem;
   border-left: 1px solid transparent;
 
   ${breakpointMaxSmall} {


### PR DESCRIPTION
Closes #34912 

Visually aligns the title and Last Edit Info on dashboards by removing the left padding value.

### Before / After
![Screenshot 2023-10-20 at 12 46 06 PM](https://github.com/metabase/metabase/assets/5248953/4ca5d81a-a573-4a20-a9c6-5842eb344ac8)
![Screenshot 2023-10-20 at 12 45 50 PM](https://github.com/metabase/metabase/assets/5248953/2b96e390-39d7-4a6e-8aaa-c4a3be957198)

### To test
- Create a dashboard
- The title and the last edited by should be left aligned visually.