### PR TITLE
feat/refactor: truncate via css

### DIFF
--- a/frontend/src/metabase/containers/UndoListing.jsx
+++ b/frontend/src/metabase/containers/UndoListing.jsx
@@ -16,6 +16,7 @@ import {
   DefaultText,
   DismissIcon,
   ToastCard,
+  TruncatedText,
   UndoButton,
   UndoList,
 } from "./UndoListing.styled";
@@ -67,7 +68,7 @@ function UndoToast({ undo, onUndo, onDismiss }) {
           <CardContent>
             <CardContentSide>
               {undo.icon && <CardIcon name={undo.icon} color="white" />}
-              {renderMessage(undo)}
+              <TruncatedText>{renderMessage(undo)}</TruncatedText>
             </CardContentSide>
             <CardContentSide>
               {undo.actions?.length > 0 && (
@@ -85,7 +86,6 @@ function UndoToast({ undo, onUndo, onDismiss }) {
     </Motion>
   );
 }
-
 function UndoListingInner() {
   const dispatch = useDispatch();
   const undos = useSelector(state => state.undo);

--- a/frontend/src/metabase/containers/UndoListing.styled.tsx
+++ b/frontend/src/metabase/containers/UndoListing.styled.tsx
@@ -35,6 +35,14 @@ export const CardContentSide = styled.div`
   align-items: center;
 `;
 
+export const TruncatedText = styled.div`
+  max-width: 75ch;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+`;
+
 export const CardIcon = styled(Icon)`
   margin-right: ${space(1)};
 `;

--- a/frontend/src/metabase/dashboard/actions/utils.ts
+++ b/frontend/src/metabase/dashboard/actions/utils.ts
@@ -2,7 +2,6 @@ import _ from "underscore";
 
 import type { Draft } from "@reduxjs/toolkit";
 import { t } from "ttag";
-import { truncate } from "humanize-plus";
 import type { DashboardState, StoreDashcard } from "metabase-types/store";
 import type {
   Dashboard,
@@ -65,7 +64,7 @@ export const getDashCardMoveToTabUndoMessage = (dashCard: StoreDashcard) => {
     dashCard.visualization_settings?.virtual_card?.display;
 
   if (dashCard.card.name) {
-    return truncate(t`Card moved: ${dashCard.card.name}`, 75);
+    return t`Card moved: ${dashCard.card.name}`;
   }
 
   switch (virtualCardType) {


### PR DESCRIPTION
### Description

This addresses comments in the parent PR about using css to truncate the text: [#35378 feat: use name of card in undo toast message](https://github.com/metabase/metabase/pull/35378)

## Changes:
- truncation is done via css
- **truncation is done on all undo toast**
- toast don't go on two lines on small viewports


Before:

https://github.com/metabase/metabase/assets/1914270/2f5f6305-9e01-48cc-8012-1c69f71011dd




After:

https://github.com/metabase/metabase/assets/1914270/47d929a7-091c-47bf-a75c-630dad5ef9f1

