### PR TITLE
Fix column filter type checks

### DIFF
--- a/frontend/src/metabase-lib/filter.ts
+++ b/frontend/src/metabase-lib/filter.ts
@@ -3,6 +3,14 @@ import moment from "moment-timezone";
 import * as ML from "cljs/metabase.lib.js";
 
 import {
+  isBoolean,
+  isTime,
+  isDate,
+  isCoordinate,
+  isString,
+  isNumeric,
+} from "./column_types";
+import {
   BOOLEAN_FILTER_OPERATORS,
   COORDINATE_FILTER_OPERATORS,
   EXCLUDE_DATE_BUCKETS,
@@ -109,7 +117,11 @@ export function stringFilterParts(
   }
 
   const [column, ...values] = args;
-  if (!isColumnMetadata(column) || !isStringLiteralArray(values)) {
+  if (
+    !isColumnMetadata(column) ||
+    !isString(column) ||
+    !isStringLiteralArray(values)
+  ) {
     return null;
   }
 
@@ -148,7 +160,11 @@ export function numberFilterParts(
   }
 
   const [column, ...values] = args;
-  if (!isColumnMetadata(column) || !isNumberLiteralArray(values)) {
+  if (
+    !isColumnMetadata(column) ||
+    !isNumeric(column) ||
+    !isNumberLiteralArray(values)
+  ) {
     return null;
   }
 
@@ -191,7 +207,7 @@ export function coordinateFilterParts(
   }
 
   const [column, ...otherArgs] = args;
-  if (!isColumnMetadata(column)) {
+  if (!isColumnMetadata(column) || !isCoordinate(column)) {
     return null;
   }
 
@@ -237,7 +253,11 @@ export function booleanFilterParts(
   }
 
   const [column, ...values] = args;
-  if (!isColumnMetadata(column) || !isBooleanLiteralArray(values)) {
+  if (
+    !isColumnMetadata(column) ||
+    !isBoolean(column) ||
+    !isBooleanLiteralArray(values)
+  ) {
     return null;
   }
 
@@ -291,7 +311,11 @@ export function specificDateFilterParts(
   }
 
   const [column, ...serializedValues] = args;
-  if (!isColumnMetadata(column) || !isStringLiteralArray(serializedValues)) {
+  if (
+    !isColumnMetadata(column) ||
+    !isDate(column) ||
+    !isStringLiteralArray(serializedValues)
+  ) {
     return null;
   }
 
@@ -393,7 +417,7 @@ export function excludeDateFilterParts(
   }
 
   const [column, ...serializedValues] = args;
-  if (!isColumnMetadata(column)) {
+  if (!isColumnMetadata(column) || !isDate(column)) {
     return null;
   }
 
@@ -452,7 +476,11 @@ export function timeFilterParts(
   }
 
   const [column, ...serializedValues] = args;
-  if (!isColumnMetadata(column) || !isStringLiteralArray(serializedValues)) {
+  if (
+    !isColumnMetadata(column) ||
+    !isTime(column) ||
+    !isStringLiteralArray(serializedValues)
+  ) {
     return null;
   }
 
@@ -493,15 +521,12 @@ export function filterParts(
   );
 }
 
-export function isCustomFilter(
+export function isColumnFilter(
   query: Query,
   stageIndex: number,
   filter: FilterClause,
 ) {
-  return (
-    !filterParts(query, stageIndex, filter) &&
-    !isSegmentFilter(query, stageIndex, filter)
-  );
+  return filterParts(query, stageIndex, filter) != null;
 }
 
 export function isSegmentFilter(
@@ -509,7 +534,7 @@ export function isSegmentFilter(
   stageIndex: number,
   filter: FilterClause,
 ) {
-  const { operator } = ML.expression_parts(query, stageIndex, filter);
+  const { operator } = expressionParts(query, stageIndex, filter);
   return operator === "segment";
 }
 
@@ -689,6 +714,7 @@ function relativeDateFilterPartsWithoutOffset(
   const [column, value, bucket] = args;
   if (
     !isColumnMetadata(column) ||
+    !isDate(column) ||
     !isNumberOrCurrentLiteral(value) ||
     !isStringLiteral(bucket) ||
     !isRelativeDateBucket(bucket)
@@ -733,6 +759,7 @@ function relativeDateFilterPartsWithOffset(
   const [column, intervalParts] = offsetParts.args;
   if (
     !isColumnMetadata(column) ||
+    !isDate(column) ||
     !isExpression(intervalParts) ||
     intervalParts.operator !== "interval"
   ) {

--- a/frontend/src/metabase-lib/filter.ts
+++ b/frontend/src/metabase-lib/filter.ts
@@ -521,7 +521,7 @@ export function filterParts(
   );
 }
 
-export function isColumnFilter(
+export function isStandardFilter(
   query: Query,
   stageIndex: number,
   filter: FilterClause,

--- a/frontend/src/metabase-lib/filter.unit.spec.ts
+++ b/frontend/src/metabase-lib/filter.unit.spec.ts
@@ -365,6 +365,20 @@ describe("filter", () => {
 
       expect(filterParts).toBeNull();
     });
+
+    it("should ignore expressions with incorrect column type", () => {
+      const { filterParts } = addStringFilter(
+        query,
+        Lib.stringFilterClause({
+          operator: "=",
+          column: findColumn(query, tableName, "PRICE"),
+          values: ["A"],
+          options: {},
+        }),
+      );
+
+      expect(filterParts).toBeNull();
+    });
   });
 
   describe("number filters", () => {
@@ -481,6 +495,19 @@ describe("filter", () => {
       const { filterParts } = addNumberFilter(
         query,
         Lib.expressionClause("=", [column, column]),
+      );
+
+      expect(filterParts).toBeNull();
+    });
+
+    it("should ignore expressions with incorrect column type", () => {
+      const { filterParts } = addNumberFilter(
+        query,
+        Lib.numberFilterClause({
+          operator: "=",
+          column: findColumn(query, tableName, "CREATED_AT"),
+          values: [10],
+        }),
       );
 
       expect(filterParts).toBeNull();
@@ -634,6 +661,19 @@ describe("filter", () => {
 
       expect(filterParts).toBeNull();
     });
+
+    it("should ignore expressions with incorrect column type", () => {
+      const { filterParts } = addCoordinateFilter(
+        query,
+        Lib.coordinateFilterClause({
+          operator: "=",
+          column: findColumn(query, tableName, "CREATED_AT"),
+          values: [10],
+        }),
+      );
+
+      expect(filterParts).toBeNull();
+    });
   });
 
   describe("boolean filters", () => {
@@ -708,6 +748,19 @@ describe("filter", () => {
       const { filterParts } = addBooleanFilter(
         query,
         Lib.expressionClause("=", [column, column]),
+      );
+
+      expect(filterParts).toBeNull();
+    });
+
+    it("should ignore expressions with incorrect column type", () => {
+      const { filterParts } = addBooleanFilter(
+        query,
+        Lib.booleanFilterClause({
+          operator: "=",
+          column: findColumn(query, tableName, "CREATED_AT"),
+          values: [true],
+        }),
       );
 
       expect(filterParts).toBeNull();
@@ -928,6 +981,19 @@ describe("filter", () => {
 
       expect(filterParts).toBeNull();
     });
+
+    it("should ignore expressions with incorrect column type", () => {
+      const { filterParts } = addSpecificDateFilter(
+        query,
+        Lib.specificDateFilterClause(query, 0, {
+          operator: "=",
+          column: findColumn(query, tableName, "PRICE"),
+          values: [new Date(2020, 1, 1)],
+        }),
+      );
+
+      expect(filterParts).toBeNull();
+    });
   });
 
   describe("relative date filters", () => {
@@ -1093,7 +1159,7 @@ describe("filter", () => {
     it("should ignore expressions without first column", () => {
       const { filterParts } = addRelativeDateFilter(
         query,
-        Lib.expressionClause("!=", ["2020-01-01", column]),
+        Lib.expressionClause("time-interval", ["current", column, "day"]),
       );
 
       expect(filterParts).toBeNull();
@@ -1102,7 +1168,39 @@ describe("filter", () => {
     it("should ignore expressions with non-time arguments", () => {
       const { filterParts } = addRelativeDateFilter(
         query,
-        Lib.expressionClause("!=", [column, column]),
+        Lib.expressionClause("time-interval", [column, column, "day"]),
+      );
+
+      expect(filterParts).toBeNull();
+    });
+
+    it("should ignore expressions with incorrect column type", () => {
+      const { filterParts } = addRelativeDateFilter(
+        query,
+        Lib.relativeDateFilterClause({
+          column: findColumn(query, tableName, "PRICE"),
+          value: 1,
+          bucket: "day",
+          offsetValue: null,
+          offsetBucket: null,
+          options: {},
+        }),
+      );
+
+      expect(filterParts).toBeNull();
+    });
+
+    it("should ignore expressions with offset and incorrect column type", () => {
+      const { filterParts } = addRelativeDateFilter(
+        query,
+        Lib.relativeDateFilterClause({
+          column: findColumn(query, tableName, "PRICE"),
+          value: 1,
+          bucket: "day",
+          offsetValue: 1,
+          offsetBucket: "day",
+          options: {},
+        }),
       );
 
       expect(filterParts).toBeNull();
@@ -1242,6 +1340,20 @@ describe("filter", () => {
 
       expect(filterParts).toBeNull();
     });
+
+    it("should ignore expressions with incorrect column type", () => {
+      const { filterParts } = addExcludeDateFilter(
+        query,
+        Lib.excludeDateFilterClause(query, 0, {
+          operator: "!=",
+          column: findColumn(query, tableName, "PRICE"),
+          bucket: "day-of-week",
+          values: [1, 2],
+        }),
+      );
+
+      expect(filterParts).toBeNull();
+    });
   });
 
   describe("time filters", () => {
@@ -1336,6 +1448,19 @@ describe("filter", () => {
       const { filterParts } = addTimeFilter(
         query,
         Lib.expressionClause(">", [column, column]),
+      );
+
+      expect(filterParts).toBeNull();
+    });
+
+    it("should ignore expressions with incorrect column type", () => {
+      const { filterParts } = addTimeFilter(
+        query,
+        Lib.timeFilterClause({
+          operator: "between",
+          column: findColumn(query, tableName, "CREATED_AT"),
+          values: [new Date(2015, 0, 1, 10, 20), new Date(2015, 0, 1, 18, 50)],
+        }),
       );
 
       expect(filterParts).toBeNull();

--- a/frontend/src/metabase/common/components/DatePicker/DateShortcutPicker/DateShortcutPicker.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/DateShortcutPicker/DateShortcutPicker.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useMemo } from "react";
 import type { ReactNode } from "react";
 import { Button, Box, Divider } from "metabase/ui";
+import { MIN_WIDTH } from "../constants";
 import type {
   DatePickerOperator,
   DatePickerShortcut,
@@ -33,7 +34,7 @@ export function DateShortcutPicker({
   }, [availableOperators]);
 
   return (
-    <Box p="sm">
+    <Box p="sm" miw={MIN_WIDTH}>
       {backButton}
       {shortcutGroups.map((group, groupIndex) => (
         <Fragment key={groupIndex}>

--- a/frontend/src/metabase/common/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { t } from "ttag";
 import { Box, Button, Checkbox, Divider, Group, Stack } from "metabase/ui";
 import { BackButton } from "../BackButton";
+import { MIN_WIDTH } from "../constants";
 import type {
   DatePickerExtractionUnit,
   DatePickerOperator,
@@ -97,7 +98,7 @@ export function ExcludeOptionPicker({
   };
 
   return (
-    <div>
+    <Box miw={MIN_WIDTH}>
       <BackButton onClick={onBack}>{t`Exclude…`}</BackButton>
       <Divider />
       <Box p="sm">
@@ -127,7 +128,7 @@ export function ExcludeOptionPicker({
           </Button>
         ))}
       </Box>
-    </div>
+    </Box>
   );
 }
 
@@ -181,7 +182,7 @@ function ExcludeValuePicker({
   };
 
   return (
-    <div>
+    <Box miw={MIN_WIDTH}>
       <BackButton onClick={onBack}>{option?.label}</BackButton>
       <Divider />
       <Stack p="md">
@@ -214,6 +215,6 @@ function ExcludeValuePicker({
           {isNew ? t`Add filter` : t`Update filter`}
         </Button>
       </Group>
-    </div>
+    </Box>
   );
 }

--- a/frontend/src/metabase/common/components/DatePicker/constants.ts
+++ b/frontend/src/metabase/common/components/DatePicker/constants.ts
@@ -1,3 +1,5 @@
+export const MIN_WIDTH = 300;
+
 export const SPECIFIC_DATE_PICKER_OPERATORS = [
   "=",
   "<",

--- a/frontend/src/metabase/common/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
@@ -3,12 +3,13 @@ import type { FormEvent } from "react";
 import { t } from "ttag";
 import { checkNotNull } from "metabase/lib/types";
 import { Icon } from "metabase/core/components/Icon";
-import { Button, Radio, Stack } from "metabase/ui";
+import { Box, Button, Radio, Stack } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import { FilterHeader } from "../FilterHeader";
 import { FilterFooter } from "../FilterFooter";
-import type { FilterPickerWidgetProps } from "../types";
+import { MIN_WIDTH } from "../constants";
 import { getAvailableOperatorOptions } from "../utils";
+import type { FilterPickerWidgetProps } from "../types";
 import { OPTIONS } from "./constants";
 import { getFilterClause, getOptionType } from "./utils";
 
@@ -51,7 +52,12 @@ export function BooleanFilterPicker({
   };
 
   return (
-    <form data-testid="boolean-filter-picker" onSubmit={handleSubmit}>
+    <Box
+      component="form"
+      miw={MIN_WIDTH}
+      data-testid="boolean-filter-picker"
+      onSubmit={handleSubmit}
+    >
       <FilterHeader columnName={columnName} onBack={onBack} />
       <div>
         <Radio.Group value={optionType} onChange={handleOptionChange}>
@@ -80,6 +86,6 @@ export function BooleanFilterPicker({
         )}
         <FilterFooter isNew={isNew} canSubmit />
       </div>
-    </form>
+    </Box>
   );
 }

--- a/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
@@ -5,7 +5,7 @@ import { Box, Flex, NumberInput, Stack, Text } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
 import type { FilterPickerWidgetProps } from "../types";
-import { MAX_WIDTH } from "../constants";
+import { MAX_WIDTH, MIN_WIDTH } from "../constants";
 import { getAvailableOperatorOptions } from "../utils";
 import { ColumnValuesWidget } from "../ColumnValuesWidget";
 import { FilterHeader } from "../FilterHeader";
@@ -83,6 +83,7 @@ export function CoordinateFilterPicker({
   return (
     <Box
       component="form"
+      miw={MIN_WIDTH}
       maw={MAX_WIDTH}
       data-testid="coordinate-filter-picker"
       onSubmit={handleSubmit}

--- a/frontend/src/metabase/common/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
-import type { DatePickerValue } from "metabase/common/components/DatePicker";
 import { DatePicker } from "metabase/common/components/DatePicker";
+import type { DatePickerValue } from "metabase/common/components/DatePicker";
 import * as Lib from "metabase-lib";
 import { BackButton } from "../BackButton";
 import type { FilterPickerWidgetProps } from "../types";

--- a/frontend/src/metabase/common/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.styled.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.styled.tsx
@@ -1,7 +1,10 @@
 import styled from "@emotion/styled";
 import AccordionList from "metabase/core/components/AccordionList";
 import { color } from "metabase/lib/colors";
+import { MAX_WIDTH, MIN_WIDTH } from "../constants";
 
 export const StyledAccordionList = styled(AccordionList)`
   color: ${color("filter")};
+  min-width: ${MIN_WIDTH}px;
+  max-width: ${MAX_WIDTH}px;
 `;

--- a/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
@@ -58,9 +58,7 @@ export function FilterPicker({
   const [
     isEditingExpression,
     { turnOn: openExpressionEditor, turnOff: closeExpressionEditor },
-  ] = useToggle(
-    isExpressionEditorInitiallyOpen(query, stageIndex, column, filter),
-  );
+  ] = useToggle(isExpressionEditorInitiallyOpen(query, stageIndex, filter));
 
   const isNewFilter = !initialFilter;
 
@@ -166,14 +164,13 @@ function getInitialColumn(
 function isExpressionEditorInitiallyOpen(
   query: Lib.Query,
   stageIndex: number,
-  column: Lib.ColumnMetadata | undefined,
   filter?: Lib.FilterClause,
 ) {
-  if (!filter || Lib.isSegmentFilter(query, stageIndex, filter)) {
-    return false;
-  }
-  const hasWidget = column && getFilterWidget(column) != null;
-  return Lib.isCustomFilter(query, stageIndex, filter) || !hasWidget;
+  return (
+    filter != null &&
+    !Lib.isColumnFilter(query, stageIndex, filter) &&
+    !Lib.isSegmentFilter(query, stageIndex, filter)
+  );
 }
 
 function getFilterWidget(column: Lib.ColumnMetadata) {

--- a/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
@@ -168,7 +168,7 @@ function isExpressionEditorInitiallyOpen(
 ) {
   return (
     filter != null &&
-    !Lib.isColumnFilter(query, stageIndex, filter) &&
+    !Lib.isStandardFilter(query, stageIndex, filter) &&
     !Lib.isSegmentFilter(query, stageIndex, filter)
   );
 }

--- a/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useLayoutEffect, useState } from "react";
 
-import { Box } from "metabase/ui";
 import { useToggle } from "metabase/hooks/use-toggle";
 
 import { ExpressionWidget } from "metabase/query_builder/components/expressions/ExpressionWidget";
@@ -14,7 +13,6 @@ import LegacyFilter from "metabase-lib/queries/structured/Filter";
 import type LegacyQuery from "metabase-lib/queries/StructuredQuery";
 
 import type { ColumnListItem, SegmentListItem } from "./types";
-import { MIN_WIDTH, MAX_WIDTH } from "./constants";
 
 import { BooleanFilterPicker } from "./BooleanFilterPicker";
 import { DateFilterPicker } from "./DateFilterPicker";
@@ -115,16 +113,14 @@ export function FilterPicker({
 
   if (!column) {
     return (
-      <Box miw={MIN_WIDTH} maw={MAX_WIDTH}>
-        <FilterColumnPicker
-          query={query}
-          stageIndex={stageIndex}
-          checkItemIsSelected={checkItemIsSelected}
-          onColumnSelect={handleColumnSelect}
-          onSegmentSelect={handleChange}
-          onExpressionSelect={openExpressionEditor}
-        />
-      </Box>
+      <FilterColumnPicker
+        query={query}
+        stageIndex={stageIndex}
+        checkItemIsSelected={checkItemIsSelected}
+        onColumnSelect={handleColumnSelect}
+        onSegmentSelect={handleChange}
+        onExpressionSelect={openExpressionEditor}
+      />
     );
   }
 
@@ -132,17 +128,15 @@ export function FilterPicker({
 
   if (FilterWidget) {
     return (
-      <Box miw={MIN_WIDTH}>
-        <FilterWidget
-          query={query}
-          stageIndex={stageIndex}
-          column={column}
-          filter={filter}
-          isNew={isNewFilter}
-          onChange={handleChange}
-          onBack={() => setColumn(undefined)}
-        />
-      </Box>
+      <FilterWidget
+        query={query}
+        stageIndex={stageIndex}
+        column={column}
+        filter={filter}
+        isNew={isNewFilter}
+        onChange={handleChange}
+        onBack={() => setColumn(undefined)}
+      />
     );
   }
 

--- a/frontend/src/metabase/common/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
@@ -4,7 +4,7 @@ import { t } from "ttag";
 import { Box, Flex, NumberInput, Text } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type { FilterPickerWidgetProps } from "../types";
-import { MAX_WIDTH } from "../constants";
+import { MAX_WIDTH, MIN_WIDTH } from "../constants";
 import { getAvailableOperatorOptions } from "../utils";
 import { ColumnValuesWidget } from "../ColumnValuesWidget";
 import { FilterHeader } from "../FilterHeader";
@@ -66,6 +66,7 @@ export function NumberFilterPicker({
   return (
     <Box
       component="form"
+      miw={MIN_WIDTH}
       maw={MAX_WIDTH}
       data-testid="number-filter-picker"
       onSubmit={handleSubmit}

--- a/frontend/src/metabase/common/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -3,7 +3,7 @@ import type { FormEvent } from "react";
 import { t } from "ttag";
 import { Box, Checkbox, Flex, TextInput } from "metabase/ui";
 import * as Lib from "metabase-lib";
-import { MAX_WIDTH } from "../constants";
+import { MAX_WIDTH, MIN_WIDTH } from "../constants";
 import type { FilterPickerWidgetProps } from "../types";
 import { getAvailableOperatorOptions } from "../utils";
 import { ColumnValuesWidget } from "../ColumnValuesWidget";
@@ -72,6 +72,7 @@ export function StringFilterPicker({
   return (
     <Box
       component="form"
+      miw={MIN_WIDTH}
       maw={MAX_WIDTH}
       data-testid="string-filter-picker"
       onSubmit={handleSubmit}

--- a/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
@@ -3,7 +3,7 @@ import type { FormEvent } from "react";
 import { t } from "ttag";
 import { Box, Flex, Text, TimeInput } from "metabase/ui";
 import * as Lib from "metabase-lib";
-import { MAX_WIDTH } from "../constants";
+import { MAX_WIDTH, MIN_WIDTH } from "../constants";
 import type { FilterPickerWidgetProps } from "../types";
 import { getAvailableOperatorOptions } from "../utils";
 import { FilterOperatorPicker } from "../FilterOperatorPicker";
@@ -59,6 +59,7 @@ export function TimeFilterPicker({
   return (
     <Box
       component="form"
+      miw={MIN_WIDTH}
       maw={MAX_WIDTH}
       data-testid="time-filter-picker"
       onSubmit={handleSubmit}


### PR DESCRIPTION
When splitting the filter picker I thought about that it's incorrect that we need to handle filter expression shape vs column type mismatches in the component. In this PR I've moved these checks to `metabase-lib`.