### PR TITLE
Fix audit v2 merge conflicts with master and rework audit_log API

### DIFF
--- a/bin/build/src/metabuild_common/files.clj
+++ b/bin/build/src/metabuild_common/files.clj
@@ -161,7 +161,7 @@
    zip the directory and writes it to the destination"
   ([source-dir zip-file]
    (zip-directory->file source-dir zip-file {}))
-  ([^String source-dir ^String zip-file {:keys [verbose]}]
+  ([^String source-dir ^String zip-file {:keys [_verbose]}]
    (let [verbose true
          ^File source-path (File. source-dir)
          entry-count (atom 0)]

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
@@ -36,7 +36,7 @@
   (u/prog1 (first (t2/insert-returning-instances! User (merge user {:password (str (random-uuid))})))
     (log/info (trs "New SSO user created: {0} ({1})" (:common_name <>) (:email <>)))
     ;; publish user-invited event for audit logging
-    (events/publish-event! :event/user-invited (assoc <> :sso_source (:sso_source user)))
+    (events/publish-event! :event/user-invited {:object (assoc <> :sso_source (:sso_source user))})
     ;; send an email to everyone including the site admin if that's set
     (when (integrations.common/send-new-sso-user-admin-email?)
       (messages/send-user-joined-admin-notification-email! <>, :google-auth? true))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/models/pulse_channel_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/models/pulse_channel_test.clj
@@ -54,7 +54,8 @@
       (is (= "metabase.com"
              (advanced-config.models.pulse-channel/subscription-allowed-domains! "metabase.com")))))
   (testing "Should be unable to set the subscription-allowed-domains setting without the email-allow-list feature"
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo
-         #"Setting subscription-allowed-domains is not enabled because feature :email-allow-list is not available"
-         (advanced-config.models.pulse-channel/subscription-allowed-domains! "metabase.com")))))
+    (premium-features-test/with-premium-features #{}
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Setting subscription-allowed-domains is not enabled because feature :email-allow-list is not available"
+           (advanced-config.models.pulse-channel/subscription-allowed-domains! "metabase.com"))))))

--- a/enterprise/backend/test/metabase_enterprise/audit_app/pages/alerts_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/pages/alerts_test.clj
@@ -37,7 +37,7 @@
                                                                    :pulse_id pulse-id}
                          PulseChannel          {channel-id :id}   {:pulse_id       pulse-id
                                                                    :channel_type   "email"
-                                                                   :details        {:emails ["amazing@fake.com"]}
+                                                                   :details        {:emails ["amazing@metabase.com"]}
                                                                    :schedule_type  "monthly"
                                                                    :schedule_frame "first"
                                                                    :schedule_day   "mon"

--- a/enterprise/backend/test/metabase_enterprise/audit_app/pages/dashboard_subscriptions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/pages/dashboard_subscriptions_test.clj
@@ -35,7 +35,7 @@
                                                                     :collection_id collection-id}
                           PulseChannel          {channel-id :id}   {:pulse_id       pulse-id
                                                                     :channel_type   "email"
-                                                                    :details        {:emails ["amazing@fake.com"]}
+                                                                    :details        {:emails ["amazing@metabase.com"]}
                                                                     :schedule_type  "monthly"
                                                                     :schedule_frame "first"
                                                                     :schedule_day   "mon"

--- a/enterprise/backend/test/metabase_enterprise/audit_app/pages/dashboard_subscriptions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/pages/dashboard_subscriptions_test.clj
@@ -19,69 +19,70 @@
         :args [dashboard-name]}))))
 
 (deftest table-test
-  (is (= []
-         (mt/rows (dashboard-subscriptions (mt/random-name)))))
-  (let [dashboard-name (mt/random-name)]
-    (mt/with-temp! [Collection {collection-id :id, collection-name :name}]
-      ;; test with both the Root Collection and a non-Root Collection
-      (doseq [{:keys [collection-id collection-name]} [{:collection-id   collection-id
-                                                        :collection-name collection-name}
-                                                       {:collection-id   nil
-                                                        :collection-name "Our analytics"}]]
-        (testing (format "Collection = %d %s" collection-id collection-name)
-          (mt/with-temp! [Dashboard             {dashboard-id :id} {:name          dashboard-name
-                                                                    :collection_id collection-id}
-                          Pulse                 {pulse-id :id}     {:dashboard_id  dashboard-id
-                                                                    :collection_id collection-id}
-                          PulseChannel          {channel-id :id}   {:pulse_id       pulse-id
-                                                                    :channel_type   "email"
-                                                                    :details        {:emails ["amazing@metabase.com"]}
-                                                                    :schedule_type  "monthly"
-                                                                    :schedule_frame "first"
-                                                                    :schedule_day   "mon"
-                                                                    :schedule_hour  8}
-                          PulseChannelRecipient _                  {:pulse_channel_id channel-id
-                                                                    :user_id          (mt/user->id :rasta)}
-                          PulseChannel          {channel-2-id :id} {:pulse_id      pulse-id
-                                                                    :channel_type  "slack"
-                                                                    :details       {:channel "#wow"}
-                                                                    :schedule_type "hourly"}]
-            (is (= {:columns ["dashboard_id"
-                              "dashboard_name"
-                              "pulse_id"
-                              "recipients"
-                              "subscription_type"
-                              "collection_id"
-                              "collection_name"
-                              "frequency"
-                              "creator_id"
-                              "creator_name"
-                              "created_at"
-                              "num_filters"]
-                    ;; sort by newest first.
-                    :rows    [[dashboard-id
-                               dashboard-name
-                               pulse-id
-                               nil
-                               "Slack"
-                               collection-id
-                               collection-name
-                               "Every hour"
-                               (mt/user->id :rasta)
-                               "Rasta Toucan"
-                               (t2/select-one-fn :created_at PulseChannel :id channel-2-id)
-                               0]
-                              [dashboard-id
-                               dashboard-name
-                               pulse-id
-                               2
-                               "Email"
-                               collection-id
-                               collection-name
-                               "At 8:00 AM, on the first Tuesday of the month"
-                               (mt/user->id :rasta)
-                               "Rasta Toucan"
-                               (t2/select-one-fn :created_at PulseChannel :id channel-id)
-                               0]]}
-                   (mt/rows+column-names
-                    (dashboard-subscriptions (str/join (rest (butlast dashboard-name)))))))))))))
+  (premium-features-test/with-premium-features #{}
+   (is (= []
+          (mt/rows (dashboard-subscriptions (mt/random-name)))))
+   (let [dashboard-name (mt/random-name)]
+     (mt/with-temp! [Collection {collection-id :id, collection-name :name}]
+       ;; test with both the Root Collection and a non-Root Collection
+       (doseq [{:keys [collection-id collection-name]} [{:collection-id   collection-id
+                                                         :collection-name collection-name}
+                                                        {:collection-id   nil
+                                                         :collection-name "Our analytics"}]]
+         (testing (format "Collection = %d %s" collection-id collection-name)
+           (mt/with-temp! [Dashboard             {dashboard-id :id} {:name          dashboard-name
+                                                                     :collection_id collection-id}
+                           Pulse                 {pulse-id :id}     {:dashboard_id  dashboard-id
+                                                                     :collection_id collection-id}
+                           PulseChannel          {channel-id :id}   {:pulse_id       pulse-id
+                                                                     :channel_type   "email"
+                                                                     :details        {:emails ["amazing@fake.com"]}
+                                                                     :schedule_type  "monthly"
+                                                                     :schedule_frame "first"
+                                                                     :schedule_day   "mon"
+                                                                     :schedule_hour  8}
+                           PulseChannelRecipient _                  {:pulse_channel_id channel-id
+                                                                     :user_id          (mt/user->id :rasta)}
+                           PulseChannel          {channel-2-id :id} {:pulse_id      pulse-id
+                                                                     :channel_type  "slack"
+                                                                     :details       {:channel "#wow"}
+                                                                     :schedule_type "hourly"}]
+             (is (= {:columns ["dashboard_id"
+                               "dashboard_name"
+                               "pulse_id"
+                               "recipients"
+                               "subscription_type"
+                               "collection_id"
+                               "collection_name"
+                               "frequency"
+                               "creator_id"
+                               "creator_name"
+                               "created_at"
+                               "num_filters"]
+                     ;; sort by newest first.
+                     :rows    [[dashboard-id
+                                dashboard-name
+                                pulse-id
+                                nil
+                                "Slack"
+                                collection-id
+                                collection-name
+                                "Every hour"
+                                (mt/user->id :rasta)
+                                "Rasta Toucan"
+                                (t2/select-one-fn :created_at PulseChannel :id channel-2-id)
+                                0]
+                               [dashboard-id
+                                dashboard-name
+                                pulse-id
+                                2
+                                "Email"
+                                collection-id
+                                collection-name
+                                "At 8:00 AM, on the first Tuesday of the month"
+                                (mt/user->id :rasta)
+                                "Rasta Toucan"
+                                (t2/select-one-fn :created_at PulseChannel :id channel-id)
+                                0]]}
+                    (mt/rows+column-names
+                     (dashboard-subscriptions (str/join (rest (butlast dashboard-name))))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
@@ -36,15 +36,14 @@
      (audit-db/ensure-audit-db-installed!)
      (premium-features-test/with-premium-features #{:audit-app}
        (mt/with-test-user :crowberto
-         ;; TODO: re-enable this test once all of the audit content is updated to use new views
-         #_(testing "A query using a saved audit model as the source table runs succesfully"
-             (let [audit-card (t2/select-one :model/Card :database_id perms/audit-db-id :dataset true)]
-               (is (partial=
-                    {:status :completed}
-                    (qp/process-query
-                     {:database perms/audit-db-id
-                      :type     :query
-                      :query    {:source-table (str "card__" (u/the-id audit-card))}})))))
+         (testing "A query using a saved audit model as the source table runs succesfully"
+           (let [audit-card (t2/select-one :model/Card :database_id perms/audit-db-id :dataset true)]
+             (is (partial=
+                  {:status :completed}
+                  (qp/process-query
+                   {:database perms/audit-db-id
+                    :type     :query
+                    :query    {:source-table (str "card__" (u/the-id audit-card))}})))))
 
          (testing "A non-native query can be run on views in the audit DB"
            (let [audit-view (t2/select-one :model/Table :db_id perms/audit-db-id)]

--- a/enterprise/backend/test/metabase_enterprise/email/messages_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/email/messages_test.clj
@@ -21,5 +21,6 @@
                        (:email user))
                  (set (#'messages/admin-or-ee-monitoring-details-emails db-id))))))
       (testing "Only send to admin users if advanced-permissions is disabled"
-        (is (= (set (#'messages/all-admin-recipients))
-               (set (#'messages/admin-or-ee-monitoring-details-emails db-id))))))))
+        (premium-features-test/with-premium-features #{}
+          (is (= (set (#'messages/all-admin-recipients))
+                 (set (#'messages/admin-or-ee-monitoring-details-emails db-id)))))))))

--- a/enterprise/backend/test/metabase_enterprise/public_settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/public_settings_test.clj
@@ -34,11 +34,11 @@
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
              #"Setting embedding-app-origin is not enabled because feature :embedding is not available"
-             (public-settings/embedding-app-origin! "https://metabase.com"))))
+             (public-settings/embedding-app-origin! "https://metabase.com")))
 
-      (testing "even if env is set, return the default value"
-        (mt/with-temp-env-var-value [mb-embedding-app-origin "https://metabase.com"]
-          (is (nil? (public-settings/embedding-app-origin))))))
+        (testing "even if env is set, return the default value"
+          (mt/with-temp-env-var-value [mb-embedding-app-origin "https://metabase.com"]
+            (is (nil? (public-settings/embedding-app-origin)))))))
 
     (testing "can change embedding-app-origin if :embedding is enabled"
       (premium-features-test/with-premium-features #{:embedding}

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -472,7 +472,7 @@
                         :model_id (:id new-user)
                         :topic    :user-invited
                         :user_id  nil}
-                       (audit-log-test/event :user-invited (:id new-user))))))
+                       (audit-log-test/latest-event :user-invited (:id new-user))))))
             (testing "attributes"
               (is (= (some-saml-attributes "newuser")
                      (saml-login-attributes "newuser@metabase.com"))))

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15905,6 +15905,40 @@ databaseChangeLog:
         - sql:
             sql: drop view if exists v_view_log;
 
+  - changeSet:
+      id: v48.00-047
+      author: noahmoss
+      comment: Drop foreign key on recent_views so that it can be recreated with onDelete policy
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: recent_views
+            constraintName: fk_recent_views_ref_user_id
+      rollback:
+        - addForeignKeyConstraint:
+            baseTableName: recent_views
+            constraintName: fk_recent_views_ref_user_id
+            referencedTableName: core_user
+            baseColumnNames: user_id
+            referencedColumnNames: id
+            onDelete: CASCADE
+
+  - changeSet:
+      id: v48.00-048
+      author: noahmoss
+      comment: Add foreign key on recent_views with onDelete CASCADE
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: recent_views
+            constraintName: fk_recent_views_ref_user_id
+            referencedTableName: core_user
+            baseColumnNames: user_id
+            referencedColumnNames: id
+            onDelete: CASCADE
+      rollback:
+        - dropForeignKeyConstraint:
+            baseTableName: recent_views
+            constraintName: fk_recent_views_ref_user_id
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15794,7 +15794,7 @@ databaseChangeLog:
       comment: Added 0.48.0 - new view v_alerts
       changes:
         - sqlFile:
-            dbms: postgres
+            dbms: postgresql
             path: instance_analytics_views/alerts/v1/postgres-alerts.sql
             relativeToChangelogFile: true
         - sqlFile:

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15827,7 +15827,7 @@ databaseChangeLog:
       comment: Added 0.48.0 - new view v_fields
       changes:
         - sqlFile:
-            dbms: postgres
+            dbms: postgresql
             path: instance_analytics_views/fields/v1/postgres-fields.sql
             relativeToChangelogFile: true
         - sqlFile:
@@ -15848,7 +15848,7 @@ databaseChangeLog:
       comment: Added 0.48.0 - new view v_query_log
       changes:
         - sqlFile:
-            dbms: postgres
+            dbms: postgresql
             path: instance_analytics_views/query_log/v1/postgres-query_log.sql
             relativeToChangelogFile: true
         - sqlFile:

--- a/resources/migrations/instance_analytics_views/alerts/v1/h2-alerts.sql
+++ b/resources/migrations/instance_analytics_views/alerts/v1/h2-alerts.sql
@@ -1,14 +1,15 @@
 drop view if exists v_alerts;
 
 create or replace view v_alerts as
-with agg_recipients as (
-    select
-        pulse_channel_id,
-        listagg(core_user.email,',') as recipients
-    from pulse_channel_recipient
-        left join core_user on pulse_channel_recipient.user_id = core_user.id
-    group by pulse_channel_id
-)
+-- TODO: debug why this subquery doesn't work when run from Liquibase
+--with agg_recipients as (
+--    select
+--        pulse_channel_id,
+--        listagg(core_user.email,',') as recipients
+--    from pulse_channel_recipient
+--        left join core_user on pulse_channel_recipient.user_id = core_user.id
+--    group by pulse_channel_id
+--)
 select
     pulse.id as entity_id,
     concat('pulse_', pulse.id) as entity_qualified_id,
@@ -23,11 +24,11 @@ select
     pulse_channel.schedule_hour,
     archived,
     channel_type as recipient_type,
-    agg_recipients.recipients,
+    NULL as recipients, -- recipients is constantly NULL for H2
     details as recipient_external
     from pulse
         left join pulse_card on pulse.id = pulse_card.pulse_id
         left join pulse_channel on pulse.id = pulse_channel.pulse_id
-        left join agg_recipients on pulse_channel.id = agg_recipients.pulse_channel_id
+--        left join agg_recipients on pulse_channel.id = agg_recipients.pulse_channel_id
     where alert_condition is not null;
 

--- a/resources/migrations/instance_analytics_views/subscriptions/v1/h2-subscriptions.sql
+++ b/resources/migrations/instance_analytics_views/subscriptions/v1/h2-subscriptions.sql
@@ -1,14 +1,15 @@
 drop view if exists v_subscriptions;
 
 create or replace view v_subscriptions as
-with agg_recipients as (
-    select
-        pulse_channel_id,
-        listagg(core_user.email,',') as recipients
-    from pulse_channel_recipient
-        left join core_user on pulse_channel_recipient.user_id = core_user.id
-    group by pulse_channel_id
-)
+-- TODO: debug why this subquery doesn't work when run from Liquibase
+-- with agg_recipients as (
+--     select
+--         pulse_channel_id,
+--         listagg(core_user.email,',') as recipients
+--     from pulse_channel_recipient
+--         left join core_user on pulse_channel_recipient.user_id = core_user.id
+--     group by pulse_channel_id
+-- )
 select
     pulse.id as entity_id,
     'pulse_' || pulse.id as entity_qualified_id,
@@ -21,11 +22,12 @@ select
     pulse_channel.schedule_day,
     pulse_channel.schedule_hour,
     channel_type as recipient_type,
-    agg_recipients.recipients,
+    NULL as recipients,
+--     agg_recipients.recipients,
     details as recipient_external,
     parameters
     from pulse
         left join pulse_channel on pulse.id = pulse_channel.pulse_id
-        left join agg_recipients on pulse_channel.id = agg_recipients.pulse_channel_id
+--        left join agg_recipients on pulse_channel.id = agg_recipients.pulse_channel_id
     where alert_condition is null
 

--- a/src/metabase/api/alert.clj
+++ b/src/metabase/api/alert.clj
@@ -260,7 +260,8 @@
     (let [user @api/*current-user*]
       (when (email/email-configured?)
         (messages/send-you-unsubscribed-alert-email! alert user))
-      (events/publish-event! :event/alert-unsubscribe {:details {:email (:email user)}}))
+      (events/publish-event! :event/alert-unsubscribe {:object {:email (:email user)}
+                                                       :user-id api/*current-user-id*}))
     ;; finally, return a 204 No Content
     api/generic-204-no-content))
 

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -757,7 +757,7 @@ saved later when it is ready."
 
   (let [card (t2/select-one Card :id id)]
     (delete-alerts-if-needed! card-before-update card)
-    (events/publish-event! :event/card-update {:object card})
+    (events/publish-event! :event/card-update {:object card :user-id api/*current-user-id*})
     ;; include same information returned by GET /api/card/:id since frontend replaces the Card it currently
     ;; has with returned one -- See #4142
     (-> card
@@ -835,7 +835,7 @@ saved later when it is ready."
   (log/warn (tru "DELETE /api/card/:id is deprecated. Instead, change its `archived` value via PUT /api/card/:id."))
   (let [card (api/write-check Card id)]
     (t2/delete! Card :id id)
-    (events/publish-event! :event/card-delete {:object card}))
+    (events/publish-event! :event/card-delete {:object card :user-id api/*current-user-id*}))
   api/generic-204-no-content)
 
 ;;; -------------------------------------------- Bulk Collections Update ---------------------------------------------

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -544,17 +544,13 @@
                            api/*current-user-id*
                            {:dashboard-id   dashboard-id
                             :num-tabs       (count deleted-tab-ids)
-                            :total-num-tabs total-num-tabs})
-    (events/publish-event! :event/dashboard-remove-tabs
-                           {:object dashboard :tab-ids deleted-tab-ids :user-id api/*current-user-id*}))
+                            :total-num-tabs total-num-tabs}))
   (when (seq created-tab-ids)
     (snowplow/track-event! ::snowplow/dashboard-tab-created
                            api/*current-user-id*
                            {:dashboard-id   dashboard-id
                             :num-tabs       (count created-tab-ids)
-                            :total-num-tabs total-num-tabs})
-    (events/publish-event! :event/dashboard-add-tabs
-                           {:object dashboard :tab-ids created-tab-ids :user-id api/*current-user-id*})))
+                            :total-num-tabs total-num-tabs})))
 
 (defn- update-dashboard
   "Updates a Dashboard. Designed to be reused by PUT /api/dashboard/:id and PUT /api/dashboard/:id/cards"

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -952,7 +952,7 @@
         (let [db (t2/select-one Database :id id)]
           (events/publish-event! :event/database-update {:object db
                                                          :user-id api/*current-user-id*
-                                                         :audit-log/previous existing-database})
+                                                         :previous-object existing-database})
           ;; return the DB with the expanded schedules back in place
           (add-expanded-schedules db))))))
 

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -60,7 +60,8 @@
   ;; store table id trivially iff we get a query with simple source-table
   (let [table-id (get-in query [:query :source-table])]
     (when (int? table-id)
-      (events/publish-event! :event/table-read {:object (t2/select-one Table :id table-id)})))
+      (events/publish-event! :event/table-read {:object (t2/select-one Table :id table-id)
+                                                :user-id api/*current-user-id*})))
   ;; add sensible constraints for results limits on our query
   (let [source-card-id (query->source-card-id query)
         source-card    (when source-card-id

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -292,8 +292,8 @@
           (let [{session-uuid :id, :as session} (create-session! :password user (request.u/device-info request))
                 response                        {:success    true
                                                  :session_id (str session-uuid)}]
-            (mw.session/set-session-cookies request response session (t/zoned-date-time (t/zone-id "GMT")))))
-        (api/throw-invalid-param-exception :password (tru "Invalid reset token")))))
+            (mw.session/set-session-cookies request response session (t/zoned-date-time (t/zone-id "GMT"))))))
+      (api/throw-invalid-param-exception :password (tru "Invalid reset token"))))
 
 (api/defendpoint GET "/password_reset_token_valid"
   "Check is a password reset token is valid and isn't expired."

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -233,7 +233,7 @@
           (log/info password-reset-url)
           (messages/send-password-reset-email! email nil password-reset-url is-active?)))
       (events/publish-event! :event/password-reset-initiated
-                             (assoc user :token (t2/select-one-fn :reset_token :model/User :id user-id))))))
+                             {:object (assoc user :token (t2/select-one-fn :reset_token :model/User :id user-id))}))))
 
 (api/defendpoint POST "/forgot_password"
   "Send a reset email when user has forgotten their password."
@@ -285,7 +285,7 @@
           ;; if this is the first time the user has logged in it means that they're just accepted their Metabase invite.
           ;; Otherwise, send audit log event that a user reset their password.
           (if (:last_login user)
-            (events/publish-event! :event/password-reset-successful (assoc user :token reset-token))
+            (events/publish-event! :event/password-reset-successful {:object (assoc user :token reset-token)})
             ;; Send all the active admins an email :D
             (messages/send-user-joined-admin-notification-email! (t2/select-one User :id user-id)))
           ;; after a successful password update go ahead and offer the client a new session that they can use

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -292,8 +292,8 @@
           (let [{session-uuid :id, :as session} (create-session! :password user (request.u/device-info request))
                 response                        {:success    true
                                                  :session_id (str session-uuid)}]
-            (mw.session/set-session-cookies request response session (t/zoned-date-time (t/zone-id "GMT"))))))
-        (api/throw-invalid-param-exception :password (tru "Invalid reset token"))))
+            (mw.session/set-session-cookies request response session (t/zoned-date-time (t/zone-id "GMT")))))
+        (api/throw-invalid-param-exception :password (tru "Invalid reset token")))))
 
 (api/defendpoint GET "/password_reset_token_valid"
   "Check is a password reset token is valid and isn't expired."
@@ -364,7 +364,7 @@
         (throw (ex-info (tru "Email for pulse-id doesn't exist.")
                         {:type        type
                          :status-code 400}))))
-    (events/publish-event! :event/subscription-unsubscribe {:details {:email email}})
+    (events/publish-event! :event/subscription-unsubscribe {:object {:email email}})
     {:status :success :title (:name (pulse/retrieve-notification pulse-id :archived false))}))
 
 (api/defendpoint POST "/pulse/unsubscribe/undo"
@@ -382,7 +382,7 @@
                         {:type        type
                          :status-code 400}))
         (t2/update! PulseChannel (:id pulse-channel) (update-in pulse-channel [:details :emails] conj email))))
-    (events/publish-event! :event/subscription-unsubscribe-undo {:details {:email email}})
+    (events/publish-event! :event/subscription-unsubscribe-undo {:object {:email email}})
     {:status :success :title (:name (pulse/retrieve-notification pulse-id :archived false))}))
 
 (api/define-routes +log-all-request-failures)

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -82,7 +82,7 @@
       (log/error (trs "Could not invite user because email is not configured."))
       (u/prog1 (user/create-and-invite-user! user invitor true)
         (user/set-permissions-groups! <> [(perms-group/all-users) (perms-group/admin)])
-        (events/publish-event! :event/user-invited (assoc <> :invite_method "email"))
+        (events/publish-event! :event/user-invited {:object (assoc <> :invite_method "email")})
         (snowplow/track-event! ::snowplow/invite-sent api/*current-user-id* {:invited-user-id (u/the-id <>)
                                                                              :source          "setup"})))))
 
@@ -168,10 +168,10 @@
     (let [{:keys [user-id session-id database session]} (create!)
           superuser (t2/select-one :model/User :id user-id)]
       (when database
-        (events/publish-event! :event/database-create {:object database}))
-      (events/publish-event! :event/user-login superuser)
+        (events/publish-event! :event/database-create {:object database :user-id user-id}))
+      (events/publish-event! :event/user-login {:user-id user-id})
       (when-not (:last_login superuser)
-        (events/publish-event! :event/user-joined superuser))
+        (events/publish-event! :event/user-joined {:user-id user-id}))
       (snowplow/track-event! ::snowplow/new-user-created user-id)
       (when database (snowplow/track-event! ::snowplow/database-connection-successful
                                             user-id

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -467,7 +467,7 @@
   [id]
   {id ms/PositiveInt}
   (let [table (api/write-check (t2/select-one Table :id id))]
-    (events/publish-event! :event/table-manual-scan table)
+    (events/publish-event! :event/table-manual-scan {:object table :user-id api/*current-user-id*})
     ;; Override *current-user-permissions-set* so that permission checks pass during sync. If a user has DB detail perms
     ;; but no data perms, they should stll be able to trigger a sync of field values. This is fine because we don't
     ;; return any actual field values from this API. (#21764)

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -452,7 +452,8 @@
                                          api/*is-superuser?* (conj :is_superuser))))]
           (t2/update! User id changes)
           (events/publish-event! :event/user-update {:object (t2/select-one User :id id)
-                                                     :previous-object user-before-update}))
+                                                     :previous-object user-before-update
+                                                     :user-id api/*current-user-id*}))
         (maybe-update-user-personal-collection-name! user-before-update body))
       (maybe-set-user-group-memberships! id user_group_memberships is_superuser)))
   (-> (fetch-user :id id)
@@ -486,7 +487,7 @@
     ;; Can only reactivate inactive users
     (api/check (not (:is_active user))
       [400 {:message (tru "Not able to reactivate an active user")}])
-    (events/publish-event! :event/user-reactivated {:object user})
+    (events/publish-event! :event/user-reactivated {:object user :user-id api/*current-user-id*})
     (reactivate-user! (dissoc user [:email :first_name :last_name]))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -527,7 +528,7 @@
   (check-not-internal-user id)
   (api/check-500
    (when (pos? (t2/update! User id {:is_active false}))
-     (events/publish-event! :event/user-deactivated {:object (t2/select-one User :id id)})))
+     (events/publish-event! :event/user-deactivated {:object (t2/select-one User :id id) :user-id api/*current-user-id*})))
   {:success true})
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/events.clj
+++ b/src/metabase/events.clj
@@ -142,7 +142,7 @@
   (if (contains? (set (keys object)) :id)
     (:id object)
     (let [model (topic->model topic)]
-      (get object (keyword (format "%s_id" model))))))
+      (get object (keyword (format "%s-id" model))))))
 
 (defn object->metadata
   "Determine metadata, if there is any, for given `object`.

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -127,12 +127,9 @@
 (methodical/defmethod events/publish-event! ::pulse-event
   [topic {:keys [object user-id] :as _event}]
   ;; Check if topic is a pulse or not (can be an unsubscribe event, which only contains email)
-  (def object object)
-  (def user-id user-id)
   (let [details-map (if (some? (:id object))
                       (create-details-map object (:name object) false (:dashboard_id object))
                       object)]
-    (def details-map details-map)
     (audit-log/record-event! topic
                              {:details  details-map
                               :user-id  user-id

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -1,7 +1,6 @@
 (ns metabase.events.audit-log
   "This namespace is responsible for publishing events to the audit log. "
   (:require
-   [clojure.data :as data]
    [metabase.events :as events]
    [metabase.models.audit-log :as audit-log]
    [metabase.util :as u]
@@ -9,7 +8,6 @@
    [toucan2.core :as t2]))
 
 (derive ::event :metabase/event)
-
 
 (derive ::card-event ::event)
 (derive :event/card-create ::card-event)
@@ -201,10 +199,5 @@
 (derive :event/database-update ::database-update-event)
 
 (methodical/defmethod events/publish-event! ::database-update-event
-  [topic {:keys [object previous-object] :as _event}]
-  (audit-log/record-event!
-   topic
-   {:object          object
-    :previous-object previous-object
-    :model           :model/Database
-    :model-id        (:id object)}))
+  [topic event]
+  (audit-log/record-event! topic event))

--- a/src/metabase/events/recent_views.clj
+++ b/src/metabase/events/recent_views.clj
@@ -1,33 +1,21 @@
 (ns metabase.events.recent-views
+  "This namespace is responsible for subscribing to events which should update the recent views for a user."
   (:require
    [metabase.api.common :as api]
    [metabase.events :as events]
    [metabase.models.recent-views :as recent-views]
-   [metabase.util :as u]
    [metabase.util.log :as log]
-   [methodical.core :as methodical]
-   [toucan2.core :as t2]))
+   [methodical.core :as m]))
 
 (derive ::event :metabase/event)
 
-(derive :event/card-read ::event)
 (derive :event/card-query ::event)
 (derive :event/dashboard-read ::event)
 (derive :event/table-read ::event)
 
-(defn record-view!
-  "Simple base function for recording a view of a given `model` and `model-id` by a certain `user`."
-  [model model-id user-id metadata]
-  (t2/insert! :model/ViewLog
-              :user_id  user-id
-              :model    (u/lower-case-en model)
-              :model_id model-id
-              :metadata metadata))
-
-(methodical/defmethod events/publish-event! ::event
-  "Handle processing for a single event notification received on the view-log-channel"
+(m/defmethod events/publish-event! ::event
+  "Handle processing for a single event notification which should update the recent views for a user."
   [topic object]
-  ;; try/catch here to prevent individual topic processing exceptions from bubbling up.  better to handle them here.
   (try
     (when object
       (let [model                          (events/topic->model topic)
@@ -36,11 +24,9 @@
             ;; `:context` comes
             ;; from [[metabase.query-processor.middleware.process-userland-query/add-and-save-execution-info-xform!]],
             ;; and it should only be present for `:event/card-query`
-            {:keys [context] :as metadata} (events/object->metadata object)]
-        (when (and (#{:event/card-query :event/dashboard-read :event/table-read} topic)
-                   ;; we don't want to count pinned card views
-                   ((complement #{:collection :dashboard}) context))
-          (recent-views/update-users-recent-views! user-id model model-id))
-        (record-view! model model-id user-id metadata)))
+            {:keys [context]} (events/object->metadata object)]
+        ;; we don't want to count pinned card views
+        (when ((complement #{:collection :dashboard}) context)
+          (recent-views/update-users-recent-views! user-id model model-id))))
     (catch Throwable e
-      (log/warnf e "Failed to process activity event. %s" topic))))
+      (log/warnf e "Failed to process activity event: %s" topic))))

--- a/src/metabase/events/recent_views.clj
+++ b/src/metabase/events/recent_views.clj
@@ -9,13 +9,12 @@
 
 (derive ::event :metabase/event)
 
-(derive :event/card-query ::event)
 (derive :event/dashboard-read ::event)
 (derive :event/table-read ::event)
 
 (m/defmethod events/publish-event! ::event
   "Handle processing for a single event notification which should update the recent views for a user."
-  [topic object]
+  [topic {:keys [object] :as _event}]
   (try
     (when object
       (let [model             (events/topic->model topic)
@@ -30,3 +29,17 @@
           (recent-views/update-users-recent-views! user-id model model-id))))
     (catch Throwable e
       (log/warnf e "Failed to process activity event: %s" topic))))
+
+(derive ::query-event :metabase/event)
+(derive :event/card-query ::query-event)
+
+(m/defmethod events/publish-event! ::query-event
+  "Handle processing for a single read event notification received on the view-log-channel"
+  [topic {:keys [user-id card-id] :as event}]
+  (try
+    (when event
+      (let [model    "card"
+            user-id  (or user-id api/*current-user-id*)]
+        (recent-views/update-users-recent-views! user-id model card-id)))
+    (catch Throwable e
+      (log/warnf e "Failed to process activity event. %s" topic))))

--- a/src/metabase/events/recent_views.clj
+++ b/src/metabase/events/recent_views.clj
@@ -18,9 +18,9 @@
   [topic object]
   (try
     (when object
-      (let [model                          (events/topic->model topic)
-            model-id                       (events/object->model-id topic object)
-            user-id                        api/*current-user-id*
+      (let [model             (events/topic->model topic)
+            model-id          (events/object->model-id topic object)
+            user-id           (or (:user-id object) api/*current-user-id*)
             ;; `:context` comes
             ;; from [[metabase.query-processor.middleware.process-userland-query/add-and-save-execution-info-xform!]],
             ;; and it should only be present for `:event/card-query`

--- a/src/metabase/events/recent_views.clj
+++ b/src/metabase/events/recent_views.clj
@@ -35,11 +35,12 @@
 
 (m/defmethod events/publish-event! ::query-event
   "Handle processing for a single read event notification received on the view-log-channel"
-  [topic {:keys [user-id card-id] :as event}]
+  [topic {:keys [user-id card-id context] :as event}]
   (try
     (when event
-      (let [model    "card"
-            user-id  (or user-id api/*current-user-id*)]
-        (recent-views/update-users-recent-views! user-id model card-id)))
+      (let [model   "card"
+            user-id (or user-id api/*current-user-id*)]
+        (when ((complement #{:collection :dashboard}) context)
+          (recent-views/update-users-recent-views! user-id model card-id))))
     (catch Throwable e
       (log/warnf e "Failed to process activity event. %s" topic))))

--- a/src/metabase/events/schema.clj
+++ b/src/metabase/events/schema.clj
@@ -89,7 +89,6 @@
 
   (def ^:private database-events
     {:event/database-create with-user
-
      :event/database-update default-schema
      :event/database-delete default-schema}))
 

--- a/src/metabase/events/schema.clj
+++ b/src/metabase/events/schema.clj
@@ -81,14 +81,11 @@
 
 (let [default-schema (mc/schema
                       [:map {:closed true}
-                       [:object [:fn #(t2/instance-of? :model/Database %)]]])
-      with-user      (mc/schema
-                      [:merge default-schema
-                       [:map {:closed true}
-                        [:user-id  pos-int?]]])]
-
+                       [:object [:fn #(t2/instance-of? :model/Database %)]]
+                       [:previous-object {:optional true} [:fn #(t2/instance-of? :model/Database %)]]
+                       [:user-id pos-int?]])]
   (def ^:private database-events
-    {:event/database-create with-user
+    {:event/database-create default-schema
      :event/database-update default-schema
      :event/database-delete default-schema}))
 

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -1,7 +1,62 @@
 (ns metabase.events.view-log
+  "This namespace is responsible for subscribing to events which should update the view log."
   (:require
+   [metabase.api.common :as api]
+   [metabase.events :as events]
    [metabase.models.setting :as setting :refer [defsetting]]
-   [metabase.util.i18n :as i18n :refer [deferred-tru]]))
+   [metabase.util :as u]
+   [metabase.util.i18n :as i18n :refer [deferred-tru]]
+   [metabase.util.log :as log]
+   [methodical.core :as m]
+   [toucan2.core :as t2]))
+
+(defn record-view!
+  "Simple base function for recording a view of a given `model` and `model-id` by a certain `user`."
+  [model model-id user-id metadata]
+  (t2/insert! :model/ViewLog
+              :user_id  user-id
+              :model    (u/lower-case-en model)
+              :model_id model-id
+              :metadata metadata))
+
+(derive ::read-event :metabase/event)
+(derive :event/card-read ::read-event)
+(derive :event/dashboard-read ::read-event)
+(derive :event/table-read ::read-event)
+
+(m/defmethod events/publish-event! ::event
+  "Handle processing for a single read event notification received on the view-log-channel"
+  [topic {object :object :as event}]
+  (try
+    (when object
+      (let [model    (events/topic->model topic)
+            model-id (events/object->model-id topic object)
+            user-id  (or (:user-id event) api/*current-user-id*)
+            ;; `:context` comes
+            ;; from [[metabase.query-processor.middleware.process-userland-query/add-and-save-execution-info-xform!]],
+            ;; and it should only be present for `:event/card-query`
+            metadata (events/object->metadata object)]
+        (record-view! model model-id user-id metadata)))
+    (catch Throwable e
+      (log/warnf e "Failed to process activity event. %s" topic))))
+
+(derive ::query-event :metabase/event)
+(derive :event/card-query ::query-event)
+
+#_(m/defmethod events/publish-event! ::query-event
+    "Handle processing for a single read event notification received on the view-log-channel"
+    [topic event]
+    (def topic topic)
+    (def event event)
+    (try
+      (when event
+        (let [model    "card"
+              model-id (:card-id event)
+              user-id  (or (:user-id event) api/*current-user-id*)
+              metadata (events/object->metadata event)]
+          (record-view! model model-id user-id metadata)))
+      (catch Throwable e
+        (log/warnf e "Failed to process activity event. %s" topic))))
 
 (defsetting dismissed-custom-dashboard-toast
   (deferred-tru "Toggle which is true after a user has dismissed the custom dashboard toast.")

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -24,7 +24,7 @@
 (derive :event/dashboard-read ::read-event)
 (derive :event/table-read ::read-event)
 
-(m/defmethod events/publish-event! ::event
+(m/defmethod events/publish-event! ::read-event
   "Handle processing for a single read event notification received on the view-log-channel"
   [topic {object :object :as event}]
   (try

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -43,20 +43,18 @@
 (derive ::query-event :metabase/event)
 (derive :event/card-query ::query-event)
 
-#_(m/defmethod events/publish-event! ::query-event
-    "Handle processing for a single read event notification received on the view-log-channel"
-    [topic event]
-    (def topic topic)
-    (def event event)
-    (try
-      (when event
-        (let [model    "card"
-              model-id (:card-id event)
-              user-id  (or (:user-id event) api/*current-user-id*)
-              metadata (events/object->metadata event)]
-          (record-view! model model-id user-id metadata)))
-      (catch Throwable e
-        (log/warnf e "Failed to process activity event. %s" topic))))
+(m/defmethod events/publish-event! ::query-event
+  "Handle processing for a single read event notification received on the view-log-channel"
+  [topic {:keys [user-id card-id] :as event}]
+  (try
+    (when event
+      (let [model    "card"
+            model-id card-id
+            user-id  (or user-id api/*current-user-id*)
+            metadata (events/object->metadata event)]
+        (record-view! model model-id user-id metadata)))
+    (catch Throwable e
+      (log/warnf e "Failed to process activity event. %s" topic))))
 
 (defsetting dismissed-custom-dashboard-toast
   (deferred-tru "Toggle which is true after a user has dismissed the custom dashboard toast.")

--- a/src/metabase/models/activity.clj
+++ b/src/metabase/models/activity.clj
@@ -100,9 +100,9 @@
            table-id user-id model model-id]
     :or   {object {}}}                      :- [:map {:closed true}
                                                 [:topic                        :keyword]
-                                                [:user-id                      pos-int?]
-                                                [:model                        :string]
-                                                [:model-id                     pos-int?]
+                                                [:user-id     {:optional true} [:maybe pos-int?]]
+                                                [:model       {:optional true} [:maybe :string]]
+                                                [:model-id    {:optional true} [:maybe pos-int?]]
                                                 [:object      {:optional true} [:maybe :map]]
                                                 [:details     {:optional true} [:maybe :map]]
                                                 [:database-id {:optional true} [:maybe pos-int?]]

--- a/src/metabase/models/audit_log.clj
+++ b/src/metabase/models/audit_log.clj
@@ -72,8 +72,6 @@
               [:model           {:optional true} [:maybe [:or :keyword :string]]]
               [:model-id        {:optional true} [:maybe pos-int?]]
               [:details         {:optional true} [:maybe :map]]]]
-  (def topic topic)
-  (def params params)
   (let [unqualified-topic (keyword (name topic))
         object            (:object params)
         previous-object   (:previous-object params)
@@ -86,7 +84,7 @@
                            (:details params)
                            (if (not-empty previous-object)
                              (prepare-update-event-data object-details previous-details)
-                             {:object object-details}))]
+                             object-details))]
     (t2/insert! :model/AuditLog
                 :topic    unqualified-topic
                 :details  details

--- a/src/metabase/models/audit_log.clj
+++ b/src/metabase/models/audit_log.clj
@@ -36,7 +36,7 @@
   [model]
   (some-> (or (t2/model model) model) name))
 
-(mu/defn record-event-2!
+(mu/defn record-event!
   "Records an event in the Audit Log.
 
   `topic` is a keyword representing the type of event being recorded, e.g. `:dashboard-create`. If the keyword is
@@ -90,7 +90,7 @@
         :model-id model-id
         :user-id  user-id}))))
 
-(defn record-event!
+(defn record-event-old!
   "Record an event in the Audit Log.
 
   `topic` is a keyword representing the type of event being recorded, e.g. `:dashboard-create`. If the keyword is
@@ -103,13 +103,13 @@
   `object` can also be a map of arbitrary details relavent to the event, which is recorded as-is. If the name and/or ID
   of a model are also relevant to the event and should be recorded, they can be passed as fourth and fifth arguments."
   ([topic object]
-   (record-event! topic object api/*current-user-id*))
+   (record-event-old! topic object api/*current-user-id*))
 
   ([topic object user-id]
-   (record-event! topic object user-id (some-> (t2/model object) name)))
+   (record-event-old! topic object user-id (some-> (t2/model object) name)))
 
   ([topic object user-id model]
-   (record-event! topic object user-id model (u/id object)))
+   (record-event-old! topic object user-id model (u/id object)))
 
   ([topic object user-id model model-id]
    (let [unqualified-topic (keyword (name topic))

--- a/src/metabase/models/audit_log.clj
+++ b/src/metabase/models/audit_log.clj
@@ -3,13 +3,15 @@
   distinct from the Activity and View Log models, which predate this namespace, and which power specific API endpoints
   used for in-app functionality, such as the recently-viewed items displayed on the homepage."
   (:require
+   [clojure.data :as data]
    [metabase.api.common :as api]
    [metabase.models.activity :as activity]
    [metabase.models.interface :as mi]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
    [methodical.core :as m]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2]
+   [clojure.set :as set]))
 
 (doto :model/AuditLog
   (derive :metabase/model))
@@ -36,6 +38,15 @@
   [model]
   (some-> (or (t2/model model) model) name))
 
+(defn- prepare-update-event-data
+  "Returns a map with previous and new versions of the objects, _keeping only fields that are present in both
+  but have changed values_."
+  [object previous-object]
+  (let [[previous-only new-only _both] (data/diff previous-object object)
+        shared-updated-keys (set/intersection (set (keys previous-only)) (set (keys new-only)))]
+    {:previous (select-keys previous-object shared-updated-keys)
+     :new (select-keys object shared-updated-keys)}))
+
 (mu/defn record-event!
   "Records an event in the Audit Log.
 
@@ -51,7 +62,8 @@
   - `:details`: a map of arbitrary details relavent to the event, which is recorded as-is (default: {})
 
   `:object` and `:previous-object` both have `model-details` called on them to determine which fields should be audited,
-  then they are added to `:details` before the event is recorded."
+  then they are added to `:details` before the event is recorded. `:previous-object` is only included if any audited fields
+  were updated."
   [topic :- :keyword
    params :- [:map {:closed true}
               [:object          {:optional true} [:maybe :map]]
@@ -60,19 +72,21 @@
               [:model           {:optional true} [:maybe [:or :keyword :string]]]
               [:model-id        {:optional true} [:maybe pos-int?]]
               [:details         {:optional true} [:maybe :map]]]]
+  (def topic topic)
+  (def params params)
   (let [unqualified-topic (keyword (name topic))
         object            (:object params)
         previous-object   (:previous-object params)
+        object-details    (model-details object unqualified-topic)
+        previous-details  (model-details previous-object unqualified-topic)
         user-id           (or (:user-id params) api/*current-user-id*)
         model             (model-name (or (:model params) object))
         model-id          (or (:model-id params) (u/id object))
-        details           (merge
-                           {}
+        details           (merge {}
                            (:details params)
-                           (when object
-                             (model-details object unqualified-topic))
-                           (when previous-object
-                             {:previous-object (model-details previous-object unqualified-topic)}))]
+                           (if (not-empty previous-object)
+                             (prepare-update-event-data object-details previous-details)
+                             {:object object-details}))]
     (t2/insert! :model/AuditLog
                 :topic    unqualified-topic
                 :details  details
@@ -89,50 +103,6 @@
         :model    model
         :model-id model-id
         :user-id  user-id}))))
-
-(defn record-event-old!
-  "Record an event in the Audit Log.
-
-  `topic` is a keyword representing the type of event being recorded, e.g. `:dashboard-create`. If the keyword is
-  namespaced (e.g. `:event/dashboard-create`) the namespace is stripped before the event is recorded.
-
-  `object` is typically the object that the event is acting on, e.g. a `Dashboard` instance. The details about the
-  object which are recorded are determined by the `model-details` multimethod, which is typically implemented in the
-  appropriate model namespace.
-
-  `object` can also be a map of arbitrary details relavent to the event, which is recorded as-is. If the name and/or ID
-  of a model are also relevant to the event and should be recorded, they can be passed as fourth and fifth arguments."
-  ([topic object]
-   (record-event-old! topic object api/*current-user-id*))
-
-  ([topic object user-id]
-   (record-event-old! topic object user-id (some-> (t2/model object) name)))
-
-  ([topic object user-id model]
-   (record-event-old! topic object user-id model (u/id object)))
-
-  ([topic object user-id model model-id]
-   (let [unqualified-topic (keyword (name topic))
-         model-name        (model-name model)
-         details           (cond
-                             (:raw? object) (dissoc object :raw?)
-                             (t2/model object) (model-details object unqualified-topic)
-                             :else (or object {}))]
-     (t2/insert! :model/AuditLog
-                 :topic    unqualified-topic
-                 :details  details
-                 :model    model-name
-                 :model_id model-id
-                 :user_id  user-id)
-     ;; TODO: temporarily double-writing to the `activity` table, delete this in Metabase v48
-     (when-not (#{:card-read :dashboard-read :table-read :card-query :setting-update} unqualified-topic)
-      (activity/record-activity!
-        {:topic    topic
-         :object   object
-         :details  details
-         :model    model-name
-         :model_id model-id
-         :user-id  user-id})))))
 
 (t2/define-before-insert :model/AuditLog
   [activity]

--- a/src/metabase/models/audit_log.clj
+++ b/src/metabase/models/audit_log.clj
@@ -4,14 +4,14 @@
   used for in-app functionality, such as the recently-viewed items displayed on the homepage."
   (:require
    [clojure.data :as data]
+   [clojure.set :as set]
    [metabase.api.common :as api]
    [metabase.models.activity :as activity]
    [metabase.models.interface :as mi]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
    [methodical.core :as m]
-   [toucan2.core :as t2]
-   [clojure.set :as set]))
+   [toucan2.core :as t2]))
 
 (doto :model/AuditLog
   (derive :metabase/model))

--- a/src/metabase/models/audit_log.clj
+++ b/src/metabase/models/audit_log.clj
@@ -7,6 +7,7 @@
    [metabase.models.activity :as activity]
    [metabase.models.interface :as mi]
    [metabase.util :as u]
+   [metabase.util.malli :as mu]
    [methodical.core :as m]
    [toucan2.core :as t2]))
 
@@ -31,9 +32,63 @@
   {})
 
 (defn model-name
-  "Given a keyword identifier for a model, returns the name to store in the database"
+  "Given an instance of a model or a keyword model identifier, returns the name to store in the database as a string."
   [model]
-  (some-> model name))
+  (some-> (or (t2/model model) model) name))
+
+(mu/defn record-event-2!
+  "Records an event in the Audit Log.
+
+  `topic` is a keyword representing the type of event being recorded, e.g. `:dashboard-create`. If the keyword is
+  namespaced (e.g. `:event/dashboard-create`) the namespace is stripped before the event is recorded.
+
+  `params` is a map that can optionally include the following fields:
+  - `:object`: the object the event is acting on, e.g. a `Card` instance
+  - `:previous-object`: the previous version of the object, for update events
+  - `:user-id`: the user ID that initiated the event (defaults: `api/*current-user-id*`)
+  - `:model`: the name of the model the event is acting on, e.g. `:model/Card` or \"Card\" (default: model of `:object`)
+  - `:model-id`: the ID of the model the event is acting on (default: ID of `:object`)
+  - `:details`: a map of arbitrary details relavent to the event, which is recorded as-is (default: {})
+
+  `:object` and `:previous-object` both have `model-details` called on them to determine which fields should be audited,
+  then they are added to `:details` before the event is recorded."
+  [topic :- :keyword
+   params :- [:map {:closed true}
+              [:object          {:optional true} [:maybe :map]]
+              [:previous-object {:optional true} [:maybe :map]]
+              [:user-id         {:optional true} [:maybe pos-int?]]
+              [:model           {:optional true} [:maybe [:or :keyword :string]]]
+              [:model-id        {:optional true} [:maybe pos-int?]]
+              [:details         {:optional true} [:maybe :map]]]]
+  (let [unqualified-topic (keyword (name topic))
+        object            (:object params)
+        previous-object   (:previous-object params)
+        user-id           (or (:user-id params) api/*current-user-id*)
+        model             (model-name (or (:model params) object))
+        model-id          (or (:model-id params) (u/id object))
+        details           (merge
+                           {}
+                           (:details params)
+                           (when object
+                             (model-details object unqualified-topic))
+                           (when previous-object
+                             {:previous-object (model-details previous-object unqualified-topic)}))]
+    (t2/insert! :model/AuditLog
+                :topic    unqualified-topic
+                :details  details
+                :model    model
+                :model_id model-id
+                :user_id  user-id)
+    ;; TODO: temporarily double-writing to the `activity` table, delete this in Metabase v48
+    ;; TODO figure out set of events to actually continue recording in activity
+    (when-not (#{:card-read :dashboard-read :table-read :card-query :setting-update} unqualified-topic)
+      (activity/record-activity!
+       {:topic    topic
+        :object   object
+        :details  details
+        :model    model
+        :model-id model-id
+        :user-id  user-id}))))
 
 (defn record-event!
   "Record an event in the Audit Log.
@@ -72,10 +127,12 @@
      ;; TODO: temporarily double-writing to the `activity` table, delete this in Metabase v48
      (when-not (#{:card-read :dashboard-read :table-read :card-query :setting-update} unqualified-topic)
       (activity/record-activity!
-       :topic      topic
-       :object     object
-       :details-fn (fn [_] details)
-       :user-id    user-id)))))
+        {:topic    topic
+         :object   object
+         :details  details
+         :model    model-name
+         :model_id model-id
+         :user-id  user-id})))))
 
 (t2/define-before-insert :model/AuditLog
   [activity]

--- a/src/metabase/models/audit_log.clj
+++ b/src/metabase/models/audit_log.clj
@@ -34,7 +34,7 @@
   {})
 
 (defn model-name
-  "Given an instance of a model or a keyword model identifier, returns the name to store in the database as a string."
+  "Given an instance of a model or a keyword model identifier, returns the name to store in the database as a string, or `nil` if it cannot be computed."
   [model]
   (some-> (or (t2/model model) model) name))
 

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -589,8 +589,8 @@
   [alert]
   (update-notification! (alert->notification alert))
   ;; fetch the fully updated pulse, log an update event, and return it
-  (events/publish-event! :event/alert-update {:object (retrieve-alert (u/the-id alert))
-                                              :user-id api/*current-user-id*}))
+  (u/prog1 (retrieve-alert (u/the-id alert))
+    (events/publish-event! :event/alert-update {:object <> :user-id api/*current-user-id*})))
 
 ;;; ------------------------------------------------- Serialization --------------------------------------------------
 

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -510,7 +510,8 @@
   (let [pulse-id (create-notification-and-add-cards-and-channels! kvs cards channels)]
     ;; return the full Pulse (and record our create event).
     (u/prog1 (retrieve-pulse pulse-id)
-      (events/publish-event! :event/subscription-create {:object <>}))))
+      (events/publish-event! :event/subscription-create {:object <>
+                                                         :user-id api/*current-user-id*}))))
 
 (defn create-alert!
   "Creates a pulse with the correct fields specified for an alert"
@@ -571,7 +572,7 @@
   (update-notification! pulse)
   ;; fetch the fully updated pulse, log an update event, and return it
   (u/prog1 (retrieve-pulse (u/the-id pulse))
-    (events/publish-event! :event/subscription-update {:object <>})))
+    (events/publish-event! :event/subscription-update {:object <> :user-id api/*current-user-id*})))
 
 (defn- alert->notification
   "Convert an 'Alert` back into the generic 'Notification' format."
@@ -588,7 +589,8 @@
   [alert]
   (update-notification! (alert->notification alert))
   ;; fetch the fully updated pulse, log an update event, and return it
-  (events/publish-event! :event/alert-update (retrieve-alert (u/the-id alert))))
+  (events/publish-event! :event/alert-update {:object (retrieve-alert (u/the-id alert))
+                                              :user-id api/*current-user-id*}))
 
 ;;; ------------------------------------------------- Serialization --------------------------------------------------
 

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -509,7 +509,8 @@
                 [:parameters          {:optional true} [:maybe [:sequential :map]]]]]
   (let [pulse-id (create-notification-and-add-cards-and-channels! kvs cards channels)]
     ;; return the full Pulse (and record our create event).
-    (events/publish-event! :event/subscription-create {:object (retrieve-pulse pulse-id)})))
+    (u/prog1 (retrieve-pulse pulse-id)
+      (events/publish-event! :event/subscription-create {:object <>}))))
 
 (defn create-alert!
   "Creates a pulse with the correct fields specified for an alert"
@@ -569,7 +570,8 @@
   [pulse]
   (update-notification! pulse)
   ;; fetch the fully updated pulse, log an update event, and return it
-  (events/publish-event! :event/subscription-update (retrieve-pulse (u/the-id pulse))))
+  (u/prog1 (retrieve-pulse (u/the-id pulse))
+    (events/publish-event! :event/subscription-update {:object <>})))
 
 (defn- alert->notification
   "Convert an 'Alert` back into the generic 'Notification' format."

--- a/src/metabase/models/recent_views.clj
+++ b/src/metabase/models/recent_views.clj
@@ -45,7 +45,7 @@
 
 (mu/defn update-users-recent-views!
   "Updates the RecentViews table for a given user with a new view, and prunes old views."
-  [user-id  :- [:maybe ms/PositiveInt]
+  [user-id  :- ms/PositiveInt
    model    :- [:or
                 [:enum :model/Card :model/Table :model/Dashboard]
                 :string]

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -830,12 +830,12 @@
   (let [maybe-obfuscate #(if sensitive? (obfuscate-value %) %)]
    (audit-log/record-event!
     :setting-update
-     {:details (merge {:key name}
-                      (when (not= audit :no-value)
-                        {:previous-value (maybe-obfuscate previous-value)
-                         :new-value      (maybe-obfuscate new-value)}))
-      :user-id api/*current-user-id*
-      :model  :model/Setting})))
+    {:details (merge {:key name}
+                     (when (not= audit :no-value)
+                       {:previous-value (maybe-obfuscate previous-value)
+                        :new-value      (maybe-obfuscate new-value)}))
+     :user-id api/*current-user-id*
+     :model  :model/Setting})))
 
 (defn- should-audit?
   "Returns true if the setting change should be written to the `audit_log`."

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -830,12 +830,12 @@
   (let [maybe-obfuscate #(if sensitive? (obfuscate-value %) %)]
    (audit-log/record-event!
     :setting-update
-    (merge {:key name}
-           (when (not= audit :no-value)
-             {:previous-value (maybe-obfuscate previous-value)
-              :new-value      (maybe-obfuscate new-value)}))
-    api/*current-user-id*
-    :model/Setting)))
+     {:details (merge {:key name}
+                      (when (not= audit :no-value)
+                        {:previous-value (maybe-obfuscate previous-value)
+                         :new-value      (maybe-obfuscate new-value)}))
+      :user-id api/*current-user-id*
+      :model  :model/Setting})))
 
 (defn- should-audit?
   "Returns true if the setting change should be written to the `audit_log`."

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -433,7 +433,10 @@
 (defmethod audit-log/model-details :model/User
   [entity event-type]
   (case event-type
-    :user-update               (:changes entity)
+    :user-update               (select-keys (t2/hydrate entity :user_group_memberships)
+                                            [:groups :first_name :last_name :email
+                                             :invite_method :sso_source
+                                             :user_group_memberships])
     :user-invited              (select-keys (t2/hydrate entity :user_group_memberships)
                                             [:groups :first_name :last_name :email
                                              :invite_method :sso_source

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -343,9 +343,11 @@
   [new-user :- NewUser invitor :- Invitor setup? :- :boolean]
   ;; create the new user
   (u/prog1 (insert-new-user! new-user)
-    (events/publish-event! :event/user-invited (assoc <>
-                                                      :invite_method "email"
-                                                      :sso_source (:sso_source new-user)))
+    (events/publish-event! :event/user-invited
+                           {:object
+                            (assoc <>
+                                   :invite_method "email"
+                                   :sso_source (:sso_source new-user))})
     (send-welcome-email! <> invitor setup?)))
 
 (mu/defn create-new-google-auth-user!

--- a/test/metabase/api/activity_test.clj
+++ b/test/metabase/api/activity_test.clj
@@ -40,31 +40,30 @@
                                     :archived    true
                                     :creator_id  (mt/user->id :crowberto)}
                  Table     table-1 {:name "rand-name"}]
-    (mt/with-model-cleanup [:model/RecentViews]
-      (mt/with-test-user :crowberto
-        (doseq [{:keys [topic event]} [{:topic :event/dashboard-read :event {:object dash-1}}
-                                       {:topic :event/dashboard-read :event {:object dash-2}}
-                                       {:topic :event/dashboard-read :event {:object dash-3}}
-                                       {:topic :event/card-query :event {:card-id (:id card-1)}}
-                                       {:topic :event/table-read :event {:object table-1}}]]
-          (events/publish-event! topic event)
-          (testing "most_recently_viewed_dashboard endpoint shows the current user's most recently viewed dashboard."
-            (is (= dash-3 #_dash-2 ;; TODO: this should be dash-2, because dash-3 is archived
-                   (mt/user-http-request :crowberto :get 200 "activity/most_recently_viewed_dashboard"))))))
-      (mt/with-test-user :rasta
-        (testing "If nothing has been viewed, return a 204"
+    (mt/with-test-user :crowberto
+      (doseq [{:keys [topic event]} [{:topic :event/dashboard-read :event {:object dash-1}}
+                                     {:topic :event/dashboard-read :event {:object dash-2}}
+                                     {:topic :event/dashboard-read :event {:object dash-3}}
+                                     {:topic :event/card-query :event {:card-id (:id card-1)}}
+                                     {:topic :event/table-read :event {:object table-1}}]]
+        (events/publish-event! topic (assoc event :user-id (mt/user->id :crowberto))))
+      (testing "most_recently_viewed_dashboard endpoint shows the current user's most recently viewed dashboard."
+        (is (= (assoc dash-3 :collection nil) #_dash-2 ;; TODO: this should be dash-2, because dash-3 is archived
+               (mt/user-http-request :crowberto :get 200 "activity/most_recently_viewed_dashboard")))))
+    (mt/with-test-user :rasta
+      (testing "If nothing has been viewed, return a 204"
+        (is (nil? (mt/user-http-request :rasta :get 204
+                                        "activity/most_recently_viewed_dashboard"))))
+      (events/publish-event! :event/dashboard-read {:object dash-1 :user-id (mt/user->id :rasta)})
+      (testing "Only the user's own views are returned."
+        (is (= (assoc dash-1 :collection nil)
+               (mt/user-http-request :rasta :get 200
+                                     "activity/most_recently_viewed_dashboard"))))
+      (events/publish-event! :event/dashboard-read {:object dash-1 :user-id (mt/user->id :rasta)})
+      (testing "If the user has no permissions for the dashboard, return a 204"
+        (mt/with-non-admin-groups-no-root-collection-perms
           (is (nil? (mt/user-http-request :rasta :get 204
-                                          "activity/most_recently_viewed_dashboard"))))
-        (events/publish-event! :event/dashboard-read {:object dash-1})
-        (testing "Only the user's own views are returned."
-          (is (= (assoc dash-1 :collection nil)
-                 (mt/user-http-request :rasta :get 200
-                                       "activity/most_recently_viewed_dashboard"))))
-        (events/publish-event! :event/dashboard-read {:object dash-1})
-        (testing "If the user has no permissions for the dashboard, return a 204"
-          (mt/with-non-admin-groups-no-root-collection-perms
-            (is (nil? (mt/user-http-request :rasta :get 204
-                                            "activity/most_recently_viewed_dashboard")))))))))
+                                          "activity/most_recently_viewed_dashboard"))))))))
 
 (deftest most-recently-viewed-dashboard-views-include-colllection-test
   (mt/with-temp [:model/Collection coll   {:name "Analytics"}
@@ -111,36 +110,34 @@
     (testing "recent_views endpoint shows the current user's recently viewed items."
       (mt/with-model-cleanup [ViewLog]
         (mt/with-test-user :crowberto
-          (mt/with-temporary-setting-values [user-recent-views []]
-            (doseq [{:keys [topic event]} [{:topic :event/card-query :event {:card-id (:id dataset)}}
-                                           {:topic :event/card-query :event {:card-id (:id dataset)}}
-                                           {:topic :event/card-query :event {:card-id (:id card1)}}
-                                           {:topic :event/card-query :event {:card-id (:id card1)}}
-                                           {:topic :event/card-query :event {:card-id (:id card1)}}
-                                           {:topic :event/dashboard-read :event {:object dash}}
-                                           {:topic :event/card-query :event {:card-id (:id card1)}}
-                                           {:topic :event/dashboard-read :event {:object dash}}
-                                           {:topic :event/table-read :event {:object table1}}
-                                           {:topic :event/card-query :event {:card-id (:id archived)}}
-                                           {:topic :event/table-read :event {:object hidden-table}}]]
-              (events/publish-event! topic event))
-           (testing "No duplicates or archived items are returned."
-             (let [recent-views (mt/user-http-request :crowberto :get 200 "activity/recent_views")]
-               (is (partial=
-                    [{:model "table" :model_id (u/the-id table1)}
-                     {:model "dashboard" :model_id (u/the-id dash)}
-                     {:model "card" :model_id (u/the-id card1)}
-                     {:model "dataset" :model_id (u/the-id dataset)}]
-                    recent-views))))))
+          (doseq [{:keys [topic event]} [{:topic :event/card-query :event {:card-id (:id dataset)}}
+                                         {:topic :event/card-query :event {:card-id (:id dataset)}}
+                                         {:topic :event/card-query :event {:card-id (:id card1)}}
+                                         {:topic :event/card-query :event {:card-id (:id card1)}}
+                                         {:topic :event/card-query :event {:card-id (:id card1)}}
+                                         {:topic :event/dashboard-read :event {:object dash}}
+                                         {:topic :event/card-query :event {:card-id (:id card1)}}
+                                         {:topic :event/dashboard-read :event {:object dash}}
+                                         {:topic :event/table-read :event {:object table1}}
+                                         {:topic :event/card-query :event {:card-id (:id archived)}}
+                                         {:topic :event/table-read :event {:object hidden-table}}]]
+            (events/publish-event! topic (assoc event :user-id (mt/user->id :crowberto))))
+          (testing "No duplicates or archived items are returned."
+            (let [recent-views (mt/user-http-request :crowberto :get 200 "activity/recent_views")]
+              (is (partial=
+                   [{:model "table" :model_id (u/the-id table1)}
+                    {:model "dashboard" :model_id (u/the-id dash)}
+                    {:model "card" :model_id (u/the-id card1)}
+                    {:model "dataset" :model_id (u/the-id dataset)}]
+                   recent-views)))))
         (mt/with-test-user :rasta
-          (mt/with-temporary-setting-values [user-recent-views []]
-            (events/publish-event! :event/card-query {:card-id (:id dataset)})
-            (events/publish-event! :event/card-query {:card-id (:id card1)})
-            (testing "Only the user's own views are returned."
-              (let [recent-views (mt/user-http-request :rasta :get 200 "activity/recent_views")]
-                (is (partial=
-                     [{:model "dataset" :model_id (u/the-id dataset)}]
-                     (reverse recent-views)))))))))))
+          (events/publish-event! :event/card-query {:card-id (:id dataset) :user-id (mt/user->id :rasta)})
+          (events/publish-event! :event/card-query {:card-id (:id card1) :user-id (mt/user->id :crowberto)})
+          (testing "Only the user's own views are returned."
+            (let [recent-views (mt/user-http-request :rasta :get 200 "activity/recent_views")]
+              (is (partial=
+                   [{:model "dataset" :model_id (u/the-id dataset)}]
+                   (reverse recent-views))))))))))
 
 (defn- create-views!
   "Insert views [user-id model model-id]. Views are entered a second apart with last view as most recent."

--- a/test/metabase/api/alert_test.clj
+++ b/test/metabase/api/alert_test.clj
@@ -927,7 +927,7 @@
 
 (deftest alert-unsubscribe-event-test
   (testing "Alert has two recipients, and non-admin unsubscribes"
-    (mt/with-model-cleanup [:model/Activity :model/AuditLog :model/User]
+    (mt/with-model-cleanup [:model/User]
       (mt/with-temp [Card                  card  (basic-alert-query)
                      Pulse                 alert (basic-alert)
                      PulseCard             _     (pulse-card alert card)

--- a/test/metabase/api/alert_test.clj
+++ b/test/metabase/api/alert_test.clj
@@ -494,7 +494,7 @@
 (deftest update-alerts-admin-test
   (testing "Admin users can update any alert"
     (mt/with-temp [Pulse                 alert (basic-alert)
-                   Card                  card {}
+                   Card                  card  {}
                    PulseCard             _     (pulse-card alert card)
                    PulseChannel          pc    (pulse-channel alert)
                    PulseChannelRecipient _     (recipient pc :rasta)]
@@ -506,7 +506,7 @@
 
   (testing "Admin users can update any alert, changing the related alert attributes"
     (mt/with-temp [Pulse                 alert (basic-alert)
-                   Card                  card {}
+                   Card                  card  {}
                    PulseCard             _     (pulse-card alert card)
                    PulseChannel          pc    (pulse-channel alert)
                    PulseChannelRecipient _     (recipient pc :rasta)]
@@ -522,7 +522,7 @@
 
   (testing "Admin users can add a recipient, that recipient should be notified"
     (mt/with-temp [Pulse                 alert (basic-alert)
-                   Card                  card {}
+                   Card                  card  {}
                    PulseCard             _     (pulse-card alert card)
                    PulseChannel          pc    (pulse-channel alert)
                    PulseChannelRecipient _     (recipient pc :crowberto)]
@@ -543,7 +543,7 @@
 (deftest update-alerts-non-admin-test
   (testing "Non-admin users can update alerts they created"
     (mt/with-temp [Pulse                 alert (basic-alert)
-                   Card                  card {}
+                   Card                  card  {}
                    PulseCard             _     (pulse-card alert card)
                    PulseChannel          pc    (pulse-channel alert)
                    PulseChannelRecipient _     (recipient pc :rasta)]
@@ -557,7 +557,7 @@
 
   (testing "Non-admin users cannot change the recipients of an alert"
     (mt/with-temp [Pulse                 alert (basic-alert)
-                   Card                  card {}
+                   Card                  card  {}
                    PulseCard             _     (pulse-card alert card)
                    PulseChannel          pc    (pulse-channel alert)
                    PulseChannelRecipient _     (recipient pc :rasta)]
@@ -571,7 +571,7 @@
 (deftest admin-users-remove-recipient-test
   (testing "admin users can remove a recipieint, that recipient should be notified"
     (mt/with-temp [Pulse                 alert (basic-alert)
-                   Card                  card {}
+                   Card                  card  {}
                    PulseCard             _     (pulse-card alert card)
                    PulseChannel          pc    (pulse-channel alert)
                    PulseChannelRecipient _     (recipient pc :crowberto)

--- a/test/metabase/api/alert_test.clj
+++ b/test/metabase/api/alert_test.clj
@@ -658,7 +658,7 @@
                                    :channel      ["email"]
                                    :schedule     ["daily"]
                                    :recipients   [[]]}}
-                       (audit-log-test/event :alert-create (u/the-id alert)))))
+                       (audit-log-test/latest-event :alert-create (u/the-id alert)))))
               (testing "Updating alert also logs event."
                 (mt/user-http-request :crowberto :put 200 (alert-url alert) alert-details)
                 (is (= {:topic    :alert-update
@@ -672,7 +672,7 @@
                                    :channel    ["email"]
                                    :schedule   ["daily"]
                                    :recipients [[]]}}
-                       (audit-log-test/event :alert-update (u/the-id alert)))))))))))
+                       (audit-log-test/latest-event :alert-update (u/the-id alert)))))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                            GET /alert/question/:id                                             |
@@ -939,4 +939,4 @@
                 :model    "Pulse"
                 :model_id nil
                 :details  {:email "rasta@metabase.com"}}
-               (audit-log-test/event :alert-unsubscribe)))))))
+               (audit-log-test/latest-event :alert-unsubscribe)))))))

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -334,12 +334,11 @@
 (deftest create-db-audit-log-test
   (testing "POST /api/database"
     (testing "The id captured in the database-create event matches the new db's id"
-      (mt/with-model-cleanup [:model/Activity :model/AuditLog]
-        (with-redefs [premium-features/enable-cache-granular-controls? (constantly true)]
-          (let [{:keys [id] :as _db} (create-db-via-api! {:id 19999999})
-                audit-entry (mt/latest-audit-log-entry "database-create")]
-            (is (= id (-> audit-entry :model_id)))
-            (is (= id (-> audit-entry :details :id)))))))))
+      (with-redefs [premium-features/enable-cache-granular-controls? (constantly true)]
+        (let [{:keys [id] :as _db} (create-db-via-api! {:id 19999999})
+              audit-entry (mt/latest-audit-log-entry "database-create")]
+          (is (= id (-> audit-entry :model_id)))
+          (is (= id (-> audit-entry :details :id))))))))
 
 (deftest disallow-creating-h2-database-test
   (testing "POST /api/database/:id"

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -266,7 +266,7 @@
   (with-redefs [api.session/forgot-password-impl
                 (let [orig @#'api.session/forgot-password-impl]
                   (fn [& args] (u/deref-with-timeout (apply orig args) 1000)))]
-    (mt/with-model-cleanup [:model/Activity :model/AuditLog :model/User]
+    (mt/with-model-cleanup [:model/User]
       (testing "Test that forgot password event is logged."
         (mt/user-http-request :rasta :post 204 "session/forgot_password"
                               {:email (:username (mt/user->credentials :rasta))})

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -276,7 +276,7 @@
                   :model_id rasta-id
                   :model    "User"
                   :details  {:token (t2/select-one-fn :reset_token :model/User :id rasta-id)}}
-                 (audit-log-test/event :password-reset-initiated rasta-id))))))))
+                 (audit-log-test/latest-event :password-reset-initiated rasta-id))))))))
 
 (deftest forgot-password-throttling-test
   (reset-throttlers!)
@@ -348,7 +348,7 @@
                       :model    "User"
                       :model_id id
                       :details  {:token reset-token}}
-                     (audit-log-test/event :password-reset-successful id))))))))))
+                     (audit-log-test/latest-event :password-reset-successful id))))))))))
 
 (deftest reset-password-validation-test
   (reset-throttlers!)
@@ -623,7 +623,7 @@
                 :model    "Pulse"
                 :model_id nil
                 :details  {:email "test@metabase.com"}}
-               (audit-log-test/event :subscription-unsubscribe)))))))
+               (audit-log-test/latest-event :subscription-unsubscribe)))))))
 
 (deftest unsubscribe-undo-test
   (reset-throttlers!)
@@ -667,4 +667,4 @@
                 :model    "Pulse"
                 :model_id nil
                 :details  {:email "test@metabase.com"}}
-               (audit-log-test/event :subscription-unsubscribe-undo)))))))
+               (audit-log-test/latest-event :subscription-unsubscribe-undo)))))))

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -93,7 +93,7 @@
             (let [user-id (u/the-id (t2/select-one User :email email))]
               (is (= {:topic    :user-joined
                       :model_id user-id
-                      :user_id  nil
+                      :user_id  user-id
                       :model    "User"
                       :details  {}}
                      (audit-log-test/latest-event :user-joined user-id))))))))))
@@ -125,16 +125,17 @@
                      (re-pattern (str invitor-first-name " could use your help setting up Metabase.*"))))
                 (testing "The audit-log :user-invited event is recorded"
                   (let [logged-event (audit-log-test/latest-event :user-invited (u/the-id invited-user))]
-                    (is (= {:topic    :user-invited
-                            :user_id  nil
-                            :model    "User"
-                            :model_id (u/the-id (t2/select-one User :email email))
-                            :details  {:invite_method          "email"
-                                       :first_name             first-name
-                                       :last_name              last-name
-                                       :email                  email
-                                       :user_group_memberships [{:id 1} {:id 2}]}}
-                           logged-event))))))))))))
+                    (is (partial=
+                         {:topic    :user-invited
+                          :user_id  nil
+                          :model    "User"
+                          :model_id (u/the-id (t2/select-one User :email email))
+                          :details  {:invite_method          "email"
+                                     :first_name             first-name
+                                     :last_name              last-name
+                                     :email                  email
+                                     :user_group_memberships [{:id 1} {:id 2}]}}
+                         logged-event))))))))))))
 
 (deftest invite-user-test-2
   (testing "POST /api/setup"

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -96,7 +96,7 @@
                       :user_id  nil
                       :model    "User"
                       :details  {}}
-                     (audit-log-test/event :user-joined user-id))))))))))
+                     (audit-log-test/latest-event :user-joined user-id))))))))))
 
 (deftest invite-user-test
   (testing "POST /api/setup"
@@ -124,7 +124,7 @@
                      email
                      (re-pattern (str invitor-first-name " could use your help setting up Metabase.*"))))
                 (testing "The audit-log :user-invited event is recorded"
-                  (let [logged-event (audit-log-test/event :user-invited (u/the-id invited-user))]
+                  (let [logged-event (audit-log-test/latest-event :user-invited (u/the-id invited-user))]
                     (is (= {:topic    :user-invited
                             :user_id  nil
                             :model    "User"

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -475,44 +475,45 @@
           (is (nil? (:custom_homepage (mt/user-http-request :rasta :get 200 "user/current")))))))))
 
 (deftest get-user-test
-  (testing "GET /api/user/:id"
-    (testing "should return a smaller set of fields"
-      (let [resp (mt/user-http-request :rasta :get 200 (str "user/" (mt/user->id :rasta)))]
-        (is (= [{:id (:id (perms-group/all-users))}]
-               (:user_group_memberships resp)))
-        (is (= (-> (merge
-                    @user-defaults
-                    {:email       "rasta@metabase.com"
-                     :first_name  "Rasta"
-                     :last_name   "Toucan"
-                     :common_name "Rasta Toucan"})
-                   (dissoc :is_qbnewb :last_login))
-               (-> resp
-                   mt/boolean-ids-and-timestamps
-                   (dissoc :is_qbnewb :last_login :user_group_memberships))))))
+  (premium-features-test/with-premium-features #{}
+    (testing "GET /api/user/:id"
+      (testing "should return a smaller set of fields"
+        (let [resp (mt/user-http-request :rasta :get 200 (str "user/" (mt/user->id :rasta)))]
+          (is (= [{:id (:id (perms-group/all-users))}]
+                 (:user_group_memberships resp)))
+          (is (= (-> (merge
+                      @user-defaults
+                      {:email       "rasta@metabase.com"
+                       :first_name  "Rasta"
+                       :last_name   "Toucan"
+                       :common_name "Rasta Toucan"})
+                     (dissoc :is_qbnewb :last_login))
+                 (-> resp
+                     mt/boolean-ids-and-timestamps
+                     (dissoc :is_qbnewb :last_login :user_group_memberships))))))
 
-    (testing "Check that a non-superuser CANNOT fetch someone else's user details"
-      (is (= "You don't have permissions to do that."
-             (mt/user-http-request :rasta :get 403 (str "user/" (mt/user->id :trashbird))))))
+      (testing "Check that a non-superuser CANNOT fetch someone else's user details"
+        (is (= "You don't have permissions to do that."
+               (mt/user-http-request :rasta :get 403 (str "user/" (mt/user->id :trashbird))))))
 
-    (testing "A superuser should be allowed to fetch another users data"
-      (let [resp (mt/user-http-request :crowberto :get 200 (str "user/" (mt/user->id :rasta)))]
-        (is (= [{:id (:id (perms-group/all-users)) :is_group_manager false}]
-               (:user_group_memberships resp)))
-        (is (= (-> (merge
-                    @user-defaults
-                    {:email       "rasta@metabase.com"
-                     :first_name  "Rasta"
-                     :last_name   "Toucan"
-                     :common_name "Rasta Toucan"})
-                   (dissoc :is_qbnewb :last_login))
-               (-> resp
-                   mt/boolean-ids-and-timestamps
-                   (dissoc :is_qbnewb :last_login :user_group_memberships))))))
+      (testing "A superuser should be allowed to fetch another users data"
+        (let [resp (mt/user-http-request :crowberto :get 200 (str "user/" (mt/user->id :rasta)))]
+          (is (= [{:id (:id (perms-group/all-users))}]
+                 (:user_group_memberships resp)))
+          (is (= (-> (merge
+                      @user-defaults
+                      {:email       "rasta@metabase.com"
+                       :first_name  "Rasta"
+                       :last_name   "Toucan"
+                       :common_name "Rasta Toucan"})
+                     (dissoc :is_qbnewb :last_login))
+                 (-> resp
+                     mt/boolean-ids-and-timestamps
+                     (dissoc :is_qbnewb :last_login :user_group_memberships))))))
 
-    (testing "We should get a 404 when trying to access a disabled account"
-      (is (= "Not found."
-             (mt/user-http-request :crowberto :get 404 (str "user/" (mt/user->id :trashbird))))))))
+      (testing "We should get a 404 when trying to access a disabled account"
+        (is (= "Not found."
+               (mt/user-http-request :crowberto :get 404 (str "user/" (mt/user->id :trashbird)))))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -522,28 +523,29 @@
 (deftest create-user-test
   (testing "POST /api/user"
     (testing "Test that we can create a new User"
-      (let [user-name (mt/random-name)
-            email     (mt/random-email)]
-        (mt/with-model-cleanup [User]
-          (mt/with-fake-inbox
-            (let [resp (mt/user-http-request :crowberto :post 200 "user"
-                                             {:first_name       user-name
-                                              :last_name        user-name
-                                              :email            email
-                                              :login_attributes {:test "value"}})]
-              (is (= (merge @user-defaults
-                            (merge
-                             @user-defaults
-                             {:email                  email
-                              :first_name             user-name
-                              :last_name              user-name
-                              :common_name            (str user-name " " user-name)
-                              :login_attributes       {:test "value"}}))
-                     (-> resp
-                         mt/boolean-ids-and-timestamps
-                         (dissoc :user_group_memberships))))
-              (is (= [{:id (:id (perms-group/all-users)), :is_group_manager false}]
-                     (:user_group_memberships resp))))))))
+      (premium-features-test/with-premium-features #{}
+        (let [user-name (mt/random-name)
+              email     (mt/random-email)]
+          (mt/with-model-cleanup [User]
+            (mt/with-fake-inbox
+              (let [resp (mt/user-http-request :crowberto :post 200 "user"
+                                               {:first_name       user-name
+                                                :last_name        user-name
+                                                :email            email
+                                                :login_attributes {:test "value"}})]
+                (is (= (merge @user-defaults
+                              (merge
+                               @user-defaults
+                               {:email                  email
+                                :first_name             user-name
+                                :last_name              user-name
+                                :common_name            (str user-name " " user-name)
+                                :login_attributes       {:test "value"}}))
+                       (-> resp
+                           mt/boolean-ids-and-timestamps
+                           (dissoc :user_group_memberships))))
+                (is (= [{:id (:id (perms-group/all-users))}]
+                       (:user_group_memberships resp)))))))))
 
     (testing "Check that non-superusers are denied access"
       (is (= "You don't have permissions to do that."

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -1248,8 +1248,8 @@
                      :model    "User"
                      :model_id id
                      :details  {}}]
-                   [(audit-log-test/event :user-deactivated id)
-                    (audit-log-test/event :user-reactivated id)])))))))
+                   [(audit-log-test/latest-event :user-deactivated id)
+                    (audit-log-test/latest-event :user-reactivated id)])))))))
 
 (deftest user-update-event-test
   (testing "User Updates via the API are recorded in the audit log"
@@ -1265,4 +1265,4 @@
                     :model_id id
                     :details  {:first_name "Johnny"
                                :last_name "Appleseed"}}
-                   (audit-log-test/event :user-update id))))))))
+                   (audit-log-test/latest-event :user-update id))))))))

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -478,7 +478,7 @@
   (testing "GET /api/user/:id"
     (testing "should return a smaller set of fields"
       (let [resp (mt/user-http-request :rasta :get 200 (str "user/" (mt/user->id :rasta)))]
-        (is (= [{:id (:id (perms-group/all-users))}]
+        (is (= [{:id (:id (perms-group/all-users)) :is_group_manager false}]
                (:user_group_memberships resp)))
         (is (= (-> (merge
                     @user-defaults
@@ -497,7 +497,7 @@
 
     (testing "A superuser should be allowed to fetch another users data"
       (let [resp (mt/user-http-request :crowberto :get 200 (str "user/" (mt/user->id :rasta)))]
-        (is (= [{:id (:id (perms-group/all-users))}]
+        (is (= [{:id (:id (perms-group/all-users)) :is_group_manager false}]
                (:user_group_memberships resp)))
         (is (= (-> (merge
                     @user-defaults
@@ -542,7 +542,7 @@
                      (-> resp
                          mt/boolean-ids-and-timestamps
                          (dissoc :user_group_memberships))))
-              (is (= [{:id (:id (perms-group/all-users))}]
+              (is (= [{:id (:id (perms-group/all-users)), :is_group_manager false}]
                      (:user_group_memberships resp))))))))
 
     (testing "Check that non-superusers are denied access"

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -1214,9 +1214,8 @@
                             "v_content"
                             "v_dashboardcard"
                             "v_group_members"
-                            ;; TODO: re-enable test for v_subscriptions and v_alerts once these are fixed
-                            #_"v_subscriptions"
-                            #_"v_alerts"
+                            "v_subscriptions"
+                            "v_alerts"
                             "v_users"
                             "v_databases"
                             "v_fields"

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -19,9 +19,9 @@
 
 (comment events.audit-log/keep-me)
 
-(defn event
+(defn latest-event
   ([topic]
-   (event topic nil))
+   (latest-event topic nil))
 
   ([topic model-id]
    (t2/select-one [:model/AuditLog :topic :user_id :model :model_id :details]
@@ -30,19 +30,17 @@
                   {:order-by [[:id :desc]]})))
 
 (deftest card-create-test
-  (testing :card-create
-    (mt/with-model-cleanup [:model/AuditLog]
-      (mt/with-test-user :rasta
-        (t2.with-temp/with-temp [Card card {:name "My Cool Card"}]
-          (is (= {:object card}
-                 (events/publish-event! :event/card-create {:object card})))
-          (is (partial=
-               {:topic    :card-create
-                :user_id  (mt/user->id :rasta)
-                :model    "Card"
-                :model_id (:id card)
-                :details  {:name "My Cool Card", :description nil, :database_id (mt/id) :table_id nil}}
-               (event "card-create" (:id card)))))))))
+  (testing ":card-create event"
+    (t2.with-temp/with-temp [Card card {:name "My Cool Card"}]
+      (is (= {:object card :user-id (mt/user->id :rasta)}
+             (events/publish-event! :event/card-create {:object card :user-id (mt/user->id :rasta)})))
+      (is (partial=
+           {:topic    :card-create
+            :user_id  (mt/user->id :rasta)
+            :model    "Card"
+            :model_id (:id card)
+            :details  {:name "My Cool Card", :description nil, :database_id (mt/id) :table_id nil}}
+           (latest-event "card-create" (:id card)))))))
 
 (deftest card-create-nested-query-test
   (testing :card-create
@@ -55,272 +53,251 @@
                                   :dataset_query {:database lib.schema.id/saved-questions-virtual-database-id
                                                   :type     :query
                                                   :query    {:source-table (str "card__" (u/the-id card-1))}}}]
-        (mt/with-model-cleanup [:model/AuditLog]
-          (mt/with-test-user :rasta
-            (is (= {:object card-2}
-                   (events/publish-event! :event/card-create {:object card-2})))
-            (is (partial=
-                 {:topic    :card-create
-                  :user_id  (mt/user->id :rasta)
-                  :model    "Card"
-                  :model_id (:id card-2)
-                  :details  {:name        "My Cool NESTED Card"
-                             :description nil
-                             :database_id (mt/id)
-                             :table_id    (mt/id :venues)}}
-                 (event "card-create" (:id card-2))))))))))
+        (is (= {:object card-2 :user-id (mt/user->id :rasta)}
+               (events/publish-event! :event/card-create {:object card-2 :user-id (mt/user->id :rasta)})))
+        (is (partial=
+             {:topic    :card-create
+              :user_id  (mt/user->id :rasta)
+              :model    "Card"
+              :model_id (:id card-2)
+              :details  {:name        "My Cool NESTED Card"
+                         :description nil
+                         :database_id (mt/id)
+                         :table_id    (mt/id :venues)}}
+             (latest-event "card-create" (:id card-2))))))))
 
 (deftest card-update-event-test
   (testing :card-update
     (doseq [dataset? [false true]]
       (testing (if dataset? "Dataset" "Card")
         (t2.with-temp/with-temp [Card card {:name "My Cool Card" :dataset dataset?}]
-          (mt/with-model-cleanup [:model/AuditLog]
-           (mt/with-test-user :rasta
-             (is (= {:object card}
-                    (events/publish-event! :event/card-update {:object card})))
-             (is (partial=
-                  {:topic    :card-update
-                   :user_id  (mt/user->id :rasta)
-                   :model    "Card"
-                   :model_id (:id card)
-                   :details  (cond-> {:name        "My Cool Card"
-                                      :description nil
-                                      :table_id    nil
-                                      :database_id (mt/id)}
-                               dataset? (assoc :model? true))}
-                  (event "card-update" (:id card)))))))))))
+          (mt/with-test-user :rasta
+            (is (= {:object card :user-id (mt/user->id :rasta)}
+                   (events/publish-event! :event/card-update {:object card :user-id (mt/user->id :rasta)})))
+            (is (partial=
+                 {:topic    :card-update
+                  :user_id  (mt/user->id :rasta)
+                  :model    "Card"
+                  :model_id (:id card)
+                  :details  (cond-> {:name        "My Cool Card"
+                                     :description nil
+                                     :table_id    nil
+                                     :database_id (mt/id)}
+                              dataset? (assoc :model? true))}
+                 (latest-event "card-update" (:id card))))))))))
 
 (deftest card-delete-event-test
   (testing :card-delete
     (doseq [dataset? [false true]]
       (testing (if dataset? "Dataset" "Card")
         (t2.with-temp/with-temp [Card card {:name "My Cool Card", :dataset dataset?}]
-          (mt/with-model-cleanup [:model/AuditLog]
-            (mt/with-test-user :rasta
-              (is (= {:object card}
-                     (events/publish-event! :event/card-delete {:object card})))
-              (is (partial=
-                   {:topic    :card-delete
-                    :user_id  (mt/user->id :rasta)
-                    :model    "Card"
-                    :model_id (:id card)
-                    :details  (cond-> {:name "My Cool Card", :description nil}
-                                dataset? (assoc :model? true))}
-                   (event "card-delete" (:id card)))))))))))
+          (mt/with-test-user :rasta
+            (is (= {:object card :user-id (mt/user->id :rasta)}
+                   (events/publish-event! :event/card-delete {:object card :user-id (mt/user->id :rasta)})))
+            (is (partial=
+                 {:topic    :card-delete
+                  :user_id  (mt/user->id :rasta)
+                  :model    "Card"
+                  :model_id (:id card)
+                  :details  (cond-> {:name "My Cool Card", :description nil}
+                              dataset? (assoc :model? true))}
+                 (latest-event "card-delete" (:id card))))))))))
 
 (deftest card-read-event-test
   (testing :card-read
     (doseq [dataset? [false true]]
       (testing (if dataset? "Dataset" "Card")
         (t2.with-temp/with-temp [Card card {:name "My Cool Card", :dataset dataset?}]
-          (mt/with-model-cleanup [:model/AuditLog]
-            (mt/with-test-user :rasta
-              (is (= card
-                     (events/publish-event! :event/card-read card)))
-              (is (partial=
-                   {:topic    :card-read
-                    :user_id  (mt/user->id :rasta)
-                    :model    "Card"
-                    :model_id (:id card)
-                    :details  (cond-> {:name "My Cool Card", :description nil}
-                                dataset? (assoc :model? true))}
-                   (event "card-read" (:id card)))))))))))
+          (is (= {:object card :user-id (mt/user->id :rasta)}
+                 (events/publish-event! :event/card-read {:object card :user-id (mt/user->id :rasta)})))
+          (is (partial=
+               {:topic    :card-read
+                :user_id  (mt/user->id :rasta)
+                :model    "Card"
+                :model_id (:id card)
+                :details  (cond-> {:name "My Cool Card", :description nil}
+                            dataset? (assoc :model? true))}
+               (latest-event "card-read" (:id card)))))))))
 
 (deftest card-query-event-test
   (testing :card-query
     (doseq [dataset? [false true]]
       (testing (if dataset? "Dataset" "Card")
         (t2.with-temp/with-temp [Card card {:name "My Cool Card", :dataset dataset?}]
-          (mt/with-model-cleanup [:model/AuditLog]
-            (mt/with-test-user :rasta
-              (events/publish-event! :event/card-query {:card_id      (u/the-id card)
-                                                        :cached       false
-                                                        :ignore_cache false
-                                                        :context      :question})
-              (is (partial=
-                   {:topic    :card-query
-                    :user_id  (mt/user->id :rasta)
-                    :model    "Card"
-                    :model_id (:id card)
-                    :details  {:cached false :ignore_cache false :context "question"}}
-                   (event "card-query" (:id card)))))))))))
+          (events/publish-event! :event/card-query {:user-id      (mt/user->id :rasta)
+                                                    :card-id      (u/the-id card)
+                                                    :cached       false
+                                                    :ignore_cache false
+                                                    :context      :question})
+          (is (partial=
+               {:topic    :card-query
+                :user_id  (mt/user->id :rasta)
+                :model    "Card"
+                :model_id (:id card)
+                :details  {:cached false :ignore_cache false :context "question"}}
+               (latest-event "card-query" (:id card)))))))))
 
 (deftest dashboard-create-event-test
   (testing :dashboard-create
     (t2.with-temp/with-temp [Dashboard dashboard {:name "My Cool Dashboard"}]
-      (mt/with-model-cleanup [:model/AuditLog]
-        (mt/with-test-user :rasta
-          (is (= {:object dashboard}
-                 (events/publish-event! :event/dashboard-create {:object dashboard})))
-          (is (partial=
-               {:topic    :dashboard-create
-                :user_id  (mt/user->id :rasta)
-                :model    "Dashboard"
-                :model_id (:id dashboard)
-                :details  {:name "My Cool Dashboard", :description nil}}
-               (event "dashboard-create" (:id dashboard)))))))))
+      (is (= {:object dashboard :user-id (mt/user->id :rasta)}
+             (events/publish-event! :event/dashboard-create {:object dashboard :user-id (mt/user->id :rasta)})))
+      (is (partial=
+           {:topic    :dashboard-create
+            :user_id  (mt/user->id :rasta)
+            :model    "Dashboard"
+            :model_id (:id dashboard)
+            :details  {:name "My Cool Dashboard", :description nil}}
+           (latest-event "dashboard-create" (:id dashboard)))))))
 
 (deftest dashboard-delete-event-test
   (testing :dashboard-delete
     (t2.with-temp/with-temp [Dashboard dashboard {:name "My Cool Dashboard"}]
-      (mt/with-model-cleanup [:model/AuditLog]
-        (mt/with-test-user :rasta
-          (is (= {:object dashboard}
-                 (events/publish-event! :event/dashboard-delete {:object dashboard})))
-          (is (partial=
-               {:topic    :dashboard-delete
-                :user_id  (mt/user->id :rasta)
-                :model    "Dashboard"
-                :model_id (:id dashboard)
-                :details  {:name "My Cool Dashboard", :description nil}}
-               (event "dashboard-delete" (:id dashboard)))))))))
+      (is (= {:object dashboard :user-id (mt/user->id :rasta)}
+             (events/publish-event! :event/dashboard-delete {:object dashboard :user-id (mt/user->id :rasta)})))
+      (is (partial=
+           {:topic    :dashboard-delete
+            :user_id  (mt/user->id :rasta)
+            :model    "Dashboard"
+            :model_id (:id dashboard)
+            :details  {:name "My Cool Dashboard", :description nil}}
+           (latest-event "dashboard-delete" (:id dashboard)))))))
 
 (deftest dashboard-add-cards-event-test
   (testing :dashboard-add-cards
     (mt/with-temp [Dashboard     dashboard {:name "My Cool Dashboard"}
                    Card          card {}
                    DashboardCard dashcard  {:dashboard_id (:id dashboard), :card_id (:id card)}]
-      (mt/with-model-cleanup [:model/AuditLog]
-        (mt/with-test-user :rasta
-          (let [event {:id        (:id dashboard)
-                       :dashcards [dashcard]}]
-            (is (= event
-                   (events/publish-event! :event/dashboard-add-cards event))))
-          (is (partial=
-               {:topic    :dashboard-add-cards
-                :user_id  (mt/user->id :rasta)
-                :model    "Dashboard"
-                :model_id (:id dashboard)
-                :details  {:name        "My Cool Dashboard"
-                           :description nil
-                           :dashcards   [{:description (:description card)
-                                          :name        (:name card)
-                                          :id          (:id dashcard)
-                                          :card_id     (:id card)}]}}
-               (event "dashboard-add-cards" (:id dashboard)))))))))
+      (let [event {:object    dashboard
+                   :dashcards [dashcard]
+                   :user-id   (mt/user->id :rasta)}]
+        (is (= event
+               (events/publish-event! :event/dashboard-add-cards event)))
+        (is (partial=
+             {:topic    :dashboard-add-cards
+              :user_id  (mt/user->id :rasta)
+              :model    "Dashboard"
+              :model_id (:id dashboard)
+              :details  {:name        "My Cool Dashboard"
+                         :description nil
+                         :dashcards   [{:description (:description card)
+                                        :name        (:name card)
+                                        :id          (:id dashcard)
+                                        :card_id     (:id card)}]}}
+             (latest-event "dashboard-add-cards" (:id dashboard))))))))
 
 (deftest dashboard-remove-cards-event-test
   (testing :dashboard-remove-cards
     (mt/with-temp [Dashboard     dashboard {:name "My Cool Dashboard"}
                    Card          card {}
                    DashboardCard dashcard  {:dashboard_id (:id dashboard), :card_id (:id card)}]
-      (mt/with-model-cleanup [:model/AuditLog]
-        (mt/with-test-user :rasta
-          (let [event {:id        (:id dashboard)
-                       :dashcards [dashcard]}]
-            (is (= event
-                   (events/publish-event! :event/dashboard-remove-cards event))))
-          (is (partial=
-               {:topic       :dashboard-remove-cards
-                :user_id     (mt/user->id :rasta)
-                :model       "Dashboard"
-                :model_id    (:id dashboard)
-                :details     {:name        "My Cool Dashboard"
-                              :description nil
-                              :dashcards   [{:description (:description card)
-                                             :name        (:name card)
-                                             :id          (:id dashcard)
-                                             :card_id     (:id card)}]}}
-               (event "dashboard-remove-cards" (:id dashboard)))))))))
+      (let [event {:object    dashboard
+                   :dashcards [dashcard]
+                   :user-id   (mt/user->id :rasta)}]
+        (is (= event
+               (events/publish-event! :event/dashboard-remove-cards event)))
+        (is (partial=
+             {:topic       :dashboard-remove-cards
+              :user_id     (mt/user->id :rasta)
+              :model       "Dashboard"
+              :model_id    (:id dashboard)
+              :details     {:name        "My Cool Dashboard"
+                            :description nil
+                            :dashcards   [{:description (:description card)
+                                           :name        (:name card)
+                                           :id          (:id dashcard)
+                                           :card_id     (:id card)}]}}
+             (latest-event "dashboard-remove-cards" (:id dashboard))))))))
 
 (deftest dashboard-read-event-test
   (testing :dashboard-read
     (t2.with-temp/with-temp [Dashboard dashboard {:name "My Cool Dashboard"}]
-      (mt/with-model-cleanup [:model/AuditLog]
-        (mt/with-test-user :rasta
-          (is (= dashboard
-                 (events/publish-event! :event/dashboard-read dashboard)))
-          (is (partial=
-               {:topic    :dashboard-read
-                :user_id  (mt/user->id :rasta)
-                :model    "Dashboard"
-                :model_id (:id dashboard)
-                :details  {:name "My Cool Dashboard", :description nil}}
-               (event "dashboard-read" (:id dashboard)))))))))
+      (is (= {:object dashboard :user-id (mt/user->id :rasta)}
+             (events/publish-event! :event/dashboard-read {:object dashboard :user-id (mt/user->id :rasta)})))
+      (is (partial=
+           {:topic    :dashboard-read
+            :user_id  (mt/user->id :rasta)
+            :model    "Dashboard"
+            :model_id (:id dashboard)
+            :details  {:name "My Cool Dashboard", :description nil}}
+           (latest-event "dashboard-read" (:id dashboard)))))))
 
 (deftest table-read-event-test
   (testing :table-read
     (t2.with-temp/with-temp [Table table {:name "My Cool Table"}]
-      (mt/with-model-cleanup [:model/AuditLog]
-        (mt/with-test-user :rasta
-          (is (= table
-                 (events/publish-event! :event/table-read table)))
-          (is (partial=
-               {:topic    :table-read
-                :user_id  (mt/user->id :rasta)
-                :model    "Table"
-                :model_id (:id table)
-                :details  {}}
-               (event "table-read" (:id table)))))))))
+      (is (= {:object table :user-id (mt/user->id :rasta)}
+             (events/publish-event! :event/table-read {:object table :user-id (mt/user->id :rasta)})))
+      (is (partial=
+           {:topic    :table-read
+            :user_id  (mt/user->id :rasta)
+            :model    "Table"
+            :model_id (:id table)
+            :details  {}}
+           (latest-event "table-read" (:id table)))))))
 
 (deftest install-event-test
   (testing :install
-    (mt/with-model-cleanup [:model/AuditLog]
-      (is (= {}
-             (events/publish-event! :event/install {})))
-      (is (= {:topic       :install
-              :user_id     nil
-              :model       nil
-              :model_id    nil
-              :details     {}}
-             (event "install"))))))
+    (is (= {}
+           (events/publish-event! :event/install {})))
+    (is (= {:topic       :install
+            :user_id     nil
+            :model       nil
+            :model_id    nil
+            :details     {}}
+           (latest-event "install")))))
 
 (deftest metric-create-event-test
   (testing :metric-create
     (t2.with-temp/with-temp [Metric metric {:table_id (mt/id :venues)}]
-      (mt/with-model-cleanup [:model/AuditLog]
-        (mt/with-test-user :rasta
-          (is (= {:object metric}
-                 (events/publish-event! :event/metric-create {:object metric})))
-          (is (= {:topic       :metric-create
-                  :user_id     (mt/user->id :rasta)
-                  :model       "Metric"
-                  :model_id    (:id metric)
-                  :details     {:name        (:name metric)
-                                :description (:description metric)
-                                :database_id (mt/id)
-                                :table_id    (mt/id :venues)}}
-                 (event "metric-create" (:id metric)))))))))
+      (is (= {:object metric :user-id (mt/user->id :rasta)}
+             (events/publish-event! :event/metric-create {:object metric :user-id (mt/user->id :rasta)})))
+      (is (= {:topic       :metric-create
+              :user_id     (mt/user->id :rasta)
+              :model       "Metric"
+              :model_id    (:id metric)
+              :details     {:name        (:name metric)
+                            :description (:description metric)
+                            :database_id (mt/id)
+                            :table_id    (mt/id :venues)}}
+             (latest-event "metric-create" (:id metric)))))))
 
 (deftest metric-update-event-test
   (testing :metric-update
     (t2.with-temp/with-temp [Metric metric {:table_id (mt/id :venues)}]
-      (mt/with-model-cleanup [:model/AuditLog]
-        (mt/with-test-user :rasta
-         (let [event (-> (assoc metric :revision_message "update this mofo"))]
-           (is (= event
-                  (events/publish-event! :event/metric-update event))))
-         (is (= {:topic       :metric-update
-                 :user_id     (mt/user->id :rasta)
-                 :model       "Metric"
-                 :model_id    (:id metric)
-                 :details     {:name             (:name metric)
-                               :description      (:description metric)
-                               :revision_message "update this mofo"
-                               :database_id (mt/id)
-                               :table_id    (mt/id :venues)}}
-                (event "metric-update" (:id metric)))))))))
+      (let [event {:object           metric
+                   :revision-message "update this mofo"
+                   :user-id          (mt/user->id :rasta)}]
+        (is (= event
+               (events/publish-event! :event/metric-update event)))
+        (is (= {:topic       :metric-update
+                :user_id     (mt/user->id :rasta)
+                :model       "Metric"
+                :model_id    (:id metric)
+                :details     {:name             (:name metric)
+                              :description      (:description metric)
+                              :database_id (mt/id)
+                              :table_id    (mt/id :venues)
+                              :revision-message "update this mofo"}}
+               (latest-event "metric-update" (:id metric))))))))
 
 (deftest metric-delete-event-test
   (testing :metric-delete
     (t2.with-temp/with-temp [Metric metric {:table_id (mt/id :venues)}]
-      (mt/with-model-cleanup [:model/AuditLog]
-        (mt/with-test-user :rasta
-         (let [event (assoc metric
-                            :revision_message "deleted")]
-           (is (= event
-                  (events/publish-event! :event/metric-delete event))))
-         (is (= {:topic       :metric-delete
-                 :user_id     (mt/user->id :rasta)
-                 :model       "Metric"
-                 :model_id    (:id metric)
-                 :details     {:name             (:name metric)
-                               :description      (:description metric)
-                               :revision_message "deleted"
-                               :database_id (mt/id)
-                               :table_id    (mt/id :venues)}}
-                (event "metric-delete" (:id metric)))))))))
+      (let [event {:object           metric
+                   :revision-message "deleted"
+                   :user-id          (mt/user->id :rasta)}]
+       (is (= event
+              (events/publish-event! :event/metric-delete event)))
+       (is (= {:topic       :metric-delete
+               :user_id     (mt/user->id :rasta)
+               :model       "Metric"
+               :model_id    (:id metric)
+               :details     {:name             (:name metric)
+                             :description      (:description metric)
+                             :revision-message "deleted"
+                             :database_id (mt/id)
+                             :table_id    (mt/id :venues)}}
+              (latest-event "metric-delete" (:id metric))))))))
 
 (deftest subscription-events-test
   (t2.with-temp/with-temp [Dashboard      {dashboard-id :id} {}
@@ -335,38 +312,36 @@
                             :channels [{:channel_type  :email
                                         :schedule_type :daily
                                         :recipients    recipients}])]
-      (mt/with-model-cleanup [:model/AuditLog]
-        (mt/with-test-user :rasta
-          (testing :subscription-update
-            (is (= {:object pulse}
-                   (events/publish-event! :event/subscription-update {:object pulse})))
-            (is (= {:topic       :subscription-update
-                    :user_id     (mt/user->id :rasta)
-                    :model       "Pulse"
-                    :model_id    (:id pulse)
-                    :details     {:archived     false
-                                  :name         "name"
-                                  :dashboard_id dashboard-id
-                                  :parameters   []
-                                  :channel      ["email"]
-                                  :schedule     ["daily"]
-                                  :recipients   [recipients]}}
-                   (event "subscription-update" (:id pulse)))))
-          (testing :subscription-create
-            (is (= {:object pulse}
-                   (events/publish-event! :event/subscription-create {:object pulse})))
-            (is (= {:topic       :subscription-create
-                    :user_id     (mt/user->id :rasta)
-                    :model       "Pulse"
-                    :model_id    (:id pulse)
-                    :details     {:archived     false
-                                  :name         "name"
-                                  :dashboard_id dashboard-id
-                                  :parameters   []
-                                  :channel      ["email"]
-                                  :schedule     ["daily"]
-                                  :recipients   [recipients]}}
-                   (event "subscription-create" (:id pulse))))))))))
+      (testing :subscription-update
+        (is (= {:object pulse :user-id (mt/user->id :rasta)}
+               (events/publish-event! :event/subscription-update {:object pulse :user-id (mt/user->id :rasta)})))
+        (is (= {:topic       :subscription-update
+                :user_id     (mt/user->id :rasta)
+                :model       "Pulse"
+                :model_id    (:id pulse)
+                :details     {:archived     false
+                              :name         "name"
+                              :dashboard_id dashboard-id
+                              :parameters   []
+                              :channel      ["email"]
+                              :schedule     ["daily"]
+                              :recipients   [recipients]}}
+               (latest-event "subscription-update" (:id pulse)))))
+      (testing :subscription-create
+        (is (= {:object pulse :user-id (mt/user->id :rasta)}
+               (events/publish-event! :event/subscription-create {:object pulse :user-id (mt/user->id :rasta)})))
+        (is (= {:topic       :subscription-create
+                :user_id     (mt/user->id :rasta)
+                :model       "Pulse"
+                :model_id    (:id pulse)
+                :details     {:archived     false
+                              :name         "name"
+                              :dashboard_id dashboard-id
+                              :parameters   []
+                              :channel      ["email"]
+                              :schedule     ["daily"]
+                              :recipients   [recipients]}}
+               (latest-event "subscription-create" (:id pulse))))))))
 
 (deftest alert-events-test
   (t2.with-temp/with-temp [Dashboard      {dashboard-id :id} {}
@@ -385,209 +360,201 @@
                                       {:channel_type  :slack
                                        :schedule_type :hourly
                                        :recipients    [{:id (mt/user->id :rasta)}]}]))]
-      (mt/with-model-cleanup [:model/AuditLog]
-        (mt/with-test-user :rasta
-          (testing :alert-update
-            (is (= pulse
-                   (events/publish-event! :event/alert-update pulse)))
-            (is (= {:topic       :alert-update
-                    :user_id     (mt/user->id :rasta)
-                    :model       "Card"
-                    :model_id    (:id pulse)
-                    :details     {:archived   false
-                                  :name       "card-name"
-                                  :card_id    (:id card)
-                                  :parameters []
-                                  :channel    ["email" "slack"]
-                                  :schedule   ["daily" "hourly"]
-                                  :recipients [[{:email "test@metabase.com"}
-                                                {:id    (mt/user->id :rasta)
-                                                 :email "rasta@metabase.com"}]
-                                               [{:id (mt/user->id :rasta)}]]}}
-                   (event "alert-update" (:id pulse))))))))))
+      (testing :alert-update
+        (is (= {:object pulse :user-id (mt/user->id :rasta)}
+               (events/publish-event! :event/alert-update {:object pulse :user-id (mt/user->id :rasta)})))
+        (is (= {:topic       :alert-update
+                :user_id     (mt/user->id :rasta)
+                :model       "Card"
+                :model_id    (:id pulse)
+                :details     {:archived   false
+                              :name       "card-name"
+                              :card_id    (:id card)
+                              :parameters []
+                              :channel    ["email" "slack"]
+                              :schedule   ["daily" "hourly"]
+                              :recipients [[{:email "test@metabase.com"}
+                                            {:id    (mt/user->id :rasta)
+                                             :email "rasta@metabase.com"}]
+                                           [{:id (mt/user->id :rasta)}]]}}
+               (latest-event "alert-update" (:id pulse))))))))
 
 (deftest subscription-unsubscribe-event-test
   (testing :subscription-unsubscribe
-    (mt/with-model-cleanup [:model/AuditLog]
-        (mt/with-test-user :rasta
-          (events/publish-event! :event/subscription-unsubscribe {:details {:email "test"}})
-          (is (= {:topic       :subscription-unsubscribe
-                  :user_id     (mt/user->id :rasta)
-                  :model       "Pulse"
-                  :model_id    nil
-                  :details     {:email "test"}}
-                 (event "subscription-unsubscribe")))))))
+    (mt/with-test-user :rasta
+      (events/publish-event! :event/subscription-unsubscribe {:object {:email "test"}})
+      (is (= {:topic       :subscription-unsubscribe
+              :user_id     (mt/user->id :rasta)
+              :model       "Pulse"
+              :model_id    nil
+              :details     {:email "test"}}
+             (latest-event "subscription-unsubscribe"))))))
 
 (deftest subscription-unsubscribe-undo-event-test
   (testing :subscription-unsubscribe-undo
-    (mt/with-model-cleanup [:model/AuditLog]
-      (mt/with-test-user :rasta
-        (events/publish-event! :event/subscription-unsubscribe-undo {:details {:email "test"}}))
+    (mt/with-test-user :rasta
+      (events/publish-event! :event/subscription-unsubscribe-undo {:object {:email "test"}})
       (is (= {:topic       :subscription-unsubscribe-undo
               :user_id     (mt/user->id :rasta)
               :model       "Pulse"
               :model_id    nil
               :details     {:email "test"}}
-             (event "subscription-unsubscribe-undo"))))))
+             (latest-event "subscription-unsubscribe-undo"))))))
 
 (deftest alert-unsubscribe-event-test
   (testing :alert-unsubscribe
-    (mt/with-model-cleanup [:model/AuditLog]
-      (mt/with-test-user :rasta
-        (events/publish-event! :event/alert-unsubscribe {:details {:email "test"}}))
+    (mt/with-test-user :rasta
+      (events/publish-event! :event/alert-unsubscribe {:object {:email "test"}})
       (is (= {:topic       :alert-unsubscribe
               :user_id     (mt/user->id :rasta)
               :model       "Pulse"
               :model_id    nil
               :details     {:email "test"}}
-             (event "alert-unsubscribe"))))))
+             (latest-event "alert-unsubscribe"))))))
 
 (deftest segment-create-event-test
   (testing :segment-create
     (t2.with-temp/with-temp [Segment segment]
-      (mt/with-model-cleanup [:model/AuditLog]
-        (mt/with-test-user :rasta
-         (is (= {:object segment}
-                (events/publish-event! :event/segment-create {:object segment})))
-         (is (= {:topic       :segment-create
-                 :user_id     (mt/user->id :rasta)
-                 :model       "Segment"
-                 :model_id    (:id segment)
-                 :details     {:name        (:name segment)
-                               :description (:description segment)
-                               :database_id (mt/id)
-                               :table_id    (mt/id :checkins)}}
-                (event "segment-create" (:id segment)))))))))
+      (mt/with-test-user :rasta
+       (is (= {:object segment :user-id (mt/user->id :rasta)}
+              (events/publish-event! :event/segment-create {:object segment :user-id (mt/user->id :rasta)})))
+       (is (= {:topic       :segment-create
+               :user_id     (mt/user->id :rasta)
+               :model       "Segment"
+               :model_id    (:id segment)
+               :details     {:name        (:name segment)
+                             :description (:description segment)
+                             :database_id (mt/id)
+                             :table_id    (mt/id :checkins)}}
+              (latest-event "segment-create" (:id segment))))))))
 
 (deftest segment-update-event-test
   (testing :segment-update
     (t2.with-temp/with-temp [Segment segment]
-      (mt/with-model-cleanup [:model/AuditLog]
-        (mt/with-test-user :rasta
-         (let [event (-> {:object segment}
-                         (assoc :revision_message "update this mofo"))]
-           (is (= event
-                  (events/publish-event! :event/segment-update event))))
-         (is (= {:topic       :segment-update
-                 :user_id     (mt/user->id :rasta)
-                 :model       "Segment"
-                 :model_id    (:id segment)
-                 :details     {:name             (:name segment)
-                               :description      (:description segment)
-                               :revision_message "update this mofo"
-                               :database_id (mt/id)
-                               :table_id    (mt/id :checkins)}}
-                (event "segment-update" (:id segment)))))))))
+     (let [event (-> {:object segment}
+                     (assoc :revision-message "update this mofo")
+                     (assoc :user-id (mt/user->id :rasta)))]
+       (is (= event
+              (events/publish-event! :event/segment-update event)))
+       (is (= {:topic       :segment-update
+               :user_id     (mt/user->id :rasta)
+               :model       "Segment"
+               :model_id    (:id segment)
+               :details     {:name             (:name segment)
+                             :description      (:description segment)
+                             :revision-message "update this mofo"
+                             :database_id (mt/id)
+                             :table_id    (mt/id :checkins)}}
+              (latest-event "segment-update" (:id segment))))))))
 
 (deftest segment-delete-event-test
   (testing :segment-delete
     (t2.with-temp/with-temp [Segment segment]
-      (mt/with-model-cleanup [:model/AuditLog]
-        (mt/with-test-user :rasta
-         (let [event (assoc {:object segment}
-                            :revision_message "deleted")]
-           (is (= event
-                  (events/publish-event! :event/segment-delete event))))
-         (is (= {:topic       :segment-delete
-                 :user_id     (mt/user->id :rasta)
-                 :model       "Segment"
-                 :model_id    (:id segment)
-                 :details     {:name             (:name segment)
-                               :description      (:description segment)
-                               :revision_message "deleted"
-                               :database_id (mt/id)
-                               :table_id    (mt/id :checkins)}}
-                (event "segment-delete" (:id segment)))))))))
+     (let [event (assoc {:object segment}
+                        :revision-message "deleted"
+                        :user-id (mt/user->id :rasta))]
+       (is (= event
+              (events/publish-event! :event/segment-delete event)))
+       (is (= {:topic       :segment-delete
+               :user_id     (mt/user->id :rasta)
+               :model       "Segment"
+               :model_id    (:id segment)
+               :details     {:name             (:name segment)
+                             :description      (:description segment)
+                             :revision-message "deleted"
+                             :database_id (mt/id)
+                             :table_id    (mt/id :checkins)}}
+              (latest-event "segment-delete" (:id segment))))))))
 
 (deftest user-joined-event-test
   (testing :user-joined
     ;; TODO - what's the difference between `user-login` / `user-joined`?
-    (mt/with-current-user (mt/user->id :rasta)
-      (mt/with-model-cleanup [:model/AuditLog]
-        (let [event (mt/fetch-user :rasta)]
-          (is (= event (events/publish-event! :event/user-joined event))))
-        (is (= {:topic       :user-joined
-                :user_id     (mt/user->id :rasta)
-                :model       "User"
-                :model_id    (mt/user->id :rasta)
-                :details     {}}
-               (event :user-joined (mt/user->id :rasta))))))))
+    (is (= {:user-id (mt/user->id :rasta)}
+           (events/publish-event! :event/user-joined {:user-id (mt/user->id :rasta)})))
+    (is (= {:topic       :user-joined
+            :user_id     (mt/user->id :rasta)
+            :model       "User"
+            :model_id    (mt/user->id :rasta)
+            :details     {}}
+           (latest-event :user-joined (mt/user->id :rasta))))))
 
 (deftest user-invited-event-test
   (testing :event/user-invited
     (mt/with-current-user (mt/user->id :rasta)
-      (mt/with-model-cleanup [:model/AuditLog]
-        (mt/with-temp [:model/User {:keys [id] :as new-user}]
-          (is (= new-user (events/publish-event! :event/user-invited new-user)))
-          (is (= {:model_id id
-                  :user_id  (mt/user->id :rasta)
-                  :details  (assoc (select-keys new-user [:first_name :last_name :email])
-                                   :user_group_memberships [{:id 1}])
-                  :topic    :user-invited
-                  :model    "User"}
-                 (event :user-invited id))))))))
+      (mt/with-temp [:model/User {:keys [id] :as new-user}]
+        (is (= {:object new-user}
+               (events/publish-event! :event/user-invited {:object new-user})))
+        (is (= {:model_id id
+                :user_id  (mt/user->id :rasta)
+                :details  (assoc (select-keys new-user [:first_name :last_name :email])
+                                 :user_group_memberships [{:id 1 :is_group_manager false}])
+                :topic    :user-invited
+                :model    "User"}
+               (latest-event :user-invited id)))))))
 
 (deftest user-update-event-test
   (testing :event/user-update
     (mt/with-current-user (mt/user->id :rasta)
-      (mt/with-model-cleanup [:model/AuditLog]
-        (let [event (assoc (mt/fetch-user :lucky) :changes {:last_name "Charms"})]
-          (is (= event (events/publish-event! :event/user-update event))))
-        (is (= {:model_id (mt/user->id :lucky)
-                :user_id  (mt/user->id :rasta)
-                :details  {:last_name "Charms"}
-                :topic    :user-update
-                :model    "User"}
-               (event :user-update (mt/user->id :lucky))))))))
+      (let [user   (mt/fetch-user :lucky)
+            event {:object          user
+                   :previous-object (assoc user :last_name "Charms")}]
+        (is (= event (events/publish-event! :event/user-update event)))
+        (is (partial=
+             {:model_id (mt/user->id :lucky)
+              :user_id  (mt/user->id :rasta)
+              :details  {:previous-object {:last_name "Charms"}}
+              :topic    :user-update
+              :model    "User"}
+             (latest-event :user-update (mt/user->id :lucky))))))))
 
 (deftest user-deactivated-event-test
  (testing :event/user-deactivated
    (mt/with-current-user (mt/user->id :rasta)
-     (mt/with-model-cleanup [:model/AuditLog]
-       (let [event (mt/fetch-user :lucky)]
-         (is (= event (events/publish-event! :event/user-deactivated event))))
+     (let [user (mt/fetch-user :lucky)]
+       (is (= {:object user}
+              (events/publish-event! :event/user-deactivated {:object user})))
        (is (= {:model_id (mt/user->id :lucky)
                :user_id  (mt/user->id :rasta)
                :details  {}
                :topic    :user-deactivated
                :model    "User"}
-              (event :user-deactivated (mt/user->id :lucky))))))))
+              (latest-event :user-deactivated (mt/user->id :lucky))))))))
 
 (deftest user-reactivated-event-test
  (testing :event/user-reactivated
    (mt/with-current-user (mt/user->id :rasta)
-     (mt/with-model-cleanup [:model/AuditLog]
-       (let [event (mt/fetch-user :lucky)]
-         (is (= event (events/publish-event! :event/user-reactivated event))))
+     (let [user (mt/fetch-user :lucky)]
+       (is (= {:object user}
+              (events/publish-event! :event/user-reactivated {:object user})))
        (is (= {:model_id (mt/user->id :lucky)
                :user_id  (mt/user->id :rasta)
                :details  {}
                :topic    :user-reactivated
                :model    "User"}
-              (event :user-reactivated (mt/user->id :lucky))))))))
+              (latest-event :user-reactivated (mt/user->id :lucky))))))))
 
 (deftest password-reset-initiated-event-test
   (testing :event/password-reset-initiated
     (mt/with-current-user (mt/user->id :rasta)
-      (mt/with-model-cleanup [:model/AuditLog]
-        (let [event (assoc (mt/fetch-user :rasta) :token "hash")]
-          (is (= event (events/publish-event! :event/password-reset-initiated event))))
+      (let [user (assoc (mt/fetch-user :rasta) :token "hash")]
+        (is (= {:object user}
+               (events/publish-event! :event/password-reset-initiated {:object user})))
         (is (= {:model_id (mt/user->id :rasta)
                 :user_id  (mt/user->id :rasta)
                 :details  {:token "hash"}
                 :topic    :password-reset-initiated
                 :model    "User"}
-               (event :password-reset-initiated (mt/user->id :rasta))))))))
+               (latest-event :password-reset-initiated (mt/user->id :rasta))))))))
 
 (deftest password-reset-successful-event-test
   (testing :event/password-reset-successful
     (mt/with-current-user (mt/user->id :rasta)
-      (mt/with-model-cleanup [:model/AuditLog]
-        (let [event (assoc (mt/fetch-user :rasta) :token "hash")]
-          (is (= event (events/publish-event! :event/password-reset-successful event))))
+      (let [user (assoc (mt/fetch-user :rasta) :token "hash")]
+        (is (= {:object user}
+               (events/publish-event! :event/password-reset-successful {:object user})))
         (is (= {:model_id (mt/user->id :rasta)
                 :user_id  (mt/user->id :rasta)
                 :details  {:token "hash"}
                 :topic    :password-reset-successful
                 :model    "User"}
-               (event :password-reset-successful (mt/user->id :rasta))))))))
+               (latest-event :password-reset-successful (mt/user->id :rasta))))))))

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -484,13 +484,14 @@
       (mt/with-temp [:model/User {:keys [id] :as new-user}]
         (is (= {:object new-user}
                (events/publish-event! :event/user-invited {:object new-user})))
-        (is (= {:model_id id
-                :user_id  (mt/user->id :rasta)
-                :details  (assoc (select-keys new-user [:first_name :last_name :email])
-                                 :user_group_memberships [{:id 1 :is_group_manager false}])
-                :topic    :user-invited
-                :model    "User"}
-               (latest-event :user-invited id)))))))
+        (is (partial=
+             {:model_id id
+              :user_id  (mt/user->id :rasta)
+              :details  (assoc (select-keys new-user [:first_name :last_name :email])
+                               :user_group_memberships [{:id 1}])
+              :topic    :user-invited
+              :model    "User"}
+             (latest-event :user-invited id)))))))
 
 (deftest user-update-event-test
   (testing :event/user-update

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -503,7 +503,8 @@
         (is (partial=
              {:model_id (mt/user->id :lucky)
               :user_id  (mt/user->id :rasta)
-              :details  {:previous-object {:last_name "Charms"}}
+              :details  {:previous {:last_name "Charms"}
+                         :new      {:last_name "Pigeon"}}
               :topic    :user-update
               :model    "User"}
              (latest-event :user-update (mt/user->id :lucky))))))))

--- a/test/metabase/events/recent_views_test.clj
+++ b/test/metabase/events/recent_views_test.clj
@@ -25,7 +25,7 @@
 (deftest table-read-test
   (mt/with-temp [Table table {}]
     (mt/with-test-user :rasta
-     (events/publish-event! :event/table-read table)
+     (events/publish-event! :event/table-read {:object table :user-id (mt/user->id :rasta)})
      (is (partial=
           {:user_id  (mt/user->id :rasta)
            :model    "table"
@@ -35,7 +35,7 @@
 (deftest dashboard-read-test
   (mt/with-temp [Dashboard dashboard {:creator_id (mt/user->id :rasta)}]
     (mt/with-test-user :rasta
-     (events/publish-event! :event/dashboard-read dashboard)
+     (events/publish-event! :event/dashboard-read {:object dashboard :user-id (mt/user->id :rasta)})
      (is (partial
            {:user_id  (mt/user->id :rasta)
             :model    "dashboard"

--- a/test/metabase/events/recent_views_test.clj
+++ b/test/metabase/events/recent_views_test.clj
@@ -16,7 +16,10 @@
 (deftest card-query-test
   (mt/with-temp [Card card {:creator_id (mt/user->id :rasta)}]
     (mt/with-test-user :rasta
-      (events/publish-event! :event/card-query {:card_id (u/id card) :cached false :ignore_cache true})
+      (events/publish-event! :event/card-query {:card-id      (u/id card)
+                                                :user-id      (mt/user->id :rasta)
+                                                :cached       false
+                                                :ignore_cache true})
       (is (= {:user_id  (mt/user->id :rasta)
               :model    "card"
               :model_id (:id card)}

--- a/test/metabase/events/revision_test.clj
+++ b/test/metabase/events/revision_test.clj
@@ -56,38 +56,36 @@
 
 (deftest card-create-test
   (testing :event/card-create
-    (mt/with-test-user :crowberto
-     (t2.with-temp/with-temp [Card {card-id :id, :as card} (card-properties)]
-       (events/publish-event! :event/card-create {:object card})
-       (is (= {:model        "Card"
-               :model_id     card-id
-               :user_id      (mt/user->id :crowberto)
-               :object       (card->revision-object card)
-               :is_reversion false
-               :is_creation  true}
-              (t2/select-one [Revision :model :model_id :user_id :object :is_reversion :is_creation]
-                             :model       "Card"
-                             :model_id    card-id)))))))
+    (t2.with-temp/with-temp [Card {card-id :id, :as card} (card-properties)]
+      (events/publish-event! :event/card-create {:object card :user-id (mt/user->id :crowberto)})
+      (is (= {:model        "Card"
+              :model_id     card-id
+              :user_id      (mt/user->id :crowberto)
+              :object       (card->revision-object card)
+              :is_reversion false
+              :is_creation  true}
+             (t2/select-one [Revision :model :model_id :user_id :object :is_reversion :is_creation]
+                            :model       "Card"
+                            :model_id    card-id))))))
 
 (deftest card-update-test
   (testing :event/card-update
-    (mt/with-test-user :crowberto
-     (t2.with-temp/with-temp [Card {card-id :id, :as card} (card-properties)]
-       (events/publish-event! :event/card-update {:object card})
-       (is (= {:model        "Card"
-               :model_id     card-id
-               :user_id      (mt/user->id :crowberto)
-               :object       (card->revision-object card)
-               :is_reversion false
-               :is_creation  false}
-              (t2/select-one [Revision :model :model_id :user_id :object :is_reversion :is_creation]
-                             :model       "Card"
-                             :model_id    card-id)))))))
+   (t2.with-temp/with-temp [Card {card-id :id, :as card} (card-properties)]
+     (events/publish-event! :event/card-update {:object card :user-id (mt/user->id :crowberto)})
+     (is (= {:model        "Card"
+             :model_id     card-id
+             :user_id      (mt/user->id :crowberto)
+             :object       (card->revision-object card)
+             :is_reversion false
+             :is_creation  false}
+            (t2/select-one [Revision :model :model_id :user_id :object :is_reversion :is_creation]
+                           :model       "Card"
+                           :model_id    card-id))))))
 
 (deftest card-update-shoud-not-contains-public-info-test
   (testing :event/card-update
     (t2.with-temp/with-temp [Card {card-id :id, :as card} (card-properties)]
-      (events/publish-event! :event/card-update {:object card})
+      (events/publish-event! :event/card-update {:object card :user-id (mt/user->id :crowberto)})
       ;; we don't want the public_uuid and made_public_by_id to be recorded in a revision
       ;; otherwise revert a card to earlier revision might toggle the public sharing settings
       (is (empty? (set/intersection #{:public_uuid :made_public_by_id}
@@ -100,7 +98,7 @@
   (testing :event/dashboard-create
     (mt/with-test-user :rasta
      (t2.with-temp/with-temp [Dashboard {dashboard-id :id, :as dashboard}]
-       (events/publish-event! :event/dashboard-create {:object dashboard})
+       (events/publish-event! :event/dashboard-create {:object dashboard :user-id (mt/user->id :rasta)})
        (is (= {:model        "Dashboard"
                :model_id     dashboard-id
                :user_id      (mt/user->id :rasta)
@@ -115,7 +113,7 @@
   (testing :event/dashboard-update
     (mt/with-test-user :rasta
      (t2.with-temp/with-temp [Dashboard {dashboard-id :id, :as dashboard}]
-       (events/publish-event! :event/dashboard-update {:object dashboard})
+       (events/publish-event! :event/dashboard-update {:object dashboard :user-id (mt/user->id :rasta)})
        (is (= {:model        "Dashboard"
                :model_id     dashboard-id
                :user_id      (mt/user->id :rasta)
@@ -130,7 +128,7 @@
   (testing :event/dashboard-update
     (mt/with-test-user :rasta
      (t2.with-temp/with-temp [Dashboard {dashboard-id :id, :as dashboard}]
-       (events/publish-event! :event/dashboard-update {:object dashboard})
+       (events/publish-event! :event/dashboard-update {:object dashboard :user-id (mt/user->id :rasta)})
 
        ;; we don't want the public_uuid and made_public_by_id to be recorded in a revision
        ;; otherwise revert a card to earlier revision might toggle the public sharing settings
@@ -268,167 +266,162 @@
 
 (deftest metric-create-test
   (testing :event/metric-create
-    (mt/with-test-user :rasta
-     (t2.with-temp/with-temp [Database {database-id :id} {}
-                              Table    {:keys [id]}      {:db_id database-id}
-                              Metric   metric            {:table_id id, :definition {:a "b"}}]
-       (events/publish-event! :event/metric-create {:object metric})
-       (let [revision (t2/select-one [Revision :model :user_id :object :is_reversion :is_creation :message]
-                                     :model "Metric"
-                                     :model_id (:id metric))]
-         (is (= {:model        "Metric"
-                 :user_id      (mt/user->id :rasta)
-                 :object       {:name                    "Toucans in the rainforest"
-                                :description             "Lookin' for a blueberry"
-                                :entity_id               (:entity_id metric)
-                                :how_is_this_calculated  nil
-                                :show_in_getting_started false
-                                :caveats                 nil
-                                :points_of_interest      nil
-                                :archived                false
-                                :creator_id              (mt/user->id :rasta)
-                                :definition              {:a "b"}}
-                 :is_reversion false
-                 :is_creation  true
-                 :message      nil}
-                (assoc revision :object (dissoc (:object revision) :id :table_id)))))))))
+    (t2.with-temp/with-temp [Database {database-id :id} {}
+                             Table    {:keys [id]}      {:db_id database-id}
+                             Metric   metric            {:table_id id, :definition {:a "b"}}]
+      (events/publish-event! :event/metric-create {:object metric :user-id (mt/user->id :rasta)})
+      (let [revision (t2/select-one [Revision :model :user_id :object :is_reversion :is_creation :message]
+                                    :model "Metric"
+                                    :model_id (:id metric))]
+        (is (= {:model        "Metric"
+                :user_id      (mt/user->id :rasta)
+                :object       {:name                    "Toucans in the rainforest"
+                               :description             "Lookin' for a blueberry"
+                               :entity_id               (:entity_id metric)
+                               :how_is_this_calculated  nil
+                               :show_in_getting_started false
+                               :caveats                 nil
+                               :points_of_interest      nil
+                               :archived                false
+                               :creator_id              (mt/user->id :rasta)
+                               :definition              {:a "b"}}
+                :is_reversion false
+                :is_creation  true
+                :message      nil}
+               (assoc revision :object (dissoc (:object revision) :id :table_id))))))))
 
 (deftest metric-update-test
   (testing :event/metric-update
-    (mt/with-test-user :crowberto
-     (t2.with-temp/with-temp [Database {database-id :id} {}
-                              Table    {:keys [id]}      {:db_id database-id}
-                              Metric   metric            {:table_id id, :definition {:a "b"}}]
-       (events/publish-event! :event/metric-update
-                              (assoc {:object metric}
-                                     :revision_message "updated"))
-       (let [revision (t2/select-one [Revision :model :user_id :object :is_reversion :is_creation :message]
-                                     :model "Metric"
-                                     :model_id (:id metric))]
-         (is (= {:model        "Metric"
-                 :user_id      (mt/user->id :crowberto)
-                 :object       {:name                    "Toucans in the rainforest"
-                                :description             "Lookin' for a blueberry"
-                                :entity_id               (:entity_id metric)
-                                :how_is_this_calculated  nil
-                                :show_in_getting_started false
-                                :caveats                 nil
-                                :points_of_interest      nil
-                                :archived                false
-                                :creator_id              (mt/user->id :rasta)
-                                :definition              {:a "b"}}
-                 :is_reversion false
-                 :is_creation  false
-                 :message      "updated"}
-                (assoc revision :object (dissoc (:object revision) :id :table_id)))))))))
-
-(deftest metric-delete-test
-  (testing ":metric-delete"
-    (mt/with-test-user :rasta
-     (t2.with-temp/with-temp [Database {database-id :id} {}
-                              Table    {:keys [id]}      {:db_id database-id}
-                              Metric   metric            {:table_id id, :definition {:a "b"}, :archived true}]
-       (events/publish-event! :event/metric-delete {:object metric})
-       (let [revision (t2/select-one [Revision :model :user_id :object :is_reversion :is_creation :message]
-                                     :model "Metric"
-                                     :model_id (:id metric))]
-         (is (= {:model        "Metric"
-                 :user_id      (mt/user->id :rasta)
-                 :object       {:name                    "Toucans in the rainforest"
-                                :description             "Lookin' for a blueberry"
-                                :how_is_this_calculated  nil
-                                :show_in_getting_started false
-                                :caveats                 nil
-                                :entity_id               (:entity_id metric)
-                                :points_of_interest      nil
-                                :archived                true
-                                :creator_id              (mt/user->id :rasta)
-                                :definition              {:a "b"}}
-                 :is_reversion false
-                 :is_creation  false
-                 :message      nil}
-                (assoc revision :object (dissoc (:object revision) :id :table_id)))))))))
-
-
-(deftest segment-create-test
-  (testing :event/segment-create
-    (mt/with-test-user :rasta
-     (t2.with-temp/with-temp [Database {database-id :id} {}
-                              Table    {:keys [id]}      {:db_id database-id}
-                              Segment  segment           {:table_id   id
-                                                          :definition {:a "b"}}]
-       (events/publish-event! :event/segment-create {:object segment})
-       (let [revision (-> (t2/select-one Revision :model "Segment", :model_id (:id segment))
-                          (select-keys [:model :user_id :object :is_reversion :is_creation :message]))]
-         (is (= {:model        "Segment"
-                 :user_id      (mt/user->id :rasta)
-                 :object       {:name                    "Toucans in the rainforest"
-                                :description             "Lookin' for a blueberry"
-                                :show_in_getting_started false
-                                :caveats                 nil
-                                :points_of_interest      nil
-                                :entity_id               (:entity_id segment)
-                                :archived                false
-                                :creator_id              (mt/user->id :rasta)
-                                :definition              {:a "b"}}
-                 :is_reversion false
-                 :is_creation  true
-                 :message      nil}
-                (assoc revision :object (dissoc (:object revision) :id :table_id)))))))))
-
-(deftest segment-update-test
-  (testing :event/segment-update
-    (mt/with-test-user :crowberto
-     (t2.with-temp/with-temp [Database {database-id :id} {}
-                              Table    {:keys [id]}      {:db_id database-id}
-                              Segment  segment           {:table_id   id
-                                                          :definition {:a "b"}}]
-       (events/publish-event! :event/segment-update
-                              (assoc {:object segment}
-                                     :revision_message "updated"))
-       (is (= {:model        "Segment"
+   (t2.with-temp/with-temp [Database {database-id :id} {}
+                            Table    {:keys [id]}      {:db_id database-id}
+                            Metric   metric            {:table_id id, :definition {:a "b"}}]
+     (events/publish-event! :event/metric-update
+                            (assoc {:object metric}
+                                   :revision-message "updated"
+                                   :user-id (mt/user->id :crowberto)))
+     (let [revision (t2/select-one [Revision :model :user_id :object :is_reversion :is_creation :message]
+                                   :model "Metric"
+                                   :model_id (:id metric))]
+       (is (= {:model        "Metric"
                :user_id      (mt/user->id :crowberto)
                :object       {:name                    "Toucans in the rainforest"
                               :description             "Lookin' for a blueberry"
+                              :entity_id               (:entity_id metric)
+                              :how_is_this_calculated  nil
                               :show_in_getting_started false
                               :caveats                 nil
                               :points_of_interest      nil
-                              :entity_id               (:entity_id segment)
                               :archived                false
                               :creator_id              (mt/user->id :rasta)
                               :definition              {:a "b"}}
                :is_reversion false
                :is_creation  false
                :message      "updated"}
-              (update (t2/select-one [Revision :model :user_id :object :is_reversion :is_creation :message]
-                                     :model "Segment"
-                                     :model_id (:id segment))
-                      :object dissoc :id :table_id)))))))
+              (assoc revision :object (dissoc (:object revision) :id :table_id))))))))
+
+(deftest metric-delete-test
+  (testing ":metric-delete"
+    (t2.with-temp/with-temp [Database {database-id :id} {}
+                             Table    {:keys [id]}      {:db_id database-id}
+                             Metric   metric            {:table_id id, :definition {:a "b"}, :archived true}]
+      (events/publish-event! :event/metric-delete {:object metric :user-id (mt/user->id :rasta)})
+      (let [revision (t2/select-one [Revision :model :user_id :object :is_reversion :is_creation :message]
+                                    :model "Metric"
+                                    :model_id (:id metric))]
+        (is (= {:model        "Metric"
+                :user_id      (mt/user->id :rasta)
+                :object       {:name                    "Toucans in the rainforest"
+                               :description             "Lookin' for a blueberry"
+                               :how_is_this_calculated  nil
+                               :show_in_getting_started false
+                               :caveats                 nil
+                               :entity_id               (:entity_id metric)
+                               :points_of_interest      nil
+                               :archived                true
+                               :creator_id              (mt/user->id :rasta)
+                               :definition              {:a "b"}}
+                :is_reversion false
+                :is_creation  false
+                :message      nil}
+               (assoc revision :object (dissoc (:object revision) :id :table_id))))))))
+
+(deftest segment-create-test
+  (testing :event/segment-create
+    (t2.with-temp/with-temp [Database {database-id :id} {}
+                             Table    {:keys [id]}      {:db_id database-id}
+                             Segment  segment           {:table_id   id
+                                                         :definition {:a "b"}}]
+      (events/publish-event! :event/segment-create {:object segment :user-id (mt/user->id :rasta)})
+      (let [revision (-> (t2/select-one Revision :model "Segment", :model_id (:id segment))
+                         (select-keys [:model :user_id :object :is_reversion :is_creation :message]))]
+        (is (= {:model        "Segment"
+                :user_id      (mt/user->id :rasta)
+                :object       {:name                    "Toucans in the rainforest"
+                               :description             "Lookin' for a blueberry"
+                               :show_in_getting_started false
+                               :caveats                 nil
+                               :points_of_interest      nil
+                               :entity_id               (:entity_id segment)
+                               :archived                false
+                               :creator_id              (mt/user->id :rasta)
+                               :definition              {:a "b"}}
+                :is_reversion false
+                :is_creation  true
+                :message      nil}
+               (assoc revision :object (dissoc (:object revision) :id :table_id))))))))
+
+(deftest segment-update-test
+  (testing :event/segment-update
+    (t2.with-temp/with-temp [Database {database-id :id} {}
+                             Table    {:keys [id]}      {:db_id database-id}
+                             Segment  segment           {:table_id   id
+                                                         :definition {:a "b"}}]
+      (events/publish-event! :event/segment-update
+                             (assoc {:object segment}
+                                    :revision-message "updated"
+                                    :user-id (mt/user->id :crowberto)))
+      (is (= {:model        "Segment"
+              :user_id      (mt/user->id :crowberto)
+              :object       {:name                    "Toucans in the rainforest"
+                             :description             "Lookin' for a blueberry"
+                             :show_in_getting_started false
+                             :caveats                 nil
+                             :points_of_interest      nil
+                             :entity_id               (:entity_id segment)
+                             :archived                false
+                             :creator_id              (mt/user->id :rasta)
+                             :definition              {:a "b"}}
+              :is_reversion false
+              :is_creation  false
+              :message      "updated"}
+             (update (t2/select-one [Revision :model :user_id :object :is_reversion :is_creation :message]
+                                    :model "Segment"
+                                    :model_id (:id segment))
+                     :object dissoc :id :table_id))))))
 
 (deftest segment-delete-test
   (testing :event/segment-delete
-    (mt/with-test-user :rasta
-     (t2.with-temp/with-temp [Database {database-id :id} {}
-                              Table    {:keys [id]}      {:db_id database-id}
-                              Segment  segment           {:table_id   id
-                                                          :definition {:a "b"}
-                                                          :archived   true}]
-       (events/publish-event! :event/segment-delete {:object segment})
-       (is (= {:model        "Segment"
-               :user_id      (mt/user->id :rasta)
-               :object       {:name                    "Toucans in the rainforest"
-                              :description             "Lookin' for a blueberry"
-                              :show_in_getting_started false
-                              :caveats                 nil
-                              :points_of_interest      nil
-                              :entity_id               (:entity_id segment)
-                              :archived                true
-                              :creator_id              (mt/user->id :rasta)
-                              :definition              {:a "b"}}
-               :is_reversion false
-               :is_creation  false
-               :message      nil}
-              (update (t2/select-one [Revision :model :user_id :object :is_reversion :is_creation :message]
-                                     :model "Segment"
-                                     :model_id (:id segment))
-                      :object dissoc :id :table_id)))))))
+    (t2.with-temp/with-temp [Database {database-id :id} {}
+                             Table    {:keys [id]}      {:db_id database-id}
+                             Segment  segment           {:table_id   id
+                                                         :definition {:a "b"}
+                                                         :archived   true}]
+      (events/publish-event! :event/segment-delete {:object segment :user-id (mt/user->id :rasta)})
+      (is (= {:model        "Segment"
+              :user_id      (mt/user->id :rasta)
+              :object       {:name                    "Toucans in the rainforest"
+                             :description             "Lookin' for a blueberry"
+                             :show_in_getting_started false
+                             :caveats                 nil
+                             :points_of_interest      nil
+                             :entity_id               (:entity_id segment)
+                             :archived                true
+                             :creator_id              (mt/user->id :rasta)
+                             :definition              {:a "b"}}
+              :is_reversion false
+              :is_creation  false
+              :message      nil}
+             (update (t2/select-one [Revision :model :user_id :object :is_reversion :is_creation :message]
+                                    :model "Segment"
+                                    :model_id (:id segment))
+                     :object dissoc :id :table_id))))))

--- a/test/metabase/events/view_log_test.clj
+++ b/test/metabase/events/view_log_test.clj
@@ -6,16 +6,6 @@
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
-(deftest card-create-test
-  (mt/with-temp [User user {}
-                 Card card {:creator_id (:id user)}]
-
-    (events/publish-event! :event/card-create {:object card :user-id (:id user)})
-    (is (= {:user_id  (:id user)
-            :model    "card"
-            :model_id (:id card)}
-           (t2/select-one [ViewLog :user_id :model :model_id], :user_id (:id user))))))
-
 (deftest card-read-test
   (mt/with-temp [User user {}
                  Card card {:creator_id (:id user)}]

--- a/test/metabase/models/audit_log_test.clj
+++ b/test/metabase/models/audit_log_test.clj
@@ -12,7 +12,7 @@
     (mt/with-test-user :rasta
       (testing "Test that `record-event!` succesfully records basic card events"
         (t2.with-temp/with-temp [:model/Card {card-id :id :as card} {:name "Test card"}]
-          (audit-log/record-event! :event/card-create card)
+          (audit-log/record-event! :event/card-create {:object card})
           ;; Not an exhaustive match since we're mainly testing that the event is recorded
           (is (partial=
                {:topic    :card-create
@@ -24,7 +24,11 @@
 
       (testing "Test that `record-event!` succesfully records basic card events with the user, model, and model ID specified"
         (t2.with-temp/with-temp [:model/Card {card-id :id :as card} {:name "Test card"}]
-          (audit-log/record-event! :event/card-create card (mt/user->id :rasta) :model/Card card-id)
+          (audit-log/record-event! :event/card-create
+                                     {:object card
+                                      :user-id (mt/user->id :rasta)
+                                      :model :model/Card
+                                      :model-id card-id})
           (is (partial=
                {:topic    :card-create
                 :user_id  (mt/user->id :rasta)
@@ -34,7 +38,7 @@
                (t2/select-one :model/AuditLog :model_id card-id)))))
 
       (testing "Test that `record-event!` records an event with arbitrary data and no model specified"
-        (audit-log/record-event! :event/test-event {:foo "bar"})
+        (audit-log/record-event! :event/test-event {:details {:foo "bar"}})
         (is (partial=
              {:topic :test-event
               :user_id (mt/user->id :rasta)

--- a/test/metabase/models/pulse_channel_test.clj
+++ b/test/metabase/models/pulse_channel_test.clj
@@ -8,6 +8,8 @@
    [metabase.models.pulse-channel-recipient :refer [PulseChannelRecipient]]
    [metabase.models.serialization :as serdes]
    [metabase.models.user :refer [User]]
+   [metabase.public-settings.premium-features-test
+    :as premium-features-test]
    [metabase.test :as mt]
    [metabase.util :as u]
    [toucan2.core :as t2]
@@ -156,168 +158,170 @@
 
 ;; create-pulse-channel!
 (deftest create-pulse-channel!-test
-  (t2.with-temp/with-temp [Pulse {:keys [id]}]
-    (mt/with-model-cleanup [Pulse]
-      (testing "disabled"
-        (is (= {:enabled        false
-                :entity_id      true
-                :channel_type   :email
-                :schedule_type  :daily
-                :schedule_hour  18
-                :schedule_day   nil
-                :schedule_frame nil
-                :recipients     [(user-details :crowberto)
-                                 {:email "foo@bar.com"}
-                                 (user-details :rasta)]}
-               (create-channel-then-select!
-                {:pulse_id      id
-                 :enabled       false
-                 :channel_type  :email
-                 :schedule_type :daily
-                 :schedule_hour 18
-                 :recipients    [{:email "foo@bar.com"}
-                                 {:id (mt/user->id :rasta)}
-                                 {:id (mt/user->id :crowberto)}]}))))
-      (testing "email"
-        (is (= {:enabled        true
-                :entity_id      true
-                :channel_type   :email
-                :schedule_type  :daily
-                :schedule_hour  18
-                :schedule_day   nil
-                :schedule_frame nil
-                :recipients     [(user-details :crowberto)
-                                 {:email "foo@bar.com"}
-                                 (user-details :rasta)]}
-               (create-channel-then-select!
-                {:pulse_id      id
-                 :enabled       true
-                 :channel_type  :email
-                 :schedule_type :daily
-                 :schedule_hour 18
-                 :recipients    [{:email "foo@bar.com"}
-                                 {:id (mt/user->id :rasta)}
-                                 {:id (mt/user->id :crowberto)}]}))))
+  (premium-features-test/with-premium-features #{}
+    (t2.with-temp/with-temp [Pulse {:keys [id]}]
+      (mt/with-model-cleanup [Pulse]
+        (testing "disabled"
+          (is (= {:enabled        false
+                  :entity_id      true
+                  :channel_type   :email
+                  :schedule_type  :daily
+                  :schedule_hour  18
+                  :schedule_day   nil
+                  :schedule_frame nil
+                  :recipients     [(user-details :crowberto)
+                                   {:email "foo@bar.com"}
+                                   (user-details :rasta)]}
+                 (create-channel-then-select!
+                  {:pulse_id      id
+                   :enabled       false
+                   :channel_type  :email
+                   :schedule_type :daily
+                   :schedule_hour 18
+                   :recipients    [{:email "foo@bar.com"}
+                                   {:id (mt/user->id :rasta)}
+                                   {:id (mt/user->id :crowberto)}]}))))
+        (testing "email"
+          (is (= {:enabled        true
+                  :entity_id      true
+                  :channel_type   :email
+                  :schedule_type  :daily
+                  :schedule_hour  18
+                  :schedule_day   nil
+                  :schedule_frame nil
+                  :recipients     [(user-details :crowberto)
+                                   {:email "foo@bar.com"}
+                                   (user-details :rasta)]}
+                 (create-channel-then-select!
+                  {:pulse_id      id
+                   :enabled       true
+                   :channel_type  :email
+                   :schedule_type :daily
+                   :schedule_hour 18
+                   :recipients    [{:email "foo@bar.com"}
+                                   {:id (mt/user->id :rasta)}
+                                   {:id (mt/user->id :crowberto)}]}))))
 
-      (testing "slack"
-        (is (= {:enabled        true
-                :entity_id      true
-                :channel_type   :slack
-                :schedule_type  :hourly
-                :schedule_hour  nil
-                :schedule_day   nil
-                :schedule_frame nil
-                :recipients     []
-                :details        {:something "random"}}
-               (create-channel-then-select!
-                {:pulse_id      id
-                 :enabled       true
-                 :channel_type  :slack
-                 :schedule_type :hourly
-                 :details       {:something "random"}
-                 :recipients    [{:email "foo@bar.com"}
-                                 {:id (mt/user->id :rasta)}
-                                 {:id (mt/user->id :crowberto)}]})))))))
+        (testing "slack"
+          (is (= {:enabled        true
+                  :entity_id      true
+                  :channel_type   :slack
+                  :schedule_type  :hourly
+                  :schedule_hour  nil
+                  :schedule_day   nil
+                  :schedule_frame nil
+                  :recipients     []
+                  :details        {:something "random"}}
+                 (create-channel-then-select!
+                  {:pulse_id      id
+                   :enabled       true
+                   :channel_type  :slack
+                   :schedule_type :hourly
+                   :details       {:something "random"}
+                   :recipients    [{:email "foo@bar.com"}
+                                   {:id (mt/user->id :rasta)}
+                                   {:id (mt/user->id :crowberto)}]}))))))))
 
 (deftest update-pulse-channel!-test
-  (t2.with-temp/with-temp [Pulse {pulse-id :id}]
-    (testing "simple starting case where we modify the schedule hour and add a recipient"
-      (t2.with-temp/with-temp [PulseChannel {channel-id :id} {:pulse_id pulse-id}]
-        (is (= {:enabled        true
-                :entity_id      true
-                :channel_type   :email
-                :schedule_type  :daily
-                :schedule_hour  18
-                :schedule_day   nil
-                :schedule_frame nil
-                :recipients     [{:email "foo@bar.com"}]}
-               (update-channel-then-select!
-                {:id            channel-id
-                 :enabled       true
-                 :channel_type  :email
-                 :schedule_type :daily
-                 :schedule_hour 18
-                 :recipients    [{:email "foo@bar.com"}]})))))
+  (premium-features-test/with-premium-features #{}
+    (t2.with-temp/with-temp [Pulse {pulse-id :id}]
+      (testing "simple starting case where we modify the schedule hour and add a recipient"
+        (t2.with-temp/with-temp [PulseChannel {channel-id :id} {:pulse_id pulse-id}]
+          (is (= {:enabled        true
+                  :entity_id      true
+                  :channel_type   :email
+                  :schedule_type  :daily
+                  :schedule_hour  18
+                  :schedule_day   nil
+                  :schedule_frame nil
+                  :recipients     [{:email "foo@bar.com"}]}
+                 (update-channel-then-select!
+                  {:id            channel-id
+                   :enabled       true
+                   :channel_type  :email
+                   :schedule_type :daily
+                   :schedule_hour 18
+                   :recipients    [{:email "foo@bar.com"}]})))))
 
-    (testing "monthly schedules require a schedule_frame and can optionally omit they schedule_day"
-      (t2.with-temp/with-temp [PulseChannel {channel-id :id} {:pulse_id pulse-id}]
-        (is (= {:enabled        true
-                :entity_id      true
-                :channel_type  :email
-                :schedule_type :monthly
-                :schedule_hour 8
-                :schedule_day  nil
-                :schedule_frame :mid
-                :recipients    [{:email "foo@bar.com"} (user-details :rasta)]}
-               (update-channel-then-select!
-                {:id             channel-id
-                 :enabled        true
-                 :channel_type   :email
-                 :schedule_type  :monthly
-                 :schedule_hour  8
-                 :schedule_day   nil
-                 :schedule_frame :mid
-                 :recipients     [{:email "foo@bar.com"} {:id (mt/user->id :rasta)}]})))))
+      (testing "monthly schedules require a schedule_frame and can optionally omit they schedule_day"
+        (t2.with-temp/with-temp [PulseChannel {channel-id :id} {:pulse_id pulse-id}]
+          (is (= {:enabled        true
+                  :entity_id      true
+                  :channel_type  :email
+                  :schedule_type :monthly
+                  :schedule_hour 8
+                  :schedule_day  nil
+                  :schedule_frame :mid
+                  :recipients    [{:email "foo@bar.com"} (user-details :rasta)]}
+                 (update-channel-then-select!
+                  {:id             channel-id
+                   :enabled        true
+                   :channel_type   :email
+                   :schedule_type  :monthly
+                   :schedule_hour  8
+                   :schedule_day   nil
+                   :schedule_frame :mid
+                   :recipients     [{:email "foo@bar.com"} {:id (mt/user->id :rasta)}]})))))
 
-    (testing "weekly schedule should have a day in it, show that we can get full users"
-      (t2.with-temp/with-temp [PulseChannel {channel-id :id} {:pulse_id pulse-id}]
-        (is (= {:enabled        true
-                :entity_id      true
-                :channel_type   :email
-                :schedule_type  :weekly
-                :schedule_hour  8
-                :schedule_day   "mon"
-                :schedule_frame nil
-                :recipients     [{:email "foo@bar.com"} (user-details :rasta)]}
-               (update-channel-then-select!
-                {:id            channel-id
-                 :enabled       true
-                 :channel_type  :email
-                 :schedule_type :weekly
-                 :schedule_hour 8
-                 :schedule_day  "mon"
-                 :recipients    [{:email "foo@bar.com"} {:id (mt/user->id :rasta)}]})))))
+      (testing "weekly schedule should have a day in it, show that we can get full users"
+        (t2.with-temp/with-temp [PulseChannel {channel-id :id} {:pulse_id pulse-id}]
+          (is (= {:enabled        true
+                  :entity_id      true
+                  :channel_type   :email
+                  :schedule_type  :weekly
+                  :schedule_hour  8
+                  :schedule_day   "mon"
+                  :schedule_frame nil
+                  :recipients     [{:email "foo@bar.com"} (user-details :rasta)]}
+                 (update-channel-then-select!
+                  {:id            channel-id
+                   :enabled       true
+                   :channel_type  :email
+                   :schedule_type :weekly
+                   :schedule_hour 8
+                   :schedule_day  "mon"
+                   :recipients    [{:email "foo@bar.com"} {:id (mt/user->id :rasta)}]})))))
 
-    (testing "hourly schedules don't require day/hour settings (should be nil), fully change recipients"
-      (t2.with-temp/with-temp [PulseChannel {channel-id :id} {:pulse_id pulse-id, :details {:emails ["foo@bar.com"]}}]
-        (pulse-channel/update-recipients! channel-id [(mt/user->id :rasta)])
-        (is (= {:enabled       true
-                :entity_id     true
-                :channel_type  :email
-                :schedule_type :hourly
-                :schedule_hour nil
-                :schedule_day  nil
-                :schedule_frame nil
-                :recipients    [(user-details :crowberto)]}
-               (update-channel-then-select!
-                {:id            channel-id
-                 :enabled       true
-                 :channel_type  :email
-                 :schedule_type :hourly
-                 :schedule_hour 12
-                 :schedule_day  "tue"
-                 :recipients    [{:id (mt/user->id :crowberto)}]})))))
+      (testing "hourly schedules don't require day/hour settings (should be nil), fully change recipients"
+        (t2.with-temp/with-temp [PulseChannel {channel-id :id} {:pulse_id pulse-id, :details {:emails ["foo@bar.com"]}}]
+          (pulse-channel/update-recipients! channel-id [(mt/user->id :rasta)])
+          (is (= {:enabled       true
+                  :entity_id     true
+                  :channel_type  :email
+                  :schedule_type :hourly
+                  :schedule_hour nil
+                  :schedule_day  nil
+                  :schedule_frame nil
+                  :recipients    [(user-details :crowberto)]}
+                 (update-channel-then-select!
+                  {:id            channel-id
+                   :enabled       true
+                   :channel_type  :email
+                   :schedule_type :hourly
+                   :schedule_hour 12
+                   :schedule_day  "tue"
+                   :recipients    [{:id (mt/user->id :crowberto)}]})))))
 
-    (testing "custom details for channels that need it"
-      (t2.with-temp/with-temp [PulseChannel {channel-id :id} {:pulse_id pulse-id}]
-        (is (= {:enabled       true
-                :entity_id     true
-                :channel_type  :email
-                :schedule_type :daily
-                :schedule_hour 12
-                :schedule_day  nil
-                :schedule_frame nil
-                :recipients    [{:email "foo@bar.com"} {:email "blah@bar.com"}]
-                :details       {:channel "#metabaserocks"}}
-               (update-channel-then-select!
-                {:id            channel-id
-                 :enabled       true
-                 :channel_type  :email
-                 :schedule_type :daily
-                 :schedule_hour 12
-                 :schedule_day  "tue"
-                 :recipients    [{:email "foo@bar.com"} {:email "blah@bar.com"}]
-                 :details       {:channel "#metabaserocks"}})))))))
+      (testing "custom details for channels that need it"
+        (t2.with-temp/with-temp [PulseChannel {channel-id :id} {:pulse_id pulse-id}]
+          (is (= {:enabled       true
+                  :entity_id     true
+                  :channel_type  :email
+                  :schedule_type :daily
+                  :schedule_hour 12
+                  :schedule_day  nil
+                  :schedule_frame nil
+                  :recipients    [{:email "foo@bar.com"} {:email "blah@bar.com"}]
+                  :details       {:channel "#metabaserocks"}}
+                 (update-channel-then-select!
+                  {:id            channel-id
+                   :enabled       true
+                   :channel_type  :email
+                   :schedule_type :daily
+                   :schedule_hour 12
+                   :schedule_day  "tue"
+                   :recipients    [{:email "foo@bar.com"} {:email "blah@bar.com"}]
+                   :details       {:channel "#metabaserocks"}}))))))))
 
 (deftest update-recipients!-test
   (mt/with-temp [Pulse        {pulse-id :id} {}
@@ -419,28 +423,29 @@
 
 (deftest inactive-users-test
   (testing "Inactive users shouldn't get Pulses"
-    (mt/with-temp [Pulse                 {pulse-id :id} {}
-                   PulseChannel          {channel-id :id :as channel} {:pulse_id pulse-id
-                                                                       :details  {:emails ["cam@test.com"]}}
-                   User                  {inactive-user-id :id} {:is_active false}
-                   PulseChannelRecipient _ {:pulse_channel_id channel-id :user_id inactive-user-id}
-                   PulseChannelRecipient _ {:pulse_channel_id channel-id :user_id (mt/user->id :rasta)}
-                   PulseChannelRecipient _ {:pulse_channel_id channel-id :user_id (mt/user->id :lucky)}]
-      (is (= (cons
-              {:email "cam@test.com"}
-              (sort-by
-               :id
-               [{:id          (mt/user->id :lucky)
-                 :email       "lucky@metabase.com"
-                 :first_name  "Lucky"
-                 :last_name   "Pigeon"
-                 :common_name "Lucky Pigeon"}
-                {:id          (mt/user->id :rasta)
-                 :email       "rasta@metabase.com"
-                 :first_name  "Rasta"
-                 :last_name   "Toucan"
-                 :common_name "Rasta Toucan"}]))
-             (:recipients (t2/hydrate channel :recipients)))))))
+    (premium-features-test/with-premium-features #{}
+      (mt/with-temp [Pulse                 {pulse-id :id} {}
+                     PulseChannel          {channel-id :id :as channel} {:pulse_id pulse-id
+                                                                         :details  {:emails ["cam@test.com"]}}
+                     User                  {inactive-user-id :id} {:is_active false}
+                     PulseChannelRecipient _ {:pulse_channel_id channel-id :user_id inactive-user-id}
+                     PulseChannelRecipient _ {:pulse_channel_id channel-id :user_id (mt/user->id :rasta)}
+                     PulseChannelRecipient _ {:pulse_channel_id channel-id :user_id (mt/user->id :lucky)}]
+        (is (= (cons
+                {:email "cam@test.com"}
+                (sort-by
+                 :id
+                 [{:id          (mt/user->id :lucky)
+                   :email       "lucky@metabase.com"
+                   :first_name  "Lucky"
+                   :last_name   "Pigeon"
+                   :common_name "Lucky Pigeon"}
+                  {:id          (mt/user->id :rasta)
+                   :email       "rasta@metabase.com"
+                   :first_name  "Rasta"
+                   :last_name   "Toucan"
+                   :common_name "Rasta Toucan"}]))
+               (:recipients (t2/hydrate channel :recipients))))))))
 
 (deftest validate-email-domains-check-user-ids-match-emails
   (testing `pulse-channel/validate-email-domains
@@ -467,13 +472,14 @@
 
 (deftest identity-hash-test
   (testing "Pulse channel hashes are composed of the pulse's hash, the channel type, and the details and the collection hash"
-    (let [now (LocalDateTime/of 2022 9 1 12 34 56)]
-      (mt/with-temp [Collection   coll  {:name "field-db" :location "/" :created_at now}
-                     Pulse        pulse {:name "my pulse" :collection_id (:id coll) :created_at now}
-                     PulseChannel chan  {:pulse_id     (:id pulse)
-                                         :channel_type :email
-                                         :details      {:emails ["cam@test.com"]}
-                                         :created_at   now}]
-        (is (= "2f5f0269"
-               (serdes/raw-hash [(serdes/identity-hash pulse) :email {:emails ["cam@test.com"]} now])
-               (serdes/identity-hash chan)))))))
+    (premium-features-test/with-premium-features #{}
+      (let [now (LocalDateTime/of 2022 9 1 12 34 56)]
+        (mt/with-temp [Collection   coll  {:name "field-db" :location "/" :created_at now}
+                       Pulse        pulse {:name "my pulse" :collection_id (:id coll) :created_at now}
+                       PulseChannel chan  {:pulse_id     (:id pulse)
+                                           :channel_type :email
+                                           :details      {:emails ["cam@test.com"]}
+                                           :created_at   now}]
+          (is (= "2f5f0269"
+                 (serdes/raw-hash [(serdes/identity-hash pulse) :email {:emails ["cam@test.com"]} now])
+                 (serdes/identity-hash chan))))))))

--- a/test/metabase/models/pulse_test.clj
+++ b/test/metabase/models/pulse_test.clj
@@ -207,7 +207,7 @@
                              :channel      ["email"],
                              :schedule     ["daily"],
                              :recipients   [[{:email "foo@bar.com"}]]}}
-                 (audit-log-test/event :subscription-create (u/the-id pulse)))))))))
+                 (audit-log-test/latest-event :subscription-create (u/the-id pulse)))))))))
 
 (deftest create-dashboard-subscription-test
   (testing "Make sure that the dashboard_id is set correctly when creating a Dashboard Subscription pulse"
@@ -304,7 +304,7 @@
                                         :email       "crowberto@metabase.com"
                                         :common_name "Crowberto Corv"
                                         :id          (mt/user->id :crowberto)}]]}}
-           (audit-log-test/event :subscription-update (u/the-id pulse))))))
+           (audit-log-test/latest-event :subscription-update (u/the-id pulse))))))
 
 (deftest dashboard-subscription-update-test
   (testing "collection_id and dashboard_id of a dashboard subscription cannot be directly modified"

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -124,35 +124,32 @@
 (deftest record-view-log-when-process-userland-query-test
   (testing "record a view log with only card id"
     (mt/with-temp [:model/Card card {:dataset_query (mt/mbql-query users)}]
-      (mt/with-model-cleanup [:model/ViewLog]
-        (qp/process-userland-query (assoc
-                                    (:dataset_query card)
-                                    :info {:card-id (:id card)}))
+      (qp/process-userland-query (assoc
+                                  (:dataset_query card)
+                                  :info {:card-id (:id card)}))
 
-        (is (true? (t2/exists? :model/ViewLog :model "card" :model_id (:id card) :user_id nil))))))
+      (is (true? (t2/exists? :model/ViewLog :model "card" :model_id (:id card) :user_id nil)))))
 
   (testing "record a view log with card id and executed by"
     (mt/with-temp [:model/Card card {:dataset_query (mt/mbql-query users)}]
-      (mt/with-model-cleanup [:model/ViewLog]
-        (qp/process-userland-query (assoc
-                                    (:dataset_query card)
-                                    :info {:card-id (:id card)
-                                           :executed-by (mt/user->id :rasta)}))
+      (qp/process-userland-query (assoc
+                                  (:dataset_query card)
+                                  :info {:card-id (:id card)
+                                         :executed-by (mt/user->id :rasta)}))
 
-        (is (true? (t2/exists? :model/ViewLog :model "card" :model_id (:id card) :user_id (mt/user->id :rasta)))))))
+      (is (true? (t2/exists? :model/ViewLog :model "card" :model_id (:id card) :user_id (mt/user->id :rasta))))))
 
   (testing "skip if context is dashboard or collection"
     (mt/with-temp [:model/Card card {:dataset_query (mt/mbql-query users)}]
-      (mt/with-model-cleanup [:model/ViewLog]
-        (qp/process-userland-query (assoc
-                                    (:dataset_query card)
-                                    :info {:card-id     (:id card)
-                                           :context     "collection"}))
-        (qp/process-userland-query (assoc
-                                    (:dataset_query card)
-                                    :info {:card-id     (:id card)
-                                           :context     "dashboard"}))
-       (is (false? (t2/exists? :model/ViewLog :model "card" :model_id (:id card))))))))
+      (qp/process-userland-query (assoc
+                                  (:dataset_query card)
+                                  :info {:card-id     (:id card)
+                                         :context     "collection"}))
+      (qp/process-userland-query (assoc
+                                  (:dataset_query card)
+                                  :info {:card-id     (:id card)
+                                         :context     "dashboard"}))
+      (is (false? (t2/exists? :model/ViewLog :model "card" :model_id (:id card)))))))
 
 (defn- async-middleware [qp]
   (fn async-middleware-qp [query rff context]


### PR DESCRIPTION
**Problem**

There were a great deal of merge conflicts with the `auditv2-main` feature branch, primarily because of [this PR](https://github.com/metabase/metabase/pull/34947). This PR was mainly working on the revision subsystem, not audit, but it changed the `publish-event!` API to expect a map of this structure:
```
{:object object, :user-id user-id, :other-keys ...}
```
rather than just an instance of a model itself (like a card, dashboard, etc). It also enforced this structure with new malli schemas for all the existing event types.

I like this approach, but it required adapting a lot of our `audit_log` code to use this new structure. In addition, since that PR was pretty large, it conflicted with audit v2 changes in other assorted ways which broke a number of tests (over 400 backend tests were failing once I finished the initial rebase).

**Approach to fixing this**

1. I've created a new branch `auditv2-main-2` which has a PR open here: https://github.com/metabase/metabase/pull/35434 This branch is just `auditv2-main` rebased on master, with a best-effort attempt to fix code conflicts. This doesn't do any larger architecture changes or test fixes, for the most part.
2. I've opened this PR with my changes to the way audit is structured, targeting that branch. This way, these changes can be reviewed in a slightly more visible way, instead of them just being hidden by a giant rebase. Once this PR is green I'll merge it into `auditv2-main-2` and we can use that as the authoritative feature branch.

**New things in this PR**
- `publish-event!` calls have been changed to take `:object` and `:user-id` keys.
- I restructured the `audit-log/record-event!` API to make it much more flexible. Now it's just a two-argument function that takes a `params` map, and most of the event handlers in `metabase.events.audit-log` can pass their data straight through to it. See the docstring for that function for more details (I've left a comment highlighting where it is)
- Some misc test fixes and renamings. Will self-review to shine light on some interesting areas.