### PR TITLE
restore correct position when undoing dashcard tab movement or deletion

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.js
+++ b/e2e/support/helpers/e2e-dashboard-helpers.js
@@ -67,7 +67,8 @@ export function showDashboardCardActions(index = 0) {
 
 export function removeDashboardCard(index = 0) {
   showDashboardCardActions(index);
-  cy.findAllByTestId("dashboardcard-actions-panel")
+  getDashboardCard(index)
+    .findAllByTestId("dashboardcard-actions-panel")
     .eq(0)
     .should("be.visible")
     .icon("close")

--- a/e2e/support/helpers/e2e-dashboard-helpers.js
+++ b/e2e/support/helpers/e2e-dashboard-helpers.js
@@ -67,7 +67,7 @@ export function showDashboardCardActions(index = 0) {
 
 export function removeDashboardCard(index = 0) {
   getDashboardCard(index)
-    .realHover()
+    .realHover({ scrollBehavior: "bottom" })
     .findByTestId("dashboardcard-actions-panel")
     .should("be.visible")
     .icon("close")

--- a/e2e/support/helpers/e2e-dashboard-helpers.js
+++ b/e2e/support/helpers/e2e-dashboard-helpers.js
@@ -66,10 +66,9 @@ export function showDashboardCardActions(index = 0) {
 }
 
 export function removeDashboardCard(index = 0) {
-  showDashboardCardActions(index);
   getDashboardCard(index)
-    .findAllByTestId("dashboardcard-actions-panel")
-    .eq(0)
+    .realHover()
+    .findByTestId("dashboardcard-actions-panel")
     .should("be.visible")
     .icon("close")
     .click();

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-undo.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-undo.cy.spec.js
@@ -1,0 +1,96 @@
+import {
+  createNewTab,
+  editDashboard,
+  getDashboardCard,
+  getDashboardCards,
+  getTextCardDetails,
+  goToTab,
+  moveDashCardToTab,
+  removeDashboardCard,
+  restore,
+  undo,
+  updateDashboardCards,
+  visitDashboard,
+} from "e2e/support/helpers";
+
+describe("scenarios > dashboard cards > undo", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it(
+    "when undoing a dashcard removal or dashcard tab movement, it should try to restore the position (best effort)",
+    { scrollBehavior: false },
+    () => {
+      const checkOrder = () => {
+        getDashboardCard(0).findByText("Text card 1");
+        getDashboardCard(1).findByText("Text card 2");
+        getDashboardCard(2).findByText("Text card 3");
+        getDashboardCard(3).findByText("Text card 4");
+      };
+
+      const cards = [
+        getTextCardDetails({
+          text: "Text card 1",
+          size_x: 4,
+          size_y: 1,
+          row: 0,
+          col: 1,
+        }),
+        getTextCardDetails({
+          text: "Text card 2",
+          size_x: 4,
+          size_y: 1,
+          row: 1,
+          col: 0,
+        }),
+        getTextCardDetails({
+          text: "Text card 3",
+          size_x: 4,
+          size_y: 1,
+          row: 2,
+          col: 3,
+        }),
+        getTextCardDetails({
+          text: "Text card 4",
+          size_x: 4,
+          size_y: 1,
+          row: 3,
+          col: 0,
+        }),
+      ];
+
+      cy.createDashboard().then(({ body: { id: dashboard_id } }) => {
+        updateDashboardCards({ dashboard_id, cards });
+
+        visitDashboard(dashboard_id);
+      });
+
+      checkOrder();
+
+      editDashboard();
+
+      for (let i = 0; i < cards.length; i++) {
+        removeDashboardCard(i);
+        getDashboardCards().should("have.length", cards.length - 1);
+
+        undo();
+        getDashboardCards().should("have.length", cards.length);
+        checkOrder();
+      }
+
+      createNewTab();
+      goToTab("Tab 1");
+
+      for (let i = 0; i < cards.length; i++) {
+        moveDashCardToTab({ dashcardIndex: i, tabName: "Tab 2" });
+        getDashboardCards().should("have.length", cards.length - 1);
+
+        undo();
+        getDashboardCards().should("have.length", cards.length);
+        checkOrder();
+      }
+    },
+  );
+});

--- a/frontend/src/metabase/dashboard/actions/cards.js
+++ b/frontend/src/metabase/dashboard/actions/cards.js
@@ -13,6 +13,7 @@ import { createCard } from "metabase/lib/card";
 import { getVisualizationRaw } from "metabase/visualizations";
 import { trackCardCreated } from "../analytics";
 import { getDashCardById } from "../selectors";
+import { isVirtualDashCard } from "../utils";
 import {
   ADD_CARD_TO_DASH,
   REMOVE_CARD_FROM_DASH,
@@ -77,7 +78,9 @@ export const undoRemoveCardFromDashboard = createThunkAction(
       const dashcard = getDashCardById(getState(), dashcardId);
       const card = dashcard.card;
 
-      dispatch(fetchCardData(card, dashcard));
+      if (!isVirtualDashCard(dashcard)) {
+        dispatch(fetchCardData(card, dashcard));
+      }
 
       return { dashcardId };
     },

--- a/frontend/src/metabase/dashboard/actions/tabs.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.ts
@@ -366,7 +366,9 @@ export const tabsReducer = createReducer<DashboardState>(
       ) => {
         const dashCard = state.dashcards[dashCardId];
 
-        dashCard.row = originalRow;
+        // when a card is moved, another card could steal its position,
+        // this trick gives the original tab precedence on the position
+        dashCard.row = originalRow - 0.1;
         dashCard.col = originalCol;
         dashCard.dashboard_tab_id = originalTabId;
         dashCard.isDirty = true;

--- a/frontend/src/metabase/dashboard/actions/tabs.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.ts
@@ -23,6 +23,7 @@ import { addUndo } from "metabase/redux/undo";
 import { INITIAL_DASHBOARD_STATE } from "../constants";
 import { getDashCardById } from "../selectors";
 import { trackCardMoved } from "../analytics";
+import { calculateDashCardRowAfterUndo } from "../utils";
 import { getDashCardMoveToTabUndoMessage, getExistingDashCards } from "./utils";
 
 type CreateNewTabPayload = { tabId: DashboardTabId };
@@ -366,9 +367,7 @@ export const tabsReducer = createReducer<DashboardState>(
       ) => {
         const dashCard = state.dashcards[dashCardId];
 
-        // when a card is moved, another card could steal its position,
-        // this trick gives the original tab precedence on the position
-        dashCard.row = originalRow - 0.1;
+        dashCard.row = calculateDashCardRowAfterUndo(originalRow);
         dashCard.col = originalCol;
         dashCard.dashboard_tab_id = originalTabId;
         dashCard.isDirty = true;

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -227,7 +227,11 @@ const dashcards = handleActions(
     }),
     [UNDO_REMOVE_CARD_FROM_DASH]: (state, { payload: { dashcardId } }) => ({
       ...state,
-      [dashcardId]: { ...state[dashcardId], isRemoved: false },
+      [dashcardId]: {
+        ...state[dashcardId],
+        isRemoved: false,
+        row: state[dashcardId].row - 0.1,
+      },
     }),
     [MARK_NEW_CARD_SEEN]: (state, { payload: dashcardId }) => ({
       ...state,

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -46,7 +46,10 @@ import {
   tabsReducer,
   FETCH_CARD_DATA_PENDING,
 } from "./actions";
-import { syncParametersAndEmbeddingParams } from "./utils";
+import {
+  calculateDashCardRowAfterUndo,
+  syncParametersAndEmbeddingParams,
+} from "./utils";
 import { INITIAL_DASHBOARD_STATE } from "./constants";
 
 const dashboardId = handleActions(
@@ -230,7 +233,7 @@ const dashcards = handleActions(
       [dashcardId]: {
         ...state[dashcardId],
         isRemoved: false,
-        row: state[dashcardId].row - 0.1,
+        row: calculateDashCardRowAfterUndo(state[dashcardId].row),
       },
     }),
     [MARK_NEW_CARD_SEEN]: (state, { payload: dashcardId }) => ({

--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -283,3 +283,13 @@ export const getActionIsEnabledInDatabase = (
 ): boolean => {
   return !!card.action?.database_enabled_actions;
 };
+
+/**
+ * When you remove a dashcard from a dashboard (either via removing or via moving it to another tab),
+ * another dashcard can take its place. This small offset ensures that the grid will put this dashcard
+ * in the correct place, pushing back down the other card.
+ * This is a "best effort" solution, it doesn't always work but it's good enough for the most common case
+ * see https://github.com/metabase/metabase/pull/35502
+ */
+export const calculateDashCardRowAfterUndo = (originalRow: number) =>
+  originalRow - 0.1;


### PR DESCRIPTION
### Description

**Problem:** Undoing a dash-card "moved-to-another-tab" or deletion does not always put the card back in the place it was moved/deleted from.

https://github.com/metabase/metabase/assets/1914270/365db584-5b68-45f0-bf6a-5fd7a3bad5dd

This pr tries to address it:

https://github.com/metabase/metabase/assets/1914270/2118a32c-53e2-4230-b1da-e4bf8217b445

The code is... not what I expected to write to fix this, but it seems to work and I haven't found any issue so 🤷 



### How to verify

1. Stack two cards horizontally
2. Move the top one to another tab/remove it from the dashboard
3. Press undo


## Known issues
This doesn't always work (see videos), but it's a bit better than before

Case 1:
there's a "hole" and a card goes too far up

https://github.com/metabase/metabase/assets/1914270/347eff62-33d4-408d-ace5-badde431569f

Case 2:

it doesn't work if you press undo on multiple cards in the wrong order 
see https://github.com/metabase/metabase/pull/35502#issuecomment-1805778244
