### PR TITLE
Mark top tier E2E flakes

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-nested.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-nested.cy.spec.js
@@ -23,100 +23,104 @@ describe("scenarios > dashboard > filters > nested questions", () => {
     );
   });
 
-  it("dashboard filters should work on nested question (metabase#12614, metabase#13186, metabase#18113, metabase#32126)", () => {
-    const filter = {
-      name: "Text Filter",
-      slug: "text",
-      id: "27454068",
-      type: "string/=",
-      sectionId: "string",
-    };
+  it(
+    "dashboard filters should work on nested question (metabase#12614, metabase#13186, metabase#18113, metabase#32126)",
+    { tags: ["@flake"] },
+    () => {
+      const filter = {
+        name: "Text Filter",
+        slug: "text",
+        id: "27454068",
+        type: "string/=",
+        sectionId: "string",
+      };
 
-    cy.createNativeQuestion({
-      name: "18113 Source",
-      native: {
-        query: "select * from products limit 5",
-      },
-      display: "table",
-    }).then(({ body: { id: Q1_ID } }) => {
-      const nestedQuestion = {
-        name: "18113 Nested",
-        query: {
-          "source-table": `card__${Q1_ID}`,
+      cy.createNativeQuestion({
+        name: "18113 Source",
+        native: {
+          query: "select * from products limit 5",
         },
-      };
+        display: "table",
+      }).then(({ body: { id: Q1_ID } }) => {
+        const nestedQuestion = {
+          name: "18113 Nested",
+          query: {
+            "source-table": `card__${Q1_ID}`,
+          },
+        };
 
-      const dashboardDetails = {
-        name: "Nested Filters",
-        parameters: [filter],
-      };
+        const dashboardDetails = {
+          name: "Nested Filters",
+          parameters: [filter],
+        };
 
-      cy.createQuestionAndDashboard({
-        questionDetails: nestedQuestion,
-        dashboardDetails,
-      }).then(({ body: { dashboard_id } }) => {
-        visitDashboard(dashboard_id);
+        cy.createQuestionAndDashboard({
+          questionDetails: nestedQuestion,
+          dashboardDetails,
+        }).then(({ body: { dashboard_id } }) => {
+          visitDashboard(dashboard_id);
+        });
       });
-    });
 
-    editDashboard();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(filter.name).find(".Icon-gear").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Select…").click();
+      editDashboard();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText(filter.name).find(".Icon-gear").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Select…").click();
 
-    // This part reproduces metabase#13186
-    cy.log("Reported failing in v0.36.4 (`Category` is missing)");
-    popover().within(() => {
-      cy.findByText(/Ean/i);
-      cy.findByText(/Title/i);
-      cy.findByText(/Vendor/i);
-      cy.findByText(/Category/i).click();
-    });
+      // This part reproduces metabase#13186
+      cy.log("Reported failing in v0.36.4 (`Category` is missing)");
+      popover().within(() => {
+        cy.findByText(/Ean/i);
+        cy.findByText(/Title/i);
+        cy.findByText(/Vendor/i);
+        cy.findByText(/Category/i).click();
+      });
 
-    saveDashboard();
+      saveDashboard();
 
-    // Add multiple values (metabase#18113)
-    filterWidget().click();
-    popover().within(() => {
-      cy.findByText("Gizmo").click();
-      cy.findByText("Gadget").click();
-    });
+      // Add multiple values (metabase#18113)
+      filterWidget().click();
+      popover().within(() => {
+        cy.findByText("Gizmo").click();
+        cy.findByText("Gadget").click();
+      });
 
-    cy.button("Add filter").click();
-    cy.wait("@dashcardQuery");
+      cy.button("Add filter").click();
+      cy.wait("@dashcardQuery");
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("2 selections");
-    cy.get("tbody > tr").should("have.length", 2);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("2 selections");
+      cy.get("tbody > tr").should("have.length", 2);
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Doohickey").should("not.exist");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Doohickey").should("not.exist");
 
-    cy.reload();
-    cy.wait("@dashcardQuery");
+      cy.reload();
+      cy.wait("@dashcardQuery");
 
-    cy.location("search").should("eq", "?text=Gizmo&text=Gadget");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("2 selections");
+      cy.location("search").should("eq", "?text=Gizmo&text=Gadget");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("2 selections");
 
-    editDashboard();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(filter.name).find(".Icon-gear").click();
+      editDashboard();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText(filter.name).find(".Icon-gear").click();
 
-    getDashboardCard().within(() => {
-      cy.findByText("Column to filter on");
-      cy.findByText("18113 Source.CATEGORY").click();
-    });
+      getDashboardCard().within(() => {
+        cy.findByText("Column to filter on");
+        cy.findByText("18113 Source.CATEGORY").click();
+      });
 
-    // This part reproduces metabase#12614
-    popover().within(() => {
-      cy.findByText(/Ean/i);
-      cy.findByText(/Title/i);
-      cy.findByText(/Vendor/i);
-      cy.findByText(/Category/i).click();
-    });
-  });
+      // This part reproduces metabase#12614
+      popover().within(() => {
+        cy.findByText(/Ean/i);
+        cy.findByText(/Title/i);
+        cy.findByText(/Vendor/i);
+        cy.findByText(/Category/i).click();
+      });
+    },
+  );
 
   it("should be possible to use ID filter on a nested question (metabase#17212)", () => {
     const baseQuestion = {

--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -214,95 +214,99 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
       dashboard: ORDERS_DASHBOARD_ID,
     };
     ["question", "dashboard"].forEach(object => {
-      it(`should be able to publish/embed and then unpublish a ${object} without filters`, () => {
-        const embeddableObject = object === "question" ? "card" : "dashboard";
-        const objectName =
-          object === "question" ? "Orders" : "Orders in a dashboard";
+      it(
+        `should be able to publish/embed and then unpublish a ${object} without filters`,
+        { tags: ["@flake"] },
+        () => {
+          const embeddableObject = object === "question" ? "card" : "dashboard";
+          const objectName =
+            object === "question" ? "Orders" : "Orders in a dashboard";
 
-        cy.intercept("PUT", `/api/${embeddableObject}/${ids[object]}`).as(
-          "embedObject",
-        );
-        cy.intercept("GET", `/api/${embeddableObject}/embeddable`).as(
-          "currentlyEmbeddedObject",
-        );
-
-        visitAndEnableSharing(object);
-
-        cy.findByTestId("embedding-settings").within(() => {
-          cy.findByRole("heading", { name: "Style" });
-          cy.findByRole("heading", { name: "Appearance" });
-          cy.findByRole("heading", { name: "Font" }).should("not.exist");
-          cy.findByRole("heading", { name: "Download data" }).should(
-            "not.exist",
+          cy.intercept("PUT", `/api/${embeddableObject}/${ids[object]}`).as(
+            "embedObject",
+          );
+          cy.intercept("GET", `/api/${embeddableObject}/embeddable`).as(
+            "currentlyEmbeddedObject",
           );
 
-          cy.findByText("Parameters");
-          cy.findByText(
-            /This (question|dashboard) doesn't have any parameters to configure yet./,
+          visitAndEnableSharing(object);
+
+          cy.findByTestId("embedding-settings").within(() => {
+            cy.findByRole("heading", { name: "Style" });
+            cy.findByRole("heading", { name: "Appearance" });
+            cy.findByRole("heading", { name: "Font" }).should("not.exist");
+            cy.findByRole("heading", { name: "Download data" }).should(
+              "not.exist",
+            );
+
+            cy.findByText("Parameters");
+            cy.findByText(
+              /This (question|dashboard) doesn't have any parameters to configure yet./,
+            );
+            cy.findByText("Parameters");
+          });
+
+          cy.findByTestId("embedding-preview").within(() => {
+            cy.findByText(
+              /You will need to publish this (question|dashboard) before you can embed it in another application./,
+            );
+
+            cy.button("Publish").click();
+            cy.wait("@embedObject");
+          });
+
+          visitIframe();
+
+          cy.findByTestId("embed-frame").within(() => {
+            cy.findByRole("heading", { name: objectName });
+            cy.get(".cellData").contains("37.65");
+          });
+
+          cy.findByRole("contentinfo").within(() => {
+            cy.findByRole("link")
+              .should("have.text", "Powered by Metabase")
+              .and("have.attr", "href")
+              .and("eq", "https://metabase.com/");
+          });
+
+          cy.log(
+            `Make sure the ${object} shows up in the standalone embeds page`,
           );
-          cy.findByText("Parameters");
-        });
+          cy.signInAsAdmin();
+          cy.visit(standalonePath);
+          cy.wait("@currentlyEmbeddedObject");
 
-        cy.findByTestId("embedding-preview").within(() => {
-          cy.findByText(
-            /You will need to publish this (question|dashboard) before you can embed it in another application./,
+          const sectionTestId = new RegExp(`-embedded-${object}s-setting`);
+
+          cy.findByTestId(sectionTestId)
+            .find("tbody tr")
+            .should("have.length", 1)
+            .and("contain", objectName);
+
+          cy.log(`Unpublish ${object}`);
+          visitAndEnableSharing(object);
+
+          cy.findByTestId("embedding-settings").within(() => {
+            cy.findByRole("heading", { name: "Danger zone" });
+            cy.findByText(`This will disable embedding for this ${object}.`);
+            cy.button("Unpublish").click();
+            cy.wait("@embedObject");
+          });
+
+          visitIframe();
+          cy.findByTestId("embed-frame").findByText(
+            "Embedding is not enabled for this object.",
           );
 
-          cy.button("Publish").click();
-          cy.wait("@embedObject");
-        });
+          cy.signInAsAdmin();
+          cy.visit(standalonePath);
+          cy.wait("@currentlyEmbeddedObject");
 
-        visitIframe();
-
-        cy.findByTestId("embed-frame").within(() => {
-          cy.findByRole("heading", { name: objectName });
-          cy.get(".cellData").contains("37.65");
-        });
-
-        cy.findByRole("contentinfo").within(() => {
-          cy.findByRole("link")
-            .should("have.text", "Powered by Metabase")
-            .and("have.attr", "href")
-            .and("eq", "https://metabase.com/");
-        });
-
-        cy.log(
-          `Make sure the ${object} shows up in the standalone embeds page`,
-        );
-        cy.signInAsAdmin();
-        cy.visit(standalonePath);
-        cy.wait("@currentlyEmbeddedObject");
-
-        const sectionTestId = new RegExp(`-embedded-${object}s-setting`);
-
-        cy.findByTestId(sectionTestId)
-          .find("tbody tr")
-          .should("have.length", 1)
-          .and("contain", objectName);
-
-        cy.log(`Unpublish ${object}`);
-        visitAndEnableSharing(object);
-
-        cy.findByTestId("embedding-settings").within(() => {
-          cy.findByRole("heading", { name: "Danger zone" });
-          cy.findByText(`This will disable embedding for this ${object}.`);
-          cy.button("Unpublish").click();
-          cy.wait("@embedObject");
-        });
-
-        visitIframe();
-        cy.findByTestId("embed-frame").findByText(
-          "Embedding is not enabled for this object.",
-        );
-
-        cy.signInAsAdmin();
-        cy.visit(standalonePath);
-        cy.wait("@currentlyEmbeddedObject");
-
-        mainPage()
-          .findAllByText(/No (questions|dashboards) have been embedded yet./)
-          .should("have.length", 2);
-      });
+          mainPage()
+            .findAllByText(/No (questions|dashboards) have been embedded yet./)
+            .should("have.length", 2);
+        },
+      );
     });
 
     it("should regenerate embedding token and invalidate previous embed url", () => {

--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -192,33 +192,37 @@ describe("scenarios > models metadata", () => {
     // Check that the relation is automatically suggested in the notebook once it is implemented.
   });
 
-  it("should keep metadata in sync with the query", () => {
-    cy.createNativeQuestion(
-      {
-        name: "Native Model",
-        dataset: true,
-        native: {
-          query: "SELECT * FROM ORDERS LIMIT 5",
+  it(
+    "should keep metadata in sync with the query",
+    { tags: ["@flake"] },
+    () => {
+      cy.createNativeQuestion(
+        {
+          name: "Native Model",
+          dataset: true,
+          native: {
+            query: "SELECT * FROM ORDERS LIMIT 5",
+          },
         },
-      },
-      { visitQuestion: true },
-    );
+        { visitQuestion: true },
+      );
 
-    openQuestionActions();
-    popover().findByTextEnsureVisible("Edit query definition").click();
+      openQuestionActions();
+      popover().findByTextEnsureVisible("Edit query definition").click();
 
-    cy.get(".ace_content").type(
-      "{selectAll}{backspace}SELECT TOTAL FROM ORDERS LIMIT 5",
-    );
+      cy.get(".ace_content").type(
+        "{selectAll}{backspace}SELECT TOTAL FROM ORDERS LIMIT 5",
+      );
 
-    cy.findByTestId("editor-tabs-metadata-name").click();
-    cy.wait("@dataset");
+      cy.findByTestId("editor-tabs-metadata-name").click();
+      cy.wait("@dataset");
 
-    cy.findAllByTestId("header-cell")
-      .should("have.length", 1)
-      .and("have.text", "TOTAL");
-    cy.findByLabelText("Display name").should("have.value", "TOTAL");
-  });
+      cy.findAllByTestId("header-cell")
+        .should("have.length", 1)
+        .and("have.text", "TOTAL");
+      cy.findByLabelText("Display name").should("have.value", "TOTAL");
+    },
+  );
 
   it("should allow reverting to a specific metadata revision", () => {
     cy.intercept("POST", "/api/revision/revert").as("revert");

--- a/e2e/test/scenarios/models/models-query-editor.cy.spec.js
+++ b/e2e/test/scenarios/models/models-query-editor.cy.spec.js
@@ -27,7 +27,7 @@ describe("scenarios > models query editor", () => {
       });
     });
 
-    it("allows to edit GUI model query", () => {
+    it("allows to edit GUI model query", { tags: ["@flake"] }, () => {
       cy.visit(`/model/${ORDERS_QUESTION_ID}`);
       cy.wait("@dataset");
 

--- a/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
@@ -22,7 +22,7 @@ const questionDetails = {
   dataset: true,
 };
 
-describe("issue 29951", { requestTimeout: 10000 }, () => {
+describe("issue 29951", { requestTimeout: 10000 }, { tags: ["@flake"] }, () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/native/native_subquery.cy.spec.js
+++ b/e2e/test/scenarios/native/native_subquery.cy.spec.js
@@ -308,23 +308,27 @@ describe("scenarios > question > native subquery", () => {
     );
   });
 
-  it("should be able to reference a saved native question that ends with a semicolon `;` (metabase#28218)", () => {
-    const questionDetails = {
-      name: "28218",
-      native: { query: "select 1;" }, // semicolon is important here
-    };
+  it(
+    "should be able to reference a saved native question that ends with a semicolon `;` (metabase#28218)",
+    { tags: ["@flake"] },
+    () => {
+      const questionDetails = {
+        name: "28218",
+        native: { query: "select 1;" }, // semicolon is important here
+      };
 
-    cy.createNativeQuestion(questionDetails).then(
-      ({ body: { id: baseQuestionId } }) => {
-        const tagID = `#${baseQuestionId}`;
+      cy.createNativeQuestion(questionDetails).then(
+        ({ body: { id: baseQuestionId } }) => {
+          const tagID = `#${baseQuestionId}`;
 
-        startNewNativeQuestion();
-        SQLFilter.enterParameterizedQuery(`SELECT * FROM {{${tagID}`);
+          startNewNativeQuestion();
+          SQLFilter.enterParameterizedQuery(`SELECT * FROM {{${tagID}`);
 
-        runNativeQuery();
+          runNativeQuery();
 
-        cy.get(".cellData").should("contain", "1");
-      },
-    );
-  });
+          cy.get(".cellData").should("contain", "1");
+        },
+      );
+    },
+  );
 });

--- a/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
@@ -39,13 +39,13 @@ describe("search > recently viewed", () => {
     cy.findByTestId("loading-spinner").should("not.exist");
   });
 
-  it("shows list of recently viewed items", () => {
+  it("shows list of recently viewed items", { tags: ["@flake"] }, () => {
     assertRecentlyViewedItem(0, "Orders in a dashboard", "Dashboard");
     assertRecentlyViewedItem(1, "Orders", "Question");
     assertRecentlyViewedItem(2, "People", "Table");
   });
 
-  it("allows to select an item from keyboard", () => {
+  it("allows to select an item from keyboard", { tags: ["@flake"] }, () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Recently viewed");
     cy.get("body").trigger("keydown", { key: "ArrowDown" });

--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.js
@@ -234,65 +234,69 @@ describe("scenarios > setup", () => {
     });
   });
 
-  it(`should allow you to connect a db during setup`, () => {
-    const dbName = "SQLite db";
+  it(
+    `should allow you to connect a db during setup`,
+    { tags: ["@flake"] },
+    () => {
+      const dbName = "SQLite db";
 
-    cy.intercept("GET", "api/collection/root").as("getRootCollection");
-    cy.intercept("GET", "api/database").as("getDatabases");
+      cy.intercept("GET", "api/collection/root").as("getRootCollection");
+      cy.intercept("GET", "api/database").as("getDatabases");
 
-    cy.visit(`/setup#123456`);
+      cy.visit(`/setup#123456`);
 
-    cy.findByTestId("welcome-page").within(() => {
-      cy.findByText("Welcome to Metabase");
-      cy.findByTextEnsureVisible("Let's get started").click();
-    });
-
-    cy.findByTestId("setup-forms").within(() => {
-      cy.findByText("What's your preferred language?");
-      cy.findByLabelText("English");
-
-      cy.findByText("Next").click();
-
-      const strongPassword = "QJbHYJN3tPW[";
-      cy.findByLabelText(/^Create a password/)
-        .clear()
-        .type(strongPassword, { delay: 0 });
-      cy.findByLabelText(/^Confirm your password/)
-        .clear()
-        .type(strongPassword, { delay: 0 })
-        .blur();
-
-      cy.findByText("Next").click();
-    });
-
-    cy.findByTestId("database-form").within(() => {
-      cy.findByPlaceholderText("Search for a database…").type("lite").blur();
-      cy.findByText("SQLite").click();
-      cy.findByLabelText("Display name").type(dbName);
-      cy.findByLabelText("Filename").type("./resources/sqlite-fixture.db", {
-        delay: 0,
+      cy.findByTestId("welcome-page").within(() => {
+        cy.findByText("Welcome to Metabase");
+        cy.findByTextEnsureVisible("Let's get started").click();
       });
-      cy.button("Connect database").click();
-    });
 
-    // usage data
-    cy.get("section").last().button("Finish").click();
+      cy.findByTestId("setup-forms").within(() => {
+        cy.findByText("What's your preferred language?");
+        cy.findByLabelText("English");
 
-    // done
-    cy.get("section").last().findByText("Take me to Metabase").click();
+        cy.findByText("Next").click();
 
-    // in app
-    cy.location("pathname").should("eq", "/");
-    cy.wait(["@getRootCollection", "@getDatabases"]);
+        const strongPassword = "QJbHYJN3tPW[";
+        cy.findByLabelText(/^Create a password/)
+          .clear()
+          .type(strongPassword, { delay: 0 });
+        cy.findByLabelText(/^Confirm your password/)
+          .clear()
+          .type(strongPassword, { delay: 0 })
+          .blur();
 
-    cy.get("main").within(() => {
-      cy.findByText("Here are some explorations of");
-      cy.findAllByRole("link").should("contain", dbName);
-    });
+        cy.findByText("Next").click();
+      });
 
-    cy.visit("/browse");
-    cy.findByTestId("database-browser").findByText(dbName);
-  });
+      cy.findByTestId("database-form").within(() => {
+        cy.findByPlaceholderText("Search for a database…").type("lite").blur();
+        cy.findByText("SQLite").click();
+        cy.findByLabelText("Display name").type(dbName);
+        cy.findByLabelText("Filename").type("./resources/sqlite-fixture.db", {
+          delay: 0,
+        });
+        cy.button("Connect database").click();
+      });
+
+      // usage data
+      cy.get("section").last().button("Finish").click();
+
+      // done
+      cy.get("section").last().findByText("Take me to Metabase").click();
+
+      // in app
+      cy.location("pathname").should("eq", "/");
+      cy.wait(["@getRootCollection", "@getDatabases"]);
+
+      cy.get("main").within(() => {
+        cy.findByText("Here are some explorations of");
+        cy.findAllByRole("link").should("contain", dbName);
+      });
+
+      cy.visit("/browse");
+      cy.findByTestId("database-browser").findByText(dbName);
+    },
+  );
 });
 
 describeWithSnowplow("scenarios > setup", () => {

--- a/e2e/test/scenarios/onboarding/urls.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/urls.cy.spec.js
@@ -72,7 +72,7 @@ describe("URLs", () => {
   });
 
   describe("collections", () => {
-    it("should slugify collection name", () => {
+    it("should slugify collection name", { tags: ["@flake"] }, () => {
       cy.visit("/collection/root");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("First collection").click();

--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -444,148 +444,54 @@ describeEE("formatting > sandboxes", () => {
       cy.findByText("97.44"); // Subtotal for order #10
     });
 
-    describe("with display values remapped to use a foreign key", () => {
-      beforeEach(() => {
-        cy.log("Remap Product ID's display value to `title`");
-        remapDisplayValueToFK({
-          display_value: ORDERS.PRODUCT_ID,
-          name: "Product ID",
-          fk: PRODUCTS.TITLE,
-        });
-      });
-
-      /**
-       * There isn't an exact issue that this test reproduces, but it is basically a version of (metabase-enterprise#520)
-       * that uses a query builder instead of SQL based questions.
-       */
-      it("should be able to sandbox using query builder saved questions", () => {
-        cy.log("Create 'Orders'-based question using QB");
-        cy.createQuestion({
-          name: "520_Orders",
-          query: {
-            "source-table": ORDERS_ID,
-            filter: [">", ["field", ORDERS.TOTAL, null], 10],
-          },
-        }).then(({ body: { id: CARD_ID } }) => {
-          cy.sandboxTable({
-            table_id: ORDERS_ID,
-            card_id: CARD_ID,
-            attribute_remappings: {
-              attr_uid: ["dimension", ["field", ORDERS.USER_ID, null]],
-            },
+    describe(
+      "with display values remapped to use a foreign key",
+      { tags: ["@flake"] },
+      () => {
+        beforeEach(() => {
+          cy.log("Remap Product ID's display value to `title`");
+          remapDisplayValueToFK({
+            display_value: ORDERS.PRODUCT_ID,
+            name: "Product ID",
+            fk: PRODUCTS.TITLE,
           });
         });
 
-        cy.log("Create 'Products'-based question using QB");
-        cy.createQuestion({
-          name: "520_Products",
-          query: {
-            "source-table": PRODUCTS_ID,
-            filter: [">", ["field", PRODUCTS.PRICE, null], 10],
-          },
-        }).then(({ body: { id: CARD_ID } }) => {
-          cy.sandboxTable({
-            table_id: PRODUCTS_ID,
-            card_id: CARD_ID,
-            attribute_remappings: {
-              attr_cat: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
-            },
-          });
-        });
-
-        cy.signOut();
-        cy.signInAsSandboxedUser();
-
-        openOrdersTable({
-          callback: xhr => expect(xhr.response.body.error).not.to.exist,
-        });
-
-        cy.get(".cellData").contains("Awesome Concrete Shoes").click();
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText(/View details/i).click();
-
-        cy.log(
-          "It should show object details instead of filtering by this Product ID",
-        );
-        cy.findByTestId("object-detail");
-        cy.findAllByText("McClure-Lockman");
-      });
-
-      /**
-       * This issue (metabase-enterprise#520) has a peculiar quirk:
-       *  - It works ONLY if SQL question is first run (`result_metadata` builds), and then the question is saved.
-       *  - In a real-world scenario it is quite possible for an admin to save that SQL question without running it first. This fails!
-       *  (more info: https://github.com/metabase/metabase-enterprise/issues/520#issuecomment-772528159)
-       *
-       * That's why this test has 2 versions that reflect both scenarios. We'll call them "normal" and "workaround".
-       * Until the underlying issue is fixed, "normal" scenario will be skipped.
-       *
-       * Related issues: metabase#10474, metabase#14629
-       */
-
-      // skipping the workaround test because the function `runAndSaveQuestion`
-      // relies on the existence of a save button on a saved question that is not dirty
-      // which is a bug fixed in ssue metabase#14302
-      ["normal" /* , "workaround" */].forEach(test => {
-        it(`${test.toUpperCase()} version:\n advanced sandboxing should not ignore data model features like object detail of FK (metabase-enterprise#520)`, () => {
-          cy.intercept("POST", "/api/card/*/query").as("cardQuery");
-          cy.intercept("PUT", "/api/card/*").as("questionUpdate");
-
-          cy.createNativeQuestion({
-            name: "EE_520_Q1",
-            native: {
-              query:
-                "SELECT * FROM ORDERS WHERE USER_ID={{sandbox}} AND TOTAL > 10",
-              "template-tags": {
-                sandbox: {
-                  "display-name": "Sandbox",
-                  id: "1115dc4f-6b9d-812e-7f72-b87ab885c88a",
-                  name: "sandbox",
-                  type: "number",
-                },
-              },
+        /**
+         * There isn't an exact issue that this test reproduces, but it is basically a version of (metabase-enterprise#520)
+         * that uses a query builder instead of SQL based questions.
+         */
+        it("should be able to sandbox using query builder saved questions", () => {
+          cy.log("Create 'Orders'-based question using QB");
+          cy.createQuestion({
+            name: "520_Orders",
+            query: {
+              "source-table": ORDERS_ID,
+              filter: [">", ["field", ORDERS.TOTAL, null], 10],
             },
           }).then(({ body: { id: CARD_ID } }) => {
-            test === "workaround"
-              ? runAndSaveQuestion({ question: CARD_ID, sandboxValue: "1" })
-              : null;
-
             cy.sandboxTable({
               table_id: ORDERS_ID,
               card_id: CARD_ID,
               attribute_remappings: {
-                attr_uid: ["variable", ["template-tag", "sandbox"]],
+                attr_uid: ["dimension", ["field", ORDERS.USER_ID, null]],
               },
             });
           });
 
-          cy.createNativeQuestion({
-            name: "EE_520_Q2",
-            native: {
-              query:
-                "SELECT * FROM PRODUCTS WHERE CATEGORY={{sandbox}} AND PRICE > 10",
-              "template-tags": {
-                sandbox: {
-                  "display-name": "Sandbox",
-                  id: "3d69ba99-7076-2252-30bd-0bb8810ba895",
-                  name: "sandbox",
-                  type: "text",
-                },
-              },
+          cy.log("Create 'Products'-based question using QB");
+          cy.createQuestion({
+            name: "520_Products",
+            query: {
+              "source-table": PRODUCTS_ID,
+              filter: [">", ["field", PRODUCTS.PRICE, null], 10],
             },
           }).then(({ body: { id: CARD_ID } }) => {
-            test === "workaround"
-              ? runAndSaveQuestion({
-                  question: CARD_ID,
-                  sandboxValue: "Widget",
-                })
-              : null;
-
             cy.sandboxTable({
               table_id: PRODUCTS_ID,
               card_id: CARD_ID,
               attribute_remappings: {
-                attr_cat: ["variable", ["template-tag", "sandbox"]],
+                attr_cat: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
               },
             });
           });
@@ -593,13 +499,10 @@ describeEE("formatting > sandboxes", () => {
           cy.signOut();
           cy.signInAsSandboxedUser();
 
-          openOrdersTable();
+          openOrdersTable({
+            callback: xhr => expect(xhr.response.body.error).not.to.exist,
+          });
 
-          cy.log("Reported failing on v1.36.x");
-
-          cy.log(
-            "It should show remapped Display Values instead of Product ID",
-          );
           cy.get(".cellData").contains("Awesome Concrete Shoes").click();
           // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText(/View details/i).click();
@@ -607,56 +510,157 @@ describeEE("formatting > sandboxes", () => {
           cy.log(
             "It should show object details instead of filtering by this Product ID",
           );
-          // The name of this Vendor is visible in "details" only
           cy.findByTestId("object-detail");
           cy.findAllByText("McClure-Lockman");
+        });
 
-          /**
-           * Helper function related to this test only!
-           */
-          function runAndSaveQuestion({ question, sandboxValue } = {}) {
-            // Run the question
-            cy.visit(`/question/${question}?sandbox=${sandboxValue}`);
-            // Wait for results
-            cy.wait("@cardQuery");
-            // Save the question
-            cy.findByText("Save").click();
-            modal().within(() => {
-              cy.button("Save").click();
+        /**
+         * This issue (metabase-enterprise#520) has a peculiar quirk:
+         *  - It works ONLY if SQL question is first run (`result_metadata` builds), and then the question is saved.
+         *  - In a real-world scenario it is quite possible for an admin to save that SQL question without running it first. This fails!
+         *  (more info: https://github.com/metabase/metabase-enterprise/issues/520#issuecomment-772528159)
+         *
+         * That's why this test has 2 versions that reflect both scenarios. We'll call them "normal" and "workaround".
+         * Until the underlying issue is fixed, "normal" scenario will be skipped.
+         *
+         * Related issues: metabase#10474, metabase#14629
+         */
+
+        // skipping the workaround test because the function `runAndSaveQuestion`
+        // relies on the existence of a save button on a saved question that is not dirty
+        // which is a bug fixed in ssue metabase#14302
+        ["normal" /* , "workaround" */].forEach(test => {
+          it(`${test.toUpperCase()} version:\n advanced sandboxing should not ignore data model features like object detail of FK (metabase-enterprise#520)`, () => {
+            cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+            cy.intercept("PUT", "/api/card/*").as("questionUpdate");
+
+            cy.createNativeQuestion({
+              name: "EE_520_Q1",
+              native: {
+                query:
+                  "SELECT * FROM ORDERS WHERE USER_ID={{sandbox}} AND TOTAL > 10",
+                "template-tags": {
+                  sandbox: {
+                    "display-name": "Sandbox",
+                    id: "1115dc4f-6b9d-812e-7f72-b87ab885c88a",
+                    name: "sandbox",
+                    type: "number",
+                  },
+                },
+              },
+            }).then(({ body: { id: CARD_ID } }) => {
+              test === "workaround"
+                ? runAndSaveQuestion({ question: CARD_ID, sandboxValue: "1" })
+                : null;
+
+              cy.sandboxTable({
+                table_id: ORDERS_ID,
+                card_id: CARD_ID,
+                attribute_remappings: {
+                  attr_uid: ["variable", ["template-tag", "sandbox"]],
+                },
+              });
             });
-            // Wait for an update so the other queries don't accidentally cancel it
-            cy.wait("@questionUpdate");
-          }
-        });
-      });
 
-      it("simple sandboxing should work (metabase#14629)", () => {
-        cy.sandboxTable({
-          table_id: ORDERS_ID,
-          attribute_remappings: {
-            attr_uid: ["dimension", ["field", ORDERS.USER_ID, null]],
-          },
+            cy.createNativeQuestion({
+              name: "EE_520_Q2",
+              native: {
+                query:
+                  "SELECT * FROM PRODUCTS WHERE CATEGORY={{sandbox}} AND PRICE > 10",
+                "template-tags": {
+                  sandbox: {
+                    "display-name": "Sandbox",
+                    id: "3d69ba99-7076-2252-30bd-0bb8810ba895",
+                    name: "sandbox",
+                    type: "text",
+                  },
+                },
+              },
+            }).then(({ body: { id: CARD_ID } }) => {
+              test === "workaround"
+                ? runAndSaveQuestion({
+                    question: CARD_ID,
+                    sandboxValue: "Widget",
+                  })
+                : null;
+
+              cy.sandboxTable({
+                table_id: PRODUCTS_ID,
+                card_id: CARD_ID,
+                attribute_remappings: {
+                  attr_cat: ["variable", ["template-tag", "sandbox"]],
+                },
+              });
+            });
+
+            cy.signOut();
+            cy.signInAsSandboxedUser();
+
+            openOrdersTable();
+
+            cy.log("Reported failing on v1.36.x");
+
+            cy.log(
+              "It should show remapped Display Values instead of Product ID",
+            );
+            cy.get(".cellData").contains("Awesome Concrete Shoes").click();
+            // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+            cy.findByText(/View details/i).click();
+
+            cy.log(
+              "It should show object details instead of filtering by this Product ID",
+            );
+            // The name of this Vendor is visible in "details" only
+            cy.findByTestId("object-detail");
+            cy.findAllByText("McClure-Lockman");
+
+            /**
+             * Helper function related to this test only!
+             */
+            function runAndSaveQuestion({ question, sandboxValue } = {}) {
+              // Run the question
+              cy.visit(`/question/${question}?sandbox=${sandboxValue}`);
+              // Wait for results
+              cy.wait("@cardQuery");
+              // Save the question
+              cy.findByText("Save").click();
+              modal().within(() => {
+                cy.button("Save").click();
+              });
+              // Wait for an update so the other queries don't accidentally cancel it
+              cy.wait("@questionUpdate");
+            }
+          });
         });
 
-        cy.updatePermissionsSchemas({
-          schemas: {
-            PUBLIC: {
-              [PRODUCTS_ID]: "all",
+        it("simple sandboxing should work (metabase#14629)", () => {
+          cy.sandboxTable({
+            table_id: ORDERS_ID,
+            attribute_remappings: {
+              attr_uid: ["dimension", ["field", ORDERS.USER_ID, null]],
             },
-          },
-        });
+          });
 
-        cy.signOut();
-        cy.signInAsSandboxedUser();
-        openOrdersTable({
-          callback: xhr => expect(xhr.response.body.error).not.to.exist,
-        });
+          cy.updatePermissionsSchemas({
+            schemas: {
+              PUBLIC: {
+                [PRODUCTS_ID]: "all",
+              },
+            },
+          });
 
-        // Title of the first order for User ID = 1
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText("Awesome Concrete Shoes");
-      });
-    });
+          cy.signOut();
+          cy.signInAsSandboxedUser();
+          openOrdersTable({
+            callback: xhr => expect(xhr.response.body.error).not.to.exist,
+          });
+
+          // Title of the first order for User ID = 1
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+          cy.findByText("Awesome Concrete Shoes");
+        });
+      },
+    );
 
     ["remapped", "default"].forEach(test => {
       it(`${test.toUpperCase()} version:\n should work on questions with joins, with sandboxed target table, where target fields cannot be filtered (metabase#13642)`, () => {

--- a/e2e/test/scenarios/question/reproductions/25144-saved-questions-first-question.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/25144-saved-questions-first-question.cy.spec.js
@@ -1,7 +1,7 @@
 import { modal, popover, restore, describeOSS } from "e2e/support/helpers";
 
 // this is only testable in OSS because EE always has models from auditv2
-describeOSS("issue 25144", { tags: "@OSS" }, () => {
+describeOSS("issue 25144", { tags: ["@OSS", "@flake"] }, () => {
   beforeEach(() => {
     restore("setup");
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
@@ -258,7 +258,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     });
   });
 
-  it("should drill through a nested query", () => {
+  it("should drill through a nested query", { tags: ["@flake"] }, () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
     cy.createQuestion({

--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -462,7 +462,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
     cy.findByText(/Sort order/).should("not.be.visible");
   });
 
-  it("should allow sorting fields", () => {
+  it("should allow sorting fields", { tags: ["@flake"] }, () => {
     // Pivot by a single column with many values (100 bins).
     // Having many values hides values that are sorted to the end.
     // This lets us assert on presence of a certain value.
@@ -1103,73 +1103,85 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
     main().findByText("User → Address").should("be.visible");
   });
 
-  it("should return the same number of rows when running as an ad-hoc query vs a saved card (metabase#34278)", () => {
-    const query = {
-      type: "query",
-      query: {
-        "source-table": ANALYTIC_EVENTS_ID,
-        aggregation: [["count"]],
-        breakout: [
-          ["field", ANALYTIC_EVENTS.BUTTON_LABEL, { "base-type": "type/Text" }],
-          ["field", ANALYTIC_EVENTS.PAGE_URL, { "base-type": "type/Text" }],
-          [
-            "field",
-            ANALYTIC_EVENTS.TIMESTAMP,
-            { "base-type": "type/DateTime", "temporal-unit": "day" },
-          ],
-          ["field", ANALYTIC_EVENTS.EVENT, { "base-type": "type/Text" }],
-          ["field", ANALYTIC_EVENTS.ACCOUNT_ID, { "base-type": "type/Text" }],
-          ["field", ANALYTIC_EVENTS.ID, { "base-type": "type/Text" }],
-        ],
-      },
-      database: SAMPLE_DB_ID,
-    };
-
-    visitQuestionAdhoc({
-      dataset_query: query,
-      display: "pivot",
-      visualization_settings: {
-        "pivot_table.column_split": {
-          rows: [
-            ["field", ANALYTIC_EVENTS.PAGE_URL, { "base-type": "type/Text" }],
+  it(
+    "should return the same number of rows when running as an ad-hoc query vs a saved card (metabase#34278)",
+    { tags: ["@flake"] },
+    () => {
+      const query = {
+        type: "query",
+        query: {
+          "source-table": ANALYTIC_EVENTS_ID,
+          aggregation: [["count"]],
+          breakout: [
             [
               "field",
               ANALYTIC_EVENTS.BUTTON_LABEL,
               { "base-type": "type/Text" },
             ],
-            ["field", ANALYTIC_EVENTS.ACCOUNT_ID, { "base-type": "type/Text" }],
+            ["field", ANALYTIC_EVENTS.PAGE_URL, { "base-type": "type/Text" }],
             [
               "field",
               ANALYTIC_EVENTS.TIMESTAMP,
               { "base-type": "type/DateTime", "temporal-unit": "day" },
             ],
+            ["field", ANALYTIC_EVENTS.EVENT, { "base-type": "type/Text" }],
+            ["field", ANALYTIC_EVENTS.ACCOUNT_ID, { "base-type": "type/Text" }],
             ["field", ANALYTIC_EVENTS.ID, { "base-type": "type/Text" }],
           ],
-          columns: [
-            ["field", ANALYTIC_EVENTS.EVENT, { "base-type": "type/Text" }],
-          ],
-          values: [["aggregation", 0]],
         },
-      },
-    });
+        database: SAMPLE_DB_ID,
+      };
 
-    cy.findByTestId("question-row-count").should(
-      "have.text",
-      "Showing first 52,711 rows",
-    );
+      visitQuestionAdhoc({
+        dataset_query: query,
+        display: "pivot",
+        visualization_settings: {
+          "pivot_table.column_split": {
+            rows: [
+              ["field", ANALYTIC_EVENTS.PAGE_URL, { "base-type": "type/Text" }],
+              [
+                "field",
+                ANALYTIC_EVENTS.BUTTON_LABEL,
+                { "base-type": "type/Text" },
+              ],
+              [
+                "field",
+                ANALYTIC_EVENTS.ACCOUNT_ID,
+                { "base-type": "type/Text" },
+              ],
+              [
+                "field",
+                ANALYTIC_EVENTS.TIMESTAMP,
+                { "base-type": "type/DateTime", "temporal-unit": "day" },
+              ],
+              ["field", ANALYTIC_EVENTS.ID, { "base-type": "type/Text" }],
+            ],
+            columns: [
+              ["field", ANALYTIC_EVENTS.EVENT, { "base-type": "type/Text" }],
+            ],
+            values: [["aggregation", 0]],
+          },
+        },
+      });
 
-    cy.findByTestId("qb-header-action-panel").findByText("Save").click();
-    modal().button("Save").click();
-    cy.wait("@createCard");
-    cy.intercept("POST", "/api/card/pivot/*/query").as("cardPivotQuery");
-    cy.reload();
-    cy.wait("@cardPivotQuery");
+      cy.findByTestId("question-row-count").should(
+        "have.text",
+        "Showing first 52,711 rows",
+      );
 
-    cy.findByTestId("question-row-count").should(
-      "have.text",
-      "Showing first 52,711 rows",
-    );
-  });
+      cy.findByTestId("qb-header-action-panel").findByText("Save").click();
+      modal().button("Save").click();
+      cy.wait("@createCard");
+      cy.intercept("POST", "/api/card/pivot/*/query").as("cardPivotQuery");
+      cy.reload();
+      cy.wait("@cardPivotQuery");
+
+      cy.findByTestId("question-row-count").should(
+        "have.text",
+        "Showing first 52,711 rows",
+      );
+    },
+  );
 });
 
 const testQuery = {

--- a/e2e/test/scenarios/visualizations-tabular/table-column-settings.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table-column-settings.cy.spec.js
@@ -577,23 +577,27 @@ describe("scenarios > visualizations > table column settings", () => {
   });
 
   describe("nested structured questions", () => {
-    it("should be able to show and hide fields from a nested query", () => {
-      cy.createQuestion(tableQuestion).then(({ body: card }) => {
-        cy.createQuestion(nestedQuestion(card), { visitQuestion: true });
-      });
-      openSettings();
+    it(
+      "should be able to show and hide fields from a nested query",
+      { tags: ["@flake"] },
+      () => {
+        cy.createQuestion(tableQuestion).then(({ body: card }) => {
+          cy.createQuestion(nestedQuestion(card), { visitQuestion: true });
+        });
+        openSettings();
 
-      const testData = {
-        column: "Tax",
-        columnName: "Tax",
-        table: "test question",
-      };
+        const testData = {
+          column: "Tax",
+          columnName: "Tax",
+          table: "test question",
+        };
 
-      _hideColumn(testData);
-      _showColumn(testData);
-      _removeColumn(testData);
-      _addColumn(testData);
-    });
+        _hideColumn(testData);
+        _showColumn(testData);
+        _removeColumn(testData);
+        _addColumn(testData);
+      },
+    );
 
     it("should be able to show and hide fields from a nested query with joins (metabase#32373)", () => {
       cy.createQuestion(tableQuestionWithJoin).then(({ body: card }) => {


### PR DESCRIPTION
Prep work for #35661 (or maybe even a PR that resolves that issue).

This PR marks top flaky tests in E2E suite.
I used two criteria for the "top tier" flakes:
1. failures above 2% frequency on `master` in the last seven days
2. flakes above 10% frequency on `master` in the last seven days

I didn't mark "search" related failures and flakes, because they are exception caused by a real bug. Those should be fixed by https://github.com/metabase/metabase/pull/35655 anyway.

I also didn't mark flakes that have been fixed and confirmed to run correctly within the last seven days.