### PR TITLE
Improve card_read event for audit_log and view_log

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15886,6 +15886,51 @@ databaseChangeLog:
         - sql:
             sql: drop view if exists v_view_log;
 
+  - changeSet:
+      id: v48.00-041
+      author: adam-james
+      comment: 'Added 0.48.0 - Adjust view_log schema for Audit Log v2'
+      changes:
+        - addColumn:
+            tableName: view_log
+            columns:
+              - column:
+                  name: has_access
+                  type: boolean
+                  constraints:
+                    nullable: true
+                  remarks: 'Whether the user who initiated the view had read access to the item being viewed.'
+
+  - changeSet:
+      id: v48.00-042
+      author: adam-james
+      comment: 'Added 0.48.0 - Adjust view_log schema for Audit Log v2'
+      changes:
+        - addColumn:
+            tableName: view_log
+            columns:
+              - column:
+                  name: error_message
+                  type: ${text.type}
+                  constraints:
+                    nullable: true
+                  remarks: 'An error message in the case of a failure or error when a user tried to view something.'
+
+  - changeSet:
+      id: v48.00-043
+      author: adam-james
+      comment: 'Added 0.48.0 - Adjust view_log schema for Audit Log v2'
+      changes:
+        - addColumn:
+            tableName: view_log
+            columns:
+              - column:
+                  name: context
+                  type: varchar(32)
+                  constraints:
+                    nullable: true
+                  remarks: 'The context of the view, can be collection, question, or dashboard. Only for cards.'
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -25,8 +25,7 @@
    [metabase.mbql.normalize :as mbql.normalize]
    [metabase.mbql.util :as mbql.u]
    [metabase.models
-    :refer [Card CardBookmark Collection Database PersistedInfo Pulse Table
-            ViewLog]]
+    :refer [Card CardBookmark Collection Database PersistedInfo Pulse Table]]
    [metabase.models.card :as card]
    [metabase.models.collection :as collection]
    [metabase.models.collection.root :as collection.root]
@@ -118,7 +117,7 @@
 ;; Return the 10 Cards most recently viewed by the current user, sorted by how recently they were viewed.
 (defmethod cards-for-filter-option* :recent
   [_]
-  (cards-with-ids (map :model_id (t2/select [ViewLog :model_id [:%max.timestamp :max]]
+  (cards-with-ids (map :model_id (t2/select [:model/ViewLog :model_id [:%max.timestamp :max]]
                                    :model   "card"
                                    :user_id api/*current-user-id*
                                    {:group-by [:model_id]
@@ -130,7 +129,7 @@
 ;; being).
 (defmethod cards-for-filter-option* :popular
   [_]
-  (cards-with-ids (map :model_id (t2/select [ViewLog :model_id [:%count.* :count]]
+  (cards-with-ids (map :model_id (t2/select [:model/ViewLog :model_id [:%count.* :count]]
                                    :model "card"
                                    {:group-by [:model_id]
                                     :order-by [[:count :desc]]}))))

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -209,7 +209,12 @@
                  (last-edit/with-last-edit-info :card))]
     (u/prog1 card
       (when-not ignore_view
-        (events/publish-event! :event/card-read <>)))))
+        ;; TODO api/read-check ensures we only ever get here if access is true
+        ;; if we want to record card view attempts (adding error message)
+        ;; this has to be reworked to publish an event even when a read check fails.
+        (events/publish-event! :event/card-read (assoc <>
+                                                       :has_access true
+                                                       :error_message nil))))))
 
 (defn- card-columns-from-names
   [card names]

--- a/src/metabase/events/recent_views.clj
+++ b/src/metabase/events/recent_views.clj
@@ -17,12 +17,14 @@
 
 (defn record-view!
   "Simple base function for recording a view of a given `model` and `model-id` by a certain `user`."
-  [model model-id user-id metadata]
+  [{:keys [model model-id user-id context has_access]}]
   (t2/insert! :model/ViewLog
               :user_id  user-id
               :model    (u/lower-case-en model)
               :model_id model-id
-              :metadata metadata))
+              :context context
+              :has_access has_access
+              :metadata {}))
 
 (methodical/defmethod events/publish-event! ::event
   "Handle processing for a single event notification received on the view-log-channel"
@@ -30,17 +32,21 @@
   ;; try/catch here to prevent individual topic processing exceptions from bubbling up.  better to handle them here.
   (try
     (when object
-      (let [model                          (events/topic->model topic)
-            model-id                       (events/object->model-id topic object)
-            user-id                        api/*current-user-id*
+      (let [model                        (events/topic->model topic)
+            model-id                     (events/object->model-id topic object)
+            user-id                      api/*current-user-id*
             ;; `:context` comes
             ;; from [[metabase.query-processor.middleware.process-userland-query/add-and-save-execution-info-xform!]],
             ;; and it should only be present for `:event/card-query`
-            {:keys [context] :as metadata} (events/object->metadata object)]
-        (when (and (#{:event/card-query :event/dashboard-read :event/table-read} topic)
-                   ;; we don't want to count pinned card views
-                   ((complement #{:collection :dashboard}) context))
-          (recent-views/update-users-recent-views! user-id model model-id))
-        (record-view! model model-id user-id metadata)))
+            {:keys [has_access context]} object]
+        (when (and (#{:event/card-read :event/dashboard-read :event/table-read} topic)
+                   ;; we do want to count pinned card views since there is now an option to turn off viz
+                   ((complement #{:dashboard}) context))
+          (recent-views/update-users-recent-views! user-id model model-id)
+          (record-view! {:model      model
+                         :model-id   model-id
+                         :user-id    user-id
+                         :context    (name context)
+                         :has_access has_access}))))
     (catch Throwable e
       (log/warnf e "Failed to process activity event. %s" topic))))

--- a/src/metabase/events/recent_views.clj
+++ b/src/metabase/events/recent_views.clj
@@ -38,7 +38,7 @@
             ;; `:context` comes
             ;; from [[metabase.query-processor.middleware.process-userland-query/add-and-save-execution-info-xform!]],
             ;; and it should only be present for `:event/card-query`
-            {:keys [has_access context]} object]
+            {:keys [has_access context] :or {context "card"}} object]
         (when (and (#{:event/card-read :event/dashboard-read :event/table-read} topic)
                    ;; we do want to count pinned card views since there is now an option to turn off viz
                    ((complement #{:dashboard}) context))

--- a/src/metabase/events/recent_views.clj
+++ b/src/metabase/events/recent_views.clj
@@ -38,7 +38,7 @@
             ;; `:context` comes
             ;; from [[metabase.query-processor.middleware.process-userland-query/add-and-save-execution-info-xform!]],
             ;; and it should only be present for `:event/card-query`
-            {:keys [has_access context] :or {context "card"}} object]
+            {:keys [has_access context]} object]
         (when (and (#{:event/card-read :event/dashboard-read :event/table-read} topic)
                    ;; we do want to count pinned card views since there is now an option to turn off viz
                    ((complement #{:dashboard}) context))
@@ -46,7 +46,7 @@
           (record-view! {:model      model
                          :model-id   model-id
                          :user-id    user-id
-                         :context    (name context)
+                         :context    context
                          :has_access has_access}))))
     (catch Throwable e
       (log/warnf e "Failed to process activity event. %s" topic))))

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -29,6 +29,17 @@
                   :model_id model-id
                   {:order-by [[:id :desc]]})))
 
+(defn view
+  "Find the view from the ViewLog table for the given :model and model-id"
+  ([model]
+   (view model nil))
+
+  ([model model-id]
+   (t2/select-one [:model/ViewLog :user_id :model :model_id :metadata]
+                  :model    (u/lower-case-en (name model))
+                  :model_id model-id
+                  {:order-by [[:id :desc]]})))
+
 (deftest card-create-test
   (testing :card-create
     (mt/with-model-cleanup [:model/AuditLog]

--- a/test/metabase/events/recent_views_test.clj
+++ b/test/metabase/events/recent_views_test.clj
@@ -16,7 +16,7 @@
 (deftest card-query-test
   (mt/with-temp [Card card {:creator_id (mt/user->id :rasta)}]
     (mt/with-test-user :rasta
-      (events/publish-event! :event/card-query {:card_id (u/id card) :cached false :ignore_cache true})
+      (events/publish-event! :event/card-read {:card_id (u/id card) :context "card" :has_access true})
       (is (= {:user_id  (mt/user->id :rasta)
               :model    "card"
               :model_id (:id card)}

--- a/test/metabase/events/recent_views_test.clj
+++ b/test/metabase/events/recent_views_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.events :as events]
-   [metabase.models :refer [Card Dashboard Table]]
+   [metabase.models :refer [Card Collection Dashboard Table]]
    [metabase.test :as mt]
    [metabase.util :as u]
    [toucan2.core :as t2]))
@@ -41,3 +41,21 @@
             :model    "dashboard"
             :model_id (:id dashboard)}
            (most-recent-view (mt/user->id :rasta)))))))
+
+(deftest pinning-card-logs-only-one-view
+  (mt/with-temp [Collection {collection-id :id} {:name "Suitcase"}
+                 Card       {card-id :id} {:name               "money"
+                                           :collection_preview false
+                                           :collection_id      collection-id}]
+    (mt/with-test-user :rasta
+      (mt/user-http-request :rasta :put 200 (format "card/%s" card-id) {:collection_position 1})
+      (mt/user-http-request :rasta :get 200 (format "card/%s" card-id))
+      (mt/user-http-request :rasta :post 202 (format "card/%s/query" card-id)
+                            {:collection_preview true
+                             :ignore_cache false
+                             :parameters []})
+      (mt/user-http-request :rasta :post 202 (format "card/%s/query" card-id)
+                            {:collection_preview true
+                             :ignore_cache false
+                             :parameters []})
+      (is (= 1 (t2/count :model/ViewLog))))))

--- a/test/metabase/events/recent_views_test.clj
+++ b/test/metabase/events/recent_views_test.clj
@@ -14,48 +14,65 @@
                  {:order-by [[:id :desc]]}))
 
 (deftest card-query-test
-  (mt/with-temp [Card card {:creator_id (mt/user->id :rasta)}]
-    (mt/with-test-user :rasta
-      (events/publish-event! :event/card-read {:card_id (u/id card) :context "card" :has_access true})
-      (is (= {:user_id  (mt/user->id :rasta)
-              :model    "card"
-              :model_id (:id card)}
-             (most-recent-view (mt/user->id :rasta)))))))
+  (mt/with-model-cleanup [:model/AuditLog :model/ViewLog]
+    (mt/with-temp [Card card {:creator_id (mt/user->id :rasta)}]
+      (mt/with-test-user :rasta
+        (events/publish-event! :event/card-read {:card_id (u/id card) :context "card" :has_access true})
+        (is (= {:user_id  (mt/user->id :rasta)
+                :model    "card"
+                :model_id (:id card)}
+               (most-recent-view (mt/user->id :rasta))))))))
 
 (deftest table-read-test
-  (mt/with-temp [Table table {}]
-    (mt/with-test-user :rasta
-     (events/publish-event! :event/table-read table)
-     (is (partial=
-          {:user_id  (mt/user->id :rasta)
-           :model    "table"
-           :model_id (:id table)}
-          (most-recent-view (mt/user->id :rasta)))))))
+  (mt/with-model-cleanup [:model/AuditLog :model/ViewLog]
+    (mt/with-temp [Table table {}]
+      (mt/with-test-user :rasta
+        (events/publish-event! :event/table-read table)
+        (is (partial=
+             {:user_id  (mt/user->id :rasta)
+              :model    "table"
+              :model_id (:id table)}
+             (most-recent-view (mt/user->id :rasta))))))))
 
 (deftest dashboard-read-test
-  (mt/with-temp [Dashboard dashboard {:creator_id (mt/user->id :rasta)}]
-    (mt/with-test-user :rasta
-     (events/publish-event! :event/dashboard-read dashboard)
-     (is (partial
-           {:user_id  (mt/user->id :rasta)
-            :model    "dashboard"
-            :model_id (:id dashboard)}
-           (most-recent-view (mt/user->id :rasta)))))))
+  (mt/with-model-cleanup [:model/AuditLog :model/ViewLog]
+    (mt/with-temp [Dashboard dashboard {:creator_id (mt/user->id :rasta)}]
+      (mt/with-test-user :rasta
+        (events/publish-event! :event/dashboard-read dashboard)
+        (is (partial
+             {:user_id  (mt/user->id :rasta)
+              :model    "dashboard"
+              :model_id (:id dashboard)}
+             (most-recent-view (mt/user->id :rasta))))))))
 
 (deftest pinning-card-logs-only-one-view
-  (mt/with-temp [Collection {collection-id :id} {:name "Suitcase"}
-                 Card       {card-id :id} {:name               "money"
-                                           :collection_preview false
-                                           :collection_id      collection-id}]
-    (mt/with-test-user :rasta
-      (mt/user-http-request :rasta :put 200 (format "card/%s" card-id) {:collection_position 1})
-      (mt/user-http-request :rasta :get 200 (format "card/%s" card-id))
-      (mt/user-http-request :rasta :post 202 (format "card/%s/query" card-id)
-                            {:collection_preview true
-                             :ignore_cache false
-                             :parameters []})
-      (mt/user-http-request :rasta :post 202 (format "card/%s/query" card-id)
-                            {:collection_preview true
-                             :ignore_cache false
-                             :parameters []})
-      (is (= 1 (t2/count :model/ViewLog))))))
+  (mt/with-model-cleanup [:model/AuditLog :model/ViewLog]
+    (mt/with-temp [Collection {collection-id :id} {:name "Suitcase"}
+                   Card       {card-id :id} {:name               "money"
+                                             :collection_preview false
+                                             :collection_id      collection-id
+                                             ;; need a query here for the post to /card/:id/query to actually trigger a :card-query event
+                                             ;; this is because without a query, the QP fails, and
+                                             ;; `metabase.query-processor.middleware.process-userland-query/add-and-save-execution-info-xform!`
+                                             ;; doesn't get run, which is where the publish-event! actually occurs.
+                                             :dataset_query      {:type   :native
+                                                                  :native {:query "SELECT 1000000", :template-tags {}}
+                                                                  :database 1}}]
+      (mt/with-test-user :rasta
+        ;; A user pins a card and the first thing that happens is the card is updated to store collection_position.
+        (mt/user-http-request :rasta :put 200 (format "card/%s" card-id) {:collection_position 1})
+        ;; A pinned card has visualization on by default, so a query for the card's contents is needed.
+        (mt/user-http-request :rasta :post 202 (format "card/%s/query" card-id)
+                              {:collection_preview true
+                               :ignore_cache       false
+                               :parameters         []})
+        (testing "the audit_log records :card-update and :card-query events when a user pins a card."
+          ;; the AuditLog records the :card-update and the :card-query events
+          (is (= [:card-update :card-query]
+                 (remove #{:setting-update :user-joined} (mapv :topic (t2/select :model/AuditLog))))))
+        (testing "the view_log does not record a view when a user pins a card."
+          ;; the ViewLog doesn't record the :card-query, which we take to be equivalent to a card-read in this context.
+          (is (= 0 (t2/count :model/ViewLog))))
+        (testing ":card-read occurs with a GET request to api/card/:id and is recorded as a view in the view_log"
+          (mt/user-http-request :rasta :get 200 (format "card/%s" card-id))
+          (is (= 1 (t2/count :model/ViewLog))))))))


### PR DESCRIPTION
Closes: https://github.com/metabase/metabase/issues/27782

This PR works to improve the ViewLog table by changing when and how the can_read event ends up writing to the ViewLog.

The primary point where ViewLog entries are recorded occurs in `metabase.events.recent-views`, where the `events/publish-event!` method for `::event` is defined. Basically, if the event topic coming in is `:event/card-read`, `:event/dashboard-read`, or `:event/table-read` then the ViewLog is written to with the function `record-view!`.

This PR changes:
- the ViewLog schema:
  - ADD :has_access -> if the user who initiated the view has read acesss
  - ADD :error_message -> if an error occurred, put it here. Eg. "don't have permission", or perhaps a query error?
  - ADD :context -> the context in which the card was viewed (:collection, :question, :dashboard) -> comes originally from a qp middleware
  - (not done yet) REMOVE: :metadata. This is no longer needed. But removing it in a migration conflicted with some v_audit_log views, so tabled that until those stabilize
- the record-view! was being triggered on :event/card-query, but is now :event/card-read
- adds a test that recreates the API calls that happen when a user pins a card in a collection and ensures the View is NOT recorded. Then, when the page is refreshed, a card-read occurs, and that IS recorded.

This PR still needs:
- [ ] add a test to ensure the Dashboard view records properly
- [ ] add a test to ensure a view via the question url records properly (can probably just mock this with a GET to the correct endpoint api/card/:id)
- [ ] handle the situation where an unsaved question causes a :event/table-read (occurs because the query still needs to run but no card exists yet, so card-read doesn't occur.) see `metabase.query-processor.middleware.process-userland-query/add-and-save-execution-info-xform!` and also `metabase.api.dataset/run-query-async` to start tracking this down.