### PR TITLE
ensure that column is removed from table.columns when updating question

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -775,13 +775,12 @@ class Question {
     const tableColumns = this.setting("table.columns");
     if (
       tableColumns &&
-      addedColumnNames.length > 0 &&
-      removedColumnNames.length === 0
+      (addedColumnNames.length > 0 || removedColumnNames.length > 0)
     ) {
       return this.updateSettings({
         "table.columns": [
           ...tableColumns.filter(
-            column => !addedColumnNames.includes(column.name),
+            column => !removedColumnNames.includes(column.name),
           ),
           ...addedColumnNames.map(name => {
             const dimension = query.columnDimensionWithName(name);

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -780,7 +780,9 @@ class Question {
       return this.updateSettings({
         "table.columns": [
           ...tableColumns.filter(
-            column => !removedColumnNames.includes(column.name),
+            column =>
+              !removedColumnNames.includes(column.name) &&
+              !addedColumnNames.includes(column.name),
           ),
           ...addedColumnNames.map(name => {
             const dimension = query.columnDimensionWithName(name);

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.unit.spec.ts
@@ -23,9 +23,6 @@ import {
   createMockStructuredDatasetQuery,
   createMockStructuredQuery,
   createMockTable,
-  createMockCard,
-  createMockVisualizationSettings,
-  createMockTableColumnOrderSetting,
 } from "metabase-types/api/mocks";
 import {
   createSampleDatabase,
@@ -811,69 +808,6 @@ describe("QB Actions > updateQuestion", () => {
           expect(setTemplateTagEditorVisibleSpy).toHaveBeenCalledWith(false);
         });
       });
-    });
-  });
-
-  describe("table column sync", () => {
-    it("removes columns from table.columns when a column is removed from a query", async () => {
-      const tableColumns = [
-        createMockTableColumnOrderSetting({
-          name: "ID",
-          fieldRef: ["field", ORDERS.ID, {}],
-          enabled: true,
-        }),
-        createMockTableColumnOrderSetting({
-          name: "TOTAL",
-          fieldRef: ["field", ORDERS.TOTAL, {}],
-          enabled: true,
-        }),
-        createMockTableColumnOrderSetting({
-          name: "QUANTITY",
-          fieldRef: ["field", ORDERS.QUANTITY, {}],
-          enabled: true,
-        }),
-      ];
-
-      const cardWithoutQuantity = createMockCard({
-        dataset_query: createMockStructuredDatasetQuery({
-          query: createMockStructuredQuery({
-            "source-table": ORDERS_ID,
-            fields: [
-              ["field", ORDERS.ID, {}],
-              ["field", ORDERS.TOTAL, {}],
-            ],
-          }),
-        }),
-        visualization_settings: createMockVisualizationSettings({
-          "table.columns": tableColumns,
-        }),
-      });
-
-      const cardWithQuantity = createMockCard({
-        dataset_query: createMockStructuredDatasetQuery({
-          query: createMockStructuredQuery({
-            "source-table": ORDERS_ID,
-            fields: [
-              ["field", ORDERS.ID, {}],
-              ["field", ORDERS.TOTAL, {}],
-              ["field", ORDERS.QUANTITY, {}],
-            ],
-          }),
-        }),
-        visualization_settings: createMockVisualizationSettings({
-          "table.columns": tableColumns,
-        }),
-      });
-
-      const { result } = await setup({
-        card: cardWithoutQuantity,
-        originalCard: cardWithQuantity,
-        run: false,
-      });
-
-      expect(tableColumns).not.toEqual(
-        result.card.visualization_settings["table.columns"],
-      );
     });
   });
 

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.unit.spec.ts
@@ -23,6 +23,9 @@ import {
   createMockStructuredDatasetQuery,
   createMockStructuredQuery,
   createMockTable,
+  createMockCard,
+  createMockVisualizationSettings,
+  createMockTableColumnOrderSetting,
 } from "metabase-types/api/mocks";
 import {
   createSampleDatabase,
@@ -808,6 +811,69 @@ describe("QB Actions > updateQuestion", () => {
           expect(setTemplateTagEditorVisibleSpy).toHaveBeenCalledWith(false);
         });
       });
+    });
+  });
+
+  describe("table column sync", () => {
+    it("removes columns from table.columns when a column is removed from a query", async () => {
+      const tableColumns = [
+        createMockTableColumnOrderSetting({
+          name: "ID",
+          fieldRef: ["field", ORDERS.ID, {}],
+          enabled: true,
+        }),
+        createMockTableColumnOrderSetting({
+          name: "TOTAL",
+          fieldRef: ["field", ORDERS.TOTAL, {}],
+          enabled: true,
+        }),
+        createMockTableColumnOrderSetting({
+          name: "QUANTITY",
+          fieldRef: ["field", ORDERS.QUANTITY, {}],
+          enabled: true,
+        }),
+      ];
+
+      const cardWithoutQuantity = createMockCard({
+        dataset_query: createMockStructuredDatasetQuery({
+          query: createMockStructuredQuery({
+            "source-table": ORDERS_ID,
+            fields: [
+              ["field", ORDERS.ID, {}],
+              ["field", ORDERS.TOTAL, {}],
+            ],
+          }),
+        }),
+        visualization_settings: createMockVisualizationSettings({
+          "table.columns": tableColumns,
+        }),
+      });
+
+      const cardWithQuantity = createMockCard({
+        dataset_query: createMockStructuredDatasetQuery({
+          query: createMockStructuredQuery({
+            "source-table": ORDERS_ID,
+            fields: [
+              ["field", ORDERS.ID, {}],
+              ["field", ORDERS.TOTAL, {}],
+              ["field", ORDERS.QUANTITY, {}],
+            ],
+          }),
+        }),
+        visualization_settings: createMockVisualizationSettings({
+          "table.columns": tableColumns,
+        }),
+      });
+
+      const { result } = await setup({
+        card: cardWithoutQuantity,
+        originalCard: cardWithQuantity,
+        run: false,
+      });
+
+      expect(tableColumns).not.toEqual(
+        result.card.visualization_settings["table.columns"],
+      );
     });
   });
 

--- a/frontend/test/metabase/lib/dataset.unit.spec.js
+++ b/frontend/test/metabase/lib/dataset.unit.spec.js
@@ -4,6 +4,7 @@ import {
   PRODUCTS,
   PRODUCTS_ID,
 } from "metabase-types/api/mocks/presets";
+import { createMockTableColumnOrderSetting } from "metabase-types/api/mocks";
 import {
   fieldRefForColumn,
   findColumnForColumnSetting,
@@ -92,6 +93,80 @@ describe("metabase/util/dataset", () => {
         "sum",
       ]);
       expect(newQuestion.query().columns()).toHaveLength(4);
+    });
+
+    it("removes columns from table.columns when a column is removed from a query", () => {
+      const prevQuestion = productsTable
+        .query({
+          fields: [
+            ["field", PRODUCTS.ID, null],
+            ["field", PRODUCTS.CATEGORY, null],
+            ["field", PRODUCTS.VENDOR, null],
+          ],
+        })
+        .question()
+        .setSettings({
+          "table.columns": [
+            createMockTableColumnOrderSetting({
+              name: "ID",
+              fieldRef: ["field", PRODUCTS.ID, null],
+              enabled: true,
+            }),
+            createMockTableColumnOrderSetting({
+              name: "CATEGORY",
+              fieldRef: ["field", PRODUCTS.CATEGORY, null],
+              enabled: true,
+            }),
+            createMockTableColumnOrderSetting({
+              name: "VENDOR",
+              fieldRef: ["field", PRODUCTS.VENDOR, null],
+              enabled: true,
+            }),
+          ],
+        });
+
+      const newQuestion = prevQuestion
+        .query()
+        .removeField(2)
+        .question()
+        .syncColumnsAndSettings(prevQuestion);
+
+      expect(prevQuestion.setting("table.columns")).toHaveLength(3);
+      expect(newQuestion.setting("table.columns")).toHaveLength(2);
+    });
+
+    it("adds columns to table.columns when a column is added to a query", () => {
+      const prevQuestion = productsTable
+        .query({
+          fields: [
+            ["field", PRODUCTS.ID, null],
+            ["field", PRODUCTS.CATEGORY, null],
+          ],
+        })
+        .question()
+        .setSettings({
+          "table.columns": [
+            createMockTableColumnOrderSetting({
+              name: "ID",
+              fieldRef: ["field", PRODUCTS.ID, null],
+              enabled: true,
+            }),
+            createMockTableColumnOrderSetting({
+              name: "CATEGORY",
+              fieldRef: ["field", PRODUCTS.CATEGORY, null],
+              enabled: true,
+            }),
+          ],
+        });
+
+      const newQuestion = prevQuestion
+        .query()
+        .addField(["field", PRODUCTS.VENDOR, null])
+        .question()
+        .syncColumnsAndSettings(prevQuestion);
+
+      expect(prevQuestion.setting("table.columns")).toHaveLength(2);
+      expect(newQuestion.setting("table.columns")).toHaveLength(3);
     });
   });
 

--- a/frontend/test/metabase/lib/dataset.unit.spec.js
+++ b/frontend/test/metabase/lib/dataset.unit.spec.js
@@ -132,7 +132,9 @@ describe("metabase/util/dataset", () => {
         .syncColumnsAndSettings(prevQuestion);
 
       expect(prevQuestion.setting("table.columns")).toHaveLength(3);
-      expect(newQuestion.setting("table.columns")).toHaveLength(2);
+      expect(newQuestion.setting("table.columns")).toEqual(
+        prevQuestion.setting("table.columns").slice(0, 2),
+      );
     });
 
     it("adds columns to table.columns when a column is added to a query", () => {
@@ -166,7 +168,14 @@ describe("metabase/util/dataset", () => {
         .syncColumnsAndSettings(prevQuestion);
 
       expect(prevQuestion.setting("table.columns")).toHaveLength(2);
-      expect(newQuestion.setting("table.columns")).toHaveLength(3);
+      expect(newQuestion.setting("table.columns")).toEqual([
+        ...prevQuestion.setting("table.columns"),
+        createMockTableColumnOrderSetting({
+          name: "VENDOR",
+          fieldRef: ["field", PRODUCTS.VENDOR, null],
+          enabled: true,
+        }),
+      ]);
     });
   });
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/33348

### Description
The reason for this issue is that syncing `table.columns` to fields in the query only happened when adding a field to a query, but not when removing. Looking at the history, it looks like this was adjusted back in https://github.com/metabase/metabase/pull/24503, which ensured that duplicate fields were not re-added, and in https://github.com/metabase/metabase/pull/16761, where we simply moved the logic (`Note: don't be afraid of a huge diff` kills me every time haha). The issue was that removing a field from the query cause the `isValid` logic to return false for `table.columns`, since we would have a column setting that didn't have a query column.

This change makes it so that any columns identified as being removed from the query are removed from `table.columns`, as well as leaving the logic for adding any new columns in place. This should ensure that the `table.columns` viz setting remains vaild while updating the query.


### How to verify

1. Create a question (orders will work), but don't include all fields in the query. Visualize
2. Go to settings, re-arrange the columns (this makes us save a `table.columns` setting
3. Add a new field to the query and visualize. You should see your new field appended to the end
4. Go back to the notebook editor and remove that field (or any field). Your field order should be preserved

### Demo
![9sBvfIEUBL](https://github.com/metabase/metabase/assets/1328979/fffa67ea-0c3e-4559-9e49-4e47185e52e7)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
