### PR TITLE
Don't look into viz settings when doing `validate-temporal-bucketing` query validation

### DIFF
--- a/src/metabase/query_processor/middleware/validate_temporal_bucketing.clj
+++ b/src/metabase/query_processor/middleware/validate_temporal_bucketing.clj
@@ -32,7 +32,7 @@
   "Make sure temporal bucketing of Fields (i.e., `:datetime-field` clauses) in this query is valid given the combination
   of Field base-type and unit. For example, you should not be allowed to bucket a `:type/Date` Field by `:minute`."
   [query]
-  (doseq [[_ id-or-name {:keys [temporal-unit base-type]} :as clause] (mbql.u/match query [:field _ (_ :guard :temporal-unit)])]
+  (doseq [[_ id-or-name {:keys [temporal-unit base-type]} :as clause] (mbql.u/match (:query query) [:field _ (_ :guard :temporal-unit)])]
     (let [base-type (if (integer? id-or-name)
                       (:base-type (lib.metadata/field (qp.store/metadata-provider) id-or-name))
                       base-type)


### PR DESCRIPTION
This is #35071, but targeting `master` instead.

This actually did still cause the query to break if the Field didn't exist at all.

Fixes #34950