### PR TITLE
Isomorphic timeline events viz 34924

### DIFF
--- a/dev/src/dev/render_png.clj
+++ b/dev/src/dev/render_png.clj
@@ -2,16 +2,17 @@
   "Improve feedback loop for dealing with png rendering code. Will create images using the rendering that underpins
   pulses and subscriptions and open those images without needing to send them to slack or email."
   (:require
-   [clojure.java.io :as io]
-   [clojure.java.shell :as sh]
-   [hiccup.core :as hiccup]
-   [metabase.models.card :as card]
-   [metabase.models.user :as user]
-   [metabase.pulse :as pulse]
-   [metabase.pulse.render :as render]
-   [metabase.pulse.render.test-util :as render.tu]
-   [metabase.query-processor :as qp]
-   [metabase.query-processor.middleware.permissions :as qp.perms]))
+    [clojure.java.io :as io]
+    [clojure.java.shell :as sh]
+    [hiccup.core :as hiccup]
+    [metabase.models.card :as card]
+    [metabase.models.user :as user]
+    [metabase.pulse :as pulse]
+    [metabase.pulse.render :as render]
+    [metabase.pulse.render.test-util :as render.tu]
+    [metabase.query-processor :as qp]
+    [metabase.query-processor.middleware.permissions :as qp.perms]
+    [toucan2.core :as t2]))
 
 ;; taken from https://github.com/aysylu/loom/blob/master/src/loom/io.clj
 (defn- os
@@ -75,6 +76,8 @@
 
 (comment
   (render-card-to-png 1)
+  (render-card-to-png 2700)
+
   ;; open viz in your browser
   (-> [["A" "B"]
        [1 2]
@@ -91,5 +94,6 @@
                                        :custom-column-names {:names ["-A-" "-B-" "-C-" "-D-"]}
                                        :hidden-columns      {:hide [0 2]}})
       :viz-tree
-      open-hiccup-as-html))
+      open-hiccup-as-html)
+  )
 

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -472,13 +472,19 @@
            :src   (:image-src image-bundle)}]]})
 
 (s/defmethod render :isomorphic :- common/RenderedPulseCard
-   [_ render-type _timezone-id card dashcard data]
+   [_
+    render-type
+    _timezone-id
+    {card-viz-settings :visualization_settings :as card}
+    {dashcard-viz-settings :visualization_settings :as dashcard}
+    data]
    (let [combined-cards-results    (pu/execute-multi-card card dashcard)
          cards-with-data (map (fn [c d] {:card c :data d})
                               (cons card (map :card combined-cards-results))
                               (cons data (map #(get-in % [:result :data]) combined-cards-results)))
-         dashcard-viz-settings (get dashcard :visualization_settings)
-
+         dashcard-viz-settings     (or
+                                     dashcard-viz-settings
+                                     card-viz-settings)
          image-bundle   (image-bundle/make-image-bundle
                          render-type
                          (js-svg/isomorphic cards-with-data dashcard-viz-settings))]

--- a/src/metabase/pulse/util.clj
+++ b/src/metabase/pulse/util.clj
@@ -47,10 +47,17 @@
   This is as opposed to combo cards and cards with visualizations with multiple series,
   which are viz settings."
   [card-or-id dashcard-or-id]
-  (let [card-id      (u/the-id card-or-id)
-        dashcard-id  (u/the-id dashcard-or-id)
-        card         (t2/select-one Card :id card-id, :archived false)
-        dashcard     (t2/select-one DashboardCard :id dashcard-id)
-        multi-cards  (dashboard-card/dashcard->multi-cards dashcard)]
-    (for [multi-card multi-cards]
-      (execute-card {:creator_id (:creator_id card)} (:id multi-card)))))
+  (if dashcard-or-id
+    (let [card-id     (u/the-id card-or-id)
+          card        (t2/select-one Card :id card-id, :archived false)
+          ;; NOTE/TODO - dashcard-or-id is nil with multiple time series
+          dashcard-id (u/the-id dashcard-or-id)
+          dashcard    (t2/select-one DashboardCard :id dashcard-id)
+          multi-cards (dashboard-card/dashcard->multi-cards dashcard)]
+      (for [multi-card multi-cards]
+        (execute-card {:creator_id (:creator_id card)} (:id multi-card))))
+    (let [card-id     (u/the-id card-or-id)
+          ;; NOTE/TODO - dashcard-or-id is nil with multiple time series
+          card        (t2/select-one Card :id card-id, :archived false)]
+      (for [multi-card [card]]
+        (execute-card {:creator_id (:creator_id card)} (:id multi-card))))))

--- a/src/metabase/pulse/util.clj
+++ b/src/metabase/pulse/util.clj
@@ -14,6 +14,7 @@
    [toucan2.core :as t2]))
 
 ;; TODO - this should be done async
+;; TODO - this and `execute-multi-card` should be made more efficient: eg. we query for the card several times
 (defn execute-card
   "Execute the query for a single Card. `options` are passed along to the Query Processor."
   [{pulse-creator-id :creator_id} card-or-id & {:as options}]
@@ -59,5 +60,4 @@
     (let [card-id     (u/the-id card-or-id)
           ;; NOTE/TODO - dashcard-or-id is nil with multiple time series
           card        (t2/select-one Card :id card-id, :archived false)]
-      (for [multi-card [card]]
-        (execute-card {:creator_id (:creator_id card)} (:id multi-card))))))
+      [(execute-card {:creator_id (:creator_id card)} (:id card))])))

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -1,12 +1,15 @@
 (ns metabase.pulse.render.body-test
   (:require
-   [clojure.string :as str]
    [clojure.test :refer :all]
    [clojure.walk :as walk]
    [hiccup.core :refer [html]]
    [metabase.pulse.render.body :as body]
    [metabase.pulse.render.common :as common]
    [metabase.pulse.render.test-util :as render.tu]
+   [metabase.pulse.util :as pu]
+   [metabase.query-processor :as qp]
+   [metabase.test :as mt]
+   [metabase.util :as u]
    [schema.core :as s]))
 
 (use-fixtures :each
@@ -530,3 +533,37 @@
     " "  "1,234,543 21%"
     nil  "1,234,543.21%"
     ""   "1,234,543.21%"))
+
+(deftest add-dashcard-timeline-events-test-34924
+  (testing "Timeline events should be added to the isomorphic renderer stages"
+    (mt/dataset sample-dataset
+      (mt/with-current-user (mt/user->id :crowberto)
+        (mt/with-temp [:model/Collection {collection-id :id :as _collection} {:name "Rasta's Collection"}
+                       :model/Timeline tl-a {:name "tl-a" :collection_id collection-id}
+                       :model/Timeline tl-b {:name "tl-b" :collection_id collection-id}
+                       :model/TimelineEvent _ {:timeline_id (u/the-id tl-a) :name "un-1"}
+                       :model/TimelineEvent _ {:timeline_id (u/the-id tl-a) :name "archived-1"}
+                       :model/TimelineEvent _ {:timeline_id (u/the-id tl-b) :name "un-2"}
+                       :model/TimelineEvent _ {:timeline_id (u/the-id tl-b) :name "archived-2"}
+                       :model/Card {dataset-query :dataset_query
+                                    :as           card} {:name          "Dashboard Test Card"
+                                                         :collection_id collection-id
+                                                         :dataset_query {:type     :query,
+                                                                         :database (mt/id)
+                                                                         :query    {:source-table (mt/id :orders)
+                                                                                    :breakout     [[:field (mt/id :orders :created_at)
+                                                                                                    {:temporal-unit :month}]],
+                                                                                    :aggregation  [[:sum [:field (mt/id :orders :subtotal) nil]]
+                                                                                                   [:avg [:field (mt/id :orders :subtotal) nil]]]}}
+                                                         :creator_id    (mt/user->id :crowberto)}]
+          (let [data                   (qp/process-query dataset-query)
+                combined-cards-results (pu/execute-multi-card card nil)
+                cards-with-data        (map
+                                        (comp
+                                         #'body/add-dashcard-timeline-events
+                                         (fn [c d] {:card c :data d}))
+                                        (cons card (map :card combined-cards-results))
+                                        (cons data (map #(get-in % [:result :data]) combined-cards-results)))]
+            (testing "The underlying add-dashcard-timeline-events call adds the timeline events to the card"
+              (is (=? [tl-a tl-b] (:timeline_events (#'body/add-dashcard-timeline-events {:card card})))))
+            (is (= 2 (count (:timeline_events (first cards-with-data)))))))))))


### PR DESCRIPTION
This primarily required adding logic as found in `/api/timeline?include=events` to `s/defmethod render :isomorphic :- common/RenderedPulseCard`. This is done by adding one extra accretion function, `add-dashcard-timeline-events` to the logic and making code that expected a dashboard also take a dashcard.

Resolves #34924