### PR TITLE
combo chart goal line

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/goal-line.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/goal-line.ts
@@ -1,0 +1,32 @@
+import type {
+  ComputedVisualizationSettings,
+  RenderingContext,
+} from "metabase/visualizations/types";
+
+export function getGoalLineEChartsSeries(
+  settings: ComputedVisualizationSettings,
+  renderingContext: RenderingContext,
+) {
+  return {
+    type: "line",
+    markLine: {
+      data: [{ name: "goal-line", yAxis: settings["graph.goal_value"] }], // todo, how does this work with normalization?
+      label: {
+        position: "insideEndTop",
+        formatter: () => settings["graph.goal_label"],
+        fontFamily: renderingContext.fontFamily,
+        fontSize: 14,
+        fontWeight: 700,
+        color: renderingContext.getColor("text-medium"),
+        textBorderWidth: 1,
+        textBorderColor: renderingContext.getColor("white"),
+      },
+      symbol: ["none", "none"],
+      lineStyle: {
+        color: renderingContext.getColor("text-medium"),
+        type: [5, 5],
+        width: 2,
+      },
+    },
+  };
+}

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/goal-line.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/goal-line.ts
@@ -10,7 +10,7 @@ export function getGoalLineEChartsSeries(
   return {
     type: "line",
     markLine: {
-      data: [{ name: "goal-line", yAxis: settings["graph.goal_value"] }], // todo, how does this work with normalization?
+      data: [{ name: "goal-line", yAxis: settings["graph.goal_value"] }],
       label: {
         position: "insideEndTop",
         formatter: () => settings["graph.goal_label"],

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/goal-line.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/goal-line.ts
@@ -1,3 +1,4 @@
+import type { RegisteredSeriesOption } from "echarts";
 import type {
   ComputedVisualizationSettings,
   RenderingContext,
@@ -6,14 +7,18 @@ import type {
 export function getGoalLineEChartsSeries(
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
-) {
+): RegisteredSeriesOption["line"] | null {
+  if (!settings["graph.show_goal"]) {
+    return null;
+  }
+
   return {
     type: "line",
     markLine: {
       data: [{ name: "goal-line", yAxis: settings["graph.goal_value"] }],
       label: {
         position: "insideEndTop",
-        formatter: () => settings["graph.goal_label"],
+        formatter: () => settings["graph.goal_label"] ?? "",
         fontFamily: renderingContext.fontFamily,
         fontSize: 14,
         fontWeight: 700,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/goal-line.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/goal-line.ts
@@ -3,21 +3,25 @@ import type {
   ComputedVisualizationSettings,
   RenderingContext,
 } from "metabase/visualizations/types";
+import type { CartesianChartModel } from "../model/types";
 
 export function getGoalLineEChartsSeries(
+  chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
 ): RegisteredSeriesOption["line"] | null {
   if (!settings["graph.show_goal"]) {
     return null;
   }
+  const [_leftAxisKeys, rightAxisKeys] = chartModel.yAxisSplit;
 
   return {
     type: "line",
     markLine: {
       data: [{ name: "goal-line", yAxis: settings["graph.goal_value"] }],
       label: {
-        position: "insideEndTop",
+        position:
+          rightAxisKeys.length === 0 ? "insideEndTop" : "insideStartTop",
         formatter: () => settings["graph.goal_label"] ?? "",
         fontFamily: renderingContext.fontFamily,
         fontSize: 14,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/goal-line.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/goal-line.ts
@@ -5,7 +5,7 @@ import type {
 } from "metabase/visualizations/types";
 import type { CartesianChartModel } from "../model/types";
 
-export function getGoalLineEChartsSeries(
+export function getGoalLineSeriesOption(
   chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -16,7 +16,11 @@ export const getCartesianChartOption = (
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
 ): EChartsOption => {
-  const goalLineSeries = getGoalLineEChartsSeries(settings, renderingContext);
+  const goalLineSeries = getGoalLineEChartsSeries(
+    chartModel,
+    settings,
+    renderingContext,
+  );
   const dataSeries = buildEChartsSeries(chartModel, settings, renderingContext);
 
   const axesFormatters = getAxesFormatters(

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -7,18 +7,17 @@ import type {
 } from "metabase/visualizations/types";
 import { buildAxes } from "metabase/visualizations/echarts/cartesian/option/axis";
 import { getAxesFormatters } from "metabase/visualizations/echarts/cartesian/option/format";
+
 import { getChartGrid } from "./grid";
+import { getGoalLineEChartsSeries } from "./goal-line";
 
 export const getCartesianChartOption = (
   chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
 ): EChartsOption => {
-  const echartsSeries = buildEChartsSeries(
-    chartModel,
-    settings,
-    renderingContext,
-  );
+  const dataSeries = buildEChartsSeries(chartModel, settings, renderingContext);
+  const goalLineSeries = getGoalLineEChartsSeries(settings, renderingContext);
 
   const axesFormatters = getAxesFormatters(
     chartModel,
@@ -37,31 +36,7 @@ export const getCartesianChartOption = (
   return {
     grid: getChartGrid(chartModel, settings),
     dataset: echartsDataset,
-    series: [
-      {
-        type: "line",
-        markLine: {
-          data: [{ name: "goal-line", yAxis: settings["graph.goal_value"] }], // todo, how does this work with normalization?
-          label: {
-            position: "insideEndTop",
-            formatter: () => settings["graph.goal_label"],
-            fontFamily: renderingContext.fontFamily,
-            fontSize: 14,
-            fontWeight: 700,
-            color: renderingContext.getColor("text-medium"),
-            textBorderWidth: 1,
-            textBorderColor: renderingContext.getColor("white"),
-          },
-          symbol: ["none", "none"],
-          lineStyle: {
-            color: renderingContext.getColor("text-medium"),
-            type: [5, 5],
-            width: 2,
-          },
-        },
-      },
-      ...echartsSeries,
-    ],
+    series: [goalLineSeries, ...dataSeries],
     ...buildAxes(chartModel, settings, axesFormatters, renderingContext),
   } as EChartsOption;
 };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -37,7 +37,31 @@ export const getCartesianChartOption = (
   return {
     grid: getChartGrid(chartModel, settings),
     dataset: echartsDataset,
-    series: echartsSeries,
+    series: [
+      {
+        type: "line",
+        markLine: {
+          data: [{ name: "goal-line", yAxis: settings["graph.goal_value"] }], // todo, how does this work with normalization?
+          label: {
+            position: "insideEndTop",
+            formatter: () => settings["graph.goal_label"],
+            fontFamily: renderingContext.fontFamily,
+            fontSize: 14,
+            fontWeight: 700,
+            color: renderingContext.getColor("text-medium"),
+            textBorderWidth: 1,
+            textBorderColor: renderingContext.getColor("white"),
+          },
+          symbol: ["none", "none"],
+          lineStyle: {
+            color: renderingContext.getColor("text-medium"),
+            type: [5, 5],
+            width: 2,
+          },
+        },
+      },
+      ...echartsSeries,
+    ],
     ...buildAxes(chartModel, settings, axesFormatters, renderingContext),
   } as EChartsOption;
 };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -9,19 +9,23 @@ import { buildAxes } from "metabase/visualizations/echarts/cartesian/option/axis
 import { getAxesFormatters } from "metabase/visualizations/echarts/cartesian/option/format";
 
 import { getChartGrid } from "./grid";
-import { getGoalLineEChartsSeries } from "./goal-line";
+import { getGoalLineSeriesOption } from "./goal-line";
 
 export const getCartesianChartOption = (
   chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
 ): EChartsOption => {
-  const goalLineSeries = getGoalLineEChartsSeries(
+  const goalSeriesOption = getGoalLineSeriesOption(
     chartModel,
     settings,
     renderingContext,
   );
-  const dataSeries = buildEChartsSeries(chartModel, settings, renderingContext);
+  const dataSeriesOption = buildEChartsSeries(
+    chartModel,
+    settings,
+    renderingContext,
+  );
 
   const axesFormatters = getAxesFormatters(
     chartModel,
@@ -40,7 +44,9 @@ export const getCartesianChartOption = (
   return {
     grid: getChartGrid(chartModel, settings),
     dataset: echartsDataset,
-    series: goalLineSeries ? [goalLineSeries, ...dataSeries] : dataSeries,
+    series: goalSeriesOption
+      ? [goalSeriesOption, ...dataSeriesOption]
+      : dataSeriesOption,
     ...buildAxes(chartModel, settings, axesFormatters, renderingContext),
   } as EChartsOption;
 };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -16,8 +16,8 @@ export const getCartesianChartOption = (
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
 ): EChartsOption => {
-  const dataSeries = buildEChartsSeries(chartModel, settings, renderingContext);
   const goalLineSeries = getGoalLineEChartsSeries(settings, renderingContext);
+  const dataSeries = buildEChartsSeries(chartModel, settings, renderingContext);
 
   const axesFormatters = getAxesFormatters(
     chartModel,
@@ -36,7 +36,7 @@ export const getCartesianChartOption = (
   return {
     grid: getChartGrid(chartModel, settings),
     dataset: echartsDataset,
-    series: [goalLineSeries, ...dataSeries],
+    series: goalLineSeries ? [goalLineSeries, ...dataSeries] : dataSeries,
     ...buildAxes(chartModel, settings, axesFormatters, renderingContext),
   } as EChartsOption;
 };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -1,4 +1,4 @@
-import type { EChartsOption, RegisteredSeriesOption } from "echarts";
+import type { RegisteredSeriesOption } from "echarts";
 import type { SeriesLabelOption } from "echarts/types/src/util/types";
 import type {
   SeriesModel,
@@ -143,7 +143,7 @@ export const buildEChartsSeries = (
   chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
-): EChartsOption["series"] => {
+): (RegisteredSeriesOption["line"] | RegisteredSeriesOption["bar"])[] => {
   const seriesSettingsByDataKey = chartModel.seriesModels.reduce(
     (acc, seriesModel) => {
       acc[seriesModel.dataKey] = settings.series(


### PR DESCRIPTION
Part of https://github.com/metabase/metabase/issues/34672

### Description

Implements the goal line setting for the echarts combo chart.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create any line, area, bar, or combo chart
2. In viz settings, add a goal line
3. Add the chart to a dashboard, send it in a subscription

### Demo

![Screenshot 2023-11-02 at 7.14.55 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/599cd094-e32b-4594-9910-d620a2b852d7.png)


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

Can test with Percy later