### PR TITLE
dismiss undo notifications when saving a dashboard

### DIFF
--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -207,7 +207,7 @@ describe("scenarios > dashboard > tabs", () => {
 
       cy.findAllByTestId("toast-undo").should("have.length", cards.length);
 
-      cy.log("undo toasts should be dismiss when saving");
+      cy.log("'Undo' toasts should be dismissed when saving the dashboard");
 
       saveDashboard();
 

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -204,6 +204,14 @@ describe("scenarios > dashboard > tabs", () => {
       goToTab("Tab 2");
 
       getDashboardCards().should("have.length", cards.length);
+
+      cy.findAllByTestId("toast-undo").should("have.length", cards.length);
+
+      cy.log("undo toasts should be dismiss when saving");
+
+      saveDashboard();
+
+      cy.findAllByTestId("toast-undo").should("have.length", 0);
     },
   );
 

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -40,6 +40,7 @@ import {
 import { hasDatabaseActionsEnabled } from "metabase/dashboard/utils";
 import { saveDashboardPdf } from "metabase/visualizations/lib/save-dashboard-pdf";
 import { getSetting } from "metabase/selectors/settings";
+import { dismissAllUndo } from "metabase/redux/undo";
 
 import { DashboardHeaderComponent } from "../components/DashboardHeader";
 import { SIDEBAR_NAME } from "../constants";
@@ -70,6 +71,7 @@ const mapDispatchToProps = {
   onChangeLocation: push,
   toggleSidebar,
   addActionToDashboard,
+  dismissAllUndo,
 };
 
 class DashboardHeader extends Component {
@@ -109,6 +111,7 @@ class DashboardHeader extends Component {
     fetchDashboard: PropTypes.func.isRequired,
     updateDashboardAndCards: PropTypes.func.isRequired,
     setDashboardAttribute: PropTypes.func.isRequired,
+    dismissAllUndo: PropTypes.func.isRequired,
 
     onEditingChange: PropTypes.func.isRequired,
     onRefreshPeriodChange: PropTypes.func.isRequired,
@@ -209,6 +212,9 @@ class DashboardHeader extends Component {
   }
 
   async onSave() {
+    // optimistically dismissing all the undos before the saving has finished
+    // clicking on them wouldn't do anything at this moment anyway
+    this.props.dismissAllUndo();
     await this.props.updateDashboardAndCards();
     this.onDoneEditing();
   }

--- a/frontend/src/metabase/redux/undo.js
+++ b/frontend/src/metabase/redux/undo.js
@@ -1,10 +1,11 @@
 import _ from "underscore";
 
-import { createThunkAction } from "metabase/lib/redux";
+import { createAction, createThunkAction } from "metabase/lib/redux";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 
 const ADD_UNDO = "metabase/questions/ADD_UNDO";
 const DISMISS_UNDO = "metabase/questions/DISMISS_UNDO";
+const DISMISS_ALL_UNDO = "metabase/questions/DISMISS_ALL_UNDO";
 const PERFORM_UNDO = "metabase/questions/PERFORM_UNDO";
 
 let nextUndoId = 0;
@@ -35,6 +36,8 @@ export const dismissUndo = createThunkAction(
     };
   },
 );
+
+export const dismissAllUndo = createAction(DISMISS_ALL_UNDO);
 
 export const performUndo = createThunkAction(PERFORM_UNDO, undoId => {
   return (dispatch, getState) => {
@@ -91,6 +94,8 @@ export default function (state = [], { type, payload, error }) {
       return state;
     }
     return state.filter(undo => undo.id !== payload);
+  } else if (type === DISMISS_ALL_UNDO) {
+    return [];
   }
   return state;
 }


### PR DESCRIPTION
Part of M4 of epic https://github.com/metabase/metabase/issues/34367

slack thread: https://metaboat.slack.com/archives/C057T1QTB3L/p1698244251384019

### Description

Cliking "undo" on a toast for a tab deletion, a card movement and similar doesn't work  after you save the dashboard (and doesn't make sense as those toast undo local draft state).

This PR dismissed all the undo toasts when saving the dashboard.

### How to verify

Move a card to another tab and immediately save the dashboard, the notification should disappear

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
