### PR TITLE
Handle search in dashboard and question picker

### DIFF
--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -253,7 +253,7 @@ describe("scenarios > home > custom homepage", () => {
 
         //Ensure that child dashboards of personal collections do not
         //appear in search
-        cy.findByRole("button", { name: /search/ }).click();
+        cy.findByRole("button", { name: "Search" }).click();
         cy.findByPlaceholderText("Search").type("das{enter}");
         cy.findByText("Orders in a dashboard").should("exist");
         cy.findByText("nested dash").should("not.exist");

--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -89,4 +89,5 @@ export interface SearchListQuery {
   limit?: number;
   offset?: number;
   collection?: CollectionId;
+  filter_items_in_personal_collection?: "only" | "exclude";
 }

--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -1,6 +1,6 @@
 import type { UserId } from "metabase-types/api/user";
 import type { CardId } from "./card";
-import type { Collection } from "./collection";
+import type { Collection, CollectionId } from "./collection";
 import type { DatabaseId, InitialSyncStatus } from "./database";
 import type { FieldReference } from "./query";
 import type { TableId } from "./table";
@@ -88,4 +88,5 @@ export interface SearchListQuery {
   table_db_id?: DatabaseId;
   limit?: number;
   offset?: number;
+  collection?: CollectionId;
 }

--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -49,7 +49,7 @@ export interface SearchResults {
 }
 
 export interface SearchResult {
-  id: number | undefined;
+  id: number;
   name: string;
   model: SearchModelType;
   description: string | null;

--- a/frontend/src/metabase-types/entities/common.ts
+++ b/frontend/src/metabase-types/entities/common.ts
@@ -1,0 +1,9 @@
+import type { Collection } from "metabase-types/api";
+import type { IconName } from "metabase/core/components/Icon";
+
+export type WrappedEntity<Entity> = {
+  getName: () => string;
+  getIcon: () => { name: IconName };
+  getColor: () => string;
+  getCollection: () => Collection;
+} & Entity;

--- a/frontend/src/metabase-types/entities/index.ts
+++ b/frontend/src/metabase-types/entities/index.ts
@@ -1,2 +1,3 @@
 export * from "./table";
 export * from "./database";
+export * from "./common";

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -127,7 +127,6 @@ const setup = async ({
     new Set([dashboard, mostRecentlyViewedDashboard].filter(isNotNull)),
   );
 
-  // setupSearchEndpoints([]);
   setupCollectionsEndpoints({ collections, rootCollection: ROOT_COLLECTION });
   setupDashboardCollectionItemsEndpoint(dashboards);
   setupCollectionByIdEndpoint({ collections, error });

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -664,7 +664,7 @@ describe("AddToDashSelectDashModal", () => {
 
     describe("search dashboards", () => {
       describe("questions in the root collection (public collection)", () => {
-        it("should search questions only in public collections", async () => {
+        it("should search dashboards only in public collections", async () => {
           await setup({
             card: CARD_IN_ROOT_COLLECTION,
           });
@@ -709,7 +709,7 @@ describe("AddToDashSelectDashModal", () => {
       });
 
       describe("questions in public collections", () => {
-        it("should search questions only in public collections", async () => {
+        it("should search dashboards only in public collections", async () => {
           await setup({
             card: CARD_IN_PUBLIC_COLLECTION,
           });
@@ -754,7 +754,7 @@ describe("AddToDashSelectDashModal", () => {
       });
 
       describe("questions in personal collections", () => {
-        it("should search all questions", async () => {
+        it("should search all dashboards", async () => {
           await setup({
             card: CARD_IN_PERSONAL_COLLECTION,
           });

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -18,30 +18,31 @@ import {
 import type { Card, Collection, Dashboard } from "metabase-types/api";
 import { ROOT_COLLECTION as ROOT } from "metabase/entities/collections";
 import { checkNotNull, isNotNull } from "metabase/lib/types";
+import { getNextId } from "__support__/utils";
 import { ConnectedAddToDashSelectDashModal } from "./AddToDashSelectDashModal";
 
 const CURRENT_USER = createMockUser({
-  id: 1,
-  personal_collection_id: 100,
+  id: getNextId(),
+  personal_collection_id: getNextId(),
   is_superuser: true,
 });
 
 const DASHBOARD = createMockDashboard({
-  id: 3,
+  id: getNextId(),
   name: "Test dashboard",
   collection_id: 2,
   model: "dashboard",
 });
 
 const DASHBOARD_AT_ROOT = createMockDashboard({
-  id: 4,
+  id: getNextId(),
   name: "Dashboard at root",
   collection_id: null,
   model: "dashboard",
 });
 
 const COLLECTION = createMockCollection({
-  id: 1,
+  id: getNextId(),
   name: "Collection",
   can_write: true,
   is_personal: false,
@@ -49,7 +50,7 @@ const COLLECTION = createMockCollection({
 });
 
 const SUBCOLLECTION = createMockCollection({
-  id: 2,
+  id: getNextId(),
   name: "Nested collection",
   can_write: true,
   is_personal: false,
@@ -66,7 +67,7 @@ const PERSONAL_COLLECTION = createMockCollection({
 });
 
 const PERSONAL_SUBCOLLECTION = createMockCollection({
-  id: CURRENT_USER.personal_collection_id + 1,
+  id: getNextId(),
   name: "Nested personal collection",
   can_write: true,
   is_personal: true,
@@ -87,22 +88,36 @@ const COLLECTIONS = [
 ];
 
 const CARD_IN_ROOT_COLLECTION = createMockCard({
-  id: 1,
+  id: getNextId(),
   name: "Model Uno",
   dataset: true,
 });
 
 const CARD_IN_PUBLIC_COLLECTION = createMockCard({
-  id: 1,
+  id: getNextId(),
   name: "Model Uno",
   dataset: true,
   collection: COLLECTION,
 });
 
 const CARD_IN_PERSONAL_COLLECTION = createMockCard({
-  id: 3,
+  id: getNextId(),
   name: "Card in a personal collection",
   dataset: true,
+  collection: PERSONAL_COLLECTION,
+});
+
+const DASHBOARD_RESULT_IN_PUBLIC_COLLECTION = createMockSearchResult({
+  id: getNextId(),
+  name: "dashboard in public collection",
+  model: "dashboard",
+  collection: COLLECTION,
+});
+
+const DASHBOARD_RESULT_IN_PERSONAL_COLLECTION = createMockSearchResult({
+  id: getNextId(),
+  name: "dashboard in personal collection",
+  model: "dashboard",
   collection: PERSONAL_COLLECTION,
 });
 
@@ -229,7 +244,7 @@ describe("AddToDashSelectDashModal", () => {
 
       describe("when last visited dashboard belongs to public subcollections", () => {
         const dashboardInPublicSubcollection = createMockDashboard({
-          id: 5,
+          id: getNextId(),
           name: "Dashboard in public subcollection",
           collection: SUBCOLLECTION,
           collection_id: SUBCOLLECTION.id as number,
@@ -268,7 +283,7 @@ describe("AddToDashSelectDashModal", () => {
 
       describe("when last visited dashboard belongs to personal subcollections", () => {
         const dashboardInPersonalSubcollection = createMockDashboard({
-          id: 5,
+          id: getNextId(),
           name: "Dashboard in personal subcollection",
           collection: PERSONAL_SUBCOLLECTION,
           collection_id: PERSONAL_SUBCOLLECTION.id as number,
@@ -414,7 +429,7 @@ describe("AddToDashSelectDashModal", () => {
           it("should render dashboards when opening the root collection (public collection)", async () => {
             // no `collection` and `collection_id` means it's in the root collection
             const dashboardInRootCollection = createMockDashboard({
-              id: 5,
+              id: getNextId(),
               name: "Dashboard in root collection",
               model: "dashboard",
             });
@@ -432,7 +447,7 @@ describe("AddToDashSelectDashModal", () => {
 
           it("should render dashboards when opening public subcollections", async () => {
             const dashboardInPublicSubcollection = createMockDashboard({
-              id: 5,
+              id: getNextId(),
               name: "Dashboard in public subcollection",
               collection_id: COLLECTION.id as number,
               model: "dashboard",
@@ -457,7 +472,7 @@ describe("AddToDashSelectDashModal", () => {
 
           it("should render dashboards when opening personal collections", async () => {
             const dashboardInPersonalCollection = createMockDashboard({
-              id: 5,
+              id: getNextId(),
               name: "Dashboard in personal collection",
               collection_id: PERSONAL_COLLECTION.id as number,
               model: "dashboard",
@@ -482,7 +497,7 @@ describe("AddToDashSelectDashModal", () => {
 
           it("should render dashboards when opening personal subcollections", async () => {
             const dashboardInPersonalSubcollection = createMockDashboard({
-              id: 5,
+              id: getNextId(),
               name: "Dashboard in personal subcollection",
               collection_id: PERSONAL_SUBCOLLECTION.id as number,
               model: "dashboard",
@@ -578,7 +593,7 @@ describe("AddToDashSelectDashModal", () => {
         describe("whether we should render dashboards in a collection", () => {
           it("should not render dashboards when opening the root collection (public collection)", async () => {
             const dashboardInPublicCollection = createMockDashboard({
-              id: 5,
+              id: getNextId(),
               name: "Dashboard in public collection",
               // `null` means it's in the root collection
               collection_id: null,
@@ -603,7 +618,7 @@ describe("AddToDashSelectDashModal", () => {
 
           it("should render dashboards when opening personal collections", async () => {
             const dashboardInPersonalCollection = createMockDashboard({
-              id: 5,
+              id: getNextId(),
               name: "Dashboard in personal collection",
               collection_id: PERSONAL_COLLECTION.id as number,
               model: "dashboard",
@@ -629,7 +644,7 @@ describe("AddToDashSelectDashModal", () => {
 
           it("should render dashboards when opening personal subcollections", async () => {
             const dashboardInPersonalSubcollection = createMockDashboard({
-              id: 5,
+              id: getNextId(),
               name: "Dashboard in personal subcollection",
               collection_id: PERSONAL_SUBCOLLECTION.id as number,
               model: "dashboard",
@@ -670,10 +685,6 @@ describe("AddToDashSelectDashModal", () => {
           });
 
           const typedText = "question";
-          const dashboardInPublicCollection = createMockSearchResult({
-            name: "dashboard in public collection",
-            model: "dashboard",
-          });
           fetchMock.get(
             {
               url: "path:/api/search",
@@ -683,7 +694,7 @@ describe("AddToDashSelectDashModal", () => {
               },
             },
             {
-              data: [dashboardInPublicCollection],
+              data: [DASHBOARD_RESULT_IN_PUBLIC_COLLECTION],
             },
           );
 
@@ -694,7 +705,7 @@ describe("AddToDashSelectDashModal", () => {
           );
 
           expect(
-            await screen.findByText(dashboardInPublicCollection.name),
+            await screen.findByText(DASHBOARD_RESULT_IN_PUBLIC_COLLECTION.name),
           ).toBeInTheDocument();
 
           // There's no way to math a URL that a query param is not present
@@ -715,10 +726,6 @@ describe("AddToDashSelectDashModal", () => {
           });
 
           const typedText = "question";
-          const dashboardInPublicCollection = createMockSearchResult({
-            name: "dashboard in public collection",
-            model: "dashboard",
-          });
           fetchMock.get(
             {
               url: "path:/api/search",
@@ -728,7 +735,7 @@ describe("AddToDashSelectDashModal", () => {
               },
             },
             {
-              data: [dashboardInPublicCollection],
+              data: [DASHBOARD_RESULT_IN_PUBLIC_COLLECTION],
             },
           );
 
@@ -739,7 +746,7 @@ describe("AddToDashSelectDashModal", () => {
           );
 
           expect(
-            await screen.findByText(dashboardInPublicCollection.name),
+            await screen.findByText(DASHBOARD_RESULT_IN_PUBLIC_COLLECTION.name),
           ).toBeInTheDocument();
 
           // There's no way to math a URL that a query param is not present
@@ -760,16 +767,6 @@ describe("AddToDashSelectDashModal", () => {
           });
 
           const typedText = "question";
-          const dashboardInPublicCollection = createMockSearchResult({
-            id: 1,
-            name: "dashboard in public collection",
-            model: "dashboard",
-          });
-          const dashboardInPersonalCollection = createMockSearchResult({
-            id: 2,
-            name: "dashboard in personal collection",
-            model: "dashboard",
-          });
           fetchMock.get(
             {
               url: "path:/api/search",
@@ -781,8 +778,8 @@ describe("AddToDashSelectDashModal", () => {
             },
             {
               data: [
-                dashboardInPublicCollection,
-                dashboardInPersonalCollection,
+                DASHBOARD_RESULT_IN_PUBLIC_COLLECTION,
+                DASHBOARD_RESULT_IN_PERSONAL_COLLECTION,
               ],
             },
           );
@@ -794,10 +791,10 @@ describe("AddToDashSelectDashModal", () => {
           );
 
           expect(
-            await screen.findByText(dashboardInPublicCollection.name),
+            await screen.findByText(DASHBOARD_RESULT_IN_PUBLIC_COLLECTION.name),
           ).toBeInTheDocument();
           expect(
-            screen.getByText(dashboardInPersonalCollection.name),
+            screen.getByText(DASHBOARD_RESULT_IN_PERSONAL_COLLECTION.name),
           ).toBeInTheDocument();
         });
       });

--- a/frontend/src/metabase/containers/ItemPicker/ItemPicker.tsx
+++ b/frontend/src/metabase/containers/ItemPicker/ItemPicker.tsx
@@ -150,6 +150,9 @@ function ItemPicker<TId>({
 
     if (searchString) {
       query.q = searchString;
+      if (showOnlyPersonalCollections) {
+        query.filter_items_in_personal_collection = "only";
+      }
     } else {
       query.collection = openCollectionId;
     }
@@ -159,7 +162,7 @@ function ItemPicker<TId>({
     }
 
     return query;
-  }, [models, searchString, openCollectionId]);
+  }, [searchString, models, showOnlyPersonalCollections, openCollectionId]);
 
   const checkIsItemSelected = useCallback(
     (item: PickerItem<TId>) => {

--- a/frontend/src/metabase/containers/ItemPicker/ItemPickerView.tsx
+++ b/frontend/src/metabase/containers/ItemPicker/ItemPickerView.tsx
@@ -120,7 +120,7 @@ function ItemPickerView<TId>({
       <ItemPickerHeader data-testid="item-picker-header">
         <Breadcrumbs crumbs={crumbs} />
         {showSearch && (
-          <SearchToggle onClick={handleOpenSearch}>
+          <SearchToggle onClick={handleOpenSearch} aria-label={t`Search`}>
             <Icon name="search" />
           </SearchToggle>
         )}

--- a/frontend/src/metabase/containers/ItemPicker/types.ts
+++ b/frontend/src/metabase/containers/ItemPicker/types.ts
@@ -24,4 +24,5 @@ export type SearchQuery = {
   q?: string;
   collection?: Collection["id"];
   models?: PickerModel[];
+  filter_items_in_personal_collection?: "only" | "exclude";
 };

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/AddCardSidebar/AddCardSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/AddCardSidebar/AddCardSidebar.unit.spec.tsx
@@ -118,151 +118,154 @@ describe("AddCardSideBar", () => {
     expect(screen.getByText("Nothing here")).toBeInTheDocument();
   });
 
-  it("should hide all personal collections when adding questions to dashboards in the root collection (public collection)", async () => {
-    const dashboardInPublicCollection = createMockDashboard({
-      collection: ROOT_COLLECTION,
-    });
-    await setup({
-      collections: COLLECTIONS,
-      dashboard: dashboardInPublicCollection,
-    });
-
-    assertBreadcrumbs([ROOT_COLLECTION]);
-
-    expect(
-      screen.getByRole("menuitem", {
-        name: COLLECTION.name,
-      }),
-    ).toBeInTheDocument();
-
-    expect(
-      screen.queryByRole("menuitem", {
-        name: PERSONAL_COLLECTION.name,
-      }),
-    ).not.toBeInTheDocument();
-  });
-
-  it("should show all questions when adding questions to dashboards in the root collection (public collection)", async () => {
+  describe("dashboards in the root collection (public collection)", () => {
     const dashboardInRootCollection = createMockDashboard({
       collection: ROOT_COLLECTION,
     });
 
-    const collectionItems = [
-      createMockCollectionItem({
-        id: getNextId(),
-        model: "card",
-        name: "question 1",
-      }),
-      createMockCollectionItem({
-        id: getNextId(),
-        model: "card",
-        name: "question 2",
-      }),
-    ];
-    await setup({
-      collections: COLLECTIONS,
-      dashboard: dashboardInRootCollection,
-      collectionItems,
-    });
+    it("should hide all personal collections", async () => {
+      await setup({
+        collections: COLLECTIONS,
+        dashboard: dashboardInRootCollection,
+      });
 
-    assertBreadcrumbs([ROOT_COLLECTION]);
+      assertBreadcrumbs([ROOT_COLLECTION]);
 
-    collectionItems.forEach(collectionItem => {
       expect(
         screen.getByRole("menuitem", {
-          name: collectionItem.name,
+          name: COLLECTION.name,
         }),
       ).toBeInTheDocument();
+
+      expect(
+        screen.queryByRole("menuitem", {
+          name: PERSONAL_COLLECTION.name,
+        }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should show all questions", async () => {
+      const collectionItems = [
+        createMockCollectionItem({
+          id: getNextId(),
+          model: "card",
+          name: "question 1",
+        }),
+        createMockCollectionItem({
+          id: getNextId(),
+          model: "card",
+          name: "question 2",
+        }),
+      ];
+      await setup({
+        collections: COLLECTIONS,
+        dashboard: dashboardInRootCollection,
+        collectionItems,
+      });
+
+      assertBreadcrumbs([ROOT_COLLECTION]);
+
+      collectionItems.forEach(collectionItem => {
+        expect(
+          screen.getByRole("menuitem", {
+            name: collectionItem.name,
+          }),
+        ).toBeInTheDocument();
+      });
     });
   });
 
-  it("should show all questions when adding questions to dashboards in public collections", async () => {
-    const dashboardInPublicSubcollection = createMockDashboard({
-      collection: SUBCOLLECTION,
-    });
+  describe("dashboards in public collections", () => {
+    it("should show all questions", async () => {
+      const dashboardInPublicSubcollection = createMockDashboard({
+        collection: SUBCOLLECTION,
+      });
 
-    const collectionItems = [
-      createMockCollectionItem({
-        id: getNextId(),
-        model: "card",
-        name: "question 1",
-      }),
-      createMockCollectionItem({
-        id: getNextId(),
-        model: "card",
-        name: "question 2",
-      }),
-    ];
-    await setup({
-      collections: COLLECTIONS,
-      dashboard: dashboardInPublicSubcollection,
-      collectionItems,
-    });
-
-    assertBreadcrumbs([ROOT_COLLECTION, COLLECTION, SUBCOLLECTION]);
-
-    collectionItems.forEach(collectionItem => {
-      expect(
-        screen.getByRole("menuitem", {
-          name: collectionItem.name,
+      const collectionItems = [
+        createMockCollectionItem({
+          id: getNextId(),
+          model: "card",
+          name: "question 1",
         }),
-      ).toBeInTheDocument();
+        createMockCollectionItem({
+          id: getNextId(),
+          model: "card",
+          name: "question 2",
+        }),
+      ];
+      await setup({
+        collections: COLLECTIONS,
+        dashboard: dashboardInPublicSubcollection,
+        collectionItems,
+      });
+
+      assertBreadcrumbs([ROOT_COLLECTION, COLLECTION, SUBCOLLECTION]);
+
+      collectionItems.forEach(collectionItem => {
+        expect(
+          screen.getByRole("menuitem", {
+            name: collectionItem.name,
+          }),
+        ).toBeInTheDocument();
+      });
     });
   });
 
-  it("should show all collections when adding questions to dashboards in personal subcollections", async () => {
-    const dashboardInPersonalSubcollection = createMockDashboard({
-      collection: PERSONAL_SUBCOLLECTION,
-    });
-    await setup({
-      collections: COLLECTIONS,
-      dashboard: dashboardInPersonalSubcollection,
-    });
+  describe("dashboards in personal collections", () => {
+    it("should show all collections", async () => {
+      const dashboardInPersonalSubcollection = createMockDashboard({
+        collection: PERSONAL_SUBCOLLECTION,
+      });
+      await setup({
+        collections: COLLECTIONS,
+        dashboard: dashboardInPersonalSubcollection,
+      });
 
-    assertBreadcrumbs([
-      ROOT_COLLECTION,
-      PERSONAL_COLLECTION,
-      PERSONAL_SUBCOLLECTION,
-    ]);
+      assertBreadcrumbs([
+        ROOT_COLLECTION,
+        PERSONAL_COLLECTION,
+        PERSONAL_SUBCOLLECTION,
+      ]);
 
-    expect(screen.getByText("Nothing here")).toBeInTheDocument();
-  });
-
-  it("should show all questions when adding questions to dashboards in personal subcollections", async () => {
-    const dashboardInPersonalSubcollection = createMockDashboard({
-      collection: PERSONAL_SUBCOLLECTION,
+      expect(screen.getByText("Nothing here")).toBeInTheDocument();
     });
 
-    const collectionItems = [
-      createMockCollectionItem({
-        id: getNextId(),
-        model: "card",
-        name: "private question 1",
-      }),
-      createMockCollectionItem({
-        id: getNextId(),
-        model: "card",
-        name: "private question 2",
-      }),
-    ];
-    await setup({
-      collections: COLLECTIONS,
-      dashboard: dashboardInPersonalSubcollection,
-      collectionItems,
-    });
+    it("should show all questions", async () => {
+      const dashboardInPersonalSubcollection = createMockDashboard({
+        collection: PERSONAL_SUBCOLLECTION,
+      });
 
-    assertBreadcrumbs([
-      ROOT_COLLECTION,
-      PERSONAL_COLLECTION,
-      PERSONAL_SUBCOLLECTION,
-    ]);
-
-    collectionItems.forEach(collectionItem => {
-      expect(
-        screen.getByRole("menuitem", {
-          name: collectionItem.name,
+      const collectionItems = [
+        createMockCollectionItem({
+          id: getNextId(),
+          model: "card",
+          name: "private question 1",
         }),
-      ).toBeInTheDocument();
+        createMockCollectionItem({
+          id: getNextId(),
+          model: "card",
+          name: "private question 2",
+        }),
+      ];
+      await setup({
+        collections: COLLECTIONS,
+        dashboard: dashboardInPersonalSubcollection,
+        collectionItems,
+      });
+
+      assertBreadcrumbs([
+        ROOT_COLLECTION,
+        PERSONAL_COLLECTION,
+        PERSONAL_SUBCOLLECTION,
+      ]);
+
+      collectionItems.forEach(collectionItem => {
+        expect(
+          screen.getByRole("menuitem", {
+            name: collectionItem.name,
+          }),
+        ).toBeInTheDocument();
+      });
     });
   });
 });

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/AddCardSidebar/AddCardSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/AddCardSidebar/AddCardSidebar.unit.spec.tsx
@@ -177,7 +177,7 @@ describe("AddCardSideBar", () => {
       });
     });
 
-    it("should search dashboard only in public collections", async () => {
+    it("should search questions only in public collections", async () => {
       await setup({
         collections: COLLECTIONS,
         dashboard: dashboardInRootCollection,
@@ -249,7 +249,7 @@ describe("AddCardSideBar", () => {
       });
     });
 
-    it("should search dashboard only in public collections", async () => {
+    it("should search questions only in public collections", async () => {
       await setup({
         collections: COLLECTIONS,
         dashboard: dashboardInPublicSubcollection,
@@ -340,7 +340,7 @@ describe("AddCardSideBar", () => {
       });
     });
 
-    it("should search all dashboards", async () => {
+    it("should search all questions", async () => {
       await setup({
         collections: COLLECTIONS,
         dashboard: dashboardInPersonalSubcollection,

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionList.tsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionList.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from "react";
-import PropTypes from "prop-types";
 import { t } from "ttag";
 
 import { PLUGIN_MODERATION } from "metabase/plugins";
@@ -11,25 +10,35 @@ import { DEFAULT_SEARCH_LIMIT } from "metabase/lib/constants";
 import PaginationControls from "metabase/components/PaginationControls";
 import { usePagination } from "metabase/hooks/use-pagination";
 
+import type { CollectionId, SearchListQuery } from "metabase-types/api";
+import type { BaseSelectListItemProps } from "metabase/components/SelectList/BaseSelectListItem";
+import type Questions from "metabase/entities/questions";
 import {
   EmptyStateContainer,
   QuestionListItem,
   PaginationControlsContainer,
 } from "./QuestionList.styled";
 
-QuestionList.propTypes = {
-  searchText: PropTypes.string,
-  collectionId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  onSelect: PropTypes.func.isRequired,
-  hasCollections: PropTypes.bool,
-};
+interface QuestionListProps {
+  searchText: string;
+  collectionId: CollectionId;
+  onSelect: BaseSelectListItemProps["onSelect"];
+  hasCollections: boolean;
+}
+
+interface SearchListLoaderProps {
+  list: typeof Questions[];
+  metadata: {
+    total: number;
+  };
+}
 
 export function QuestionList({
   searchText,
   collectionId,
   onSelect,
   hasCollections,
-}) {
+}: QuestionListProps) {
   const [queryOffset, setQueryOffset] = useState(0);
   const { handleNextPage, handlePreviousPage, page, setPage } = usePagination();
 
@@ -45,7 +54,7 @@ export function QuestionList({
   const trimmedSearchText = searchText.trim();
   const isSearching = !!trimmedSearchText;
 
-  let query = isSearching
+  let query: SearchListQuery = isSearching
     ? { q: trimmedSearchText }
     : { collection: collectionId };
 
@@ -68,7 +77,7 @@ export function QuestionList({
 
   return (
     <Search.ListLoader entityQuery={query} wrapped>
-      {({ list, metadata }) => {
+      {({ list, metadata }: SearchListLoaderProps) => {
         const shouldShowEmptyState =
           list.length === 0 && (isSearching || !hasCollections);
         if (shouldShowEmptyState) {

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionList.tsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionList.tsx
@@ -10,9 +10,13 @@ import { DEFAULT_SEARCH_LIMIT } from "metabase/lib/constants";
 import PaginationControls from "metabase/components/PaginationControls";
 import { usePagination } from "metabase/hooks/use-pagination";
 
-import type { CollectionId, SearchListQuery } from "metabase-types/api";
+import type {
+  CollectionId,
+  SearchListQuery,
+  SearchResult,
+} from "metabase-types/api";
 import type { BaseSelectListItemProps } from "metabase/components/SelectList/BaseSelectListItem";
-import type Questions from "metabase/entities/questions";
+import type { WrappedEntity } from "metabase-types/entities";
 import {
   EmptyStateContainer,
   QuestionListItem,
@@ -28,7 +32,7 @@ interface QuestionListProps {
 }
 
 interface SearchListLoaderProps {
-  list: typeof Questions[];
+  list: WrappedEntity<SearchResult>[];
   metadata: {
     total: number;
   };
@@ -113,7 +117,7 @@ export function QuestionList({
                   }}
                   onSelect={onSelect}
                   rightIcon={PLUGIN_MODERATION.getStatusIcon(
-                    item.moderated_status,
+                    item.moderated_status ?? undefined,
                   )}
                 />
               ))}

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionList.tsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionList.tsx
@@ -24,6 +24,7 @@ interface QuestionListProps {
   collectionId: CollectionId;
   onSelect: BaseSelectListItemProps["onSelect"];
   hasCollections: boolean;
+  showOnlyPublicCollections: boolean;
 }
 
 interface SearchListLoaderProps {
@@ -38,6 +39,7 @@ export function QuestionList({
   collectionId,
   onSelect,
   hasCollections,
+  showOnlyPublicCollections,
 }: QuestionListProps) {
   const [queryOffset, setQueryOffset] = useState(0);
   const { handleNextPage, handlePreviousPage, page, setPage } = usePagination();
@@ -54,16 +56,25 @@ export function QuestionList({
   const trimmedSearchText = searchText.trim();
   const isSearching = !!trimmedSearchText;
 
-  let query: SearchListQuery = isSearching
-    ? { q: trimmedSearchText }
-    : { collection: collectionId };
+  const query = createQuery();
 
-  query = {
-    ...query,
-    models: ["card", "dataset"],
-    offset: queryOffset,
-    limit: DEFAULT_SEARCH_LIMIT,
-  };
+  function createQuery(): SearchListQuery {
+    const baseQuery = isSearching
+      ? {
+          q: trimmedSearchText,
+          ...(showOnlyPublicCollections && {
+            filter_items_in_personal_collection: "exclude" as const,
+          }),
+        }
+      : { collection: collectionId };
+
+    return {
+      ...baseQuery,
+      models: ["card", "dataset"],
+      offset: queryOffset,
+      limit: DEFAULT_SEARCH_LIMIT,
+    };
+  }
 
   const handleClickNextPage = () => {
     setQueryOffset(queryOffset + DEFAULT_SEARCH_LIMIT);

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionPicker.jsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionPicker.jsx
@@ -50,7 +50,8 @@ function QuestionPicker({ onSelect, collectionsById, getCollectionIcon }) {
   const handleSearchTextChange = e => setSearchText(e.target.value);
 
   const allCollections = (collection && collection.children) || [];
-  const collections = isPublicCollection(dashboardCollection)
+  const showOnlyPublicCollections = isPublicCollection(dashboardCollection);
+  const collections = showOnlyPublicCollections
     ? allCollections.filter(isPublicCollection)
     : allCollections;
 
@@ -107,6 +108,7 @@ function QuestionPicker({ onSelect, collectionsById, getCollectionIcon }) {
         searchText={debouncedSearchText}
         collectionId={currentCollectionId}
         onSelect={onSelect}
+        showOnlyPublicCollections={showOnlyPublicCollections}
       />
     </QuestionPickerRoot>
   );


### PR DESCRIPTION
This PR implements the first 2 tasks of the milestone in [this epic](https://github.com/metabase/metabase/issues/34733)
- [Hide items when searching in question picker (dashboards)](https://github.com/metabase/metabase/issues/34733#search-question-picker)
- [Hide items when searching in dashboard picker (query builder)](https://github.com/metabase/metabase/issues/34733#search-dashboard-picker)

#### How to verify
Dashboards
![image](https://github.com/metabase/metabase/assets/1937582/3a42cf3a-dcfe-43a4-9ebf-669cfbc25ddc)

1. Search questions for a dashboard in a public collection
    **expectation**:
    - show only questions in public collections
1. Search questions for a dashboard in a personal collection
    **expectation**:
    - show all questions

Query builder

Newly created question
![image](https://github.com/metabase/metabase/assets/1937582/959bc11c-1ce1-4538-b09e-24eb1b350940)

1. Search a dashboard for a question in a public collection
    **expectation**:
    - show all dashboards
1. Search a dashboard for a question in a personal collection
    **expectation**:
    - show only questions in personal collections