### PR TITLE
[MLv2] Filters — Highlight filter column or segment

### DIFF
--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -137,6 +137,7 @@ export type ColumnDisplayInfo = {
   table?: TableInlineDisplayInfo;
 
   breakoutPosition?: number;
+  filterPositions?: number[];
   orderByPosition?: number;
   selected?: boolean; // used in aggregation and field clauses
 };
@@ -146,6 +147,7 @@ export type SegmentDisplayInfo = {
   displayName: string;
   longDisplayName: string;
   description: string;
+  filterPositions?: number[];
 };
 
 export type AggregationOperatorDisplayInfo = {

--- a/frontend/src/metabase/common/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
@@ -19,6 +19,7 @@ import { StyledAccordionList } from "./FilterColumnPicker.styled";
 export interface FilterColumnPickerProps {
   query: Lib.Query;
   stageIndex: number;
+  checkItemIsSelected: (item: ColumnListItem | SegmentListItem) => boolean;
   onColumnSelect: (column: Lib.ColumnMetadata) => void;
   onSegmentSelect: (segment: Lib.SegmentMetadata) => void;
   onExpressionSelect: () => void;
@@ -45,6 +46,7 @@ const CUSTOM_EXPRESSION_SECTION: Section = {
 export function FilterColumnPicker({
   query,
   stageIndex,
+  checkItemIsSelected,
   onColumnSelect,
   onSegmentSelect,
   onExpressionSelect,
@@ -80,8 +82,6 @@ export function FilterColumnPicker({
     return [...sections, CUSTOM_EXPRESSION_SECTION];
   }, [query, stageIndex]);
 
-  const checkColumnSelected = () => false;
-
   const handleSectionChange = (section: Section) => {
     if (section.key === "custom-expression") {
       onExpressionSelect();
@@ -101,7 +101,7 @@ export function FilterColumnPicker({
       sections={sections}
       onChange={handleSelect}
       onChangeSection={handleSectionChange}
-      itemIsSelected={checkColumnSelected}
+      itemIsSelected={checkItemIsSelected}
       renderItemName={renderItemName}
       renderItemDescription={omitItemDescription}
       renderItemIcon={renderItemIcon}

--- a/frontend/src/metabase/common/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
@@ -13,7 +13,6 @@ import type { IconName } from "metabase/core/components/Icon";
 import * as Lib from "metabase-lib";
 
 import type { ColumnListItem, SegmentListItem } from "../types";
-import { isSegmentListItem } from "../utils";
 import { StyledAccordionList } from "./FilterColumnPicker.styled";
 
 export interface FilterColumnPickerProps {
@@ -37,6 +36,12 @@ const CUSTOM_EXPRESSION_SECTION: Section = {
   name: t`Custom Expression`,
   items: [],
   icon: "filter",
+};
+
+export const isSegmentListItem = (
+  item: ColumnListItem | SegmentListItem,
+): item is SegmentListItem => {
+  return (item as SegmentListItem).segment != null;
 };
 
 /**

--- a/frontend/src/metabase/common/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
@@ -12,6 +12,8 @@ import type { IconName } from "metabase/core/components/Icon";
 
 import * as Lib from "metabase-lib";
 
+import type { ColumnListItem, SegmentListItem } from "../types";
+import { isSegmentListItem } from "../utils";
 import { StyledAccordionList } from "./FilterColumnPicker.styled";
 
 export interface FilterColumnPickerProps {
@@ -34,20 +36,6 @@ const CUSTOM_EXPRESSION_SECTION: Section = {
   name: t`Custom Expression`,
   items: [],
   icon: "filter",
-};
-
-export type ColumnListItem = Lib.ColumnDisplayInfo & {
-  column: Lib.ColumnMetadata;
-};
-
-export type SegmentListItem = Lib.SegmentDisplayInfo & {
-  segment: Lib.SegmentMetadata;
-};
-
-const isSegmentListItem = (
-  item: ColumnListItem | SegmentListItem,
-): item is SegmentListItem => {
-  return (item as SegmentListItem).segment != null;
 };
 
 /**

--- a/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
@@ -13,6 +13,8 @@ import { isExpression as isLegacyExpression } from "metabase-lib/expressions";
 import LegacyFilter from "metabase-lib/queries/structured/Filter";
 import type LegacyQuery from "metabase-lib/queries/StructuredQuery";
 
+import type { ColumnListItem, SegmentListItem } from "./types";
+
 import { BooleanFilterPicker } from "./BooleanFilterPicker";
 import { DateFilterPicker } from "./DateFilterPicker";
 import { NumberFilterPicker } from "./NumberFilterPicker";
@@ -25,6 +27,7 @@ export interface FilterPickerProps {
   query: Lib.Query;
   stageIndex: number;
   filter?: Lib.FilterClause;
+  filterIndex?: number;
 
   legacyQuery: LegacyQuery;
   legacyFilter?: LegacyFilter;
@@ -40,6 +43,7 @@ export function FilterPicker({
   query,
   stageIndex,
   filter,
+  filterIndex,
   legacyQuery,
   legacyFilter,
   onSelect,
@@ -59,6 +63,16 @@ export function FilterPicker({
     onSelect(filter);
     onClose?.();
   };
+
+  const checkItemIsSelected = useCallback(
+    (item: ColumnListItem | SegmentListItem) => {
+      return !!(
+        typeof filterIndex === "number" &&
+        item.filterPositions?.includes?.(filterIndex)
+      );
+    },
+    [filterIndex],
+  );
 
   const handleExpressionChange = useCallback(
     (name: string, expression: LegacyExpressionClause) => {
@@ -92,6 +106,7 @@ export function FilterPicker({
         <FilterColumnPicker
           query={query}
           stageIndex={stageIndex}
+          checkItemIsSelected={checkItemIsSelected}
           onColumnSelect={setColumn}
           onSegmentSelect={handleChange}
           onExpressionSelect={openExpressionEditor}

--- a/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
@@ -66,9 +66,8 @@ export function FilterPicker({
 
   const checkItemIsSelected = useCallback(
     (item: ColumnListItem | SegmentListItem) => {
-      return !!(
-        typeof filterIndex === "number" &&
-        item.filterPositions?.includes?.(filterIndex)
+      return Boolean(
+        filterIndex != null && item.filterPositions?.includes?.(filterIndex),
       );
     },
     [filterIndex],

--- a/frontend/src/metabase/common/components/FilterPicker/FilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterPicker.unit.spec.tsx
@@ -3,9 +3,14 @@ import { createMockMetadata } from "__support__/metadata";
 import { render, screen } from "__support__/ui";
 
 import type { StructuredDatasetQuery } from "metabase-types/api";
+import { createMockSegment } from "metabase-types/api/mocks";
 import {
   createAdHocCard,
+  createOrdersTable,
+  createProductsTable,
   createSampleDatabase,
+  ORDERS,
+  ORDERS_ID,
 } from "metabase-types/api/mocks/presets";
 
 import * as Lib from "metabase-lib";
@@ -15,8 +20,42 @@ import { createQuery, columnFinder } from "metabase-lib/test-helpers";
 
 import { FilterPicker } from "./FilterPicker";
 
+const SEGMENT_1 = createMockSegment({
+  id: 1,
+  table_id: ORDERS_ID,
+  name: "Discounted",
+  description: "Orders with a discount",
+  definition: {
+    "source-table": ORDERS_ID,
+    filter: ["not-null", ["field", ORDERS.DISCOUNT, null]],
+  },
+});
+
+const SEGMENT_2 = createMockSegment({
+  id: 2,
+  table_id: ORDERS_ID,
+  name: "Many items",
+  description: "Orders with more than 5 items",
+  definition: {
+    "source-table": ORDERS_ID,
+    filter: [">", ["field", ORDERS.QUANTITY, null], 20],
+  },
+});
+
+const metadata = createMockMetadata({
+  databases: [
+    createSampleDatabase({
+      tables: [
+        createOrdersTable({ segments: [SEGMENT_1, SEGMENT_2] }),
+        createProductsTable(),
+      ],
+    }),
+  ],
+  segments: [SEGMENT_1, SEGMENT_2],
+});
+
 function createQueryWithFilter() {
-  const initialQuery = createQuery();
+  const initialQuery = createQuery({ metadata });
   const columns = Lib.filterableColumns(initialQuery, 0);
   const findColumn = columnFinder(initialQuery, columns);
   const totalColumn = findColumn("ORDERS", "TOTAL");
@@ -26,14 +65,20 @@ function createQueryWithFilter() {
   return { query, filter };
 }
 
+function createQueryWithSegmentFilter() {
+  const initialQuery = createQuery({ metadata });
+  const [segment] = Lib.availableSegments(initialQuery, 0);
+  const query = Lib.filter(initialQuery, 0, segment);
+  const [filter] = Lib.filters(query, 0);
+  return { query, filter };
+}
+
 type SetupOpts = {
   query?: Lib.Query;
   filter?: Lib.FilterClause;
 };
 
-const metadata = createMockMetadata({ databases: [createSampleDatabase()] });
-
-function setup({ query = createQuery(), filter }: SetupOpts = {}) {
+function setup({ query = createQuery({ metadata }), filter }: SetupOpts = {}) {
   const dataset_query = Lib.toLegacyQuery(query) as StructuredDatasetQuery;
   const question = new Question(createAdHocCard({ dataset_query }), metadata);
   const legacyQuery = question.query() as StructuredQuery;
@@ -46,6 +91,7 @@ function setup({ query = createQuery(), filter }: SetupOpts = {}) {
       query={query}
       stageIndex={0}
       filter={filter}
+      filterIndex={0}
       legacyQuery={legacyQuery}
       onSelect={onSelect}
       onSelectLegacy={onSelectLegacy}
@@ -70,6 +116,42 @@ describe("FilterPicker", () => {
     it("should show the filter editor", () => {
       setup(createQueryWithFilter());
       expect(screen.getByText("Update filter")).toBeInTheDocument();
+    });
+
+    it("should highlight the selected column", async () => {
+      setup(createQueryWithFilter());
+
+      userEvent.click(screen.getByLabelText("Back"));
+
+      expect(await screen.findByLabelText("Total")).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      expect(screen.getByLabelText("Discount")).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
+      expect(screen.getByLabelText(SEGMENT_1.name)).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
+    });
+
+    it("should highlight the selected segment", async () => {
+      setup(createQueryWithSegmentFilter());
+
+      expect(await screen.findByLabelText(SEGMENT_1.name)).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      expect(screen.getByLabelText(SEGMENT_2.name)).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
+      expect(screen.getByLabelText("Total")).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
     });
   });
 });

--- a/frontend/src/metabase/common/components/FilterPicker/types.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/types.ts
@@ -1,7 +1,10 @@
 import type {
+  ColumnDisplayInfo,
   ColumnMetadata,
   FilterClause,
   ExpressionClause,
+  SegmentDisplayInfo,
+  SegmentMetadata,
   Query,
 } from "metabase-lib/types";
 
@@ -21,3 +24,11 @@ export interface PickerOperatorOption<Operator> {
   // but widgets can overwrite it with a custom name.
   name?: string;
 }
+
+export type ColumnListItem = ColumnDisplayInfo & {
+  column: ColumnMetadata;
+};
+
+export type SegmentListItem = SegmentDisplayInfo & {
+  segment: SegmentMetadata;
+};

--- a/frontend/src/metabase/common/components/FilterPicker/utils.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/utils.ts
@@ -1,10 +1,6 @@
 import _ from "underscore";
 import * as Lib from "metabase-lib";
-import type {
-  ColumnListItem,
-  SegmentListItem,
-  PickerOperatorOption,
-} from "./types";
+import type { PickerOperatorOption } from "./types";
 
 export function getAvailableOperatorOptions<
   T extends PickerOperatorOption<Lib.FilterOperatorName>,
@@ -30,9 +26,3 @@ export function getAvailableOperatorOptions<
     ...option,
   }));
 }
-
-export const isSegmentListItem = (
-  item: ColumnListItem | SegmentListItem,
-): item is SegmentListItem => {
-  return (item as SegmentListItem).segment != null;
-};

--- a/frontend/src/metabase/common/components/FilterPicker/utils.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/utils.ts
@@ -1,6 +1,10 @@
 import _ from "underscore";
 import * as Lib from "metabase-lib";
-import type { PickerOperatorOption } from "./types";
+import type {
+  ColumnListItem,
+  SegmentListItem,
+  PickerOperatorOption,
+} from "./types";
 
 export function getAvailableOperatorOptions<
   T extends PickerOperatorOption<Lib.FilterOperatorName>,
@@ -26,3 +30,9 @@ export function getAvailableOperatorOptions<
     ...option,
   }));
 }
+
+export const isSegmentListItem = (
+  item: ColumnListItem | SegmentListItem,
+): item is SegmentListItem => {
+  return (item as SegmentListItem).segment != null;
+};

--- a/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep/FilterStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep/FilterStep.tsx
@@ -73,6 +73,7 @@ export function FilterStep({
             query={topLevelQuery}
             stageIndex={stageIndex}
             filter={filter}
+            filterIndex={index}
             legacyQuery={legacyQuery}
             legacyFilter={
               typeof index === "number"
@@ -95,6 +96,7 @@ interface FilterPopoverProps {
   query: Lib.Query;
   stageIndex: number;
   filter?: Lib.FilterClause;
+  filterIndex?: number;
   legacyQuery: LegacyQuery;
   legacyFilter?: LegacyFilter;
   onAddFilter: (filter: Lib.ExpressionClause | Lib.SegmentMetadata) => void;
@@ -110,6 +112,7 @@ function FilterPopover({
   query,
   stageIndex,
   filter,
+  filterIndex,
   legacyQuery,
   legacyFilter,
   onAddFilter,
@@ -122,6 +125,7 @@ function FilterPopover({
       query={query}
       stageIndex={stageIndex}
       filter={filter}
+      filterIndex={filterIndex}
       legacyQuery={legacyQuery}
       legacyFilter={legacyFilter}
       onSelect={newFilter => {


### PR DESCRIPTION
Closes #34737 — highlights filter's column/segment in the item picker

### To Verify

1. Go to `/admin/datamodel/segments` and create a segment for the sample Orders table
1. New > Question > Raw Data > Sample Database > Orders
2. Add a filter using the segment from step 1, click the added filter clause, ensure the segment is highlighted
3. Add a regular filter on some column, click the added filter clause, and ensure that the column is highlighted

### Demo

![demo](https://github.com/metabase/metabase/assets/17258145/6824fe6d-d49a-4653-ae78-1dee8e79df1a)
