### PR TITLE
Remove a retired field's FK target references during sync

### DIFF
--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -164,8 +164,7 @@
   (u/prog1 (t2/changes field)
     (when (false? (:active field))
       (t2/update! :model/Field {:fk_target_field_id (:id field)} {:semantic_type      nil
-                                                                  :fk_target_field_id nil})))
-  field)
+                                                                  :fk_target_field_id nil}))))
 
 ;;; Field permissions
 ;; There are several API endpoints where large instances can return many thousands of Fields. Normally Fields require

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -162,7 +162,7 @@
 (t2/define-before-update :model/Field
   [field]
   (u/prog1 (t2/changes field)
-    (when (false? (:active field))
+    (when (false? (:active <>))
       (t2/update! :model/Field {:fk_target_field_id (:id field)} {:semantic_type      nil
                                                                   :fk_target_field_id nil}))))
 

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -159,6 +159,14 @@
   (let [defaults {:display_name (humanization/name->human-readable-name (:name field))}]
     (merge defaults field)))
 
+(t2/define-before-update :model/Field
+  [field]
+  (u/prog1 (t2/changes field)
+    (when (false? (:active field))
+      (t2/update! :model/Field {:fk_target_field_id (:id field)} {:semantic_type      nil
+                                                                  :fk_target_field_id nil})))
+  field)
+
 ;;; Field permissions
 ;; There are several API endpoints where large instances can return many thousands of Fields. Normally Fields require
 ;; a DB call to fetch information about their Table, because a Field's permissions set is the same as its parent

--- a/src/metabase/sync/sync_metadata/fields/sync_instances.clj
+++ b/src/metabase/sync/sync_metadata/fields/sync_instances.clj
@@ -151,7 +151,7 @@
   [table          :- i/TableInstance
    metabase-field :- common/TableMetadataFieldWithID]
   (log/info (trs "Marking Field ''{0}'' as inactive." (common/field-metadata-name-for-logging table metabase-field)))
-  (when (pos? (t2/update! :model/Field (u/the-id metabase-field) {:active false}))
+  (when (pos? (t2/update! Field (u/the-id metabase-field) {:active false}))
     1))
 
 (mu/defn ^:private retire-fields! :- ms/IntGreaterThanOrEqualToZero

--- a/src/metabase/sync/sync_metadata/fields/sync_instances.clj
+++ b/src/metabase/sync/sync_metadata/fields/sync_instances.clj
@@ -152,9 +152,6 @@
    metabase-field :- common/TableMetadataFieldWithID]
   (log/info (trs "Marking Field ''{0}'' as inactive." (common/field-metadata-name-for-logging table metabase-field)))
   (when (pos? (t2/update! :model/Field (u/the-id metabase-field) {:active false}))
-    ;; if we marked the Field inactive, remove it as an fk target for other Fields
-    (t2/update! :model/Field {:fk_target_field_id (u/the-id metabase-field)} {:semantic_type      nil
-                                                                              :fk_target_field_id nil})
     1))
 
 (mu/defn ^:private retire-fields! :- ms/IntGreaterThanOrEqualToZero

--- a/src/metabase/sync/sync_metadata/fields/sync_instances.clj
+++ b/src/metabase/sync/sync_metadata/fields/sync_instances.clj
@@ -151,7 +151,10 @@
   [table          :- i/TableInstance
    metabase-field :- common/TableMetadataFieldWithID]
   (log/info (trs "Marking Field ''{0}'' as inactive." (common/field-metadata-name-for-logging table metabase-field)))
-  (when (pos? (t2/update! Field (u/the-id metabase-field) {:active false}))
+  (when (pos? (t2/update! :model/Field (u/the-id metabase-field) {:active false}))
+    ;; if we marked the Field inactive, remove it as an fk target for other Fields
+    (t2/update! :model/Field {:fk_target_field_id (u/the-id metabase-field)} {:semantic_type      nil
+                                                                              :fk_target_field_id nil})
     1))
 
 (mu/defn ^:private retire-fields! :- ms/IntGreaterThanOrEqualToZero

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -107,7 +107,7 @@
                                   :table_id [:in (t2/select-pks-set Table :db_id (u/the-id database))])))))))
 
 (deftest mark-inactive-remove-fks-test
-  (testing "when a column is dropped from the DB, sync should wipe foreign key targets"
+  (testing "when a column is dropped from the DB, sync should wipe foreign key targets and their semantic type"
     (is (=? {:before-sync {:semantic_type      :type/FK
                            :fk_target_field_id int?}
              :after-sync  {:semantic_type      nil

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -138,7 +138,6 @@
               (let [table (t2/hydrate (t2/select-one Table :db_id (u/the-id database)) :fields)]
                 (set (map :name (:fields table))))))))))
 
-;; TODO: is this test relevant?
 (deftest dont-splice-inactive-columns-into-queries-test
   (testing (str "make sure that inactive columns don't end up getting spliced into queries! This test arguably "
                 "belongs in the query processor tests since it's ultimately checking to make sure columns marked as "


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/13130 by setting `metabase_field.fk_target_field_id` and `metabase_field.semantic_type` to `NULL` if a field has `active` set to `false` during sync.

I chose to implement this with a `define-before-update` hook on the Field model, rather than the more direct approach to modify the sync code (see [this commit to compare implementations](https://github.com/metabase/metabase/pull/35496/commits/4ba23e247de2e28c6a9ec4c961e8e88751f11f5c)). I couldn't find any other instances where we set active to false other than sync, but it's worth enforcing this at the model level.

I'm going to follow this PR up with a migration to solve the issue for previously removed FK targets.