### PR TITLE
Fix serdes of click_behavior on dashcards

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -412,6 +412,7 @@
 (deftest dashboard-card-test
   ;; DashboardCard.parameter_mappings and Card.parameter_mappings are JSON-encoded lists of parameter maps, which
   ;; contain field IDs - these need to be converted to a portable form and read back in.
+  ;; DashboardCard.visualization_settings contains JSON with several places where IDs are embedded.
   ;; This test has a database, table and fields, that exist on both sides with different IDs, and expects a Card and
   ;; DashboardCard to be correctly loaded with the dest IDs.
   (testing "parameter_mappings are portable"
@@ -422,6 +423,7 @@
           field1s    (atom nil)
           field2s    (atom nil)
           dash1s     (atom nil)
+          dash2s     (atom nil)
           card1s     (atom nil)
           dashcard1s (atom nil)
           user1s     (atom nil)
@@ -448,6 +450,7 @@
             (reset! field2s  (ts/create! Field :name "invoice" :table_id (:id @table1s)))
             (reset! user1s   (ts/create! User  :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
             (reset! dash1s   (ts/create! Dashboard :name "My Dashboard" :collection_id (:id @coll1s) :creator_id (:id @user1s)))
+            (reset! dash2s   (ts/create! Dashboard :name "Linked dashboard" :collection_id (:id @coll1s) :creator_id (:id @user1s)))
             (reset! card1s   (ts/create! Card :name "The Card" :database_id (:id @db1s) :table_id (:id @table1s)
                                          :collection_id (:id @coll1s) :creator_id (:id @user1s)
                                          :visualization_settings
@@ -488,7 +491,14 @@
                                               :fieldRef [:field "Average order total" {:base-type :type/Float}]
                                               :enabled true}]
                                             :column_settings
-                                            {(str "[\"ref\",[\"field\"," (:id @field2s) ",null]]") {:column_title "Locus"}}}
+                                            {(str "[\"ref\",[\"field\"," (:id @field2s) ",null]]") {:column_title "Locus"}
+                                             (str "[\"ref\",[\"field\"," (:id @field1s) ",null]]")
+                                             {:click_behavior {:type     "link"
+                                                               :linkType "dashboard"
+                                                               :targetId (:id @dash2s)}}}
+                                            :click_behavior {:type     "link"
+                                                             :linkType "question"
+                                                             :targetId (:id @card1s)}}
                                            :parameter_mappings [{:parameter_id "deadbeef"
                                                                  :card_id (:id @card1s)
                                                                  :target [:dimension [:field (:id @field1s) {:source-field (:id @field2s)}]]}]))
@@ -508,7 +518,7 @@
                         (:dashcards dash))))
 
               (testing "exported :visualization_settings are properly converted"
-                (let [expected {:table.pivot_column "SOURCE"
+                (let [exp-card {:table.pivot_column "SOURCE"
                                 :table.cell_column "sum"
                                 :table.columns
                                 [{:name "SOME_FIELD"
@@ -524,10 +534,19 @@
                                   :fieldRef [:field "Average order total" {:base-type :type/Float}]
                                   :enabled true}]
                                 :column_settings
-                                {"[\"ref\",[\"field\",[\"my-db\",null,\"orders\",\"invoice\"],null]]" {:column_title "Locus"}}}]
-                  (is (= expected
+                                {"[\"ref\",[\"field\",[\"my-db\",null,\"orders\",\"invoice\"],null]]" {:column_title "Locus"}}}
+                      exp-dashcard (-> exp-card
+                                       (assoc :click_behavior {:type     "link"
+                                                               :linkType "question"
+                                                               :targetId (:entity_id @card1s)})
+                                       (assoc-in [:column_settings
+                                                  "[\"ref\",[\"field\",[\"my-db\",null,\"orders\",\"subtotal\"],null]]"]
+                                                 {:click_behavior {:type     "link"
+                                                                   :linkType "dashboard"
+                                                                   :targetId (:entity_id @dash2s)}}))]
+                  (is (= exp-card
                          (:visualization_settings card)))
-                  (is (= expected
+                  (is (= exp-dashcard
                          (-> dash :dashcards first :visualization_settings))))))))
 
 

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -79,7 +79,7 @@
   (fn [model-name _instance] model-name))
 
 (defmethod entity-id :default [_ {:keys [entity_id]}]
-  entity_id)
+  (str/trim entity_id))
 
 ;;; ## Hashing entities
 ;;; In the worst case, an entity is already present in two instances linked by serdes, and it doesn't have `entity_id`
@@ -371,6 +371,7 @@
   (let [model (t2.model/resolve-model (symbol model-name))
         pk    (first (t2/primary-keys model))]
     (-> (into {} entity)
+        (m/update-existing :entity_id str/trim)
         (assoc :serdes/meta (generate-path model-name entity))
         (dissoc pk :updated_at))))
 
@@ -1049,11 +1050,14 @@
 
 ;;; ## Dashboard/Question Parameters
 
+(defn- export-parameter-mapping [mapping]
+  (ids->fully-qualified-names mapping))
+
 (defn export-parameter-mappings
   "Given the :parameter_mappings field of a `Card` or `DashboardCard`, as a vector of maps, converts
   it to a portable form with the field IDs replaced with `[db schema table field]` references."
   [mappings]
-  (map ids->fully-qualified-names mappings))
+  (map export-parameter-mapping mappings))
 
 (defn import-parameter-mappings
   "Given the :parameter_mappings field as exported by serialization convert its field references
@@ -1102,6 +1106,7 @@
    "collection" :model/Collection
    "database"   :model/Database
    "dashboard"  :model/Dashboard
+   "question"   :model/Card
    "table"      :model/Table})
 
 (defn- export-viz-link-card
@@ -1115,6 +1120,74 @@
                    "table"    (*export-table-fk* id)
                    "database" (*export-fk-keyed* id 'Database :name)
                    (*export-fk* id (link-card-model->toucan-model model)))}))))
+
+(defn- json-ids->fully-qualified-names
+  "Converts IDs to fully qualified names inside a JSON string.
+  Returns a new JSON string with the IDs converted inside."
+  [json-str]
+  (-> json-str
+      (json/parse-string true)
+      ids->fully-qualified-names
+      json/generate-string))
+
+(defn- json-mbql-fully-qualified-names->ids
+  "Converts fully qualified names to IDs in MBQL embedded inside a JSON string.
+  Returns a new JSON string with teh IDs converted inside."
+  [json-str]
+  (-> json-str
+      (json/parse-string true)
+      mbql-fully-qualified-names->ids
+      json/generate-string))
+
+(defn- export-viz-click-behavior-link
+  [{:keys [linkType type] :as click-behavior}]
+  (cond-> click-behavior
+    (= type "link") (update :targetId *export-fk* (link-card-model->toucan-model linkType))))
+
+(defn- import-viz-click-behavior-link
+  [{:keys [linkType type] :as click-behavior}]
+  (cond-> click-behavior
+    (= type "link") (update :targetId *import-fk* (link-card-model->toucan-model linkType))))
+
+(defn- export-viz-click-behavior-mapping [mapping]
+  (-> mapping
+      (m/update-existing    :id                  json-ids->fully-qualified-names)
+      (m/update-existing-in [:target :id]        json-ids->fully-qualified-names)
+      (m/update-existing-in [:target :dimension] ids->fully-qualified-names)))
+
+(defn- import-viz-click-behavior-mapping [mapping]
+  (-> mapping
+      (m/update-existing    :id                  json-mbql-fully-qualified-names->ids)
+      (m/update-existing-in [:target :id]        json-mbql-fully-qualified-names->ids)
+      (m/update-existing-in [:target :dimension] mbql-fully-qualified-names->ids)))
+
+(defn- export-viz-click-behavior-mappings
+  "The `:parameterMappings` on a `:click_behavior` viz settings is a map of... IDs turned into JSON strings which have
+  been keywordized. Therefore the keys must be converted to strings, parsed, exported, and JSONified. The values are
+  ported by [[export-viz-click-behavior-mapping]]."
+  [mappings]
+  (into {} (for [[kw-key mapping] mappings]
+             [(json-ids->fully-qualified-names (name kw-key))
+              (export-viz-click-behavior-mapping mapping)])))
+
+(defn- import-viz-click-behavior-mappings
+  "The exported form of `:parameterMappings` on a `:click_behavior` viz settings is a map of JSON strings which contain
+  fully qualified names. These must be parsed, imported, JSONified and then turned back into keywords, since that's the
+  form used internally."
+  [mappings]
+  (into {} (for [[json-key mapping] mappings]
+             [(keyword (json-mbql-fully-qualified-names->ids json-key))
+              (import-viz-click-behavior-mapping mapping)])))
+
+(defn- export-viz-click-behavior [settings]
+  (some-> settings
+          (m/update-existing    :click_behavior export-viz-click-behavior-link)
+          (m/update-existing-in [:click_behavior :parameterMapping] export-viz-click-behavior-mappings)))
+
+(defn- import-viz-click-behavior [settings]
+  (some-> settings
+          (m/update-existing    :click_behavior import-viz-click-behavior-link)
+          (m/update-existing-in [:click_behavior :parameterMapping] import-viz-click-behavior-mappings)))
 
 (defn- export-visualizations [entity]
   (mbql.u/replace
@@ -1150,7 +1223,9 @@
   This function parses those keys, converts the IDs to portable values, and serializes them back to JSON."
   [settings]
   (when settings
-    (update-keys settings #(-> % json/parse-string export-visualizations json/generate-string))))
+    (-> settings
+        (update-keys #(-> % json/parse-string export-visualizations json/generate-string))
+        (update-vals export-viz-click-behavior))))
 
 (defn export-visualization-settings
   "Given the `:visualization_settings` map, convert all its field-ids to portable `[db schema table field]` form."
@@ -1159,6 +1234,7 @@
     (-> settings
         export-visualizations
         export-viz-link-card
+        export-viz-click-behavior
         (update :column_settings export-column-settings))))
 
 (defn- import-viz-link-card
@@ -1194,7 +1270,9 @@
 
 (defn- import-column-settings [settings]
   (when settings
-    (update-keys settings #(-> % name json/parse-string import-visualizations json/generate-string))))
+    (-> settings
+        (update-keys #(-> % name json/parse-string import-visualizations json/generate-string))
+        (update-vals import-viz-click-behavior))))
 
 (defn import-visualization-settings
   "Given an EDN value as exported by [[export-visualization-settings]], convert its portable `[db schema table field]`
@@ -1204,6 +1282,7 @@
     (-> settings
         import-visualizations
         import-viz-link-card
+        import-viz-click-behavior
         (update :column_settings import-column-settings))))
 
 (defn- viz-link-card-deps
@@ -1214,18 +1293,57 @@
         [{:model (name (link-card-model->toucan-model model))
           :id    id}])}))
 
+(defn- viz-click-behavior-deps
+  [settings]
+  (when-let [{:keys [linkType targetId type]} (:click_behavior settings)]
+    (case type
+      "link" (when-let [model (some-> linkType link-card-model->toucan-model name)]
+               #{[{:model model
+                   :id    targetId}]})
+      ;; TODO: We might need to handle the click behavior that updates dashboard filters? I can't figure out how get
+      ;; that to actually attach to a filter to check what it looks like.
+      nil)))
+
 (defn visualization-settings-deps
   "Given the :visualization_settings (possibly nil) for an entity, return any embedded serdes-deps as a set.
   Always returns an empty set even if the input is nil."
   [viz]
-  (let [vis-column-settings (some->> viz
-                                     :column_settings
-                                     keys
-                                     (map (comp mbql-deps json/parse-string name)))
-        link-card-deps      (viz-link-card-deps viz)]
-    (->> (concat vis-column-settings [(mbql-deps viz) link-card-deps])
+  (let [column-settings-keys-deps (some->> viz
+                                           :column_settings
+                                           keys
+                                           (map (comp mbql-deps json/parse-string name)))
+        column-settings-vals-deps (some->> viz
+                                           :column_settings
+                                           vals
+                                           (map viz-click-behavior-deps))
+        link-card-deps            (viz-link-card-deps viz)
+        click-behavior-deps       (viz-click-behavior-deps viz)]
+    (->> (concat column-settings-keys-deps
+                 column-settings-vals-deps
+                 [(mbql-deps viz) link-card-deps click-behavior-deps])
          (filter some?)
          (reduce set/union #{}))))
+
+(defn- viz-click-behavior-descendants [{:keys [click_behavior]}]
+  (when-let [{:keys [linkType targetId type]} click_behavior]
+    (case type
+      "link" #{[(name (link-card-model->toucan-model linkType)) targetId]}
+      ;; TODO: We might need to handle the click behavior that updates dashboard filters? I can't figure out how get
+      ;; that to actually attach to a filter to check what it looks like.
+      nil)))
+
+(defn- viz-column-settings-descendants [{:keys [column_settings]}]
+  (when column_settings
+    (->> (vals column_settings)
+         (mapcat viz-click-behavior-descendants)
+         set)))
+
+(defn visualization-settings-descendants
+  "Given the :visualization_settings (possibly nil) for an entity, return anything that should be considered a
+  descendant. Always returns an empty set even if the input is nil."
+  [viz]
+  (set/union (viz-click-behavior-descendants  viz)
+             (viz-column-settings-descendants viz)))
 
 ;;; ## Memoizing appdb lookups
 


### PR DESCRIPTION
Fix serdes of `click_behavior` on dashcards

Several parts of this structure contain MBQL and dashboard/card
references that need exporting and importing, which was being missed.

Fixes #33699.
