### PR TITLE
Do not set `updated_at` when pinned

### DIFF
--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -57,6 +57,7 @@
   (derive :metabase/model)
   ;; You can read/write a Card if you can read/write its parent Collection
   (derive ::perms/use-parent-collection-perms)
+  (derive ::collection/no-updated-at-on-position-change)
   (derive :hook/timestamped?)
   (derive :hook/entity-id))
 

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -25,6 +25,7 @@
    [methodical.core :as methodical]
    [potemkin :as p]
    [toucan2.core :as t2]
+   [toucan2.tools.before-update :as t2.before-update]
    [toucan2.protocols :as t2.protocols]
    [toucan2.realize :as t2.realize]))
 
@@ -65,6 +66,16 @@
   (derive :hook/entity-id)
   (derive ::mi/read-policy.full-perms-for-perms-set)
   (derive ::mi/write-policy.full-perms-for-perms-set))
+
+(t2/define-before-update ::no-updated-at-on-position-change
+  [obj]
+  (let [changes (if (t2/instance? obj) (t2/changes obj) obj)
+        only-changes-position? (set/subset? (set (keys changes))
+                                            #{:collection_position})]
+    (cond-> obj
+      only-changes-position? (assoc :updated_at nil))))
+
+(methodical/prefer-method! #'t2.before-update/before-update ::no-updated-at-on-position-change :hook/timestamped?)
 
 (def AuthorityLevel
   "Malli Schema for valid collection authority levels."

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -45,6 +45,7 @@
 (doto :model/Dashboard
   (derive :metabase/model)
   (derive ::perms/use-parent-collection-perms)
+  (derive ::collection/no-updated-at-on-position-change)
   (derive :hook/timestamped?)
   (derive :hook/entity-id))
 

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -381,12 +381,13 @@
 
 (defn- add-updated-at-timestamp [obj]
   ;; don't stomp on `:updated_at` if it's already explicitly specified.
-  (let [changes-already-include-updated-at? (if (t2/instance? obj)
-                                              (:updated_at (t2/changes obj))
-                                              (:updated_at obj))]
+  (let [changes (if (t2/instance? obj) (t2/changes obj) obj)
+        changes-already-include-updated-at? (contains? changes :updated_at)
+        ;; explicitly set to `nil` means "do not change this"
+        nil-updated-at? (and changes-already-include-updated-at? (nil? (:updated_at changes)))]
     (cond-> obj
-      (not changes-already-include-updated-at?) (assoc :updated_at (now)))))
-
+      (not changes-already-include-updated-at?) (assoc :updated_at (now))
+      nil-updated-at? (dissoc :updated_at))))
 
 (t2/define-before-insert :hook/timestamped?
   [instance]

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -50,6 +50,7 @@
 (doto :model/Pulse
   (derive :metabase/model)
   (derive :hook/timestamped?)
+  (derive ::collection/no-updated-at-on-position-change)
   (derive :hook/entity-id)
   (derive ::mi/read-policy.full-perms-for-perms-set))
 

--- a/test/metabase/models/interface_test.clj
+++ b/test/metabase/models/interface_test.clj
@@ -85,6 +85,17 @@
                  :updated_at (partial not= updated-at)}
                 (t2/select-one [Table :id :name :updated_at] (u/the-id table))))))))
 
+(deftest add-updated-at-respects-existing
+  (testing "when explicitly set to a value, it's not affected"
+    (is (= {:updated_at "123"}
+           (#'mi/add-updated-at-timestamp {:updated_at "123"}))))
+  (testing "when explicitly set to `nil`, it's removed"
+    (is (= {}
+           (#'mi/add-updated-at-timestamp {:updated_at nil}))))
+  (testing "when not set at all, it's added"
+    (is (some? (:updated_at
+                (#'mi/add-updated-at-timestamp {}))))))
+
 (deftest timestamped-property-do-not-stomp-on-explicit-values-test
   (testing "The :timestamped property should not stomp on :created_at/:updated_at if they are explicitly specified"
     (t2.with-temp/with-temp [Field field]


### PR DESCRIPTION
This was a bit of a wild goose chase, for a few reasons, but I'm looking at it as an educational experience :joy:

First of all, I had a bit of trouble deciding on the best route for fixing this. I _think_ I arrived at an expedient and workable solution, but a few other options I considered:

- somehow allow setting a list of keys to ignore for the purpose of setting "updated_at" on a given model. This didn't seem workable because there doesn't seem to be a way to figure out what model you're working with from a `t2` hook like `before-update` (though I'd be happy if I'm wrong here)

- write my own version of `:hook/timestamped?` - this would seem to duplicate a lot of code, and felt too hacky.

- rearrange the database schema to put information about the collection/item link in its own table. In some ways this feels like the "right" solution - collection position isn't really a property of the item itself - but it would have involved a pretty extensive migration plus a lot of changes that I didn't feel comfortable with (although maybe that's just a measure of my current knowledge of the codebase, t2, etc.). If this *is* worth doing, I could dive in and try to attempt it - but I didn't want to do that without some external validation that it's the right path forward.

In the end, I arrived at the following fairly simple solution:

- change the method that adds `updated_at` to:
  - check for the *presence* of `updated_at` rather than its truthiness
  - if `updated_at` is explicitly set to `nil`, it removes it from the changes
    - before, it would have replaced the `nil` with `(now)`
    - this is arguably the hackiest part of this change - feedback definitely welcome here.

- add an additional `before-update` hook that explicitly sets `updated_at` to `nil` when only `collection_position` has changedA

- use `methodical/prefer-method!` to sequence the latter hook before the `timestamped?` hook, so that we explicitly set `updated_at` to `nil` in this case

The biggest problem here is a really odd one: this seems to work in the database, but somehow the frontend still reports that the card was updated. I am still figuring out why this is the case, but it may be that this requires frontend work that I'm not qualified to do.

Fixing the backend might still be worth it, since it's probably necessary for whatever frontend fix is necessary as well - but maybe it's not, since we seem to be ignoring `updated_at` entirely on the frontend - presumably it's cached somewhere and would be populated eventually?

One final note - while typing this up, it occurred to me that maybe a better solution would be to add a custom `updated-at` hook *after* `timestamped?` instead of before. Instead of adding a slightly surprising behavior to the `timestamped?` hook (removing nil `updated_at`s) we could keep it exactly the same, and just *remove* `updated_at` if the only changed keys were `#{:updated_at :collection_position}`. I might implement that - now that I have a better understanding of t2 it should be a quick change.