### PR TITLE
Follow up on deprecating `moment`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,10 @@
       {
         "paths": [
           {
+            "name": "moment",
+            "message": "Moment is deprecated, please use dayjs"
+          },
+          {
             "name": "moment-timezone",
             "message": "Moment is deprecated, please use dayjs"
           }

--- a/enterprise/frontend/.eslintrc
+++ b/enterprise/frontend/.eslintrc
@@ -6,6 +6,10 @@
         "patterns": ["cljs/metabase.lib*"],
         "paths": [
           {
+            "name": "moment",
+            "message": "Moment is deprecated, please use dayjs"
+          },
+          {
             "name": "moment-timezone",
             "message": "Moment is deprecated, please use dayjs"
           }

--- a/frontend/src/metabase-lib/.eslintrc
+++ b/frontend/src/metabase-lib/.eslintrc
@@ -26,6 +26,10 @@
         ],
         "paths": [
           {
+            "name": "moment",
+            "message": "Moment is deprecated, please use dayjs"
+          },
+          {
             "name": "moment-timezone",
             "message": "Moment is deprecated, please use dayjs"
           }

--- a/frontend/src/metabase/.eslintrc
+++ b/frontend/src/metabase/.eslintrc
@@ -52,7 +52,26 @@
     {
       "files": ["ui/**/*.{js,jsx,ts,tsx}"],
       "rules": {
-        "no-restricted-imports": 0
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              "metabase-enterprise",
+              "metabase-enterprise/*",
+              "cljs/metabase.lib*"
+            ],
+            "paths": [
+              {
+                "name": "moment",
+                "message": "Moment is deprecated, please use dayjs"
+              },
+              {
+                "name": "moment-timezone",
+                "message": "Moment is deprecated, please use dayjs"
+              }
+            ]
+          }
+        ]
       }
     }
   ]

--- a/frontend/src/metabase/.eslintrc
+++ b/frontend/src/metabase/.eslintrc
@@ -19,6 +19,10 @@
             "message": "Please import from `metabase/ui` instead."
           },
           {
+            "name": "moment",
+            "message": "Moment is deprecated, please use dayjs"
+          },
+          {
             "name": "moment-timezone",
             "message": "Moment is deprecated, please use dayjs"
           }

--- a/frontend/src/metabase/search/components/InfoText/InfoText.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/InfoText/InfoText.unit.spec.tsx
@@ -1,4 +1,5 @@
 import { waitFor } from "@testing-library/react";
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment";
 import {
   setupCollectionByIdEndpoint,

--- a/frontend/src/metabase/static-viz/lib/format.ts
+++ b/frontend/src/metabase/static-viz/lib/format.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment";
 // eslint-disable-next-line no-restricted-imports -- deprecated usage
 import type { Moment } from "moment-timezone";

--- a/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.tsx
+++ b/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.tsx
@@ -1,5 +1,6 @@
 import { useLayoutEffect, useState } from "react";
 import type { ChangeEvent } from "react";
+// eslint-disable-next-line no-restricted-imports
 import moment from "moment-timezone";
 import { TimeInput as MantineTimeInput } from "@mantine/dates";
 import type { TimeInputProps as MantineTimeInputProps } from "@mantine/dates";


### PR DESCRIPTION
Adds a few things missed in #35020

1. Disallows `moment` imports too (not only `moment-timezone`)
2. Fixes `no-restricted-imports` rule was completely disabled for `metabase/ui` (I suppose it was made to allow direct `@mantine` imports)