### PR TITLE
Refine CI triggers for `i18n` workflow

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -112,7 +112,9 @@ codeql:
 
 i18n:
   - *default
-  - *ci
+  - ".github/actions/prepare-frontend/**"
+  - ".github/actions/prepare-backend/**"
+  - ".github/workflows/i18n.yml"
   - *sources
 
 visualizations:

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -12,8 +12,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  files-changed:
+    name: Check which files changed
+    runs-on: ubuntu-22.04
+    timeout-minutes: 3
+    outputs:
+      i18n: ${{ steps.changes.outputs.i18n }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Test which files changed
+        uses: dorny/paths-filter@v2.11.1
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-paths.yaml
 
   verify-i18n-files:
+    needs: files-changed
+    if: needs.files-changed.outputs.i18n == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
A part of #34880

Although we had an entry for this defined in file-paths.yml, we never used it before. This PR is doing two things:
1. it adds "which files changed" to the workflow
2. it refines CI triggers for i18n workflow to not include all files under the github folder

> **Note**
> This workflow ran more than 30k times so far!

## Test
- [Expect i18n workflow to run on change in the workflow itself](https://github.com/metabase/metabase/actions/runs/6811806979/job/18522897146?pr=35534) ✅ 
- [Expect i18n workflow to run on change in `bin/` folder](https://github.com/metabase/metabase/actions/runs/6811872539/job/18523097587?pr=35535) ✅
- [Exepct i18n workflow to not run on unrelated change](https://github.com/metabase/metabase/actions/runs/6811918888/job/18523226667?pr=35536) ✅