### PR TITLE
Fix broken Root Collection permissions

### DIFF
--- a/e2e/test/scenarios/collections/permissions.cy.spec.js
+++ b/e2e/test/scenarios/collections/permissions.cy.spec.js
@@ -9,9 +9,12 @@ import {
   openCollectionMenu,
   openCollectionItemMenu,
   modal,
+  setTokenFeatures,
+  sidebar,
 } from "e2e/support/helpers";
 
 import { USERS } from "e2e/support/cypress_data";
+import { FIRST_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data.js";
 import { displaySidebarChildOf } from "./helpers/e2e-collections-sidebar.js";
 
 const PERMISSIONS = {
@@ -430,6 +433,37 @@ describe("collection permissions", () => {
     cy.findByText("Save").click();
 
     cy.findByTestId("select-button").findByText("Our analytics");
+  });
+
+  it("should load the collection permissions admin pages", () => {
+    cy.signInAsAdmin();
+    setTokenFeatures("all");
+    cy.intercept("GET", "/api/collection/graph").as("permissionsGraph");
+    cy.intercept("GET", "/api/permissions/group").as("permissionsGroups");
+
+    cy.visit("/admin/permissions/collections");
+    cy.get("main").findByText("Select a collection to see its permissions");
+
+    cy.visit("/admin/permissions/collections/root");
+    cy.wait(["@permissionsGraph", "@permissionsGroups"]);
+
+    cy.findByTestId("permissions-editor").findByText(
+      "Permissions for Our analytics",
+    );
+    cy.findByTestId("permission-table");
+
+    cy.visit(`/admin/permissions/collections/${FIRST_COLLECTION_ID}`);
+    cy.wait(["@permissionsGraph", "@permissionsGroups"]);
+    cy.findByTestId("permissions-editor").findByText(
+      "Permissions for First collection",
+    );
+    cy.findByTestId("permission-table");
+
+    sidebar().findByText("Metabase analytics").click();
+    cy.findByTestId("permissions-editor").findByText(
+      "Permissions for Metabase analytics",
+    );
+    cy.findByTestId("permission-table");
   });
 });
 

--- a/enterprise/frontend/src/metabase-enterprise/collections/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/collections/utils.ts
@@ -1,4 +1,9 @@
-import type { Bookmark, Collection } from "metabase-types/api";
+import type {
+  Bookmark,
+  Collection,
+  CollectionAuthorityLevelConfig,
+  CollectionInstanceAnaltyicsConfig,
+} from "metabase-types/api";
 import {
   REGULAR_COLLECTION,
   COLLECTION_TYPES,
@@ -19,8 +24,12 @@ export function isRegularCollection({
 export function getCollectionType({
   authority_level,
   type,
-}: Partial<Collection>) {
-  return COLLECTION_TYPES[String(type || authority_level)];
+}: Partial<Collection>):
+  | CollectionAuthorityLevelConfig
+  | CollectionInstanceAnaltyicsConfig {
+  return (
+    COLLECTION_TYPES?.[String(type || authority_level)] ?? REGULAR_COLLECTION
+  );
 }
 
 export const getInstanceAnalyticsCustomCollection = (

--- a/enterprise/frontend/src/metabase-enterprise/collections/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/collections/utils.unit.spec.ts
@@ -43,5 +43,11 @@ describe("Collections plugin utils", () => {
       const collection = createMockCollection({ type: "instance-analytics" });
       expect(getCollectionType(collection).icon).toBe("audit");
     });
+
+    it("root collection", () => {
+      const collection = createMockCollection();
+      expect(getCollectionType(collection).type).toBe(null);
+      expect(getCollectionType({}).type).toBe(null);
+    });
   });
 });

--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.jsx
@@ -61,7 +61,7 @@ export function PermissionsEditorContent({
   const handleFilterChange = e => setFilter(e.target.value);
 
   return (
-    <PermissionEditorContentRoot>
+    <PermissionEditorContentRoot data-testid="permissions-editor">
       <Subhead>
         {title}{" "}
         {breadcrumbs && (


### PR DESCRIPTION
### Description

Our instance analytics collection type check was breaking collection permissions for the root collection because it's object looks different than all other collections.

Before | After
--- | ---
![Screen Shot 2023-11-14 at 11 12 59 AM](https://github.com/metabase/metabase/assets/30528226/625c7df7-e873-4245-adae-1d27fb4f17a8) | ![Screen Shot 2023-11-14 at 11 12 38 AM](https://github.com/metabase/metabase/assets/30528226/9c660ee4-425e-468c-9c93-ee4e571b810b)

I also added some unit and e2e tests for this. Crazy that we didn't have any does-this-page work coverage on this page at all. Now we do.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

## PS

I also played around with adding some error boundaries to this component so that if the main permissions table panel crashed, the sidebar could still work instead of the the whole page dying. However, since the problem here was in the redux selector that sits above both of those components, it wasn't possible 😢  This is good evidence that untangling/simplifying some of the structure of our admin pages could improve not just the code's usability, but also allow us to build a more robust user experience.