### PR TITLE
[MLv2] Filters — Fix quarter labels in `ExcludeDatePicker`

### DIFF
--- a/frontend/src/metabase/common/components/DatePicker/ExcludeDatePicker/utils.ts
+++ b/frontend/src/metabase/common/components/DatePicker/ExcludeDatePicker/utils.ts
@@ -1,5 +1,6 @@
 import _ from "underscore";
 import dayjs from "dayjs";
+import { t } from "ttag";
 import type {
   DatePickerExtractionUnit,
   DatePickerOperator,
@@ -57,7 +58,7 @@ export function getExcludeValueOptionGroups(
         _.range(6, 12).map(getExcludeMonthOption),
       ];
     case "quarter-of-year":
-      return [_.range(1, 5).map(getExcludeQuarterOption)];
+      return [getExcludeQuarterOptions()];
   }
 }
 
@@ -76,9 +77,13 @@ function getExcludeMonthOption(month: number): ExcludeValueOption {
   return { value: month, label: date.format("MMMM") };
 }
 
-function getExcludeQuarterOption(quarter: number): ExcludeValueOption {
-  const date = dayjs().quarter(quarter);
-  return { value: quarter, label: date.format("Qo") };
+function getExcludeQuarterOptions(): ExcludeValueOption[] {
+  return [
+    { value: 1, label: t`1st` },
+    { value: 2, label: t`2nd` },
+    { value: 3, label: t`3rd` },
+    { value: 4, label: t`4th` },
+  ];
 }
 
 export function getExcludeOperatorValue(


### PR DESCRIPTION
It seems quarter labels in the `ExcludeDatePicker` broke after migrating the picker to `dayjs`. It doesn't handle the `Qo` format we used to get ordinal quarter numbers (1st, 2nd, 3rd, etc). The [`format` docs](https://day.js.org/docs/en/display/format#docsNav) don't mention quarters at all. There's an [`AdvancedFormat` plugin](https://day.js.org/docs/en/plugin/advanced-format) that adds `Q` format, but not `Qo` or any alternative. 

### To Verify

1. New > Question > Raw Data > Sample Database > Orders
2. Filter by Created At > Exclude > Quarter
3. Ensure the options are "1st, 2nd, 3rd, 4th" instead of "Qo, Qo, Qo, Qo"

Not adding tests, there's already one [failing on the base branch](https://github.com/metabase/metabase/actions/runs/6849378709/job/18621453482?pr=34191)