### PR TITLE
Drop dead code of the dashboard filters stickiness calculation

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -58,10 +58,9 @@ class Dashboard extends Component {
   }
 
   async componentDidUpdate(prevProps) {
-    updateParametersWidgetStickiness(this);
-
     if (prevProps.dashboardId !== this.props.dashboardId) {
       await this.loadDashboard(this.props.dashboardId);
+      updateParametersWidgetStickiness(this);
       return;
     }
 
@@ -212,7 +211,6 @@ class Dashboard extends Component {
       parameters,
       parameterValues,
       draftParameterValues,
-      isNavbarOpen,
       editingParameter,
       setParameterValue,
       setParameterIndex,
@@ -271,7 +269,6 @@ class Dashboard extends Component {
               >
                 <DashboardHeader
                   {...this.props}
-                  isNavbarOpen={isNavbarOpen}
                   onEditingChange={this.setEditing}
                   setDashboardAttribute={this.setDashboardAttribute}
                   addParameter={addParameter}

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -58,9 +58,10 @@ class Dashboard extends Component {
   }
 
   async componentDidUpdate(prevProps) {
+    updateParametersWidgetStickiness(this);
+
     if (prevProps.dashboardId !== this.props.dashboardId) {
       await this.loadDashboard(this.props.dashboardId);
-      updateParametersWidgetStickiness(this);
       return;
     }
 

--- a/frontend/src/metabase/dashboard/components/Dashboard/stickyParameters.js
+++ b/frontend/src/metabase/dashboard/components/Dashboard/stickyParameters.js
@@ -2,13 +2,7 @@ import { isSmallScreen } from "metabase/lib/dom";
 
 export const MAXIMUM_PARAMETERS_FOR_STICKINESS = 5;
 
-const checkIfParametersWidgetShouldBeSticky = dashboard =>
-  !(
-    dashboard.state.parametersListLength > MAXIMUM_PARAMETERS_FOR_STICKINESS &&
-    isSmallScreen()
-  );
-
-// Dashboard Filters should always be sticky, except the case with small screen:
+// Dashboard filters container should always be sticky, except the case with small screen:
 // if more than MAXIMUM_PARAMETERS_FOR_STICKINESS parameters exist, we do not stick them to avoid
 // taking to much space on the screen
 export const updateParametersWidgetStickiness = dashboard => {
@@ -22,3 +16,9 @@ export const updateParametersWidgetStickiness = dashboard => {
     });
   }
 };
+
+const checkIfParametersWidgetShouldBeSticky = dashboard =>
+  !(
+    dashboard.state.parametersListLength > MAXIMUM_PARAMETERS_FOR_STICKINESS &&
+    isSmallScreen()
+  );

--- a/frontend/src/metabase/dashboard/components/Dashboard/stickyParameters.js
+++ b/frontend/src/metabase/dashboard/components/Dashboard/stickyParameters.js
@@ -2,6 +2,12 @@ import { isSmallScreen } from "metabase/lib/dom";
 
 export const MAXIMUM_PARAMETERS_FOR_STICKINESS = 5;
 
+const checkIfParametersWidgetShouldBeSticky = dashboard =>
+  !(
+    dashboard.state.parametersListLength > MAXIMUM_PARAMETERS_FOR_STICKINESS &&
+    isSmallScreen()
+  );
+
 // Dashboard Filters should always be sticky, except the case with small screen:
 // if more than MAXIMUM_PARAMETERS_FOR_STICKINESS parameters exist, we do not stick them to avoid
 // taking to much space on the screen
@@ -16,9 +22,3 @@ export const updateParametersWidgetStickiness = dashboard => {
     });
   }
 };
-
-const checkIfParametersWidgetShouldBeSticky = dashboard =>
-  !(
-    dashboard.state.parametersListLength > MAXIMUM_PARAMETERS_FOR_STICKINESS &&
-    isSmallScreen()
-  );

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.jsx
@@ -554,6 +554,7 @@ class DashboardHeaderContainer extends Component {
       collection,
       isEditing,
       isFullscreen,
+      isNavBarOpen,
       isAdditionalInfoVisible,
       setDashboardAttribute,
       setSidebar,
@@ -577,7 +578,7 @@ class DashboardHeaderContainer extends Component {
           }
           isLastEditInfoVisible={hasLastEditInfo && isAdditionalInfoVisible}
           isEditingInfo={isEditing}
-          isNavBarOpen={this.props.isNavBarOpen}
+          isNavBarOpen={isNavBarOpen}
           headerButtons={this.getHeaderButtons()}
           editWarning={this.getEditWarning(dashboard)}
           editingTitle={t`You're editing this dashboard.`.concat(

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.jsx
@@ -25,8 +25,6 @@ import {
   getUserIsAdmin,
 } from "metabase/selectors/user";
 
-import { getEmbedOptions } from "metabase/selectors/embed";
-
 import { parseHashOptions } from "metabase/lib/browser";
 import * as Urls from "metabase/lib/urls";
 
@@ -103,7 +101,6 @@ const mapStateToProps = state => {
     isLoadingComplete: getIsLoadingComplete(state),
     isHeaderVisible: getIsHeaderVisible(state),
     isAdditionalInfoVisible: getIsAdditionalInfoVisible(state),
-    embedOptions: getEmbedOptions(state),
     selectedTabId: getSelectedTabId(state),
     isAutoApplyFilters: getIsAutoApplyFilters(state),
     isNavigatingBackToDashboard: getIsNavigatingBackToDashboard(state),


### PR DESCRIPTION
### Description

Follow up of https://github.com/metabase/metabase/pull/35333

### How to verify

Filters container on dashboard should be sticky always, except when it's mobile and 6+ filters added.

Dropped code was a leftover after moving from js solution to css


### Checklist

~- [ ] Tests have been added/updated to cover changes in this PR~
