### PR TITLE
Release Slack Messages

### DIFF
--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -192,3 +192,25 @@ jobs:
           ./metabase.jar
           ./COMMIT-ID
           ./SHA256.sum
+
+  trigger-tests:
+    needs: [build-uberjar-for-release]
+    permissions:
+      actions: write
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - name: trigger pre-release testing
+        uses: actions/github-script@v6
+        with:
+          script: | # js
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'pre-release.yml',
+              ref: '${{ github.ref }}',
+              inputs: {
+                commit: '${{ inputs.commit }}',
+                version: '${{ inputs.version }}',
+              }
+            });

--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -13,6 +13,34 @@ on:
         required: true
 
 jobs:
+  start-message:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          sparse-checkout: release
+      - name: Prepare build scripts
+        run: cd ${{ github.workspace }}/release && yarn && yarn build
+      - name: Send build start message
+        uses: actions/github-script@v6
+        env:
+          SLACK_RELEASE_CHANNEL: ${{ vars.SLACK_RELEASE_CHANNEL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          script: | # js
+            const { sendReleaseMessage } = require('${{ github.workspace }}/release/dist/index.cjs');
+
+            await sendReleaseMessage({
+              stage: 'build-start',
+              github,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              version: '${{ inputs.version }}',
+              runId: '${{ github.run_id }}',
+              releaseSha: '${{ inputs.commit }}',
+            }).catch(console.error);
+
   check-version:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
@@ -192,6 +220,35 @@ jobs:
           ./metabase.jar
           ./COMMIT-ID
           ./SHA256.sum
+
+  done-message:
+    needs: [build-uberjar-for-release]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          sparse-checkout: release
+      - name: Prepare build scripts
+        run: cd ${{ github.workspace }}/release && yarn && yarn build
+      - name: Send build done message
+        uses: actions/github-script@v6
+        env:
+          SLACK_RELEASE_CHANNEL: ${{ vars.SLACK_RELEASE_CHANNEL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          script: | # js
+            const { sendReleaseMessage } = require('${{ github.workspace }}/release/dist/index.cjs');
+
+            await sendReleaseMessage({
+              stage: 'build-done',
+              github,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              version: '${{ inputs.version }}',
+              runId: '${{ github.run_id }}',
+              releaseSha: '${{ inputs.commit }}',
+            }).catch(console.error);
 
   trigger-tests:
     needs: [build-uberjar-for-release]

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -13,6 +13,34 @@ on:
         required: true
 
 jobs:
+  send-start-message:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          sparse-checkout: release
+      - name: Prepare build scripts
+        run: cd ${{ github.workspace }}/release && yarn && yarn build
+      - name: Send build start message
+        uses: actions/github-script@v6
+        env:
+          SLACK_RELEASE_CHANNEL: ${{ vars.SLACK_RELEASE_CHANNEL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          script: | # js
+            const { sendReleaseMessage } = require('${{ github.workspace }}/release/dist/index.cjs');
+
+            await sendReleaseMessage({
+              stage: 'test-start',
+              github,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              runId: '${{ github.run_id }}',
+              version: '${{ inputs.version }}',
+              releaseSha: '${{ inputs.commit }}',
+            }).catch(console.error);
+
   release-artifact:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
@@ -280,3 +308,32 @@ jobs:
     - name: Wait for Metabase to start
       run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
       timeout-minutes: 3
+
+  done-message:
+    needs: [verify-docker-pull]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          sparse-checkout: release
+      - name: Prepare build scripts
+        run: cd ${{ github.workspace }}/release && yarn && yarn build
+      - name: Send build done message
+        uses: actions/github-script@v6
+        env:
+          SLACK_RELEASE_CHANNEL: ${{ vars.SLACK_RELEASE_CHANNEL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          script: | # js
+            const { sendReleaseMessage } = require('${{ github.workspace }}/release/dist/index.cjs');
+
+            await sendReleaseMessage({
+              stage: 'test-done',
+              github,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              runId: '${{ github.run_id }}',
+              version: '${{ inputs.version }}',
+              releaseSha: '${{ inputs.commit }}',
+            }).catch(console.error);

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,14 +1,19 @@
 name: Release 2 - Pre-release testing
-run-name: Pre-release Testing of ${{ github.event.workflow_run.name }}
+run-name: Publish Release ${{ inputs.version }}
 
 on:
-  workflow_run:
-    workflows: [Release 1 - Build Release Artifact]
-    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Metabase version (e.g. v0.46.3)'
+        type: string
+        required: true
+      commit:
+        description: 'A full-length commit SHA-1 hash'
+        required: true
 
 jobs:
   release-artifact:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     strategy:
@@ -18,36 +23,33 @@ jobs:
       ee_version: ${{ steps.version-properties.outputs.ee_version }}
       oss_version: ${{ steps.version-properties.outputs.oss_version }}
       commit: ${{ steps.version-properties.outputs.commit }}
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: 'Download artifact'
+      - name: find_release_artifact
+        id: find_release_artifact
         uses: actions/github-script@v6
         with:
-          script: |
+          result-encoding: string
+          script: | # js
             const fs = require('fs');
 
-            const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
+            const artifacts = await github.rest.actions.listArtifactsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: `metabase-${{ matrix.edition }}-${{ inputs.commit }}-uberjar`,
+              per_page: 1,
             });
 
-            const matchArtifact = allArtifacts.data.artifacts.find((artifact) => {
-              return artifact.name.includes('-${{ matrix.edition }}-');
-            });
-
-            if (!matchArtifact) {
-              throw new Error('No artifact found');
+            if (!artifacts.data?.artifacts?.[0]?.id) {
+              throw new Error(`No artifacts found for ${{ inputs.commit }}`);
             }
 
+            const artifact_id = artifacts.data.artifacts[0].id;
+
             const download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: artifact_id,
+              archive_format: 'zip',
             });
 
             fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/mb.zip`, Buffer.from(download.data));
@@ -56,14 +58,13 @@ jobs:
       - name: Extract the version.properties file from the JAR
         run: |
           jar xf metabase.jar version.properties
-          mv version.properties resources/
       - name: Reveal Metabase ${{ matrix.edition }} properties
         id: version-properties
         run: |
-          cat ./resources/version.properties
+          cat version.properties
           echo "commit=$(cat ./COMMIT-ID)" >> $GITHUB_OUTPUT
 
-          version=$(grep -o '^tag=.*' ./resources/version.properties | cut -d'=' -f2)
+          version=$(grep -o '^tag=.*' version.properties | cut -d'=' -f2)
 
           if [[ "${{ matrix.edition }}" == "ee" ]]; then
             echo "ee_version=$version" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,34 @@ on:
         required: true
 
 jobs:
+  start-message:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          sparse-checkout: release
+      - name: Prepare build scripts
+        run: cd ${{ github.workspace }}/release && yarn && yarn build
+      - name: Send publish start message
+        uses: actions/github-script@v6
+        env:
+          SLACK_RELEASE_CHANNEL: ${{ vars.SLACK_RELEASE_CHANNEL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          script: | # js
+            const { sendReleaseMessage } = require('${{ github.workspace }}/release/dist/index.cjs');
+
+            await sendReleaseMessage({
+              stage: 'publish-start',
+              github,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              version: '${{ inputs.version }}',
+              runId: '${{ github.run_id }}',
+              releaseSha: '${{ inputs.commit }}',
+            }).catch(console.error);
+
   check-version:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
@@ -604,3 +632,32 @@ jobs:
             repo: context.repo.repo,
             version,
           });
+
+  done-message:
+    needs: [manage-issues]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          sparse-checkout: release
+      - name: Prepare build scripts
+        run: cd ${{ github.workspace }}/release && yarn && yarn build
+      - name: Send publish done message
+        uses: actions/github-script@v6
+        env:
+          SLACK_RELEASE_CHANNEL: ${{ vars.SLACK_RELEASE_CHANNEL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          script: | # js
+            const { sendReleaseMessage } = require('${{ github.workspace }}/release/dist/index.cjs');
+
+            await sendReleaseMessage({
+              stage: 'publish-done',
+              github,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              version: '${{ inputs.version }}',
+              runId: '${{ github.run_id }}',
+              releaseSha: '${{ inputs.commit }}',
+            }).catch(console.error);

--- a/release/package.json
+++ b/release/package.json
@@ -16,6 +16,7 @@
   "license": "AGPL-3.0-or-later",
   "dependencies": {
     "@octokit/rest": "^20.0.1",
+    "@slack/web-api": "^6.9.0",
     "dotenv": "^16.3.1",
     "esbuild": "^0.19.2",
     "node-fetch": "^3.3.2",

--- a/release/src/github.ts
+++ b/release/src/github.ts
@@ -8,7 +8,7 @@ import {
 
 import type { ReleaseProps, Issue } from "./types";
 
-const findMilestone = async ({
+export const findMilestone = async ({
   version,
   github,
   owner,

--- a/release/src/index.ts
+++ b/release/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./github";
 export * from "./release-notes";
+export * from "./slack";
 export * from "./version-helpers";
 export * from "./version-info";

--- a/release/src/slack.ts
+++ b/release/src/slack.ts
@@ -1,0 +1,246 @@
+import { WebClient } from "@slack/web-api";
+import { getGenericVersion } from "./version-helpers";
+import { findMilestone } from "./github";
+import type { ReleaseProps } from "./types";
+
+const slack = new WebClient(process.env.SLACK_BOT_TOKEN);
+
+const SLACK_CHANNEL_NAME = process.env.SLACK_RELEASE_CHANNEL ?? "bot-testing";
+
+type BuildStage =
+  | "build-start"
+  | "build-done"
+  | "test-start"
+  | "test-done"
+  | "publish-start"
+  | "publish-done";
+
+function sendSlackMessage(message: string) {
+  return slack.chat.postMessage({
+    channel: SLACK_CHANNEL_NAME,
+    text: message,
+  });
+}
+
+async function updateSlackMessage(message: string, messageId: string) {
+  const channelId = await getSlackChannelId(SLACK_CHANNEL_NAME);
+  if (!channelId) {
+    throw new Error(`Could not find channel ${SLACK_CHANNEL_NAME}`);
+  }
+  return slack.chat.update({
+    channel: channelId,
+    text: message,
+    ts: messageId,
+  });
+}
+
+async function sendSlackReply(message: string, messageId: string) {
+  const channelId = await getSlackChannelId(SLACK_CHANNEL_NAME);
+  if (!channelId) {
+    throw new Error(`Could not find channel ${SLACK_CHANNEL_NAME}`);
+  }
+
+  return slack.chat.postMessage({
+    channel: channelId,
+    text: message,
+    thread_ts: messageId,
+  });
+}
+
+async function getSlackChannelId(channelName: string) {
+  const response = await slack.conversations.list({
+    limit: 9999,
+    exclude_archived: true,
+  });
+  return response.channels?.find((channel) => channel.name === channelName)?.id;
+}
+
+async function getExistingSlackMessage(version: string) {
+  const channelId = await getSlackChannelId(SLACK_CHANNEL_NAME);
+  if (!channelId) {
+    throw new Error(`Could not find channel ${SLACK_CHANNEL_NAME}`);
+  }
+
+  const response = await slack.conversations.history({
+    channel: channelId,
+  });
+
+  const existingMessage = response.messages?.find(
+    message => message.text?.includes(getReleaseTitle(version)),
+  );
+
+  if (!existingMessage) {
+    return null;
+  }
+
+  return {
+    id: existingMessage.ts ?? '',
+    body: existingMessage.text ?? '',
+  };
+}
+
+const getReleaseTitle = (version: string) =>
+  `:rocket: *${getGenericVersion(version)} Release* :rocket:`;
+
+function slackLink(text: string, url: string) {
+  return `<${url}|${text}>`;
+}
+
+function githubRunLink(
+  text: string,
+  runId: string,
+  owner: string,
+  repo: string,
+) {
+  return '>' + slackLink(
+    text,
+    `https://github.com/${owner}/${repo}/actions/runs/${runId}`,
+  );
+}
+
+async function getReleaseMessage({
+  github,
+  version,
+  owner,
+  stage,
+  repo,
+  previousMessage,
+  runId = "",
+  releaseSha,
+}: ReleaseProps & {
+  stage: BuildStage;
+  previousMessage?: { body: string, id: string } | null;
+  runId?: string;
+  releaseSha: string;
+}) {
+  const title = getReleaseTitle(version);
+  const space = "\n";
+
+  const stageMessagesText: Record<BuildStage, string> = {
+    "build-start": ":loading: Building",
+    "build-done": ":white_check_mark: Build Complete",
+    "test-start": ":loading: Testing",
+    "test-done": `:white_check_mark: Tests Complete`,
+    "publish-start": ":loading: Publishing",
+    "publish-done": ":white_check_mark: Publish Complete",
+  };
+
+  if (stage === "build-start") {
+    const preReleaseMessage = await getPreReleaseInfo({
+      version,
+      github,
+      owner,
+      repo,
+      releaseSha,
+    });
+
+    return [
+      title,
+      preReleaseMessage,
+      githubRunLink(stageMessagesText["build-start"], runId, owner, repo),
+    ].join(space);
+  }
+
+  if (!previousMessage) {
+    return `:warning: Something went wrong`;
+  }
+
+  switch (stage) {
+    case "build-done":
+      return previousMessage.body.replace(
+        stageMessagesText["build-start"],
+        stageMessagesText["build-done"],
+      );
+    case "test-start":
+      return [
+        previousMessage.body,
+        githubRunLink(stageMessagesText["test-start"], runId, owner, repo),
+      ].join(space);
+    case "test-done": {
+      const publishReminder = `${slackLink(
+        ":rocket: Ready to Publish",
+        `https://github.com/${owner}/${repo}/actions/workflows/release.yml`,
+      )}`;
+
+      // we want to make sure we send a new message so someone can get pinged when they need to act
+      await sendSlackReply(
+        `:white_check_mark: Tests are complete\n${publishReminder}`,
+        previousMessage.id,
+      );
+
+      return previousMessage.body.replace(
+        stageMessagesText["test-start"],
+        stageMessagesText["test-done"],
+      );
+    }
+    case "publish-start":
+      return [
+        previousMessage.body,
+        githubRunLink(stageMessagesText["publish-start"], runId, owner, repo),
+      ].join(space);
+    case "publish-done":
+      return previousMessage.body.replace(
+        stageMessagesText["publish-start"],
+        stageMessagesText["publish-done"],
+      );
+  }
+}
+
+export async function sendReleaseMessage({
+  github,
+  owner,
+  repo,
+  releaseSha,
+  stage,
+  version,
+  runId,
+}: ReleaseProps & {
+  stage: BuildStage;
+  version: string;
+  runId?: string;
+  releaseSha: string;
+}) {
+  const existingMessage = await getExistingSlackMessage(version);
+
+  const message = await getReleaseMessage({
+    github,
+    version,
+    owner,
+    stage,
+    repo,
+    releaseSha,
+    previousMessage: existingMessage,
+    runId,
+  });
+
+  if (existingMessage?.id) {
+    return updateSlackMessage(message, existingMessage.id);
+  }
+
+  return sendSlackMessage(message);
+}
+
+async function getPreReleaseInfo({
+  version,
+  github,
+  owner,
+  repo,
+  releaseSha,
+}: ReleaseProps & {
+  releaseSha: string;
+}) {
+  const milestoneId = await findMilestone({ version, github, owner, repo });
+  const milestoneLink = milestoneId
+    ? slackLink(
+        `_:rock: Milestone_`,
+        `https://github.com/${owner}/${repo}/milestone/${milestoneId}?closed=1`,
+      )
+    : "";
+
+  const releaseCommitLink = slackLink(
+    `_:merged: Release Commit_`,
+    `https://github.com/${owner}/${repo}/commit/${releaseSha}`,
+  );
+
+  return [milestoneLink, releaseCommitLink].filter(Boolean).join(" - ");
+}

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -36,6 +36,11 @@ export const getCanonicalVersion = (
     : getOSSVersion(versionString);
 };
 
+export const getGenericVersion = (versionString: string) => {
+  // turn v0.88.0 into 88.0
+  return getOSSVersion(versionString).replace(/v0\./, "");
+};
+
 export const getVersionType = (versionString: string) => {
   if (!isValidVersionString(versionString)) {
     throw new Error(`Invalid version string: ${versionString}`);

--- a/release/yarn.lock
+++ b/release/yarn.lock
@@ -980,6 +980,35 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
+"@slack/logger@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@slack/logger/-/logger-3.0.0.tgz#b736d4e1c112c22a10ffab0c2d364620aedcb714"
+  integrity sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==
+  dependencies:
+    "@types/node" ">=12.0.0"
+
+"@slack/types@^2.8.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@slack/types/-/types-2.9.0.tgz#c4c7bc704a4c0c62a30490e85679febac9314543"
+  integrity sha512-YfZGo0xVOmI7CHhiwCmEC33HzjQl1lakNmyo5GPGb4KHKEaUoY7zenAdKsYCJqYwdaM9OL+hqYt/tZ2zgvVc7g==
+
+"@slack/web-api@^6.9.0":
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/@slack/web-api/-/web-api-6.9.0.tgz#d829dcfef490dbce8e338912706b6f39dcde3ad2"
+  integrity sha512-RME5/F+jvQmZHkoP+ogrDbixq1Ms1mBmylzuWq4sf3f7GCpMPWoiZ+WqWk+sism3vrlveKWIgO9R4Qg9fiRyoQ==
+  dependencies:
+    "@slack/logger" "^3.0.0"
+    "@slack/types" "^2.8.0"
+    "@types/is-stream" "^1.1.0"
+    "@types/node" ">=12.0.0"
+    axios "^0.27.2"
+    eventemitter3 "^3.1.0"
+    form-data "^2.5.0"
+    is-electron "2.2.2"
+    is-stream "^1.1.0"
+    p-queue "^6.6.1"
+    p-retry "^4.0.0"
+
 "@types/babel__core@^7.1.14":
   version "7.20.1"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.1.tgz#916ecea274b0c776fec721e333e55762d3a9614b"
@@ -1028,6 +1057,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/is-stream@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/is-stream/-/is-stream-1.1.0.tgz#b84d7bb207a210f2af9bed431dc0fbe9c4143be1"
+  integrity sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"
@@ -1072,6 +1108,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.9.tgz#c7164e0f8d3f12dfae336af0b1f7fdec8c6b204f"
   integrity sha512-8e2HYcg7ohnTUbHk8focoklEQYvemQmu9M/f43DZVx43kHn0tE3BY/6gSDxS7k0SprtS0NHvj+L80cGLnoOUcQ==
 
+"@types/node@>=12.0.0":
+  version "20.8.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.8.9.tgz#646390b4fab269abce59c308fc286dcd818a2b08"
+  integrity sha512-UzykFsT3FhHb1h7yD4CA4YhBHq545JC0YnEz41xkipN88eKQtL6rSgocL5tbAP6Ola9Izm/Aw4Ora8He4x0BHg==
+  dependencies:
+    undici-types "~5.26.4"
+
 "@types/node@^18.16.3":
   version "18.17.17"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.17.17.tgz#53cc07ce582c9d7c5850702a3c2cb0af0d7b0ca1"
@@ -1081,6 +1124,11 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@types/ps-tree/-/ps-tree-1.1.2.tgz#5c60773a38ffb1402e049902a7b7a8d3c67cd59a"
   integrity sha512-ZREFYlpUmPQJ0esjxoG1fMvB2HNaD3z+mjqdSosZvd3RalncI9NEur73P8ZJz4YQdL64CmV1w0RuqoRUlhQRBw==
+
+"@types/retry@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
+  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
@@ -1149,6 +1197,19 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+axios@^0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
+  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+  dependencies:
+    follow-redirects "^1.14.9"
+    form-data "^4.0.0"
 
 babel-jest@^29.7.0:
   version "29.7.0"
@@ -1357,6 +1418,13 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+combined-stream@^1.0.6, combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1415,6 +1483,11 @@ deepmerge@^4.2.2:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 deprecation@^2.0.0:
   version "2.3.1"
@@ -1559,6 +1632,16 @@ event-stream@=3.3.4:
     stream-combiner "~0.0.4"
     through "~2.3.1"
 
+eventemitter3@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
+  integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
+
+eventemitter3@^4.0.4:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
+  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+
 execa@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
@@ -1642,6 +1725,29 @@ find-up@^4.0.0, find-up@^4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+follow-redirects@^1.14.9:
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
+  integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
+
+form-data@^2.5.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
+  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 formdata-polyfill@^4.0.10:
   version "4.0.10"
@@ -1826,6 +1932,11 @@ is-core-module@^2.13.0:
   dependencies:
     has "^1.0.3"
 
+is-electron@2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/is-electron/-/is-electron-2.2.2.tgz#3778902a2044d76de98036f5dc58089ac4d80bb9"
+  integrity sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -1857,6 +1968,11 @@ is-plain-object@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
   integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
+
+is-stream@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+  integrity sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==
 
 is-stream@^2.0.0:
   version "2.0.1"
@@ -2389,6 +2505,18 @@ micromatch@^4.0.4:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -2475,6 +2603,11 @@ onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+  integrity sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==
+
 p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
@@ -2495,6 +2628,29 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
+
+p-queue@^6.6.1:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
+  integrity sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==
+  dependencies:
+    eventemitter3 "^4.0.4"
+    p-timeout "^3.2.0"
+
+p-retry@^4.0.0:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
+  integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
+  dependencies:
+    "@types/retry" "0.12.0"
+    retry "^0.13.1"
+
+p-timeout@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
+  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
+  dependencies:
+    p-finally "^1.0.0"
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -2649,6 +2805,11 @@ resolve@^1.20.0:
     is-core-module "^2.13.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
+
+retry@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
 reusify@^1.0.4:
   version "1.0.4"
@@ -2874,6 +3035,11 @@ typescript@^5.1.6:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
   integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 universal-user-agent@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
closes https://github.com/metabase/metabase-private/issues/174

### Description

Adds automated slack status update messages to builds in CI. This relieves the release manager from needing to find these links for every build, and keeps everyone updated with the state of the build, with links to all the relevant CI jobs.

https://metaboat.slack.com/archives/C01BWAZJE0N/p1698437558822379
![Screen Shot 2023-10-27 at 4 36 19 PM](https://github.com/metabase/metabase/assets/30528226/9e18d87b-ae4f-435a-af16-dd1250a5e50e)

The message reply is particularly helpful, because the release manager can just set it up to ping them when the tests complete.

## Fork Test:
- [Build](https://github.com/iethree/metabase/actions/runs/6671800164)
- [Test](https://github.com/iethree/metabase/actions/runs/6671941024)
- [Publish](https://github.com/iethree/metabase/actions/runs/6672701702)

### Requirements

Requires one new (non-secret) variable: `vars.SLACK_RELEASE_CHANNEL`