### PR TITLE
support custom y-axis range

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
@@ -1,8 +1,8 @@
 import type { DatasetColumn, RawSeries, RowValue } from "metabase-types/api";
 import type {
   DataKey,
-  Extent,
   GroupedDataset,
+  SeriesExtents,
   SeriesModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import type { CartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
@@ -278,13 +278,13 @@ export const getNormalizedDataset = (
  *
  * @param {DataKey[]} keys - The keys of the series to calculate extents for.
  * @param {GroupedDataset} dataset - The dataset containing the series data.
- * @returns {Record<DataKey, Extent>} Series extent by a series data key.
+ * @returns {SeriesExtents} Series extent by a series data key.
  */
 export const getDatasetExtents = (
   keys: DataKey[],
   dataset: GroupedDataset,
-): Record<DataKey, Extent> => {
-  const extents: Record<DataKey, Extent> = {};
+): SeriesExtents => {
+  const extents: SeriesExtents = {};
 
   dataset.forEach(item => {
     keys.forEach(key => {

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
@@ -118,5 +118,6 @@ export const getCartesianChartModel = (
     yAxisSplit,
     leftAxisColumn,
     rightAxisColumn,
+    extents,
   };
 };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -57,6 +57,7 @@ export type CartesianChartModel = {
   dataset: GroupedDataset;
   normalizedDataset: GroupedDataset;
   yAxisSplit: AxisSplit;
+  extents: SeriesExtents;
 
   leftAxisColumn?: DatasetColumn;
   rightAxisColumn?: DatasetColumn;


### PR DESCRIPTION
### Description

Adds the support of custom y-axis range to the new combo chart. It replicates the existing behavior so by specifying a custom range you can only extend axis range but not shrink.

### How to verify

1. Create Line/Area/Bar/Combo with specified custom ranges
2. Send a test subscription
3. Ensure the custom range is respected in the static charts

### Demo

<img width="595" alt="Screenshot 2023-11-03 at 9 34 34 PM" src="https://github.com/metabase/metabase/assets/14301985/4c3ba11c-d963-4ae8-b170-e68796668cfd">

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
