### PR TITLE
Support log and pow y-axis scales

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
@@ -16,10 +16,8 @@ import { getCartesianChartColumns } from "metabase/visualizations/lib/graph/colu
 import {
   getDatasetExtents,
   getJoinedCardsDataset,
-  getNormalizedDataset,
-  getNullReplacerFunction,
   getSortedSeriesModels,
-  replaceValues,
+  getTransformedDataset,
 } from "metabase/visualizations/echarts/cartesian/model/dataset";
 import {
   getYAxesExtents,
@@ -84,15 +82,12 @@ export const getCartesianChartModel = (
   const seriesModels = getSortedSeriesModels(unsortedSeriesModels, settings);
 
   const seriesDataKeys = seriesModels.map(seriesModel => seriesModel.dataKey);
-  const dataset = replaceValues(
-    getJoinedCardsDataset(rawSeries, cardsColumns),
-    getNullReplacerFunction(settings, seriesModels),
-  );
-
-  const normalizedDataset = getNormalizedDataset(
+  const dataset = getJoinedCardsDataset(rawSeries, cardsColumns);
+  const transformedDataset = getTransformedDataset(
     dataset,
-    seriesDataKeys,
-    dimensionModel.dataKey,
+    seriesModels,
+    settings,
+    dimensionModel,
   );
 
   const extents = getDatasetExtents(seriesDataKeys, dataset);
@@ -118,7 +113,7 @@ export const getCartesianChartModel = (
 
   return {
     dataset,
-    normalizedDataset,
+    transformedDataset,
     seriesModels,
     dimensionModel,
     yAxisSplit,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
@@ -23,8 +23,18 @@ import {
 export const getSeriesVizSettingsKey = (
   columnNameOrFormattedBreakoutValue: string,
   isFirstCard: boolean,
+  hasMultipleCards: boolean,
+  metricsCount: number,
+  isBreakoutSeries: boolean,
   cardName?: string,
 ): VizSettingsKey => {
+  const isSingleMetricCard = metricsCount === 1 && !isBreakoutSeries;
+
+  // When multiple cards are combined and one of them is a single metric card without a breakout,
+  // the default series name is the card name.
+  if (hasMultipleCards && isSingleMetricCard) {
+    return cardName ?? columnNameOrFormattedBreakoutValue;
+  }
   // When multiple cards are combined on a dashboard, all cards
   // except the first include the card name in the viz settings key.
   const prefix = isFirstCard && cardName == null ? `${cardName}: ` : "";
@@ -116,6 +126,9 @@ export const getCardSeriesModels = (
       const vizSettingsKey = getSeriesVizSettingsKey(
         metric.column.name,
         isFirstCard,
+        hasMultipleCards,
+        columns.metrics.length,
+        false,
         card.name,
       );
       const legacySeriesSettingsObjectKey =
@@ -160,6 +173,9 @@ export const getCardSeriesModels = (
     const vizSettingsKey = getSeriesVizSettingsKey(
       formattedBreakoutValue,
       isFirstCard,
+      hasMultipleCards,
+      1,
+      true,
       card.name,
     );
     const legacySeriesSettingsObjectKey =

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -57,7 +57,7 @@ export type CartesianChartModel = {
   dimensionModel: DimensionModel;
   seriesModels: SeriesModel[];
   dataset: GroupedDataset;
-  normalizedDataset: GroupedDataset;
+  transformedDataset: GroupedDataset;
   yAxisSplit: AxisSplit;
   yAxisExtents: AxisExtents;
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
@@ -18,6 +18,7 @@ import type {
 } from "metabase/visualizations/echarts/cartesian/option/types";
 import { CHART_STYLE } from "metabase/visualizations/echarts/cartesian/option/style";
 
+import { getMetricDisplayValueGetter } from "metabase/visualizations/echarts/cartesian/model/dataset";
 import { isNumeric } from "metabase-lib/types/utils/isa";
 
 const NORMALIZED_RANGE = { min: 0, max: 1 };
@@ -321,7 +322,11 @@ const buildMetricAxis = (
     renderingContext,
   );
 
+  const valueGetter = getMetricDisplayValueGetter(settings);
+  const axisType = settings["graph.y_axis.scale"] === "log" ? "log" : "value";
+
   return {
+    type: axisType,
     ...range,
     ...getAxisNameDefaultOption(
       renderingContext,
@@ -340,7 +345,7 @@ const buildMetricAxis = (
       show: !!settings["graph.y_axis.axis_enabled"],
       ...getTicksDefaultOption(renderingContext),
       // @ts-expect-error TODO: figure out EChart types
-      formatter,
+      formatter: value => formatter(valueGetter(value)),
     },
   };
 };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -31,8 +31,7 @@ export const getCartesianChartOption = (
     ...chartModel.seriesModels.map(seriesModel => seriesModel.dataKey),
   ];
   const echartsDataset = [
-    { source: chartModel.dataset, dimensions },
-    { source: chartModel.normalizedDataset, dimensions },
+    { source: chartModel.transformedDataset, dimensions },
   ];
 
   return {

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -10,6 +10,7 @@ import type {
 } from "metabase/visualizations/types";
 import type { SeriesSettings } from "metabase-types/api";
 import { isNotNull } from "metabase/lib/types";
+import { getMetricDisplayValueGetter } from "metabase/visualizations/echarts/cartesian/model/dataset";
 
 const buildEChartsLabelOptions = (
   seriesModel: SeriesModel,
@@ -22,6 +23,8 @@ const buildEChartsLabelOptions = (
       jsx: false,
       compact: settings["graph.label_value_formatting"] === "compact",
     });
+
+  const valueGetter = getMetricDisplayValueGetter(settings);
 
   return {
     show: settings["graph.show_values"],
@@ -39,7 +42,7 @@ const buildEChartsLabelOptions = (
       if (dimensionName == null) {
         return " ";
       }
-      const value = (datum?.value as any)?.[dimensionName];
+      const value = valueGetter((datum?.value as any)?.[dimensionName]);
       return valueFormatter(value);
     },
   };
@@ -55,13 +58,10 @@ const buildEChartsBarSeries = (
 ): RegisteredSeriesOption["bar"] => {
   const stackName =
     settings["stackable.stack_type"] != null ? `bar_${yAxisIndex}` : undefined;
-  const datasetIndex =
-    settings["stackable.stack_type"] === "normalized" ? 1 : 0;
 
   return {
     type: "bar",
     yAxisIndex,
-    datasetIndex,
     stack: stackName,
     encode: {
       y: seriesModel.dataKey,
@@ -89,13 +89,10 @@ const buildEChartsLineAreaSeries = (
 
   const stackName =
     settings["stackable.stack_type"] != null ? `area_${yAxisIndex}` : undefined;
-  const datasetIndex =
-    settings["stackable.stack_type"] === "normalized" ? 1 : 0;
 
   return {
     type: "line",
     yAxisIndex,
-    datasetIndex,
     showSymbol: seriesSettings["line.marker_enabled"] !== false,
     symbolSize: 6,
     smooth: seriesSettings["line.interpolate"] === "cardinal",

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/types.ts
@@ -1,9 +1,11 @@
+import type { RowValue } from "metabase-types/api";
+
 export type AxisRange = {
   min?: number;
   max?: number;
 };
 
-export type AxisFormatter = (value: unknown) => string;
+export type AxisFormatter = (value: RowValue) => string;
 
 export type AxesFormatters = {
   left?: AxisFormatter;


### PR DESCRIPTION
### Description

Adds the support of log/pow Y-axis scales. ECharts ticks behavior is slightly different, so for power scale ticks are evenly spaced.

### How to verify

1. Create a dashboard with questions that use all types of Y-axes: linear, log, pow
2. Sent a test subscription
3. Ensure the static viz renders them correctly

### Demo

#### Log
Dashcard:
<img width="688" alt="Screenshot 2023-11-15 at 8 37 50 PM" src="https://github.com/metabase/metabase/assets/14301985/a0f25f69-b0e7-4e81-a986-843aad4fe827">

Static viz:
<img width="596" alt="Screenshot 2023-11-15 at 8 38 02 PM" src="https://github.com/metabase/metabase/assets/14301985/ea8a1e17-91a1-486d-bd7f-5c4c35855af4">


#### Power
Dashcard:
<img width="688" alt="Screenshot 2023-11-15 at 8 37 46 PM" src="https://github.com/metabase/metabase/assets/14301985/05f40a58-fad6-41b2-83c8-adaa051e66f8">

Static viz:
<img width="599" alt="Screenshot 2023-11-15 at 8 37 58 PM" src="https://github.com/metabase/metabase/assets/14301985/1a494496-dc16-41d3-9f82-9f22642ddf4d">

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
