### PR TITLE
Filter min max width

### DIFF
--- a/frontend/src/metabase/common/components/DatePicker/DateShortcutPicker/DateShortcutPicker.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/DateShortcutPicker/DateShortcutPicker.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useMemo } from "react";
 import type { ReactNode } from "react";
 import { Button, Box, Divider } from "metabase/ui";
+import { MIN_WIDTH } from "../constants";
 import type {
   DatePickerOperator,
   DatePickerShortcut,
@@ -33,7 +34,7 @@ export function DateShortcutPicker({
   }, [availableOperators]);
 
   return (
-    <Box p="sm">
+    <Box p="sm" miw={MIN_WIDTH}>
       {backButton}
       {shortcutGroups.map((group, groupIndex) => (
         <Fragment key={groupIndex}>

--- a/frontend/src/metabase/common/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { t } from "ttag";
 import { Box, Button, Checkbox, Divider, Group, Stack } from "metabase/ui";
 import { BackButton } from "../BackButton";
+import { MIN_WIDTH } from "../constants";
 import type {
   DatePickerExtractionUnit,
   DatePickerOperator,
@@ -97,7 +98,7 @@ export function ExcludeOptionPicker({
   };
 
   return (
-    <div>
+    <Box miw={MIN_WIDTH}>
       <BackButton onClick={onBack}>{t`Exclude…`}</BackButton>
       <Divider />
       <Box p="sm">
@@ -127,7 +128,7 @@ export function ExcludeOptionPicker({
           </Button>
         ))}
       </Box>
-    </div>
+    </Box>
   );
 }
 
@@ -181,7 +182,7 @@ function ExcludeValuePicker({
   };
 
   return (
-    <div>
+    <Box miw={MIN_WIDTH}>
       <BackButton onClick={onBack}>{option?.label}</BackButton>
       <Divider />
       <Stack p="md">
@@ -214,6 +215,6 @@ function ExcludeValuePicker({
           {isNew ? t`Add filter` : t`Update filter`}
         </Button>
       </Group>
-    </div>
+    </Box>
   );
 }

--- a/frontend/src/metabase/common/components/DatePicker/constants.ts
+++ b/frontend/src/metabase/common/components/DatePicker/constants.ts
@@ -1,3 +1,5 @@
+export const MIN_WIDTH = 300;
+
 export const SPECIFIC_DATE_PICKER_OPERATORS = [
   "=",
   "<",

--- a/frontend/src/metabase/common/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
@@ -3,12 +3,13 @@ import type { FormEvent } from "react";
 import { t } from "ttag";
 import { checkNotNull } from "metabase/lib/types";
 import { Icon } from "metabase/core/components/Icon";
-import { Button, Radio, Stack } from "metabase/ui";
+import { Box, Button, Radio, Stack } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import { FilterHeader } from "../FilterHeader";
 import { FilterFooter } from "../FilterFooter";
-import type { FilterPickerWidgetProps } from "../types";
+import { MIN_WIDTH } from "../constants";
 import { getAvailableOperatorOptions } from "../utils";
+import type { FilterPickerWidgetProps } from "../types";
 import { OPTIONS } from "./constants";
 import { getFilterClause, getOptionType } from "./utils";
 
@@ -51,7 +52,12 @@ export function BooleanFilterPicker({
   };
 
   return (
-    <form data-testid="boolean-filter-picker" onSubmit={handleSubmit}>
+    <Box
+      component="form"
+      miw={MIN_WIDTH}
+      data-testid="boolean-filter-picker"
+      onSubmit={handleSubmit}
+    >
       <FilterHeader columnName={columnName} onBack={onBack} />
       <div>
         <Radio.Group value={optionType} onChange={handleOptionChange}>
@@ -80,6 +86,6 @@ export function BooleanFilterPicker({
         )}
         <FilterFooter isNew={isNew} canSubmit />
       </div>
-    </form>
+    </Box>
   );
 }

--- a/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
@@ -5,7 +5,7 @@ import { Box, Flex, NumberInput, Stack, Text } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
 import type { FilterPickerWidgetProps } from "../types";
-import { MAX_WIDTH } from "../constants";
+import { MAX_WIDTH, MIN_WIDTH } from "../constants";
 import { getAvailableOperatorOptions } from "../utils";
 import { ColumnValuesWidget } from "../ColumnValuesWidget";
 import { FilterHeader } from "../FilterHeader";
@@ -83,6 +83,7 @@ export function CoordinateFilterPicker({
   return (
     <Box
       component="form"
+      miw={MIN_WIDTH}
       maw={MAX_WIDTH}
       data-testid="coordinate-filter-picker"
       onSubmit={handleSubmit}

--- a/frontend/src/metabase/common/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
-import type { DatePickerValue } from "metabase/common/components/DatePicker";
 import { DatePicker } from "metabase/common/components/DatePicker";
+import type { DatePickerValue } from "metabase/common/components/DatePicker";
 import * as Lib from "metabase-lib";
 import { BackButton } from "../BackButton";
 import type { FilterPickerWidgetProps } from "../types";

--- a/frontend/src/metabase/common/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.styled.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.styled.tsx
@@ -1,7 +1,10 @@
 import styled from "@emotion/styled";
 import AccordionList from "metabase/core/components/AccordionList";
 import { color } from "metabase/lib/colors";
+import { MAX_WIDTH, MIN_WIDTH } from "../constants";
 
 export const StyledAccordionList = styled(AccordionList)`
   color: ${color("filter")};
+  min-width: ${MIN_WIDTH}px;
+  max-width: ${MAX_WIDTH}px;
 `;

--- a/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useLayoutEffect, useState } from "react";
 
-import { Box } from "metabase/ui";
 import { useToggle } from "metabase/hooks/use-toggle";
 
 import { ExpressionWidget } from "metabase/query_builder/components/expressions/ExpressionWidget";
@@ -14,7 +13,6 @@ import LegacyFilter from "metabase-lib/queries/structured/Filter";
 import type LegacyQuery from "metabase-lib/queries/StructuredQuery";
 
 import type { ColumnListItem, SegmentListItem } from "./types";
-import { MIN_WIDTH, MAX_WIDTH } from "./constants";
 
 import { BooleanFilterPicker } from "./BooleanFilterPicker";
 import { DateFilterPicker } from "./DateFilterPicker";
@@ -115,16 +113,14 @@ export function FilterPicker({
 
   if (!column) {
     return (
-      <Box miw={MIN_WIDTH} maw={MAX_WIDTH}>
-        <FilterColumnPicker
-          query={query}
-          stageIndex={stageIndex}
-          checkItemIsSelected={checkItemIsSelected}
-          onColumnSelect={handleColumnSelect}
-          onSegmentSelect={handleChange}
-          onExpressionSelect={openExpressionEditor}
-        />
-      </Box>
+      <FilterColumnPicker
+        query={query}
+        stageIndex={stageIndex}
+        checkItemIsSelected={checkItemIsSelected}
+        onColumnSelect={handleColumnSelect}
+        onSegmentSelect={handleChange}
+        onExpressionSelect={openExpressionEditor}
+      />
     );
   }
 

--- a/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/FilterPicker.tsx
@@ -132,17 +132,15 @@ export function FilterPicker({
 
   if (FilterWidget) {
     return (
-      <Box miw={MIN_WIDTH}>
-        <FilterWidget
-          query={query}
-          stageIndex={stageIndex}
-          column={column}
-          filter={filter}
-          isNew={isNewFilter}
-          onChange={handleChange}
-          onBack={() => setColumn(undefined)}
-        />
-      </Box>
+      <FilterWidget
+        query={query}
+        stageIndex={stageIndex}
+        column={column}
+        filter={filter}
+        isNew={isNewFilter}
+        onChange={handleChange}
+        onBack={() => setColumn(undefined)}
+      />
     );
   }
 

--- a/frontend/src/metabase/common/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
@@ -4,7 +4,7 @@ import { t } from "ttag";
 import { Box, Flex, NumberInput, Text } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type { FilterPickerWidgetProps } from "../types";
-import { MAX_WIDTH } from "../constants";
+import { MAX_WIDTH, MIN_WIDTH } from "../constants";
 import { getAvailableOperatorOptions } from "../utils";
 import { ColumnValuesWidget } from "../ColumnValuesWidget";
 import { FilterHeader } from "../FilterHeader";
@@ -66,6 +66,7 @@ export function NumberFilterPicker({
   return (
     <Box
       component="form"
+      miw={MIN_WIDTH}
       maw={MAX_WIDTH}
       data-testid="number-filter-picker"
       onSubmit={handleSubmit}

--- a/frontend/src/metabase/common/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -3,7 +3,7 @@ import type { FormEvent } from "react";
 import { t } from "ttag";
 import { Box, Checkbox, Flex, TextInput } from "metabase/ui";
 import * as Lib from "metabase-lib";
-import { MAX_WIDTH } from "../constants";
+import { MAX_WIDTH, MIN_WIDTH } from "../constants";
 import type { FilterPickerWidgetProps } from "../types";
 import { getAvailableOperatorOptions } from "../utils";
 import { ColumnValuesWidget } from "../ColumnValuesWidget";
@@ -72,6 +72,7 @@ export function StringFilterPicker({
   return (
     <Box
       component="form"
+      miw={MIN_WIDTH}
       maw={MAX_WIDTH}
       data-testid="string-filter-picker"
       onSubmit={handleSubmit}

--- a/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
+++ b/frontend/src/metabase/common/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
@@ -3,7 +3,7 @@ import type { FormEvent } from "react";
 import { t } from "ttag";
 import { Box, Flex, Text, TimeInput } from "metabase/ui";
 import * as Lib from "metabase-lib";
-import { MAX_WIDTH } from "../constants";
+import { MAX_WIDTH, MIN_WIDTH } from "../constants";
 import type { FilterPickerWidgetProps } from "../types";
 import { getAvailableOperatorOptions } from "../utils";
 import { FilterOperatorPicker } from "../FilterOperatorPicker";
@@ -59,6 +59,7 @@ export function TimeFilterPicker({
   return (
     <Box
       component="form"
+      miw={MIN_WIDTH}
       maw={MAX_WIDTH}
       data-testid="time-filter-picker"
       onSubmit={handleSubmit}


### PR DESCRIPTION
Currently `FilterPicker` subcomponents look broken on their own because we set `min-width` only in `FilterPicker`. This PR solves the issue by setting the desired `min-width` in each component. This is especially important for `DatePicker` - the component is supposed to work outside of `FilterPicker`.