### PR TITLE
Remove read events from audit_log

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -16053,6 +16053,51 @@ databaseChangeLog:
               );
       rollback: # no change
 
+  - changeSet:
+      id: v48.00-053
+      author: adam-james
+      comment: 'Added 0.48.0 - Adjust view_log schema for Audit Log v2'
+      changes:
+        - addColumn:
+            tableName: view_log
+            columns:
+              - column:
+                  name: has_access
+                  type: boolean
+                  constraints:
+                    nullable: true
+                  remarks: 'Whether the user who initiated the view had read access to the item being viewed.'
+
+  - changeSet:
+      id: v48.00-054
+      author: adam-james
+      comment: 'Added 0.48.0 - Adjust view_log schema for Audit Log v2'
+      changes:
+        - addColumn:
+            tableName: view_log
+            columns:
+              - column:
+                  name: error_message
+                  type: ${text.type}
+                  constraints:
+                    nullable: true
+                  remarks: 'An error message in the case of a failure or error when a user tried to view something.'
+
+  - changeSet:
+      id: v48.00-055
+      author: adam-james
+      comment: 'Added 0.48.0 - Adjust view_log schema for Audit Log v2'
+      changes:
+        - addColumn:
+            tableName: view_log
+            columns:
+              - column:
+                  name: context
+                  type: varchar(32)
+                  constraints:
+                    nullable: true
+                  remarks: 'The context of the view, can be collection, question, or dashboard. Only for cards.'
+
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -18,16 +18,16 @@
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::card-query-event ::event)
-(derive :event/card-query ::card-query-event)
+; (derive ::card-query-event ::event)
+; (derive :event/card-query ::card-query-event)
 
-(methodical/defmethod events/publish-event! ::card-query-event
-  [topic {:keys [user-id card-id] :as object}]
-  (let [details (select-keys object [:cached :ignore_cache :context])]
-    (audit-log/record-event! topic {:details    details
-                                    :user-id    user-id
-                                    :model      :model/Card
-                                    :model-id   card-id})))
+; (methodical/defmethod events/publish-event! ::card-query-event
+;   [topic {:keys [user-id card-id] :as object}]
+;   (let [details (select-keys object [:cached :ignore_cache :context])]
+;     (audit-log/record-event! topic {:details    details
+;                                     :user-id    user-id
+;                                     :model      :model/Card
+;                                     :model-id   card-id})))
 
 (derive ::dashboard-event ::event)
 (derive :event/dashboard-create ::dashboard-event)

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -18,13 +18,6 @@
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::card-read-event :metabase/event)
-(derive :event/card-read ::card-read-event)
-
-(methodical/defmethod events/publish-event! ::card-read-event
-  [topic event]
-  (audit-log/record-event! topic event))
-
 (derive ::card-query-event ::event)
 (derive :event/card-query ::card-query-event)
 
@@ -62,20 +55,13 @@
                                             (assoc :id id)
                                             (assoc :card_id card_id)))))]
     (audit-log/record-event! topic
-                               {:details  details
-                                :user-id  user-id
-                                :model    :model/Dashboard
-                                :model-id (u/id object)})))
+                             {:details  details
+                              :user-id  user-id
+                              :model    :model/Dashboard
+                              :model-id (u/id object)})))
 
-(derive ::dashboard-read-event ::event)
-(derive :event/dashboard-read ::dashboard-read-event)
-
-(methodical/defmethod events/publish-event! ::dashboard-read-event
-  [topic event]
-  (audit-log/record-event! topic event))
 
 (derive ::table-event ::event)
-(derive :event/table-read ::table-event)
 (derive :event/table-manual-scan ::table-event)
 
 (methodical/defmethod events/publish-event! ::table-event

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -9,7 +9,7 @@
    [metabase.events.audit-log :as events.audit-log]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.models
-    :refer [Card Dashboard DashboardCard Table Metric Pulse Segment]]
+    :refer [Card Dashboard DashboardCard Metric Pulse Segment]]
    [metabase.test :as mt]
    [metabase.util :as u]
    [toucan2.core :as t2]

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -103,22 +103,6 @@
                               dataset? (assoc :model? true))}
                  (latest-event "card-delete" (:id card))))))))))
 
-(deftest card-read-event-test
-  (testing :card-read
-    (doseq [dataset? [false true]]
-      (testing (if dataset? "Dataset" "Card")
-        (t2.with-temp/with-temp [Card card {:name "My Cool Card", :dataset dataset?}]
-          (is (= {:object card :user-id (mt/user->id :rasta)}
-                 (events/publish-event! :event/card-read {:object card :user-id (mt/user->id :rasta)})))
-          (is (partial=
-               {:topic    :card-read
-                :user_id  (mt/user->id :rasta)
-                :model    "Card"
-                :model_id (:id card)
-                :details  (cond-> {:name "My Cool Card", :description nil}
-                            dataset? (assoc :model? true))}
-               (latest-event "card-read" (:id card)))))))))
-
 (deftest card-query-event-test
   (testing :card-query
     (doseq [dataset? [false true]]
@@ -208,32 +192,6 @@
                                            :id          (:id dashcard)
                                            :card_id     (:id card)}]}}
              (latest-event "dashboard-remove-cards" (:id dashboard))))))))
-
-(deftest dashboard-read-event-test
-  (testing :dashboard-read
-    (t2.with-temp/with-temp [Dashboard dashboard {:name "My Cool Dashboard"}]
-      (is (= {:object dashboard :user-id (mt/user->id :rasta)}
-             (events/publish-event! :event/dashboard-read {:object dashboard :user-id (mt/user->id :rasta)})))
-      (is (partial=
-           {:topic    :dashboard-read
-            :user_id  (mt/user->id :rasta)
-            :model    "Dashboard"
-            :model_id (:id dashboard)
-            :details  {:name "My Cool Dashboard", :description nil}}
-           (latest-event "dashboard-read" (:id dashboard)))))))
-
-(deftest table-read-event-test
-  (testing :table-read
-    (t2.with-temp/with-temp [Table table {:name "My Cool Table"}]
-      (is (= {:object table :user-id (mt/user->id :rasta)}
-             (events/publish-event! :event/table-read {:object table :user-id (mt/user->id :rasta)})))
-      (is (partial=
-           {:topic    :table-read
-            :user_id  (mt/user->id :rasta)
-            :model    "Table"
-            :model_id (:id table)
-            :details  {}}
-           (latest-event "table-read" (:id table)))))))
 
 (deftest install-event-test
   (testing :install


### PR DESCRIPTION
Pretty straightforward—these events are going into `view_log`, since we're keeping it around, so they don't need to go into `audit_log` anymore.