### PR TITLE
feat: use name of card in undo toast message

### DIFF
--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -130,6 +130,12 @@ describe("scenarios > dashboard > tabs", () => {
       cy.findAllByTestId("toast-undo").should("have.length", 2);
       getDashboardCards().should("have.length", 0);
 
+      cy.log("should show undo toast with the correct text");
+      cy.findByTestId("undo-list").within(() => {
+        cy.findByText("Text card moved").should("be.visible");
+        cy.findByText("Card moved: Orders").should("be.visible");
+      });
+
       cy.log("cards should be in second tab");
       goToTab("Tab 2");
       getDashboardCards().should("have.length", 2);

--- a/frontend/src/metabase/containers/UndoListing.jsx
+++ b/frontend/src/metabase/containers/UndoListing.jsx
@@ -9,14 +9,15 @@ import { dismissUndo, performUndo } from "metabase/redux/undo";
 import BodyComponent from "metabase/components/BodyComponent";
 
 import { isReducedMotionPreferred } from "metabase/lib/dom";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import {
   CardContent,
   CardContentSide,
   CardIcon,
+  ControlsCardContent,
   DefaultText,
   DismissIcon,
   ToastCard,
-  TruncatedText,
   UndoButton,
   UndoList,
 } from "./UndoListing.styled";
@@ -68,9 +69,9 @@ function UndoToast({ undo, onUndo, onDismiss }) {
           <CardContent>
             <CardContentSide>
               {undo.icon && <CardIcon name={undo.icon} color="white" />}
-              <TruncatedText>{renderMessage(undo)}</TruncatedText>
+              <Ellipsified>{renderMessage(undo)}</Ellipsified>
             </CardContentSide>
-            <CardContentSide>
+            <ControlsCardContent>
               {undo.actions?.length > 0 && (
                 <UndoButton role="button" onClick={onUndo}>
                   {undo.actionLabel ?? t`Undo`}
@@ -79,7 +80,7 @@ function UndoToast({ undo, onUndo, onDismiss }) {
               {undo.canDismiss && (
                 <DismissIcon name="close" onClick={onDismiss} />
               )}
-            </CardContentSide>
+            </ControlsCardContent>
           </CardContent>
         </ToastCard>
       )}

--- a/frontend/src/metabase/containers/UndoListing.jsx
+++ b/frontend/src/metabase/containers/UndoListing.jsx
@@ -16,6 +16,7 @@ import {
   DefaultText,
   DismissIcon,
   ToastCard,
+  TruncatedText,
   UndoButton,
   UndoList,
 } from "./UndoListing.styled";
@@ -67,7 +68,7 @@ function UndoToast({ undo, onUndo, onDismiss }) {
           <CardContent>
             <CardContentSide>
               {undo.icon && <CardIcon name={undo.icon} color="white" />}
-              {renderMessage(undo)}
+              <TruncatedText>{renderMessage(undo)}</TruncatedText>
             </CardContentSide>
             <CardContentSide>
               {undo.actions?.length > 0 && (
@@ -85,7 +86,6 @@ function UndoToast({ undo, onUndo, onDismiss }) {
     </Motion>
   );
 }
-
 function UndoListingInner() {
   const dispatch = useDispatch();
   const undos = useSelector(state => state.undo);

--- a/frontend/src/metabase/containers/UndoListing.jsx
+++ b/frontend/src/metabase/containers/UndoListing.jsx
@@ -67,9 +67,11 @@ function UndoToast({ undo, onUndo, onDismiss }) {
           role="status"
         >
           <CardContent>
-            <CardContentSide>
+            <CardContentSide maw="75ch">
               {undo.icon && <CardIcon name={undo.icon} color="white" />}
-              <Ellipsified>{renderMessage(undo)}</Ellipsified>
+              <Ellipsified showTooltip={false}>
+                {renderMessage(undo)}
+              </Ellipsified>
             </CardContentSide>
             <ControlsCardContent>
               {undo.actions?.length > 0 && (

--- a/frontend/src/metabase/containers/UndoListing.styled.tsx
+++ b/frontend/src/metabase/containers/UndoListing.styled.tsx
@@ -1,4 +1,6 @@
 import styled from "@emotion/styled";
+import type { BoxProps } from "metabase/ui";
+import { Box } from "metabase/ui";
 import Card from "metabase/components/Card";
 import { Icon } from "metabase/core/components/Icon";
 import Link from "metabase/core/components/Link";
@@ -13,6 +15,9 @@ export const UndoList = styled.ul`
   bottom: 0;
   margin: ${LIST_H_MARGINS};
   z-index: 999;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
 `;
 
 export const ToastCard = styled(Card)<{
@@ -33,7 +38,7 @@ export const CardContent = styled.div`
   justify-content: space-between;
 `;
 
-export const CardContentSide = styled.div`
+export const CardContentSide = styled(Box)<BoxProps>`
   display: flex;
   align-items: center;
   overflow: hidden;

--- a/frontend/src/metabase/containers/UndoListing.styled.tsx
+++ b/frontend/src/metabase/containers/UndoListing.styled.tsx
@@ -5,11 +5,13 @@ import Link from "metabase/core/components/Link";
 import { alpha, color, lighten } from "metabase/lib/colors";
 import { space } from "metabase/styled-components/theme";
 
+const LIST_H_MARGINS = space(2);
+
 export const UndoList = styled.ul`
   position: fixed;
   left: 0;
   bottom: 0;
-  margin: ${space(2)};
+  margin: ${LIST_H_MARGINS};
   z-index: 999;
 `;
 
@@ -20,6 +22,7 @@ export const ToastCard = styled(Card)<{
   padding: 10px ${space(2)};
   margin-top: ${space(1)};
   min-width: 310px;
+  max-width: calc(100vw - ${LIST_H_MARGINS} - ${LIST_H_MARGINS});
   transform: ${props => `translateY(${props.translateY}px)`};
   ${props => (props.color ? `background-color: ${color(props.color)}` : "")}
 `;
@@ -33,18 +36,16 @@ export const CardContent = styled.div`
 export const CardContentSide = styled.div`
   display: flex;
   align-items: center;
+  overflow: hidden;
 `;
 
-export const TruncatedText = styled.div`
-  max-width: 75ch;
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-line-clamp: 1;
-  -webkit-box-orient: vertical;
+export const ControlsCardContent = styled(CardContentSide)`
+  flex-shrink: 0;
 `;
 
 export const CardIcon = styled(Icon)`
   margin-right: ${space(1)};
+  flex-shrink: 0;
 `;
 
 export const DefaultText = styled.span`

--- a/frontend/src/metabase/containers/UndoListing.styled.tsx
+++ b/frontend/src/metabase/containers/UndoListing.styled.tsx
@@ -35,6 +35,14 @@ export const CardContentSide = styled.div`
   align-items: center;
 `;
 
+export const TruncatedText = styled.div`
+  max-width: 75ch;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+`;
+
 export const CardIcon = styled(Icon)`
   margin-right: ${space(1)};
 `;

--- a/frontend/src/metabase/containers/UndoListing.styled.tsx
+++ b/frontend/src/metabase/containers/UndoListing.styled.tsx
@@ -27,7 +27,7 @@ export const ToastCard = styled(Card)<{
   padding: 10px ${space(2)};
   margin-top: ${space(1)};
   min-width: 310px;
-  max-width: calc(100vw - ${LIST_H_MARGINS} - ${LIST_H_MARGINS});
+  max-width: calc(100vw - 2 * ${LIST_H_MARGINS});
   transform: ${props => `translateY(${props.translateY}px)`};
   ${props => (props.color ? `background-color: ${color(props.color)}` : "")}
 `;

--- a/frontend/src/metabase/dashboard/actions/tabs.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.ts
@@ -23,7 +23,7 @@ import { addUndo } from "metabase/redux/undo";
 import { INITIAL_DASHBOARD_STATE } from "../constants";
 import { getDashCardById } from "../selectors";
 import { trackCardMoved } from "../analytics";
-import { getExistingDashCards } from "./utils";
+import { getDashCardMoveToTabUndoMessage, getExistingDashCards } from "./utils";
 
 type CreateNewTabPayload = { tabId: DashboardTabId };
 type DeleteTabPayload = {
@@ -112,7 +112,7 @@ export const moveDashCardToTab =
 
     dispatch(
       addUndo({
-        message: t`Card moved`,
+        message: getDashCardMoveToTabUndoMessage(dashCard),
         undo: true,
         action: () => {
           dispatch(

--- a/frontend/src/metabase/dashboard/actions/utils.ts
+++ b/frontend/src/metabase/dashboard/actions/utils.ts
@@ -1,7 +1,9 @@
 import _ from "underscore";
 
 import type { Draft } from "@reduxjs/toolkit";
-import type { DashboardState } from "metabase-types/store";
+import { t } from "ttag";
+import { truncate } from "humanize-plus";
+import type { DashboardState, StoreDashcard } from "metabase-types/store";
 import type {
   Dashboard,
   DashboardId,
@@ -57,3 +59,25 @@ export function haveDashboardCardsChanged(
     )
   );
 }
+
+export const getDashCardMoveToTabUndoMessage = (dashCard: StoreDashcard) => {
+  const virtualCardType =
+    dashCard.visualization_settings?.virtual_card?.display;
+
+  if (dashCard.card.name) {
+    return truncate(t`Card moved: ${dashCard.card.name}`, 75);
+  }
+
+  switch (virtualCardType) {
+    case "action":
+      return t`Action card moved`;
+    case "text":
+      return t`Text card moved`;
+    case "heading":
+      return t`Heading card moved`;
+    case "link":
+      return t`Link card moved`;
+    default:
+      return t`Card moved`;
+  }
+};

--- a/frontend/src/metabase/dashboard/actions/utils.ts
+++ b/frontend/src/metabase/dashboard/actions/utils.ts
@@ -2,7 +2,6 @@ import _ from "underscore";
 
 import type { Draft } from "@reduxjs/toolkit";
 import { t } from "ttag";
-import { truncate } from "humanize-plus";
 import type { DashboardState, StoreDashcard } from "metabase-types/store";
 import type {
   Dashboard,
@@ -65,7 +64,7 @@ export const getDashCardMoveToTabUndoMessage = (dashCard: StoreDashcard) => {
     dashCard.visualization_settings?.virtual_card?.display;
 
   if (dashCard.card.name) {
-    return truncate(t`Card moved: ${dashCard.card.name}`, 75);
+    return t`Card moved: ${dashCard.card.name}`;
   }
 
   switch (virtualCardType) {

--- a/frontend/src/metabase/dashboard/actions/utils.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/utils.unit.spec.ts
@@ -2,7 +2,12 @@ import {
   createMockDashboard,
   createMockDashboardCard,
 } from "metabase-types/api/mocks";
-import { hasDashboardChanged, haveDashboardCardsChanged } from "./utils";
+import { createMockCard } from "./../../../metabase-types/api/mocks/card";
+import {
+  getDashCardMoveToTabUndoMessage,
+  hasDashboardChanged,
+  haveDashboardCardsChanged,
+} from "./utils";
 
 describe("dashboard > actions > utils", () => {
   describe("hasDashboardChanged", () => {
@@ -199,6 +204,51 @@ describe("dashboard > actions > utils", () => {
       const endTime = performance.now();
 
       expect(endTime - startTime).toBeLessThan(100); // 100 ms (locally this was 6 ms)
+    });
+  });
+
+  describe("getDashCardMoveToTabUndoMessage", () => {
+    it("should return the correct message for dashCard with a name", () => {
+      const dashCard = createMockDashboardCard({
+        card: createMockCard({ name: "foo" }),
+      });
+      expect(getDashCardMoveToTabUndoMessage(dashCard)).toBe("Card moved: foo");
+    });
+
+    it("should return the correct message for a link dashCard", () => {
+      const dashCard = createMockDashboardCard({
+        card: createMockCard({ name: undefined }),
+        visualization_settings: { virtual_card: { display: "link" } },
+      });
+      expect(getDashCardMoveToTabUndoMessage(dashCard)).toBe("Link card moved");
+    });
+
+    it("should return the correct message for an action dashCard", () => {
+      const dashCard = createMockDashboardCard({
+        card: createMockCard({ name: undefined }),
+        visualization_settings: { virtual_card: { display: "action" } },
+      });
+      expect(getDashCardMoveToTabUndoMessage(dashCard)).toBe(
+        "Action card moved",
+      );
+    });
+
+    it("should return the correct message for a text dashCard", () => {
+      const dashCard = createMockDashboardCard({
+        card: createMockCard({ name: undefined }),
+        visualization_settings: { virtual_card: { display: "text" } },
+      });
+      expect(getDashCardMoveToTabUndoMessage(dashCard)).toBe("Text card moved");
+    });
+
+    it("should return the correct message for a heading dashCard", () => {
+      const dashCard = createMockDashboardCard({
+        card: createMockCard({ name: undefined }),
+        visualization_settings: { virtual_card: { display: "heading" } },
+      });
+      expect(getDashCardMoveToTabUndoMessage(dashCard)).toBe(
+        "Heading card moved",
+      );
     });
   });
 });

--- a/frontend/src/metabase/dashboard/selectors/selectors-typed.ts
+++ b/frontend/src/metabase/dashboard/selectors/selectors-typed.ts
@@ -1,3 +1,4 @@
+import type { DashCardId } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
 export function getDashboardId(state: State) {
@@ -16,3 +17,10 @@ export function getTabs(state: State) {
 export function getSelectedTabId(state: State) {
   return state.dashboard.selectedTabId;
 }
+
+export const getDashcards = (state: State) => state.dashboard.dashcards;
+
+export const getDashCardById = (state: State, dashcardId: DashCardId) => {
+  const dashcards = getDashcards(state);
+  return dashcards[dashcardId];
+};

--- a/frontend/src/metabase/dashboard/selectors/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors/selectors.js
@@ -17,7 +17,11 @@ import { getEmbedOptions, getIsEmbedded } from "metabase/selectors/embed";
 import Question from "metabase-lib/Question";
 
 import { isVirtualDashCard } from "../utils";
-import { getDashboardId } from "./selectors-typed";
+import {
+  getDashboardId,
+  getDashCardById,
+  getDashcards,
+} from "./selectors-typed";
 
 export const getIsEditing = state => !!state.dashboard.isEditing;
 export const getDashboardBeforeEditing = state => state.dashboard.isEditing;
@@ -28,7 +32,6 @@ export const getClickBehaviorSidebarDashcard = state => {
     : null;
 };
 export const getDashboards = state => state.dashboard.dashboards;
-export const getDashcards = state => state.dashboard.dashcards;
 export const getCardData = state => state.dashboard.dashcardData;
 export const getSlowCards = state => state.dashboard.slowCards;
 export const getParameterValues = state => state.dashboard.parameterValues;
@@ -87,11 +90,6 @@ export const getLoadingDashCards = state => state.dashboard.loadingDashCards;
 export const getDashboardById = (state, dashboardId) => {
   const dashboards = getDashboards(state);
   return dashboards[dashboardId];
-};
-
-export const getDashCardById = (state, dashcardId) => {
-  const dashcards = getDashcards(state);
-  return dashcards[dashcardId];
 };
 
 export const getSingleDashCardData = (state, dashcardId) => {


### PR DESCRIPTION
### Description
[Epic](https://github.com/metabase/metabase/issues/34367)
[Product doc](https://www.notion.so/metabase/Let-people-move-cards-between-dashboard-tabs-e797b321092b45a1bcbc4478d982a01e)

This helps distinguish the undo toast from one another using the card name if present, the card type otherwise.

Specs are in the [frame A05 of the figma](https://www.notion.so/metabase/Let-people-move-cards-between-dashboard-tabs-e797b321092b45a1bcbc4478d982a01e?pvs=4#1b2b364225a7477999c2b62a29b15e8d), linked in the prod doc


This also truncates the message to 75chars for all undo toast, there is a thread in figma about it. (I''m not posting the link as anyone with the link can open it)






### Demo

<img width="373" alt="image" src="https://github.com/metabase/metabase/assets/1914270/66f09583-5c57-473e-8bdc-854fe175c1be">

https://github.com/metabase/metabase/assets/1914270/b4e4b5b4-c85e-434e-9f53-e26282088ad6


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
