### PR TITLE
Remove `:rff` from the Query Processor context map

### DIFF
--- a/.clj-kondo/hooks/clojure/test.clj
+++ b/.clj-kondo/hooks/clojure/test.clj
@@ -91,6 +91,24 @@
      clojure.core/volatile!
      clojure.core/vreset!
      clojure.core/vswap!
+     clojure.core.async/<!
+     clojure.core.async/<!!
+     clojure.core.async/>!
+     clojure.core.async/>!!
+     clojure.core.async/alt!
+     clojure.core.async/alt!!
+     clojure.core.async/alts!
+     clojure.core.async/alts!!
+     clojure.core.async/close!
+     clojure.core.async/ioc-alts!
+     clojure.core.async/offer!
+     clojure.core.async/onto-chan!
+     clojure.core.async/onto-chan!!
+     clojure.core.async/poll!
+     clojure.core.async/put!
+     clojure.core.async/take!
+     clojure.core.async/to-chan!
+     clojure.core.async/to-chan!!
      metabase.query-processor/process-query-and-save-execution!
      metabase.query-processor/process-query-and-save-with-max-results-constraints!
      metabase.query-processor.store/store-database!})

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/query_processor/middleware/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/query_processor/middleware/permissions_test.clj
@@ -11,7 +11,7 @@
    [metabase.models.permissions-group :as perms-group]
    [metabase.public-settings.premium-features-test
     :as premium-features-test]
-   [metabase.query-processor.context.default :as context.default]
+   [metabase.query-processor.reducible :as qp.reducible]
    [metabase.query-processor.streaming-test :as streaming-test]
    [metabase.test :as mt]
    [metabase.util :as u])
@@ -97,7 +97,7 @@
 
 ;; Inspired by the similar middleware wrapper [[metabase.query-processor.middleware.limit-test/limit]]
 (defn- limit-download-result-rows [query]
-  (let [rff (ee.qp.perms/limit-download-result-rows query context.default/default-rff)
+  (let [rff (ee.qp.perms/limit-download-result-rows query qp.reducible/default-rff)
         rf  (rff {})]
     (transduce identity rf (repeat (inc @#'ee.qp.perms/max-rows-in-limited-downloads) [:ok]))))
 

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -71,8 +71,8 @@
                          (:dataset source-card)
                          (assoc :metadata/dataset-metadata (:result_metadata source-card)))]
     (binding [qp.perms/*card-id* source-card-id]
-      (qp.streaming/streaming-response [context export-format]
-        (qp-runner query info context)))))
+      (qp.streaming/streaming-response [{:keys [rff context]} export-format]
+        (qp-runner query info rff context)))))
 
 (api/defendpoint POST "/"
   "Execute a query and retrieve the results in the usual format. The query will not use the cache."
@@ -181,11 +181,12 @@
   (api/read-check Database database)
   (let [info {:executed-by api/*current-user-id*
               :context     :ad-hoc}]
-    (qp.streaming/streaming-response [context :api]
+    (qp.streaming/streaming-response [{:keys [rff context]} :api]
       (qp.pivot/run-pivot-query (assoc query
                                        :async? true
                                        :constraints (qp.constraints/default-query-constraints))
                                 info
+                                rff
                                 context))))
 
 (defn- parameter-field-values

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -137,14 +137,15 @@
   "Create the `:run` function used for [[run-query-for-card-with-id-async]] and [[public-dashcard-results-async]]."
   [qp-runner export-format]
   (fn [query info]
-    (qp.streaming/streaming-response
-     [{:keys [reducedf], :as context} export-format (u/slugify (:card-name info))]
-     (let [context  (assoc context :reducedf (public-reducedf reducedf))
-           in-chan  (mw.session/as-admin
-                     (qp-runner query info context))
-           out-chan (a/promise-chan (map transform-results))]
-       (async.u/promise-pipe in-chan out-chan)
-       out-chan))))
+    (qp.streaming/streaming-response [{:keys [rff], {:keys [reducedf], :as context} :context}
+                                      export-format
+                                      (u/slugify (:card-name info))]
+      (let [context  (assoc context :reducedf (public-reducedf reducedf))
+            in-chan  (mw.session/as-admin
+                       (qp-runner query info rff context))
+            out-chan (a/promise-chan (map transform-results))]
+        (async.u/promise-pipe in-chan out-chan)
+        out-chan))))
 
 (defn run-query-for-card-with-id-async
   "Run the query belonging to Card with `card-id` with `parameters` and other query options (e.g. `:constraints`).

--- a/src/metabase/db/metadata_queries.clj
+++ b/src/metabase/db/metadata_queries.clj
@@ -93,7 +93,7 @@
     [:truncation-size {:optional true} :int]
     [:limit           {:optional true} :int]
     [:order-by        {:optional true} (helpers/distinct (helpers/non-empty [:sequential mbql.s/OrderBy]))]
-    [:rff             {:optional true} :any]]])
+    [:rff             {:optional true} fn?]]])
 
 (defn- text-field?
   "Identify text fields which can accept our substring optimization.
@@ -145,11 +145,11 @@
 
   ([table  :- (ms/InstanceOf :model/Table)
     fields :- [:sequential (ms/InstanceOf :model/Field)]
-    rff
+    rff    :- fn?
     opts   :- TableRowsSampleOptions]
    (let [query (table-rows-sample-query table fields opts)
          qp    (requiring-resolve 'metabase.query-processor/process-query)]
-     (qp query {:rff rff}))))
+     (qp query rff nil))))
 
 (defmethod driver/table-rows-sample :default
   [_driver table fields rff opts]

--- a/src/metabase/models/params/chain_filter.clj
+++ b/src/metabase/models/params/chain_filter.clj
@@ -428,7 +428,7 @@
     (log/debugf "Chain filter MBQL query:\n%s" (u/pprint-to-str 'magenta mbql-query))
     (try
       (let [query-limit (get-in mbql-query [:query :limit])
-            values      (qp/process-query mbql-query {:rff (constantly conj)})]
+            values      (qp/process-query mbql-query (constantly conj) nil)]
         {:values          values
          ;; It's unlikely that we don't have a query-limit, but better safe than sorry and default it true
          ;; so that calling chain-filter-search on the same field will search from DB.

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -12,6 +12,7 @@
    [metabase.driver.util :as driver.u]
    [metabase.mbql.util :as mbql.u]
    [metabase.plugins.classloader :as classloader]
+   [metabase.query-processor.context.default :as qp.context.default]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.middleware.add-default-temporal-unit
     :as qp.add-default-temporal-unit]
@@ -95,9 +96,8 @@
    [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
-   [schema.core :as s]
    [metabase.util.malli :as mu]
-   [metabase.query-processor.context.default :as qp.context.default]))
+   [schema.core :as s]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                QUERY PROCESSOR                                                 |
@@ -388,7 +388,7 @@
     #'process-userland-query/process-userland-query
     #'catch-exceptions/catch-exceptions]))
 
-(def ^{:arglists '([query] [query context] [query rff context])} process-userland-query-async
+(def ^{:arglists '([query] [query context] [query rff context])} ^:private process-userland-query-async
   "Like [[process-query-async]], but for 'userland' queries (e.g., queries ran via the REST API). Adds extra middleware."
   (base-qp userland-middleware))
 

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -95,7 +95,9 @@
    [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
-   [schema.core :as s]))
+   [schema.core :as s]
+   [metabase.util.malli :as mu]
+   [metabase.query-processor.context.default :as qp.context.default]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                QUERY PROCESSOR                                                 |
@@ -287,15 +289,27 @@
   "Process a query synchronously, blocking until results are returned. Throws raised Exceptions directly."
   (qp.reducible/sync-qp process-query-async))
 
-(defn process-query
+(mu/defn process-query
   "Process an MBQL query. This is the main entrypoint to the magical realm of the Query Processor. Returns a *single*
   core.async channel if option `:async?` is true; otherwise returns results in the usual format. For async queries, if
   the core.async channel is closed, the query will be canceled."
-  {:arglists '([query] [query context] [query rff context])}
-  [{:keys [async?], :as query} & args]
-  (apply (if async? process-query-async process-query-sync)
-         query
-         args))
+  ([query]
+   (process-query query nil))
+
+  ([query context]
+   (process-query query nil context))
+
+  ([{:keys [async?], :as query} :- :map
+    rff                         :- [:maybe fn?]
+    context                     :- [:maybe
+                                    [:and
+                                     :map
+                                     [:fn
+                                      {:error/message ":rff should no longer be included in context, pass it as a separate argument."}
+                                      (complement :rff)]]]]
+   (let [rff     (or rff qp.reducible/default-rff)
+         context (or context (qp.context.default/default-context))]
+     ((if async? process-query-async process-query-sync) query rff context))))
 
 (defn preprocess
   "Return the fully preprocessed form for `query`, the way it would look immediately
@@ -374,17 +388,17 @@
     #'process-userland-query/process-userland-query
     #'catch-exceptions/catch-exceptions]))
 
-(def ^{:arglists '([query] [query context])} process-userland-query-async
+(def ^{:arglists '([query] [query context] [query rff context])} process-userland-query-async
   "Like [[process-query-async]], but for 'userland' queries (e.g., queries ran via the REST API). Adds extra middleware."
   (base-qp userland-middleware))
 
-(def ^{:arglists '([query] [query context])} process-userland-query-sync
+(def ^{:arglists '([query] [query context] [query rff context])} process-userland-query-sync
   "Like [[process-query-sync]], but for 'userland' queries (e.g., queries ran via the REST API). Adds extra middleware."
   (qp.reducible/sync-qp process-userland-query-async))
 
 (defn process-userland-query
   "Like [[process-query]], but for 'userland' queries (e.g., queries ran via the REST API). Adds extra middleware."
-  {:arglists '([query] [query context])}
+  {:arglists '([query] [query context] [query rff context])}
   [{:keys [async?], :as query} & args]
   (apply (if async? process-userland-query-async process-userland-query-sync)
          query
@@ -397,7 +411,10 @@
    (process-userland-query (assoc query :info info)))
 
   ([query info context]
-   (process-userland-query (assoc query :info info) context)))
+   (process-userland-query (assoc query :info info) context))
+
+  ([query info rff context]
+   (process-userland-query (assoc query :info info) rff context)))
 
 (defn- add-default-constraints [query]
   (assoc-in query [:middleware :add-default-userland-constraints?] true))
@@ -409,4 +426,7 @@
    (process-query-and-save-execution! (add-default-constraints query) info))
 
   ([query info context]
-   (process-query-and-save-execution! (add-default-constraints query) info context)))
+   (process-query-and-save-execution! (add-default-constraints query) info context))
+
+  ([query info rff context]
+   (process-query-and-save-execution! (add-default-constraints query) info rff context)))

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -201,8 +201,8 @@
                   ;; param `run` can be used to control how the query is ran, e.g. if you need to
                   ;; customize the `context` passed to the QP
                   (^:once fn* [query info]
-                   (qp.streaming/streaming-response [context export-format (u/slugify (:card-name info))]
-                                                    (qp-runner query info context))))
+                   (qp.streaming/streaming-response [{:keys [rff context]} export-format (u/slugify (:card-name info))]
+                     (qp-runner query info rff context))))
         card  (api/read-check (t2/select-one [Card :id :name :dataset_query :database_id :cache_ttl :collection_id
                                               :dataset :result_metadata :visualization_settings]
                                              :id card-id))
@@ -225,4 +225,4 @@
     (log/tracef "Running query for Card %d:\n%s" card-id
                 (u/pprint-to-str query))
     (binding [qp.perms/*card-id* card-id]
-     (run query info))))
+      (run query info))))

--- a/src/metabase/query_processor/context.clj
+++ b/src/metabase/query_processor/context.clj
@@ -98,15 +98,6 @@
   {:pre [(int? timeout*)]}
   timeout*)
 
-(defn rff
-  "Reducing function.
-
-    (rff metadata) -> rf"
-  {:arglists '([context])}
-  [{rff* :rff}]
-  {:pre [(fn? rff*)]}
-  rff*)
-
 (defn canceled-chan
   "Gets a message if query is canceled."
   {:arglists '([context])}

--- a/src/metabase/query_processor/context/default.clj
+++ b/src/metabase/query_processor/context/default.clj
@@ -19,30 +19,6 @@
      20
      3)))
 
-(defn default-rff
-  "Default function returning a reducing function. Results are returned in the 'standard' map format e.g.
-
-    {:data {:cols [...], :rows [...]}, :row_count ...}"
-  [metadata]
-  (let [row-count (volatile! 0)
-        rows      (volatile! [])]
-    (fn default-rf
-      ([]
-       {:data metadata})
-
-      ([result]
-       {:pre [(map? (unreduced result))]}
-       ;; if the result is a clojure.lang.Reduced, unwrap it so we always get back the standard-format map
-       (-> (unreduced result)
-           (assoc :row_count @row-count
-                  :status :completed)
-           (assoc-in [:data :rows] @rows)))
-
-      ([result row]
-       (vswap! row-count inc)
-       (vswap! rows conj row)
-       result))))
-
 (defn- default-reducedf [reduced-result context]
   (qp.context/resultf reduced-result context))
 
@@ -97,7 +73,6 @@
   []
   {::complete?    true
    :timeout       query-timeout-ms
-   :rff           default-rff
    :raisef        default-raisef
    :runf          default-runf
    :executef      driver/execute-reducible-query

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -10,6 +10,7 @@
    [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.query-processor.middleware.resolve-database-and-driver
     :as qp.resolve-database-and-driver]
+   [metabase.query-processor.reducible :as qp.reducible]
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.util :as qp.util]
    [metabase.util :as u]
@@ -142,16 +143,16 @@
   [query rf init info context]
   (if (a/poll! (qp.context/canceled-chan context))
     (ensure-reduced init)
-    (let [context {:canceled-chan (qp.context/canceled-chan context)
-                   :rff           (fn [_]
-                                    (fn
-                                      ([]        init)
-                                      ([acc]     acc)
-                                      ([acc row] (rf acc ((:row-mapping-fn context) row context)))))}]
+    (let [rff (fn [_]
+                (fn
+                  ([]        init)
+                  ([acc]     acc)
+                  ([acc row] (rf acc ((:row-mapping-fn context) row context)))))
+          context {:canceled-chan (qp.context/canceled-chan context)}]
       (try
         (if info
-          (qp/process-userland-query-sync (assoc query :info info) context)
-          (qp/process-query-sync (dissoc query :info) context))
+          (qp/process-userland-query-sync (assoc query :info info) rff context)
+          (qp/process-query-sync (dissoc query :info) rff context))
         (catch Throwable e
           (log/error e (trs "Error processing additional pivot table query"))
           (throw e))))))
@@ -166,51 +167,50 @@
    init
    queries))
 
-(defn- append-queries-context
+(defn- append-queries-rff-and-context
   "Update Query Processor `context` so it appends the rows fetched when running `more-queries`."
-  [info context more-queries]
+  [info rff context more-queries]
   (let [vrf (volatile! nil)]
-    (cond-> context
-      (seq more-queries)
-      (->  (update :rff (fn [rff]
-                          (fn [metadata]
-                            (u/prog1 (rff metadata)
-                              ;; this captures the reducing function before composed with limit and other middleware
-                              (vreset! vrf <>)))))
-           (update :executef
-                   (fn [orig]
-                     ;; execute holds open a connection from [[execute-reducible-query]] so we need to manage
-                     ;; connections in the reducing part reducef. The default runf is what orchestrates this together
-                     ;; and we just pass the original executef to the reducing part so we can control our multiple
-                     ;; connections.
-                     (fn multiple-executef [driver query _context respond]
-                       (respond [orig driver] query))))
-           (assoc :reducef
-                  ;; signature usually has metadata in place of driver but we are hijacking
-                  (fn multiple-reducing [rff context [orig-executef driver] query]
-                    (let [respond     (fn [metadata reducible-rows]
-                                        (let [rf (rff metadata)]
-                                          (assert (fn? rf))
-                                          (try
-                                            (transduce identity (completing rf) reducible-rows)
-                                            (catch Throwable e
-                                              (qp.context/raisef (ex-info (tru "Error reducing result rows")
-                                                                          {:type qp.error-type/qp}
-                                                                          e)
-                                                                 context)))))
-                          acc         (-> (orig-executef driver query context respond)
-                                          (process-queries-append-results
-                                           more-queries @vrf info context))]
-                      ;; completion arity can't be threaded because the value is derefed too early
-                      (qp.context/reducedf (@vrf acc) context))))))))
+    {:rff     (fn [metadata]
+                (u/prog1 (rff metadata)
+                  ;; this captures the reducing function before composed with limit and other middleware
+                  (vreset! vrf <>)))
+     :context (cond-> context
+                (seq more-queries)
+                (-> (update :executef
+                            (fn [orig]
+                              ;; execute holds open a connection from [[execute-reducible-query]] so we need to manage
+                              ;; connections in the reducing part reducef. The default runf is what orchestrates this
+                              ;; together and we just pass the original executef to the reducing part so we can control
+                              ;; our multiple connections.
+                              (fn multiple-executef [driver query _context respond]
+                                (respond [orig driver] query))))
+                    (assoc :reducef
+                           ;; signature usually has metadata in place of driver but we are hijacking
+                           (fn multiple-reducing [rff context [orig-executef driver] query]
+                             (let [respond (fn [metadata reducible-rows]
+                                             (let [rf (rff metadata)]
+                                               (assert (fn? rf))
+                                               (try
+                                                 (transduce identity (completing rf) reducible-rows)
+                                                 (catch Throwable e
+                                                   (qp.context/raisef (ex-info (tru "Error reducing result rows")
+                                                                               {:type qp.error-type/qp}
+                                                                               e)
+                                                                      context)))))
+                                   acc     (-> (orig-executef driver query context respond)
+                                               (process-queries-append-results
+                                                more-queries @vrf info context))]
+                               ;; completion arity can't be threaded because the value is derefed too early
+                               (qp.context/reducedf (@vrf acc) context))))))}))
 
 (defn process-multiple-queries
   "Allows the query processor to handle multiple queries, stitched together to appear as one"
-  [[first-query & more-queries] info context]
-  (let [context (append-queries-context info context more-queries)]
+  [[first-query & more-queries] info rff context]
+  (let [{:keys [rff context]} (append-queries-rff-and-context info rff context more-queries)]
     (if info
-      (qp/process-query-and-save-with-max-results-constraints! first-query info context)
-      (qp/process-query (dissoc first-query :info) context))))
+      (qp/process-query-and-save-with-max-results-constraints! first-query info rff context)
+      (qp/process-query (dissoc first-query :info) rff context))))
 
 (defn pivot-options
   "Given a pivot table query and a card ID, looks at the `pivot_table.column_split` key in the card's visualization
@@ -230,15 +230,21 @@
   "Run the pivot query. Unlike many query execution functions, this takes `context` as the first parameter to support
    its application via `partial`.
 
-   You are expected to wrap this call in `qp.streaming/streaming-response` yourself."
+   You are expected to wrap this call in [[metabase.query-processor.streaming/streaming-response]] yourself."
   ([query]
    (run-pivot-query query nil))
+
   ([query info]
    (run-pivot-query query info nil))
+
   ([query info context]
+   (run-pivot-query query info nil context))
+
+  ([query info rff context]
    (binding [qp.perms/*card-id* (get info :card-id)]
      (qp.store/with-metadata-provider (qp.resolve-database-and-driver/resolve-database-id query)
        (let [context                 (merge (context.default/default-context) context)
+             rff                     (or rff qp.reducible/default-rff)
              query                   (mbql.normalize/normalize query)
              pivot-options           (or
                                       (not-empty (select-keys query [:pivot-rows :pivot-cols]))
@@ -250,6 +256,7 @@
          (process-multiple-queries
           all-queries
           info
+          rff
           (assoc context
                  ;; this function needs to be executed at the start of every new query to
                  ;; determine the mapping for maintaining query shape

--- a/src/metabase/query_processor/reducible.clj
+++ b/src/metabase/query_processor/reducible.clj
@@ -9,6 +9,30 @@
 
 (set! *warn-on-reflection* true)
 
+(defn default-rff
+  "Default function returning a reducing function. Results are returned in the 'standard' map format e.g.
+
+    {:data {:cols [...], :rows [...]}, :row_count ...}"
+  [metadata]
+  (let [row-count (volatile! 0)
+        rows      (volatile! [])]
+    (fn default-rf
+      ([]
+       {:data metadata})
+
+      ([result]
+       {:pre [(map? (unreduced result))]}
+       ;; if the result is a clojure.lang.Reduced, unwrap it so we always get back the standard-format map
+       (-> (unreduced result)
+           (assoc :row_count @row-count
+                  :status :completed)
+           (assoc-in [:data :rows] @rows)))
+
+      ([result row]
+       (vswap! row-count inc)
+       (vswap! rows conj row)
+       result))))
+
 (defn identity-qp
   "The initial value of `qp` passed to QP middleware."
   [query rff context]
@@ -97,8 +121,7 @@
      {:pre [(map? query) ((some-fn nil? map?) context)]}
      (let [context (doto (merge (context.default/default-context) context)
                      wire-up-context-channels!)
-           rff     (or rff
-                       (qp.context/rff context))
+           rff     (or rff default-rff)
            thunk   (fn [] (try
                             (qp query rff context)
                             (catch Throwable e
@@ -121,7 +144,8 @@
   Exceptions thrown. Resulting QP has the signatures
 
     (qp query)
-    (qp query context)"
+    (qp query context)
+    (qp query rff context)"
   [qp]
   {:pre [(fn? qp)]}
   (fn qp* [& args]

--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -135,20 +135,21 @@
       (.close os))
     (qp.context/resultf final-metadata context)))
 
-(defn streaming-context
+(defn streaming-context-and-rff
   "Context to pass to the QP to streaming results as `export-format` to an output stream. Can be used independently of
   the normal `streaming-response` macro, which is geared toward Ring responses.
 
     (with-open [os ...]
-      (qp/process-query query (qp.streaming/streaming-context :csv os canceled-chan)))"
+      (let [{:keys [rff context]} (qp.streaming/streaming-context-and-rff :csv os canceled-chan)]
+        (qp/process-query query rff context)))"
   ([export-format os]
    (let [results-writer (qp.si/streaming-results-writer export-format os)]
-     (merge (context.default/default-context)
-            {:rff      (streaming-rff results-writer)
-             :reducedf (streaming-reducedf results-writer os)})))
+     {:context (merge (context.default/default-context)
+                      {:reducedf (streaming-reducedf results-writer os)})
+      :rff     (streaming-rff results-writer)}))
 
   ([export-format os canceled-chan]
-   (assoc (streaming-context export-format os) :canceled-chan canceled-chan)))
+   (assoc-in (streaming-context-and-rff export-format os) [:context :canceled-chan] canceled-chan)))
 
 (defn- await-async-result [out-chan canceled-chan]
   ;; if we get a cancel message, close `out-chan` so the query will be canceled
@@ -162,13 +163,14 @@
   "Impl for `streaming-response`."
   ^StreamingResponse [export-format filename-prefix f]
   (streaming-response/streaming-response (qp.si/stream-options export-format filename-prefix) [os canceled-chan]
-    (let [result (try
-                   (f (streaming-context export-format os canceled-chan))
-                   (catch Throwable e
-                     e))
-          result (if (instance? ManyToManyChannel result)
-                   (await-async-result result canceled-chan)
-                   result)]
+    (let [{:keys [rff context]} (streaming-context-and-rff export-format os canceled-chan)
+          result                (try
+                                  (f {:rff rff, :context context})
+                                  (catch Throwable e
+                                    e))
+          result                (if (instance? ManyToManyChannel result)
+                                  (await-async-result result canceled-chan)
+                                  result)]
       (when (or (instance? Throwable result)
                 (= (:status result) :failed))
         (streaming-response/write-error! os result)))))
@@ -181,14 +183,14 @@
   Typical example:
 
     (api/defendpoint-schema GET \"/whatever\" []
-      (qp.streaming/streaming-response [context :json]
-        (qp/process-query-and-save-with-max-results-constraints! (assoc query :async true) context)))
+      (qp.streaming/streaming-response [{:keys [rff context]} :json]
+        (qp/process-query-and-save-with-max-results-constraints! (assoc query :async true) rff context)))
 
   Handles either async or sync QP results, but you should prefer returning sync results so we can handle query
   cancelations properly."
   {:style/indent 1}
-  [[context-binding export-format filename-prefix] & body]
-  `(streaming-response* ~export-format ~filename-prefix (bound-fn [~context-binding] ~@body)))
+  [[map-binding export-format filename-prefix] & body]
+  `(streaming-response* ~export-format ~filename-prefix (bound-fn [~map-binding] ~@body)))
 
 (defn export-formats
   "Set of valid streaming response formats. Currently, `:json`, `:csv`, `:xlsx`, and `:api` (normal JSON API results

--- a/src/metabase/query_processor/streaming/interface.clj
+++ b/src/metabase/query_processor/streaming/interface.clj
@@ -27,4 +27,5 @@
 (defmulti streaming-results-writer
   "Given a `export-format` and `java.io.Writer`, return an object that implements `StreamingResultsWriter`."
   {:arglists '(^metabase.query_processor.streaming.interface.StreamingResultsWriter [export-format ^java.io.OutputStream os])}
-  (fn [export-format _] (keyword export-format)))
+  (fn [export-format _os]
+    (keyword export-format)))

--- a/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
+++ b/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
@@ -6,9 +6,9 @@
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.macros :as lib.tu.macros]
    [metabase.query-processor :as qp]
-   [metabase.query-processor.context.default :as context.default]
    [metabase.query-processor.middleware.add-dimension-projections
     :as qp.add-dimension-projections]
+   [metabase.query-processor.reducible :as qp.reducible]
    [metabase.query-processor.store :as qp.store]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]))
@@ -174,7 +174,7 @@
 ;;; ---------------------------------------- remap-results (post-processing) -----------------------------------------
 
 (defn- remap-results [query metadata rows]
-  (let [rff (qp.add-dimension-projections/remap-results query context.default/default-rff)
+  (let [rff (qp.add-dimension-projections/remap-results query qp.reducible/default-rff)
         rf  (rff metadata)]
     (transduce identity rf rows)))
 

--- a/test/metabase/query_processor/middleware/add_rows_truncated_test.clj
+++ b/test/metabase/query_processor/middleware/add_rows_truncated_test.clj
@@ -2,13 +2,13 @@
   (:require
    [clojure.test :refer :all]
    [metabase.query-processor :as qp]
-   [metabase.query-processor.context.default :as context.default]
    [metabase.query-processor.middleware.add-rows-truncated
     :as add-rows-truncated]
+   [metabase.query-processor.reducible :as qp.reducible]
    [metabase.test :as mt]))
 
 (defn- add-rows-truncated [query rows]
-  (let [rff (add-rows-truncated/add-rows-truncated query context.default/default-rff)
+  (let [rff (add-rows-truncated/add-rows-truncated query qp.reducible/default-rff)
         rf  (rff nil)]
     (transduce identity rf rows)))
 

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -379,7 +379,8 @@
       (let [query (assoc (mt/mbql-query venues {:order-by [[:asc $id]], :limit 6})
                          :cache-ttl 100)]
         (with-open [os (java.io.ByteArrayOutputStream.)]
-          (qp/process-query query (qp.streaming/streaming-context :csv os))
+          (let [{:keys [context rff]} (qp.streaming/streaming-context-and-rff :csv os)]
+            (qp/process-query query rff context))
           (mt/wait-for-result save-chan))
         (is (= true
                (:cached (qp/process-query query)))
@@ -387,14 +388,16 @@
         (let [uncached-results (with-open [ostream (java.io.PipedOutputStream.)
                                            istream (java.io.PipedInputStream. ostream)
                                            reader  (java.io.InputStreamReader. istream)]
-                                 (qp/process-query (dissoc query :cache-ttl) (qp.streaming/streaming-context :csv ostream))
+                                 (let [{:keys [context rff]} (qp.streaming/streaming-context-and-rff :csv ostream)]
+                                   (qp/process-query (dissoc query :cache-ttl) rff context))
                                  (vec (csv/read-csv reader)))]
           (with-redefs [sql-jdbc.execute/execute-reducible-query (fn [& _]
                                                                    (throw (Exception. "Should be cached!")))]
             (with-open [ostream (java.io.PipedOutputStream.)
                         istream (java.io.PipedInputStream. ostream)
                         reader  (java.io.InputStreamReader. istream)]
-              (qp/process-query query (qp.streaming/streaming-context :csv ostream))
+              (let [{:keys [context rff]} (qp.streaming/streaming-context-and-rff :csv ostream)]
+                (qp/process-query query rff context))
               (is (= uncached-results
                      (vec (csv/read-csv reader)))
                   "CSV results should match results when caching isn't in play"))))))))
@@ -409,9 +412,10 @@
       (with-mock-cache [save-chan]
         (let [query (assoc query :cache-ttl 100)]
           (with-open [os (java.io.ByteArrayOutputStream.)]
-            (is (= false
-                   (boolean (:cached (qp/process-query query (qp.streaming/streaming-context :csv os)))))
-                "Query shouldn't be cached after first run with the mock cache in place")
+            (let [{:keys [rff context]} (qp.streaming/streaming-context-and-rff :csv os)]
+              (is (= false
+                     (boolean (:cached (qp/process-query query rff context))))
+                  "Query shouldn't be cached after first run with the mock cache in place"))
             (mt/wait-for-result save-chan))
           (is (= (-> (assoc normal-results :cached true)
                      (dissoc :updated_at)

--- a/test/metabase/query_processor/middleware/limit_test.clj
+++ b/test/metabase/query_processor/middleware/limit_test.clj
@@ -2,16 +2,16 @@
   "Tests for the `:limit` clause and `:max-results` constraints."
   (:require
    [clojure.test :refer :all]
-   [metabase.query-processor.context.default :as context.default]
    [metabase.query-processor.interface :as qp.i]
    [metabase.query-processor.middleware.limit :as limit]
+   [metabase.query-processor.reducible :as qp.reducible]
    [metabase.test :as mt]))
 
 (def ^:private test-max-results 10000)
 
 (defn- limit [query]
   (with-redefs [qp.i/absolute-max-results test-max-results]
-    (let [rff (limit/limit-result-rows query context.default/default-rff)
+    (let [rff (limit/limit-result-rows query qp.reducible/default-rff)
           rf  (rff {})]
       (transduce identity rf (repeat (inc test-max-results) [:ok])))))
 

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -230,7 +230,7 @@
               ([acc] acc)
               ([acc _] (inc acc))))]
     (is (= (count (mt/rows (qp.pivot/run-pivot-query (api.pivots/pivot-query))))
-           (qp.pivot/run-pivot-query (api.pivots/pivot-query) nil {:rff rff})))))
+           (qp.pivot/run-pivot-query (api.pivots/pivot-query) nil rff nil)))))
 
 (deftest parameters-query-test
   (mt/dataset sample-dataset

--- a/test/metabase/query_processor/streaming/test_util.clj
+++ b/test/metabase/query_processor/streaming/test_util.clj
@@ -55,9 +55,9 @@
   [export-format query & args]
   (with-open [bos (ByteArrayOutputStream.)
               os  (BufferedOutputStream. bos)]
-    (is (= :completed
-           (:status (qp/process-query query (assoc (qp.streaming/streaming-context export-format os)
-                                                   :timeout 15000)))))
+    (let [{:keys [context rff]} (qp.streaming/streaming-context-and-rff export-format os)]
+      (is (= :completed
+             (:status (qp/process-query query rff (assoc context :timeout 15000))))))
     (.flush os)
     (let [bytea (.toByteArray bos)]
       (with-open [is (BufferedInputStream. (ByteArrayInputStream. bytea))]

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -80,10 +80,10 @@
   (testing "Bindings established outside the `streaming-response` should be preserved inside the body"
     (with-open [os (java.io.ByteArrayOutputStream.)]
       (let [streaming-response (binding [*number-of-cans* 2]
-                                 (qp.streaming/streaming-response [context :json]
+                                 (qp.streaming/streaming-response [{:keys [rff context]} :json]
                                    (let [metadata {:cols [{:name "num_cans", :base_type :type/Integer}]}
                                          rows     [[*number-of-cans*]]]
-                                     (qp.context/reducef (qp.context/rff context) context metadata rows))))
+                                     (qp.context/reducef rff context metadata rows))))
             complete-promise   (promise)]
         (server.protocols/respond streaming-response
                                   {:response      (reify HttpServletResponse

--- a/test/metabase/sync/analyze/fingerprint_test.clj
+++ b/test/metabase/sync/analyze/fingerprint_test.clj
@@ -28,24 +28,23 @@
   (is (= #{"type/ImageURL" "type/AvatarURL"}
          (#'fingerprint/base-types->descendants #{:type/ImageURL :type/AvatarURL}))))
 
-
-;; Make sure we generate the correct HoneySQL WHERE clause based on whatever is in
-;; `*fingerprint-version->types-that-should-be-re-fingerprinted*`
 (deftest ^:parallel honeysql-for-fields-that-need-fingerprint-updating-test
-  (is (= {:where
-          [:and
-           [:= :active true]
-           [:or
-            [:not (mdb.u/isa :semantic_type :type/PK)]
-            [:= :semantic_type nil]]
-           [:not-in :visibility_type ["retired" "sensitive"]]
-           [:not (mdb.u/isa :base_type :type/Structured)]
-           [:or
+  (testing (str "Make sure we generate the correct HoneySQL WHERE clause based on whatever is in "
+                "`*fingerprint-version->types-that-should-be-re-fingerprinted*`")
+    (is (= {:where
             [:and
-             [:< :fingerprint_version 1]
-             [:in :base_type #{"type/URL" "type/ImageURL" "type/AvatarURL"}]]]]}
-         (binding [i/*fingerprint-version->types-that-should-be-re-fingerprinted* {1 #{:type/URL}}]
-           (#'fingerprint/honeysql-for-fields-that-need-fingerprint-updating)))))
+             [:= :active true]
+             [:or
+              [:not (mdb.u/isa :semantic_type :type/PK)]
+              [:= :semantic_type nil]]
+             [:not-in :visibility_type ["retired" "sensitive"]]
+             [:not (mdb.u/isa :base_type :type/Structured)]
+             [:or
+              [:and
+               [:< :fingerprint_version 1]
+               [:in :base_type #{"type/URL" "type/ImageURL" "type/AvatarURL"}]]]]}
+           (binding [i/*fingerprint-version->types-that-should-be-re-fingerprinted* {1 #{:type/URL}}]
+             (#'fingerprint/honeysql-for-fields-that-need-fingerprint-updating))))))
 
 (deftest ^:parallel honeysql-for-fields-that-need-fingerprint-updating-test-2
   (is (= {:where
@@ -137,8 +136,9 @@
 (defn- field-was-fingerprinted?! [fingerprint-versions field-properties]
   (let [fingerprinted? (atom false)]
     (binding [i/*fingerprint-version->types-that-should-be-re-fingerprinted* fingerprint-versions]
-      (with-redefs [qp/process-query              (fn [_ {:keys [rff]}]
-                                                    (transduce identity (rff :metadata) [[1] [2] [3] [4] [5]]))
+      (with-redefs [qp/process-query              (fn process-query
+                                                    ([_query rff _context]
+                                                     (transduce identity (rff :metadata) [[1] [2] [3] [4] [5]])))
                     fingerprint/save-fingerprint! (fn [& _] (reset! fingerprinted? true))]
         (t2.with-temp/with-temp [Table table {}
                                  Field _     (assoc field-properties :table_id (u/the-id table))]
@@ -255,7 +255,7 @@
                                           :fingerprint_version 1
                                           :last_analyzed       #t "2017-08-09T00:00:00"}]
       (binding [i/*latest-fingerprint-version* 3]
-        (with-redefs [qp/process-query             (fn [_ {:keys [rff]}]
+        (with-redefs [qp/process-query             (fn [_query rff _context]
                                                      (transduce identity (rff :metadata) [[1] [2] [3] [4] [5]]))
                       fingerprinters/fingerprinter (constantly (fingerprinters/constant-fingerprinter {:experimental {:fake-fingerprint? true}}))]
           (is (= {:no-data-fingerprints 0, :failed-fingerprints    0,
@@ -299,9 +299,11 @@
       (let [table (t2/select-one Table :id (mt/id :categories))
             field (t2/select-one Field :id (mt/id :categories :name))]
         (binding [fingerprint/*truncation-size* size]
-          (#'fingerprint/fingerprint-table! table [field])
+          (is (=? {:updated-fingerprints 1}
+                  (#'fingerprint/fingerprint-table! table [field])))
           (let [field' (t2/select-one [Field :fingerprint] :id (u/id field))
                 fingerprinted-size (get-in field' [:fingerprint :type :type/Text :average-length])]
+            (is fingerprinted-size)
             (is (<= fingerprinted-size size))))))))
 
 (deftest refingerprint-fields-for-db!-test


### PR DESCRIPTION
This minor refactor makes the QP code a little easier to understand.

The QP has always had a 3-arity like

```clojure
(qp query rff context)
```

Where `query` is an MBQL query map, `rff` is a function that returns a reducing function (as you would pass to `transduce`) with the signature

```clj
(fn metadata) => reducing function
```

and `context` is a map with functions that are called at various points in the QP lifecycle, like `executef` (to "execute" the query) and `reducedf` (when query results are fully reduced).

For some goofy reason the context map could also contain an `:rff` key, meaning there were two different ways to pass an RFF to the QP, and it wasn't really obvious which one would be used if you specified both.

This PR removes `:rff` from the context map entirely (simplifying the context a bit) and updates a few QP entrypoints to pass around `rff` as a positional arg.

This refactor is a step towards an overall goal of simplifying the QP context a bit and making the QP code easier to wrap your head around. (Lately I've been experimenting with different approaches to refactoring the QP context and entrypoints; this is one change I'm certain is a net improvement)