### PR TITLE
Track dashboard_saved snowplow event

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -201,7 +201,7 @@ describe("scenarios > dashboard", () => {
     });
   });
 
-  describeWithSnowplow("existing dashboard", () => {
+  describe("existing dashboard", () => {
     const originalDashboardName = "Amazing Dashboard";
 
     beforeEach(() => {
@@ -210,10 +210,6 @@ describe("scenarios > dashboard", () => {
           visitDashboard(id);
         },
       );
-    });
-
-    afterEach(() => {
-      expectNoBadSnowplowEvents();
     });
 
     context("add a question (dashboard card)", () => {
@@ -248,10 +244,6 @@ describe("scenarios > dashboard", () => {
         assertBothCardsArePresent();
         saveDashboard();
         assertBothCardsArePresent();
-
-        expectGoodSnowplowEvent({
-          event: "dashboard_saved",
-        });
 
         function assertBothCardsArePresent() {
           getDashboardCards()

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -977,7 +977,7 @@ describeWithSnowplow("scenarios > dashboard", () => {
   });
 
   it("saving a dashboard should track a 'dashboard_saved' snowplow event", () => {
-    visitDashboard(1);
+    visitDashboard(ORDERS_DASHBOARD_ID);
     editDashboard();
     const newTitle = "New title";
     cy.findByTestId("dashboard-name-heading").clear().type(newTitle).blur();

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -201,7 +201,7 @@ describe("scenarios > dashboard", () => {
     });
   });
 
-  describe("existing dashboard", () => {
+  describeWithSnowplow("existing dashboard", () => {
     const originalDashboardName = "Amazing Dashboard";
 
     beforeEach(() => {
@@ -210,6 +210,10 @@ describe("scenarios > dashboard", () => {
           visitDashboard(id);
         },
       );
+    });
+
+    afterEach(() => {
+      expectNoBadSnowplowEvents();
     });
 
     context("add a question (dashboard card)", () => {
@@ -244,6 +248,10 @@ describe("scenarios > dashboard", () => {
         assertBothCardsArePresent();
         saveDashboard();
         assertBothCardsArePresent();
+
+        expectGoodSnowplowEvent({
+          event: "dashboard_saved",
+        });
 
         function assertBothCardsArePresent() {
           getDashboardCards()
@@ -974,6 +982,17 @@ describeWithSnowplow("scenarios > dashboard", () => {
 
   afterEach(() => {
     expectNoBadSnowplowEvents();
+  });
+
+  it("saving a dashboard should track a 'dashboard_saved' snowplow event", () => {
+    visitDashboard(1);
+    editDashboard();
+    const newTitle = "New title";
+    cy.findByTestId("dashboard-name-heading").clear().type(newTitle).blur();
+    saveDashboard();
+    expectGoodSnowplowEvent({
+      event: "dashboard_saved",
+    });
   });
 
   it("should allow users to add link cards to dashboards", () => {

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -373,12 +373,14 @@ describeWithSnowplow("scenarios > dashboard > tabs", () => {
     editDashboard();
     createNewTab();
     saveDashboard();
-    expectGoodSnowplowEvents(PAGE_VIEW_EVENT + 1); // dashboard_tab_created
+    expectGoodSnowplowEvent({ event: "dashboard_saved" }, 1);
+    expectGoodSnowplowEvent({ event: "dashboard_tab_created" }, 1);
 
     editDashboard();
     deleteTab("Tab 2");
     saveDashboard();
-    expectGoodSnowplowEvents(PAGE_VIEW_EVENT + 2); // dashboard_tab_deleted
+    expectGoodSnowplowEvent({ event: "dashboard_saved" }, 2);
+    expectGoodSnowplowEvent({ event: "dashboard_tab_deleted" }, 1);
   });
 
   it("should send snowplow events when cards are moved between tabs", () => {

--- a/frontend/src/metabase/dashboard/actions/save.js
+++ b/frontend/src/metabase/dashboard/actions/save.js
@@ -8,6 +8,7 @@ import Dashboards from "metabase/entities/dashboards";
 import { CardApi } from "metabase/services";
 import { clickBehaviorIsValid } from "metabase-lib/parameters/utils/click-behavior";
 
+import { trackDashboardSaved } from "../analytics";
 import { getDashboardBeforeEditing } from "../selectors";
 
 import { fetchDashboard } from "./data-fetching";
@@ -22,6 +23,7 @@ export const updateDashboardAndCards = createThunkAction(
   UPDATE_DASHBOARD_AND_CARDS,
   function () {
     return async function (dispatch, getState) {
+      const startTime = Date.now();
       const state = getState();
       const { dashboards, dashcards, dashboardId } = state.dashboard;
       const dashboard = {
@@ -120,6 +122,13 @@ export const updateDashboardAndCards = createThunkAction(
           tabs: tabsToUpdate,
         }),
       );
+
+      const endTime = Date.now();
+      const duration_milliseconds = endTime - startTime;
+      trackDashboardSaved({
+        dashboard_id: dashboard.id,
+        duration_milliseconds,
+      });
 
       // make sure that we've fully cleared out any dirty state from editing (this is overkill, but simple)
       dispatch(

--- a/frontend/src/metabase/dashboard/actions/save.js
+++ b/frontend/src/metabase/dashboard/actions/save.js
@@ -23,7 +23,7 @@ export const updateDashboardAndCards = createThunkAction(
   UPDATE_DASHBOARD_AND_CARDS,
   function () {
     return async function (dispatch, getState) {
-      const startTime = Date.now();
+      const startTime = performance.now();
       const state = getState();
       const { dashboards, dashcards, dashboardId } = state.dashboard;
       const dashboard = {
@@ -123,8 +123,8 @@ export const updateDashboardAndCards = createThunkAction(
         }),
       );
 
-      const endTime = Date.now();
-      const duration_milliseconds = endTime - startTime;
+      const endTime = performance.now();
+      const duration_milliseconds = parseInt(endTime - startTime);
       trackDashboardSaved({
         dashboard_id: dashboard.id,
         duration_milliseconds,

--- a/frontend/src/metabase/dashboard/analytics.ts
+++ b/frontend/src/metabase/dashboard/analytics.ts
@@ -1,7 +1,7 @@
 import { trackSchemaEvent } from "metabase/lib/analytics";
 import type { DashboardId } from "metabase-types/api";
 
-const DASHBOARD_SCHEMA_VERSION = "1-1-2";
+const DASHBOARD_SCHEMA_VERSION = "1-1-3";
 
 export const trackAutoApplyFiltersDisabled = (dashboardId: DashboardId) => {
   trackSchemaEvent("dashboard", DASHBOARD_SCHEMA_VERSION, {
@@ -26,6 +26,17 @@ export const trackCardCreated = (type: CardTypes, dashboard_id: number) => {
   trackSchemaEvent("dashboard", DASHBOARD_SCHEMA_VERSION, {
     event: `new_${type}_card_created`,
     dashboard_id,
+  });
+};
+
+export const trackDashboardSaved = (
+  duration_milliseconds: number,
+  dashboard_id: number,
+) => {
+  trackSchemaEvent("dashboard", DASHBOARD_SCHEMA_VERSION, {
+    event: "dashboard_saved",
+    dashboard_id,
+    duration_milliseconds,
   });
 };
 

--- a/frontend/src/metabase/dashboard/analytics.ts
+++ b/frontend/src/metabase/dashboard/analytics.ts
@@ -29,10 +29,13 @@ export const trackCardCreated = (type: CardTypes, dashboard_id: number) => {
   });
 };
 
-export const trackDashboardSaved = (
-  duration_milliseconds: number,
-  dashboard_id: number,
-) => {
+export const trackDashboardSaved = ({
+  duration_milliseconds,
+  dashboard_id,
+}: {
+  dashboard_id: number;
+  duration_milliseconds: number;
+}) => {
   trackSchemaEvent("dashboard", DASHBOARD_SCHEMA_VERSION, {
     event: "dashboard_saved",
     dashboard_id,

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-1-3
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-1-3
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Dashboard events",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "dashboard",
+    "format": "jsonschema",
+    "version": "1-1-3"
+  },
+  "type": "object",
+  "properties": {
+    "event": {
+      "description": "Event name",
+      "type": "string",
+      "enum": [
+        "dashboard_created",
+        "dashboard_saved",
+        "question_added_to_dashboard",
+        "auto_apply_filters_disabled",
+        "dashboard_tab_created",
+        "dashboard_tab_deleted",
+        "new_text_card_created",
+        "new_heading_card_created",
+        "new_link_card_created",
+        "new_action_card_created",
+        "card_set_to_hide_when_no_results",
+        "dashboard_pdf_exported",
+        "card_moved_to_tab"
+      ],
+      "maxLength": 1024
+    },
+    "dashboard_id": {
+      "description": "Unique identifier for a dashboard within the Metabase instance",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "question_id": {
+      "description": "Unique identifier for a question added to a dashboard",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "num_tabs": {
+      "description": "Number of tabs affected after the event",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "total_num_tabs": {
+      "description": "Total number of active tabs after the events",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "duration_milliseconds": {
+      "description": "Duration the action took to complete in milliseconds",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    }
+  },
+  "required": [
+    "event",
+    "dashboard_id"
+  ],
+  "additionalProperties": true
+}

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -140,7 +140,7 @@
   {::account      "1-0-1"
    ::invite       "1-0-1"
    ::csvupload    "1-0-0"
-   ::dashboard    "1-1-2"
+   ::dashboard    "1-1-3"
    ::database     "1-0-1"
    ::instance     "1-1-2"
    ::metabot      "1-0-1"


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/34751

Evolves the existing dashboard events schema, adding a new nullable field `duration_milliseconds`, and a new event type, `dashboard_saved`. 

The `dashboard_saved` event is fired from the `updateDashboardAndCards` action creator, which is called if and only if the dashboard is saved from editing mode. This event will not be tracked if a dashboard is updated another way, such as editing the dashboard name from a collection page.