### PR TITLE
Refine CI triggers for `snowplow` workflow

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -95,7 +95,7 @@ e2e_all:
   - *e2e_specs
 
 snowplow:
-  - *ci
+  - ".github/workflows/snowplow.yml"
   - "snowplow/**"
 
 documentation:


### PR DESCRIPTION
A part of #34880.

No need to run this workflow for any change in `./.github/**` folder when it really only depends on `.github/workflows/snowplow.yml`

## Tests
- [Snowplow ran on a relevant file change](https://github.com/metabase/metabase/actions/runs/6810805943/job/18519858449?pr=35528) ✅ 
- [Snowplow didn't run and didn't block PR on irrelevant file change](https://github.com/metabase/metabase/actions/runs/6810830429/job/18519938485?pr=35529)