### PR TITLE
[Auditv2] Don't allow moving custom collection

### DIFF
--- a/e2e/test/scenarios/collections/instance-analytics.cy.spec.js
+++ b/e2e/test/scenarios/collections/instance-analytics.cy.spec.js
@@ -126,7 +126,7 @@ describeEE("scenarios > Instance Analytics Collection", () => {
       });
     });
 
-    it.skip("should not allow moving or archiving custom reports collection", () => {
+    it("should not allow moving or archiving custom reports collection", () => {
       navigationSidebar().within(() => {
         cy.findByText(ANALYTICS_COLLECTION_NAME).click();
         cy.findByText("Custom reports").click();

--- a/enterprise/frontend/src/metabase-enterprise/collections/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/collections/index.ts
@@ -13,6 +13,7 @@ import {
   AUTHORITY_LEVELS,
   REGULAR_COLLECTION,
   OFFICIAL_COLLECTION,
+  CUSTOM_INSTANCE_ANALYTICS_COLLECTION_ENTITY_ID,
 } from "./constants";
 import {
   getCollectionType,
@@ -70,6 +71,8 @@ if (hasPremiumFeature("audit_app")) {
   PLUGIN_COLLECTIONS.getCollectionType = getCollectionType;
   PLUGIN_COLLECTIONS.getInstanceAnalyticsCustomCollection =
     getInstanceAnalyticsCustomCollection;
+  PLUGIN_COLLECTIONS.CUSTOM_INSTANCE_ANALYTICS_COLLECTION_ENTITY_ID =
+    CUSTOM_INSTANCE_ANALYTICS_COLLECTION_ENTITY_ID;
 
   PLUGIN_COLLECTIONS.INSTANCE_ANALYTICS_ADMIN_READONLY_MESSAGE = t`This instance analytics collection is read-only for admin users`;
 }

--- a/frontend/src/metabase/collections/components/CollectionHeader/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/tests/enterprise.unit.spec.tsx
@@ -58,6 +58,39 @@ describe("Instance Analytics Collection Header", () => {
   });
 });
 
+describe("instance analytics custom reports collection", () => {
+  const defaultOptions = {
+    collection: {
+      name: "Custom Reports",
+      can_write: true,
+      entity_id: "okNLSZKdSxaoG58JSQY54",
+    },
+    hasEnterprisePlugins: true,
+    // 😬 this test needs the official_collections feature flag so that it
+    // doesn't cause the following test block to fail
+    tokenFeatures: { audit_app: true, official_collections: true },
+    isAdmin: true,
+  };
+
+  it("should not show move button", () => {
+    setup(defaultOptions);
+    userEvent.click(getIcon("ellipsis"));
+
+    expect(getIcon("lock")).toBeInTheDocument();
+    expect(queryIcon("move")).not.toBeInTheDocument();
+    expect(screen.queryByText("Move")).not.toBeInTheDocument();
+  });
+
+  it("should not show archive button", () => {
+    setup(defaultOptions);
+    userEvent.click(getIcon("ellipsis"));
+
+    expect(getIcon("lock")).toBeInTheDocument();
+    expect(queryIcon("archive")).not.toBeInTheDocument();
+    expect(screen.queryByText("Archive")).not.toBeInTheDocument();
+  });
+});
+
 describe("Official Collections Header", () => {
   const officialCollectionOptions = {
     collection: {
@@ -66,7 +99,6 @@ describe("Official Collections Header", () => {
       can_write: true,
     },
     hasEnterprisePlugins: true,
-
     tokenFeatures: { official_collections: true },
     isAdmin: true,
   };

--- a/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
@@ -5,6 +5,7 @@ import * as Urls from "metabase/lib/urls";
 import EntityMenu from "metabase/components/EntityMenu";
 import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 import {
+  isInstanceAnalyticsCustomCollection,
   isPersonalCollection,
   isRootCollection,
 } from "metabase/collections/utils";
@@ -27,6 +28,8 @@ export const CollectionMenu = ({
   const url = Urls.collection(collection);
   const isRoot = isRootCollection(collection);
   const isPersonal = isPersonalCollection(collection);
+  const isInstanceAnalyticsCustom =
+    isInstanceAnalyticsCustomCollection(collection);
   const canWrite = collection.can_write;
 
   if (
@@ -53,7 +56,7 @@ export const CollectionMenu = ({
     });
   }
 
-  if (!isRoot && !isPersonal && canWrite) {
+  if (!isRoot && !isPersonal && canWrite && !isInstanceAnalyticsCustom) {
     items.push({
       title: t`Move`,
       icon: "move",

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -36,6 +36,15 @@ export function getInstanceAnalyticsCustomCollection(
   return PLUGIN_COLLECTIONS.getInstanceAnalyticsCustomCollection(collections);
 }
 
+export function isInstanceAnalyticsCustomCollection(
+  collection: Collection,
+): boolean {
+  return (
+    PLUGIN_COLLECTIONS.CUSTOM_INSTANCE_ANALYTICS_COLLECTION_ENTITY_ID ===
+    collection.entity_id
+  );
+}
+
 // Replace the name for the current user's collection
 // @Question - should we just update the API to do this?
 function preparePersonalCollection(c: Collection): Collection {

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -168,6 +168,7 @@ export const PLUGIN_COLLECTIONS = {
   getInstanceAnalyticsCustomCollection: (
     collections: Collection[],
   ): Collection | null => null,
+  CUSTOM_INSTANCE_ANALYTICS_COLLECTION_ENTITY_ID: "",
   INSTANCE_ANALYTICS_ADMIN_READONLY_MESSAGE: UNABLE_TO_CHANGE_ADMIN_PERMISSIONS,
   getAuthorityLevelMenuItems: (
     _collection: Collection,


### PR DESCRIPTION
Closes #35212

### Description

Archive and move actions are disabled for the "custom reports" subcollection in the Metabase Analytics collection. This hides those buttons in the UI.

![Screen Shot 2023-10-30 at 2 06 40 PM](https://github.com/metabase/metabase/assets/30528226/1cf19217-8c6f-41c8-ae8f-436ae1040094)


### How to verify

Describe the steps to verify that the changes are working as expected.

1. Open the custom reports collection
2. you shouldn't see move or archive buttons in the `...` menu

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

also has a skipped e2e test in https://github.com/metabase/metabase/pull/35172
