### PR TITLE
Decrease unit tests timeout

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -71,7 +71,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.frontend_all == 'true'
     runs-on: buildjet-2vcpu-ubuntu-2204
-    timeout-minutes: 60
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v3
       - name: Prepare front-end environment


### PR DESCRIPTION
### Description

Jest tests don't need 60min anymore, they usually take 20-30min, if longer, most likely, the process is crashed or stuck (happened to me https://github.com/metabase/metabase/actions/runs/6659834835?pr=35014) 