### PR TITLE
fix `enable-email-restrict-recipients?` check for the wrong flag

### DIFF
--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -388,7 +388,7 @@
 
 (define-premium-feature ^{:added "0.47.0"} enable-email-restrict-recipients?
   "Enable restrict email recipients?"
-  :serialization)
+  :email-restrict-recipients)
 
 (defsetting is-hosted?
   "Is the Metabase instance running in the cloud?"


### PR DESCRIPTION
it should be using its own flag, not `serialization`