### PR TITLE
make max results configurable

### DIFF
--- a/docs/installation-and-operation/serialization.md
+++ b/docs/installation-and-operation/serialization.md
@@ -241,7 +241,8 @@ custom-geojson-enabled
 start-of-week
 custom-geojson
 available-timezones
-max-results-bare-rows
+max-unaggregated-query-row-limit
+max-aggregated-query-row-limit
 hide-embed-branding?
 search-typeahead-enabled
 enable-sandboxes?

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -690,5 +690,5 @@
     ;; if the user has set the rowcount-override connection property, it ends up in the details map, but it actually
     ;; needs to be moved over to the settings map (which is where DB local settings go, as per #19399)
     (-> (update database :details #(dissoc % :rowcount-override))
-        (update :settings #(assoc % :max-results-bare-rows rowcount-override)))
+        (update :settings #(assoc % :max-unaggregated-query-row-limit rowcount-override)))
     database))

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -188,7 +188,8 @@
      humanization-strategy
      landing-page
      loading-message
-     max-results-bare-rows
+     max-aggregated-query-row-limit
+     max-unaggregated-query-row-limit
      native-query-autocomplete-match-style
      persisted-models-enabled
      report-timezone

--- a/src/metabase/query_processor/middleware/constraints.clj
+++ b/src/metabase/query_processor/middleware/constraints.clj
@@ -5,33 +5,46 @@
    [metabase.models.setting :as setting]
    [metabase.util.i18n :refer [deferred-tru]]))
 
-(def ^:private ^:const default-max-results-bare-rows 2000)
+(def ^:private ^:const default-max-unaggregated-query-row-limit 2000)
+(def ^:private ^:const default-max-aggregated-query-row-limit 10000)
 
-;; NOTE: this was changed from a hardcoded var with value of 2000 (now moved to [[default-max-results-bare-rows]])
+;; NOTE: this was changed from a hardcoded var with value of 2000 (now moved to [[default-max-unaggregated-query-row-limit]])
 ;; to a setting in 0.43 the setting, which allows for DB local value, can still be nil, so any places below that used
 ;; to reference the former constant value have to expect it could return nil instead
-(setting/defsetting max-results-bare-rows
+(setting/defsetting max-unaggregated-query-row-limit
   (deferred-tru "Maximum number of rows to return specifically on :rows type queries via the API.")
   :visibility     :authenticated
   :type           :integer
   :database-local :allowed
   :audit          :getter)
 
-(def ^:private max-results
-  "General maximum number of rows to return from an API query."
-  10000)
+(setting/defsetting max-aggregated-query-row-limit
+  (deferred-tru "Maximum number of rows to return for aggregated queries via the API.")
+  :visibility     :authenticated
+  :type           :integer
+  :database-local :allowed
+  :audit          :getter)
+
+(defn query->max-rows
+  "Given a query, returns the max rows that should be returned *as defined by settings*. In other words,
+  return `(max-aggregated-query-row-limit)` or `(max-unaggregated-query-row-limit)` depending on whether the query is
+  aggregated or not."
+  [{{aggregations :aggregation} :query}]
+  (if-not aggregations
+    (max-unaggregated-query-row-limit)
+    (max-aggregated-query-row-limit)))
 
 (defn default-query-constraints
   "Default map of constraints that we apply on dataset queries executed by the api."
   []
-  {:max-results           max-results
-   :max-results-bare-rows (or (max-results-bare-rows) default-max-results-bare-rows)})
+  {:max-results           (or (max-aggregated-query-row-limit) default-max-aggregated-query-row-limit)
+   :max-results-bare-rows (or (max-unaggregated-query-row-limit) default-max-unaggregated-query-row-limit)})
 
 (defn- ensure-valid-constraints
-  "`:max-results-bare-rows` must be less than or equal to `:max-results`, so if someone sets `:max-results` but not
-  `:max-results-bare-rows` or sets an both but sets an invalid value for ``:max-results-bare-rows` use the same value
-  for both. Otherwise the default bare rows value could end up being higher than the custom `:max-rows` value, causing
-  an error."
+  "`:max-unaggregated-query-row-limit` must be less than or equal to `:max-results`, so if someone sets `:max-results`
+  but not `:max-unaggregated-query-row-limit` or sets an both but sets an invalid value for
+  ``:max-unaggregated-query-row-limit` use the same value for both. Otherwise the default bare rows value could end up
+  being higher than the custom `:max-rows` value, causing an error."
   [{:keys [max-results max-results-bare-rows], :as constraints}]
   (if (<= max-results-bare-rows max-results)
     constraints

--- a/src/metabase/query_processor/middleware/limit.clj
+++ b/src/metabase/query_processor/middleware/limit.clj
@@ -28,13 +28,13 @@
   "Given a `query`, return the max rows that should be returned, or `nil` if no limit should be applied.
   If a limit should be applied, this is the first non-nil value from (in decreasing priority order):
 
-  1. the value of the [[metabase.query-processor.middleware.constraints/max-results-bare-rows]] setting, which allows
+  1. the value of the [[metabase.query-processor.middleware.constraints/query->max-rows]] setting, which allows
      for database-local override
   2. the output of [[metabase.mbql.util/query->max-rows-limit]] when called on the given query
   3. [[metabase.query-processor.interface/absolute-max-results]] (a constant, non-nil backstop value)"
   [query]
   (when-not (disable-max-results? query)
-    (or (qp.constraints/max-results-bare-rows)
+    (or (qp.constraints/query->max-rows query)
         (mbql.u/query->max-rows-limit query)
         qp.i/absolute-max-results)))
 

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -1809,33 +1809,33 @@
           (is (nil? (settings))))
         (testing "Set initial value"
           (testing "response"
-            (is (partial= {:settings {:max-results-bare-rows 1337}}
-                          (set-settings! {:max-results-bare-rows 1337}))))
+            (is (partial= {:settings {:max-unaggregated-query-row-limit 1337}}
+                          (set-settings! {:max-unaggregated-query-row-limit 1337}))))
           (testing "App DB"
-            (is (= {:max-results-bare-rows 1337}
+            (is (= {:max-unaggregated-query-row-limit 1337}
                    (settings)))))
         (testing "Setting a different value should not affect anything not specified (PATCH-style update)"
           (testing "response"
-            (is (partial= {:settings {:max-results-bare-rows   1337
+            (is (partial= {:settings {:max-unaggregated-query-row-limit   1337
                                       :database-enable-actions true}}
                           (set-settings! {:database-enable-actions true}))))
           (testing "App DB"
-            (is (= {:max-results-bare-rows   1337
+            (is (= {:max-unaggregated-query-row-limit   1337
                     :database-enable-actions true}
                    (settings)))))
         (testing "Update existing value"
           (testing "response"
-            (is (partial= {:settings {:max-results-bare-rows   1337
+            (is (partial= {:settings {:max-unaggregated-query-row-limit   1337
                                       :database-enable-actions false}}
                           (set-settings! {:database-enable-actions false}))))
           (testing "App DB"
-            (is (= {:max-results-bare-rows   1337
+            (is (= {:max-unaggregated-query-row-limit   1337
                     :database-enable-actions false}
                    (settings)))))
         (testing "Unset a value"
           (testing "response"
             (is (partial= {:settings {:database-enable-actions false}}
-                          (set-settings! {:max-results-bare-rows nil}))))
+                          (set-settings! {:max-unaggregated-query-row-limit nil}))))
           (testing "App DB"
             (is (= {:database-enable-actions false}
                    (settings)))))))))

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -75,16 +75,16 @@
                        {:description nil
                         :name        "testpg"
                         :details     {}
-                        :settings    {:database-enable-actions true ; visibility: :public
-                                      :max-results-bare-rows 2000}  ; visibility: :authenticated
+                        :settings    {:database-enable-actions          true   ; visibility: :public
+                                      :max-unaggregated-query-row-limit 2000}  ; visibility: :authenticated
                         :id          3})]
     (testing "authenticated users should see settings with authenticated visibility"
       (mw.session/with-current-user
         (mt/user->id :rasta)
         (is (= {"description" nil
                 "name"        "testpg"
-                "settings"    {"database-enable-actions" true
-                               "max-results-bare-rows"  2000}
+                "settings"    {"database-enable-actions"          true
+                               "max-unaggregated-query-row-limit" 2000}
                 "id"          3}
                (encode-decode pg-db)))))
     (testing "non-authenticated users shouldn't see settings with authenticated visibility"

--- a/test/metabase/query_processor/middleware/constraints_test.clj
+++ b/test/metabase/query_processor/middleware/constraints_test.clj
@@ -15,8 +15,8 @@
 (deftest ^:parallel add-constraints-test
   (testing "if it is *truthy* add the constraints"
     (is (= {:middleware  {:add-default-userland-constraints? true},
-            :constraints {:max-results           @#'qp.constraints/max-results
-                          :max-results-bare-rows @#'qp.constraints/default-max-results-bare-rows}}
+            :constraints {:max-results           @#'qp.constraints/default-max-aggregated-query-row-limit
+                          :max-results-bare-rows @#'qp.constraints/default-max-unaggregated-query-row-limit}}
            (add-default-userland-constraints
             {:middleware {:add-default-userland-constraints? true}})))))
 
@@ -29,7 +29,7 @@
 (deftest ^:parallel dont-overwrite-existing-constraints-test
   (testing "if it already has constraints, don't overwrite those!"
     (is (= {:middleware  {:add-default-userland-constraints? true}
-            :constraints {:max-results           @#'qp.constraints/max-results
+            :constraints {:max-results           @#'qp.constraints/default-max-aggregated-query-row-limit
                           :max-results-bare-rows 1}}
            (add-default-userland-constraints
             {:constraints {:max-results-bare-rows 1}


### PR DESCRIPTION
This replaces the existing setting `max-results-bare-rows` with two settings:

- `max-unaggregated-query-row-limit`, and
- `max-aggregated-query-row-limit`

Fixes #35428 