### PR TITLE
Fix Custom Label Line Height in Radio Component

### DIFF
--- a/frontend/src/metabase/ui/components/inputs/Radio/Radio.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Radio/Radio.styled.tsx
@@ -60,7 +60,6 @@ export const getRadioOverrides = (): MantineThemeOverride["components"] => ({
         color: theme.colors.text[2],
         fontSize: theme.fontSizes.md,
         fontWeight: "bold",
-        lineHeight: theme.lineHeight,
       },
       description: {
         ref: getStylesRef("description"),


### PR DESCRIPTION
**Problem:** Our new radio component from Mantine is having a custom line height set that does not match the height of the radio itself. This is causing the label to not be center aligned with the radio. This PR fixes that.

**Context**
_Old_
![Screenshot from 2023-11-09 17-56-02](https://github.com/metabase/metabase/assets/22608765/cb63ba9a-8343-46bd-9afc-770059c99ca3)

_New_
![Screenshot from 2023-11-09 17-56-14](https://github.com/metabase/metabase/assets/22608765/0c5bef00-dad7-4ca9-a947-156f2e148f0a)

_Old_
![Screenshot from 2023-11-09 17-55-53](https://github.com/metabase/metabase/assets/22608765/5578cd94-493a-4cc6-b014-0660bd2eaebc)

_New_
![Screenshot from 2023-11-09 17-56-19](https://github.com/metabase/metabase/assets/22608765/bf358bf1-b961-41ea-a035-9ba3359cb948)


**Desired Behavior**/**Acceptance Criteria**
- [ ] Radio labels are center aligned with their radio component