### PR TITLE
Fix negative value on loading dashboard title

### DIFF
--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -388,7 +388,9 @@ const loadingDashCards = handleActions(
     },
     [FETCH_CARD_DATA_PENDING]: {
       next: (state, { payload: { dashcard_id } }) => {
-        const loadingIds = state.loadingIds.concat(dashcard_id);
+        const loadingIds = !state.loadingIds.includes(dashcard_id)
+          ? state.loadingIds.concat(dashcard_id)
+          : state.loadingIds;
         return {
           ...state,
           loadingIds,

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.js
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.js
@@ -8,6 +8,7 @@ import {
   SET_DASHBOARD_ATTRIBUTES,
   FETCH_DASHBOARD_CARD_DATA,
   FETCH_CARD_DATA,
+  FETCH_CARD_DATA_PENDING,
 } from "./actions";
 
 describe("dashboard reducers", () => {
@@ -345,6 +346,27 @@ describe("dashboard reducers", () => {
         },
         dashcardData: { 3: { 1: {} } },
       });
+    });
+
+    it("should not has duplicated id in loadingIds on pending (metabase#33692, metabase#34767)", () => {
+      const result = reducer(
+        {
+          ...initState,
+          loadingDashCards: {
+            loadingIds: [3],
+            loadingStatus: "running",
+            startTime: 100,
+          },
+        },
+        {
+          type: FETCH_CARD_DATA_PENDING,
+          payload: {
+            dashcard_id: 3,
+            card_id: 1,
+          },
+        },
+      );
+      expect(result.loadingDashCards.loadingIds).toEqual([3]);
     });
   });
 });

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.js
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.js
@@ -348,7 +348,7 @@ describe("dashboard reducers", () => {
       });
     });
 
-    it("should not has duplicated id in loadingIds on pending (metabase#33692, metabase#34767)", () => {
+    it("should not have duplicated elements in loadingIds on pending (metabase#33692, metabase#34767)", () => {
       const result = reducer(
         {
           ...initState,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/34767
Closes https://github.com/metabase/metabase/issues/33692

### Description

In the `updateLoadingTitle` action, the `loadingDashCards.loadingIds` initial size is greater than the `totalCards` size. Hence the calculation result is negative.

#### Root cause

In the `fetchCardData` action, `FETCH_CARD_DATA_PENDING` [dispatched](https://github.com/ibedwi/metabase/blob/b2fb7b356058c60ffcde03f9c424a6a6fd8ccf61/frontend/src/metabase/dashboard/actions/data-fetching.js#L268).  

```js
dispatch({
  type: FETCH_CARD_DATA_PENDING,
  payload: {
    dashcard_id: dashcard.id,
    card_id: card.id,
  },
});
```

In the `reducers`, the passed `dashcard_id` is added to the `loadingIds` regardless it's already there or not:

```
[FETCH_CARD_DATA_PENDING]: {
  next: (state, { payload: { dashcard_id } }) => {
    const loadingIds = state.loadingIds.concat(dashcard_id);
    return {
      ...state,
      loadingIds,
    };
  },
},
```

Therefore, the size of `loadingIds` might be doubled the size of the dashboard's cards.

#### How this fixed

In this PR, the `dashcard_id` would be added if the `loadingIds` array doesn't have it yet. 

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Go to the dashboard with cards
2. Reload the page, check the browser's tab and see the title "`.../... loaded`"


### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

Sometimes, the title isn't updated. So to check this issue, I log the returned value of `updateLoadingTitle` action

#### Before

![CleanShot 2023-11-11 at 20 38 03@2x](https://github.com/metabase/metabase/assets/15979404/7bd48199-c2da-4381-a8f9-2fbd2da68c5f)


#### After
![CleanShot 2023-11-11 at 20 34 20@2x](https://github.com/metabase/metabase/assets/15979404/868f3077-a249-4398-9fa5-583fa4c1f467)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
