### PR TITLE
fix indexes

### DIFF
--- a/resources/migrations/instance_analytics_views/h2-indexes.sql
+++ b/resources/migrations/instance_analytics_views/h2-indexes.sql
@@ -1,0 +1,4 @@
+drop index idx_view_log_timestamp;
+
+create index idx_view_log_timestamp
+    on view_log(timestamp)

--- a/resources/migrations/instance_analytics_views/mariadb-indexes.sql
+++ b/resources/migrations/instance_analytics_views/mariadb-indexes.sql
@@ -1,0 +1,4 @@
+-- view_log
+drop index idx_view_log_timestamp on view_log;
+create index idx_view_log_timestamp
+    on view_log (timestamp);

--- a/resources/migrations/instance_analytics_views/mysql-indexes.sql
+++ b/resources/migrations/instance_analytics_views/mysql-indexes.sql
@@ -1,38 +1,32 @@
 -- audit_log
 create index idx_audit_log_entity_qualified_id
     on audit_log ((case
-           when model = 'Dataset' then (concat('card_', model_id))
-           when model_id is null then null
-           else (concat(lower(model), '_', model_id))
-           end));
+                       when model = 'Dataset' then (concat('card_', model_id))
+                       when model_id is null then null
+                       else (concat(lower(model), '_', model_id))
+                       end));
 
 -- activity
 create index idx_activity_entity_qualified_id
     on activity ((
-            case when model = 'Dataset' then (concat('card_', model_id))
-           when model_id is null then null
-           else (concat(lower(model), '_', model_id))
-           end));
-
--- field
-create index idx_field_entity_qualified_id
-    on metabase_field((concat('field_', id)));
+                 case
+                     when model = 'Dataset' then (concat('card_', model_id))
+                     when model_id is null then null
+                     else (concat(lower(model), '_', model_id))
+                     end));
 
 -- query_execution
 create index idx_query_execution_card_qualified_id
-    on query_execution((concat('card_', card_id)));
+    on query_execution ((concat('card_', card_id)));
 
--- user
-create index idx_user_qualified_id
-    on core_user((concat('user_', id)));
 
 create index idx_user_full_name
-    on core_user((concat(first_name, ' ', last_name)));
+    on core_user ((concat(first_name, ' ', last_name)));
 
 -- view_log
+drop index idx_view_log_timestamp on view_log;
 create index idx_view_log_timestamp
-    on view_log(timestamp);
-
+    on view_log (timestamp);
 
 create index idx_view_log_entity_qualified_id
-    on view_log((concat(model, '_', model_id)));
+    on view_log ((concat(model, '_', model_id)));

--- a/resources/migrations/instance_analytics_views/postgres-indexes.sql
+++ b/resources/migrations/instance_analytics_views/postgres-indexes.sql
@@ -28,6 +28,7 @@ create index idx_user_full_name
     on core_user((first_name || ' ' || last_name));
 
 -- view_log
+drop index idx_view_log_timestamp;
 create index idx_view_log_timestamp
     on view_log(timestamp);
 


### PR DESCRIPTION
Create individual files for H2 and MariaDB as these don't support functional indexes.

Add explicit drop index command to replace `idx_view_log_timestamp` on all databases because it was likely created wrong in the first place. Before, `idx_view_log_timestamp` was targeting `model_id` column.