### PR TITLE
Copy `activity` table data to `audit_log`

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15981,7 +15981,11 @@ databaseChangeLog:
                   user_id,
                   model,
                   model_id,
-                  '{}'
+                  JSON_OBJECT(
+                    'database_id': database_id,
+                    'table_id': table_id
+                    ABSENT ON NULL
+                  )
               FROM activity;
       rollback: # not necessary
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15966,8 +15966,8 @@ databaseChangeLog:
                   user_id,
                   model,
                   model_id,
-                  JSON_MERGE_PATCH(
-                      JSON_UNQUOTE(details),
+                  JSON_MERGE_PRESERVE(
+                      details,
                       JSON_OBJECT('database_id', database_id, 'table_id', table_id)
                   )
               FROM activity;

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15966,7 +15966,7 @@ databaseChangeLog:
                   user_id,
                   model,
                   model_id,
-                  JSON_MERGE_PRESERVE(
+                  JSON_MERGE(
                       details,
                       JSON_OBJECT('database_id', database_id, 'table_id', table_id)
                   )

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15983,6 +15983,8 @@ databaseChangeLog:
                   model_id,
                   '{}'
               FROM activity;
+      rollback: # not necessary
+
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15939,6 +15939,51 @@ databaseChangeLog:
             baseTableName: recent_views
             constraintName: fk_recent_views_ref_user_id
 
+  - changeSet:
+      id: v48.00-049
+      author: noahmoss
+      comment: Migrate data from activity to audit_log
+      changes:
+        - sql:
+            dbms: postgresql
+            sql: >-
+              INSERT INTO audit_log (topic, timestamp, user_id, model, model_id, details)
+              SELECT
+                topic,
+                timestamp,
+                user_id,
+                model,
+                model_id,
+                details::jsonb || json_strip_nulls(json_build_object('database_id', database_id, 'table_id', table_id))::jsonb
+              FROM activity;
+        - sql:
+            dbms: mysql,mariadb
+            sql: >-
+              INSERT INTO audit_log (topic, timestamp, user_id, model, model_id, details)
+              SELECT
+                  topic,
+                  timestamp,
+                  user_id,
+                  model,
+                  model_id,
+                  JSON_MERGE_PATCH(
+                      JSON_UNQUOTE(details),
+                      JSON_OBJECT('database_id', database_id, 'table_id', table_id)
+                  )
+              FROM activity;
+        - sql:
+            dbms: h2
+            sql: >-
+              INSERT INTO audit_log (topic, timestamp, user_id, model, model_id, details)
+              SELECT
+                  topic,
+                  timestamp,
+                  user_id,
+                  model,
+                  model_id,
+                  '{}'
+              FROM activity;
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -73,7 +73,7 @@
 (defsetting version-info
   (deferred-tru "Information about available versions of Metabase.")
   :type    :json
-  :audit   :getter
+  :audit   :never
   :default {}
   :doc     false)
 

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -1247,7 +1247,7 @@
                                                     :model_id    2
                                                     :database_id 1
                                                     :table_id    6
-                                                    :details     "{arbitrary_key: \"arbitrary_value\"}"})]
+                                                    :details     "{\"arbitrary_key\": \"arbitrary_value\"}"})]
          (testing "activity rows are copied into audit_log"
            (is (= 0 (t2/count :model/AuditLog)))
            (is (= 1 (t2/count :model/Activity)))
@@ -1278,7 +1278,7 @@
                                                     :model_id    2
                                                     :database_id 1
                                                     :table_id    6
-                                                    :details     "{arbitrary_key: \"arbitrary_value\"}"})]
+                                                    :details     "{\"arbitrary_key\": \"arbitrary_value\"}"})]
          (testing "activity rows are copied into audit_log"
            (is (= 0 (t2/count :model/AuditLog)))
            (is (= 1 (t2/count :model/Activity)))


### PR DESCRIPTION
Migration to copy the data in `activity` into `audit_log`. `database_id` and `table_id`, which were previously top-level fields in the table, are merged into `details` on postgres and mysql. H2 doesn't have the ability to merge JSON fields like this so I'm instead constructing a new JSON object (this won't migrate other existing data in `details` but there are already other limitations for auditv2 on H2 as well, and enterprise customers are discouraged from using H2, so I think it's OK)