### PR TITLE
Add tests verifying that #18817 has been fixed

### DIFF
--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -1402,6 +1402,33 @@
                           (lib/remove-field -1 vis-price)
                           lib.metadata.calculation/returned-columns))))))))))
 
+(deftest ^:parallel nested-aggregation-query-remove-fields-test
+  (testing "can remove a breakout field from a nested aggregated query (#18817)"
+    (let [provider (lib.tu/metadata-provider-with-cards-for-queries
+                    meta/metadata-provider
+                    [(-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                         (lib/aggregate (lib/count))
+                         (lib/breakout (meta/field-metadata :orders :user-id))
+                         (lib/breakout (lib/with-temporal-bucket (meta/field-metadata :orders :created-at) :month)))])
+          base     (lib/query provider (lib.metadata/card provider 1))]
+      (is (=? [{:display-name "User ID"}
+               {:display-name "Created At: Month"}
+               {:display-name "Count"}]
+              (lib.metadata.calculation/returned-columns base)))
+      (let [col-user-id (->> base
+                             lib.metadata.calculation/visible-columns
+                             (filter #(= (:name %) "USER_ID"))
+                             first)
+            query (lib/remove-field base -1 col-user-id)]
+        (is (=? {:lib/type    :metadata/column
+                 :name        "USER_ID"
+                 :lib/card-id (get-in base [:stages 0 :source-card])
+                 :lib/source  :source/card}
+                col-user-id))
+        (is (=? [{:display-name "Created At: Month"}
+                 {:display-name "Count"}]
+              (lib.metadata.calculation/returned-columns query)))))))
+
 (defn- mark-selected [query]
   (lib.equality/mark-selected-columns query -1
                                       (lib.metadata.calculation/visible-columns query)

--- a/test/metabase/lib/remove_replace_test.cljc
+++ b/test/metabase/lib/remove_replace_test.cljc
@@ -64,33 +64,39 @@
 
 (deftest ^:parallel remove-clause-breakout-test
   (let [query (-> lib.tu/venues-query
+                  (lib/aggregate (lib/count))
                   (lib/breakout (meta/field-metadata :venues :id))
                   (lib/breakout (meta/field-metadata :venues :name)))
         breakouts (lib/breakouts query)]
     (is (= 2 (count breakouts)))
-    (is (= 1 (-> query
-                 (lib/remove-clause (first breakouts))
-                 (lib/breakouts)
-                 count)))
-    (is (nil? (-> query
-                  (lib/remove-clause (first breakouts))
-                  (lib/remove-clause (second breakouts))
-                  (lib/breakouts))))
+    (is (=? [{:display-name "ID"}
+             {:display-name "Name"}
+             {:display-name "Count"}]
+            (lib/returned-columns query)))
+    (let [query'  (lib/remove-clause query (first breakouts))
+          query'' (lib/remove-clause query' (second breakouts))]
+      (is (= 1 (-> query' lib/breakouts count)))
+      (is (=? [{:display-name "Name"}
+               {:display-name "Count"}]
+            (lib/returned-columns query')))
+      (is (nil? (lib/breakouts query'')))
+      (is (=? [{:display-name "Count"}]
+            (lib/returned-columns query''))))
     (testing "removing with dependent should cascade"
       (is (=? {:stages [{:breakout [(second breakouts)]} (complement :filters)]}
               (-> query
-                (lib/append-stage)
-                (lib/filter (lib/= [:field {:lib/uuid (str (random-uuid)) :base-type :type/Integer} "ID"] 1))
-                (lib/remove-clause 0 (first breakouts)))))
+                  (lib/append-stage)
+                  (lib/filter (lib/= [:field {:lib/uuid (str (random-uuid)) :base-type :type/Integer} "ID"] 1))
+                  (lib/remove-clause 0 (first breakouts)))))
       (is (=? {:stages [{:breakout [(second breakouts)]}
                         (complement :fields)
                         (complement :filters)]}
-            (-> query
-                (lib/append-stage)
-                (lib/with-fields [[:field {:lib/uuid (str (random-uuid)) :base-type :type/Integer} "ID"]])
-                (lib/append-stage)
-                (lib/filter (lib/= [:field {:lib/uuid (str (random-uuid)) :base-type :type/Integer} "ID"] 1))
-                (lib/remove-clause 0 (first breakouts)))))
+              (-> query
+                  (lib/append-stage)
+                  (lib/with-fields [[:field {:lib/uuid (str (random-uuid)) :base-type :type/Integer} "ID"]])
+                  (lib/append-stage)
+                  (lib/filter (lib/= [:field {:lib/uuid (str (random-uuid)) :base-type :type/Integer} "ID"] 1))
+                  (lib/remove-clause 0 (first breakouts)))))
       (is (nil? (-> query
                     (lib/remove-clause 0 (second breakouts))
                     (lib/append-stage)


### PR DESCRIPTION
It verifies both that after removing breakouts the returned columns are valid, as well as that given a question based on an aggregated source query, a fields corresponding a breakout can be removed.

While testing, I found that questions based on saved questions involving pivoting are quite broken, but I think that's not what #18817 was about. (In the description there saving the question with breakouts is never mentioned.)
![image](https://github.com/metabase/metabase/assets/103100869/fe78fefc-88c0-4fdb-b3e4-8c69aa979e8c)

@uladzimirdev is working on a FE test for this, I think.