### PR TITLE
Manual backport - JavaScript TypeError when removing dashboard filter (#33826)

### DIFF
--- a/frontend/src/metabase/dashboard/actions/parameters.js
+++ b/frontend/src/metabase/dashboard/actions/parameters.js
@@ -101,6 +101,7 @@ export const removeParameter = createThunkAction(
     updateParameters(dispatch, getState, parameters =>
       parameters.filter(p => p.id !== parameterId),
     );
+    return { id: parameterId };
   },
 );
 

--- a/frontend/src/metabase/dashboard/actions/parameters.unit.spec.js
+++ b/frontend/src/metabase/dashboard/actions/parameters.unit.spec.js
@@ -1,0 +1,32 @@
+import { removeParameter, REMOVE_PARAMETER } from "./parameters";
+
+describe("removeParameter", () => {
+  let dispatch;
+  let getState;
+  beforeEach(() => {
+    dispatch = jest.fn();
+    getState = () => ({
+      dashboard: {
+        dashboardId: 1,
+        dashboards: {
+          1: {
+            id: 1,
+            parameters: [{ id: 123 }, { id: 456 }],
+          },
+        },
+        parameterValues: {
+          123: null,
+          456: null,
+        },
+      },
+    });
+  });
+
+  it("should return the `parameterId` as `payload.id` (metabase#33826)", async () => {
+    const result = await removeParameter(123)(dispatch, getState);
+    expect(result).toEqual({
+      type: REMOVE_PARAMETER,
+      payload: { id: 123 },
+    });
+  });
+});


### PR DESCRIPTION
Manual backport of #34680 (which is a fix for #33826).

#34680 was a community contribution.