### PR TITLE
[AuditV2] Add Audit deprecation banner

### DIFF
--- a/e2e/test/scenarios/admin-2/auditing/auditing.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/auditing/auditing.cy.spec.js
@@ -45,6 +45,19 @@ function generateDashboards(user) {
   cy.createDashboard({ name: `${user} dashboard` });
 }
 
+describeEE("auditing > Auditv1 deprecation", () => {
+  it("should show an audit deprecation notice", () => {
+    restore();
+    cy.signInAsAdmin();
+    setTokenFeatures("all");
+
+    cy.visit("/admin/audit");
+
+    cy.findByTextEnsureVisible(/metabase analytics collection/i);
+    cy.findByTextEnsureVisible(/will be removed in a future release/i);
+  });
+});
+
 describeEE("audit > auditing", () => {
   const ADMIN_QUESTION = "admin question";
   const ADMIN_DASHBOARD = "admin dashboard";

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditApp.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditApp.jsx
@@ -1,15 +1,75 @@
 /* eslint-disable react/prop-types */
-import fitViewport from "metabase/hoc/FitViewPort";
+import { useMemo } from "react";
+import { jt, t } from "ttag";
 
+import Link from "metabase/core/components/Link";
+import { useCollectionListQuery } from "metabase/common/hooks";
+import { isInstanceAnalyticsCollection } from "metabase/collections/utils";
+import fitViewport from "metabase/hoc/FitViewPort";
+import { Icon } from "metabase/core/components/Icon";
+import { Flex, Box } from "metabase/ui";
 import SidebarLayout from "../components/SidebarLayoutFixedWidth";
 import { AuditSidebar } from "../components/AuditSidebar";
+import { DeprecationNotice } from "./AuditApp.styled";
 
 const Layout = fitViewport(SidebarLayout);
 
+const DeprecationSection = () => {
+  const { data: collections } = useCollectionListQuery();
+
+  const auditCollection = useMemo(
+    () => collections?.find?.(isInstanceAnalyticsCollection),
+    [collections],
+  );
+
+  if (!auditCollection) {
+    return null;
+  }
+
+  return (
+    <DeprecationNotice>
+      <Flex align="center" px="lg" py="md">
+        <Icon name="info_filled" />
+        <Box pl="sm">
+          <Box>
+            {jt`This Audit section has been upgraded to the
+              ${(
+                <Link
+                  variant="brandBold"
+                  key="link"
+                  to={`${window.MetabaseRoot}collection/${auditCollection.id}`}
+                >
+                  {t`Metabase Analytics Collection`}
+                </Link>
+              )}
+               and will be removed in a future release.`}
+          </Box>
+          <Box>
+            {jt`It's now easier to explore and to give others
+              ${(
+                <Link
+                  variant="brandBold"
+                  key="link"
+                  to={`${window.MetabaseRoot}admin/permissions/collections/${auditCollection.id}`}
+                >
+                  {t`access`}
+                </Link>
+              )}
+            to these insights.`}
+          </Box>
+        </Box>
+      </Flex>
+    </DeprecationNotice>
+  );
+};
+
 const AuditApp = ({ children }) => (
-  <Layout sidebar={<AuditSidebar />}>
-    <div>{children}</div>
-  </Layout>
+  <>
+    <DeprecationSection />
+    <Layout sidebar={<AuditSidebar />}>
+      <div>{children}</div>
+    </Layout>
+  </>
 );
 
 export default AuditApp;

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditApp.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditApp.jsx
@@ -37,7 +37,7 @@ const DeprecationSection = () => {
                 <Link
                   variant="brandBold"
                   key="link"
-                  to={`${window.MetabaseRoot}collection/${auditCollection.id}`}
+                  to={`/collection/${auditCollection.id}`}
                 >
                   {t`Metabase Analytics Collection`}
                 </Link>
@@ -50,7 +50,7 @@ const DeprecationSection = () => {
                 <Link
                   variant="brandBold"
                   key="link"
-                  to={`${window.MetabaseRoot}admin/permissions/collections/${auditCollection.id}`}
+                  to={`/admin/permissions/collections/${auditCollection.id}`}
                 >
                   {t`access`}
                 </Link>

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditApp.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditApp.jsx
@@ -28,7 +28,7 @@ const DeprecationSection = () => {
 
   return (
     <DeprecationNotice>
-      <Flex align="center" px="lg" py="md">
+      <Flex align="center" px="xl" py="md">
         <Icon name="info_filled" />
         <Box pl="sm">
           <Box>

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditApp.styled.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditApp.styled.jsx
@@ -1,0 +1,7 @@
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+
+export const DeprecationNotice = styled.div`
+  background-color: ${color("bg-light")};
+  border-bottom: 1px solid ${color("border")};
+`;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/35295

### Description

Add a deprecation notice to the audit app to give people some notice before we remove it.

![Screen Shot 2023-11-02 at 2 48 35 PM](https://github.com/metabase/metabase/assets/30528226/9901519e-6e9e-45d0-8d3c-25eb97793665)


### How to verify

1. Go to the old audit app
2. See helpful banner
3. Make sure links work

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
