### PR TITLE
Support replacing nulls with zeros

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
@@ -15,7 +15,9 @@ import type { CartesianChartColumns } from "metabase/visualizations/lib/graph/co
 import { getCartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
 import {
   getJoinedCardsDataset,
+  getNullReplacerFunction,
   getSortedSeriesModels,
+  replaceValues,
 } from "metabase/visualizations/echarts/cartesian/model/dataset";
 
 export const getCardsColumns = (
@@ -69,7 +71,10 @@ export const getCartesianChartModel = (
   const seriesModels = getSortedSeriesModels(unsortedSeriesModels, settings);
 
   const seriesDataKeys = seriesModels.map(seriesModel => seriesModel.dataKey);
-  const dataset = getJoinedCardsDataset(rawSeries, cardsColumns);
+  const dataset = replaceValues(
+    getJoinedCardsDataset(rawSeries, cardsColumns),
+    getNullReplacerFunction(settings, seriesModels),
+  );
 
   const yAxisSplit: AxisSplit = [seriesDataKeys, []];
 


### PR DESCRIPTION
### Description

Applies the replace missing values with zeros series setting.

### How to verify

1. Create a line/area/bar/chart where series values can be null
2. Set "Replace missing values" series settings to "zero"
3. Send a test dashboard subscription with the chart

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
