### PR TITLE
docs - notes on private channels

### DIFF
--- a/docs/configuring-metabase/slack.md
+++ b/docs/configuring-metabase/slack.md
@@ -6,7 +6,7 @@ redirect_from:
 
 # Slack
 
-If you want to have your [Dashboard subscriptions](../dashboards/subscriptions.md) or [alerts](../questions/sharing/alerts.md) sent to Slack channels (or people on Slack), an admin must first integrate your Metabase with Slack.
+If you want to have your [dashboard subscriptions](../dashboards/subscriptions.md) or [alerts](../questions/sharing/alerts.md) sent to Slack channels (or people on Slack), an admin must first integrate your Metabase with Slack.
 
 ## Create your Slack App
 
@@ -76,6 +76,14 @@ In your Slack workspace, create a public channel named whatever you want — we 
 ## Save your changes in Metabase
 
 In Metabase, click on the **Save changes** button and that’s it! Metabase will automatically run a quick test to check that the API token and your dedicated Slack channel are working properly. If something goes wrong, it'll give you an error message.
+
+## Sending alerts and subscriptions to private Slack channels
+
+In order to send subscriptions and alerts to private Slack channels, you must first add the Metabase app to the private channel. 
+
+In Slack, go to the private channel and mention the Metabase app. For example, if you called your Slack app "Metabase", you'd just type `@Metabase`. Slack will ask you if you want to invite your app to your channel, which you should.
+
+Once your Metabase app is added to the private channel, you'll need to type out the private channel's name in the subscription or alert. Make sure to spell the channel's name correctly, or Metabase won't be able to send the notification.
 
 ## Further reading
 

--- a/docs/dashboards/subscriptions.md
+++ b/docs/dashboards/subscriptions.md
@@ -49,7 +49,7 @@ You can specify how often Metabase sends a Slack message (hourly, daily, weekly,
 
 ### Sending subscriptions to private channels
 
-See [Sending alerts and subscriptions to private Slack channels](../configuring-metabase/slack#sending-alerts-and-subscriptions-to-private-channels).
+See [Sending alerts and subscriptions to private Slack channels](../configuring-metabase/slack.md#sending-alerts-and-subscriptions-to-private-channels).
 
 ## Adding multiple subscriptions
 

--- a/docs/dashboards/subscriptions.md
+++ b/docs/dashboards/subscriptions.md
@@ -47,6 +47,10 @@ For Slack subscriptions, you can set up a subscription for a channel (like #gene
 
 You can specify how often Metabase sends a Slack message (hourly, daily, weekly, or monthly), and whether to send a message if the dashboard fails to return results.
 
+### Sending subscriptions to private channels
+
+See [Sending alerts and subscriptions to private Slack channels](../configuring-metabase/slack#sending-alerts-and-subscriptions-to-private-channels).
+
 ## Adding multiple subscriptions
 
 You can add multiple subscriptions to a single dashboard. To add a subscription, click on the **+** icon in the dashboard subscription panel.

--- a/docs/questions/sharing/alerts.md
+++ b/docs/questions/sharing/alerts.md
@@ -103,7 +103,7 @@ See [Notification permissions](../../permissions/notifications.md).
 
 ### Sending to private Slack channels
 
-See [Sending alerts and subscriptions to private Slack channels](../../configuring-metabase/slack#sending-alerts-and-subscriptions-to-private-channels).
+See [Sending alerts and subscriptions to private Slack channels](../../configuring-metabase/slack.md#sending-alerts-and-subscriptions-to-private-channels).
 
 ## Further reading
 

--- a/docs/questions/sharing/alerts.md
+++ b/docs/questions/sharing/alerts.md
@@ -101,7 +101,7 @@ Admins can view a list of all alerts and dashboard subscriptions that people hav
 
 See [Notification permissions](../../permissions/notifications.md).
 
-### Sending to private Slack channels
+### Sending alerts to private Slack channels
 
 See [Sending alerts and subscriptions to private Slack channels](../../configuring-metabase/slack.md#sending-alerts-and-subscriptions-to-private-channels).
 

--- a/docs/questions/sharing/alerts.md
+++ b/docs/questions/sharing/alerts.md
@@ -101,6 +101,10 @@ Admins can view a list of all alerts and dashboard subscriptions that people hav
 
 See [Notification permissions](../../permissions/notifications.md).
 
+### Sending to private Slack channels
+
+See [Sending alerts and subscriptions to private Slack channels](../../configuring-metabase/slack#sending-alerts-and-subscriptions-to-private-channels).
+
 ## Further reading
 
 - [Dashboard subscriptions](../../dashboards/subscriptions.md)


### PR DESCRIPTION
Updates alert and subscriptions docs to include how you'd set up notifications for private Slack channels.