### PR TITLE
Auditv2 disable audit db sync

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -117,7 +117,7 @@
                              :name             "Internal Metabase Database"
                              :description      "Internal Audit DB used to power metabase analytics."
                              :engine           engine
-                             :initial_sync_status "complete"
+                             :is_full_sync true
                              :is_on_demand     false
                              :creator_id       nil
                              :auto_run_queries true})))))

--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -4,6 +4,7 @@
    [clojure.core :as c]
    [clojure.java.io :as io]
    [clojure.string :as str]
+   [malli.core :as mc]
    [metabase-enterprise.internal-user :as ee.internal-user]
    [metabase-enterprise.serialization.cmd :as serialization.cmd]
    [metabase.db.connection :as mdb.connection]
@@ -13,11 +14,10 @@
    [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.sync.util :as sync-util]
    [metabase.util :as u]
+   [metabase.util.cron :as u.cron]
    [metabase.util.files :as u.files]
    [metabase.util.log :as log]
-   [toucan2.core :as t2]
-   [malli.core :as mc]
-   [metabase.util.cron :as u.cron])
+   [toucan2.core :as t2])
   (:import [java.util.jar JarEntry JarFile]))
 
 (set! *warn-on-reflection* true)

--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -4,7 +4,6 @@
    [clojure.core :as c]
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [malli.core :as mc]
    [metabase-enterprise.internal-user :as ee.internal-user]
    [metabase-enterprise.serialization.cmd :as serialization.cmd]
    [metabase.db.connection :as mdb.connection]
@@ -14,7 +13,6 @@
    [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.sync.util :as sync-util]
    [metabase.util :as u]
-   [metabase.util.cron :as u.cron]
    [metabase.util.files :as u.files]
    [metabase.util.log :as log]
    [toucan2.core :as t2])

--- a/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
@@ -55,14 +55,11 @@
   (mt/test-drivers #{:postgres :h2 :mysql}
     (with-audit-db-restoration
       (is (= :metabase-enterprise.audit-db/installed (audit-db/ensure-audit-db-installed!)))
-      (let [adb (t2/select-one 'Database {:where [:= :is_audit true]})
-            sync-job-info (task/job-info "metabase.task.sync-and-analyze.job")
+      (let [sync-job-info (task/job-info "metabase.task.sync-and-analyze.job")
             db-has-sync-job-trigger? (fn [db-id]
                                        (contains?
                                         (set (map #(-> % :data (get "db-id")) (:triggers sync-job-info)))
                                         db-id))]
-        (is (= (:metadata_sync_schedule adb) "0 0 0 1 1 ? 2147483647")
-            "Metadata Sync scheduled for 2 billion years in the future")
         (is (db-has-sync-job-trigger? 1))
         (is (not (db-has-sync-job-trigger? (audit-db/default-audit-db-id))))))))
 

--- a/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
@@ -38,7 +38,7 @@
         (is (= :metabase-enterprise.audit-db/installed (audit-db/ensure-audit-db-installed!)))
         (is (= (audit-db/default-audit-db-id) (t2/select-one-fn :id 'Database {:where [:= :is_audit true]}))
             "Audit DB is installed.")
-        (is (= 0 (t2/count 'Card {:where [:= :database_id (audit-db/default-audit-db-id)]}))
+        (is (= 0 (t2/count :model/Card {:where [:= :database_id (audit-db/default-audit-db-id)]}))
             "No cards created for Audit DB.")))))
 
 (deftest audit-db-content-is-installed-when-found
@@ -48,19 +48,18 @@
       (is (= (audit-db/default-audit-db-id) (t2/select-one-fn :id 'Database {:where [:= :is_audit true]}))
           "Audit DB is installed.")
       (is (some? (io/resource "instance_analytics")))
-      (is (not= 0 (t2/count 'Card {:where [:= :database_id (audit-db/default-audit-db-id)]}))
+      (is (not= 0 (t2/count :model/Card {:where [:= :database_id (audit-db/default-audit-db-id)]}))
           "Cards should be created for Audit DB when the content is there."))))
 
 (deftest audit-db-does-not-have-scheduled-syncs
   (mt/test-drivers #{:postgres :h2 :mysql}
     (with-audit-db-restoration
       (is (= :metabase-enterprise.audit-db/installed (audit-db/ensure-audit-db-installed!)))
-      (let [sync-job-info (task/job-info "metabase.task.sync-and-analyze.job")
-            db-has-sync-job-trigger? (fn [db-id]
+      (let [db-has-sync-job-trigger? (fn [db-id]
                                        (contains?
-                                        (set (map #(-> % :data (get "db-id")) (:triggers sync-job-info)))
+                                        (set (map #(-> % :data (get "db-id"))
+                                                  (task/job-info "metabase.task.sync-and-analyze.job")))
                                         db-id))]
-        (is (db-has-sync-job-trigger? 1))
         (is (not (db-has-sync-job-trigger? (audit-db/default-audit-db-id))))))))
 
 (deftest audit-db-instance-analytics-content-is-coppied-properly

--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -227,6 +227,11 @@
       ;; See https://www.nurkiewicz.com/2012/04/quartz-scheduler-misfire-instructions.html for more info
       (cron/with-misfire-handling-instruction-do-nothing)))))
 
+(defn is-audit-db-sync-job? [database {:keys [key db-schedule-column]}]
+  (and (:is_audit database)
+       (= key :sync-and-analyze)
+       (= db-schedule-column :metadata_sync_schedule)))
+
 ;; called [[from metabase.models.database/schedule-tasks!]] from the post-insert and the pre-update
 (mu/defn check-and-schedule-tasks-for-db!
   "Schedule a new Quartz job for `database` and `task-info` if it doesn't already exist or is incorrect."
@@ -242,28 +247,31 @@
                                     (:triggers sync-job))
         existing-fv-trigger   (some (fn [trigger] (when (= (:key trigger) (.. fv-trigger getKey getName))
                                                     trigger))
-                                    (:triggers fv-job))]
-
-    (doseq [{:keys [existing-trigger existing-schedule ti trigger description]}
-            [{:existing-trigger  existing-sync-trigger
-              :existing-schedule (:metadata_sync_schedule database)
-              :ti                sync-analyze-task-info
-              :trigger           sync-trigger
-              :description       "sync/analyze"}
-             {:existing-trigger  existing-fv-trigger
-              :existing-schedule (:cache_field_values_schedule database)
-              :ti                field-values-task-info
-              :trigger           fv-trigger
-              :description       "field-values"}]
+                                    (:triggers fv-job))
+        job-data [{:existing-trigger  existing-sync-trigger
+                   :existing-schedule (:metadata_sync_schedule database)
+                   :ti                sync-analyze-task-info
+                   :trigger           sync-trigger
+                   :description       "sync/analyze"}
+                  {:existing-trigger  existing-fv-trigger
+                   :existing-schedule (:cache_field_values_schedule database)
+                   :ti                field-values-task-info
+                   :trigger           fv-trigger
+                   :description       "field-values"}]
+        {:keys [jobs-to-create
+                jobs-to-skip]} (group-by (fn [{:keys [ti]}]
+                                           (if (is-audit-db-sync-job? database ti)
+                                             :jobs-to-skip
+                                             :jobs-to-create))
+                                         job-data)]
+    (doseq [{:keys [description]} jobs-to-skip]
+      (log/info (u/format-color :red "Not scheduling %s for database %d" description (:id database))))
+    (doseq [{:keys [existing-trigger existing-schedule ti trigger description]} jobs-to-create
             :when (or (not existing-trigger)
-                      (not= (:schedule existing-trigger) existing-schedule))
-            :when (not (and (:is_audit database) (= description "sync/analyze")
-                            (u/prog1 true
-                              (log/info
-                               (u/format-color 'red "Not scheduling %s for database %d" description (:id database))))))]
+                      (not= (:schedule existing-trigger) existing-schedule))]
       (delete-task! database ti)
       (log/info
-       (u/format-color 'green "Scheduling %s for database %d: trigger: %s"
+       (u/format-color :green "Scheduling %s for database %d: trigger: %s"
                        description (:id database) (.. ^org.quartz.Trigger trigger getKey getName)))
       ;; now (re)schedule the task
       (task/add-trigger! trigger))))

--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -227,7 +227,11 @@
       ;; See https://www.nurkiewicz.com/2012/04/quartz-scheduler-misfire-instructions.html for more info
       (cron/with-misfire-handling-instruction-do-nothing)))))
 
-(defn is-audit-db-sync-job? [database {:keys [key db-schedule-column]}]
+(defn is-audit-db-sync-job?
+  "Returns true when the job is a sync job, and the database is an audit database.
+
+  This is in [[check-and-schedule-tasks-for-db!]] to skip the creation of the sync job test for audit databases."
+  [database {:keys [key db-schedule-column]}]
   (and (:is_audit database)
        (= key :sync-and-analyze)
        (= db-schedule-column :metadata_sync_schedule)))

--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -254,15 +254,19 @@
               :existing-schedule (:cache_field_values_schedule database)
               :ti                field-values-task-info
               :trigger           fv-trigger
-              :description       "field-values"}]]
-      (when (or (not existing-trigger)
-                (not= (:schedule existing-trigger) existing-schedule))
-        (delete-task! database ti)
-        (log/info
-         (u/format-color 'green "Scheduling %s for database %d: trigger: %s"
-                         description (u/the-id database) (.. ^org.quartz.Trigger trigger getKey getName)))
-        ;; now (re)schedule the task
-        (task/add-trigger! trigger)))))
+              :description       "field-values"}]
+            :when (or (not existing-trigger)
+                      (not= (:schedule existing-trigger) existing-schedule))
+            :when (not (and (:is_audit database) (= description "sync/analyze")
+                            (u/prog1 true
+                              (log/info
+                               (u/format-color 'red "Not scheduling %s for database %d" description (:id database))))))]
+      (delete-task! database ti)
+      (log/info
+       (u/format-color 'green "Scheduling %s for database %d: trigger: %s"
+                       description (:id database) (.. ^org.quartz.Trigger trigger getKey getName)))
+      ;; now (re)schedule the task
+      (task/add-trigger! trigger))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
We want to disable db syncs for the audit-db. This alters `check-and-schedule-tasks-for-db!` to skip the creation of the sync job (`"scan/analyze"`) for the audit-db. The scan/analyze info already exists because of the way we load the instance analytics content.

I considered making the `metadata_sync_schedule` be about 2 billion years, since that is possible in a valid cron string. But that doesn't seem right, because the job would be in there, and it isn't needed at all.

So, we skip creating the sync job by partitioning jobs into `jobs-to-create` and `jobs-to-skip` , for the one we skip, we print out a log about not creating the job, and the codepath creating jobs is left untouched.

## How do you know this works?
- On app startup, there is a log message about _not_ installing a sync job for the audit-db. It is in red, too. ✨
- No sync messages occur in the logs.