### PR TITLE
Attempt to fix the flaky `hydrate-is-personal-test` test

### DIFF
--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -1260,7 +1260,7 @@
                                   (-> (t2/select-one :model/Collection id-or-ids)
                                       (t2/hydrate :is_personal)
                                       :is_personal)
-                                  (as-> (t2/select :model/Collection :id [:in id-or-ids]) collections
+                                  (as-> (t2/select :model/Collection :id [:in id-or-ids] {:order-by [:id]}) collections
                                     (t2/hydrate collections :is_personal)
                                     (map :is_personal collections))))]
 


### PR DESCRIPTION
failed CI https://github.com/metabase/metabase/actions/runs/6691021110/job/18177457410


I can't reproduce this locally but my hypothesis is `select id in [...]` sometimes does not return things in the exact order of the id list?
