### PR TITLE
[MLv2] Filters — Fix failing tests

### DIFF
--- a/e2e/test/scenarios/question/reproductions/34414-populate-field-values.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/34414-populate-field-values.cy.spec.js
@@ -43,7 +43,7 @@ describe("issue 34414", () => {
       assertPlanFieldValues();
 
       cy.log("Open filter again");
-      cy.findByTestId("sidebar-header-title").click();
+      cy.findByLabelText("Back").click();
 
       cy.log("Open plan field again");
       cy.findByText("Plan").click();

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -363,7 +363,7 @@ class StructuredQuery extends AtomicQuery {
   /**
    * Removes invalid clauses from the query (and source-query, recursively)
    */
-  clean(): StructuredQuery {
+  clean({ skipFilters = false } = {}): StructuredQuery {
     if (!this.hasMetadata()) {
       console.warn("Warning: can't clean query without metadata!");
       return this;
@@ -377,12 +377,13 @@ class StructuredQuery extends AtomicQuery {
       query = query.setSourceQuery(sourceQuery.clean());
     }
 
-    return query
-      .cleanJoins()
-      .cleanExpressions()
-      .cleanFilters()
-      .cleanFields()
-      .cleanEmpty();
+    query = query.cleanJoins().cleanExpressions().cleanFields().cleanEmpty();
+
+    if (!skipFilters) {
+      query = query.cleanFilters();
+    }
+
+    return query;
   }
 
   /**

--- a/frontend/src/metabase-lib/queries/structured/Filter.ts
+++ b/frontend/src/metabase-lib/queries/structured/Filter.ts
@@ -128,20 +128,17 @@ export default class Filter extends MBQLClause {
       // has an operator name and dimension or expression
       const dimension = this.dimension().getMLv1CompatibleDimension();
 
-      if (!dimension) {
-        return isExpression(this[1]);
+      if (!dimension && isExpression(this[1])) {
+        return true;
       }
 
       const query = this.query();
-      const dimensionOptions = query.filterDimensionOptions();
 
-      if (query && !dimensionOptions.hasDimension(dimension)) {
-        const dimensions = dimensionOptions.all();
-
-        // workaround for https://github.com/metabase/metabase/issues/29763
-        if (!dimensions.some(d => d.columnName() === dimension.columnName())) {
-          return false;
-        }
+      if (
+        !dimension ||
+        !(query && query.filterDimensionOptions().hasDimension(dimension))
+      ) {
+        return false;
       }
 
       if (!this.operatorName()) {

--- a/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
@@ -56,7 +56,7 @@ const Notebook = ({ className, updateQuestion, ...props }: NotebookProps) => {
 
     // MLv2 doesn't clean up redundant stages, so we do it with MLv1 for now
     const query = cleanQuestion.query() as StructuredQuery;
-    cleanQuestion = cleanQuestion.setQuery(query.clean());
+    cleanQuestion = cleanQuestion.setQuery(query.clean({ skipFilters: true }));
 
     if (cleanQuestion.display() === "table") {
       cleanQuestion = cleanQuestion.setDefaultDisplay();


### PR DESCRIPTION
Fixes two failing tests on the MLv2 filters milestone branch. One test was using old filter popover's test IDs. The other seems to be relying on MLv1 filter validation that was removed in #35323. This PR brings it back, but disables it in the notebook editor