### PR TITLE
Skip excess keys on serialization load

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
@@ -2,10 +2,12 @@
   (:require
    [clojure.java.io :as io]
    [clojure.test :refer :all]
-   [metabase-enterprise.serialization.cmd :as serialization.cmd]
    [metabase-enterprise.serialization.load :as load]
    [metabase-enterprise.serialization.test-util :as ts]
    [metabase.cmd :as cmd]
+   [metabase.core :as mbc]
+   [metabase.db :as mdb]
+   [metabase.db.schema-migrations-test.impl :as schema-migrations-test.impl]
    [metabase.models :refer [Card Dashboard DashboardCard Database User]]
    [metabase.public-settings.premium-features-test :as premium-features-test]
    [metabase.test :as mt]
@@ -70,13 +72,19 @@
          (spit ~path original#)))))
 
 (deftest loading-does-not-fail-on-extra-yaml-keys
-  (testing "an extra key does not break loading"
-    (premium-features-test/with-premium-features #{:serialization}
-      (is (serialization.cmd/v2-load-internal! "resources/instance_analytics/" {} :token-check? false))
-
+  (premium-features-test/with-premium-features #{:serialization}
+    (testing "it works without an extra key (sanity check)"
+      (schema-migrations-test.impl/with-temp-empty-app-db [_conn :h2]
+        ;; NOTE: this is probably not the ideal way to set things up. It seems that we need to set up the DB and
+        ;; install the audit DB before we run `v2-load-internal`, but this is clearly awkard.
+        (mdb/setup-db!)
+        (mbc/ensure-audit-db-installed!)))
+    (testing "and it works with an extra key"
       (let [path "resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/vG58R8k-QddHWA7_47umn_metabase_analytics.yaml"]
         (with-file-updated [path #(-> % yaml/parse-string (assoc :foo? "bar") yaml/generate-string)]
-          (is (serialization.cmd/v2-load-internal! "resources/instance_analytics/" {} :token-check? false)))))))
+          (schema-migrations-test.impl/with-temp-empty-app-db [_conn :h2]
+            (mdb/setup-db!)
+            (mbc/ensure-audit-db-installed!)))))))
 
 (deftest blank-target-db-test
   (testing "Loading a dump into an empty app DB still works (#16639)"

--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -367,6 +367,9 @@
       (cond-> (= (:type action) "query")
         (update :database_id serdes/*import-fk-keyed* 'Database :name))))
 
+(defmethod serdes/ingested-model-columns "Action" [_ingested]
+  (into #{} (conj action-columns :database_id :dataset_query :kind :template :response_handle :error_handle :type)))
+
 (defmethod serdes/load-update! "Action" [_model-name ingested local]
   (log/tracef "Upserting Action %d: old %s new %s" (:id local) (pr-str local) (pr-str ingested))
   (update! (assoc ingested :id (:id local)) local)

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -984,10 +984,10 @@
                        (str location id "/"))
                      "/")]
     (-> contents
-        serdes/load-xform-basics
         (dissoc :parent_id)
         (assoc :location loc)
-        (update :personal_owner_id serdes/*import-user*))))
+        (update :personal_owner_id serdes/*import-user*)
+        serdes/load-xform-basics)))
 
 (defmethod serdes/dependencies "Collection"
   [{:keys [parent_id]}]

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -16,6 +16,7 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [medley.core :as m]
+   [metabase.db.connection :as mdb.connection]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.mbql.normalize :as mbql.normalize]
    [metabase.mbql.util :as mbql.u]
@@ -510,7 +511,7 @@
 
 (def ^:private fields-for-table
   "Given a table name, returns a map of column_name -> column_type"
-  (memoize
+  (mdb.connection/memoize-for-application-db
    (fn fields-for-table [table-name]
      (t2/with-connection [conn]
        (u.conn/app-db-column-types conn table-name)))))

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -548,13 +548,13 @@
 
 (defn load-xform-basics
   "Performs the usual steps for an incoming entity:
-  - Drop :serdes/meta
+  - removes extraneous keys (e.g. `:serdes/meta`)
 
   You should call this as part of any implementation of [[load-xform]].
 
   This is a mirror (but not precise inverse) of [[extract-one-basics]]."
   [ingested]
-  (-> ingested drop-excess-keys (dissoc :serdes/meta)))
+  (drop-excess-keys ingested))
 
 (defmethod load-xform :default [ingested]
   (load-xform-basics ingested))

--- a/src/metabase/util/connection.clj
+++ b/src/metabase/util/connection.clj
@@ -1,16 +1,21 @@
 (ns metabase.util.connection
+  (:require [metabase.util :as u]
+            [toucan2.core :as t2])
   (:import
    (java.sql Connection)))
 
 (set! *warn-on-reflection* true)
 
 (defn app-db-column-types
-  "Returns a map of all column names to their respective type names, for the given `table-name`, by using the JDBC
-  .getMetaData method of the given `conn` (which is presumed to be an app DB connection)."
-  [^Connection conn table-name]
-  (with-open [rset (.getColumns (.getMetaData conn) nil nil table-name nil)]
-    (into {} (take-while some?)
-             (repeatedly
+  "Returns a map of all column names to their respective type names for the given `table-name` in the provided
+  application-db."
+  [app-db table-name']
+  (let [table-name (cond-> table-name'
+                     (= (:db-type app-db) :h2) u/upper-case-en)]
+    (t2/with-connection [^Connection conn]
+      (with-open [rset (.getColumns (.getMetaData conn) nil nil table-name nil)]
+        (into {} (take-while some?)
+              (repeatedly
                (fn []
                  (when (.next rset)
-                   [(.getString rset "COLUMN_NAME") (.getString rset "TYPE_NAME")]))))))
+                   [(.getString rset "COLUMN_NAME") (.getString rset "TYPE_NAME")]))))))))

--- a/src/metabase/util/connection.clj
+++ b/src/metabase/util/connection.clj
@@ -1,0 +1,16 @@
+(ns metabase.util.connection
+  (:import
+   (java.sql Connection)))
+
+(set! *warn-on-reflection* true)
+
+(defn app-db-column-types
+  "Returns a map of all column names to their respective type names, for the given `table-name`, by using the JDBC
+  .getMetaData method of the given `conn` (which is presumed to be an app DB connection)."
+  [^Connection conn table-name]
+  (with-open [rset (.getColumns (.getMetaData conn) nil nil table-name nil)]
+    (into {} (take-while some?)
+             (repeatedly
+               (fn []
+                 (when (.next rset)
+                   [(.getString rset "COLUMN_NAME") (.getString rset "TYPE_NAME")]))))))

--- a/src/metabase/util/connection.clj
+++ b/src/metabase/util/connection.clj
@@ -14,8 +14,8 @@
                      (= (:db-type app-db) :h2) u/upper-case-en)]
     (t2/with-connection [^Connection conn]
       (with-open [rset (.getColumns (.getMetaData conn) nil nil table-name nil)]
-        (into {} (take-while some?)
-              (repeatedly
-               (fn []
+        (into {}
+              (iteration
+               (fn [_]
                  (when (.next rset)
                    [(.getString rset "COLUMN_NAME") (.getString rset "TYPE_NAME")]))))))))

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -31,9 +31,7 @@
    [metabase.test.fixtures :as fixtures]
    [metabase.test.util.random :as tu.random]
    [toucan2.core :as t2]
-   [toucan2.execute :as t2.execute])
-  (:import
-   (java.sql Connection)))
+   [toucan2.execute :as t2.execute]))
 
 (set! *warn-on-reflection* true)
 
@@ -69,16 +67,6 @@
                                          :is_active    true
                                          :is_superuser false)))
 
-(defn app-db-column-types
-  "Returns a map of all column names to their respective type names, for the given `table-name`, by using the JDBC
-  .getMetaData method of the given `conn` (which is presumed to be an app DB connection)."
-  [^Connection conn table-name]
-  (with-open [rset (.getColumns (.getMetaData conn) nil nil table-name nil)]
-    (into {} (take-while some?)
-             (repeatedly
-               (fn []
-                 (when (.next rset)
-                   [(.getString rset "COLUMN_NAME") (.getString rset "TYPE_NAME")]))))))
 
 (deftest make-database-details-not-null-test
   (testing "Migrations v45.00-042 and v45.00-043: set default value of '{}' for Database rows with NULL details"


### PR DESCRIPTION
When loading from a backup, we should not fail if the previous version saved keys that are no longer needed in the current version. This adds a step (after ingestion but before loading) that removes any "extra" keys from the ingested entity.

Co-authored by: escherize <343288+escherize@users.noreply.github.com>