### PR TITLE
Prevent updating a database from closing connections unnecessarily when updating `database-enable-actions` setting

### DIFF
--- a/src/metabase/events/driver_notifications.clj
+++ b/src/metabase/events/driver_notifications.clj
@@ -5,6 +5,7 @@
   this writing, the SQL JDBC driver 'superclass' is the only thing that implements this method, and does so to close
   connection pools when database details change or when they are deleted."
   (:require
+   [medley.core :as m]
    [metabase.driver :as driver]
    [metabase.events :as events]
    [metabase.util.log :as log]
@@ -15,10 +16,15 @@
 (derive :event/database-delete ::event)
 
 (methodical/defmethod events/publish-event! ::event
-  [topic {database :object :as _event}]
+  [topic {database :object, previous-database :previous-object :as _event}]
   ;; try/catch here to prevent individual topic processing exceptions from bubbling up.  better to handle them here.
   (try
-   ;; notify the appropriate driver about the updated database
-   (driver/notify-database-updated (:engine database) database)
-   (catch Throwable e
-     (log/warnf e "Failed to process driver notifications event. %s" topic))))
+    ;; notify the appropriate driver about the updated database to release any resources it may be holding onto.
+    ;; don't notify the driver if the changes should not impact the state of any resource.
+    (let [paths-that-dont-impact-resource-state [[:updated_at]
+                                                 [:settings :database-enable-actions]]]
+      (when (not= (reduce m/dissoc-in database paths-that-dont-impact-resource-state)
+                  (reduce m/dissoc-in previous-database paths-that-dont-impact-resource-state))
+        (driver/notify-database-updated (:engine database) database)))
+    (catch Throwable e
+      (log/warnf e "Failed to process driver notifications event. %s" topic))))

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -9,6 +9,7 @@
    [metabase.api.table :as api.table]
    [metabase.driver :as driver]
    [metabase.driver.h2 :as h2]
+   [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.util :as driver.u]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.models
@@ -19,6 +20,7 @@
    [metabase.models.permissions-group :as perms-group]
    [metabase.models.setting :as setting :refer [defsetting]]
    [metabase.public-settings.premium-features :as premium-features]
+   [metabase.sync :as sync]
    [metabase.sync.analyze :as analyze]
    [metabase.sync.field-values :as field-values]
    [metabase.sync.sync-metadata :as sync-metadata]
@@ -33,7 +35,11 @@
    [metabase.util.malli.schema :as ms]
    [ring.util.codec :as codec]
    [toucan2.core :as t2]
-   [toucan2.tools.with-temp :as t2.with-temp]))
+   [toucan2.tools.with-temp :as t2.with-temp])
+  (:import
+   (java.sql Connection)))
+
+(set! *warn-on-reflection* true)
 
 (use-fixtures :once (fixtures/initialize :db :plugins :test-drivers))
 
@@ -510,6 +516,42 @@
                                                (format "database/%s" db-id)
                                                {:settings {:database-enable-actions true}})
                          [:settings :database-enable-actions]))))))
+
+(deftest update-database-enable-actions-open-connection-test
+  (testing "Updating a database's `database-enable-actions` setting shouldn't close existing connections (metabase#27877)"
+    (mt/test-drivers (filter #(isa? driver/hierarchy % :sql-jdbc) (mt/normal-drivers-with-feature :actions))
+      (let [;; 1. create a database and sync
+            database-name      (name (gensym))
+            empty-dbdef        {:database-name database-name}
+            _                  (tx/create-db! :postgres empty-dbdef)
+            connection-details (tx/dbdef->connection-details driver/*driver* :db empty-dbdef)
+            db                 (first (t2/insert-returning-instances! :model/Database {:name    database-name
+                                                                                       :engine  (u/qualified-name driver/*driver*)
+                                                                                       :details connection-details}))
+            _                  (sync/sync-database! db)]
+        (let [;; 2. start a long running process on another thread that uses a connection
+              connections-stay-open? (future
+                                       (sql-jdbc.execute/do-with-connection-with-options
+                                        driver/*driver*
+                                        db
+                                        nil
+                                        (fn [^Connection conn]
+                                          ;; sleep long enough to make sure the PUT request below finishes processing,
+                                          ;; including any async operations that it might trigger
+                                          (Thread/sleep 1000)
+                                          ;; test the connection is open by executing a query
+                                          (try
+                                            (let [stmt      (.createStatement conn)
+                                                  resultset (.executeQuery stmt "SELECT 1")]
+                                              (.next resultset))
+                                            (catch Exception _e
+                                              false)))))]
+          ;; 3. update the database's `database-enable-actions` setting
+          (mt/user-http-request :crowberto :put 200 (format "database/%d" (u/the-id db))
+                                {:settings {:database-enable-actions true}})
+          ;; 4. test the connection was still open at the end of it of the long running process
+          (is (true? @connections-stay-open?))
+          (tx/destroy-db! driver/*driver* empty-dbdef))))))
 
 (deftest fetch-database-metadata-test
   (testing "GET /api/database/:id/metadata"

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -523,7 +523,7 @@
       (let [;; 1. create a database and sync
             database-name      (name (gensym))
             empty-dbdef        {:database-name database-name}
-            _                  (tx/create-db! :postgres empty-dbdef)
+            _                  (tx/create-db! driver/*driver* empty-dbdef)
             connection-details (tx/dbdef->connection-details driver/*driver* :db empty-dbdef)
             db                 (first (t2/insert-returning-instances! :model/Database {:name    database-name
                                                                                        :engine  (u/qualified-name driver/*driver*)


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/27877, see [this comment](https://github.com/metabase/metabase/issues/27877#issuecomment-1810283147) for an explanation of the root cause.

Avoids calling `driver/notify-database-updated` if we update only the `database-enable-actions` setting for a database.

That method has the docstring:
https://github.com/metabase/metabase/blob/66af1e4cd7aa2a9afa657d1ef2b0cfba36842918/src/metabase/driver.clj#L703-L706

It shouldn't be called unless there's a reason to update the state of related resources. In the case of `database-enable-actions`, there's no reason why any driver-specific resources need to be updated.