### PR TITLE
Remove recommendation for keeping user/pass enabled

### DIFF
--- a/docs/people-and-groups/google-and-ldap.md
+++ b/docs/people-and-groups/google-and-ldap.md
@@ -123,8 +123,6 @@ User attributes can't be synced with regular Google Sign-In. You'll need to set 
 
 On paid plans, you can require people to log in with SSO by disabling password authentication from **Admin settings** > **Authentication**.
 
-**Avoid locking yourself out of your Metabase!** This setting will apply to all Metabase accounts, _including your Metabase admin account_. We recommend that you keep password authentication **enabled**. This will safeguard you from getting locked out of Metabase in case of any problems with SSO.
-
 ## Troubleshooting login issues
 
  - [Can't log in](../troubleshooting-guide/cant-log-in.md).


### PR DESCRIPTION
Remove the recommendation for keeping the user/pass enabled