### PR TITLE
Fix E2E flake 17514

### DIFF
--- a/e2e/test/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
@@ -133,9 +133,8 @@ describe("issue 17514", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save").click();
 
-      cy.get(".Modal").within(() => {
-        cy.button("Save").click();
-      });
+      cy.get(".Modal").button("Save").click();
+      cy.get(".Modal").should("not.exist");
     });
 
     it("should not show the run overlay because of the references to the orphaned fields (metabase#17514-2)", () => {


### PR DESCRIPTION
Flake/Failure data for the last two days
https://www.deploysentinel.com/ci/analysis?branch=master&from=2d

![image](https://github.com/metabase/metabase/assets/31325167/e06878a4-c5d5-4f68-ace2-6b25767469ec)

Stress-test results
```
issue 17514
    scenario 1
      ✓ should not show the run overlay when we apply dashboard filter on a question with removed column and then click through its title (metabase#17514-1): burning 1 of 10 (28693ms)
      ✓ should not show the run overlay when we apply dashboard filter on a question with removed column and then click through its title (metabase#17514-1): burning 2 of 10 (21291ms)
      ✓ should not show the run overlay when we apply dashboard filter on a question with removed column and then click through its title (metabase#17514-1): burning 3 of 10 (19868ms)
      ✓ should not show the run overlay when we apply dashboard filter on a question with removed column and then click through its title (metabase#17514-1): burning 4 of 10 (20538ms)
      ✓ should not show the run overlay when we apply dashboard filter on a question with removed column and then click through its title (metabase#17514-1): burning 5 of 10 (20031ms)
      ✓ should not show the run overlay when we apply dashboard filter on a question with removed column and then click through its title (metabase#17514-1): burning 6 of 10 (19625ms)
      ✓ should not show the run overlay when we apply dashboard filter on a question with removed column and then click through its title (metabase#17514-1): burning 7 of 10 (20122ms)
      ✓ should not show the run overlay when we apply dashboard filter on a question with removed column and then click through its title (metabase#17514-1): burning 8 of 10 (20563ms)
      ✓ should not show the run overlay when we apply dashboard filter on a question with removed column and then click through its title (metabase#17514-1): burning 9 of 10 (18577ms)
      ✓ should not show the run overlay when we apply dashboard filter on a question with removed column and then click through its title (metabase#17514-1): burning 10 of 10 (18681ms)
    scenario 2
      ✓ should not show the run overlay because of the references to the orphaned fields (metabase#17514-2): burning 1 of 10 (35821ms)
      ✓ should not show the run overlay because of the references to the orphaned fields (metabase#17514-2): burning 2 of 10 (36[170](https://github.com/metabase/metabase/actions/runs/6651316853/job/18073109810#step:9:170)ms)
      ✓ should not show the run overlay because of the references to the orphaned fields (metabase#17514-2): burning 3 of 10 (36305ms)
      ✓ should not show the run overlay because of the references to the orphaned fields (metabase#17514-2): burning 4 of 10 (36112ms)
      ✓ should not show the run overlay because of the references to the orphaned fields (metabase#17514-2): burning 5 of 10 (38263ms)
      ✓ should not show the run overlay because of the references to the orphaned fields (metabase#17514-2): burning 6 of 10 (39517ms)
      ✓ should not show the run overlay because of the references to the orphaned fields (metabase#[175](https://github.com/metabase/metabase/actions/runs/6651316853/job/18073109810#step:9:175)14-2): burning 7 of 10 (36584ms)
      ✓ should not show the run overlay because of the references to the orphaned fields (metabase#17514-2): burning 8 of 10 (36735ms)
      ✓ should not show the run overlay because of the references to the orphaned fields (metabase#17514-2): burning 9 of 10 (35093ms)
      ✓ should not show the run overlay because of the references to the orphaned fields (metabase#17514-2): burning 10 of 10 (35922ms)
```