### PR TITLE
Fix `be-checks-stub`

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -257,11 +257,11 @@ jobs:
         run: clojure -M:ee:drivers:check
 
   be-check-stub:
-    needs: [files-changed, static-viz-files-changed]
+    needs: [files-changed, static-viz-files-changed, be-check]
     if: |
       always() &&
       github.event.pull_request.draft == false &&
-      (needs.files-changed.outputs.backend_all == 'false' && needs.static-viz-files-changed.outputs.static_viz == 'false')
+      needs.be-check.result == 'skipped'
     runs-on: ubuntu-22.04
     name: be-check-java-${{ matrix.java-version }}
     timeout-minutes: 10


### PR DESCRIPTION
As @iethree said, "this is so stupid", and tedious if I may add.

Example of a PR blocked by these required checks not being triggered:
https://github.com/metabase/metabase/pull/35685

![image](https://github.com/metabase/metabase/assets/31325167/0673ca1e-78b8-494f-b174-6f184ad37dea)

Backend run
https://github.com/metabase/metabase/actions/runs/6855711430/job/18641350311

