### PR TITLE
wip: Process linked filters having more than one join to the same table

### DIFF
--- a/src/metabase/models/params/chain_filter.clj
+++ b/src/metabase/models/params/chain_filter.clj
@@ -548,10 +548,12 @@
   ;; TODO: why don't we remap the human readable values here?
   (let [{:keys [values has_more_values]}
         (if (empty? constraints)
-          (params.field-values/get-or-create-field-values-for-current-user! (t2/select-one Field :id (:field-id field)))
-          (params.field-values/get-or-create-linked-filter-field-values! (t2/select-one Field :id (:field-id field)) constraints
-                                                                         (fn []
-                                                                           (unremapped-chain-filter field constraints {}))))]
+          (params.field-values/get-or-create-field-values-for-current-user!
+           (t2/select-one Field :id (:field-id field)))
+          (params.field-values/get-or-create-linked-filter-field-values!
+           (t2/select-one Field :id (:field-id field))
+           {:constraints constraints
+            :cache-fn (fn [_field] (unremapped-chain-filter field constraints {}))}))]
     {:values          (cond->> values
                         limit (take limit))
      :has_more_values (or (when limit

--- a/src/metabase/models/params/chain_filter/dedupe_joins.clj
+++ b/src/metabase/models/params/chain_filter/dedupe_joins.clj
@@ -68,7 +68,7 @@
 
   `keep-ids` = the IDs of Tables that we want to keep joins for. Joins that are not needed to keep these Tables may be
   removed."
-  [source-id in-joins keep-ids]
+  [source-id keep-ids in-joins]
   ;; we can't keep any joins that don't exist in `in-joins`, so go ahead and remove IDs for those joins if they're not
   ;; present
   (let [keep-ids (set/intersection (set keep-ids)

--- a/src/metabase/models/params/field_values.clj
+++ b/src/metabase/models/params/field_values.clj
@@ -69,14 +69,13 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defn- fetch-advanced-field-values
-  [fv-type field constraints]
+  [fv-type field cache-fn]
   {:pre [(field-values/advanced-field-values-types fv-type)]}
   (case fv-type
     :linked-filter
     (do
       (classloader/require 'metabase.models.params.chain-filter)
-      (let [{:keys [values has_more_values]} ((resolve 'metabase.models.params.chain-filter/unremapped-chain-filter)
-                                              (:id field) constraints {})
+      (let [{:keys [values has_more_values]} (cache-fn)
             ;; we have a hard limit for how many values we want to store in FieldValues,
             ;; let's make sure we respect that limit here.
             ;; For a more detailed docs on this limt check out [[field-values/distinct-values]]
@@ -105,9 +104,9 @@
   "Fetch and construct the FieldValues for `field` with type `fv-type`. This does not do any insertion.
    The human_readable_values of Advanced FieldValues will be automatically fixed up based on the
    list of values and human_readable_values of the full FieldValues of the same field."
-  [fv-type field hash-key constraints]
-  (when-let [{wrapped-values :values :keys [has_more_values]}
-             (fetch-advanced-field-values fv-type field constraints)]
+  [fv-type field hash-key cache-fn]
+  (when-let [{wrapped-values :values
+              :keys [has_more_values]} (fetch-advanced-field-values fv-type field cache-fn)]
     (let [;; each value in `wrapped-values` is a 1-tuple, so unwrap the raw values for storage
           values                (map first wrapped-values)
           ;; If the full FieldValues of this field have human-readable-values, ensure that we reuse them
@@ -123,14 +122,14 @@
 (defn get-or-create-advanced-field-values!
   "Fetch an Advanced FieldValues with type `fv-type` for a `field`, creating them if needed.
   If the fetched FieldValues is expired, we delete them then try to create it."
-  ([fv-type field]
-   (get-or-create-advanced-field-values! fv-type field nil))
+  ([fv-type field cache-fn]
+   (get-or-create-advanced-field-values! fv-type field nil cache-fn))
 
-  ([fv-type field constraints]
+  ([fv-type field constraints cache-fn]
    (let [hash-key   (hash-key-for-advanced-field-values fv-type (:id field) constraints)
          select-kvs {:field_id (:id field) :type fv-type :hash_key hash-key}
          fv         (mdb.query/select-or-insert! :model/FieldValues select-kvs
-                      #(prepare-advanced-field-values fv-type field hash-key constraints))]
+                      #(prepare-advanced-field-values fv-type field hash-key cache-fn))]
      (cond
        (nil? fv) nil
 
@@ -139,7 +138,7 @@
        (do
          ;; It's possible another process has already recalculated this, but spurious recalculations are OK.
          (t2/delete! FieldValues :id (:id fv))
-         (recur fv-type field constraints))
+         (recur fv-type field constraints cache-fn))
 
        :else fv))))
 
@@ -175,6 +174,6 @@
     {:values           [[value]]
      :field_id         field-id
      :has_field_values boolean}"
-  [field constraints]
-  (-> (get-or-create-advanced-field-values! :linked-filter field constraints)
+  [field constraints cache-fn]
+  (-> (get-or-create-advanced-field-values! :linked-filter field constraints cache-fn)
       (postprocess-field-values field)))

--- a/src/metabase/models/params/field_values.clj
+++ b/src/metabase/models/params/field_values.clj
@@ -7,7 +7,6 @@
    [metabase.models.field :as field]
    [metabase.models.field-values :as field-values :refer [FieldValues]]
    [metabase.models.interface :as mi]
-   [metabase.plugins.classloader :as classloader]
    [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.util :as u]
    [toucan2.core :as t2]))
@@ -74,8 +73,8 @@
   (case fv-type
     :linked-filter
     (do
-      (classloader/require 'metabase.models.params.chain-filter)
-      (let [{:keys [values has_more_values]} (cache-fn)
+      (assert cache-fn "Linked filters should pass `cache-fn` to execute the fetch")
+      (let [{:keys [values has_more_values]} (cache-fn field)
             ;; we have a hard limit for how many values we want to store in FieldValues,
             ;; let's make sure we respect that limit here.
             ;; For a more detailed docs on this limt check out [[field-values/distinct-values]]
@@ -122,11 +121,12 @@
 (defn get-or-create-advanced-field-values!
   "Fetch an Advanced FieldValues with type `fv-type` for a `field`, creating them if needed.
   If the fetched FieldValues is expired, we delete them then try to create it."
-  ([fv-type field cache-fn]
-   (get-or-create-advanced-field-values! fv-type field nil cache-fn))
+  ([fv-type field]
+   (get-or-create-advanced-field-values! fv-type field nil))
 
-  ([fv-type field constraints cache-fn]
-   (let [hash-key   (hash-key-for-advanced-field-values fv-type (:id field) constraints)
+  ;; constraints and cache-fn used for :linked-filter
+  ([fv-type field {:keys [constraints cache-fn] :as opts}]
+   (let [hash-key (hash-key-for-advanced-field-values fv-type (:id field) constraints)
          select-kvs {:field_id (:id field) :type fv-type :hash_key hash-key}
          fv         (mdb.query/select-or-insert! :model/FieldValues select-kvs
                       #(prepare-advanced-field-values fv-type field hash-key cache-fn))]
@@ -138,7 +138,7 @@
        (do
          ;; It's possible another process has already recalculated this, but spurious recalculations are OK.
          (t2/delete! FieldValues :id (:id fv))
-         (recur fv-type field constraints cache-fn))
+         (recur fv-type field opts))
 
        :else fv))))
 
@@ -174,6 +174,6 @@
     {:values           [[value]]
      :field_id         field-id
      :has_field_values boolean}"
-  [field constraints cache-fn]
-  (-> (get-or-create-advanced-field-values! :linked-filter field constraints cache-fn)
+  [field opts]
+  (-> (get-or-create-advanced-field-values! :linked-filter field opts)
       (postprocess-field-values field)))

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -943,11 +943,18 @@
 (defn seek
   "Like (first (filter ... )), but doesn't realize chunks of the sequence. Returns the first item in `coll` for which
   `pred` returns a truthy value, or `nil` if no such item is found."
-  [pred coll]
-  (reduce
-   (fn [acc x] (if (pred x) (reduced x) acc))
-   nil
-   coll))
+  ([pred coll] (seek pred coll nil))
+  ([pred coll not-found]
+   (reduce
+    (fn [default x] (if (pred x) (reduced x) default))
+    not-found
+    coll)))
+
+(defn seek=
+  "(seek= :idx 1 [{:idx 0} {:idx 1}]) ; => {:idx 1}"
+  [key value items]
+  (seek #(= (get % key) value) items))
+
 
 #?(:clj
    (let [sym->enum (fn ^Enum [sym]

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4624,23 +4624,25 @@
         (let [dashboard (t2/hydrate dashboard :resolved-params)]
           (testing "Should return correct join information after looking up for a field"
             (mt/$ids nil
-              (is (= [{:field-id %users.name
-                       :join     {:lhs {:table $$messages :field %messages.sender_id}
-                                  :rhs {:table $$users :field %users.id}}
-                       :op       :=
-                       :options  nil
-                       :value    nil}]
-                     (#'api.dashboard/param->fields (get-in dashboard [:resolved-params "sender"]) false)))
-              (testing "Top-level should have reverse join going on"
-                (is (= [{:field-id %users.name
-                         :join     {:lhs {:table $$users :field %users.id}
-                                    :rhs {:table $$messages :field %messages.receiver_id}}
-                         :op       :=
-                         :options  nil
-                         :value    nil}]
-                       (#'api.dashboard/param->fields (get-in dashboard [:resolved-params "receiver"]) true)))))))
+              (is (= [{:field-ref &snd.users.name
+                       :query     {:source-table $$messages
+                                   :fields       [$messages.text
+                                                  &snd.users.name
+                                                  &rcv.users.name]
+                                   :joins        [{:source-table $$users
+                                                   :alias        "snd"
+                                                   :condition    [:= $messages.sender_id &snd.users.id]
+                                                   :strategy     :left-join}
+                                                  {:source-table $$users
+                                                   :alias        "rcv"
+                                                   :condition    [:= $messages.receiver_id &snd.users.id]
+                                                   :strategy     :left-join}]}
+                       :op        :=
+                       :options   nil
+                       :value     nil}]
+                     (#'api.dashboard/param->fields (get-in dashboard [:resolved-params "sender"])))))))
         (testing "GET /api/dashboard/:id/params/:param-key/values"
           (mt/let-url [url (chain-filter-values-url dashboard "receiver")]
-            (is (= {:values [["Annie Albatross"] ["Bob the Sea Gull"] ["Brenda Blackbird"]]
+            (is (= {:values          [["Annie Albatross"] ["Bob the Sea Gull"] ["Brenda Blackbird"]]
                     :has_more_values false}
                    (chain-filter-test/take-n-values 3 (mt/user-http-request :rasta :get 200 url))))))))))


### PR DESCRIPTION
Constraints for linked filters now carry over the information about joins necessary to construct correct queries. Works only for MBQL queries, since we have no data from native queries to latch onto.

Resolves #16872
