### PR TITLE
Hide personal collections and items when configuring click behavior

### DIFF
--- a/frontend/src/metabase-lib/parameters/utils/click-behavior.ts
+++ b/frontend/src/metabase-lib/parameters/utils/click-behavior.ts
@@ -7,6 +7,7 @@ import type {
   ClickBehaviorTarget,
   Dashboard,
   DashboardCard,
+  DashboardId,
   DatasetColumn,
   DatetimeUnit,
   Parameter,
@@ -411,7 +412,9 @@ function getParameter(
     (clickBehavior.linkType === "dashboard" ||
       clickBehavior.linkType === "question")
   ) {
-    const dashboard = (extraData.dashboards || {})[clickBehavior.targetId];
+    const dashboard = (extraData.dashboards || {})[
+      clickBehavior.targetId as DashboardId
+    ];
     const parameters = dashboard?.parameters || [];
     return parameters.find(parameter => parameter.id === target.id);
   }

--- a/frontend/src/metabase-lib/parameters/utils/click-behavior.ts
+++ b/frontend/src/metabase-lib/parameters/utils/click-behavior.ts
@@ -412,9 +412,8 @@ function getParameter(
     (clickBehavior.linkType === "dashboard" ||
       clickBehavior.linkType === "question")
   ) {
-    const dashboard = (extraData.dashboards || {})[
-      clickBehavior.targetId as DashboardId
-    ];
+    const dashboard =
+      extraData.dashboards?.[clickBehavior.targetId as DashboardId];
     const parameters = dashboard?.parameters || [];
     return parameters.find(parameter => parameter.id === target.id);
   }

--- a/frontend/src/metabase-types/api/click-behavior.ts
+++ b/frontend/src/metabase-types/api/click-behavior.ts
@@ -69,7 +69,7 @@ export type EntityCustomDestinationClickBehavior =
 export interface DashboardCustomDestinationClickBehavior {
   type: "link";
   linkType: "dashboard";
-  targetId: DashboardId;
+  targetId?: DashboardId;
   /**
    * tabId will be undefined when user edits click behavior that
    * was created before we supported links to dashboard tabs.
@@ -81,7 +81,7 @@ export interface DashboardCustomDestinationClickBehavior {
 export interface QuestionCustomDestinationClickBehavior {
   type: "link";
   linkType: "question";
-  targetId: CardId;
+  targetId?: CardId;
   parameterMapping?: ClickBehaviorParameterMapping;
 }
 

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionCaption.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionCaption.tsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { t } from "ttag";
 import { PLUGIN_COLLECTION_COMPONENTS } from "metabase/plugins";
 import {
-  isPersonalCollection,
+  isRootPersonalCollection,
   isRootCollection,
 } from "metabase/collections/utils";
 import { color } from "metabase/lib/colors";
@@ -25,7 +25,7 @@ export const CollectionCaption = ({
   onUpdateCollection,
 }: CollectionCaptionProps): JSX.Element => {
   const isRoot = isRootCollection(collection);
-  const isPersonal = isPersonalCollection(collection);
+  const isPersonal = isRootPersonalCollection(collection);
   const isEditable = !isRoot && !isPersonal && collection.can_write;
   const hasDescription = Boolean(collection.description);
 

--- a/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
@@ -6,7 +6,7 @@ import EntityMenu from "metabase/components/EntityMenu";
 import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 import {
   isInstanceAnalyticsCustomCollection,
-  isPersonalCollection,
+  isRootPersonalCollection,
   isRootCollection,
 } from "metabase/collections/utils";
 import type { Collection } from "metabase-types/api";
@@ -27,7 +27,7 @@ export const CollectionMenu = ({
   const items = [];
   const url = Urls.collection(collection);
   const isRoot = isRootCollection(collection);
-  const isPersonal = isPersonalCollection(collection);
+  const isPersonal = isRootPersonalCollection(collection);
   const isInstanceAnalyticsCustom =
     isInstanceAnalyticsCustomCollection(collection);
   const canWrite = collection.can_write;

--- a/frontend/src/metabase/collections/components/CreateCollectionForm/CreateCollectionForm.tsx
+++ b/frontend/src/metabase/collections/components/CreateCollectionForm/CreateCollectionForm.tsx
@@ -26,6 +26,7 @@ import FormCollectionPicker from "metabase/collections/containers/FormCollection
 import type { Collection } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
+import type { FilterItemsInPersonalCollection } from "metabase/containers/ItemPicker";
 import FormAuthorityLevelFieldContainer from "../../containers/FormAuthorityLevelFieldContainer";
 
 const COLLECTION_SCHEMA = Yup.object({
@@ -52,7 +53,7 @@ export interface CreateCollectionFormOwnProps {
   collectionId?: Collection["id"]; // can be used by `getInitialCollectionId`
   onCreate?: (collection: Collection) => void;
   onCancel?: () => void;
-  showOnlyPersonalCollections?: boolean;
+  filterPersonalCollections?: FilterItemsInPersonalCollection;
 }
 
 interface CreateCollectionFormStateProps {
@@ -90,7 +91,7 @@ function CreateCollectionForm({
   handleCreateCollection,
   onCreate,
   onCancel,
-  showOnlyPersonalCollections,
+  filterPersonalCollections,
 }: Props) {
   const initialValues = useMemo(
     () => ({
@@ -133,7 +134,7 @@ function CreateCollectionForm({
           <FormCollectionPicker
             name="parent_id"
             title={t`Collection it's saved in`}
-            showOnlyPersonalCollections={showOnlyPersonalCollections}
+            filterPersonalCollections={filterPersonalCollections}
           />
           <FormAuthorityLevelFieldContainer
             collectionParentId={values.parent_id}

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -21,6 +21,7 @@ import { isValidCollectionId } from "metabase/collections/utils";
 import type { CollectionId } from "metabase-types/api";
 
 import { useSelector } from "metabase/lib/redux";
+import type { FilterItemsInPersonalCollection } from "metabase/containers/ItemPicker";
 import {
   PopoverItemPicker,
   MIN_POPOVER_WIDTH,
@@ -34,7 +35,7 @@ export interface FormCollectionPickerProps
   type?: "collections" | "snippet-collections";
   initialOpenCollectionId?: CollectionId;
   onOpenCollectionChange?: (collectionId: CollectionId) => void;
-  showOnlyPersonalCollections?: boolean;
+  filterPersonalCollections?: FilterItemsInPersonalCollection;
 }
 
 function ItemName({
@@ -60,7 +61,7 @@ function FormCollectionPicker({
   type = "collections",
   initialOpenCollectionId,
   onOpenCollectionChange,
-  showOnlyPersonalCollections,
+  filterPersonalCollections,
 }: FormCollectionPickerProps) {
   const id = useUniqueId();
   const [{ value }, { error, touched }, { setValue }] = useField(name);
@@ -107,7 +108,8 @@ function FormCollectionPicker({
 
   const isOpenCollectionInPersonalCollection = openCollection?.is_personal;
   const showCreateNewCollectionOption =
-    !showOnlyPersonalCollections || isOpenCollectionInPersonalCollection;
+    filterPersonalCollections !== "only" ||
+    isOpenCollectionInPersonalCollection;
 
   const renderContent = useCallback(
     ({ closePopover }) => {
@@ -132,11 +134,11 @@ function FormCollectionPicker({
             onOpenCollectionChange?.(id);
             setOpenCollectionId(id);
           }}
-          showOnlyPersonalCollections={showOnlyPersonalCollections}
+          filterPersonalCollections={filterPersonalCollections}
         >
           {showCreateNewCollectionOption && (
             <CreateCollectionOnTheGoButton
-              showOnlyPersonalCollections={showOnlyPersonalCollections}
+              filterPersonalCollections={filterPersonalCollections}
               openCollectionId={openCollectionId}
             />
           )}
@@ -148,7 +150,7 @@ function FormCollectionPicker({
       value,
       width,
       initialOpenCollectionId,
-      showOnlyPersonalCollections,
+      filterPersonalCollections,
       showCreateNewCollectionOption,
       openCollectionId,
       setValue,

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -11,13 +11,25 @@ export function nonPersonalOrArchivedCollection(
   collection: Collection,
 ): boolean {
   // @TODO - should this be an API thing?
-  return !isPersonalCollection(collection) && !collection.archived;
+  return !isRootPersonalCollection(collection) && !collection.archived;
 }
 
-export function isPersonalCollection(
+export function isRootPersonalCollection(
   collection: Partial<Collection> | CollectionItem,
 ): boolean {
   return typeof collection.personal_owner_id === "number";
+}
+
+export function isPersonalCollection(
+  collection: Pick<Collection, "is_personal">,
+) {
+  return collection.is_personal;
+}
+
+export function isPublicCollection(
+  collection: Pick<Collection, "is_personal">,
+) {
+  return !isPersonalCollection(collection);
 }
 
 export function isInstanceAnalyticsCollection(
@@ -92,7 +104,7 @@ export function isPersonalCollectionOrChild(
   collectionList: Collection[],
 ): boolean {
   return (
-    isPersonalCollection(collection) ||
+    isRootPersonalCollection(collection) ||
     isPersonalCollectionChild(collection, collectionList)
   );
 }
@@ -129,14 +141,14 @@ export function canMoveItem(item: CollectionItem, collection: Collection) {
   return (
     collection.can_write &&
     item.setCollection != null &&
-    !(isItemCollection(item) && isPersonalCollection(item))
+    !(isItemCollection(item) && isRootPersonalCollection(item))
   );
 }
 
 export function canArchiveItem(item: CollectionItem, collection: Collection) {
   return (
     collection.can_write &&
-    !(isItemCollection(item) && isPersonalCollection(item))
+    !(isItemCollection(item) && isRootPersonalCollection(item))
   );
 }
 
@@ -191,7 +203,7 @@ function isPersonalOrPersonalChild(
     return false;
   }
   return (
-    isPersonalCollection(collection) ||
+    isRootPersonalCollection(collection) ||
     isPersonalCollectionChild(collection, collections)
   );
 }
@@ -200,7 +212,7 @@ export function canManageCollectionAuthorityLevel(
   collection: Partial<Collection>,
   collectionMap: Partial<Record<CollectionId, Collection>>,
 ) {
-  if (isPersonalCollection(collection)) {
+  if (isRootPersonalCollection(collection)) {
     return false;
   }
   const parentId = coerceCollectionId(collection.parent_id);

--- a/frontend/src/metabase/collections/utils.unit.spec.ts
+++ b/frontend/src/metabase/collections/utils.unit.spec.ts
@@ -1,5 +1,5 @@
 import {
-  isPersonalCollection,
+  isRootPersonalCollection,
   canonicalCollectionId,
   isRootCollection,
 } from "metabase/collections/utils";
@@ -7,17 +7,17 @@ import {
 import { createMockCollection } from "metabase-types/api/mocks";
 
 describe("Collections > utils", () => {
-  describe("isPersonalCollection", () => {
+  describe("isRootPersonalCollection", () => {
     it("returns true if personal_owner_id is a number", () => {
       const collection = { personal_owner_id: 1 };
 
-      expect(isPersonalCollection(collection)).toBe(true);
+      expect(isRootPersonalCollection(collection)).toBe(true);
     });
 
     it("returns false if personal_owner_id is not a number", () => {
       const collection = {};
 
-      expect(isPersonalCollection(collection)).toBe(false);
+      expect(isRootPersonalCollection(collection)).toBe(false);
     });
   });
 

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.tsx
@@ -92,7 +92,9 @@ const AddToDashSelectDashModal = ({
   if (shouldCreateDashboard) {
     return (
       <CreateDashboardModal
-        showOnlyPersonalCollections={isQuestionInPersonalCollection}
+        filterPersonalCollections={
+          isQuestionInPersonalCollection ? "only" : undefined
+        }
         collectionId={card.collection_id}
         onCreate={navigateToDashboard}
         onClose={() => setShouldCreateDashboard(false)}
@@ -120,7 +122,9 @@ const AddToDashSelectDashModal = ({
     >
       <DashboardPicker
         onOpenCollectionChange={setOpenCollectionId}
-        showOnlyPersonalCollections={isQuestionInPersonalCollection}
+        filterPersonalCollections={
+          isQuestionInPersonalCollection ? "only" : undefined
+        }
         onChange={onDashboardSelected}
         collectionId={initialOpenCollectionId}
         value={mostRecentlyViewedDashboardQuery.data?.id}

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/utils.ts
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/utils.ts
@@ -1,6 +1,9 @@
 import type { CollectionId, Dashboard } from "metabase-types/api";
 import { ROOT_COLLECTION } from "metabase/entities/collections";
-import { coerceCollectionId } from "metabase/collections/utils";
+import {
+  coerceCollectionId,
+  isPublicCollection,
+} from "metabase/collections/utils";
 
 interface GetInitialOpenCollectionIdProps {
   isQuestionInPersonalCollection: boolean;
@@ -26,5 +29,5 @@ export const getInitialOpenCollectionId = ({
 };
 
 export function isInPublicCollection(dashboard: Dashboard | undefined) {
-  return !dashboard?.collection?.is_personal;
+  return isPublicCollection(dashboard?.collection ?? ROOT_COLLECTION);
 }

--- a/frontend/src/metabase/containers/CreateCollectionOnTheGo.tsx
+++ b/frontend/src/metabase/containers/CreateCollectionOnTheGo.tsx
@@ -7,6 +7,7 @@ import { useFormikContext } from "formik";
 import type { Collection, CollectionId } from "metabase-types/api";
 import CreateCollectionModal from "metabase/collections/containers/CreateCollectionModal";
 import { NewCollectionButton } from "./CreateCollectionOnTheGo.styled";
+import type { FilterItemsInPersonalCollection } from "./ItemPicker";
 
 interface Values extends FormikValues {
   collection_id: CollectionId;
@@ -16,7 +17,7 @@ interface State {
   enabled?: boolean;
   resumedValues?: Values;
   openCollectionId?: CollectionId;
-  showOnlyPersonalCollections?: boolean;
+  filterPersonalCollections?: FilterItemsInPersonalCollection;
 }
 
 const Context = createContext<{
@@ -38,7 +39,7 @@ export function CreateCollectionOnTheGo({
     enabled,
     resumedValues,
     openCollectionId,
-    showOnlyPersonalCollections,
+    filterPersonalCollections,
   } = state;
   return enabled ? (
     <CreateCollectionModal
@@ -50,7 +51,7 @@ export function CreateCollectionOnTheGo({
           resumedValues: { ...resumedValues, collection_id: collection.id },
         });
       }}
-      showOnlyPersonalCollections={showOnlyPersonalCollections}
+      filterPersonalCollections={filterPersonalCollections}
     />
   ) : (
     <Context.Provider value={{ canCreateNew: true, updateState }}>
@@ -61,12 +62,12 @@ export function CreateCollectionOnTheGo({
 
 interface CreateCollectionOnTheGoButtonProps {
   openCollectionId?: CollectionId;
-  showOnlyPersonalCollections?: boolean;
+  filterPersonalCollections?: FilterItemsInPersonalCollection;
 }
 
 export function CreateCollectionOnTheGoButton({
   openCollectionId,
-  showOnlyPersonalCollections,
+  filterPersonalCollections,
 }: CreateCollectionOnTheGoButtonProps) {
   const { canCreateNew, updateState } = useContext(Context);
   const formik = useFormikContext<Values>();
@@ -79,7 +80,7 @@ export function CreateCollectionOnTheGoButton({
           enabled: true,
           resumedValues: formik.values,
           openCollectionId,
-          showOnlyPersonalCollections,
+          filterPersonalCollections,
         })
       }
     >

--- a/frontend/src/metabase/containers/DashboardPicker.tsx
+++ b/frontend/src/metabase/containers/DashboardPicker.tsx
@@ -6,7 +6,7 @@ import ItemPicker from "./ItemPicker";
 export interface DashboardPickerProps
   extends Pick<
     ItemPickerProps<DashboardId>,
-    "showOnlyPersonalCollections" | "onOpenCollectionChange"
+    "filterPersonalCollections" | "onOpenCollectionChange"
   > {
   value?: DashboardId;
   onChange: (dashboardId: DashboardId) => void;

--- a/frontend/src/metabase/containers/DataPicker/CardPicker/utils.ts
+++ b/frontend/src/metabase/containers/DataPicker/CardPicker/utils.ts
@@ -3,7 +3,7 @@ import {
   buildCollectionTree as _buildCollectionTree,
 } from "metabase/entities/collections";
 import {
-  isPersonalCollection,
+  isRootPersonalCollection,
   nonPersonalOrArchivedCollection,
   currentUserPersonalCollections,
 } from "metabase/collections/utils";
@@ -52,7 +52,7 @@ export function buildCollectionTree({
   if (currentUser.is_superuser) {
     const otherPersonalCollections = collections.filter(
       collection =>
-        isPersonalCollection(collection) &&
+        isRootPersonalCollection(collection) &&
         collection.personal_owner_id !== currentUser.id,
     );
 

--- a/frontend/src/metabase/containers/ItemPicker/ItemPicker.tsx
+++ b/frontend/src/metabase/containers/ItemPicker/ItemPicker.tsx
@@ -124,11 +124,7 @@ function ItemPicker<TId>({
 
     const collectionItems = list
       .filter(canWriteToCollectionOrChildren)
-      .filter(
-        filterPersonalCollections === "only"
-          ? collection => collection.is_personal
-          : _.identity,
-      )
+      .filter(getCollectionFilter(filterPersonalCollections))
       .map(collection => ({
         ...collection,
         model: "collection",
@@ -151,8 +147,8 @@ function ItemPicker<TId>({
 
     if (searchString) {
       query.q = searchString;
-      if (filterPersonalCollections === "only") {
-        query.filter_items_in_personal_collection = "only";
+      if (filterPersonalCollections) {
+        query.filter_items_in_personal_collection = filterPersonalCollections;
       }
     } else {
       query.collection = openCollectionId;
@@ -269,6 +265,28 @@ function ItemPicker<TId>({
       </ItemPickerView>
     </ScrollAwareLoadingAndErrorWrapper>
   );
+}
+
+function getCollectionFilter(
+  filterPersonalCollections?: FilterItemsInPersonalCollection,
+) {
+  if (filterPersonalCollections === "only") {
+    return isPersonalCollection;
+  }
+
+  if (filterPersonalCollections === "exclude") {
+    return isPublicCollection;
+  }
+
+  return _.identity;
+}
+
+function isPersonalCollection(collection: Collection) {
+  return collection.is_personal;
+}
+
+function isPublicCollection(collection: Collection) {
+  return !collection.is_personal;
 }
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage

--- a/frontend/src/metabase/containers/ItemPicker/ItemPicker.tsx
+++ b/frontend/src/metabase/containers/ItemPicker/ItemPicker.tsx
@@ -18,6 +18,7 @@ import type { State } from "metabase-types/store";
 
 import type {
   CollectionPickerItem,
+  FilterItemsInPersonalCollection,
   PickerItem,
   PickerModel,
   PickerValue,
@@ -33,7 +34,7 @@ interface OwnProps<TId> {
   entity?: typeof Collections; // collections/snippets entity
   showSearch?: boolean;
   showScroll?: boolean;
-  showOnlyPersonalCollections?: boolean;
+  filterPersonalCollections?: FilterItemsInPersonalCollection;
   className?: string;
   style?: React.CSSProperties;
   onChange: (value: PickerValue<TId>) => void;
@@ -86,7 +87,7 @@ function ItemPicker<TId>({
   className,
   showSearch = true,
   showScroll = true,
-  showOnlyPersonalCollections = false,
+  filterPersonalCollections,
   style,
   onChange,
   getCollectionIcon,
@@ -105,7 +106,7 @@ function ItemPicker<TId>({
   const isOpenCollectionInPersonalCollection = openCollection?.is_personal;
   const showItems = Boolean(
     searchString ||
-      !showOnlyPersonalCollections ||
+      filterPersonalCollections !== "only" ||
       isOpenCollectionInPersonalCollection,
   );
 
@@ -124,7 +125,7 @@ function ItemPicker<TId>({
     const collectionItems = list
       .filter(canWriteToCollectionOrChildren)
       .filter(
-        showOnlyPersonalCollections
+        filterPersonalCollections === "only"
           ? collection => collection.is_personal
           : _.identity,
       )
@@ -134,7 +135,7 @@ function ItemPicker<TId>({
       }));
 
     return collectionItems as CollectionPickerItem<TId>[];
-  }, [openCollection, models, showOnlyPersonalCollections]);
+  }, [openCollection, models, filterPersonalCollections]);
 
   const crumbs = useMemo(
     () =>
@@ -150,7 +151,7 @@ function ItemPicker<TId>({
 
     if (searchString) {
       query.q = searchString;
-      if (showOnlyPersonalCollections) {
+      if (filterPersonalCollections === "only") {
         query.filter_items_in_personal_collection = "only";
       }
     } else {
@@ -162,7 +163,7 @@ function ItemPicker<TId>({
     }
 
     return query;
-  }, [searchString, models, showOnlyPersonalCollections, openCollectionId]);
+  }, [searchString, models, filterPersonalCollections, openCollectionId]);
 
   const checkIsItemSelected = useCallback(
     (item: PickerItem<TId>) => {

--- a/frontend/src/metabase/containers/ItemPicker/ItemPicker.tsx
+++ b/frontend/src/metabase/containers/ItemPicker/ItemPicker.tsx
@@ -11,7 +11,11 @@ import Collections from "metabase/entities/collections";
 
 import { entityListLoader } from "metabase/entities/containers/EntityListLoader";
 import { entityObjectLoader } from "metabase/entities/containers/EntityObjectLoader";
-import { isRootCollection } from "metabase/collections/utils";
+import {
+  isPersonalCollection,
+  isPublicCollection,
+  isRootCollection,
+} from "metabase/collections/utils";
 
 import type { Collection, CollectionId } from "metabase-types/api";
 import type { State } from "metabase-types/store";
@@ -277,14 +281,6 @@ function getCollectionFilter(
   }
 
   return _.identity;
-}
-
-function isPersonalCollection(collection: Collection) {
-  return collection.is_personal;
-}
-
-function isPublicCollection(collection: Collection) {
-  return !collection.is_personal;
 }
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage

--- a/frontend/src/metabase/containers/ItemPicker/ItemPicker.tsx
+++ b/frontend/src/metabase/containers/ItemPicker/ItemPicker.tsx
@@ -154,9 +154,7 @@ function ItemPicker<TId>({
       query.collection = openCollectionId;
     }
 
-    if (models.length === 1) {
-      query.models = models;
-    }
+    query.models = models;
 
     return query;
   }, [searchString, models, filterPersonalCollections, openCollectionId]);

--- a/frontend/src/metabase/containers/ItemPicker/types.ts
+++ b/frontend/src/metabase/containers/ItemPicker/types.ts
@@ -24,5 +24,7 @@ export type SearchQuery = {
   q?: string;
   collection?: Collection["id"];
   models?: PickerModel[];
-  filter_items_in_personal_collection?: "only" | "exclude";
+  filter_items_in_personal_collection?: FilterItemsInPersonalCollection;
 };
+
+export type FilterItemsInPersonalCollection = "only" | "exclude";

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkOptions.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkOptions.tsx
@@ -13,7 +13,7 @@ import type { IconName } from "metabase/core/components/Icon";
 import type { UiParameter } from "metabase-lib/parameters/types";
 import { SidebarContent } from "../ClickBehaviorSidebar.styled";
 import CustomLinkText from "./CustomLinkText";
-import LinkedEntityPicker from "./LinkedEntityPicker";
+import { LinkedEntityPicker } from "./LinkedEntityPicker";
 
 import CustomURLPicker from "./CustomURLPicker";
 import LinkOption from "./LinkOption";

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.tsx
@@ -227,8 +227,8 @@ function LinkedEntityPicker({
       if (
         isDashboard &&
         !dashboardTabExists &&
-        dashboard?.tabs &&
-        dashboard.tabs.length < 2 &&
+        targetDashboard?.tabs &&
+        targetDashboard.tabs.length < 2 &&
         typeof dashboardTabId !== "undefined"
       ) {
         updateSettings({ ...clickBehavior, tabId: defaultDashboardTabId });
@@ -236,7 +236,7 @@ function LinkedEntityPicker({
     },
     [
       clickBehavior,
-      dashboard,
+      targetDashboard,
       dashboardTabId,
       dashboardTabExists,
       defaultDashboardTabId,

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.tsx
@@ -32,13 +32,13 @@ import { getDashboard } from "metabase/dashboard/selectors";
 import { useSelector } from "metabase/lib/redux";
 import type Question from "metabase-lib/Question";
 
-import { SidebarItem } from "../SidebarItem";
-import { Heading } from "../ClickBehaviorSidebar.styled";
+import { SidebarItem } from "../../SidebarItem";
+import { Heading } from "../../ClickBehaviorSidebar.styled";
 import {
   LinkTargetEntityPickerContent,
   SelectedEntityPickerIcon,
   SelectedEntityPickerContent,
-} from "./LinkOptions.styled";
+} from "../LinkOptions.styled";
 
 const LINK_TARGETS = {
   question: {
@@ -317,5 +317,4 @@ function isPublicCollection(collection: Partial<Collection>) {
   return !collection.is_personal;
 }
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default LinkedEntityPicker;
+export { LinkedEntityPicker };

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.tsx
@@ -25,11 +25,11 @@ import type {
   ClickBehavior,
   EntityCustomDestinationClickBehavior,
   DashboardTab,
-  Collection,
 } from "metabase-types/api";
 import { ROOT_COLLECTION } from "metabase/entities/collections";
 import { getDashboard } from "metabase/dashboard/selectors";
 import { useSelector } from "metabase/lib/redux";
+import { isPublicCollection } from "metabase/collections/utils";
 import type Question from "metabase-lib/Question";
 
 import { SidebarItem } from "../../SidebarItem";
@@ -311,10 +311,6 @@ function LinkedEntityPicker({
       )}
     </div>
   );
-}
-
-function isPublicCollection(collection: Partial<Collection>) {
-  return !collection.is_personal;
 }
 
 export { LinkedEntityPicker };

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.unit.spec.tsx
@@ -1,0 +1,382 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+import type {
+  CollectionItem,
+  Dashboard,
+  DashboardCustomDestinationClickBehavior,
+  EntityCustomDestinationClickBehavior,
+  QuestionCustomDestinationClickBehavior,
+  SearchResult,
+} from "metabase-types/api";
+import {
+  createMockCollection,
+  createMockCollectionItem,
+  createMockDashboard,
+  createMockDashboardCard,
+  createMockSearchResult,
+} from "metabase-types/api/mocks";
+import type { StoreDashboard } from "metabase-types/store";
+import { createMockDashboardState } from "metabase-types/store/mocks";
+import { ROOT_COLLECTION as ROOT } from "metabase/entities/collections";
+import { checkNotNull } from "metabase/lib/types";
+import {
+  setupCollectionItemsEndpoint,
+  setupCollectionsEndpoints,
+  setupSearchEndpoints,
+} from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import { getNextId } from "__support__/utils";
+import { LinkedEntityPicker } from "./LinkedEntityPicker";
+
+const ROOT_COLLECTION = createMockCollection({
+  ...ROOT,
+  can_write: true,
+});
+
+const PUBLIC_COLLECTION = createMockCollection({
+  id: getNextId(),
+  name: "Public collection",
+  can_write: true,
+  is_personal: false,
+  location: "/",
+});
+
+const PERSONAL_COLLECTION = createMockCollection({
+  id: getNextId(),
+  name: "Personal collection",
+  can_write: true,
+  is_personal: true,
+  location: "/",
+});
+
+const COLLECTIONS = [ROOT_COLLECTION, PUBLIC_COLLECTION, PERSONAL_COLLECTION];
+
+interface SetupOpts {
+  clickBehavior: EntityCustomDestinationClickBehavior;
+  dashboard: Dashboard;
+  searchResults?: SearchResult[];
+  collectionItems?: CollectionItem[];
+}
+
+function setup({
+  clickBehavior,
+  dashboard,
+  searchResults = [],
+  collectionItems = [],
+}: SetupOpts) {
+  setupCollectionsEndpoints({ collections: COLLECTIONS });
+  setupSearchEndpoints(searchResults);
+  setupCollectionItemsEndpoint({
+    collection: ROOT_COLLECTION,
+    collectionItems,
+  });
+
+  renderWithProviders(
+    <LinkedEntityPicker
+      clickBehavior={clickBehavior}
+      dashcard={createMockDashboardCard()}
+      updateSettings={jest.fn()}
+    />,
+    {
+      storeInitialState: {
+        dashboard: createMockDashboardState({
+          dashboardId: dashboard.id,
+          dashboards: {
+            [dashboard.id]: createDashboardState(dashboard),
+          },
+        }),
+      },
+    },
+  );
+}
+
+function createDashboardState(dashboard: Dashboard): StoreDashboard {
+  return { ...dashboard, dashcards: [] };
+}
+
+describe("LinkedEntityPicker", () => {
+  describe("link to a dashboard", () => {
+    const clickBehavior: DashboardCustomDestinationClickBehavior = {
+      type: "link",
+      linkType: "dashboard",
+    };
+
+    const dashboardItem = {
+      id: getNextId(),
+      name: "dashboard in root collection",
+      model: "dashboard" as const,
+      collection: ROOT_COLLECTION,
+    };
+    const dashboardCollectionItem = createMockCollectionItem(dashboardItem);
+    const dashboardSearchResult = createMockSearchResult(dashboardItem);
+
+    describe("dashboard in a public collection", () => {
+      const dashboardInPublicCollection = createMockDashboard({
+        collection: PUBLIC_COLLECTION,
+        collection_id: PUBLIC_COLLECTION.id as number,
+      });
+
+      it("should render only public collections", async () => {
+        setup({
+          clickBehavior,
+          dashboard: dashboardInPublicCollection,
+          collectionItems: [dashboardCollectionItem],
+        });
+
+        expect(
+          screen.getByText("Pick a dashboard to link to"),
+        ).toBeInTheDocument();
+        expect(
+          await screen.findByText(PUBLIC_COLLECTION.name),
+        ).toBeInTheDocument();
+        expect(
+          screen.queryByText(PERSONAL_COLLECTION.name),
+        ).not.toBeInTheDocument();
+        expect(
+          await screen.findByText(dashboardCollectionItem.name),
+        ).toBeInTheDocument();
+      });
+
+      describe("search dashboards", () => {
+        it("should search dashboards only in public collections", async () => {
+          setup({
+            clickBehavior,
+            dashboard: dashboardInPublicCollection,
+            searchResults: [dashboardSearchResult],
+          });
+          userEvent.click(screen.getByRole("button", { name: "Search" }));
+          const typedText = "dashboard";
+          userEvent.type(
+            screen.getByPlaceholderText("Search"),
+            `${typedText}{enter}`,
+          );
+
+          expect(
+            await screen.findByText(dashboardSearchResult.name),
+          ).toBeInTheDocument();
+
+          const call = fetchMock.lastCall("path:/api/search");
+          const urlObject = new URL(checkNotNull(call?.request?.url));
+          expect(urlObject.pathname).toEqual("/api/search");
+          expect(
+            fromEntriesWithMultipleValues(urlObject.searchParams.entries()),
+          ).toEqual({
+            models: "dashboard",
+            q: typedText,
+            filter_items_in_personal_collection: "exclude",
+          });
+        });
+      });
+    });
+
+    describe("dashboard in a personal collection", () => {
+      const dashboardInPersonalCollection = createMockDashboard({
+        collection: PERSONAL_COLLECTION,
+        collection_id: PERSONAL_COLLECTION.id as number,
+      });
+
+      it("should render all collections", async () => {
+        setup({
+          clickBehavior,
+          dashboard: dashboardInPersonalCollection,
+          collectionItems: [dashboardCollectionItem],
+        });
+
+        expect(
+          screen.getByText("Pick a dashboard to link to"),
+        ).toBeInTheDocument();
+        expect(
+          await screen.findByText(PUBLIC_COLLECTION.name),
+        ).toBeInTheDocument();
+        expect(screen.getByText(PERSONAL_COLLECTION.name)).toBeInTheDocument();
+        expect(
+          await screen.findByText(dashboardCollectionItem.name),
+        ).toBeInTheDocument();
+      });
+
+      describe("search dashboards", () => {
+        it("should search dashboards only in public collections", async () => {
+          setup({
+            clickBehavior,
+            dashboard: dashboardInPersonalCollection,
+            searchResults: [dashboardSearchResult],
+          });
+          userEvent.click(screen.getByRole("button", { name: "Search" }));
+          const typedText = "dashboard";
+          userEvent.type(
+            screen.getByPlaceholderText("Search"),
+            `${typedText}{enter}`,
+          );
+
+          expect(
+            await screen.findByText(dashboardSearchResult.name),
+          ).toBeInTheDocument();
+
+          const call = fetchMock.lastCall("path:/api/search");
+          const urlObject = new URL(checkNotNull(call?.request?.url));
+          expect(urlObject.pathname).toEqual("/api/search");
+          expect(
+            fromEntriesWithMultipleValues(urlObject.searchParams.entries()),
+          ).toEqual({
+            models: "dashboard",
+            q: typedText,
+          });
+        });
+      });
+    });
+  });
+
+  describe("link to a saved question", () => {
+    const clickBehavior: QuestionCustomDestinationClickBehavior = {
+      type: "link",
+      linkType: "question",
+    };
+    const questionItem = {
+      id: getNextId(),
+      name: "question in root collection",
+      model: "card" as const,
+      collection: ROOT_COLLECTION,
+    };
+    const questionCollectionItem = createMockCollectionItem(questionItem);
+    const questionSearchResult = createMockSearchResult(questionItem);
+
+    describe("dashboard in a public collection", () => {
+      const dashboardInPublicCollection = createMockDashboard({
+        collection: PUBLIC_COLLECTION,
+        collection_id: PUBLIC_COLLECTION.id as number,
+      });
+
+      it("should render only public collections", async () => {
+        setup({
+          clickBehavior,
+          dashboard: dashboardInPublicCollection,
+          collectionItems: [questionCollectionItem],
+        });
+
+        expect(
+          screen.getByText("Pick a question to link to"),
+        ).toBeInTheDocument();
+        expect(
+          await screen.findByText(PUBLIC_COLLECTION.name),
+        ).toBeInTheDocument();
+        expect(
+          screen.queryByText(PERSONAL_COLLECTION.name),
+        ).not.toBeInTheDocument();
+        expect(
+          await screen.findByText(questionCollectionItem.name),
+        ).toBeInTheDocument();
+      });
+
+      describe("questions", () => {
+        it("should search questions in all collections", async () => {
+          setup({
+            clickBehavior,
+            dashboard: dashboardInPublicCollection,
+            searchResults: [questionSearchResult],
+          });
+          userEvent.click(screen.getByRole("button", { name: "Search" }));
+          const typedText = "question";
+          userEvent.type(
+            screen.getByPlaceholderText("Search"),
+            `${typedText}{enter}`,
+          );
+
+          expect(
+            await screen.findByText(questionSearchResult.name),
+          ).toBeInTheDocument();
+
+          const call = fetchMock.lastCall("path:/api/search");
+          const urlObject = new URL(checkNotNull(call?.request?.url));
+          expect(urlObject.pathname).toEqual("/api/search");
+
+          expect(urlObject.searchParams.getAll("models")).toEqual([
+            "card",
+            "dataset",
+          ]);
+          expect(
+            fromEntriesWithMultipleValues(urlObject.searchParams.entries()),
+          ).toEqual({
+            models: ["card", "dataset"],
+            q: typedText,
+            filter_items_in_personal_collection: "exclude",
+          });
+        });
+      });
+    });
+
+    describe("dashboard in a personal collection", () => {
+      const dashboardInPersonalCollection = createMockDashboard({
+        collection: PERSONAL_COLLECTION,
+        collection_id: PERSONAL_COLLECTION.id as number,
+      });
+
+      it("should render all collections", async () => {
+        setup({
+          clickBehavior,
+          dashboard: dashboardInPersonalCollection,
+          collectionItems: [questionCollectionItem],
+        });
+
+        expect(
+          screen.getByText("Pick a question to link to"),
+        ).toBeInTheDocument();
+        expect(
+          await screen.findByText(PUBLIC_COLLECTION.name),
+        ).toBeInTheDocument();
+        expect(screen.getByText(PERSONAL_COLLECTION.name)).toBeInTheDocument();
+        expect(
+          await screen.findByText(questionCollectionItem.name),
+        ).toBeInTheDocument();
+      });
+
+      describe("search questions", () => {
+        it("should search questions in all collections", async () => {
+          setup({
+            clickBehavior,
+            dashboard: dashboardInPersonalCollection,
+            searchResults: [questionSearchResult],
+          });
+          userEvent.click(screen.getByRole("button", { name: "Search" }));
+          const typedText = "question";
+          userEvent.type(
+            screen.getByPlaceholderText("Search"),
+            `${typedText}{enter}`,
+          );
+
+          expect(
+            await screen.findByText(questionSearchResult.name),
+          ).toBeInTheDocument();
+
+          const call = fetchMock.lastCall("path:/api/search");
+          const urlObject = new URL(checkNotNull(call?.request?.url));
+          expect(urlObject.pathname).toEqual("/api/search");
+          expect(
+            fromEntriesWithMultipleValues(urlObject.searchParams.entries()),
+          ).toEqual({
+            models: ["card", "dataset"],
+            q: typedText,
+          });
+        });
+      });
+    });
+  });
+});
+
+function fromEntriesWithMultipleValues(
+  entries: IterableIterator<[string, string]>,
+): Record<string, string | string[]> {
+  const object: Record<string, string | string[]> = {};
+
+  for (const [key, value] of entries) {
+    if (object[key]) {
+      const existingValue = object[key];
+      object[key] = Array.isArray(existingValue)
+        ? [...existingValue, value]
+        : [existingValue, value];
+    } else {
+      object[key] = value;
+    }
+  }
+
+  return object;
+}

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.unit.spec.tsx
@@ -158,9 +158,7 @@ describe("LinkedEntityPicker", () => {
           const call = fetchMock.lastCall("path:/api/search");
           const urlObject = new URL(checkNotNull(call?.request?.url));
           expect(urlObject.pathname).toEqual("/api/search");
-          expect(
-            fromEntriesWithMultipleValues(urlObject.searchParams.entries()),
-          ).toEqual({
+          expect(urlSearchParamsToObject(urlObject.searchParams)).toEqual({
             models: "dashboard",
             q: typedText,
             filter_items_in_personal_collection: "exclude",
@@ -215,9 +213,7 @@ describe("LinkedEntityPicker", () => {
           const call = fetchMock.lastCall("path:/api/search");
           const urlObject = new URL(checkNotNull(call?.request?.url));
           expect(urlObject.pathname).toEqual("/api/search");
-          expect(
-            fromEntriesWithMultipleValues(urlObject.searchParams.entries()),
-          ).toEqual({
+          expect(urlSearchParamsToObject(urlObject.searchParams)).toEqual({
             models: "dashboard",
             q: typedText,
           });
@@ -293,9 +289,7 @@ describe("LinkedEntityPicker", () => {
             "card",
             "dataset",
           ]);
-          expect(
-            fromEntriesWithMultipleValues(urlObject.searchParams.entries()),
-          ).toEqual({
+          expect(urlSearchParamsToObject(urlObject.searchParams)).toEqual({
             models: ["card", "dataset"],
             q: typedText,
             filter_items_in_personal_collection: "exclude",
@@ -350,9 +344,7 @@ describe("LinkedEntityPicker", () => {
           const call = fetchMock.lastCall("path:/api/search");
           const urlObject = new URL(checkNotNull(call?.request?.url));
           expect(urlObject.pathname).toEqual("/api/search");
-          expect(
-            fromEntriesWithMultipleValues(urlObject.searchParams.entries()),
-          ).toEqual({
+          expect(urlSearchParamsToObject(urlObject.searchParams)).toEqual({
             models: ["card", "dataset"],
             q: typedText,
           });
@@ -362,21 +354,13 @@ describe("LinkedEntityPicker", () => {
   });
 });
 
-function fromEntriesWithMultipleValues(
-  entries: IterableIterator<[string, string]>,
+function urlSearchParamsToObject(
+  searchParams: URLSearchParams,
 ): Record<string, string | string[]> {
   const object: Record<string, string | string[]> = {};
-
-  for (const [key, value] of entries) {
-    if (object[key]) {
-      const existingValue = object[key];
-      object[key] = Array.isArray(existingValue)
-        ? [...existingValue, value]
-        : [existingValue, value];
-    } else {
-      object[key] = value;
-    }
+  for (const [key] of Array.from(searchParams)) {
+    const value = searchParams.getAll(key);
+    object[key] = value.length > 1 ? value : value[0];
   }
-
   return object;
 }

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/index.ts
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/index.ts
@@ -1,0 +1,1 @@
+export { LinkedEntityPicker } from "./LinkedEntityPicker";

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionPicker.jsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionPicker.jsx
@@ -18,6 +18,7 @@ import { SEARCH_DEBOUNCE_DURATION } from "metabase/lib/constants";
 import SelectList from "metabase/components/SelectList";
 import { getDashboard } from "metabase/dashboard/selectors";
 import { useSelector } from "metabase/lib/redux";
+import { isPublicCollection } from "metabase/collections/utils";
 import { QuestionList } from "./QuestionList";
 
 import {
@@ -114,9 +115,6 @@ function QuestionPicker({ onSelect, collectionsById, getCollectionIcon }) {
   );
 }
 
-function isPublicCollection(collection) {
-  return !collection.is_personal;
-}
 export default _.compose(
   entityObjectLoader({
     id: () => "root",

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
@@ -22,6 +22,7 @@ import FormCollectionPicker from "metabase/collections/containers/FormCollection
 
 import type { CollectionId, Dashboard } from "metabase-types/api";
 import type { State } from "metabase-types/store";
+import type { FilterItemsInPersonalCollection } from "metabase/containers/ItemPicker";
 
 const DASHBOARD_SCHEMA = Yup.object({
   name: Yup.string()
@@ -43,7 +44,7 @@ export interface CreateDashboardFormOwnProps {
   onCreate?: (dashboard: Dashboard) => void;
   onCancel?: () => void;
   initialValues?: CreateDashboardProperties | null;
-  showOnlyPersonalCollections?: boolean;
+  filterPersonalCollections?: FilterItemsInPersonalCollection;
 }
 
 interface CreateDashboardFormStateProps {
@@ -79,7 +80,7 @@ function CreateDashboardForm({
   onCreate,
   onCancel,
   initialValues,
-  showOnlyPersonalCollections,
+  filterPersonalCollections,
 }: Props) {
   const computedInitialValues = useMemo(
     () => ({
@@ -122,7 +123,7 @@ function CreateDashboardForm({
           <FormCollectionPicker
             name="collection_id"
             title={t`Which collection should this go in?`}
-            showOnlyPersonalCollections={showOnlyPersonalCollections}
+            filterPersonalCollections={filterPersonalCollections}
           />
           <FormFooter>
             <FormErrorMessage inline />

--- a/frontend/src/metabase/dashboard/selectors/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors/selectors.js
@@ -77,6 +77,9 @@ export const getIsShowDashboardInfoSidebar = createSelector(
   sidebar => sidebar.name === SIDEBAR_NAME.info,
 );
 
+/**
+ * @type {(state: import("metabase-types/store").State) => import("metabase-types/api").Dashboard}
+ */
 export const getDashboard = createSelector(
   [getDashboardId, getDashboards],
   (dashboardId, dashboards) => dashboards[dashboardId],

--- a/frontend/src/metabase/entities/collections/utils.ts
+++ b/frontend/src/metabase/entities/collections/utils.ts
@@ -4,7 +4,7 @@ import { color } from "metabase/lib/colors";
 import { getUserPersonalCollectionId } from "metabase/selectors/user";
 import {
   isRootCollection,
-  isPersonalCollection,
+  isRootPersonalCollection,
 } from "metabase/collections/utils";
 
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
@@ -29,7 +29,7 @@ export function getCollectionIcon(
   if (collection.id === PERSONAL_COLLECTIONS.id) {
     return { name: "group" };
   }
-  if (isPersonalCollection(collection)) {
+  if (isRootPersonalCollection(collection)) {
     return { name: "person" };
   }
 

--- a/frontend/src/metabase/lib/urls/collections.ts
+++ b/frontend/src/metabase/lib/urls/collections.ts
@@ -1,6 +1,7 @@
 import slugg from "slugg";
 
 import type { Collection as BaseCollection } from "metabase-types/api";
+import { isRootPersonalCollection } from "metabase/collections/utils";
 
 import { appendSlug, extractEntityId } from "./utils";
 
@@ -40,9 +41,7 @@ export function collection(collection?: Collection) {
     return `/collection/${id}`;
   }
 
-  const isRootPersonalCollection =
-    typeof collection.personal_owner_id === "number";
-  const slug = isRootPersonalCollection
+  const slug = isRootPersonalCollection(collection)
     ? slugifyPersonalCollection(collection)
     : slugg(collection.name);
 

--- a/frontend/src/metabase/lib/urls/collections.ts
+++ b/frontend/src/metabase/lib/urls/collections.ts
@@ -40,8 +40,9 @@ export function collection(collection?: Collection) {
     return `/collection/${id}`;
   }
 
-  const isPersonalCollection = typeof collection.personal_owner_id === "number";
-  const slug = isPersonalCollection
+  const isRootPersonalCollection =
+    typeof collection.personal_owner_id === "number";
+  const slug = isRootPersonalCollection
     ? slugifyPersonalCollection(collection)
     : slugg(collection.name);
 

--- a/frontend/src/metabase/query_builder/components/DataSelector/saved-question-picker/SavedQuestionPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/saved-question-picker/SavedQuestionPicker.jsx
@@ -11,7 +11,7 @@ import Collection, {
   buildCollectionTree,
 } from "metabase/entities/collections";
 import {
-  isPersonalCollection,
+  isRootPersonalCollection,
   nonPersonalOrArchivedCollection,
   currentUserPersonalCollections,
 } from "metabase/collections/utils";
@@ -80,7 +80,7 @@ function SavedQuestionPicker({
     if (currentUser.is_superuser) {
       const otherPersonalCollections = collections.filter(
         collection =>
-          isPersonalCollection(collection) &&
+          isRootPersonalCollection(collection) &&
           collection.personal_owner_id !== currentUser.id,
       );
 


### PR DESCRIPTION
This is the final part of the epic https://github.com/metabase/metabase/issues/34733

This PR implements
- Hide personal collections and dashboards when configuring click behavior linking to dashboards
- Hide personal collections and questions when configuring click behavior linking to questions

![image](https://github.com/metabase/metabase/assets/1937582/fd364bb5-4eb4-488c-81de-4fa3fe840119)


#### How to verify

Dashboard click behavior

1. Link to questions/dashboards for a question in a public collection
    **expectation**:
    - show only questions/dashboards in public collections
    - search should return only questions/dashboards in public collections
1. Link to questions/dashboards for a question in a personal collection
    **expectation**:
    - show all questions/dashboards
    - search should return all questions/dashboards