### PR TITLE
Remove innappropriate type casts and type guards for FieldFilterUiParameter

### DIFF
--- a/frontend/src/metabase-lib/parameters/utils/parameter-type.ts
+++ b/frontend/src/metabase-lib/parameters/utils/parameter-type.ts
@@ -1,6 +1,5 @@
 import _ from "underscore";
 import type { Parameter } from "metabase-types/api";
-import type { FieldFilterUiParameter } from "metabase-lib/parameters/types";
 import { FIELD_FILTER_PARAMETER_TYPES } from "metabase-lib/parameters/constants";
 
 export function getParameterType(parameter: Parameter | string) {
@@ -42,9 +41,7 @@ export function isStringParameter(parameter: Parameter) {
   return type === "string";
 }
 
-export function isFieldFilterParameter(
-  parameter: Parameter,
-): parameter is FieldFilterUiParameter {
+export function isFieldFilterParameter(parameter: Parameter) {
   const type = getParameterType(parameter);
   return FIELD_FILTER_PARAMETER_TYPES.includes(type);
 }

--- a/frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx
+++ b/frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx
@@ -1,7 +1,10 @@
 import { formatParameterValue } from "metabase/parameters/utils/formatting";
 import ParameterFieldWidgetValue from "metabase/parameters/components/widgets/ParameterFieldWidget/ParameterFieldWidgetValue/ParameterFieldWidgetValue";
 import type { UiParameter } from "metabase-lib/parameters/types";
-import { hasFields } from "metabase-lib/parameters/utils/parameter-fields";
+import {
+  getFields,
+  hasFields,
+} from "metabase-lib/parameters/utils/parameter-fields";
 import { isDateParameter } from "metabase-lib/parameters/utils/parameter-type";
 
 type FormattedParameterValueProps = {
@@ -21,7 +24,7 @@ function FormattedParameterValue({
 
   if (hasFields(parameter) && !isDateParameter(parameter)) {
     return (
-      <ParameterFieldWidgetValue fields={parameter.fields} value={value} />
+      <ParameterFieldWidgetValue fields={getFields(parameter)} value={value} />
     );
   }
 

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceTypeModal.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceTypeModal.tsx
@@ -25,10 +25,7 @@ import type Question from "metabase-lib/Question";
 import type Field from "metabase-lib/metadata/Field";
 import { getQuestionVirtualTableId } from "metabase-lib/metadata/utils/saved-questions";
 import { isValidSourceConfig } from "metabase-lib/parameters/utils/parameter-source";
-import type {
-  FieldFilterUiParameter,
-  UiParameter,
-} from "metabase-lib/parameters/types";
+import type { UiParameter } from "metabase-lib/parameters/types";
 import { hasFields } from "metabase-lib/parameters/utils/parameter-fields";
 import type { FetchParameterValuesOpts } from "../../actions";
 import { fetchParameterValues } from "../../actions";
@@ -98,7 +95,7 @@ const ValuesSourceTypeModal = ({
       {sourceType === null ? (
         <FieldSourceModal
           // if sourceType === null the parameter must have fields
-          parameter={parameter as FieldFilterUiParameter}
+          parameter={parameter}
           sourceType={sourceType}
           sourceConfig={sourceConfig}
           onFetchParameterValues={onFetchParameterValues}
@@ -173,7 +170,7 @@ const SourceTypeOptions = ({
 };
 
 interface FieldSourceModalProps {
-  parameter: FieldFilterUiParameter;
+  parameter: UiParameter;
   sourceType: ValuesSourceType;
   sourceConfig: ValuesSourceConfig;
   onFetchParameterValues: (

--- a/frontend/src/metabase/parameters/utils/formatting.ts
+++ b/frontend/src/metabase/parameters/utils/formatting.ts
@@ -7,6 +7,10 @@ import {
 } from "metabase-lib/parameters/utils/parameter-type";
 
 import type { UiParameter } from "metabase-lib/parameters/types";
+import {
+  getFields,
+  hasFields,
+} from "metabase-lib/parameters/utils/parameter-fields";
 import { formatDateValue } from "./date-formatting";
 
 function inferValueType(parameter: UiParameter) {
@@ -51,12 +55,13 @@ export function formatParameterValue(
     }
 
     // format using the parameter's first targeted field
-    if (parameter.fields?.length > 0) {
-      const [firstField] = parameter.fields;
+    if (hasFields(parameter)) {
+      const fields = getFields(parameter);
+      const [firstField] = fields;
       // when a parameter targets multiple fields we won't know
       // which parameter the value is associated with, meaning we
       // are unable to remap the value to the correct field
-      const remap = parameter.fields.length === 1;
+      const remap = fields.length === 1;
       return formatValue(value as string, {
         column: firstField,
         maximumFractionDigits: 20,


### PR DESCRIPTION
This PR removes a couple of innappropriate uses of type casts and guards.

It was made based on [this discussion](https://github.com/metabase/metabase/pull/35086#issuecomment-1784880354). We shoudn't be using narrower types than we can enforce using the type checker.
