### PR TITLE
Restore mock in the `FilterPicker` test

### DIFF
--- a/frontend/src/metabase/common/components/FilterPicker/FilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterPicker.unit.spec.tsx
@@ -156,9 +156,14 @@ describe("FilterPicker", () => {
     });
 
     it("should open the expression editor when column type isn't supported", () => {
-      jest.spyOn(Lib_ColumnTypes, "isNumeric").mockReturnValue(false);
+      const spy = jest
+        .spyOn(Lib_ColumnTypes, "isNumeric")
+        .mockReturnValue(false);
+
       setup(createQueryWithFilter());
       expect(screen.getByText(/Custom expression/i)).toBeInTheDocument();
+
+      spy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
I was hoping Jest would do a clean-up, but it has to be done manually 😢
We'd have problems when we adding and running more `FilterPicker` tests in parallel without that