### PR TITLE
Tweak audit view migration test to catch subsequent migrations that break the views

### DIFF
--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -559,7 +559,9 @@
 
 (deftest audit-v2-views-test
   (testing "Migrations v48.00-029 - v48.00-040"
-    (impl/test-migrations ["v48.00-029" "v48.00-040"] [migrate!]
+    ;; Use an open-ended migration range so that we can detect if any migrations added after these views broke the view
+    ;; queries
+    (impl/test-migrations ["v48.00-029"] [migrate!]
       (let [new-view-names ["v_audit_log"
                             "v_content"
                             "v_dashboardcard"


### PR DESCRIPTION
Switches the test to use an open-ended migration range, so that `migrate!` will create all the views and then run all subsequent migrations. This should catch if a migration added after the views breaks the view queries, such as renaming a table that they depend on.