### PR TITLE
Give cljs tests 15 min

### DIFF
--- a/.github/workflows/cljs.yml
+++ b/.github/workflows/cljs.yml
@@ -15,7 +15,7 @@ jobs:
 
   shared-tests-cljs:
     runs-on: ubuntu-22.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
     - uses: actions/checkout@v3
     - name: Prepare front-end environment


### PR DESCRIPTION
I've been seeing not-infrequent CLJS tests fail due to hitting the timeout of 10 min. I think this makes sense since we've been adding more CLJS code, and I assume more CLJS tests as well.

This bumps the job timeout to 15 min

https://github.com/metabase/metabase/actions/workflows/cljs.yml?query=is%3Afailure