### PR TITLE
Make E2E workflow 3rd party friendly

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -7,14 +7,31 @@ on:
       - 'release-**'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  workflow_run:
+    workflows: [External Trigger Filter]
+    types: [completed]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
+  external-filter:
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 3
+    steps:
+      - run: |
+          if ${{ github.event.pull_request.head.repo.full_name == github.repository }}; then
+            echo 'Running E2E tests within the organization.'
+          elif ${{ github.event.workflow_run.conclusion == 'success' }}; then
+            echo "Running E2E tests for the external contributor. Thank you!"
+          fi
+
   files-changed:
     name: Check which files changed
+    needs: external-filter
+    if: needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 3
     outputs:
@@ -29,6 +46,8 @@ jobs:
           filters: .github/file-paths.yaml
 
   e2e-matrix-builder:
+    needs: external-filter
+    if: needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     outputs:
@@ -40,9 +59,10 @@ jobs:
         uses: ./.github/actions/build-e2e-matrix
 
   build:
-    needs: [files-changed, e2e-matrix-builder]
+    needs: [files-changed, e2e-matrix-builder, external-filter]
     if: |
       !cancelled() &&
+      needs.external-filter.result == 'success' &&
       github.event.pull_request.draft == false &&
       needs.e2e-matrix-builder.result == 'success' &&
       needs.files-changed.outputs.e2e_all == 'true'
@@ -72,9 +92,9 @@ jobs:
           name: metabase-${{ matrix.edition }}-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
 
   e2e-tests:
-    needs: [build, e2e-matrix-builder]
+    needs: [build, e2e-matrix-builder, external-filter]
     if: |
-      !cancelled() && needs.build.result == 'success'
+      !cancelled() && needs.build.result == 'success' && needs.external-filter.result == 'success'
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     name: e2e-tests-${{ matrix.name }}-${{ matrix.edition }}
@@ -182,10 +202,10 @@ jobs:
           if-no-files-found: ignore
 
   e2e-tests-skipped-stub:
-    needs: [e2e-tests, e2e-matrix-builder]
+    needs: [e2e-tests, e2e-matrix-builder, external-filter]
     if: |
       !cancelled() &&
-      needs.e2e-tests.result == 'skipped'
+      needs.e2e-tests.result == 'skipped' && needs.external-filter.result == 'success'
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 5
     name: e2e-tests-${{ matrix.name }}-${{ matrix.edition }}
@@ -199,9 +219,9 @@ jobs:
   visual-regression-tests:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
-    needs: [build]
+    needs: [build, external-filter]
     if: |
-      !cancelled() && needs.build.result == 'success'
+      !cancelled() && needs.build.result == 'success' && needs.external-filter.result == 'success'
     name: percy-visual-regression-tests
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR is a follow up after https://github.com/metabase/metabase/pull/34951.
It should be straight-forward, but I'm always wary when touching Github workflows as they are notoriously hard to test, so please be vigilant when reviewing.

Unfortunately, it is impossible to actually test this until it gets merged into `master`.
If people feel uneasy merging it without some test runs, I can set things up tomorrow in my own fork, and then test it using completely different account (fork of a fork).

## Test
I created a separate account which forked my own fork of Metabase 😅
Here's what I tested:
- Created a PR from external account -> had to wait for an approval
- Once approved, it started running
    - E2E on `pull_request` skipped ✅
    - `external-filer.yml` on `pull_request` recognized this was an external PR and passed which, in turn, triggered E2E tests on `workflow_run`, as designed ✅
- All tests ran and passed, meaning access to the secrets works
![image](https://github.com/metabase/metabase/assets/31325167/5683c347-dedd-4a0c-81c4-13ddd250f2c5)

> **Important**
> - External contributor cannot hit re-run (only the owner can)! 🎉
> - Force-push, rebase, etc. cannot circumvent waiting for an approval! Each new commit has to be explicitly approved by owner/maintainer. 🎉 


### Downsides
- File path filtering doesn't work when we trigger the workflow via `workflow_run`. This means that all tests run even on unrelated file changes. Given that we don't have a high volume of external contributions this is a completely acceptable tradeoff IMO.