### PR TITLE
Merging table.columns for dashcards

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings.js
+++ b/frontend/src/metabase/visualizations/lib/settings.js
@@ -244,31 +244,32 @@ export function mergeSettings(first = {}, second = {}) {
     }
   }
 
-  const findColumn = (colName, list) => {
-    return list.findIndex(({ name }) => name === colName);
-  };
-
   if (first["table.columns"] && second["table.columns"]) {
-    const firstTableColumns = first["table.columns"];
-    const secondTableColumns = second["table.columns"];
-
-    const addedColumns = firstTableColumns.filter(
-      ({ name }) => findColumn(name, secondTableColumns) === -1,
+    merged["table.columns"] = mergeTableColumns(
+      first["table.columns"],
+      second["table.columns"],
     );
-    const removedColumns = secondTableColumns
-      .filter(({ name }) => findColumn(name, firstTableColumns) === -1)
-      .map(({ name }) => name);
-
-    merged["table.columns"] = [
-      ...secondTableColumns.filter(
-        ({ name }) => !removedColumns.includes(name),
-      ),
-      ...addedColumns,
-    ];
   }
 
   return merged;
 }
+
+const mergeTableColumns = (firstTableColumns, secondTableColumns) => {
+  const addedColumns = firstTableColumns.filter(
+    ({ name }) => secondTableColumns.findIndex(col => col.name === name) === -1,
+  );
+  const removedColumns = secondTableColumns
+    .filter(
+      ({ name }) =>
+        firstTableColumns.findIndex(col => col.name === name) === -1,
+    )
+    .map(({ name }) => name);
+
+  return [
+    ...secondTableColumns.filter(({ name }) => !removedColumns.includes(name)),
+    ...addedColumns,
+  ];
+};
 
 export function getClickBehaviorSettings(settings) {
   const newSettings = {};

--- a/frontend/src/metabase/visualizations/lib/settings.js
+++ b/frontend/src/metabase/visualizations/lib/settings.js
@@ -243,6 +243,30 @@ export function mergeSettings(first = {}, second = {}) {
       }
     }
   }
+
+  const findColumn = (colName, list) => {
+    return list.findIndex(({ name }) => name === colName);
+  };
+
+  if (first["table.columns"] && second["table.columns"]) {
+    const firstTableColumns = first["table.columns"];
+    const secondTableColumns = second["table.columns"];
+
+    const addedColumns = firstTableColumns.filter(
+      ({ name }) => findColumn(name, secondTableColumns) === -1,
+    );
+    const removedColumns = secondTableColumns
+      .filter(({ name }) => findColumn(name, firstTableColumns) === -1)
+      .map(({ name }) => name);
+
+    merged["table.columns"] = [
+      ...secondTableColumns.filter(
+        ({ name }) => !removedColumns.includes(name),
+      ),
+      ...addedColumns,
+    ];
+  }
+
   return merged;
 }
 

--- a/frontend/src/metabase/visualizations/lib/settings.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/settings.unit.spec.js
@@ -1,3 +1,6 @@
+import { ORDERS } from "metabase-types/api/mocks/presets";
+import { createMockTableColumnOrderSetting } from "metabase-types/api/mocks";
+
 // NOTE: need to load visualizations first for getSettings to work
 import "metabase/visualizations/index";
 
@@ -195,6 +198,81 @@ describe("settings framework", () => {
       expect(
         mergeSettings({}, { column_settings: { col1: { set1: "val" } } }),
       ).toEqual({ column_settings: { col1: { set1: "val" } } });
+    });
+
+    describe("table.columns", () => {
+      const ID_COLUMN = createMockTableColumnOrderSetting({
+        name: "ID",
+        fieldRef: ["field", ORDERS.ID, null],
+      });
+
+      const QUANTITY_COLUMN = createMockTableColumnOrderSetting({
+        name: "QUANTITY",
+        fieldRef: ["field", ORDERS.QUANTITY, null],
+      });
+
+      const TAX_COLUMN = createMockTableColumnOrderSetting({
+        name: "TAX",
+        fieldRef: ["field", ORDERS.TAX, null],
+      });
+
+      const DISCOUNT_COLUMN = createMockTableColumnOrderSetting({
+        name: "DISCOUNT",
+        fieldRef: ["field", ORDERS.DISCOUNT, null],
+      });
+
+      it("should remove columns that don't appear in the first settings", () => {
+        expect(
+          mergeSettings(
+            {
+              "table.columns": [ID_COLUMN, QUANTITY_COLUMN],
+            },
+            {
+              "table.columns": [ID_COLUMN, QUANTITY_COLUMN, TAX_COLUMN],
+            },
+          ),
+        ).toEqual({
+          "table.columns": [ID_COLUMN, QUANTITY_COLUMN],
+        });
+      });
+      it("should add new columns that don't appear in the second settings", () => {
+        expect(
+          mergeSettings(
+            {
+              "table.columns": [ID_COLUMN, QUANTITY_COLUMN, DISCOUNT_COLUMN],
+            },
+            {
+              "table.columns": [ID_COLUMN, QUANTITY_COLUMN],
+            },
+          ),
+        ).toEqual({
+          "table.columns": [ID_COLUMN, QUANTITY_COLUMN, DISCOUNT_COLUMN],
+        });
+      });
+
+      it("should preserve settings and order from the second settings", () => {
+        expect(
+          mergeSettings(
+            {
+              "table.columns": [ID_COLUMN, QUANTITY_COLUMN, DISCOUNT_COLUMN],
+            },
+            {
+              "table.columns": [
+                DISCOUNT_COLUMN,
+                { ...ID_COLUMN, enabled: false },
+                QUANTITY_COLUMN,
+                TAX_COLUMN,
+              ],
+            },
+          ),
+        ).toEqual({
+          "table.columns": [
+            DISCOUNT_COLUMN,
+            { ...ID_COLUMN, enabled: false },
+            QUANTITY_COLUMN,
+          ],
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/25592

### Description
The linked issue stemmed from how we merge viz settings for dashcards. We give dashcard settings precedence, which works well for most things, but when merging `table.columns`, the dashcard setting would completely overwrite the setting from the source card. This meant that any columns added to the source card would not appear if the dashcard already had a `table.columns` setting written, and would likely cause errors if a column was removed.

This change merged the 2 `table.columns` arrays, using the column names to identify which columns have been added or removed, ensuring that we preserve as much data from the dashcard's `table.columns` array as possible.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a table visualization and re-order the columns to ensure that `table.columns` gets set.
2. Add that card to a dashboard, and disable a couple columns in the dashcard viz settings. Save the Dashboard
3. Return to the source question and add a custom column. Save the question, replacing the original
4. Return to the dashboard and you should see the custom column in the dashcard.

### Demo
![chrome_oJPRTRAKXp](https://github.com/metabase/metabase/assets/1328979/1d76d641-8282-40e2-89ca-115f47012714)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
