### PR TITLE
Handle moving dashboards to a different collection type

### DIFF
--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -2,6 +2,7 @@ import { assoc, dissoc, assocIn, updateIn, chain, merge } from "icepick";
 import reduceReducers from "reduce-reducers";
 import _ from "underscore";
 
+import produce from "immer";
 import { handleActions, combineReducers } from "metabase/lib/redux";
 import Dashboards from "metabase/entities/dashboards";
 import Questions from "metabase/entities/questions";
@@ -142,12 +143,15 @@ const dashboards = handleActions(
         ),
     },
     [Dashboards.actionTypes.UPDATE]: {
-      next: (state, { payload }) =>
-        assocIn(
-          state,
-          [payload.dashboard.id, "collection_id"],
-          payload.dashboard.collection_id,
-        ),
+      next: (state, { payload }) => {
+        return produce(state, draftState => {
+          const draftDashboard = draftState[payload.dashboard.id];
+          if (draftDashboard) {
+            draftDashboard.collection_id = payload.dashboard.collection_id;
+            draftDashboard.collection = payload.dashboard.collection;
+          }
+        });
+      },
     },
   },
   INITIAL_DASHBOARD_STATE.dashboards,


### PR DESCRIPTION
This PR handles the case where the dashboard has been moved to another collection type e.g. from public collection to personal collection and vice versa

#### After
![image](https://github.com/metabase/metabase/assets/1937582/73818eb9-cc89-4bb5-9030-ed9316c14fe3)

#### Before
![image](https://github.com/metabase/metabase/assets/1937582/56920c9c-de28-489a-b8c0-64db96716164)

#### Testing plan for milestone 1
Dashboards
1. Add a question to a dashboard in a public collection
    **expectation**:
    - hides all personal collections
    - show all questions
1. Add a question to a dashboard in a personal collection
    **expectation**:
    - shows all collections
    - show all questions
1. move a dashboard from a personal collection to a public collection and test 1)
    **expectation**: hides all personal collections
    - hides all personal collections
    - show all questions
1. move a dashboard from a public collection to a personal collection and test 2)
    **expectation**:
    - shows all collections
    - show all questions