### PR TITLE
Fix field values re-rendering for virtual tables

### DIFF
--- a/e2e/test/scenarios/question/reproductions/34414-populate-field-values.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/34414-populate-field-values.cy.spec.js
@@ -1,0 +1,47 @@
+import { popover, restore, startNewQuestion } from "e2e/support/helpers";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { INVOICES_ID } = SAMPLE_DATABASE;
+
+describe("issue 34414", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("Populate field values after re-adding filter on virtual table field (metabase#33079)", () => {
+    cy.createQuestion({
+      name: "Invoices Model",
+      query: { "source-table": INVOICES_ID },
+      dataset: true,
+    });
+
+    startNewQuestion();
+
+    popover().within(() => {
+      cy.findByText("Models").click();
+      cy.findByText("Invoices Model").click();
+    });
+
+    cy.findAllByTestId("notebook-cell-item").contains("Add filters").click();
+
+    popover().within(() => {
+      cy.findByText("Plan").click();
+      assertPlanFieldValues();
+
+      cy.log("Open filter again");
+      cy.findByTestId("sidebar-header-title").click();
+
+      cy.log("Open plan field again");
+      cy.findByText("Plan").click();
+
+      assertPlanFieldValues();
+    });
+  });
+});
+
+function assertPlanFieldValues() {
+  cy.contains("Basic");
+  cy.contains("Business");
+  cy.contains("Premium");
+}

--- a/e2e/test/scenarios/question/reproductions/34414-populate-field-values.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/34414-populate-field-values.cy.spec.js
@@ -1,4 +1,10 @@
-import { popover, restore, visitQuestionAdhoc } from "e2e/support/helpers";
+import {
+  filter,
+  openNotebook,
+  popover,
+  restore,
+  visitQuestionAdhoc,
+} from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 
@@ -29,12 +35,8 @@ describe("issue 34414", () => {
       });
     });
 
-    popover().within(() => {
-      cy.findByText("Models").click();
-      cy.findByText("Invoices Model").click();
-    });
-
-    cy.findAllByTestId("notebook-cell-item").contains("Add filters").click();
+    openNotebook();
+    filter({ mode: "notebook" });
 
     popover().within(() => {
       cy.findByText("Plan").click();

--- a/e2e/test/scenarios/question/reproductions/34414-populate-field-values.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/34414-populate-field-values.cy.spec.js
@@ -1,4 +1,4 @@
-import { popover, restore, visitQuestionAdHoc } from "e2e/support/helpers";
+import { popover, restore, visitQuestionAdhoc } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 
@@ -20,7 +20,7 @@ describe("issue 34414", () => {
     cy.createQuestion(INVOICE_MODEL_DETAILS).then(response => {
       const modelId = response.body.id;
 
-      visitQuestionAdHoc({
+      visitQuestionAdhoc({
         dataset_query: {
           type: "query",
           database: SAMPLE_DB_ID,

--- a/e2e/test/scenarios/question/reproductions/34414-populate-field-values.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/34414-populate-field-values.cy.spec.js
@@ -1,8 +1,6 @@
 import { popover, restore, visitQuestionAdHoc } from "e2e/support/helpers";
-import {
-  SAMPLE_DATABASE,
-  SAMPLE_DATABASE_ID,
-} from "e2e/support/cypress_sample_database";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 
 const { INVOICES_ID } = SAMPLE_DATABASE;
 
@@ -25,7 +23,7 @@ describe("issue 34414", () => {
       visitQuestionAdHoc({
         dataset_query: {
           type: "query",
-          database: SAMPLE_DATABASE_ID,
+          database: SAMPLE_DB_ID,
           query: { "source-table": `card__${modelId}` },
         },
       });

--- a/e2e/test/scenarios/question/reproductions/34414-populate-field-values.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/34414-populate-field-values.cy.spec.js
@@ -1,22 +1,35 @@
-import { popover, restore, startNewQuestion } from "e2e/support/helpers";
-import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { popover, restore, visitQuestionAdHoc } from "e2e/support/helpers";
+import {
+  SAMPLE_DATABASE,
+  SAMPLE_DATABASE_ID,
+} from "e2e/support/cypress_sample_database";
 
 const { INVOICES_ID } = SAMPLE_DATABASE;
+
+const INVOICE_MODEL_DETAILS = {
+  name: "Invoices Model",
+  query: { "source-table": INVOICES_ID },
+  dataset: true,
+};
 
 describe("issue 34414", () => {
   beforeEach(() => {
     restore();
-    cy.signInAsAdmin();
+    cy.signInAsNormalUser();
   });
 
-  it("Populate field values after re-adding filter on virtual table field (metabase#33079)", () => {
-    cy.createQuestion({
-      name: "Invoices Model",
-      query: { "source-table": INVOICES_ID },
-      dataset: true,
-    });
+  it("populate field values after re-adding filter on virtual table field (metabase#34414)", () => {
+    cy.createQuestion(INVOICE_MODEL_DETAILS).then(response => {
+      const modelId = response.body.id;
 
-    startNewQuestion();
+      visitQuestionAdHoc({
+        dataset_query: {
+          type: "query",
+          database: SAMPLE_DATABASE_ID,
+          query: { "source-table": `card__${modelId}` },
+        },
+      });
+    });
 
     popover().within(() => {
       cy.findByText("Models").click();
@@ -41,7 +54,7 @@ describe("issue 34414", () => {
 });
 
 function assertPlanFieldValues() {
-  cy.contains("Basic");
-  cy.contains("Business");
-  cy.contains("Premium");
+  cy.findByText("Basic").should("be.visible");
+  cy.findByText("Business").should("be.visible");
+  cy.findByText("Premium").should("be.visible");
 }

--- a/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.tsx
+++ b/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.tsx
@@ -212,7 +212,12 @@ export function FieldValuesWidgetInner({
 
       const results = await Promise.all(
         nonVirtualFields.map(field =>
-          dispatch(Fields.objectActions.fetchFieldValues({ id: field.id })),
+          dispatch(
+            Fields.objectActions.fetchFieldValues({
+              id: field.id,
+              table_id: field.table_id,
+            }),
+          ),
         ),
       );
 
@@ -222,7 +227,7 @@ export function FieldValuesWidgetInner({
         (field, index) =>
           results[index]?.payload?.values ??
           Fields.selectors.getFieldValues(results[index]?.payload, {
-            entityId: field.id,
+            entityId: field.getUniqueId(),
           }),
       );
 

--- a/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.tsx
+++ b/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.tsx
@@ -212,12 +212,7 @@ export function FieldValuesWidgetInner({
 
       const results = await Promise.all(
         nonVirtualFields.map(field =>
-          dispatch(
-            Fields.objectActions.fetchFieldValues({
-              id: field.id,
-              table_id: field.table_id,
-            }),
-          ),
+          dispatch(Fields.objectActions.fetchFieldValues(field)),
         ),
       );
 

--- a/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.unit.spec.tsx
+++ b/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.unit.spec.tsx
@@ -103,6 +103,7 @@ describe("FieldValuesWidget", () => {
         });
         expect(fetchFieldValues).toHaveBeenCalledWith({
           id: PRODUCTS.CATEGORY,
+          table_id: field?.table_id,
         });
       });
 
@@ -263,9 +264,11 @@ describe("FieldValuesWidget", () => {
       expect(screen.getByText(LISTABLE_PK_FIELD_VALUE)).toBeInTheDocument();
       expect(fetchFieldValues).toHaveBeenCalledWith({
         id: LISTABLE_PK_FIELD_ID,
+        table_id: valuesField.table_id,
       });
       expect(fetchFieldValues).not.toHaveBeenCalledWith({
         id: EXPRESSION_FIELD_ID,
+        table_id: expressionField.table_id,
       });
     });
   });

--- a/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.unit.spec.tsx
+++ b/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.unit.spec.tsx
@@ -95,7 +95,7 @@ describe("FieldValuesWidget", () => {
     });
 
     describe("has_field_values = list", () => {
-      const field = metadata.field(PRODUCTS.CATEGORY);
+      const field = checkNotNull(metadata.field(PRODUCTS.CATEGORY));
 
       it("should call fetchFieldValues", async () => {
         const { fetchFieldValues } = await setup({
@@ -103,7 +103,7 @@ describe("FieldValuesWidget", () => {
         });
         expect(fetchFieldValues).toHaveBeenCalledWith({
           id: PRODUCTS.CATEGORY,
-          table_id: field?.table_id,
+          table_id: field.table_id,
         });
       });
 

--- a/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.unit.spec.tsx
+++ b/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.unit.spec.tsx
@@ -101,10 +101,7 @@ describe("FieldValuesWidget", () => {
         const { fetchFieldValues } = await setup({
           fields: [field],
         });
-        expect(fetchFieldValues).toHaveBeenCalledWith({
-          id: PRODUCTS.CATEGORY,
-          table_id: field.table_id,
-        });
+        expect(fetchFieldValues).toHaveBeenCalledWith(field);
       });
 
       it("should not have 'Search the list' as the placeholder text for fields with less or equal than 10 values", async () => {
@@ -262,14 +259,18 @@ describe("FieldValuesWidget", () => {
       });
 
       expect(screen.getByText(LISTABLE_PK_FIELD_VALUE)).toBeInTheDocument();
-      expect(fetchFieldValues).toHaveBeenCalledWith({
-        id: LISTABLE_PK_FIELD_ID,
-        table_id: valuesField.table_id,
-      });
-      expect(fetchFieldValues).not.toHaveBeenCalledWith({
-        id: EXPRESSION_FIELD_ID,
-        table_id: expressionField.table_id,
-      });
+      expect(fetchFieldValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: LISTABLE_PK_FIELD_ID,
+          table_id: valuesField.table_id,
+        }),
+      );
+      expect(fetchFieldValues).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: EXPRESSION_FIELD_ID,
+          table_id: expressionField.table_id,
+        }),
+      );
     });
   });
 

--- a/frontend/src/metabase/components/FormCategoryInput/CategoryRadioPicker.tsx
+++ b/frontend/src/metabase/components/FormCategoryInput/CategoryRadioPicker.tsx
@@ -5,6 +5,7 @@ import Radio from "metabase/core/components/Radio";
 import Fields from "metabase/entities/fields";
 
 import type { State } from "metabase-types/store";
+import type Field from "metabase-lib/metadata/Field";
 
 import type { CategoryWidgetProps as CategoryWidgetOwnProps } from "./types";
 
@@ -13,7 +14,7 @@ interface CategoryWidgetStateProps {
 }
 
 interface CategoryWidgetDispatchProps {
-  fetchFieldValues: (opts: { id: number }) => void;
+  fetchFieldValues: (field: Field) => void;
 }
 
 interface CategoryWidgetProps
@@ -43,7 +44,7 @@ function CategoryRadioPicker({
 }: CategoryWidgetProps) {
   useMount(() => {
     if (typeof field.id === "number") {
-      fetchFieldValues({ id: field.id });
+      fetchFieldValues(field);
     }
   });
 

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
@@ -353,7 +353,7 @@ export default class AccordionList extends Component {
 
     const searchRow = this.getRows().findIndex(row => row.type === "search");
 
-    if (searchRow >= 0) {
+    if (searchRow >= 0 && this.isVirtualized()) {
       this._list.scrollToRow(searchRow);
     }
   };

--- a/frontend/src/metabase/entities/fields.js
+++ b/frontend/src/metabase/entities/fields.js
@@ -93,8 +93,10 @@ const Fields = createEntity({
         ...params,
       });
 
+      const table_id = params.table_id;
+
       // table_id is required for uniqueFieldId as it's a way to know if field is virtual
-      return { id, values, has_more_values, table_id: params.table_id };
+      return { id, values, has_more_values, ...(table_id && { table_id }) };
     }),
 
     updateField(field, values, opts) {

--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -166,7 +166,7 @@ export function createEntity(def) {
 
   // normalize helpers
   entity.normalize = (object, schema = entity.schema) => ({
-    // include raw `object` (and alias under nameOne) for convienence
+    // include raw `object` (and alias under nameOne) for convenience
     object,
     [entity.nameOne]: object,
     // include standard normalizr properties, `result` and `entities`
@@ -174,7 +174,7 @@ export function createEntity(def) {
   });
 
   entity.normalizeList = (list, schema = entity.schema) => ({
-    // include raw `list` (and alias under nameMany) for convienence
+    // include raw `list` (and alias under nameMany) for convenience
     list,
     [entity.nameMany]: list,
     // include standard normalizr properties, `result` and `entities`

--- a/frontend/src/metabase/redux/metadata.js
+++ b/frontend/src/metabase/redux/metadata.js
@@ -99,11 +99,6 @@ export const fetchField = createThunkAction(
   },
 );
 
-export const fetchFieldValues = (id, reload = false) => {
-  deprecated("metabase/redux/metadata fetchFieldValues");
-  return Fields.actions.fetchFieldValues({ id }, reload);
-};
-
 export const updateFieldValues = (fieldId, fieldValuePairs) => {
   deprecated("metabase/redux/metadata updateFieldValues");
   return Fields.actions.updateFieldValues({ id: fieldId }, fieldValuePairs);


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/34414

### Description

Virtual tables have different keys in the store - `card__23:id`, our custom method of fetching field values utilizes Fields entity and updates store with the duplicated key (both `card__23:150` and `150` will present in the store).

So this PR removes this unnecessary duplication and updates field of the virtual table.  

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a model from Invoices table (new question -> Invoices -> convert into model)
2. new question -> from Model -> Invoices Model -> Filter -> Plan
3. click back from Plan (click on title with left arrow), then click Plan again -> values should be rendered (not only empty textarea)

### Demo

Before

https://github.com/metabase/metabase/assets/125459446/35a2c9f4-176d-4e52-b8e5-29c3e975446a

After

https://github.com/metabase/metabase/assets/125459446/bc20f06f-b5b2-429e-9995-894ab91a7b65


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
