### PR TITLE
Improve external filter checks

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -16,7 +16,11 @@ concurrency:
 
 jobs:
   external-filter:
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success'
+    # 1. within the organization OR
+    # 2. fork
+    if: |
+      github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 3
     steps:

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -16,6 +16,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  external-filter:
+    # 1. within the organization OR
+    # 2. fork
+    if: |
+      github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 3
+    steps:
+      - run: |
+          if ${{ github.event.pull_request.head.repo.full_name == github.repository }}; then
+            echo 'Running Chromatic workflow within the organization.'
+          elif ${{ github.event.workflow_run.conclusion == 'success' }}; then
+            echo "Running Chromatic workflow for the external contributor. Thank you!"
+          fi
+
   files-changed:
     name: Check which files changed
     runs-on: ubuntu-22.04
@@ -32,10 +48,10 @@ jobs:
           filters: .github/file-paths.yaml
 
   be-tests-athena-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -54,10 +70,10 @@ jobs:
         test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-bigquery-cloud-sdk-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -78,10 +94,10 @@ jobs:
         test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-druid-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -103,10 +119,10 @@ jobs:
         test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-googleanalytics-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -121,10 +137,10 @@ jobs:
         test-args: ":exclude-tags '[:mb/once]'"
 
   be-google-related-drivers-classpath-test:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -145,10 +161,10 @@ jobs:
         test-args: ':only "[metabase.query-processor-test.expressions-test metabase.driver.google-test metabase.driver.googleanalytics-test]"'
 
   be-tests-mariadb-10-2-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -173,10 +189,10 @@ jobs:
         junit-name: 'be-tests-mariadb-10-2-ee'
 
   be-tests-mariadb-latest-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -201,10 +217,10 @@ jobs:
         junit-name: 'be-tests-mariadb-latest-ee'
 
   be-tests-mongo-4-4-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -226,10 +242,10 @@ jobs:
         test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-mongo-4-4-ssl-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -263,10 +279,10 @@ jobs:
           test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-mongo-5-0-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -288,10 +304,10 @@ jobs:
         test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-mongo-5-0-ssl-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -325,10 +341,10 @@ jobs:
         test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-mongo-latest-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -353,10 +369,10 @@ jobs:
         test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-mysql-8-0-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -381,10 +397,10 @@ jobs:
         junit-name: 'be-tests-mysql-8-0-ee'
 
   be-tests-mysql-latest-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -421,10 +437,10 @@ jobs:
         junit-name: 'be-tests-mysql-latest-ee'
 
   be-tests-oracle-18-4-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -450,10 +466,10 @@ jobs:
         test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-oracle-21-3-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -488,10 +504,10 @@ jobs:
         test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-postgres-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -520,10 +536,10 @@ jobs:
         junit-name: 'be-tests-postgres-ee'
 
   be-tests-postgres-latest-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -555,10 +571,10 @@ jobs:
         junit-name: 'be-tests-postgres-latest-ee'
 
   be-tests-presto-jdbc-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -607,10 +623,10 @@ jobs:
         test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-redshift-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -629,10 +645,10 @@ jobs:
         test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-snowflake-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -653,10 +669,10 @@ jobs:
         test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-sparksql-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -676,10 +692,10 @@ jobs:
         test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-sqlite-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -694,10 +710,10 @@ jobs:
         test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-sqlserver-2017-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -724,10 +740,10 @@ jobs:
         test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-sqlserver-2022-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -754,10 +770,10 @@ jobs:
         test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-vertica-ee:
-    needs: files-changed
+    needs: [files-changed, external-filter]
     if: |
       (github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true') &&
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success')
+      needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -27,9 +27,9 @@ jobs:
     steps:
       - run: |
           if ${{ github.event.pull_request.head.repo.full_name == github.repository }}; then
-            echo 'Running Chromatic workflow within the organization.'
+            echo 'Running Drivers tests within the organization.'
           elif ${{ github.event.workflow_run.conclusion == 'success' }}; then
-            echo "Running Chromatic workflow for the external contributor. Thank you!"
+            echo "Running Drivers tests for the external contributor. Thank you!"
           fi
 
   files-changed:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -34,8 +34,6 @@ jobs:
 
   files-changed:
     name: Check which files changed
-    needs: external-filter
-    if: needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 3
     outputs:
@@ -50,8 +48,6 @@ jobs:
           filters: .github/file-paths.yaml
 
   e2e-matrix-builder:
-    needs: external-filter
-    if: needs.external-filter.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     outputs:
@@ -214,10 +210,10 @@ jobs:
           if-no-files-found: ignore
 
   e2e-tests-skipped-stub:
-    needs: [e2e-tests, e2e-matrix-builder, external-filter]
+    needs: [e2e-tests, e2e-matrix-builder]
     if: |
       !cancelled() &&
-      needs.e2e-tests.result == 'skipped' && needs.external-filter.result == 'success'
+      needs.e2e-tests.result == 'skipped'
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 5
     name: e2e-tests-${{ matrix.name }}-${{ matrix.edition }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -17,7 +17,11 @@ concurrency:
 
 jobs:
   external-filter:
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_run.conclusion == 'success'
+    # 1. within the organization OR
+    # 2. fork
+    if: |
+      github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 3
     steps:


### PR DESCRIPTION
This PR unifies "external-filter" checks across multiple workflows that require such check.

It also improves the conditional logic, which never accounted for the `push` scenario!
This led to checks on master being skipped even when pushed within the organization. Here is an example: https://github.com/metabase/metabase/actions/runs/6873940799/job/18694765866
```diff
- github.event.pull_request.head.repo.full_name == github.repository
+ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository 
```

All of this is a result of trying to work around the GitHub limitations, and the lack of first-class support for 3rd party (fork) pull requests in CI.

> **Important**
> The "fix" is relying on the fact that we don't allow direct pushes to any branch. The pull request is always needed. This means that every change that runs on `push` comes from within the organization (from a merged pull request that was previously approved and passed all checks)