### PR TITLE
Fix - Unsaved changes warning shown when going back to notebook after visualizing the question

### DIFF
--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -401,7 +401,7 @@ describe("QueryBuilder", () => {
           });
 
           await triggerNotebookQueryChange();
-          await waitForSaveModelToBeEnabled();
+          await waitForSaveChangesToBeEnabled();
 
           const mockEvent = callMockEvent(mockEventListener, "beforeunload");
           expect(mockEvent.preventDefault).toHaveBeenCalled();
@@ -429,7 +429,7 @@ describe("QueryBuilder", () => {
           });
 
           await triggerMetadataChange();
-          await waitForSaveModelToBeEnabled();
+          await waitForSaveChangesToBeEnabled();
 
           const mockEvent = callMockEvent(mockEventListener, "beforeunload");
           expect(mockEvent.preventDefault).toHaveBeenCalled();
@@ -464,7 +464,7 @@ describe("QueryBuilder", () => {
         await waitForLoaderToBeRemoved();
 
         await triggerNativeQueryChange();
-        await waitForSaveNewQuestionToBeEnabled();
+        await waitForSaveToBeEnabled();
 
         const mockEvent = callMockEvent(mockEventListener, "beforeunload");
         expect(mockEvent.preventDefault).toHaveBeenCalled();
@@ -606,7 +606,7 @@ describe("QueryBuilder", () => {
         setupCardQueryMetadataEndpoint(TEST_NATIVE_CARD);
 
         await startNewNotebookModel();
-        await waitForSaveQuestionToBeEnabled();
+        await waitForSaveToBeEnabled();
 
         userEvent.click(screen.getByRole("button", { name: "Save" }));
         userEvent.click(
@@ -652,7 +652,7 @@ describe("QueryBuilder", () => {
           });
 
           await triggerNotebookQueryChange();
-          await waitForSaveQuestionToBeEnabled();
+          await waitForSaveToBeEnabled();
 
           userEvent.click(screen.getByText("Save"));
           userEvent.click(
@@ -688,7 +688,7 @@ describe("QueryBuilder", () => {
           });
 
           await triggerNotebookQueryChange();
-          await waitForSaveModelToBeEnabled();
+          await waitForSaveChangesToBeEnabled();
 
           history.push("/redirect");
 
@@ -702,10 +702,10 @@ describe("QueryBuilder", () => {
           });
 
           await triggerNotebookQueryChange();
-          await waitForSaveModelToBeEnabled();
+          await waitForSaveChangesToBeEnabled();
 
           await revertNotebookQueryChange();
-          await waitForSaveModelToBeDisabled();
+          await waitForSaveChangesToBeDisabled();
 
           history.push("/redirect");
 
@@ -721,7 +721,7 @@ describe("QueryBuilder", () => {
           });
 
           await triggerNotebookQueryChange();
-          await waitForSaveModelToBeEnabled();
+          await waitForSaveChangesToBeEnabled();
 
           userEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
@@ -735,10 +735,10 @@ describe("QueryBuilder", () => {
           });
 
           await triggerNotebookQueryChange();
-          await waitForSaveModelToBeEnabled();
+          await waitForSaveChangesToBeEnabled();
 
           await revertNotebookQueryChange();
-          await waitForSaveModelToBeDisabled();
+          await waitForSaveChangesToBeDisabled();
 
           userEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
@@ -754,7 +754,7 @@ describe("QueryBuilder", () => {
           });
 
           await triggerNotebookQueryChange();
-          await waitForSaveModelToBeEnabled();
+          await waitForSaveChangesToBeEnabled();
 
           userEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
@@ -785,7 +785,7 @@ describe("QueryBuilder", () => {
           });
 
           await triggerMetadataChange();
-          await waitForSaveModelToBeEnabled();
+          await waitForSaveChangesToBeEnabled();
 
           history.push("/redirect");
 
@@ -830,7 +830,7 @@ describe("QueryBuilder", () => {
           });
 
           await triggerMetadataChange();
-          await waitForSaveModelToBeEnabled();
+          await waitForSaveChangesToBeEnabled();
 
           userEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
@@ -852,7 +852,7 @@ describe("QueryBuilder", () => {
           userEvent.click(screen.getByText("Metadata"));
 
           await triggerMetadataChange();
-          await waitForSaveModelToBeEnabled();
+          await waitForSaveChangesToBeEnabled();
 
           userEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
@@ -882,7 +882,7 @@ describe("QueryBuilder", () => {
         });
 
         await triggerNotebookQueryChange();
-        await waitForSaveModelToBeEnabled();
+        await waitForSaveChangesToBeEnabled();
 
         userEvent.click(screen.getByTestId("editor-tabs-metadata-name"));
 
@@ -891,7 +891,7 @@ describe("QueryBuilder", () => {
         ).not.toBeInTheDocument();
 
         await triggerMetadataChange();
-        await waitForSaveModelToBeEnabled();
+        await waitForSaveChangesToBeEnabled();
 
         userEvent.click(screen.getByTestId("editor-tabs-query-name"));
 
@@ -907,7 +907,7 @@ describe("QueryBuilder", () => {
         });
 
         await triggerNotebookQueryChange();
-        await waitForSaveQuestionToBeEnabled();
+        await waitForSaveToBeEnabled();
 
         userEvent.click(screen.getByText("Visualize"));
         await waitForLoaderToBeRemoved();
@@ -938,7 +938,7 @@ describe("QueryBuilder", () => {
         await waitForLoaderToBeRemoved();
 
         await triggerNativeQueryChange();
-        await waitForSaveNewQuestionToBeEnabled();
+        await waitForSaveToBeEnabled();
 
         history.push("/redirect");
 
@@ -1002,7 +1002,7 @@ describe("QueryBuilder", () => {
         await waitForLoaderToBeRemoved();
 
         await triggerNativeQueryChange();
-        await waitForSaveNewQuestionToBeEnabled();
+        await waitForSaveToBeEnabled();
 
         userEvent.click(screen.getByText("Save"));
 
@@ -1044,7 +1044,7 @@ describe("QueryBuilder", () => {
         });
 
         await triggerNativeQueryChange();
-        await waitForSaveQuestionToBeEnabled();
+        await waitForSaveToBeEnabled();
 
         history.push("/redirect");
 
@@ -1073,7 +1073,7 @@ describe("QueryBuilder", () => {
         });
 
         await triggerNativeQueryChange();
-        await waitForSaveQuestionToBeEnabled();
+        await waitForSaveToBeEnabled();
 
         userEvent.click(
           within(screen.getByTestId("query-builder-main")).getByRole("button", {
@@ -1093,7 +1093,7 @@ describe("QueryBuilder", () => {
         });
 
         await triggerNativeQueryChange();
-        await waitForSaveQuestionToBeEnabled();
+        await waitForSaveToBeEnabled();
 
         userEvent.click(screen.getByText("Save"));
 
@@ -1128,7 +1128,7 @@ describe("QueryBuilder", () => {
         });
 
         await triggerNativeQueryChange();
-        await waitForSaveQuestionToBeEnabled();
+        await waitForSaveToBeEnabled();
 
         userEvent.click(screen.getByText("Save"));
 
@@ -1173,7 +1173,7 @@ describe("QueryBuilder", () => {
         });
 
         await triggerNotebookQueryChange();
-        await waitForSaveQuestionToBeEnabled();
+        await waitForSaveToBeEnabled();
 
         history.push("/redirect");
 
@@ -1187,7 +1187,7 @@ describe("QueryBuilder", () => {
         });
 
         await triggerVisualizationQueryChange();
-        await waitForSaveQuestionToBeEnabled();
+        await waitForSaveToBeEnabled();
 
         history.push("/redirect");
 
@@ -1216,7 +1216,7 @@ describe("QueryBuilder", () => {
         });
 
         await triggerNotebookQueryChange();
-        await waitForSaveQuestionToBeEnabled();
+        await waitForSaveToBeEnabled();
 
         userEvent.click(screen.getByText("Visualize"));
         await waitForLoaderToBeRemoved();
@@ -1239,7 +1239,7 @@ describe("QueryBuilder", () => {
         });
 
         await triggerNotebookQueryChange();
-        await waitForSaveQuestionToBeEnabled();
+        await waitForSaveToBeEnabled();
 
         userEvent.click(screen.getByText("Save"));
 
@@ -1274,7 +1274,7 @@ describe("QueryBuilder", () => {
         });
 
         await triggerNotebookQueryChange();
-        await waitForSaveQuestionToBeEnabled();
+        await waitForSaveToBeEnabled();
 
         userEvent.click(screen.getByText("Save"));
 
@@ -1456,26 +1456,22 @@ const revertNotebookQueryChange = async () => {
   userEvent.tab();
 };
 
-const waitForSaveModelToBeEnabled = async () => {
+const waitForSaveChangesToBeEnabled = async () => {
   await waitFor(() => {
     expect(screen.getByRole("button", { name: "Save changes" })).toBeEnabled();
   });
 };
 
-const waitForSaveModelToBeDisabled = async () => {
+const waitForSaveChangesToBeDisabled = async () => {
   await waitFor(() => {
     expect(screen.getByRole("button", { name: "Save changes" })).toBeDisabled();
   });
 };
 
-const waitForSaveQuestionToBeEnabled = async () => {
+const waitForSaveToBeEnabled = async () => {
   await waitFor(() => {
     expect(screen.getByText("Save")).toBeEnabled();
   });
-};
-
-const waitForSaveNewQuestionToBeEnabled = async () => {
-  await waitForSaveQuestionToBeEnabled();
 };
 
 const waitForNativeQueryEditoReady = async () => {

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -262,6 +262,7 @@ const setup = async ({
         <Route path="new" component={NewModelOptions} />
         <Route path="query" component={TestQueryBuilder} />
         <Route path="metadata" component={TestQueryBuilder} />
+        <Route path="notebook" component={TestQueryBuilder} />
         <Route path=":slug/query" component={TestQueryBuilder} />
         <Route path=":slug/metadata" component={TestQueryBuilder} />
         <Route path=":slug/notebook" component={TestQueryBuilder} />
@@ -893,6 +894,29 @@ describe("QueryBuilder", () => {
         await waitForSaveModelToBeEnabled();
 
         userEvent.click(screen.getByTestId("editor-tabs-query-name"));
+
+        expect(
+          screen.queryByTestId("leave-confirmation"),
+        ).not.toBeInTheDocument();
+      });
+
+      it("does not show custom warning modal when editing & visualizing the model back and forth (metabase#35000)", async () => {
+        await setup({
+          card: TEST_MODEL_CARD,
+          initialRoute: `/model/${TEST_MODEL_CARD.id}/notebook`,
+        });
+
+        await triggerNotebookQueryChange();
+        await waitForSaveQuestionToBeEnabled();
+
+        userEvent.click(screen.getByText("Visualize"));
+        await waitForLoaderToBeRemoved();
+
+        userEvent.click(screen.getByLabelText("notebook icon"));
+
+        await waitFor(() => {
+          expect(screen.getByText("Visualize")).toBeInTheDocument();
+        });
 
         expect(
           screen.queryByTestId("leave-confirmation"),

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -1185,6 +1185,29 @@ describe("QueryBuilder", () => {
         ).not.toBeInTheDocument();
       });
 
+      it("does not show custom warning modal when editing & visualizing the question back and forth (metabase#35000)", async () => {
+        await setup({
+          card: TEST_STRUCTURED_CARD,
+          initialRoute: `/question/${TEST_STRUCTURED_CARD.id}/notebook`,
+        });
+
+        await triggerNotebookQueryChange();
+        await waitForSaveQuestionToBeEnabled();
+
+        userEvent.click(screen.getByText("Visualize"));
+        await waitForLoaderToBeRemoved();
+
+        userEvent.click(screen.getByLabelText("notebook icon"));
+
+        await waitFor(() => {
+          expect(screen.getByText("Visualize")).toBeInTheDocument();
+        });
+
+        expect(
+          screen.queryByTestId("leave-confirmation"),
+        ).not.toBeInTheDocument();
+      });
+
       it("does not show custom warning modal when saving edited question", async () => {
         const { history } = await setup({
           card: TEST_STRUCTURED_CARD,

--- a/frontend/src/metabase/query_builder/utils.ts
+++ b/frontend/src/metabase/query_builder/utils.ts
@@ -79,7 +79,12 @@ export const isNavigationAllowed = ({
   }
 
   const { hash, pathname } = destination;
-  const isRunningModel = pathname === "/model" && hash.length > 0;
+
+  const runModelPathnames = question.isStructured()
+    ? ["/model", "/model/notebook"]
+    : ["/model"];
+  const isRunningModel =
+    runModelPathnames.includes(pathname) && hash.length > 0;
   const validSlugs = [question.id(), question.slug()]
     .filter(Boolean)
     .map(String);

--- a/frontend/src/metabase/query_builder/utils.ts
+++ b/frontend/src/metabase/query_builder/utils.ts
@@ -80,7 +80,6 @@ export const isNavigationAllowed = ({
 
   const { hash, pathname } = destination;
   const isRunningModel = pathname === "/model" && hash.length > 0;
-  const isRunningQuestion = pathname === "/question" && hash.length > 0;
   const validSlugs = [question.id(), question.slug()]
     .filter(Boolean)
     .map(String);
@@ -101,6 +100,7 @@ export const isNavigationAllowed = ({
   }
 
   if (question.isNative()) {
+    const isRunningQuestion = pathname === "/question" && hash.length > 0;
     return isRunningQuestion;
   }
 
@@ -109,6 +109,8 @@ export const isNavigationAllowed = ({
    * https://github.com/metabase/metabase/issues/34686
    */
   if (!isNewQuestion && question.isStructured()) {
+    const isRunningQuestion =
+      ["/question", "/question/notebook"].includes(pathname) && hash.length > 0;
     const allowedPathnames = validSlugs.flatMap(slug => [
       `/question/${slug}`,
       `/question/${slug}/notebook`,

--- a/frontend/src/metabase/query_builder/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.ts
@@ -104,6 +104,11 @@ const runQuestionLocation = createMockLocation({
   hash: `#${serializeCardForUrl(nativeCard)}`,
 });
 
+const runQuestionEditNotebookLocation = createMockLocation({
+  pathname: "/question/notebook",
+  hash: `#${serializeCardForUrl(nativeCard)}`,
+});
+
 describe("isNavigationAllowed", () => {
   describe("when there is no destination (i.e. it's a beforeunload event)", () => {
     const destination = undefined;
@@ -144,6 +149,7 @@ describe("isNavigationAllowed", () => {
       newModelMetadataTabLocation,
       runModelLocation,
       runQuestionLocation,
+      runQuestionEditNotebookLocation,
     ])("allows navigating away to `$pathname`", destination => {
       expect(
         isNavigationAllowed({ destination, question, isNewQuestion: true }),
@@ -169,6 +175,7 @@ describe("isNavigationAllowed", () => {
         newModelMetadataTabLocation,
         runModelLocation,
         runQuestionLocation,
+        runQuestionEditNotebookLocation,
       ])("to `$pathname`", destination => {
         expect(
           isNavigationAllowed({ destination, question, isNewQuestion }),
@@ -199,6 +206,7 @@ describe("isNavigationAllowed", () => {
         newModelQueryTabLocation,
         newModelMetadataTabLocation,
         runModelLocation,
+        runQuestionEditNotebookLocation,
       ])("to `$pathname`", destination => {
         expect(
           isNavigationAllowed({ destination, question, isNewQuestion }),
@@ -213,6 +221,14 @@ describe("isNavigationAllowed", () => {
 
     it("allows to run the question", () => {
       const destination = runQuestionLocation;
+
+      expect(
+        isNavigationAllowed({ destination, question, isNewQuestion }),
+      ).toBe(true);
+    });
+
+    it("allows to run the question and then edit it again", () => {
+      const destination = runQuestionEditNotebookLocation;
 
       expect(
         isNavigationAllowed({ destination, question, isNewQuestion }),
@@ -276,6 +292,7 @@ describe("isNavigationAllowed", () => {
         newModelQueryTabLocation,
         newModelMetadataTabLocation,
         runModelLocation,
+        runQuestionEditNotebookLocation,
       ])("to `$pathname`", destination => {
         expect(
           isNavigationAllowed({ destination, question, isNewQuestion }),
@@ -315,6 +332,7 @@ describe("isNavigationAllowed", () => {
         ...getStructuredQuestionLocations(structuredQuestion),
         ...getNativeQuestionLocations(nativeQuestion),
         runQuestionLocation,
+        runQuestionEditNotebookLocation,
       ])("to `$pathname`", destination => {
         expect(
           isNavigationAllowed({ destination, question, isNewQuestion }),
@@ -351,6 +369,7 @@ describe("isNavigationAllowed", () => {
         ...getNativeQuestionLocations(nativeQuestion),
         newModelMetadataTabLocation,
         newModelQueryTabLocation,
+        runQuestionEditNotebookLocation,
       ])("to `$pathname`", destination => {
         expect(
           isNavigationAllowed({ destination, question, isNewQuestion }),
@@ -387,6 +406,7 @@ describe("isNavigationAllowed", () => {
         ...getNativeQuestionLocations(nativeQuestion),
         newModelMetadataTabLocation,
         newModelQueryTabLocation,
+        runQuestionEditNotebookLocation,
       ])("to `$pathname`", destination => {
         expect(
           isNavigationAllowed({ destination, question, isNewQuestion }),

--- a/frontend/src/metabase/query_builder/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.ts
@@ -99,6 +99,11 @@ const runModelLocation = createMockLocation({
   hash: `#${serializeCardForUrl(nativeModelCard)}`,
 });
 
+const runModelEditNotebookLocation = createMockLocation({
+  pathname: "/model/notebook",
+  hash: `#${serializeCardForUrl(nativeModelCard)}`,
+});
+
 const runQuestionLocation = createMockLocation({
   pathname: "/question",
   hash: `#${serializeCardForUrl(nativeCard)}`,
@@ -148,6 +153,7 @@ describe("isNavigationAllowed", () => {
       newModelQueryTabLocation,
       newModelMetadataTabLocation,
       runModelLocation,
+      runModelEditNotebookLocation,
       runQuestionLocation,
       runQuestionEditNotebookLocation,
     ])("allows navigating away to `$pathname`", destination => {
@@ -174,6 +180,7 @@ describe("isNavigationAllowed", () => {
         newModelQueryTabLocation,
         newModelMetadataTabLocation,
         runModelLocation,
+        runModelEditNotebookLocation,
         runQuestionLocation,
         runQuestionEditNotebookLocation,
       ])("to `$pathname`", destination => {
@@ -206,6 +213,7 @@ describe("isNavigationAllowed", () => {
         newModelQueryTabLocation,
         newModelMetadataTabLocation,
         runModelLocation,
+        runModelEditNotebookLocation,
         runQuestionEditNotebookLocation,
       ])("to `$pathname`", destination => {
         expect(
@@ -292,6 +300,7 @@ describe("isNavigationAllowed", () => {
         newModelQueryTabLocation,
         newModelMetadataTabLocation,
         runModelLocation,
+        runModelEditNotebookLocation,
         runQuestionEditNotebookLocation,
       ])("to `$pathname`", destination => {
         expect(
@@ -318,6 +327,14 @@ describe("isNavigationAllowed", () => {
 
     it("allows to run the model", () => {
       const destination = runModelLocation;
+
+      expect(
+        isNavigationAllowed({ destination, question, isNewQuestion }),
+      ).toBe(true);
+    });
+
+    it("allows to run the model and then edit it again", () => {
+      const destination = runModelEditNotebookLocation;
 
       expect(
         isNavigationAllowed({ destination, question, isNewQuestion }),
@@ -355,6 +372,14 @@ describe("isNavigationAllowed", () => {
 
     it("allows to run the model", () => {
       const destination = runModelLocation;
+
+      expect(
+        isNavigationAllowed({ destination, question, isNewQuestion }),
+      ).toBe(true);
+    });
+
+    it("allows to run the model and then edit it again", () => {
+      const destination = runModelEditNotebookLocation;
 
       expect(
         isNavigationAllowed({ destination, question, isNewQuestion }),
@@ -406,6 +431,7 @@ describe("isNavigationAllowed", () => {
         ...getNativeQuestionLocations(nativeQuestion),
         newModelMetadataTabLocation,
         newModelQueryTabLocation,
+        runModelEditNotebookLocation,
         runQuestionEditNotebookLocation,
       ])("to `$pathname`", destination => {
         expect(


### PR DESCRIPTION
Closes #35000

### Description

`/question/notebook` & `/model/notebook` routes were not taken into account.

This PR also includes [small refactoring](https://github.com/metabase/metabase/pull/35003/commits/64088717eebda0b1ad9bc1469d0f2d4c6ef62639) because `waitForSave*Question*ToBeEnabled` applies also for **models** in notebook view (but not in query or metadata view), which I didn't initially know.

### How to verify

Tests are green.
2 new tests marked with `(metabase#35000)` fail in `master`.
