### PR TITLE
Add to view_log schema and clean up view events

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -181,7 +181,8 @@
   :default    true
   :visibility :internal
   :setter     :none
-  :audit      :never)
+  :audit      :never
+  :doc        false)
 
 (defn- maybe-load-analytics-content!
   [audit-db]

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -4070,9 +4070,9 @@ databaseChangeLog:
         - sql: DELETE FROM core_user WHERE id = 13371338;
 
   - changeSet:
-      id: v48.00-055
-      author: adam-james
-      comment: 'Added 0.48.0 - Adjust view_log schema for Audit Log v2'
+      id: v48.00-056
+      author: noahmoss
+      comment: 'Adjust view_log schema for Audit Log v2'
       changes:
         - addColumn:
             tableName: view_log
@@ -4086,8 +4086,8 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-057
-      author: adam-james
-      comment: 'Added 0.48.0 - Adjust view_log schema for Audit Log v2'
+      author: noahmoss
+      comment: 'Adjust view_log schema for Audit Log v2'
       changes:
         - addColumn:
             tableName: view_log
@@ -4098,6 +4098,18 @@ databaseChangeLog:
                   constraints:
                     nullable: true
                   remarks: 'The context of the view, can be collection, question, or dashboard. Only for cards.'
+
+  - changeSet:
+      id: v48.00-058
+      author: noahmoss
+      comment: 'Increase length of `view_log.model` to fit longer model names'
+      changes:
+        - modifyDataType:
+            tableName: view_log
+            columnName: model
+            newDataType: VARCHAR(32)
+      rollback: # not necessary
+
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -4099,17 +4099,6 @@ databaseChangeLog:
                     nullable: true
                   remarks: 'The context of the view, can be collection, question, or dashboard. Only for cards.'
 
-  - changeSet:
-      id: v48.00-058
-      author: noahmoss
-      comment: 'Increase length of `view_log.model` to fit longer model names'
-      changes:
-        - modifyDataType:
-            tableName: view_log
-            columnName: model
-            newDataType: VARCHAR(32)
-      rollback: # not necessary
-
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -4069,6 +4069,51 @@ databaseChangeLog:
       rollback:
         - sql: DELETE FROM core_user WHERE id = 13371338;
 
+  - changeSet:
+      id: v48.00-055
+      author: adam-james
+      comment: 'Added 0.48.0 - Adjust view_log schema for Audit Log v2'
+      changes:
+        - addColumn:
+            tableName: view_log
+            columns:
+              - column:
+                  name: has_access
+                  type: boolean
+                  constraints:
+                    nullable: true
+                  remarks: 'Whether the user who initiated the view had read access to the item being viewed.'
+
+  - changeSet:
+      id: v48.00-056
+      author: adam-james
+      comment: 'Added 0.48.0 - Adjust view_log schema for Audit Log v2'
+      changes:
+        - addColumn:
+            tableName: view_log
+            columns:
+              - column:
+                  name: error_message
+                  type: ${text.type}
+                  constraints:
+                    nullable: true
+                  remarks: 'An error message in the case of a failure or error when a user tried to view something.'
+
+  - changeSet:
+      id: v48.00-057
+      author: adam-james
+      comment: 'Added 0.48.0 - Adjust view_log schema for Audit Log v2'
+      changes:
+        - addColumn:
+            tableName: view_log
+            columns:
+              - column:
+                  name: context
+                  type: varchar(32)
+                  constraints:
+                    nullable: true
+                  remarks: 'The context of the view, can be collection, question, or dashboard. Only for cards.'
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -4085,21 +4085,6 @@ databaseChangeLog:
                   remarks: 'Whether the user who initiated the view had read access to the item being viewed.'
 
   - changeSet:
-      id: v48.00-056
-      author: adam-james
-      comment: 'Added 0.48.0 - Adjust view_log schema for Audit Log v2'
-      changes:
-        - addColumn:
-            tableName: view_log
-            columns:
-              - column:
-                  name: error_message
-                  type: ${text.type}
-                  constraints:
-                    nullable: true
-                  remarks: 'An error message in the case of a failure or error when a user tried to view something.'
-
-  - changeSet:
       id: v48.00-057
       author: adam-james
       comment: 'Added 0.48.0 - Adjust view_log schema for Audit Log v2'

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -137,7 +137,7 @@
 (api/defendpoint GET "/"
   "Get all the Cards. Option filter param `f` can be used to change the set of Cards that are returned; default is
   `all`, but other options include `mine`, `bookmarked`, `database`, `table`, `using_model` and `archived`. See
-  corresponditng implementation functions above for the specific behavior of each filterp option. :card_index:"
+  corresponding implementation functions above for the specific behavior of each filterp option. :card_index:"
   [f model_id]
   {f        [:maybe (into [:enum] card-filter-options)]
    model_id [:maybe ms/PositiveInt]}

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -431,9 +431,9 @@
    (try
      (check-403 (mi/can-read? obj))
      (catch clojure.lang.ExceptionInfo e
-       ;; this is commented out until we write a handler to add this to the view_log
-       #_(events/publish-event! :event/read-permission-failure {:user-id *current-user-id*
-                                                                :object obj})
+       (events/publish-event! :event/read-permission-failure {:user-id    *current-user-id*
+                                                              :object     obj
+                                                              :has-access false})
        (throw e)))
    obj)
 

--- a/src/metabase/events.clj
+++ b/src/metabase/events.clj
@@ -9,7 +9,6 @@
   by [[initialize-events!]]."
   (:require
    [clojure.spec.alpha :as s]
-   [clojure.string :as str]
    [metabase.events.schema :as events.schema]
    [metabase.plugins.classloader :as classloader]
    [metabase.util :as u]
@@ -134,20 +133,6 @@
                             {:topic topic, :event event}
                             e))))
         event))))
-
-(mu/defn topic->model :- [:maybe :string]
-  "Determine a valid `model` identifier for the given `topic`."
-  [topic :- Topic]
-  ;; just take the first part of the topic name after splitting on dashes.
-  (first (str/split (name topic) #"-")))
-
-(defn object->model-id
-  "Determine the appropriate `model_id` (if possible) for a given `object`."
-  [topic object]
-  (if (contains? (set (keys object)) :id)
-    (:id object)
-    (let [model (topic->model topic)]
-      (get object (keyword (format "%s-id" model))))))
 
 (defn object->metadata
   "Determine metadata, if there is any, for given `object`.

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -18,16 +18,16 @@
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::card-query-event ::event)
-(derive :event/card-query ::card-query-event)
+; (derive ::card-query-event ::event)
+; (derive :event/card-query ::card-query-event)
 
-(methodical/defmethod events/publish-event! ::card-query-event
-  [topic {:keys [user-id card-id] :as object}]
-  (let [details (select-keys object [:cached :ignore_cache :context])]
-    (audit-log/record-event! topic {:details    details
-                                    :user-id    user-id
-                                    :model      :model/Card
-                                    :model-id   card-id})))
+; (methodical/defmethod events/publish-event! ::card-query-event
+;   [topic {:keys [user-id card-id] :as object}]
+;   (let [details (select-keys object [:cached :ignore_cache :context])]
+;     (audit-log/record-event! topic {:details    details
+;                                     :user-id    user-id
+;                                     :model      :model/Card
+;                                     :model-id   card-id})))
 
 (derive ::dashboard-event ::event)
 (derive :event/dashboard-create ::dashboard-event)

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -18,17 +18,6 @@
   [topic event]
   (audit-log/record-event! topic event))
 
-; (derive ::card-query-event ::event)
-; (derive :event/card-query ::card-query-event)
-
-; (methodical/defmethod events/publish-event! ::card-query-event
-;   [topic {:keys [user-id card-id] :as object}]
-;   (let [details (select-keys object [:cached :ignore_cache :context])]
-;     (audit-log/record-event! topic {:details    details
-;                                     :user-id    user-id
-;                                     :model      :model/Card
-;                                     :model-id   card-id})))
-
 (derive ::dashboard-event ::event)
 (derive :event/dashboard-create ::dashboard-event)
 (derive :event/dashboard-delete ::dashboard-event)

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -18,13 +18,6 @@
   [topic event]
   (audit-log/record-event! topic event))
 
-(derive ::card-read-event :metabase/event)
-(derive :event/card-read ::card-read-event)
-
-(methodical/defmethod events/publish-event! ::card-read-event
-  [topic event]
-  (audit-log/record-event! topic event))
-
 (derive ::card-query-event ::event)
 (derive :event/card-query ::card-query-event)
 
@@ -62,20 +55,13 @@
                                             (assoc :id id)
                                             (assoc :card_id card_id)))))]
     (audit-log/record-event! topic
-                               {:details  details
-                                :user-id  user-id
-                                :model    :model/Dashboard
-                                :model-id (u/id object)})))
+                             {:details  details
+                              :user-id  user-id
+                              :model    :model/Dashboard
+                              :model-id (u/id object)})))
 
-(derive ::dashboard-read-event ::event)
-(derive :event/dashboard-read ::dashboard-read-event)
-
-(methodical/defmethod events/publish-event! ::dashboard-read-event
-  [topic event]
-  (audit-log/record-event! topic event))
 
 (derive ::table-event ::event)
-(derive :event/table-read ::table-event)
 (derive :event/table-manual-scan ::table-event)
 
 (methodical/defmethod events/publish-event! ::table-event

--- a/src/metabase/events/recent_views.clj
+++ b/src/metabase/events/recent_views.clj
@@ -13,7 +13,6 @@
 
 (derive :event/dashboard-read ::event)
 (derive :event/table-read ::event)
-(derive :event/card-read ::event)
 
 (m/defmethod events/publish-event! ::event
   "Handle processing for a single event notification which should update the recent views for a user."
@@ -24,5 +23,20 @@
             model-id (u/id object)
             user-id  (or user-id api/*current-user-id*)]
         (recent-views/update-users-recent-views! user-id model model-id)))
+    (catch Throwable e
+      (log/warnf e "Failed to process recent_views event: %s" topic))))
+
+(derive ::card-query-event :metabase/event)
+(derive :event/card-query ::card-query-event)
+
+(m/defmethod events/publish-event! ::card-query-event
+  "Handle processing for a single card query event."
+  [topic {:keys [card-id user-id context] :as _event}]
+  (try
+    (let [model    "card"
+          user-id  (or user-id api/*current-user-id*)]
+      ;; we don't want to count pinned card views
+      (when-not (#{:collection :dashboard} context)
+        (recent-views/update-users-recent-views! user-id model card-id)))
     (catch Throwable e
       (log/warnf e "Failed to process recent_views event: %s" topic))))

--- a/src/metabase/events/recent_views.clj
+++ b/src/metabase/events/recent_views.clj
@@ -20,9 +20,9 @@
   [topic {:keys [object user-id] :as _event}]
   (try
     (when object
-      (let [model             (audit-log/model-name object)
-            model-id          (u/id object)
-            user-id           (or user-id api/*current-user-id*)]
+      (let [model    (audit-log/model-name object)
+            model-id (u/id object)
+            user-id  (or user-id api/*current-user-id*)]
         (recent-views/update-users-recent-views! user-id model model-id)))
     (catch Throwable e
       (log/warnf e "Failed to process recent_views event: %s" topic))))

--- a/src/metabase/events/recent_views.clj
+++ b/src/metabase/events/recent_views.clj
@@ -3,7 +3,9 @@
   (:require
    [metabase.api.common :as api]
    [metabase.events :as events]
+   [metabase.models.audit-log :as audit-log]
    [metabase.models.recent-views :as recent-views]
+   [metabase.util :as u]
    [metabase.util.log :as log]
    [methodical.core :as m]))
 
@@ -11,36 +13,16 @@
 
 (derive :event/dashboard-read ::event)
 (derive :event/table-read ::event)
+(derive :event/card-read ::event)
 
 (m/defmethod events/publish-event! ::event
   "Handle processing for a single event notification which should update the recent views for a user."
-  [topic {:keys [object] :as _event}]
+  [topic {:keys [object user-id] :as _event}]
   (try
     (when object
-      (let [model             (events/topic->model topic)
-            model-id          (events/object->model-id topic object)
-            user-id           (or (:user-id object) api/*current-user-id*)
-            ;; `:context` comes
-            ;; from [[metabase.query-processor.middleware.process-userland-query/add-and-save-execution-info-xform!]],
-            ;; and it should only be present for `:event/card-query`
-            {:keys [context]} (events/object->metadata object)]
-        ;; we don't want to count pinned card views
-        (when ((complement #{:collection :dashboard}) context)
-          (recent-views/update-users-recent-views! user-id model model-id))))
+      (let [model             (audit-log/model-name object)
+            model-id          (u/id object)
+            user-id           (or user-id api/*current-user-id*)]
+        (recent-views/update-users-recent-views! user-id model model-id)))
     (catch Throwable e
-      (log/warnf e "Failed to process activity event: %s" topic))))
-
-(derive ::query-event :metabase/event)
-(derive :event/card-query ::query-event)
-
-(m/defmethod events/publish-event! ::query-event
-  "Handle processing for a single read event notification received on the view-log-channel"
-  [topic {:keys [user-id card-id context] :as event}]
-  (try
-    (when event
-      (let [model   "card"
-            user-id (or user-id api/*current-user-id*)]
-        (when ((complement #{:collection :dashboard}) context)
-          (recent-views/update-users-recent-views! user-id model card-id))))
-    (catch Throwable e
-      (log/warnf e "Failed to process activity event. %s" topic))))
+      (log/warnf e "Failed to process recent_views event: %s" topic))))

--- a/src/metabase/events/schema.clj
+++ b/src/metabase/events/schema.clj
@@ -30,7 +30,11 @@
     {:event/card-create default-schema
      :event/card-read   default-schema
      :event/card-update default-schema
-     :event/card-delete default-schema}))
+     :event/card-delete default-schema
+     :event/card-query  [:map {:closed true}
+                         [:card-id pos-int?]
+                         [:user-id [:maybe pos-int?]]
+                         [:context {:optional true} :any]]}))
 
 ;; user events
 

--- a/src/metabase/events/schema.clj
+++ b/src/metabase/events/schema.clj
@@ -30,14 +30,7 @@
     {:event/card-create default-schema
      :event/card-read   default-schema
      :event/card-update default-schema
-     :event/card-delete default-schema
-     :event/card-query  [:map {:closed true}
-                         [:card-id                       pos-int?]
-                         [:user-id                       [:maybe pos-int?]]
-                         [:cached       {:optional true} :any]
-                         [:context      {:optional true} :any]
-                         [:ignore_cache {:optional true} :any]]}))
-
+     :event/card-delete default-schema}))
 
 ;; user events
 
@@ -117,7 +110,8 @@
 (let [default-schema (mc/schema
                       [:map {:closed true}
                        [:user-id [:maybe pos-int?]]
-                       [:object [:fn #(boolean (t2/model %))]]])]
+                       [:object [:maybe [:fn #(boolean (t2/model %))]]]
+                       [:has-access {:optional true} [:maybe :boolean]]])]
   (def ^:private permission-failure-events
     {:event/read-permission-failure default-schema
      :event/write-permission-failure default-schema

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -36,6 +36,7 @@
   (try
     (-> event
         generate-view
+        (assoc :context "question")
         record-views!)
     (catch Throwable e
       (log/warnf e "Failed to process view_log event. %s" topic))))

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -22,7 +22,7 @@
   "Generates a view, given an event map."
   [{:keys [object user-id has-access]
     :or   {has-access true}}]
-  {:model      (audit-log/model-name object)
+  {:model      (u/lower-case-en (audit-log/model-name object))
    :user_id    (or user-id api/*current-user-id*)
    :model_id   (u/id object)
    :has_access has-access})
@@ -72,11 +72,11 @@
     (let [dashcards (filter :card_id (:dashcards object)) ;; filter out link/text cards wtih no card_id
           user-id   (or user-id api/*current-user-id*)
           views     (map (fn [dashcard]
-                           {:model      "Card"
+                           {:model      "card"
                             :model_id   (u/id (:card_id dashcard))
                             :user_id    user-id
                             :has_access (readable-dashcard? dashcard)
-                            :context    "Dashboard"})
+                            :context    "dashboard"})
                          dashcards)
           dash-view (generate-view event)]
       (record-views! (cons dash-view views)))

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -41,8 +41,8 @@
     (catch Throwable e
       (log/warnf e "Failed to process view_log event. %s" topic))))
 
-(derive ::dashcard-read :metabase/event)
-(derive :event/dashboard-read ::dashcard-read)
+(derive ::dashboard-read :metabase/event)
+(derive :event/dashboard-read ::dashboard-read)
 
 (defn- readable-dashcard?
   "Returns true if the dashcard's card was readable by the current user, and false otherwise. Unreadable cards are
@@ -51,7 +51,7 @@
   (let [card (:card dashcard)]
     (not= (set (keys card)) #{:id})))
 
-(m/defmethod events/publish-event! ::dashboard-read-event
+(m/defmethod events/publish-event! ::dashboard-read
   "Handle processing for the dashboard read event. Logs the dashboard view as well as card views for each card on the
   dashboard."
   [topic {:keys [object user-id] :as event}]
@@ -60,7 +60,7 @@
           user-id   (or user-id api/*current-user-id*)
           views     (map (fn [dashcard]
                            {:model      "Card"
-                            :model_id   (u/id dashcard)
+                            :model_id   (u/id (:card_id dashcard))
                             :user_id    user-id
                             :has_access (readable-dashcard? dashcard)
                             :context    "Dashboard"})

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -56,7 +56,7 @@
   dashboard."
   [topic {:keys [object user-id] :as event}]
   (try
-    (let [dashcards (:dashcards object)
+    (let [dashcards (filter :card_id (:dashcards object)) ;; filter out link/text cards wtih no card_id
           user-id   (or user-id api/*current-user-id*)
           views     (map (fn [dashcard]
                            {:model      "Card"

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -27,10 +27,10 @@
    :model_id   (u/id object)
    :has_access has-access})
 
-(derive ::read-event :metabase/event)
-(derive :event/card-read ::read-event)
+(derive ::card-read-event :metabase/event)
+(derive :event/card-read ::card-read-event)
 
-(m/defmethod events/publish-event! ::read-event
+(m/defmethod events/publish-event! ::card-read-event
   "Handle processing for a generic read event notification"
   [topic event]
   (try
@@ -47,6 +47,8 @@
   "Handle processing for a generic read event notification"
   [topic {:keys [object] :as event}]
   (try
+    ;; Only log permission check failures for Cards and Dashboards. This set can be expanded if we add view logging of
+    ;; other models.
     (when (#{:model/Card :model/Dashboard} (t2/model object))
      (-> event
          generate-view

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -42,10 +42,10 @@
 
 (derive ::read-permission-failure :metabase/event)
 (derive :event/read-permission-failure ::read-permission-failure)
+
 (m/defmethod events/publish-event! ::read-permission-failure
   "Handle processing for a generic read event notification"
   [topic {:keys [object] :as event}]
-  (def object object)
   (try
     (when (#{:model/Card :model/Dashboard} (t2/model object))
      (-> event

--- a/src/metabase/models/audit_log.clj
+++ b/src/metabase/models/audit_log.clj
@@ -119,6 +119,14 @@
               [:model-id        {:optional true} [:maybe pos-int?]]
               [:details         {:optional true} [:maybe :map]]]]
   (span/with-span!
+    {:name       "record-event!"
+     :attributes (cond-> {}
+                   (:model-id params)
+                   (assoc :model/id (:model-id params))
+                   (:user-id params)
+                   (assoc :user/id (:user-id params))
+                   (:model params)
+                   (assoc :model/name (u/lower-case-en (:model params))))}
     (let [unqualified-topic (keyword (name topic))
           object            (:object params)
           previous-object   (:previous-object params)

--- a/src/metabase/models/recent_views.clj
+++ b/src/metabase/models/recent_views.clj
@@ -27,7 +27,7 @@
 (def ^:private ^:dynamic *recent-views-stored-per-user*
   "The number of recently viewed items to keep per user. This should be larger than the number of items returned by the
   /api/activity/recent_views endpoint, but it should still be lightweight to read all of a user's recent views at once."
-  100)
+  30)
 
 (defn- view-ids-to-prune
   "Returns a set of view IDs to prune from the RecentViews table so we only keep the most recent n views per user.

--- a/src/metabase/models/recent_views.clj
+++ b/src/metabase/models/recent_views.clj
@@ -38,7 +38,7 @@
     (let [ids-to-keep                    (map :id (take n prior-views))
           ;; We want to make sure we keep the most recent dashboard view for the user
           ids-to-prune                   (map :id (drop n prior-views))
-          most-recent-dashboard-id       (->> prior-views (filter #(= "Dashboard" (:model %))) first :id)
+          most-recent-dashboard-id       (->> prior-views (filter #(= "dashboard" (:model %))) first :id)
           pruning-most-recent-dashboard? ((set ids-to-prune) most-recent-dashboard-id)]
       (if pruning-most-recent-dashboard?
         (conj (remove #{most-recent-dashboard-id} (set ids-to-prune))
@@ -60,7 +60,7 @@
                     :model/name (u/lower-case-en model)}}
       (t2/with-transaction [_conn]
         (t2/insert! :model/RecentViews {:user_id  user-id
-                                        :model    (name model)
+                                        :model    (u/lower-case-en (name model))
                                         :model_id model-id})
         (let [current-views (t2/select :model/RecentViews :user_id user-id {:order-by [[:id :desc]]})
               ids-to-prune  (view-ids-to-prune current-views *recent-views-stored-per-user*)]

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -113,6 +113,14 @@
   :visibility :public
   :audit      :getter)
 
+(defsetting dismissed-custom-dashboard-toast
+  (deferred-tru "Toggle which is true after a user has dismissed the custom dashboard toast.")
+  :user-local :only
+  :visibility :authenticated
+  :type       :boolean
+  :default    false
+  :audit      :never)
+
 ;; `::uuid-nonce` is a Setting that sets a site-wide random UUID value the first time it is fetched.
 (defmethod setting/get-value-of-type ::uuid-nonce
   [_ setting]

--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -4,7 +4,6 @@
   These include things like saving QueryExecutions and adding query ViewLogs, storing exceptions and formatting the results."
   (:require
    [java-time.api :as t]
-   [metabase.events :as events]
    [metabase.models.query :as query]
    [metabase.models.query-execution
     :as query-execution
@@ -90,14 +89,6 @@
        (rf))
 
       ([acc]
-       ;; We don't actually have a guarantee that it's from a card just because it's userland
-       (when (integer? (:card_id execution-info))
-         (events/publish-event! :event/card-query {:user-id      (:executor_id execution-info)
-                                                   :card-id      (:card_id execution-info)
-                                                   :cached       (:cached acc)
-                                                   :context      (:context execution-info)
-                                                   :ignore_cache (get-in execution-info
-                                                                         [:json_query :middleware :ignore-cached-results?])}))
        (save-successful-query-execution! (:cached acc) execution-info @row-count)
        (rf (if (map? acc)
              (success-response execution-info acc)

--- a/test/metabase/api/activity_test.clj
+++ b/test/metabase/api/activity_test.clj
@@ -44,7 +44,7 @@
       (doseq [{:keys [topic event]} [{:topic :event/dashboard-read :event {:object dash-1}}
                                      {:topic :event/dashboard-read :event {:object dash-2}}
                                      {:topic :event/dashboard-read :event {:object dash-3}}
-                                     {:topic :event/card-read :event {:object card-1}}
+                                     {:topic :event/card-query :event {:card-id (:id card-1)}}
                                      {:topic :event/table-read :event {:object table-1}}]]
         (events/publish-event! topic (assoc event :user-id (mt/user->id :crowberto))))
       (testing "most_recently_viewed_dashboard endpoint shows the current user's most recently viewed dashboard."
@@ -110,16 +110,16 @@
     (testing "recent_views endpoint shows the current user's recently viewed items."
       (mt/with-model-cleanup [ViewLog]
         (mt/with-test-user :crowberto
-          (doseq [{:keys [topic event]} [{:topic :event/card-read :event {:object dataset}}
-                                         {:topic :event/card-read :event {:object dataset}}
-                                         {:topic :event/card-read :event {:object card1}}
-                                         {:topic :event/card-read :event {:object card1}}
-                                         {:topic :event/card-read :event {:object card1}}
+          (doseq [{:keys [topic event]} [{:topic :event/card-query :event {:card-id (:id dataset)}}
+                                         {:topic :event/card-query :event {:card-id (:id dataset)}}
+                                         {:topic :event/card-query :event {:card-id (:id card1)}}
+                                         {:topic :event/card-query :event {:card-id (:id card1)}}
+                                         {:topic :event/card-query :event {:card-id (:id card1)}}
                                          {:topic :event/dashboard-read :event {:object dash}}
-                                         {:topic :event/card-read :event {:object card1}}
+                                         {:topic :event/card-query :event {:card-id (:id card1)}}
                                          {:topic :event/dashboard-read :event {:object dash}}
                                          {:topic :event/table-read :event {:object table1}}
-                                         {:topic :event/card-read :event {:object archived}}
+                                         {:topic :event/card-query :event {:card-id (:id archived)}}
                                          {:topic :event/table-read :event {:object hidden-table}}]]
             (events/publish-event! topic (assoc event :user-id (mt/user->id :crowberto))))
           (testing "No duplicates or archived items are returned."
@@ -131,8 +131,8 @@
                     {:model "dataset" :model_id (u/the-id dataset)}]
                    recent-views)))))
         (mt/with-test-user :rasta
-          (events/publish-event! :event/card-read {:object dataset :user-id (mt/user->id :rasta)})
-          (events/publish-event! :event/card-read {:object card1 :user-id (mt/user->id :crowberto)})
+          (events/publish-event! :event/card-query {:card-id (:id dataset) :user-id (mt/user->id :rasta)})
+          (events/publish-event! :event/card-query {:card-id (:id card1) :user-id (mt/user->id :crowberto)})
           (testing "Only the user's own views are returned."
             (let [recent-views (mt/user-http-request :rasta :get 200 "activity/recent_views")]
               (is (partial=

--- a/test/metabase/api/activity_test.clj
+++ b/test/metabase/api/activity_test.clj
@@ -44,7 +44,7 @@
       (doseq [{:keys [topic event]} [{:topic :event/dashboard-read :event {:object dash-1}}
                                      {:topic :event/dashboard-read :event {:object dash-2}}
                                      {:topic :event/dashboard-read :event {:object dash-3}}
-                                     {:topic :event/card-query :event {:card-id (:id card-1)}}
+                                     {:topic :event/card-read :event {:object card-1}}
                                      {:topic :event/table-read :event {:object table-1}}]]
         (events/publish-event! topic (assoc event :user-id (mt/user->id :crowberto))))
       (testing "most_recently_viewed_dashboard endpoint shows the current user's most recently viewed dashboard."
@@ -110,16 +110,16 @@
     (testing "recent_views endpoint shows the current user's recently viewed items."
       (mt/with-model-cleanup [ViewLog]
         (mt/with-test-user :crowberto
-          (doseq [{:keys [topic event]} [{:topic :event/card-query :event {:card-id (:id dataset)}}
-                                         {:topic :event/card-query :event {:card-id (:id dataset)}}
-                                         {:topic :event/card-query :event {:card-id (:id card1)}}
-                                         {:topic :event/card-query :event {:card-id (:id card1)}}
-                                         {:topic :event/card-query :event {:card-id (:id card1)}}
+          (doseq [{:keys [topic event]} [{:topic :event/card-read :event {:object dataset}}
+                                         {:topic :event/card-read :event {:object dataset}}
+                                         {:topic :event/card-read :event {:object card1}}
+                                         {:topic :event/card-read :event {:object card1}}
+                                         {:topic :event/card-read :event {:object card1}}
                                          {:topic :event/dashboard-read :event {:object dash}}
-                                         {:topic :event/card-query :event {:card-id (:id card1)}}
+                                         {:topic :event/card-read :event {:object card1}}
                                          {:topic :event/dashboard-read :event {:object dash}}
                                          {:topic :event/table-read :event {:object table1}}
-                                         {:topic :event/card-query :event {:card-id (:id archived)}}
+                                         {:topic :event/card-read :event {:object archived}}
                                          {:topic :event/table-read :event {:object hidden-table}}]]
             (events/publish-event! topic (assoc event :user-id (mt/user->id :crowberto))))
           (testing "No duplicates or archived items are returned."
@@ -131,8 +131,8 @@
                     {:model "dataset" :model_id (u/the-id dataset)}]
                    recent-views)))))
         (mt/with-test-user :rasta
-          (events/publish-event! :event/card-query {:card-id (:id dataset) :user-id (mt/user->id :rasta)})
-          (events/publish-event! :event/card-query {:card-id (:id card1) :user-id (mt/user->id :crowberto)})
+          (events/publish-event! :event/card-read {:object dataset :user-id (mt/user->id :rasta)})
+          (events/publish-event! :event/card-read {:object card1 :user-id (mt/user->id :crowberto)})
           (testing "Only the user's own views are returned."
             (let [recent-views (mt/user-http-request :rasta :get 200 "activity/recent_views")]
               (is (partial=

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3064,6 +3064,6 @@
         (mt/user-http-request :crowberto :get 200 (format "card/%s" (u/id card)))
         (is (partial=
              {:user_id  (mt/user->id :crowberto)
-              :model    "Card"
+              :model    "card"
               :model_id (u/id card)}
              (view-log-test/latest-view (mt/user->id :crowberto) (u/id card))))))))

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -9,7 +9,7 @@
    [metabase.events.audit-log :as events.audit-log]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.models
-    :refer [Card Dashboard DashboardCard Table Metric Pulse Segment]]
+    :refer [Card Dashboard DashboardCard Metric Pulse Segment]]
    [metabase.test :as mt]
    [metabase.util :as u]
    [toucan2.core :as t2]

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -103,22 +103,6 @@
                               dataset? (assoc :model? true))}
                  (latest-event "card-delete" (:id card))))))))))
 
-(deftest card-read-event-test
-  (testing :card-read
-    (doseq [dataset? [false true]]
-      (testing (if dataset? "Dataset" "Card")
-        (t2.with-temp/with-temp [Card card {:name "My Cool Card", :dataset dataset?}]
-          (is (= {:object card :user-id (mt/user->id :rasta)}
-                 (events/publish-event! :event/card-read {:object card :user-id (mt/user->id :rasta)})))
-          (is (partial=
-               {:topic    :card-read
-                :user_id  (mt/user->id :rasta)
-                :model    "Card"
-                :model_id (:id card)
-                :details  (cond-> {:name "My Cool Card", :description nil}
-                            dataset? (assoc :model? true))}
-               (latest-event "card-read" (:id card)))))))))
-
 (deftest card-query-event-test
   (testing :card-query
     (doseq [dataset? [false true]]
@@ -208,32 +192,6 @@
                                            :id          (:id dashcard)
                                            :card_id     (:id card)}]}}
              (latest-event "dashboard-remove-cards" (:id dashboard))))))))
-
-(deftest dashboard-read-event-test
-  (testing :dashboard-read
-    (t2.with-temp/with-temp [Dashboard dashboard {:name "My Cool Dashboard"}]
-      (is (= {:object dashboard :user-id (mt/user->id :rasta)}
-             (events/publish-event! :event/dashboard-read {:object dashboard :user-id (mt/user->id :rasta)})))
-      (is (partial=
-           {:topic    :dashboard-read
-            :user_id  (mt/user->id :rasta)
-            :model    "Dashboard"
-            :model_id (:id dashboard)
-            :details  {:name "My Cool Dashboard", :description nil}}
-           (latest-event "dashboard-read" (:id dashboard)))))))
-
-(deftest table-read-event-test
-  (testing :table-read
-    (t2.with-temp/with-temp [Table table {:name "My Cool Table"}]
-      (is (= {:object table :user-id (mt/user->id :rasta)}
-             (events/publish-event! :event/table-read {:object table :user-id (mt/user->id :rasta)})))
-      (is (partial=
-           {:topic    :table-read
-            :user_id  (mt/user->id :rasta)
-            :model    "Table"
-            :model_id (:id table)
-            :details  {}}
-           (latest-event "table-read" (:id table)))))))
 
 (deftest install-event-test
   (testing :install

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -103,24 +103,6 @@
                               dataset? (assoc :model? true))}
                  (latest-event "card-delete" (:id card))))))))))
 
-(deftest card-query-event-test
-  (testing :card-query
-    (doseq [dataset? [false true]]
-      (testing (if dataset? "Dataset" "Card")
-        (t2.with-temp/with-temp [Card card {:name "My Cool Card", :dataset dataset?}]
-          (events/publish-event! :event/card-query {:user-id      (mt/user->id :rasta)
-                                                    :card-id      (u/the-id card)
-                                                    :cached       false
-                                                    :ignore_cache false
-                                                    :context      :question})
-          (is (partial=
-               {:topic    :card-query
-                :user_id  (mt/user->id :rasta)
-                :model    "Card"
-                :model_id (:id card)
-                :details  {:cached false :ignore_cache false :context "question"}}
-               (latest-event "card-query" (:id card)))))))))
-
 (deftest dashboard-create-event-test
   (testing :dashboard-create
     (t2.with-temp/with-temp [Dashboard dashboard {:name "My Cool Dashboard"}]

--- a/test/metabase/events/recent_views_test.clj
+++ b/test/metabase/events/recent_views_test.clj
@@ -4,7 +4,6 @@
    [metabase.events :as events]
    [metabase.models :refer [Card Dashboard Table]]
    [metabase.test :as mt]
-   [metabase.util :as u]
    [toucan2.core :as t2]))
 
 (defn- most-recent-view
@@ -16,10 +15,8 @@
 (deftest card-query-test
   (mt/with-temp [Card card {:creator_id (mt/user->id :rasta)}]
     (mt/with-test-user :rasta
-      (events/publish-event! :event/card-query {:card-id      (u/id card)
-                                                :user-id      (mt/user->id :rasta)
-                                                :cached       false
-                                                :ignore_cache true})
+      (events/publish-event! :event/card-read {:object  card
+                                               :user-id (mt/user->id :rasta)})
       (is (= {:user_id  (mt/user->id :rasta)
               :model    "card"
               :model_id (:id card)}

--- a/test/metabase/events/recent_views_test.clj
+++ b/test/metabase/events/recent_views_test.clj
@@ -15,8 +15,9 @@
 (deftest card-query-test
   (mt/with-temp [Card card {:creator_id (mt/user->id :rasta)}]
     (mt/with-test-user :rasta
-      (events/publish-event! :event/card-read {:object  card
-                                               :user-id (mt/user->id :rasta)})
+      (events/publish-event! :event/card-query {:object  card
+                                                :user-id (mt/user->id :rasta)
+                                                :context :dashboard})
       (is (= {:user_id  (mt/user->id :rasta)
               :model    "card"
               :model_id (:id card)}

--- a/test/metabase/events/recent_views_test.clj
+++ b/test/metabase/events/recent_views_test.clj
@@ -7,21 +7,29 @@
    [toucan2.core :as t2]))
 
 (defn- most-recent-view
-  [user-id]
+  [user-id model-id]
   (t2/select-one [:model/RecentViews :user_id :model :model_id]
                  :user_id user-id
+                 :model_id model-id
                  {:order-by [[:id :desc]]}))
 
 (deftest card-query-test
   (mt/with-temp [Card card {:creator_id (mt/user->id :rasta)}]
     (mt/with-test-user :rasta
-      (events/publish-event! :event/card-query {:object  card
+      (events/publish-event! :event/card-query {:card-id (:id card)
                                                 :user-id (mt/user->id :rasta)
-                                                :context :dashboard})
+                                                :context :question})
       (is (= {:user_id  (mt/user->id :rasta)
               :model    "card"
               :model_id (:id card)}
-             (most-recent-view (mt/user->id :rasta)))))))
+             (most-recent-view (mt/user->id :rasta) (:id card))))
+
+      (testing "pinned cards should not be counted"
+        (mt/with-temp [Card card-2 {:creator_id (mt/user->id :rasta)}]
+          (events/publish-event! :event/card-query {:card-id (:id card-2)
+                                                    :user-id (mt/user->id :rasta)
+                                                    :context :collection})
+          (is (nil? (most-recent-view (mt/user->id :rasta) (:id card-2)))))))))
 
 (deftest table-read-test
   (mt/with-temp [Table table {}]
@@ -31,7 +39,7 @@
           {:user_id  (mt/user->id :rasta)
            :model    "table"
            :model_id (:id table)}
-          (most-recent-view (mt/user->id :rasta)))))))
+          (most-recent-view (mt/user->id :rasta) (:id table)))))))
 
 (deftest dashboard-read-test
   (mt/with-temp [Dashboard dashboard {:creator_id (mt/user->id :rasta)}]
@@ -41,4 +49,4 @@
            {:user_id  (mt/user->id :rasta)
             :model    "dashboard"
             :model_id (:id dashboard)}
-           (most-recent-view (mt/user->id :rasta)))))))
+           (most-recent-view (mt/user->id :rasta) (:id dashboard)))))))

--- a/test/metabase/events/view_log_test.clj
+++ b/test/metabase/events/view_log_test.clj
@@ -23,7 +23,7 @@
       (events/publish-event! :event/card-read {:object card :user-id (u/the-id user)})
       (is (partial=
            {:user_id  (u/id user)
-            :model    "Card"
+            :model    "card"
             :model_id (u/id card)
             :has_access true
             :context    nil}
@@ -36,7 +36,7 @@
         (events/publish-event! :event/table-read {:object table :user-id (u/id user)})
         (is (partial=
              {:user_id  (u/id user)
-              :model    "Table"
+              :model    "table"
               :model_id (u/id table)
               :has_access nil
               :context    nil}
@@ -62,7 +62,7 @@
         (events/publish-event! :event/dashboard-read {:object dashboard :user-id (u/id user)})
         (is (partial=
              {:user_id    (u/id user)
-              :model      "Dashboard"
+              :model      "dashboard"
               :model_id   (u/id dashboard)
               :has_access true
               :context    nil}
@@ -70,8 +70,8 @@
 
         (is (partial=
              {:user_id    (u/id user)
-              :model      "Card"
+              :model      "card"
               :model_id   (u/id card)
               :has_access true
-              :context    "Dashboard"}
+              :context    "dashboard"}
              (latest-view (u/id user) (u/id card))))))))

--- a/test/metabase/events/view_log_test.clj
+++ b/test/metabase/events/view_log_test.clj
@@ -2,48 +2,75 @@
   (:require
    [clojure.test :refer :all]
    [metabase.events :as events]
-   [metabase.models :refer [Card Dashboard Table User ViewLog]]
    [metabase.test :as mt]
-   [toucan2.core :as t2]))
+   [metabase.util :as u]
+   [toucan2.core :as t2]
+   [metabase.api.common :as api]
+   [metabase.models.permissions :as perms]))
+
+(defn- latest-view
+  [user-id model-id]
+  (t2/select-one :model/ViewLog
+                 :user_id user-id
+                 :model_id model-id
+                 {:order-by [[:id :desc]]}))
 
 (deftest card-read-test
-  (mt/with-temp [User user {}
-                 Card card {:creator_id (:id user)}]
-
-    (events/publish-event! :event/card-read {:object card :user-id (:id user)})
-    (is (= {:user_id  (:id user)
-            :model    "card"
-            :model_id (:id card)}
-           (t2/select-one [ViewLog :user_id :model :model_id], :user_id (:id user))))))
-
-(deftest card-query-test
-  (mt/with-temp [User user {}
-                 Card card {:creator_id (:id user)}]
-    (events/publish-event! :event/card-query {:cached       false
-                                              :ignore_cache true
-                                              :card-id      (:id card)
-                                              :user-id      (:id user)
-                                              :context      "dashboard"})
-    (is (= {:user_id  (:id user)
-            :model    "card"
-            :model_id (:id card)
-            :metadata {:cached false :ignore_cache true :context "dashboard"}}
-           (t2/select-one [ViewLog :user_id :model :model_id :metadata], :user_id (:id user))))))
+  (mt/with-temp [:model/User user {}
+                 :model/Card card {:creator_id (u/id user)}]
+    (testing "A basic card read event is recorded"
+      (events/publish-event! :event/card-read {:object card :user-id (u/the-id user)})
+      (is (partial=
+           {:user_id  (u/id user)
+            :model    "Card"
+            :model_id (u/id card)
+            :has_access true
+            :context    nil}
+           (latest-view (u/id user) (u/id card)))))))
 
 (deftest table-read-test
-  (mt/with-temp [User  user  {}
-                 Table table {}]
-    (events/publish-event! :event/table-read {:object table :user-id (:id user)})
-    (is (= {:user_id  (:id user)
-            :model    "table"
-            :model_id (:id table)}
-           (t2/select-one [ViewLog :user_id :model :model_id], :user_id (:id user))))))
+  (mt/with-temp [:model/User user {}]
+    (let [table (t2/select-one :model/Table :id (mt/id :users))]
+      (testing "A basic table read event is recorded"
+        (events/publish-event! :event/table-read {:object table :user-id (u/id user)})
+        (is (partial=
+             {:user_id  (u/id user)
+              :model    "Table"
+              :model_id (u/id table)
+              :has_access nil
+              :context    nil}
+             (latest-view (u/id user) (u/id table)))))
+
+      (testing "If a user is bound, has_access is recorded based on the user's current permissions"
+        (binding [api/*current-user-id* (u/id user)
+                  api/*current-user-permissions-set* (delay #{(perms/table-query-path (mt/id :users))})]
+          (events/publish-event! :event/table-read {:object table :user-id (u/id user)})
+          (is (true? (:has_access (latest-view (u/id user) (u/id table)))))
+
+          (binding [api/*current-user-permissions-set* (delay #{(perms/table-query-path (mt/id :checkins))})]
+            (events/publish-event! :event/table-read {:object table :user-id (u/id user)})
+            (is (false? (:has_access (latest-view (u/id user) (u/id table)))))))))))
 
 (deftest dashboard-read-test
-  (mt/with-temp [User      user {}
-                 Dashboard dashboard {:creator_id (:id user)}]
-    (events/publish-event! :event/dashboard-read {:object dashboard :user-id (:id user)})
-    (is (= {:user_id  (:id user)
-            :model    "dashboard"
-            :model_id (:id dashboard)}
-           (t2/select-one [ViewLog :user_id :model :model_id], :user_id (:id user))))))
+  (mt/with-temp [:model/User          user      {}
+                 :model/Dashboard     dashboard {:name "Test Dashboard"}
+                 :model/Card          card      {:name "Dashboard Test Card"}
+                 :model/DashboardCard _dashcard {:dashboard_id (u/id dashboard) :card_id (u/id card)}]
+    (let [dashboard (t2/hydrate dashboard [:dashcards :card])]
+      (testing "A basic dashboard read event is recorded, as well as events for its cards"
+        (events/publish-event! :event/dashboard-read {:object dashboard :user-id (u/id user)})
+        (is (partial=
+             {:user_id    (u/id user)
+              :model      "Dashboard"
+              :model_id   (u/id dashboard)
+              :has_access true
+              :context    nil}
+             (latest-view (u/id user) (u/id dashboard))))
+
+        (is (partial=
+             {:user_id    (u/id user)
+              :model      "Card"
+              :model_id   (u/id card)
+              :has_access true
+              :context    "Dashboard"}
+             (latest-view (u/id user) (u/id card))))))))

--- a/test/metabase/events/view_log_test.clj
+++ b/test/metabase/events/view_log_test.clj
@@ -26,7 +26,7 @@
             :model    "card"
             :model_id (u/id card)
             :has_access true
-            :context    nil}
+            :context    "question"}
            (latest-view (u/id user) (u/id card)))))))
 
 (deftest table-read-test

--- a/test/metabase/events/view_log_test.clj
+++ b/test/metabase/events/view_log_test.clj
@@ -1,12 +1,12 @@
 (ns metabase.events.view-log-test
   (:require
    [clojure.test :refer :all]
+   [metabase.api.common :as api]
    [metabase.events :as events]
+   [metabase.models.permissions :as perms]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [toucan2.core :as t2]
-   [metabase.api.common :as api]
-   [metabase.models.permissions :as perms]))
+   [toucan2.core :as t2]))
 
 (defn- latest-view
   [user-id model-id]

--- a/test/metabase/events/view_log_test.clj
+++ b/test/metabase/events/view_log_test.clj
@@ -8,7 +8,8 @@
    [metabase.util :as u]
    [toucan2.core :as t2]))
 
-(defn- latest-view
+(defn latest-view
+  "Returns the most recent view for a given user and model ID"
   [user-id model-id]
   (t2/select-one :model/ViewLog
                  :user_id user-id

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -5,15 +5,13 @@
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.events :as events]
-   [metabase.query-processor :as qp]
    [metabase.query-processor.context :as qp.context]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.middleware.process-userland-query
     :as process-userland-query]
    [metabase.query-processor.util :as qp.util]
    [metabase.test :as mt]
-   [methodical.core :as methodical]
-   [toucan2.core :as t2]))
+   [methodical.core :as methodical]))
 
 (set! *warn-on-reflection* true)
 
@@ -108,8 +106,6 @@
 
 (def ^:private ^:dynamic *viewlog-call-count* nil)
 
-(derive :event/card-query ::event)
-
 (methodical/defmethod events/publish-event! ::event
   [_topic _event]
   (when *viewlog-call-count*
@@ -120,36 +116,6 @@
     (binding [*viewlog-call-count* (atom 0)]
       (mt/test-qp-middleware process-userland-query/process-userland-query {:query? true} {} [] nil)
       (is (zero? @*viewlog-call-count*)))))
-
-(deftest record-view-log-when-process-userland-query-test
-  (testing "record a view log with only card id"
-    (mt/with-temp [:model/Card card {:dataset_query (mt/mbql-query users)}]
-      (qp/process-userland-query (assoc
-                                  (:dataset_query card)
-                                  :info {:card-id (:id card)}))
-
-      (is (true? (t2/exists? :model/ViewLog :model "card" :model_id (:id card) :user_id nil)))))
-
-  (testing "record a view log with card id and executed by"
-    (mt/with-temp [:model/Card card {:dataset_query (mt/mbql-query users)}]
-      (qp/process-userland-query (assoc
-                                  (:dataset_query card)
-                                  :info {:card-id (:id card)
-                                         :executed-by (mt/user->id :rasta)}))
-
-      (is (true? (t2/exists? :model/ViewLog :model "card" :model_id (:id card) :user_id (mt/user->id :rasta))))))
-
-  (testing "skip if context is dashboard or collection"
-    (mt/with-temp [:model/Card card {:dataset_query (mt/mbql-query users)}]
-      (qp/process-userland-query (assoc
-                                  (:dataset_query card)
-                                  :info {:card-id     (:id card)
-                                         :context     "collection"}))
-      (qp/process-userland-query (assoc
-                                  (:dataset_query card)
-                                  :info {:card-id     (:id card)
-                                         :context     "dashboard"}))
-      (is (false? (t2/exists? :model/ViewLog :model "card" :model_id (:id card)))))))
 
 (defn- async-middleware [qp]
   (fn async-middleware-qp [query rff context]


### PR DESCRIPTION
(Mostly) closes https://github.com/metabase/metabase/issues/27782

This PR reworks the events that we store in the `view_log`, and modifies the schema of the `view_log` table. Specifically:
* It adds `has_access` (bool) and `context` (string) fields to `view_log`
* It deletes the `card-query` event entirely. Queries are only stored in the `query_execution` table.
* It refactors the view events for cards, dashboards and tables. Most of this is the same, but as a summary:
	* Card views are recorded during `GET /api/card/:id` calls, regardless of the origin. Card views are also recorded when cards are viewed in dashboards.
	* Dashboard views are recorded during `GET /api/dashboard/:id` calls
	* Table views are recorded during `POST /api/dataset` for queries that have a simple source table. `has_access` is determined based on whether the current user has query access for that table. 
	* `can-read?` permission check failures for Cards and Dashboards are also recorded, with `has_access` = `false`
	
Things from the issue which I haven't added:
* I didn't add an `error_string` field to `view_log` because the only errors we're logging are read permission failures, which is already reflected by the `has_access` field. Since we're not logging query executions in this table, there aren't any other types of failures that are expected. Query execution errors are logged in the `query_execution` table.
* `context` is being set to `dashboard` for dashboard card views, but not set for any other views currently. The main reason is that the backend can't distinguish between normal card views and pinned collection views. We'd need a FE change to pass this in the API.
* `metadata` is still in the table for backwards compatibility and to avoid breaking views. We can drop it in the next release.