### PR TITLE
Revert "Workaround for E2E search failures due to audit V2 (#35655)"

### DIFF
--- a/e2e/test/scenarios/onboarding/search/search.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search.cy.spec.js
@@ -1484,18 +1484,9 @@ function expectSearchResultItemNameContent(
   { strict } = { strict: true },
 ) {
   cy.findAllByTestId("search-result-item-name").then($searchResultLabel => {
-    console.log($searchResultLabel);
     const searchResultLabelList = $searchResultLabel
       .toArray()
-      // FIXME!
-      // AuditV2 `MODERATION_REVIEW` table is unexpectedly and intermitently showing up
-      // in search results. This is causing test failures due to the count of search items mismatch.
-      // TODO:
-      // Remove the `filter()` as soon as audit v2 part is fixed!
-      .filter(el => el.textContent !== "MODERATION_REVIEW")
-      .map(el => {
-        return el.textContent;
-      });
+      .map(el => el.textContent);
 
     if (strict) {
       expect(searchResultLabelList).to.have.length(itemNames.length);
@@ -1516,7 +1507,6 @@ function expectSearchResultItemNameContent(
  * @param {string} options.expectedSearchResults[].timestamp - The timestamp label of the search result item .
  * @param {boolean} [strict=true] - Whether to check if the contents AND length of search results are the same
  */
-
 function expectSearchResultContent({ expectedSearchResults, strict = true }) {
   const searchResultItemSelector = "[data-testid=search-result-item]";
 
@@ -1525,15 +1515,7 @@ function expectSearchResultContent({ expectedSearchResults, strict = true }) {
   searchResultItems.then($results => {
     if (strict) {
       // Check if the length of the search results is the same as the expected length
-      // FIXME!
-      // AuditV2 `MODERATION_REVIEW` table is unexpectedly and intermitently showing up
-      // in search results. This is causing test failures due to the count of search items mismatch.
-      // TODO:
-      // Remove the `filter()` as soon as audit v2 part is fixed!
-      const results = $results
-        .toArray()
-        .filter(el => el.textContent !== "MODERATION_REVIEW");
-      expect(results).to.have.length(expectedSearchResults.length);
+      expect($results).to.have.length(expectedSearchResults.length);
     }
   });
 


### PR DESCRIPTION
This reverts commit adfda064996b4f7e084374287a00e238b156e198 now that https://github.com/metabase/metabase/pull/35621 has fixed the underlying issue

