### PR TITLE
Fix newly created E2E CSV flakes

### DIFF
--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -263,13 +263,13 @@ function uploadFile(testFile, valid = true) {
     );
   });
 
-  cy.findByRole("status").within(() => {
+  cy.findAllByRole("status").within(() => {
     cy.findByText(/Uploading/i);
     cy.findByText(testFile.fileName);
   });
 
   if (valid) {
-    cy.findByRole("status").within(() => {
+    cy.findAllByRole("status").within(() => {
       cy.findByText("Data added to Uploads Collection", {
         timeout: 10 * 1000,
       });
@@ -281,14 +281,14 @@ function uploadFile(testFile, valid = true) {
       cy.findByText(testFile.humanName);
     });
 
-    cy.findByRole("status").within(() => {
+    cy.findAllByRole("status").within(() => {
       cy.findByText("Start exploring").click();
     });
 
     cy.url().should("include", `/model/`);
     cy.findByTestId("TableInteractive-root");
   } else {
-    cy.findByRole("status").within(() => {
+    cy.findAllByRole("status").within(() => {
       cy.findByText("Error uploading your File");
     });
   }

--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -266,14 +266,18 @@ function uploadFile(testFile, valid = true) {
   // After #35498 has been merged, we now sometimes encounter two elements with the "status" role in UI.
   // The first (older) one is related to the sync that didn't finish, and the second one is related to CSV upload.
   // This is the reason we have to start using `findAllByRole` rather than `findByRole`.
+  // Since CSV status element is newer, we can and must use `.last()` to yield only one element within we perform the search.
   cy.findAllByRole("status")
+    .last()
     .should("contain", "Uploading data to")
     .and("contain", testFile.fileName);
 
   if (valid) {
-    cy.findAllByRole("status").findByText("Data added to Uploads Collection", {
-      timeout: 10 * 1000,
-    });
+    cy.findAllByRole("status")
+      .last()
+      .findByText("Data added to Uploads Collection", {
+        timeout: 10 * 1000,
+      });
 
     cy.get("main").within(() => cy.findByText("Uploads Collection"));
 
@@ -281,12 +285,12 @@ function uploadFile(testFile, valid = true) {
       cy.findByText(testFile.humanName);
     });
 
-    cy.findAllByRole("status").findByText("Start exploring").click();
+    cy.findAllByRole("status").last().findByText("Start exploring").click();
 
     cy.url().should("include", `/model/`);
     cy.findByTestId("TableInteractive-root");
   } else {
-    cy.findAllByRole("status").findByText("Error uploading your File");
+    cy.findAllByRole("status").last().findByText("Error uploading your File");
   }
 }
 

--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -263,16 +263,16 @@ function uploadFile(testFile, valid = true) {
     );
   });
 
-  cy.findAllByRole("status").within(() => {
-    cy.findByText(/Uploading/i);
-    cy.findByText(testFile.fileName);
-  });
+  // After #35498 has been merged, we now sometimes encounter two elements with the "status" role in UI.
+  // The first (older) one is related to the sync that didn't finish, and the second one is related to CSV upload.
+  // This is the reason we have to start using `findAllByRole` rather than `findByRole`.
+  cy.findAllByRole("status")
+    .should("contain", "Uploading data to")
+    .and("contain", testFile.fileName);
 
   if (valid) {
-    cy.findAllByRole("status").within(() => {
-      cy.findByText("Data added to Uploads Collection", {
-        timeout: 10 * 1000,
-      });
+    cy.findAllByRole("status").findByText("Data added to Uploads Collection", {
+      timeout: 10 * 1000,
     });
 
     cy.get("main").within(() => cy.findByText("Uploads Collection"));
@@ -281,16 +281,12 @@ function uploadFile(testFile, valid = true) {
       cy.findByText(testFile.humanName);
     });
 
-    cy.findAllByRole("status").within(() => {
-      cy.findByText("Start exploring").click();
-    });
+    cy.findAllByRole("status").findByText("Start exploring").click();
 
     cy.url().should("include", `/model/`);
     cy.findByTestId("TableInteractive-root");
   } else {
-    cy.findAllByRole("status").within(() => {
-      cy.findByText("Error uploading your File");
-    });
+    cy.findAllByRole("status").findByText("Error uploading your File");
   }
 }
 


### PR DESCRIPTION
After battling with sync problems caused by MySQL, @iethree found a potential solution in the form of https://github.com/metabase/metabase/pull/35498.

tl;dr
Instead of throwing an error if API doesn't report that the sync is complete, we move on and hope that the sync will complete by the time tests start running. I've noticed the edge case that affects some tests - CSV uploads being one such case.

![image](https://github.com/metabase/metabase/assets/31325167/ba74aeb8-63bd-442e-b157-2707cb8192c2)

If you look at the UI from the recording, you'll notice that the sync status is still ongoing when the test starts. Cypress was implicitly failing because `findByRole` expects to find a single element. The easy fix here is to use `findAllByRole`. It doesn't compromise the test logic whatsoever.

Example of a failed run:
https://www.deploysentinel.com/ci/runs/654d28c67bcc148681663e5b

## Testing
I spun up three separate stress-test runs in order to increase chances of sync not finishing and having two "status" UI elements. All three are green and all of them individually burn through each affected test five times.
- https://github.com/metabase/metabase/actions/runs/6824845132/job/18561550975
- https://github.com/metabase/metabase/actions/runs/6824847605/job/18561559995
- https://github.com/metabase/metabase/actions/runs/6824850012/job/18561567034

Because we cannot rely on CI to reliably reproduce this edge case, I did a series of local testing by hard coding another "status" element on this page. This should simulate what's going on in CI when sync doesn't finish.
![image](https://github.com/metabase/metabase/assets/31325167/46dfe309-099f-49d6-acd6-c81f0e9b7b61)

The final solution with using the `.last()` selector to isolate only one status element (see https://github.com/metabase/metabase/commit/ccbc68a20a8a04a49448e60ccb73f1b812871b40) makes all tests reliably pass regardless of the total number of elements.