### PR TITLE
Make `SESSION_COOKIE_SAMESITE` a setting

### DIFF
--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -56,8 +56,7 @@
 
 ;; separate map for EE stuff so merge conflicts aren't annoying.
 (def ^:private ee-app-defaults
-  {:embed-max-session-age      "1440"   ; how long a FULL APP EMBED session is valid for. One day, by default
-   :mb-session-cookie-samesite "lax"})
+  {:embed-max-session-age      "1440"}) ; how long a FULL APP EMBED session is valid for. One day, by default
 
 (alter-var-root #'app-defaults merge ee-app-defaults)
 
@@ -132,18 +131,6 @@
   ^{:doc "A string that contains identifying information about the Metabase version and the local process."}
   mb-version-and-process-identifier
   (format "%s [%s]" mb-app-id-string local-process-uuid))
-
-(defn- mb-session-cookie-samesite*
-  []
-  #_{:clj-kondo/ignore [:discouraged-var]}
-  (let [same-site (str/lower-case (config-str :mb-session-cookie-samesite))]
-    (when-not (#{"none", "lax", "strict"} same-site)
-      (throw (ex-info "Invalid value for MB_SESSION_COOKIE_SAMESITE" {:mb-session-cookie-samesite same-site})))
-    (keyword same-site)))
-
-(def ^Keyword mb-session-cookie-samesite
-  "Value for session cookie's `SameSite` directive. Must be one of \"none\", \"lax\", or \"strict\" (case insensitive)."
-  (mb-session-cookie-samesite*))
 
 ;; In 0.41.0 we switched from Leiningen to deps.edn. This warning here to keep people from being bitten in the ass by
 ;; the little gotcha described below.

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -56,7 +56,7 @@
 
 ;; separate map for EE stuff so merge conflicts aren't annoying.
 (def ^:private ee-app-defaults
-  {:embed-max-session-age      "1440"}) ; how long a FULL APP EMBED session is valid for. One day, by default
+  {:embed-max-session-age "1440"}) ; how long a FULL APP EMBED session is valid for. One day, by default
 
 (alter-var-root #'app-defaults merge ee-app-defaults)
 

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -6,7 +6,6 @@
    [environ.core :as env]
    [java-time.api :as t]
    [metabase.api.common :as api :refer [*current-user* *current-user-id*]]
-   [metabase.config :as config]
    [metabase.core.initialization-status :as init-status]
    [metabase.db :as mdb]
    [metabase.driver.sql.query-processor :as sql.qp]
@@ -39,19 +38,19 @@
   (testing "`SameSite` value is read from config (env)"
     (is (= :lax ; Default value
            (with-redefs [env/env (dissoc env/env :mb-session-cookie-samesite)]
-             (#'config/mb-session-cookie-samesite*))))
+             (mw.session/session-cookie-samesite))))
 
     (is (= :strict
            (with-redefs [env/env (assoc env/env :mb-session-cookie-samesite "StRiCt")]
-             (#'config/mb-session-cookie-samesite*))))
+             (mw.session/session-cookie-samesite))))
 
     (is (= :none
            (with-redefs [env/env (assoc env/env :mb-session-cookie-samesite "NONE")]
-             (#'config/mb-session-cookie-samesite*))))
+             (mw.session/session-cookie-samesite))))
 
-    (is (thrown-with-msg? ExceptionInfo #"Invalid value for MB_SESSION_COOKIE_SAMESITE"
+    (is (thrown-with-msg? ExceptionInfo #"Invalid value for session cookie samesite"
           (with-redefs [env/env (assoc env/env :mb-session-cookie-samesite "invalid value")]
-            (#'config/mb-session-cookie-samesite*))))))
+            (mw.session/session-cookie-samesite))))))
 
 (deftest set-session-cookie-test
   (mt/with-temporary-setting-values [session-timeout nil]
@@ -82,22 +81,22 @@
                      (get-in [:cookies "metabase.SESSION"])))))))))
 
 (deftest samesite-none-log-warning-test
-  (with-redefs [config/mb-session-cookie-samesite :none]
+  (mt/with-temporary-setting-values [session-cookie-samesite :none]
     (let [session {:id   (random-uuid)
                    :type :normal}
           request-time (t/zoned-date-time "2022-07-06T02:00Z[UTC]")]
-         (testing "should log a warning if SameSite is configured to \"None\" and the site is served over an insecure connection."
-           (is (contains? (into #{}
-                                (map (fn [[_log-level _error message]] message))
-                                (mt/with-log-messages-for-level :warn
-                                  (mw.session/set-session-cookies {:headers {"x-forwarded-proto" "http"}} {} session request-time)))
-                          "Session cookies SameSite is configured to \"None\", but site is served over an insecure connection. Some browsers will reject cookies under these conditions. https://www.chromestatus.com/feature/5633521622188032")))
-         (testing "should not log a warning over a secure connection."
-           (is (not (contains? (into #{}
-                                     (map (fn [[_log-level _error message]] message))
-                                     (mt/with-log-messages-for-level :warn
-                                       (mw.session/set-session-cookies {:headers {"x-forwarded-proto" "https"}} {} session request-time)))
-                               "Session cookies SameSite is configured to \"None\", but site is served over an insecure connection. Some browsers will reject cookies under these conditions. https://www.chromestatus.com/feature/5633521622188032")))))))
+      (testing "should log a warning if SameSite is configured to \"None\" and the site is served over an insecure connection."
+        (is (contains? (into #{}
+                             (map (fn [[_log-level _error message]] message))
+                             (mt/with-log-messages-for-level :warn
+                               (mw.session/set-session-cookies {:headers {"x-forwarded-proto" "http"}} {} session request-time)))
+                       "Session cookies SameSite is configured to \"None\", but site is served over an insecure connection. Some browsers will reject cookies under these conditions. https://www.chromestatus.com/feature/5633521622188032")))
+      (testing "should not log a warning over a secure connection."
+        (is (not (contains? (into #{}
+                                  (map (fn [[_log-level _error message]] message))
+                                  (mt/with-log-messages-for-level :warn
+                                    (mw.session/set-session-cookies {:headers {"x-forwarded-proto" "https"}} {} session request-time)))
+                            "Session cookies SameSite is configured to \"None\", but site is served over an insecure connection. Some browsers will reject cookies under these conditions. https://www.chromestatus.com/feature/5633521622188032")))))))
 
 ;; if request is an HTTPS request then we should set `:secure true`. There are several different headers we check for
 ;; this. Make sure they all work.


### PR DESCRIPTION
Considerations here:

- I didn't want to break the existing behavior, which allows the env var to be case insensitive. This required a bit of weirdness in the getter/setter - we get the *raw* value, then normalize it to a keyword, then make sure it's one of the valid options.

- I'm not sure what the best practice is regarding i18n - I just went off the existing code, but I'm not entirely sure whether I need to also add translations to the `locales/*.po` files, and how I get those translations if so (err... chatGPT?).

- permissions: I'm not exactly sure how we decide between the `:settings-manager` and `:admin` settings. I went with `:settings-manager` here.

- I'm not sure whether the frontend has its own definitions of possible values for set-based settings, or if I need to expose that somehow?

The existing tests were good, easily adapted to the new behavior, and caught the above-mentioned backwards incompatibility issue with case insensitivity.

- Related: https://github.com/metabase/metabase-private/issues/182