### PR TITLE
Add otel instrumentation to diagnose 33499

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -36,6 +36,7 @@
   com.github.seancorfield/honeysql          {:mvn/version "2.4.1066"}           ; Honey SQL 2. SQL generation from Clojure data maps
   com.github.seancorfield/next.jdbc         {:git/url "https://github.com/seancorfield/next-jdbc.git"
                                              :sha     "abd926cde3730087d3729dcea0ce0ab7ef1194f2"} ; for https://github.com/seancorfield/next-jdbc/issues/245; when this makes it to a release we can switch to that.
+  com.github.steffan-westcott/clj-otel-api  {:mvn/version "0.2.4.1"}            ; Telemetry library
   com.github.vertical-blank/sql-formatter   {:mvn/version "2.0.4"}              ; Java SQL formatting library https://github.com/vertical-blank/sql-formatter
   com.google.guava/guava                    {:mvn/version "32.1.2-jre"}         ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
   com.fasterxml.jackson.core/jackson-databind

--- a/deps.edn
+++ b/deps.edn
@@ -206,27 +206,28 @@
   ;;    (dev/start!)
   :dev
   {:extra-deps
-   {com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.1.1"}
-    clj-http-fake/clj-http-fake              {:mvn/version "1.0.4"
-                                              :exclusions  [slingshot/slingshot]}
-    clj-kondo/clj-kondo                      {:mvn/version "2023.09.07"} ; this is not for RUNNING kondo, but so we can hack on custom hooks code from the REPL.
-    cloverage/cloverage                      {:mvn/version "1.2.4"}
-    com.gfredericks/test.chuck               {:mvn/version "0.2.14"} ; generating strings from regexes (useful with malli)
-    djblue/portal                            {:mvn/version "0.46.0"} ; ui for inspecting values
-    io.github.camsaul/humane-are             {:mvn/version "1.0.2"}
-    io.github.metabase/hawk                  {:sha "9c97bcb6d4de116325e651b40973fd0a75b7ae21"}
-    jonase/eastwood                          {:mvn/version "1.4.0" ; inspects namespaces and reports possible problems using tools.analyzer
-                                              :exclusions
-                                              [org.ow2.asm/asm-all]}
-    lambdaisland/deep-diff2                  {:mvn/version "2.10.211"} ; way better diffs
-    methodical/methodical                    {:mvn/version "0.15.1"} ; drop-in replacements for Clojure multimethods and adds several advanced features
-    org.clojure/algo.generic                 {:mvn/version "0.1.3"}
-    pjstadig/humane-test-output              {:mvn/version "0.11.0"}
-    reifyhealth/specmonstah                  {:mvn/version "2.1.0"
-                                              :exclusions  [org.clojure/clojure
-                                                            org.clojure/clojurescript]} ; lets you write test fixtures that are clear, concise, and easy to maintain (clojure.spec)
-    ring/ring-mock                           {:mvn/version "0.4.0"}                     ; creating Ring request maps for testing purposes
-    talltale/talltale                        {:mvn/version "0.5.13"}}                   ; generates fake data, useful for prototyping or load testing
+   {com.clojure-goes-fast/clj-async-profiler
+                                 {:mvn/version "1.1.1"}                     ; Enables local profiling and heat map generation
+    clj-http-fake/clj-http-fake  {:mvn/version "1.0.4"
+                                  :exclusions  [slingshot/slingshot]}
+    clj-kondo/clj-kondo          {:mvn/version "2023.09.07"}                ; this is not for RUNNING kondo, but so we can hack on custom hooks code from the REPL.
+    cloverage/cloverage          {:mvn/version "1.2.4"}
+    com.gfredericks/test.chuck   {:mvn/version "0.2.14"}                    ; generating strings from regexes (useful with malli)
+    djblue/portal                {:mvn/version "0.46.0"}                    ; ui for inspecting values
+    io.github.camsaul/humane-are {:mvn/version "1.0.2"}
+    io.github.metabase/hawk      {:sha "9c97bcb6d4de116325e651b40973fd0a75b7ae21"}
+    jonase/eastwood              {:mvn/version "1.4.0"                      ; inspects namespaces and reports possible problems using tools.analyzer
+                                  :exclusions
+                                  [org.ow2.asm/asm-all]}
+    lambdaisland/deep-diff2      {:mvn/version "2.10.211"}                  ; way better diffs
+    methodical/methodical        {:mvn/version "0.15.1"}                    ; drop-in replacements for Clojure multimethods and adds several advanced features
+    org.clojure/algo.generic     {:mvn/version "0.1.3"}
+    pjstadig/humane-test-output  {:mvn/version "0.11.0"}
+    reifyhealth/specmonstah      {:mvn/version "2.1.0"
+                                  :exclusions  [org.clojure/clojure
+                                                org.clojure/clojurescript]} ; lets you write test fixtures that are clear, concise, and easy to maintain (clojure.spec)
+    ring/ring-mock               {:mvn/version "0.4.0"}                     ; creating Ring request maps for testing purposes
+    talltale/talltale            {:mvn/version "0.5.13"}}                   ; generates fake data, useful for prototyping or load testing
 
    :extra-paths ["dev/src" "local/src" "test" "shared/test" "test_resources"]
    :jvm-opts    ["-Dmb.run.mode=dev"

--- a/deps.edn
+++ b/deps.edn
@@ -205,26 +205,27 @@
   ;;    (dev/start!)
   :dev
   {:extra-deps
-   {clj-http-fake/clj-http-fake  {:mvn/version "1.0.4"
-                                  :exclusions  [slingshot/slingshot]}
-    clj-kondo/clj-kondo          {:mvn/version "2023.09.07"}                ; this is not for RUNNING kondo, but so we can hack on custom hooks code from the REPL.
-    cloverage/cloverage          {:mvn/version "1.2.4"}
-    com.gfredericks/test.chuck   {:mvn/version "0.2.14"}                    ; generating strings from regexes (useful with malli)
-    djblue/portal                {:mvn/version "0.46.0"}                    ; ui for inspecting values
-    io.github.camsaul/humane-are {:mvn/version "1.0.2"}
-    io.github.metabase/hawk      {:sha "9c97bcb6d4de116325e651b40973fd0a75b7ae21"}
-    jonase/eastwood              {:mvn/version "1.4.0"                      ; inspects namespaces and reports possible problems using tools.analyzer
-                                  :exclusions
-                                  [org.ow2.asm/asm-all]}
-    lambdaisland/deep-diff2      {:mvn/version "2.10.211"}                  ; way better diffs
-    methodical/methodical        {:mvn/version "0.15.1"}                    ; drop-in replacements for Clojure multimethods and adds several advanced features
-    org.clojure/algo.generic     {:mvn/version "0.1.3"}
-    pjstadig/humane-test-output  {:mvn/version "0.11.0"}
-    reifyhealth/specmonstah      {:mvn/version "2.1.0"
-                                  :exclusions  [org.clojure/clojure
-                                                org.clojure/clojurescript]} ; lets you write test fixtures that are clear, concise, and easy to maintain (clojure.spec)
-    ring/ring-mock               {:mvn/version "0.4.0"}                     ; creating Ring request maps for testing purposes
-    talltale/talltale            {:mvn/version "0.5.13"}}                   ; generates fake data, useful for prototyping or load testing
+   {com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.1.1"}
+    clj-http-fake/clj-http-fake              {:mvn/version "1.0.4"
+                                              :exclusions  [slingshot/slingshot]}
+    clj-kondo/clj-kondo                      {:mvn/version "2023.09.07"} ; this is not for RUNNING kondo, but so we can hack on custom hooks code from the REPL.
+    cloverage/cloverage                      {:mvn/version "1.2.4"}
+    com.gfredericks/test.chuck               {:mvn/version "0.2.14"} ; generating strings from regexes (useful with malli)
+    djblue/portal                            {:mvn/version "0.46.0"} ; ui for inspecting values
+    io.github.camsaul/humane-are             {:mvn/version "1.0.2"}
+    io.github.metabase/hawk                  {:sha "9c97bcb6d4de116325e651b40973fd0a75b7ae21"}
+    jonase/eastwood                          {:mvn/version "1.4.0" ; inspects namespaces and reports possible problems using tools.analyzer
+                                              :exclusions
+                                              [org.ow2.asm/asm-all]}
+    lambdaisland/deep-diff2                  {:mvn/version "2.10.211"} ; way better diffs
+    methodical/methodical                    {:mvn/version "0.15.1"} ; drop-in replacements for Clojure multimethods and adds several advanced features
+    org.clojure/algo.generic                 {:mvn/version "0.1.3"}
+    pjstadig/humane-test-output              {:mvn/version "0.11.0"}
+    reifyhealth/specmonstah                  {:mvn/version "2.1.0"
+                                              :exclusions  [org.clojure/clojure
+                                                            org.clojure/clojurescript]} ; lets you write test fixtures that are clear, concise, and easy to maintain (clojure.spec)
+    ring/ring-mock                           {:mvn/version "0.4.0"}                     ; creating Ring request maps for testing purposes
+    talltale/talltale                        {:mvn/version "0.5.13"}}                   ; generates fake data, useful for prototyping or load testing
 
    :extra-paths ["dev/src" "local/src" "test" "shared/test" "test_resources"]
    :jvm-opts    ["-Dmb.run.mode=dev"
@@ -232,6 +233,8 @@
                  "-Dmb.test.env.setting=ABCDEFG"
                  "-Duser.timezone=UTC"
                  "-Dfile.encoding=UTF-8"
+                 ;; Allow clojure goes fast tooling to work
+                 "-Djdk.attach.allowAttachSelf"
                  "-Duser.language=en"
                  "-Duser.country=US"
                  ;; set the logging properties set in metabase.bootstrap. calling (dev) will load it but putting here to be sure
@@ -317,7 +320,7 @@
 
   ;; Find outdated versions of dependencies. Run with `clojure -M:outdated`
   :outdated {;; Note that it is `:deps`, not `:extra-deps`
-             :deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}
+             :deps      {com.github.liquidz/antq {:mvn/version "RELEASE"}}
              :main-opts ["-m" "antq.core"]}
 
   :cljs
@@ -364,7 +367,7 @@
     "modules/drivers/sqlserver/test"
     "modules/drivers/vertica/test"]}
 
-;;; Linters
+  ;;; Linters
 
   ;; clojure -M:ee:drivers:check
   ;;
@@ -397,32 +400,32 @@
   {:exec-fn   metabase.linters.eastwood/eastwood
    :exec-args {;; manually specify the source paths for the time being (exclude test paths) until we fix Eastwood
                ;; errors in the test paths (once PR #17193 is merged)
-               :source-paths    ["src"
-                                 "shared/src"
-                                 "enterprise/backend/src"
-                                 "modules/drivers/athena/src"
-                                 "modules/drivers/bigquery-cloud-sdk/src"
-                                 "modules/drivers/druid/src"
-                                 "modules/drivers/googleanalytics/src"
-                                 "modules/drivers/mongo/src"
-                                 "modules/drivers/oracle/src"
-                                 "modules/drivers/presto-jdbc/src"
-                                 "modules/drivers/redshift/src"
-                                 "modules/drivers/snowflake/src"
-                                 "modules/drivers/sparksql/src"
-                                 "modules/drivers/sqlite/src"
-                                 "modules/drivers/sqlserver/src"
-                                 "modules/drivers/vertica/src"]
-               :exclude-linters [ ;; Turn this off temporarily until we finish removing
-                                 ;; self-deprecated functions & macros
-                                 :deprecations
-                                 ;; this has a fit in libs that use Potemkin `import-vars` such
-                                 ;; as `java-time`
-                                 :implicit-dependencies
-                                 ;; too many false positives for now
-                                 :unused-ret-vals
-                                 ;; Kondo lints this for us anyway, and this isn't as easy to configure.
-                                 :wrong-arity]
+               :source-paths       ["src"
+                                    "shared/src"
+                                    "enterprise/backend/src"
+                                    "modules/drivers/athena/src"
+                                    "modules/drivers/bigquery-cloud-sdk/src"
+                                    "modules/drivers/druid/src"
+                                    "modules/drivers/googleanalytics/src"
+                                    "modules/drivers/mongo/src"
+                                    "modules/drivers/oracle/src"
+                                    "modules/drivers/presto-jdbc/src"
+                                    "modules/drivers/redshift/src"
+                                    "modules/drivers/snowflake/src"
+                                    "modules/drivers/sparksql/src"
+                                    "modules/drivers/sqlite/src"
+                                    "modules/drivers/sqlserver/src"
+                                    "modules/drivers/vertica/src"]
+               :exclude-linters    [;; Turn this off temporarily until we finish removing
+                                    ;; self-deprecated functions & macros
+                                    :deprecations
+                                    ;; this has a fit in libs that use Potemkin `import-vars` such
+                                    ;; as `java-time`
+                                    :implicit-dependencies
+                                    ;; too many false positives for now
+                                    :unused-ret-vals
+                                    ;; Kondo lints this for us anyway, and this isn't as easy to configure.
+                                    :wrong-arity]
                ;; Snowplow has a dynamic dependency on okhttp3.CookieJar that we
                ;; don't use but eastwood detects. This is discussed in Slack here
                ;; https://clojurians.slack.com/archives/C03S1KBA2/p1667925853699669
@@ -500,9 +503,9 @@
                ["metabase\\.driver\\.mysql.*"
                 "metabase\\.driver\\.postgres.*"]}
    ;; different port from `:test` so you can run it at the same time as `:test`.
-   :jvm-opts ["-Dmb.jetty.port=3002"
-              ;; default heap size is 1GB, we were getting OOM on CI so we need to bump this
-              "-Xmx4g"]}
+   :jvm-opts  ["-Dmb.jetty.port=3002"
+               ;; default heap size is 1GB, we were getting OOM on CI so we need to bump this
+               "-Xmx4g"]}
 
   ;; clj -T:cljfmt fix '{:paths ["src/metabase/events/view_log.clj"]}'
   :cljfmt
@@ -615,7 +618,7 @@
    :exec-args {:only ["bin/build/test"]}}
 
 
-;;; Other misc convenience aliases
+  ;;; Other misc convenience aliases
 
   ;; Profile Metabase start time with clojure -M:profile
   :profile
@@ -640,7 +643,7 @@
    :main-opts  ["-m" "nrepl.cmdline" "-p" "50605"]}
 
   ;; - start a Socket REPL on port 50505 that you can connect your editor to:
-  :socket {:jvm-opts ["-Dclojure.server.repl={:address,\"0.0.0.0\",:port,50505,:accept,clojure.core.server/repl}"]}
+  :socket   {:jvm-opts ["-Dclojure.server.repl={:address,\"0.0.0.0\",:port,50505,:accept,clojure.core.server/repl}"]}
 
   ;; Liquibase CLI:
   ;;
@@ -686,5 +689,5 @@
 
 
 
-  ;; TODO -- consider creating an alias that includes the `./bin` build-drivers & release code as well so we can work
-  ;; on them all from a single REPL process.
+;; TODO -- consider creating an alias that includes the `./bin` build-drivers & release code as well so we can work
+;; on them all from a single REPL process.

--- a/deps.edn
+++ b/deps.edn
@@ -321,7 +321,7 @@
 
   ;; Find outdated versions of dependencies. Run with `clojure -M:outdated`
   :outdated {;; Note that it is `:deps`, not `:extra-deps`
-             :deps      {com.github.liquidz/antq {:mvn/version "RELEASE"}}
+             :deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}
              :main-opts ["-m" "antq.core"]}
 
   :cljs
@@ -368,7 +368,7 @@
     "modules/drivers/sqlserver/test"
     "modules/drivers/vertica/test"]}
 
-  ;;; Linters
+;;; Linters
 
   ;; clojure -M:ee:drivers:check
   ;;
@@ -401,32 +401,32 @@
   {:exec-fn   metabase.linters.eastwood/eastwood
    :exec-args {;; manually specify the source paths for the time being (exclude test paths) until we fix Eastwood
                ;; errors in the test paths (once PR #17193 is merged)
-               :source-paths       ["src"
-                                    "shared/src"
-                                    "enterprise/backend/src"
-                                    "modules/drivers/athena/src"
-                                    "modules/drivers/bigquery-cloud-sdk/src"
-                                    "modules/drivers/druid/src"
-                                    "modules/drivers/googleanalytics/src"
-                                    "modules/drivers/mongo/src"
-                                    "modules/drivers/oracle/src"
-                                    "modules/drivers/presto-jdbc/src"
-                                    "modules/drivers/redshift/src"
-                                    "modules/drivers/snowflake/src"
-                                    "modules/drivers/sparksql/src"
-                                    "modules/drivers/sqlite/src"
-                                    "modules/drivers/sqlserver/src"
-                                    "modules/drivers/vertica/src"]
-               :exclude-linters    [;; Turn this off temporarily until we finish removing
-                                    ;; self-deprecated functions & macros
-                                    :deprecations
-                                    ;; this has a fit in libs that use Potemkin `import-vars` such
-                                    ;; as `java-time`
-                                    :implicit-dependencies
-                                    ;; too many false positives for now
-                                    :unused-ret-vals
-                                    ;; Kondo lints this for us anyway, and this isn't as easy to configure.
-                                    :wrong-arity]
+               :source-paths    ["src"
+                                 "shared/src"
+                                 "enterprise/backend/src"
+                                 "modules/drivers/athena/src"
+                                 "modules/drivers/bigquery-cloud-sdk/src"
+                                 "modules/drivers/druid/src"
+                                 "modules/drivers/googleanalytics/src"
+                                 "modules/drivers/mongo/src"
+                                 "modules/drivers/oracle/src"
+                                 "modules/drivers/presto-jdbc/src"
+                                 "modules/drivers/redshift/src"
+                                 "modules/drivers/snowflake/src"
+                                 "modules/drivers/sparksql/src"
+                                 "modules/drivers/sqlite/src"
+                                 "modules/drivers/sqlserver/src"
+                                 "modules/drivers/vertica/src"]
+               :exclude-linters [ ;; Turn this off temporarily until we finish removing
+                                 ;; self-deprecated functions & macros
+                                 :deprecations
+                                 ;; this has a fit in libs that use Potemkin `import-vars` such
+                                 ;; as `java-time`
+                                 :implicit-dependencies
+                                 ;; too many false positives for now
+                                 :unused-ret-vals
+                                 ;; Kondo lints this for us anyway, and this isn't as easy to configure.
+                                 :wrong-arity]
                ;; Snowplow has a dynamic dependency on okhttp3.CookieJar that we
                ;; don't use but eastwood detects. This is discussed in Slack here
                ;; https://clojurians.slack.com/archives/C03S1KBA2/p1667925853699669
@@ -504,16 +504,16 @@
                ["metabase\\.driver\\.mysql.*"
                 "metabase\\.driver\\.postgres.*"]}
    ;; different port from `:test` so you can run it at the same time as `:test`.
-   :jvm-opts  ["-Dmb.jetty.port=3002"
-               ;; default heap size is 1GB, we were getting OOM on CI so we need to bump this
-               "-Xmx4g"]}
+   :jvm-opts ["-Dmb.jetty.port=3002"
+              ;; default heap size is 1GB, we were getting OOM on CI so we need to bump this
+              "-Xmx4g"]}
 
   ;; clj -T:cljfmt fix '{:paths ["src/metabase/events/view_log.clj"]}'
   :cljfmt
   {:deps       {io.github.weavejester/cljfmt {:git/tag "0.11.2", :git/sha "fb26b22f569724b05c93eb2502592dfc2de898c3"}}
    :ns-default cljfmt.tool}
 
-  ;;; building Uberjar, build and release scripts
+;;; building Uberjar, build and release scripts
 
   :build
   {:extra-paths
@@ -619,7 +619,7 @@
    :exec-args {:only ["bin/build/test"]}}
 
 
-  ;;; Other misc convenience aliases
+;;; Other misc convenience aliases
 
   ;; Profile Metabase start time with clojure -M:profile
   :profile
@@ -644,7 +644,7 @@
    :main-opts  ["-m" "nrepl.cmdline" "-p" "50605"]}
 
   ;; - start a Socket REPL on port 50505 that you can connect your editor to:
-  :socket   {:jvm-opts ["-Dclojure.server.repl={:address,\"0.0.0.0\",:port,50505,:accept,clojure.core.server/repl}"]}
+  :socket {:jvm-opts ["-Dclojure.server.repl={:address,\"0.0.0.0\",:port,50505,:accept,clojure.core.server/repl}"]}
 
   ;; Liquibase CLI:
   ;;
@@ -690,5 +690,5 @@
 
 
 
-;; TODO -- consider creating an alias that includes the `./bin` build-drivers & release code as well so we can work
-;; on them all from a single REPL process.
+  ;; TODO -- consider creating an alias that includes the `./bin` build-drivers & release code as well so we can work
+  ;; on them all from a single REPL process.

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -367,7 +367,7 @@
   [id]
   {id ms/PositiveInt}
   (let [dashboard (get-dashboard id)]
-    (events/publish-event! :event/dashboard-read {:object dashboard :user-id api/*current-user-id*})
+    (events/publish-event-async! :event/dashboard-read {:object dashboard :user-id api/*current-user-id*})
     (last-edit/with-last-edit-info dashboard :dashboard)))
 
 (defn- check-allowed-to-change-embedding

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -195,7 +195,7 @@
                        :attributes {:dashboard/id id}}
                       (t2/hydrate dashboard [:dashcards
                                              [:card [:moderation_reviews :moderator_details]]
-                   [:card :can_write]
+                                             [:card :can_write]
                                              :series
                                              :dashcard/action
                                              :dashcard/linkcard-info]

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -186,7 +186,7 @@
   (span/with-span!
     {:name       "get-dashboard"
      :attributes {:dashboard/id id}}
-    (let [dashboard (-> (t2/select-one :model/Dashboard :id id) api/check-404 api/read-check)
+    (let [dashboard (api/read-check (t2/select-one :model/Dashboard :id id))
           ;; i'm a bit worried that this is an n+1 situation here. The cards can be batch hydrated i think because they
           ;; have a hydration key and an id. moderation_reviews currently aren't batch hydrated but i'm worried they
           ;; cannot be in this situation

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -374,7 +374,7 @@
   [id]
   {id ms/PositiveInt}
   (let [dashboard (get-dashboard id)]
-    (events/publish-event-async! :event/dashboard-read {:object dashboard :user-id api/*current-user-id*})
+    (events/publish-event! :event/dashboard-read {:object dashboard :user-id api/*current-user-id*})
     (last-edit/with-last-edit-info dashboard :dashboard)))
 
 (defn- check-allowed-to-change-embedding

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -44,6 +44,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
+   [steffan-westcott.clj-otel.api.trace.span :as span]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -182,27 +183,33 @@
 (defn- get-dashboard
   "Get Dashboard with ID."
   [id]
-  (-> (t2/select-one :model/Dashboard :id id)
-      api/read-check
-      ;; i'm a bit worried that this is an n+1 situation here. The cards can be batch hydrated i think because they
-      ;; have a hydration key and an id. moderation_reviews currently aren't batch hydrated but i'm worried they
-      ;; cannot be in this situation
-      (t2/hydrate [:dashcards
-                   [:card [:moderation_reviews :moderator_details]]
+  (span/with-span!
+    {:name       "get-dashboard"
+     :attributes {:dashboard/id id}}
+    (let [dashboard (-> (t2/select-one :model/Dashboard :id id) api/check-404 api/read-check)
+          ;; i'm a bit worried that this is an n+1 situation here. The cards can be batch hydrated i think because they
+          ;; have a hydration key and an id. moderation_reviews currently aren't batch hydrated but i'm worried they
+          ;; cannot be in this situation
+          hydrated  (span/with-span!
+                      {:name       "hydrate"
+                       :attributes {:dashboard/id id}}
+                      (t2/hydrate dashboard [:dashcards
+                                             [:card [:moderation_reviews :moderator_details]]
                    [:card :can_write]
-                   :series
-                   :dashcard/action
-                   :dashcard/linkcard-info]
-                  :tabs
-                  :collection_authority_level
-                  :can_write
-                  :param_fields
-                  :param_values
-                  [:collection :is_personal])
-      collection.root/hydrate-root-collection
-      api/check-not-archived
-      hide-unreadable-cards
-      add-query-average-durations))
+                                             :series
+                                             :dashcard/action
+                                             :dashcard/linkcard-info]
+                                  :tabs
+                                  :collection_authority_level
+                                  :can_write
+                                  :param_fields
+                                  :param_values
+                                  [:collection :is_personal]))]
+      (-> hydrated
+          collection.root/hydrate-root-collection
+          api/check-not-archived
+          hide-unreadable-cards
+          add-query-average-durations))))
 
 (defn- cards-to-copy
   "Returns a map of which cards we need to copy and which are not to be copied. The `:copy` key is a map from id to

--- a/src/metabase/events.clj
+++ b/src/metabase/events.clj
@@ -163,6 +163,8 @@
 (def ^:private async-publish-event-timeout 10000)
 
 (defn publish-event-async!
+  ;; TODO - per team discussions, this will give us a short-term fix to performance issues related to blocking DB
+  ;; operations from resource contention. However, we'd still prefer to minimize resource contention.
   "Publish an event asynchronously with an optional timeout (default is 10s).
   If the event fails, will log a warning."
   ([topic event]

--- a/src/metabase/events.clj
+++ b/src/metabase/events.clj
@@ -162,14 +162,6 @@
 
 (def ^:private async-publish-event-timeout 10000)
 
-(defn timeout-code [future]
-  ;; Wait for the specified timeout duration
-  (Thread/sleep 10000)
-  ;; If the timeout is reached, cancel the future
-  (when-not @future
-    (future-cancel future)
-    (println "Task cancelled due to timeout.")))
-
 (defn publish-event-async!
   "Publish an event asynchronously with an optional timeout (default is 10s).
   If the event fails, will log a warning."

--- a/src/metabase/events.clj
+++ b/src/metabase/events.clj
@@ -19,7 +19,8 @@
    [metabase.util.methodical.null-cache :as u.methodical.null-cache]
    [metabase.util.methodical.unsorted-dispatcher
     :as u.methodical.unsorted-dispatcher]
-   [methodical.core :as methodical]))
+   [methodical.core :as methodical]
+   [steffan-westcott.clj-otel.api.trace.span :as span]))
 
 (set! *warn-on-reflection* true)
 
@@ -107,28 +108,31 @@
 
 (methodical/defmethod publish-event! :around :default
   [topic event]
-  (assert (not *compile-files*) "Calls to publish-event! are not allowed in the top level.")
-  (if-not @events-initialized?
-    ;; if the event namespaces aren't initialized yet, make sure they're all loaded up before trying to do dispatch.
-    (do
-     (initialize-events!)
-     (publish-event! topic event))
-    (do
-     (log/debugf "Publishing %s event:\n\n%s" (u/colorize :yellow (pr-str topic)) (u/pprint-to-str event))
-     (assert (and (qualified-keyword? topic)
-                  (isa? topic :metabase/event))
-             (format "Invalid event topic %s: events must derive from :metabase/event" (pr-str topic)))
-     (assert (map? event)
-             (format "Invalid event %s: event must be a map." (pr-str event)))
-     (try
-      (when-let [schema (events.schema/topic->schema topic)]
-        (mu/validate-throw schema event))
-      (next-method topic event)
-      (catch Throwable e
-        (throw (ex-info (i18n/tru "Error publishing {0} event: {1}" topic (ex-message e))
-                        {:topic topic, :event event}
-                        e))))
-     event)))
+  (span/with-span!
+    {:name       "publish-event!"
+     :attributes {:event/topic topic}}
+    (assert (not *compile-files*) "Calls to publish-event! are not allowed in the top level.")
+    (if-not @events-initialized?
+      ;; if the event namespaces aren't initialized yet, make sure they're all loaded up before trying to do dispatch.
+      (do
+        (initialize-events!)
+        (publish-event! topic event))
+      (do
+        (log/debugf "Publishing %s event:\n\n%s" (u/colorize :yellow (pr-str topic)) (u/pprint-to-str event))
+        (assert (and (qualified-keyword? topic)
+                     (isa? topic :metabase/event))
+                (format "Invalid event topic %s: events must derive from :metabase/event" (pr-str topic)))
+        (assert (map? event)
+                (format "Invalid event %s: event must be a map." (pr-str event)))
+        (try
+          (when-let [schema (events.schema/topic->schema topic)]
+            (mu/validate-throw schema event))
+          (next-method topic event)
+          (catch Throwable e
+            (throw (ex-info (i18n/tru "Error publishing {0} event: {1}" topic (ex-message e))
+                            {:topic topic, :event event}
+                            e))))
+        event))))
 
 (mu/defn topic->model :- [:maybe :string]
   "Determine a valid `model` identifier for the given `topic`."
@@ -155,3 +159,29 @@
    ;; and is important for distinguishing view events triggered when pinned cards are 'viewed'
    ;; when a user opens a collection.
    :context      (:context object)})
+
+(def ^:private async-publish-event-timeout 10000)
+
+(defn timeout-code [future]
+  ;; Wait for the specified timeout duration
+  (Thread/sleep 10000)
+  ;; If the timeout is reached, cancel the future
+  (when-not @future
+    (future-cancel future)
+    (println "Task cancelled due to timeout.")))
+
+(defn publish-event-async!
+  "Publish an event asynchronously with an optional timeout (default is 10s).
+  If the event fails, will log a warning."
+  ([topic event]
+   (publish-event-async! topic event async-publish-event-timeout))
+  ([topic event timeout]
+   (let [event-thread (future (publish-event! topic event))]
+     (future (Thread/sleep ^long timeout)
+             (when-not (future-done? event-thread)
+               (log/warnf "%s event %s event in %sms:\n\n%s"
+                          (u/colorize :red "Failed to publish async event")
+                          (u/colorize :yellow (pr-str topic))
+                          async-publish-event-timeout
+                          (u/pprint-to-str event))
+               (future-cancel event-thread))))))

--- a/src/metabase/query_processor/dashboard.clj
+++ b/src/metabase/query_processor/dashboard.clj
@@ -17,9 +17,9 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
+   [steffan-westcott.clj-otel.api.trace.span :as span]
    #_{:clj-kondo/ignore [:discouraged-namespace]}
-   [toucan2.core :as t2]
-   [steffan-westcott.clj-otel.api.trace.span :as span]))
+   [toucan2.core :as t2]))
 
 (defn- check-card-and-dashcard-are-in-dashboard
   "Check that the Card with `card-id` is in Dashboard with `dashboard-id`, either in the DashboardCard with

--- a/src/metabase/query_processor/dashboard.clj
+++ b/src/metabase/query_processor/dashboard.clj
@@ -18,7 +18,8 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
    #_{:clj-kondo/ignore [:discouraged-namespace]}
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2]
+   [steffan-westcott.clj-otel.api.trace.span :as span]))
 
 (defn- check-card-and-dashcard-are-in-dashboard
   "Check that the Card with `card-id` is in Dashboard with `dashboard-id`, either in the DashboardCard with
@@ -164,21 +165,25 @@
   [& {:keys [dashboard-id card-id dashcard-id parameters export-format]
       :or   {export-format :api}
       :as   options}]
-  ;; make sure we can read this Dashboard. Card will get read-checked later on inside
-  ;; [[qp.card/run-query-for-card-async]]
-  (api/read-check Dashboard dashboard-id)
-  (check-card-and-dashcard-are-in-dashboard dashboard-id card-id dashcard-id)
-  (let [resolved-params (resolve-params-for-query dashboard-id card-id dashcard-id parameters)
-        options         (merge
-                         {:ignore_cache false
-                          :constraints  (qp.constraints/default-query-constraints)
-                          :context      :dashboard}
-                         options
-                         {:parameters   resolved-params
-                          :dashboard-id dashboard-id})]
-    (log/tracef "Running Query for Dashboard %d, Card %d, Dashcard %d with options\n%s"
-                dashboard-id card-id dashcard-id
-                (u/pprint-to-str options))
-    ;; we've already validated our parameters, so we don't need the [[qp.card]] namespace to do it again
-    (binding [qp.card/*allow-arbitrary-mbql-parameters* true]
-      (m/mapply qp.card/run-query-for-card-async card-id export-format options))))
+  (span/with-span! {:name       "run-query-for-dashcard-async"
+                    :attributes {:dashboard/id dashboard-id
+                                 :dashcard/id  dashcard-id
+                                 :card/id      card-id}}
+    ;; make sure we can read this Dashboard. Card will get read-checked later on inside
+    ;; [[qp.card/run-query-for-card-async]]
+    (api/read-check Dashboard dashboard-id)
+    (check-card-and-dashcard-are-in-dashboard dashboard-id card-id dashcard-id)
+    (let [resolved-params (resolve-params-for-query dashboard-id card-id dashcard-id parameters)
+          options         (merge
+                            {:ignore_cache false
+                             :constraints  (qp.constraints/default-query-constraints)
+                             :context      :dashboard}
+                            options
+                            {:parameters   resolved-params
+                             :dashboard-id dashboard-id})]
+      (log/tracef "Running Query for Dashboard %d, Card %d, Dashcard %d with options\n%s"
+                  dashboard-id card-id dashcard-id
+                  (u/pprint-to-str options))
+      ;; we've already validated our parameters, so we don't need the [[qp.card]] namespace to do it again
+      (binding [qp.card/*allow-arbitrary-mbql-parameters* true]
+        (m/mapply qp.card/run-query-for-card-async card-id export-format options)))))


### PR DESCRIPTION
This PR contains changes and a potential fix to the problems described in #33499 (Dashboards taking a long time to load on stats). The underlying issue appears to be that there is resource contention on the backend that is manifesting itself in the synchronous calls to `metabase.events/publish-event!`.

Instrumentation was added to this PR to better understand how long each function takes as well as to better understand the context in which already-instrumented functions (e.g. server api calls, db calls) are called. For example, we already get spans for JDBC operations, but we don't know what function is calling these operations. With the right in-app spans, we can know what functions are making the calls as well as get better information on where timeouts are occurring.

### Instrumentation

- The `com.github.steffan-westcott/clj-otel-api` [library](https://github.com/steffan-westcott/clj-otel) was added so that we could add custom [Open Telemetry](https://opentelemetry.io/) instrumentation to metabase in a Clojure-friendly way.
- The `com.clojure-goes-fast/clj-async-profiler` was added to the `:dev` profile along with the `"-Djdk.attach.allowAttachSelf"` flag (again, dev-only) for local profiling.

The above, primarily the first bullet, allows for more detailed analysis of our code, as shown below.

![jaeger](https://github.com/metabase/metabase/assets/8381441/bd438417-a9ea-41e6-89a9-d2396a3a050d)

Note that in the diagram, the problem described in #33499 is not shown, but the comments and images from Grafana on that issue illustrate the value of better instrumentation.

### Short term fix

This PR includes a new function, `publish-event-async!`, in `metabase.events` that is used in the `GET "api/dashboard/:id"` endpoint and should resolve the immediate performance issue. However, based on [this slack thread](https://metaboat.slack.com/archives/CKZEMT1MJ/p1697604232592589) we may want to either not use this function or only use it as a short term fix.