### PR TITLE
Align combo chart ticks, axes names

### DIFF
--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -110,7 +110,12 @@ export type VisualizationSettings = {
   // X-axis
   "graph.x_axis.title_text"?: string;
   "graph.x_axis.scale"?: "ordinal" | "timeseries" | "linear" | "histogram";
-  "graph.x_axis.axis_enabled"?: "compact";
+  "graph.x_axis.axis_enabled"?:
+    | true
+    | false
+    | "compact"
+    | "rotate-45"
+    | "rotate-90";
 
   // Y-axis
   "graph.y_axis.title_text"?: string;

--- a/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.stories.tsx
+++ b/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.stories.tsx
@@ -3,6 +3,7 @@ import { color } from "metabase/lib/colors";
 import { formatStaticValue } from "metabase/static-viz/lib/format";
 import { measureTextWidth } from "metabase/static-viz/lib/text";
 import * as questions from "metabase/static-viz/components/ComboChart/stories-data";
+import type { RenderingContext } from "metabase/visualizations/types";
 import { ComboChart } from "./ComboChart";
 
 export default {
@@ -11,17 +12,31 @@ export default {
 };
 
 const Template: ComponentStory<typeof ComboChart> = args => {
-  return <ComboChart {...args} />;
+  return (
+    <div style={{ border: "1px solid black", display: "inline-block" }}>
+      <ComboChart {...args} />
+    </div>
+  );
+};
+
+const renderingContext: RenderingContext = {
+  getColor: color,
+  formatValue: formatStaticValue as any,
+  measureText: (text, style) =>
+    measureTextWidth(text, style.size, style.weight),
+  fontFamily: "Lato",
+};
+
+export const SplitYAxis = Template.bind({});
+SplitYAxis.args = {
+  rawSeries: questions.autoYSplit as any,
+  dashcardSettings: {},
+  renderingContext,
 };
 
 export const Default = Template.bind({});
 Default.args = {
-  rawSeries: questions.autoYSplit as any,
+  rawSeries: questions.messedUpAxis as any,
   dashcardSettings: {},
-  renderingContext: {
-    getColor: color,
-    formatValue: formatStaticValue as any,
-    measureText: measureTextWidth as any,
-    fontFamily: "Lato",
-  },
+  renderingContext,
 };

--- a/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
+++ b/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
@@ -11,7 +11,7 @@ import { computeStaticComboChartSettings } from "./settings";
 
 const WIDTH = 540;
 const HEIGHT = 360;
-const LEGEND_PADDING = 24;
+const LEGEND_PADDING = 8;
 
 export const ComboChart = ({
   rawSeries,
@@ -41,7 +41,7 @@ export const ComboChart = ({
 
   const legendItems = getLegendItems(chartModel);
   const { height: legendHeight, items: legendLayoutItems } =
-    calculateLegendRows(legendItems, width, LEGEND_PADDING);
+    calculateLegendRows(legendItems, width, LEGEND_PADDING, LEGEND_PADDING);
 
   const option = getCartesianChartOption(
     chartModel,
@@ -56,7 +56,7 @@ export const ComboChart = ({
   return (
     <svg width={width} height={height + legendHeight}>
       <Legend items={legendLayoutItems} />
-      <Group y={height + legendHeight}>
+      <Group top={legendHeight}>
         <g dangerouslySetInnerHTML={{ __html: chartSvg }}></g>
       </Group>
     </svg>

--- a/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
+++ b/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
@@ -17,6 +17,10 @@ import {
 import { getCommonStaticVizSettings } from "metabase/static-viz/lib/settings";
 import {
   getDefaultStackingValue,
+  getDefaultXAxisTitle,
+  getDefaultYAxisTitle,
+  getIsXAxisLabelEnabledDefault,
+  getIsYAxisLabelEnabledDefault,
   getSeriesOrderVisibilitySettings,
   isStackingValueValid,
 } from "metabase/visualizations/shared/settings/cartesian-chart";
@@ -24,6 +28,7 @@ import {
   getCardsColumns,
   getCardsSeriesModels,
 } from "metabase/visualizations/echarts/cartesian/model";
+import { getDimensionModel } from "metabase/visualizations/echarts/cartesian/model/series";
 import type { LegacySeriesSettingsObjectKey } from "metabase/visualizations/echarts/cartesian/model/types";
 
 const fillWithDefaultValue = (
@@ -93,9 +98,11 @@ export const computeStaticComboChartSettings = (
   const settings = getCommonStaticVizSettings(rawSeries, dashcardSettings);
 
   const cardsColumns = getCardsColumns(rawSeries, settings);
+  const dimensionModel = getDimensionModel(rawSeries, cardsColumns);
   const seriesModels = getCardsSeriesModels(
     rawSeries,
     cardsColumns,
+    settings,
     renderingContext,
   );
 
@@ -130,6 +137,36 @@ export const computeStaticComboChartSettings = (
     "graph.series_order",
     getSeriesOrderVisibilitySettings(settings, seriesVizSettingsKeys),
   );
+
+  fillWithDefaultValue(
+    settings,
+    "graph.y_axis.title_text",
+    getDefaultYAxisTitle(
+      seriesModels.map(seriesModel => seriesModel.column.display_name),
+    ),
+  );
+
+  fillWithDefaultValue(
+    settings,
+    "graph.y_axis.labels_enabled",
+    getIsYAxisLabelEnabledDefault(),
+  );
+
+  fillWithDefaultValue(
+    settings,
+    "graph.x_axis.labels_enabled",
+    getIsXAxisLabelEnabledDefault(),
+  );
+
+  fillWithDefaultValue(
+    settings,
+    "graph.x_axis.title_text",
+    getDefaultXAxisTitle(dimensionModel.column),
+  );
+
+  fillWithDefaultValue(settings, "graph.x_axis.axis_enabled", true);
+
+  fillWithDefaultValue(settings, "graph.y_axis.axis_enabled", true);
 
   return settings;
 };

--- a/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
+++ b/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
@@ -168,5 +168,35 @@ export const computeStaticComboChartSettings = (
 
   fillWithDefaultValue(settings, "graph.y_axis.axis_enabled", true);
 
+  fillWithDefaultValue(
+    settings,
+    "graph.y_axis.title_text",
+    getDefaultYAxisTitle(
+      seriesModels.map(seriesModel => seriesModel.column.display_name),
+    ),
+  );
+
+  fillWithDefaultValue(
+    settings,
+    "graph.y_axis.labels_enabled",
+    getIsYAxisLabelEnabledDefault(),
+  );
+
+  fillWithDefaultValue(
+    settings,
+    "graph.x_axis.labels_enabled",
+    getIsXAxisLabelEnabledDefault(),
+  );
+
+  fillWithDefaultValue(
+    settings,
+    "graph.x_axis.title_text",
+    getDefaultXAxisTitle(dimensionModel.column),
+  );
+
+  fillWithDefaultValue(settings, "graph.x_axis.axis_enabled", true);
+
+  fillWithDefaultValue(settings, "graph.y_axis.axis_enabled", true);
+
   return settings;
 };

--- a/frontend/src/metabase/static-viz/components/ComboChart/stories-data.ts
+++ b/frontend/src/metabase/static-viz/components/ComboChart/stories-data.ts
@@ -887,3 +887,317 @@ export const autoYSplit = [
     },
   },
 ];
+
+export const messedUpAxis = [
+  {
+    card: {
+      description: null,
+      archived: false,
+      collection_position: null,
+      table_id: 2,
+      result_metadata: [
+        {
+          description: "The total billed amount.",
+          semantic_type: null,
+          coercion_strategy: null,
+          name: "TOTAL",
+          settings: null,
+          fk_target_field_id: null,
+          field_ref: [
+            "field",
+            15,
+            {
+              "base-type": "type/Float",
+              binning: {
+                strategy: "num-bins",
+                "min-value": 0,
+                "max-value": 160,
+                "num-bins": 8,
+                "bin-width": 20,
+              },
+            },
+          ],
+          effective_type: "type/Float",
+          id: 15,
+          visibility_type: "normal",
+          display_name: "Total",
+          fingerprint: {
+            global: { "distinct-count": 4426, "nil%": 0 },
+            type: {
+              "type/Number": {
+                min: 8.93914247937167,
+                q1: 51.34535490743823,
+                q3: 110.29428389265787,
+                max: 159.34900526552292,
+                sd: 34.26469575709948,
+                avg: 80.35871658771228,
+              },
+            },
+          },
+          base_type: "type/Float",
+        },
+        {
+          display_name: "Count",
+          semantic_type: "type/Quantity",
+          field_ref: ["aggregation", 0],
+          name: "count",
+          base_type: "type/BigInteger",
+          effective_type: "type/BigInteger",
+          fingerprint: {
+            global: { "distinct-count": 9, "nil%": 0 },
+            type: {
+              "type/Number": {
+                min: 1,
+                q1: 665.25,
+                q3: 2988.5,
+                max: 4107,
+                sd: 1513.4439295123484,
+                avg: 2084.4444444444443,
+              },
+            },
+          },
+        },
+      ],
+      include_xls: false,
+      database_id: 1,
+      enable_embedding: false,
+      collection_id: null,
+      query_type: "query",
+      name: "sv: ugly axis",
+      creator_id: 1,
+      updated_at: "2023-11-06T20:09:59.417123-03:00",
+      made_public_by_id: null,
+      embedding_params: null,
+      cache_ttl: null,
+      dataset_query: {
+        database: 1,
+        type: "query",
+        query: {
+          "source-table": 2,
+          aggregation: [["count"]],
+          breakout: [
+            [
+              "field",
+              15,
+              { "base-type": "type/Float", binning: { strategy: "default" } },
+            ],
+          ],
+        },
+      },
+      id: 63,
+      parameter_mappings: [],
+      include_csv: false,
+      display: "bar",
+      entity_id: "hEsBfhQIjP_kAu8mDvP7W",
+      collection_preview: true,
+      visualization_settings: {
+        "graph.x_axis.scale": "ordinal",
+        "graph.x_axis.axis_enabled": "rotate-45",
+        series_settings: {
+          count: {
+            axis: "left",
+            title: "CountCountCountCountCountCountCountCountCountCount",
+            display: "area",
+          },
+        },
+        "graph.dimensions": ["TOTAL"],
+        column_settings: {
+          '["ref",["field",15,{"base-type":"type/Float"}]]': {
+            prefix: "2323________11111232323",
+            suffix: "232323___________2222232323",
+          },
+          '["name","count"]': {
+            prefix: "____________________________",
+            suffix: "____________________________",
+          },
+        },
+        "graph.metrics": ["count"],
+      },
+      metabase_version: "v0.47.1-SNAPSHOT (d46d14f)",
+      parameters: [],
+      dataset: false,
+      created_at: "2023-11-06T20:02:07.70439",
+      public_uuid: null,
+    },
+    data: {
+      cols: [
+        {
+          description: "The total billed amount.",
+          semantic_type: null,
+          table_id: 2,
+          coercion_strategy: null,
+          binning_info: {
+            min_value: 0,
+            max_value: 160,
+            num_bins: 8,
+            bin_width: 20,
+            binning_strategy: "num-bins",
+          },
+          name: "TOTAL",
+          settings: null,
+          source: "breakout",
+          fk_target_field_id: null,
+          field_ref: [
+            "field",
+            15,
+            {
+              "base-type": "type/Float",
+              binning: {
+                strategy: "num-bins",
+                "min-value": 0,
+                "max-value": 160,
+                "num-bins": 8,
+                "bin-width": 20,
+              },
+            },
+          ],
+          effective_type: "type/Float",
+          nfc_path: null,
+          parent_id: null,
+          id: 15,
+          position: 5,
+          visibility_type: "normal",
+          display_name: "Total",
+          fingerprint: {
+            global: { "distinct-count": 4426, "nil%": 0 },
+            type: {
+              "type/Number": {
+                min: 8.93914247937167,
+                q1: 51.34535490743823,
+                q3: 110.29428389265787,
+                max: 159.34900526552292,
+                sd: 34.26469575709948,
+                avg: 80.35871658771228,
+              },
+            },
+          },
+          base_type: "type/Float",
+        },
+        {
+          base_type: "type/BigInteger",
+          name: "count",
+          display_name: "Count",
+          semantic_type: "type/Quantity",
+          source: "aggregation",
+          field_ref: ["aggregation", 0],
+          aggregation_index: 0,
+          effective_type: "type/BigInteger",
+        },
+      ],
+      native_form: {
+        query:
+          'SELECT FLOOR(("PUBLIC"."ORDERS"."TOTAL" / 20)) * 20 AS "TOTAL", COUNT(*) AS "count" FROM "PUBLIC"."ORDERS" GROUP BY FLOOR(("PUBLIC"."ORDERS"."TOTAL" / 20)) * 20 ORDER BY FLOOR(("PUBLIC"."ORDERS"."TOTAL" / 20)) * 20 ASC',
+        params: null,
+      },
+      "viz-settings": {
+        "graph.x_axis.scale": "ordinal",
+        "graph.x_axis.axis_enabled": "rotate-45",
+        series_settings: {
+          count: {
+            axis: "left",
+            title: "CountCountCountCountCountCountCountCountCountCount",
+            display: "area",
+          },
+        },
+        "graph.dimensions": ["TOTAL"],
+        "graph.metrics": ["count"],
+        "metabase.shared.models.visualization-settings/column-settings": {
+          '{:metabase.shared.models.visualization-settings/field-id 15, :metabase.shared.models.visualization-settings/field-metadata {"base-type" "type/Float"}}':
+            {
+              "metabase.shared.models.visualization-settings/prefix":
+                "2323________11111232323",
+              "metabase.shared.models.visualization-settings/suffix":
+                "232323___________2222232323",
+            },
+          '{:metabase.shared.models.visualization-settings/column-name "count"}':
+            {
+              "metabase.shared.models.visualization-settings/prefix":
+                "____________________________",
+              "metabase.shared.models.visualization-settings/suffix":
+                "____________________________",
+            },
+        },
+        "metabase.shared.models.visualization-settings/global-column-settings":
+          {},
+      },
+      results_timezone: "America/Montevideo",
+      results_metadata: {
+        columns: [
+          {
+            description: "The total billed amount.",
+            semantic_type: null,
+            coercion_strategy: null,
+            name: "TOTAL",
+            settings: null,
+            fk_target_field_id: null,
+            field_ref: [
+              "field",
+              15,
+              {
+                "base-type": "type/Float",
+                binning: {
+                  strategy: "num-bins",
+                  "min-value": 0,
+                  "max-value": 160,
+                  "num-bins": 8,
+                  "bin-width": 20,
+                },
+              },
+            ],
+            effective_type: "type/Float",
+            id: 15,
+            visibility_type: "normal",
+            display_name: "Total",
+            fingerprint: {
+              global: { "distinct-count": 4426, "nil%": 0 },
+              type: {
+                "type/Number": {
+                  min: 8.93914247937167,
+                  q1: 51.34535490743823,
+                  q3: 110.29428389265787,
+                  max: 159.34900526552292,
+                  sd: 34.26469575709948,
+                  avg: 80.35871658771228,
+                },
+              },
+            },
+            base_type: "type/Float",
+          },
+          {
+            display_name: "Count",
+            semantic_type: "type/Quantity",
+            field_ref: ["aggregation", 0],
+            name: "count",
+            base_type: "type/BigInteger",
+            effective_type: "type/BigInteger",
+            fingerprint: {
+              global: { "distinct-count": 9, "nil%": 0 },
+              type: {
+                "type/Number": {
+                  min: 1,
+                  q1: 665.25,
+                  q3: 2988.5,
+                  max: 4107,
+                  sd: 1513.4439295123484,
+                  avg: 2084.4444444444443,
+                },
+              },
+            },
+          },
+        ],
+      },
+      insights: null,
+      rows: [
+        [-60, 1],
+        [0, 51],
+        [20, 2190],
+        [40, 4107],
+        [60, 4007],
+        [80, 2649],
+        [100, 2429],
+        [120, 2456],
+        [140, 870],
+      ],
+    },
+  },
+];

--- a/frontend/src/metabase/static-viz/components/Legend/utils.ts
+++ b/frontend/src/metabase/static-viz/components/Legend/utils.ts
@@ -27,7 +27,8 @@ const calculateItemWidth = (
  *
  * @param {LegendItem[]} items - The legend items to be positioned.
  * @param {number} width - The available width for the legend.
- * @param {number} [padding=0] - The padding to be applied on both sides of the legend.
+ * @param {number} [horizontalPadding=0] - The horizontal padding of the legend.
+ * @param {number} [verticalPadding=0] - The vertical padding of the legend.
  * @param {number} [lineHeight=DEFAULT_LEGEND_LINE_HEIGHT] - The line height for each row of legend items.
  * @param {number} [fontSize=DEFAULT_LEGEND_FONT_SIZE] - The font size to be used for the legend items.
  * @param {number} [fontWeight=DEFAULT_LEGEND_FONT_WEIGHT] - The font weight to be used for the legend items.
@@ -37,7 +38,8 @@ const calculateItemWidth = (
 export const calculateLegendRows = (
   items: LegendItem[],
   width: number,
-  padding = 0,
+  horizontalPadding = 0,
+  verticalPadding = 0,
   lineHeight: number = DEFAULT_LEGEND_LINE_HEIGHT,
   fontSize: number = DEFAULT_LEGEND_FONT_SIZE,
   fontWeight: number = DEFAULT_LEGEND_FONT_WEIGHT,
@@ -49,11 +51,11 @@ export const calculateLegendRows = (
     };
   }
 
-  const availableTotalWidth = width - 2 * padding;
+  const availableTotalWidth = width - 2 * horizontalPadding;
 
   const rows: PositionedLegendItem[][] = [[]];
 
-  let currentRowX = padding;
+  let currentRowX = horizontalPadding;
 
   for (const item of items) {
     const currentRowIndex = rows.length - 1;
@@ -67,7 +69,7 @@ export const calculateLegendRows = (
       currentRow.push({
         ...item,
         left: currentRowX,
-        top: currentRowIndex * lineHeight,
+        top: currentRowIndex * lineHeight + verticalPadding,
       });
 
       currentRowX += itemWidth + LEGEND_ITEM_MARGIN_RIGHT;
@@ -78,11 +80,11 @@ export const calculateLegendRows = (
       rows.push([
         {
           ...item,
-          left: padding,
-          top: (currentRowIndex + 1) * lineHeight,
+          left: horizontalPadding,
+          top: (currentRowIndex + 1) * lineHeight + verticalPadding,
         },
       ]);
-      currentRowX = padding + itemWidth + LEGEND_ITEM_MARGIN_RIGHT;
+      currentRowX = horizontalPadding + itemWidth + LEGEND_ITEM_MARGIN_RIGHT;
     } else {
       currentRow.push({
         color: item.color,
@@ -92,15 +94,15 @@ export const calculateLegendRows = (
           fontSize,
           fontWeight,
         ),
-        left: padding,
-        top: currentRowIndex * lineHeight,
+        left: horizontalPadding,
+        top: currentRowIndex * lineHeight + verticalPadding,
       });
 
       currentRowX = availableTotalWidth;
     }
   }
 
-  const height = rows.length * lineHeight;
+  const height = rows.length * lineHeight + verticalPadding * 2;
 
   return {
     height,

--- a/frontend/src/metabase/static-viz/constants/char-sizes.ts
+++ b/frontend/src/metabase/static-viz/constants/char-sizes.ts
@@ -1,4 +1,5 @@
 export const CHAR_SIZES_FONT_SIZE = 10;
+export const CHAR_SIZES_FONT_WEIGHT = 400;
 
 // Generated with the mapping tool from here https://github.com/Evgenus/js-server-text-width
 export const CHAR_SIZES = {

--- a/frontend/src/metabase/static-viz/containers/StaticChart/StaticChart.tsx
+++ b/frontend/src/metabase/static-viz/containers/StaticChart/StaticChart.tsx
@@ -50,7 +50,8 @@ const StaticChart = ({ type, options }: StaticChartProps) => {
           renderingContext={{
             getColor,
             formatValue: formatStaticValue as any,
-            measureText: measureTextWidth as any,
+            measureText: (text, style) =>
+              measureTextWidth(text, style.size, style.weight),
             fontFamily: "Lato", // TODO make this based on admin settings value
           }}
         />

--- a/frontend/src/metabase/static-viz/index.js
+++ b/frontend/src/metabase/static-viz/index.js
@@ -1,5 +1,11 @@
+import { setPlatformAPI } from "echarts";
 import ReactDOMServer from "react-dom/server";
+import { measureTextEChartsAdapter } from "metabase/static-viz/lib/text";
 import StaticChart from "./containers/StaticChart";
+
+setPlatformAPI({
+  measureText: measureTextEChartsAdapter,
+});
 
 // stub setTimeout because GraalVM does not provide it
 global.setTimeout = () => {};

--- a/frontend/src/metabase/static-viz/lib/text.ts
+++ b/frontend/src/metabase/static-viz/lib/text.ts
@@ -1,24 +1,32 @@
 import { init } from "server-text-width";
-import { CHAR_SIZES, CHAR_SIZES_FONT_SIZE } from "../constants/char-sizes";
+import {
+  CHAR_SIZES,
+  CHAR_SIZES_FONT_SIZE,
+  CHAR_SIZES_FONT_WEIGHT,
+} from "../constants/char-sizes";
 
 const CHAR_ELLIPSES = "…";
-const DEFAULT_FONT_WEIGHT = 400;
+const FONT_WEIGHT_WIDTH_FACTOR = 0.039;
 
 export const { getTextWidth } = init(CHAR_SIZES);
 
 export const measureTextWidth = (
   text: string,
   fontSize: number,
-  fontWeight = DEFAULT_FONT_WEIGHT,
+  fontWeight: number = CHAR_SIZES_FONT_WEIGHT,
 ) => {
   const sizeFactor = fontSize / CHAR_SIZES_FONT_SIZE;
+  const weightFactor =
+    1 +
+    (fontWeight - CHAR_SIZES_FONT_WEIGHT) *
+      (FONT_WEIGHT_WIDTH_FACTOR / CHAR_SIZES_FONT_WEIGHT);
 
   const baseWidth = getTextWidth(text, {
     fontSize: `${CHAR_SIZES_FONT_SIZE}px`,
-    fontWeight: fontWeight.toString(),
+    fontWeight: CHAR_SIZES_FONT_WEIGHT.toString(),
   });
 
-  return sizeFactor * baseWidth;
+  return sizeFactor * baseWidth * weightFactor;
 };
 
 export const measureTextHeight = (fontSize: number) => {
@@ -29,7 +37,7 @@ export const truncateText = (
   text: string,
   width: number,
   fontSize: number,
-  fontWeight = DEFAULT_FONT_WEIGHT,
+  fontWeight = CHAR_SIZES_FONT_WEIGHT,
 ) => {
   if (measureTextWidth(text, fontSize, fontWeight) <= width) {
     return text;
@@ -43,4 +51,69 @@ export const truncateText = (
   }
 
   return text + CHAR_ELLIPSES;
+};
+
+const parseEChartsFontString = (fontString: string) => {
+  const parts = fontString.split(/\s+/);
+
+  if (parts.length < 2) {
+    throw new Error("Invalid font string format");
+  }
+
+  let fontWeightPart: string;
+  let fontSizePart: string;
+  let fontFamilyParts: string[];
+
+  if (/^\d+$/.test(parts[0])) {
+    // Format: "fontWeight fontSize fontFamily", example: 900 12px Lato
+    [fontWeightPart, fontSizePart, ...fontFamilyParts] = parts;
+  } else {
+    // Format: "fontWeight??? fontWeight fontSize fontFamily", example: normal 900 12px Lato
+    [, fontWeightPart, fontSizePart, ...fontFamilyParts] = parts;
+  }
+
+  let parsedFontWeight: number;
+  switch (fontWeightPart.toLowerCase()) {
+    case "normal":
+      parsedFontWeight = 400;
+      break;
+    case "bold":
+      parsedFontWeight = 700;
+      break;
+    case "bolder":
+      parsedFontWeight = 800;
+      break;
+    case "lighter":
+      parsedFontWeight = 300;
+      break;
+    default:
+      parsedFontWeight = parseInt(fontWeightPart, 10) || 400;
+      break;
+  }
+
+  return {
+    fontFamily: fontFamilyParts.join(" "),
+    fontSize: parseFloat(fontSizePart),
+    fontWeight: parsedFontWeight,
+  };
+};
+
+export const measureTextEChartsAdapter = (
+  text: string,
+  font?: string,
+): { width: number } => {
+  let fontSize = CHAR_SIZES_FONT_SIZE;
+  let fontWeight = CHAR_SIZES_FONT_WEIGHT;
+
+  if (font) {
+    const parsedFont = parseEChartsFontString(font);
+    fontSize = parsedFont.fontSize;
+    fontWeight = parsedFont.fontWeight;
+  }
+
+  const width = measureTextWidth(text, fontSize, fontWeight);
+
+  return {
+    width,
+  };
 };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
@@ -21,7 +21,10 @@ import {
   getSortedSeriesModels,
   replaceValues,
 } from "metabase/visualizations/echarts/cartesian/model/dataset";
-import { getYAxisSplit } from "metabase/visualizations/echarts/cartesian/model/axis";
+import {
+  getYAxesExtents,
+  getYAxisSplit,
+} from "metabase/visualizations/echarts/cartesian/model/axis";
 
 const SUPPORTED_AUTO_SPLIT_TYPES = ["line", "area", "bar", "combo"];
 
@@ -45,6 +48,7 @@ export const getCardsColumns = (
 export const getCardsSeriesModels = (
   rawSeries: RawSeries,
   cardsColumns: CartesianChartColumns[],
+  settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
 ) => {
   const hasMultipleCards = rawSeries.length > 1;
@@ -74,6 +78,7 @@ export const getCartesianChartModel = (
   const unsortedSeriesModels = getCardsSeriesModels(
     rawSeries,
     cardsColumns,
+    settings,
     renderingContext,
   );
   const seriesModels = getSortedSeriesModels(unsortedSeriesModels, settings);
@@ -101,6 +106,7 @@ export const getCartesianChartModel = (
     settings,
     isAutoSplitSupported,
   );
+  const yAxisExtents = getYAxesExtents(yAxisSplit, dataset, settings);
 
   const [leftSeriesDataKeys, rightSeriesDataKeys] = yAxisSplit;
   const leftAxisColumn = seriesModels.find(
@@ -118,6 +124,6 @@ export const getCartesianChartModel = (
     yAxisSplit,
     leftAxisColumn,
     rightAxisColumn,
-    extents,
+    yAxisExtents,
   };
 };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -50,6 +50,8 @@ export type Extent = [number, number];
 export type SeriesExtents = Record<DataKey, Extent>;
 
 export type AxisSplit = [DataKey[], DataKey[]];
+export type AxisExtent = Extent | null;
+export type AxisExtents = [AxisExtent, AxisExtent];
 
 export type CartesianChartModel = {
   dimensionModel: DimensionModel;
@@ -57,7 +59,7 @@ export type CartesianChartModel = {
   dataset: GroupedDataset;
   normalizedDataset: GroupedDataset;
   yAxisSplit: AxisSplit;
-  extents: SeriesExtents;
+  yAxisExtents: AxisExtents;
 
   leftAxisColumn?: DatasetColumn;
   rightAxisColumn?: DatasetColumn;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -8,12 +8,6 @@ export type LegacySeriesSettingsObjectKey = {
   };
 };
 
-export type LegacySeriesSettingsObjectKey = {
-  card: {
-    _seriesKey: string;
-  };
-};
-
 export type RegularSeriesModel = {
   name: string;
   color: string;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -8,6 +8,12 @@ export type LegacySeriesSettingsObjectKey = {
   };
 };
 
+export type LegacySeriesSettingsObjectKey = {
+  card: {
+    _seriesKey: string;
+  };
+};
+
 export type RegularSeriesModel = {
   name: string;
   color: string;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/format.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/format.ts
@@ -1,0 +1,80 @@
+import type {
+  AxesFormatters,
+  AxisFormatter,
+} from "metabase/visualizations/echarts/cartesian/option/types";
+import type { CartesianChartModel } from "metabase/visualizations/echarts/cartesian/model/types";
+import type {
+  ComputedVisualizationSettings,
+  RenderingContext,
+} from "metabase/visualizations/types";
+import type { DatasetColumn } from "metabase-types/api";
+
+const getYAxisFormatter = (
+  column: DatasetColumn,
+  settings: ComputedVisualizationSettings,
+  renderingContext: RenderingContext,
+): AxisFormatter => {
+  const isNormalized = settings["stackable.stack_type"] === "normalized";
+
+  if (isNormalized) {
+    return (value: unknown) =>
+      renderingContext.formatValue(value, {
+        column,
+        number_style: "percent",
+        jsx: false,
+      });
+  }
+
+  return (value: unknown) => {
+    return renderingContext.formatValue(value, {
+      column,
+      ...(settings.column?.(column) ?? {}),
+      jsx: false,
+    });
+  };
+};
+
+const getXAxisFormatter = (
+  column: DatasetColumn,
+  settings: ComputedVisualizationSettings,
+  renderingContext: RenderingContext,
+) => {
+  return (value: unknown) =>
+    renderingContext.formatValue(value, {
+      column,
+      ...(settings.column?.(column) ?? {}),
+      jsx: false,
+    });
+};
+
+export const getAxesFormatters = (
+  chartModel: CartesianChartModel,
+  settings: ComputedVisualizationSettings,
+  renderingContext: RenderingContext,
+): AxesFormatters => {
+  const formatters: AxesFormatters = {
+    bottom: getXAxisFormatter(
+      chartModel.dimensionModel.column,
+      settings,
+      renderingContext,
+    ),
+  };
+
+  if (chartModel.leftAxisColumn) {
+    formatters.left = getYAxisFormatter(
+      chartModel.leftAxisColumn,
+      settings,
+      renderingContext,
+    );
+  }
+
+  if (chartModel.rightAxisColumn) {
+    formatters.right = getYAxisFormatter(
+      chartModel.rightAxisColumn,
+      settings,
+      renderingContext,
+    );
+  }
+
+  return formatters;
+};

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/grid.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/grid.ts
@@ -1,0 +1,43 @@
+import type { GridOption } from "echarts/types/dist/shared";
+import type { Padding } from "metabase/visualizations/echarts/cartesian/option/types";
+import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
+import { CHART_STYLE } from "metabase/visualizations/echarts/cartesian/option/style";
+import type { CartesianChartModel } from "metabase/visualizations/echarts/cartesian/model/types";
+import { getYAxisName } from "metabase/visualizations/echarts/cartesian/option/axis";
+
+export const getChartGrid = (
+  chartModel: CartesianChartModel,
+  settings: ComputedVisualizationSettings,
+): GridOption => {
+  const padding: Padding = {
+    top: CHART_STYLE.padding.y,
+    left: CHART_STYLE.padding.x,
+    bottom: CHART_STYLE.padding.y,
+    right: CHART_STYLE.padding.x,
+  };
+
+  const yAxisNameTotalWidth =
+    CHART_STYLE.axisName.size / 2 + CHART_STYLE.axisNameMargin;
+
+  const hasLeftYAxisName = getYAxisName(chartModel, settings, "left");
+  const hasRightYAxisName = getYAxisName(chartModel, settings, "right");
+
+  if (hasLeftYAxisName) {
+    padding.left += yAxisNameTotalWidth;
+  }
+  if (hasRightYAxisName) {
+    padding.right += yAxisNameTotalWidth;
+  }
+
+  const hasXAxisName = settings["graph.x_axis.labels_enabled"];
+
+  if (hasXAxisName) {
+    padding.bottom +=
+      CHART_STYLE.axisName.size / 2 + CHART_STYLE.axisNameMargin;
+  }
+
+  return {
+    containLabel: true,
+    ...padding,
+  };
+};

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -6,6 +6,8 @@ import type {
   RenderingContext,
 } from "metabase/visualizations/types";
 import { buildAxes } from "metabase/visualizations/echarts/cartesian/option/axis";
+import { getAxesFormatters } from "metabase/visualizations/echarts/cartesian/option/format";
+import { getChartGrid } from "./grid";
 
 export const getCartesianChartOption = (
   chartModel: CartesianChartModel,
@@ -13,6 +15,12 @@ export const getCartesianChartOption = (
   renderingContext: RenderingContext,
 ): EChartsOption => {
   const echartsSeries = buildEChartsSeries(
+    chartModel,
+    settings,
+    renderingContext,
+  );
+
+  const axesFormatters = getAxesFormatters(
     chartModel,
     settings,
     renderingContext,
@@ -28,8 +36,9 @@ export const getCartesianChartOption = (
   ];
 
   return {
+    grid: getChartGrid(chartModel, settings),
     dataset: echartsDataset,
     series: echartsSeries,
-    ...buildAxes(chartModel, settings, renderingContext),
+    ...buildAxes(chartModel, settings, axesFormatters, renderingContext),
   } as EChartsOption;
 };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/style.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/style.ts
@@ -1,0 +1,15 @@
+export const CHART_STYLE = {
+  axisTicks: {
+    size: 12,
+    weight: 900,
+  },
+  axisName: {
+    size: 14,
+    weight: 900,
+  },
+  axisNameMargin: 18,
+  padding: {
+    x: 16,
+    y: 16,
+  },
+};

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/types.ts
@@ -1,0 +1,19 @@
+export type AxisRange = {
+  min?: number;
+  max?: number;
+};
+
+export type AxisFormatter = (value: unknown) => string;
+
+export type AxesFormatters = {
+  left?: AxisFormatter;
+  right?: AxisFormatter;
+  bottom: AxisFormatter;
+};
+
+export type Padding = {
+  top: number;
+  left: number;
+  bottom: number;
+  right: number;
+};

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -2,7 +2,6 @@ import { t } from "ttag";
 import _ from "underscore";
 import {
   columnsAreValid,
-  getFriendlyName,
   getDefaultDimensionsAndMetrics,
   preserveExistingColumnsOrder,
   MAX_SERIES,
@@ -26,6 +25,10 @@ import {
 import { ChartSettingOrderedSimple } from "metabase/visualizations/components/settings/ChartSettingOrderedSimple";
 import {
   getDefaultStackingValue,
+  getDefaultXAxisTitle,
+  getDefaultYAxisTitle,
+  getIsXAxisLabelEnabledDefault,
+  getIsYAxisLabelEnabledDefault,
   getSeriesOrderVisibilitySettings,
   isStackingValueValid,
   STACKABLE_DISPLAY_TYPES,
@@ -47,9 +50,7 @@ const HISTOGRAM_DATE_EXTRACTS = new Set([
 ]);
 
 export function getDefaultDimensionLabel(multipleSeries) {
-  return multipleSeries.length > 0 && multipleSeries[0].data.cols[0]
-    ? getFriendlyName(multipleSeries[0].data.cols[0])
-    : null;
+  return getDefaultXAxisTitle(multipleSeries[0]?.data.cols[0]);
 }
 
 export function getDefaultColumns(series) {
@@ -587,7 +588,7 @@ export const GRAPH_AXIS_SETTINGS = {
     title: t`Show label`,
     inline: true,
     widget: "toggle",
-    default: true,
+    getDefault: getIsXAxisLabelEnabledDefault,
   },
   "graph.x_axis.title_text": {
     section: t`Axes`,
@@ -609,7 +610,7 @@ export const GRAPH_AXIS_SETTINGS = {
     group: t`Y-axis`,
     widget: "toggle",
     inline: true,
-    default: true,
+    getDefault: getIsYAxisLabelEnabledDefault,
   },
   "graph.y_axis.title_text": {
     section: t`Axes`,
@@ -623,15 +624,12 @@ export const GRAPH_AXIS_SETTINGS = {
       // If there are multiple series, we check if the metric names match.
       // If they do, we use that as the default y axis label.
       const [metric] = vizSettings["graph.metrics"];
-      const metricNames = Array.from(
-        new Set(
-          series.map(({ data: { cols } }) => {
-            const metricCol = cols.find(c => c.name === metric);
-            return metricCol && metricCol.display_name;
-          }),
-        ),
-      );
-      return metricNames.length === 1 ? metricNames[0] : null;
+      const metricNames = series.map(({ data: { cols } }) => {
+        const metricCol = cols.find(c => c.name === metric);
+        return metricCol && metricCol.display_name;
+      });
+
+      return getDefaultYAxisTitle(metricNames);
     },
     readDependencies: ["series", "graph.metrics"],
   },

--- a/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
@@ -1,6 +1,11 @@
 import _ from "underscore";
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
-import type { Card, SeriesOrderSetting } from "metabase-types/api";
+import type {
+  Card,
+  DatasetColumn,
+  SeriesOrderSetting,
+} from "metabase-types/api";
+import { getFriendlyName } from "metabase/visualizations/lib/utils";
 
 export const STACKABLE_DISPLAY_TYPES = new Set(["area", "bar"]);
 
@@ -87,3 +92,22 @@ export const getSeriesOrderVisibilitySettings = (
     color: seriesColors[item.key],
   }));
 };
+
+export const getDefaultYAxisTitle = (metricNames: string[]) => {
+  const metricsCount = new Set(metricNames).size;
+  return metricsCount === 1 ? metricNames[0] : null;
+};
+
+export const getIsYAxisLabelEnabledDefault = () => true;
+
+export const getDefaultXAxisTitle = (
+  dimensionColumn: DatasetColumn | undefined,
+) => {
+  if (!dimensionColumn) {
+    return null;
+  }
+
+  return getFriendlyName(dimensionColumn);
+};
+
+export const getIsXAxisLabelEnabledDefault = () => true;


### PR DESCRIPTION
### Description

Aligns axis ticks and labels of the combo chart.

Closes https://github.com/metabase/metabase/issues/35776

### How to verify

1. Create combo charts with different combinations of axes to verify long ticks, short ticks, rotated X-axis ticks, disabled axes, disabled labels
2. Add them on a dashboard
3. Sent a test subscription to verify they look as expected and layouts are correct

### Demo

#### Show axes, show axes names
Dashcard:
<img width="552" alt="Screenshot 2023-11-14 at 9 33 00 PM" src="https://github.com/metabase/metabase/assets/14301985/e4031525-acdc-4a67-b752-5ecf5bc9b082">
Static viz:
<img width="590" alt="Screenshot 2023-11-14 at 9 33 43 PM" src="https://github.com/metabase/metabase/assets/14301985/1debcadb-2705-45de-9544-44421d0af8b1">

#### Hide axes, show axes names
Dashcard:
<img width="553" alt="Screenshot 2023-11-14 at 9 33 06 PM" src="https://github.com/metabase/metabase/assets/14301985/14e879c7-7c7a-4a5b-8ac8-52e79c228b81">

Static viz:
<img width="605" alt="Screenshot 2023-11-14 at 9 33 49 PM" src="https://github.com/metabase/metabase/assets/14301985/78b13c35-637b-4ddc-b747-9b4754e7989f">

#### Show axes, hide axes names
Dashcard:
<img width="555" alt="Screenshot 2023-11-14 at 9 33 13 PM" src="https://github.com/metabase/metabase/assets/14301985/8bc319b0-c2ef-41c6-9b9c-c884e86a5db2">

Static viz:
<img width="592" alt="Screenshot 2023-11-14 at 9 33 57 PM" src="https://github.com/metabase/metabase/assets/14301985/4d86ecb8-06d0-4352-affb-1de3a452a006">

#### Hide axes, hide axes names
Dashcard:
<img width="551" alt="Screenshot 2023-11-14 at 9 33 17 PM" src="https://github.com/metabase/metabase/assets/14301985/16c913f4-8b25-4c6b-9b97-22322a4fbf37">

Static viz:
<img width="602" alt="Screenshot 2023-11-14 at 9 34 04 PM" src="https://github.com/metabase/metabase/assets/14301985/84f589a0-322f-4f21-a395-6e8a010981f1">

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
