### PR TITLE
add basic static combo chart built with echarts

### DIFF
--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -62,6 +62,11 @@ export type SeriesSettings = {
   title: string;
   color?: string;
   show_series_values?: boolean;
+  display?: string;
+  axis?: string;
+  "line.interpolate"?: string;
+  "line.marker_enabled"?: boolean;
+  "line.missing"?: string;
 };
 
 export type SeriesOrderSetting = {
@@ -104,7 +109,7 @@ export type VisualizationSettings = {
 
   // X-axis
   "graph.x_axis.title_text"?: string;
-  "graph.x_axis.scale"?: "ordinal";
+  "graph.x_axis.scale"?: "ordinal" | "timeseries" | "linear" | "histogram";
   "graph.x_axis.axis_enabled"?: "compact";
 
   // Y-axis

--- a/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
+++ b/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
@@ -1,0 +1,52 @@
+import { init } from "echarts";
+import { getCartesianChartModel } from "metabase/visualizations/echarts/cartesian/model";
+import { getCartesianChartOption } from "metabase/visualizations/echarts/cartesian/option";
+import { sanitizeSvgForBatik } from "metabase/static-viz/lib/svg";
+import type { IsomorphicStaticChartProps } from "metabase/static-viz/containers/IsomorphicStaticChart/types";
+import { computeStaticComboChartSettings } from "./settings";
+
+const WIDTH = 540;
+const HEIGHT = 360;
+
+export const ComboChart = ({
+  rawSeries,
+  dashcardSettings,
+  renderingContext,
+  width = WIDTH,
+  height = HEIGHT,
+}: IsomorphicStaticChartProps) => {
+  const chart = init(null, null, {
+    renderer: "svg",
+    ssr: true,
+    width,
+    height,
+  });
+
+  const computedVisualizationSettings = computeStaticComboChartSettings(
+    rawSeries,
+    dashcardSettings,
+    renderingContext,
+  );
+
+  const chartModel = getCartesianChartModel(
+    rawSeries,
+    computedVisualizationSettings,
+    renderingContext,
+  );
+
+  const option = getCartesianChartOption(
+    chartModel,
+    computedVisualizationSettings,
+    renderingContext,
+  );
+
+  chart.setOption(option);
+
+  const chartSvg = sanitizeSvgForBatik(chart.renderToSVGString());
+
+  return (
+    <svg width={width} height={height}>
+      <g dangerouslySetInnerHTML={{ __html: chartSvg }}></g>
+    </svg>
+  );
+};

--- a/frontend/src/metabase/static-viz/components/ComboChart/index.ts
+++ b/frontend/src/metabase/static-viz/components/ComboChart/index.ts
@@ -1,0 +1,1 @@
+export * from "./ComboChart";

--- a/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
+++ b/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
@@ -1,0 +1,127 @@
+import type {
+  ComputedVisualizationSettings,
+  RenderingContext,
+} from "metabase/visualizations/types";
+import type { RawSeries, VisualizationSettings } from "metabase-types/api";
+
+import {
+  COLOR_SETTING_ID,
+  getSeriesColors,
+  getSeriesDefaultDisplay,
+  getSeriesDefaultLinearInterpolate,
+  getSeriesDefaultLineMarker,
+  getSeriesDefaultLineMissing,
+  getSeriesDefaultShowSeriesValues,
+  SETTING_ID,
+} from "metabase/visualizations/shared/settings/series";
+import { getCommonStaticVizSettings } from "metabase/static-viz/lib/settings";
+import {
+  getDefaultStackingValue,
+  getSeriesOrderVisibilitySettings,
+} from "metabase/visualizations/shared/settings/cartesian-chart";
+import {
+  getCardsColumns,
+  getCardsSeries,
+} from "metabase/visualizations/echarts/cartesian/model";
+
+const fillWithDefaultValue = (
+  settings: Record<string, unknown>,
+  key: string,
+  defaultValue: unknown,
+) => {
+  if (typeof settings[key] === "undefined") {
+    settings[key] = defaultValue;
+  }
+};
+
+const getSeriesFunction = (
+  rawSeries: RawSeries,
+  settings: Partial<ComputedVisualizationSettings>,
+  keys: string[],
+) => {
+  return (legacySeriesObject: any) => {
+    const seriesSettings = settings[SETTING_ID] ?? {};
+    const key = legacySeriesObject.card._seriesKey;
+    const singleSeriesSettings = seriesSettings[key] ?? {};
+
+    fillWithDefaultValue(
+      singleSeriesSettings,
+      "display",
+      getSeriesDefaultDisplay(rawSeries[0].card.display, keys.indexOf(key)),
+    );
+
+    fillWithDefaultValue(
+      singleSeriesSettings,
+      "line.interpolate",
+      getSeriesDefaultLinearInterpolate(settings),
+    );
+
+    fillWithDefaultValue(
+      singleSeriesSettings,
+      "line.marker_enabled",
+      getSeriesDefaultLineMarker(settings),
+    );
+
+    fillWithDefaultValue(
+      singleSeriesSettings,
+      "line.missing",
+      getSeriesDefaultLineMissing(settings),
+    );
+
+    fillWithDefaultValue(
+      singleSeriesSettings,
+      "show_series_values",
+      getSeriesDefaultShowSeriesValues(settings),
+    );
+
+    return singleSeriesSettings;
+  };
+};
+
+// This function should be in sync with the dynamic chart settings definitions logic.
+// The only reason it exists is the inability to import settings definitions with the
+// settings computation code in the static rendering environment
+export const computeStaticComboChartSettings = (
+  rawSeries: RawSeries,
+  dashcardSettings: VisualizationSettings,
+  renderingContext: RenderingContext,
+): ComputedVisualizationSettings => {
+  const mainCard = rawSeries[0].card;
+  const settings = getCommonStaticVizSettings(rawSeries, dashcardSettings);
+
+  const cardsColumns = getCardsColumns(rawSeries, settings);
+  const seriesModels = getCardsSeries(
+    rawSeries,
+    cardsColumns,
+    settings,
+    renderingContext,
+  );
+
+  const seriesVizSettingsKeys = seriesModels.map(
+    seriesModel => seriesModel.vizSettingsKey,
+  );
+
+  settings[COLOR_SETTING_ID] = getSeriesColors(seriesVizSettingsKeys, settings);
+  settings.series = getSeriesFunction(
+    rawSeries,
+    settings,
+    seriesVizSettingsKeys,
+  );
+
+  fillWithDefaultValue(
+    settings,
+    "stackable.stack_type",
+    getDefaultStackingValue(settings, mainCard),
+  );
+
+  fillWithDefaultValue(
+    settings,
+    "graph.series_order",
+    getSeriesOrderVisibilitySettings(
+      settings,
+      seriesModels.map(seriesModel => seriesModel.vizSettingsKey),
+    ),
+  );
+
+  return settings;
+};

--- a/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
+++ b/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
@@ -21,8 +21,9 @@ import {
 } from "metabase/visualizations/shared/settings/cartesian-chart";
 import {
   getCardsColumns,
-  getCardsSeries,
+  getCardsSeriesModels,
 } from "metabase/visualizations/echarts/cartesian/model";
+import type { LegacySeriesSettingsObjectKey } from "metabase/visualizations/echarts/cartesian/model/types";
 
 const fillWithDefaultValue = (
   settings: Record<string, unknown>,
@@ -39,7 +40,7 @@ const getSeriesFunction = (
   settings: Partial<ComputedVisualizationSettings>,
   keys: string[],
 ) => {
-  return (legacySeriesObject: any) => {
+  return (legacySeriesObject: LegacySeriesSettingsObjectKey) => {
     const seriesSettings = settings[SETTING_ID] ?? {};
     const key = legacySeriesObject.card._seriesKey;
     const singleSeriesSettings = seriesSettings[key] ?? {};
@@ -90,7 +91,7 @@ export const computeStaticComboChartSettings = (
   const settings = getCommonStaticVizSettings(rawSeries, dashcardSettings);
 
   const cardsColumns = getCardsColumns(rawSeries, settings);
-  const seriesModels = getCardsSeries(
+  const seriesModels = getCardsSeriesModels(
     rawSeries,
     cardsColumns,
     settings,
@@ -117,10 +118,7 @@ export const computeStaticComboChartSettings = (
   fillWithDefaultValue(
     settings,
     "graph.series_order",
-    getSeriesOrderVisibilitySettings(
-      settings,
-      seriesModels.map(seriesModel => seriesModel.vizSettingsKey),
-    ),
+    getSeriesOrderVisibilitySettings(settings, seriesVizSettingsKeys),
   );
 
   return settings;

--- a/frontend/src/metabase/static-viz/containers/IsomorphicStaticChart/IsomorphicStaticChart.tsx
+++ b/frontend/src/metabase/static-viz/containers/IsomorphicStaticChart/IsomorphicStaticChart.tsx
@@ -1,4 +1,5 @@
 import type { IsomorphicStaticChartProps } from "metabase/static-viz/containers/IsomorphicStaticChart/types";
+import { ComboChart } from "metabase/static-viz/components/ComboChart";
 
 const Placeholder = ({ text }: { text: string }) => {
   return (
@@ -18,7 +19,7 @@ export const IsomorphicStaticChart = (props: IsomorphicStaticChartProps) => {
     case "area":
     case "bar":
     case "combo":
-      return <Placeholder text="line/area/bar placeholder" />;
+      return <ComboChart {...props} />;
     case "scalar":
       return <Placeholder text="combined scalar placeholder" />;
     case "pie":

--- a/frontend/src/metabase/static-viz/containers/IsomorphicStaticChart/types.ts
+++ b/frontend/src/metabase/static-viz/containers/IsomorphicStaticChart/types.ts
@@ -5,4 +5,6 @@ export interface IsomorphicStaticChartProps {
   rawSeries: RawSeries;
   dashcardSettings: VisualizationSettings;
   renderingContext: RenderingContext;
+  width?: number;
+  height?: number;
 }

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
@@ -1,0 +1,129 @@
+import type { DatasetColumn, RawSeries, RowValue } from "metabase-types/api";
+import type { DataKey } from "metabase/visualizations/echarts/cartesian/model/types";
+import type { CartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
+import { isMetric } from "metabase-lib/types/utils/isa";
+
+/**
+ * Sums two metric column values.
+ *
+ * @param left - A value to sum.
+ * @param right - A value to sum.
+ * @returns The sum of the two values unless both values are not numbers.
+ */
+export const sumMetric = (left: RowValue, right: RowValue): number | null => {
+  if (typeof left === "number" && typeof right === "number") {
+    return left + right;
+  } else if (typeof left === "number") {
+    return left;
+  } else if (typeof right === "number") {
+    return right;
+  }
+
+  return null;
+};
+
+/**
+ * Creates a unique series key for a dataset based on the provided column, card ID, and optional breakout value.
+ * For unsaved questions without cardId the format is "columnName" or "breakoutValue:columnName" for breakout series.
+ * For saved questions keys include "cardId:" prefix.
+ *
+ * @param {DatasetColumn} column - The series metric column.
+ * @param {number | undefined} cardId - The ID of the card.
+ * @param {RowValue} [breakoutValue] - An optional breakout value when two dimensions columns are selected.
+ * @returns {string} A unique key for the series.
+ */
+export const getDatasetKey = (
+  column: DatasetColumn,
+  cardId?: number,
+  breakoutValue?: RowValue,
+): string => {
+  const cardIdPart = cardId != null ? `${cardId}:` : "";
+  const breakoutPart =
+    typeof breakoutValue !== "undefined" ? `${breakoutValue}:` : "";
+  const columnNamePart = column.name;
+
+  return `${cardIdPart}${breakoutPart}${columnNamePart}`;
+};
+
+/**
+ * Aggregates metric column values in a datum for a given row.
+ * When a breakoutIndex is specified it aggregates metrics per breakout value.
+ *
+ * @param {Record<DataKey, RowValue>} datum - The datum object to aggregate metric values.
+ * @param {DatasetColumn[]} columns - The columns of the raw dataset.
+ * @param {RowValue[]} row - The raw row of values.
+ * @param {number} cardId - The ID of the card.
+ * @param {number} [breakoutIndex] - The breakout column index for charts with two dimension columns selected.
+ */
+const aggregateMetricsForDatum = (
+  datum: Record<DataKey, RowValue>,
+  columns: DatasetColumn[],
+  row: RowValue[],
+  cardId: number,
+  breakoutIndex?: number,
+): void => {
+  columns.forEach((column, columnIndex) => {
+    if (!isMetric(column)) {
+      return;
+    }
+
+    const rowValue = row[columnIndex];
+    const seriesKey = getDatasetKey(column, cardId);
+    datum[seriesKey] = sumMetric(datum[seriesKey], rowValue);
+
+    if (breakoutIndex != null) {
+      const breakoutValue = row[breakoutIndex];
+      const breakoutSeriesKey = getDatasetKey(column, cardId, breakoutValue);
+      datum[breakoutSeriesKey] = sumMetric(datum[breakoutSeriesKey], rowValue);
+    }
+  });
+};
+
+/**
+ * Accepts merged raw cards and raw datasets, groups and joins the metric columns on the dimension column
+ * of each card.
+ *
+ * @param {RawSeries} rawSeries - An array of raw cards merged with raw datasets.
+ * @param {CartesianChartColumns[]} cardsColumns - The columns of each card.
+ * @returns {Record<DataKey, RowValue>[]} The aggregated dataset.
+ */
+export const getJoinedCardsDataset = (
+  rawSeries: RawSeries,
+  cardsColumns: CartesianChartColumns[],
+): Record<DataKey, RowValue>[] => {
+  const groupedData = new Map<RowValue, Record<DataKey, RowValue>>();
+
+  rawSeries.forEach((cardSeries, index) => {
+    const {
+      card,
+      data: { rows, cols },
+    } = cardSeries;
+    const columns = cardsColumns[index];
+
+    const cardId = card.id;
+
+    const dimensionIndex = columns.dimension.index;
+    const dimensionColumn = cols[dimensionIndex];
+    const dimensionDataKey = getDatasetKey(dimensionColumn, cardId);
+
+    const breakoutIndex =
+      "breakout" in columns ? columns.breakout.index : undefined;
+
+    for (const row of rows) {
+      const dimensionValue = row[dimensionIndex];
+
+      // Get the existing datum by the dimension value if exists
+      const datum = groupedData.get(dimensionValue) ?? {
+        [dimensionDataKey]: dimensionValue,
+      };
+
+      if (!groupedData.has(dimensionValue)) {
+        groupedData.set(dimensionValue, datum);
+      }
+
+      aggregateMetricsForDatum(datum, cols, row, cardId, breakoutIndex);
+    }
+  });
+
+  return Array.from(groupedData.values());
+};

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
@@ -34,7 +34,7 @@ export const sumMetric = (left: RowValue, right: RowValue): number | null => {
  */
 export const getDatasetKey = (
   column: DatasetColumn,
-  cardId?: number,
+  cardId: number | undefined,
   breakoutValue?: RowValue,
 ): string => {
   const cardIdPart = cardId != null ? `${cardId}:` : "";
@@ -84,7 +84,7 @@ const aggregateMetricsForDatum = (
  * of each card.
  *
  * @param {RawSeries} rawSeries - An array of raw cards merged with raw datasets.
- * @param {CartesianChartColumns[]} cardsColumns - The columns of each card.
+ * @param {CartesianChartColumns[]} cardsColumns - The column descriptors of each card.
  * @returns {Record<DataKey, RowValue>[]} The aggregated dataset.
  */
 export const getJoinedCardsDataset = (

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.unit.spec.ts
@@ -1,0 +1,181 @@
+import {
+  createMockCard,
+  createMockColumn,
+  createMockDatasetData,
+} from "metabase-types/api/mocks";
+import type {
+  BreakoutChartColumns,
+  CartesianChartColumns,
+} from "metabase/visualizations/lib/graph/columns";
+import type { SingleSeries } from "metabase-types/api";
+import { sumMetric, getDatasetKey, getJoinedCardsDataset } from "./dataset";
+
+describe("dataset transform functions", () => {
+  describe("sumMetric", () => {
+    it("should return the sum when both arguments are numbers", () => {
+      expect(sumMetric(3, 7)).toBe(10);
+    });
+
+    it("should return the left number when right is not a number", () => {
+      expect(sumMetric(5, null)).toBe(5);
+    });
+
+    it("should return the right number when left is not a number", () => {
+      expect(sumMetric(null, 5)).toBe(5);
+    });
+
+    it("should return null when neither left nor right is a number", () => {
+      expect(sumMetric(null, null)).toBeNull();
+    });
+  });
+
+  describe("getDatasetKey", () => {
+    const column = createMockColumn({ name: "count" });
+
+    it("should return the column name if cardId and breakoutValue are undefined", () => {
+      expect(getDatasetKey(column)).toBe("count");
+    });
+
+    it("should return the cardId concatenated with column name if cardId is provided and breakoutValue is undefined", () => {
+      expect(getDatasetKey(column, 1)).toBe("1:count");
+    });
+
+    it("should return the breakoutValue concatenated with column name if breakoutValue is provided and cardId is undefined", () => {
+      expect(getDatasetKey(column, undefined, "breakoutValue")).toBe(
+        "breakoutValue:count",
+      );
+    });
+
+    it("should return the cardId, breakoutValue and column name concatenated if all are provided", () => {
+      expect(getDatasetKey(column, 1, "breakoutValue")).toBe(
+        "1:breakoutValue:count",
+      );
+    });
+
+    it("should handle different types of breakout values correctly", () => {
+      expect(getDatasetKey(column, 1, "stringValue")).toBe(
+        "1:stringValue:count",
+      );
+      expect(getDatasetKey(column, 1, 123)).toBe("1:123:count");
+      expect(getDatasetKey(column, 1, true)).toBe("1:true:count");
+      expect(getDatasetKey(column, 1, null)).toBe("1:null:count");
+    });
+  });
+
+  describe("getJoinedCardsDataset", () => {
+    const columns1: CartesianChartColumns = {
+      dimension: { index: 0, column: createMockColumn({ name: "month" }) },
+      metrics: [
+        {
+          index: 2,
+          column: createMockColumn({
+            name: "count",
+            base_type: "type/Integer",
+          }),
+        },
+      ],
+    };
+
+    const columns2: BreakoutChartColumns = {
+      dimension: { index: 0, column: createMockColumn({ name: "also_month" }) },
+      metric: {
+        index: 2,
+        column: createMockColumn({
+          name: "count",
+          base_type: "type/Integer",
+        }),
+      },
+      breakout: { index: 1, column: createMockColumn({ name: "type" }) },
+    };
+
+    const rawSeries1: SingleSeries = {
+      card: createMockCard({ id: 1 }),
+      data: createMockDatasetData({
+        rows: [
+          [1, "category1", 200],
+          [2, "category1", 300],
+          [3, "category2", 400],
+          [3, "category3", 500],
+        ],
+        cols: [
+          columns1.dimension.column,
+          createMockColumn({ name: "category" }),
+          columns1.metrics[0].column,
+        ],
+      }),
+    };
+
+    const rawSeries2: SingleSeries = {
+      card: createMockCard({ id: 2 }),
+      data: createMockDatasetData({
+        rows: [
+          [1, "type1", 100],
+          [2, "type1", 200],
+          [3, "type2", 300],
+          [3, "type3", 400],
+        ],
+        cols: [
+          columns2.dimension.column,
+          columns2.breakout.column,
+          columns2.metric.column,
+        ],
+      }),
+    };
+
+    it("should sum metrics by the specified dimension", () => {
+      const result = getJoinedCardsDataset([rawSeries1], [columns1]);
+      expect(result).toStrictEqual([
+        { "1:month": 1, "1:count": 200 },
+        { "1:month": 2, "1:count": 300 },
+        { "1:month": 3, "1:count": 900 },
+      ]);
+    });
+
+    it("should handle breakout column if provided", () => {
+      const result = getJoinedCardsDataset([rawSeries2], [columns2]);
+      expect(result).toStrictEqual([
+        { "2:also_month": 1, "2:count": 100, "2:type1:count": 100 },
+        { "2:also_month": 2, "2:count": 200, "2:type1:count": 200 },
+        {
+          "2:also_month": 3,
+          "2:count": 700,
+          "2:type2:count": 300,
+          "2:type3:count": 400,
+        },
+      ]);
+    });
+
+    it("should join multiple rawSeries (combined cards) by their dimension columns", () => {
+      const result = getJoinedCardsDataset(
+        [rawSeries1, rawSeries2],
+        [columns1, columns2],
+      );
+      expect(result).toStrictEqual([
+        {
+          "1:month": 1,
+          "1:count": 200,
+          "2:count": 100,
+          "2:type1:count": 100,
+        },
+        {
+          "1:month": 2,
+          "1:count": 300,
+          "2:count": 200,
+          "2:type1:count": 200,
+        },
+        {
+          "1:month": 3,
+          "1:count": 900,
+          "2:count": 700,
+          "2:type2:count": 300,
+          "2:type3:count": 400,
+        },
+      ]);
+    });
+
+    it("should handle empty arrays", () => {
+      const result = getJoinedCardsDataset([], []);
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
@@ -1,0 +1,90 @@
+import type { RawSeries } from "metabase-types/api";
+import type {
+  ComputedVisualizationSettings,
+  RenderingContext,
+} from "metabase/visualizations/types";
+import type {
+  AxisSplit,
+  CartesianChartModel,
+} from "metabase/visualizations/echarts/cartesian/model/types";
+import {
+  getCardSeriesModels,
+  getDimensionModel,
+} from "metabase/visualizations/echarts/cartesian/model/series";
+import type { CartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
+import { getCartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
+import { getJoinedCardsDataset } from "metabase/visualizations/echarts/cartesian/model/dataset";
+
+export const getCardsColumns = (
+  rawSeries: RawSeries,
+  settings: ComputedVisualizationSettings,
+) => {
+  return rawSeries.map(({ data, card }) => {
+    // When multiple cards are combined on a dashboard card, computed visualization settings contain
+    // dimensions and metrics settings of the first card only which is not correct.
+    // Using the raw visualization settings for that is safe because we can combine
+    // only saved cards that have these settings.
+    const shouldUseIndividualCardSettings = rawSeries.length > 0;
+    return getCartesianChartColumns(
+      data.cols,
+      shouldUseIndividualCardSettings ? card.visualization_settings : settings,
+    );
+  });
+};
+
+export const getCardsSeries = (
+  rawSeries: RawSeries,
+  cardsColumns: CartesianChartColumns[],
+  settings: ComputedVisualizationSettings,
+  renderingContext: RenderingContext,
+) => {
+  return rawSeries.flatMap((cardDataset, index) => {
+    const isFirstCard = index === 0;
+    const cardColumns = cardsColumns[index];
+
+    return getCardSeriesModels(
+      cardDataset,
+      cardColumns,
+      isFirstCard,
+      renderingContext,
+    );
+  });
+};
+
+export const getCartesianChartModel = (
+  rawSeries: RawSeries,
+  settings: ComputedVisualizationSettings,
+  renderingContext: RenderingContext,
+): CartesianChartModel => {
+  const cardsColumns = getCardsColumns(rawSeries, settings);
+
+  const dimensionModel = getDimensionModel(rawSeries, cardsColumns);
+  const seriesModels = getCardsSeries(
+    rawSeries,
+    cardsColumns,
+    settings,
+    renderingContext,
+  );
+
+  const seriesDataKeys = seriesModels.map(seriesModel => seriesModel.dataKey);
+  const dataset = getJoinedCardsDataset(rawSeries, cardsColumns);
+
+  const yAxisSplit: AxisSplit = [seriesDataKeys, []];
+
+  const [leftSeries, rightSeries] = yAxisSplit;
+  const leftAxisColumn = seriesModels.find(
+    seriesModel => seriesModel.dataKey === leftSeries[0],
+  )?.column;
+  const rightAxisColumn = seriesModels.find(
+    seriesModel => seriesModel.dataKey === rightSeries[0],
+  )?.column;
+
+  return {
+    dataset,
+    seriesModels,
+    dimensionModel,
+    yAxisSplit,
+    leftAxisColumn,
+    rightAxisColumn,
+  };
+};

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
@@ -32,10 +32,9 @@ export const getCardsColumns = (
   });
 };
 
-export const getCardsSeries = (
+export const getCardsSeriesModels = (
   rawSeries: RawSeries,
   cardsColumns: CartesianChartColumns[],
-  settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
 ) => {
   return rawSeries.flatMap((cardDataset, index) => {
@@ -59,10 +58,9 @@ export const getCartesianChartModel = (
   const cardsColumns = getCardsColumns(rawSeries, settings);
 
   const dimensionModel = getDimensionModel(rawSeries, cardsColumns);
-  const seriesModels = getCardsSeries(
+  const seriesModels = getCardsSeriesModels(
     rawSeries,
     cardsColumns,
-    settings,
     renderingContext,
   );
 
@@ -71,12 +69,12 @@ export const getCartesianChartModel = (
 
   const yAxisSplit: AxisSplit = [seriesDataKeys, []];
 
-  const [leftSeries, rightSeries] = yAxisSplit;
+  const [leftSeriesDataKeys, rightSeriesDataKeys] = yAxisSplit;
   const leftAxisColumn = seriesModels.find(
-    seriesModel => seriesModel.dataKey === leftSeries[0],
+    seriesModel => seriesModel.dataKey === leftSeriesDataKeys[0],
   )?.column;
   const rightAxisColumn = seriesModels.find(
-    seriesModel => seriesModel.dataKey === rightSeries[0],
+    seriesModel => seriesModel.dataKey === rightSeriesDataKeys[0],
   )?.column;
 
   return {

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
@@ -1,0 +1,150 @@
+import type {
+  SingleSeries,
+  DatasetData,
+  RowValue,
+  DatasetColumn,
+  RawSeries,
+} from "metabase-types/api";
+import type { CartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
+import type {
+  SeriesModel,
+  VizSettingsKey,
+} from "metabase/visualizations/echarts/cartesian/model/types";
+import { getDatasetKey } from "metabase/visualizations/echarts/cartesian/model/dataset";
+import type {
+  Formatter,
+  RenderingContext,
+} from "metabase/visualizations/types";
+
+type MetricSeriesParams = {
+  metricColumn: DatasetColumn;
+};
+
+type BreakoutSeriesParams = {
+  breakoutColumn: DatasetColumn;
+  breakoutValue: RowValue;
+  formatValue: Formatter;
+};
+
+type SeriesVizSettingsKeyParams = {
+  cardName?: string;
+  isFirstCard: boolean;
+} & (MetricSeriesParams | BreakoutSeriesParams);
+
+export const getSeriesVizSettingsKey = ({
+  cardName,
+  isFirstCard,
+  ...params
+}: SeriesVizSettingsKeyParams): VizSettingsKey => {
+  // When multiple cards are combined on a dashboard, all cards
+  // except the first include the card name in the viz settings key.
+  const prefix = isFirstCard && cardName == null ? `${cardName}: ` : "";
+
+  const isBreakoutSeries = "breakoutValue" in params;
+
+  // Unfortunately, breakout series include formatted breakout values in the key
+  // which can be different based on a user's locale.
+  const key = isBreakoutSeries
+    ? params.formatValue(params.breakoutValue, {
+        column: params.breakoutColumn,
+      })
+    : params.metricColumn.name;
+
+  return prefix + key;
+};
+
+// HACK: creates a pseudo legacy series object to integrate with the `series` function in computed settings.
+// This workaround is necessary for generating a compatible key with `keyForSingleSeries` function,
+// ensuring the correct retrieval of series visualization settings based on the provided `seriesVizSettingsKey`.
+// Will be replaced with just a string key when implementing the dynamic line/area/bar.
+const createLegacySeriesObjectKey = (seriesVizSettingsKey: string) => ({
+  card: {
+    _seriesKey: seriesVizSettingsKey,
+  },
+});
+
+export const getBreakoutDistinctValues = (
+  data: DatasetData,
+  breakoutIndex: number,
+) => Array.from(new Set<RowValue>(data.rows.map(row => row[breakoutIndex])));
+
+/**
+ * Generates series models for a given card with a dataset.
+ *
+ * @param {SingleSeries} singleSeries - The single card and dataset.
+ * @param {CartesianChartColumns} columns - The columns model for the card.
+ * @param {boolean} isFirstCard - Indicates whether the card is the first card in the
+ *                                case of combined cards on a dashboard.
+ * @param {RenderingContext} renderingContext - The rendering context.
+ * @returns {SeriesModel[]} The generated series models for the card.
+ */
+export const getCardSeriesModels = (
+  { card, data }: SingleSeries,
+  columns: CartesianChartColumns,
+  isFirstCard: boolean,
+  renderingContext: RenderingContext,
+): SeriesModel[] => {
+  const hasBreakout = "breakout" in columns;
+
+  // Charts without breakout have one series per selected metric column.
+  if (!hasBreakout) {
+    return columns.metrics.map(metric => {
+      const vizSettingsKey = getSeriesVizSettingsKey({
+        cardName: card.name,
+        metricColumn: metric.column,
+        isFirstCard,
+      });
+
+      return {
+        cardId: card.id,
+        column: metric.column,
+        columnIndex: metric.index,
+        dataKey: getDatasetKey(metric.column, card.id),
+        vizSettingsKey,
+        legacySeriesSettingsObjectKey:
+          createLegacySeriesObjectKey(vizSettingsKey),
+      };
+    });
+  }
+
+  // Charts with breakout have one series per a unique breakout value. They can have only one metric in such cases.
+  const { metric, breakout } = columns;
+  const breakoutValues = getBreakoutDistinctValues(data, breakout.index);
+
+  return breakoutValues.map(breakoutValue => {
+    const vizSettingsKey = getSeriesVizSettingsKey({
+      cardName: card.name,
+      isFirstCard,
+      breakoutValue,
+      breakoutColumn: breakout.column,
+      formatValue: renderingContext.formatValue,
+    });
+
+    return {
+      cardId: card.id,
+      column: metric.column,
+      columnIndex: metric.index,
+      vizSettingsKey,
+      legacySeriesSettingsObjectKey:
+        createLegacySeriesObjectKey(vizSettingsKey),
+      dataKey: getDatasetKey(metric.column, card.id, breakoutValue),
+      breakoutColumnIndex: breakout.index,
+      breakoutColumn: breakout.column,
+      breakoutValue,
+    };
+  });
+};
+
+export const getDimensionModel = (
+  rawSeries: RawSeries,
+  cardColumns: CartesianChartColumns[],
+) => {
+  return {
+    dataKey: getDatasetKey(
+      cardColumns[0].dimension.column,
+      rawSeries[0].card.id,
+    ),
+    column: cardColumns[0].dimension.column,
+    columnIndex: cardColumns[0].dimension.index,
+  };
+};

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
@@ -7,6 +7,7 @@ import type {
 } from "metabase-types/api";
 import type { CartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
 import type {
+  LegacySeriesSettingsObjectKey,
   SeriesModel,
   VizSettingsKey,
 } from "metabase/visualizations/echarts/cartesian/model/types";
@@ -31,7 +32,7 @@ type SeriesVizSettingsKeyParams = {
   isFirstCard: boolean;
 } & (MetricSeriesParams | BreakoutSeriesParams);
 
-export const getSeriesVizSettingsKey = ({
+const getSeriesVizSettingsKey = ({
   cardName,
   isFirstCard,
   ...params
@@ -57,16 +58,16 @@ export const getSeriesVizSettingsKey = ({
 // This workaround is necessary for generating a compatible key with `keyForSingleSeries` function,
 // ensuring the correct retrieval of series visualization settings based on the provided `seriesVizSettingsKey`.
 // Will be replaced with just a string key when implementing the dynamic line/area/bar.
-const createLegacySeriesObjectKey = (seriesVizSettingsKey: string) => ({
+const createLegacySeriesObjectKey = (
+  seriesVizSettingsKey: string,
+): LegacySeriesSettingsObjectKey => ({
   card: {
     _seriesKey: seriesVizSettingsKey,
   },
 });
 
-export const getBreakoutDistinctValues = (
-  data: DatasetData,
-  breakoutIndex: number,
-) => Array.from(new Set<RowValue>(data.rows.map(row => row[breakoutIndex])));
+const getBreakoutDistinctValues = (data: DatasetData, breakoutIndex: number) =>
+  Array.from(new Set<RowValue>(data.rows.map(row => row[breakoutIndex])));
 
 /**
  * Generates series models for a given card with a dataset.

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -1,0 +1,49 @@
+import type { DatasetColumn, RowValue } from "metabase-types/api";
+
+export type DataKey = string;
+export type VizSettingsKey = string;
+
+export type RegularSeriesModel = {
+  dataKey: DataKey;
+  vizSettingsKey: VizSettingsKey;
+
+  // TODO: remove when the settings definitions are updated for the dynamic combo chart.
+  // This object is used as a key for the `series` function of the computed
+  // visualization settings to get the computed series settings
+  legacySeriesSettingsObjectKey: any;
+
+  cardId?: number;
+
+  column: DatasetColumn;
+  columnIndex: number;
+};
+
+export type BreakoutSeriesModel = RegularSeriesModel & {
+  breakoutColumn: DatasetColumn;
+  breakoutColumnIndex: number;
+  breakoutValue: RowValue;
+};
+
+export type SeriesModel = RegularSeriesModel | BreakoutSeriesModel;
+
+export type DimensionModel = {
+  dataKey: DataKey;
+  column: DatasetColumn;
+  columnIndex: number;
+};
+
+export type GroupedDataset = Record<DataKey, RowValue>[];
+export type Extent = [number, number];
+export type SeriesExtents = Record<DataKey, Extent>;
+
+export type AxisSplit = [DataKey[], DataKey[]];
+
+export type CartesianChartModel = {
+  dimensionModel: DimensionModel;
+  seriesModels: SeriesModel[];
+  dataset: GroupedDataset;
+  yAxisSplit: AxisSplit;
+
+  leftAxisColumn?: DatasetColumn;
+  rightAxisColumn?: DatasetColumn;
+};

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -2,6 +2,11 @@ import type { DatasetColumn, RowValue } from "metabase-types/api";
 
 export type DataKey = string;
 export type VizSettingsKey = string;
+export type LegacySeriesSettingsObjectKey = {
+  card: {
+    _seriesKey: VizSettingsKey;
+  };
+};
 
 export type RegularSeriesModel = {
   dataKey: DataKey;
@@ -10,7 +15,7 @@ export type RegularSeriesModel = {
   // TODO: remove when the settings definitions are updated for the dynamic combo chart.
   // This object is used as a key for the `series` function of the computed
   // visualization settings to get the computed series settings
-  legacySeriesSettingsObjectKey: any;
+  legacySeriesSettingsObjectKey: LegacySeriesSettingsObjectKey;
 
   cardId?: number;
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
@@ -1,0 +1,190 @@
+// eslint-disable-next-line no-restricted-imports
+import moment from "moment-timezone";
+import type { AxisBaseOptionCommon } from "echarts/types/src/coord/axisCommonTypes";
+import type { CartesianAxisOption } from "echarts/types/src/coord/cartesian/AxisModel";
+import type {
+  ComputedVisualizationSettings,
+  RemappingHydratedDatasetColumn,
+  RenderingContext,
+} from "metabase/visualizations/types";
+import type { CartesianChartModel } from "metabase/visualizations/echarts/cartesian/model/types";
+
+import { isNumeric } from "metabase-lib/types/utils/isa";
+
+const getAxisNameDefaultOption = (
+  { getColor, fontFamily }: RenderingContext,
+  nameGap: number,
+  name?: string,
+): Partial<AxisBaseOptionCommon> => ({
+  name,
+  nameGap,
+  nameLocation: "middle",
+  nameTextStyle: {
+    color: getColor("text-dark"),
+    fontSize: 14,
+    fontWeight: 900,
+    fontFamily,
+  },
+});
+
+const getTicksDefaultOption = ({ getColor, fontFamily }: RenderingContext) => {
+  return {
+    hideOverlap: true,
+    color: getColor("text-dark"),
+    fontSize: 12,
+    fontWeight: 900,
+    fontFamily,
+  };
+};
+
+export const getXAxisType = (settings: ComputedVisualizationSettings) => {
+  switch (settings["graph.x_axis.scale"]) {
+    case "timeseries":
+      return "time";
+    case "linear":
+      return "value";
+    default:
+      // TODO: implement histogram
+      return "category";
+  }
+};
+
+export const buildDimensionAxis = (
+  settings: ComputedVisualizationSettings,
+  column: RemappingHydratedDatasetColumn,
+  renderingContext: RenderingContext,
+): CartesianAxisOption => {
+  const { getColor } = renderingContext;
+  const axisType = getXAxisType(settings);
+
+  const formatter = (value: unknown) => {
+    return renderingContext.formatValue(value, {
+      column,
+      ...(settings.column?.(column) ?? {}),
+      jsx: false,
+    });
+  };
+
+  const boundaryGap =
+    axisType === "value" ? undefined : ([0.02, 0.02] as [number, number]);
+
+  return {
+    ...getAxisNameDefaultOption(
+      renderingContext,
+      24, // TODO: compute
+      settings["graph.x_axis.title_text"],
+    ),
+    axisTick: {
+      show: false,
+    },
+    boundaryGap,
+    splitLine: {
+      show: false,
+    },
+    type: axisType,
+    axisLabel: {
+      ...getTicksDefaultOption(renderingContext),
+      // Value is always converted to a string by ECharts
+      formatter: (value: string) => {
+        let valueToFormat: string | number = value;
+
+        if (axisType === "time") {
+          valueToFormat = moment(value).format("YYYY-MM-DDTHH:mm:ss");
+        } else if (isNumeric(column)) {
+          valueToFormat = parseInt(value, 10);
+        }
+
+        const formatted = formatter(valueToFormat);
+
+        // Spaces force having padding between ticks
+        return ` ${formatted} `;
+      },
+    },
+    axisLine: {
+      lineStyle: {
+        color: getColor("text-dark"),
+      },
+    },
+  };
+};
+
+const buildMetricAxis = (
+  settings: ComputedVisualizationSettings,
+  column: RemappingHydratedDatasetColumn,
+  position: "left" | "right",
+  renderingContext: RenderingContext,
+  name?: string,
+): CartesianAxisOption => {
+  const formatter = (value: unknown) => {
+    return renderingContext.formatValue(value, {
+      column,
+      ...(settings.column?.(column) ?? {}),
+    });
+  };
+
+  return {
+    ...getAxisNameDefaultOption(
+      renderingContext,
+      40, // TODO: compute
+      name,
+    ),
+    splitLine: {
+      lineStyle: {
+        type: 5,
+        color: renderingContext.getColor("border"),
+      },
+    },
+    position,
+    axisLabel: {
+      ...getTicksDefaultOption(renderingContext),
+      // @ts-expect-error TODO: figure out EChart types
+      formatter: (value: string) => {
+        return formatter(value);
+      },
+    },
+  };
+};
+
+const buildMetricsAxes = (
+  settings: ComputedVisualizationSettings,
+  leftAxisColumn: RemappingHydratedDatasetColumn | undefined,
+  rightAxisColumn: RemappingHydratedDatasetColumn | undefined,
+  renderingContext: RenderingContext,
+): CartesianAxisOption[] => {
+  return [
+    ...(leftAxisColumn != null
+      ? [
+          buildMetricAxis(
+            settings,
+            leftAxisColumn,
+            "left",
+            renderingContext,
+            settings["graph.y_axis.title_text"],
+          ),
+        ]
+      : []),
+    ...(rightAxisColumn != null
+      ? [buildMetricAxis(settings, rightAxisColumn, "right", renderingContext)]
+      : []),
+  ];
+};
+
+export const buildAxes = (
+  chartModel: CartesianChartModel,
+  settings: ComputedVisualizationSettings,
+  renderingContext: RenderingContext,
+) => {
+  return {
+    xAxis: buildDimensionAxis(
+      settings,
+      chartModel.dimensionModel.column,
+      renderingContext,
+    ),
+    yAxis: buildMetricsAxes(
+      settings,
+      chartModel.leftAxisColumn,
+      chartModel.rightAxisColumn,
+      renderingContext,
+    ),
+  };
+};

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -1,0 +1,32 @@
+import type { EChartsOption } from "echarts";
+import type { CartesianChartModel } from "metabase/visualizations/echarts/cartesian/model/types";
+import { buildEChartsSeries } from "metabase/visualizations/echarts/cartesian/option/series";
+import type {
+  ComputedVisualizationSettings,
+  RenderingContext,
+} from "metabase/visualizations/types";
+import { buildAxes } from "metabase/visualizations/echarts/cartesian/option/axis";
+
+export const getCartesianChartOption = (
+  chartModel: CartesianChartModel,
+  settings: ComputedVisualizationSettings,
+  renderingContext: RenderingContext,
+): EChartsOption => {
+  const echartsSeries = buildEChartsSeries(
+    chartModel,
+    settings,
+    renderingContext,
+  );
+
+  const dimensions = [
+    chartModel.dimensionModel.dataKey,
+    ...chartModel.seriesModels.map(seriesModel => seriesModel.dataKey),
+  ];
+  const echartsDataset = [{ source: chartModel.dataset, dimensions }];
+
+  return {
+    dataset: echartsDataset,
+    series: echartsSeries,
+    ...buildAxes(chartModel, settings, renderingContext),
+  } as EChartsOption;
+};

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -1,0 +1,159 @@
+import type { EChartsOption, RegisteredSeriesOption } from "echarts";
+import type { SeriesLabelOption } from "echarts/types/src/util/types";
+import type {
+  SeriesModel,
+  CartesianChartModel,
+} from "metabase/visualizations/echarts/cartesian/model/types";
+import type {
+  ComputedVisualizationSettings,
+  RenderingContext,
+} from "metabase/visualizations/types";
+import type { SeriesSettings } from "metabase-types/api";
+import { isNotNull } from "metabase/lib/types";
+
+const buildEChartsLabelOptions = (
+  seriesModel: SeriesModel,
+  settings: ComputedVisualizationSettings,
+  { getColor, fontFamily, formatValue }: RenderingContext,
+): SeriesLabelOption => {
+  const valueFormatter = (value: unknown) =>
+    formatValue(value, {
+      ...(settings.column?.(seriesModel.column) ?? {}),
+      jsx: false,
+      compact: settings["graph.label_value_formatting"] === "compact",
+    });
+
+  return {
+    show: settings["graph.show_values"],
+    position: "top",
+    fontFamily,
+    fontWeight: 900,
+    fontSize: 12,
+    color: getColor("text-dark"),
+    textBorderColor: getColor("white"),
+    textBorderWidth: 3,
+    formatter: datum => {
+      const dimensionIndex = datum?.encode?.y[0];
+      const dimensionName =
+        dimensionIndex != null ? datum?.dimensionNames?.[dimensionIndex] : null;
+      if (dimensionIndex == null || dimensionName == null) {
+        return " ";
+      }
+      const value = (datum?.value as any)?.[dimensionName];
+      return valueFormatter(value);
+    },
+  };
+};
+
+const buildEChartsBarSeries = (
+  seriesModel: SeriesModel,
+  seriesSettings: SeriesSettings,
+  seriesColor: string,
+  settings: ComputedVisualizationSettings,
+  dimensionDataKey: string,
+  yAxisIndex: number,
+  renderingContext: RenderingContext,
+): RegisteredSeriesOption["bar"] => {
+  const stackName =
+    settings["stackable.stack_type"] != null ? `bar_${yAxisIndex}` : undefined;
+
+  return {
+    type: "bar",
+    yAxisIndex,
+    stack: stackName,
+    encode: {
+      y: seriesModel.dataKey,
+      x: dimensionDataKey,
+    },
+    label: buildEChartsLabelOptions(seriesModel, settings, renderingContext),
+    labelLayout: {
+      hideOverlap: settings["graph.label_value_frequency"] === "fit",
+    },
+    itemStyle: {
+      color: seriesColor,
+    },
+  };
+};
+
+const buildEChartsLineAreaSeries = (
+  seriesModel: SeriesModel,
+  seriesSettings: SeriesSettings,
+  seriesColor: string,
+  settings: ComputedVisualizationSettings,
+  dimensionDataKey: string,
+  yAxisIndex: number,
+  renderingContext: RenderingContext,
+): RegisteredSeriesOption["line"] => {
+  const display = seriesSettings?.display ?? "line";
+
+  const stackName =
+    settings["stackable.stack_type"] != null ? `area_${yAxisIndex}` : undefined;
+
+  return {
+    type: "line",
+    yAxisIndex,
+    showSymbol: seriesSettings["line.marker_enabled"] !== false,
+    symbolSize: 6,
+    smooth: seriesSettings["line.interpolate"] === "cardinal",
+    connectNulls: seriesSettings["line.missing"] === "interpolate",
+    step:
+      seriesSettings["line.interpolate"] === "step-after" ? "end" : undefined,
+    stack: stackName,
+    areaStyle: display === "area" ? { opacity: 0.3 } : undefined,
+    encode: {
+      y: seriesModel.dataKey,
+      x: dimensionDataKey,
+    },
+    label: buildEChartsLabelOptions(seriesModel, settings, renderingContext),
+    labelLayout: {
+      hideOverlap: settings["graph.label_value_frequency"] === "fit",
+    },
+    itemStyle: {
+      color: seriesColor,
+    },
+  };
+};
+
+export const buildEChartsSeries = (
+  chartModel: CartesianChartModel,
+  settings: ComputedVisualizationSettings,
+  renderingContext: RenderingContext,
+): EChartsOption["series"] => {
+  return chartModel.seriesModels
+    .map(seriesModel => {
+      const seriesSettings: SeriesSettings = settings.series(
+        seriesModel.legacySeriesSettingsObjectKey,
+      );
+      const seriesColor =
+        settings?.["series_settings.colors"]?.[seriesModel.vizSettingsKey];
+
+      const yAxisIndex = chartModel.yAxisSplit[0].includes(seriesModel.dataKey)
+        ? 0
+        : 1;
+
+      switch (seriesSettings.display) {
+        case "line":
+        case "area":
+          return buildEChartsLineAreaSeries(
+            seriesModel,
+            seriesSettings,
+            seriesColor,
+            settings,
+            chartModel.dimensionModel.dataKey,
+            yAxisIndex,
+            renderingContext,
+          );
+        case "bar":
+          return buildEChartsBarSeries(
+            seriesModel,
+            seriesSettings,
+            seriesColor,
+            settings,
+            chartModel.dimensionModel.dataKey,
+            yAxisIndex,
+            renderingContext,
+          );
+      }
+    })
+    .filter(isNotNull);
+};

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -36,7 +36,7 @@ const buildEChartsLabelOptions = (
       const dimensionIndex = datum?.encode?.y[0];
       const dimensionName =
         dimensionIndex != null ? datum?.dimensionNames?.[dimensionIndex] : null;
-      if (dimensionIndex == null || dimensionName == null) {
+      if (dimensionName == null) {
         return " ";
       }
       const value = (datum?.value as any)?.[dimensionName];

--- a/frontend/src/metabase/visualizations/lib/series.ts
+++ b/frontend/src/metabase/visualizations/lib/series.ts
@@ -2,7 +2,8 @@ import { assocIn } from "icepick";
 import type { VisualizationSettings, Card } from "metabase-types/api/card";
 import type { Series, TransformedSeries } from "metabase-types/api/dataset";
 import { isNotNull } from "metabase/lib/types";
-import { SETTING_ID, keyForSingleSeries } from "./settings/series";
+import { SETTING_ID } from "metabase/visualizations/shared/settings/series";
+import { keyForSingleSeries } from "./settings/series";
 
 export const updateSeriesColor = (
   settings: VisualizationSettings,

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -25,6 +25,10 @@ import {
 
 import { ChartSettingOrderedSimple } from "metabase/visualizations/components/settings/ChartSettingOrderedSimple";
 import {
+  getDefaultStackingValue,
+  getSeriesOrderVisibilitySettings,
+} from "metabase/visualizations/shared/settings/cartesian-chart";
+import {
   isDimension,
   isMetric,
   isNumeric,
@@ -178,54 +182,7 @@ export const GRAPH_DATA_SETTINGS = {
 
     getValue: (series, settings) => {
       const seriesKeys = series.map(s => keyForSingleSeries(s));
-      const seriesSettings = settings["series_settings"];
-      const seriesColors = settings["series_settings.colors"] || {};
-      const seriesOrder = settings["graph.series_order"];
-      // Because this setting is a read dependency of graph.series_order_dimension, this should
-      // Always be the stored setting, not calculated.
-      const seriesOrderDimension = settings["graph.series_order_dimension"];
-      const currentDimension = settings["graph.dimensions"][1];
-
-      if (currentDimension === undefined) {
-        return [];
-      }
-
-      const generateDefault = keys => {
-        return keys.map(key => ({
-          key,
-          color: seriesColors[key],
-          enabled: true,
-          name: seriesSettings[key]?.title || key,
-        }));
-      };
-
-      const removeMissingOrder = (keys, order) =>
-        order.filter(o => keys.includes(o.key));
-      const newKeys = (keys, order) =>
-        keys.filter(key => !order.find(o => o.key === key));
-
-      if (
-        !seriesOrder ||
-        !_.isArray(seriesOrder) ||
-        !seriesOrder.every(
-          order =>
-            order.key !== undefined &&
-            order.name !== undefined &&
-            order.color !== undefined,
-        ) ||
-        seriesOrderDimension !== currentDimension
-      ) {
-        return generateDefault(seriesKeys);
-      }
-
-      return [
-        ...removeMissingOrder(seriesKeys, seriesOrder),
-        ...generateDefault(newKeys(seriesKeys, seriesOrder)),
-      ].map(item => ({
-        ...item,
-        name: seriesSettings[item.key]?.title || item.key,
-        color: seriesColors[item.key],
-      }));
+      return getSeriesOrderVisibilitySettings(settings, seriesKeys);
     },
     getHidden: (series, settings) => {
       return (
@@ -360,23 +317,14 @@ export const STACKABLE_SETTINGS = {
       return true;
     },
     getDefault: ([{ card, data }], settings) => {
-      // legacy setting and default for D-M-M+ charts
-      if (settings["stackable.stacked"]) {
-        return settings["stackable.stacked"];
-      }
-
-      const shouldStack =
-        card.display === "area" &&
-        (settings["graph.metrics"].length > 1 ||
-          settings["graph.dimensions"].length > 1);
-
-      return shouldStack ? "stacked" : null;
+      return getDefaultStackingValue(settings, card);
     },
     getHidden: (series, settings) => {
       const displays = series.map(single => settings.series(single).display);
       const stackableDisplays = displays.filter(display =>
         STACKABLE_DISPLAY_TYPES.has(display),
       );
+
       return stackableDisplays.length <= 1;
     },
     readDependencies: ["graph.metrics", "graph.dimensions", "series"],

--- a/frontend/src/metabase/visualizations/lib/settings/series.js
+++ b/frontend/src/metabase/visualizations/lib/settings/series.js
@@ -1,9 +1,17 @@
 import { t } from "ttag";
-import _ from "underscore";
 import { getIn } from "icepick";
 
 import ChartNestedSettingSeries from "metabase/visualizations/components/settings/ChartNestedSettingSeries";
-import { getColorsForValues } from "metabase/lib/colors/charts";
+import {
+  COLOR_SETTING_ID,
+  getSeriesDefaultLinearInterpolate,
+  getSeriesDefaultLineMarker,
+  getSeriesDefaultLineMissing,
+  getSeriesColors,
+  getSeriesDefaultDisplay,
+  SETTING_ID,
+  getSeriesDefaultShowSeriesValues,
+} from "metabase/visualizations/shared/settings/series";
 import { getNameForCard } from "../series";
 import { nestedSettings } from "./nested";
 
@@ -14,16 +22,13 @@ export function keyForSingleSeries(single) {
 
 const LINE_DISPLAY_TYPES = new Set(["line", "area"]);
 
-export const SETTING_ID = "series_settings";
-export const COLOR_SETTING_ID = "series_settings.colors";
-
 export function seriesSetting({
   readDependencies = [],
   noPadding,
   ...def
 } = {}) {
   const COMMON_SETTINGS = {
-    // title, and color don't need widgets because they're handled direclty in ChartNestedSettingSeries
+    // title, and color don't need widgets because they're handled directly in ChartNestedSettingSeries
     title: {
       getDefault: (single, settings, { series, settings: vizSettings }) => {
         const legacyTitles = vizSettings["graph.series_labels"];
@@ -54,16 +59,8 @@ export function seriesSetting({
       },
 
       getDefault: (single, settings, { series }) => {
-        if (single.card.display === "combo") {
-          const index = series.indexOf(single);
-          if (index === 0) {
-            return "line";
-          } else {
-            return "bar";
-          }
-        } else {
-          return single.card.display;
-        }
+        const cardDisplay = single.card.display;
+        return getSeriesDefaultDisplay(cardDisplay, series.indexOf(single));
       },
     },
     color: {
@@ -85,7 +82,7 @@ export function seriesSetting({
         !LINE_DISPLAY_TYPES.has(settings["display"]),
       getDefault: (single, settings, { settings: vizSettings }) =>
         // use legacy global line.interpolate setting if present
-        vizSettings["line.interpolate"] || "linear",
+        getSeriesDefaultLinearInterpolate(vizSettings),
       readDependencies: ["display"],
     },
     "line.marker_enabled": {
@@ -102,9 +99,7 @@ export function seriesSetting({
         !LINE_DISPLAY_TYPES.has(settings["display"]),
       getDefault: (single, settings, { settings: vizSettings }) =>
         // use legacy global line.marker_enabled setting if present
-        vizSettings["line.marker_enabled"] == null
-          ? null
-          : vizSettings["line.marker_enabled"],
+        getSeriesDefaultLineMarker(vizSettings),
       readDependencies: ["display"],
     },
     "line.missing": {
@@ -121,7 +116,7 @@ export function seriesSetting({
         !LINE_DISPLAY_TYPES.has(settings["display"]),
       getDefault: (single, settings, { settings: vizSettings }) =>
         // use legacy global line.missing setting if present
-        vizSettings["line.missing"] || "interpolate",
+        getSeriesDefaultLineMissing(vizSettings),
       readDependencies: ["display"],
     },
     axis: {
@@ -147,7 +142,7 @@ export function seriesSetting({
         !Object.prototype.hasOwnProperty.call(settings, "graph.show_values") || // don't show it unless this chart has a global setting
         settings["stackable.stack_type"], // hide series controls if the chart is stacked
       getDefault: (single, seriesSettings, { settings }) =>
-        settings["graph.show_values"],
+        getSeriesDefaultShowSeriesValues(settings),
       readDependencies: ["graph.show_values", "stackable.stack_type"],
     },
   };
@@ -183,23 +178,7 @@ export function seriesSetting({
     [COLOR_SETTING_ID]: {
       getValue(series, settings) {
         const keys = series.map(single => keyForSingleSeries(single));
-
-        const assignments = _.chain(keys)
-          .map(key => [key, getIn(settings, [SETTING_ID, key, "color"])])
-          .filter(([key, color]) => color != null)
-          .object()
-          .value();
-
-        const legacyColors = settings["graph.colors"];
-        if (legacyColors) {
-          for (const [index, key] of keys.entries()) {
-            if (!(key in assignments)) {
-              assignments[key] = legacyColors[index];
-            }
-          }
-        }
-
-        return getColorsForValues(keys, assignments);
+        return getSeriesColors(keys, settings);
       },
     },
   };

--- a/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
@@ -1,0 +1,74 @@
+import _ from "underscore";
+import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
+import type { Card, SeriesOrderSetting } from "metabase-types/api";
+
+export const getDefaultStackingValue = (
+  settings: ComputedVisualizationSettings,
+  card: Card,
+) => {
+  // legacy setting and default for D-M-M+ charts
+  if (settings["stackable.stacked"]) {
+    return settings["stackable.stacked"];
+  }
+
+  const shouldStack =
+    card.display === "area" &&
+    ((settings["graph.metrics"] ?? []).length > 1 ||
+      (settings["graph.dimensions"] ?? []).length > 1);
+
+  return shouldStack ? "stacked" : null;
+};
+
+export const getSeriesOrderVisibilitySettings = (
+  settings: ComputedVisualizationSettings,
+  seriesKeys: string[],
+) => {
+  const seriesSettings = settings["series_settings"];
+  const seriesColors = settings["series_settings.colors"] || {};
+  const seriesOrder = settings["graph.series_order"];
+  // Because this setting is a read dependency of graph.series_order_dimension, this should
+  // Always be the stored setting, not calculated.
+  const seriesOrderDimension = settings["graph.series_order_dimension"];
+  const currentDimension = settings["graph.dimensions"]?.[1];
+
+  if (currentDimension === undefined) {
+    return [];
+  }
+
+  const generateDefault = (keys: string[]) => {
+    return keys.map(key => ({
+      key,
+      color: seriesColors[key],
+      enabled: true,
+      name: seriesSettings?.[key]?.title || key,
+    }));
+  };
+
+  const removeMissingOrder = (keys: string[], order: SeriesOrderSetting[]) =>
+    order.filter(o => keys.includes(o.key));
+  const newKeys = (keys: string[], order: SeriesOrderSetting[]) =>
+    keys.filter(key => !order.find(o => o.key === key));
+
+  if (
+    !seriesOrder ||
+    !_.isArray(seriesOrder) ||
+    !seriesOrder.every(
+      order =>
+        order.key !== undefined &&
+        order.name !== undefined &&
+        order.color !== undefined,
+    ) ||
+    seriesOrderDimension !== currentDimension
+  ) {
+    return generateDefault(seriesKeys);
+  }
+
+  return [
+    ...removeMissingOrder(seriesKeys, seriesOrder),
+    ...generateDefault(newKeys(seriesKeys, seriesOrder)),
+  ].map(item => ({
+    ...item,
+    name: seriesSettings?.[item.key]?.title || item.key,
+    color: seriesColors[item.key],
+  }));
+};

--- a/frontend/src/metabase/visualizations/shared/settings/series.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/series.ts
@@ -1,0 +1,57 @@
+import _ from "underscore";
+import { getIn } from "icepick";
+import type { VisualizationSettings } from "metabase-types/api";
+import { getColorsForValues } from "metabase/lib/colors/charts";
+import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
+
+export const SETTING_ID = "series_settings";
+export const COLOR_SETTING_ID = "series_settings.colors";
+
+export const getSeriesColors = (
+  seriesVizSettingsKeys: string[],
+  settings: VisualizationSettings,
+) => {
+  const assignments = _.chain(seriesVizSettingsKeys)
+    .map(key => [key, getIn(settings, [SETTING_ID, key, "color"])])
+    .filter(([_key, color]) => color != null)
+    .object()
+    .value();
+
+  const legacyColors = settings["graph.colors"];
+  if (legacyColors) {
+    for (const [index, key] of seriesVizSettingsKeys.entries()) {
+      if (!(key in assignments)) {
+        assignments[key] = legacyColors[index];
+      }
+    }
+  }
+
+  return getColorsForValues(seriesVizSettingsKeys, assignments);
+};
+
+export const getSeriesDefaultDisplay = (cardDisplay: string, index: number) => {
+  if (cardDisplay === "combo") {
+    return index === 0 ? "line" : "bar";
+  }
+
+  return cardDisplay;
+};
+
+export const getSeriesDefaultLinearInterpolate = (
+  settings: ComputedVisualizationSettings,
+) => settings["line.interpolate"] ?? "linear";
+
+export const getSeriesDefaultLineMarker = (
+  settings: ComputedVisualizationSettings,
+) =>
+  settings["line.marker_enabled"] == null
+    ? null
+    : settings["line.marker_enabled"];
+
+export const getSeriesDefaultLineMissing = (
+  settings: ComputedVisualizationSettings,
+) => settings["line.missing"] ?? "interpolate";
+
+export const getSeriesDefaultShowSeriesValues = (
+  settings: ComputedVisualizationSettings,
+) => settings["graph.show_values"];

--- a/frontend/src/metabase/visualizations/shared/utils/data.ts
+++ b/frontend/src/metabase/visualizations/shared/utils/data.ts
@@ -20,23 +20,12 @@ import type {
 } from "metabase/visualizations/shared/types/data";
 import type { Series } from "metabase/visualizations/shared/components/RowChart/types";
 import { formatNullable } from "metabase/lib/formatting/nullable";
+import { sumMetric } from "metabase/visualizations/echarts/cartesian/model/dataset";
 import { getChartMetrics } from "./series";
 
 const getMetricValue = (value: RowValue): MetricValue => {
   if (typeof value === "number") {
     return value;
-  }
-
-  return null;
-};
-
-export const sumMetric = (left: RowValue, right: RowValue) => {
-  if (typeof left === "number" && typeof right === "number") {
-    return left + right;
-  } else if (typeof left === "number") {
-    return left;
-  } else if (typeof right === "number") {
-    return right;
   }
 
   return null;

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -10,6 +10,7 @@ import type {
 import type { ClickObject } from "metabase/visualizations/types";
 import type { IconName, IconProps } from "metabase/core/components/Icon";
 import type { TextWidthMeasurer } from "metabase/visualizations/shared/types/measure-text";
+import type { OptionsType } from "metabase/lib/formatting/types";
 import type { StaticFormattingOptions } from "metabase/static-viz/lib/format";
 import type Query from "metabase-lib/queries/Query";
 
@@ -17,10 +18,14 @@ import type { HoveredObject } from "./hover";
 import type { RemappingHydratedDatasetColumn } from "./columns";
 
 export type ColorGetter = (colorName: string) => string;
+export type Formatter = (
+  value: unknown,
+  options?: OptionsType | StaticFormattingOptions,
+) => string;
 
 export interface RenderingContext {
   getColor: ColorGetter;
-  formatValue: (value: unknown, options: StaticFormattingOptions) => string;
+  formatValue: Formatter;
   measureText: TextWidthMeasurer;
   fontFamily: string;
 }
@@ -34,7 +39,7 @@ type OnChangeCardAndRunOpts = {
 export type OnChangeCardAndRun = (opts: OnChangeCardAndRunOpts) => void;
 
 export type ComputedVisualizationSettings = VisualizationSettings & {
-  column?: (col: RemappingHydratedDatasetColumn) => StaticFormattingOptions;
+  column?: (col: RemappingHydratedDatasetColumn) => Record<string, unknown>;
 };
 
 export interface VisualizationProps {

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.ts
@@ -24,7 +24,7 @@ import type {
   TooltipRowModel,
 } from "metabase/visualizations/types";
 import { getStackOffset } from "metabase/visualizations/lib/settings/stacking";
-import { sumMetric } from "metabase/visualizations/shared/utils/data";
+import { sumMetric } from "metabase/visualizations/echarts/cartesian/model/dataset";
 import { isMetric } from "metabase-lib/types/utils/isa";
 import type {
   ClickObject,


### PR DESCRIPTION
### Description

Adds basic static combo chart built with ECharts, the code moved from the prototype branch. Many visualization settings are not working on this PR but it still should render provided data.

### How to verify

1. Send a test dashboard subscription with any line/area/bar/combo
2. Ensure the data somehow rendered

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
