### PR TITLE
UI Library text updates

### DIFF
--- a/frontend/src/metabase/ui/components/inputs/Checkbox/Checkbox.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Checkbox/Checkbox.styled.tsx
@@ -62,7 +62,6 @@ export const getCheckboxOverrides = (): MantineThemeOverride["components"] => ({
         ref: getStylesRef("label"),
         color: theme.colors.text[2],
         fontSize: theme.fontSizes.md,
-        fontWeight: "bold",
         lineHeight: theme.lineHeight,
       },
       description: {

--- a/frontend/src/metabase/ui/components/inputs/DateInput/DateInput.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/DateInput/DateInput.styled.tsx
@@ -1,4 +1,5 @@
 import type { MantineThemeOverride } from "@mantine/core";
+import { getSize } from "@mantine/core";
 
 export const getDateInputOverrides =
   (): MantineThemeOverride["components"] => ({
@@ -6,7 +7,7 @@ export const getDateInputOverrides =
       defaultProps: {
         size: "md",
       },
-      styles: theme => ({
+      styles: (theme, _, { size = "md" }) => ({
         wrapper: {
           "&:not(:only-child)": {
             marginTop: theme.spacing.xs,
@@ -14,6 +15,10 @@ export const getDateInputOverrides =
         },
         calendar: {
           padding: `${theme.spacing.sm} ${theme.spacing.md}`,
+        },
+        label: {
+          color: theme.colors.text[1],
+          fontSize: getSize({ size, sizes: theme.fontSizes }),
         },
       }),
     },

--- a/frontend/src/metabase/ui/components/inputs/FileInput/FileInput.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/FileInput/FileInput.styled.tsx
@@ -1,4 +1,5 @@
 import type { MantineThemeOverride } from "@mantine/core";
+import { getSize } from "@mantine/core";
 import { FileInputValue } from "./FileInputValue";
 
 export const getFileInputOverrides =
@@ -8,9 +9,13 @@ export const getFileInputOverrides =
         size: "md",
         valueComponent: FileInputValue,
       },
-      styles: theme => ({
+      styles: (theme, _, { size = "md" }) => ({
         wrapper: {
           marginTop: theme.spacing.xs,
+        },
+        label: {
+          color: theme.colors.text[1],
+          fontSize: getSize({ size, sizes: theme.fontSizes }),
         },
       }),
     },

--- a/frontend/src/metabase/ui/components/inputs/Radio/Radio.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Radio/Radio.styled.tsx
@@ -59,7 +59,6 @@ export const getRadioOverrides = (): MantineThemeOverride["components"] => ({
         ref: getStylesRef("label"),
         color: theme.colors.text[2],
         fontSize: theme.fontSizes.md,
-        fontWeight: "bold",
       },
       description: {
         ref: getStylesRef("description"),

--- a/frontend/src/metabase/ui/components/inputs/Select/Select.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.styled.tsx
@@ -1,4 +1,4 @@
-import { px, rem } from "@mantine/core";
+import { px, rem, getSize } from "@mantine/core";
 import type { MantineThemeOverride } from "@mantine/core";
 import { SelectItem } from "./SelectItem";
 
@@ -10,9 +10,13 @@ export const getSelectOverrides = (): MantineThemeOverride["components"] => ({
       itemComponent: SelectItem,
       maxDropdownHeight: 512,
     },
-    styles: theme => ({
+    styles: (theme, _, { size = "md" }) => ({
       wrapper: {
         marginTop: theme.spacing.xs,
+      },
+      label: {
+        color: theme.colors.text[1],
+        fontSize: getSize({ size, sizes: theme.fontSizes }),
       },
       rightSection: {
         svg: {

--- a/frontend/src/metabase/ui/components/inputs/Switch/Switch.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Switch/Switch.styled.tsx
@@ -69,7 +69,6 @@ export const getSwitchOverrides = (): MantineThemeOverride["components"] => ({
         },
         label: {
           padding: 0,
-          fontWeight: 700,
           fontSize: getSize({ size, sizes: LABEL_FONT_SIZES }),
           lineHeight: getSize({ size, sizes: LABEL_LINE_HEIGHT }),
           color: theme.colors.text[2],

--- a/frontend/src/metabase/ui/components/inputs/TextInput/TextInput.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/TextInput/TextInput.styled.tsx
@@ -1,4 +1,5 @@
 import type { MantineThemeOverride } from "@mantine/core";
+import { getSize } from "@mantine/core";
 
 export const getTextInputOverrides =
   (): MantineThemeOverride["components"] => ({
@@ -6,9 +7,13 @@ export const getTextInputOverrides =
       defaultProps: {
         size: "md",
       },
-      styles: theme => ({
+      styles: (theme, _, { size = "md" }) => ({
         wrapper: {
           marginTop: theme.spacing.xs,
+        },
+        label: {
+          color: theme.colors.text[1],
+          fontSize: getSize({ size, sizes: theme.fontSizes }),
         },
       }),
     },

--- a/frontend/src/metabase/ui/components/inputs/Textarea/Textarea.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Textarea/Textarea.styled.tsx
@@ -1,13 +1,18 @@
 import type { MantineThemeOverride } from "@mantine/core";
+import { getSize } from "@mantine/core";
 
 export const getTextareaOverrides = (): MantineThemeOverride["components"] => ({
   Textarea: {
     defaultProps: {
       size: "md",
     },
-    styles: theme => ({
+    styles: (theme, _, { size = "md" }) => ({
       wrapper: {
         marginTop: theme.spacing.xs,
+      },
+      label: {
+        color: theme.colors.text[1],
+        fontSize: getSize({ size, sizes: theme.fontSizes }),
       },
     }),
   },


### PR DESCRIPTION
- use normal font weight for 'values'
- update label styles across inputs

We had a few inconsistencies in size and color across our Figma components. Those have been updated to standardize on 14px text-medium and bold for labels, and 14px text-dark regular weight for values. This PR puts those sync'd values into place here in code.
