### PR TITLE
Don't automatically increment the audit db id

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -97,24 +97,20 @@
 (defn- install-database!
   "Creates the audit db, a clone of the app db used for auditing purposes.
 
-  - This uses a weird ID because some tests are hardcoded to look for database with ID = 2, and inserting an extra db
-  throws that off since the IDs are sequential."
-  ([engine] (install-database! engine perms/audit-db-id))
-  ([engine id]
-   (if (t2/select-one Database :id id)
-     (install-database! engine (inc id))
-     (do
-       ;; guard against someone manually deleting the audit-db entry, but not removing the audit-db permissions.
-       (t2/delete! :permissions {:where [:like :object (str "%/db/" id "/%")]})
-       (t2/insert! Database {:is_audit         true
-                             :id               id
-                             :name             "Internal Metabase Database"
-                             :description      "Internal Audit DB used to power metabase analytics."
-                             :engine           engine
-                             :is_full_sync     true
-                             :is_on_demand     false
-                             :creator_id       nil
-                             :auto_run_queries true})))))
+  - This uses a weird ID because some tests were hardcoded to look for database with ID = 2, and inserting an extra db
+  throws that off since these IDs are sequential."
+  [engine id]
+  ;; guard against someone manually deleting the audit-db entry, but not removing the audit-db permissions.
+  (t2/delete! :permissions {:where [:like :object (str "%/db/" id "/%")]})
+  (t2/insert! Database {:is_audit         true
+                        :id               id
+                        :name             "Internal Metabase Database"
+                        :description      "Internal Audit DB used to power metabase analytics."
+                        :engine           engine
+                        :is_full_sync     true
+                        :is_on_demand     false
+                        :creator_id       nil
+                        :auto_run_queries true}))
 
 (defn- adjust-audit-db-to-source!
   [{audit-db-id :id}]
@@ -213,7 +209,7 @@
       (nil? audit-db)
       (u/prog1 ::installed
        (log/info "Installing Audit DB...")
-       (install-database! mdb.env/db-type))
+       (install-database! mdb.env/db-type perms/audit-db-id))
 
       (not= mdb.env/db-type (:engine audit-db))
       (u/prog1 ::updated


### PR DESCRIPTION
This was a bit of cruft left I meant to clean up in a refactor but missed.

The idea _was_ that there might be over thirteen million databases in the customer's app db. That's not a thing that is going to happen though.

So there is no need to handle that case.