### PR TITLE
Fix Milestone Reminder

### DIFF
--- a/.github/workflows/check-milestone.yml
+++ b/.github/workflows/check-milestone.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   milestone-reminder:
-    if: github.event.pull_request.merged == 'true'
+    if: github.event.pull_request.merged == true
     name: Remind to set milestone
     runs-on: ubuntu-22.04
     timeout-minutes: 5


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/pull/35322 😊 

The snazzy new reminder action [never ran](https://github.com/metabase/metabase/actions/workflows/check-milestone.yml). I guess 'true' isn't supposed to be in quotes. [See Docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges)
