### PR TITLE
Revert "Add fonts in Dockerfile to fix pulses (#31764)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ FROM --platform=linux/amd64 eclipse-temurin:11-jre-alpine as runner
 ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 
 # dependencies
-RUN apk add -U bash fontconfig curl font-noto font-noto-arabic font-noto-hebrew font-noto-cjk java-cacerts && \
+RUN apk add -U bash ttf-dejavu fontconfig curl java-cacerts && \
     apk upgrade && \
     rm -rf /var/cache/apk/* && \
     mkdir -p /app/certs && \

--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=linux/amd64 eclipse-temurin:11-jre-alpine
 ENV FC_LANG=en-US LC_CTYPE=en_US.UTF-8
 
 # dependencies
-RUN apk add -U bash fontconfig curl font-noto font-noto-arabic font-noto-hebrew font-noto-cjk java-cacerts && \
+RUN apk add -U bash ttf-dejavu fontconfig curl java-cacerts && \
     apk upgrade && \
     rm -rf /var/cache/apk/* && \
     mkdir -p /app/certs && \

--- a/bin/docker/Dockerfile_ubuntu
+++ b/bin/docker/Dockerfile_ubuntu
@@ -5,7 +5,7 @@ ENV FC_LANG=en-US LC_CTYPE=en_US.UTF-8
 # Dependencies
 RUN apt-get update && \
   apt-get upgrade -y && \
-  apt-get install -y ca-certificates ca-certificates-java fonts-noto fonts-noto-arabic fonts-noto-hebrew fonts-noto-cjk && \
+  apt-get install -y ca-certificates ca-certificates-java fonts-dejavu && \
   apt-get clean && \
   curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -o /usr/local/share/ca-certificates/rds-combined-ca-bundle.pem && \
   curl https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem -o /usr/local/share/ca-certificates/DigiCertGlobalRootG2.crt.pem && \


### PR DESCRIPTION
This reverts commit 44de976d97ad4fbebf41bb512a8386ba03bc5a09.

It introduced a breaking change to the `master` branch.  Multi-arch build job is failing (https://github.com/metabase/metabase/actions/runs/6869885102/job/18693459426#step:10:450) with the following errors:

```
#10 5.886 E: Unable to locate package fonts-noto-arabic
#10 5.887 E: Unable to locate package fonts-noto-hebrew

ERROR: failed to solve: process "/bin/sh -c apt-get update &&   apt-get upgrade -y &&   apt-get install -y ca-certificates ca-certificates-java fonts-noto fonts-noto-arabic fonts-noto-hebrew fonts-noto-cjk &&   apt-get clean &&   curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -o /usr/local/share/ca-certificates/rds-combined-ca-bundle.pem &&   curl https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem -o /usr/local/share/ca-certificates/DigiCertGlobalRootG2.crt.pem &&   update-ca-certificates &&   mkdir -p /plugins && chmod a+rwx /plugins &&   keytool -list -cacerts" did not complete successfully: exit code: 100

Error: buildx failed with: ERROR: failed to solve: process "/bin/sh -c apt-get update &&   apt-get upgrade -y &&   apt-get install -y ca-certificates ca-certificates-java fonts-noto fonts-noto-arabic fonts-noto-hebrew fonts-noto-cjk &&   apt-get clean &&   curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -o /usr/local/share/ca-certificates/rds-combined-ca-bundle.pem &&   curl https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem -o /usr/local/share/ca-certificates/DigiCertGlobalRootG2.crt.pem &&   update-ca-certificates &&   mkdir -p /plugins && chmod a+rwx /plugins &&   keytool -list -cacerts" did not complete successfully: exit code: 100
```

![image](https://github.com/metabase/metabase/assets/31325167/0096d750-db68-47f3-9aaf-ba5299bb11c7)
