### PR TITLE
avoid calling fetchCardData in undoRemoveCardFromDashboard for virtual cards

### DIFF
--- a/e2e/test/scenarios/dashboard/reproductions/12926-editing-dashboards-doesnt-cancel-running-queries.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/12926-editing-dashboards-doesnt-cancel-running-queries.cy.spec.js
@@ -1,8 +1,10 @@
 import {
+  addTextBox,
   editDashboard,
   getDashboardCard,
   openQuestionsSidebar,
   popover,
+  removeDashboardCard,
   restore,
   saveDashboard,
   setFilter,
@@ -73,6 +75,20 @@ describe("issue 12926", () => {
       cy.wait("@dashcardQueryRestored");
 
       getDashboardCard().findByText(queryResult);
+    });
+
+    it("should not break virtual cards (metabase#35545)", () => {
+      cy.createDashboard().then(({ body: { id: dashboardId } }) => {
+        visitDashboard(dashboardId);
+      });
+
+      addTextBox("Text card content");
+
+      removeDashboardCard();
+
+      undo();
+
+      getDashboardCard().findByText("Text card content");
     });
   });
 

--- a/frontend/src/metabase/dashboard/actions/cards.js
+++ b/frontend/src/metabase/dashboard/actions/cards.js
@@ -13,6 +13,7 @@ import { createCard } from "metabase/lib/card";
 import { getVisualizationRaw } from "metabase/visualizations";
 import { trackCardCreated } from "../analytics";
 import { getDashCardById } from "../selectors";
+import { isVirtualDashCard } from "../utils";
 import {
   ADD_CARD_TO_DASH,
   REMOVE_CARD_FROM_DASH,
@@ -77,7 +78,9 @@ export const undoRemoveCardFromDashboard = createThunkAction(
       const dashcard = getDashCardById(getState(), dashcardId);
       const card = dashcard.card;
 
-      dispatch(fetchCardData(card, dashcard));
+      if (!isVirtualDashCard(dashcard)) {
+        dispatch(fetchCardData(card, dashcard));
+      }
 
       return { dashcardId };
     },


### PR DESCRIPTION
### Description

_I definitely did not introduced this bug with my first pull request._

`undoRemoveCardFromDashboard` refetches the data for cards, this was added in #32842 to fix a bug with slow queries


I believe this is scope of dash viz, if not please tell me who to ask the review to

### Demo

Before:

https://github.com/metabase/metabase/assets/1914270/6d6c44de-9000-4be4-bb9f-48e8e00650a1

After:


https://github.com/metabase/metabase/assets/1914270/b207b4dc-37ff-41a4-9054-6c1964d7d934




