### PR TITLE
Explain why linked filters and "From connected fields" don't work for native variables on the dashcard

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
@@ -28,7 +28,6 @@ import {
 import { isActionDashCard } from "metabase/actions/utils";
 import { Ellipsified } from "metabase/core/components/Ellipsified";
 import Question from "metabase-lib/Question";
-import { isDateParameter } from "metabase-lib/parameters/utils/parameter-type";
 import { isVariableTarget } from "metabase-lib/parameters/utils/targets";
 
 import { normalize } from "metabase-lib/queries/utils/normalize";
@@ -99,8 +98,6 @@ export function DashCardCardParameterMapper({
   const [isDropdownVisible, setIsDropdownVisible] = useState(false);
 
   const hasSeries = dashcard.series && dashcard.series.length > 0;
-  const onlyAcceptsSingleValue =
-    isVariableTarget(target) && !isDateParameter(editingParameter);
   const isDisabled = mappingOptions.length === 0 || isActionDashCard(dashcard);
   const selectedMappingOption = _.find(mappingOptions, option =>
     _.isEqual(normalize(option.target), normalize(target)),
@@ -294,9 +291,9 @@ export function DashCardCardParameterMapper({
           </Tooltip>
         </>
       )}
-      {onlyAcceptsSingleValue && (
+      {isVariableTarget(target) && (
         <Warning>
-          {t`This field only accepts a single value because it's used in a SQL query.`}
+          {t`Native question variables only accept a single value. They do not support dropdown lists or search box filters, and can't limit values for linked filters.`}
         </Warning>
       )}
     </Container>

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
@@ -29,6 +29,7 @@ import { isActionDashCard } from "metabase/actions/utils";
 import { Ellipsified } from "metabase/core/components/Ellipsified";
 import Question from "metabase-lib/Question";
 import { isVariableTarget } from "metabase-lib/parameters/utils/targets";
+import { isDateParameter } from "metabase-lib/parameters/utils/parameter-type";
 
 import { normalize } from "metabase-lib/queries/utils/normalize";
 import {
@@ -293,7 +294,9 @@ export function DashCardCardParameterMapper({
       )}
       {isVariableTarget(target) && (
         <Warning>
-          {t`Native question variables only accept a single value. They do not support dropdown lists or search box filters, and can't limit values for linked filters.`}
+          {isDateParameter(editingParameter) // Date parameters types that can be wired to variables can only take a single value anyway, so don't explain it in the warning.
+            ? t`Native question variables do not support dropdown lists or search box filters, and can't limit values for linked filters.`
+            : t`Native question variables only accept a single value. They do not support dropdown lists or search box filters, and can't limit values for linked filters.`}
         </Warning>
       )}
     </Container>

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
@@ -7,6 +7,7 @@ import {
   createMockDashboardCard,
   createMockActionDashboardCard,
   createMockHeadingDashboardCard,
+  createMockParameter,
   createMockTextDashboardCard,
   createMockStructuredDatasetQuery,
   createMockNativeDatasetQuery,
@@ -197,7 +198,38 @@ describe("DashCardParameterMapper", () => {
       target: ["variable", ["template-tag", "source"]],
     });
     expect(
-      screen.getByText(/Native question variables only accept a single value/i),
+      screen.getByText(
+        /Native question variables only accept a single value\. They do not support dropdown lists/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("should show native question variable warning without single value explanation if parameter is date type", () => {
+    const card = createMockCard({
+      dataset_query: createMockNativeDatasetQuery({
+        dataset_query: {
+          native: createMockNativeQuery({
+            query: "SELECT * FROM ORDERS WHERE created_at = {{ created_at }}",
+            "template-tags": [
+              createMockTemplateTag({
+                name: "created_at",
+                type: "date/month-year",
+              }),
+            ],
+          }),
+        },
+      }),
+    });
+    setup({
+      card,
+      dashcard: createMockDashboardCard({ card }),
+      target: ["variable", ["template-tag", "created_at"]],
+      editingParameter: createMockParameter({ type: "date/month-year" }),
+    });
+    expect(
+      screen.getByText(
+        /Native question variables do not support dropdown lists/i,
+      ),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
@@ -3,11 +3,14 @@ import { getIcon } from "__support__/ui";
 
 import {
   createMockCard,
+  createMockTemplateTag,
   createMockDashboardCard,
   createMockActionDashboardCard,
   createMockHeadingDashboardCard,
   createMockTextDashboardCard,
   createMockStructuredDatasetQuery,
+  createMockNativeDatasetQuery,
+  createMockNativeQuery,
 } from "metabase-types/api/mocks";
 
 import { getMetadata } from "metabase/selectors/metadata";
@@ -175,6 +178,27 @@ describe("DashCardParameterMapper", () => {
       mappingOptions: ["foo", "bar"],
     });
     expect(screen.queryByText(/Column to filter on/i)).not.toBeInTheDocument();
+  });
+
+  it("should show native question variable warning if a native question variable is used", () => {
+    const card = createMockCard({
+      dataset_query: createMockNativeDatasetQuery({
+        dataset_query: {
+          native: createMockNativeQuery({
+            query: "SELECT * FROM ACCOUNTS WHERE source = {{ source }}",
+            "template-tags": [createMockTemplateTag({ name: "source" })],
+          }),
+        },
+      }),
+    });
+    setup({
+      card,
+      dashcard: createMockDashboardCard({ card }),
+      target: ["variable", ["template-tag", "source"]],
+    });
+    expect(
+      screen.getByText(/Native question variables only accept a single value/i),
+    ).toBeInTheDocument();
   });
 
   describe("mobile", () => {


### PR DESCRIPTION
Fixes #34570 by adding to the warning message on dashcards that are mapped to native question variables.

[Slack thread about product decisions](https://metaboat.slack.com/archives/C057T1QTB3L/p1697629797841749?thread_ts=1697469877.162559&cid=C057T1QTB3L)

The message differs slightly depending on whether the filter is a date filter or not.

For non-date filters:
<img width="593" alt="image" src="https://github.com/metabase/metabase/assets/39073188/6d40d20b-eb4c-4518-8ae3-04cc6f19fcee">

For date filters we can omit the "takes a single value" part because date filters always take a single value:
<img width="597" alt="image" src="https://github.com/metabase/metabase/assets/39073188/7eae5d01-a3ba-44ab-9e00-85454e2b15a2">