### PR TITLE
Deprecate PUT /api/dashboard/:id/cards endpoint

### DIFF
--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -40,7 +40,7 @@
    [metabase.query-processor.util :as qp.util]
    [metabase.related :as related]
    [metabase.util :as u]
-   [metabase.util.i18n :refer [deferred-tru tru]]
+   [metabase.util.i18n :refer [deferred-tru trs tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
@@ -638,7 +638,8 @@
   (update-dashboard id dash-updates))
 
 (api/defendpoint PUT "/:id/cards"
-  "Update `Cards` and `Tabs` on a Dashboard. Request body should have the form:
+  "(DEPRECATED -- Use the `PUT /api/dashboard/:id` endpoint instead.)
+   Update `Cards` and `Tabs` on a Dashboard. Request body should have the form:
 
     {:cards        [{:id                 ... ; DashboardCard ID
                      :size_x             ...
@@ -657,6 +658,8 @@
    ;; tabs should be required in production, making it optional because lots of
    ;; e2e tests curerntly doesn't include it
    tabs [:maybe (ms/maps-with-unique-key [:sequential UpdatedDashboardTab] :id)]}
+  (log/warn
+   (trs "DELETE /api/dashboard/:id/cards is deprecated. Use PUT /api/dashboard/:id instead."))
   (let [dashboard (update-dashboard id {:dashcards cards :tabs tabs})]
     {:cards (:dashcards dashboard)
      :tabs  (:tabs dashboard)}))

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -557,7 +557,8 @@
   [id {:keys [dashcards tabs] :as dash-updates}]
   (let [current-dash               (api/write-check Dashboard id)
         changes-stats              (atom nil)
-        ;; tabs are sent in production as well, but there are lots of tests that exclude it. so this only checks for dashcards
+        ;; tabs are always sent in production as well when dashcards are updated, but there are lots of
+        ;; tests that exclude it. so this only checks for dashcards
         update-dashcards-and-tabs? (contains? dash-updates :dashcards)]
     (collection/check-allowed-to-change-collection current-dash dash-updates)
     (check-allowed-to-change-embedding current-dash dash-updates)
@@ -607,9 +608,7 @@
        true))
     (let [dashboard (t2/select-one :model/Dashboard id)]
       (events/publish-event! :event/dashboard-update {:object dashboard :user-id api/*current-user-id*})
-      (when update-dashcards-and-tabs?
-        ;; execute these events for old PUT /api/dashboard/:id/cards calls and new PUT /api/dashboard/:id calls, and not for old PUT /api/dashboard/:id calls
-        (track-dashcard-and-tab-events! dashboard @changes-stats))
+      (track-dashcard-and-tab-events! dashboard @changes-stats)
       (-> (t2/hydrate dashboard [:collection :is_personal] [:dashcards :series] :tabs)
           (assoc :last-edit-info (last-edit/edit-information-for-user @api/*current-user*))))))
 

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -658,7 +658,7 @@
    ;; e2e tests curerntly doesn't include it
    tabs [:maybe (ms/maps-with-unique-key [:sequential UpdatedDashboardTab] :id)]}
   (log/warn
-   (trs "DELETE /api/dashboard/:id/cards is deprecated. Use PUT /api/dashboard/:id instead."))
+   "DELETE /api/dashboard/:id/cards is deprecated. Use PUT /api/dashboard/:id instead.")
   (let [dashboard (update-dashboard id {:dashcards cards :tabs tabs})]
     {:cards (:dashcards dashboard)
      :tabs  (:tabs dashboard)}))

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -40,7 +40,7 @@
    [metabase.query-processor.util :as qp.util]
    [metabase.related :as related]
    [metabase.util :as u]
-   [metabase.util.i18n :refer [deferred-tru trs tru]]
+   [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/35209

This PR adds a warning log if some 3rd party tries to use the `PUT /api/dashboard/:id/cards` endpoint, and updates the docstring to say it's deprecated.

It also tidies up `PUT /api/dashboard/:id` a bit (no change in behaviour).

**Release notes mention:**
`PUT /api/dashboard/:id/cards` is deprecated. Instead you can use `PUT /api/dashboard/:id` to update the dashcards and tabs of a dashboard, along with all the other dashboard data.