### PR TITLE
Editing existing click behavior after target dashboard tab has been removed

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -350,7 +350,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       });
     });
 
-    it("should show error and disable form after target dashboard tab has been removed and there is more than 1 tab", () => {
+    it("should show error and disable the form after target dashboard tab has been removed and there is more than 1 tab left", () => {
       cy.createDashboard(TARGET_DASHBOARD, {
         wrapId: true,
         idAlias: "targetDashboardId",
@@ -410,7 +410,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       });
     });
 
-    it("should fall back to the first tab after target dashboard tab has been removed and there only 1 tab left", () => {
+    it("should fall back to the first tab after target dashboard tab has been removed and there is only 1 tab left", () => {
       cy.createDashboard(TARGET_DASHBOARD, {
         wrapId: true,
         idAlias: "targetDashboardId",

--- a/frontend/src/metabase-lib/parameters/utils/click-behavior.ts
+++ b/frontend/src/metabase-lib/parameters/utils/click-behavior.ts
@@ -245,7 +245,6 @@ function baseTypeFilterForParameterType(parameterType: string) {
 
 export function clickBehaviorIsValid(
   clickBehavior: ClickBehavior | undefined | null,
-  targetDashboard: Dashboard | undefined,
 ): boolean {
   // opens drill-through menu
   if (clickBehavior == null) {
@@ -267,21 +266,35 @@ export function clickBehaviorIsValid(
       return (clickBehavior.linkTemplate || "").length > 0;
     }
 
-    if (linkType === "dashboard") {
-      const tabs = targetDashboard?.tabs || [];
-      const dashboardTabExists = tabs.some(
-        tab => tab.id === clickBehavior.tabId,
-      );
-      return clickBehavior.targetId != null && dashboardTabExists;
-    }
-
-    if (linkType === "question") {
+    if (linkType === "dashboard" || linkType === "question") {
       return clickBehavior.targetId != null;
     }
   }
 
   // we've picked "link" without picking a link type
   return false;
+}
+
+export function canSaveClickBehavior(
+  clickBehavior: ClickBehavior | undefined | null,
+  targetDashboard: Dashboard | undefined,
+): boolean {
+  if (
+    clickBehavior?.type === "link" &&
+    clickBehavior.linkType === "dashboard"
+  ) {
+    const tabs = targetDashboard?.tabs || [];
+    const dashboardTabExists = tabs.some(tab => tab.id === clickBehavior.tabId);
+
+    if (tabs.length > 1 && !dashboardTabExists) {
+      // If the target dashboard tab has been deleted, and there are other tabs
+      // to choose from (we don't render <Select/> when there is only 1 tab)
+      // make user manually pick a new dashboard tab.
+      return false;
+    }
+  }
+
+  return clickBehaviorIsValid(clickBehavior);
 }
 
 export function formatSourceForTarget(

--- a/frontend/src/metabase-lib/parameters/utils/click-behavior.ts
+++ b/frontend/src/metabase-lib/parameters/utils/click-behavior.ts
@@ -245,6 +245,7 @@ function baseTypeFilterForParameterType(parameterType: string) {
 
 export function clickBehaviorIsValid(
   clickBehavior: ClickBehavior | undefined | null,
+  targetDashboard: Dashboard | undefined,
 ): boolean {
   // opens drill-through menu
   if (clickBehavior == null) {
@@ -262,13 +263,19 @@ export function clickBehaviorIsValid(
   if (clickBehavior.type === "link") {
     const { linkType } = clickBehavior;
 
-    // if it's not a crossfilter/action, it's a link
     if (linkType === "url") {
       return (clickBehavior.linkTemplate || "").length > 0;
     }
 
-    // if we're linking to a Metabase entity we just need a targetId
-    if (linkType === "dashboard" || linkType === "question") {
+    if (linkType === "dashboard") {
+      const tabs = targetDashboard?.tabs || [];
+      const dashboardTabExists = tabs.some(
+        tab => tab.id === clickBehavior.tabId,
+      );
+      return clickBehavior.targetId != null && dashboardTabExists;
+    }
+
+    if (linkType === "question") {
       return clickBehavior.targetId != null;
     }
   }

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.tsx
@@ -17,7 +17,10 @@ import type {
 } from "metabase-types/api";
 import { isTableDisplay } from "metabase/lib/click-behavior";
 import type { UiParameter } from "metabase-lib/parameters/types";
-import { clickBehaviorIsValid } from "metabase-lib/parameters/utils/click-behavior";
+import {
+  canSaveClickBehavior,
+  clickBehaviorIsValid,
+} from "metabase-lib/parameters/utils/click-behavior";
 
 import { getColumnKey } from "metabase-lib/queries/utils/get-column-key";
 import { getClickBehaviorForColumn } from "./utils";
@@ -99,7 +102,12 @@ function ClickBehaviorSidebar({
   });
 
   const isValidClickBehavior = useMemo(
-    () => clickBehaviorIsValid(clickBehavior, targetDashboard),
+    () => clickBehaviorIsValid(clickBehavior),
+    [clickBehavior],
+  );
+
+  const closeIsDisabled = useMemo(
+    () => !canSaveClickBehavior(clickBehavior, targetDashboard),
     [clickBehavior, targetDashboard],
   );
 
@@ -193,7 +201,7 @@ function ClickBehaviorSidebar({
     <Sidebar
       onClose={hideClickBehaviorSidebar}
       onCancel={handleCancel}
-      closeIsDisabled={!isValidClickBehavior}
+      closeIsDisabled={closeIsDisabled}
     >
       <ClickBehaviorSidebarHeader
         dashcard={dashcard}

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.tsx
@@ -3,6 +3,7 @@ import { getIn } from "icepick";
 
 import { useMount, usePrevious } from "react-use";
 
+import { useDashboardQuery } from "metabase/common/hooks";
 import Sidebar from "metabase/dashboard/components/Sidebar";
 
 import type {
@@ -90,9 +91,16 @@ function ClickBehaviorSidebar({
     }
   }, [dashcard, selectedColumn, hasSelectedColumn]);
 
+  const isDashboardLink =
+    clickBehavior?.type === "link" && clickBehavior.linkType === "dashboard";
+  const { data: targetDashboard } = useDashboardQuery({
+    enabled: isDashboardLink,
+    id: isDashboardLink ? clickBehavior.targetId : undefined,
+  });
+
   const isValidClickBehavior = useMemo(
-    () => clickBehaviorIsValid(clickBehavior),
-    [clickBehavior],
+    () => clickBehaviorIsValid(clickBehavior, targetDashboard),
+    [clickBehavior, targetDashboard],
   );
 
   const handleChangeSettings = useCallback(

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker.tsx
@@ -214,25 +214,6 @@ function LinkedEntityPicker({
     [clickBehavior, defaultDashboardTabId, isDashboard, updateSettings],
   );
 
-  useEffect(
-    function migrateDeletedTab() {
-      if (
-        isDashboard &&
-        !dashboardTabExists &&
-        typeof defaultDashboardTabId !== "undefined"
-      ) {
-        updateSettings({ ...clickBehavior, tabId: defaultDashboardTabId });
-      }
-    },
-    [
-      clickBehavior,
-      dashboardTabExists,
-      defaultDashboardTabId,
-      isDashboard,
-      updateSettings,
-    ],
-  );
-
   return (
     <div>
       <div className="pb1">
@@ -266,6 +247,11 @@ function LinkedEntityPicker({
 
       {isDashboard && dashboardTabs.length > 1 && (
         <Select
+          error={
+            dashboardTabExists
+              ? undefined
+              : t`The selected tab is no longer available`
+          }
           data={dashboardTabs.map(tab => ({
             label: tab.name,
             value: String(tab.id),

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker.tsx
@@ -214,6 +214,33 @@ function LinkedEntityPicker({
     [clickBehavior, defaultDashboardTabId, isDashboard, updateSettings],
   );
 
+  useEffect(
+    // If the target dashboard tab has been deleted, and there are no other tabs
+    // to choose from (we don't render <Select/> when there is only 1 tab)
+    // automatically pick the correct target dashboard tab for the user.
+    // Otherwise, make user manually pick a new dashboard tab.
+    function migrateDeletedTab() {
+      if (
+        isDashboard &&
+        !dashboardTabExists &&
+        dashboard?.tabs &&
+        dashboard.tabs.length < 2 &&
+        typeof dashboardTabId !== "undefined"
+      ) {
+        updateSettings({ ...clickBehavior, tabId: defaultDashboardTabId });
+      }
+    },
+    [
+      clickBehavior,
+      dashboard,
+      dashboardTabId,
+      dashboardTabExists,
+      defaultDashboardTabId,
+      isDashboard,
+      updateSettings,
+    ],
+  );
+
   return (
     <div>
       <div className="pb1">


### PR DESCRIPTION
Closes #35524

### Description

When editing existing click behavior that points to a dashboard tab that has been removed:
1. if there is more than 1 tab left, show an error, clear tabs dropdown value and make user manually pick new target dashboard tab (disable the "Done" button until this happens) (see [Slack](https://metaboat.slack.com/archives/C0645JP1W81/p1699476408213059?thread_ts=1699286399.660789&cid=C0645JP1W81))
2. if there is only 1 tab left (we don't show tabs dropdown) automatically pick new target dashboard tab (see [Slack](https://metaboat.slack.com/archives/C0645JP1W81/p1699516518994459?thread_ts=1699286399.660789&cid=C0645JP1W81))

### Demo


https://github.com/metabase/metabase/assets/6830683/ccdcd097-a367-4978-86d9-e49b5d466e79

