### PR TITLE
Milestone Reminder Github Action

### DIFF
--- a/.github/workflows/check-milestone.yml
+++ b/.github/workflows/check-milestone.yml
@@ -70,7 +70,7 @@ jobs:
 
             const author = pull.data.user.login;
             const guideLink = "https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#3dea255ffa3b4f74942a227844e889fa";
-            const message = `@${author} Did you forget to add a milestone to this pull request or its issue? _[When and where should I add a milestone?](${guideLink})_`;
+            const message = `@${author} Did you forget to add a milestone to the issue for this PR? _[When and where should I add a milestone?](${guideLink})_`;
 
             await github.rest.issues.createComment({
               owner,

--- a/.github/workflows/check-milestone.yml
+++ b/.github/workflows/check-milestone.yml
@@ -1,0 +1,80 @@
+name: Milestone Reminder
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - "master"
+
+jobs:
+  milestone-reminder:
+    if: github.event.pull_request.merged == 'true'
+    name: Remind to set milestone
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+      issues: read
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: | # js
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const pullNumber = '${{ github.event.pull_request.number }}';
+
+            // the github API doesn't expose linked issues, so we have to parse the body ourselves
+            function getLinkedIssueId(pull) {
+              // https://regexr.com/7mjnp
+              const match = pull.data.body.match(/(\/issues\/|#)(\d+)/);
+              return match && match?.[2];
+            }
+
+            function getMilestone(pullOrIssue) {
+              // pull has pull.data.milestone, issue has issue.milestone
+              return pullOrIssue?.data?.milestone || pullOrIssue?.milestone;
+            }
+
+            const pull = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullNumber,
+            });
+
+            if (getMilestone(pull)) {
+              console.log("Pull request has milestone", pull.data.milestone?.title);
+              process.exit(0);
+            }
+
+            const issueId = getLinkedIssueId(pull);
+
+            if (issueId) {
+              console.log('linked issue found', issueId);
+
+              const issue = await github.rest.issues.get({
+                owner,
+                repo,
+                issue_number: issueId,
+              });
+
+              const milestone = getMilestone(issue);
+
+              if (milestone) {
+                console.log("Linked issue has milestone", milestone.title);
+                process.exit(0);
+              }
+            }
+
+            console.log("No milestone found");
+
+            const author = pull.data.user.login;
+            const guideLink = "https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#3dea255ffa3b4f74942a227844e889fa";
+            const message = `@${author} Did you forget to add a milestone to this pull request or its issue? _[When and where should I add a milestone?](${guideLink})_`;
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: pullNumber,
+              body: message,
+            });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/35299

### Description

It's hard to remember to add milestones to closed PRs, and having to add them to _every_ PR might be overkill (though we can revisit this if necessary). For now, let's just comment on any closed PR that doesn't have a linked milestone with a gentle reminder, and a link to the guide for when you should add a milestone.

(this is me running it locally. In the wild, it'll come from github actions)

![Screen Shot 2023-11-02 at 8 47 49 AM](https://github.com/metabase/metabase/assets/30528226/97848546-421d-46ce-a431-3b8ed1b0e9a9)

