### PR TITLE
Fix - Text weirdly wrapped in column dropdown in Polish language

### DIFF
--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.styled.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.styled.tsx
@@ -32,6 +32,7 @@ export const ColumnPickerHeaderTitle = styled.span`
 `;
 
 export const InfoIconContainer = styled.div`
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.styled.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.styled.tsx
@@ -32,7 +32,6 @@ export const ColumnPickerHeaderTitle = styled.span`
 `;
 
 export const InfoIconContainer = styled.div`
-  flex: 0 0 auto;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.styled.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.styled.tsx
@@ -1,17 +1,22 @@
 import styled from "@emotion/styled";
 import Button from "metabase/core/components/Button";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import { Icon } from "metabase/core/components/Icon";
 import BaseSelectList from "metabase/components/SelectList";
 import { alpha, color } from "metabase/lib/colors";
 import type { ColorName } from "metabase/lib/colors/types";
 
+export const TriggerContent = styled(Ellipsified)``;
+
 export const TriggerIcon = styled(Icon)`
   color: ${color("white")} !important;
+  flex: 0 0 auto;
 `;
 
 export const TriggerButton = styled.button`
   display: flex;
   align-items: center;
+  min-width: 1px;
   gap: 0.5rem;
 
   color: ${alpha(color("white"), 0.5)};

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.styled.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.styled.tsx
@@ -16,7 +16,7 @@ export const TriggerIcon = styled(Icon)`
 export const TriggerButton = styled.button`
   display: flex;
   align-items: center;
-  min-width: 1px;
+  min-width: 0;
   gap: 0.5rem;
 
   color: ${alpha(color("white"), 0.5)};

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.styled.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.styled.tsx
@@ -17,6 +17,7 @@ export const TriggerButton = styled.button`
   display: flex;
   align-items: center;
   min-width: 0;
+  max-width: 50%;
   gap: 0.5rem;
 
   color: ${alpha(color("white"), 0.5)};

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.styled.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.styled.tsx
@@ -1,12 +1,9 @@
 import styled from "@emotion/styled";
 import Button from "metabase/core/components/Button";
-import { Ellipsified } from "metabase/core/components/Ellipsified";
 import { Icon } from "metabase/core/components/Icon";
 import BaseSelectList from "metabase/components/SelectList";
 import { alpha, color } from "metabase/lib/colors";
 import type { ColorName } from "metabase/lib/colors/types";
-
-export const TriggerContent = styled(Ellipsified)``;
 
 export const TriggerIcon = styled(Icon)`
   color: ${color("white")} !important;

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 import SelectList from "metabase/components/SelectList";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import type { ColorName } from "metabase/lib/colors/types";
 import * as Lib from "metabase-lib";
 import {
@@ -11,7 +12,6 @@ import {
   TriggerButton,
   TriggerIcon,
   SelectListItem,
-  TriggerContent,
 } from "./BaseBucketPickerPopover.styled";
 
 export const INITIALLY_VISIBLE_ITEMS_COUNT = 7;
@@ -95,9 +95,9 @@ function _BaseBucketPickerPopover({
           // Prefer using a11y role selectors
           data-testid="dimension-list-item-binning"
         >
-          <TriggerContent>
+          <Ellipsified>
             {renderTriggerContent(triggerContentBucketDisplayInfo)}
-          </TriggerContent>
+          </Ellipsified>
           {hasArrowIcon && <TriggerIcon name="chevronright" />}
         </TriggerButton>
       )}

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 import SelectList from "metabase/components/SelectList";
@@ -31,7 +32,7 @@ export interface BaseBucketPickerPopoverProps {
   hasArrowIcon?: boolean;
   color?: ColorName;
   checkBucketIsSelected: (item: BucketListItem) => boolean;
-  renderTriggerContent: (bucket?: Lib.BucketDisplayInfo) => void;
+  renderTriggerContent: (bucket?: Lib.BucketDisplayInfo) => ReactNode;
   onSelect: (column: Lib.Bucket | NoBucket) => void;
 }
 

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
@@ -10,6 +10,7 @@ import {
   TriggerButton,
   TriggerIcon,
   SelectListItem,
+  TriggerContent,
 } from "./BaseBucketPickerPopover.styled";
 
 export const INITIALLY_VISIBLE_ITEMS_COUNT = 7;
@@ -93,7 +94,9 @@ function _BaseBucketPickerPopover({
           // Prefer using a11y role selectors
           data-testid="dimension-list-item-binning"
         >
-          {renderTriggerContent(triggerContentBucketDisplayInfo)}
+          <TriggerContent>
+            {renderTriggerContent(triggerContentBucketDisplayInfo)}
+          </TriggerContent>
           {hasArrowIcon && <TriggerIcon name="chevronright" />}
         </TriggerButton>
       )}

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
@@ -9,7 +9,11 @@ import { Icon } from "metabase/core/components/Icon";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 import ListSearchField from "metabase/components/ListSearchField";
 import { Box } from "metabase/ui";
-import { ListCellItem, FilterContainer } from "./AccordionListCell.styled";
+import {
+  ListCellItem,
+  FilterContainer,
+  Content,
+} from "./AccordionListCell.styled";
 
 export const AccordionListCell = ({
   style,
@@ -141,11 +145,8 @@ export const AccordionListCell = ({
         )}
         style={getItemStyles(item, itemIndex)}
       >
-        <span
-          className={cx(
-            "p1 flex-auto flex align-center",
-            isClickable ? "cursor-pointer" : "cursor-default",
-          )}
+        <Content
+          isClickable={isClickable}
           onClick={isClickable ? () => onChange(item) : undefined}
         >
           {icon && (
@@ -166,7 +167,7 @@ export const AccordionListCell = ({
               <LoadingSpinner size={16} borderWidth={2} />
             </Box>
           )}
-        </span>
+        </Content>
         {extra}
         {showItemArrows && (
           <div className="List-item-arrow flex align-center px1">

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.styled.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.styled.tsx
@@ -14,9 +14,9 @@ export const FilterContainer = styled.div`
 `;
 
 export const Content = styled.div<{ isClickable: boolean }>`
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
-  flex: auto;
   padding: 0.5rem;
   cursor: ${props => (props.isClickable ? "pointer" : "default")};
 `;

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.styled.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.styled.tsx
@@ -14,7 +14,7 @@ export const FilterContainer = styled.div`
 `;
 
 export const Content = styled.div<{ isClickable: boolean }>`
-  flex: 0 0 auto;
+  flex: 1 0 auto;
   display: flex;
   align-items: center;
   padding: 0.5rem;

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.styled.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.styled.tsx
@@ -14,7 +14,7 @@ export const FilterContainer = styled.div`
 `;
 
 export const Content = styled.div<{ isClickable: boolean }>`
-  flex: 1 0 auto;
+  flex: 1 1 auto;
   display: flex;
   align-items: center;
   padding: 0.5rem;

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.styled.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.styled.tsx
@@ -12,3 +12,11 @@ export const ListCellItem = styled.div<ListCellItemProps>`
 export const FilterContainer = styled.div`
   padding: 0.5rem;
 `;
+
+export const Content = styled.div<{ isClickable: boolean }>`
+  display: flex;
+  align-items: center;
+  flex: auto;
+  padding: 0.5rem;
+  cursor: ${props => (props.isClickable ? "pointer" : "default")};
+`;


### PR DESCRIPTION
Closes #35047

### Description

Screenshots:
- real labels: [before](https://github.com/metabase/metabase/assets/6830683/3a1fe0b3-a1c8-41cd-aa68-6887b8a52bd7) & [after](https://github.com/metabase/metabase/assets/6830683/e9e6cdf8-f2f5-4619-bb17-ac59749361af)
- artificially long labels: [before](https://github.com/metabase/metabase/assets/6830683/1ee19e33-aef4-42fb-b440-43ffd4713934) & [after](https://github.com/metabase/metabase/assets/6830683/c60593d4-5f59-4883-ba2d-a9d3ec3871e9)
- English: [before](https://github.com/metabase/metabase/assets/6830683/d35ed160-af5a-4fcb-9a62-3800365fe0c6) & [after](https://github.com/metabase/metabase/assets/6830683/6d6303d3-7516-4285-8eb3-6027f5ca40ec) (identical, no change)

### How to verify

1. Switch app language to Polish
2. Create a new GUI question
3. Select Orders table from Sample Database as data source
4. Aggregate by rows count
5. Open breakout column dropdown

All dropdown menu items representing columns should have the same height (but they should wrap into multiple lines if they are in fact very long - this does not happen in the above testing scenario though).
Words in dropdown menu items should not be broken into multiple lines.