### PR TITLE
Fix flaky x-ray e2e test

### DIFF
--- a/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
@@ -280,6 +280,7 @@ describe("scenarios > x-rays", { tags: "@slow" }, () => {
         });
 
         visitDashboardAndCreateTab({ dashboardId: dashboard_id });
+        cy.findByText("There's nothing here, yet.");
         cy.findByRole("tab", { name: "Tab 1" }).click();
 
         cy.get("circle").eq(0).click({ force: true });


### PR DESCRIPTION
This feels like a dumb solution, but it's quite genius, albeit a bit subtle.

This test is:

```javascript
  it("should be able to open x-ray on a dashcard from a dashboard with multiple tabs", () => {
    cy.intercept("POST", "/api/dataset").as("dataset");

    return cy
      .createDashboard({ name: "my dashboard" })
      .then(({ body: { id: dashboard_id } }) => {
        addOrUpdateDashboardCard({
          card_id: ORDERS_BY_YEAR_QUESTION_ID,
          dashboard_id,
          card: {
            row: 0,
            col: 0,
            size_x: 24,
            size_y: 10,
            visualization_settings: {},
          },
        });

        visitDashboardAndCreateTab({ dashboardId: dashboard_id });
        cy.findByText("There's nothing here, yet."); // <--- new clever bit here
        cy.findByRole("tab", { name: "Tab 1" }).click();

        cy.get("circle").eq(0).click({ force: true });
        popover().findByText("Automatic insights…").click();
        popover().findByText("X-ray").click();
        cy.wait("@dataset", { timeout: 30000 });

        // Ensure charts actually got rendered
        cy.get("text.x-axis-label").contains("Created At");
      });
  });
```

In english:
1. create a dashboard
2. add a card to it
3. add a new (empty) tab
4. save the tab
5. go to tab 1
6. click on one of the data points (circles) in the graph
7. x-ray that data point
8. assert that an x-ray dashboard happened

This was _failing_ because it would click on tab 1 right after saving and the UI wouldn't react. It would still show it as on tab2. Tab 2 is empty, so no graph, no circle, and we cannot make an x-ray.

So this clever fix is to wait until the UI shows the message "There's nothing here, yet" which means the UI is responsive and ready. Only then do we click on tab 1, then see the graph, and continue.

If you want to run this locally:

```shell
yarn run test-cypress-run --open
```

(the --open) gives a lovely browser instead of just running it for hours.
