### PR TITLE
fixes move to tab menu going below link dest selection menu

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
@@ -144,7 +144,11 @@ function LinkVizInner({
   if (isEditing && !isEditingParameter) {
     return (
       <EditLinkCardWrapper data-testid="custom-edit-text-link">
-        <Popover opened={inputIsFocused && !isUrlString(url)}>
+        <Popover
+          opened={inputIsFocused && !isUrlString(url)}
+          withinPortal={false}
+          zIndex={1}
+        >
           <Popover.Target>
             <Input
               fullWidth


### PR DESCRIPTION
# Description
There was a bug while editing a link card and hovering the "move to tab" icon, the tab selection popover was below the link card selection menu.

This requires [#35309 refactor: use metabase/ui Popover instead of TippyPopover](https://github.com/metabase/metabase/pull/35309)

Before:
<img width="527" alt="image" src="https://github.com/metabase/metabase/assets/1914270/08df42c8-90f8-48dc-8e7a-7abd10498c57">

After: 
<img width="525" alt="image" src="https://github.com/metabase/metabase/assets/1914270/c136db7e-3353-4eb4-8a40-36591e352244">
