### PR TITLE
Hide description icon in header for micro-sized cards

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartCaption.tsx
@@ -13,6 +13,7 @@ interface ChartCaptionProps {
   settings: VisualizationSettings;
   icon?: IconProps;
   actionButtons?: ReactNode;
+  width: number;
   onChangeCardAndRun: (data: Record<string, unknown>) => void;
 }
 
@@ -22,6 +23,7 @@ const ChartCaption = ({
   icon,
   actionButtons,
   onChangeCardAndRun,
+  width,
 }: ChartCaptionProps) => {
   const title = settings["card.title"] ?? series[0].card.name;
   const description = settings["card.description"];
@@ -48,6 +50,7 @@ const ChartCaption = ({
       icon={icon}
       actionButtons={actionButtons}
       onSelectTitle={canSelectTitle ? handleSelectTitle : undefined}
+      width={width}
     />
   );
 };

--- a/frontend/src/metabase/visualizations/components/ChartCaption.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartCaption.unit.spec.tsx
@@ -1,7 +1,7 @@
 import type { ComponentPropsWithoutRef } from "react";
 import _ from "underscore";
 import userEvent from "@testing-library/user-event";
-import { render, screen, getIcon } from "__support__/ui";
+import { render, screen, getIcon, queryIcon } from "__support__/ui";
 
 import type { Card, Series } from "metabase-types/api";
 import {
@@ -47,6 +47,7 @@ const setup = (props: Partial<Props> = {}) => {
     series = getSeries(),
     onChangeCardAndRun = _.noop,
     settings = {},
+    width = 200,
   } = props;
 
   render(
@@ -54,6 +55,7 @@ const setup = (props: Partial<Props> = {}) => {
       series={series}
       onChangeCardAndRun={onChangeCardAndRun}
       settings={settings}
+      width={width}
       {...props}
     />,
   );
@@ -86,5 +88,15 @@ describe("ChartCaption", () => {
     const tooltipContent = screen.getByRole("link");
     expect(tooltipContent).toBeInTheDocument();
     expect(tooltipContent).toHaveTextContent("link");
+  });
+
+  it("should hide description icon if too narrow", () => {
+    setup({
+      width: 50,
+      series: getSeries({ card: createMockCard({ name: "card name" }) }),
+      settings: { "card.description": "description" },
+    });
+
+    expect(queryIcon("info")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -97,6 +97,7 @@ export default class LineAreaBarChart extends Component {
     showTitle: PropTypes.bool,
     isDashboard: PropTypes.bool,
     headerIcon: PropTypes.object,
+    width: PropTypes.number,
   };
 
   static defaultProps = {};
@@ -262,6 +263,7 @@ export default class LineAreaBarChart extends Component {
       onRemoveSeries,
       settings,
       canRemoveSeries,
+      width,
     } = this.props;
 
     // Note (EmmadUsmani): Stacked charts should be reversed so series are stacked
@@ -296,6 +298,7 @@ export default class LineAreaBarChart extends Component {
             icon={headerIcon}
             actionButtons={actionButtons}
             onSelectTitle={canSelectTitle ? this.handleSelectTitle : undefined}
+            width={width}
           />
         )}
         <LegendLayout

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -466,6 +466,7 @@ class Visualization extends PureComponent {
                 settings={settings}
                 icon={headerIcon}
                 actionButtons={extra}
+                width={width}
                 onChangeCardAndRun={
                   this.props.onChangeCardAndRun && !replacementContent
                     ? this.handleOnChangeCardAndRun

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption.jsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption.jsx
@@ -19,7 +19,13 @@ const propTypes = {
   icon: PropTypes.object,
   actionButtons: PropTypes.node,
   onSelectTitle: PropTypes.func,
+  width: PropTypes.number,
 };
+
+function shouldHideDescription(width) {
+  const HIDE_DESCRIPTION_THRESHOLD = 100;
+  return width != null && width < HIDE_DESCRIPTION_THRESHOLD;
+}
 
 const LegendCaption = ({
   className,
@@ -28,6 +34,7 @@ const LegendCaption = ({
   icon,
   actionButtons,
   onSelectTitle,
+  width,
 }) => {
   return (
     <LegendCaptionRoot className={className} data-testid="legend-caption">
@@ -39,7 +46,7 @@ const LegendCaption = ({
         <Ellipsified>{title}</Ellipsified>
       </LegendLabel>
       <LegendRightContent>
-        {description && (
+        {description && !shouldHideDescription(width) && (
           <Tooltip
             tooltip={
               <Markdown dark disallowHeading unstyleLinks>

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
@@ -101,6 +101,7 @@ const RowChartVisualization = ({
   rawSeries: rawMultipleSeries,
   series: multipleSeries,
   fontFamily,
+  width,
 }: VisualizationProps) => {
   const formatColumnValue = useMemo(() => {
     return getColumnValueFormatter();
@@ -266,6 +267,7 @@ const RowChartVisualization = ({
           icon={headerIcon}
           actionButtons={actionButtons}
           onSelectTitle={canSelectTitle ? openQuestion : undefined}
+          width={width}
         />
       )}
       <RowChartLegendLayout


### PR DESCRIPTION
Trend charts have a minimum grid size of 2x2.  The [new trend chart design](https://github.com/metabase/metabase/issues/33411) moves the question name to the card header, which doesn’t work great at our min size.  As a quick fix, this PR adds a `width` prop to the ChartCaption which receives the pixel width of the card. We use it to conditionally remove the description icon when the card is too narrow to keep the title visible.

old | new | new fixed
---|---|---
<img src="https://github.com/metabase/metabase/assets/116838/b71af4a8-1631-4ae4-9ced-f2c282a82916"> | <img src="https://github.com/metabase/metabase/assets/116838/da8bc1f6-63d8-433f-b140-a033af8ef3c9"> | <img src="https://github.com/metabase/metabase/assets/116838/92acb67f-4858-4845-b8d5-cf42facdf3c5">

