### PR TITLE
Add Check for Audit App arount ::events to only publish when allowed

### DIFF
--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -5,10 +5,16 @@
    [metabase.api.common :as api]
    [metabase.events :as events]
    [metabase.models.audit-log :as audit-log]
+   [metabase.public-settings.premium-features :as premium-features]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
 (derive ::event :metabase/event)
+
+(methodical/defmethod events/publish-event! :around ::event
+  [topic card]
+  (when (premium-features/enable-audit-app?)
+    (next-method topic card)))
 
 (defn maybe-prepare-update-event-data
   "When `:audit-db/previous` is present in the event-data, we return a map with previous and new versions of the

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -13,7 +13,9 @@
 
 (methodical/defmethod events/publish-event! :around ::event
   [topic card]
-  (when (premium-features/enable-audit-app?)
+  (when (or (premium-features/enable-audit-app?)
+            ;; Cloud Starters won't have the Audit App enabled, but we want to log events in case they upgrade to premium
+            (premium-features/is-hosted?))
     (next-method topic card)))
 
 (defn maybe-prepare-update-event-data


### PR DESCRIPTION
This PR gates writing to the audit_log by checking 2 things:

- `(premium-features/enable-audit-app?)` is `true`
- `(premium-features/is-hosted?)` is `true`

If either of those is true, audit_log records. This is achieved with a method that is invoked on every `event/publish-event!`. Using Methodical's `:around` multimethod dispatch, it is possible to have a pre-check that only passes events along to the next method when `(premium-features/enable-audit-app?)` is `true`. Otherwise no further methods are invoked and thus no audit-log entry is created.

This PR still needs:
- [ ] to fix failing tests. Probably need to wrap these audit log failing tests in `(premium-features-test/with-premium-features #{:audit-app} ...)`
- [ ] make sure that the logic is correct, especially for Cloud Starter Instances -> they *must* record to the audit log. Why? This is because it's a real value proposition to upgrade to premium and suddenly have useful analytics on your instance up front.