### PR TITLE
Fix E2E 20517 flake

### DIFF
--- a/e2e/test/scenarios/models/reproductions/20517-edit-metadata-empty-description.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/20517-edit-metadata-empty-description.cy.spec.js
@@ -1,28 +1,45 @@
 import { restore } from "e2e/support/helpers";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { ORDERS_ID } = SAMPLE_DATABASE;
+
+const modelDetails = {
+  name: "20517",
+  query: {
+    "source-table": ORDERS_ID,
+    limit: 5,
+  },
+  dataset: true,
+};
 
 describe("issue 20517", () => {
   beforeEach(() => {
-    cy.intercept("PUT", `/api/card/${ORDERS_QUESTION_ID}`).as("updateCard");
-
     restore();
     cy.signInAsAdmin();
 
-    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { dataset: true });
+    cy.createQuestion(modelDetails).then(({ body: { id } }) => {
+      cy.intercept("POST", `/api/card/${id}/query`).as("modelQuery");
+      cy.intercept("PUT", `/api/card/${id}`).as("updateModel");
+      cy.visit(`/model/${id}/metadata`);
+      cy.wait("@modelQuery");
+    });
   });
 
   it("should be able to save metadata changes with empty description (metabase#20517)", () => {
-    cy.visit(`/model/${ORDERS_QUESTION_ID}/metadata`);
-
-    cy.findByLabelText("Description").clear().blur();
-
-    cy.button("Save changes").click();
-
-    cy.wait("@updateCard").then(({ response: { body, statusCode } }) => {
+    cy.findByTestId("dataset-edit-bar")
+      .button("Save changes")
+      .should("be.disabled");
+    cy.findByDisplayValue(/^This is a unique ID/).clear();
+    cy.findByDisplayValue(/^This is a unique ID/).should("not.exist");
+    cy.findByTestId("dataset-edit-bar")
+      .button("Save changes")
+      .should("not.be.disabled")
+      .click();
+    cy.wait("@updateModel").then(({ response: { body, statusCode } }) => {
       expect(statusCode).not.to.eq(400);
       expect(body.errors).not.to.exist;
+      expect(body.description).to.be.null;
     });
-
     cy.button("Save failed").should("not.exist");
   });
 });


### PR DESCRIPTION
Not running this in CI because I kicked a stress-test run that passed 30/30 times.

```
  Running:  20517-edit-metadata-empty-description.cy.spec.js                                (1 of 1)


  issue 20517
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 1 of 30 (10369ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 2 of 30 (7536ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 3 of 30 (7988ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 4 of 30 (7411ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 5 of 30 (7055ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 6 of 30 (7088ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 7 of 30 (6281ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 8 of 30 (6403ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 9 of 30 (5757ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 10 of 30 (6638ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 11 of 30 (5894ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 12 of 30 (5862ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 13 of 30 (6421ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 14 of 30 (5500ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 15 of 30 (6049ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 16 of 30 (5139ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 17 of 30 (6415ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 18 of 30 (6167ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 19 of 30 (5106ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 20 of 30 (5608ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 21 of 30 (6220ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 22 of 30 (6716ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 23 of 30 (5071ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 24 of 30 (5957ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 25 of 30 (5888ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 26 of 30 (5543ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 27 of 30 (5838ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 28 of 30 (5846ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 29 of 30 (5544ms)
    ✓ should be able to save metadata changes with empty description (metabase#20517): burning 30 of 30 (5675ms)
```