### PR TITLE
Hide edit question menu item on dashboards when there is no collection write permission

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
@@ -131,7 +131,11 @@ interface QueryDownloadWidgetOpts {
 }
 
 const canEditQuestion = (question: Question) => {
-  return question.query() != null && question.query().isEditable();
+  return (
+    question.canWrite() &&
+    question.query() != null &&
+    question.query().isEditable()
+  );
 };
 
 const canDownloadResults = (result?: Dataset) => {

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.unit.spec.tsx
@@ -21,6 +21,7 @@ import { getIcon, renderWithProviders, screen } from "__support__/ui";
 import DashCardMenu from "./DashCardMenu";
 
 const TEST_CARD = createMockCard({
+  can_write: true,
   dataset_query: createMockStructuredDatasetQuery({
     database: SAMPLE_DB_ID,
     query: {
@@ -40,9 +41,19 @@ const TEST_CARD_NATIVE = createMockCard({
   }),
 });
 
-const TEST_CARD_UNAUTHORIZED = createMockCard({
+const TEST_CARD_NO_DATA_ACCESS = createMockCard({
   dataset_query: createMockStructuredDatasetQuery({
     database: SAMPLE_DB_ID,
+  }),
+});
+
+const TEST_CARD_NO_COLLECTION_WRITE_ACCESS = createMockCard({
+  can_write: false,
+  dataset_query: createMockStructuredDatasetQuery({
+    database: SAMPLE_DB_ID,
+    query: {
+      "source-table": ORDERS_ID,
+    },
   }),
 });
 
@@ -113,8 +124,17 @@ describe("DashCardMenu", () => {
     expect(pathname).toBe(`/question/${TEST_CARD_SLUG}`);
   });
 
-  it("should not display a link to the notebook editor if the user does not have permissions", async () => {
-    setup({ card: TEST_CARD_UNAUTHORIZED });
+  it("should not display a link to the notebook editor if the user does not have the data permission", async () => {
+    setup({ card: TEST_CARD_NO_DATA_ACCESS });
+
+    userEvent.click(getIcon("ellipsis"));
+
+    expect(await screen.findByText("Download results")).toBeInTheDocument();
+    expect(screen.queryByText("Edit question")).not.toBeInTheDocument();
+  });
+
+  it("should not display a link to the notebook editor if the user does not have the collection write permission (metabase#35077)", async () => {
+    setup({ card: TEST_CARD_NO_COLLECTION_WRITE_ACCESS });
 
     userEvent.click(getIcon("ellipsis"));
 

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -189,6 +189,7 @@
       ;; cannot be in this situation
       (t2/hydrate [:dashcards
                    [:card [:moderation_reviews :moderator_details]]
+                   [:card :can_write]
                    :series
                    :dashcard/action
                    :dashcard/linkcard-info]

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -357,6 +357,7 @@
                                                     :card                       (merge api.card-test/card-defaults-no-hydrate
                                                                                        {:name                   "Dashboard Test Card"
                                                                                         :creator_id             (mt/user->id :rasta)
+                                                                                        :can_write              false ;; hydrate :can_write for issue #35077
                                                                                         :collection_id          true
                                                                                         :display                "table"
                                                                                         :entity_id              (:entity_id card)


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/35077

### Description

When users have "View" collection permission for a dashcard, they should not see "Edit question" menu item.

## This PR needs a BE change:

Include `can_write` to every `card` entity in the response of `/api/dashboard/:id` handler:
<img width="791" alt="Screenshot 2023-11-13 at 6 54 26 PM" src="https://github.com/metabase/metabase/assets/14301985/1a2b8a39-5e7e-48e9-9ee1-70c4af95031b">

### How to verify

- As an admin create any question Q1 and add it to a dashboard D1
- Create a user that has the data access to a question, but set only the "View" access level for the question's collection
- Login as the user, open the D1 dashboard
- In the top right corner of the card click on "..." to open the menu
- Ensure it does not show the "Edit question" menu item

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
