### PR TITLE
polish pie chart styles

### DIFF
--- a/frontend/src/metabase/lib/colors/palette.ts
+++ b/frontend/src/metabase/lib/colors/palette.ts
@@ -140,20 +140,3 @@ export const getFocusColor = (
   colorName: string,
   palette: ColorPalette = colors,
 ) => lighten(color(colorName, palette), 0.465);
-
-// We intentionally want to return white text color more frequently
-// https://www.notion.so/Maz-notes-on-viz-settings-67aed0e4ddcc4d4a83028992c4301820?d=513f4f7fa9c143cb874c7e4525dfb1e9#277d6b3eeb464eac86088abd144fde9e
-const whiteTextColorPriorityFactor = 3;
-
-export const getTextColorForBackground = (backgroundColor: string) => {
-  const whiteTextContrast =
-    Color(color(backgroundColor)).contrast(Color(color("white"))) *
-    whiteTextColorPriorityFactor;
-  const darkTextContrast = Color(color(backgroundColor)).contrast(
-    Color(color("text-dark")),
-  );
-
-  return whiteTextContrast > darkTextContrast
-    ? color("white")
-    : color("text-dark");
-};

--- a/frontend/src/metabase/static-viz/components/CategoricalDonutChart/CategoricalDonutChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalDonutChart/CategoricalDonutChart.jsx
@@ -3,7 +3,9 @@ import { t } from "ttag";
 import { Group } from "@visx/group";
 import { Pie } from "@visx/shape";
 import { Text } from "@visx/text";
-import { getTextColorForBackground } from "metabase/lib/colors";
+
+import { getTextColorForBackground } from "metabase/static-viz/lib/colors";
+
 import { formatNumber, formatPercent } from "../../lib/numbers";
 import { DIMENSION_ACCESSORS } from "../../constants/accessors";
 

--- a/frontend/src/metabase/static-viz/components/PieChart/PieChart.tsx
+++ b/frontend/src/metabase/static-viz/components/PieChart/PieChart.tsx
@@ -6,13 +6,10 @@ import { sanitizeSvgForBatik } from "metabase/static-viz/lib/svg";
 import { getPieChartModel } from "metabase/visualizations/echarts/pie/model";
 import { getPieChartOption } from "metabase/visualizations/echarts/pie/option";
 import { getPieChartFormatters } from "metabase/visualizations/echarts/pie/format";
+import { DIMENSIONS } from "metabase/visualizations/echarts/pie/constants";
 
 import { computeStaticPieChartSettings } from "./setttings";
 import { getPieChartLegend } from "./legend";
-
-const PADDING_TOP = 16; // TODO confirm with design
-const WIDTH = 540;
-const HEIGHT = 360;
 
 export function PieChart({
   rawSeries,
@@ -43,15 +40,15 @@ export function PieChart({
     chartModel,
     formatters,
     computedVizSettings,
-    WIDTH,
-    PADDING_TOP,
+    DIMENSIONS.sideLen,
+    DIMENSIONS.paddingTop,
   );
 
   const chart = init(null, null, {
     renderer: "svg",
     ssr: true,
-    width: WIDTH,
-    height: HEIGHT,
+    width: DIMENSIONS.sideLen,
+    height: DIMENSIONS.sideLen,
   });
 
   chart.setOption(option);
@@ -59,10 +56,13 @@ export function PieChart({
   const chartSvg = sanitizeSvgForBatik(chart.renderToSVGString());
 
   return (
-    <svg width={WIDTH} height={PADDING_TOP + HEIGHT + legendHeight}>
+    <svg
+      width={DIMENSIONS.sideLen}
+      height={DIMENSIONS.sideLen + DIMENSIONS.paddingTop + legendHeight}
+    >
       <Legend />
       <Group
-        top={PADDING_TOP + legendHeight}
+        top={DIMENSIONS.paddingTop + legendHeight}
         dangerouslySetInnerHTML={{ __html: chartSvg }}
       ></Group>
     </svg>

--- a/frontend/src/metabase/static-viz/components/PieChart/legend.tsx
+++ b/frontend/src/metabase/static-viz/components/PieChart/legend.tsx
@@ -5,6 +5,12 @@ import type { PieChartModel } from "metabase/visualizations/echarts/pie/model/ty
 import { calculateLegendRows } from "../Legend/utils";
 import { Legend } from "../Legend";
 
+const FONT = {
+  lineHeight: 20,
+  size: 14,
+  weight: 700,
+};
+
 export function getPieChartLegend(
   chartModel: PieChartModel,
   formatters: PieChartFormatters,
@@ -25,9 +31,9 @@ export function getPieChartLegend(
       color: s.color,
     })),
     width,
-    24,
-    18,
-    400,
+    FONT.lineHeight,
+    FONT.size,
+    FONT.weight,
   );
   if (!legendRows) {
     throw Error("Error calculating legend rows");
@@ -38,7 +44,12 @@ export function getPieChartLegend(
   return {
     legendHeight,
     Legend: () => (
-      <Legend items={items} top={top} fontSize={18} fontWeight={400} />
+      <Legend
+        items={items}
+        top={top}
+        fontSize={FONT.size}
+        fontWeight={FONT.weight}
+      />
     ),
   };
 }

--- a/frontend/src/metabase/static-viz/lib/colors.ts
+++ b/frontend/src/metabase/static-viz/lib/colors.ts
@@ -1,3 +1,4 @@
+import Color from "color";
 import { colors, color } from "metabase/lib/colors/palette";
 import type { ColorPalette } from "metabase/lib/colors/types";
 import type { ColorGetter } from "metabase/visualizations/types";
@@ -25,4 +26,24 @@ export const getWaterfallColors = (
     waterfallPositive: colorSettings.waterfallPositive ?? getColor("accent1"),
     waterfallNegative: colorSettings.waterfallNegative ?? getColor("accent3"),
   };
+};
+
+// We intentionally want to return white text color more frequently
+// https://www.notion.so/Maz-notes-on-viz-settings-67aed0e4ddcc4d4a83028992c4301820?d=513f4f7fa9c143cb874c7e4525dfb1e9#277d6b3eeb464eac86088abd144fde9e
+const WHITE_TEXT_PRIORITY_FACTOR = 3;
+
+export const getTextColorForBackground = (
+  backgroundColor: string,
+  getColor: ColorGetter = color,
+) => {
+  const whiteTextContrast =
+    Color(getColor(backgroundColor)).contrast(Color(getColor("white"))) *
+    WHITE_TEXT_PRIORITY_FACTOR;
+  const darkTextContrast = Color(getColor(backgroundColor)).contrast(
+    Color(getColor("text-dark")),
+  );
+
+  return whiteTextContrast > darkTextContrast
+    ? getColor("white")
+    : getColor("text-dark");
 };

--- a/frontend/src/metabase/visualizations/echarts/pie/constants.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/constants.ts
@@ -1,3 +1,21 @@
+export const DIMENSIONS = {
+  paddingTop: 16,
+  sideLen: 540,
+  margin: 20,
+  slice: {
+    thickness: 100,
+    borderWidth: 4,
+  },
+  // placeholders, real values computed below
+  innerSideLen: 0,
+  outerRadius: 0,
+  innerRadius: 0,
+};
+
+DIMENSIONS.innerSideLen = DIMENSIONS.sideLen - DIMENSIONS.margin * 2;
+DIMENSIONS.outerRadius = DIMENSIONS.innerSideLen / 2;
+DIMENSIONS.innerRadius = DIMENSIONS.outerRadius - DIMENSIONS.slice.thickness;
+
 export const SLICE_THRESHOLD = 0.025; // approx 1 degree in percentage
 
 export const OTHER_SLICE_MIN_PERCENTAGE = 0.003;

--- a/frontend/src/metabase/visualizations/echarts/pie/option/constants.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/option/constants.ts
@@ -1,17 +1,22 @@
 import type { RegisteredSeriesOption } from "echarts";
 import { t } from "ttag";
 
+import { DIMENSIONS } from "../constants";
+
 export const SUNBURST_SERIES_OPTION: RegisteredSeriesOption["sunburst"] = {
   type: "sunburst",
   sort: undefined,
+  radius: [DIMENSIONS.innerRadius, DIMENSIONS.outerRadius],
   label: {
     rotate: 0,
     overflow: "none",
-    lineHeight: 50, // TODO update this later
-    fontSize: 16, // TODO update this later
+    fontSize: 20,
+    fontWeight: 700,
     color: "white", // TODO select color dynamically based on contrast with slice color
   },
-  radius: ["60%", "90%"], // TODO compute this dynamically based on side length like in PieChart.jsx
+  itemStyle: {
+    borderWidth: DIMENSIONS.slice.borderWidth,
+  },
 };
 
 export const TOTAL_GRAPHIC_OPTION = {
@@ -34,7 +39,7 @@ export const TOTAL_GRAPHIC_OPTION = {
     {
       type: "text",
       cursor: "text",
-      top: 25, // TODO confirm this and other style values later
+      top: 24,
       style: {
         fontSize: "14px",
         fontWeight: "700",

--- a/frontend/src/metabase/visualizations/echarts/pie/option/constants.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/option/constants.ts
@@ -12,7 +12,6 @@ export const SUNBURST_SERIES_OPTION: RegisteredSeriesOption["sunburst"] = {
     overflow: "none",
     fontSize: 20,
     fontWeight: 700,
-    color: "white", // TODO select color dynamically based on contrast with slice color
   },
   itemStyle: {
     borderWidth: DIMENSIONS.slice.borderWidth,

--- a/frontend/src/metabase/visualizations/echarts/pie/option/constants.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/option/constants.ts
@@ -38,7 +38,7 @@ export const TOTAL_GRAPHIC_OPTION = {
     {
       type: "text",
       cursor: "text",
-      top: 24,
+      top: 26,
       style: {
         fontSize: "14px",
         fontWeight: "700",

--- a/frontend/src/metabase/visualizations/echarts/pie/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/option/index.ts
@@ -7,6 +7,7 @@ import type {
   RenderingContext,
 } from "metabase/visualizations/types";
 
+import { getTextColorForBackground } from "metabase/static-viz/lib/colors";
 import type { PieChartModel, PieSlice } from "../model/types";
 import type { PieChartFormatters } from "../format";
 import { SUNBURST_SERIES_OPTION, TOTAL_GRAPHIC_OPTION } from "./constants";
@@ -85,6 +86,9 @@ export function getPieChartOption(
         value: s.value,
         name: s.key,
         itemStyle: { color: s.color },
+        label: {
+          color: getTextColorForBackground(s.color, renderingContext.getColor),
+        },
       })),
     },
   };

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/PieArc.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/PieArc.tsx
@@ -1,7 +1,9 @@
 import type { SVGAttributes } from "react";
 import { useEffect, useRef, useState } from "react";
 import type d3 from "d3";
-import { getTextColorForBackground } from "metabase/lib/colors";
+
+import { getTextColorForBackground } from "metabase/static-viz/lib/colors";
+
 import { Label } from "./PieArc.styled";
 import { getMaxLabelDimension } from "./utils";
 


### PR DESCRIPTION
Part of https://github.com/metabase/metabase/issues/33281

### Description

Miscellaneous updating of style values. Note that we aimed to match the styles to the existing dynamic pie chart for consistency, not with the existing static pie chart. Also, the text will look uncentered for now because the `dominant-baseline` svg text property is not supported by batik. We'll look into fixing this later.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a question
2. Set visualization type to `Pie 2`
4. Add to a dashboard
5. Send in an email subscription
6. Confirm it appears with the updated styles

### Demo

![Pie - Products, Count, Average of Price, and Standard deviation of Rating, Grouped by Category-10_24_2023, 3_17_34 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/16f166b5-c520-423b-81d7-ede8fa868ca6.png)

Dynamic pie chart

![metabase_pulse_image_12441911141064344691.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/3e509b1c-6c92-475e-a9da-279ceefccc3f.png)

Same question and viz settings but with echarts static pie

### Checklist

- [] Tests have been added/updated to cover changes in this PR

_Will be covered later in percy tests._