### PR TITLE
[MLv2] Filters — Fix nested native question + expression E2E test 

### DIFF
--- a/e2e/test/scenarios/filters/filter-sources.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter-sources.cy.spec.js
@@ -137,7 +137,7 @@ const nestedQuestionWithExpression = card => ({
     query: {
       "source-table": `card__${card.id}`,
       expressions: {
-        Total100: ["+", ["field", ORDERS.TOTAL, null], 100],
+        Total100: ["+", ["field", "TOTAL", { "base-type": "type/Float" }], 100],
       },
     },
   },

--- a/e2e/test/scenarios/filters/filter-sources.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter-sources.cy.spec.js
@@ -505,7 +505,7 @@ describe("scenarios > filters > filter sources", () => {
       assertQueryBuilderRowCount(10);
     });
 
-    it.skip("column from an expression based on a question column", () => {
+    it("column from an expression based on a question column", () => {
       cy.createNativeQuestion(nativeQuestion).then(({ body: card }) => {
         visitQuestionAdhoc(nestedQuestionWithExpression(card), {
           mode: "notebook",


### PR DESCRIPTION
Fixes an incorrect field reference in of the E2E test:

```js
{
  "source-table": "card__1", // <— native query
  "expressions": {
     "Total100": [ "+", [ "field", 1, null ], 100 ]
   }
}
```

It should be using the column name when referring to a column from `source-card`:

```js
[ "+", [ "field", "TOTAL", { "base-type": "..." } ], 100 ]
```