### PR TITLE
fix restore z index between resize handle and dashcard actions

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
@@ -30,7 +30,6 @@ const hiddenBackgroundStyle = css`
 `;
 
 export const DashCardRoot = styled.div<DashCardRootProps>`
-  container-type: inline-size;
   background-color: ${color("white")};
 
   ${({ isNightMode }) => isNightMode && rootNightModeStyle}
@@ -62,7 +61,7 @@ export const DashboardCardActionsPanel = styled.div<{
   // react-resizable covers panel, we have to override it
   z-index: 2;
   // left align on small cards on the left edge to not make the actions go out of the viewport
-  @container (max-width: 12rem) {
+  @container DashboardCard (max-width: 12rem) {
     ${({ onLeftEdge }) => onLeftEdge && "right: unset;"}
     ${({ onLeftEdge }) => onLeftEdge && "left: 20px;"}
   }

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.styled.tsx
@@ -9,6 +9,9 @@ export const DashboardCard = styled.div<DashboardCardProps>`
   position: relative;
   z-index: 1;
 
+  container-name: DashboardCard;
+  container-type: inline-size;
+
   /**
   * Dashcards are positioned absolutely so each one forms a new stacking context.
   * The dashcard user is currently interacting with needs to be positioned above other dashcards


### PR DESCRIPTION
### Description

https://github.com/metabase/metabase/pull/35327 introduced a [failure in CI](https://www.deploysentinel.com/ci/runs/6544eaf7c9fa8b50a45b5924)
I merged that PR to the feature branch thinking it was a flake and because I wanted to flat the PR situation to not have conflicts in other PRs.

The issue was introduced by the `container-type` property in css, as it creates a new stacking context.

This is a simplified visualization of what happened:
```tsx
<DashboardCard>
  <DashCardRoot> <- new stacking context that was introduced
    <Actions> <- has zindex but it became local to DashCard
  <ResizeHandle /> <- has zindex
```
Before the bug, the actions were on top of the resize handle because it had higher zIndex, but adding the `container-type` property to `DashCardRoot` made that zindex local to it.

This PR fixes it by making moving the `container-type` property up one level to `DashboardCard`