### PR TITLE
Add Data Test ID for sidebar

### DIFF
--- a/frontend/src/metabase/dashboard/components/Sidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.jsx
@@ -9,11 +9,19 @@ const propTypes = {
   children: PropTypes.node,
   onClose: PropTypes.func,
   onCancel: PropTypes.func,
+  "data-testid": PropTypes.string,
 };
 
-function Sidebar({ closeIsDisabled, children, onClose, onCancel }) {
+function Sidebar({
+  closeIsDisabled,
+  children,
+  onClose,
+  onCancel,
+  "data-testid": dataTestId,
+}) {
   return (
     <aside
+      data-testid={dataTestId}
       style={{ width: WIDTH, minWidth: WIDTH }}
       className="flex flex-column border-left bg-white"
     >

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/AddCardSidebar/AddCardSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/AddCardSidebar/AddCardSidebar.jsx
@@ -10,7 +10,7 @@ AddCardSidebar.propTypes = {
 
 export function AddCardSidebar(props) {
   return (
-    <Sidebar>
+    <Sidebar data-testid="add-card-sidebar">
       <QuestionPicker {...props} />
     </Sidebar>
   );


### PR DESCRIPTION
Added a `data-testid` attribute for tests in #35280. Just wanted to put it in a different PR to keep things separated