### PR TITLE
Hide elements in create new dashboard modal

### DIFF
--- a/frontend/src/metabase/collections/components/CreateCollectionForm/CreateCollectionForm.tsx
+++ b/frontend/src/metabase/collections/components/CreateCollectionForm/CreateCollectionForm.tsx
@@ -52,6 +52,7 @@ export interface CreateCollectionFormOwnProps {
   collectionId?: Collection["id"]; // can be used by `getInitialCollectionId`
   onCreate?: (collection: Collection) => void;
   onCancel?: () => void;
+  showOnlyPersonalCollections?: boolean;
 }
 
 interface CreateCollectionFormStateProps {
@@ -89,6 +90,7 @@ function CreateCollectionForm({
   handleCreateCollection,
   onCreate,
   onCancel,
+  showOnlyPersonalCollections,
 }: Props) {
   const initialValues = useMemo(
     () => ({
@@ -131,6 +133,7 @@ function CreateCollectionForm({
           <FormCollectionPicker
             name="parent_id"
             title={t`Collection it's saved in`}
+            showOnlyPersonalCollections={showOnlyPersonalCollections}
           />
           <FormAuthorityLevelFieldContainer
             collectionParentId={values.parent_id}

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -136,6 +136,7 @@ function FormCollectionPicker({
         >
           {showCreateNewCollectionOption && (
             <CreateCollectionOnTheGoButton
+              showOnlyPersonalCollections={showOnlyPersonalCollections}
               openCollectionId={openCollectionId}
             />
           )}

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -20,6 +20,7 @@ import { isValidCollectionId } from "metabase/collections/utils";
 
 import type { CollectionId } from "metabase-types/api";
 
+import { useSelector } from "metabase/lib/redux";
 import {
   PopoverItemPicker,
   MIN_POPOVER_WIDTH,
@@ -98,6 +99,15 @@ function FormCollectionPicker({
 
   const [openCollectionId, setOpenCollectionId] =
     useState<CollectionId>("root");
+  const openCollection = useSelector(state =>
+    Collections.selectors.getObject(state, {
+      entityId: openCollectionId,
+    }),
+  );
+
+  const isOpenCollectionInPersonalCollection = openCollection?.is_personal;
+  const showCreateNewCollectionOption =
+    !showOnlyPersonalCollections || isOpenCollectionInPersonalCollection;
 
   const renderContent = useCallback(
     ({ closePopover }) => {
@@ -124,7 +134,11 @@ function FormCollectionPicker({
           }}
           showOnlyPersonalCollections={showOnlyPersonalCollections}
         >
-          <CreateCollectionOnTheGoButton openCollectionId={openCollectionId} />
+          {showCreateNewCollectionOption && (
+            <CreateCollectionOnTheGoButton
+              openCollectionId={openCollectionId}
+            />
+          )}
         </PopoverItemPicker>
       );
     },
@@ -134,6 +148,7 @@ function FormCollectionPicker({
       width,
       initialOpenCollectionId,
       showOnlyPersonalCollections,
+      showCreateNewCollectionOption,
       openCollectionId,
       setValue,
       onOpenCollectionChange,

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -33,6 +33,7 @@ export interface FormCollectionPickerProps
   type?: "collections" | "snippet-collections";
   initialOpenCollectionId?: CollectionId;
   onOpenCollectionChange?: (collectionId: CollectionId) => void;
+  showOnlyPersonalCollections?: boolean;
 }
 
 function ItemName({
@@ -58,6 +59,7 @@ function FormCollectionPicker({
   type = "collections",
   initialOpenCollectionId,
   onOpenCollectionChange,
+  showOnlyPersonalCollections,
 }: FormCollectionPickerProps) {
   const id = useUniqueId();
   const [{ value }, { error, touched }, { setValue }] = useField(name);
@@ -120,18 +122,20 @@ function FormCollectionPicker({
             onOpenCollectionChange?.(id);
             setOpenCollectionId(id);
           }}
+          showOnlyPersonalCollections={showOnlyPersonalCollections}
         >
           <CreateCollectionOnTheGoButton openCollectionId={openCollectionId} />
         </PopoverItemPicker>
       );
     },
     [
-      value,
       type,
+      value,
       width,
-      setValue,
       initialOpenCollectionId,
+      showOnlyPersonalCollections,
       openCollectionId,
+      setValue,
       onOpenCollectionChange,
     ],
   );

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.tsx
@@ -92,6 +92,7 @@ const AddToDashSelectDashModal = ({
   if (shouldCreateDashboard) {
     return (
       <CreateDashboardModal
+        showOnlyPersonalCollections={isQuestionInPersonalCollection}
         collectionId={card.collection_id}
         onCreate={navigateToDashboard}
         onClose={() => setShouldCreateDashboard(false)}

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.tsx
@@ -69,8 +69,8 @@ const AddToDashSelectDashModal = ({
     }),
   );
   const isOpenCollectionInPersonalCollection = openCollection?.is_personal;
-  const hideCreateNewDashboardOption =
-    isQuestionInPersonalCollection && !isOpenCollectionInPersonalCollection;
+  const showCreateNewDashboardOption =
+    !isQuestionInPersonalCollection || isOpenCollectionInPersonalCollection;
 
   const navigateToDashboard: Required<CreateDashboardFormOwnProps>["onCreate"] =
     dashboard => {
@@ -125,7 +125,7 @@ const AddToDashSelectDashModal = ({
         collectionId={initialOpenCollectionId}
         value={mostRecentlyViewedDashboardQuery.data?.id}
       />
-      {!hideCreateNewDashboardOption && (
+      {showCreateNewDashboardOption && (
         <Link onClick={() => setShouldCreateDashboard(true)} to="">
           <LinkContent>
             <Icon name="add" className="mx1" />

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -440,6 +440,7 @@ describe("AddToDashSelectDashModal", () => {
                 }),
               );
             });
+
             it("should render all collections", async () => {
               // Create a new dashboard modal
               expect(

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -433,7 +433,7 @@ describe("AddToDashSelectDashModal", () => {
           });
 
           describe('when "Create a new dashboard" option is clicked', () => {
-            beforeEach(async () => {
+            beforeEach(() => {
               userEvent.click(
                 screen.getByRole("heading", {
                   name: "Create a new dashboard",
@@ -651,7 +651,7 @@ describe("AddToDashSelectDashModal", () => {
             });
           });
 
-          it('should not render "Create a new dashboard" option when opening the root collection (public collection)', async () => {
+          it('should not render "Create a new dashboard" option when opening the root collection (public collection)', () => {
             expect(
               screen.queryByRole("heading", {
                 name: "Create a new dashboard",
@@ -659,7 +659,7 @@ describe("AddToDashSelectDashModal", () => {
             ).not.toBeInTheDocument();
           });
 
-          it('should render "Create a new dashboard" option when opening personal subcollections', async () => {
+          it('should render "Create a new dashboard" option when opening personal subcollections', () => {
             userEvent.click(
               screen.getByRole("heading", {
                 name: PERSONAL_COLLECTION.name,
@@ -686,7 +686,7 @@ describe("AddToDashSelectDashModal", () => {
           });
 
           describe('when "Create a new dashboard" option is clicked when opening personal collections', () => {
-            beforeEach(async () => {
+            beforeEach(() => {
               // "Create a new dashboard" option only renders when opening personal collections
               userEvent.click(
                 screen.getByRole("heading", {

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -439,15 +439,14 @@ describe("AddToDashSelectDashModal", () => {
                   name: "Create a new dashboard",
                 }),
               );
+              // Open "Create a new dashboard" modal
+              userEvent.click(screen.getByTestId("select-button"));
             });
 
             it("should render all collections", async () => {
-              // Create a new dashboard modal
               expect(
                 screen.getByRole("heading", { name: "New dashboard" }),
               ).toBeInTheDocument();
-              userEvent.click(screen.getByTestId("select-button"));
-
               const popover = screen.getByRole("tooltip");
               expect(popover).toBeInTheDocument();
               expect(
@@ -468,11 +467,9 @@ describe("AddToDashSelectDashModal", () => {
             });
 
             it('should render "New collection" option', async () => {
-              // Create a new dashboard modal
               expect(
                 screen.getByRole("heading", { name: "New dashboard" }),
               ).toBeInTheDocument();
-              userEvent.click(screen.getByTestId("select-button"));
 
               const popover = screen.getByRole("tooltip");
               expect(popover).toBeInTheDocument();
@@ -484,9 +481,6 @@ describe("AddToDashSelectDashModal", () => {
 
             describe('when "New collection" option is clicked', () => {
               beforeEach(async () => {
-                // Create a new dashboard modal
-                userEvent.click(screen.getByTestId("select-button"));
-
                 const popover = screen.getByRole("tooltip");
 
                 userEvent.click(
@@ -495,7 +489,6 @@ describe("AddToDashSelectDashModal", () => {
               });
 
               it("should render all collections", async () => {
-                // Create a new collection modal
                 expect(
                   screen.getByRole("heading", { name: "New collection" }),
                 ).toBeInTheDocument();
@@ -701,7 +694,6 @@ describe("AddToDashSelectDashModal", () => {
             });
 
             it("should render only personal collections", async () => {
-              // Create a new dashboard modal
               expect(
                 screen.getByRole("heading", { name: "New dashboard" }),
               ).toBeInTheDocument();
@@ -727,7 +719,6 @@ describe("AddToDashSelectDashModal", () => {
             });
 
             it('should not render "New collection" option when opening the root collection (public collection)', async () => {
-              // Create a new dashboard modal
               expect(
                 screen.getByRole("heading", { name: "New dashboard" }),
               ).toBeInTheDocument();
@@ -747,7 +738,6 @@ describe("AddToDashSelectDashModal", () => {
 
             describe('when "New collection" option is clicked when opening personal collections', () => {
               beforeEach(async () => {
-                // Create a new dashboard modal
                 userEvent.click(screen.getByTestId("select-button"));
                 const popover = screen.getByRole("tooltip");
 
@@ -759,7 +749,6 @@ describe("AddToDashSelectDashModal", () => {
               });
 
               it("should render only personal collections", async () => {
-                // Create a new collection modal
                 expect(
                   screen.getByRole("heading", { name: "New collection" }),
                 ).toBeInTheDocument();

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -685,7 +685,7 @@ describe("AddToDashSelectDashModal", () => {
             ).toBeInTheDocument();
           });
 
-          describe('when "Create a new dashboard" option is clicked', () => {
+          describe('when "Create a new dashboard" option is clicked when opening personal collections', () => {
             beforeEach(async () => {
               // "Create a new dashboard" option only renders when opening personal collections
               userEvent.click(
@@ -726,7 +726,7 @@ describe("AddToDashSelectDashModal", () => {
               ).not.toBeInTheDocument();
             });
 
-            it('should not render "New collection" option', async () => {
+            it('should not render "New collection" option when opening the root collection (public collection)', async () => {
               // Create a new dashboard modal
               expect(
                 screen.getByRole("heading", { name: "New dashboard" }),
@@ -745,7 +745,7 @@ describe("AddToDashSelectDashModal", () => {
               ).not.toBeInTheDocument();
             });
 
-            describe('when "New collection" option is clicked', () => {
+            describe('when "New collection" option is clicked when opening personal collections', () => {
               beforeEach(async () => {
                 // Create a new dashboard modal
                 userEvent.click(screen.getByTestId("select-button"));

--- a/frontend/src/metabase/containers/CreateCollectionOnTheGo.tsx
+++ b/frontend/src/metabase/containers/CreateCollectionOnTheGo.tsx
@@ -16,6 +16,7 @@ interface State {
   enabled?: boolean;
   resumedValues?: Values;
   openCollectionId?: CollectionId;
+  showOnlyPersonalCollections?: boolean;
 }
 
 const Context = createContext<{
@@ -33,7 +34,12 @@ export function CreateCollectionOnTheGo({
     (newState: State) => setState({ ...state, ...newState }),
     [state, setState],
   );
-  const { enabled, resumedValues, openCollectionId } = state;
+  const {
+    enabled,
+    resumedValues,
+    openCollectionId,
+    showOnlyPersonalCollections,
+  } = state;
   return enabled ? (
     <CreateCollectionModal
       collectionId={openCollectionId}
@@ -44,6 +50,7 @@ export function CreateCollectionOnTheGo({
           resumedValues: { ...resumedValues, collection_id: collection.id },
         });
       }}
+      showOnlyPersonalCollections={showOnlyPersonalCollections}
     />
   ) : (
     <Context.Provider value={{ canCreateNew: true, updateState }}>
@@ -52,11 +59,15 @@ export function CreateCollectionOnTheGo({
   );
 }
 
+interface CreateCollectionOnTheGoButtonProps {
+  openCollectionId?: CollectionId;
+  showOnlyPersonalCollections?: boolean;
+}
+
 export function CreateCollectionOnTheGoButton({
   openCollectionId,
-}: {
-  openCollectionId?: CollectionId;
-}) {
+  showOnlyPersonalCollections,
+}: CreateCollectionOnTheGoButtonProps) {
   const { canCreateNew, updateState } = useContext(Context);
   const formik = useFormikContext<Values>();
   return canCreateNew && formik ? (
@@ -68,6 +79,7 @@ export function CreateCollectionOnTheGoButton({
           enabled: true,
           resumedValues: formik.values,
           openCollectionId,
+          showOnlyPersonalCollections,
         })
       }
     >

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
@@ -43,6 +43,7 @@ export interface CreateDashboardFormOwnProps {
   onCreate?: (dashboard: Dashboard) => void;
   onCancel?: () => void;
   initialValues?: CreateDashboardProperties | null;
+  showOnlyPersonalCollections?: boolean;
 }
 
 interface CreateDashboardFormStateProps {
@@ -78,6 +79,7 @@ function CreateDashboardForm({
   onCreate,
   onCancel,
   initialValues,
+  showOnlyPersonalCollections,
 }: Props) {
   const computedInitialValues = useMemo(
     () => ({
@@ -120,6 +122,7 @@ function CreateDashboardForm({
           <FormCollectionPicker
             name="collection_id"
             title={t`Which collection should this go in?`}
+            showOnlyPersonalCollections={showOnlyPersonalCollections}
           />
           <FormFooter>
             <FormErrorMessage inline />


### PR DESCRIPTION
This PRs completes task 3-5 in this Epic: https://github.com/metabase/metabase/issues/34733

This PR implements:
- Hide public collections in create a new dashboard modal
    ![image](https://github.com/metabase/metabase/assets/1937582/b28e8822-31d1-44a4-b162-8bb859d99b83)
- Hide "+ New collection option" in FormCollectionPicker
    ![image](https://github.com/metabase/metabase/assets/1937582/ab4afc27-f239-4389-aabe-3015e8d6e4bd)
- Hide public collections in create a new collection modal
    ![image](https://github.com/metabase/metabase/assets/1937582/d05762b9-133e-4496-9b2b-f6b10963eaf3)


#### How to verify
Query builder

Newly created question
1. Select `Create a new dashboard` for a question in a public collection
    **expectation**:
    - show all collections
    - always show `New collection`
1. Select `Create a new dashboard` for a question in a personal collection
    **expectation**:
    - show only personal collections
    - only show `New collection` option in personal collections
1. Select `New collection` for a question in a public collection
    **expectation**:
    - show all collections
1. Select `New collection` for a question in a personal collection
    **expectation**:
    - show only personal collections
