### PR TITLE
PoC External workflow run trigger

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -7,6 +7,9 @@ on:
       - 'release-**'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  workflow_run:
+    workflows: [External Trigger Filter]
+    types: [completed]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
@@ -30,7 +33,9 @@ jobs:
 
   be-tests-athena-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -50,7 +55,9 @@ jobs:
 
   be-tests-bigquery-cloud-sdk-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -72,7 +79,9 @@ jobs:
 
   be-tests-druid-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -95,7 +104,9 @@ jobs:
 
   be-tests-googleanalytics-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -111,7 +122,9 @@ jobs:
 
   be-google-related-drivers-classpath-test:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -133,7 +146,9 @@ jobs:
 
   be-tests-mariadb-10-2-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -159,7 +174,9 @@ jobs:
 
   be-tests-mariadb-latest-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -185,7 +202,9 @@ jobs:
 
   be-tests-mongo-4-4-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -208,7 +227,9 @@ jobs:
 
   be-tests-mongo-4-4-ssl-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -243,7 +264,9 @@ jobs:
 
   be-tests-mongo-5-0-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -266,7 +289,9 @@ jobs:
 
   be-tests-mongo-5-0-ssl-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -301,7 +326,9 @@ jobs:
 
   be-tests-mongo-latest-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -327,7 +354,9 @@ jobs:
 
   be-tests-mysql-5-7-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -353,7 +382,9 @@ jobs:
 
   be-tests-mysql-latest-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -391,7 +422,9 @@ jobs:
 
   be-tests-oracle-18-4-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -418,7 +451,9 @@ jobs:
 
   be-tests-oracle-21-3-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -454,7 +489,9 @@ jobs:
 
   be-tests-postgres-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -484,7 +521,9 @@ jobs:
 
   be-tests-postgres-latest-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -517,7 +556,9 @@ jobs:
 
   be-tests-presto-jdbc-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -567,7 +608,9 @@ jobs:
 
   be-tests-redshift-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -587,7 +630,9 @@ jobs:
 
   be-tests-snowflake-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -609,7 +654,9 @@ jobs:
 
   be-tests-sparksql-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -630,7 +677,9 @@ jobs:
 
   be-tests-sqlite-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -646,7 +695,9 @@ jobs:
 
   be-tests-sqlserver-2017-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -674,7 +725,9 @@ jobs:
 
   be-tests-sqlserver-2022-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -702,7 +755,9 @@ jobs:
 
   be-tests-vertica-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: |
+      (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:

--- a/.github/workflows/external-filter.yml
+++ b/.github/workflows/external-filter.yml
@@ -1,0 +1,17 @@
+name: External Trigger Filter
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - 'master'
+    paths-ignore:
+      - '.github/**'
+
+jobs:
+  trigger:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    steps:
+      - run: echo 'Thank you for your contribution to Metabase!'


### PR DESCRIPTION
## The Problem
Running CI for external contributors can be risky, especially if workflows contain secrets. GitHub has a couple of mechanism in place to protect public open-source repositories from malicious external PRs. But there isn't a single widely-accepted approach that _just works™_.

We've previously attempted an approach laid out in this article: https://iterative.ai/blog/testing-external-contributions-using-github-actions-secrets. It proved to be too hacky for our taste as it relied on using mechanisms[^1] that were not designed for this purpose.

This PR attempts to solve this problem in-house with a custom and simple solution.

## The Solution
 tl;dr It Introduces an additional layer (buffer, filter) between an external PR and the target workflows that contain secrets. That layer can be best described as a router with a firewall, albeit an extremely simple one :)

> **Important**
> In order to minimize the human error, and to greatly reduce the risk, this filter will automatically reject (skip) all PRs that touch any of the files in `./.github/**` repo!
> We can maybe add `./bin/**` to this list, or any other file, folder that seems risky. That's easy to change at any point. Tbd...

### Detailed explanation 
1. The first and the most important step is to make explicit PR approvals mandatory for all forks (not just the first time contributors!)
    - **Note that this requires approval on every commit in a PR - which is great!** 🎉 
    
<details><summary>Expand to see the screenshot</summary>

![image](https://github.com/metabase/metabase/assets/31325167/053a9e9d-9ec0-42c8-9525-15d3dadb6da0)

</details>

2. Internal PRs don't require approvals - it's business as usual
    2a. `external-filter.yml` workflow will be skipped
    2b. Target workflow (with secrets) runs on `pull_request` only (as it did before). Since it is not a fork, the PR has access to all secrets.
3. External PR will just sit there waiting for an approval. If it doesn't get approved, nothing happens. Let's consider a scenario when we decide to approve it (after a careful inspection of the proposed changes):
    3a. `external-filter.yml` workflow will run and complete successfully (unless the PR touches files inside `./.github/**`
    3b. This, in turn, triggers a target workflow with secrets but from a safe context. The trigger is on `workflow_run` (completed). Since it is a safe context triggered internally, that particular run will have access to secrets.
    3c. Target workflow with secrets will also be triggered on `pull_request` but all runs will be skipped because the conditional we put in place detects this is a fork.

The best thing about this solution is that is safe.
Even if we don't detect a fork (let's say someone forgets to add that conditional in some target workflow with secrets) the external PR will run, but will not have access to secrets by design! The worst case scenario would be a bunch of failed tests because they didn't have secrets.

### Internal PR
```mermaid
stateDiagram-v2
    state "CI runs" as S1
    state "Workflow with secrets" as S2
    state "Filter workflow" as S3
    [*] --> S1: Internal
    S1 --> S2: (on) pull_request
    S1 --> S3: (on) pull_request
    S2 --> runs: Has access to secrets by default
    S3 --> [*]: skipped
```

### External PR
```mermaid
stateDiagram-v2
    state if_state <<choice>>
    state filter_state <<choice>>
    state "CI runs" as S1
    state "Workflow with secrets\n(run 1)" as S2
    state "Workflow with secrets\n(run 2)" as S3
    state "Filter workflow" as S4

    [*] --> Approved: External
    Approved --> if_state
    if_state --> S1: yes
    if_state --> [*]: no
    S1 --> S2: (on) pull_request
    S1 --> S4: (on) pull_request
    S2 --> WS1_skipped: detects it's a fork
    S4 --> filter_state: checks which files changed
    filter_state --> F_skipped: nope
    filter_state --> F_completed: yep
    F_completed --> S3: (on) workflow_run
    S3 --> runs: Creates safe environment that\nhas access to secrets
```
## Reading material
- https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run
- https://securitylab.github.com/research/github-actions-preventing-pwn-requests/


[^1]: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment