### PR TITLE
[MLv2] Filters — Re-use values when switching filter operators

### DIFF
--- a/frontend/src/metabase/common/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { t } from "ttag";
+import _ from "underscore";
 import { Icon } from "metabase/core/components/Icon";
 import { Button, Divider, Group, Radio, Stack } from "metabase/ui";
 import * as Lib from "metabase-lib";
@@ -25,7 +26,13 @@ export function BooleanFilterPicker({
   );
 
   const options = useMemo(
-    () => getAvailableOperatorOptions(query, stageIndex, column, OPTIONS),
+    () =>
+      getAvailableOperatorOptions(
+        query,
+        stageIndex,
+        column,
+        _.indexBy(OPTIONS, "operator"),
+      ),
     [query, stageIndex, column],
   );
 

--- a/frontend/src/metabase/common/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState } from "react";
 import { t } from "ttag";
-import _ from "underscore";
 import { Icon } from "metabase/core/components/Icon";
 import { Button, Divider, Group, Radio, Stack } from "metabase/ui";
 import * as Lib from "metabase-lib";
@@ -26,13 +25,7 @@ export function BooleanFilterPicker({
   );
 
   const options = useMemo(
-    () =>
-      getAvailableOperatorOptions(
-        query,
-        stageIndex,
-        column,
-        _.indexBy(OPTIONS, "operator"),
-      ),
+    () => getAvailableOperatorOptions(query, stageIndex, column, OPTIONS),
     [query, stageIndex, column],
   );
 
@@ -40,8 +33,8 @@ export function BooleanFilterPicker({
     getOptionType(query, stageIndex, filter),
   );
 
-  const [isExpanded, setIsExpanded] = useState(() =>
-    options.some(option => option.type === optionType && option.isAdvanced),
+  const [isExpanded, setIsExpanded] = useState(
+    () => OPTIONS[optionType].isAdvanced,
   );
 
   const visibleOptions = useMemo(() => {

--- a/frontend/src/metabase/common/components/FilterPicker/BooleanFilterPicker/constants.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/BooleanFilterPicker/constants.ts
@@ -1,27 +1,27 @@
 import { t } from "ttag";
-import type { Option } from "./types";
+import type { Option, OptionType } from "./types";
 
-export const OPTIONS: Option[] = [
-  {
+export const OPTIONS: Record<OptionType, Option> = {
+  true: {
     name: t`True`,
     operator: "=",
     type: "true",
   },
-  {
+  false: {
     name: t`False`,
     operator: "=",
     type: "false",
   },
-  {
+  "is-null": {
     name: t`Empty`,
-    type: "is-null",
     operator: "is-null",
+    type: "is-null",
     isAdvanced: true,
   },
-  {
+  "not-null": {
     name: t`Not empty`,
-    type: "not-null",
     operator: "not-null",
+    type: "not-null",
     isAdvanced: true,
   },
-];
+};

--- a/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
@@ -13,7 +13,7 @@ import { Footer } from "../Footer";
 import { FlexWithScroll } from "../FilterPicker.styled";
 import { FilterOperatorPicker } from "../FilterOperatorPicker";
 
-import { OPERATOR_OPTIONS } from "./constants";
+import { OPERATOR_OPTIONS, OPERATOR_OPTIONS_MAP } from "./constants";
 import { findSecondColumn, isFilterValid } from "./utils";
 import { CoordinateColumnSelect } from "./CoordinateColumnSelect";
 
@@ -45,12 +45,7 @@ export function CoordinateFilterPicker({
     findSecondColumn({ query, stageIndex, column, filter, operatorName }),
   );
 
-  const valueCount = useMemo(() => {
-    const option = availableOperators.find(
-      option => option.operator === operatorName,
-    );
-    return option?.valueCount ?? 0;
-  }, [availableOperators, operatorName]);
+  const { valueCount = 0 } = OPERATOR_OPTIONS_MAP[operatorName] ?? {};
 
   const isValid = useMemo(
     () => isFilterValid(operatorName, values),
@@ -58,17 +53,23 @@ export function CoordinateFilterPicker({
   );
 
   const handleOperatorChange = (
-    newOperatorName: Lib.CoordinateFilterOperatorName,
+    nextOperatorName: Lib.CoordinateFilterOperatorName,
   ) => {
-    setOperatorName(newOperatorName);
-    setValues([]);
+    const nextOption = OPERATOR_OPTIONS_MAP[nextOperatorName];
+    const nextValues =
+      nextOperatorName === "inside"
+        ? []
+        : values.slice(0, nextOption.valueCount);
+
+    setOperatorName(nextOperatorName);
+    setValues(nextValues);
     setColumn2(
       findSecondColumn({
         query,
         stageIndex,
         column,
         filter,
-        operatorName: newOperatorName,
+        operatorName: nextOperatorName,
       }),
     );
   };

--- a/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
@@ -13,7 +13,7 @@ import { Footer } from "../Footer";
 import { FlexWithScroll } from "../FilterPicker.styled";
 import { FilterOperatorPicker } from "../FilterOperatorPicker";
 
-import { OPERATOR_OPTIONS, OPERATOR_OPTIONS_MAP } from "./constants";
+import { OPERATOR_OPTIONS } from "./constants";
 import { findSecondColumn, isFilterValid } from "./utils";
 import { CoordinateColumnSelect } from "./CoordinateColumnSelect";
 
@@ -45,7 +45,7 @@ export function CoordinateFilterPicker({
     findSecondColumn({ query, stageIndex, column, filter, operatorName }),
   );
 
-  const { valueCount = 0 } = OPERATOR_OPTIONS_MAP[operatorName] ?? {};
+  const { valueCount = 0 } = OPERATOR_OPTIONS[operatorName] ?? {};
 
   const isValid = useMemo(
     () => isFilterValid(operatorName, values),
@@ -55,7 +55,7 @@ export function CoordinateFilterPicker({
   const handleOperatorChange = (
     nextOperatorName: Lib.CoordinateFilterOperatorName,
   ) => {
-    const nextOption = OPERATOR_OPTIONS_MAP[nextOperatorName];
+    const nextOption = OPERATOR_OPTIONS[nextOperatorName];
     const nextValues =
       nextOperatorName === "inside"
         ? []

--- a/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.unit.spec.tsx
@@ -1,0 +1,128 @@
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders, screen } from "__support__/ui";
+import { createMockEntitiesState } from "__support__/store";
+import { getMetadata } from "metabase/selectors/metadata";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+import { createMockState } from "metabase-types/store/mocks";
+import * as Lib from "metabase-lib";
+import { createQuery, columnFinder } from "metabase-lib/test-helpers";
+import { CoordinateFilterPicker } from "./CoordinateFilterPicker";
+
+const storeInitialState = createMockState({
+  entities: createMockEntitiesState({
+    databases: [createSampleDatabase()],
+  }),
+});
+
+const metadata = getMetadata(storeInitialState);
+
+function findLatitudeColumn(query: Lib.Query) {
+  const columns = Lib.filterableColumns(query, 0);
+  const findColumn = columnFinder(query, columns);
+  return findColumn("PEOPLE", "LATITUDE");
+}
+
+function createFilteredQuery({
+  operator = "=",
+  values = [0],
+  ...rest
+}: Partial<Lib.CoordinateFilterParts> = {}) {
+  const initialQuery = createQuery({ metadata });
+  const column = findLatitudeColumn(initialQuery);
+
+  const clause = Lib.coordinateFilterClause({
+    operator,
+    column,
+    values,
+    ...rest,
+  });
+  const query = Lib.filter(initialQuery, 0, clause);
+  const [filter] = Lib.filters(query, 0);
+
+  return { query, column, filter };
+}
+
+type SetupOpts = {
+  query?: Lib.Query;
+  column?: Lib.ColumnMetadata;
+  filter?: Lib.FilterClause;
+};
+
+function setup({
+  query = createQuery({ metadata }),
+  column = findLatitudeColumn(query),
+  filter,
+}: SetupOpts = {}) {
+  const onChange = jest.fn();
+  const onBack = jest.fn();
+
+  renderWithProviders(
+    <CoordinateFilterPicker
+      query={query}
+      stageIndex={0}
+      column={column}
+      filter={filter}
+      isNew={!filter}
+      onChange={onChange}
+      onBack={onBack}
+    />,
+    { storeInitialState },
+  );
+
+  function getNextFilterParts() {
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
+    const [filter] = lastCall;
+    return Lib.numberFilterParts(query, 0, filter);
+  }
+
+  return { query, column, getNextFilterParts, onChange, onBack };
+}
+
+async function setOperator(operator: string) {
+  userEvent.click(screen.getByLabelText("Filter operator"));
+  userEvent.click(await screen.findByText(operator));
+}
+
+describe("CoordinateFilterPicker", () => {
+  describe("existing filter", () => {
+    it("should re-use values when changing an operator", async () => {
+      setup(createFilteredQuery({ operator: "=", values: [-100, 200] }));
+      const updateButton = screen.getByRole("button", {
+        name: "Update filter",
+      });
+
+      expect(screen.getByText("100.00000000° S")).toBeInTheDocument();
+      expect(screen.getByText("200.00000000° N")).toBeInTheDocument();
+
+      await setOperator("Is not");
+
+      expect(screen.getByText("100.00000000° S")).toBeInTheDocument();
+      expect(screen.getByText("200.00000000° N")).toBeInTheDocument();
+      expect(updateButton).toBeEnabled();
+
+      await setOperator("Between");
+
+      expect(screen.getByDisplayValue("-100")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("200")).toBeInTheDocument();
+      expect(screen.queryByText("100.00000000° S")).not.toBeInTheDocument();
+      expect(screen.queryByText("200.00000000° N")).not.toBeInTheDocument();
+      expect(updateButton).toBeEnabled();
+
+      await setOperator("Greater than");
+
+      expect(screen.getByDisplayValue("-100")).toBeInTheDocument();
+      expect(screen.queryByDisplayValue("200")).not.toBeInTheDocument();
+      expect(screen.queryByText("100.00000000° S")).not.toBeInTheDocument();
+      expect(screen.queryByText("200.00000000° N")).not.toBeInTheDocument();
+      expect(updateButton).toBeEnabled();
+
+      await setOperator("Inside");
+
+      expect(screen.queryByDisplayValue("-100")).not.toBeInTheDocument();
+      expect(screen.queryByDisplayValue("200")).not.toBeInTheDocument();
+      expect(screen.queryByText("100.00000000° S")).not.toBeInTheDocument();
+      expect(screen.queryByText("200.00000000° N")).not.toBeInTheDocument();
+      expect(updateButton).toBeDisabled();
+    });
+  });
+});

--- a/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/constants.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/constants.ts
@@ -1,3 +1,4 @@
+import _ from "underscore";
 import type { OperatorOption } from "./types";
 
 export const OPERATOR_OPTIONS: OperatorOption[] = [
@@ -34,3 +35,5 @@ export const OPERATOR_OPTIONS: OperatorOption[] = [
     valueCount: 1,
   },
 ];
+
+export const OPERATOR_OPTIONS_MAP = _.indexBy(OPERATOR_OPTIONS, "operator");

--- a/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/constants.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/constants.ts
@@ -1,39 +1,36 @@
-import _ from "underscore";
 import type { OperatorOption } from "./types";
 
-export const OPERATOR_OPTIONS: OperatorOption[] = [
-  {
+export const OPERATOR_OPTIONS: Record<string, OperatorOption> = {
+  "=": {
     operator: "=",
     valueCount: Infinity,
   },
-  {
+  "!=": {
     operator: "!=",
     valueCount: Infinity,
   },
-  {
+  inside: {
     operator: "inside",
     valueCount: 4,
   },
-  {
+  ">": {
     operator: ">",
     valueCount: 1,
   },
-  {
+  "<": {
     operator: "<",
     valueCount: 1,
   },
-  {
+  between: {
     operator: "between",
     valueCount: 2,
   },
-  {
+  ">=": {
     operator: ">=",
     valueCount: 1,
   },
-  {
+  "<=": {
     operator: "<=",
     valueCount: 1,
   },
-];
-
-export const OPERATOR_OPTIONS_MAP = _.indexBy(OPERATOR_OPTIONS, "operator");
+};

--- a/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/utils.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/utils.ts
@@ -1,6 +1,6 @@
 import * as Lib from "metabase-lib";
 import type { CoordinateFilterOperatorName } from "metabase-lib";
-import { OPERATOR_OPTIONS } from "./constants";
+import { OPERATOR_OPTIONS_MAP } from "./constants";
 
 export function findLatitudeColumns(query: Lib.Query, stageIndex: number) {
   const filterableColumns = Lib.filterableColumns(query, stageIndex);
@@ -87,9 +87,7 @@ export function isFilterValid(
   operatorName: CoordinateFilterOperatorName,
   values: number[],
 ) {
-  const option = OPERATOR_OPTIONS.find(
-    option => option.operator === operatorName,
-  );
+  const option = OPERATOR_OPTIONS_MAP[operatorName];
   if (!option) {
     return false;
   }

--- a/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/utils.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/utils.ts
@@ -1,6 +1,6 @@
 import * as Lib from "metabase-lib";
 import type { CoordinateFilterOperatorName } from "metabase-lib";
-import { OPERATOR_OPTIONS_MAP } from "./constants";
+import { OPERATOR_OPTIONS } from "./constants";
 
 export function findLatitudeColumns(query: Lib.Query, stageIndex: number) {
   const filterableColumns = Lib.filterableColumns(query, stageIndex);
@@ -87,7 +87,7 @@ export function isFilterValid(
   operatorName: CoordinateFilterOperatorName,
   values: number[],
 ) {
-  const option = OPERATOR_OPTIONS_MAP[operatorName];
+  const option = OPERATOR_OPTIONS[operatorName];
   if (!option) {
     return false;
   }

--- a/frontend/src/metabase/common/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
@@ -11,7 +11,7 @@ import { ColumnValuesWidget } from "../ColumnValuesWidget";
 import { Footer } from "../Footer";
 import { FlexWithScroll } from "../FilterPicker.styled";
 import { FilterOperatorPicker } from "../FilterOperatorPicker";
-import { OPERATOR_OPTIONS } from "./constants";
+import { OPERATOR_OPTIONS, OPERATOR_OPTIONS_MAP } from "./constants";
 import { isFilterValid } from "./utils";
 
 export function NumberFilterPicker({
@@ -40,12 +40,7 @@ export function NumberFilterPicker({
 
   const [values, setValues] = useState(filterParts?.values ?? []);
 
-  const valueCount = useMemo(() => {
-    const option = availableOperators.find(
-      option => option.operator === operatorName,
-    );
-    return option?.valueCount ?? 0;
-  }, [availableOperators, operatorName]);
+  const { valueCount = 0 } = OPERATOR_OPTIONS_MAP[operatorName] ?? {};
 
   const isValid = useMemo(
     () => isFilterValid(operatorName, values),
@@ -53,10 +48,12 @@ export function NumberFilterPicker({
   );
 
   const handleOperatorChange = (
-    newOperatorName: Lib.NumberFilterOperatorName,
+    nextOperatorName: Lib.NumberFilterOperatorName,
   ) => {
-    setOperatorName(newOperatorName);
-    setValues([]);
+    const nextOption = OPERATOR_OPTIONS_MAP[nextOperatorName];
+    const nextValues = values.slice(0, nextOption.valueCount);
+    setOperatorName(nextOperatorName);
+    setValues(nextValues);
   };
 
   const handleFilterChange = () => {

--- a/frontend/src/metabase/common/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
@@ -11,7 +11,7 @@ import { ColumnValuesWidget } from "../ColumnValuesWidget";
 import { Footer } from "../Footer";
 import { FlexWithScroll } from "../FilterPicker.styled";
 import { FilterOperatorPicker } from "../FilterOperatorPicker";
-import { OPERATOR_OPTIONS, OPERATOR_OPTIONS_MAP } from "./constants";
+import { OPERATOR_OPTIONS } from "./constants";
 import { isFilterValid } from "./utils";
 
 export function NumberFilterPicker({
@@ -40,7 +40,7 @@ export function NumberFilterPicker({
 
   const [values, setValues] = useState(filterParts?.values ?? []);
 
-  const { valueCount = 0 } = OPERATOR_OPTIONS_MAP[operatorName] ?? {};
+  const { valueCount = 0 } = OPERATOR_OPTIONS[operatorName] ?? {};
 
   const isValid = useMemo(
     () => isFilterValid(operatorName, values),
@@ -50,7 +50,7 @@ export function NumberFilterPicker({
   const handleOperatorChange = (
     nextOperatorName: Lib.NumberFilterOperatorName,
   ) => {
-    const nextOption = OPERATOR_OPTIONS_MAP[nextOperatorName];
+    const nextOption = OPERATOR_OPTIONS[nextOperatorName];
     const nextValues = values.slice(0, nextOption.valueCount);
     setOperatorName(nextOperatorName);
     setValues(nextValues);

--- a/frontend/src/metabase/common/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.unit.spec.tsx
@@ -1,0 +1,116 @@
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders, screen } from "__support__/ui";
+import { createMockEntitiesState } from "__support__/store";
+import { getMetadata } from "metabase/selectors/metadata";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+import { createMockState } from "metabase-types/store/mocks";
+import * as Lib from "metabase-lib";
+import { createQuery, columnFinder } from "metabase-lib/test-helpers";
+import { NumberFilterPicker } from "./NumberFilterPicker";
+
+const storeInitialState = createMockState({
+  entities: createMockEntitiesState({
+    databases: [createSampleDatabase()],
+  }),
+});
+
+const metadata = getMetadata(storeInitialState);
+
+function findNumericColumn(query: Lib.Query) {
+  const columns = Lib.filterableColumns(query, 0);
+  const findColumn = columnFinder(query, columns);
+  return findColumn("ORDERS", "TOTAL");
+}
+
+function createFilteredQuery({
+  operator = "=",
+  values = [0],
+}: Partial<Lib.NumberFilterParts> = {}) {
+  const initialQuery = createQuery({ metadata });
+  const column = findNumericColumn(initialQuery);
+
+  const clause = Lib.numberFilterClause({ operator, column, values });
+  const query = Lib.filter(initialQuery, 0, clause);
+  const [filter] = Lib.filters(query, 0);
+
+  return { query, column, filter };
+}
+
+type SetupOpts = {
+  query?: Lib.Query;
+  column?: Lib.ColumnMetadata;
+  filter?: Lib.FilterClause;
+};
+
+function setup({
+  query = createQuery({ metadata }),
+  column = findNumericColumn(query),
+  filter,
+}: SetupOpts = {}) {
+  const onChange = jest.fn();
+  const onBack = jest.fn();
+
+  renderWithProviders(
+    <NumberFilterPicker
+      query={query}
+      stageIndex={0}
+      column={column}
+      filter={filter}
+      isNew={!filter}
+      onChange={onChange}
+      onBack={onBack}
+    />,
+    { storeInitialState },
+  );
+
+  function getNextFilterParts() {
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
+    const [filter] = lastCall;
+    return Lib.numberFilterParts(query, 0, filter);
+  }
+
+  return { query, column, getNextFilterParts, onChange, onBack };
+}
+
+async function setOperator(operator: string) {
+  userEvent.click(screen.getByLabelText("Filter operator"));
+  userEvent.click(await screen.findByText(operator));
+}
+
+describe("NumberFilterPicker", () => {
+  describe("existing filter", () => {
+    it("should re-use values when changing an operator", async () => {
+      setup(createFilteredQuery({ operator: "=", values: [10, 20] }));
+      const updateButton = screen.getByRole("button", {
+        name: "Update filter",
+      });
+
+      expect(screen.getByText("10")).toBeInTheDocument();
+      expect(screen.getByText("20")).toBeInTheDocument();
+
+      await setOperator("Not equal to");
+
+      expect(screen.getByText("10")).toBeInTheDocument();
+      expect(screen.getByText("20")).toBeInTheDocument();
+      expect(updateButton).toBeEnabled();
+
+      await setOperator("Greater than");
+
+      expect(screen.getByDisplayValue("10")).toBeInTheDocument();
+      expect(screen.queryByText("20")).not.toBeInTheDocument();
+      expect(updateButton).toBeEnabled();
+
+      await setOperator("Is empty");
+
+      expect(screen.queryByText("10")).not.toBeInTheDocument();
+      expect(screen.queryByText("20")).not.toBeInTheDocument();
+      expect(updateButton).toBeEnabled();
+
+      await setOperator("Equal to");
+
+      expect(screen.queryByText("10")).not.toBeInTheDocument();
+      expect(screen.queryByText("20")).not.toBeInTheDocument();
+      expect(updateButton).toBeDisabled();
+    });
+  });
+});

--- a/frontend/src/metabase/common/components/FilterPicker/NumberFilterPicker/constants.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/NumberFilterPicker/constants.ts
@@ -1,3 +1,4 @@
+import _ from "underscore";
 import type { OperatorOption } from "./types";
 
 export const OPERATOR_OPTIONS: OperatorOption[] = [
@@ -38,3 +39,5 @@ export const OPERATOR_OPTIONS: OperatorOption[] = [
     valueCount: 0,
   },
 ];
+
+export const OPERATOR_OPTIONS_MAP = _.indexBy(OPERATOR_OPTIONS, "operator");

--- a/frontend/src/metabase/common/components/FilterPicker/NumberFilterPicker/constants.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/NumberFilterPicker/constants.ts
@@ -1,43 +1,40 @@
-import _ from "underscore";
 import type { OperatorOption } from "./types";
 
-export const OPERATOR_OPTIONS: OperatorOption[] = [
-  {
+export const OPERATOR_OPTIONS: Record<string, OperatorOption> = {
+  "=": {
     operator: "=",
     valueCount: Infinity,
   },
-  {
+  "!=": {
     operator: "!=",
     valueCount: Infinity,
   },
-  {
+  ">": {
     operator: ">",
     valueCount: 1,
   },
-  {
+  "<": {
     operator: "<",
     valueCount: 1,
   },
-  {
+  between: {
     operator: "between",
     valueCount: 2,
   },
-  {
+  ">=": {
     operator: ">=",
     valueCount: 1,
   },
-  {
+  "<=": {
     operator: "<=",
     valueCount: 1,
   },
-  {
+  "is-null": {
     operator: "is-null",
     valueCount: 0,
   },
-  {
+  "not-null": {
     operator: "not-null",
     valueCount: 0,
   },
-];
-
-export const OPERATOR_OPTIONS_MAP = _.indexBy(OPERATOR_OPTIONS, "operator");
+};

--- a/frontend/src/metabase/common/components/FilterPicker/NumberFilterPicker/utils.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/NumberFilterPicker/utils.ts
@@ -1,13 +1,11 @@
 import type { NumberFilterOperatorName } from "metabase-lib/types";
-import { OPERATOR_OPTIONS } from "./constants";
+import { OPERATOR_OPTIONS_MAP } from "./constants";
 
 export function isFilterValid(
   operatorName: NumberFilterOperatorName,
   values: number[],
 ) {
-  const option = OPERATOR_OPTIONS.find(
-    option => option.operator === operatorName,
-  );
+  const option = OPERATOR_OPTIONS_MAP[operatorName];
   if (!option) {
     return false;
   }

--- a/frontend/src/metabase/common/components/FilterPicker/NumberFilterPicker/utils.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/NumberFilterPicker/utils.ts
@@ -1,11 +1,11 @@
 import type { NumberFilterOperatorName } from "metabase-lib/types";
-import { OPERATOR_OPTIONS_MAP } from "./constants";
+import { OPERATOR_OPTIONS } from "./constants";
 
 export function isFilterValid(
   operatorName: NumberFilterOperatorName,
   values: number[],
 ) {
-  const option = OPERATOR_OPTIONS_MAP[operatorName];
+  const option = OPERATOR_OPTIONS[operatorName];
   if (!option) {
     return false;
   }

--- a/frontend/src/metabase/common/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -13,7 +13,7 @@ import { Footer } from "../Footer";
 import { FilterOperatorPicker } from "../FilterOperatorPicker";
 import { FlexWithScroll } from "../FilterPicker.styled";
 
-import { OPERATOR_OPTIONS } from "./constants";
+import { OPERATOR_OPTIONS, OPERATOR_OPTIONS_MAP } from "./constants";
 import { isFilterValid } from "./utils";
 
 export function StringFilterPicker({
@@ -43,12 +43,8 @@ export function StringFilterPicker({
   const [values, setValues] = useState(filterParts?.values ?? []);
   const [options, setOptions] = useState(filterParts?.options ?? {});
 
-  const { valueCount, hasCaseSensitiveOption } = useMemo(() => {
-    const option = availableOperators.find(
-      option => option.operator === operatorName,
-    );
-    return option ?? { valueCount: 0, hasCaseSensitiveOption: false };
-  }, [availableOperators, operatorName]);
+  const { valueCount = 0, hasCaseSensitiveOption = false } =
+    OPERATOR_OPTIONS_MAP[operatorName] ?? {};
 
   const isValid = useMemo(
     () => isFilterValid(operatorName, values),
@@ -56,11 +52,16 @@ export function StringFilterPicker({
   );
 
   const handleOperatorChange = (
-    newOperatorName: Lib.StringFilterOperatorName,
+    nextOperatorName: Lib.StringFilterOperatorName,
   ) => {
-    setOperatorName(newOperatorName);
-    setValues([]);
-    setOptions({});
+    const nextOption = OPERATOR_OPTIONS_MAP[nextOperatorName];
+
+    const nextValues = values.slice(0, nextOption.valueCount);
+    const nextOptions = nextOption.hasCaseSensitiveOption ? options : {};
+
+    setOperatorName(nextOperatorName);
+    setValues(nextValues);
+    setOptions(nextOptions);
   };
 
   const handleFilterChange = () => {

--- a/frontend/src/metabase/common/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -13,7 +13,7 @@ import { Footer } from "../Footer";
 import { FilterOperatorPicker } from "../FilterOperatorPicker";
 import { FlexWithScroll } from "../FilterPicker.styled";
 
-import { OPERATOR_OPTIONS, OPERATOR_OPTIONS_MAP } from "./constants";
+import { OPERATOR_OPTIONS } from "./constants";
 import { isFilterValid } from "./utils";
 
 export function StringFilterPicker({
@@ -44,7 +44,7 @@ export function StringFilterPicker({
   const [options, setOptions] = useState(filterParts?.options ?? {});
 
   const { valueCount = 0, hasCaseSensitiveOption = false } =
-    OPERATOR_OPTIONS_MAP[operatorName] ?? {};
+    OPERATOR_OPTIONS[operatorName] ?? {};
 
   const isValid = useMemo(
     () => isFilterValid(operatorName, values),
@@ -54,7 +54,7 @@ export function StringFilterPicker({
   const handleOperatorChange = (
     nextOperatorName: Lib.StringFilterOperatorName,
   ) => {
-    const nextOption = OPERATOR_OPTIONS_MAP[nextOperatorName];
+    const nextOption = OPERATOR_OPTIONS[nextOperatorName] ?? {};
 
     const nextValues = values.slice(0, nextOption.valueCount);
     const nextOptions = nextOption.hasCaseSensitiveOption ? options : {};

--- a/frontend/src/metabase/common/components/FilterPicker/StringFilterPicker/StringFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/StringFilterPicker/StringFilterPicker.unit.spec.tsx
@@ -1,0 +1,159 @@
+import userEvent from "@testing-library/user-event";
+import {
+  renderWithProviders,
+  screen,
+  waitForLoaderToBeRemoved,
+} from "__support__/ui";
+import { setupFieldsValuesEndpoints } from "__support__/server-mocks";
+import { createMockEntitiesState } from "__support__/store";
+import { getMetadata } from "metabase/selectors/metadata";
+import {
+  createSampleDatabase,
+  PRODUCT_CATEGORY_VALUES,
+} from "metabase-types/api/mocks/presets";
+import { createMockState } from "metabase-types/store/mocks";
+import * as Lib from "metabase-lib";
+import { createQuery, columnFinder } from "metabase-lib/test-helpers";
+import { StringFilterPicker } from "./StringFilterPicker";
+
+const storeInitialState = createMockState({
+  entities: createMockEntitiesState({
+    databases: [createSampleDatabase()],
+  }),
+});
+
+const metadata = getMetadata(storeInitialState);
+
+function findStringColumn(query: Lib.Query) {
+  const columns = Lib.filterableColumns(query, 0);
+  const findColumn = columnFinder(query, columns);
+  return findColumn("PRODUCTS", "CATEGORY");
+}
+
+function createFilteredQuery({
+  operator = "=",
+  values = ["Gadget", "Gizmo"],
+}: Partial<Lib.StringFilterParts> = {}) {
+  const initialQuery = createQuery({ metadata });
+  const column = findStringColumn(initialQuery);
+
+  const clause = Lib.stringFilterClause({
+    operator,
+    column,
+    values,
+    options: {},
+  });
+
+  const query = Lib.filter(initialQuery, 0, clause);
+  const [filter] = Lib.filters(query, 0);
+
+  return { query, column, filter };
+}
+
+type SetupOpts = {
+  query?: Lib.Query;
+  column?: Lib.ColumnMetadata;
+  filter?: Lib.FilterClause;
+};
+
+function setup({
+  query = createQuery({ metadata }),
+  column = findStringColumn(query),
+  filter,
+}: SetupOpts = {}) {
+  const onChange = jest.fn();
+  const onBack = jest.fn();
+
+  setupFieldsValuesEndpoints([PRODUCT_CATEGORY_VALUES]);
+
+  renderWithProviders(
+    <StringFilterPicker
+      query={query}
+      stageIndex={0}
+      column={column}
+      filter={filter}
+      isNew={!filter}
+      onChange={onChange}
+      onBack={onBack}
+    />,
+    { storeInitialState },
+  );
+
+  function getNextFilterParts() {
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
+    const [filter] = lastCall;
+    return Lib.stringFilterParts(query, 0, filter);
+  }
+
+  return { query, column, getNextFilterParts, onChange, onBack };
+}
+
+async function setOperator(operator: string) {
+  userEvent.click(screen.getByLabelText("Filter operator"));
+  userEvent.click(await screen.findByText(operator));
+}
+
+describe("StringFilterPicker", () => {
+  describe("new filter", () => {
+    it("should handle options when changing an operator", async () => {
+      setup();
+      await waitForLoaderToBeRemoved();
+
+      await setOperator("Contains");
+      expect(screen.getByLabelText("Case sensitive")).not.toBeChecked();
+
+      await setOperator("Does not contain");
+      expect(screen.getByLabelText("Case sensitive")).not.toBeChecked();
+
+      userEvent.click(screen.getByLabelText("Case sensitive"));
+      await setOperator("Starts with");
+      expect(screen.getByLabelText("Case sensitive")).toBeChecked();
+
+      await setOperator("Ends with");
+      expect(screen.getByLabelText("Case sensitive")).toBeChecked();
+
+      await setOperator("Is empty");
+      await setOperator("Contains");
+      expect(screen.getByLabelText("Case sensitive")).not.toBeChecked();
+    });
+  });
+
+  describe("existing filter", () => {
+    it("should re-use values when changing an operator", async () => {
+      setup(
+        createFilteredQuery({ operator: "=", values: ["Gadget", "Gizmo"] }),
+      );
+      await waitForLoaderToBeRemoved();
+      const updateButton = screen.getByRole("button", {
+        name: "Update filter",
+      });
+
+      expect(screen.getByLabelText("Gadget")).toBeChecked();
+      expect(screen.getByLabelText("Gizmo")).toBeChecked();
+
+      await setOperator("Is not");
+
+      expect(screen.getByLabelText("Gadget")).toBeChecked();
+      expect(screen.getByLabelText("Gizmo")).toBeChecked();
+      expect(updateButton).toBeEnabled();
+
+      await setOperator("Contains");
+
+      expect(screen.getByDisplayValue("Gadget")).toBeInTheDocument();
+      expect(screen.queryByDisplayValue("Gizmo")).not.toBeInTheDocument();
+      expect(updateButton).toBeEnabled();
+
+      await setOperator("Is empty");
+
+      expect(screen.queryByText("Gadget")).not.toBeInTheDocument();
+      expect(screen.queryByText("Gizmo")).not.toBeInTheDocument();
+      expect(updateButton).toBeEnabled();
+
+      await setOperator("Is");
+
+      expect(await screen.findByLabelText("Gadget")).not.toBeChecked();
+      expect(screen.getByLabelText("Gizmo")).not.toBeChecked();
+      expect(updateButton).toBeDisabled();
+    });
+  });
+});

--- a/frontend/src/metabase/common/components/FilterPicker/StringFilterPicker/constants.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/StringFilterPicker/constants.ts
@@ -1,3 +1,4 @@
+import _ from "underscore";
 import type { OperatorOption } from "./types";
 
 export const OPERATOR_OPTIONS: OperatorOption[] = [
@@ -38,3 +39,5 @@ export const OPERATOR_OPTIONS: OperatorOption[] = [
     valueCount: 0,
   },
 ];
+
+export const OPERATOR_OPTIONS_MAP = _.indexBy(OPERATOR_OPTIONS, "operator");

--- a/frontend/src/metabase/common/components/FilterPicker/StringFilterPicker/constants.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/StringFilterPicker/constants.ts
@@ -1,43 +1,40 @@
-import _ from "underscore";
 import type { OperatorOption } from "./types";
 
-export const OPERATOR_OPTIONS: OperatorOption[] = [
-  {
+export const OPERATOR_OPTIONS: Record<string, OperatorOption> = {
+  "=": {
     operator: "=",
     valueCount: Infinity,
   },
-  {
+  "!=": {
     operator: "!=",
     valueCount: Infinity,
   },
-  {
+  contains: {
     operator: "contains",
     valueCount: 1,
     hasCaseSensitiveOption: true,
   },
-  {
+  "does-not-contain": {
     operator: "does-not-contain",
     valueCount: 1,
     hasCaseSensitiveOption: true,
   },
-  {
+  "starts-with": {
     operator: "starts-with",
     valueCount: 1,
     hasCaseSensitiveOption: true,
   },
-  {
+  "ends-with": {
     operator: "ends-with",
     valueCount: 1,
     hasCaseSensitiveOption: true,
   },
-  {
+  "is-empty": {
     operator: "is-empty",
     valueCount: 0,
   },
-  {
+  "not-empty": {
     operator: "not-empty",
     valueCount: 0,
   },
-];
-
-export const OPERATOR_OPTIONS_MAP = _.indexBy(OPERATOR_OPTIONS, "operator");
+};

--- a/frontend/src/metabase/common/components/FilterPicker/StringFilterPicker/utils.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/StringFilterPicker/utils.ts
@@ -1,13 +1,11 @@
 import type { StringFilterOperatorName } from "metabase-lib/types";
-import { OPERATOR_OPTIONS } from "./constants";
+import { OPERATOR_OPTIONS_MAP } from "./constants";
 
 export function isFilterValid(
   operatorName: StringFilterOperatorName,
   values: string[],
 ) {
-  const option = OPERATOR_OPTIONS.find(
-    option => option.operator === operatorName,
-  );
+  const option = OPERATOR_OPTIONS_MAP[operatorName];
   if (!option) {
     return false;
   }

--- a/frontend/src/metabase/common/components/FilterPicker/StringFilterPicker/utils.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/StringFilterPicker/utils.ts
@@ -1,11 +1,11 @@
 import type { StringFilterOperatorName } from "metabase-lib/types";
-import { OPERATOR_OPTIONS_MAP } from "./constants";
+import { OPERATOR_OPTIONS } from "./constants";
 
 export function isFilterValid(
   operatorName: StringFilterOperatorName,
   values: string[],
 ) {
-  const option = OPERATOR_OPTIONS_MAP[operatorName];
+  const option = OPERATOR_OPTIONS[operatorName];
   if (!option) {
     return false;
   }

--- a/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
@@ -12,7 +12,7 @@ import { Header } from "../Header";
 import { Footer } from "../Footer";
 import { FilterOperatorPicker } from "../FilterOperatorPicker";
 
-import { OPERATOR_OPTIONS, OPERATOR_OPTIONS_MAP } from "./constants";
+import { OPERATOR_OPTIONS } from "./constants";
 import {
   getDefaultValue,
   getDefaultValuesForOperator,
@@ -49,7 +49,7 @@ export function TimeFilterPicker({
     filterParts?.values ?? getDefaultValuesForOperator(operatorName),
   );
 
-  const { valueCount = 0 } = OPERATOR_OPTIONS_MAP[operatorName] ?? {};
+  const { valueCount = 0 } = OPERATOR_OPTIONS[operatorName] ?? {};
 
   const isValid = useMemo(
     () => isFilterValid(operatorName, values),
@@ -59,7 +59,7 @@ export function TimeFilterPicker({
   const handleOperatorChange = (
     nextOperatorName: Lib.TimeFilterOperatorName,
   ) => {
-    const nextOption = OPERATOR_OPTIONS_MAP[nextOperatorName];
+    const nextOption = OPERATOR_OPTIONS[nextOperatorName];
     const nextValues = getNextValues(values, nextOption.valueCount);
     setOperatorName(nextOperatorName);
     setValues(nextValues);

--- a/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
@@ -12,10 +12,11 @@ import { Header } from "../Header";
 import { Footer } from "../Footer";
 import { FilterOperatorPicker } from "../FilterOperatorPicker";
 
-import { OPERATOR_OPTIONS } from "./constants";
+import { OPERATOR_OPTIONS, OPERATOR_OPTIONS_MAP } from "./constants";
 import {
   getDefaultValue,
   getDefaultValuesForOperator,
+  getNextValues,
   isFilterValid,
 } from "./utils";
 
@@ -48,12 +49,7 @@ export function TimeFilterPicker({
     filterParts?.values ?? getDefaultValuesForOperator(operatorName),
   );
 
-  const valueCount = useMemo(() => {
-    const option = availableOperators.find(
-      option => option.operator === operatorName,
-    );
-    return option?.valueCount ?? 0;
-  }, [availableOperators, operatorName]);
+  const { valueCount = 0 } = OPERATOR_OPTIONS_MAP[operatorName] ?? {};
 
   const isValid = useMemo(
     () => isFilterValid(operatorName, values),
@@ -61,10 +57,12 @@ export function TimeFilterPicker({
   );
 
   const handleOperatorChange = (
-    newOperatorName: Lib.TimeFilterOperatorName,
+    nextOperatorName: Lib.TimeFilterOperatorName,
   ) => {
-    setOperatorName(newOperatorName);
-    setValues(getDefaultValuesForOperator(newOperatorName));
+    const nextOption = OPERATOR_OPTIONS_MAP[nextOperatorName];
+    const nextValues = getNextValues(values, nextOption.valueCount);
+    setOperatorName(nextOperatorName);
+    setValues(nextValues);
   };
 
   const handleFilterChange = () => {

--- a/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
@@ -113,6 +113,11 @@ function setup({
   return { query, column, getNextFilterParts, onChange, onBack };
 }
 
+async function setOperator(operator: string) {
+  userEvent.click(screen.getByLabelText("Filter operator"));
+  userEvent.click(await screen.findByText(operator));
+}
+
 describe("TimeFilterPicker", () => {
   describe("new filter", () => {
     it("should render a blank editor", () => {
@@ -329,13 +334,49 @@ describe("TimeFilterPicker", () => {
       });
       const { getNextFilterParts } = setup(opts);
 
-      userEvent.click(screen.getByDisplayValue("Before"));
-      userEvent.click(await screen.findByText("After"));
+      await setOperator("After");
       userEvent.click(screen.getByText("Update filter"));
 
       const filterParts = getNextFilterParts();
       expect(filterParts?.operator).toBe(">");
-      expect(filterParts?.values).toEqual([getDefaultValue()]);
+      expect(filterParts?.values).toEqual([dayjs("11:15", "HH:mm").toDate()]);
+    });
+
+    it("should re-use values when changing an operator", async () => {
+      setup(
+        createFilteredQuery({
+          operator: "between",
+          values: [
+            dayjs("11:15", "HH:mm").toDate(),
+            dayjs("12:30", "HH:mm").toDate(),
+          ],
+        }),
+      );
+      const updateButton = screen.getByRole("button", {
+        name: "Update filter",
+      });
+
+      expect(screen.getByDisplayValue("11:15")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("12:30")).toBeInTheDocument();
+
+      await setOperator("Before");
+
+      expect(screen.getByDisplayValue("11:15")).toBeInTheDocument();
+      expect(screen.queryByDisplayValue("12:30")).not.toBeInTheDocument();
+      expect(updateButton).toBeEnabled();
+
+      await setOperator("Is empty");
+
+      expect(screen.queryByDisplayValue("11:15")).not.toBeInTheDocument();
+      expect(screen.queryByDisplayValue("12:30")).not.toBeInTheDocument();
+      expect(updateButton).toBeEnabled();
+
+      await setOperator("After");
+
+      expect(screen.getByDisplayValue("00:00")).toBeInTheDocument();
+      expect(screen.queryByDisplayValue("11:15")).not.toBeInTheDocument();
+      expect(screen.queryByDisplayValue("12:30")).not.toBeInTheDocument();
+      expect(updateButton).toBeEnabled();
     });
 
     it("should handle invalid filter value", () => {

--- a/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/constants.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/constants.ts
@@ -1,27 +1,24 @@
-import _ from "underscore";
 import type { OperatorOption } from "./types";
 
-export const OPERATOR_OPTIONS: OperatorOption[] = [
-  {
+export const OPERATOR_OPTIONS: Record<string, OperatorOption> = {
+  "<": {
     operator: "<",
     valueCount: 1,
   },
-  {
+  ">": {
     operator: ">",
     valueCount: 1,
   },
-  {
+  between: {
     operator: "between",
     valueCount: 2,
   },
-  {
+  "is-null": {
     operator: "is-null",
     valueCount: 0,
   },
-  {
+  "not-null": {
     operator: "not-null",
     valueCount: 0,
   },
-];
-
-export const OPERATOR_OPTIONS_MAP = _.indexBy(OPERATOR_OPTIONS, "operator");
+};

--- a/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/constants.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/constants.ts
@@ -1,3 +1,4 @@
+import _ from "underscore";
 import type { OperatorOption } from "./types";
 
 export const OPERATOR_OPTIONS: OperatorOption[] = [
@@ -22,3 +23,5 @@ export const OPERATOR_OPTIONS: OperatorOption[] = [
     valueCount: 0,
   },
 ];
+
+export const OPERATOR_OPTIONS_MAP = _.indexBy(OPERATOR_OPTIONS, "operator");

--- a/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/utils.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/utils.ts
@@ -1,6 +1,6 @@
 import dayjs from "dayjs";
 import type { TimeFilterOperatorName } from "metabase-lib";
-import { OPERATOR_OPTIONS_MAP } from "./constants";
+import { OPERATOR_OPTIONS } from "./constants";
 
 export function getDefaultValue() {
   return dayjs().startOf("day").toDate(); // 00:00:00
@@ -9,7 +9,7 @@ export function getDefaultValue() {
 export function getDefaultValuesForOperator(
   operatorName: TimeFilterOperatorName,
 ): Date[] {
-  const option = OPERATOR_OPTIONS_MAP[operatorName];
+  const option = OPERATOR_OPTIONS[operatorName];
   const valueCount = option?.valueCount ?? 0;
   return Array(valueCount)
     .fill(null)
@@ -28,7 +28,7 @@ export function isFilterValid(
   operatorName: TimeFilterOperatorName,
   values: (Date | null)[],
 ) {
-  const option = OPERATOR_OPTIONS_MAP[operatorName];
+  const option = OPERATOR_OPTIONS[operatorName];
   if (!option) {
     return false;
   }

--- a/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/utils.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/utils.ts
@@ -1,6 +1,6 @@
 import dayjs from "dayjs";
 import type { TimeFilterOperatorName } from "metabase-lib";
-import { OPERATOR_OPTIONS } from "./constants";
+import { OPERATOR_OPTIONS_MAP } from "./constants";
 
 export function getDefaultValue() {
   return dayjs().startOf("day").toDate(); // 00:00:00
@@ -9,24 +9,26 @@ export function getDefaultValue() {
 export function getDefaultValuesForOperator(
   operatorName: TimeFilterOperatorName,
 ): Date[] {
-  const option = OPERATOR_OPTIONS.find(
-    option => option.operator === operatorName,
-  );
-  if (!option) {
-    return [];
-  }
-  return Array(option.valueCount)
+  const option = OPERATOR_OPTIONS_MAP[operatorName];
+  const valueCount = option?.valueCount ?? 0;
+  return Array(valueCount)
     .fill(null)
     .map(() => getDefaultValue());
+}
+
+export function getNextValues(values: Date[], valueCount: number): Date[] {
+  const nextValues = values.slice(0, valueCount);
+  while (nextValues.length < valueCount) {
+    nextValues.push(getDefaultValue());
+  }
+  return nextValues;
 }
 
 export function isFilterValid(
   operatorName: TimeFilterOperatorName,
   values: (Date | null)[],
 ) {
-  const option = OPERATOR_OPTIONS.find(
-    option => option.operator === operatorName,
-  );
+  const option = OPERATOR_OPTIONS_MAP[operatorName];
   if (!option) {
     return false;
   }

--- a/frontend/src/metabase/common/components/FilterPicker/utils.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/utils.ts
@@ -8,7 +8,7 @@ export function getAvailableOperatorOptions<
   query: Lib.Query,
   stageIndex: number,
   column: Lib.ColumnMetadata,
-  pickerOptions: T[],
+  pickerOptions: Record<string, T>,
 ) {
   const columnOperatorInfos = Lib.filterableColumnOperators(column).map(
     operator => Lib.displayInfo(query, stageIndex, operator),
@@ -17,7 +17,7 @@ export function getAvailableOperatorOptions<
   const columnOperatorsByName = _.indexBy(columnOperatorInfos, "shortName");
   const columnOperatorNames = Object.keys(columnOperatorsByName);
 
-  const supportedPickerOptions = pickerOptions.filter(option =>
+  const supportedPickerOptions = Object.values(pickerOptions).filter(option =>
     columnOperatorNames.includes(option.operator),
   );
 


### PR DESCRIPTION
Fixes #34959

We used to wipe the filter pickers' `values` state when changing an operator. An input component would receive an `undefined` value, become uncontrolled, and enter an unexpected UI state (input shows the previous value, but the "Update filter" button is disabled).

The PR updates filter picker components, so they do their best to re-use `values` when an operator changes. Also, it updates the filter picker's `constants/OPERATOR_OPTION` to be a map instead of an array. I think the map turned out to be a handier format for everything except the `BooleanFilterPicker`.

### To Verify

1. New > Question > Raw Data > Sample Database > Orders
2. Add a filter for a numeric column, e.g. Subtotal > 10
3. Change the operator to something like "Equals to"
4. Ensure the value 10 is re-used, and you can still update the filter
5. Repeat for a string, time, and coordinate columns with different operators

### Demo

https://github.com/metabase/metabase/assets/17258145/3f948ec9-bf72-4cbb-920e-2d253e135ac8
