### PR TITLE
Enable Embedding Metabase with a Transparent Frame

### DIFF
--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.css
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.css
@@ -56,3 +56,7 @@ body {
 .Theme--transparent.EmbedFrame .DashCard .Card {
   background-color: transparent;
 }
+
+.Theme--transparent-frame.EmbedFrame {
+  backgrund-color: transparent;
+}

--- a/frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx
+++ b/frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx
@@ -23,6 +23,7 @@ const THEME_OPTIONS = [
   { name: t`Light`, value: null },
   { name: t`Dark`, value: "night" },
   { name: t`Transparent`, value: "transparent" },
+  { name: t`Transparent Frame`, value: "transparent-frame" },
 ];
 
 const mapStateToProps = state => ({


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/35008

### Description

Currently, it is not possible to make an embed that ends with a transparent background and "white" widgets. There is either the "Light" Theme that forces a white background on the IFrame or a transparent Theme that also makes the cards transparent.

Unfortunately, that causes the dashboard to look sub-optimal as the widgets / cards visually blend with the background.

This PR introduces a new Theme, called Transparent-Frame to alleviate the issue and make the dashboard look better.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a Dashboard
2. Go to Public Sharing
3. Select "Embed in your application"
4. Select "Transparent Frame"

### Demo

#### Before
![Screenshot_20231021_160302](https://github.com/metabase/metabase/assets/724759/d011eff4-14d3-4fcc-9c4e-c8b6446d2994)


#### After
![Screenshot_20231021_160556](https://github.com/metabase/metabase/assets/724759/f1f404c5-99d2-4107-81b9-6c0933ed8021)



