### PR TITLE
Support normalized stacking

### DIFF
--- a/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
+++ b/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
@@ -18,6 +18,7 @@ import { getCommonStaticVizSettings } from "metabase/static-viz/lib/settings";
 import {
   getDefaultStackingValue,
   getSeriesOrderVisibilitySettings,
+  isStackingValueValid,
 } from "metabase/visualizations/shared/settings/cartesian-chart";
 import {
   getCardsColumns,
@@ -29,8 +30,9 @@ const fillWithDefaultValue = (
   settings: Record<string, unknown>,
   key: string,
   defaultValue: unknown,
+  isValid = true,
 ) => {
-  if (typeof settings[key] === "undefined") {
+  if (typeof settings[key] === "undefined" || !isValid) {
     settings[key] = defaultValue;
   }
 };
@@ -112,6 +114,12 @@ export const computeStaticComboChartSettings = (
     settings,
     "stackable.stack_type",
     getDefaultStackingValue(settings, mainCard),
+    isStackingValueValid(
+      settings,
+      seriesModels.map(seriesModel =>
+        settings.series(seriesModel.legacySeriesSettingsObjectKey),
+      ),
+    ),
   );
 
   fillWithDefaultValue(

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.unit.spec.ts
@@ -15,6 +15,7 @@ import {
   getJoinedCardsDataset,
   replaceValues,
   getNullReplacerFunction,
+  getNormalizedDataset,
 } from "./dataset";
 import type { DataKey, SeriesModel } from "./types";
 
@@ -239,6 +240,73 @@ describe("dataset transform functions", () => {
       expect(replacer("key1", 1)).toBe(1);
       expect(replacer("key2", null)).toBe(null);
       expect(replacer("key2", 2)).toBe(2);
+    });
+  });
+
+  describe("getNormalizedDataset", () => {
+    it("should return an array of normalized datasets", () => {
+      const groupedData = [
+        { dimensionKey: "A", series1: 100, series2: 200, unusedSeries: 100 },
+        { dimensionKey: "B", series1: 300, series2: 400, unusedSeries: 100 },
+      ];
+
+      const normalizedSeriesKeys = ["series1", "series2"];
+      const dimensionKey = "dimensionKey";
+
+      const result = getNormalizedDataset(
+        groupedData,
+        normalizedSeriesKeys,
+        dimensionKey,
+      );
+
+      expect(result).toEqual([
+        {
+          dimensionKey: "A",
+          series1: 1 / 3,
+          series2: 2 / 3,
+        },
+        {
+          dimensionKey: "B",
+          series1: 3 / 7,
+          series2: 4 / 7,
+        },
+      ]);
+    });
+
+    it("should handle rows with missing values", () => {
+      const groupedData = [{ dimensionKey: "A", series1: null, series2: 200 }];
+
+      const normalizedSeriesKeys = ["series1", "series2"];
+      const dimensionKey = "dimensionKey";
+
+      const result = getNormalizedDataset(
+        groupedData,
+        normalizedSeriesKeys,
+        dimensionKey,
+      );
+
+      expect(result).toEqual([
+        {
+          dimensionKey: "A",
+          series1: 0,
+          series2: 1,
+        },
+      ]);
+    });
+
+    it("should work on empty datasets", () => {
+      const groupedData: Record<DataKey, RowValue>[] = [];
+
+      const normalizedSeriesKeys = ["series1", "series2"];
+      const dimensionKey = "dimensionKey";
+
+      const result = getNormalizedDataset(
+        groupedData,
+        normalizedSeriesKeys,
+        dimensionKey,
+      );
+
+      expect(result).toEqual([]);
     });
   });
 });

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
@@ -15,6 +15,7 @@ import type { CartesianChartColumns } from "metabase/visualizations/lib/graph/co
 import { getCartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
 import {
   getJoinedCardsDataset,
+  getNormalizedDataset,
   getNullReplacerFunction,
   getSortedSeriesModels,
   replaceValues,
@@ -76,6 +77,12 @@ export const getCartesianChartModel = (
     getNullReplacerFunction(settings, seriesModels),
   );
 
+  const normalizedDataset = getNormalizedDataset(
+    dataset,
+    seriesDataKeys,
+    dimensionModel.dataKey,
+  );
+
   const yAxisSplit: AxisSplit = [seriesDataKeys, []];
 
   const [leftSeriesDataKeys, rightSeriesDataKeys] = yAxisSplit;
@@ -88,6 +95,7 @@ export const getCartesianChartModel = (
 
   return {
     dataset,
+    normalizedDataset,
     seriesModels,
     dimensionModel,
     yAxisSplit,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -47,6 +47,7 @@ export type CartesianChartModel = {
   dimensionModel: DimensionModel;
   seriesModels: SeriesModel[];
   dataset: GroupedDataset;
+  normalizedDataset: GroupedDataset;
   yAxisSplit: AxisSplit;
 
   leftAxisColumn?: DatasetColumn;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
@@ -11,6 +11,8 @@ import type { CartesianChartModel } from "metabase/visualizations/echarts/cartes
 
 import { isNumeric } from "metabase-lib/types/utils/isa";
 
+const NORMALIZED_RANGE = { min: 0, max: 1 };
+
 const getAxisNameDefaultOption = (
   { getColor, fontFamily }: RenderingContext,
   nameGap: number,
@@ -122,7 +124,17 @@ const buildMetricAxis = (
     });
   };
 
+  const isNormalized = settings["stackable.stack_type"] === "normalized";
+  const range = isNormalized ? NORMALIZED_RANGE : {};
+
+  const percentageFormatter = (value: unknown) =>
+    renderingContext.formatValue(value, {
+      column: column,
+      number_style: "percent",
+    });
+
   return {
+    ...range,
     ...getAxisNameDefaultOption(
       renderingContext,
       40, // TODO: compute
@@ -139,7 +151,8 @@ const buildMetricAxis = (
       ...getTicksDefaultOption(renderingContext),
       // @ts-expect-error TODO: figure out EChart types
       formatter: (value: string) => {
-        return formatter(value);
+        const formatterFn = isNormalized ? percentageFormatter : formatter;
+        return formatterFn(value);
       },
     },
   };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -22,7 +22,10 @@ export const getCartesianChartOption = (
     chartModel.dimensionModel.dataKey,
     ...chartModel.seriesModels.map(seriesModel => seriesModel.dataKey),
   ];
-  const echartsDataset = [{ source: chartModel.dataset, dimensions }];
+  const echartsDataset = [
+    { source: chartModel.dataset, dimensions },
+    { source: chartModel.normalizedDataset, dimensions },
+  ];
 
   return {
     dataset: echartsDataset,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -56,10 +56,13 @@ const buildEChartsBarSeries = (
 ): RegisteredSeriesOption["bar"] => {
   const stackName =
     settings["stackable.stack_type"] != null ? `bar_${yAxisIndex}` : undefined;
+  const datasetIndex =
+    settings["stackable.stack_type"] === "normalized" ? 1 : 0;
 
   return {
     type: "bar",
     yAxisIndex,
+    datasetIndex,
     stack: stackName,
     encode: {
       y: seriesModel.dataKey,
@@ -88,10 +91,13 @@ const buildEChartsLineAreaSeries = (
 
   const stackName =
     settings["stackable.stack_type"] != null ? `area_${yAxisIndex}` : undefined;
+  const datasetIndex =
+    settings["stackable.stack_type"] === "normalized" ? 1 : 0;
 
   return {
     type: "line",
     yAxisIndex,
+    datasetIndex,
     showSymbol: seriesSettings["line.marker_enabled"] !== false,
     symbolSize: 6,
     smooth: seriesSettings["line.interpolate"] === "cardinal",

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -27,6 +27,8 @@ import { ChartSettingOrderedSimple } from "metabase/visualizations/components/se
 import {
   getDefaultStackingValue,
   getSeriesOrderVisibilitySettings,
+  isStackingValueValid,
+  STACKABLE_DISPLAY_TYPES,
 } from "metabase/visualizations/shared/settings/cartesian-chart";
 import {
   isDimension,
@@ -292,8 +294,6 @@ export const LINE_SETTINGS = {
   },
 };
 
-const STACKABLE_DISPLAY_TYPES = new Set(["area", "bar"]);
-
 export const STACKABLE_SETTINGS = {
   "stackable.stack_type": {
     section: t`Display`,
@@ -307,14 +307,11 @@ export const STACKABLE_SETTINGS = {
       ],
     },
     isValid: (series, settings) => {
-      if (settings["stackable.stack_type"] != null) {
-        const displays = series.map(single => settings.series(single).display);
-        const stackableDisplays = displays.filter(display =>
-          STACKABLE_DISPLAY_TYPES.has(display),
-        );
-        return stackableDisplays.length > 1;
-      }
-      return true;
+      const seriesDisplays = series.map(
+        single => settings.series(single).display,
+      );
+
+      return isStackingValueValid(settings, seriesDisplays);
     },
     getDefault: ([{ card, data }], settings) => {
       return getDefaultStackingValue(settings, card);

--- a/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
@@ -2,6 +2,21 @@ import _ from "underscore";
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
 import type { Card, SeriesOrderSetting } from "metabase-types/api";
 
+export const STACKABLE_DISPLAY_TYPES = new Set(["area", "bar"]);
+
+export const isStackingValueValid = (
+  settings: ComputedVisualizationSettings,
+  seriesDisplays: string[],
+) => {
+  if (settings["stackable.stack_type"] != null) {
+    const stackableDisplays = seriesDisplays.filter(display =>
+      STACKABLE_DISPLAY_TYPES.has(display),
+    );
+    return stackableDisplays.length > 1;
+  }
+  return true;
+};
+
 export const getDefaultStackingValue = (
   settings: ComputedVisualizationSettings,
   card: Card,


### PR DESCRIPTION
### Description

Supports normalized stacking on bar/area charts

### How to verify

1. Create a bar/area chart with normalized stacking
2. Send a test dashboard subscription with the chart
3. Ensure it is rendered as normalized

### Demo

<img width="584" alt="Screenshot 2023-11-01 at 8 46 15 PM" src="https://github.com/metabase/metabase/assets/14301985/b0006cd7-1d86-44d6-8d9c-8ef9fdc62b5e">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
