### PR TITLE
Don't look into viz settings when doing `validate-temporal-bucketing` query validation

### DIFF
--- a/src/metabase/query_processor/middleware/validate_temporal_bucketing.clj
+++ b/src/metabase/query_processor/middleware/validate_temporal_bucketing.clj
@@ -31,7 +31,7 @@
   "Make sure temporal bucketing of Fields (i.e., `:datetime-field` clauses) in this query is valid given the combination
   of Field base-type and unit. For example, you should not be allowed to bucket a `:type/Date` Field by `:minute`."
   [query]
-  (doseq [[_ id-or-name {:keys [temporal-unit base-type]} :as clause] (mbql.u/match query [:field _ (_ :guard :temporal-unit)])]
+  (doseq [[_ id-or-name {:keys [temporal-unit base-type]} :as clause] (mbql.u/match (:query query) [:field _ (_ :guard :temporal-unit)])]
     (let [base-type (if (integer? id-or-name)
                       (:base_type (qp.store/field id-or-name))
                       base-type)


### PR DESCRIPTION
Fixes #34950

https://github.com/metabase/metabase/pull/34823 added Card `:visualization_settings` to query `:info`... if Viz settings was busted for one reason or another (had entries for Fields that aren't actually part of the query anymore) then it caused the `validate-temporal-bucketing` middleware to fail, it would try to fetch that Field to validate it but it wouldn't be present since it's not actually part of the query.

The fix here was to have the `validate-temporal-bucketing` ignore top-level query keys like `:info`. I added a test to make sure a query with invalid viz-settings can run end-to-end.

This fix is not really needed in 48+ since the code there uses MLv2 metadata providers which fetch Fields on demand, but I'll probably do a different version of this for 48 anyway since it's doing unnecessary app DB calls either way.