### PR TITLE
Fix calling API more than necessary

### DIFF
--- a/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.unit.spec.tsx
@@ -1,0 +1,57 @@
+import fetchMock from "fetch-mock";
+import {
+  createMockCard,
+  createMockCollection,
+  createMockCollectionItem,
+  createMockDataset,
+} from "metabase-types/api/mocks";
+import { ROOT_COLLECTION } from "metabase/entities/collections";
+import {
+  setupCardEndpoints,
+  setupCardQueryEndpoints,
+} from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import registerVisualizations from "metabase/visualizations/register";
+import { createMockState } from "metabase-types/store/mocks";
+import { createMockEntitiesState } from "__support__/store";
+import PinnedQuestionCard from "./PinnedQuestionCard";
+
+registerVisualizations();
+
+function setup() {
+  const card = createMockCard({
+    id: 1,
+  });
+  const collectionItem = createMockCollectionItem({
+    id: card.id,
+    type: "card",
+    collection_preview: true,
+  });
+  setupCardEndpoints(card);
+  setupCardQueryEndpoints(card, createMockDataset());
+  renderWithProviders(
+    <PinnedQuestionCard
+      item={collectionItem}
+      collection={createMockCollection(ROOT_COLLECTION)}
+      onCopy={jest.fn()}
+      onMove={jest.fn()}
+    />,
+    {
+      storeInitialState: createMockState({
+        entities: createMockEntitiesState({
+          questions: [card],
+        }),
+      }),
+    },
+  );
+}
+
+describe("PinnedQuestionCard", () => {
+  it("should render query card once", async () => {
+    setup();
+
+    expect(await screen.findByTestId("visualization-root")).toBeInTheDocument();
+
+    expect(fetchMock.calls("path:/api/card/1/query")).toHaveLength(1);
+  });
+});

--- a/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.unit.spec.tsx
@@ -47,7 +47,7 @@ function setup() {
 }
 
 describe("PinnedQuestionCard", () => {
-  it("should render query card once", async () => {
+  it("should render query card once (metabase#25848)", async () => {
     setup();
 
     expect(await screen.findByTestId("visualization-root")).toBeInTheDocument();

--- a/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionLoader.tsx
+++ b/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionLoader.tsx
@@ -41,10 +41,11 @@ const PinnedQuestionLoader = ({
 
   return (
     <Questions.Loader id={id} loadingAndErrorWrapper={false}>
-      {({
-        loading: questionLoading,
-        question: loadedQuestion,
-      }: QuestionLoaderProps) => {
+      {({ loading, question: loadedQuestion }: QuestionLoaderProps) => {
+        if (loading !== false || !loadedQuestion.query()) {
+          return children({ loading: true });
+        }
+
         const question = questionRef.current ?? loadedQuestion;
         questionRef.current = question;
 
@@ -59,7 +60,7 @@ const PinnedQuestionLoader = ({
             }: QuestionResultLoaderProps) =>
               children({
                 question,
-                loading: questionLoading || loading || results == null,
+                loading: loading || results == null,
                 rawSeries: getRawSeries(rawSeries),
                 error: getError(error, result),
                 errorIcon: getErrorIcon(error, result),

--- a/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionLoader.tsx
+++ b/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionLoader.tsx
@@ -41,11 +41,10 @@ const PinnedQuestionLoader = ({
 
   return (
     <Questions.Loader id={id} loadingAndErrorWrapper={false}>
-      {({ loading, question: loadedQuestion }: QuestionLoaderProps) => {
-        if (loading || !loadedQuestion.query()) {
-          return children({ loading: true });
-        }
-
+      {({
+        loading: questionLoading,
+        question: loadedQuestion,
+      }: QuestionLoaderProps) => {
         const question = questionRef.current ?? loadedQuestion;
         questionRef.current = question;
 
@@ -60,7 +59,7 @@ const PinnedQuestionLoader = ({
             }: QuestionResultLoaderProps) =>
               children({
                 question,
-                loading: loading || results == null,
+                loading: questionLoading || loading || results == null,
                 rawSeries: getRawSeries(rawSeries),
                 error: getError(error, result),
                 errorIcon: getErrorIcon(error, result),


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/25848

[Slack discussion](https://metaboat.slack.com/archives/C505ZNNH4/p1698968942243609)

This ensure we don't render `QuestionResultLoader` and then unrender and render it again causing `POST /api/card/:id/query` to be called 2 times

#### To reproduce

1. Go to a collection view that has any question that can be visible when pinned
1. Refresh the page to clear the cache
1. Pin a question
1. Observe that there's only 1 `POST /api/card/:id/query`
