### PR TITLE
Fix E2E "move dashcards to tabs" flake

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.js
+++ b/e2e/support/helpers/e2e-dashboard-helpers.js
@@ -172,8 +172,11 @@ export function goToTab(tabName) {
 }
 
 export function moveDashCardToTab({ dashcardIndex = 0, tabName }) {
-  getDashboardCard(dashcardIndex).realHover().icon("move_card").click();
-  menu().findByText(tabName).click();
+  getDashboardCard(dashcardIndex)
+    .realHover()
+    .icon("move_card")
+    .click({ force: true });
+  menu().findByText(tabName).click({ force: true });
 }
 
 export function visitDashboardAndCreateTab({ dashboardId, save = true }) {

--- a/e2e/support/helpers/e2e-dashboard-helpers.js
+++ b/e2e/support/helpers/e2e-dashboard-helpers.js
@@ -172,11 +172,8 @@ export function goToTab(tabName) {
 }
 
 export function moveDashCardToTab({ dashcardIndex = 0, tabName }) {
-  getDashboardCard(dashcardIndex)
-    .realHover()
-    .icon("move_card")
-    .realHover();
-  menu().findByText(tabName).click({ force: true });
+  getDashboardCard(dashcardIndex).realHover().icon("move_card").realHover();
+  menu().findByText(tabName).click();
 }
 
 export function visitDashboardAndCreateTab({ dashboardId, save = true }) {

--- a/e2e/support/helpers/e2e-dashboard-helpers.js
+++ b/e2e/support/helpers/e2e-dashboard-helpers.js
@@ -175,7 +175,7 @@ export function moveDashCardToTab({ dashcardIndex = 0, tabName }) {
   getDashboardCard(dashcardIndex)
     .realHover()
     .icon("move_card")
-    .click({ force: true });
+    .realHover();
   menu().findByText(tabName).click({ force: true });
 }
 


### PR DESCRIPTION
This test has been failing and flaking fairly frequently in `master` in the last 7 days.
https://www.deploysentinel.com/ci/analysis?branch=master

It's actually the second worst performer:
![image](https://github.com/metabase/metabase/assets/31325167/b6092077-21fd-4b74-8bf1-216861254dbb)

Example of the failed run
https://www.deploysentinel.com/ci/runs/65412d8f2beaab0325bdcfd9

This PR fixes the flake, but it uses "force click" because UI elements are not always visible or even actionable. Perhaps a more elegant and more permanent solution is needed here. This will do for now.

Stress-testing this change passes with flying colors 20/20 ✅ 
https://github.com/metabase/metabase/actions/runs/6773657219/job/18409020101
```
    ✓ should allow moving different types of dashcards to other tabs: burning 1 of 20 (8695ms)
    ✓ should allow moving different types of dashcards to other tabs: burning 2 of 20 (7832ms)
    ✓ should allow moving different types of dashcards to other tabs: burning 3 of 20 (7868ms)
    ✓ should allow moving different types of dashcards to other tabs: burning 4 of 20 (6349ms)
    ✓ should allow moving different types of dashcards to other tabs: burning 5 of 20 (6295ms)
    ✓ should allow moving different types of dashcards to other tabs: burning 6 of 20 (5803ms)
    ✓ should allow moving different types of dashcards to other tabs: burning 7 of 20 (5644ms)
    ✓ should allow moving different types of dashcards to other tabs: burning 8 of 20 (3941ms)
    ✓ should allow moving different types of dashcards to other tabs: burning 9 of 20 (3759ms)
    ✓ should allow moving different types of dashcards to other tabs: burning 10 of 20 (5900ms)
    ✓ should allow moving different types of dashcards to other tabs: burning 11 of 20 (6287ms)
    ✓ should allow moving different types of dashcards to other tabs: burning 12 of 20 (5786ms)
    ✓ should allow moving different types of dashcards to other tabs: burning 13 of 20 (3753ms)
    ✓ should allow moving different types of dashcards to other tabs: burning 14 of 20 (3524ms)
    ✓ should allow moving different types of dashcards to other tabs: burning 15 of 20 (5286ms)
    ✓ should allow moving different types of dashcards to other tabs: burning 16 of 20 (3681ms)
    ✓ should allow moving different types of dashcards to other tabs: burning 17 of 20 (3711ms)
    ✓ should allow moving different types of dashcards to other tabs: burning 18 of 20 (3769ms)
    ✓ should allow moving different types of dashcards to other tabs: burning 19 of 20 (4206ms)
    ✓ should allow moving different types of dashcards to other tabs: burning 20 of 20 (3800ms)
```