### PR TITLE
Fixing aggregate dropdowns in dashboard filters

### DIFF
--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -785,6 +785,7 @@
         :let  [ttag      (get-template-tag dimension card)
                dimension (condp mbql.u/is-clause? dimension
                            :field        dimension
+                           :expression   dimension
                            :template-tag (:dimension ttag)
                            (log/error "cannot handle this dimension" {:dimension dimension}))
                field-id  (or

--- a/src/metabase/models/params/custom_values.clj
+++ b/src/metabase/models/params/custom_values.clj
@@ -52,13 +52,16 @@
 
 (defn- values-from-card-query
   [card value-field query]
-  (let [value-base-type (:base_type (qp.util/field->field-info value-field (:result_metadata card)))]
+  (let [value-base-type (:base_type (qp.util/field->field-info value-field (:result_metadata card)))
+        expressions (get-in card [:dataset_query :query :expressions])]
     {:database (:database_id card)
      :type     :query
      :query    (merge
-                 {:source-table (format "card__%d" (:id card))
-                  :breakout     [value-field]
-                  :limit        *max-rows*}
+                 (cond-> {:source-table (format "card__%d" (:id card))
+                          :breakout     [value-field]
+                          :limit        *max-rows*}
+                   expressions
+                   (assoc :expressions expressions))
                  {:filter [:and
                            [(if (isa? value-base-type :type/Text)
                               :not-empty

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -3833,3 +3833,42 @@
               (is (= {:values          [["Abbeville"] ["Aberdeen"] ["Abilene"] ["Abiquiu"] ["Ackworth"]]
                       :has_more_values true}
                      (update response :values (partial take 5)))))))))))
+
+(deftest param-values-expression-test
+  (testing "Ensure param value lookup works for when the value is an expression"
+    (mt/dataset sample-dataset
+      (mt/with-temp-copy-of-db
+        (perms/revoke-data-perms! (perms-group/all-users) (mt/id))
+        (perms/grant-permissions! (perms-group/all-users) (perms/table-read-path (mt/id :products)))
+        (mt/with-temp [Dashboard {dashboard-id :id} {:name       "Test Dashboard"
+                                                     :parameters [{:name      "Vendor Title"
+                                                                   :slug      "vendor_title"
+                                                                   :id        "_VENDOR_TITLE_"
+                                                                   :type      :string/=
+                                                                   :sectionId "string"}]}
+                       Card {base-card-id :id} {:dataset_query {:database (mt/id)
+                                                                :type     :query
+                                                                :query    {:source-table (mt/id :products)}}}
+                       Card {final-card-id :id} {:dataset_query {:database (mt/id)
+                                                                 :type     :query
+                                                                 :query    {:expressions  {"VendorTitle" [:concat
+                                                                                                          [:field
+                                                                                                           "vendor"
+                                                                                                           {:base-type :type/Text}]
+                                                                                                          "🦜🦜🦜"
+                                                                                                          [:field
+                                                                                                           "title"
+                                                                                                           {:base-type :type/Text}]]},
+                                                                            :source-table (format "card__%s" base-card-id)}}}
+                       DashboardCard {_ :id} {:dashboard_id       dashboard-id
+                                              :card_id            final-card-id
+                                              :parameter_mappings [{:card_id      final-card-id
+                                                                    :parameter_id "_VENDOR_TITLE_"
+                                                                    :target       [:dimension [:expression "VendorTitle"]]}]}]
+          (let [param "_VENDOR_TITLE_"
+                url   (str "dashboard/" dashboard-id "/params/" param "/values")
+                {:keys [values has_more_values]} (mt/user-http-request :rasta :get 200 url)]
+            (is (false? has_more_values))
+            (testing "We have values and they all match the expression concatenation"
+              (is (pos? (count values)))
+              (is (every? (partial re-matches #"[^🦜]+🦜🦜🦜[^🦜]+") (map first values))))))))))


### PR DESCRIPTION
The `values-from-card-query` constructs a new query to determine enumerable values for filter drop-downs in dashboards. It does this by generating a simple query from the passed in query with the filtered value as a query filter. This query didn't know about expressions which the filter might use. The fix was to just add in the expressions from the base query.

Fixes #12985