### PR TITLE
Hide Viz Settings Buttons in Column Headers in Raw Table Mode

### DIFF
--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -7,7 +7,6 @@ import {
   popover,
   modal,
   sidebar,
-  moveColumnDown,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";

--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -7,6 +7,7 @@ import {
   popover,
   modal,
   sidebar,
+  moveColumnDown,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";

--- a/e2e/test/scenarios/visualizations/pie_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/pie_chart.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, visitQuestionAdhoc } from "e2e/support/helpers";
+import { restore, visitQuestionAdhoc, popover } from "e2e/support/helpers";
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
@@ -21,13 +21,22 @@ describe("scenarios > visualizations > pie chart", () => {
     cy.signInAsNormalUser();
   });
 
-  it("should render a pie chart (metabase#12506)", () => {
+  it("should render a pie chart (metabase#12506) (#35244)", () => {
     visitQuestionAdhoc({
       dataset_query: testQuery,
       display: "pie",
     });
 
     ensurePieChartRendered(["Doohickey", "Gadget", "Gizmo", "Widget"], 200);
+
+    cy.log("#35244");
+    cy.findByLabelText("Switch to data").click();
+    cy.findAllByTestId("header-cell").contains("Count").click();
+    popover().within(() => {
+      cy.findByRole("img", { name: /filter/ }).should("exist");
+      cy.findByRole("img", { name: /gear/ }).should("not.exist");
+      cy.findByRole("img", { name: /eye_crossed_out/ }).should("not.exist");
+    });
   });
 
   it("should mute items in legend when hovering (metabase#29224)", () => {

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -53,8 +53,11 @@ export const getIsShowingSnippetSidebar = state =>
   getUiControls(state).isShowingSnippetSidebar;
 export const getIsShowingDataReference = state =>
   getUiControls(state).isShowingDataReference;
+
+// This selector can be called from public questions / dashboards, which do not
+// have state.qb
 export const getIsShowingRawTable = state =>
-  getUiControls(state).isShowingRawTable;
+  !!state.qb?.uiControls.isShowingRawTable;
 
 const SIDEBARS = [
   "isShowingQuestionDetailsSidebar",

--- a/frontend/src/metabase/visualizations/click-actions/actions/ColumnFormattingAction/ColumnFormattingAction.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/ColumnFormattingAction/ColumnFormattingAction.tsx
@@ -18,6 +18,7 @@ export const ColumnFormattingAction: LegacyDrill = ({ question, clicked }) => {
     !clicked ||
     clicked.value !== undefined ||
     !clicked.column ||
+    clicked?.extraData?.isRawTable ||
     !question.query().isEditable()
   ) {
     return [];

--- a/frontend/src/metabase/visualizations/click-actions/actions/HideColumnAction/HideColumnAction.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/HideColumnAction/HideColumnAction.tsx
@@ -15,6 +15,7 @@ export const HideColumnAction: LegacyDrill = ({
     !clicked ||
     clicked.value !== undefined ||
     !clicked.column ||
+    clicked?.extraData?.isRawTable ||
     !question.query().isEditable()
   ) {
     return [];

--- a/frontend/src/metabase/visualizations/components/ClickActions/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ClickActions/utils.ts
@@ -76,13 +76,6 @@ export const getGroupedAndSortedActions = (
     });
     delete groupedClickActions["sum"];
   }
-  if (groupedClickActions["sort"]?.length === 1) {
-    // restyle the Formatting action when there is only one option
-    groupedClickActions["sort"][0] = {
-      ...groupedClickActions["sort"][0],
-      buttonType: "horizontal",
-    };
-  }
 
   return _.chain(groupedClickActions)
     .pairs()
@@ -163,9 +156,7 @@ export const getSectionContentDirection = (
     }
 
     case "sort": {
-      if (actions.length > 1) {
-        return "row";
-      }
+      return "row";
     }
   }
 

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -30,6 +30,7 @@ import { isSameSeries, getCardKey } from "metabase/visualizations/lib/utils";
 
 import { getMode } from "metabase/visualizations/click-actions/lib/modes";
 import { getFont } from "metabase/styled-components/selectors";
+import { getIsShowingRawTable } from "metabase/query_builder/selectors";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
 import { isRegularClickAction } from "metabase/visualizations/types";
@@ -64,6 +65,7 @@ const defaultProps = {
 
 const mapStateToProps = state => ({
   fontFamily: getFont(state),
+  isRawTable: getIsShowingRawTable(state),
 });
 
 class Visualization extends PureComponent {
@@ -236,7 +238,13 @@ class Visualization extends PureComponent {
 
     return mode
       ? mode.actionsForClick(
-          { ...clicked, extraData: getExtraDataForClick(clicked) },
+          {
+            ...clicked,
+            extraData: {
+              ...getExtraDataForClick(clicked),
+              isRawTable: this.props.isRawTable,
+            },
+          },
           this.state.computedSettings,
         )
       : [];

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -229,7 +229,11 @@ class Visualization extends PureComponent {
     if (!clicked) {
       return [];
     }
-    const { metadata, getExtraDataForClick = () => ({}) } = this.props;
+    const {
+      metadata,
+      isRawTable,
+      getExtraDataForClick = () => ({}),
+    } = this.props;
 
     const seriesIndex = clicked.seriesIndex || 0;
     const card = this.state.series[seriesIndex].card;
@@ -242,7 +246,7 @@ class Visualization extends PureComponent {
             ...clicked,
             extraData: {
               ...getExtraDataForClick(clicked),
-              isRawTable: this.props.isRawTable,
+              isRawTable,
             },
           },
           this.state.computedSettings,


### PR DESCRIPTION
resolves https://github.com/metabase/metabase/issues/35244

### Description

For a long time, in the "raw table" view, we've been showing buttons that do nothing because we don't apply visualization settings in the raw view.  #34087 adds a new button that doesn't work for the same reason. This simply hides those buttons that don't work in rawTable mode.

![Screen Shot 2023-10-26 at 2 16 59 PM](https://github.com/metabase/metabase/assets/30528226/bf9c7bd7-65b9-46ff-a09a-107c8fe200ff)

### How to verify

On the base branch
- go into raw table mode by clicking the left button in the bottom-center of the screen
- click on a column header > click hide column
- see nothing happens
- click on a column header > click column settings
- change anything you want
- see that nothing happens

On this branch:
- see that in raw table mode, neither of those buttons appears

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
