### PR TITLE
fix: prevent dispatch fetchCardData on virtual_card

### DIFF
--- a/frontend/src/metabase/dashboard/actions/cards.js
+++ b/frontend/src/metabase/dashboard/actions/cards.js
@@ -77,7 +77,9 @@ export const undoRemoveCardFromDashboard = createThunkAction(
       const dashcard = getDashCardById(getState(), dashcardId);
       const card = dashcard.card;
 
-      dispatch(fetchCardData(card, dashcard));
+      if (!["text", "action", "heading", "link"].includes(card.display)) {
+        dispatch(fetchCardData(card, dashcard));
+      }
 
       return { dashcardId };
     },


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/35581

### Description

#### Root Cause

The shown error was API call error. In `undoRemoveCardFromDashboard` action, the `fetchCardData` action dispatched. But since the card with `text`, `action`, `heading`, and `link` display doesn't have `cardId`, the request will failed and the card ended up showing error.

#### Approach

In the `undoRemoveCardFromDashboard` action, the `fetchCardData` action will only be dispatched when the card's display is not `text`, `action`, `heading`, or `link`.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Go to a dashboard
2. Add text card, heading card, link card, and action card
3. For each card, remove the card and undo the removal
4. The visualizations will be broken

### Demo

#### Before

https://github.com/metabase/metabase/assets/15979404/d492e74a-1b91-42a5-8b2f-5ddb115b9e69

#### After

https://github.com/metabase/metabase/assets/15979404/0dbde2a5-517a-47ed-93c8-8bcccbd8fefa

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
