### PR TITLE
Fix migration added in  #35134

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15101,6 +15101,11 @@ databaseChangeLog:
       id: v47.00-058
       author: qnkhuat
       comment: 'Drop parameter_card.entity_id'
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: parameter_card
+            columnName: entity_id
       changes:
         - dropColumn:
             tableName: parameter_card

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15098,6 +15098,20 @@ databaseChangeLog:
             onDelete: CASCADE
 
   - changeSet:
+      id: v47.00-058
+      author: qnkhuat
+      comment: 'Drop parameter_card.entity_id'
+      changes:
+        - dropColumn:
+            tableName: parameter_card
+            columnName: entity_id
+      rollback:
+        - sql:
+            sql: >-
+                ALTER TABLE parameter_card
+                ADD COLUMN IF NOT EXISTS entity_id CHAR(21) NULL;
+
+  - changeSet:
       id: v48.00-001
       author: qnkhuat
       comment: Added 0.47.0 - Migrate database.options to database.settings
@@ -15529,7 +15543,13 @@ databaseChangeLog:
   - changeSet:
       id: v48.00-027
       author: qnkhuat
+      validCheckSum: ANY
       comment: 'Drop parameter_card.entity_id'
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: parameter_card
+            columnName: entity_id
       changes:
         - dropColumn:
             tableName: parameter_card

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15111,10 +15111,16 @@ databaseChangeLog:
             tableName: parameter_card
             columnName: entity_id
       rollback:
-        - sql:
-            sql: >-
-                ALTER TABLE parameter_card
-                ADD COLUMN IF NOT EXISTS entity_id CHAR(21) NULL;
+        - addColumn:
+          tableName: parameter_card
+          columns:
+            - column:
+                remarks: Random NanoID tag for unique identity.
+                name: entity_id
+                type: char(21)
+                constraints:
+                  nullable: true
+                  unique: true
 
   - changeSet:
       id: v48.00-001

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15112,15 +15112,15 @@ databaseChangeLog:
             columnName: entity_id
       rollback:
         - addColumn:
-          tableName: parameter_card
-          columns:
-            - column:
-                remarks: Random NanoID tag for unique identity.
-                name: entity_id
-                type: char(21)
-                constraints:
-                  nullable: true
-                  unique: true
+            tableName: parameter_card
+            columns:
+              - column:
+                  remarks: Random NanoID tag for unique identity.
+                  name: entity_id
+                  type: char(21)
+                  constraints:
+                    nullable: true
+                    unique: true
 
   - changeSet:
       id: v48.00-001

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15563,6 +15563,7 @@ databaseChangeLog:
       changes:
         - sql:
           sql: SELECT 1;
+      rollback:
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15545,31 +15545,18 @@ databaseChangeLog:
             where: semantic_type = 'type/Number'
       rollback:
 
+  # this is a no op, it was previously used to Drop parameter_card.entity_id,
+  # now it's moved to v47.00-058
+  # this is still here because we want the change set id to be consistent
+  # see #35239 for details
   - changeSet:
       id: v48.00-027
       author: qnkhuat
       validCheckSum: ANY
-      comment: 'Drop parameter_card.entity_id'
-      preConditions:
-        - onFail: MARK_RAN
-        - columnExists:
-            tableName: parameter_card
-            columnName: entity_id
+      comment: 'No op migration'
       changes:
-        - dropColumn:
-            tableName: parameter_card
-            columnName: entity_id
-      rollback:
-        - addColumn:
-            columns:
-            - column:
-                remarks: Random NanoID tag for unique identity.
-                name: entity_id
-                type: char(21)
-                constraints:
-                  nullable: true
-                  unique: true
-            tableName: parameter_card
+        - sql:
+          sql: SELECT 1;
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 


### PR DESCRIPTION
Silly mistake, so in https://github.com/metabase/metabase/pull/35134 I added the `v48.00-027` migration to paramter_card.entity_id, but I forgot that we need to backport it so the migration id has to start with `v47`, not `v48`

To make sure everything works normally if someone upgrades from v47:
- In the backport [PR](https://github.com/metabase/metabase/pull/35238) I used the id `v47.00-058` instead of `v48.00-027` to drop parameter.entity_id
- in this PR, I included that migration, and also updated the migration `v48.00-027` to be a no-op


What I tested:
- Boot up with the branch of the manual backport [PR](https://github.com/metabase/metabase/pull/35238), then switch to this branch to boot up again
- boot up with `master`, then switch to boot up with this branch. This is basically to make sure stats will be okay