### PR TITLE
Do not set `updated_at` when pinned

### DIFF
--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -57,6 +57,7 @@
   (derive :metabase/model)
   ;; You can read/write a Card if you can read/write its parent Collection
   (derive ::perms/use-parent-collection-perms)
+  (derive ::collection/remove-updated-at-for-collection-position-changes)
   (derive :hook/timestamped?)
   (derive :hook/entity-id))
 

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -45,6 +45,7 @@
 (doto :model/Dashboard
   (derive :metabase/model)
   (derive ::perms/use-parent-collection-perms)
+  (derive ::collection/remove-updated-at-for-collection-position-changes)
   (derive :hook/timestamped?)
   (derive :hook/entity-id))
 

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -387,7 +387,6 @@
     (cond-> obj
       (not changes-already-include-updated-at?) (assoc :updated_at (now)))))
 
-
 (t2/define-before-insert :hook/timestamped?
   [instance]
   (-> instance

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -50,6 +50,7 @@
 (doto :model/Pulse
   (derive :metabase/model)
   (derive :hook/timestamped?)
+  (derive ::collection/remove-updated-at-for-collection-position-changes)
   (derive :hook/entity-id)
   (derive ::mi/read-policy.full-perms-for-perms-set))
 


### PR DESCRIPTION
- add an additional `before-update` hook that removes the `updated_at` field when it and `collection_position` are the only updated fields

- use `methodical/prefer-method!` to sequence the latter hook after the `timestamped?` hook

The biggest problem here is a really odd one: this seems to work in the database, but somehow the frontend still reports that the card was updated. I am still figuring out why this is the case, but it may be that this requires frontend work that I'm not qualified to do.

Fixing the backend might still be worth it, since it's probably necessary for whatever frontend fix is necessary as well - but maybe it's not, since we seem to be ignoring `updated_at` entirely on the frontend - presumably it's cached somewhere and would be populated eventually?

