### PR TITLE
Run stubbed backend jobs when main `backend` tests are skipped

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -217,11 +217,10 @@ jobs:
           fail-on-error: false
 
   be-tests-stub:
-    needs: [files-changed, static-viz-files-changed]
+    needs: [be-tests]
     if: |
-      always() &&
-      github.event.pull_request.draft == false &&
-      (needs.files-changed.outputs.backend_all == 'false' && needs.static-viz-files-changed.outputs.static_viz == 'false')
+      !cancelled() &&
+      github.event.pull_request.draft == false && needs.be-tests.result == 'skipped'
     runs-on: ubuntu-22.04
     name: be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}
     timeout-minutes: 5


### PR DESCRIPTION
This should make this way more simple.

We have a few chained conditions under which `be-tests` run. Since these checks are marked as required, we need the backend-tests-stub to run if main tests are skipped. Rather than trying to mimic those chained conditions (inverted), is there anything stopping us from simply saying: "Run a stub job if the main one is skipped"?

The example of the mismatch in conditions that left these required checks pending is this run:
https://github.com/metabase/metabase/actions/runs/6850259807/job/18624077495

Files changed output:
`Changes output set to ["e2e_specs","e2e_all"]`

Note six expected checks
![image](https://github.com/metabase/metabase/assets/31325167/a491444a-4ac6-4d50-aaf2-1b39b1268b6e)

With this proposed approach, such scenarios shouldn't happen anymore.