### PR TITLE
[E2E] Fix dashboard card resize flake

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
@@ -236,7 +236,7 @@ describe("scenarios > dashboard card resizing", () => {
 
   it(
     `should not allow cards to be resized smaller than min height`,
-    { tags: "@flaky" },
+    { tags: "@flaky", requestTimeout: 15000 },
     () => {
       const cardIds = [];
       TEST_QUESTIONS.forEach(question => {

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
@@ -236,7 +236,7 @@ describe("scenarios > dashboard card resizing", () => {
 
   it(
     `should not allow cards to be resized smaller than min height`,
-    { tags: "@flaky", requestTimeout: 15000 },
+    { requestTimeout: 15000 },
     () => {
       const cardIds = [];
       TEST_QUESTIONS.forEach(question => {

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
@@ -236,7 +236,7 @@ describe("scenarios > dashboard card resizing", () => {
 
   it(
     `should not allow cards to be resized smaller than min height`,
-    { requestTimeout: 15000 },
+    { requestTimeout: 15000, tags: "@slow" },
     () => {
       const cardIds = [];
       TEST_QUESTIONS.forEach(question => {


### PR DESCRIPTION
### Stats
This particular flake is responsible for most failed runs in the last two days
![image](https://github.com/metabase/metabase/assets/31325167/30a35663-3cd2-4bbb-b897-4b391b37466e)

Examples of failed runs:
- https://www.deploysentinel.com/ci/runs/65523f0a7bcc148681c76757
- https://www.deploysentinel.com/ci/runs/6552b13d7bcc148681e0a6c9
- https://www.deploysentinel.com/ci/runs/655324cec9fa8b50a4d7c21b

### The cause
This dashboard contains 17 cards. It fires a request and waits for the response for each of them. A helper `visitDashboard()` makes sure we intercept each of these requests. When the conditions are particularly bad in CI, Cypress times out because it takes more than 5000 ms for a request to go out.

![image](https://github.com/metabase/metabase/assets/31325167/14087a67-2c5b-4477-8937-99c66d39d004)

### The solution
Increase the `requestTimeout` for this particular test only from the default 5000 ms to 15000 ms. This should give Cypress more time even in bad CI conditions. For the reference: https://docs.cypress.io/guides/references/configuration#Timeouts
> Time, in milliseconds, to wait for a request to go out in a `cy.wait()` command.

### Stress-Tests
In order to increase the chance of hitting this problem I spun up three different runners, and burned through the fix ten times in each. All green ✅ 
- https://github.com/metabase/metabase/actions/runs/6878276061
- https://github.com/metabase/metabase/actions/runs/6878278349
- https://github.com/metabase/metabase/actions/runs/6878281052

### Additional Notes
I'm working on a fix for a related flake from this spec ("should display all visualization cards with their default sizes") where it makes sense to apply this same approach. But in order to keep the diff clean, I'll fix the other one in a separate PR.