### PR TITLE
Fix outdated serialization references in docs/comments

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
@@ -1,7 +1,7 @@
 (ns metabase-enterprise.serialization.v2.extract
   "Extraction is the first step in serializing a Metabase appdb so it can be eg. written to disk.
 
-  See the detailed descriptions of the (de)serialization processes in [[metabase.models.serialization.base]]."
+  See the detailed descriptions of the (de)serialization processes in [[metabase.models.serialization]]."
   (:require
    [clojure.set :as set]
    [clojure.string :as str]

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest.clj
@@ -2,7 +2,7 @@
   "Ingestion is the first step in deserialization - reading from the export format (eg. a tree of YAML files) and
   producing Clojure maps with `:serdes/meta` keys.
 
-  See the detailed description of the (de)serialization processes in [[metabase.models.serialization.base]]."
+  See the detailed description of the (de)serialization processes in [[metabase.models.serialization]]."
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]
@@ -20,7 +20,7 @@
   (ingest-list
     [this]
     "Return a reducible stream of `:serdes/meta`-style abstract paths, one for each entity in the dump.
-    See the description of these abstract paths in [[metabase.models.serialization.base]].
+    See the description of these abstract paths in [[metabase.models.serialization]].
     Each path is ordered from the root to the leaf.
 
     The order of the whole list is not specified and should not be relied upon!")

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -1,6 +1,6 @@
 (ns metabase-enterprise.serialization.v2.load
   "Loading is the interesting part of deserialization: integrating the maps \"ingested\" from files into the appdb.
-  See the detailed breakdown of the (de)serialization processes in [[metabase.models.serialization.base]]."
+  See the detailed breakdown of the (de)serialization processes in [[metabase.models.serialization]]."
   (:require
    [medley.core :as m]
    [metabase-enterprise.serialization.v2.backfill-ids :as serdes.backfill]
@@ -38,7 +38,7 @@
   references in this entity can be resolved properly.
 
   This is mostly bookkeeping for the overall deserialization process - the actual load of any given entity is done by
-  [[metabase.models.serialization.base/load-one!]] and its various overridable parts, which see.
+  [[metabase.models.serialization/load-one!]] and its various overridable parts, which see.
 
   Circular dependencies are not allowed, and are detected and thrown as an error."
   [{:keys [expanding ingestion seen] :as ctx} path]

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -417,7 +417,7 @@
 ;;; Then for each ingested entity:
 ;;;
 ;;; - `(ingest-one serdes-path opts)` is called to read the value into memory, then
-;;; - `(serdes-dependencies ingested)` gets a list of other `:serdes/meta` paths need to be loaded first.
+;;; - `(dependencies ingested)` gets a list of other `:serdes/meta` paths need to be loaded first.
 ;;;     - See below on depenencies.
 ;;; - Dependencies are loaded recursively in postorder; that is an entity is loaded after all its deps.
 ;;;     - Circular dependencies will make the load process throw.
@@ -696,7 +696,7 @@
 
   The identifier can be a single entity ID string, a single identity-hash string, or a vector of entity ID and hash
   strings. If the ID is compound, then the last ID is the one that corresponds to the model. This allows for the
-  compound IDs needed for nested entities like `DashboardCard`s to get their [[serdes/serdes-dependencies]].
+  compound IDs needed for nested entities like `DashboardCard`s to get their [[dependencies]].
 
   Throws if the corresponding entity cannot be found.
 
@@ -711,7 +711,7 @@
           entity     (lookup-by-id model eid)]
       (if entity
         (get entity (first (t2/primary-keys model)))
-        (throw (ex-info "Could not find foreign key target - bad serdes-dependencies or other serialization error"
+        (throw (ex-info "Could not find foreign key target - bad serdes dependencies or other serialization error"
                         {:entity_id eid :model (name model)}))))))
 
 (defn ^:dynamic ^::cache *export-fk-keyed*
@@ -775,7 +775,7 @@
 
 (defn table->path
   "Given a `table_id` as exported by [[export-table-fk]], turn it into a `[{:model ...}]` path for the Table.
-  This is useful for writing [[metabase.models.serialization.base/serdes-dependencies]] implementations."
+  This is useful for writing [[dependencies]] implementations."
   [[db-name schema table-name]]
   (filterv some? [{:model "Database" :id db-name}
                   (when schema {:model "Schema" :id schema})
@@ -819,7 +819,7 @@
 
 (defn field->path
   "Given a `field_id` as exported by [[export-field-fk]], turn it into a `[{:model ...}]` path for the Field.
-  This is useful for writing [[metabase.models.serialization.base/serdes-dependencies]] implementations."
+  This is useful for writing [[dependencies]] implementations."
   [[db-name schema table-name field-name]]
   (filterv some? [{:model "Database" :id db-name}
                   (when schema {:model "Schema" :id schema})
@@ -1039,7 +1039,7 @@
 
 (defn mbql-deps
   "Given an MBQL expression as exported, with qualified names like `[\"some-db\" \"schema\" \"table_name\"]` instead of
-  raw IDs, return the corresponding set of serdes-dependencies. The query can't be imported until all the referenced
+  raw IDs, return the corresponding set of serdes dependencies. The query can't be imported until all the referenced
   databases, tables and fields are loaded."
   [entity]
   (cond


### PR DESCRIPTION
There were a few references to `metabase.models.serialization.base`, which is now `metabase.models.serialization`.

Also `metabase.models.serialization.base/serdes-dependencies` is now `metabase.models.serialization/dependencies`.