### PR TITLE
Add question picker tests

### DIFF
--- a/frontend/src/metabase-types/api/mocks/collection.ts
+++ b/frontend/src/metabase-types/api/mocks/collection.ts
@@ -9,6 +9,7 @@ export const createMockCollection = (
   location: "/",
   can_write: true,
   archived: false,
+  is_personal: false,
   ...opts,
 });
 

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -111,13 +111,13 @@ const setup = async ({
   error,
   waitForContent = true,
 }: SetupOpts = {}) => {
-  const dashboardSet = new Set(
-    [dashboard, mostRecentlyViewedDashboard].filter(isNotNull),
+  const dashboards = Array.from(
+    new Set([dashboard, mostRecentlyViewedDashboard].filter(isNotNull)),
   );
 
   setupSearchEndpoints([]);
   setupCollectionsEndpoints({ collections, rootCollection: ROOT_COLLECTION });
-  setupDashboardCollectionItemsEndpoint(Array.from(dashboardSet));
+  setupDashboardCollectionItemsEndpoint(dashboards);
   setupCollectionByIdEndpoint({ collections, error });
   setupMostRecentlyViewedDashboard(mostRecentlyViewedDashboard);
 

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -47,8 +47,6 @@ const COLLECTION = createMockCollection({
   location: "/",
 });
 
-// Do not remove. This is being used by `DASHBOARD`
-// because its `collection_id` is `2` (this collection's ID)
 const SUBCOLLECTION = createMockCollection({
   id: 2,
   name: "Nested collection",

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -213,113 +213,10 @@ describe("AddToDashSelectDashModal", () => {
         );
       });
 
-      describe("question is in a personal collection", () => {
-        const CARD_IN_PERSONAL_COLLECTION = createMockCard({
-          id: 2,
-          name: "Card in a personal collection",
-          dataset: true,
-          collection: PERSONAL_COLLECTION,
-        });
-
-        describe('"Create a new dashboard" option', () => {
-          // XXX: #5
-          it('should not render "Create a new dashboard" option when opening the root collection (public collection)', async () => {
-            await setup({
-              card: CARD_IN_PERSONAL_COLLECTION,
-              noRecentDashboard: true,
-            });
-
-            expect(
-              screen.queryByRole("heading", {
-                name: "Create a new dashboard",
-              }),
-            ).not.toBeInTheDocument();
-          });
-
-          // XXX: #6
-          it('should render "Create a new dashboard" option when opening personal subcollections', async () => {
-            await setup({
-              card: CARD_IN_PERSONAL_COLLECTION,
-              noRecentDashboard: true,
-            });
-
-            userEvent.click(
-              screen.getByRole("heading", {
-                name: PERSONAL_COLLECTION.name,
-              }),
-            );
-
-            expect(
-              screen.getByRole("heading", {
-                name: "Create a new dashboard",
-              }),
-            ).toBeInTheDocument();
-          });
-        });
-
-        describe("whether we should render dashboards in a collection", () => {
-          // XXX: #5
-          it("should not render dashboards when opening the root collection (public collection)", async () => {
-            const dashboardInPublicCollection = createMockDashboard({
-              id: 3,
-              name: "Dashboard in public collection",
-              // `null` means it's in the root collection
-              collection_id: null,
-              model: "dashboard",
-            });
-
-            await setup({
-              card: CARD_IN_PERSONAL_COLLECTION,
-              dashboard: dashboardInPublicCollection,
-              noRecentDashboard: true,
-            });
-
-            expect(
-              screen.queryByRole("heading", {
-                name: dashboardInPublicCollection.name,
-              }),
-            ).not.toBeInTheDocument();
-          });
-
-          // XXX: #6
-          it("should render dashboards when opening personal subcollections", async () => {
-            const dashboardInPersonalSubcollection = createMockDashboard({
-              id: 3,
-              name: "Dashboard in personal subcollection",
-              collection_id: PERSONAL_SUBCOLLECTION.id as number,
-              model: "dashboard",
-            });
-
-            await setup({
-              card: CARD_IN_PERSONAL_COLLECTION,
-              dashboard: dashboardInPersonalSubcollection,
-              noRecentDashboard: true,
-            });
-
-            userEvent.click(
-              screen.getByRole("heading", {
-                name: PERSONAL_COLLECTION.name,
-              }),
-            );
-
-            userEvent.click(
-              screen.getByRole("heading", {
-                name: PERSONAL_SUBCOLLECTION.name,
-              }),
-            );
-
-            expect(
-              await screen.findByRole("heading", {
-                name: dashboardInPersonalSubcollection.name,
-              }),
-            ).toBeInTheDocument();
-          });
-        });
-      });
-
       describe("question is in a public collection", () => {
         describe('"Create a new dashboard" option', () => {
-          it('should render "Create a new dashboard" option when opening public collections', async () => {
+          // XXX: #3
+          it('should render "Create a new dashboard" option when opening the root collection (public collection)', async () => {
             await setup({
               noRecentDashboard: true,
             });
@@ -331,6 +228,7 @@ describe("AddToDashSelectDashModal", () => {
             ).toBeInTheDocument();
           });
 
+          // XXX: #3
           it('should render "Create a new dashboard" option when opening public subcollections', async () => {
             await setup({
               noRecentDashboard: true,
@@ -347,9 +245,22 @@ describe("AddToDashSelectDashModal", () => {
                 name: "Create a new dashboard",
               }),
             ).toBeInTheDocument();
+
+            userEvent.click(
+              screen.getByRole("heading", {
+                name: SUBCOLLECTION.name,
+              }),
+            );
+
+            expect(
+              screen.getByRole("heading", {
+                name: "Create a new dashboard",
+              }),
+            ).toBeInTheDocument();
           });
 
-          it('should render "Create a new dashboard" option when opening personal collections', async () => {
+          // XXX: #4
+          it('should render "Create a new dashboard" option when opening personal subcollections', async () => {
             await setup({
               noRecentDashboard: true,
             });
@@ -365,18 +276,7 @@ describe("AddToDashSelectDashModal", () => {
                 name: "Create a new dashboard",
               }),
             ).toBeInTheDocument();
-          });
 
-          it('should render "Create a new dashboard" option when opening personal subcollections', async () => {
-            await setup({
-              noRecentDashboard: true,
-            });
-
-            userEvent.click(
-              screen.getByRole("heading", {
-                name: PERSONAL_COLLECTION.name,
-              }),
-            );
             userEvent.click(
               screen.getByRole("heading", {
                 name: PERSONAL_SUBCOLLECTION.name,
@@ -507,6 +407,122 @@ describe("AddToDashSelectDashModal", () => {
 
             expect(
               screen.getByRole("heading", {
+                name: dashboardInPersonalSubcollection.name,
+              }),
+            ).toBeInTheDocument();
+          });
+        });
+      });
+
+      describe("question is in a personal collection", () => {
+        const CARD_IN_PERSONAL_COLLECTION = createMockCard({
+          id: 2,
+          name: "Card in a personal collection",
+          dataset: true,
+          collection: PERSONAL_COLLECTION,
+        });
+
+        describe('"Create a new dashboard" option', () => {
+          // XXX: #5
+          it('should not render "Create a new dashboard" option when opening the root collection (public collection)', async () => {
+            await setup({
+              card: CARD_IN_PERSONAL_COLLECTION,
+              noRecentDashboard: true,
+            });
+
+            expect(
+              screen.queryByRole("heading", {
+                name: "Create a new dashboard",
+              }),
+            ).not.toBeInTheDocument();
+          });
+
+          // XXX: #6
+          it('should render "Create a new dashboard" option when opening personal subcollections', async () => {
+            await setup({
+              card: CARD_IN_PERSONAL_COLLECTION,
+              noRecentDashboard: true,
+            });
+
+            userEvent.click(
+              screen.getByRole("heading", {
+                name: PERSONAL_COLLECTION.name,
+              }),
+            );
+
+            expect(
+              screen.getByRole("heading", {
+                name: "Create a new dashboard",
+              }),
+            ).toBeInTheDocument();
+
+            userEvent.click(
+              screen.getByRole("heading", {
+                name: PERSONAL_SUBCOLLECTION.name,
+              }),
+            );
+
+            expect(
+              screen.getByRole("heading", {
+                name: "Create a new dashboard",
+              }),
+            ).toBeInTheDocument();
+          });
+        });
+
+        describe("whether we should render dashboards in a collection", () => {
+          // XXX: #5
+          it("should not render dashboards when opening the root collection (public collection)", async () => {
+            const dashboardInPublicCollection = createMockDashboard({
+              id: 3,
+              name: "Dashboard in public collection",
+              // `null` means it's in the root collection
+              collection_id: null,
+              model: "dashboard",
+            });
+
+            await setup({
+              card: CARD_IN_PERSONAL_COLLECTION,
+              dashboard: dashboardInPublicCollection,
+              noRecentDashboard: true,
+            });
+
+            expect(
+              screen.queryByRole("heading", {
+                name: dashboardInPublicCollection.name,
+              }),
+            ).not.toBeInTheDocument();
+          });
+
+          // XXX: #6
+          it("should render dashboards when opening personal subcollections", async () => {
+            const dashboardInPersonalSubcollection = createMockDashboard({
+              id: 3,
+              name: "Dashboard in personal subcollection",
+              collection_id: PERSONAL_SUBCOLLECTION.id as number,
+              model: "dashboard",
+            });
+
+            await setup({
+              card: CARD_IN_PERSONAL_COLLECTION,
+              dashboard: dashboardInPersonalSubcollection,
+              noRecentDashboard: true,
+            });
+
+            userEvent.click(
+              screen.getByRole("heading", {
+                name: PERSONAL_COLLECTION.name,
+              }),
+            );
+
+            userEvent.click(
+              screen.getByRole("heading", {
+                name: PERSONAL_SUBCOLLECTION.name,
+              }),
+            );
+
+            expect(
+              await screen.findByRole("heading", {
                 name: dashboardInPersonalSubcollection.name,
               }),
             ).toBeInTheDocument();

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -188,7 +188,6 @@ describe("AddToDashSelectDashModal", () => {
       expect(screen.getByText(ERROR)).toBeInTheDocument();
     });
 
-    // XXX: 7,8,9,10
     describe("when user visited some dashboard in last 24hrs", () => {
       it("should preselected last visited dashboard in the picker", async () => {
         await setup({
@@ -230,7 +229,6 @@ describe("AddToDashSelectDashModal", () => {
           model: "dashboard",
         });
 
-        // XXX: #7
         it("should show most recently visited dashboard if the question is in a public collection", async () => {
           await setup({
             mostRecentlyViewedDashboard: dashboardInPublicSubcollection,
@@ -247,7 +245,6 @@ describe("AddToDashSelectDashModal", () => {
           ).toBeInTheDocument();
         });
 
-        // XXX: #9
         it("should show the root collection if the question is in a personal collection", async () => {
           await setup({
             card: CARD_IN_PERSONAL_COLLECTION,
@@ -273,7 +270,6 @@ describe("AddToDashSelectDashModal", () => {
           model: "dashboard",
         });
 
-        // XXX: #8
         it("should show most recently visited dashboard if the question is in a public collection", async () => {
           await setup({
             mostRecentlyViewedDashboard: dashboardInPersonalSubcollection,
@@ -294,7 +290,6 @@ describe("AddToDashSelectDashModal", () => {
           ).toBeInTheDocument();
         });
 
-        // XXX: #10
         it("should show most recently visited dashboard if the question is in a personal collection", async () => {
           await setup({
             card: CARD_IN_PERSONAL_COLLECTION,
@@ -330,7 +325,6 @@ describe("AddToDashSelectDashModal", () => {
 
       describe("question is in a public collection", () => {
         describe('"Create a new dashboard" option', () => {
-          // XXX: #3
           it('should render "Create a new dashboard" option when opening the root collection (public collection)', async () => {
             await setup();
 
@@ -341,7 +335,6 @@ describe("AddToDashSelectDashModal", () => {
             ).toBeInTheDocument();
           });
 
-          // XXX: #3
           it('should render "Create a new dashboard" option when opening public subcollections', async () => {
             await setup();
 
@@ -370,7 +363,6 @@ describe("AddToDashSelectDashModal", () => {
             ).toBeInTheDocument();
           });
 
-          // XXX: #4
           it('should render "Create a new dashboard" option when opening personal subcollections', async () => {
             await setup();
 
@@ -401,7 +393,6 @@ describe("AddToDashSelectDashModal", () => {
         });
 
         describe("whether we should render dashboards in a collection", () => {
-          // XXX: #1
           it("should render dashboards when opening the root collection (public collection)", async () => {
             // no `collection` and `collection_id` means it's in the root collection
             const dashboardInRootCollection = createMockDashboard({
@@ -421,7 +412,6 @@ describe("AddToDashSelectDashModal", () => {
             ).toBeInTheDocument();
           });
 
-          // XXX: #1
           it("should render dashboards when opening public subcollections", async () => {
             const dashboardInPublicSubcollection = createMockDashboard({
               id: 5,
@@ -447,7 +437,6 @@ describe("AddToDashSelectDashModal", () => {
             ).toBeInTheDocument();
           });
 
-          // XXX: #1
           it("should render dashboards when opening personal collections", async () => {
             const dashboardInPersonalCollection = createMockDashboard({
               id: 5,
@@ -473,7 +462,6 @@ describe("AddToDashSelectDashModal", () => {
             ).toBeInTheDocument();
           });
 
-          // XXX: #1
           it("should render dashboards when opening personal subcollections", async () => {
             const dashboardInPersonalSubcollection = createMockDashboard({
               id: 5,
@@ -508,7 +496,6 @@ describe("AddToDashSelectDashModal", () => {
 
       describe("question is in a personal collection", () => {
         describe('"Create a new dashboard" option', () => {
-          // XXX: #5
           it('should not render "Create a new dashboard" option when opening the root collection (public collection)', async () => {
             await setup({
               card: CARD_IN_PERSONAL_COLLECTION,
@@ -521,7 +508,6 @@ describe("AddToDashSelectDashModal", () => {
             ).not.toBeInTheDocument();
           });
 
-          // XXX: #6
           it('should render "Create a new dashboard" option when opening personal subcollections', async () => {
             await setup({
               card: CARD_IN_PERSONAL_COLLECTION,
@@ -554,7 +540,6 @@ describe("AddToDashSelectDashModal", () => {
         });
 
         describe("whether we should render dashboards in a collection", () => {
-          // XXX: #2
           it("should not render dashboards when opening the root collection (public collection)", async () => {
             const dashboardInPublicCollection = createMockDashboard({
               id: 5,
@@ -580,7 +565,6 @@ describe("AddToDashSelectDashModal", () => {
             ).not.toBeInTheDocument();
           });
 
-          // XXX: #2
           it("should render dashboards when opening personal collections", async () => {
             const dashboardInPersonalCollection = createMockDashboard({
               id: 5,
@@ -607,7 +591,6 @@ describe("AddToDashSelectDashModal", () => {
             ).toBeInTheDocument();
           });
 
-          // XXX: #2
           it("should render dashboards when opening personal subcollections", async () => {
             const dashboardInPersonalSubcollection = createMockDashboard({
               id: 5,

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -16,7 +16,7 @@ import {
 } from "metabase-types/api/mocks";
 import type { Card, Collection, Dashboard } from "metabase-types/api";
 import { ROOT_COLLECTION as ROOT } from "metabase/entities/collections";
-import { isNotNull } from "metabase/core/utils/types";
+import { checkNotNull, isNotNull } from "metabase/core/utils/types";
 import { ConnectedAddToDashSelectDashModal } from "./AddToDashSelectDashModal";
 
 const CURRENT_USER = createMockUser({
@@ -194,15 +194,14 @@ describe("AddToDashSelectDashModal", () => {
           mostRecentlyViewedDashboard: DASHBOARD,
         });
 
-        const dashboardCollection = COLLECTIONS.find(
-          collection => collection.id === DASHBOARD.collection_id,
+        const dashboardCollection = checkNotNull(
+          COLLECTIONS.find(
+            collection => collection.id === DASHBOARD.collection_id,
+          ),
         );
 
         // breadcrumbs
-        expect(
-          screen.getByText(`${dashboardCollection?.name}`),
-        ).toBeInTheDocument();
-        // dashboard item
+        assertBreadcrumbs([dashboardCollection]);
         expect(screen.getByText(DASHBOARD.name)).toBeInTheDocument();
       });
 
@@ -214,8 +213,7 @@ describe("AddToDashSelectDashModal", () => {
           });
 
           // breadcrumbs
-          expect(screen.getByText(ROOT_COLLECTION.name)).toBeInTheDocument();
-          // dashboard item
+          assertBreadcrumbs([ROOT_COLLECTION]);
           expect(screen.getByText(DASHBOARD_AT_ROOT.name)).toBeInTheDocument();
         });
       });
@@ -235,9 +233,7 @@ describe("AddToDashSelectDashModal", () => {
           });
 
           // breadcrumbs
-          expect(screen.getByText(ROOT_COLLECTION.name)).toBeInTheDocument();
-          expect(screen.getByText(COLLECTION.name)).toBeInTheDocument();
-          expect(screen.getByText(SUBCOLLECTION.name)).toBeInTheDocument();
+          assertBreadcrumbs([ROOT_COLLECTION, COLLECTION, SUBCOLLECTION]);
 
           // dashboard item
           expect(
@@ -252,7 +248,7 @@ describe("AddToDashSelectDashModal", () => {
           });
 
           // breadcrumbs
-          expect(screen.getByText(ROOT_COLLECTION.name)).toBeInTheDocument();
+          assertBreadcrumbs([ROOT_COLLECTION]);
 
           // Showing personal collection means we're viewing the root collection
           expect(
@@ -276,13 +272,11 @@ describe("AddToDashSelectDashModal", () => {
           });
 
           // breadcrumbs
-          expect(screen.getByText(ROOT_COLLECTION.name)).toBeInTheDocument();
-          expect(
-            screen.getByText(PERSONAL_COLLECTION.name),
-          ).toBeInTheDocument();
-          expect(
-            screen.getByText(PERSONAL_SUBCOLLECTION.name),
-          ).toBeInTheDocument();
+          assertBreadcrumbs([
+            ROOT_COLLECTION,
+            PERSONAL_COLLECTION,
+            PERSONAL_SUBCOLLECTION,
+          ]);
 
           // dashboard item
           expect(
@@ -297,13 +291,11 @@ describe("AddToDashSelectDashModal", () => {
           });
 
           // breadcrumbs
-          expect(screen.getByText(ROOT_COLLECTION.name)).toBeInTheDocument();
-          expect(
-            screen.getByText(PERSONAL_COLLECTION.name),
-          ).toBeInTheDocument();
-          expect(
-            screen.getByText(PERSONAL_SUBCOLLECTION.name),
-          ).toBeInTheDocument();
+          assertBreadcrumbs([
+            ROOT_COLLECTION,
+            PERSONAL_COLLECTION,
+            PERSONAL_SUBCOLLECTION,
+          ]);
 
           // dashboard item
           expect(
@@ -627,3 +619,9 @@ describe("AddToDashSelectDashModal", () => {
     });
   });
 });
+
+function assertBreadcrumbs(collections: Collection[]) {
+  collections.forEach(collection => {
+    expect(screen.getByText(collection.name)).toBeInTheDocument();
+  });
+}

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -171,6 +171,7 @@ describe("AddToDashSelectDashModal", () => {
       expect(screen.getByText(ERROR)).toBeInTheDocument();
     });
 
+    // XXX: 7,8,9,10
     describe("when user visited some dashboard in last 24hrs", () => {
       it("should preselected last visited dashboard in the picker", async () => {
         await setup();
@@ -292,31 +293,28 @@ describe("AddToDashSelectDashModal", () => {
         });
 
         describe("whether we should render dashboards in a collection", () => {
-          it("should render dashboards when opening public collections", async () => {
-            const dashboardInPublicCollection = createMockDashboard({
+          // XXX: #1
+          it("should render dashboards when opening the root collection (public collection)", async () => {
+            // no `collection` and `collection_id` means it's in the root collection
+            const dashboardInRootCollection = createMockDashboard({
               id: 3,
-              name: "Dashboard in public collection",
-              // `null` means it's in the root collection
-              collection_id: null,
+              name: "Dashboard in root collection",
               model: "dashboard",
             });
 
             await setup({
-              dashboard: dashboardInPublicCollection,
+              dashboard: dashboardInRootCollection,
               noRecentDashboard: true,
             });
 
-            await waitFor(() => {
-              expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
-            });
-
             expect(
-              screen.getByRole("heading", {
-                name: dashboardInPublicCollection.name,
+              await screen.findByRole("heading", {
+                name: dashboardInRootCollection.name,
               }),
             ).toBeInTheDocument();
           });
 
+          // XXX: #1
           it("should render dashboards when opening public subcollections", async () => {
             const dashboardInPublicSubcollection = createMockDashboard({
               id: 3,
@@ -336,17 +334,14 @@ describe("AddToDashSelectDashModal", () => {
               }),
             );
 
-            await waitFor(() => {
-              expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
-            });
-
             expect(
-              screen.getByRole("heading", {
+              await screen.findByRole("heading", {
                 name: dashboardInPublicSubcollection.name,
               }),
             ).toBeInTheDocument();
           });
 
+          // XXX: #1
           it("should render dashboards when opening personal collections", async () => {
             const dashboardInPersonalCollection = createMockDashboard({
               id: 3,
@@ -366,17 +361,14 @@ describe("AddToDashSelectDashModal", () => {
               }),
             );
 
-            await waitFor(() => {
-              expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
-            });
-
             expect(
-              screen.getByRole("heading", {
+              await screen.findByRole("heading", {
                 name: dashboardInPersonalCollection.name,
               }),
             ).toBeInTheDocument();
           });
 
+          // XXX: #1
           it("should render dashboards when opening personal subcollections", async () => {
             const dashboardInPersonalSubcollection = createMockDashboard({
               id: 3,
@@ -401,12 +393,8 @@ describe("AddToDashSelectDashModal", () => {
               }),
             );
 
-            await waitFor(() => {
-              expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
-            });
-
             expect(
-              screen.getByRole("heading", {
+              await screen.findByRole("heading", {
                 name: dashboardInPersonalSubcollection.name,
               }),
             ).toBeInTheDocument();
@@ -471,7 +459,7 @@ describe("AddToDashSelectDashModal", () => {
         });
 
         describe("whether we should render dashboards in a collection", () => {
-          // XXX: #5
+          // XXX: #2
           it("should not render dashboards when opening the root collection (public collection)", async () => {
             const dashboardInPublicCollection = createMockDashboard({
               id: 3,
@@ -487,6 +475,10 @@ describe("AddToDashSelectDashModal", () => {
               noRecentDashboard: true,
             });
 
+            await waitFor(() => {
+              expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+            });
+
             expect(
               screen.queryByRole("heading", {
                 name: dashboardInPublicCollection.name,
@@ -494,7 +486,35 @@ describe("AddToDashSelectDashModal", () => {
             ).not.toBeInTheDocument();
           });
 
-          // XXX: #6
+          // XXX: #2
+          it("should render dashboards when opening personal collections", async () => {
+            const dashboardInPersonalCollection = createMockDashboard({
+              id: 3,
+              name: "Dashboard in personal collection",
+              collection_id: PERSONAL_COLLECTION.id as number,
+              model: "dashboard",
+            });
+
+            await setup({
+              card: CARD_IN_PERSONAL_COLLECTION,
+              dashboard: dashboardInPersonalCollection,
+              noRecentDashboard: true,
+            });
+
+            userEvent.click(
+              screen.getByRole("heading", {
+                name: PERSONAL_COLLECTION.name,
+              }),
+            );
+
+            expect(
+              await screen.findByRole("heading", {
+                name: dashboardInPersonalCollection.name,
+              }),
+            ).toBeInTheDocument();
+          });
+
+          // XXX: #2
           it("should render dashboards when opening personal subcollections", async () => {
             const dashboardInPersonalSubcollection = createMockDashboard({
               id: 3,

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -314,6 +314,23 @@ describe("AddToDashSelectDashModal", () => {
       });
 
       describe("question is in a public collection", () => {
+        it("should render all collections", async () => {
+          await setup({
+            collections: COLLECTIONS,
+          });
+
+          expect(
+            screen.getByRole("heading", {
+              name: PERSONAL_COLLECTION.name,
+            }),
+          ).toBeInTheDocument();
+          expect(
+            screen.getByRole("heading", {
+              name: COLLECTION.name,
+            }),
+          ).toBeInTheDocument();
+        });
+
         describe('"Create a new dashboard" option', () => {
           it('should render "Create a new dashboard" option when opening the root collection (public collection)', async () => {
             await setup();
@@ -485,6 +502,24 @@ describe("AddToDashSelectDashModal", () => {
       });
 
       describe("question is in a personal collection", () => {
+        it("should not render public collections", async () => {
+          await setup({
+            card: CARD_IN_PERSONAL_COLLECTION,
+            collections: COLLECTIONS,
+          });
+
+          expect(
+            screen.getByRole("heading", {
+              name: PERSONAL_COLLECTION.name,
+            }),
+          ).toBeInTheDocument();
+          expect(
+            screen.queryByRole("heading", {
+              name: COLLECTION.name,
+            }),
+          ).not.toBeInTheDocument();
+        });
+
         describe('"Create a new dashboard" option', () => {
           it('should not render "Create a new dashboard" option when opening the root collection (public collection)', async () => {
             await setup({

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -16,7 +16,7 @@ import {
 } from "metabase-types/api/mocks";
 import type { Card, Collection, Dashboard } from "metabase-types/api";
 import { ROOT_COLLECTION as ROOT } from "metabase/entities/collections";
-import { checkNotNull, isNotNull } from "metabase/core/utils/types";
+import { checkNotNull, isNotNull } from "metabase/lib/types";
 import { ConnectedAddToDashSelectDashModal } from "./AddToDashSelectDashModal";
 
 const CURRENT_USER = createMockUser({

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -7,18 +7,14 @@ import {
   setupCollectionByIdEndpoint,
   setupDashboardCollectionItemsEndpoint,
 } from "__support__/server-mocks";
-import {
-  renderWithProviders,
-  screen,
-  waitForLoaderToBeRemoved,
-} from "__support__/ui";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import {
   createMockCard,
   createMockCollection,
   createMockDashboard,
   createMockUser,
 } from "metabase-types/api/mocks";
-import type { Collection, Dashboard } from "metabase-types/api";
+import type { Card, Collection, Dashboard } from "metabase-types/api";
 import { ROOT_COLLECTION as ROOT } from "metabase/entities/collections";
 import { ConnectedAddToDashSelectDashModal } from "./AddToDashSelectDashModal";
 
@@ -44,22 +40,39 @@ const DASHBOARD_AT_ROOT = createMockDashboard({
   model: "dashboard",
 });
 
-const COLLECTION_1 = createMockCollection({
+const COLLECTION = createMockCollection({
   id: 1,
-  name: "C1",
+  name: "Collection",
   can_write: true,
+  is_personal: false,
+  location: "/",
 });
 
-const COLLECTION_2 = createMockCollection({
+// Do not remove. This is being used by `DASHBOARD`
+// because its `collection_id` is `2` (this collection's ID)
+const SUBCOLLECTION = createMockCollection({
   id: 2,
-  name: "C2",
+  name: "Nested collection",
   can_write: true,
+  is_personal: false,
+  location: `/${COLLECTION.id}/`,
 });
 
 const PERSONAL_COLLECTION = createMockCollection({
   id: CURRENT_USER.personal_collection_id,
   name: "My personal collection",
   personal_owner_id: CURRENT_USER.id,
+  can_write: true,
+  is_personal: true,
+  location: "/",
+});
+
+const PERSONAL_SUBCOLLECTION = createMockCollection({
+  id: CURRENT_USER.personal_collection_id + 1,
+  name: "Nested personal collection",
+  can_write: true,
+  is_personal: true,
+  location: `/${PERSONAL_COLLECTION.id}/`,
 });
 
 const ROOT_COLLECTION = createMockCollection({
@@ -69,12 +82,14 @@ const ROOT_COLLECTION = createMockCollection({
 
 const COLLECTIONS = [
   ROOT_COLLECTION,
-  COLLECTION_1,
-  COLLECTION_2,
+  COLLECTION,
+  SUBCOLLECTION,
   PERSONAL_COLLECTION,
+  PERSONAL_SUBCOLLECTION,
 ];
 
 interface SetupOpts {
+  card?: Card;
   collections?: Collection[];
   error?: string;
   dashboard?: Dashboard;
@@ -83,6 +98,7 @@ interface SetupOpts {
 }
 
 const setup = async ({
+  card = CARD,
   collections = COLLECTIONS,
   dashboard = DASHBOARD,
   noRecentDashboard = false,
@@ -100,7 +116,7 @@ const setup = async ({
       path="/"
       component={() => (
         <ConnectedAddToDashSelectDashModal
-          card={CARD}
+          card={card}
           onChangeLocation={() => undefined}
           onClose={() => undefined}
         />
@@ -115,7 +131,9 @@ const setup = async ({
   );
 
   if (waitForContent) {
-    await waitForLoaderToBeRemoved();
+    await waitFor(() => {
+      expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+    });
   }
 };
 
@@ -125,7 +143,7 @@ describe("AddToDashSelectDashModal", () => {
       await setup();
 
       const createNewDashboard = screen.getByRole("heading", {
-        name: /create a new dashboard/i,
+        name: "Create a new dashboard",
       });
 
       userEvent.click(createNewDashboard);
@@ -143,7 +161,7 @@ describe("AddToDashSelectDashModal", () => {
     it("should show loading", async () => {
       await setup({ waitForContent: false });
 
-      expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+      expect(screen.getByText("Loading...")).toBeInTheDocument();
     });
 
     it("should show error", async () => {
@@ -193,6 +211,307 @@ describe("AddToDashSelectDashModal", () => {
         expect(screen.getByTestId("item-picker-header")).toHaveTextContent(
           ROOT_COLLECTION.name,
         );
+      });
+
+      describe("question is in a personal collection", () => {
+        const CARD_IN_PERSONAL_COLLECTION = createMockCard({
+          id: 2,
+          name: "Card in a personal collection",
+          dataset: true,
+          collection: PERSONAL_COLLECTION,
+        });
+
+        describe('"Create a new dashboard" option', () => {
+          // XXX: #5
+          it('should not render "Create a new dashboard" option when opening the root collection (public collection)', async () => {
+            await setup({
+              card: CARD_IN_PERSONAL_COLLECTION,
+              noRecentDashboard: true,
+            });
+
+            expect(
+              screen.queryByRole("heading", {
+                name: "Create a new dashboard",
+              }),
+            ).not.toBeInTheDocument();
+          });
+
+          // XXX: #6
+          it('should render "Create a new dashboard" option when opening personal subcollections', async () => {
+            await setup({
+              card: CARD_IN_PERSONAL_COLLECTION,
+              noRecentDashboard: true,
+            });
+
+            userEvent.click(
+              screen.getByRole("heading", {
+                name: PERSONAL_COLLECTION.name,
+              }),
+            );
+
+            expect(
+              screen.getByRole("heading", {
+                name: "Create a new dashboard",
+              }),
+            ).toBeInTheDocument();
+          });
+        });
+
+        describe("whether we should render dashboards in a collection", () => {
+          // XXX: #5
+          it("should not render dashboards when opening the root collection (public collection)", async () => {
+            const dashboardInPublicCollection = createMockDashboard({
+              id: 3,
+              name: "Dashboard in public collection",
+              // `null` means it's in the root collection
+              collection_id: null,
+              model: "dashboard",
+            });
+
+            await setup({
+              card: CARD_IN_PERSONAL_COLLECTION,
+              dashboard: dashboardInPublicCollection,
+              noRecentDashboard: true,
+            });
+
+            expect(
+              screen.queryByRole("heading", {
+                name: dashboardInPublicCollection.name,
+              }),
+            ).not.toBeInTheDocument();
+          });
+
+          // XXX: #6
+          it("should render dashboards when opening personal subcollections", async () => {
+            const dashboardInPersonalSubcollection = createMockDashboard({
+              id: 3,
+              name: "Dashboard in personal subcollection",
+              collection_id: PERSONAL_SUBCOLLECTION.id as number,
+              model: "dashboard",
+            });
+
+            await setup({
+              card: CARD_IN_PERSONAL_COLLECTION,
+              dashboard: dashboardInPersonalSubcollection,
+              noRecentDashboard: true,
+            });
+
+            userEvent.click(
+              screen.getByRole("heading", {
+                name: PERSONAL_COLLECTION.name,
+              }),
+            );
+
+            userEvent.click(
+              screen.getByRole("heading", {
+                name: PERSONAL_SUBCOLLECTION.name,
+              }),
+            );
+
+            expect(
+              await screen.findByRole("heading", {
+                name: dashboardInPersonalSubcollection.name,
+              }),
+            ).toBeInTheDocument();
+          });
+        });
+      });
+
+      describe("question is in a public collection", () => {
+        describe('"Create a new dashboard" option', () => {
+          it('should render "Create a new dashboard" option when opening public collections', async () => {
+            await setup({
+              noRecentDashboard: true,
+            });
+
+            expect(
+              screen.getByRole("heading", {
+                name: "Create a new dashboard",
+              }),
+            ).toBeInTheDocument();
+          });
+
+          it('should render "Create a new dashboard" option when opening public subcollections', async () => {
+            await setup({
+              noRecentDashboard: true,
+            });
+
+            userEvent.click(
+              screen.getByRole("heading", {
+                name: COLLECTION.name,
+              }),
+            );
+
+            expect(
+              screen.getByRole("heading", {
+                name: "Create a new dashboard",
+              }),
+            ).toBeInTheDocument();
+          });
+
+          it('should render "Create a new dashboard" option when opening personal collections', async () => {
+            await setup({
+              noRecentDashboard: true,
+            });
+
+            userEvent.click(
+              screen.getByRole("heading", {
+                name: PERSONAL_COLLECTION.name,
+              }),
+            );
+
+            expect(
+              screen.getByRole("heading", {
+                name: "Create a new dashboard",
+              }),
+            ).toBeInTheDocument();
+          });
+
+          it('should render "Create a new dashboard" option when opening personal subcollections', async () => {
+            await setup({
+              noRecentDashboard: true,
+            });
+
+            userEvent.click(
+              screen.getByRole("heading", {
+                name: PERSONAL_COLLECTION.name,
+              }),
+            );
+            userEvent.click(
+              screen.getByRole("heading", {
+                name: PERSONAL_SUBCOLLECTION.name,
+              }),
+            );
+
+            expect(
+              screen.getByRole("heading", {
+                name: "Create a new dashboard",
+              }),
+            ).toBeInTheDocument();
+          });
+        });
+
+        describe("whether we should render dashboards in a collection", () => {
+          it("should render dashboards when opening public collections", async () => {
+            const dashboardInPublicCollection = createMockDashboard({
+              id: 3,
+              name: "Dashboard in public collection",
+              // `null` means it's in the root collection
+              collection_id: null,
+              model: "dashboard",
+            });
+
+            await setup({
+              dashboard: dashboardInPublicCollection,
+              noRecentDashboard: true,
+            });
+
+            await waitFor(() => {
+              expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+            });
+
+            expect(
+              screen.getByRole("heading", {
+                name: dashboardInPublicCollection.name,
+              }),
+            ).toBeInTheDocument();
+          });
+
+          it("should render dashboards when opening public subcollections", async () => {
+            const dashboardInPublicSubcollection = createMockDashboard({
+              id: 3,
+              name: "Dashboard in public subcollection",
+              collection_id: COLLECTION.id as number,
+              model: "dashboard",
+            });
+
+            await setup({
+              dashboard: dashboardInPublicSubcollection,
+              noRecentDashboard: true,
+            });
+
+            userEvent.click(
+              screen.getByRole("heading", {
+                name: COLLECTION.name,
+              }),
+            );
+
+            await waitFor(() => {
+              expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+            });
+
+            expect(
+              screen.getByRole("heading", {
+                name: dashboardInPublicSubcollection.name,
+              }),
+            ).toBeInTheDocument();
+          });
+
+          it("should render dashboards when opening personal collections", async () => {
+            const dashboardInPersonalCollection = createMockDashboard({
+              id: 3,
+              name: "Dashboard in personal collection",
+              collection_id: PERSONAL_COLLECTION.id as number,
+              model: "dashboard",
+            });
+
+            await setup({
+              dashboard: dashboardInPersonalCollection,
+              noRecentDashboard: true,
+            });
+
+            userEvent.click(
+              screen.getByRole("heading", {
+                name: PERSONAL_COLLECTION.name,
+              }),
+            );
+
+            await waitFor(() => {
+              expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+            });
+
+            expect(
+              screen.getByRole("heading", {
+                name: dashboardInPersonalCollection.name,
+              }),
+            ).toBeInTheDocument();
+          });
+
+          it("should render dashboards when opening personal subcollections", async () => {
+            const dashboardInPersonalSubcollection = createMockDashboard({
+              id: 3,
+              name: "Dashboard in personal subcollection",
+              collection_id: PERSONAL_SUBCOLLECTION.id as number,
+              model: "dashboard",
+            });
+
+            await setup({
+              dashboard: dashboardInPersonalSubcollection,
+              noRecentDashboard: true,
+            });
+
+            userEvent.click(
+              screen.getByRole("heading", {
+                name: PERSONAL_COLLECTION.name,
+              }),
+            );
+            userEvent.click(
+              screen.getByRole("heading", {
+                name: PERSONAL_SUBCOLLECTION.name,
+              }),
+            );
+
+            await waitFor(() => {
+              expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+            });
+
+            expect(
+              screen.getByRole("heading", {
+                name: dashboardInPersonalSubcollection.name,
+              }),
+            ).toBeInTheDocument();
+          });
+        });
       });
     });
   });

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/AddCardSidebar/AddCardSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/AddCardSidebar/AddCardSidebar.jsx
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 
 import Sidebar from "metabase/dashboard/components/Sidebar";
-import QuestionPicker from "./QuestionPicker";
+import QuestionPicker from "../QuestionPicker";
 
 AddCardSidebar.propTypes = {
   onSelect: PropTypes.func.isRequired,

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/AddCardSidebar/AddCardSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/AddCardSidebar/AddCardSidebar.unit.spec.tsx
@@ -1,0 +1,49 @@
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import {
+  createMockDashboardState,
+  createMockState,
+} from "metabase-types/store/mocks";
+import {
+  createMockCollection,
+  createMockDashboard,
+} from "metabase-types/api/mocks";
+import {
+  setupCollectionItemsEndpoint,
+  setupCollectionsEndpoints,
+} from "__support__/server-mocks";
+import { ROOT_COLLECTION } from "metabase/entities/collections";
+import { AddCardSidebar } from "./AddCardSidebar";
+
+async function setup() {
+  setupCollectionsEndpoints({
+    collections: [],
+  });
+  setupCollectionItemsEndpoint({
+    collection: createMockCollection(ROOT_COLLECTION),
+    collectionItems: [],
+  });
+
+  const dashboard = createMockDashboard();
+  renderWithProviders(<AddCardSidebar onSelect={jest.fn()} />, {
+    storeInitialState: createMockState({
+      dashboard: createMockDashboardState({
+        dashboards: {
+          [dashboard.id]: { ...dashboard, dashcards: [] },
+        },
+        dashboardId: dashboard.id,
+      }),
+    }),
+  });
+
+  await waitFor(() => {
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+  });
+}
+
+describe("AddCardSideBar", () => {
+  it("should render no items", async () => {
+    await setup();
+
+    expect(screen.getByText("Nothing here")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/AddCardSidebar/AddCardSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/AddCardSidebar/AddCardSidebar.unit.spec.tsx
@@ -16,6 +16,7 @@ import {
 import { ROOT_COLLECTION as ROOT } from "metabase/entities/collections";
 import type { Collection, CollectionItem, Dashboard } from "metabase-types/api";
 import { getNextId } from "__support__/utils";
+import { checkNotNull } from "metabase/lib/types";
 import { AddCardSidebar } from "./AddCardSidebar";
 
 const CURRENT_USER = createMockUser({
@@ -87,7 +88,7 @@ async function setup({
     collections,
   });
   setupCollectionItemsEndpoint({
-    collection: createMockCollection(dashboard.collection),
+    collection: createMockCollection(checkNotNull(dashboard.collection)),
     collectionItems,
   });
 

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/AddCardSidebar/AddCardSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/AddCardSidebar/AddCardSidebar.unit.spec.tsx
@@ -5,27 +5,95 @@ import {
 } from "metabase-types/store/mocks";
 import {
   createMockCollection,
+  createMockCollectionItem,
   createMockDashboard,
+  createMockUser,
 } from "metabase-types/api/mocks";
 import {
   setupCollectionItemsEndpoint,
   setupCollectionsEndpoints,
 } from "__support__/server-mocks";
-import { ROOT_COLLECTION } from "metabase/entities/collections";
+import { ROOT_COLLECTION as ROOT } from "metabase/entities/collections";
+import type { Collection, CollectionItem, Dashboard } from "metabase-types/api";
+import { getNextId } from "__support__/utils";
 import { AddCardSidebar } from "./AddCardSidebar";
 
-async function setup() {
+const CURRENT_USER = createMockUser({
+  id: 1,
+  personal_collection_id: 100,
+  is_superuser: true,
+});
+
+const COLLECTION = createMockCollection({
+  id: 1,
+  name: "Collection",
+  can_write: true,
+  is_personal: false,
+  location: "/",
+});
+
+const SUBCOLLECTION = createMockCollection({
+  id: 2,
+  name: "Nested collection",
+  can_write: true,
+  is_personal: false,
+  location: `/${COLLECTION.id}/`,
+});
+
+const PERSONAL_COLLECTION = createMockCollection({
+  id: CURRENT_USER.personal_collection_id,
+  name: "My personal collection",
+  personal_owner_id: CURRENT_USER.id,
+  can_write: true,
+  is_personal: true,
+  location: "/",
+});
+
+const PERSONAL_SUBCOLLECTION = createMockCollection({
+  id: CURRENT_USER.personal_collection_id + 1,
+  name: "Nested personal collection",
+  can_write: true,
+  is_personal: true,
+  location: `/${PERSONAL_COLLECTION.id}/`,
+});
+
+const ROOT_COLLECTION = createMockCollection({
+  ...ROOT,
+  can_write: true,
+});
+
+const COLLECTIONS = [
+  ROOT_COLLECTION,
+  COLLECTION,
+  SUBCOLLECTION,
+  PERSONAL_COLLECTION,
+  PERSONAL_SUBCOLLECTION,
+];
+
+interface SetupOpts {
+  collections: Collection[];
+  collectionItems?: CollectionItem[];
+  dashboard?: Dashboard;
+}
+
+async function setup({
+  collections,
+  collectionItems = [],
+  dashboard = createMockDashboard({
+    collection: ROOT_COLLECTION,
+  }),
+}: SetupOpts) {
   setupCollectionsEndpoints({
-    collections: [],
+    collections,
   });
   setupCollectionItemsEndpoint({
-    collection: createMockCollection(ROOT_COLLECTION),
-    collectionItems: [],
+    collection: createMockCollection(dashboard.collection),
+    collectionItems,
   });
 
-  const dashboard = createMockDashboard();
   renderWithProviders(<AddCardSidebar onSelect={jest.fn()} />, {
     storeInitialState: createMockState({
+      currentUser: CURRENT_USER,
       dashboard: createMockDashboardState({
         dashboards: {
           [dashboard.id]: { ...dashboard, dashcards: [] },
@@ -42,8 +110,164 @@ async function setup() {
 
 describe("AddCardSideBar", () => {
   it("should render no items", async () => {
-    await setup();
+    await setup({
+      collections: [],
+    });
 
     expect(screen.getByText("Nothing here")).toBeInTheDocument();
   });
+
+  it("should hide all personal collections when adding questions to dashboards in the root collection (public collection)", async () => {
+    const dashboardInPublicCollection = createMockDashboard({
+      collection: ROOT_COLLECTION,
+    });
+    await setup({
+      collections: COLLECTIONS,
+      dashboard: dashboardInPublicCollection,
+    });
+
+    assertBreadcrumbs([ROOT_COLLECTION]);
+
+    expect(
+      screen.getByRole("menuitem", {
+        name: COLLECTION.name,
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("menuitem", {
+        name: PERSONAL_COLLECTION.name,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should show all questions when adding questions to dashboards in the root collection (public collection)", async () => {
+    const dashboardInRootCollection = createMockDashboard({
+      collection: ROOT_COLLECTION,
+    });
+
+    const collectionItems = [
+      createMockCollectionItem({
+        id: getNextId(),
+        model: "card",
+        name: "question 1",
+      }),
+      createMockCollectionItem({
+        id: getNextId(),
+        model: "card",
+        name: "question 2",
+      }),
+    ];
+    await setup({
+      collections: COLLECTIONS,
+      dashboard: dashboardInRootCollection,
+      collectionItems,
+    });
+
+    assertBreadcrumbs([ROOT_COLLECTION]);
+
+    collectionItems.forEach(collectionItem => {
+      expect(
+        screen.getByRole("menuitem", {
+          name: collectionItem.name,
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should show all questions when adding questions to dashboards in public collections", async () => {
+    const dashboardInPublicSubcollection = createMockDashboard({
+      collection: SUBCOLLECTION,
+    });
+
+    const collectionItems = [
+      createMockCollectionItem({
+        id: getNextId(),
+        model: "card",
+        name: "question 1",
+      }),
+      createMockCollectionItem({
+        id: getNextId(),
+        model: "card",
+        name: "question 2",
+      }),
+    ];
+    await setup({
+      collections: COLLECTIONS,
+      dashboard: dashboardInPublicSubcollection,
+      collectionItems,
+    });
+
+    assertBreadcrumbs([ROOT_COLLECTION, COLLECTION, SUBCOLLECTION]);
+
+    collectionItems.forEach(collectionItem => {
+      expect(
+        screen.getByRole("menuitem", {
+          name: collectionItem.name,
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should show all collections when adding questions to dashboards in personal subcollections", async () => {
+    const dashboardInPersonalSubcollection = createMockDashboard({
+      collection: PERSONAL_SUBCOLLECTION,
+    });
+    await setup({
+      collections: COLLECTIONS,
+      dashboard: dashboardInPersonalSubcollection,
+    });
+
+    assertBreadcrumbs([
+      ROOT_COLLECTION,
+      PERSONAL_COLLECTION,
+      PERSONAL_SUBCOLLECTION,
+    ]);
+
+    expect(screen.getByText("Nothing here")).toBeInTheDocument();
+  });
+
+  it("should show all questions when adding questions to dashboards in personal subcollections", async () => {
+    const dashboardInPersonalSubcollection = createMockDashboard({
+      collection: PERSONAL_SUBCOLLECTION,
+    });
+
+    const collectionItems = [
+      createMockCollectionItem({
+        id: getNextId(),
+        model: "card",
+        name: "private question 1",
+      }),
+      createMockCollectionItem({
+        id: getNextId(),
+        model: "card",
+        name: "private question 2",
+      }),
+    ];
+    await setup({
+      collections: COLLECTIONS,
+      dashboard: dashboardInPersonalSubcollection,
+      collectionItems,
+    });
+
+    assertBreadcrumbs([
+      ROOT_COLLECTION,
+      PERSONAL_COLLECTION,
+      PERSONAL_SUBCOLLECTION,
+    ]);
+
+    collectionItems.forEach(collectionItem => {
+      expect(
+        screen.getByRole("menuitem", {
+          name: collectionItem.name,
+        }),
+      ).toBeInTheDocument();
+    });
+  });
 });
+
+function assertBreadcrumbs(collections: Collection[]) {
+  collections.forEach(collection => {
+    expect(screen.getByText(collection.name)).toBeInTheDocument();
+  });
+}

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/AddCardSidebar/index.ts
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/AddCardSidebar/index.ts
@@ -1,0 +1,1 @@
+export { AddCardSidebar } from "./AddCardSidebar";

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionList.jsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionList.jsx
@@ -19,7 +19,7 @@ import {
 
 QuestionList.propTypes = {
   searchText: PropTypes.string,
-  collectionId: PropTypes.string,
+  collectionId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   onSelect: PropTypes.func.isRequired,
   hasCollections: PropTypes.bool,
 };

--- a/frontend/test/__support__/server-mocks/collection.ts
+++ b/frontend/test/__support__/server-mocks/collection.ts
@@ -3,7 +3,6 @@ import _ from "underscore";
 import type {
   Card,
   Collection,
-  CollectionId,
   CollectionItem,
   Dashboard,
 } from "metabase-types/api";
@@ -32,7 +31,7 @@ export function setupCollectionsEndpoints({
       query: { tree: true, "exclude-archived": true },
       overwriteRoutes: false,
     },
-    buildCollectionTree(collections.filter(collection => !collection.archived)),
+    collections.filter(collection => !collection.archived),
   );
   fetchMock.get(
     {
@@ -40,63 +39,12 @@ export function setupCollectionsEndpoints({
       query: { tree: true },
       overwriteRoutes: false,
     },
-    buildCollectionTree(collections),
+    collections,
   );
   fetchMock.get(
     { url: "path:/api/collection", overwriteRoutes: false },
     collections,
   );
-}
-
-function buildCollectionTree(collections: Collection[]) {
-  const nonRootCollections = collections.filter(
-    collection => collection.id !== "root",
-  );
-  const usedCollectionIds = new Set();
-  const tree: Collection[] = [];
-
-  let currentTreeLevel = 0;
-  while (usedCollectionIds.size < nonRootCollections.length) {
-    for (let index = 0; index < nonRootCollections.length; index++) {
-      if (usedCollectionIds.has(index)) {
-        continue;
-      }
-
-      const collection = nonRootCollections[index];
-      const ROOT_LOCATION = "/";
-      const collectionPath = (collection.location ?? ROOT_LOCATION)
-        .split("/")
-        .filter(collectionId => collectionId)
-        .map(Number);
-      const collectionLevel = collectionPath.length;
-      const isAtCurrentTreeLevel = collectionLevel === currentTreeLevel;
-
-      if (isAtCurrentTreeLevel) {
-        const node = walkTree(tree, collectionPath);
-        node.push({ ...collection });
-        usedCollectionIds.add(index);
-      }
-    }
-    currentTreeLevel++;
-  }
-
-  return tree;
-}
-
-function walkTree(tree: Collection[], path: CollectionId[]): Collection[] {
-  let collectionChildren = tree;
-  for (const collectionId of path) {
-    const collection = collectionChildren.find(
-      node => node.id === collectionId,
-    );
-    if (collection) {
-      if (!collection.children) {
-        collection.children = [];
-      }
-      collectionChildren = collection.children;
-    }
-  }
-  return collectionChildren;
 }
 
 function getCollectionVirtualSchemaURLs(collection: Collection) {


### PR DESCRIPTION
This adds tests to `QuestionPicker` or when we're adding cards to a dashboard.

![image](https://github.com/metabase/metabase/assets/1937582/73b71b86-613c-4946-b599-b22c02dc54af)

#### Testing plan for milestone 1
Dashboards
1. Add a question to a dashboard in a public collection
    **expectation**:
    - hides all personal collections
    - show all questions
1. Add a question to a dashboard in a personal collection
    **expectation**:
    - shows all collections
    - show all questions