### PR TITLE
Fix possibility of e2e-update-cards-only-test failure

### DIFF
--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1535,7 +1535,9 @@
        DashboardCardSeries _                   {:dashboardcard_id dashcard-id-1, :card_id series-id-1
                                                 :position         0}]
       ;; send a request that update and create and delete some cards at the same time
-      (let [cards (:dashcards (mt/user-http-request
+      (let [get-revision-count (fn [] (t2/count :model/Revision :model_id dashboard-id :model "Dashboard"))
+            revisions-before   (get-revision-count)
+            cards (:dashcards (mt/user-http-request
                                :crowberto :put 200 (format "dashboard/%d" dashboard-id)
                                {:dashcards [{:id      dashcard-id-1
                                              :size_x  4
@@ -1584,15 +1586,16 @@
                             :action_id    nil
                             :row          3
                             :col          3
-                            :series       [{:name "Series Card 1"}]}]
+                            :series       [{:name "Series Card 1"}]}
+            revisions-after (get-revision-count)]
         (is (=? [updated-card-1
                  updated-card-2
                  new-card]
                 cards))
         ;; dashcard 3 is deleted
         (is (nil? (t2/select-one DashboardCard :id dashcard-id-3)))
-        (testing "only one revision is created"
-          (is (= 1 (t2/count :model/Revision :model_id dashboard-id))))))))
+        (testing "only one revision is created from the request"
+          (is (= 1 (- revisions-after revisions-before))))))))
 
 (deftest e2e-update-tabs-only-test
   (testing "PUT /api/dashboard/:id/cards with create/update/delete tabs in a single req"


### PR DESCRIPTION
This PR fixes the possibility that `e2e-update-cards-only-test` fails because there are other revisions in the app DB with the same `model_id`.