### PR TITLE
Increasing scroll count for flakey table columns test

### DIFF
--- a/e2e/test/scenarios/visualizations/table-column-settings.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/table-column-settings.cy.spec.js
@@ -485,6 +485,7 @@ describe("scenarios > visualizations > table column settings", () => {
         column: "Math",
         columnName: "Math",
         table: "orders",
+        scrollTimes: 2,
       };
 
       _hideColumn(testData);

--- a/e2e/test/scenarios/visualizations/table-column-settings.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/table-column-settings.cy.spec.js
@@ -688,6 +688,7 @@ describe("scenarios > visualizations > table column settings", () => {
         column: "Math",
         columnName: "Math",
         table: "test question",
+        scrollTimes: 2,
       };
 
       _hideColumn(mathColumn);


### PR DESCRIPTION
### Description
The "should be able to show and hide custom expressions from a nested query" test in `table-column-settings.cy.spec.js` requires that we scroll all the way to the end of the table to ensure that added columns are present. This doesn't seem to be happening in CI (though it passes locally). Will try increasing the scroll count to see if this helps.

### How to verify
Green CI

