### PR TITLE
Add humanize-filter-value implementations for inequality operators to fix 30350

### DIFF
--- a/src/metabase/automagic_dashboards/names.clj
+++ b/src/metabase/automagic_dashboards/names.clj
@@ -139,6 +139,38 @@
       (tru "{0} is {1}" field-name (humanize-datetime value (:unit field)))
       (tru "{0} is {1}" field-name value))))
 
+(defmethod humanize-filter-value :>=
+  [root [_ field-reference value]]
+  (let [field      (magic.util/field-reference->field root field-reference)
+        field-name (field-name field)]
+    (if (isa? ((some-fn :effective_type :base_type) field) :type/Temporal)
+      (tru "{0} is at least {1}" field-name (humanize-datetime value (:unit field)))
+      (tru "{0} is at least {1}" field-name value))))
+
+(defmethod humanize-filter-value :>
+  [root [_ field-reference value]]
+  (let [field      (magic.util/field-reference->field root field-reference)
+        field-name (field-name field)]
+    (if (isa? ((some-fn :effective_type :base_type) field) :type/Temporal)
+      (tru "{0} is greater than {1}" field-name (humanize-datetime value (:unit field)))
+      (tru "{0} is greater than {1}" field-name value))))
+
+(defmethod humanize-filter-value :<=
+  [root [_ field-reference value]]
+  (let [field      (magic.util/field-reference->field root field-reference)
+        field-name (field-name field)]
+    (if (isa? ((some-fn :effective_type :base_type) field) :type/Temporal)
+      (tru "{0} is at most {1}" field-name (humanize-datetime value (:unit field)))
+      (tru "{0} is at most {1}" field-name value))))
+
+(defmethod humanize-filter-value :<
+  [root [_ field-reference value]]
+  (let [field      (magic.util/field-reference->field root field-reference)
+        field-name (field-name field)]
+    (if (isa? ((some-fn :effective_type :base_type) field) :type/Temporal)
+      (tru "{0} is less than {1}" field-name (humanize-datetime value (:unit field)))
+      (tru "{0} is less than {1}" field-name value))))
+
 (defmethod humanize-filter-value :between
   [root [_ field-reference min-value max-value]]
   (tru "{0} is between {1} and {2}" (field-name root field-reference) min-value max-value))

--- a/src/metabase/automagic_dashboards/names.clj
+++ b/src/metabase/automagic_dashboards/names.clj
@@ -187,6 +187,14 @@
        (map (partial humanize-filter-value root))
        join-enumeration))
 
+(defmethod humanize-filter-value :default
+  [root [_ field-reference value]]
+  (let [field      (magic.util/field-reference->field root field-reference)
+        field-name (field-name field)]
+    (if (isa? ((some-fn :effective_type :base_type) field) :type/Temporal)
+      (tru "{0} relates to {1}" field-name (humanize-datetime value (:unit field)))
+      (tru "{0} relates to {1}" field-name value))))
+
 (defn cell-title
   "Return a cell title given a root object and a cell query."
   [root cell-query]

--- a/src/metabase/automagic_dashboards/names.clj
+++ b/src/metabase/automagic_dashboards/names.clj
@@ -144,7 +144,7 @@
   (let [field      (magic.util/field-reference->field root field-reference)
         field-name (field-name field)]
     (if (isa? ((some-fn :effective_type :base_type) field) :type/Temporal)
-      (tru "{0} is at least {1}" field-name (humanize-datetime value (:unit field)))
+      (tru "{0} is not before {1}" field-name (humanize-datetime value (:unit field)))
       (tru "{0} is at least {1}" field-name value))))
 
 (defmethod humanize-filter-value :>
@@ -152,7 +152,7 @@
   (let [field      (magic.util/field-reference->field root field-reference)
         field-name (field-name field)]
     (if (isa? ((some-fn :effective_type :base_type) field) :type/Temporal)
-      (tru "{0} is greater than {1}" field-name (humanize-datetime value (:unit field)))
+      (tru "{0} is after {1}" field-name (humanize-datetime value (:unit field)))
       (tru "{0} is greater than {1}" field-name value))))
 
 (defmethod humanize-filter-value :<=
@@ -160,15 +160,15 @@
   (let [field      (magic.util/field-reference->field root field-reference)
         field-name (field-name field)]
     (if (isa? ((some-fn :effective_type :base_type) field) :type/Temporal)
-      (tru "{0} is at most {1}" field-name (humanize-datetime value (:unit field)))
-      (tru "{0} is at most {1}" field-name value))))
+      (tru "{0} is not after {1}" field-name (humanize-datetime value (:unit field)))
+      (tru "{0} is no more than {1}" field-name value))))
 
 (defmethod humanize-filter-value :<
   [root [_ field-reference value]]
   (let [field      (magic.util/field-reference->field root field-reference)
         field-name (field-name field)]
     (if (isa? ((some-fn :effective_type :base_type) field) :type/Temporal)
-      (tru "{0} is less than {1}" field-name (humanize-datetime value (:unit field)))
+      (tru "{0} is before {1}" field-name (humanize-datetime value (:unit field)))
       (tru "{0} is less than {1}" field-name value))))
 
 (defmethod humanize-filter-value :between

--- a/test/metabase/automagic_dashboards/names_test.clj
+++ b/test/metabase/automagic_dashboards/names_test.clj
@@ -61,6 +61,18 @@
         (is (= "number of Venues where Name is Test"
                ;; Test specifically the un-normalized form (metabase#15737)
                (names/cell-title root ["=" ["field" %name nil] "Test"]))))
+      (testing "Should humanize greater than filter"
+        (is (= "number of Venues where Name is greater than Test"
+               (names/cell-title root [">" ["field" %name nil] "Test"]))))
+      (testing "Should humanize at least filter"
+        (is (= "number of Venues where Name is at least Test"
+               (names/cell-title root [">=" ["field" %name nil] "Test"]))))
+      (testing "Should humanize less than filter"
+        (is (= "number of Venues where Name is less than Test"
+               (names/cell-title root ["<" ["field" %name nil] "Test"]))))
+      (testing "Should humanize at most filter"
+        (is (= "number of Venues where Name is at most Test"
+               (names/cell-title root ["<=" ["field" %name nil] "Test"]))))
       (testing "Should humanize and filter"
         (is (= "number of Venues where Name is Test and Price is 0"
                (names/cell-title root ["and"

--- a/test/metabase/automagic_dashboards/names_test.clj
+++ b/test/metabase/automagic_dashboards/names_test.clj
@@ -70,8 +70,8 @@
       (testing "Should humanize less than filter"
         (is (= "number of Venues where Name is less than Test"
                (names/cell-title root ["<" ["field" %name nil] "Test"]))))
-      (testing "Should humanize at most filter"
-        (is (= "number of Venues where Name is at most Test"
+      (testing "Should humanize no more than filter"
+        (is (= "number of Venues where Name is no more than Test"
                (names/cell-title root ["<=" ["field" %name nil] "Test"]))))
       (testing "Should humanize and filter"
         (is (= "number of Venues where Name is Test and Price is 0"
@@ -84,3 +84,34 @@
       (testing "Should humanize inside filter"
         (is (= "number of Venues where Longitude is between 2 and 4; and Latitude is between 3 and 1"
                (names/cell-title root ["inside" (mt/$ids venues $latitude) (mt/$ids venues $longitude) 1 2 3 4])))))))
+
+(deftest ^:parallel cell-title-with-dates-comparison-test
+  (testing "Ensure cell titles with date comparisons display correctly"
+    (mt/$ids users
+      (let [query (query/adhoc-query {:query    {:source-table (mt/id :users)
+                                                 :aggregation  [:count]}
+                                      :type     :query
+                                      :database (mt/id)})
+            root  (magic/->root query)]
+        ;; The "in" and "on" might read a little odd here, but this would require a larger change to
+        ;; humanize-datetime which we probably should not do right now.
+        (testing "Should humanize temporal field with = test"
+          (is (= "number of Users where Last Login is on September 9, 1990"
+                 (names/cell-title root
+                                   ["=" ["field" %last_login {:temporal-unit :day}] "1990-09-09T12:30:00"]))))
+        (testing "Should humanize temporal field with > test"
+          (is (= "number of Users where Last Login is after on September 9, 1990"
+                 (names/cell-title root
+                                   [">" ["field" %last_login {:temporal-unit :day}] "1990-09-09T12:30:00"]))))
+        (testing "Should humanize temporal field with < test"
+          (is (= "number of Users where Last Login is before on September 9, 1990"
+                 (names/cell-title root
+                                   ["<" ["field" %last_login {:temporal-unit :day}] "1990-09-09T12:30:00"]))))
+        (testing "Should humanize temporal field with >= test"
+          (is (= "number of Users where Last Login is not before on September 9, 1990"
+                 (names/cell-title root
+                                   [">=" ["field" %last_login {:temporal-unit :day}] "1990-09-09T12:30:00"]))))
+        (testing "Should humanize temporal field with <= test"
+          (is (= "number of Users where Last Login is not after on September 9, 1990"
+                 (names/cell-title root
+                                   ["<=" ["field" %last_login {:temporal-unit :day}] "1990-09-09T12:30:00"]))))))))

--- a/test/metabase/automagic_dashboards/names_test.clj
+++ b/test/metabase/automagic_dashboards/names_test.clj
@@ -85,6 +85,17 @@
         (is (= "number of Venues where Longitude is between 2 and 4; and Latitude is between 3 and 1"
                (names/cell-title root ["inside" (mt/$ids venues $latitude) (mt/$ids venues $longitude) 1 2 3 4])))))))
 
+(deftest ^:parallel cell-title-default-test
+  (mt/$ids venues
+    (let [query (query/adhoc-query {:query    {:source-table (mt/id :venues)
+                                               :aggregation  [:count]}
+                                    :type     :query
+                                    :database (mt/id)})
+          root  (magic/->root query)]
+      (testing "Just say \"relates to\" when we don't know what the operator is"
+        (is (= "number of Venues where Name relates to Test"
+               (names/cell-title root ["???" ["field" %name nil] "Test"])))))))
+
 (deftest ^:parallel cell-title-with-dates-comparison-test
   (testing "Ensure cell titles with date comparisons display correctly"
     (mt/$ids users

--- a/test/metabase/automagic_dashboards/names_test.clj
+++ b/test/metabase/automagic_dashboards/names_test.clj
@@ -93,7 +93,7 @@
                                       :type     :query
                                       :database (mt/id)})
             root  (magic/->root query)]
-        ;; The "in" and "on" might read a little odd here, but this would require a larger change to
+        ;; The "on" might read a little odd here, but this would require a larger change to
         ;; humanize-datetime which we probably should not do right now.
         (testing "Should humanize temporal field with = test"
           (is (= "number of Users where Last Login is on September 9, 1990"


### PR DESCRIPTION
Fixes #30350 

Added the following `humanize-filter-value` implementations as well as corresponding `">"`, `"<"`, `">="`, and `"<="` test clauses to the `cell-title-test` in `metabase.automagic-dashboards.names-test`.

```clojure
(defmethod humanize-filter-value :>=
  [root [_ field-reference value]]
  (let [field      (magic.util/field-reference->field root field-reference)
        field-name (field-name field)]
    (if (isa? ((some-fn :effective_type :base_type) field) :type/Temporal)
      (tru "{0} is at least {1}" field-name (humanize-datetime value (:unit field)))
      (tru "{0} is at least {1}" field-name value))))

(defmethod humanize-filter-value :>
  [root [_ field-reference value]]
  (let [field      (magic.util/field-reference->field root field-reference)
        field-name (field-name field)]
    (if (isa? ((some-fn :effective_type :base_type) field) :type/Temporal)
      (tru "{0} is greater than {1}" field-name (humanize-datetime value (:unit field)))
      (tru "{0} is greater than {1}" field-name value))))

(defmethod humanize-filter-value :<=
  [root [_ field-reference value]]
  (let [field      (magic.util/field-reference->field root field-reference)
        field-name (field-name field)]
    (if (isa? ((some-fn :effective_type :base_type) field) :type/Temporal)
      (tru "{0} is at most {1}" field-name (humanize-datetime value (:unit field)))
      (tru "{0} is at most {1}" field-name value))))

(defmethod humanize-filter-value :<
  [root [_ field-reference value]]
  (let [field      (magic.util/field-reference->field root field-reference)
        field-name (field-name field)]
    (if (isa? ((some-fn :effective_type :base_type) field) :type/Temporal)
      (tru "{0} is less than {1}" field-name (humanize-datetime value (:unit field)))
      (tru "{0} is less than {1}" field-name value))))
``` 

With these in place, both the unit tests pass and the UI bug goes away, producing the right result.