### PR TITLE
Fix flaky test because of the current date

### DIFF
--- a/e2e/test/scenarios/native-filters/reproductions/16756.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/reproductions/16756.cy.spec.js
@@ -52,7 +52,8 @@ describe("issue 16756", () => {
     // The previous filter value should reset
     cy.location("search").should("eq", "?filter=");
 
-    // Set the date to the 15th of whichever the month and year are when this tests runs
+    cy.log("Set the date to the 15th of October 2023");
+    cy.clock(new Date("2023-10-31"), ["Date"]);
     filterWidget().click();
 
     popover().contains("15").click();


### PR DESCRIPTION
[Slack discussion](https://metaboat.slack.com/archives/C5XHN8GLW/p1698837660692509)

Fix flaky test by always mock the current date.

From @qnkhuat 
> I think it’s a test setup problem.
so the test set the filter to the 15th of this month, it expects there will be no products created on that date. but (un)fortunately we have one created on 15th November 2023.
which is why we started to see this test today because today is the 1st of Nov

Example failure
- https://www.deploysentinel.com/ci/runs/654232299f1ec992df388cb6
- https://github.com/metabase/metabase/actions/runs/6717431141
