### PR TITLE
Set up writable database directly in `table.cy.spec.js`

### DIFF
--- a/e2e/test/scenarios/visualizations/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/table.cy.spec.js
@@ -13,6 +13,8 @@ import {
   visitQuestionAdhoc,
   getTable,
   leftSidebar,
+  setupWritableDB,
+  addPostgresDatabase,
 } from "e2e/support/helpers";
 
 import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
@@ -320,10 +322,17 @@ describe("scenarios > visualizations > table", () => {
 });
 
 describe("scenarios > visualizations > table > conditional formatting", () => {
-  beforeEach(() => {
-    resetTestTable({ type: "postgres", table: "many_data_types" });
-    restore(`postgres-writable`);
+  before(() => {
+    restore("default");
     cy.signInAsAdmin();
+
+    setupWritableDB("postgres");
+    addPostgresDatabase("Writable Postgres12", true);
+  });
+
+  beforeEach(() => {
+    cy.signInAsAdmin();
+    resetTestTable({ type: "postgres", table: "many_data_types" });
     resyncDatabase({
       dbId: WRITABLE_DB_ID,
       tableName: "many_data_types",


### PR DESCRIPTION
Part of #35449.

Stress-test this change
https://github.com/metabase/metabase/actions/runs/6785782462/job/18444846137

```
  scenarios > visualizations > table > conditional formatting
    ✓ should work with boolean columns: burning 1 of 5 (6969ms)
    ✓ should work with boolean columns: burning 2 of 5 (3272ms)
    ✓ should work with boolean columns: burning 3 of 5 (3147ms)
    ✓ should work with boolean columns: burning 4 of 5 (3536ms)
    ✓ should work with boolean columns: burning 5 of 5 (3399ms)
```