### PR TITLE
Swap out deprecated form components in CreateActionForm

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionCreator/CreateActionForm/CreateActionForm.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/CreateActionForm/CreateActionForm.tsx
@@ -4,11 +4,14 @@ import * as Yup from "yup";
 
 import Button from "metabase/core/components/Button";
 import FormFooter from "metabase/core/components/FormFooter";
-import { Form, FormProvider } from "metabase/forms";
-import FormInput from "metabase/core/components/FormInput";
+import {
+  Form,
+  FormErrorMessage,
+  FormProvider,
+  FormTextInput,
+  FormSubmitButton,
+} from "metabase/forms";
 import FormTextArea from "metabase/core/components/FormTextArea";
-import FormSubmitButton from "metabase/core/components/FormSubmitButton";
-import FormErrorMessage from "metabase/core/components/FormErrorMessage";
 
 import * as Errors from "metabase/lib/errors";
 
@@ -59,7 +62,7 @@ function CreateActionForm({
     >
       {({ isValid }) => (
         <Form disabled={!isValid} data-testid="create-action-form">
-          <FormInput
+          <FormTextInput
             name="name"
             title={t`Name`}
             placeholder={t`My new fantastic action`}
@@ -77,7 +80,7 @@ function CreateActionForm({
             {!!onCancel && (
               <Button type="button" onClick={onCancel}>{t`Cancel`}</Button>
             )}
-            <FormSubmitButton title={t`Create`} disabled={!isValid} primary />
+            <FormSubmitButton label={t`Create`} disabled={!isValid} />
           </FormFooter>
         </Form>
       )}


### PR DESCRIPTION
Part of https://github.com/metabase/metabase/issues/26178

CreateActionForm is already using Formik, but some of the form inputs are deprecated, so we’re swapping them out for the new ones.

WIP: FormSubmitButton isn’t blue, presumably because `primary` attribute isn’t supported.  Looking.