### PR TITLE
Add don't bin option for temporal bucketing

### DIFF
--- a/e2e/test/scenarios/binning/binning-options.cy.spec.js
+++ b/e2e/test/scenarios/binning/binning-options.cy.spec.js
@@ -79,6 +79,7 @@ const TIME_BUCKETS = [
   "Week of year",
   "Month of year",
   "Quarter of year",
+  "Don't bin",
 ];
 
 const LONGITUDE_BUCKETS = [
@@ -191,7 +192,8 @@ describe("scenarios > binning > binning options", () => {
   });
 
   context("via time series footer (metabase#11183)", () => {
-    it("should render time series binning options correctly", () => {
+    // TODO: enable again when metabase#35546 is completed
+    it.skip("should render time series binning options correctly", () => {
       openTable({ table: ORDERS_ID });
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/frontend/src/metabase-lib/test-helpers.ts
+++ b/frontend/src/metabase-lib/test-helpers.ts
@@ -95,6 +95,10 @@ export const findTemporalBucket = (
   column: ML.ColumnMetadata,
   bucketName: string,
 ) => {
+  if (bucketName === "Don't bin") {
+    return null;
+  }
+
   const buckets = ML.availableTemporalBuckets(query, 0, column);
   const bucket = buckets.find(
     bucket => ML.displayInfo(query, 0, bucket).displayName === bucketName,

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BucketPickerPopover.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BucketPickerPopover.unit.spec.tsx
@@ -62,8 +62,9 @@ describe("BucketPickerPopover", () => {
 
     userEvent.click(screen.getByRole("button", { name: "More…" }));
 
-    const bucketsSize = buckets.length + 1; // includes Don't bin
-    expect(screen.getAllByRole("menuitem")).toHaveLength(bucketsSize);
+    expect(screen.getAllByRole("menuitem")).toHaveLength(
+      [...buckets, "Don't bin"].length,
+    );
   });
 
   it("shouldn't show the More button if there are a few buckets", async () => {
@@ -82,8 +83,9 @@ describe("BucketPickerPopover", () => {
     const column = Lib.withTemporalBucket(dateColumn, lastBucket);
     await setupTemporalBucketPicker({ column });
 
-    const bucketsSize = buckets.length + 1; // includes Don't bin
-    expect(screen.getAllByRole("menuitem")).toHaveLength(bucketsSize);
+    expect(screen.getAllByRole("menuitem")).toHaveLength(
+      [...buckets, "Don't bin"].length,
+    );
     expect(screen.queryByText("More…")).not.toBeInTheDocument();
   });
 
@@ -118,7 +120,8 @@ describe("BucketPickerPopover", () => {
     userEvent.click(screen.getByLabelText("Temporal bucket"));
     await screen.findByText("Month");
 
-    const bucketsSize = buckets.length + 1; // includes Don't bin
-    expect(screen.getAllByRole("menuitem")).toHaveLength(bucketsSize);
+    expect(screen.getAllByRole("menuitem")).toHaveLength(
+      [...buckets, "Don't bin"].length,
+    );
   });
 });

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BucketPickerPopover.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BucketPickerPopover.unit.spec.tsx
@@ -62,7 +62,8 @@ describe("BucketPickerPopover", () => {
 
     userEvent.click(screen.getByRole("button", { name: "More…" }));
 
-    expect(screen.getAllByRole("menuitem")).toHaveLength(buckets.length);
+    const bucketsSize = buckets.length + 1; // includes Don't bin
+    expect(screen.getAllByRole("menuitem")).toHaveLength(bucketsSize);
   });
 
   it("shouldn't show the More button if there are a few buckets", async () => {
@@ -81,7 +82,8 @@ describe("BucketPickerPopover", () => {
     const column = Lib.withTemporalBucket(dateColumn, lastBucket);
     await setupTemporalBucketPicker({ column });
 
-    expect(screen.getAllByRole("menuitem")).toHaveLength(buckets.length);
+    const bucketsSize = buckets.length + 1; // includes Don't bin
+    expect(screen.getAllByRole("menuitem")).toHaveLength(bucketsSize);
     expect(screen.queryByText("More…")).not.toBeInTheDocument();
   });
 
@@ -116,6 +118,7 @@ describe("BucketPickerPopover", () => {
     userEvent.click(screen.getByLabelText("Temporal bucket"));
     await screen.findByText("Month");
 
-    expect(screen.getAllByRole("menuitem")).toHaveLength(buckets.length);
+    const bucketsSize = buckets.length + 1; // includes Don't bin
+    expect(screen.getAllByRole("menuitem")).toHaveLength(bucketsSize);
   });
 });

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/TemporalBucketPickerPopover.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/TemporalBucketPickerPopover.tsx
@@ -23,7 +23,10 @@ export function TemporalBucketPickerPopover({
   const selectedBucket = useMemo(() => Lib.temporalBucket(column), [column]);
 
   const items = useMemo(
-    () => buckets.map(bucket => getBucketListItem(query, stageIndex, bucket)),
+    () => [
+      ...buckets.map(bucket => getBucketListItem(query, stageIndex, bucket)),
+      { displayName: t`Don't bin`, bucket: null },
+    ],
     [query, stageIndex, buckets],
   );
 
@@ -50,5 +53,5 @@ export function TemporalBucketPickerPopover({
 }
 
 function renderTriggerContent(bucket?: Lib.BucketDisplayInfo) {
-  return bucket ? t`by ${bucket.displayName.toLowerCase()}` : null;
+  return bucket ? t`by ${bucket.displayName.toLowerCase()}` : t`Unbinned`;
 }

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/TemporalBucketPickerPopover.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/TemporalBucketPickerPopover.tsx
@@ -8,6 +8,10 @@ import {
   getBucketListItem,
 } from "./BaseBucketPickerPopover";
 
+function checkBucketIsSelected(item: BucketListItem) {
+  return !!item.selected;
+}
+
 export function TemporalBucketPickerPopover({
   query,
   stageIndex,
@@ -22,9 +26,13 @@ export function TemporalBucketPickerPopover({
   const items = useMemo(
     () => [
       ...buckets.map(bucket => getBucketListItem(query, stageIndex, bucket)),
-      { displayName: t`Don't bin`, bucket: null },
+      {
+        displayName: t`Don't bin`,
+        bucket: null,
+        selected: !selectedBucket && isEditing,
+      },
     ],
-    [query, stageIndex, buckets],
+    [buckets, selectedBucket, isEditing, query, stageIndex],
   );
 
   const handleBucketSelect = useCallback(
@@ -32,19 +40,6 @@ export function TemporalBucketPickerPopover({
       onSelect(Lib.withTemporalBucket(column, bucket));
     },
     [column, onSelect],
-  );
-
-  const checkBucketIsSelected = useCallback(
-    (item: BucketListItem) => {
-      // `bucket: null` represents the "Don't bin" option
-      // It's considered selected when editing an existing clause without a binning strategy
-      if (item.bucket === null) {
-        return !selectedBucket && isEditing;
-      }
-
-      return !!item.selected;
-    },
-    [selectedBucket, isEditing],
   );
 
   return (

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/TemporalBucketPickerPopover.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/TemporalBucketPickerPopover.tsx
@@ -8,15 +8,12 @@ import {
   getBucketListItem,
 } from "./BaseBucketPickerPopover";
 
-function checkBucketIsSelected(item: BucketListItem) {
-  return !!item.selected;
-}
-
 export function TemporalBucketPickerPopover({
   query,
   stageIndex,
   column,
   buckets,
+  isEditing,
   onSelect,
   ...props
 }: CommonBucketPickerProps) {
@@ -37,10 +34,24 @@ export function TemporalBucketPickerPopover({
     [column, onSelect],
   );
 
+  const checkBucketIsSelected = useCallback(
+    (item: BucketListItem) => {
+      // `bucket: null` represents the "Don't bin" option
+      // It's considered selected when editing an existing clause without a binning strategy
+      if (item.bucket === null) {
+        return !selectedBucket && isEditing;
+      }
+
+      return !!item.selected;
+    },
+    [selectedBucket, isEditing],
+  );
+
   return (
     <BaseBucketPickerPopover
       {...props}
       query={query}
+      isEditing={isEditing}
       stageIndex={stageIndex}
       items={items}
       selectedBucket={selectedBucket}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.unit.spec.tsx
@@ -35,7 +35,7 @@ function createQueryWithBinning(bucketName = "10 bins") {
   return { query, columnInfo: Lib.displayInfo(query, 0, columnWithBinning) };
 }
 
-function createQueryWithTemporalBreakout(bucketName = "Quarter") {
+function createQueryWithTemporalBreakout(bucketName: string) {
   const initialQuery = createQuery();
   const findColumn = columnFinder(
     initialQuery,
@@ -260,7 +260,7 @@ describe("BreakoutStep", () => {
     });
 
     it("should highlight selected temporal bucket", async () => {
-      const { query } = createQueryWithTemporalBreakout();
+      const { query } = createQueryWithTemporalBreakout("Quarter");
       setup(createMockNotebookStep({ topLevelQuery: query }));
 
       userEvent.click(screen.getByText("Created At: Quarter"));
@@ -273,26 +273,29 @@ describe("BreakoutStep", () => {
     });
 
     it("should handle `Don't bin` option for temporal bucket (metabase#19684)", async () => {
-      const { query, columnInfo } =
-        createQueryWithTemporalBreakout("Don't bin");
+      const { query } = createQueryWithTemporalBreakout("Don't bin");
       setup(createMockNotebookStep({ topLevelQuery: query }));
 
-      userEvent.click(screen.getByText(columnInfo.displayName));
+      userEvent.click(screen.getByText("Created At"));
       const option = screen.getByRole("option", {
-        name: columnInfo.displayName,
+        name: "Created At",
       });
 
       expect(within(option).getByText("Unbinned")).toBeInTheDocument();
 
-      // verifies Created At is rendered without binning
-      const step = screen.getByTestId("breakout-step");
+      userEvent.click(within(option).getByLabelText("Temporal bucket"));
+
+      // click on More... item as Don't bin is hidden
+      // userEvent.click closes popup
+      fireEvent.click(await screen.findByText("More…"));
+
       expect(
-        within(step).getByText(columnInfo.displayName),
-      ).toBeInTheDocument();
+        await screen.findByRole("menuitem", { name: "Don't bin" }),
+      ).toHaveAttribute("aria-selected", "true");
     });
 
     it("shouldn't update a query when clicking a selected column with temporal bucketing", async () => {
-      const { query } = createQueryWithTemporalBreakout();
+      const { query } = createQueryWithTemporalBreakout("Quarter");
       const { updateQuery } = setup(
         createMockNotebookStep({ topLevelQuery: query }),
       );


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/19684
Closes https://github.com/metabase/metabase/issues/35550

### Description

Add `Don't bin` option for temporal bucketing.

Doesn't cover https://github.com/metabase/metabase/issues/35546

### How to verify

Create a new question like in [figma](https://www.figma.com/file/HPg8IDPGo9seZafglWmhIk/Querying-Bug-Fixes?type=design&node-id=101-30315&mode=design&t=zAUnLpMXJI49RCXz-0)
`Don't bin` should be on the list

### Demo


https://github.com/metabase/metabase/assets/125459446/e67dbc3d-5765-46a0-8f8f-1379dd2d7157

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
