### PR TITLE
[MLv2] Filters — Extract test helpers, add more `FilterPicker` tests

### DIFF
--- a/frontend/src/metabase/common/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
@@ -50,7 +50,7 @@ export function BooleanFilterPicker({
   };
 
   return (
-    <div>
+    <div data-testid="boolean-filter-picker">
       <BackButton onClick={onBack}>{columnInfo.longDisplayName}</BackButton>
       <Divider />
       <Radio.Group value={optionType} onChange={handleOptionChange}>

--- a/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
@@ -100,7 +100,7 @@ export function CoordinateFilterPicker({
   };
 
   return (
-    <>
+    <div data-testid="coordinate-filter-picker">
       <Header>
         <BackButton onClick={onBack}>{columnName}</BackButton>
         <FilterOperatorPicker
@@ -134,7 +134,7 @@ export function CoordinateFilterPicker({
           {isNew ? t`Add filter` : t`Update filter`}
         </Button>
       </Footer>
-    </>
+    </div>
   );
 }
 

--- a/frontend/src/metabase/common/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
@@ -41,18 +41,20 @@ export function DateFilterPicker({
   };
 
   return (
-    <DatePicker
-      value={value}
-      availableOperators={availableOperators}
-      availableUnits={availableUnits}
-      backButton={
-        <BackButton pl="sm" onClick={onBack}>
-          {columnInfo.longDisplayName}
-        </BackButton>
-      }
-      canUseRelativeOffsets
-      isNew={isNew}
-      onChange={handleChange}
-    />
+    <div data-testid="datetime-filter-picker">
+      <DatePicker
+        value={value}
+        availableOperators={availableOperators}
+        availableUnits={availableUnits}
+        backButton={
+          <BackButton pl="sm" onClick={onBack}>
+            {columnInfo.longDisplayName}
+          </BackButton>
+        }
+        canUseRelativeOffsets
+        isNew={isNew}
+        onChange={handleChange}
+      />
+    </div>
   );
 }

--- a/frontend/src/metabase/common/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
@@ -67,7 +67,7 @@ export function NumberFilterPicker({
   };
 
   return (
-    <>
+    <div data-testid="number-filter-picker">
       <Header>
         <BackButton onClick={onBack}>{columnName}</BackButton>
         <FilterOperatorPicker
@@ -92,7 +92,7 @@ export function NumberFilterPicker({
           {isNew ? t`Add filter` : t`Update filter`}
         </Button>
       </Footer>
-    </>
+    </div>
   );
 }
 

--- a/frontend/src/metabase/common/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -78,7 +78,7 @@ export function StringFilterPicker({
   const canHaveManyValues = !Number.isFinite(valueCount);
 
   return (
-    <>
+    <div data-testid="string-filter-picker">
       <Header>
         <BackButton onClick={onBack}>{columnName}</BackButton>
         <FilterOperatorPicker
@@ -114,7 +114,7 @@ export function StringFilterPicker({
           {isNew ? t`Add filter` : t`Update filter`}
         </Button>
       </Footer>
-    </>
+    </div>
   );
 }
 

--- a/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
@@ -76,7 +76,7 @@ export function TimeFilterPicker({
   };
 
   return (
-    <>
+    <div data-testid="time-filter-picker">
       <Header>
         <BackButton onClick={onBack}>{columnName}</BackButton>
         <FilterOperatorPicker
@@ -104,7 +104,7 @@ export function TimeFilterPicker({
           {isNew ? t`Add filter` : t`Update filter`}
         </Button>
       </Footer>
-    </>
+    </div>
   );
 }
 

--- a/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
@@ -1,63 +1,15 @@
 import dayjs from "dayjs";
 import userEvent from "@testing-library/user-event";
 import { render, screen, within } from "__support__/ui";
-import { createMockMetadata } from "__support__/metadata";
 import { checkNotNull } from "metabase/lib/types";
-import { createMockField } from "metabase-types/api/mocks";
-import {
-  createSampleDatabase,
-  createOrdersTable,
-  ORDERS_ID,
-} from "metabase-types/api/mocks/presets";
 import * as Lib from "metabase-lib";
-import { TYPE } from "metabase-lib/types/constants";
-import { createQuery, columnFinder } from "metabase-lib/test-helpers";
+import {
+  createQuery,
+  createQueryWithTimeFilter,
+  findTimeColumn,
+} from "../test-utils";
 import { getDefaultValue } from "./utils";
 import { TimeFilterPicker } from "./TimeFilterPicker";
-
-const TIME_FIELD = createMockField({
-  id: 100,
-  name: "TIME",
-  display_name: "Time",
-  table_id: ORDERS_ID,
-  base_type: TYPE.Time,
-  effective_type: TYPE.Time,
-  semantic_type: null,
-});
-
-const _ordersFields = createOrdersTable().fields?.filter(checkNotNull) ?? [];
-
-const database = createSampleDatabase({
-  tables: [
-    createOrdersTable({
-      fields: [..._ordersFields, TIME_FIELD],
-    }),
-  ],
-});
-
-const metadata = createMockMetadata({
-  databases: [database],
-});
-
-function findTimeColumn(query: Lib.Query) {
-  const columns = Lib.filterableColumns(query, 0);
-  const findColumn = columnFinder(query, columns);
-  return findColumn("ORDERS", "TIME");
-}
-
-function createFilteredQuery({
-  operator = ">",
-  values = [getDefaultValue()],
-}: Partial<Lib.TimeFilterParts> = {}) {
-  const initialQuery = createQuery({ metadata });
-  const column = findTimeColumn(initialQuery);
-
-  const clause = Lib.timeFilterClause({ operator, column, values });
-  const query = Lib.filter(initialQuery, 0, clause);
-  const [filter] = Lib.filters(query, 0);
-
-  return { query, column, filter };
-}
 
 type SetupOpts = {
   query?: Lib.Query;
@@ -74,7 +26,7 @@ const EXPECTED_OPERATORS = [
 ];
 
 function setup({
-  query = createQuery({ metadata }),
+  query = createQuery(),
   column = findTimeColumn(query),
   filter,
 }: SetupOpts = {}) {
@@ -124,7 +76,7 @@ describe("TimeFilterPicker", () => {
     it("should render a blank editor", () => {
       setup();
 
-      expect(screen.getByText(TIME_FIELD.display_name)).toBeInTheDocument();
+      expect(screen.getByText("Time")).toBeInTheDocument();
       expect(screen.getByDisplayValue("Before")).toBeInTheDocument();
       expect(screen.getByDisplayValue("00:00")).toBeInTheDocument();
       expect(screen.getByText("Add filter")).toBeEnabled();
@@ -236,13 +188,13 @@ describe("TimeFilterPicker", () => {
     describe("with one value", () => {
       it("should render a filter", () => {
         setup(
-          createFilteredQuery({
+          createQueryWithTimeFilter({
             operator: ">",
             values: [dayjs("11:15", "HH:mm").toDate()],
           }),
         );
 
-        expect(screen.getByText(TIME_FIELD.display_name)).toBeInTheDocument();
+        expect(screen.getByText("Time")).toBeInTheDocument();
         expect(screen.getByDisplayValue("After")).toBeInTheDocument();
         expect(screen.getByDisplayValue("11:15")).toBeInTheDocument();
         expect(screen.getByText("Update filter")).toBeEnabled();
@@ -250,7 +202,7 @@ describe("TimeFilterPicker", () => {
 
       it("should update a filter", () => {
         const { getNextFilterParts, getNextFilterColumnName } = setup(
-          createFilteredQuery({ operator: ">" }),
+          createQueryWithTimeFilter({ operator: ">" }),
         );
 
         userEvent.type(screen.getByDisplayValue("00:00"), "20:45");
@@ -269,7 +221,7 @@ describe("TimeFilterPicker", () => {
     describe("with two values", () => {
       it("should render a filter", () => {
         setup(
-          createFilteredQuery({
+          createQueryWithTimeFilter({
             operator: "between",
             values: [
               dayjs("11:15", "HH:mm").toDate(),
@@ -278,7 +230,7 @@ describe("TimeFilterPicker", () => {
           }),
         );
 
-        expect(screen.getByText(TIME_FIELD.display_name)).toBeInTheDocument();
+        expect(screen.getByText("Time")).toBeInTheDocument();
         expect(screen.getByDisplayValue("Between")).toBeInTheDocument();
         expect(screen.getByDisplayValue("11:15")).toBeInTheDocument();
         expect(screen.getByDisplayValue("13:00")).toBeInTheDocument();
@@ -287,7 +239,7 @@ describe("TimeFilterPicker", () => {
 
       it("should update a filter", () => {
         const { getNextFilterParts, getNextFilterColumnName } = setup(
-          createFilteredQuery({
+          createQueryWithTimeFilter({
             operator: "between",
             values: [
               dayjs("11:15", "HH:mm").toDate(),
@@ -328,20 +280,20 @@ describe("TimeFilterPicker", () => {
     describe("with no values", () => {
       it("should render a filter", () => {
         setup(
-          createFilteredQuery({
+          createQueryWithTimeFilter({
             operator: "not-null",
             values: [],
           }),
         );
 
-        expect(screen.getByText(TIME_FIELD.display_name)).toBeInTheDocument();
+        expect(screen.getByText("Time")).toBeInTheDocument();
         expect(screen.getByDisplayValue("Not empty")).toBeInTheDocument();
         expect(screen.getByText("Update filter")).toBeEnabled();
       });
 
       it("should update a filter", async () => {
         const { getNextFilterParts, getNextFilterColumnName } = setup(
-          createFilteredQuery({ operator: "not-null", values: [] }),
+          createQueryWithTimeFilter({ operator: "not-null", values: [] }),
         );
 
         await setOperator("Is empty");
@@ -358,7 +310,7 @@ describe("TimeFilterPicker", () => {
     });
 
     it("should list operators", async () => {
-      setup(createFilteredQuery({ operator: "<" }));
+      setup(createQueryWithTimeFilter({ operator: "<" }));
 
       userEvent.click(screen.getByDisplayValue("Before"));
       const listbox = await screen.findByRole("listbox");
@@ -372,7 +324,7 @@ describe("TimeFilterPicker", () => {
 
     it("should change an operator", async () => {
       const { getNextFilterParts, getNextFilterColumnName } = setup(
-        createFilteredQuery({
+        createQueryWithTimeFilter({
           operator: "<",
           values: [dayjs("11:15", "HH:mm").toDate()],
         }),
@@ -392,7 +344,7 @@ describe("TimeFilterPicker", () => {
 
     it("should re-use values when changing an operator", async () => {
       setup(
-        createFilteredQuery({
+        createQueryWithTimeFilter({
           operator: "between",
           values: [
             dayjs("11:15", "HH:mm").toDate(),
@@ -429,7 +381,7 @@ describe("TimeFilterPicker", () => {
 
     it("should handle invalid filter value", () => {
       const { getNextFilterParts } = setup(
-        createFilteredQuery({
+        createQueryWithTimeFilter({
           values: [dayjs("32:66", "HH:mm").toDate()],
         }),
       );
@@ -450,7 +402,7 @@ describe("TimeFilterPicker", () => {
 
     it("should go back", () => {
       const { onBack, onChange } = setup(
-        createFilteredQuery({ operator: "<" }),
+        createQueryWithTimeFilter({ operator: "<" }),
       );
 
       userEvent.click(screen.getByLabelText("Back"));

--- a/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
@@ -94,8 +94,7 @@ function setup({
   );
 
   function getNextFilterParts() {
-    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
-    const [filter] = lastCall;
+    const [filter] = onChange.mock.lastCall;
     return Lib.timeFilterParts(query, 0, filter);
   }
 
@@ -145,17 +144,16 @@ describe("TimeFilterPicker", () => {
     });
 
     it("should apply a default filter", () => {
-      const { query, column, getNextFilterParts, getNextFilterColumnName } =
-        setup();
+      const { getNextFilterParts, getNextFilterColumnName } = setup();
 
       userEvent.click(screen.getByText("Add filter"));
 
       const filterParts = getNextFilterParts();
-      const columnInfo = Lib.displayInfo(query, 0, column);
-      expect(filterParts?.operator).toBe("<");
-      expect(columnInfo.displayName).toBe("Time");
-      expect(columnInfo.table?.displayName).toBe("Orders");
-      expect(filterParts?.values).toEqual([getDefaultValue()]);
+      expect(filterParts).toMatchObject({
+        operator: "<",
+        column: expect.anything(),
+        values: [getDefaultValue()],
+      });
       expect(getNextFilterColumnName()).toBe("Time");
     });
 
@@ -167,8 +165,11 @@ describe("TimeFilterPicker", () => {
       userEvent.click(screen.getByText("Add filter"));
 
       const filterParts = getNextFilterParts();
-      expect(filterParts?.operator).toBe(">");
-      expect(filterParts?.values).toEqual([dayjs("11:15", "HH:mm").toDate()]);
+      expect(filterParts).toMatchObject({
+        operator: ">",
+        column: expect.anything(),
+        values: [dayjs("11:15", "HH:mm").toDate()],
+      });
       expect(getNextFilterColumnName()).toBe("Time");
     });
 
@@ -183,11 +184,14 @@ describe("TimeFilterPicker", () => {
       userEvent.click(screen.getByText("Add filter"));
 
       const filterParts = getNextFilterParts();
-      expect(filterParts?.operator).toBe("between");
-      expect(filterParts?.values).toEqual([
-        dayjs("11:15", "HH:mm").toDate(),
-        dayjs("12:30", "HH:mm").toDate(),
-      ]);
+      expect(filterParts).toMatchObject({
+        operator: "between",
+        column: expect.anything(),
+        values: [
+          dayjs("11:15", "HH:mm").toDate(),
+          dayjs("12:30", "HH:mm").toDate(),
+        ],
+      });
       expect(getNextFilterColumnName()).toBe("Time");
     });
 
@@ -198,8 +202,11 @@ describe("TimeFilterPicker", () => {
       userEvent.click(screen.getByText("Add filter"));
 
       const filterParts = getNextFilterParts();
-      expect(filterParts?.operator).toBe("is-null");
-      expect(filterParts?.values).toEqual([]);
+      expect(filterParts).toMatchObject({
+        operator: "is-null",
+        column: expect.anything(),
+        values: [],
+      });
       expect(getNextFilterColumnName()).toBe("Time");
     });
 
@@ -210,7 +217,11 @@ describe("TimeFilterPicker", () => {
       userEvent.click(screen.getByText("Add filter"));
 
       const filterParts = getNextFilterParts();
-      expect(filterParts?.values).toEqual([dayjs("03:59", "HH:mm").toDate()]);
+      expect(filterParts).toMatchObject({
+        operator: "<",
+        column: expect.anything(),
+        values: [dayjs("03:59", "HH:mm").toDate()],
+      });
     });
 
     it("should go back", () => {
@@ -246,8 +257,11 @@ describe("TimeFilterPicker", () => {
         userEvent.click(screen.getByText("Update filter"));
 
         const filterParts = getNextFilterParts();
-        expect(filterParts?.operator).toBe(">");
-        expect(filterParts?.values).toEqual([dayjs("20:45", "HH:mm").toDate()]);
+        expect(filterParts).toMatchObject({
+          operator: ">",
+          column: expect.anything(),
+          values: [dayjs("20:45", "HH:mm").toDate()],
+        });
         expect(getNextFilterColumnName()).toBe("Time");
       });
     });
@@ -286,21 +300,27 @@ describe("TimeFilterPicker", () => {
         userEvent.click(screen.getByText("Update filter"));
 
         let filterParts = getNextFilterParts();
-        expect(filterParts?.operator).toBe("between");
-        expect(filterParts?.values).toEqual([
-          dayjs("08:00", "HH:mm").toDate(),
-          dayjs("13:00", "HH:mm").toDate(),
-        ]);
+        expect(filterParts).toMatchObject({
+          operator: "between",
+          column: expect.anything(),
+          values: [
+            dayjs("08:00", "HH:mm").toDate(),
+            dayjs("13:00", "HH:mm").toDate(),
+          ],
+        });
 
         userEvent.type(screen.getByDisplayValue("13:00"), "17:31");
         userEvent.click(screen.getByText("Update filter"));
 
         filterParts = getNextFilterParts();
-        expect(filterParts?.operator).toBe("between");
-        expect(filterParts?.values).toEqual([
-          dayjs("08:00", "HH:mm").toDate(),
-          dayjs("17:31", "HH:mm").toDate(),
-        ]);
+        expect(filterParts).toMatchObject({
+          operator: "between",
+          column: expect.anything(),
+          values: [
+            dayjs("08:00", "HH:mm").toDate(),
+            dayjs("17:31", "HH:mm").toDate(),
+          ],
+        });
         expect(getNextFilterColumnName()).toBe("Time");
       });
     });
@@ -328,8 +348,11 @@ describe("TimeFilterPicker", () => {
         userEvent.click(screen.getByText("Update filter"));
 
         const filterParts = getNextFilterParts();
-        expect(filterParts?.operator).toBe("is-null");
-        expect(filterParts?.values).toEqual([]);
+        expect(filterParts).toMatchObject({
+          operator: "is-null",
+          column: expect.anything(),
+          values: [],
+        });
         expect(getNextFilterColumnName()).toBe("Time");
       });
     });
@@ -359,8 +382,11 @@ describe("TimeFilterPicker", () => {
       userEvent.click(screen.getByText("Update filter"));
 
       const filterParts = getNextFilterParts();
-      expect(filterParts?.operator).toBe(">");
-      expect(filterParts?.values).toEqual([dayjs("11:15", "HH:mm").toDate()]);
+      expect(filterParts).toMatchObject({
+        operator: ">",
+        column: expect.anything(),
+        values: [dayjs("11:15", "HH:mm").toDate()],
+      });
       expect(getNextFilterColumnName()).toBe("Time");
     });
 
@@ -415,7 +441,11 @@ describe("TimeFilterPicker", () => {
       userEvent.click(screen.getByText("Update filter"));
 
       const filterParts = getNextFilterParts();
-      expect(filterParts?.values).toEqual([dayjs("11:00", "HH:mm").toDate()]);
+      expect(filterParts).toMatchObject({
+        operator: ">",
+        column: expect.anything(),
+        values: [dayjs("11:00", "HH:mm").toDate()],
+      });
     });
 
     it("should go back", () => {

--- a/frontend/src/metabase/common/components/FilterPicker/test-utils.ts
+++ b/frontend/src/metabase/common/components/FilterPicker/test-utils.ts
@@ -1,0 +1,319 @@
+/* istanbul ignore file */
+import dayjs from "dayjs";
+import { createMockEntitiesState } from "__support__/store";
+import { checkNotNull } from "metabase/lib/types";
+import { getMetadata } from "metabase/selectors/metadata";
+import type { FieldValuesType } from "metabase-types/api";
+import { createMockField, createMockSegment } from "metabase-types/api/mocks";
+import {
+  createSampleDatabase,
+  createOrdersTable,
+  createPeopleTable,
+  createProductsTable,
+  ORDERS,
+  ORDERS_ID,
+  PEOPLE_ID,
+  PRODUCTS_ID,
+} from "metabase-types/api/mocks/presets";
+import { createMockState } from "metabase-types/store/mocks";
+import * as Lib from "metabase-lib";
+import { TYPE } from "metabase-lib/types/constants";
+import {
+  createQuery as _createQuery,
+  columnFinder,
+} from "metabase-lib/test-helpers";
+
+const SEGMENT_1 = createMockSegment({
+  id: 1,
+  table_id: ORDERS_ID,
+  name: "Discounted",
+  description: "Discounted",
+  definition: {
+    "source-table": ORDERS_ID,
+    filter: ["not-null", ["field", ORDERS.DISCOUNT, null]],
+  },
+});
+
+const SEGMENT_2 = createMockSegment({
+  id: 2,
+  table_id: ORDERS_ID,
+  name: "Many items",
+  description: "Orders with more than 5 items",
+  definition: {
+    "source-table": ORDERS_ID,
+    filter: [">", ["field", ORDERS.QUANTITY, null], 20],
+  },
+});
+
+const BOOLEAN_FIELD = createMockField({
+  id: 100,
+  table_id: PEOPLE_ID,
+  name: "IS_ACTIVE",
+  display_name: "Is Active",
+
+  base_type: TYPE.Boolean,
+  effective_type: TYPE.Boolean,
+  semantic_type: null,
+});
+
+const STRING_FIELD_NO_VALUES = createMockField({
+  id: 101,
+  table_id: PRODUCTS_ID,
+  name: "DESCRIPTION",
+  display_name: "Description",
+
+  base_type: TYPE.Text,
+  effective_type: TYPE.Text,
+  semantic_type: null,
+
+  has_field_values: "none",
+});
+
+const TIME_FIELD = createMockField({
+  id: 102,
+  table_id: ORDERS_ID,
+  name: "TIME",
+  display_name: "Time",
+
+  base_type: TYPE.Time,
+  effective_type: TYPE.Time,
+  semantic_type: null,
+});
+
+const _ordersFields = createOrdersTable().fields?.filter(checkNotNull) ?? [];
+const _peopleFields = createPeopleTable().fields?.filter(checkNotNull) ?? [];
+const _productsFields =
+  createProductsTable().fields?.filter(checkNotNull) ?? [];
+
+const database = createSampleDatabase({
+  tables: [
+    createOrdersTable({
+      fields: [..._ordersFields, TIME_FIELD],
+      segments: [SEGMENT_1, SEGMENT_2],
+    }),
+    createPeopleTable({ fields: [..._peopleFields, BOOLEAN_FIELD] }),
+    createProductsTable({
+      fields: [..._productsFields, STRING_FIELD_NO_VALUES],
+    }),
+  ],
+});
+
+export const storeInitialState = createMockState({
+  entities: createMockEntitiesState({
+    databases: [database],
+    segments: [SEGMENT_1, SEGMENT_2],
+  }),
+});
+
+export const metadata = getMetadata(storeInitialState);
+
+export function createQuery() {
+  return _createQuery({ metadata });
+}
+
+export function createFilteredQuery(
+  initialQuery: Lib.Query,
+  clause: Lib.ExpressionClause | Lib.SegmentMetadata,
+) {
+  const query = Lib.filter(initialQuery, 0, clause);
+  const [filter] = Lib.filters(query, 0);
+  const column = Lib.filterParts(query, 0, filter)?.column;
+  return { query, filter, column };
+}
+
+function findFilteredColumn(
+  query: Lib.Query,
+  tableName: string,
+  columnName: string,
+) {
+  const columns = Lib.filterableColumns(query, 0);
+  const findColumn = columnFinder(query, columns);
+  return findColumn(tableName, columnName);
+}
+
+export function findBooleanColumn(query: Lib.Query) {
+  return findFilteredColumn(query, "PEOPLE", "IS_ACTIVE");
+}
+
+type BooleanFilterQueryOpts = Partial<Lib.BooleanFilterParts> & {
+  query?: Lib.Query;
+  column?: Lib.ColumnMetadata;
+};
+
+export function createQueryWithBooleanFilter({
+  query = createQuery(),
+  column = findBooleanColumn(query),
+  operator = "=",
+  values = [true],
+}: BooleanFilterQueryOpts = {}) {
+  const clause = Lib.booleanFilterClause({ operator, column, values });
+  return createFilteredQuery(query, clause);
+}
+
+export function findLatitudeColumn(query: Lib.Query) {
+  return findFilteredColumn(query, "PEOPLE", "LATITUDE");
+}
+
+export function findLongitudeColumn(query: Lib.Query) {
+  return findFilteredColumn(query, "PEOPLE", "LONGITUDE");
+}
+
+type CoordinateFilterQueryOpts = Partial<Lib.CoordinateFilterParts> & {
+  query?: Lib.Query;
+  column?: Lib.ColumnMetadata;
+};
+
+export function createQueryWithCoordinateFilter({
+  query = createQuery(),
+  column = findLatitudeColumn(query),
+  operator = "=",
+  values = [0],
+  ...parts
+}: CoordinateFilterQueryOpts = {}) {
+  const clause = Lib.coordinateFilterClause({
+    operator,
+    column,
+    values,
+    ...parts,
+  });
+  return createFilteredQuery(query, clause);
+}
+
+export function findNumericColumn(query: Lib.Query) {
+  return findFilteredColumn(query, "ORDERS", "TOTAL");
+}
+
+type NumberFilterQueryOpts = Partial<Lib.NumberFilterParts> & {
+  query?: Lib.Query;
+  column?: Lib.ColumnMetadata;
+};
+
+export function createQueryWithNumberFilter({
+  query = createQuery(),
+  column = findNumericColumn(query),
+  operator = "=",
+  values = [0],
+}: NumberFilterQueryOpts = {}) {
+  const clause = Lib.numberFilterClause({ operator, column, values });
+  return createFilteredQuery(query, clause);
+}
+
+export function findStringColumn(
+  query: Lib.Query,
+  { fieldValues = "none" }: { fieldValues?: FieldValuesType } = {},
+) {
+  const fieldNameMap = {
+    none: "DESCRIPTION",
+    list: "CATEGORY",
+    search: "VENDOR",
+  };
+  return findFilteredColumn(query, "PRODUCTS", fieldNameMap[fieldValues]);
+}
+
+type StringFilterOpts = Partial<Lib.StringFilterParts> & {
+  query?: Lib.Query;
+  column?: Lib.ColumnMetadata;
+};
+
+export function createQueryWithStringFilter({
+  query = createQuery(),
+  column = findStringColumn(query),
+  operator = "=",
+  values = [""],
+  options = {},
+}: StringFilterOpts = {}) {
+  const clause = Lib.stringFilterClause({ operator, column, values, options });
+  return createFilteredQuery(query, clause);
+}
+
+export function findDateColumn(query: Lib.Query) {
+  return findFilteredColumn(query, "PEOPLE", "BIRTH_DATE");
+}
+
+export function findDateTimeColumn(query: Lib.Query) {
+  return findFilteredColumn(query, "ORDERS", "CREATED_AT");
+}
+
+type SpecificDateFilterOpts = Partial<Lib.SpecificDateFilterParts> & {
+  query?: Lib.Query;
+  column?: Lib.ColumnMetadata;
+};
+
+export function createQueryWithSpecificDateFilter({
+  query = createQuery(),
+  column = findDateTimeColumn(query),
+  operator = "=",
+  values = [new Date(2020, 1, 15)],
+}: SpecificDateFilterOpts = {}) {
+  const clause = Lib.specificDateFilterClause(query, 0, {
+    operator,
+    column,
+    values,
+  });
+  return createFilteredQuery(query, clause);
+}
+
+type RelativeDateFilterOpts = Partial<Lib.RelativeDateFilterParts> & {
+  query?: Lib.Query;
+  column?: Lib.ColumnMetadata;
+};
+
+export function createQueryWithRelativeDateFilter({
+  query = createQuery(),
+  column = findDateTimeColumn(query),
+  value = -20,
+  bucket = "day",
+  offsetValue = null,
+  offsetBucket = null,
+  options = {},
+}: RelativeDateFilterOpts = {}) {
+  const clause = Lib.relativeDateFilterClause({
+    column,
+    value,
+    bucket,
+    offsetValue,
+    offsetBucket,
+    options,
+  });
+  return createFilteredQuery(query, clause);
+}
+
+type ExcludeDateFilterOpts = Partial<Lib.ExcludeDateFilterParts> & {
+  query?: Lib.Query;
+  column?: Lib.ColumnMetadata;
+};
+
+export function createQueryWithExcludeDateFilter({
+  query = createQuery(),
+  column = findDateTimeColumn(query),
+  operator = "!=",
+  values = [1],
+  bucket = "day-of-week",
+}: ExcludeDateFilterOpts = {}) {
+  const clause = Lib.excludeDateFilterClause(query, 0, {
+    column,
+    operator,
+    values,
+    bucket,
+  });
+  return createFilteredQuery(query, clause);
+}
+
+export function findTimeColumn(query: Lib.Query) {
+  return findFilteredColumn(query, "ORDERS", "TIME");
+}
+
+type TimeFilterOpts = Partial<Lib.TimeFilterParts> & {
+  query?: Lib.Query;
+  column?: Lib.ColumnMetadata;
+};
+
+export function createQueryWithTimeFilter({
+  query = createQuery(),
+  column = findTimeColumn(query),
+  operator = ">",
+  values = [dayjs().startOf("day").toDate()],
+}: TimeFilterOpts = {}) {
+  const clause = Lib.timeFilterClause({ operator, column, values });
+  return createFilteredQuery(query, clause);
+}


### PR DESCRIPTION
Closes #35161

I wanted `FilterPicker` tests to ensure it opens a correct picker for a given column or filter. That meant the `FilterPicker` test suite now needed all the helpers from all the filter widget components. This test extracts these helpers to the `FilterPicker/test-utils` file:

* shared `Metadata` instance with the sample database and a few special columns (boolean, time, etc.)
* column finders like `findBooleanColumn`, `findStringColumn`, etc.
* functions to build queries with different filters (`createQueryWithStringFilter`, `createQueryWithExcludeDateFilter`)

<img width="675" alt="CleanShot 2023-11-02 at 20 05 53@2x" src="https://github.com/metabase/metabase/assets/17258145/b3bbe5f0-aa54-4cea-9d9d-e3d2309bb1be">
