### PR TITLE
Fix public link E2E flakes

### DIFF
--- a/e2e/test/scenarios/sharing/reproductions/20393-public-dashboard-nested-card-with-parameters.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/20393-public-dashboard-nested-card-with-parameters.cy.spec.js
@@ -2,6 +2,8 @@ import { restore, popover, visitDashboard } from "e2e/support/helpers";
 
 describe("issue 20393", () => {
   beforeEach(() => {
+    cy.intercept("POST", "/api/dashboard/*/public_link").as("publicLink");
+
     restore();
     cy.signInAsAdmin();
   });
@@ -28,14 +30,12 @@ describe("issue 20393", () => {
     cy.findByRole("switch").click();
 
     // navigate to the public dashboard link
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Public link")
-      .parent()
-      .within(() => {
-        cy.get("input").then(input => {
-          cy.visit(input.val());
-        });
-      });
+    cy.wait("@publicLink").then(({ response: { body } }) => {
+      const { uuid } = body;
+
+      cy.signOut();
+      cy.visit(`/public/dashboard/${uuid}`);
+    });
 
     // verify that the card is visible on the page
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage


### PR DESCRIPTION
This PR fixes two flakes with the same root cause, and changes the pattern from trying to get the UUID from the UI to reading it directly from the API response that's already there.

Examples of failed runs:
- https://www.deploysentinel.com/ci/runs/654e0bad9f1ec992dfc50fe1
- https://www.deploysentinel.com/ci/runs/654e12702beaab03257ef532

For both flakes, the input field shows `null` in the UI when we tried to grab it.
![image](https://github.com/metabase/metabase/assets/31325167/a3464880-5635-44bd-b42a-6747401de1d1)

Results for the last 7 days:
- 20393: failure rate 0%, flake rate 7.94%
- 22524: failure rate 0%, flake rate 11.11%

### Stress-test
I ran both tests thirty times and they passed every single time.

- https://github.com/metabase/metabase/actions/runs/6828545400/job/18572897600 (20393)
- https://github.com/metabase/metabase/actions/runs/6828548175/job/18572905651 (22524)
