### PR TITLE
Migrate Timeline and TimelineEvent "balloons" icons to "star"

### DIFF
--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -7,7 +7,7 @@
    [metabase.models.collection.root :as collection.root]
    [metabase.models.timeline :as timeline :refer [Timeline]]
    [metabase.models.timeline-event
-    :as timeline-event
+    :as timeline
     :refer [TimelineEvent]]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
@@ -26,7 +26,7 @@
   {name          ms/NonBlankString
    default       [:maybe :boolean]
    description   [:maybe :string]
-   icon          [:maybe timeline/Icons]
+   icon          [:maybe timeline-event/Icon]
    collection_id [:maybe ms/PositiveInt]
    archived      [:maybe :boolean]}
   (collection/check-write-perms-for-collection collection_id)
@@ -34,7 +34,7 @@
             body
             {:creator_id api/*current-user-id*}
             (when-not icon
-              {:icon timeline/DefaultIcon}))]
+              {:icon timeline-event/default-icon}))]
     (first (t2/insert-returning-instances! Timeline tl))))
 
 (api/defendpoint GET "/"
@@ -84,7 +84,7 @@
    name          [:maybe ms/NonBlankString]
    default       [:maybe :boolean]
    description   [:maybe :string]
-   icon          [:maybe timeline/Icons]
+   icon          [:maybe timeline-event/Icon]
    collection_id [:maybe ms/PositiveInt]
    archived      [:maybe :boolean]}
   (let [existing (api/write-check Timeline id)

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -7,7 +7,7 @@
    [metabase.models.collection.root :as collection.root]
    [metabase.models.timeline :as timeline :refer [Timeline]]
    [metabase.models.timeline-event
-    :as timeline
+    :as timeline-event
     :refer [TimelineEvent]]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]

--- a/src/metabase/api/timeline_event.clj
+++ b/src/metabase/api/timeline_event.clj
@@ -23,9 +23,9 @@
    timestamp    ms/TemporalString
    time_matters [:maybe :boolean]
    timezone     :string
-   icon         [:maybe timeline/Icons]
+   icon         [:maybe timeline-event/Icon]
    timeline_id  ms/PositiveInt
-   source       [:maybe timeline-event/Sources]
+   source       [:maybe timeline-event/Source]
    question_id  [:maybe ms/PositiveInt]
    archived     [:maybe :boolean]}
   ;; deliberately not using api/check-404 so we can have a useful error message.
@@ -67,7 +67,7 @@
    timestamp    [:maybe ms/TemporalString]
    time_matters [:maybe :boolean]
    timezone     [:maybe :string]
-   icon         [:maybe timeline/Icons]
+   icon         [:maybe timeline-event/Icon]
    timeline_id  [:maybe ms/PositiveInt]
    archived     [:maybe :boolean]}
   (let [existing (api/write-check TimelineEvent id)

--- a/src/metabase/models/timeline.clj
+++ b/src/metabase/models/timeline.clj
@@ -22,15 +22,14 @@
   (derive :hook/timestamped?)
   (derive :hook/entity-id))
 
-;;;; schemas
+;;;; transforms
 
-(def Icons
-  "Timeline and TimelineEvent icon string Schema"
- [:enum "star" "cake" "mail" "warning" "bell" "cloud"])
-
-(def DefaultIcon
-  "Timeline default icon"
-  "star")
+(t2/define-after-select :model/Timeline
+  [timeline]
+  ;; We used to have a "balloons" icon but we removed it.
+  ;; Use the default icon instead. (metabase#34586, metabase#35129)
+  (update timeline :icon (fn [icon]
+                           (if (= icon "balloons") timeline-event/default-icon icon))))
 
 ;;;; functions
 

--- a/src/metabase/models/timeline_event.clj
+++ b/src/metabase/models/timeline_event.clj
@@ -23,11 +23,11 @@
 ;;;; schemas
 
 (def default-icon
-  "The default icon for Timeline and TimelineEvents."
+  "The default icon for Timeline an TimelineEvents."
   "star")
 
 (def Icon
-  "TimelineEvent icon string Schema"
+  "Schema for Timeline and TimelineEvents `icon`"
   [:enum default-icon "cake" "mail" "warning" "bell" "cloud"])
 
 (def Source

--- a/src/metabase/models/timeline_event.clj
+++ b/src/metabase/models/timeline_event.clj
@@ -22,10 +22,27 @@
 
 ;;;; schemas
 
-(def Sources
+(def default-icon
+  "The default icon for Timeline and TimelineEvents."
+  "star")
+
+(def Icon
+  "TimelineEvent icon string Schema"
+  [:enum default-icon "cake" "mail" "warning" "bell" "cloud"])
+
+(def Source
   "Timeline Event Source Schema. For Snowplow Events, where the Event is created from is important.
   Events are added from one of three sources: `collections`, `questions` (cards in backend code), or directly with an API call. An API call is indicated by having no source key in the `timeline-event` request."
   [:enum "collections" "question"])
+
+;;;; transforms
+
+(t2/define-after-select :model/TimelineEvent
+  [timeline-event]
+  ;; We used to have a "balloons" icon but we removed it.
+  ;; Use the default icon instead. (metabase#34586, metabase#35129)
+  (update timeline-event :icon (fn [icon]
+                                 (if (= icon "balloons") default-icon icon))))
 
 ;;;; permissions
 

--- a/src/metabase/models/timeline_event.clj
+++ b/src/metabase/models/timeline_event.clj
@@ -23,7 +23,7 @@
 ;;;; schemas
 
 (def default-icon
-  "The default icon for Timeline an TimelineEvents."
+  "The default icon for Timeline and TimelineEvents."
   "star")
 
 (def Icon

--- a/test/metabase/models/timeline_test.clj
+++ b/test/metabase/models/timeline_test.clj
@@ -4,9 +4,10 @@
    [clojure.test :refer :all]
    [metabase.models.collection :refer [Collection]]
    [metabase.models.timeline :as timeline :refer [Timeline]]
-   [metabase.models.timeline-event :refer [TimelineEvent]]
+   [metabase.models.timeline-event :refer [TimelineEvent] :as timeline-event]
    [metabase.test :as mt]
    [metabase.util :as u]
+   [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
 (deftest timelines-for-collection-test
@@ -36,3 +37,12 @@
                                                            {:timeline/events? true
                                                             :events/all?      true})
                         event-names)))))))))
+
+(deftest balloon-icon-migration-test
+  (testing "timelines with icon=balloons should use the default icon instead when selected"
+    (mt/with-temp [Timeline a {:icon "balloons"}
+                   Timeline b {:icon "cake"}]
+      (is (= timeline-event/default-icon
+             (t2/select-one-fn :icon Timeline (u/the-id a))))
+      (is (= "cake"
+             (t2/select-one-fn :icon Timeline (u/the-id b)))))))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -45,12 +45,7 @@
    (java.net ServerSocket)
    (java.util Locale)
    (java.util.concurrent TimeoutException)
-   (org.quartz
-    CronTrigger
-    JobDetail
-    JobKey
-    Scheduler
-    Trigger)
+   (org.quartz CronTrigger JobDetail JobKey Scheduler Trigger)
    (org.quartz.impl StdSchedulerFactory)))
 
 (set! *warn-on-reflection* true)

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -15,17 +15,8 @@
    [metabase.db.query :as mdb.query]
    [metabase.db.util :as mdb.u]
    [metabase.models
-    :refer [Card
-            Collection
-            Dimension
-            Field
-            FieldValues
-            Permissions
-            PermissionsGroup
-            PermissionsGroupMembership
-            Setting
-            Table
-            User]]
+    :refer [Card Collection Dimension Field FieldValues Permissions
+            PermissionsGroup PermissionsGroupMembership Setting Table User]]
    [metabase.models.collection :as collection]
    [metabase.models.interface :as mi]
    [metabase.models.moderation-review :as moderation-review]
@@ -33,7 +24,7 @@
    [metabase.models.permissions-group :as perms-group]
    [metabase.models.setting :as setting]
    [metabase.models.setting.cache :as setting.cache]
-   [metabase.models.timeline :as timeline]
+   [metabase.models.timeline-event :as timeline-event]
    [metabase.plugins.classloader :as classloader]
    [metabase.task :as task]
    [metabase.test-runner.assert-exprs :as test-runner.assert-exprs]
@@ -54,7 +45,12 @@
    (java.net ServerSocket)
    (java.util Locale)
    (java.util.concurrent TimeoutException)
-   (org.quartz CronTrigger JobDetail JobKey Scheduler Trigger)
+   (org.quartz
+    CronTrigger
+    JobDetail
+    JobKey
+    Scheduler
+    Trigger)
    (org.quartz.impl StdSchedulerFactory)))
 
 (set! *warn-on-reflection* true)
@@ -254,14 +250,14 @@
      (default-timestamped
        {:name       "Timeline of bird squawks"
         :default    false
-        :icon       timeline/DefaultIcon
+        :icon       timeline-event/default-icon
         :creator_id (rasta-id)}))
 
    :model/TimelineEvent
    (fn [_]
      (default-timestamped
        {:name         "default timeline event"
-        :icon         timeline/DefaultIcon
+        :icon         timeline-event/default-icon
         :timestamp    (t/zoned-date-time)
         :timezone     "US/Pacific"
         :time_matters true


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/35129

Effectively migrates icon="balloon" to icon="star" which is the default icon. If the default icon changes to something else, so will the icon "balloon" is migrated to.

I've implemented the migration as an "on-demand migration" with toucan's `define-after-select` to avoid complications with instances downgrading versions in the future. For example if an instance upgrades from version 47.0 to 48.0 and then downgrades to 47.0 again, the rollback for a normal liquibase migration would not have been run.