### PR TITLE
Fix FE not handling dates with timezone offsets in date filters

### DIFF
--- a/frontend/src/metabase-lib/filter.ts
+++ b/frontend/src/metabase-lib/filter.ts
@@ -641,6 +641,7 @@ const DATE_FORMAT = "yyyy-MM-DD";
 const TIME_FORMAT = "HH:mm:ss";
 const TIME_FORMAT_MS = "HH:mm:SS.sss";
 const DATE_TIME_FORMAT = `${DATE_FORMAT}T${TIME_FORMAT}`;
+const UTC_OFFSET_REGEX = /(Z|[+-]\d\d:?\d\d)$/;
 
 function hasTimeParts(date: Date): boolean {
   return date.getHours() !== 0 || date.getMinutes() !== 0;
@@ -655,7 +656,9 @@ function serializeDateTime(date: Date): string {
 }
 
 function deserializeDateTime(value: string): Date | null {
-  const dateTime = moment(value, [DATE_TIME_FORMAT, DATE_FORMAT], true);
+  const dateTime = UTC_OFFSET_REGEX.test(value)
+    ? moment.parseZone(value, moment.ISO_8601, true)
+    : moment(value, moment.ISO_8601, true);
   if (!dateTime.isValid()) {
     return null;
   }

--- a/frontend/src/metabase-lib/filter.unit.spec.ts
+++ b/frontend/src/metabase-lib/filter.unit.spec.ts
@@ -859,6 +859,21 @@ describe("filter", () => {
       expect(bucketInfo?.shortName).toBe("minute");
     });
 
+    it("should support dates with timezone offsets", () => {
+      const { filterParts } = addSpecificDateFilter(
+        query,
+        Lib.expressionClause("=", [column, "2020-01-05T10:20:00+01:00"]),
+      );
+
+      const value = filterParts?.values[0];
+      expect(filterParts).toMatchObject({
+        operator: "=",
+        column: expect.anything(),
+        values: [expect.any(Date)],
+      });
+      expect(value?.toISOString()).toBe("2020-01-05T09:20:00.000Z");
+    });
+
     it("should ignore expressions with not supported operators", () => {
       const { filterParts } = addSpecificDateFilter(
         query,

--- a/frontend/src/metabase-lib/filter.unit.spec.ts
+++ b/frontend/src/metabase-lib/filter.unit.spec.ts
@@ -864,13 +864,13 @@ describe("filter", () => {
         query,
         Lib.expressionClause("=", [column, "2020-01-05T10:20:00+01:00"]),
       );
-
-      const value = filterParts?.values[0];
       expect(filterParts).toMatchObject({
         operator: "=",
         column: expect.anything(),
         values: [expect.any(Date)],
       });
+
+      const value = filterParts?.values[0];
       expect(value?.toISOString()).toBe("2020-01-05T09:20:00.000Z");
     });
 


### PR DESCRIPTION
FE part of https://github.com/metabase/metabase/issues/35153

Steps:
- Open product table
- Click on any Created At cell -> Filter by -> Equals
- Go to the notebook editor
- Click on the filter pill (which is rendered incorrectly atm)
- The filter picker should be initialized correctly
- Filtering by this date should work

Opening the filter picker:
<img width="523" alt="Screenshot 2023-10-27 at 17 51 30" src="https://github.com/metabase/metabase/assets/8542534/9c8f04cb-2217-4299-a3ec-6c82a108b059">

After the clause is updated by FE:
<img width="1173" alt="Screenshot 2023-10-27 at 19 01 22" src="https://github.com/metabase/metabase/assets/8542534/023962c2-5136-4314-ac58-5728d0321bb6">
