### PR TITLE
[TEST] Expect e2e to not build

### DIFF
--- a/e2e/test/scenarios/binning/sql.cy.spec.js
+++ b/e2e/test/scenarios/binning/sql.cy.spec.js
@@ -1,3 +1,4 @@
+// Expect E2E workflow not to build fresh uberjar
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import {
   restore,


### PR DESCRIPTION
**Expected:**
Find `metabase-oss/ee-0c4a6d863f060e3636a7ae6ae8a948b09aca20dd-uberjar` from the previous commit on `master`.

**Actual:**
1. Didn't build ✅ 
<img width="433" alt="image" src="https://github.com/metabase/metabase/assets/31325167/e1da166d-2535-42b7-af79-a0f912305160">

2. Custom download action using REST API found and downloaded previously built uberjar with the hash `0c4a6d863f060e3636a7ae6ae8a948b09aca20dd` from `master` branch. ✅ 

```
Didn't find metabase-ee-538a0838a7fd548fd870c036ac424a10f1426ffa-uberjar.

Switching to the parent commit: 0c4a6d863f060e3636a7ae6ae8a948b09aca20dd
```