### PR TITLE
Fix startup logic to correctly detect new installs when a config file is used 

### DIFF
--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -115,12 +115,12 @@
     (log/info (trs "Setting up prometheus metrics"))
     (prometheus/setup!)
     (init-status/set-progress! 0.6))
-  ;; initialize Metabase from an `config.yml` file if present (Enterprise Edition™ only)
-  (config-from-file/init-from-file-if-code-available!)
-  (init-status/set-progress! 0.7)
   ;; run a very quick check to see if we are doing a first time installation
   ;; the test we are using is if there is at least 1 User in the database
   (let [new-install? (not (setup/has-user-setup))]
+    ;; initialize Metabase from an `config.yml` file if present (Enterprise Edition™ only)
+    (config-from-file/init-from-file-if-code-available!)
+    (init-status/set-progress! 0.7)
     (when new-install?
       (log/info (trs "Looks like this is a new installation ... preparing setup wizard"))
       ;; create setup token


### PR DESCRIPTION
`new-install?` should be detected _before_ we load users from a config file, because it checks whether any users have been created.

Slack thread: https://metaboat.slack.com/archives/CKZEMT1MJ/p1699558315030329