### PR TITLE
apply breakout series sorting

### DIFF
--- a/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
+++ b/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
@@ -94,7 +94,6 @@ export const computeStaticComboChartSettings = (
   const seriesModels = getCardsSeriesModels(
     rawSeries,
     cardsColumns,
-    settings,
     renderingContext,
   );
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
@@ -38,7 +38,6 @@ export const getCardsColumns = (
 export const getCardsSeriesModels = (
   rawSeries: RawSeries,
   cardsColumns: CartesianChartColumns[],
-  settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
 ) => {
   return rawSeries.flatMap((cardDataset, index) => {
@@ -65,7 +64,6 @@ export const getCartesianChartModel = (
   const unsortedSeriesModels = getCardsSeriesModels(
     rawSeries,
     cardsColumns,
-    settings,
     renderingContext,
   );
   const seriesModels = getSortedSeriesModels(unsortedSeriesModels, settings);

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
@@ -13,7 +13,10 @@ import {
 } from "metabase/visualizations/echarts/cartesian/model/series";
 import type { CartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
 import { getCartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
-import { getJoinedCardsDataset } from "metabase/visualizations/echarts/cartesian/model/dataset";
+import {
+  getJoinedCardsDataset,
+  getSortedSeriesModels,
+} from "metabase/visualizations/echarts/cartesian/model/dataset";
 
 export const getCardsColumns = (
   rawSeries: RawSeries,
@@ -35,6 +38,7 @@ export const getCardsColumns = (
 export const getCardsSeriesModels = (
   rawSeries: RawSeries,
   cardsColumns: CartesianChartColumns[],
+  settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
 ) => {
   return rawSeries.flatMap((cardDataset, index) => {
@@ -58,11 +62,13 @@ export const getCartesianChartModel = (
   const cardsColumns = getCardsColumns(rawSeries, settings);
 
   const dimensionModel = getDimensionModel(rawSeries, cardsColumns);
-  const seriesModels = getCardsSeriesModels(
+  const unsortedSeriesModels = getCardsSeriesModels(
     rawSeries,
     cardsColumns,
+    settings,
     renderingContext,
   );
+  const seriesModels = getSortedSeriesModels(unsortedSeriesModels, settings);
 
   const seriesDataKeys = seriesModels.map(seriesModel => seriesModel.dataKey);
   const dataset = getJoinedCardsDataset(rawSeries, cardsColumns);


### PR DESCRIPTION
### Description

Applies breakout series sorting/visibility settings to a chart. 

### How to verify

1. Create a stacked bar chart with a breakout
2. Reorder series, hide some
3. Send the card in a test dashboard subscription
4. Ensure the breakout series order has been applied

### Demo

#### Dashcard

<img width="680" alt="Screenshot 2023-11-01 at 8 36 27 PM" src="https://github.com/metabase/metabase/assets/14301985/d82e5e3a-a21b-4cc5-85fc-575b6bfc13ec">

#### Subscription

<img width="653" alt="Screenshot 2023-11-01 at 8 36 22 PM" src="https://github.com/metabase/metabase/assets/14301985/ba62f1c0-898a-4174-97ee-71b3b23672c7">

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
