### PR TITLE
Fix E2E flake content-verification

### DIFF
--- a/e2e/test/scenarios/organization/content-verification.cy.spec.js
+++ b/e2e/test/scenarios/organization/content-verification.cy.spec.js
@@ -87,13 +87,13 @@ describeEE("scenarios > premium > content verification", () => {
         cy.findByPlaceholderText("Search…").click();
         cy.findByTestId("recently-viewed-item")
           .should("contain", "Orders, Count")
-          .find(".Icon-verified");
+          .find(".Icon-verified_filled");
 
         // 4. Search results
         cy.findByPlaceholderText("Search…").type("orders{enter}");
         cy.findAllByTestId("search-result-item")
           .contains("Orders, Count")
-          .siblings(".Icon-verified");
+          .siblings(".Icon-verified_filled");
 
         // 5. Question's collection
         cy.visit("/collection/root");
@@ -124,14 +124,14 @@ describeEE("scenarios > premium > content verification", () => {
         cy.findByPlaceholderText("Search…").click();
         cy.findByTestId("recently-viewed-item")
           .should("contain", "Orders, Count")
-          .find(".Icon-verified")
+          .find(".Icon-verified_filed")
           .should("not.exist");
 
         // 4. Search results
         cy.findByPlaceholderText("Search…").type("orders{enter}");
         cy.findAllByTestId("search-result-item")
           .contains("Orders, Count")
-          .siblings(".Icon-verified")
+          .siblings(".Icon-verified_filed")
           .should("not.exist");
 
         // 5. Question's collection


### PR DESCRIPTION
Flake/Failure data for the last two days
https://www.deploysentinel.com/ci/analysis?branch=master&from=2d

![image](https://github.com/metabase/metabase/assets/31325167/e06878a4-c5d5-4f68-ace2-6b25767469ec)

This particular test has been busted. Failure rate 100%.

`.Icon-verified_filled` variation was added in https://github.com/metabase/metabase/pull/32624 two days ago but this test was never updated.

Example of a failed run:
https://www.deploysentinel.com/ci/runs/6538187e7bcc1486814085eb

![image](https://github.com/metabase/metabase/assets/31325167/0a949d26-0970-4c9a-be1f-e82e39419d9f)

