### PR TITLE
[MLv2] Add `has-drill-thrus` for faster clickability checks

### DIFF
--- a/frontend/src/metabase-lib/drills.ts
+++ b/frontend/src/metabase-lib/drills.ts
@@ -28,6 +28,17 @@ export function availableDrillThrus(
   );
 }
 
+export function hasDrillThrus(
+  query: Query,
+  stageIndex: number,
+  column: ColumnMetadata | DatasetColumn | undefined,
+  value: RowValue | undefined,
+  row: DataRow | undefined,
+  dimensions: Dimension[] | undefined,
+): boolean {
+  return ML.has_drill_thrus(query, stageIndex, column, value, row, dimensions);
+}
+
 // TODO: Precise types for each of the various extra args?
 export function drillThru(
   query: Query,

--- a/frontend/src/metabase-lib/queries/drills/types.ts
+++ b/frontend/src/metabase-lib/queries/drills/types.ts
@@ -1,16 +1,10 @@
-import type {
-  DatasetColumn,
-  RowValue,
-  VisualizationSettings,
-} from "metabase-types/api";
+import type { DatasetColumn, RowValue } from "metabase-types/api";
 import type Question from "metabase-lib/Question";
 import type Dimension from "metabase-lib/Dimension";
 
 export type ClickActionProps = {
   question: Question;
   clicked?: ClickObject;
-  settings?: VisualizationSettings;
-  extraData?: Record<string, any>;
 };
 
 export type DrillProps = Pick<ClickActionProps, "question" | "clicked">;

--- a/frontend/src/metabase/visualizations/click-actions/Mode/Mode.ts
+++ b/frontend/src/metabase/visualizations/click-actions/Mode/Mode.ts
@@ -25,6 +25,23 @@ export class Mode {
     return this._queryMode.name;
   }
 
+  hasActionsForClick(
+    clicked: ClickObject | undefined,
+    settings: Record<string, any>,
+    extraData?: Record<string, any>,
+  ): boolean {
+    return (
+      Lib.hasDrillThrus(
+        this._question._getMLv2Query(),
+        /* stageIndex */ -1,
+        clicked?.column,
+        clicked?.value,
+        clicked?.data,
+        clicked?.dimensions,
+      ) || this._queryMode.clickActions.length > 0
+    );
+  }
+
   actionsForClick(
     clicked: ClickObject | undefined,
     settings: Record<string, any>,

--- a/frontend/src/metabase/visualizations/click-actions/Mode/Mode.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/click-actions/Mode/Mode.unit.spec.ts
@@ -43,7 +43,7 @@ describe("Mode", function () {
       const mode = getMode(question);
 
       it("has PivotDrill action", () => {
-        const actions = mode?.actionsForClick(undefined, {});
+        const actions = mode?.actionsForClick(undefined);
 
         expect(
           actions?.find(({ name }) => name === "breakout-by"),
@@ -101,15 +101,13 @@ function setup({
     column: createOrdersIdDatasetColumn(),
     value: undefined,
   },
-  settings = {},
 }: Partial<{
   question: Question;
   clicked: ClickObject | undefined;
-  settings: Record<string, any>;
 }> = {}) {
   const mode = checkNotNull(getMode(question));
 
-  return mode.actionsForClick(clicked, settings);
+  return mode.actionsForClick(clicked);
 }
 
 function getActionsByType(actions: ClickAction[], type: string): ClickAction[] {

--- a/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsPopover.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsPopover.unit.spec.tsx
@@ -387,12 +387,7 @@ async function setup({
     dimension: dimension || undefined,
   };
 
-  const clickActions = mode.actionsForClick(
-    {
-      ...clicked,
-    },
-    settings,
-  ) as RegularClickAction[];
+  const clickActions = mode.actionsForClick(clicked) as RegularClickAction[];
 
   const dispatch = jest.fn();
   const onChangeCardAndRun = jest.fn();

--- a/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsView.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsView.unit.spec.tsx
@@ -103,10 +103,7 @@ function setup(
     ],
   };
 
-  const clickActions = mode.actionsForClick(
-    clicked,
-    {},
-  ) as RegularClickAction[];
+  const clickActions = mode.actionsForClick(clicked) as RegularClickAction[];
   const onClick = jest.fn();
 
   render(<ClickActionsView clickActions={clickActions} onClick={onClick} />);

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -470,6 +470,9 @@ class Visualization extends PureComponent {
         (loading || error || noResults || isHeaderEnabled)) ||
       (replacementContent && (dashcard.size_y !== 1 || isMobile));
 
+    const clickActions =
+      this.getClickActions(clicked).filter(isRegularClickAction);
+
     return (
       <ErrorBoundary>
         <VisualizationRoot
@@ -543,9 +546,7 @@ class Visualization extends PureComponent {
           {this.props.onChangeCardAndRun && (
             <ConnectedClickActionsPopover
               clicked={clicked}
-              clickActions={this.getClickActions(clicked).filter(
-                isRegularClickAction,
-              )}
+              clickActions={clickActions}
               onChangeCardAndRun={this.handleOnChangeCardAndRun}
               onClose={this.hideActions}
               series={series}

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -106,7 +106,8 @@
   database-id]
  [lib.drill-thru
   available-drill-thrus
-  drill-thru]
+  drill-thru
+  has-drill-thrus]
  [lib.drill-thru.pivot
   pivot-columns-for-type
   pivot-types]

--- a/src/metabase/lib/drill_thru/object_details.cljc
+++ b/src/metabase/lib/drill_thru/object_details.cljc
@@ -50,3 +50,14 @@
              (some? value))
     (object-detail-drill-for query stage-number context
                              (> (count (lib.metadata.calculation/primary-keys query)) 1))))
+
+(mu/defn has-object-detail-drill :- :boolean
+  "When clicking a foreign key or primary key value, drill through to the details for that specific object.
+
+  Contrast [[foreign-key-drill]], which filters this query to only those rows with a specific value for a FK column.
+
+  Calls the original [[object-detail-drill]] since its conditions are too intricate to extract."
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   context      :- ::lib.schema.drill-thru/context]
+  (boolean (object-detail-drill query stage-number context)))

--- a/src/metabase/lib/drill_thru/summarize_column_by_time.cljc
+++ b/src/metabase/lib/drill_thru/summarize_column_by_time.cljc
@@ -38,6 +38,13 @@
              :breakout breakout-column
              :unit     (lib.temporal-bucket/raw-temporal-bucket bucketing-unit)}))))))
 
+(mu/defn has-summarize-column-by-time-drill :- :boolean
+  "Returns true if this column can be summarized by time."
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   context      :- ::lib.schema.drill-thru/context]
+  (boolean (summarize-column-by-time-drill query stage-number context)))
+
 (defmethod lib.drill-thru.common/drill-thru-method :drill-thru/summarize-column-by-time
   [query stage-number {:keys [breakout column unit] :as _drill-thru} & _]
   (let [bucketed (lib.temporal-bucket/with-temporal-bucket breakout unit)]

--- a/src/metabase/lib/drill_thru/zoom_in_timeseries.cljc
+++ b/src/metabase/lib/drill_thru/zoom_in_timeseries.cljc
@@ -75,6 +75,13 @@
          :dimension    dimension
          :next-unit    next-unit}))))
 
+(mu/defn has-zoom-in-timeseries-drill :- :boolean
+  "True if the clicked value can be zoomed in."
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   context      :- ::lib.schema.drill-thru/context]
+  (boolean (zoom-in-timeseries-drill query stage-number context)))
+
 (mu/defmethod lib.drill-thru.common/drill-thru-method :drill-thru/zoom-in.timeseries
   [query                         :- ::lib.schema/query
    stage-number                  :- :int

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -25,8 +25,8 @@
    [metabase.mbql.js :as mbql.js]
    [metabase.shared.util.time :as shared.ut]
    [metabase.util :as u]
-   [metabase.util.memoize :as memoize]
-   [metabase.util.log :as log]))
+   [metabase.util.log :as log]
+   [metabase.util.memoize :as memoize]))
 
 ;;; this is mostly to ensure all the relevant namespaces with multimethods impls get loaded.
 (comment lib.core/keep-me)


### PR DESCRIPTION
Several e2e tests
([example](https://www.deploysentinel.com/ci/runs/65374bdb7bcc14868115dfae))
have become flaky due to timing out waiting for a button to become clickable.
The button is slow to be clickable because the table viz is busy calling
`available-drill-thrus` for every cell in the table to determine whether the
cell is clickable.

This PR adds `has-drill-thrus` that only checks conditions rather than fully
computing the drills. It can short-circuit as soon as any drill is returned, so
it's much faster than calling `available-drill-thrus`. This also adds
`Mode.hasActionsForClick` and refactors
`Visualization.visualizationIsClickable` to use it.

- [x] BE unit tests needed
