### PR TITLE
Respect "enable nested queries" setting and database's "nested queries" feature

### DIFF
--- a/frontend/src/metabase-lib/metadata/Database.ts
+++ b/frontend/src/metabase-lib/metadata/Database.ts
@@ -78,9 +78,9 @@ class Database {
         set.has("inner-join") ||
         set.has("full-join")
       );
-    } else {
-      return set.has(feature);
     }
+
+    return set.has(feature);
   }
 
   supportsPivots() {

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
@@ -28,6 +28,7 @@ interface Props {
   tab: string;
   hasDataPermissions: boolean;
   hasActionsTab: boolean;
+  hasNestedQueriesEnabled: boolean;
   supportsNestedQueries: boolean;
   onChangeName: (name?: string) => void;
   onChangeDescription: (description?: string | null) => void;
@@ -40,6 +41,7 @@ function ModelDetailPage({
   mainTable,
   hasDataPermissions,
   hasActionsTab,
+  hasNestedQueriesEnabled,
   supportsNestedQueries,
   onChangeName,
   onChangeDescription,
@@ -77,7 +79,11 @@ function ModelDetailPage({
             <TabPanelContent>
               <ModelUsageDetails
                 model={model}
-                hasNewQuestionLink={hasDataPermissions && supportsNestedQueries}
+                hasNewQuestionLink={
+                  hasDataPermissions &&
+                  supportsNestedQueries &&
+                  hasNestedQueriesEnabled
+                }
               />
             </TabPanelContent>
           </TabPanel>

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
@@ -28,6 +28,7 @@ interface Props {
   tab: string;
   hasDataPermissions: boolean;
   hasActionsTab: boolean;
+  supportsNestedQueries: boolean;
   onChangeName: (name?: string) => void;
   onChangeDescription: (description?: string | null) => void;
   onChangeCollection: (collection: Collection) => void;
@@ -39,6 +40,7 @@ function ModelDetailPage({
   mainTable,
   hasDataPermissions,
   hasActionsTab,
+  supportsNestedQueries,
   onChangeName,
   onChangeDescription,
   onChangeCollection,
@@ -75,7 +77,7 @@ function ModelDetailPage({
             <TabPanelContent>
               <ModelUsageDetails
                 model={model}
-                hasNewQuestionLink={hasDataPermissions}
+                hasNewQuestionLink={hasDataPermissions && supportsNestedQueries}
               />
             </TabPanelContent>
           </TabPanel>

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
@@ -8,6 +8,7 @@ import type { Location, LocationDescriptor } from "history";
 
 import { NotFound } from "metabase/containers/ErrorPages";
 
+import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 
 import Actions from "metabase/entities/actions";
@@ -15,6 +16,7 @@ import Databases from "metabase/entities/databases";
 import Questions from "metabase/entities/questions";
 import Tables from "metabase/entities/tables";
 import title from "metabase/hoc/Title";
+import { getSetting } from "metabase/selectors/settings";
 
 import { loadMetadataForCard } from "metabase/questions/actions";
 
@@ -84,6 +86,9 @@ function ModelDetailPage({
   onChangeLocation,
 }: Props) {
   const [hasFetchedTableMetadata, setHasFetchedTableMetadata] = useState(false);
+  const hasNestedQueriesEnabled = useSelector(state =>
+    getSetting(state, "enable-nested-queries"),
+  );
 
   const database = model.database();
   const hasDataPermissions = model.query().isEditable();
@@ -179,6 +184,7 @@ function ModelDetailPage({
         tab={tab}
         hasDataPermissions={hasDataPermissions}
         hasActionsTab={hasActionsTab}
+        hasNestedQueriesEnabled={hasNestedQueriesEnabled}
         supportsNestedQueries={supportsNestedQueries}
         onChangeName={handleNameChange}
         onChangeDescription={handleDescriptionChange}

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
@@ -90,6 +90,8 @@ function ModelDetailPage({
   const hasActions = actions.length > 0;
   const hasActionsEnabled = database != null && database.hasActionsEnabled();
   const hasActionsTab = hasActions || hasActionsEnabled;
+  const supportsNestedQueries =
+    database != null && database.hasFeature("nested-queries");
 
   const mainTable = useMemo(
     () => (model.isStructured() ? model.query().sourceTable() : null),
@@ -177,6 +179,7 @@ function ModelDetailPage({
         tab={tab}
         hasDataPermissions={hasDataPermissions}
         hasActionsTab={hasActionsTab}
+        supportsNestedQueries={supportsNestedQueries}
         onChangeName={handleNameChange}
         onChangeDescription={handleDescriptionChange}
         onChangeCollection={handleCollectionChange}

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -34,6 +34,7 @@ import type {
   Collection,
   Database,
   Field,
+  Settings,
   WritebackAction,
   WritebackQueryAction,
 } from "metabase-types/api";
@@ -57,6 +58,10 @@ import {
   createSavedStructuredCard,
   createStructuredModelCard as _createStructuredModelCard,
 } from "metabase-types/api/mocks/presets";
+import {
+  createMockSettingsState,
+  createMockState,
+} from "metabase-types/store/mocks";
 
 import * as ML_Urls from "metabase-lib/urls";
 import { TYPE } from "metabase-lib/types/constants";
@@ -192,6 +197,7 @@ type SetupOpts = {
   databases?: Database[];
   collections?: Collection[];
   usedBy?: Card[];
+  settings?: Partial<Settings>;
 };
 
 async function setup({
@@ -201,7 +207,11 @@ async function setup({
   databases = [TEST_DATABASE],
   collections = [],
   usedBy = [],
+  settings = {},
 }: SetupOpts) {
+  const storeInitialState = createMockState({
+    settings: createMockSettingsState(settings),
+  });
   const metadata = createMockMetadata({
     databases: databases,
     tables: [TEST_TABLE, TEST_FK_TABLE_1],
@@ -257,7 +267,7 @@ async function setup({
       </Route>
       <Route path="/question/:slug" component={() => null} />
     </>,
-    { withRouter: true, initialRoute },
+    { withRouter: true, initialRoute, storeInitialState },
   );
 
   await waitForLoaderToBeRemoved();
@@ -394,6 +404,19 @@ describe("ModelDetailPage", () => {
         expect(
           screen.getByText(/This model is not used by any questions yet/i),
         ).toBeInTheDocument();
+      });
+
+      it("does not offer creating new questions if nested queries are disabled", async () => {
+        await setup({
+          model: getModel(),
+          settings: {
+            "enable-nested-queries": false,
+          },
+        });
+
+        expect(
+          screen.queryByRole("link", { name: /Create a new question/i }),
+        ).not.toBeInTheDocument();
       });
 
       it("lists questions based on the model", async () => {

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -129,6 +129,13 @@ const TEST_DATABASE = createMockDatabase({
   tables: [TEST_TABLE, TEST_FK_TABLE_1],
 });
 
+const TEST_DATABASE_WITHOUT_NESTED_QUERIES = createMockDatabase({
+  ...TEST_DATABASE,
+  features: TEST_DATABASE.features.filter(
+    feature => feature !== "nested-queries",
+  ),
+});
+
 const TEST_DATABASE_WITH_ACTIONS = createMockDatabase({
   ...TEST_DATABASE,
   settings: { "database-enable-actions": true },
@@ -404,6 +411,17 @@ describe("ModelDetailPage", () => {
         expect(
           screen.getByText(/This model is not used by any questions yet/i),
         ).toBeInTheDocument();
+      });
+
+      it("does not offer creating new questions if database does not support nested queries", async () => {
+        await setup({
+          model: getModel(),
+          databases: [TEST_DATABASE_WITHOUT_NESTED_QUERIES],
+        });
+
+        expect(
+          screen.queryByRole("link", { name: /Create a new question/i }),
+        ).not.toBeInTheDocument();
       });
 
       it("does not offer creating new questions if nested queries are disabled", async () => {


### PR DESCRIPTION
Closes #28908
Closes #33401

### Description

This PR hides the "Create a new question" link in the "Used by" tab in Model Details Page when:
- nested queries are disabled on an instance level (that's [#28908](https://github.com/metabase/metabase/issues/28908))
- database driver doesn't support nested queries (that's [#33401](https://github.com/metabase/metabase/issues/33401))

Whether we want to disable creating models in the above cases is still an open question (see [Slack discussion](https://metaboat.slack.com/archives/C01LQQ2UW03/p1699454495848059)) - models are still useful (e.g. because of actions) even when nested queries are not available. In case we decide that creating models should be prevented, I will create a separate issue for it.

### Demo


https://github.com/metabase/metabase/assets/6830683/aa7007b5-ab49-4f40-974b-22fa382e5aa0

