### PR TITLE
[E2E] Fix dashboard card "default sizes" flake

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
@@ -217,8 +217,27 @@ describe("scenarios > dashboard card resizing", () => {
           cy.findByLabelText("Add questions").click();
         });
 
-        TEST_QUESTIONS.forEach(question => {
-          cy.findByLabelText(question.name).click();
+        /**
+         * Metabase sorts all questions in the sidebar alphabetically.
+         * It makes sense to sort them out here as well in order to avoid
+         * Cypress "jumping" up and down while clicking on them.
+         * It will go in order from top to the bottom, which scrolls the
+         * sidebar naturally. This prevents acting on an element that's not visible.
+         */
+        const sortedCards = TEST_QUESTIONS.sort((a, b) =>
+          a.name.localeCompare(b.name),
+        );
+
+        /**
+         * After each card is added to the dashboard from the sidebar, there is a
+         * request to load the card query. We need to wait for each of those before
+         * we attempt to add a new card. Otherwise the save dashboard might fail
+         * because Cypress is too fast.
+         */
+        cy.intercept("POST", "/api/card/**/query").as("cardQuery");
+        sortedCards.forEach(question => {
+          cy.findByLabelText(question.name).should("be.visible").click();
+          cy.wait("@cardQuery");
         });
 
         saveDashboard();

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
@@ -204,7 +204,7 @@ describe("scenarios > dashboard card resizing", () => {
 
   it(
     "should display all visualization cards with their default sizes",
-    { tags: "@flaky" },
+    { requestTimeout: 15000 },
     () => {
       TEST_QUESTIONS.forEach(question => {
         cy.createQuestion(question);

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
@@ -204,7 +204,7 @@ describe("scenarios > dashboard card resizing", () => {
 
   it(
     "should display all visualization cards with their default sizes",
-    { requestTimeout: 15000 },
+    { requestTimeout: 15000, tags: "@slow" },
     () => {
       TEST_QUESTIONS.forEach(question => {
         cy.createQuestion(question);


### PR DESCRIPTION
This flake (and the flake fix) is somewhat related to #35751 in that we're using the same set of 17 questions in a dashboard.

### Stats
![image](https://github.com/metabase/metabase/assets/31325167/30a35663-3cd2-4bbb-b897-4b391b37466e)

Examples of failed runs:
- https://www.deploysentinel.com/ci/runs/655284a0c9fa8b50a4c496f4
- https://www.deploysentinel.com/ci/runs/6552b09e2beaab0325ce6abc
- https://www.deploysentinel.com/ci/runs/65523ecb7bcc148681c75b66

### The cause
Cypress is moving very faster through UI, and it doesn't wait for all requests/responses to finish before trying to save the dashboard. So that save fails. _I guess one could reproduce this even locally if one clicks too fast and adds too many questions to the dashboard._
![image](https://github.com/metabase/metabase/assets/31325167/3f77fc53-d41d-4977-a8c7-613ad6c419b5)

Each time we add a card to the dashboard, there is a pair of requests that we need to take into account:
1. `GET /api/card/:id` 
2. `POST /api/card/:id/query` (or `POST /api/card/pivot/:id/query`)

### The solution
Wait for the card query to load before we attempt to add the next question/card. This ensures everything's in order before we attempt to save the changes to the dashboard.

![Screenshot 2023-11-15 at 16 52 13](https://github.com/metabase/metabase/assets/31325167/6ecf492b-501b-406a-b332-ff42ba0639bc)

Compare this with the chaotic order oof requests from the failed run

![image](https://github.com/metabase/metabase/assets/31325167/2380f517-a7be-4165-b261-051f34eed354)

### Stress-test
- https://github.com/metabase/metabase/actions/runs/6879649254
- https://github.com/metabase/metabase/actions/runs/6879645906
- https://github.com/metabase/metabase/actions/runs/6879642268