### PR TITLE
Manual Backport :  Drop parameter_card.entity_id #35134 

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/seed_entity_ids_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/seed_entity_ids_test.clj
@@ -5,7 +5,6 @@
    [clojure.test :refer :all]
    [metabase-enterprise.serialization.v2.seed-entity-ids
     :as v2.seed-entity-ids]
-   [metabase.config :as config]
    [metabase.models :refer [Collection]]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp])

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/seed_entity_ids_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/seed_entity_ids_test.clj
@@ -1,11 +1,9 @@
 (ns metabase-enterprise.serialization.v2.seed-entity-ids-test
   (:require
-   [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase-enterprise.serialization.v2.seed-entity-ids
     :as v2.seed-entity-ids]
-   [metabase.config :as config]
    [metabase.models :refer [Collection]]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp])
@@ -48,51 +46,3 @@
                        (v2.seed-entity-ids/seed-entity-ids!))))
               (is (= nil
                      (entity-id))))))))))
-
-(deftest entity-models-test
-  (testing "Sanity check: list of models that does not need an entity_id column,
-           if this test fails, check if it really needs it.
-           If yes, makes surethe exported data includes `:entity_id` column
-           or the model implements [[serdes/hash-fields]] (#35097)"
-    (is (= (cond-> #{:model/MetricImportantField
-                      :model/ModerationReview
-                      :model/CollectionBookmark
-                      :model/Secret
-                      :model/FieldValues
-                      :model/ModelIndex
-                      :model/DashboardCardSeries
-                      :model/DataMigrations
-                      :model/ParameterCard
-                      :model/QueryAction
-                      :model/ImplicitAction
-                      :model/User
-                      :model/Revision
-                      :model/PermissionsRevision
-                      :model/CardBookmark
-                      :model/CollectionPermissionGraphRevision
-                      :model/BookmarkOrdering
-                      :model/ModelIndexValue
-                      :model/PermissionsGroupMembership
-                      :model/ViewLog
-                      :model/Field
-                      :model/QueryCache
-                      :model/ApplicationPermissionsRevision
-                      :model/LoginHistory
-                      :model/Database
-                      :model/Session
-                      :model/Permissions
-                      :model/TaskHistory
-                      :model/Setting
-                      :model/Activity
-                      :model/PulseChannelRecipient
-                      :model/TimelineEvent
-                      :model/PersistedInfo
-                      :model/HTTPAction
-                      :model/QueryExecution
-                      :model/DashboardBookmark
-                      :model/Table
-                      :model/Query
-                      :model/PermissionsGroup}
-             config/ee-available?
-            (conj :model/GroupTableAccessPolicy))
-           (set/difference (set (v2.seed-entity-ids/toucan-models)) (#'v2.seed-entity-ids/entity-id-models))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/seed_entity_ids_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/seed_entity_ids_test.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.serialization.v2.seed-entity-ids-test
   (:require
+   [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase-enterprise.serialization.v2.seed-entity-ids

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/seed_entity_ids_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/seed_entity_ids_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer :all]
    [metabase-enterprise.serialization.v2.seed-entity-ids
     :as v2.seed-entity-ids]
+   [metabase.config :as config]
    [metabase.models :refer [Collection]]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp])
@@ -46,3 +47,52 @@
                        (v2.seed-entity-ids/seed-entity-ids!))))
               (is (= nil
                      (entity-id))))))))))
+
+(deftest entity-models-test
+  (testing "Sanity check: list of models that does not need an entity_id column,
+           if this test fails, check if it really needs it.
+           If yes, makes surethe exported data includes `:entity_id` column
+           or the model implements [[serdes/hash-fields]] (#35097)"
+    (is (= (cond-> #{:model/MetricImportantField
+                     :model/ModerationReview
+                     :model/CollectionBookmark
+                     :model/Secret
+                     :model/GroupTableAccessPolicy
+                     :model/FieldValues
+                     :model/ModelIndex
+                     :model/DashboardCardSeries
+                     :model/ParameterCard
+                     :model/QueryAction
+                     :model/ImplicitAction
+                     :model/User
+                     :model/Revision
+                     :model/PermissionsRevision
+                     :model/CardBookmark
+                     :model/CollectionPermissionGraphRevision
+                     :model/BookmarkOrdering
+                     :model/ModelIndexValue
+                     :model/PermissionsGroupMembership
+                     :model/ViewLog
+                     :model/Field
+                     :model/QueryCache
+                     :model/ApplicationPermissionsRevision
+                     :model/LoginHistory
+                     :model/Database
+                     :model/Session
+                     :model/Permissions
+                     :model/TaskHistory
+                     :model/Setting
+                     :model/Activity
+                     :model/PulseChannelRecipient
+                     :model/TablePrivileges
+                     :model/TimelineEvent
+                     :model/PersistedInfo
+                     :model/HTTPAction
+                     :model/QueryExecution
+                     :model/DashboardBookmark
+                     :model/Table
+                     :model/Query
+                     :model/PermissionsGroup}
+             config/ee-available?
+             (conj :model/ConnectionImpersonation))
+           (set/difference (set (v2.seed-entity-ids/toucan-models)) (#'v2.seed-entity-ids/entity-id-models))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/seed_entity_ids_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/seed_entity_ids_test.clj
@@ -54,46 +54,44 @@
            if this test fails, check if it really needs it.
            If yes, makes surethe exported data includes `:entity_id` column
            or the model implements [[serdes/hash-fields]] (#35097)"
-    (is (= (cond-> #{:model/MetricImportantField
-                     :model/ModerationReview
-                     :model/CollectionBookmark
-                     :model/Secret
-                     :model/GroupTableAccessPolicy
-                     :model/FieldValues
-                     :model/ModelIndex
-                     :model/DashboardCardSeries
-                     :model/ParameterCard
-                     :model/QueryAction
-                     :model/ImplicitAction
-                     :model/User
-                     :model/Revision
-                     :model/PermissionsRevision
-                     :model/CardBookmark
-                     :model/CollectionPermissionGraphRevision
-                     :model/BookmarkOrdering
-                     :model/ModelIndexValue
-                     :model/PermissionsGroupMembership
-                     :model/ViewLog
-                     :model/Field
-                     :model/QueryCache
-                     :model/ApplicationPermissionsRevision
-                     :model/LoginHistory
-                     :model/Database
-                     :model/Session
-                     :model/Permissions
-                     :model/TaskHistory
-                     :model/Setting
-                     :model/Activity
-                     :model/PulseChannelRecipient
-                     :model/TablePrivileges
-                     :model/TimelineEvent
-                     :model/PersistedInfo
-                     :model/HTTPAction
-                     :model/QueryExecution
-                     :model/DashboardBookmark
-                     :model/Table
-                     :model/Query
-                     :model/PermissionsGroup}
-             config/ee-available?
-             (conj :model/ConnectionImpersonation))
+    (is (= #{:model/MetricImportantField
+             :model/ModerationReview
+             :model/CollectionBookmark
+             :model/Secret
+             :model/GroupTableAccessPolicy
+             :model/FieldValues
+             :model/ModelIndex
+             :model/DashboardCardSeries
+             :model/DataMigrations
+             :model/ParameterCard
+             :model/QueryAction
+             :model/ImplicitAction
+             :model/User
+             :model/Revision
+             :model/PermissionsRevision
+             :model/CardBookmark
+             :model/CollectionPermissionGraphRevision
+             :model/BookmarkOrdering
+             :model/ModelIndexValue
+             :model/PermissionsGroupMembership
+             :model/ViewLog
+             :model/Field
+             :model/QueryCache
+             :model/ApplicationPermissionsRevision
+             :model/LoginHistory
+             :model/Database
+             :model/Session
+             :model/Permissions
+             :model/TaskHistory
+             :model/Setting
+             :model/Activity
+             :model/PulseChannelRecipient
+             :model/TimelineEvent
+             :model/PersistedInfo
+             :model/HTTPAction
+             :model/QueryExecution
+             :model/DashboardBookmark
+             :model/Table
+             :model/Query
+             :model/PermissionsGroup}
            (set/difference (set (v2.seed-entity-ids/toucan-models)) (#'v2.seed-entity-ids/entity-id-models))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/seed_entity_ids_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/seed_entity_ids_test.clj
@@ -5,6 +5,7 @@
    [clojure.test :refer :all]
    [metabase-enterprise.serialization.v2.seed-entity-ids
     :as v2.seed-entity-ids]
+   [metabase.config :as config]
    [metabase.models :refer [Collection]]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp])
@@ -53,44 +54,45 @@
            if this test fails, check if it really needs it.
            If yes, makes surethe exported data includes `:entity_id` column
            or the model implements [[serdes/hash-fields]] (#35097)"
-    (is (= #{:model/MetricImportantField
-             :model/ModerationReview
-             :model/CollectionBookmark
-             :model/Secret
-             :model/GroupTableAccessPolicy
-             :model/FieldValues
-             :model/ModelIndex
-             :model/DashboardCardSeries
-             :model/DataMigrations
-             :model/ParameterCard
-             :model/QueryAction
-             :model/ImplicitAction
-             :model/User
-             :model/Revision
-             :model/PermissionsRevision
-             :model/CardBookmark
-             :model/CollectionPermissionGraphRevision
-             :model/BookmarkOrdering
-             :model/ModelIndexValue
-             :model/PermissionsGroupMembership
-             :model/ViewLog
-             :model/Field
-             :model/QueryCache
-             :model/ApplicationPermissionsRevision
-             :model/LoginHistory
-             :model/Database
-             :model/Session
-             :model/Permissions
-             :model/TaskHistory
-             :model/Setting
-             :model/Activity
-             :model/PulseChannelRecipient
-             :model/TimelineEvent
-             :model/PersistedInfo
-             :model/HTTPAction
-             :model/QueryExecution
-             :model/DashboardBookmark
-             :model/Table
-             :model/Query
-             :model/PermissionsGroup}
+    (is (= (cond-> #{:model/MetricImportantField
+                      :model/ModerationReview
+                      :model/CollectionBookmark
+                      :model/Secret
+                      :model/FieldValues
+                      :model/ModelIndex
+                      :model/DashboardCardSeries
+                      :model/DataMigrations
+                      :model/ParameterCard
+                      :model/QueryAction
+                      :model/ImplicitAction
+                      :model/User
+                      :model/Revision
+                      :model/PermissionsRevision
+                      :model/CardBookmark
+                      :model/CollectionPermissionGraphRevision
+                      :model/BookmarkOrdering
+                      :model/ModelIndexValue
+                      :model/PermissionsGroupMembership
+                      :model/ViewLog
+                      :model/Field
+                      :model/QueryCache
+                      :model/ApplicationPermissionsRevision
+                      :model/LoginHistory
+                      :model/Database
+                      :model/Session
+                      :model/Permissions
+                      :model/TaskHistory
+                      :model/Setting
+                      :model/Activity
+                      :model/PulseChannelRecipient
+                      :model/TimelineEvent
+                      :model/PersistedInfo
+                      :model/HTTPAction
+                      :model/QueryExecution
+                      :model/DashboardBookmark
+                      :model/Table
+                      :model/Query
+                      :model/PermissionsGroup}
+             config/ee-available?
+            (conj :model/GroupTableAccessPolicy))
            (set/difference (set (v2.seed-entity-ids/toucan-models)) (#'v2.seed-entity-ids/entity-id-models))))))

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15087,6 +15087,11 @@ databaseChangeLog:
       id: v47.00-058
       author: qnkhuat
       comment: 'Drop parameter_card.entity_id'
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: parameter_card
+            columnName: entity_id
       changes:
         - dropColumn:
             tableName: parameter_card

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15097,10 +15097,16 @@ databaseChangeLog:
             tableName: parameter_card
             columnName: entity_id
       rollback:
-        - sql:
-            sql: >-
-                ALTER TABLE parameter_card
-                ADD COLUMN IF NOT EXISTS entity_id CHAR(21) NULL;
+        - addColumn:
+            tableName: parameter_card
+            columns:
+            - column:
+                remarks: Random NanoID tag for unique identity.
+                name: entity_id
+                type: char(21)
+                constraints:
+                  nullable: true
+                  unique: true
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15083,6 +15083,20 @@ databaseChangeLog:
             constraintName: fk_conn_impersonation_group_id
             onDelete: CASCADE
 
+  - changeSet:
+      id: v47.00-058
+      author: qnkhuat
+      comment: 'Drop parameter_card.entity_id'
+      changes:
+        - dropColumn:
+            tableName: parameter_card
+            columnName: entity_id
+      rollback:
+        - sql:
+            sql: >-
+                ALTER TABLE parameter_card
+                ADD COLUMN IF NOT EXISTS entity_id CHAR(21) NULL;
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15100,13 +15100,13 @@ databaseChangeLog:
         - addColumn:
             tableName: parameter_card
             columns:
-            - column:
-                remarks: Random NanoID tag for unique identity.
-                name: entity_id
-                type: char(21)
-                constraints:
-                  nullable: true
-                  unique: true
+              - column:
+                  remarks: Random NanoID tag for unique identity.
+                  name: entity_id
+                  type: char(21)
+                  constraints:
+                    nullable: true
+                    unique: true
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/src/metabase/models/parameter_card.clj
+++ b/src/metabase/models/parameter_card.clj
@@ -18,8 +18,7 @@
 
 (doto :model/ParameterCard
   (derive :metabase/model)
-  (derive :hook/timestamped?)
-  (derive :hook/entity-id))
+  (derive :hook/timestamped?))
 
 (t2/deftransforms :model/ParameterCard
  {:parameterized_object_type mi/transform-keyword})


### PR DESCRIPTION
Manual backport of #35134 

The migration is not `v48.00-027` like we the original PR #35134, because we want the migration id reflect the version correctly.

See this [PR](https://github.com/metabase/metabase/pull/35239) that added the same migration we added in this one `v47.00-058` to master for completeness.