### PR TITLE
Manual backport #35695 Returns 404 when get a non-existing card

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -196,6 +196,7 @@
    ignore_view [:maybe :boolean]}
   (let [raw-card (t2/select-one Card :id id)
         card (-> raw-card
+                 api/read-check
                  (t2/hydrate :creator
                           :dashboard_count
                           :parameter_usage_count
@@ -207,7 +208,6 @@
                  collection.root/hydrate-root-collection
                  (cond-> ;; card
                    (:dataset raw-card) (t2/hydrate :persisted))
-                 api/read-check
                  (last-edit/with-last-edit-info :card))]
     (u/prog1 card
       (when-not ignore_view

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -214,7 +214,7 @@
   "Get Dashboard with ID."
   [id]
   (-> (t2/select-one :model/Dashboard :id id)
-      api/check-404
+      api/read-check
       ;; i'm a bit worried that this is an n+1 situation here. The cards can be batch hydrated i think because they
       ;; have a hydration key and an id. moderation_reviews currently aren't batch hydrated but i'm worried they
       ;; cannot be in this situation
@@ -230,7 +230,6 @@
                   :param_values
                   :collection)
       collection.root/hydrate-root-collection
-      api/read-check
       api/check-not-archived
       hide-unreadable-cards
       add-query-average-durations))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -1069,6 +1069,10 @@
                           :moderation_reviews
                           (map clean)))))))))))
 
+(deftest fetch-card-404-test
+  (testing "GET /api/card/:id"
+   (is (= "Not found."
+         (mt/user-http-request :crowberto :get 404 (format "card/%d" Integer/MAX_VALUE))))))
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                       UPDATING A CARD (PUT /api/card/:id)
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -1076,7 +1080,7 @@
 
 (deftest updating-a-card-that-doesnt-exist-should-give-a-404
   (is (= "Not found."
-         (mt/user-http-request :crowberto :put 404 "card/12345"))))
+         (mt/user-http-request :crowberto :put 404 (format "card/%d" Integer/MAX_VALUE)))))
 
 (deftest test-that-we-can-edit-a-card
   (t2.with-temp/with-temp [:model/Card card {:name "Original Name"}]


### PR DESCRIPTION
Manual backport #35695 