### PR TITLE
fix iframe-resizer readyCallback to onReady

### DIFF
--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -426,7 +426,7 @@ export function initializeIframeResizer(onReady = () => {}) {
     window.iFrameResizer = {
       autoResize: true,
       heightCalculationMethod: "max",
-      onReady: onReady,
+      onReady,
     };
 
     // FIXME: Crimes

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -412,7 +412,7 @@ export function clipPathReference(id) {
   return `url(${url})`;
 }
 
-export function initializeIframeResizer(readyCallback = () => {}) {
+export function initializeIframeResizer(onReady = () => {}) {
   if (!isWithinIframe()) {
     return;
   }
@@ -421,12 +421,12 @@ export function initializeIframeResizer(readyCallback = () => {}) {
   // have their embeds autosize to their content
   if (window.iFrameResizer) {
     console.error("iFrameResizer resizer already defined.");
-    readyCallback();
+    onReady();
   } else {
     window.iFrameResizer = {
       autoResize: true,
       heightCalculationMethod: "max",
-      readyCallback: readyCallback,
+      onReady: onReady,
     };
 
     // FIXME: Crimes


### PR DESCRIPTION
fix this warning
```[iFrameSizer][iFrameResizer0] Deprecated: 'readyCallback' has been renamed 'onReady'. The old method will be removed in the next major version.```