### PR TITLE
type createThunkAction to avoid it leaking anys in all the codebase

### DIFF
--- a/frontend/src/metabase/lib/redux/typed-utils.ts
+++ b/frontend/src/metabase/lib/redux/typed-utils.ts
@@ -1,5 +1,6 @@
 import { createAsyncThunk as createAsyncThunkOriginal } from "@reduxjs/toolkit";
-import type { State } from "metabase-types/store";
+import type { State, Dispatch, GetState } from "metabase-types/store";
+import { withAction } from "./utils";
 
 interface ThunkConfig {
   state: State;
@@ -7,3 +8,14 @@ interface ThunkConfig {
 
 export const createAsyncThunk =
   createAsyncThunkOriginal.withTypes<ThunkConfig>();
+
+// similar to createAction but accepts a (redux-thunk style) thunk and dispatches based on whether
+// the promise returned from the thunk resolves or rejects, similar to redux-promise
+export function createThunkAction<TArgs extends any[]>(
+  actionType: string,
+  thunkCreator: (
+    ...args: TArgs
+  ) => (dispatch: Dispatch, getState: GetState) => any,
+): (...args: TArgs) => any {
+  return withAction(actionType)(thunkCreator);
+}

--- a/frontend/src/metabase/lib/redux/utils.js
+++ b/frontend/src/metabase/lib/redux/utils.js
@@ -19,12 +19,6 @@ import { delay } from "metabase/lib/promise";
 export { combineReducers, compose } from "@reduxjs/toolkit";
 export { handleActions, createAction } from "redux-actions";
 
-// similar to createAction but accepts a (redux-thunk style) thunk and dispatches based on whether
-// the promise returned from the thunk resolves or rejects, similar to redux-promise
-export function createThunkAction(actionType, thunkCreator) {
-  return withAction(actionType)(thunkCreator);
-}
-
 // turns string timestamps into moment objects
 export function momentifyTimestamps(
   object,


### PR DESCRIPTION
### Description

`createThunkAction` is used in typescript files, and we often type the functions that we pass to it.
Unfortunately the returned action/thunk creator is typed as any and therefore type checking on the arguments doesn't work:
<img width="756" alt="image" src="https://github.com/metabase/metabase/assets/1914270/6c9c7113-f365-401f-8edf-cd50a16293dc">

This pr addresses that:

<img width="478" alt="image" src="https://github.com/metabase/metabase/assets/1914270/82d7bbad-51b0-47ea-97fb-3c5cbd09582b">

It should also automatically type dispatch and getState, which is a nice 
<img width="754" alt="image" src="https://github.com/metabase/metabase/assets/1914270/36d0a1d4-1114-49cd-8a97-67f2e9df7964">

