### PR TITLE
Only create one revision per request to PUT /api/dashboard/:id

### DIFF
--- a/src/metabase/events/revision.clj
+++ b/src/metabase/events/revision.clj
@@ -38,12 +38,6 @@
 (derive ::dashboard-event ::event)
 (derive :event/dashboard-create ::dashboard-event)
 (derive :event/dashboard-update ::dashboard-event)
-(derive :event/dashboard-add-cards ::dashboard-event)
-(derive :event/dashboard-remove-cards ::dashboard-event)
-(derive :event/dashboard-reposition-cards ::dashboard-event)
-(derive :event/dashboard-add-tabs ::dashboard-event)
-(derive :event/dashboard-remove-tabs ::dashboard-event)
-(derive :event/dashboard-update-tabs ::dashboard-event)
 
 (methodical/defmethod events/publish-event! ::dashboard-event
   [topic event]

--- a/src/metabase/events/schema.clj
+++ b/src/metabase/events/schema.clj
@@ -11,20 +11,14 @@
                        [:user-id pos-int?]
                        [:object [:fn #(t2/instance-of? :model/Dashboard %)]]])
       with-dashcards (mut/assoc default-schema
-                                :dashcards [:sequential [:map [:id pos-int?]]])
-      with-tab-ids   (mut/assoc default-schema
-                                :tab-ids [:sequential pos-int?])]
+                                :dashcards [:sequential [:map [:id pos-int?]]])]
   (def ^:private dashboard-events-schemas
     {:event/dashboard-read             default-schema
      :event/dashboard-create           default-schema
      :event/dashboard-update           default-schema
      :event/dashboard-delete           default-schema
-     :event/dashboard-reposition-cards with-dashcards
      :event/dashboard-remove-cards     with-dashcards
-     :event/dashboard-add-cards        with-dashcards
-     :event/dashboard-add-tabs         with-tab-ids
-     :event/dashboard-update-tabs      with-tab-ids
-     :event/dashboard-remove-tabs      with-tab-ids}))
+     :event/dashboard-add-cards        with-dashcards}))
 
 ;; card events
 

--- a/src/metabase/models/dashboard_tab.clj
+++ b/src/metabase/models/dashboard_tab.clj
@@ -132,6 +132,5 @@
       (update-tabs! current-tabs to-update))
     {:old->new-tab-id old->new-tab-id
      :created-tab-ids (vals old->new-tab-id)
-     :updated-tab-ids (map :id to-update)
      :deleted-tab-ids to-delete-ids
      :total-num-tabs  (reduce + (map count [to-create to-update]))}))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1582,8 +1582,10 @@
                  updated-card-2
                  new-card]
                 cards))
-       ;; dashcard 3 is deleted
-       (is (nil? (t2/select-one DashboardCard :id dashcard-id-3)))))))
+        ;; dashcard 3 is deleted
+        (is (nil? (t2/select-one DashboardCard :id dashcard-id-3)))
+        (testing "only one revision is created"
+          (is (= 1 (t2/count :model/Revision :model_id dashboard-id))))))))
 
 (deftest e2e-update-tabs-only-test
   (testing "PUT /api/dashboard/:id/cards with create/update/delete tabs in a single req"

--- a/test/metabase/events/revision_test.clj
+++ b/test/metabase/events/revision_test.clj
@@ -136,13 +136,12 @@
                                                            :model_id    dashboard-id)
                                          keys set)))))))
 (deftest dashboard-add-cards-test
-  (testing :event/dashboard-add-cards
+  (testing ":event/dashboard-update with adding dashcards"
     (t2.with-temp/with-temp [Dashboard     {dashboard-id :id, :as dashboard} {}
                              Card          {card-id :id}                     (card-properties)
                              DashboardCard dashcard                          {:card_id card-id, :dashboard_id dashboard-id}]
-      (events/publish-event! :event/dashboard-add-cards {:object    dashboard
-                                                         :user-id   (mt/user->id :rasta)
-                                                         :dashcards [dashcard]})
+      (events/publish-event! :event/dashboard-update {:object  dashboard
+                                                      :user-id (mt/user->id :rasta)})
       (is (= {:model        "Dashboard"
               :model_id     dashboard-id
               :user_id      (mt/user->id :rasta)
@@ -155,15 +154,14 @@
                             :model_id dashboard-id))))))
 
 (deftest dashboard-remove-cards-test
-  (testing :event/dashboard-remove-cards
+  (testing ":event/dashboard-update with removing dashcards"
     (t2.with-temp/with-temp [Dashboard     {dashboard-id :id, :as dashboard} {}
                              Card          {card-id :id}                     (card-properties)
                              DashboardCard dashcard                          {:card_id card-id, :dashboard_id dashboard-id}]
       (t2/delete! (t2/table-name DashboardCard), :id (:id dashcard))
       (events/publish-event! :event/dashboard-remove-cards
-                             {:object    dashboard
-                              :user-id   (mt/user->id :rasta)
-                              :dashcards [dashcard]})
+                             {:object  dashboard
+                              :user-id (mt/user->id :rasta)})
       (is (= {:model        "Dashboard"
               :model_id     dashboard-id
               :user_id      (mt/user->id :rasta)

--- a/test/metabase/events/revision_test.clj
+++ b/test/metabase/events/revision_test.clj
@@ -175,15 +175,12 @@
                             :model_id dashboard-id))))))
 
 (deftest dashboard-reposition-cards-test
-  (testing :event/dashboard-reposition-cards
+  (testing ":event/dashboard-reposition-cards with repositioning dashcards"
     (t2.with-temp/with-temp [Dashboard     {dashboard-id :id, :as dashboard} {}
                              Card          {card-id :id}                     (card-properties)
                              DashboardCard dashcard                          {:card_id card-id, :dashboard_id dashboard-id}]
       (t2/update! DashboardCard (:id dashcard) {:size_x 3})
-      (events/publish-event! :event/dashboard-reposition-cards
-                             {:object    dashboard
-                              :user-id   (mt/user->id :crowberto)
-                              :dashcards [(assoc dashcard :size_x 4)]})
+      (events/publish-event! :event/dashboard-update {:object dashboard :user-id (mt/user->id :crowberto)})
       (is (= {:model        "Dashboard"
               :model_id     dashboard-id
               :user_id      (mt/user->id :crowberto)
@@ -206,16 +203,13 @@
                             :model_id dashboard-id))))))
 
 (deftest dashboard-add-tabs-test
-  (testing :event/dashboard-add-tabs
+  (testing ":event/dashboard-update with added tabs"
     (t2.with-temp/with-temp
       [:model/Dashboard     {dashboard-id :id, :as dashboard} {:name "A dashboard"}
        :model/DashboardTab  {dashtab-id :id}                  {:name         "First tab"
                                                                :position     0
                                                                :dashboard_id dashboard-id}]
-      (events/publish-event! :event/dashboard-add-tabs
-                             {:object    dashboard
-                              :user-id   (mt/user->id :rasta)
-                              :tab-ids   [dashtab-id]})
+      (events/publish-event! :event/dashboard-update {:object dashboard :user-id (mt/user->id :rasta)})
       (is (= {:model        "Dashboard"
               :model_id     dashboard-id
               :user_id      (mt/user->id :rasta)
@@ -231,17 +225,14 @@
                             :model_id dashboard-id))))))
 
 (deftest dashboard-update-tabs-test
-  (testing :event/dashboard-update-tabs
+  (testing ":event/dashboard-update with updating tabs"
     (t2.with-temp/with-temp
       [:model/Dashboard     {dashboard-id :id, :as dashboard} {:name "A dashboard"}
        :model/DashboardTab  {dashtab-id :id}                  {:name         "First tab"
                                                                :position     0
                                                                :dashboard_id dashboard-id}]
       (t2/update! :model/DashboardTab dashtab-id {:name "New name"})
-      (events/publish-event! :event/dashboard-update-tabs
-                             {:object    dashboard
-                              :user-id   (mt/user->id :rasta)
-                              :tab-ids   [dashtab-id]})
+      (events/publish-event! :event/dashboard-update {:object dashboard :user-id (mt/user->id :rasta)})
       (is (= {:model        "Dashboard"
               :model_id     dashboard-id
               :user_id      (mt/user->id :rasta)
@@ -257,17 +248,14 @@
                             :model_id dashboard-id))))))
 
 (deftest dashboard-delete-tabs-test
-  (testing :event/dashboard-remove-tabs
+  (testing ":event/dashboard-update with deleting tabs"
     (t2.with-temp/with-temp
       [:model/Dashboard     {dashboard-id :id, :as dashboard} {:name "A dashboard"}
        :model/DashboardTab  {dashtab-id :id}                  {:name         "First tab"
                                                                :position     0
                                                                :dashboard_id dashboard-id}]
       (t2/delete! :model/DashboardTab dashtab-id)
-      (events/publish-event! :event/dashboard-remove-tabs
-                             {:object    dashboard
-                              :user-id   (mt/user->id :rasta)
-                              :tab-ids   [dashtab-id]})
+      (events/publish-event! :event/dashboard-update {:object dashboard :user-id (mt/user->id :rasta)})
       (is (= {:model        "Dashboard"
               :model_id     dashboard-id
               :user_id      (mt/user->id :rasta)

--- a/test/metabase/events/revision_test.clj
+++ b/test/metabase/events/revision_test.clj
@@ -159,9 +159,7 @@
                              Card          {card-id :id}                     (card-properties)
                              DashboardCard dashcard                          {:card_id card-id, :dashboard_id dashboard-id}]
       (t2/delete! (t2/table-name DashboardCard), :id (:id dashcard))
-      (events/publish-event! :event/dashboard-remove-cards
-                             {:object  dashboard
-                              :user-id (mt/user->id :rasta)})
+      (events/publish-event! :event/dashboard-update {:object dashboard :user-id (mt/user->id :rasta)})
       (is (= {:model        "Dashboard"
               :model_id     dashboard-id
               :user_id      (mt/user->id :rasta)
@@ -173,7 +171,7 @@
                             :model_id dashboard-id))))))
 
 (deftest dashboard-reposition-cards-test
-  (testing ":event/dashboard-reposition-cards with repositioning dashcards"
+  (testing ":event/dashboard-update with repositioning dashcards"
     (t2.with-temp/with-temp [Dashboard     {dashboard-id :id, :as dashboard} {}
                              Card          {card-id :id}                     (card-properties)
                              DashboardCard dashcard                          {:card_id card-id, :dashboard_id dashboard-id}]


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/35209

This is the 3rd PR in a series of 3 PRs to change the way dashboards are saved to use `PUT /api/dashboard/:id`.

1. https://github.com/metabase/metabase/pull/35223
2. https://github.com/metabase/metabase/pull/35406
3. This one

This PR changes the  `PUT /api/dashboard/:id` endpoint to only ever create one revision when a dashboard is updated. Previously it was possible for multiple revisions to be created from a single call to the endpoint.

It also removes the following events, which are unused:
- `:event/dashboard-reposition-cards`
- `:event/dashboard-update-tabs`
- `:event/dashboard-add-tabs`
- `:event/dashboard-remove-tabs`