### PR TITLE
Fix E2E models metadata flakes

### DIFF
--- a/e2e/support/helpers/e2e-models-metadata-helpers.js
+++ b/e2e/support/helpers/e2e-models-metadata-helpers.js
@@ -1,7 +1,27 @@
-import { popover } from "e2e/support/helpers";
+import { popover, interceptIfNotPreviouslyDefined } from "e2e/support/helpers";
+
+export function saveMetadataChanges() {
+  interceptIfNotPreviouslyDefined({
+    method: "POST",
+    url: "/api/dataset",
+    alias: "dataset",
+  });
+
+  cy.intercept("PUT", `/api/card/*`).as("updateModelMetadata");
+  cy.findByTestId("dataset-edit-bar").button("Save changes").click();
+  cy.wait("@updateModelMetadata");
+  cy.findByTestId("dataset-edit-bar").should("not.exist");
+
+  cy.wait("@dataset");
+}
 
 export function openColumnOptions(column) {
-  cy.findByText(column).click();
+  const columnNameRegex = new RegExp(`^${column}$`);
+
+  cy.findAllByTestId("header-cell")
+    .contains(columnNameRegex)
+    .should("be.visible")
+    .click();
 }
 
 export function renameColumn(oldName, newName) {
@@ -9,10 +29,14 @@ export function renameColumn(oldName, newName) {
 }
 
 export function setColumnType(oldType, newType) {
-  cy.findByText(oldType).click();
+  cy.findByTestId("sidebar-right")
+    .findAllByTestId("select-button")
+    .contains(oldType)
+    .click();
+
   cy.get(".ReactVirtualized__Grid.MB-Select").scrollTo("top");
   cy.findByPlaceholderText("Search for a special type").type(newType);
-  cy.findByText(newType).click();
+  popover().findByLabelText(newType).click();
 }
 
 export function mapColumnTo({ table, column } = {}) {

--- a/e2e/test/scenarios/models/helpers/e2e-models-helpers.js
+++ b/e2e/test/scenarios/models/helpers/e2e-models-helpers.js
@@ -104,8 +104,8 @@ export function selectFromDropdown(option, clickOpts) {
 }
 
 export function startQuestionFromModel(modelName) {
-  cy.findByText("New").click();
-  cy.findByText("Question").should("be.visible").click();
+  cy.findByTestId("app-bar").findByText("New").click();
+  popover().findByText("Question").should("be.visible").click();
   cy.findByText("Models").click();
   cy.findByText(modelName).click();
 }

--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -273,7 +273,7 @@ describe("scenarios > models metadata", () => {
       .and("contain", "TAX");
   });
 
-  describe("native models metadata overwrites", () => {
+  describe("native models metadata overwrites", { viewportWidth: 1400 }, () => {
     beforeEach(() => {
       cy.createNativeQuestion(
         {

--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -20,7 +20,8 @@ import {
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { startQuestionFromModel } from "./helpers/e2e-models-helpers";
 
-const { PEOPLE, PRODUCTS, PRODUCTS_ID, REVIEWS, ORDERS_ID } = SAMPLE_DATABASE;
+const { PEOPLE, PRODUCTS, PRODUCTS_ID, REVIEWS, ORDERS_ID, ORDERS } =
+  SAMPLE_DATABASE;
 
 describe("scenarios > models metadata", () => {
   beforeEach(() => {
@@ -291,7 +292,7 @@ describe("scenarios > models metadata", () => {
           if (field.display_name === "USER_ID") {
             return {
               ...field,
-              id: 11,
+              id: ORDERS.USER_ID,
               display_name: "User ID",
               semantic_type: "type/FK",
               fk_target_field_id: PEOPLE.ID,


### PR DESCRIPTION
Run results from the last two days
![image](https://github.com/metabase/metabase/assets/31325167/5f698a40-6846-479f-adbd-c0ce3f6dc676)

I'm sorry for writing such poor commit messages in this PR, and for cramming a bunch of changes together. I'd usually commit incrementally in nice small chunks, but fixing this took the better of me.

Here are the stress tests:
https://github.com/metabase/metabase/actions/runs/6672697837/job/18137112838

```
Running:  models-metadata.cy.spec.js                                                      (1 of 1)


  scenarios > models metadata
    ✓ should edit native model metadata: burning 1 of 5 (30080ms)
    ✓ should edit native model metadata: burning 2 of 5 (22727ms)
    ✓ should edit native model metadata: burning 3 of 5 (23652ms)
    ✓ should edit native model metadata: burning 4 of 5 (23721ms)
    ✓ should edit native model metadata: burning 5 of 5 (22911ms)
    ✓ should allow setting column relations (metabase#29318): burning 1 of 5 (13531ms)
    ✓ should allow setting column relations (metabase#29318): burning 2 of 5 (13851ms)
    ✓ should allow setting column relations (metabase#29318): burning 3 of 5 (14024ms)
    ✓ should allow setting column relations (metabase#29318): burning 4 of 5 (14079ms)
    ✓ should allow setting column relations (metabase#29318): burning 5 of 5 (12579ms)
    ✓ should keep metadata in sync with the query: burning 1 of 5 (1[163](https://github.com/metabase/metabase/actions/runs/6672697837/job/18137112838#step:9:164)0ms)
    ✓ should keep metadata in sync with the query: burning 2 of 5 (12426ms)
    ✓ should keep metadata in sync with the query: burning 3 of 5 (10739ms)
    ✓ should keep metadata in sync with the query: burning 4 of 5 (9742ms)
    ✓ should keep metadata in sync with the query: burning 5 of 5 (10266ms)
    ✓ should allow reverting to a specific metadata revision: burning 1 of 5 (31768ms)
    ✓ should allow reverting to a specific metadata revision: burning 2 of 5 (31897ms)
    ✓ should allow reverting to a specific metadata revision: burning 3 of 5 (33751ms)
    ✓ should allow reverting to a specific metadata revision: burning 4 of 5 (32812ms)
    ✓ should allow reverting to a specific metadata revision: burning 5 of 5 (32304ms)
    GUI model
      ✓ should edit GUI model metadata: burning 1 of 5 (21719ms)
      ✓ should edit GUI model metadata: burning 2 of 5 (21[165](https://github.com/metabase/metabase/actions/runs/6672697837/job/18137112838#step:9:166)ms)
      ✓ should edit GUI model metadata: burning 3 of 5 (24409ms)
      ✓ should edit GUI model metadata: burning 4 of 5 (21026ms)
      ✓ should edit GUI model metadata: burning 5 of 5 (22249ms)
      ✓ allows for canceling changes: burning 1 of 5 (13520ms)
      ✓ allows for canceling changes: burning 2 of 5 (13887ms)
      ✓ allows for canceling changes: burning 3 of 5 (13490ms)
      ✓ allows for canceling changes: burning 4 of 5 (12446ms)
      ✓ allows for canceling changes: burning 5 of 5 (12690ms)
      ✓ clears custom metadata when a model is turned back into a question: burning 1 of 5 (19987ms)
      ✓ clears custom metadata when a model is turned back into a question: burning 2 of 5 (20692ms)
      1) clears custom metadata when a model is turned back into a question: burning 3 of 5
      ✓ clears custom metadata when a model is turned back into a question: burning 4 of 5 (20883ms)
      ✓ clears custom metadata when a model is turned back into a question: burning 5 of 5 (21262ms)
    native models metadata overwrites
      ✓ should allow drills on FK columns: burning 1 of 5 (14952ms)
      ✓ should allow drills on FK columns: burning 2 of 5 (14302ms)
      ✓ should allow drills on FK columns: burning 3 of 5 (13278ms)
      ✓ should allow drills on FK columns: burning 4 of 5 (12694ms)
      ✓ should allow drills on FK columns: burning 5 of 5 (13717ms)
      ✓ should allow drills on FK columns from dashboards: burning 1 of 5 (11463ms)
      ✓ should allow drills on FK columns from dashboards: burning 2 of 5 (11046ms)
      ✓ should allow drills on FK columns from dashboards: burning 3 of 5 (11237ms)
      ✓ should allow drills on FK columns from dashboards: burning 4 of 5 (10285ms)
      ✓ should allow drills on FK columns from dashboards: burning 5 of 5 (8998ms)
      ✓ models metadata tab should show columns with details-only visibility (metabase#22521): burning 1 of 5 (7731ms)
      ✓ models metadata tab should show columns with details-only visibility (metabase#22521): burning 2 of 5 (6[180](https://github.com/metabase/metabase/actions/runs/6672697837/job/18137112838#step:9:181)ms)
      ✓ models metadata tab should show columns with details-only visibility (metabase#22521): burning 3 of 5 (5974ms)
      ✓ models metadata tab should show columns with details-only visibility (metabase#22521): burning 4 of 5 (6429ms)
      ✓ models metadata tab should show columns with details-only visibility (metabase#22521): burning 5 of 5 (6800ms)


  49 passing (14m)
  1 failing
```

And in the other run I isolated only the GUI models metadata group, because it's the one with the most failures:
```
Running:  models-metadata-isolated.cy.spec.js                                             (1 of 1)


  scenarios > models metadata
    GUI model
      ✓ should edit GUI model metadata: burning 1 of 10 (27972ms)
      ✓ should edit GUI model metadata: burning 2 of 10 (23746ms)
      ✓ should edit GUI model metadata: burning 3 of 10 (24975ms)
      ✓ should edit GUI model metadata: burning 4 of 10 (23422ms)
      ✓ should edit GUI model metadata: burning 5 of 10 (23610ms)
      ✓ should edit GUI model metadata: burning 6 of 10 (24697ms)
      ✓ should edit GUI model metadata: burning 7 of 10 (24112ms)
      ✓ should edit GUI model metadata: burning 8 of 10 (24476ms)
      ✓ should edit GUI model metadata: burning 9 of 10 (24723ms)
      ✓ should edit GUI model metadata: burning 10 of 10 (24133ms)
      ✓ allows for canceling changes: burning 1 of 10 (14349ms)
      ✓ allows for canceling changes: burning 2 of 10 (13897ms)
      ✓ allows for canceling changes: burning 3 of 10 (14688ms)
      ✓ allows for canceling changes: burning 4 of 10 (14717ms)
      ✓ allows for canceling changes: burning 5 of 10 (13896ms)
      ✓ allows for canceling changes: burning 6 of 10 (13997ms)
      ✓ allows for canceling changes: burning 7 of 10 (13907ms)
      ✓ allows for canceling changes: burning 8 of 10 (13891ms)
      ✓ allows for canceling changes: burning 9 of 10 (13600ms)
      ✓ allows for canceling changes: burning 10 of 10 (14286ms)
      ✓ clears custom metadata when a model is turned back into a question: burning 1 of 10 (23212ms)
      ✓ clears custom metadata when a model is turned back into a question: burning 2 of 10 (2[170](https://github.com/metabase/metabase/actions/runs/6668828440/job/18125272122#step:9:171)7ms)
      ✓ clears custom metadata when a model is turned back into a question: burning 3 of 10 (22408ms)
      ✓ clears custom metadata when a model is turned back into a question: burning 4 of 10 (21066ms)
      ✓ clears custom metadata when a model is turned back into a question: burning 5 of 10 (20679ms)
      ✓ clears custom metadata when a model is turned back into a question: burning 6 of 10 (22119ms)
      ✓ clears custom metadata when a model is turned back into a question: burning 7 of 10 (21213ms)
      ✓ clears custom metadata when a model is turned back into a question: burning 8 of 10 (20471ms)
      ✓ clears custom metadata when a model is turned back into a question: burning 9 of 10 (21852ms)
      ✓ clears custom metadata when a model is turned back into a question: burning 10 of 10 (20325ms)


  30 passing (10m)
  ```
  
  Even with this one failure, this greatly increases the chances of these tests to pass.
  The current situation is unbearable.

