### PR TITLE
[MLv2] Make `find-matching-column` correctly match implicit joins

### DIFF
--- a/src/metabase/lib/js/metadata.cljs
+++ b/src/metabase/lib/js/metadata.cljs
@@ -232,8 +232,9 @@
                                           (walk/keywordize-keys v)
                                           (js->clj v :keywordize-keys true))
       :has-field-values                 (keyword v)
-      :lib/source                       (if (= v "aggregation")
-                                          :source/aggregations
+      :lib/source                       (case v
+                                          "aggregation" :source/aggregations
+                                          "breakout"    :source/breakouts
                                           (keyword "source" v))
       :metabase.lib.field/temporal-unit (keyword v)
       :semantic-type                    (keyword v)


### PR DESCRIPTION
A draft for now, since it seems to cause an infinite loop when you try to remove a column.

@npfitz please try this out and see if you can isolate the loop.

Fixes #35152
