### PR TITLE
Manual backport - Fix - Custom expression that has a name consisting only of whitespace breaks the question (#33855)

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.tsx
@@ -62,7 +62,7 @@ export const ExpressionWidget = (props: ExpressionWidgetProps): JSX.Element => {
 
   const helpTextTargetRef = useRef(null);
 
-  const isValidName = withName ? !!name : true;
+  const isValidName = withName ? name.trim().length > 0 : true;
   const isValidExpression = !!expression && isExpression(expression);
 
   const isValid = !error && isValidName && isValidExpression;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.unit.spec.tsx
@@ -100,6 +100,9 @@ describe("ExpressionWidget", () => {
       const { onChangeExpression } = setup({ expression, withName: true });
 
       const doneButton = screen.getByRole("button", { name: "Done" });
+      const expressionNameInput = screen.getByPlaceholderText(
+        "Something nice and descriptive",
+      );
 
       expect(doneButton).toBeDisabled();
 
@@ -108,9 +111,23 @@ describe("ExpressionWidget", () => {
       // enter in expression editor should not trigger "onChangeExpression" as popover is not valid with empty "name"
       expect(onChangeExpression).toHaveBeenCalledTimes(0);
 
+      // The name must not be empty
+      userEvent.type(expressionNameInput, "");
+      expect(doneButton).toBeDisabled();
+
+      // The name must not consist of spaces or tabs only.
+      userEvent.type(expressionNameInput, " ");
+      expect(doneButton).toBeDisabled();
+      userEvent.type(expressionNameInput, "\t");
+      expect(doneButton).toBeDisabled();
+      userEvent.type(expressionNameInput, "  \t\t");
+      expect(doneButton).toBeDisabled();
+
+      userEvent.clear(expressionNameInput);
+
       userEvent.type(
-        screen.getByPlaceholderText("Something nice and descriptive"),
-        "some name",
+        expressionNameInput,
+        "Some n_am!e 2q$w&YzT(6i~#sLXv7+HjP}Ku1|9c*RlF@4o5N=e8;G*-bZ3/U0:Qa'V,t(W-_D",
       );
 
       expect(doneButton).toBeEnabled();
@@ -118,7 +135,10 @@ describe("ExpressionWidget", () => {
       userEvent.click(doneButton);
 
       expect(onChangeExpression).toHaveBeenCalledTimes(1);
-      expect(onChangeExpression).toHaveBeenCalledWith("some name", expression);
+      expect(onChangeExpression).toHaveBeenCalledWith(
+        "Some n_am!e 2q$w&YzT(6i~#sLXv7+HjP}Ku1|9c*RlF@4o5N=e8;G*-bZ3/U0:Qa'V,t(W-_D",
+        expression,
+      );
     });
   });
 });


### PR DESCRIPTION
Manual backport of #33855 (which is a external contribution fix for #32571)

Just cherry-picking the squashed commit from `master`.