### PR TITLE
fix flaky relative time test `filter-datetime-by-date-in-timezone-relative-to-days-since-test`

### DIFF
--- a/test/metabase/query_processor_test/timezones_test.clj
+++ b/test/metabase/query_processor_test/timezones_test.clj
@@ -329,7 +329,7 @@
         (mt/with-temp-test-data ["relative_filter"
                                  [{:field-name "created", :base-type :type/DateTimeWithTZ}]
                                  [[expected-datetime]]]
-          (doseq [timezone ["UTC" "US/Pacific" "US/Eastern" "Asia/Hong_Kong"]]
+          (doseq [timezone ["UTC" "Asia/Hong_Kong" "US/Hawaii" "America/Puerto_Rico"]]
             (mt/with-temporary-setting-values [report-timezone timezone]
               (let [query (mt/mbql-query relative_filter {:fields [$created]
                                                           :filter [:time-interval $created -2 :day]})]

--- a/test/metabase/query_processor_test/timezones_test.clj
+++ b/test/metabase/query_processor_test/timezones_test.clj
@@ -332,7 +332,7 @@
           (doseq [timezone ["UTC" "US/Pacific" "US/Eastern" "Asia/Hong_Kong"]]
             (mt/with-temporary-setting-values [report-timezone timezone]
               (let [query (mt/mbql-query relative_filter {:fields [$created]
-                                                          :filter [:time-interval $created -1 :day]})]
+                                                          :filter [:time-interval $created -2 :day]})]
                 (mt/with-native-query-testing-context query
                   (let [results (qp/process-query query)]
                     (is (=? {:status :completed}

--- a/test/metabase/query_processor_test/timezones_test.clj
+++ b/test/metabase/query_processor_test/timezones_test.clj
@@ -332,7 +332,7 @@
           (doseq [timezone ["UTC" "Asia/Hong_Kong" "US/Hawaii" "America/Puerto_Rico"]]
             (mt/with-temporary-setting-values [report-timezone timezone]
               (let [query (mt/mbql-query relative_filter {:fields [$created]
-                                                          :filter [:time-interval $created -2 :day]})]
+                                                          :filter [:time-interval $created -1 :day]})]
                 (mt/with-native-query-testing-context query
                   (let [results (qp/process-query query)]
                     (is (=? {:status :completed}


### PR DESCRIPTION
Failed CI https://github.com/metabase/metabase/actions/runs/6767465207/job/18390157545?pr=35405

the fix is to use timezones that don't have DST