### PR TITLE
[MLv2] Refactor `display-info`; add caching

### DIFF
--- a/src/metabase/lib/cache.cljc
+++ b/src/metabase/lib/cache.cljc
@@ -1,0 +1,28 @@
+(ns metabase.lib.cache)
+
+(defn side-channel-cache
+  "(CLJS only; this is a pass-through in CLJ.)
+
+  Attaches a JS property `__mbcache` to `x` (a JS object or CLJS map) if it doesn't already have one.
+  This property holds an `(atom {})`, which is used as a \"personal\" cache attached to `x`.
+  This property is ignored by CLJS, which only uses specific keys on the JS objects used to implement CLJS maps.
+  Since CLJS maps are immutable, any `assoc`, `update`, etc. will create a new object without the cache property.
+
+  If there is not already a key `subkey` in the map, calls `(f x)` and caches the value at `subkey`.
+  If there is a value at `subkey`, it is returned directly."
+  [subkey x f]
+  (comment subkey) ; Avoids lint warning for half-unused `subkey`.
+  #?(:clj  (f x)
+     :cljs (if (or (object? x) (map? x))
+             (do
+               (when-not (.-__mbcache ^js x)
+                 (set! (.-__mbcache ^js x) (atom {})))
+               (if-let [cache (.-__mbcache ^js x)]
+                 (if-let [cached (get @cache subkey)]
+                   cached
+                   ;; Cache miss - generate the value and cache it.
+                   (let [value (f x)]
+                     (swap! cache assoc subkey value)
+                     value))
+                 (f x)))
+             (f x))))

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -338,8 +338,9 @@
   (cond->> options
     (some #(= (:unit %) unit) options)
     (mapv (fn [option]
-            (cond-> (dissoc option option-key)
-              (= (:unit option) unit) (assoc option-key true))))))
+            (cond-> option
+              (contains? option option-key) (dissoc option option-key)
+              (= (:unit option) unit)       (assoc option-key true))))))
 
 (defmethod lib.temporal-bucket/available-temporal-buckets-method :metadata/column
   [_query _stage-number field-metadata]

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -11,6 +11,7 @@
    [clojure.walk :as walk]
    [goog.object :as gobject]
    [medley.core :as m]
+   [metabase.lib.cache :as lib.cache]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib.core]
    [metabase.lib.equality :as lib.equality]
@@ -25,7 +26,8 @@
    [metabase.mbql.js :as mbql.js]
    [metabase.shared.util.time :as shared.ut]
    [metabase.util :as u]
-   [metabase.util.log :as log]))
+   [metabase.util.log :as log]
+   [metabase.util.memoize :as memoize]))
 
 ;;; this is mostly to ensure all the relevant namespaces with multimethods impls get loaded.
 (comment lib.core/keep-me)
@@ -117,28 +119,81 @@
   [a-query stage-number]
   (to-array (lib.order-by/orderable-columns a-query stage-number)))
 
-(defn- display-info-js
-  "Converts the [[metabase.lib.metadata.calculation/display-info]] maps into a JS-friendly form - `camelCase` keys,
-  namespaced keyword values as `\"foo/bar\"` strings, etc.
-  Recurses into nested sequences and maps."
+;; Display-info =====================================================================================================
+;; This is a complicated stack of caches and inner functions, so some guidance is in order.
+;;
+;; The outer surface is `lib.js/display-info` in this file. It has a [[lib.cache/side-channel-cache]], so if
+;; `display-info` is called multiple times on the same opaque CLJS value, it will be cached.
+;;
+;; [[display-info*]] is the inner implementation. It calls [[lib.core/display-info]] to get the CLJS form, then
+;; [[display-info->js]] to convert it to JS.
+;;
+;; JS conversion in the tricky cases (maps and seqs) are handled by separate, LRU-cached functions
+;; [[display-info-map->js]] and [[display-info-seq->js]]. Keywords are converted with [[u/qualified-name]].
+;;
+;; [[display-info-map->js]] converts CLJS maps to JS objects. Keys are converted from `:kebab-case-keywords` to
+;; `"camelCaseStrings"`. Values are recursively converted by [[display-info->js]]. (Note that this passes through the
+;; LRU caches for nested maps and seqs - this is important since many inner pieces are reused across eg. columns.)
+
+;; [[display-info-seq->js]] converts CLJS `sequential?` things to JS arrays, recursively calling [[display-info->js]] on
+;; each element. (This is cached just like map values above.)
+
+;; **Note:** there's an important property here that's worth calling out explicitly. It's possible for `visible-columns`
+;; on two different queries to return columns which are `=`. Since the different queries might cause different display
+;; names or other values to be generated for those `=` columns, it's vital that the caching of `display-info` is
+;; per-query. These side-channel caches attached to individual column instances are implicitly per-query (since
+;; `visible-columns` always generates new ones even for the same query) so they work here.
+;; In contrast, the CLJS -> JS conversion doesn't know about queries, so it can use `=`-based LRU caches.
+(declare ^:private display-info->js)
+
+(defn- display-info-map->js* [x]
+  (reduce (fn [obj [cljs-key cljs-val]]
+            (let [js-key (-> cljs-key u/qualified-name u/->camelCaseEn)
+                  js-val (display-info->js cljs-val)] ;; Recursing through the cache
+              (gobject/set obj js-key js-val)
+              obj))
+          #js {}
+          x))
+
+(def ^:private display-info-map->js
+  (memoize/lru display-info-map->js* :lru/threshold 256))
+
+(defn- display-info-seq->js* [x]
+  (to-array (map display-info->js x)))
+
+(def ^:private display-info-seq->js
+  (memoize/lru display-info-seq->js* :lru/threshold 256))
+
+(defn- display-info->js
+  "Converts CLJS [[lib.core/display-info]] results into JS objects for the FE to consume.
+  Recursively converts CLJS maps and `sequential?` things likewise."
   [x]
   (cond
-    (map? x)        (-> x
-                        (update-keys u/->camelCaseEn)
-                        (update-vals display-info-js))
-    (sequential? x) (map display-info-js x)
+    ;; Note that map? is only true for CLJS maps, not JS objects.
+    (map? x)        (display-info-map->js x)
+    ;; Likewise, JS arrays are not sequential? while CLJS vectors, seqs and sets are.
+    (sequential? x) (display-info-seq->js x)
+    (keyword? x)    (u/qualified-name x)
     :else           x))
 
-(defn ^:export display-info
-  "Given an opaque Cljs object, return a plain JS object with info you'd need to implement UI for it.
-  See `:metabase.lib.metadata.calculation/display-info` for the keys this might contain. Note that the JS versions of
-  the keys are converted to the equivalent `camelCase` strings from the original `:kebab-case`."
-  [a-query stage-number x]
+(defn- display-info* [a-query stage-number x]
   (-> a-query
       (lib.stage/ensure-previous-stages-have-metadata stage-number)
       (lib.core/display-info stage-number x)
-      display-info-js
-      (clj->js :keyword-fn u/qualified-name)))
+      display-info->js))
+
+(defn ^:export display-info
+  "Given an opaque CLJS object, return a plain JS object with info you'd need to implement UI for it.
+  See `:metabase.lib.metadata.calculation/display-info` for the keys this might contain. Note that the JS versions of
+  the keys are converted to the equivalent `camelCase` strings from the original `:kebab-case`."
+  ;; See the big comment above about how `display-info` fits together.
+  [a-query stage-number x]
+  ;; Attaches a cached display-info blob to `x`, in case it gets called again for the same object.
+  ;; TODO: Keying by stage is probably unnecessary - if we eg. fetched a column from different stages, it would be a
+  ;; different object. Test that idea and remove the stage from the cache key.
+  (lib.cache/side-channel-cache
+    (keyword "display-info-outer" (str "stage-" stage-number)) x
+    #(display-info* a-query stage-number %)))
 
 (defn ^:export field-id
   "Find the field id for something or nil."

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -203,26 +203,24 @@
 (def ^{:arglists '([x])} ->kebab-case-en
   "Like [[camel-snake-kebab.core/->kebab-case]], but always uses English for lower-casing, supports keywords with
   namespaces, and returns `nil` when passed `nil` (rather than throwing an exception)."
-  (wrap-csk-conversion-fn-to-handle-nil-and-namespaced-keywords
-   (memoize/lru ->kebab-case-en* :lru/threshold 256)))
+  (memoize/lru (wrap-csk-conversion-fn-to-handle-nil-and-namespaced-keywords ->kebab-case-en*) :lru/threshold 256))
 
 (def ^{:arglists '([x])} ->snake_case_en
   "Like [[camel-snake-kebab.core/->snake_case]], but always uses English for lower-casing, supports keywords with
   namespaces, and returns `nil` when passed `nil` (rather than throwing an exception)."
-  (wrap-csk-conversion-fn-to-handle-nil-and-namespaced-keywords
-   (memoize/lru ->snake_case_en* :lru/threshold 256)))
+  (memoize/lru (wrap-csk-conversion-fn-to-handle-nil-and-namespaced-keywords ->snake_case_en*) :lru/threshold 256))
 
 (def ^{:arglists '([x])} ->camelCaseEn
   "Like [[camel-snake-kebab.core/->camelCase]], but always uses English for upper- and lower-casing, supports keywords
   with namespaces, and returns `nil` when passed `nil` (rather than throwing an exception)."
-  (wrap-csk-conversion-fn-to-handle-nil-and-namespaced-keywords
-   (memoize/lru ->camelCaseEn* :lru/threshold 256)))
+  (memoize/lru (wrap-csk-conversion-fn-to-handle-nil-and-namespaced-keywords ->camelCaseEn*) :lru/threshold 256))
+
 
 (def ^{:arglists '([x])} ->SCREAMING_SNAKE_CASE_EN
   "Like [[camel-snake-kebab.core/->SCREAMING_SNAKE_CASE]], but always uses English for upper- and lower-casing, supports
   keywords with namespaces, and returns `nil` when passed `nil` (rather than throwing an exception)."
-  (wrap-csk-conversion-fn-to-handle-nil-and-namespaced-keywords
-   (memoize/lru ->SCREAMING_SNAKE_CASE_EN* :lru/threshold 256)))
+  (memoize/lru (wrap-csk-conversion-fn-to-handle-nil-and-namespaced-keywords ->SCREAMING_SNAKE_CASE_EN*)
+               :lru/threshold 256))
 
 (defn capitalize-first-char
   "Like string/capitalize, only it ignores the rest of the string

--- a/test/metabase/lib/column_group_test.cljc
+++ b/test/metabase/lib/column_group_test.cljc
@@ -298,7 +298,8 @@
                       (for [group groups]
                         (lib/display-info lib.tu/venues-query group)))))
             (testing "Card *is* present in MetadataProvider"
-              (let [query (assoc lib.tu/venues-query :lib/metadata metadata-provider)]
+              (let [query  (assoc lib.tu/venues-query :lib/metadata metadata-provider)
+                    groups (lib/group-columns (rhs-columns query card))]
                 (is (=? [{:name         "Mock categories card"
                           :display-name "Mock Categories Card"
                           :is-from-join true}]

--- a/test/metabase/lib/fe_util_test.cljc
+++ b/test/metabase/lib/fe_util_test.cljc
@@ -1,11 +1,12 @@
-(ns metabase.lib.fe-util-test(:require
-   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
+(ns metabase.lib.fe-util-test
+  (:require
    [clojure.test :refer [deftest is testing]]
    [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
-   [metabase.lib.types.isa :as lib.types.isa]))
+   [metabase.lib.types.isa :as lib.types.isa]
+   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))))
 
 (deftest ^:parallel basic-filter-parts-test
   (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :users))


### PR DESCRIPTION
This greatly improves the performance of `ML.display_info`, which is
taking a lot of the cumulative time in the various MLv2 slowdown bugs
recently: #35205, #25296.
