### PR TITLE
Further optimize static-viz check for the backend workflow

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -22,6 +22,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       backend_all: ${{ steps.changes.outputs.backend_all }}
+      frontend_sources: ${{ steps.changes.outputs.frontend_sources }}
     steps:
       - uses: actions/checkout@v3
       - name: Test which files changed
@@ -33,7 +34,7 @@ jobs:
 
   static-viz-files-changed:
     needs: files-changed
-    if: needs.files-changed.outputs.backend_all != 'true'
+    if: needs.files-changed.outputs.backend_all != 'true' && needs.files-changed.outputs.frontend_sources == 'true'
     name: Check whether static-viz files changed
     runs-on: ubuntu-22.04
     timeout-minutes: 10


### PR DESCRIPTION
Follow up after #34209

The previous optimization made sense and had already improved the logic and the speed of this check. But I noticed that we still sometimes check whether or not static-viz files changed on completely unrelated changes. This jos can take more than five minutes so it makes sense to get the logic around it right. This PR attempts to achieve that.

The current logic was that even if backend files didn't change we needed to check did static viz files changed. "Not backend" left a huge surface for all other files. So let's say that you changed E2E spec or some unrelated workflow. This check would still kick in and waste 5-10 minutes of your and CI time only to conclude that it didn't detect any static-viz changes.

If I understand mechanics of this step correctly, we only need to run this step if frontend source changes are detected outside of the backend scope.
@npfitz  and @alxnddr please double check.
