### PR TITLE
[MLv2] Handle removing multiple dependent joins

### DIFF
--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -115,7 +115,7 @@
    If `location` contains no clause with `target-clause` no removal happens.
    If the the location is empty, dissoc it from stage.
    For the [:fields] location if only expressions remain, dissoc from stage."
-  [stage location target-clause]
+  [stage location target-clause stage-number]
   {:pre [(clause? target-clause)]}
   (if-let [target (get-in stage location)]
     (let [target-uuid (lib.options/uuid target-clause)
@@ -133,6 +133,7 @@
                         {:error ::cannot-remove-final-join-condition
                          :conditions (get-in stage location)
                          :join (get-in stage (pop location))
+                         :stage-number stage-number
                          :stage stage}))
 
         (= [:joins :fields] [first-loc last-loc])


### PR DESCRIPTION
Fixes #35049

`remove-join` was modified to handle dependent joins from subsequent stages in #34416. However, when a stage had more than two dependent joins the `m/index-by` call to find the stage number was invalid because some of the other joins have been removed at that point. The most straightforward path seemed to simply pass the stage-number of the clause being removed to `remove-clause` instead of trying to find something that may have been modified.
