### PR TITLE
refactor: remove wild cy.in in test file

### DIFF
--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -40,7 +40,6 @@ import {
 
 describe("scenarios > dashboard > tabs", () => {
   beforeEach(() => {
-    cy.in;
     restore();
     cy.signInAsAdmin();
   });


### PR DESCRIPTION
### Description

This removes a wild `cy.in;` in a e2e test which is most likely a typo.
It was added in https://github.com/metabase/metabase/commit/343b7cb7f9f8cefb729d5498a758a915c568e74a#diff-f768edefc59dafa007aecce173bb582744236482ad4de6af5ed9ca2304a1d329R31


