### PR TITLE
Fix e2e stub condition

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -238,7 +238,7 @@ jobs:
           if-no-files-found: ignore
 
   e2e-tests-skipped-stub:
-    needs: [e2e-tests]
+    needs: [e2e-tests, e2e-matrix-builder]
     if: |
       !cancelled() &&
       needs.e2e-tests.result == 'skipped'


### PR DESCRIPTION
The matrix needed for building the stub names relies on the `e2e-matrix-builder` job.
```
matrix: ${{ fromJSON(needs.e2e-matrix-builder.outputs.matrix) }}
```

That part from missing from `needs:` array.
I introduced the bug in #34647. This PR fixes it.

Test:
Opened a PR that only changes FE unit test. E2E stubs were populated successfully
https://github.com/metabase/metabase/actions/runs/6614983528/job/17966176100?pr=34963
