### PR TITLE
left align actions on small cards to not make them go out of the viewport

### DIFF
--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -174,6 +174,9 @@ describe("scenarios > dashboard > tabs", () => {
       const cards = [
         getTextCardDetails({
           text: "Text card",
+          // small card aligned to the left so that move icon is out of the viewport
+          // unless the left alignment logic kicks in
+          size_x: 1,
         }),
         getHeadingCardDetails({
           text: "Heading card",

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
@@ -41,13 +41,14 @@ export const DashCardRoot = styled.div<DashCardRootProps>`
     shouldForceHiddenBackground && hiddenBackgroundStyle}
 `;
 
-export const DashboardCardActionsPanel = styled.div`
+export const DashboardCardActionsPanel = styled.div<{ leftAlign: boolean }>`
   padding: 0.125em 0.25em;
   position: absolute;
   background: white;
   transform: translateY(-50%);
   top: 0;
-  right: 20px;
+  right: ${props => (props.leftAlign ? "initial" : "20px")};
+  left: ${props => (props.leftAlign ? "20px" : "initial")};
   border-radius: 8px;
   box-shadow: 0px 1px 3px rgb(0 0 0 / 13%);
   cursor: default;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -115,6 +115,10 @@ function DashCard({
 }: DashCardProps) {
   const [isPreviewingCard, setIsPreviewingCard] = useState(false);
   const cardRootRef = useRef<HTMLDivElement>(null);
+  const actionsRef = useRef<HTMLDivElement>(null);
+
+  const cardWidth = cardRootRef.current?.getBoundingClientRect().width;
+  const actionsWidth = actionsRef.current?.getBoundingClientRect().width;
 
   const handlePreviewToggle = useCallback(() => {
     setIsPreviewingCard(wasPreviewingCard => !wasPreviewingCard);
@@ -250,8 +254,15 @@ function DashCard({
 
   const renderDashCardActions = useCallback(() => {
     if (isEditingDashboardLayout) {
+      const actionsBiggerThanCard =
+        actionsWidth != null && cardWidth != null && actionsWidth > cardWidth;
+      // to avoid having actions buttons outside of the viewport
+      const leftAlignActions = dashcard.col <= 2 && actionsBiggerThanCard;
+
       return (
         <DashboardCardActionsPanel
+          ref={actionsRef}
+          leftAlign={leftAlignActions}
           onMouseDown={preventDragging}
           data-testid="dashboardcard-actions-panel"
         >
@@ -291,6 +302,8 @@ function DashCard({
     onUpdateVisualizationSettings,
     handlePreviewToggle,
     handleShowClickBehaviorSidebar,
+    actionsWidth,
+    cardWidth,
   ]);
 
   return (


### PR DESCRIPTION
epic https://github.com/metabase/metabase/issues/34367
milestone 4

### Description

Cards too small and with too many dashcard actions had the menu going outside of the viewport.
This fixes it by left-aligning actions on cards on the left side, if the actions container is bigger than the card

### How to verify

Resize a card to 2x2 and drag it to the far left of the dashboard, actions should be left aligned


### Demo

https://github.com/metabase/metabase/assets/1914270/af1b0e94-8c59-44a5-a760-87bfe1a25db0

