### PR TITLE
seperate data from side effects for `record-event!`

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -227,4 +227,5 @@
   (u/prog1 (maybe-install-audit-db)
    (let [audit-db (t2/select-one :model/Database :is_audit true)]
        ;; prevent sync while loading
-     ((sync-util/with-duplicate-ops-prevented :sync-database audit-db (partial maybe-load-analytics-content! audit-db))))))
+     ((sync-util/with-duplicate-ops-prevented :sync-database audit-db
+        (fn [] (maybe-load-analytics-content! audit-db)))))))

--- a/src/metabase/models/audit_log.clj
+++ b/src/metabase/models/audit_log.clj
@@ -10,6 +10,8 @@
    [metabase.models.interface :as mi]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.malli.schema :as ms]
    [methodical.core :as m]
    [toucan2.core :as t2]))
 
@@ -56,6 +58,41 @@
     {:previous (select-keys previous-object shared-updated-keys)
      :new (select-keys object shared-updated-keys)}))
 
+(mr/def ::event-params [:map {:closed true
+                              :doc "Used when inserting a value to the Audit Log."}
+                        [:object          {:optional true} [:maybe :map]]
+                        [:previous-object {:optional true} [:maybe :map]]
+                        [:user-id         {:optional true} [:maybe pos-int?]]
+                        [:model           {:optional true} [:maybe [:or :keyword :string]]]
+                        [:model-id        {:optional true} [:maybe pos-int?]]
+                        [:details         {:optional true} [:maybe :map]]])
+
+(mu/defn construct-event
+  :- [:map
+      [:unqualified-topic simple-keyword?]
+      [:user-id [:maybe ms/PositiveInt]]
+      [:model-name [:maybe :string]]
+      [:model-id [:maybe ms/PositiveInt]]
+      [:details :map]]
+  "Generates the data to be recorded in the Audit Log."
+  ([topic :- :keyword
+    params :- ::event-params
+    current-user-id :- [:maybe pos-int?]]
+   (let [unqualified-topic (keyword (name topic))
+         object            (:object params)
+         previous-object   (:previous-object params)
+         object-details    (model-details object unqualified-topic)
+         previous-details  (model-details previous-object unqualified-topic)]
+     {:unqualified-topic unqualified-topic
+      :user-id           (or (:user-id params) current-user-id)
+      :model-name        (model-name (or (:model params) object))
+      :model-id          (or (:model-id params) (u/id object))
+      :details           (merge {}
+                                (:details params)
+                                (if (not-empty previous-object)
+                                  (prepare-update-event-data object-details previous-details)
+                                  object-details))})))
+
 (mu/defn record-event!
   "Records an event in the Audit Log.
 
@@ -74,30 +111,13 @@
   then they are added to `:details` before the event is recorded. `:previous-object` is only included if any audited fields
   were updated."
   [topic :- :keyword
-   params :- [:map {:closed true}
-              [:object          {:optional true} [:maybe :map]]
-              [:previous-object {:optional true} [:maybe :map]]
-              [:user-id         {:optional true} [:maybe pos-int?]]
-              [:model           {:optional true} [:maybe [:or :keyword :string]]]
-              [:model-id        {:optional true} [:maybe pos-int?]]
-              [:details         {:optional true} [:maybe :map]]]]
-  (let [unqualified-topic (keyword (name topic))
-        object            (:object params)
-        previous-object   (:previous-object params)
-        object-details    (model-details object unqualified-topic)
-        previous-details  (model-details previous-object unqualified-topic)
-        user-id           (or (:user-id params) api/*current-user-id*)
-        model             (model-name (or (:model params) object))
-        model-id          (or (:model-id params) (u/id object))
-        details           (merge {}
-                           (:details params)
-                           (if (not-empty previous-object)
-                             (prepare-update-event-data object-details previous-details)
-                             object-details))]
+   params :- ::event-params]
+  (let [{:keys [user-id model-name model-id details unqualified-topic object]}
+        (construct-event topic params api/*current-user-id*)]
     (t2/insert! :model/AuditLog
                 :topic    unqualified-topic
                 :details  details
-                :model    model
+                :model    model-name
                 :model_id model-id
                 :user_id  user-id)
     ;; TODO: temporarily double-writing to the `activity` table, delete this in Metabase v48
@@ -107,7 +127,7 @@
        {:topic    topic
         :object   object
         :details  details
-        :model    model
+        :model    model-name
         :model-id model-id
         :user-id  user-id}))))
 

--- a/test/metabase/models/audit_log_test.clj
+++ b/test/metabase/models/audit_log_test.clj
@@ -1,11 +1,41 @@
 (ns metabase.models.audit-log-test
   (:require [clojure.test :refer :all]
+            [clojure.test.check.clojure-test :as ct :refer [defspec]]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
+            [malli.generator :as mg]
             [metabase.models.audit-log :as audit-log]
             [metabase.test :as mt]
+            [metabase.util :as u]
             [toucan2.core :as t2]
             [toucan2.tools.with-temp :as t2.with-temp]))
 
 (derive :event/test-event :metabase/event)
+
+(def topic-generator (gen/fmap (fn [k] (keyword "event" (name k))) (mg/generator :keyword)))
+
+(defspec topic-gets-unqualified 5000
+  (prop/for-all [ns-kw topic-generator]
+    (is (= (keyword (name ns-kw)) (:unqualified-topic (audit-log/construct-event ns-kw {} nil))))))
+
+(defspec params-take-precedence 1000
+  (prop/for-all [topic topic-generator
+                 event-params (mg/generator ::audit-log/event-params)
+                 user-id (mg/generator [:maybe pos-int?])]
+    (let [object (:object event-params)
+          constructed-event (audit-log/construct-event topic event-params user-id)]
+      (testing "user-id in event takes precident over current-user-id"
+        (is (= (cond
+                 (:user-id event-params) (:user-id event-params)
+                 user-id user-id
+                 :else nil)
+               (:user-id constructed-event))))
+      (testing "model-id in event takes precident over model id on object"
+        (is (= (cond
+                 (:model-id event-params) (:model-id event-params)
+                 (u/id object) (u/id object)
+                 :else nil)
+               (:model-id constructed-event)))))))
 
 (deftest basic-record-event-test
   (mt/with-model-cleanup [:model/AuditLog]


### PR DESCRIPTION
As we discussed in https://github.com/metabase/metabase/pull/35435#discussion_r1385636529.

This PR adds a seperation between _generating the data_ that goes into the audit log, and the _construction_ of that data. It let's us write better, faster tests. The added tests don't depend on the database, but still test properties about audit log entries.

This also adds quickcheck tests for user-id and model-id precedence 

e.g. if I pass in a model-id and also have an id on my object, which one gets inserted? Now there's a test for that!
