### PR TITLE
🍒 Manual backport of #34996

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -3,10 +3,10 @@
   (:require
    [metabase-enterprise.serialization.dump :as dump]
    [metabase-enterprise.serialization.load :as load]
+   [metabase-enterprise.serialization.v2.entity-ids :as v2.entity-ids]
    [metabase-enterprise.serialization.v2.extract :as v2.extract]
    [metabase-enterprise.serialization.v2.ingest :as v2.ingest]
    [metabase-enterprise.serialization.v2.load :as v2.load]
-   [metabase-enterprise.serialization.v2.seed-entity-ids :as v2.seed-entity-ids]
    [metabase-enterprise.serialization.v2.storage :as v2.storage]
    [metabase.db :as mdb]
    [metabase.models.card :refer [Card]]
@@ -220,4 +220,16 @@
 
   Returns truthy if all entity IDs were added successfully, or falsey if any errors were encountered."
   []
-  (v2.seed-entity-ids/seed-entity-ids!))
+  (v2.entity-ids/seed-entity-ids!))
+
+(defn drop-entity-ids
+  "Drop entity IDs for all instances of serializable models.
+
+  This is needed for some cases of migrating from v1 to v2 serdes. v1 doesn't dump `entity_id`, so they may have been
+  randomly generated independently in both instances. Then when v2 serdes is used to export and import, the randomly
+  generated IDs don't match and the entities get duplicated. Dropping `entity_id` from both instances first will force
+  them to be regenerated based on the hashes, so they should match up if the receiving instance is a copy of the sender.
+
+  Returns truthy if all entity IDs have been dropped, or falsey if any errors were encountered."
+  []
+  (v2.entity-ids/drop-entity-ids!))

--- a/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
@@ -7,8 +7,9 @@
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.serialization.v2.backfill-ids :as serdes.backfill]
-   [metabase-enterprise.serialization.v2.seed-entity-ids :as v2.seed-entity-ids]
+   [metabase-enterprise.serialization.v2.entity-ids :as v2.entity-ids]
    [metabase.db.data-migrations]
+   #_{:clj-kondo/ignore [:deprecated-namespace]}
    [metabase.models]
    [metabase.models.revision-test]
    [metabase.models.serialization :as serdes]))
@@ -74,7 +75,7 @@
     :model/ConnectionImpersonation})
 
 (deftest ^:parallel comprehensive-entity-id-test
-  (doseq [model (->> (v2.seed-entity-ids/toucan-models)
+  (doseq [model (->> (v2.entity-ids/toucan-models)
                      (remove (fn [model]
                                (not= (namespace model) "model")))
                      (remove entities-not-exported)
@@ -85,7 +86,7 @@
       (is (true? (serdes.backfill/has-entity-id? model))))))
 
 (deftest ^:parallel comprehensive-identity-hash-test
-  (doseq [model (->> (v2.seed-entity-ids/toucan-models)
+  (doseq [model (->> (v2.entity-ids/toucan-models)
                      (remove (fn [model]
                                (not= (namespace model) "model")))
                      (remove entities-not-exported))]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/entity_ids_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/entity_ids_test.clj
@@ -63,8 +63,13 @@
     (testing "has no entity ids"
       (t2.with-temp/with-temp [Collection _ {:name       "No Entity ID Collection"
                                              :slug       "no_entity_id_collection"}]
-        (is (nil? (t2/select-fn-set :entity-id Dashboard)))
+        (is (= 0 (t2/count Dashboard)))
+        (let [eids (t2/select-fn-set :entity-id Dashboard)]
+          (is (or (empty? eids)
+                  (= #{nil} eids))))
         (testing "but doesn't crash drop-entity-ids"
           (is (= true
                  (v2.entity-ids/drop-entity-ids!)))
-          (is (nil? (t2/select-fn-set :entity-id Dashboard))))))))
+          (let [eids (t2/select-fn-set :entity-id Dashboard)]
+            (is (or (empty? eids)
+                    (= #{nil} eids)))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/entity_ids_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/entity_ids_test.clj
@@ -3,7 +3,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase-enterprise.serialization.v2.entity-ids :as v2.entity-ids]
-   [metabase.models :refer [Collection Dashboard]]
+   [metabase.models :refer [Collection]]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp])
   (:import
@@ -58,18 +58,4 @@
           (testing "Should return truthy on success"
             (is (= true
                    (v2.entity-ids/drop-entity-ids!))))
-          (is (nil? (entity-id)))))))
-  (testing "empty table"
-    (testing "has no entity ids"
-      (t2.with-temp/with-temp [Collection _ {:name       "No Entity ID Collection"
-                                             :slug       "no_entity_id_collection"}]
-        (is (= 0 (t2/count Dashboard)))
-        (let [eids (t2/select-fn-set :entity-id Dashboard)]
-          (is (or (empty? eids)
-                  (= #{nil} eids))))
-        (testing "but doesn't crash drop-entity-ids"
-          (is (= true
-                 (v2.entity-ids/drop-entity-ids!)))
-          (let [eids (t2/select-fn-set :entity-id Dashboard)]
-            (is (or (empty? eids)
-                    (= #{nil} eids)))))))))
+          (is (nil? (entity-id))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/entity_ids_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/entity_ids_test.clj
@@ -4,7 +4,6 @@
    [clojure.test :refer :all]
    [metabase-enterprise.serialization.v2.entity-ids :as v2.entity-ids]
    [metabase.models :refer [Collection Dashboard]]
-   [metabase.test :as mt]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp])
   (:import
@@ -50,9 +49,9 @@
 (deftest drop-entity-ids-test
   (testing "With a temp Collection with an entity ID"
     (let [now (LocalDateTime/of 2022 9 1 12 34 56)]
-      (mt/with-temp! [Collection c {:name       "No Entity ID Collection"
-                                    :slug       "no_entity_id_collection"
-                                    :created_at now}]
+      (t2.with-temp/with-temp [Collection c {:name       "No Entity ID Collection"
+                                             :slug       "no_entity_id_collection"
+                                             :created_at now}]
         (letfn [(entity-id []
                   (some-> (t2/select-one-fn :entity_id Collection :id (:id c)) str/trim))]
           (is (some? (entity-id)))
@@ -62,8 +61,8 @@
           (is (nil? (entity-id)))))))
   (testing "empty table"
     (testing "has no entity ids"
-      (mt/with-temp! [Collection _ {:name       "No Entity ID Collection"
-                                    :slug       "no_entity_id_collection"}]
+      (t2.with-temp/with-temp [Collection _ {:name       "No Entity ID Collection"
+                                             :slug       "no_entity_id_collection"}]
         (is (nil? (t2/select-fn-set :entity-id Dashboard)))
         (testing "but doesn't crash drop-entity-ids"
           (is (= true

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/entity_ids_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/entity_ids_test.clj
@@ -1,10 +1,10 @@
-(ns metabase-enterprise.serialization.v2.seed-entity-ids-test
+(ns metabase-enterprise.serialization.v2.entity-ids-test
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [metabase-enterprise.serialization.v2.seed-entity-ids
-    :as v2.seed-entity-ids]
-   [metabase.models :refer [Collection]]
+   [metabase-enterprise.serialization.v2.entity-ids :as v2.entity-ids]
+   [metabase.models :refer [Collection Dashboard]]
+   [metabase.test :as mt]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp])
   (:import
@@ -14,7 +14,7 @@
 
 (deftest seed-entity-ids-test
   (testing "Sanity check: should succeed before we go around testing specific situations"
-    (is (true? (v2.seed-entity-ids/seed-entity-ids!))))
+    (is (true? (v2.entity-ids/seed-entity-ids!))))
   (testing "With a temp Collection with no entity ID"
     (let [now (LocalDateTime/of 2022 9 1 12 34 56)]
       (t2.with-temp/with-temp [Collection c {:name       "No Entity ID Collection"
@@ -28,7 +28,7 @@
                  (entity-id)))
           (testing "Should return truthy on success"
             (is (= true
-                   (v2.seed-entity-ids/seed-entity-ids!))))
+                   (v2.entity-ids/seed-entity-ids!))))
           (is (= "998b109c"
                  (entity-id))))
         (testing "Error: duplicate entity IDs"
@@ -43,6 +43,29 @@
                      (entity-id)))
               (testing "Should return falsey on error"
                 (is (= false
-                       (v2.seed-entity-ids/seed-entity-ids!))))
+                       (v2.entity-ids/seed-entity-ids!))))
               (is (= nil
                      (entity-id))))))))))
+
+(deftest drop-entity-ids-test
+  (testing "With a temp Collection with an entity ID"
+    (let [now (LocalDateTime/of 2022 9 1 12 34 56)]
+      (mt/with-temp! [Collection c {:name       "No Entity ID Collection"
+                                    :slug       "no_entity_id_collection"
+                                    :created_at now}]
+        (letfn [(entity-id []
+                  (some-> (t2/select-one-fn :entity_id Collection :id (:id c)) str/trim))]
+          (is (some? (entity-id)))
+          (testing "Should return truthy on success"
+            (is (= true
+                   (v2.entity-ids/drop-entity-ids!))))
+          (is (nil? (entity-id)))))))
+  (testing "empty table"
+    (testing "has no entity ids"
+      (mt/with-temp! [Collection _ {:name       "No Entity ID Collection"
+                                    :slug       "no_entity_id_collection"}]
+        (is (nil? (t2/select-fn-set :entity-id Dashboard)))
+        (testing "but doesn't crash drop-entity-ids"
+          (is (= true
+                 (v2.entity-ids/drop-entity-ids!)))
+          (is (nil? (t2/select-fn-set :entity-id Dashboard))))))))

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -222,6 +222,13 @@
   (when-not (call-enterprise 'metabase-enterprise.serialization.cmd/seed-entity-ids)
     (throw (Exception. "Error encountered while seeding entity IDs"))))
 
+(defn ^:command drop-entity-ids
+  "Drop entity IDs for instances of serializable models. Useful for migrating from v1 serialization (x.46 and earlier)
+  to v2 (x.47+)."
+  []
+  (when-not (call-enterprise 'metabase-enterprise.serialization.cmd/drop-entity-ids)
+    (throw (Exception. "Error encountered while dropping entity IDs"))))
+
 (defn ^:command rotate-encryption-key
   "Rotate the encryption key of a metabase database. The MB_ENCRYPTION_SECRET_KEY environment variable has to be set to
   the current key, and the parameter `new-key` has to be the new key. `new-key` has to be at least 16 chars."

--- a/test/metabase/cmd_test.clj
+++ b/test/metabase/cmd_test.clj
@@ -10,7 +10,7 @@
 
 (deftest ^:parallel error-message-test
   (is (= ["Unrecognized command: 'a-command-that-does-not-exist'"
-          "Valid commands: version, help, import, dump, profile, api-documentation, load, seed-entity-ids, dump-to-h2, environment-variables-documentation, migrate, driver-methods, load-from-h2, export, rotate-encryption-key, reset-password"]
+          "Valid commands: version, help, drop-entity-ids, import, dump, profile, api-documentation, load, seed-entity-ids, dump-to-h2, environment-variables-documentation, migrate, driver-methods, load-from-h2, export, rotate-encryption-key, reset-password"]
          (#'cmd/validate "a-command-that-does-not-exist" [])))
   (is (= ["The 'rotate-encryption-key' command requires the following arguments: [new-key], but received: []."]
          (#'cmd/validate "rotate-encryption-key" [])))


### PR DESCRIPTION
Add drop_entity_ids CLI command, to drop all entity_ids

This is useful for migrating from serdes v1 to v2.

Fixes #34871.
