### PR TITLE
Bump ring-jetty9-adapter to 0.22.3

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -68,7 +68,7 @@
   honeysql/honeysql                         {:mvn/version "1.0.461"             ; Transform Clojure data structures to SQL
                                              :exclusions  [org.clojure/clojurescript]}
   inflections/inflections                   {:mvn/version "0.14.1"}             ; Clojure/Script library used for prularizing words
-  info.sunng/ring-jetty9-adapter            {:mvn/version "0.22.1"}             ; Drop-in replacement for official Ring Jetty adapter. Supports Jetty 11 webserver.
+  info.sunng/ring-jetty9-adapter            {:mvn/version "0.22.3"}             ; Drop-in replacement for official Ring Jetty adapter. Supports Jetty 11 webserver.
   instaparse/instaparse                     {:mvn/version "1.4.12"}             ; Make your own parser
   clj-commons/clj-yaml                      {:mvn/version "1.0.27"}             ; Clojure wrapper for YAML library SnakeYAML
   io.github.camsaul/toucan2                 {:mvn/version "1.0.524"}


### PR DESCRIPTION
fixes https://github.com/metabase/metabase/issues/35165

```diff
-  info.sunng/ring-jetty9-adapter            {:mvn/version "0.22.1"}             ; Drop-in replacement for official Ring Jetty adapter. Supports Jetty 11 webserver.
+  info.sunng/ring-jetty9-adapter            {:mvn/version "0.22.3"}             ; Drop-in replacement for official Ring Jetty adapter. Supports Jetty 11 webserver.
```

Simple change, and quite possibly a no-op.

We have previously been overriding the jetty dep to be

```clojure
org.eclipse.jetty/jetty-server            {:mvn/version "11.0.17"}
```

And the dep tree before this change was:

```
info.sunng/ring-jetty9-adapter 0.22.1
  X ring/ring-core 1.10.0 :use-top
  X org.eclipse.jetty/jetty-server 11.0.15 :use-top
```

This is saying it declared a dep on 11.0.15 but was ignoring that in favor of "use-top", aka the top level dependency we declared (11.0.17).

But synk is a scanning tool that doesn't check the artifact but the manifests involved and flags issues in 11.0.15 and therefore Metabase despite us not having that version.

Now the deps tree:

```
clj -X:deps tree :aliases '[:ee :drivers]'
info.sunng/ring-jetty9-adapter 0.22.3
  X org.eclipse.jetty/jetty-server 11.0.17 :use-top
```

Doesn't specify an older version of jetty and we're using the same jetty version as we have for the last bit.