### PR TITLE
Fix `e2e_all` file path

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -92,6 +92,7 @@ e2e_all:
   - *default
   - *ci
   - *sources
+  - *e2e_specs
 
 snowplow:
   - *ci


### PR DESCRIPTION
It should include `e2e_specs`. This has been missing from #35079.

Otherwise, it will not trigger E2E tests on pure E2E changes. It happened on `master` already. https://github.com/metabase/metabase/pull/35188 was merged, but all E2E tests were skipped and only their stub jobs ran.

![image](https://github.com/metabase/metabase/assets/31325167/467d696a-6605-471f-80b1-d1ad88a481cb)

https://github.com/metabase/metabase/actions/runs/6673173774/job/18138330264
```
Didn't run due to conditional filtering
```