### PR TITLE
Mark `moment-timezone` as deprecated

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,17 @@
       }
     ],
     "no-empty": [1, { "allowEmptyCatch": true }],
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "moment-timezone",
+            "message": "Moment is deprecated, please use dayjs"
+          }
+        ]
+      }
+    ],
     "curly": [1, "all"],
     "eqeqeq": [1, "smart"],
     "import/no-default-export": 2,

--- a/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 import { WRITABLE_DB_ID } from "e2e/support/cypress_data";

--- a/e2e/test/scenarios/dashboard-filters/reproductions/22482-round-relative-ranges.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/22482-round-relative-ranges.cy.spec.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import {
   restore,

--- a/e2e/test/scenarios/filters/relative-datetime.cy.spec.js
+++ b/e2e/test/scenarios/filters/relative-datetime.cy.spec.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { restore, popover, openOrdersTable } from "e2e/support/helpers";
 

--- a/enterprise/frontend/.eslintrc
+++ b/enterprise/frontend/.eslintrc
@@ -3,7 +3,13 @@
     "no-restricted-imports": [
       "error",
       {
-        "patterns": ["cljs/metabase.lib*"]
+        "patterns": ["cljs/metabase.lib*"],
+        "paths": [
+          {
+            "name": "moment-timezone",
+            "message": "Moment is deprecated, please use dayjs"
+          }
+        ]
       }
     ]
   }

--- a/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.tsx
@@ -1,5 +1,6 @@
 import { t, jt } from "ttag";
 import { connect } from "react-redux";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 import ExternalLink from "metabase/core/components/ExternalLink";

--- a/frontend/src/metabase-lib/.eslintrc
+++ b/frontend/src/metabase-lib/.eslintrc
@@ -23,6 +23,12 @@
               "!metabase/lib/utils"
             ]
           }
+        ],
+        "paths": [
+          {
+            "name": "moment-timezone",
+            "message": "Moment is deprecated, please use dayjs"
+          }
         ]
       }
     ]

--- a/frontend/src/metabase-lib/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/expressions/helper-text-strings.ts
@@ -1,4 +1,5 @@
 import { t } from "ttag";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import type { HelpText, HelpTextConfig } from "metabase-lib/expressions/types";
 import type Database from "metabase-lib/metadata/Database";

--- a/frontend/src/metabase-lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/metadata/Field.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import _ from "underscore";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { is_coerceable, coercions_for_type } from "cljs/metabase.types";
 

--- a/frontend/src/metabase-lib/parameters/utils/mbql.js
+++ b/frontend/src/metabase-lib/parameters/utils/mbql.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import _ from "underscore";
 

--- a/frontend/src/metabase-lib/parameters/utils/mbql.unit.spec.js
+++ b/frontend/src/metabase-lib/parameters/utils/mbql.unit.spec.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { createMockMetadata } from "__support__/metadata";
 import {

--- a/frontend/src/metabase-lib/queries/utils/actions.js
+++ b/frontend/src/metabase-lib/queries/utils/actions.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 import { parseTimestamp } from "metabase/lib/time";

--- a/frontend/src/metabase-lib/queries/utils/date-filters.ts
+++ b/frontend/src/metabase-lib/queries/utils/date-filters.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import _ from "underscore";
 

--- a/frontend/src/metabase-lib/queries/utils/query-time.js
+++ b/frontend/src/metabase-lib/queries/utils/query-time.js
@@ -1,4 +1,5 @@
 import _ from "underscore";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { assoc } from "icepick";
 import { t, ngettext, msgid } from "ttag";

--- a/frontend/src/metabase/.eslintrc
+++ b/frontend/src/metabase/.eslintrc
@@ -17,6 +17,10 @@
           {
             "name": "@mantine/core",
             "message": "Please import from `metabase/ui` instead."
+          },
+          {
+            "name": "moment-timezone",
+            "message": "Moment is deprecated, please use dayjs"
           }
         ]
       }

--- a/frontend/src/metabase/account/login-history/components/LoginHistory/LoginHistory.jsx
+++ b/frontend/src/metabase/account/login-history/components/LoginHistory/LoginHistory.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import _ from "underscore";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/actions/hooks/use-action-form/utils.ts
+++ b/frontend/src/metabase/actions/hooks/use-action-form/utils.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 import { isEmpty } from "metabase/lib/validate";

--- a/frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx
@@ -3,6 +3,7 @@ import { Component } from "react";
 import PropTypes from "prop-types";
 
 import { t } from "ttag";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import UserAvatar from "metabase/components/UserAvatar";
 

--- a/frontend/src/metabase/admin/people/components/PeopleListRow.jsx
+++ b/frontend/src/metabase/admin/people/components/PeopleListRow.jsx
@@ -2,6 +2,7 @@
 import { Fragment, useMemo } from "react";
 import { t } from "ttag";
 
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 import { color } from "metabase/lib/colors";

--- a/frontend/src/metabase/admin/settings/containers/PremiumEmbeddingLicensePage/PremiumEmbeddingLicensePage.tsx
+++ b/frontend/src/metabase/admin/settings/containers/PremiumEmbeddingLicensePage/PremiumEmbeddingLicensePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { jt, t } from "ttag";
 import { connect } from "react-redux";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import AdminLayout from "metabase/components/AdminLayout";
 import ExternalLink from "metabase/core/components/ExternalLink";

--- a/frontend/src/metabase/admin/tasks/components/Logs/Logs.jsx
+++ b/frontend/src/metabase/admin/tasks/components/Logs/Logs.jsx
@@ -4,6 +4,7 @@ import ReactDOM from "react-dom";
 import reactAnsiStyle from "react-ansi-style";
 
 import _ from "underscore";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/admin/tasks/containers/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx
+++ b/frontend/src/metabase/admin/tasks/containers/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { t } from "ttag";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { connect } from "react-redux";
 

--- a/frontend/src/metabase/collections/components/BaseItemsTable.unit.spec.js
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.unit.spec.js
@@ -1,5 +1,6 @@
 import { Route } from "react-router";
 import userEvent from "@testing-library/user-event";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { renderWithProviders, screen, getIcon } from "__support__/ui";
 

--- a/frontend/src/metabase/collections/components/BaseTableItem.jsx
+++ b/frontend/src/metabase/collections/components/BaseTableItem.jsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import PropTypes from "prop-types";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 import { PLUGIN_MODERATION } from "metabase/plugins";

--- a/frontend/src/metabase/components/Calendar/Calendar.tsx
+++ b/frontend/src/metabase/components/Calendar/Calendar.tsx
@@ -1,6 +1,8 @@
 import { Component } from "react";
 import cx from "classnames";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import type { Moment } from "moment-timezone";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { Icon } from "metabase/core/components/Icon";
 import {

--- a/frontend/src/metabase/components/Calendar/Calendar.unit.spec.tsx
+++ b/frontend/src/metabase/components/Calendar/Calendar.unit.spec.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import mockDate from "mockdate";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/metabase/components/DateMonthYearWidget/DateMonthYearWidget.tsx
+++ b/frontend/src/metabase/components/DateMonthYearWidget/DateMonthYearWidget.tsx
@@ -1,4 +1,5 @@
 import { Component } from "react";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import _ from "underscore";
 

--- a/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.tsx
+++ b/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.tsx
@@ -1,4 +1,5 @@
 import { Component } from "react";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import _ from "underscore";
 import { t } from "ttag";

--- a/frontend/src/metabase/components/DateRangeWidget/DateRangeWidget.tsx
+++ b/frontend/src/metabase/components/DateRangeWidget/DateRangeWidget.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { DateAllOptionsWidget } from "metabase/components/DateAllOptionsWidget";
 

--- a/frontend/src/metabase/components/DateSingleWidget/DateSingleWidget.tsx
+++ b/frontend/src/metabase/components/DateSingleWidget/DateSingleWidget.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { DateAllOptionsWidget } from "metabase/components/DateAllOptionsWidget";
 

--- a/frontend/src/metabase/components/DateTime/DateTime.unit.spec.js
+++ b/frontend/src/metabase/components/DateTime/DateTime.unit.spec.js
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 import {

--- a/frontend/src/metabase/components/LastEditInfoLabel/LastEditInfoLabel.jsx
+++ b/frontend/src/metabase/components/LastEditInfoLabel/LastEditInfoLabel.jsx
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { t } from "ttag";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 import { getUser } from "metabase/selectors/user";

--- a/frontend/src/metabase/components/LastEditInfoLabel/LastEditInfoLabel.unit.spec.js
+++ b/frontend/src/metabase/components/LastEditInfoLabel/LastEditInfoLabel.unit.spec.js
@@ -1,4 +1,5 @@
 import mockDate from "mockdate";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { renderWithProviders, screen } from "__support__/ui";
 import { createMockUser } from "metabase-types/api/mocks";

--- a/frontend/src/metabase/core/components/DateInput/DateInput.stories.tsx
+++ b/frontend/src/metabase/core/components/DateInput/DateInput.stories.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import type { Moment } from "moment-timezone";
 import type { ComponentStory } from "@storybook/react";
 import DateInput from "./DateInput";

--- a/frontend/src/metabase/core/components/DateInput/DateInput.tsx
+++ b/frontend/src/metabase/core/components/DateInput/DateInput.tsx
@@ -6,7 +6,9 @@ import type {
   Ref,
 } from "react";
 import { forwardRef, useCallback, useMemo, useState } from "react";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import type { Moment } from "moment-timezone";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { t } from "ttag";
 import Input from "metabase/core/components/Input";

--- a/frontend/src/metabase/core/components/DateInput/DateInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/DateInput/DateInput.unit.spec.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useState } from "react";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import type { Moment } from "moment-timezone";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/metabase/core/components/DateSelector/DateSelector.stories.tsx
+++ b/frontend/src/metabase/core/components/DateSelector/DateSelector.stories.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import type { ComponentStory } from "@storybook/react";
 import DateSelector from "./DateSelector";

--- a/frontend/src/metabase/core/components/DateSelector/DateSelector.tsx
+++ b/frontend/src/metabase/core/components/DateSelector/DateSelector.tsx
@@ -1,6 +1,8 @@
 import type { CSSProperties, Ref } from "react";
 import { forwardRef, useCallback, useMemo } from "react";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import type { Moment } from "moment-timezone";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { t } from "ttag";
 import TimeInput from "metabase/core/components/TimeInput";

--- a/frontend/src/metabase/core/components/DateWidget/DateWidget.stories.tsx
+++ b/frontend/src/metabase/core/components/DateWidget/DateWidget.stories.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import type { Moment } from "moment-timezone";
 import type { ComponentStory } from "@storybook/react";
 import DateWidget from "./DateWidget";

--- a/frontend/src/metabase/core/components/DateWidget/DateWidget.tsx
+++ b/frontend/src/metabase/core/components/DateWidget/DateWidget.tsx
@@ -1,5 +1,6 @@
 import type { InputHTMLAttributes, Ref } from "react";
 import { forwardRef, useCallback, useState } from "react";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import type { Moment } from "moment-timezone";
 import DateInput from "metabase/core/components/DateInput";
 import DateSelector from "metabase/core/components/DateSelector";

--- a/frontend/src/metabase/core/components/FormDateInput/FormDateInput.tsx
+++ b/frontend/src/metabase/core/components/FormDateInput/FormDateInput.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode, Ref } from "react";
 import { forwardRef, useCallback, useMemo } from "react";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import type { Moment } from "moment-timezone";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { useField } from "formik";
 import { useUniqueId } from "metabase/hooks/use-unique-id";

--- a/frontend/src/metabase/core/components/TimeInput/TimeInput.stories.tsx
+++ b/frontend/src/metabase/core/components/TimeInput/TimeInput.stories.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import type { ComponentStory } from "@storybook/react";
 import TimeInput from "./TimeInput";

--- a/frontend/src/metabase/core/components/TimeInput/TimeInput.tsx
+++ b/frontend/src/metabase/core/components/TimeInput/TimeInput.tsx
@@ -1,7 +1,9 @@
 import type { Ref } from "react";
 import { forwardRef, useCallback } from "react";
 import { t } from "ttag";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import type { Moment } from "moment-timezone";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import Tooltip from "metabase/core/components/Tooltip";
 import {

--- a/frontend/src/metabase/core/components/TimeInput/TimeInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TimeInput/TimeInput.unit.spec.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useState } from "react";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import type { Moment } from "moment-timezone";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/metabase/home/utils.ts
+++ b/frontend/src/metabase/home/utils.ts
@@ -1,4 +1,6 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import type { MomentInput } from "moment-timezone";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { parseTimestamp } from "metabase/lib/time";
 

--- a/frontend/src/metabase/lib/date-time.ts
+++ b/frontend/src/metabase/lib/date-time.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import _ from "underscore";
 import { t } from "ttag";

--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -1,4 +1,6 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import type { Moment } from "moment-timezone";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 import { parseTimestamp } from "metabase/lib/time";

--- a/frontend/src/metabase/lib/formatting/time.ts
+++ b/frontend/src/metabase/lib/formatting/time.ts
@@ -1,4 +1,5 @@
 import { msgid, ngettext } from "ttag";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import type { Moment } from "moment-timezone";
 import { parseTime, parseTimestamp } from "metabase/lib/time";
 

--- a/frontend/src/metabase/lib/formatting/value.tsx
+++ b/frontend/src/metabase/lib/formatting/value.tsx
@@ -1,7 +1,9 @@
 import type * as React from "react";
 import ReactMarkdown from "react-markdown";
 import Mustache from "mustache";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import type { Moment } from "moment-timezone";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 import ExternalLink from "metabase/core/components/ExternalLink";

--- a/frontend/src/metabase/lib/i18n.js
+++ b/frontend/src/metabase/lib/i18n.js
@@ -1,4 +1,5 @@
 import { addLocale, useLocale } from "ttag";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import dayjs from "dayjs";
 import updateLocalePlugin from "dayjs/plugin/updateLocale";

--- a/frontend/src/metabase/lib/redux/utils.js
+++ b/frontend/src/metabase/lib/redux/utils.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import _ from "underscore";
 import { getIn } from "icepick";

--- a/frontend/src/metabase/lib/settings.ts
+++ b/frontend/src/metabase/lib/settings.ts
@@ -1,5 +1,6 @@
 import _ from "underscore";
 import { t, ngettext, msgid } from "ttag";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 import { parseTimestamp } from "metabase/lib/time";

--- a/frontend/src/metabase/lib/time.ts
+++ b/frontend/src/metabase/lib/time.ts
@@ -1,5 +1,7 @@
 import { t } from "ttag";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import type { DurationInputArg2, MomentInput } from "moment-timezone";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 import MetabaseSettings from "metabase/lib/settings";

--- a/frontend/src/metabase/parameters/utils/date-formatting.ts
+++ b/frontend/src/metabase/parameters/utils/date-formatting.ts
@@ -1,5 +1,6 @@
 import { t } from "ttag";
 import _ from "underscore";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 import { DATE_OPERATORS } from "metabase/query_builder/components/filters/pickers/DatePicker/DatePicker";

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/CurrentPicker/periodPopoverText.ts
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/CurrentPicker/periodPopoverText.ts
@@ -1,5 +1,7 @@
 import { t } from "ttag";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import type { unitOfTime } from "moment-timezone";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 const buildStartAndEndDates = (period: unitOfTime.StartOf, format: string) => {

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerFooter.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerFooter.tsx
@@ -1,5 +1,6 @@
 import type * as React from "react";
 import { t } from "ttag";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 import { Icon } from "metabase/core/components/Icon";

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/HoursMinutesInput.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/HoursMinutesInput.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { has24HourModeSetting } from "metabase/lib/time";
 import NumericInput from "metabase/components/NumericInput";

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useState } from "react";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import type { Moment } from "moment-timezone";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import Calendar from "metabase/components/Calendar";
 import type Filter from "metabase-lib/queries/structured/Filter";

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { t } from "ttag";
 import { assoc } from "icepick";
-
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import type { DurationInputArg2 } from "moment-timezone";
 import { isValidTimeInterval } from "metabase/lib/time";
 import TippyPopover from "metabase/components/Popover/TippyPopover";

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
 import { t } from "ttag";
 
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import type { Moment } from "moment-timezone";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { getDateStyleFromSettings } from "metabase/lib/time";
 import type { SelectAll } from "metabase/components/Calendar";

--- a/frontend/src/metabase/query_builder/components/filters/pickers/LegacyDatePicker/DatePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/LegacyDatePicker/DatePicker.jsx
@@ -3,6 +3,7 @@ import { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import cx from "classnames";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import _ from "underscore";
 

--- a/frontend/src/metabase/query_builder/components/filters/pickers/LegacyDatePicker/HoursMinutesInput.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/LegacyDatePicker/HoursMinutesInput.jsx
@@ -1,4 +1,5 @@
 /* eslint-disable react/prop-types */
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { has24HourModeSetting } from "metabase/lib/time";
 import NumericInput from "metabase/components/NumericInput";

--- a/frontend/src/metabase/query_builder/components/filters/pickers/LegacyDatePicker/SpecificDatePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/LegacyDatePicker/SpecificDatePicker.jsx
@@ -3,6 +3,7 @@ import { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import cx from "classnames";
 import { getDateStyleFromSettings } from "metabase/lib/time";

--- a/frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx
@@ -1,4 +1,5 @@
 /* eslint-disable react/prop-types */
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheManagementSection/ModelCacheManagementSection.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheManagementSection/ModelCacheManagementSection.tsx
@@ -1,4 +1,5 @@
 import { t } from "ttag";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { connect } from "react-redux";
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheManagementSection/ModelCacheManagementSection.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheManagementSection/ModelCacheManagementSection.unit.spec.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import fetchMock from "fetch-mock";
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { t } from "ttag";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import type { Moment } from "moment-timezone";
 import { MODAL_TYPES } from "metabase/query_builder/constants";
 import SidebarContent from "metabase/query_builder/components/SidebarContent";

--- a/frontend/src/metabase/reference/databases/TableQuestions.jsx
+++ b/frontend/src/metabase/reference/databases/TableQuestions.jsx
@@ -2,6 +2,7 @@
 import { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { t } from "ttag";
 import visualizations from "metabase/visualizations";

--- a/frontend/src/metabase/reference/metrics/MetricQuestions.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricQuestions.jsx
@@ -2,6 +2,7 @@
 import { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { t } from "ttag";
 import visualizations from "metabase/visualizations";

--- a/frontend/src/metabase/reference/segments/SegmentQuestions.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentQuestions.jsx
@@ -2,6 +2,7 @@
 import { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { t } from "ttag";
 import visualizations from "metabase/visualizations";

--- a/frontend/src/metabase/search/components/InfoText/InfoText.tsx
+++ b/frontend/src/metabase/search/components/InfoText/InfoText.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable react/prop-types */
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { t } from "ttag";
 import { isNull } from "underscore";

--- a/frontend/src/metabase/static-viz/lib/format.ts
+++ b/frontend/src/metabase/static-viz/lib/format.ts
@@ -1,4 +1,5 @@
 import moment from "moment";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import type { Moment } from "moment-timezone";
 import type { NumberLike, StringLike } from "@visx/scale";
 import type {

--- a/frontend/src/metabase/timelines/collections/components/TimelineEmptyState/TimelineEmptyState.tsx
+++ b/frontend/src/metabase/timelines/collections/components/TimelineEmptyState/TimelineEmptyState.tsx
@@ -1,4 +1,5 @@
 import { t } from "ttag";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import * as Urls from "metabase/lib/urls";
 import Link from "metabase/core/components/Link";

--- a/frontend/src/metabase/timelines/common/components/NewEventModal/NewEventModal.tsx
+++ b/frontend/src/metabase/timelines/common/components/NewEventModal/NewEventModal.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { t } from "ttag";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { getDefaultTimelineIcon } from "metabase/lib/timelines";
 import type {

--- a/frontend/src/metabase/visualizations/click-actions/drills/UnderlyingRecordsDrill.unit.spec.js
+++ b/frontend/src/metabase/visualizations/click-actions/drills/UnderlyingRecordsDrill.unit.spec.js
@@ -1,4 +1,5 @@
 import { assocIn } from "icepick";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { createMockMetadata } from "__support__/metadata";
 import {

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.tz.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.tz.unit.spec.js
@@ -1,6 +1,7 @@
 import "__support__/ui-mocks"; // included explicitly whereas with integrated tests it comes with __support__/integrated_tests
 
 import _ from "underscore";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import testAcrossTimezones from "__support__/timezones";
 import {

--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -3,6 +3,7 @@
 import _ from "underscore";
 import d3 from "d3";
 import dc from "dc";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/visualizations/lib/apply_axis.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.unit.spec.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import {
   maybeRoundValueToZero,

--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.js
@@ -1,6 +1,7 @@
 /// code to "apply" chart tooltips. (How does one apply a tooltip?)
 
 import d3 from "d3";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { getIn } from "icepick";
 import _ from "underscore";

--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.unit.spec.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 import {

--- a/frontend/src/metabase/visualizations/lib/fill_data.tz.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/fill_data.tz.unit.spec.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import testAcrossTimezones from "__support__/timezones";
 

--- a/frontend/src/metabase/visualizations/lib/fill_data.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/fill_data.unit.spec.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 import fillMissingValuesInDatas from "metabase/visualizations/lib/fill_data";

--- a/frontend/src/metabase/visualizations/lib/graph/addons.js
+++ b/frontend/src/metabase/visualizations/lib/graph/addons.js
@@ -1,4 +1,5 @@
 import dc from "dc";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 export const lineAddons = _chart => {

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.unit.spec.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 import {

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -1,4 +1,5 @@
 import { t } from "ttag";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import _ from "underscore";
 

--- a/frontend/src/metabase/visualizations/lib/timeseries.js
+++ b/frontend/src/metabase/visualizations/lib/timeseries.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import _ from "underscore";
 

--- a/frontend/src/metabase/visualizations/lib/timeseries.tz.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/timeseries.tz.unit.spec.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import testAcrossTimezones from "__support__/timezones";
 

--- a/frontend/src/metabase/visualizations/lib/timeseriesScale.js
+++ b/frontend/src/metabase/visualizations/lib/timeseriesScale.js
@@ -1,4 +1,5 @@
 import d3 from "d3";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 // moment-timezone based d3 scale

--- a/frontend/src/metabase/visualizations/lib/timeseriesScale.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/timeseriesScale.unit.spec.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 import timeseriesScale from "metabase/visualizations/lib/timeseriesScale";

--- a/frontend/src/metabase/visualizations/lib/trends.js
+++ b/frontend/src/metabase/visualizations/lib/trends.js
@@ -1,4 +1,5 @@
 import _ from "underscore";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 // mappings of allowed operators

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -1,4 +1,5 @@
 import { isElementOfType } from "react-dom/test-utils";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 import {

--- a/frontend/test/metabase/lib/query_time.unit.spec.js
+++ b/frontend/test/metabase/lib/query_time.unit.spec.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 
 import {

--- a/frontend/test/metabase/lib/time.unit.spec.js
+++ b/frontend/test/metabase/lib/time.unit.spec.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import {
   getRelativeTimeAbbreviated,


### PR DESCRIPTION
Marks `moment-timezone` as deprecated in favor of `dayjs` using [eslint's `no-restricted-imports` rule](https://eslint.org/docs/latest/rules/no-restricted-imports) (also, adds `eslint-disable` comments for current occurrences of moment)

<img width="787" alt="CleanShot 2023-10-24 at 17 35 47@2x" src="https://github.com/metabase/metabase/assets/17258145/5a013f3a-24dc-43b9-896a-b6a3a06eef45">
