### PR TITLE
Refine CI triggers for frontend tests

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -12,6 +12,11 @@ shared_sources: &shared_sources
 shared_specs: &shared_specs
   - "shared/test/**"
 
+frontend_ci: &frontend_ci
+  - ".github/actions/prepare-frontend/**"
+  - ".github/actions/prepare-backend/**"
+  - ".github/workflows/frontend.yml"
+
 frontend_sources: &frontend_sources
   - *shared_sources
   - "enterprise/frontend/!(test)**/**/{!(*.spec),}.{js,jsx,ts,tsx,css}"
@@ -33,7 +38,7 @@ frontend_specs: &frontend_specs
   - "jest.tz.unit.conf.json"
 
 frontend_all: &frontend_all
-  - *ci
+  - *frontend_ci
   - *frontend_sources
   - *frontend_specs
 


### PR DESCRIPTION
This PR is a part of https://github.com/metabase/metabase/issues/34880 Epic.

[The original PR](https://github.com/metabase/metabase/pull/34882) was merged into a "feature" branch as https://github.com/metabase/metabase/commit/8d06759a5f69b2053c4f1bed5b9efbf2a887114d.

But then I realized there is nothing preventing us from merging this change directly to master. It already works.

## Important
After we refine triggers for all major workflows, I'll add a top level `*ci` trigger. More precisely, at that point the only remaining thing to do would be to edit the existing `*ci` trigger from "include ALL files except a few" to "include only these files":
```diff
ci: &ci
-  - ".github/**/!(*.md|team.json)"
+ - ".github/file-paths.yaml"
+ - "maybe/some/other/file"
```