### PR TITLE
Fix missing indexed entity x-ray button

### DIFF
--- a/e2e/support/helpers/e2e-model-index-helper.js
+++ b/e2e/support/helpers/e2e-model-index-helper.js
@@ -1,0 +1,26 @@
+export function createModelIndex({ modelId, pkName, valueName }) {
+  // since field ids are non-deterministic, we need to get them from the api
+  cy.request("GET", `/api/table/card__${modelId}/query_metadata`).then(
+    ({ body }) => {
+      const pkRef = [
+        "field",
+        body.fields.find(f => f.name === pkName).id,
+        null,
+      ];
+      const valueRef = [
+        "field",
+        body.fields.find(f => f.name === valueName).id,
+        null,
+      ];
+
+      cy.request("POST", "/api/model-index", {
+        pk_ref: pkRef,
+        value_ref: valueRef,
+        model_id: modelId,
+      }).then(response => {
+        expect(response.body.state).to.equal("indexed");
+        expect(response.body.id).to.equal(1);
+      });
+    },
+  );
+}

--- a/e2e/test/scenarios/models/model-indexes.cy.spec.js
+++ b/e2e/test/scenarios/models/model-indexes.cy.spec.js
@@ -7,6 +7,7 @@ import {
 } from "e2e/support/helpers";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { createModelIndex } from "e2e/support/helpers/e2e-model-index-helper";
 
 const { PRODUCTS_ID, PEOPLE_ID } = SAMPLE_DATABASE;
 
@@ -244,33 +245,6 @@ function editTitleMetadata() {
   cy.findByTestId("TableInteractive-root").findByTextEnsureVisible("Title");
 
   openColumnOptions("Title");
-}
-
-function createModelIndex({ modelId, pkName, valueName }) {
-  // since field ids are non-deterministic, we need to get them from the api
-  cy.request("GET", `/api/table/card__${modelId}/query_metadata`).then(
-    ({ body }) => {
-      const pkRef = [
-        "field",
-        body.fields.find(f => f.name === pkName).id,
-        null,
-      ];
-      const valueRef = [
-        "field",
-        body.fields.find(f => f.name === valueName).id,
-        null,
-      ];
-
-      cy.request("POST", "/api/model-index", {
-        pk_ref: pkRef,
-        value_ref: valueRef,
-        model_id: modelId,
-      }).then(response => {
-        expect(response.body.state).to.equal("indexed");
-        expect(response.body.id).to.equal(1);
-      });
-    },
-  );
 }
 
 const expectCardQueries = num =>

--- a/e2e/test/scenarios/onboarding/search/search.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search.cy.spec.js
@@ -21,6 +21,7 @@ import {
 } from "e2e/support/cypress_sample_instance_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { createModelIndex } from "e2e/support/helpers/e2e-model-index-helper";
 
 const typeFilters = [
   {
@@ -51,9 +52,13 @@ const typeFilters = [
     label: "Action",
     type: "action",
   },
+  {
+    label: "Indexed record",
+    type: "indexed-entity",
+  },
 ];
 
-const { ORDERS_ID } = SAMPLE_DATABASE;
+const { ORDERS_ID, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 const NORMAL_USER_TEST_QUESTION = {
   name: `Robert's Super Duper Reviews`,
@@ -241,6 +246,23 @@ describe("scenarios > search", () => {
             visualization_settings: {
               type: "button",
             },
+          });
+        });
+
+        cy.createQuestion(
+          {
+            name: "Products Model",
+            query: { "source-table": PRODUCTS_ID },
+            dataset: true,
+          },
+          { wrapId: true, idAlias: "modelId" },
+        );
+
+        cy.get("@modelId").then(modelId => {
+          createModelIndex({
+            modelId,
+            pkName: "ID",
+            valueName: "TITLE",
           });
         });
       });

--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -12,10 +12,11 @@ export type EnabledSearchModelType =
   | "database"
   | "table"
   | "dataset"
-  | "action";
+  | "action"
+  | "indexed-entity";
 
 export type SearchModelType =
-  | ("segment" | "metric" | "pulse" | "indexed-entity" | "snippet")
+  | ("segment" | "metric" | "pulse" | "snippet")
   | EnabledSearchModelType;
 
 export interface SearchScore {

--- a/frontend/src/metabase/common/utils/model-names.ts
+++ b/frontend/src/metabase/common/utils/model-names.ts
@@ -7,7 +7,7 @@ const TRANSLATED_NAME_BY_MODEL_TYPE: Record<string, string> = {
   dashboard: t`Dashboard`,
   database: t`Database`,
   dataset: t`Model`,
-  "indexed-entity": t`Indexed Entity`,
+  "indexed-entity": t`Indexed record`,
   metric: t`Metric`,
   pulse: t`Pulse`,
   segment: t`Segment`,

--- a/frontend/src/metabase/common/utils/model-names.unit.spec.ts
+++ b/frontend/src/metabase/common/utils/model-names.unit.spec.ts
@@ -10,6 +10,6 @@ describe("common/utils/model-names", () => {
     expect(getTranslatedEntityName("dashboard")).toBe("Dashboard");
     expect(getTranslatedEntityName("card")).toBe("Question");
     expect(getTranslatedEntityName("dataset")).toBe("Model");
-    expect(getTranslatedEntityName("indexed-entity")).toBe("Indexed Entity");
+    expect(getTranslatedEntityName("indexed-entity")).toBe("Indexed record");
   });
 });

--- a/frontend/src/metabase/nav/components/search/SearchResultsDropdown/SearchResultsDropdown.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchResultsDropdown/SearchResultsDropdown.unit.spec.tsx
@@ -42,7 +42,7 @@ const TEST_SEARCH_RESULTS = [
   }),
   createMockSearchResult({
     id: 3,
-    name: "Indexed Entity",
+    name: "Indexed record",
     model: "indexed-entity",
   }),
 ];
@@ -102,9 +102,9 @@ describe("SearchResultsDropdown", () => {
 
   it("should call onSearchItemSelect when a result is clicked and has type=indexed-entity", async () => {
     const { onSearchItemSelect } = await setup({
-      searchText: "Indexed Entity",
+      searchText: "Indexed record",
     });
-    const searchItem = screen.getByText("Indexed Entity");
+    const searchItem = screen.getByText("Indexed record");
     userEvent.click(searchItem);
     expect(onSearchItemSelect).toHaveBeenCalled();
   });

--- a/frontend/src/metabase/search/components/InfoText/get-info-text.tsx
+++ b/frontend/src/metabase/search/components/InfoText/get-info-text.tsx
@@ -24,10 +24,10 @@ export const getInfoText = (result: WrappedResult): InfoTextData => {
     case "database":
       return getDatabaseInfoText();
     case "action":
+    case "indexed-entity":
       return getActionInfoText(result);
     case "card":
     case "dataset":
-    case "indexed-entity":
     default:
       return getCollectionResult(result);
   }

--- a/frontend/src/metabase/search/components/SearchResult/SearchResult.styled.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/SearchResult.styled.tsx
@@ -3,8 +3,8 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import type { AnchorHTMLAttributes, HTMLAttributes, RefObject } from "react";
 import { PLUGIN_MODERATION } from "metabase/plugins";
-import type { AnchorProps, BoxProps } from "metabase/ui";
-import { Box, Divider, Stack, Anchor } from "metabase/ui";
+import type { AnchorProps, BoxProps, ButtonProps } from "metabase/ui";
+import { Box, Divider, Stack, Anchor, Button } from "metabase/ui";
 
 const { ModerationStatusIcon } = PLUGIN_MODERATION;
 
@@ -46,7 +46,7 @@ export const SearchResultContainer = styled(Box, {
     }
 >`
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto 1fr auto auto;
   justify-content: center;
   align-items: center;
   gap: 0.5rem 0.75rem;
@@ -88,8 +88,20 @@ export const ModerationIcon = styled(ModerationStatusIcon)`
 `;
 
 export const LoadingSection = styled(Box)<BoxProps>`
-  grid-row: 1 / span 2;
+  grid-row: 1 / span 1;
   grid-column: 3;
+`;
+
+export const XRaySection = styled(Box)<BoxProps>`
+  grid-row: 1 / span 1;
+  grid-column: 4;
+`;
+
+export const XRayButton = styled(Button)<
+  ButtonProps & HTMLAttributes<HTMLButtonElement>
+>`
+  width: 2rem;
+  height: 2rem;
 `;
 
 export const DescriptionSection = styled(Box)`

--- a/frontend/src/metabase/search/components/SearchResult/SearchResult.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/SearchResult.tsx
@@ -8,6 +8,7 @@ import { Group, Text, Loader } from "metabase/ui";
 import { isSyncCompleted } from "metabase/lib/syncing";
 
 import type { WrappedResult } from "metabase/search/types";
+import { Icon } from "metabase/core/components/Icon";
 import { InfoText } from "../InfoText";
 import { ItemIcon } from "./components";
 
@@ -19,6 +20,8 @@ import {
   ResultNameSection,
   ResultTitle,
   SearchResultContainer,
+  XRayButton,
+  XRaySection,
 } from "./SearchResult.styled";
 
 export function SearchResult({
@@ -36,6 +39,11 @@ export function SearchResult({
 }) {
   const { name, model, description, moderated_status }: WrappedResult = result;
 
+  const showXRayButton =
+    result.model === "indexed-entity" &&
+    result.id !== undefined &&
+    result.model_index_id !== null;
+
   const isActive = isItemActive(result);
   const isLoading = isItemLoading(result);
 
@@ -46,6 +54,15 @@ export function SearchResult({
       dispatch(push(nextLocation)),
     [dispatch],
   );
+
+  const onXRayClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    e.preventDefault();
+
+    onChangeLocation(
+      `/auto/dashboard/model_index/${result.model_index_id}/primary_key/${result.id}`,
+    );
+  };
 
   const handleClick = (e: MouseEvent) => {
     e.stopPropagation();
@@ -99,6 +116,11 @@ export function SearchResult({
         <LoadingSection px="xs">
           <Loader />
         </LoadingSection>
+      )}
+      {showXRayButton && (
+        <XRaySection>
+          <XRayButton leftIcon={<Icon name="bolt" />} onClick={onXRayClick} />
+        </XRaySection>
       )}
       {description && showDescription && (
         <DescriptionSection>

--- a/frontend/src/metabase/search/components/SearchResult/tests/SearchResult.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/tests/SearchResult.unit.spec.tsx
@@ -1,3 +1,5 @@
+import userEvent from "@testing-library/user-event";
+import { Route } from "react-router";
 import {
   setupCollectionByIdEndpoint,
   setupUsersEndpoints,
@@ -27,6 +29,11 @@ const TEST_RESULT_COLLECTION = createWrappedSearchResult({
   collection: TEST_REGULAR_COLLECTION,
 });
 
+const TEST_RESULT_INDEXED_ENTITY = createWrappedSearchResult({
+  model: "indexed-entity",
+  model_index_id: 1,
+});
+
 const setup = ({ result }: { result: WrappedResult }) => {
   setupCollectionByIdEndpoint({
     collections: [TEST_REGULAR_COLLECTION],
@@ -34,7 +41,15 @@ const setup = ({ result }: { result: WrappedResult }) => {
 
   setupUsersEndpoints([createMockUser()]);
 
-  renderWithProviders(<SearchResult result={result} />);
+  const { history } = renderWithProviders(
+    <Route path="*" component={() => <SearchResult result={result} />} />,
+    {
+      withRouter: true,
+      initialRoute: "/",
+    },
+  );
+
+  return { history };
 };
 
 describe("SearchResult", () => {
@@ -57,5 +72,40 @@ describe("SearchResult", () => {
       screen.queryByText(TEST_RESULT_COLLECTION.collection.name),
     ).not.toBeInTheDocument();
     expect(getIcon("folder")).toBeInTheDocument();
+  });
+
+  it("should redirect to search result page when clicking item", async () => {
+    const { history } = setup({ result: TEST_RESULT_QUESTION });
+
+    userEvent.click(screen.getByText(TEST_RESULT_QUESTION.name));
+
+    const expectedPath = TEST_RESULT_QUESTION.getUrl();
+
+    expect(history?.getCurrentLocation().pathname).toEqual(expectedPath);
+  });
+
+  describe("indexed entities", () => {
+    it("renders x-ray button for indexed entity search result", () => {
+      setup({ result: TEST_RESULT_INDEXED_ENTITY });
+
+      expect(screen.getByTestId("search-result-item-icon")).toHaveAttribute(
+        "type",
+        "indexed-entity",
+      );
+
+      expect(screen.getByLabelText("bolt icon")).toBeInTheDocument();
+    });
+
+    it("redirects to x-ray page when clicking on x-ray button", () => {
+      const { history } = setup({ result: TEST_RESULT_INDEXED_ENTITY });
+
+      expect(screen.getByLabelText("bolt icon")).toBeInTheDocument();
+
+      userEvent.click(screen.getByLabelText("bolt icon"));
+
+      const expectedPath = `/auto/dashboard/model_index/${TEST_RESULT_INDEXED_ENTITY.model_index_id}/primary_key/${TEST_RESULT_INDEXED_ENTITY.id}`;
+
+      expect(history?.getCurrentLocation().pathname).toEqual(expectedPath);
+    });
   });
 });

--- a/frontend/src/metabase/search/components/filters/TypeFilter/TypeFilterContent.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/filters/TypeFilter/TypeFilterContent.unit.spec.tsx
@@ -25,6 +25,7 @@ const MODEL_NAME: Record<EnabledSearchModelType, string> = {
   database: "Database",
   dataset: "Model",
   table: "Table",
+  "indexed-entity": "Indexed record",
 };
 
 const TEST_TYPES: Array<EnabledSearchModelType> = [

--- a/frontend/src/metabase/search/components/filters/TypeFilter/TypeFilterDisplay.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/filters/TypeFilter/TypeFilterDisplay.unit.spec.tsx
@@ -11,6 +11,7 @@ const MODEL_TYPE_DISPLAY_NAMES: Record<EnabledSearchModelType, string> = {
   database: "Database",
   dataset: "Model",
   table: "Table",
+  "indexed-entity": "Indexed record",
 };
 
 const setup = (value: TypeFilterProps) => {

--- a/frontend/src/metabase/search/constants.ts
+++ b/frontend/src/metabase/search/constants.ts
@@ -18,4 +18,5 @@ export const enabledSearchTypes: EnabledSearchModelType[] = [
   "database",
   "table",
   "action",
+  "indexed-entity",
 ];

--- a/frontend/src/metabase/search/containers/SearchApp.unit.spec.tsx
+++ b/frontend/src/metabase/search/containers/SearchApp.unit.spec.tsx
@@ -39,6 +39,7 @@ const TYPE_FILTER_LABELS: Record<EnabledSearchModelType, string> = {
   table: "Table",
   card: "Question",
   action: "Action",
+  "indexed-entity": "Indexed record",
 };
 
 const TEST_ITEMS: Partial<SearchResult>[] = [


### PR DESCRIPTION
### Description

Restores the x-ray button for indexed entities within 

### How to verify

1. Ensure that you have `indexed-entity` assets within your local system
2. Search for one of those `indexed-entity` assets
3. See that there's an X-ray button that will take you to an X-Ray of the model index

### Demo

<img width="1016" alt="image" src="https://github.com/metabase/metabase/assets/25306947/5ce1de20-3ca0-4412-8425-65cc9b5db790">

<img width="1332" alt="image" src="https://github.com/metabase/metabase/assets/25306947/81ba8e17-1b2b-4a78-ba06-274b8b129516">

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
