### PR TITLE
remove internal user on rollback + test

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -16054,7 +16054,7 @@ databaseChangeLog:
       rollback: # no change
 
   - changeSet:
-      id: v48.00-052
+      id: v48.00-053
       author: johnswanson
       comment: Increase length of `activity.model` to fit longer model names
       changes:
@@ -16065,7 +16065,7 @@ databaseChangeLog:
       rollback: # not necessary
 
   - changeSet:
-      id: v48.00-053
+      id: v48.00-054
       author: escherize
       comment: Added 0.48.0 - no-op migration to remove Internal Metabase User on downgrade
       changes:

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -16054,7 +16054,7 @@ databaseChangeLog:
       rollback: # no change
 
   - changeSet:
-      id: v48.00-053
+      id: v48.00-052
       author: johnswanson
       comment: Increase length of `activity.model` to fit longer model names
       changes:

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -16064,6 +16064,14 @@ databaseChangeLog:
             newDataType: VARCHAR(32)
       rollback: # not necessary
 
+  - changeSet:
+      id: v48.00-053
+      author: escherize
+      comment: Added 0.48.0 - no-op migration to remove Internal Metabase User on downgrade
+      changes:
+        - comment: "No operation performed for this changeset on execution."
+      rollback:
+        - sql: DELETE FROM core_user WHERE id = 13371338;
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -16072,6 +16072,7 @@ databaseChangeLog:
         - comment: "No operation performed for this changeset on execution."
       rollback:
         - sql: DELETE FROM core_user WHERE id = 13371338;
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -1338,8 +1338,8 @@
                 (t2/select-one (t2/table-name :model/Field) :id field-2-id)))))))
 
 (deftest audit-v2-downgrade-test
-  (testing "Migration v48.00-050, and v48.00-53"
-    (impl/test-migrations "v48.00-053" [migrate!]
+  (testing "Migration v48.00-050, and v48.00-54"
+    (impl/test-migrations "v48.00-054" [migrate!]
       (let [{:keys [db-type ^javax.sql.DataSource data-source]} mdb.connection/*application-db*
             _db-audit-id (first (t2/insert-returning-pks! (t2/table-name :model/Database)
                                                           {:name       "Audit DB"

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -1366,12 +1366,12 @@
                                                                 :password (str (random-uuid))}))
             original-db (t2/query {:datasource data-source} "SELECT * FROM metabase_database")
             original-collections (t2/query {:datasource data-source}    "SELECT * FROM collection")
-            before-check! (fn []
-                            (is (partial= (set (map :name original-db))
-                                          (set (map :name (t2/query {:datasource data-source} "SELECT name FROM metabase_database")))))
-                            (is (partial= (set (map :name original-collections))
-                                          (set (map :name (t2/query {:datasource data-source} "SELECT name FROM collection")))))
-                            (is (= 1 (count (t2/query "SELECT * FROM core_user WHERE id = 13371338")))))]
+            check-before (fn []
+                           (is (partial= (set (map :name original-db))
+                                         (set (map :name (t2/query {:datasource data-source} "SELECT name FROM metabase_database")))))
+                           (is (partial= (set (map :name original-collections))
+                                         (set (map :name (t2/query {:datasource data-source} "SELECT name FROM collection")))))
+                           (is (= 1 (count (t2/query "SELECT * FROM core_user WHERE id = 13371338")))))]
 
         (check-before) ;; Verify that data is inserted correctly
         (migrate!) ;; no-op forward migration

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -1338,8 +1338,8 @@
                 (t2/select-one (t2/table-name :model/Field) :id field-2-id)))))))
 
 (deftest audit-v2-downgrade-test
-  (testing "Migration v48.00-050"
-    (impl/test-migrations "v48.00-050" [migrate!]
+  (testing "Migration v48.00-050, and v48.00-53"
+    (impl/test-migrations "v48.00-053" [migrate!]
       (let [{:keys [db-type ^javax.sql.DataSource data-source]} mdb.connection/*application-db*
             _db-audit-id (first (t2/insert-returning-pks! (t2/table-name :model/Database)
                                                           {:name       "Audit DB"
@@ -1359,19 +1359,23 @@
                                                              {:name       "Normal Collection"
                                                               :type       nil
                                                               :slug       "normal_collection"}))
+            _internal-user-id (first (t2/insert-returning-pks! :model/User
+                                                               {:id 13371338
+                                                                :first_name "Metabase Internal User"
+                                                                :email "internal@metabase.com"
+                                                                :password (str (random-uuid))}))
             original-db (t2/query {:datasource data-source} "SELECT * FROM metabase_database")
-            original-collections (t2/query {:datasource data-source}    "SELECT * FROM collection")]
-        ;; Verify that data is inserted correctly
-        (is (= 2 (count original-db)))
-        (is (= 2 (count original-collections)))
+            original-collections (t2/query {:datasource data-source}    "SELECT * FROM collection")
+            before-check! (fn []
+                            (is (partial= (set (map :name original-db))
+                                          (set (map :name (t2/query {:datasource data-source} "SELECT name FROM metabase_database")))))
+                            (is (partial= (set (map :name original-collections))
+                                          (set (map :name (t2/query {:datasource data-source} "SELECT name FROM collection")))))
+                            (is (= 1 (count (t2/query "SELECT * FROM core_user WHERE id = 13371338")))))]
 
+        (check-before) ;; Verify that data is inserted correctly
         (migrate!) ;; no-op forward migration
-
-        ;; Verify that forward migration did not change data
-        (is (partial= (set (map :name original-db))
-                      (set (map :name (t2/query {:datasource data-source} "SELECT name FROM metabase_database")))))
-        (is (partial= (set (map :name original-collections))
-                      (set (map :name (t2/query {:datasource data-source} "SELECT name FROM collection")))))
+        (check-before) ;; Verify that forward migration did not change data
 
         (db.setup/migrate! db-type data-source :down 47)
 
@@ -1379,4 +1383,5 @@
         (is (= 1 (count (t2/query "SELECT * FROM metabase_database"))))
         (is (= 1 (count (t2/query "SELECT * FROM collection"))))
         (is (= 0 (count (t2/query "SELECT * FROM metabase_database WHERE is_audit = TRUE"))))
-        (is (= 0 (count (t2/query "SELECT * FROM collection WHERE type = 'instance_analytics'"))))))))
+        (is (= 0 (count (t2/query "SELECT * FROM collection WHERE type = 'instance_analytics'"))))
+        (is (= 0 (count (t2/query "SELECT * FROM core_user WHERE id = 13371338"))))))))


### PR DESCRIPTION
When rolling back, we need to delete the internal metabase user (who has the id of `13371338`).

This PR adds a migration that is similar to `v48.00-050`: a no-op forward-migration, and deletes the internal user when downgrading.