### PR TITLE
Hide personal collections in question picker

### DIFF
--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -30,6 +30,7 @@ export interface Collection {
 
   parent_id?: CollectionId;
   personal_owner_id?: UserId;
+  is_personal?: boolean;
 
   location?: string;
   effective_ancestors?: Collection[];

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionPicker.jsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionPicker.jsx
@@ -34,9 +34,9 @@ QuestionPicker.propTypes = {
 
 function QuestionPicker({ onSelect, collectionsById, getCollectionIcon }) {
   const dashboard = useSelector(getDashboard);
-  const initialCollectionId = dashboard.collection.id;
+  const dashboardCollection = dashboard.collection ?? ROOT_COLLECTION;
   const [currentCollectionId, setCurrentCollectionId] = useState(
-    initialCollectionId || ROOT_COLLECTION.id,
+    dashboardCollection.id,
   );
   const [searchText, setSearchText] = useState("");
   const debouncedSearchText = useDebouncedValue(
@@ -50,7 +50,7 @@ function QuestionPicker({ onSelect, collectionsById, getCollectionIcon }) {
   const handleSearchTextChange = e => setSearchText(e.target.value);
 
   const allCollections = (collection && collection.children) || [];
-  const isDashboardInPublicCollection = !dashboard.collection.is_personal;
+  const isDashboardInPublicCollection = !dashboardCollection.is_personal;
   const collections = isDashboardInPublicCollection
     ? allCollections.filter(collection => !collection.is_personal)
     : allCollections;

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionPicker.jsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionPicker.jsx
@@ -50,9 +50,8 @@ function QuestionPicker({ onSelect, collectionsById, getCollectionIcon }) {
   const handleSearchTextChange = e => setSearchText(e.target.value);
 
   const allCollections = (collection && collection.children) || [];
-  const isDashboardInPublicCollection = !dashboardCollection.is_personal;
-  const collections = isDashboardInPublicCollection
-    ? allCollections.filter(collection => !collection.is_personal)
+  const collections = isPublicCollection(dashboardCollection)
+    ? allCollections.filter(isPublicCollection)
     : allCollections;
 
   return (
@@ -113,6 +112,9 @@ function QuestionPicker({ onSelect, collectionsById, getCollectionIcon }) {
   );
 }
 
+function isPublicCollection(collection) {
+  return !collection.is_personal;
+}
 export default _.compose(
   entityObjectLoader({
     id: () => "root",

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionPicker.jsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionPicker.jsx
@@ -34,9 +34,9 @@ QuestionPicker.propTypes = {
 
 function QuestionPicker({ onSelect, collectionsById, getCollectionIcon }) {
   const dashboard = useSelector(getDashboard);
-  const initialCollection = dashboard.collection_id;
+  const initialCollectionId = dashboard.collection.id;
   const [currentCollectionId, setCurrentCollectionId] = useState(
-    initialCollection || ROOT_COLLECTION.id,
+    initialCollectionId || ROOT_COLLECTION.id,
   );
   const [searchText, setSearchText] = useState("");
   const debouncedSearchText = useDebouncedValue(
@@ -49,7 +49,11 @@ function QuestionPicker({ onSelect, collectionsById, getCollectionIcon }) {
 
   const handleSearchTextChange = e => setSearchText(e.target.value);
 
-  const collections = (collection && collection.children) || [];
+  const allCollections = (collection && collection.children) || [];
+  const isDashboardInPublicCollection = !dashboard.collection.is_personal;
+  const collections = isDashboardInPublicCollection
+    ? allCollections.filter(collection => !collection.is_personal)
+    : allCollections;
 
   return (
     <QuestionPickerRoot>

--- a/frontend/src/metabase/entities/collections/constants.ts
+++ b/frontend/src/metabase/entities/collections/constants.ts
@@ -7,6 +7,7 @@ export const ROOT_COLLECTION = {
   name: t`Our analytics`,
   location: "",
   path: [],
+  is_personal: false,
 };
 
 export const PERSONAL_COLLECTION = {
@@ -15,6 +16,7 @@ export const PERSONAL_COLLECTION = {
   location: "/",
   path: [ROOT_COLLECTION.id],
   can_write: true,
+  is_personal: true,
 };
 
 // fake collection for admins that contains all other user's collections
@@ -24,4 +26,5 @@ export const PERSONAL_COLLECTIONS = {
   location: "/",
   path: [ROOT_COLLECTION.id],
   can_write: false,
+  is_personal: true,
 };

--- a/frontend/src/metabase/entities/collections/getExpandedCollectionsById.js
+++ b/frontend/src/metabase/entities/collections/getExpandedCollectionsById.js
@@ -54,7 +54,6 @@ function getExpandedCollectionsById(
       id: userPersonalCollectionId,
       parent: collectionsById[ROOT_COLLECTION.id],
       children: personalCollection?.children || [],
-      is_personal: true,
     });
   }
 
@@ -63,7 +62,6 @@ function getExpandedCollectionsById(
     ...PERSONAL_COLLECTIONS,
     parent: collectionsById[ROOT_COLLECTION.id],
     children: [],
-    is_personal: true,
   };
   collectionsById[ROOT_COLLECTION.id].children.push(
     collectionsById[PERSONAL_COLLECTIONS.id],

--- a/frontend/src/metabase/entities/collections/getExpandedCollectionsById.js
+++ b/frontend/src/metabase/entities/collections/getExpandedCollectionsById.js
@@ -28,7 +28,6 @@ function getExpandedCollectionsById(
           : null,
       parent: null,
       children: [],
-      is_personal: c.personal_owner_id != null,
     };
   }
 


### PR DESCRIPTION
This PR hides personal collections when adding questions to a dashboard in a public collection.

#### After
![image](https://github.com/metabase/metabase/assets/1937582/73818eb9-cc89-4bb5-9030-ed9316c14fe3)

#### Before
![image](https://github.com/metabase/metabase/assets/1937582/56920c9c-de28-489a-b8c0-64db96716164)


#### Testing plan for milestone 1
Dashboards
1. Add a question to a dashboard in a public collection
    **expectation**:
    - hides all personal collections
    - show all questions
1. Add a question to a dashboard in a personal collection
    **expectation**:
    - shows all collections
    - show all questions