### PR TITLE
Audit log CRUD permission failures

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -16053,6 +16053,20 @@ databaseChangeLog:
               );
       rollback: # no change
 
+  - changeSet:
+      id: v48.00-053
+      author: johnswanson
+      comment: Increase length of `activity.model` to fit longer model names
+      changes:
+        - modifyDataType:
+            tableName: activity
+            columnName: model
+            newDataType: VARCHAR(32)
+      rollback:
+        - modifyDataType:
+            tableName: activity
+            columnName: model
+            newDataType: VARCHAR(16)
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -16062,11 +16062,7 @@ databaseChangeLog:
             tableName: activity
             columnName: model
             newDataType: VARCHAR(32)
-      rollback:
-        - modifyDataType:
-            tableName: activity
-            columnName: model
-            newDataType: VARCHAR(16)
+      rollback: # not necessary
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -52,6 +52,7 @@
             route-fn-name
             wrap-response-if-needed]]
    [metabase.config :as config]
+   [metabase.events :as events]
    [metabase.models.interface :as mi]
    [metabase.util :as u]
    [metabase.util.i18n :as i18n :refer [deferred-tru tru]]
@@ -418,7 +419,6 @@
        (raise e)
        (handler request respond raise)))))
 
-
 ;;; ---------------------------------------- PERMISSIONS CHECKING HELPER FNS -----------------------------------------
 
 (defn read-check
@@ -428,7 +428,12 @@
   {:style/indent 2}
   ([obj]
    (check-404 obj)
-   (check-403 (mi/can-read? obj))
+   (try
+     (check-403 (mi/can-read? obj))
+     (catch clojure.lang.ExceptionInfo e
+       (events/publish-event! :event/read-permission-failure {:user-id *current-user-id*
+                                                              :object obj})
+       (throw e)))
    obj)
 
   ([entity id]
@@ -444,7 +449,12 @@
   {:style/indent 2}
   ([obj]
    (check-404 obj)
-   (check-403 (mi/can-write? obj))
+   (try
+     (check-403 (mi/can-write? obj))
+     (catch clojure.lang.ExceptionInfo e
+       (events/publish-event! :event/write-permission-failure {:user-id *current-user-id*
+                                                               :object obj})
+       (throw e)))
    obj)
   ([entity id]
    (write-check (t2/select-one entity :id id)))
@@ -459,7 +469,12 @@
   hardcoded into them -- this should be considered an antipattern and be refactored out going forward."
   {:added "0.32.0", :style/indent 2}
   [entity m]
-  (check-403 (mi/can-create? entity m)))
+  (try
+    (check-403 (mi/can-create? entity m))
+    (catch clojure.lang.ExceptionInfo e
+      (events/publish-event! :event/create-permission-failure {:model entity
+                                                               :user-id *current-user-id*})
+      (throw e))))
 
 (defn update-check
   "NEW! Check whether the current user has permissions to UPDATE an object by applying a map of `changes`.
@@ -469,7 +484,12 @@
   into them -- this should be considered an antipattern and be refactored out going forward."
   {:added "0.36.0", :style/indent 2}
   [instance changes]
-  (check-403 (mi/can-update? instance changes)))
+  (try
+    (check-403 (mi/can-update? instance changes))
+    (catch clojure.lang.ExceptionInfo e
+      (events/publish-event! :event/update-permission-failure {:user-id *current-user-id*
+                                                               :object instance})
+      (throw e))))
 
 ;;; ------------------------------------------------ OTHER HELPER FNS ------------------------------------------------
 

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -431,7 +431,8 @@
    (try
      (check-403 (mi/can-read? obj))
      (catch clojure.lang.ExceptionInfo e
-       (events/publish-event! :event/read-permission-failure {:user-id *current-user-id*
+       ;; this is commented out until we write a handler to add this to the view_log
+       #_(events/publish-event! :event/read-permission-failure {:user-id *current-user-id*
                                                               :object obj})
        (throw e)))
    obj)

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -205,3 +205,13 @@
 (methodical/defmethod events/publish-event! ::database-update-event
   [topic event]
   (audit-log/record-event! topic event))
+
+(derive ::permission-failure-event ::event)
+(derive :event/read-permission-failure ::permission-failure-event)
+(derive :event/write-permission-failure ::permission-failure-event)
+(derive :event/update-permission-failure ::permission-failure-event)
+(derive :event/create-permission-failure ::permission-failure-event)
+
+(methodical/defmethod events/publish-event! ::permission-failure-event
+  [topic event]
+  (audit-log/record-event! topic event))

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -207,7 +207,6 @@
   (audit-log/record-event! topic event))
 
 (derive ::permission-failure-event ::event)
-(derive :event/read-permission-failure ::permission-failure-event)
 (derive :event/write-permission-failure ::permission-failure-event)
 (derive :event/update-permission-failure ::permission-failure-event)
 (derive :event/create-permission-failure ::permission-failure-event)

--- a/src/metabase/events/schema.clj
+++ b/src/metabase/events/schema.clj
@@ -114,6 +114,19 @@
                        [:user-id  pos-int?]
                        [:object [:fn #(t2/instance-of? :model/Table %)]]])})
 
+(let [default-schema (mc/schema
+                      [:map {:closed true}
+                       [:user-id [:maybe pos-int?]]
+                       [:object [:fn #(t2/instance-of? :metabase/model %)]]])]
+  (def ^:private permission-failure-events
+    {:event/read-permission-failure default-schema
+     :event/write-permission-failure default-schema
+     :event/update-permission-failure default-schema
+     :event/create-permission-failure (mc/schema
+                                       [:map {:closed true}
+                                        [:user-id [:maybe pos-int?]]
+                                        [:model [:or :keyword :string]]])}))
+
 (def topic->schema
   "Returns the schema for an event topic."
   (merge dashboard-events-schemas
@@ -124,4 +137,5 @@
          database-events
          alert-schema
          pulse-schemas
-         table-events))
+         table-events
+         permission-failure-events))

--- a/src/metabase/events/schema.clj
+++ b/src/metabase/events/schema.clj
@@ -117,7 +117,7 @@
 (let [default-schema (mc/schema
                       [:map {:closed true}
                        [:user-id [:maybe pos-int?]]
-                       [:object [:fn #(t2/instance-of? :metabase/model %)]]])]
+                       [:object [:fn #(boolean (t2/model %))]]])]
   (def ^:private permission-failure-events
     {:event/read-permission-failure default-schema
      :event/write-permission-failure default-schema

--- a/src/metabase/models/audit_log.clj
+++ b/src/metabase/models/audit_log.clj
@@ -35,13 +35,17 @@
   [_entity _event-type]
   {})
 
+(def ^:private model-name->audit-logged-name
+  {"RootCollection" "Collection"})
+
 (defn model-name
   "Given an instance of a model or a keyword model identifier, returns the name to store in the database as a string, or `nil` if it cannot be computed."
   [instance-or-model]
-  (let [model (or (t2/model instance-or-model) instance-or-model)]
-    (cond
-      (keyword? model) (name model)
-      (class? model) (.getSimpleName ^java.lang.Class model))))
+  (let [model (or (t2/model instance-or-model) instance-or-model)
+        raw-model-name (cond
+                         (keyword? model) (name model)
+                         (class? model) (.getSimpleName ^java.lang.Class model))]
+    (model-name->audit-logged-name raw-model-name raw-model-name)))
 
 (defn- prepare-update-event-data
   "Returns a map with previous and new versions of the objects, _keeping only fields that are present in both

--- a/src/metabase/models/audit_log.clj
+++ b/src/metabase/models/audit_log.clj
@@ -13,6 +13,8 @@
    [methodical.core :as m]
    [toucan2.core :as t2]))
 
+(set! *warn-on-reflection* true)
+
 (doto :model/AuditLog
   (derive :metabase/model))
 
@@ -35,8 +37,11 @@
 
 (defn model-name
   "Given an instance of a model or a keyword model identifier, returns the name to store in the database as a string, or `nil` if it cannot be computed."
-  [model]
-  (some-> (or (t2/model model) model) name))
+  [instance-or-model]
+  (let [model (or (t2/model instance-or-model) instance-or-model)]
+    (cond
+      (keyword? model) (name model)
+      (class? model) (.getSimpleName ^java.lang.Class model))))
 
 (defn- prepare-update-event-data
   "Returns a map with previous and new versions of the objects, _keeping only fields that are present in both

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -689,4 +689,6 @@
                              (for [{:keys [id card_id]} dashcards]
                                   (-> (t2/select-one [Card :name :description], :id card_id)
                                       (assoc :id id)
-                                      (assoc :card_id card_id))))))))
+                                      (assoc :card_id card_id))))))
+
+    {}))

--- a/test/metabase/api/common_test.clj
+++ b/test/metabase/api/common_test.clj
@@ -100,7 +100,6 @@
 (deftest *-check-functions-publish-events
   ;; setup - derive events so they get dispatched to our test method
   (derive ::permission-failure-event :metabase/event)
-  (derive :event/read-permission-failure ::permission-failure-event)
   (derive :event/write-permission-failure ::permission-failure-event)
   (derive :event/update-permission-failure ::permission-failure-event)
   (derive :event/create-permission-failure ::permission-failure-event)
@@ -112,12 +111,6 @@
                     mi/can-update? (constantly false)
                     mi/can-create? (constantly false)]
         (mt/with-temp [:model/Card card {}]
-          (testing "read-check"
-            (binding [*events* (atom [])]
-              (is (thrown? ExceptionInfo (api/read-check card)))
-              (is (= [[:event/read-permission-failure {:user-id 1
-                                                       :object card}]]
-                     @*events*))))
           (testing "write-check"
             (binding [*events* (atom [])]
               (is (thrown? ExceptionInfo (api/write-check card)))
@@ -139,7 +132,6 @@
     (finally
       ;; teardown - underive events so they aren't dispatched in other tests
       (underive ::permission-failure-event :metabase/event)
-      (underive :event/read-permission-failure ::permission-failure-event)
       (underive :event/write-permission-failure ::permission-failure-event)
       (underive :event/update-permission-failure ::permission-failure-event)
       (underive :event/create-permission-failure ::permission-failure-event))))

--- a/test/metabase/api/common_test.clj
+++ b/test/metabase/api/common_test.clj
@@ -97,7 +97,7 @@
   [topic event]
   (swap! *events* conj [topic event]))
 
-(deftest *-check-functions-publish-events
+(deftest check-functions-publish-events
   ;; setup - derive events so they get dispatched to our test method
   (derive ::permission-failure-event :metabase/event)
   (derive :event/write-permission-failure ::permission-failure-event)

--- a/test/metabase/api/common_test.clj
+++ b/test/metabase/api/common_test.clj
@@ -3,10 +3,14 @@
    [clojure.test :refer :all]
    [mb.hawk.assert-exprs.approximately-equal :as hawk.approx]
    [metabase.api.common :as api]
+   [metabase.events :as events]
+   [metabase.models.interface :as mi]
    [metabase.server.middleware.exceptions :as mw.exceptions]
    [metabase.server.middleware.misc :as mw.misc]
    [metabase.server.middleware.security :as mw.security]
-   [methodical.core :as methodical]))
+   [metabase.test :as mt]
+   [methodical.core :as methodical])
+  (:import (clojure.lang ExceptionInfo)))
 
 ;;; TESTS FOR CHECK (ETC)
 
@@ -85,3 +89,57 @@
 
   (testing "multi values a vector as well"
     (is (= [1 2 3] (api/parse-multi-values-param ["1" "2" "3"] parse-long)))))
+
+;; set up for testing permission failure event publishing
+(def ^:dynamic *events* nil)
+
+(methodical/defmethod events/publish-event! ::permission-failure-event
+  [topic event]
+  (swap! *events* conj [topic event]))
+
+(deftest *-check-functions-publish-events
+  ;; setup - derive events so they get dispatched to our test method
+  (derive ::permission-failure-event :metabase/event)
+  (derive :event/read-permission-failure ::permission-failure-event)
+  (derive :event/write-permission-failure ::permission-failure-event)
+  (derive :event/update-permission-failure ::permission-failure-event)
+  (derive :event/create-permission-failure ::permission-failure-event)
+
+  (try
+    (binding [api/*current-user-id* 1]
+      (with-redefs [mi/can-read? (constantly false)
+                    mi/can-write? (constantly false)
+                    mi/can-update? (constantly false)
+                    mi/can-create? (constantly false)]
+        (mt/with-temp [:model/Card card {}]
+          (testing "read-check"
+            (binding [*events* (atom [])]
+              (is (thrown? ExceptionInfo (api/read-check card)))
+              (is (= [[:event/read-permission-failure {:user-id 1
+                                                       :object card}]]
+                     @*events*))))
+          (testing "write-check"
+            (binding [*events* (atom [])]
+              (is (thrown? ExceptionInfo (api/write-check card)))
+              (is (= [[:event/write-permission-failure {:object card
+                                                        :user-id 1}]]
+                     @*events*))))
+          (testing "update-check"
+            (binding [*events* (atom [])]
+              (is (thrown? ExceptionInfo (api/update-check card card)))
+              (is (= [[:event/update-permission-failure {:object card
+                                                         :user-id 1}]]
+                     @*events*))))
+          (testing "create-check"
+            (binding [*events* (atom [])]
+              (is (thrown? ExceptionInfo (api/create-check :model/Collection {})))
+              (is (= [[:event/create-permission-failure {:model :model/Collection
+                                                         :user-id 1}]]
+                     @*events*)))))))
+    (finally
+      ;; teardown - underive events so they aren't dispatched in other tests
+      (underive ::permission-failure-event :metabase/event)
+      (underive :event/read-permission-failure ::permission-failure-event)
+      (underive :event/write-permission-failure ::permission-failure-event)
+      (underive :event/update-permission-failure ::permission-failure-event)
+      (underive :event/create-permission-failure ::permission-failure-event))))


### PR DESCRIPTION
When we run `metabase.api.common/*-check` functions like `read-check` or `create-check`, publish an event when the check fails, along with enough context that, on the other side, the audit log handler can record the relevant event.
