### PR TITLE
Fix e2e stress test workflow

### DIFF
--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -47,6 +47,7 @@ jobs:
         uses: ./.github/actions/e2e-download-uberjar
         with:
           edition: 'ee'
+          was-built: false
 
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
@@ -66,7 +67,7 @@ jobs:
           yarn run test-cypress-run \
           --spec '${{ github.event.inputs.spec }}' \
           --env burn=${{ github.event.inputs.burn_in }} \
-          --config-file e2e/support/cypress-stress-test.config.js
+          --config-file e2e/support/cypress-stress-test.config.js \
           --browser ${{ steps.cypress-prep.outputs.chrome-path }}
 
       - name: Upload Cypress Artifacts upon failure


### PR DESCRIPTION
I missed two things that made this workflow broken.
1. escape a row in a multi-line command `\`
2. `was-built` input was marked as required and I haven't passed it

In order to test this, I triggered new stress-test run.
https://github.com/metabase/metabase/actions/runs/6652156186/job/18075553730

**Before**
It couldn't find our custom browser so it ran the latest one that comes preinstalled
```
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:        12.8.1                                                                         │
  │ Browser:        Chrome 118 (headless)                                                          │
  │ Node Version:   v18.16.1 (/opt/hostedtoolcache/node/18.16.1/x64/bin/node)                      │
  │ Specs:          2 found (default.cy.snap.js, qa-db.cy.snap.js)                                 │
  │ Searched:       e2e/snapshot-creators/**/*.cy.snap.js                                          │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
```

**After**
```
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:        12.8.1                                                                         │
  │ Browser:        Custom Chromium 111 (headless)                                                 │
  │ Node Version:   v18.16.1 (/opt/hostedtoolcache/node/18.16.1/x64/bin/node)                      │
  │ Specs:          2 found (default.cy.snap.js, qa-db.cy.snap.js)                                 │
  │ Searched:       e2e/snapshot-creators/**/*.cy.snap.js                                          │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
```