### PR TITLE
Revise the copy and tests for for the "don't lose your changes" confirmation modal

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
@@ -63,7 +63,7 @@ describe("scenarios > dashboard > dashboard back navigation", () => {
     cy.findByLabelText(backButtonLabel).should("be.visible");
     visualize();
     cy.findByLabelText(backButtonLabel).click();
-    modal().button("Leave anyway").click();
+    modal().button("Discard changes").click();
     cy.findByTestId("dashboard-header")
       .findByText(dashboardName)
       .should("be.visible");

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -336,7 +336,7 @@ describe("scenarios > dashboard", () => {
         cy.log("Should revert the title change if editing is cancelled");
         cy.findByTestId("dashboard-name-heading").clear().type(newTitle).blur();
         cy.findByTestId("edit-bar").button("Cancel").click();
-        modal().button("Leave anyway").click();
+        modal().button("Discard changes").click();
         cy.findByTestId("edit-bar").should("not.exist");
         cy.get("@updateDashboardSpy").should("not.have.been.called");
         cy.findByDisplayValue(originalDashboardName);

--- a/e2e/test/scenarios/models/create.cy.spec.js
+++ b/e2e/test/scenarios/models/create.cy.spec.js
@@ -18,7 +18,7 @@ describe("scenarios > models > create", () => {
 
     // Cancel creation with confirmation modal
     cy.findByTestId("dataset-edit-bar").button("Cancel").click();
-    modal().button("Leave anyway").click();
+    modal().button("Discard changes").click();
 
     // Now we will create a model
     navigateToNewModelPage();

--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -82,7 +82,7 @@ describe("scenarios > models metadata", () => {
       setColumnType("No special type", "Cost");
 
       cy.button("Cancel").click();
-      modal().button("Leave anyway").click();
+      modal().button("Discard changes").click();
 
       cy.findByTestId("TableInteractive-root").findByText("Subtotal");
     });

--- a/e2e/test/scenarios/models/models-query-editor.cy.spec.js
+++ b/e2e/test/scenarios/models/models-query-editor.cy.spec.js
@@ -90,7 +90,7 @@ describe("scenarios > models query editor", () => {
         .and("not.contain", "109.22");
 
       cy.button("Cancel").click();
-      modal().button("Leave anyway").click();
+      modal().button("Discard changes").click();
       cy.wait("@cardQuery");
 
       cy.url()
@@ -189,7 +189,7 @@ describe("scenarios > models query editor", () => {
         .and("not.contain", "109.22");
 
       cy.button("Cancel").click();
-      modal().button("Leave anyway").click();
+      modal().button("Discard changes").click();
       cy.wait("@cardQuery");
 
       cy.get(".cellData").should("contain", "37.65").and("contain", "109.22");

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -104,9 +104,9 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
       cy.get("label").contains("Data").click();
 
       modal().within(() => {
-        cy.findByText("Changes were not saved");
+        cy.findByText("Discard your changes?");
         cy.findByText(
-          "Navigating away from here will cause you to lose any changes you have made.",
+          "Your changes haven't been saved, so you'll lose them if you navigate away.",
         );
 
         cy.button("Cancel").click();
@@ -304,9 +304,9 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
       cy.get("label").contains("Collection").click();
 
       modal().within(() => {
-        cy.findByText("Changes were not saved");
+        cy.findByText("Discard your changes?");
         cy.findByText(
-          "Navigating away from here will cause you to lose any changes you have made.",
+          "Your changes haven't been saved, so you'll lose them if you navigate away.",
         );
 
         cy.button("Cancel").click();

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -117,7 +117,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
       // Switching to data permissions page again
       cy.get("label").contains("Data").click();
 
-      modal().button("Leave anyway").click();
+      modal().button("Discard changes").click();
 
       cy.url().should("include", "/admin/permissions/data/group");
     });
@@ -317,7 +317,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
       // Switching to collection permissions page again
       cy.get("label").contains("Collection").click();
 
-      modal().button("Leave anyway").click();
+      modal().button("Discard changes").click();
 
       cy.url().should("include", "/admin/permissions/collections");
     });

--- a/e2e/test/scenarios/permissions/impersonated.cy.spec.js
+++ b/e2e/test/scenarios/permissions/impersonated.cy.spec.js
@@ -277,7 +277,7 @@ describeEE("impersonated permission", () => {
       // Page leave confirmation should be on top
       modal()
         .as("leaveConfirmation")
-        .findByText("Changes were not saved")
+        .findByText("Discard your changes?")
         .should("be.visible");
 
       // Cancel

--- a/e2e/test/scenarios/permissions/impersonated.cy.spec.js
+++ b/e2e/test/scenarios/permissions/impersonated.cy.spec.js
@@ -290,7 +290,7 @@ describeEE("impersonated permission", () => {
 
       // Go to settings
       cy.findByRole("dialog").findByText("Edit settings").click();
-      cy.get("@leaveConfirmation").findByText("Leave anyway").click();
+      cy.get("@leaveConfirmation").findByText("Discard changes").click();
 
       cy.focused().should("have.attr", "placeholder", "username");
     });

--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -428,7 +428,7 @@ describe("scenarios > question > settings", () => {
       cy.contains("Orders in a dashboard").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Cancel").click();
-      modal().button("Leave anyway").click();
+      modal().button("Discard changes").click();
 
       // create a new question to see if the "add to a dashboard" modal is still there
       openNavigationSidebar();

--- a/frontend/src/metabase/components/LeaveConfirmationModal/LeaveConfirmationModalContent.tsx
+++ b/frontend/src/metabase/components/LeaveConfirmationModal/LeaveConfirmationModalContent.tsx
@@ -15,10 +15,10 @@ export const LeaveConfirmationModalContent = ({
 }: Props) => (
   <ConfirmContent
     cancelButtonText={t`Cancel`}
-    confirmButtonText={t`Leave anyway`}
+    confirmButtonText={t`Discard changes`}
     data-testid="leave-confirmation"
-    message={t`Navigating away from here will cause you to lose any changes you have made.`}
-    title={t`Changes were not saved`}
+    message={t`Your changes haven't been saved, so you'll lose them if you navigate away.`}
+    title={t`Discard your changes?`}
     onAction={onAction}
     onCancel={onCancel}
     onClose={onClose}


### PR DESCRIPTION
The previous copy in this modal didn't adhere to [our modals guidelines](https://www.notion.so/metabase/Modals-guidelines-fdf132ff081444088bcd37622fd8d023).

# Before

<img width="681" alt="image" src="https://github.com/metabase/metabase/assets/2223916/8de051be-a262-4f81-b625-ed832fc7898d">

# After
<img width="731" alt="image" src="https://github.com/metabase/metabase/assets/2223916/0ac76d1e-77d7-4e63-ad85-0e54564703a0">
