### PR TITLE
Add .portal to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 .eastwood
 .idea/
 .nrepl-port
+.portal
 .vscode
 /*.h2.db
 /*.lock.db


### PR DESCRIPTION
[Portal](https://github.com/djblue/portal) creates a new directory .portal to store settings for development. This PR adds it to the gitignore file.