### PR TITLE
Fix crash when opening filter popover's expression editor

### DIFF
--- a/e2e/test/scenarios/filters/reproductions/34794-filter-popover-navigation-error.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/34794-filter-popover-navigation-error.cy.spec.js
@@ -12,7 +12,7 @@ describe("issue 34794", () => {
     cy.signInAsNormalUser();
   });
 
-  it("should not crash when navigating to filter popover's custom expression section", () => {
+  it("should not crash when navigating to filter popover's custom expression section (metabase#34794)", () => {
     openOrdersTable({ mode: "notebook" });
 
     filter({ mode: "notebook" });

--- a/e2e/test/scenarios/filters/reproductions/34794-filter-popover-navigation-error.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/34794-filter-popover-navigation-error.cy.spec.js
@@ -1,0 +1,31 @@
+import {
+  filter,
+  getNotebookStep,
+  openOrdersTable,
+  popover,
+  restore,
+} from "e2e/support/helpers";
+
+describe("issue 34794", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should not crash when navigating to filter popover's custom expression section", () => {
+    openOrdersTable({ mode: "notebook" });
+
+    filter({ mode: "notebook" });
+    popover().within(() => {
+      cy.findByText("Created At").click();
+      cy.icon("chevronleft").click(); // go back to the main filter popover
+      cy.findByText("Custom Expression").click();
+      cy.findByLabelText("Expression").type("[Total] > 10").blur();
+      cy.button("Done").click();
+    });
+
+    getNotebookStep("filter")
+      .findByText("Total is greater than 10")
+      .should("be.visible");
+  });
+});

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover/FilterPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover/FilterPopover.tsx
@@ -165,10 +165,14 @@ export function FilterPopover({
   };
 
   if (editingFilter) {
+    const filterMBQL = filter?.raw();
+    const expression = isExpression(filterMBQL)
+      ? (filterMBQL as Expression)
+      : undefined;
     return (
       <ExpressionWidget
         query={query}
-        expression={filter?.raw() as Expression | undefined}
+        expression={expression}
         startRule="boolean"
         header={<ExpressionWidgetHeader onBack={handleExpressionWidgetClose} />}
         onChangeExpression={handleExpressionChange}


### PR DESCRIPTION
Fixes #34794

**Root cause:** the `FilterPopover` keeps the `Filter` class instance in its state. For a new filter (like in the issue), it's usually a filter with a blank clause. Opening a datetime column would change the local filter to something like `[ null, field_ref, null ]`. Navigating back in the filter popover doesn't reset that state, so we pass this clause to the expression editor, which it can't handle (specifically the [`format` function](https://github.com/metabase/metabase/blob/8a4c335a66599d317dd7a4335044c7d26deb5001/frontend/src/metabase-lib/expressions/format.js#L27) is failing)

Fixed by adding an `isExpression` check for the current clause before opening the expression editor. `isExpression` does the same checks as the failing `format` function, so `format` shouldn't throw as long as `isExpression` passes

### To verify

1. New > Question > Raw Data > Sample Database > Orders
2. Click "Add filters to narrow your answer"
3. Select "Created At"
4. Go back by clicking the column name at the top of the popover
5. Scroll to the end of the popover and click "Custom Expression"
6. Ensure the editor doesn't crash

### Demo

https://github.com/metabase/metabase/assets/17258145/4b7cbd76-d9c2-45ef-b96c-94ec69efbe61

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
