### PR TITLE
add legend to the static combo chart

### DIFF
--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -59,7 +59,7 @@ export interface UnsavedCard<Q extends DatasetQuery = DatasetQuery> {
 }
 
 export type SeriesSettings = {
-  title: string;
+  title?: string;
   color?: string;
   show_series_values?: boolean;
   display?: string;

--- a/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.stories.tsx
+++ b/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.stories.tsx
@@ -16,8 +16,6 @@ const Template: ComponentStory<typeof ComboChart> = args => {
 
 export const Default = Template.bind({});
 Default.args = {
-  width: 1000,
-  height: 600,
   rawSeries: questions.autoYSplit as any,
   dashcardSettings: {},
   renderingContext: {

--- a/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
+++ b/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
@@ -1,12 +1,17 @@
 import { init } from "echarts";
+import { Group } from "@visx/group";
 import { getCartesianChartModel } from "metabase/visualizations/echarts/cartesian/model";
 import { getCartesianChartOption } from "metabase/visualizations/echarts/cartesian/option";
 import { sanitizeSvgForBatik } from "metabase/static-viz/lib/svg";
 import type { IsomorphicStaticChartProps } from "metabase/static-viz/containers/IsomorphicStaticChart/types";
+import { getLegendItems } from "metabase/visualizations/echarts/cartesian/model/legend";
+import { calculateLegendRows } from "../Legend/utils";
+import { Legend } from "../Legend";
 import { computeStaticComboChartSettings } from "./settings";
 
 const WIDTH = 540;
 const HEIGHT = 360;
+const LEGEND_PADDING = 24;
 
 export const ComboChart = ({
   rawSeries,
@@ -34,6 +39,10 @@ export const ComboChart = ({
     renderingContext,
   );
 
+  const legendItems = getLegendItems(chartModel);
+  const { height: legendHeight, items: legendLayoutItems } =
+    calculateLegendRows(legendItems, width, LEGEND_PADDING);
+
   const option = getCartesianChartOption(
     chartModel,
     computedVisualizationSettings,
@@ -45,8 +54,11 @@ export const ComboChart = ({
   const chartSvg = sanitizeSvgForBatik(chart.renderToSVGString());
 
   return (
-    <svg width={width} height={height}>
-      <g dangerouslySetInnerHTML={{ __html: chartSvg }}></g>
+    <svg width={width} height={height + legendHeight}>
+      <Legend items={legendLayoutItems} />
+      <Group y={height + legendHeight}>
+        <g dangerouslySetInnerHTML={{ __html: chartSvg }}></g>
+      </Group>
     </svg>
   );
 };

--- a/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
+++ b/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
@@ -5,14 +5,14 @@ import type {
 import type { RawSeries, VisualizationSettings } from "metabase-types/api";
 
 import {
-  COLOR_SETTING_ID,
+  SERIES_COLORS_SETTING_KEY,
   getSeriesColors,
   getSeriesDefaultDisplay,
   getSeriesDefaultLinearInterpolate,
   getSeriesDefaultLineMarker,
   getSeriesDefaultLineMissing,
   getSeriesDefaultShowSeriesValues,
-  SETTING_ID,
+  SERIES_SETTING_KEY,
 } from "metabase/visualizations/shared/settings/series";
 import { getCommonStaticVizSettings } from "metabase/static-viz/lib/settings";
 import {
@@ -43,7 +43,7 @@ const getSeriesFunction = (
   keys: string[],
 ) => {
   return (legacySeriesObject: LegacySeriesSettingsObjectKey) => {
-    const seriesSettings = settings[SETTING_ID] ?? {};
+    const seriesSettings = settings[SERIES_SETTING_KEY] ?? {};
     const key = legacySeriesObject.card._seriesKey;
     const singleSeriesSettings = seriesSettings[key] ?? {};
 
@@ -103,7 +103,10 @@ export const computeStaticComboChartSettings = (
     seriesModel => seriesModel.vizSettingsKey,
   );
 
-  settings[COLOR_SETTING_ID] = getSeriesColors(seriesVizSettingsKeys, settings);
+  settings[SERIES_COLORS_SETTING_KEY] = getSeriesColors(
+    seriesVizSettingsKeys,
+    settings,
+  );
   settings.series = getSeriesFunction(
     rawSeries,
     settings,

--- a/frontend/src/metabase/static-viz/components/Legend/Legend.tsx
+++ b/frontend/src/metabase/static-viz/components/Legend/Legend.tsx
@@ -2,21 +2,26 @@ import { Group } from "@visx/group";
 import { Text } from "metabase/static-viz/components/Text";
 import type { PositionedLegendItem } from "./types";
 
-import { LEGEND_CIRCLE_MARGIN_RIGHT, LEGEND_CIRCLE_SIZE } from "./constants";
+import {
+  DEFAULT_LEGEND_FONT_SIZE,
+  DEFAULT_LEGEND_FONT_WEIGHT,
+  LEGEND_CIRCLE_MARGIN_RIGHT,
+  LEGEND_CIRCLE_SIZE,
+} from "./constants";
 
 type LegendProps = {
   top?: number;
   left?: number;
-  fontSize: number;
-  fontWeight: number;
+  fontSize?: number;
+  fontWeight?: number;
   items: PositionedLegendItem[];
 };
 
 export const Legend = ({
   top,
   left,
-  fontSize,
-  fontWeight,
+  fontSize = DEFAULT_LEGEND_FONT_SIZE,
+  fontWeight = DEFAULT_LEGEND_FONT_WEIGHT,
   items,
 }: LegendProps) => {
   return (

--- a/frontend/src/metabase/static-viz/components/Legend/constants.ts
+++ b/frontend/src/metabase/static-viz/components/Legend/constants.ts
@@ -1,3 +1,7 @@
 export const LEGEND_CIRCLE_SIZE = 10;
 export const LEGEND_CIRCLE_MARGIN_RIGHT = 8;
 export const LEGEND_ITEM_MARGIN_RIGHT = 16;
+
+export const DEFAULT_LEGEND_FONT_SIZE = 14;
+export const DEFAULT_LEGEND_LINE_HEIGHT = 20;
+export const DEFAULT_LEGEND_FONT_WEIGHT = 700;

--- a/frontend/src/metabase/static-viz/components/Legend/utils.ts
+++ b/frontend/src/metabase/static-viz/components/Legend/utils.ts
@@ -1,8 +1,11 @@
 import { measureTextWidth, truncateText } from "metabase/static-viz/lib/text";
 import {
+  DEFAULT_LEGEND_FONT_SIZE,
+  DEFAULT_LEGEND_FONT_WEIGHT,
   LEGEND_CIRCLE_MARGIN_RIGHT,
   LEGEND_CIRCLE_SIZE,
   LEGEND_ITEM_MARGIN_RIGHT,
+  DEFAULT_LEGEND_LINE_HEIGHT,
 } from "./constants";
 import type { LegendItem, PositionedLegendItem } from "./types";
 
@@ -18,26 +21,45 @@ const calculateItemWidth = (
   );
 };
 
+/**
+ * Calculates the positions of legend items rendered in rows based on the available width, padding,
+ * and font style.
+ *
+ * @param {LegendItem[]} items - The legend items to be positioned.
+ * @param {number} width - The available width for the legend.
+ * @param {number} [padding=0] - The padding to be applied on both sides of the legend.
+ * @param {number} [lineHeight=DEFAULT_LEGEND_LINE_HEIGHT] - The line height for each row of legend items.
+ * @param {number} [fontSize=DEFAULT_LEGEND_FONT_SIZE] - The font size to be used for the legend items.
+ * @param {number} [fontWeight=DEFAULT_LEGEND_FONT_WEIGHT] - The font weight to be used for the legend items.
+ * @returns {{ items: PositionedLegendItem[]; height: number }} An object containing the total height of the legend
+ *                                                              and the flat list of positioned legend items.
+ */
 export const calculateLegendRows = (
   items: LegendItem[],
   width: number,
-  lineHeight: number,
-  fontSize: number,
-  fontWeight: number,
-) => {
+  padding = 0,
+  lineHeight: number = DEFAULT_LEGEND_LINE_HEIGHT,
+  fontSize: number = DEFAULT_LEGEND_FONT_SIZE,
+  fontWeight: number = DEFAULT_LEGEND_FONT_WEIGHT,
+): { items: PositionedLegendItem[]; height: number } => {
   if (items.length <= 1) {
-    return null;
+    return {
+      items: [],
+      height: 0,
+    };
   }
+
+  const availableTotalWidth = width - 2 * padding;
 
   const rows: PositionedLegendItem[][] = [[]];
 
-  let currentRowX = 0;
+  let currentRowX = padding;
 
   for (const item of items) {
     const currentRowIndex = rows.length - 1;
     const currentRow = rows[currentRowIndex];
     const hasItemsInCurrentRow = currentRow.length > 0;
-    const availableRowWidth = width - currentRowX;
+    const availableRowWidth = availableTotalWidth - currentRowX;
 
     const itemWidth = calculateItemWidth(item, fontSize, fontWeight);
 
@@ -56,20 +78,25 @@ export const calculateLegendRows = (
       rows.push([
         {
           ...item,
-          left: 0,
+          left: padding,
           top: (currentRowIndex + 1) * lineHeight,
         },
       ]);
-      currentRowX = itemWidth + LEGEND_ITEM_MARGIN_RIGHT;
+      currentRowX = padding + itemWidth + LEGEND_ITEM_MARGIN_RIGHT;
     } else {
       currentRow.push({
         color: item.color,
-        name: truncateText(item.name, width, fontSize, fontWeight),
-        left: 0,
+        name: truncateText(
+          item.name,
+          availableTotalWidth,
+          fontSize,
+          fontWeight,
+        ),
+        left: padding,
         top: currentRowIndex * lineHeight,
       });
 
-      currentRowX = width;
+      currentRowX = availableTotalWidth;
     }
   }
 

--- a/frontend/src/metabase/static-viz/components/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/static-viz/components/RowChart/RowChart.tsx
@@ -95,6 +95,7 @@ const StaticRowChart = ({ data, settings, getColor }: StaticRowChartProps) => {
       color: seriesColors[series.seriesKey],
     })),
     WIDTH,
+    0,
     LEGEND_FONT.lineHeight,
     LEGEND_FONT.size,
     LEGEND_FONT.weight,
@@ -105,7 +106,7 @@ const StaticRowChart = ({ data, settings, getColor }: StaticRowChartProps) => {
 
   return (
     <svg width={WIDTH} height={fullChartHeight} fontFamily="Lato">
-      {legend && (
+      {legend.items.length > 0 && (
         <Legend
           items={legend.items}
           top={CHART_PADDING}

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -134,6 +134,7 @@ export const XYChart = ({
   const legendRows = calculateLegendRows(
     series.map(series => ({ name: series.name, color: series.color })),
     width - CHART_PADDING * 2,
+    0,
     style.legend.lineHeight,
     style.legend.fontSize,
     style.legend.fontWeight,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.unit.spec.ts
@@ -217,9 +217,11 @@ describe("dataset transform functions", () => {
         dataKey: DataKey,
         index: number,
       ): SeriesModel => ({
-        dataKey: "key1",
-        legacySeriesSettingsObjectKey: "key1",
-        vizSettingsKey: "key1",
+        dataKey,
+        name: `name for ${dataKey}`,
+        color: "red",
+        legacySeriesSettingsObjectKey: dataKey,
+        vizSettingsKey: dataKey,
         column: createMockColumn({ name: dataKey }),
         columnIndex: index,
       });

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.unit.spec.ts
@@ -43,7 +43,7 @@ describe("dataset transform functions", () => {
     const column = createMockColumn({ name: "count" });
 
     it("should return the column name if cardId and breakoutValue are undefined", () => {
-      expect(getDatasetKey(column)).toBe("count");
+      expect(getDatasetKey(column, undefined)).toBe("count");
     });
 
     it("should return the cardId concatenated with column name if cardId is provided and breakoutValue is undefined", () => {
@@ -220,7 +220,7 @@ describe("dataset transform functions", () => {
         dataKey,
         name: `name for ${dataKey}`,
         color: "red",
-        legacySeriesSettingsObjectKey: dataKey,
+        legacySeriesSettingsObjectKey: { card: { _seriesKey: dataKey } },
         vizSettingsKey: dataKey,
         column: createMockColumn({ name: dataKey }),
         columnIndex: index,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
@@ -47,6 +47,7 @@ export const getCardsSeriesModels = (
   cardsColumns: CartesianChartColumns[],
   renderingContext: RenderingContext,
 ) => {
+  const hasMultipleCards = rawSeries.length > 1;
   return rawSeries.flatMap((cardDataset, index) => {
     const isFirstCard = index === 0;
     const cardColumns = cardsColumns[index];
@@ -55,6 +56,8 @@ export const getCardsSeriesModels = (
       cardDataset,
       cardColumns,
       isFirstCard,
+      hasMultipleCards,
+      settings,
       renderingContext,
     );
   });

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/legend.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/legend.ts
@@ -1,0 +1,8 @@
+import type { CartesianChartModel } from "./types";
+
+export const getLegendItems = (chartModel: CartesianChartModel) => {
+  return chartModel.seriesModels.map(seriesModel => ({
+    name: seriesModel.name,
+    color: seriesModel.color,
+  }));
+};

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
@@ -67,6 +67,27 @@ const getDefaultSeriesName = (
   return `${cardName}: ${columnDisplayNameOrFormattedBreakoutValue}`;
 };
 
+const getDefaultSeriesName = (
+  columnDisplayNameOrFormattedBreakoutValue: string,
+  hasMultipleCards: boolean,
+  metricsCount: number,
+  isBreakoutSeries: boolean,
+  cardName?: string,
+) => {
+  // For a single card, including unsaved ones without names, return column name or breakout value
+  if (!hasMultipleCards || !cardName) {
+    return columnDisplayNameOrFormattedBreakoutValue;
+  }
+
+  // When multiple cards are combined and one card has no breakout and only one metric
+  // the default series name is the card name
+  if (hasMultipleCards && metricsCount === 1 && !isBreakoutSeries) {
+    return cardName;
+  }
+
+  return `${cardName}: ${columnDisplayNameOrFormattedBreakoutValue}`;
+};
+
 /**
  * Generates series models for a given card with a dataset.
  *

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
@@ -2,7 +2,6 @@ import type {
   SingleSeries,
   DatasetData,
   RowValue,
-  DatasetColumn,
   RawSeries,
 } from "metabase-types/api";
 import type { CartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
@@ -13,45 +12,23 @@ import type {
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import { getDatasetKey } from "metabase/visualizations/echarts/cartesian/model/dataset";
 import type {
-  Formatter,
+  ComputedVisualizationSettings,
   RenderingContext,
 } from "metabase/visualizations/types";
+import {
+  SERIES_COLORS_SETTING_KEY,
+  SERIES_SETTING_KEY,
+} from "metabase/visualizations/shared/settings/series";
 
-type MetricSeriesParams = {
-  metricColumn: DatasetColumn;
-};
-
-type BreakoutSeriesParams = {
-  breakoutColumn: DatasetColumn;
-  breakoutValue: RowValue;
-  formatValue: Formatter;
-};
-
-type SeriesVizSettingsKeyParams = {
-  cardName?: string;
-  isFirstCard: boolean;
-} & (MetricSeriesParams | BreakoutSeriesParams);
-
-const getSeriesVizSettingsKey = ({
-  cardName,
-  isFirstCard,
-  ...params
-}: SeriesVizSettingsKeyParams): VizSettingsKey => {
+export const getSeriesVizSettingsKey = (
+  columnNameOrFormattedBreakoutValue: string,
+  isFirstCard: boolean,
+  cardName?: string,
+): VizSettingsKey => {
   // When multiple cards are combined on a dashboard, all cards
   // except the first include the card name in the viz settings key.
   const prefix = isFirstCard && cardName == null ? `${cardName}: ` : "";
-
-  const isBreakoutSeries = "breakoutValue" in params;
-
-  // Unfortunately, breakout series include formatted breakout values in the key
-  // which can be different based on a user's locale.
-  const key = isBreakoutSeries
-    ? params.formatValue(params.breakoutValue, {
-        column: params.breakoutColumn,
-      })
-    : params.metricColumn.name;
-
-  return prefix + key;
+  return prefix + columnNameOrFormattedBreakoutValue;
 };
 
 // HACK: creates a pseudo legacy series object to integrate with the `series` function in computed settings.
@@ -69,6 +46,27 @@ const createLegacySeriesObjectKey = (
 const getBreakoutDistinctValues = (data: DatasetData, breakoutIndex: number) =>
   Array.from(new Set<RowValue>(data.rows.map(row => row[breakoutIndex])));
 
+const getDefaultSeriesName = (
+  columnDisplayNameOrFormattedBreakoutValue: string,
+  hasMultipleCards: boolean,
+  metricsCount: number,
+  isBreakoutSeries: boolean,
+  cardName?: string,
+) => {
+  // For a single card, including unsaved ones without names, return column name or breakout value
+  if (!hasMultipleCards || !cardName) {
+    return columnDisplayNameOrFormattedBreakoutValue;
+  }
+
+  // When multiple cards are combined and one card has no breakout and only one metric
+  // the default series name is the card name
+  if (hasMultipleCards && metricsCount === 1 && !isBreakoutSeries) {
+    return cardName;
+  }
+
+  return `${cardName}: ${columnDisplayNameOrFormattedBreakoutValue}`;
+};
+
 /**
  * Generates series models for a given card with a dataset.
  *
@@ -76,6 +74,8 @@ const getBreakoutDistinctValues = (data: DatasetData, breakoutIndex: number) =>
  * @param {CartesianChartColumns} columns - The columns model for the card.
  * @param {boolean} isFirstCard - Indicates whether the card is the first card in the
  *                                case of combined cards on a dashboard.
+ * @param {boolean} hasMultipleCards — Indicates whether the chart has multiple card combined.
+ * @param {ComputedVisualizationSettings} settings — Computed visualization settings.
  * @param {RenderingContext} renderingContext - The rendering context.
  * @returns {SeriesModel[]} The generated series models for the card.
  */
@@ -83,6 +83,8 @@ export const getCardSeriesModels = (
   { card, data }: SingleSeries,
   columns: CartesianChartColumns,
   isFirstCard: boolean,
+  hasMultipleCards: boolean,
+  settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
 ): SeriesModel[] => {
   const hasBreakout = "breakout" in columns;
@@ -90,20 +92,35 @@ export const getCardSeriesModels = (
   // Charts without breakout have one series per selected metric column.
   if (!hasBreakout) {
     return columns.metrics.map(metric => {
-      const vizSettingsKey = getSeriesVizSettingsKey({
-        cardName: card.name,
-        metricColumn: metric.column,
+      const vizSettingsKey = getSeriesVizSettingsKey(
+        metric.column.name,
         isFirstCard,
-      });
+        card.name,
+      );
+      const legacySeriesSettingsObjectKey =
+        createLegacySeriesObjectKey(vizSettingsKey);
+
+      const name =
+        settings[SERIES_SETTING_KEY]?.[vizSettingsKey]?.title ??
+        getDefaultSeriesName(
+          metric.column.display_name,
+          hasMultipleCards,
+          columns.metrics.length,
+          false,
+          card.name,
+        );
+
+      const color = settings?.[SERIES_COLORS_SETTING_KEY]?.[vizSettingsKey];
 
       return {
+        name,
+        color,
         cardId: card.id,
         column: metric.column,
         columnIndex: metric.index,
         dataKey: getDatasetKey(metric.column, card.id),
         vizSettingsKey,
-        legacySeriesSettingsObjectKey:
-          createLegacySeriesObjectKey(vizSettingsKey),
+        legacySeriesSettingsObjectKey,
       };
     });
   }
@@ -113,21 +130,40 @@ export const getCardSeriesModels = (
   const breakoutValues = getBreakoutDistinctValues(data, breakout.index);
 
   return breakoutValues.map(breakoutValue => {
-    const vizSettingsKey = getSeriesVizSettingsKey({
-      cardName: card.name,
-      isFirstCard,
-      breakoutValue,
-      breakoutColumn: breakout.column,
-      formatValue: renderingContext.formatValue,
+    // Unfortunately, breakout series include formatted breakout values in the key
+    // which can be different based on a user's locale.
+    const formattedBreakoutValue = renderingContext.formatValue(breakoutValue, {
+      column: breakout.column,
     });
 
+    const vizSettingsKey = getSeriesVizSettingsKey(
+      formattedBreakoutValue,
+      isFirstCard,
+      card.name,
+    );
+    const legacySeriesSettingsObjectKey =
+      createLegacySeriesObjectKey(vizSettingsKey);
+
+    const name =
+      settings.series_settings?.[vizSettingsKey]?.title ??
+      getDefaultSeriesName(
+        formattedBreakoutValue,
+        hasMultipleCards,
+        1, // only one metric when a chart has a breakout
+        true,
+        card.name,
+      );
+
+    const color = settings?.[SERIES_COLORS_SETTING_KEY]?.[vizSettingsKey];
+
     return {
+      name,
+      color,
       cardId: card.id,
       column: metric.column,
       columnIndex: metric.index,
       vizSettingsKey,
-      legacySeriesSettingsObjectKey:
-        createLegacySeriesObjectKey(vizSettingsKey),
+      legacySeriesSettingsObjectKey,
       dataKey: getDatasetKey(metric.column, card.id, breakoutValue),
       breakoutColumnIndex: breakout.index,
       breakoutColumn: breakout.column,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -9,6 +9,8 @@ export type LegacySeriesSettingsObjectKey = {
 };
 
 export type RegularSeriesModel = {
+  name: string;
+  color: string;
   dataKey: DataKey;
   vizSettingsKey: VizSettingsKey;
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -8,6 +8,12 @@ export type LegacySeriesSettingsObjectKey = {
   };
 };
 
+export type LegacySeriesSettingsObjectKey = {
+  card: {
+    _seriesKey: string;
+  };
+};
+
 export type RegularSeriesModel = {
   name: string;
   color: string;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -48,7 +48,6 @@ const buildEChartsLabelOptions = (
 const buildEChartsBarSeries = (
   seriesModel: SeriesModel,
   seriesSettings: SeriesSettings,
-  seriesColor: string,
   settings: ComputedVisualizationSettings,
   dimensionDataKey: string,
   yAxisIndex: number,
@@ -73,7 +72,7 @@ const buildEChartsBarSeries = (
       hideOverlap: settings["graph.label_value_frequency"] === "fit",
     },
     itemStyle: {
-      color: seriesColor,
+      color: seriesModel.color,
     },
   };
 };
@@ -81,7 +80,6 @@ const buildEChartsBarSeries = (
 const buildEChartsLineAreaSeries = (
   seriesModel: SeriesModel,
   seriesSettings: SeriesSettings,
-  seriesColor: string,
   settings: ComputedVisualizationSettings,
   dimensionDataKey: string,
   yAxisIndex: number,
@@ -115,7 +113,7 @@ const buildEChartsLineAreaSeries = (
       hideOverlap: settings["graph.label_value_frequency"] === "fit",
     },
     itemStyle: {
-      color: seriesColor,
+      color: seriesModel.color,
     },
   };
 };
@@ -130,8 +128,6 @@ export const buildEChartsSeries = (
       const seriesSettings: SeriesSettings = settings.series(
         seriesModel.legacySeriesSettingsObjectKey,
       );
-      const seriesColor =
-        settings?.["series_settings.colors"]?.[seriesModel.vizSettingsKey];
 
       const yAxisIndex = chartModel.yAxisSplit[0].includes(seriesModel.dataKey)
         ? 0
@@ -143,7 +139,6 @@ export const buildEChartsSeries = (
           return buildEChartsLineAreaSeries(
             seriesModel,
             seriesSettings,
-            seriesColor,
             settings,
             chartModel.dimensionModel.dataKey,
             yAxisIndex,
@@ -153,7 +148,6 @@ export const buildEChartsSeries = (
           return buildEChartsBarSeries(
             seriesModel,
             seriesSettings,
-            seriesColor,
             settings,
             chartModel.dimensionModel.dataKey,
             yAxisIndex,

--- a/frontend/src/metabase/visualizations/lib/series.ts
+++ b/frontend/src/metabase/visualizations/lib/series.ts
@@ -2,7 +2,7 @@ import { assocIn } from "icepick";
 import type { VisualizationSettings, Card } from "metabase-types/api/card";
 import type { Series, TransformedSeries } from "metabase-types/api/dataset";
 import { isNotNull } from "metabase/lib/types";
-import { SETTING_ID } from "metabase/visualizations/shared/settings/series";
+import { SERIES_SETTING_KEY } from "metabase/visualizations/shared/settings/series";
 import { keyForSingleSeries } from "./settings/series";
 
 export const updateSeriesColor = (
@@ -10,7 +10,7 @@ export const updateSeriesColor = (
   seriesKey: string,
   color: string,
 ) => {
-  return assocIn(settings, [SETTING_ID, seriesKey, "color"], color);
+  return assocIn(settings, [SERIES_SETTING_KEY, seriesKey, "color"], color);
 };
 
 export const findSeriesByKey = (series: Series, key: string) => {

--- a/frontend/src/metabase/visualizations/lib/settings/series.js
+++ b/frontend/src/metabase/visualizations/lib/settings/series.js
@@ -3,13 +3,13 @@ import { getIn } from "icepick";
 
 import ChartNestedSettingSeries from "metabase/visualizations/components/settings/ChartNestedSettingSeries";
 import {
-  COLOR_SETTING_ID,
+  SERIES_COLORS_SETTING_KEY,
   getSeriesDefaultLinearInterpolate,
   getSeriesDefaultLineMarker,
   getSeriesDefaultLineMissing,
   getSeriesColors,
   getSeriesDefaultDisplay,
-  SETTING_ID,
+  SERIES_SETTING_KEY,
   getSeriesDefaultShowSeriesValues,
 } from "metabase/visualizations/shared/settings/series";
 import { getNameForCard } from "../series";
@@ -66,7 +66,10 @@ export function seriesSetting({
     color: {
       getDefault: (single, settings, { settings: vizSettings }) =>
         // get the color for series key, computed in the setting
-        getIn(vizSettings, [COLOR_SETTING_ID, keyForSingleSeries(single)]),
+        getIn(vizSettings, [
+          SERIES_COLORS_SETTING_KEY,
+          keyForSingleSeries(single),
+        ]),
     },
     "line.interpolate": {
       title: t`Line style`,
@@ -152,7 +155,7 @@ export function seriesSetting({
   }
 
   return {
-    ...nestedSettings(SETTING_ID, {
+    ...nestedSettings(SERIES_SETTING_KEY, {
       getHidden: ([{ card }], settings, { isDashboard }) =>
         !isDashboard || card?.display === "waterfall",
       getSection: (series, settings, { isDashboard }) =>
@@ -162,7 +165,7 @@ export function seriesSetting({
       getObjectKey: keyForSingleSeries,
       getSettingDefinitionsForObject: getSettingDefinitionsForSingleSeries,
       component: ChartNestedSettingSeries,
-      readDependencies: [COLOR_SETTING_ID, ...readDependencies],
+      readDependencies: [SERIES_COLORS_SETTING_KEY, ...readDependencies],
       noPadding: true,
       getExtraProps: series => ({
         seriesCardNames: series.reduce((memo, singleSeries) => {
@@ -175,7 +178,7 @@ export function seriesSetting({
       ...def,
     }),
     // colors must be computed as a whole rather than individually
-    [COLOR_SETTING_ID]: {
+    [SERIES_COLORS_SETTING_KEY]: {
       getValue(series, settings) {
         const keys = series.map(single => keyForSingleSeries(single));
         return getSeriesColors(keys, settings);

--- a/frontend/src/metabase/visualizations/shared/settings/series.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/series.ts
@@ -4,15 +4,15 @@ import type { VisualizationSettings } from "metabase-types/api";
 import { getColorsForValues } from "metabase/lib/colors/charts";
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
 
-export const SETTING_ID = "series_settings";
-export const COLOR_SETTING_ID = "series_settings.colors";
+export const SERIES_SETTING_KEY = "series_settings";
+export const SERIES_COLORS_SETTING_KEY = "series_settings.colors";
 
 export const getSeriesColors = (
   seriesVizSettingsKeys: string[],
   settings: VisualizationSettings,
 ) => {
   const assignments = _.chain(seriesVizSettingsKeys)
-    .map(key => [key, getIn(settings, [SETTING_ID, key, "color"])])
+    .map(key => [key, getIn(settings, [SERIES_SETTING_KEY, key, "color"])])
     .filter(([_key, color]) => color != null)
     .object()
     .value();


### PR DESCRIPTION
### Description

Adds legend to the static combo chart.

### How to verify

Dashcards to test:
- single card, multiple metric card -> should show metric names
- single card, signle metric -> should not show legend at all
- single card, breakout series -> should show formatted breakout names
- combined cards, both have single metric -> should show card names
- combined cards, one breakout series, the other multiple metric card -> should prefix card name like `cardName: `

### Demo

<img width="553" alt="Screenshot 2023-11-02 at 8 33 23 PM" src="https://github.com/metabase/metabase/assets/14301985/bc113cb2-e310-4a2d-a99d-801a271d84ac">

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
