### PR TITLE
Set up writable database directly in `27745-cc-numeric-missing-summarize.cy.spec.js`

### DIFF
--- a/e2e/support/helpers/e2e-qa-databases-helpers.js
+++ b/e2e/support/helpers/e2e-qa-databases-helpers.js
@@ -273,3 +273,11 @@ export function resyncDatabase({ dbId = 2, tableName = "", tableAlias }) {
   cy.request("POST", `/api/database/${dbId}/rescan_values`);
   waitForSyncToFinish({ iteration: 0, dbId, tableName, tableAlias });
 }
+
+export function addWritableDatabase(dialect) {
+  if (dialect === "postgres") {
+    addPostgresDatabase("Writable Postgres12", true);
+  } else {
+    addMySQLDatabase("Writable MySQL8", true);
+  }
+}

--- a/e2e/test/scenarios/custom-column/reproductions/27745-cc-numeric-missing-summarize.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/27745-cc-numeric-missing-summarize.cy.spec.js
@@ -6,16 +6,24 @@ import {
   visualize,
   popover,
   resetTestTable,
+  setupWritableDB,
+  addWritableDatabase,
 } from "e2e/support/helpers";
 
 ["postgres", "mysql"].forEach(dialect => {
   describe(`issue 27745 (${dialect})`, { tags: "@external" }, () => {
     const tableName = "colors27745";
 
-    beforeEach(() => {
-      restore(`${dialect}-writable`);
+    before(() => {
+      restore("default");
       cy.signInAsAdmin();
 
+      setupWritableDB(dialect);
+      addWritableDatabase(dialect);
+    });
+
+    beforeEach(() => {
+      cy.signInAsAdmin();
       resetTestTable({ type: dialect, table: tableName });
       cy.request("POST", `/api/database/${WRITABLE_DB_ID}/sync_schema`);
     });


### PR DESCRIPTION
Part of https://github.com/metabase/metabase/issues/35449.

Stress-test this change
https://github.com/metabase/metabase/actions/runs/6786091393

```
  Running:  27745-cc-numeric-missing-summarize.cy.spec.js                                   (1 of 1)

  issue 27745 (postgres)
    ✓ should display all summarize options if the only numeric field is a custom column (metabase#27745): burning 1 of 5 (18439ms)
    ✓ should display all summarize options if the only numeric field is a custom column (metabase#27745): burning 2 of 5 (13411ms)
    ✓ should display all summarize options if the only numeric field is a custom column (metabase#27745): burning 3 of 5 (9535ms)
    ✓ should display all summarize options if the only numeric field is a custom column (metabase#27745): burning 4 of 5 (9629ms)
    ✓ should display all summarize options if the only numeric field is a custom column (metabase#27745): burning 5 of 5 (10090ms)
  issue 27745 (mysql)
Server pub key: <Buffer 2d 2d 2d 2d 2d 42 45 47 49 4e 20 50 55 42 4c 49 43 20 4b 45 59 2d 2d 2d 2d 2d 0a 4d 49 49 42 49 6a 41 4e 42 67 6b 71 68 6b 69 47 39 77 30 42 41 51 45 ... 401 more bytes>
    ✓ should display all summarize options if the only numeric field is a custom column (metabase#27745): burning 1 of 5 (13392ms)
    ✓ should display all summarize options if the only numeric field is a custom column (metabase#27745): burning 2 of 5 (9172ms)
    ✓ should display all summarize options if the only numeric field is a custom column (metabase#27745): burning 3 of 5 (8826ms)
    ✓ should display all summarize options if the only numeric field is a custom column (metabase#27745): burning 4 of 5 (8967ms)
    ✓ should display all summarize options if the only numeric field is a custom column (metabase#27745): burning 5 of 5 (8730ms)
  10 passing (2m)
```