### PR TITLE
Reorder type filter elements for Search

### DIFF
--- a/frontend/src/metabase/search/components/filters/TypeFilter/TypeFilterContent.tsx
+++ b/frontend/src/metabase/search/components/filters/TypeFilter/TypeFilterContent.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable react/prop-types */
 import { useState } from "react";
+import { enabledSearchTypes } from "metabase/search/constants";
 import type { SearchFilterDropdown } from "metabase/search/types";
 import { useSearchListQuery } from "metabase/common/hooks";
 import { Checkbox, Stack } from "metabase/ui";
 import { getTranslatedEntityName } from "metabase/common/utils/model-names";
 import type { EnabledSearchModelType } from "metabase-types/api";
 import { SearchFilterPopoverWrapper } from "metabase/search/components/SearchFilterPopoverWrapper";
-import { filterEnabledSearchTypes } from "metabase/search/utils";
 
 const EMPTY_SEARCH_QUERY = { models: "dataset", limit: 1 } as const;
 export const TypeFilterContent: SearchFilterDropdown<"type">["ContentComponent"] =
@@ -20,7 +20,9 @@ export const TypeFilterContent: SearchFilterDropdown<"type">["ContentComponent"]
     >(value ?? []);
 
     const availableModels = (metadata && metadata.available_models) ?? [];
-    const typeFilters = filterEnabledSearchTypes(availableModels);
+    const typeFilters = enabledSearchTypes.filter(type =>
+      availableModels.includes(type),
+    );
 
     return (
       <SearchFilterPopoverWrapper
@@ -39,6 +41,9 @@ export const TypeFilterContent: SearchFilterDropdown<"type">["ContentComponent"]
           <Stack spacing="md" p="md" justify="center" align="flex-start">
             {typeFilters.map(model => (
               <Checkbox
+                wrapperProps={{
+                  "data-testid": "type-filter-checkbox",
+                }}
                 key={model}
                 value={model}
                 label={getTranslatedEntityName(model)}

--- a/frontend/src/metabase/search/components/filters/TypeFilter/TypeFilterContent.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/filters/TypeFilter/TypeFilterContent.unit.spec.tsx
@@ -28,12 +28,12 @@ const MODEL_NAME: Record<EnabledSearchModelType, string> = {
 };
 
 const TEST_TYPES: Array<EnabledSearchModelType> = [
-  "collection",
   "dashboard",
   "card",
+  "dataset",
+  "collection",
   "database",
   "table",
-  "dataset",
   "action",
 ];
 
@@ -102,15 +102,23 @@ const setup = async ({
 const getCheckboxes = () => {
   return within(screen.getByTestId("type-filter-checkbox-group")).getAllByRole(
     "checkbox",
-    {},
   ) as HTMLInputElement[];
 };
 describe("TypeFilterContent", () => {
-  it("should display `Type` and all type labels", async () => {
+  it("should display `Type` and all type labels in order", async () => {
     await setup();
-    for (const entityType of TEST_TYPES) {
-      expect(screen.getByText(MODEL_NAME[entityType])).toBeInTheDocument();
-    }
+
+    const typeFilterElements = screen.getAllByTestId("type-filter-checkbox");
+    TEST_TYPES.forEach((type, index) => {
+      const checkboxWrapper = within(typeFilterElements[index]);
+      const checkboxValue = checkboxWrapper
+        .getByRole("checkbox")
+        .getAttribute("value");
+      expect(checkboxValue).toEqual(type);
+      expect(
+        checkboxWrapper.getByLabelText(MODEL_NAME[type]),
+      ).toBeInTheDocument();
+    });
   });
 
   it("should only display available types", async () => {

--- a/frontend/src/metabase/search/constants.ts
+++ b/frontend/src/metabase/search/constants.ts
@@ -11,11 +11,11 @@ export const SearchFilterKeys = {
 } as const;
 
 export const enabledSearchTypes: EnabledSearchModelType[] = [
-  "collection",
   "dashboard",
   "card",
+  "dataset",
+  "collection",
   "database",
   "table",
-  "dataset",
   "action",
 ];


### PR DESCRIPTION
### Description

Specifically sets the content type filter order to be: 
* Dashboards
* Questions
* Models
* Collections
* Databases
* Tables
* Actions

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Go to the search app (type a query in the search bar and click 'View and Filter')
2. Click 'Content type'
3. See that the order of the types is ordered as above

### Demo
Before:

<img width="251" alt="image" src="https://github.com/metabase/metabase/assets/25306947/3a0e46a7-1b53-4e53-b148-42c940e5cae3">


After:

<img width="256" alt="image" src="https://github.com/metabase/metabase/assets/25306947/2dac82a5-e79f-4cfe-8b87-bdd328d0a0f8">

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
