### PR TITLE
Fix E2E failure due to the DST

### DIFF
--- a/e2e/test/scenarios/visualizations/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/table.cy.spec.js
@@ -186,7 +186,7 @@ describe("scenarios > visualizations > table", () => {
           // semantic type
           cy.contains("No special type");
           // fingerprint
-          cy.findByText("-07:00");
+          cy.findByText(/-0\d:00/);
           cy.findByText("April 26, 1958, 12:00 AM");
           cy.findByText("April 3, 2000, 12:00 AM");
         },


### PR DESCRIPTION
Failure in CI
https://www.deploysentinel.com/ci/runs/6548a5329f1ec992dfd5f053

Failure reproduced locally
![image](https://github.com/metabase/metabase/assets/31325167/938795d1-e6e7-4ec5-959f-cf0e3ac9aaff)

After the fix
![image](https://github.com/metabase/metabase/assets/31325167/f9830b65-77ed-449b-91e7-695cf39ebe51)

Stress-test the fix
https://github.com/metabase/metabase/actions/runs/6770255957/job/18398278318

```
    ✓ should show field metadata in a popover when hovering over a table column header: burning 1 of 5 (17797ms)
    ✓ should show field metadata in a popover when hovering over a table column header: burning 2 of 5 (17321ms)
    ✓ should show field metadata in a popover when hovering over a table column header: burning 3 of 5 (16704ms)
    ✓ should show field metadata in a popover when hovering over a table column header: burning 4 of 5 (16126ms)
    ✓ should show field metadata in a popover when hovering over a table column header: burning 5 of 5 (16867ms)
```