### PR TITLE
Fix wrongly mocked collection item key

### DIFF
--- a/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.unit.spec.tsx
@@ -24,7 +24,7 @@ function setup() {
   });
   const collectionItem = createMockCollectionItem({
     id: card.id,
-    type: "card",
+    model: "card",
     collection_preview: true,
   });
   setupCardEndpoints(card);


### PR DESCRIPTION
This is a follow up from https://github.com/metabase/metabase/pull/35346.

That PR basically mock the wrong key, although `model` is already defaulted to `card` when called with `createMockCollectionItem`, so it makes no differenc behavior-wise.

This shouldn't be backported since I fixed this problem [on the backport PR itself.](https://github.com/metabase/metabase/pull/35361/commits/5e5d4de3d0485a517c27d0f5605ceadc113f53aa)