### PR TITLE
Add ability to specify values for setting

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -592,13 +592,7 @@
   :type       :keyword
   :default    :substring
   :audit      :raw-value
-  :setter     (fn [v]
-                (let [v (cond-> v (string? v) keyword)]
-                  (if (autocomplete-matching-options v)
-                    (setting/set-value-of-type! :keyword :native-query-autocomplete-match-style v)
-                    (throw (ex-info (tru "Invalid `native-query-autocomplete-match-style` option")
-                                    {:option v
-                                     :valid-options autocomplete-matching-options}))))))
+  :values     autocomplete-matching-options)
 
 (api/defendpoint GET "/:id/autocomplete_suggestions"
   "Return a list of autocomplete suggestions for a given `prefix`, or `substring`. Should only specify one, but

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -41,6 +41,8 @@
 
 (defsetting user-visibility
   (deferred-tru "Note: Sandboxed users will never see suggestions.")
+  ;; we could specify `:values` here, but that would result in invalid options falling back to the default (`:all`),
+  ;; where currently they fall back to `:none`.
   :visibility   :authenticated
   :feature      :email-restrict-recipients
   :type         :keyword

--- a/src/metabase/email.clj
+++ b/src/metabase/email.clj
@@ -81,10 +81,7 @@
   :default    :none
   :visibility :settings-manager
   :audit      :raw-value
-  :setter     (fn [new-value]
-                (when (some? new-value)
-                  (assert (#{:tls :ssl :none :starttls} (keyword new-value))))
-                (setting/set-value-of-type! :keyword :email-smtp-security new-value)))
+  :values #{:tls :ssl :none :starttls})
 
 ;; ## PUBLIC INTERFACE
 

--- a/src/metabase/integrations/ldap.clj
+++ b/src/metabase/integrations/ldap.clj
@@ -36,10 +36,7 @@
   :type    :keyword
   :default :none
   :audit   :raw-value
-  :setter  (fn [new-value]
-             (when (some? new-value)
-               (assert (#{:none :ssl :starttls} (keyword new-value))))
-             (setting/set-value-of-type! :keyword :ldap-security new-value)))
+  :values #{:none :ssl :starttls})
 
 (defsetting ldap-bind-dn
   (deferred-tru "The Distinguished Name to bind as (if any), this user will be used to lookup information about other users.")

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -642,17 +642,7 @@
   :type       :keyword
   :default    :sunday
   :audit      :raw-value
-  :getter     (fn []
-                ;; if something invalid is somehow in the DB just fall back to Sunday
-                (when-let [value (setting/get-value-of-type :keyword :start-of-week)]
-                  (if (#{:monday :tuesday :wednesday :thursday :friday :saturday :sunday} value)
-                    value
-                    :sunday)))
-  :setter      (fn [new-value]
-                 (when new-value
-                   (assert (#{:monday :tuesday :wednesday :thursday :friday :saturday :sunday} (keyword new-value))
-                           (trs "Invalid day of week: {0}" (pr-str new-value))))
-                 (setting/set-value-of-type! :keyword :start-of-week new-value)))
+  :values     #{:monday :tuesday :wednesday :thursday :friday :saturday :sunday})
 
 (defsetting cloud-gateway-ips-url
   "Store URL for fetching the list of Cloud gateway IP addresses"

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -69,40 +69,14 @@
                                                        metabase-session-timeout-cookie]))
 
 (def ^:private possible-session-cookie-samesite-values
-  #{:lax :none :strict nil})
-
-(defn- normalized-session-cookie-samesite [value]
-  (some-> value name u/lower-case-en keyword))
-
-(defn- valid-session-cookie-samesite?
-  [normalized-value]
-  (contains? possible-session-cookie-samesite-values normalized-value))
+  #{:lax :none :strict})
 
 (defsetting session-cookie-samesite
   (deferred-tru "Value for the session cookie's `SameSite` directive.")
   :type :keyword
   :visibility :settings-manager
   :default :lax
-  :getter (fn session-cookie-samesite-getter []
-            (let [value (normalized-session-cookie-samesite
-                         (setting/get-raw-value :session-cookie-samesite))]
-              (if (valid-session-cookie-samesite? value)
-                value
-                (throw (ex-info "Invalid value for session cookie samesite"
-                                {:possible-values possible-session-cookie-samesite-values
-                                 :session-cookie-samesite value})))))
-  :setter (fn session-cookie-samesite-setter
-            [new-value]
-            (let [normalized-value (normalized-session-cookie-samesite new-value)]
-              (if (valid-session-cookie-samesite? normalized-value)
-                (setting/set-value-of-type!
-                 :keyword
-                 :session-cookie-samesite
-                 normalized-value)
-                (throw (ex-info (tru "Invalid value for session cookie samesite")
-                                {:possible-values possible-session-cookie-samesite-values
-                                 :session-cookie-samesite normalized-value
-                                 :http-status 400}))))))
+  :values possible-session-cookie-samesite-values)
 
 (defmulti default-session-cookie-attributes
   "The appropriate cookie attributes to persist a newly created Session to `response`."

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -22,9 +22,7 @@
    [metabase.util.i18n :as i18n]
    [ring.mock.request :as ring.mock]
    [toucan2.core :as t2]
-   [toucan2.tools.with-temp :as t2.with-temp])
-  (:import
-   (clojure.lang ExceptionInfo)))
+   [toucan2.tools.with-temp :as t2.with-temp]))
 
 (set! *warn-on-reflection* true)
 
@@ -48,9 +46,10 @@
            (with-redefs [env/env (assoc env/env :mb-session-cookie-samesite "NONE")]
              (mw.session/session-cookie-samesite))))
 
-    (is (thrown-with-msg? ExceptionInfo #"Invalid value for session cookie samesite"
-          (with-redefs [env/env (assoc env/env :mb-session-cookie-samesite "invalid value")]
-            (mw.session/session-cookie-samesite))))))
+    (testing "defaults to `:lax` if set to an invalid value"
+      (is (= :lax
+           (with-redefs [env/env (assoc env/env :mb-session-cookie-samesite "invalid value")]
+             (mw.session/session-cookie-samesite)))))))
 
 (deftest set-session-cookie-test
   (mt/with-temporary-setting-values [session-timeout nil]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/35060

## Add the ability to specify `values` for a setting

This allows us to specify `:values` for a given setting.

To design this, I looked at the existing implementation for settings with `keyword` types.

There are a few different patterns for these, and unfortunately they follow quite a few different patterns in terms of
how to validate that a value is a member of the expected set.

Variously, they:

- validate when the setting is read or written, throw an exception if invalid.

- do not validate the setting anywhere (presumably the other code is written to behave sanely in the presence of an
invalid value)

- validate the keyword when it's written, but just set a default when reading.

- validate the keyword when it's written, return whatever is present when reading

This puts us in a bit of an awkward situation:

- if we validate and throw exceptions on read, we may break existing users.

- if we validate on write and warn on read, we need to watch out for cases like `user-visiblity`: the default value is
`:all`, but the fallback from invalid values is `:none`. If someone has a typo for the `MB_USER_VISIBILITY` env var,
changing the logic to fall back to the default (`all`) would unexpectedly change the value of the setting (from `none`
to `all`).

I *think* the most reasonable behavior here is to throw an exception when an invalid value is written, and warn (via
the logs) when an invalid value is read, while returning the default value.

I also went ahead and added `:values` to existing `:keyword`-typed Settings in those cases where it made sense. As
mentioned above, I excluded (and added a comment to) the `user-visibility` setting, to prevent an unexpected change
for users who might have set the env var to an invalid value.

One final note: I changed the method implementation of `get-value-of` for the `:keyword` type to lower-case its input
before turning it into a keyword - so setting an env var like `MB_SETTING_VALUE=STRICT` or `MB_SETTING_VALUE=StRiCt`
will both turn into `(= (setting-value) :strict)`. I wanted to do this to allow us to use `:values` for
`SESSION_COOKIE_SAMESITE`, where we've allowed (and had tests for) uppercase/mixed case env vars.

