### PR TITLE
Fix flake in JWT test

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -8,16 +8,18 @@
    [metabase-enterprise.sso.integrations.jwt :as mt.jwt]
    [metabase-enterprise.sso.integrations.saml-test :as saml-test]
    [metabase.config :as config]
+   [metabase.events.audit-log-test :as audit-log-test]
    [metabase.models.permissions-group :refer [PermissionsGroup]]
-   [metabase.models.permissions-group-membership :refer [PermissionsGroupMembership]]
+   [metabase.models.permissions-group-membership
+    :refer [PermissionsGroupMembership]]
    [metabase.models.user :refer [User]]
    [metabase.public-settings.premium-features :as premium-features]
-   [metabase.public-settings.premium-features-test :as premium-features-test]
+   [metabase.public-settings.premium-features-test
+    :as premium-features-test]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
-   [toucan2.core :as t2]
-   [metabase.events.audit-log-test :as audit-log-test]))
+   [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :test-users))
 

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -16,7 +16,8 @@
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2]
+   [metabase.events.audit-log-test :as audit-log-test]))
 
 (use-fixtures :once (fixtures/initialize :test-users))
 
@@ -191,24 +192,28 @@
                                                                          :for        "the new user"}
                                                                         default-jwt-secret))]
             (is (saml-test/successful-login? response))
-            (testing "new user"
-              (is (= [{:email        "newuser@metabase.com"
-                       :first_name   "New"
-                       :is_qbnewb    true
-                       :is_superuser false
-                       :id           true
-                       :last_name    "User"
-                       :date_joined  true
-                       :common_name  "New User"}]
-                     (->> (mt/boolean-ids-and-timestamps (t2/select User :email "newuser@metabase.com"))
-                          (map #(dissoc % :last_login))))))
-            (testing "User Invite Event is logged."
-              (is (= "newuser@metabase.com"
-                     (get-in (t2/select-one :model/AuditLog :topic :user-invited) [:details :email]))))
-            (testing "attributes"
-              (is (= {"more" "stuff"
-                      "for"  "the new user"}
-                     (t2/select-one-fn :login_attributes User :email "newuser@metabase.com"))))))))))
+            (let [new-user (t2/select-one User :email "newuser@metabase.com")]
+              (testing "new user"
+                (is (= {:email        "newuser@metabase.com"
+                        :first_name   "New"
+                        :is_qbnewb    true
+                        :is_superuser false
+                        :id           true
+                        :last_name    "User"
+                        :date_joined  true
+                        :common_name  "New User"}
+                       (-> (mt/boolean-ids-and-timestamps [new-user])
+                           first
+                           (dissoc :last_login)))))
+              (testing "User Invite Event is logged."
+                (is (= "newuser@metabase.com"
+                       (get-in (audit-log-test/latest-event :user-invited (:id new-user))
+                               [:details :email])
+                       #_(get-in (t2/select-one :model/AuditLog :topic :user-invited) [:details :email]))))
+              (testing "attributes"
+                (is (= {"more" "stuff"
+                        "for"  "the new user"}
+                       (t2/select-one-fn :login_attributes User :email "newuser@metabase.com")))))))))))
 
 (deftest update-account-test
   (testing "A new account with 'Unknown' name will be created for a new JWT user without a first or last name."

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -208,8 +208,7 @@
               (testing "User Invite Event is logged."
                 (is (= "newuser@metabase.com"
                        (get-in (audit-log-test/latest-event :user-invited (:id new-user))
-                               [:details :email])
-                       #_(get-in (t2/select-one :model/AuditLog :topic :user-invited) [:details :email]))))
+                               [:details :email]))))
               (testing "attributes"
                 (is (= {"more" "stuff"
                         "for"  "the new user"}


### PR DESCRIPTION
Fixes flake by using `audit-log-test/latest-event` helper function which additionally takes the `model_id` field