### PR TITLE
Correct added version for `prettify-native-form`

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -70,9 +70,6 @@ title: Driver interface changelog
   removed in 0.51.0 or later. You can easily implement `metabase.driver/db-default-timezone` directly, and use
   `metabase.driver.sql-jdbc.execute/do-with-connection-with-options` to get a `java.sql.Connection` for a Database.
 
-- `metabase.driver/prettify-native-form` was added to enable driver developers use native form formatting
-  specific to their driver. For details see the PR [#34991](https://github.com/metabase/metabase/pull/34991).
-
 ## Metabase 0.47.0
 
 - A new driver feature has been added: `:schemas`. This feature signals whether the database organizes tables in
@@ -110,6 +107,9 @@ title: Driver interface changelog
 - The function `metabase.query-processor.timezone/report-timezone-id-if-supported` has been updated to take an additional
   `database` argument for the arity which previously had one argument. This function might be used in the implementation
   of a driver's multimethods.
+
+- `metabase.driver/prettify-native-form` was added to enable driver developers use native form formatting
+  specific to their driver. For details see the PR [#34991](https://github.com/metabase/metabase/pull/34991).
 
 ## Metabase 0.46.0
 

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -657,7 +657,7 @@
   - Use [[metabase.driver.sql.util/format-sql]] in this method's implementation, providing dialect keyword
     representation that corresponds to to their driver's formatting (eg. `:sqlserver` uses `:tsql`).
   - Completly reimplement this method with their special formatting code."
-  {:added "0.48.0", :arglists '([driver native-form]), :style/indent 1}
+  {:added "0.47.0", :arglists '([driver native-form]), :style/indent 1}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 


### PR DESCRIPTION
While backporting #35269, I've realized that `:added` metadata should be set to version 47 instead of 48 for `prettify-native-form` and method should be mentioned in changelog under the 47 paragraph. This PR fixes that in master.
