### PR TITLE
Remove skipped tests for #13764 

### DIFF
--- a/e2e/test/scenarios/question/nested.cy.spec.js
+++ b/e2e/test/scenarios/question/nested.cy.spec.js
@@ -150,33 +150,6 @@ describe("scenarios > question > nested", () => {
     cy.findAllByText("13");
   });
 
-  it.skip("should display granularity for aggregated fields in nested questions (metabase#13764)", () => {
-    openOrdersTable({ mode: "notebook" });
-
-    // add initial aggregation ("Average of Total by Order ID")
-    summarize({ mode: "notebook" });
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Average of ...").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Total").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Pick a column to group by").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("ID").click();
-
-    // add another aggregation ("Count by Average of Total")
-    summarize({ mode: "notebook" });
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Count of rows").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Pick a column to group by").click();
-    cy.log("Reported failing on v0.34.3 - v0.37.0.2");
-    popover()
-      .contains("Average of Total")
-      .closest(".List-item")
-      .contains("Auto binned");
-  });
-
   it("should apply metrics including filter to the nested question (metabase#12507)", () => {
     const metric = {
       name: "Sum of discounts",

--- a/e2e/test/scenarios/question/nested.cy.spec.js
+++ b/e2e/test/scenarios/question/nested.cy.spec.js
@@ -1,7 +1,6 @@
 import {
   restore,
   popover,
-  openOrdersTable,
   remapDisplayValueToFK,
   visitQuestion,
   visitQuestionAdhoc,

--- a/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.unit.spec.tsx
@@ -4,7 +4,6 @@ import * as Lib from "metabase-lib";
 import {
   columnFinder,
   createQuery,
-  findAggregationOperator,
   findBinningStrategy,
   findTemporalBucket,
 } from "metabase-lib/test-helpers";

--- a/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.unit.spec.tsx
@@ -51,23 +51,6 @@ function createQueryWithTemporalBreakout() {
   };
 }
 
-function applyAggregation(
-  query: Lib.Query,
-  operatorShortName: string,
-  stageIndex = 0,
-): Lib.Query {
-  const operator = findAggregationOperator(query, operatorShortName);
-
-  const findColumn = columnFinder(
-    query,
-    Lib.aggregationOperatorColumns(operator),
-  );
-  const column = findColumn("ORDERS", "TOTAL");
-  const clause = Lib.aggregationClause(operator, column);
-
-  return Lib.aggregate(query, stageIndex, clause);
-}
-
 function setup(step = createMockNotebookStep()) {
   const updateQuery = jest.fn();
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.unit.spec.tsx
@@ -283,33 +283,5 @@ describe("BreakoutStep", () => {
 
       expect(updateQuery).not.toHaveBeenCalled();
     });
-
-    it("should support binning for nested numeric fields (metabase#13764)", () => {
-      const { query: queryWithBreakout, initialQuery } =
-        createQueryWithBreakout();
-      const query = applyAggregation(queryWithBreakout, "avg");
-
-      setup(
-        createMockNotebookStep({
-          topLevelQuery: Lib.appendStage(query),
-          stageIndex: 1,
-          itemIndex: null,
-          type: "summarize",
-          previous: createMockNotebookStep({
-            topLevelQuery: initialQuery,
-            stageIndex: 0,
-          }),
-        }),
-      );
-
-      userEvent.click(screen.getByText("Pick a column to group by"));
-
-      const option = screen.getByLabelText("Average of Total");
-      expect(option).toBeInTheDocument();
-
-      // TODO [13764]: Enable this test after resolving the issue in MBQLv2
-      // userEvent.hover(option);
-      // expect(within(option).getByText("Auto bin")).toBeInTheDocument();
-    });
   });
 });


### PR DESCRIPTION
#13674 is a limitation, not a bug, and there is no way in a million years we are going to be able to present binning options for columns that we don't have a min and max value for. This PR removes the skipped tests for that issue.