### PR TITLE
Revert uberjar caching for E2E tests

### DIFF
--- a/.github/actions/e2e-download-uberjar/action.yml
+++ b/.github/actions/e2e-download-uberjar/action.yml
@@ -1,24 +1,14 @@
-name: Download uberjar for E2E tests
-description: Download either a freshly built artifact or the one built in one of the previous commits.
+name: Find and download uberjar for E2E tests
+description: Download previously built artifact from one of the previous commits.
 inputs:
   edition:
     description: Metabase edition.
-    required: true
-  was-built:
-    description: Was the artifact built during the current workflof run?
     required: true
 
 runs:
   using: "composite"
   steps:
-    - uses: actions/download-artifact@v3
-      if: ${{ inputs.was-built == 'true' }}
-      name: Retrieve uberjar artifact for ${{ inputs.edition }}
-      with:
-        name: metabase-${{ inputs.edition }}-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
-
     - name: Download previously stored uberjar
-      if: ${{ inputs.was-built == 'false' }}
       uses: actions/github-script@v6
       with:
         script: | # js
@@ -76,7 +66,6 @@ runs:
           fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/mb.zip`, Buffer.from(download.data));
 
     - name: Unzip Metabase artifact containing an uberjar
-      if: ${{ inputs.was-built == 'false' }}
       run: unzip mb.zip
       shell: bash
 

--- a/.github/actions/prepare-uberjar-artifact/action.yml
+++ b/.github/actions/prepare-uberjar-artifact/action.yml
@@ -1,4 +1,11 @@
 name: Prepare Uberjar Artifact
+description: Prepare and upload Metabase JAR as a GitHub artifact.
+
+inputs:
+  name:
+    required: true
+    description: Artifact name
+
 runs:
   using: "composite"
   steps:
@@ -11,7 +18,7 @@ runs:
     - name: Upload JARs as artifact
       uses: actions/upload-artifact@v3
       with:
-        name: metabase-${{ matrix.edition }}-uberjar
+        name: ${{ inputs.name }}
         path: |
           ./target/uberjar/metabase.jar
           ./COMMIT-ID

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -68,6 +68,8 @@ jobs:
 
       - name: Prepare uberjar artifact
         uses: ./.github/actions/prepare-uberjar-artifact
+        with:
+          name: metabase-${{ matrix.edition }}-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
 
   e2e-tests:
     needs: [build, e2e-matrix-builder]
@@ -112,7 +114,7 @@ jobs:
       - name: Retrieve uberjar artifact for ${{ matrix.edition }}
         uses: actions/download-artifact@v3
         with:
-          name: metabase-${{ matrix.edition }}-uberjar
+          name: metabase-${{ matrix.edition }}-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
 
       - name: Get the version info
         run: |
@@ -214,7 +216,7 @@ jobs:
       - name: Retrieve uberjar artifact for ${{ matrix.edition }}
         uses: actions/download-artifact@v3
         with:
-          name: metabase-${{ matrix.edition }}-uberjar
+          name: metabase-${{ matrix.edition }}-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
 
       - name: Get the version info
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -216,7 +216,7 @@ jobs:
       - name: Retrieve uberjar artifact for ${{ matrix.edition }}
         uses: actions/download-artifact@v3
         with:
-          name: metabase-${{ matrix.edition }}-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
+          name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
 
       - name: Get the version info
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -18,7 +18,6 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 3
     outputs:
-      e2e_specs: ${{ steps.changes.outputs.e2e_specs }}
       e2e_all: ${{ steps.changes.outputs.e2e_all }}
     steps:
       - uses: actions/checkout@v3
@@ -67,26 +66,13 @@ jobs:
       - name: Build uberjar with ./bin/build.sh
         run: ./bin/build.sh
 
-      - name: Mark with the commit hash
-        run: echo ${{ github.sha }} > COMMIT-ID
-        shell: bash
-      - name: Calculate SHA256 checksum
-        run: sha256sum ./target/uberjar/metabase.jar > SHA256.sum
-        shell: bash
-      - name: Upload JARs as artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: metabase-${{ matrix.edition }}-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
-          path: |
-            ./target/uberjar/metabase.jar
-            ./COMMIT-ID
-            ./SHA256.sum
+      - name: Prepare uberjar artifact
+        uses: ./.github/actions/prepare-uberjar-artifact
 
   e2e-tests:
-    needs: [build, files-changed, e2e-matrix-builder]
+    needs: [build, e2e-matrix-builder]
     if: |
-      !cancelled() &&
-      (needs.files-changed.outputs.e2e_specs == 'true' || needs.build.result == 'success')
+      !cancelled() && needs.build.result == 'success'
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     name: e2e-tests-${{ matrix.name }}-${{ matrix.edition }}
@@ -111,9 +97,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          # Important in case we need to download uberjar from previous commits!
-          fetch-depth: ${{ needs.build.result == 'success' && '' || 20 }}
 
       - name: Prepare Docker containers
         uses: ./.github/actions/e2e-prepare-containers
@@ -126,14 +109,19 @@ jobs:
           mysql: ${{ matrix.name != 'mongo'}}
           mongo: ${{ matrix.name == 'mongo'}}
 
-      - name: Download Metabase ${{ matrix.edition }} uberjar
-        uses: ./.github/actions/e2e-download-uberjar
+      - name: Retrieve uberjar artifact for ${{ matrix.edition }}
+        uses: actions/download-artifact@v3
         with:
-          edition: ${{ matrix.edition }}
-          was-built: ${{ needs.build.result == 'success' }}
+          name: metabase-${{ matrix.edition }}-uberjar
+
+      - name: Get the version info
+        run: |
+          jar xf target/uberjar/metabase.jar version.properties
+          mv version.properties resources/
 
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+
       - name: Prepare JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
@@ -211,15 +199,10 @@ jobs:
     timeout-minutes: 60
     needs: [build]
     if: |
-      !cancelled() &&
-      (needs.files-changed.outputs.e2e_specs == 'true' || needs.build.result == 'success') &&
-      github.event_name != 'schedule'
+      !cancelled() && needs.build.result == 'success'
     name: percy-visual-regression-tests
     steps:
       - uses: actions/checkout@v3
-        with:
-          # Important in case we need to download uberjar from previous commits!
-          fetch-depth: ${{ needs.build.result == 'success' && '' || 20 }}
 
       - name: Prepare Docker containers
         uses: ./.github/actions/e2e-prepare-containers
@@ -228,19 +211,25 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           maildev: true
 
-      - name: Download Metabase enterprise uberjar
-        uses: ./.github/actions/e2e-download-uberjar
+      - name: Retrieve uberjar artifact for ${{ matrix.edition }}
+        uses: actions/download-artifact@v3
         with:
-          edition: 'ee'
-          was-built: ${{ needs.build.result == 'success' }}
+          name: metabase-${{ matrix.edition }}-uberjar
+
+      - name: Get the version info
+        run: |
+          jar xf target/uberjar/metabase.jar version.properties
+          mv version.properties resources/
 
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+
       - name: Prepare JDK 11
         uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: 'temurin'
+
       - name: Prepare Cypress environment
         id: cypress-prep
         uses: ./.github/actions/prepare-cypress

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -45,6 +45,8 @@ jobs:
       run: ./bin/build.sh
     - name: Prepare uberjar artifact
       uses: ./.github/actions/prepare-uberjar-artifact
+      with:
+        name: metabase-${{ matrix.edition }}-${{ github.sha }}-uberjar
 
   check_jar_health:
     runs-on: ubuntu-22.04
@@ -66,7 +68,7 @@ jobs:
     - uses: actions/download-artifact@v3
       name: Retrieve uberjar artifact
       with:
-        name: metabase-${{ matrix.edition }}-uberjar
+        name: metabase-${{ matrix.edition }}-${{ github.sha }}-uberjar
     - name: Launch uberjar
       run: java -jar ./target/uberjar/metabase.jar &
     - name: Wait for Metabase to start
@@ -98,7 +100,7 @@ jobs:
     - name: Download uploaded artifacts to insert into container
       uses: actions/download-artifact@v3
       with:
-        name: metabase-${{ matrix.edition }}-uberjar
+        name: metabase-${{ matrix.edition }}-${{ github.sha }}-uberjar
         path: bin/docker/
     - name: Move the ${{ matrix.edition }} uberjar to the context dir
       run: mv bin/docker/target/uberjar/metabase.jar bin/docker/.
@@ -216,7 +218,7 @@ jobs:
       - name: Download uploaded artifacts to insert into container
         uses: actions/download-artifact@v3
         with:
-          name: metabase-${{ matrix.edition }}-uberjar
+          name: metabase-${{ matrix.edition }}-${{ github.sha }}-uberjar
           path: bin/docker/
       - name: Move the ${{ matrix.edition }} uberjar to the context dir
         run: mv bin/docker/target/uberjar/metabase.jar bin/docker/.


### PR DESCRIPTION
This PR reverts the idea of caching the uberjar for E2E tests. It's not a 1:1 revert of the original commit, because a lot of things have changed since then.

The main point and the tl;dr is this:
That the idea to find previously built uberjar was great in theory. It worked in most of the cases but it failed in cases of force-pushes (rebase, ammend, etc.). Some people reported that it might not even work when the base branch is merged into a PR.

The other edge case happened when the base branch still didn't finish running all workflows, but your branch needed an artifact from it. Unfortunately, GitHub REST API (that we were using for this custom logic) doesn't even see the artifact if workflow is still running.

There are two ways to find/download the artifact.
1. The official `actions/download-artifact` action (which can only download the artifact from the current workflow, while it's still ongoing)
2. The REST API, which can only see and download artifacts from workflows that have already finished running

### Differences from [the original commit](https://github.com/metabase/metabase/pull/33190)
- We're keeping the commit SHA1 in the artifact name
- The custom logic is not removed, but is actually used in both E2E Replay and Stress-test E2E flake workflows

### Altered git history
The biggest problem that this custom approach faced was the frequent use of rebase and/or amend. In other words, changing the git history. Since it calculates the hashes of the previous commits by using `git rev-parse COMMIT^`, it either failed to find the uberjar or it sometimes failed to find the hash in the updated git tree.

GitHub keeps the information about the force-pushed commits and it is possible to find the previous commit (which I've tried [here](https://github.com/metabase/metabase/pull/35056), but that only works for the immediate parent/predecessor. Even if I could find a way to traverse the old history further, the effort and the risk didn't seem worth it.

The biggest of all risks was finding the wrong uberjar and then relying on tests from it.
- In a good scenario, your tests would fail and you'd be alerted (although you'd loose significant time until you realized it was testing agains the wrong commit)
- In a bad scenario, your tests would pass even though you might have introduced the breaking change.

## Conclusion
It is better to revert and to wait for the build, even when unnecessary, than it is to risk wrong results or failed builds and the lost developer time.
