### PR TITLE
Automate reordering release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -444,6 +444,8 @@ jobs:
             console.error('Failed to tag release', canonical_version, err);
             process.exit(1);
           });
+    - name: Reorder release tags to put OSS first
+      run: ./release/reorder-tags.sh ${{ needs.check-version.outputs.ee }} ${{ inputs.commit }}
 
   trigger-docs-update:
     needs: push-tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -445,7 +445,7 @@ jobs:
             process.exit(1);
           });
     - name: Reorder release tags to put OSS first
-      run: ./release/reorder-tags.sh ${{ needs.check-version.outputs.ee }} ${{ inputs.commit }}
+      run: $GITHUB_WORKSPACE/release/reorder-tags.sh ${{ needs.check-version.outputs.ee }} ${{ inputs.commit }}
 
   trigger-docs-update:
     needs: push-tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -409,9 +409,6 @@ jobs:
     needs: [verify-s3-download, verify-docker-pull, check-version]
     runs-on: ubuntu-22.04
     timeout-minutes: 10
-    strategy:
-      matrix:
-        edition: [oss, ee]
     steps:
     - uses: actions/checkout@v3
       with:
@@ -422,30 +419,40 @@ jobs:
       uses: actions/github-script@v6
       with:
         result-encoding: string
-        script: |
-          const { tagRelease, getCanonicalVersion } = require('${{ github.workspace }}/release/dist/index.cjs');
+        script: | # js
+          const { tagRelease } = require('${{ github.workspace }}/release/dist/index.cjs');
 
-          const version = '${{ inputs.version }}';
-          const edition = '${{ matrix.edition }}';
+          const OSSversion = '${{ needs.check-version.outputs.oss }}';
+          const EEversion = '${{ needs.check-version.outputs.ee }}';
 
-          const canonical_version = edition === 'ee'
-            ? '${{ needs.check-version.outputs.ee }}'
-            : '${{ needs.check-version.outputs.oss }}';
-
-          console.log("The canonical version of this Metabase", edition, "edition is", canonical_version);
-
+          // push EE tag
           await tagRelease({
             github,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            version: canonical_version,
+            version: EEversion,
             commitHash: '${{ inputs.commit }}',
           }).catch((err) => {
-            console.error('Failed to tag release', canonical_version, err);
+            console.error('Failed to tag release', EEversion, err);
+            process.exit(1);
+          });
+
+          // push OSS tag
+          await tagRelease({
+            github,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            version: OSSversion,
+            commitHash: '${{ inputs.commit }}',
+          }).catch((err) => {
+            console.error('Failed to tag release', OSSversion, err);
             process.exit(1);
           });
     - name: Reorder release tags to put OSS first
-      run: $GITHUB_WORKSPACE/release/reorder-tags.sh ${{ needs.check-version.outputs.ee }} ${{ inputs.commit }}
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        $GITHUB_WORKSPACE/release/reorder-tags.sh ${{ needs.check-version.outputs.ee }} ${{ inputs.commit }}
 
   trigger-docs-update:
     needs: push-tags

--- a/release/reorder-tags.sh
+++ b/release/reorder-tags.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# for some reason, github always puts our enterprise release notes above our open source
+# release notes on the releases page. We always want the open source release notes to be on top.
+# The hack we've found for this is to force-push yesterday's date into the enterprise release tag.
+
+# usage: ./reorder-tags.sh <enterprise-tag> <commit-hash>
+
+tagName=$1
+commit=$2
+
+if [ -z "$tagName" ]; then
+  echo "Please provide a tag name (e.g v1.49.9)"
+  exit 1
+fi
+
+if [ -z "$commit" ]; then
+  echo "Please provide a commit hash"
+  exit 1
+fi
+
+echo "Reordering commits for $tagName on $commit"
+
+git fetch origin --tags --prune-tags --force
+
+yesterday="$(date -v-1d +%Y-%m-%d)T23:00:00Z"
+
+GIT_COMMITTER_DATE=$yesterday git tag -f -a -m "$tagName" "$tagName" "$commit"
+
+git show "$tagName" --quiet
+
+git push origin --force "$tagName"

--- a/release/reorder-tags.sh
+++ b/release/reorder-tags.sh
@@ -2,6 +2,7 @@
 # for some reason, github always puts our enterprise release notes above our open source
 # release notes on the releases page. We always want the open source release notes to be on top.
 # The hack we've found for this is to force-push yesterday's date into the enterprise release tag.
+# see https://github.com/orgs/community/discussions/8226
 
 # usage: ./reorder-tags.sh <enterprise-tag> <commit-hash>
 
@@ -22,7 +23,12 @@ echo "Reordering commits for $tagName on $commit"
 
 git fetch origin --tags --prune-tags --force
 
-yesterday="$(date -v-1d +%Y-%m-%d)T23:00:00Z"
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  # osx has to be special: https://stackoverflow.com/questions/9804966/date-command-does-not-follow-linux-specifications-mac-os-x-lion
+  yesterday="$(date -v-1d +%Y-%m-%d)T23:00:00Z"
+else
+  yesterday="$(date --date="yesterday" +%Y-%m-%d)T23:00:00Z"
+fi
 
 GIT_COMMITTER_DATE=$yesterday git tag -f -a -m "$tagName" "$tagName" "$commit"
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

We always want our open source release to show up as the most recent on our github releases page. We accomplish this by manually forcing the tag date for the  enterprise version tag to -1 day. This was a boring, tedious manual affair for every release - BUT NO LONGER!

### How to verify

- I just used this locally to reorder the 47.6 release tags.
- I will also [test this in my fork](https://github.com/iethree/metabase/actions/runs/6672511506/job/18136715423) to verify that all the git operations work as expected in CI

### Demo

![Screen Shot 2023-10-26 at 10 44 28 AM](https://github.com/metabase/metabase/assets/30528226/b2dbb3f2-c6eb-4403-bb71-319c81793e6d)

