### PR TITLE
Add warning for h2 uploads db

### DIFF
--- a/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.tsx
@@ -13,13 +13,14 @@ import { updateSettings } from "metabase/admin/settings/settings";
 
 import type { State } from "metabase-types/store";
 
-import { Stack, Group } from "metabase/ui";
+import { Stack, Group, Text } from "metabase/ui";
 import Link from "metabase/core/components/Link";
 import type { SelectChangeEvent } from "metabase/core/components/Select";
 import Select from "metabase/core/components/Select";
 import Input from "metabase/core/components/Input";
 import ActionButton from "metabase/components/ActionButton";
 import EmptyState from "metabase/components/EmptyState/EmptyState";
+import Alert from "metabase/core/components/Alert";
 
 import type Database from "metabase-lib/metadata/Database";
 import type Schema from "metabase-lib/metadata/Schema";
@@ -163,10 +164,14 @@ export function UploadSettingsView({
     tablePrefix !== settings.uploads_table_prefix;
 
   const hasValidDatabases = databaseOptions.length > 0;
+  const isH2db = Boolean(
+    dbId && databases.find(db => db.id === dbId)?.engine === "h2",
+  );
 
   return (
     <PaddedForm aria-label={t`Upload Settings Form`}>
       <Header />
+      {isH2db && <H2PersistenceWarning />}
       <Group>
         <Stack>
           <SectionTitle>{t`Database to use for uploads`}</SectionTitle>
@@ -272,6 +277,16 @@ export function UploadSettingsView({
     </PaddedForm>
   );
 }
+
+const H2PersistenceWarning = () => (
+  <Stack my="md" maw={620}>
+    <Alert icon="warning" variant="warning">
+      <Text>
+        {t`Warning: uploads to the Sample Database are for testing only. If you want your data to stick around, you should upload to a PostgreSQL or MySQL database.`}
+      </Text>
+    </Alert>
+  </Stack>
+);
 
 const NoValidDatabasesMessage = () => (
   <>

--- a/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.tsx
@@ -282,7 +282,7 @@ const H2PersistenceWarning = () => (
   <Stack my="md" maw={620}>
     <Alert icon="warning" variant="warning">
       <Text>
-        {t`Warning: uploads to the Sample Database are for testing only. If you want your data to stick around, you should upload to a PostgreSQL or MySQL database.`}
+        {t`Warning: uploads to the Sample Database are for testing only and may disappear. If you want your data to stick around, you should upload to a PostgreSQL or MySQL database.`}
       </Text>
     </Alert>
   </Stack>

--- a/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.unit.spec.tsx
@@ -554,4 +554,15 @@ describe("Admin > Settings > UploadSetting", () => {
       ).toBeInTheDocument();
     });
   });
+
+  it("should show a warning for h2 databases", async () => {
+    setup();
+    userEvent.click(await screen.findByText("Select a database"));
+
+    userEvent.click(await screen.findByText("Db Cinco")); // h2
+
+    expect(
+      screen.getByText(/uploads to the Sample Database are for testing only/i),
+    ).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/35638

### Description

If an admin selects the sample database as an upload target, warn them that setting an h2 uploads DB is for testing only and they will likely lose data.

![Screen Shot 2023-11-13 at 8 46 31 AM](https://github.com/metabase/metabase/assets/30528226/3f6eb12b-f8ed-4bc1-ae9f-413a607ad09f)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

