### PR TITLE
Refine default CI triggers

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -1,9 +1,6 @@
 default: &default
   - "locales/**"
-  - "bin/**"
-
-ci: &ci
-  - ".github/**/!(*.md|team.json)"
+  - "bin/**/!(*.md)"
 
 shared_sources: &shared_sources
   - "shared/src/**"


### PR DESCRIPTION
This is the last step for [#34880](https://github.com/metabase/metabase/issues/34880).
We don't need the global `*ci` anymore as no other glob uses it.

The only other difference is that the `default` glob set now ignores markdown files in the `bin/` folder.