### PR TITLE
Moving x-ray checks to backend for 15655 to reduce flakes

### DIFF
--- a/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
@@ -5,7 +5,6 @@ import {
   summarize,
   visualize,
   startNewQuestion,
-  main,
   addOrUpdateDashboardCard,
   visitDashboardAndCreateTab,
   popover,
@@ -25,8 +24,6 @@ describe("scenarios > x-rays", { tags: "@slow" }, () => {
     restore();
     cy.signInAsAdmin();
   });
-
-  const XRAY_DATASETS = 5; // enough to load most questions
 
   it("should not display x-rays if the feature is disabled in admin settings (metabase#26571)", () => {
     cy.request("PUT", "api/setting/enable-xrays", { value: false });
@@ -127,21 +124,6 @@ describe("scenarios > x-rays", { tags: "@slow" }, () => {
         cy.findByText("Automatic insights…").click();
         cy.findByText(action).click();
       });
-
-      cy.wait(Array(XRAY_DATASETS).fill("@postDataset"), {
-        timeout: 15 * 1000,
-      });
-
-      cy.wait("@xray").then(xhr => {
-        expect(xhr.response.body.cause).not.to.exist;
-        expect(xhr.response.statusCode).not.to.eq(500);
-      });
-
-      main().within(() => {
-        cy.findByText("A look at the number of 15655").should("exist");
-      });
-
-      cy.get(".DashCard");
     });
 
     it(`"${action.toUpperCase()}" should not show NULL in titles of generated dashboard cards (metabase#15737)`, () => {

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -1598,3 +1598,78 @@
               (is (some? base-data))
               (is (some? filtered-data))
               (is (not= base-data filtered-data)))))))))
+
+(deftest compare-to-the-rest-15655-test
+  (testing "Questions based on native questions should produce a valid dashboard."
+    (mt/dataset sample-dataset
+      (mt/with-test-user :rasta
+        (let [native-query {:native   {:query "select * from people"}
+                            :type     :native
+                            :database (mt/id)}]
+          (mt/with-temp
+            [Card {native-card-id :id :as native-card} {:table_id        nil
+                                                        :name            "15655"
+                                                        :dataset_query   native-query
+                                                        :result_metadata (mt/with-test-user :rasta (result-metadata-for-query native-query))}
+             ;card__19169
+             Card card {:table_id      (mt/id :orders)
+                        :dataset_query {:query    {:source-table (format "card__%s" native-card-id)
+                                                   :aggregation  [[:count]]
+                                                   :breakout     [[:field "SOURCE" {:base-type :type/Text}]]}
+                                        :type     :query
+                                        :database (mt/id)}}]
+            (let [{:keys [description dashcards] :as dashboard} (magic/automagic-analysis card {})]
+              (testing "Questions based on native queries produce a dashboard"
+                (is (= "A closer look at the metrics and dimensions used in this saved question."
+                       description))
+                (is (set/subset?
+                      #{{:group-name "# A look at the SOURCE fields", :card-name nil}
+                        {:group-name "## The number of 15655 over time", :card-name nil}
+                        {:group-name nil, :card-name "Over time"}
+                        {:group-name nil, :card-name "Number of 15655 per day of the week"}
+                        {:group-name "## How this metric is distributed across different categories", :card-name nil}
+                        {:group-name nil, :card-name "Number of 15655 per NAME over time"}
+                        {:group-name nil, :card-name "Number of 15655 per CITY over time"}
+                        {:group-name "## Overview", :card-name nil}
+                        {:group-name nil, :card-name "Count"}
+                        {:group-name nil, :card-name "How the SOURCE is distributed"}
+                        {:group-name "## How the SOURCE fields is distributed", :card-name nil}
+                        {:group-name nil, :card-name "SOURCE by NAME"}
+                        {:group-name nil, :card-name "SOURCE by CITY"}}
+                      (set (map (fn [dashcard]
+                                  {:group-name (get-in dashcard [:visualization_settings :text])
+                                   :card-name  (get-in dashcard [:card :name])})
+                                dashcards)))))
+              (let [cell-query ["=" ["field" "SOURCE" {:base-type "type/Text"}] "Affiliate"]
+                    {comparison-description :description
+                     comparison-dashcards   :dashcards
+                     transient_name         :transient_name} (comparison/comparison-dashboard
+                                                               dashboard
+                                                               card
+                                                               native-card
+                                                               {:left {:cell-query cell-query}})]
+                (testing "Questions based on native queries produce a comparable dashboard"
+                  (is (= "Comparison of Number of 15655 where SOURCE is Affiliate and \"15655\", all 15655"
+                         transient_name))
+                  (is (= "Automatically generated comparison dashboard comparing Number of 15655 where SOURCE is Affiliate and \"15655\", all 15655"
+                         comparison-description))
+                  (is (= (take 10
+                               [{:group-name nil, :card-name "SOURCE by CITY"}
+                                {:group-name nil, :card-name "SOURCE by CITY"}
+                                {:group-name nil, :card-name "SOURCE by NAME"}
+                                {:group-name nil, :card-name "SOURCE by NAME"}
+                                {:group-name "## How the SOURCE fields is distributed", :card-name nil}
+                                {:group-name nil, :card-name "How the SOURCE is distributed (Number of 15655 where SOURCE is Affiliate)"}
+                                {:group-name nil, :card-name "Distinct values"}
+                                {:group-name nil, :card-name "Distinct values"}
+                                {:group-name nil, :card-name "Null values"}
+                                {:group-name nil, :card-name "Null values"}])
+                         (->> comparison-dashcards
+                              (take 10)
+                              (map (fn [dashcard]
+                                     {:group-name (get-in dashcard [:visualization_settings :text])
+                                      :card-name  (get-in dashcard [:card :name])})))))
+                  (mapv (fn [dashcard]
+                          {:group-name (get-in dashcard [:visualization_settings :text])
+                           :card-name  (get-in dashcard [:card :name])})
+                        comparison-dashcards))))))))))


### PR DESCRIPTION
The following x-ray e2e tests are top contributors to x-ray flakes at 6.94% and 6.62%, respectively:
- "X-RAY" should work on a nested question made from base native question (metabase#15655)
- "COMPARE TO THE REST" should work on a nested question made from base native question (metabase#15655)

This change moves the x-ray dashboard generation aspects test load to a unit test and just checks that the insight buttons are present and clickable.

Note that there is still some scenario creation type code in the fixture that could potentially be simplified with some FE help.
