### PR TITLE
Underlying-records drill should generate correct filters for binned columns

### DIFF
--- a/src/metabase/lib/binning.cljc
+++ b/src/metabase/lib/binning.cljc
@@ -1,12 +1,13 @@
 (ns metabase.lib.binning
   (:require
+   [metabase.lib.binning.util :as lib.binning.util]
    [metabase.lib.dispatch :as lib.dispatch]
    [metabase.lib.hierarchy :as lib.hierarchy]
-   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.binning :as lib.schema.binning]
    [metabase.lib.schema.common :as lib.schema.common]
+   [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.shared.formatting.numbers :as fmt.num]
    [metabase.shared.util.i18n :as i18n]
    [metabase.util.malli :as mu]))
@@ -109,7 +110,7 @@
   "This is implemented outside of [[lib.metadata.calculation/display-name]] because it needs access to the field type.
   It's called directly by `:field` or `:metadata/column`'s [[lib.metadata.calculation/display-name]]."
   [{:keys [bin-width num-bins strategy] :as binning-options} :- ::lib.schema.binning/binning
-   column-metadata                                           :- lib.metadata/ColumnMetadata]
+   column-metadata                                           :- ::lib.schema.metadata/column]
   (when binning-options
     (case strategy
       :num-bins  (i18n/trun "{0} bin" "{0} bins" num-bins)
@@ -136,3 +137,31 @@
    column-binning :- [:maybe ::lib.schema.binning/binning]]
   (= (:mbql binning-option)
      (select-keys column-binning [:strategy :num-bins :bin-width])))
+
+(mu/defn resolve-bin-width :- [:maybe [:map
+                                       [:bin-width number?]
+                                       [:min-value number?]
+                                       [:max-value number?]]]
+  "If a `column` is binned, resolve the actual bin width that will be used when a query is processed as well as min
+  and max values."
+  [column-metadata :- ::lib.schema.metadata/column
+   value           :- number?]
+  (when-let [binning-options (binning column-metadata)]
+    (case (:strategy binning-options)
+      :num-bins
+      (when-let [{min-value :min, max-value :max, :as _number-fingerprint} (get-in column-metadata [:fingerprint :type :type/Number])]
+        (let [{:keys [num-bins]} binning-options
+              bin-width          (lib.binning.util/nicer-bin-width min-value max-value num-bins)]
+          {:bin-width bin-width
+           :min-value value
+           :max-value (+ value bin-width)}))
+
+      :bin-width
+      (let [{:keys [bin-width]} binning-options]
+        (assert (number? bin-width))
+        {:bin-width bin-width
+         :min-value value
+         :max-value (+ value bin-width)})
+
+      :default
+      nil)))

--- a/src/metabase/lib/drill_thru.cljc
+++ b/src/metabase/lib/drill_thru.cljc
@@ -20,6 +20,8 @@
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
+   [metabase.util :as u]
+   [metabase.util.log :as log]
    [metabase.util.malli :as mu]))
 
 (comment
@@ -109,4 +111,6 @@
     stage-number :- :int
     drill        :- ::lib.schema.drill-thru/drill-thru
     & args]
+   (log/infof "Applying drill thru: %s"
+              (u/pprint-to-str {:query query, :stage-number stage-number, :drill drill, :args args}))
    (apply lib.drill-thru.common/drill-thru-method query stage-number drill args)))

--- a/src/metabase/lib/js/metadata.cljs
+++ b/src/metabase/lib/js/metadata.cljs
@@ -211,8 +211,9 @@
 
 (defmethod rename-key-fn :field
   [_object-type]
-  {:source :lib/source
-   :unit   :metabase.lib.field/temporal-unit})
+  {:source       :lib/source
+   :unit         :metabase.lib.field/temporal-unit
+   :binning-info :metabase.lib.field/binning})
 
 (defn- parse-field-id
   [id]
@@ -220,6 +221,20 @@
     ;; sometimes instead of an ID we get a field reference
     ;; with the name of the column in the second position
     (vector? id) second))
+
+(defn- parse-binning-info
+  [m]
+  (obj->clj
+   (map (fn [[k v]]
+          (let [k (keyword (u/->kebab-case-en k))
+                k (if (= k :binning-strategy)
+                    :strategy
+                    k)
+                v (if (= k :strategy)
+                    (keyword v)
+                    v)]
+            [k v])))
+   m))
 
 (defmethod parse-field-fn :field
   [_object-type]
@@ -240,6 +255,7 @@
       :semantic-type                    (keyword v)
       :visibility-type                  (keyword v)
       :id                               (parse-field-id v)
+      :metabase.lib.field/binning       (parse-binning-info v)
       v)))
 
 (defmethod parse-objects :field

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -615,9 +615,12 @@
 
      (pprint-to-str 'green some-obj)"
   (^String [x]
-   (with-out-str
-     #_{:clj-kondo/ignore [:discouraged-var]}
-     (pprint/pprint x)))
+   ;; we try to set this permanently above, but it doesn't seem to work in Cljs, so just bind it every time. The
+   ;; default value wastes too much space, 120 is a little easier to read actually.
+   (#?@(:clj [do] :cljs [binding [pprint/*print-right-margin* 120]])
+     (with-out-str
+       #_{:clj-kondo/ignore [:discouraged-var]}
+       (pprint/pprint x))))
 
   (^String [color-symb x]
    (u.format/colorize color-symb (pprint-to-str x))))

--- a/test/metabase/lib/drill_thru/underlying_records_test.cljc
+++ b/test/metabase/lib/drill_thru/underlying_records_test.cljc
@@ -105,7 +105,9 @@
                         [[:= {}
                           (-> (:column-ref breakout-dim)
                               (lib.options/with-options {:temporal-unit :month}))
-                          last-month]])))
+                          last-month]]))))
+
+(deftest ^:parallel underlying-records-apply-test-2
   (testing "sum_where(subtotal, products.category = \"Doohickey\") over time"
     (underlying-state (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
                           (lib/aggregate (lib/sum-where
@@ -126,8 +128,9 @@
                          [:= {} (-> (meta/field-metadata :products :category)
                                     lib/ref
                                     (lib.options/with-options {}))
-                          "Doohickey"]])))
+                          "Doohickey"]]))))
 
+(deftest ^:parallel underlying-records-apply-test-3
   (testing "metric over time"
     (let [metric   {:description "Orders with a subtotal of $100 or more."
                     :archived false
@@ -149,8 +152,8 @@
                     :creator-id 1
                     :created-at "2023-10-04T20:11:34.029582"}
           provider (lib/composed-metadata-provider
-                     meta/metadata-provider
-                     (providers.mock/mock-metadata-provider {:metrics [metric]}))]
+                    meta/metadata-provider
+                    (providers.mock/mock-metadata-provider {:metrics [metric]}))]
       (underlying-state (-> (lib/query provider (meta/table-metadata :orders))
                             (lib/aggregate metric)
                             (lib/breakout (lib/with-temporal-bucket
@@ -211,3 +214,41 @@
                                 (-> (:column-ref created-at-dim)
                                     (lib.options/with-options {:temporal-unit :day-of-month}))
                                 1]])))))))
+
+(deftest ^:parallel binned-column-test
+  (testing "Underlying records for a binned column should generate a filters for current bin's min/max values (#35431)"
+    (let [query                    (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                                       (lib/aggregate (lib/count))
+                                       (lib/breakout (-> (meta/field-metadata :orders :quantity)
+                                                         (lib/with-binning {:strategy :num-bins, :num-bins 10}))))
+          col-count                (m/find-first #(= (:name %) "count")
+                                                 (lib/returned-columns query))
+          _                        (is (some? col-count))
+          col-orders-quantity      (m/find-first #(= (:name %) "QUANTITY")
+                                                 (lib/returned-columns query))
+          _                        (is (some? col-orders-quantity))
+          context                  {:column     col-count
+                                    :column-ref (lib/ref col-count)
+                                    :value      1
+                                    :dimensions [{:column     col-orders-quantity
+                                                  :column-ref (lib/ref col-orders-quantity)
+                                                  :value      20}]}
+          available-drills         (lib/available-drill-thrus query context)
+          underlying-records-drill (m/find-first #(= (:type %) :drill-thru/underlying-records)
+                                                 available-drills)
+          _                        (is (some? underlying-records-drill))
+          query'                   (lib/drill-thru query underlying-records-drill)]
+      (is (=? {:stages [{:lib/type :mbql.stage/mbql
+                         :filters  [[:>=
+                                     {}
+                                     [:field
+                                      {:binning (symbol "nil #_\"key is not present.\"")}
+                                      (meta/id :orders :quantity)]
+                                     20]
+                                    [:<
+                                     {}
+                                     [:field
+                                      {:binning (symbol "nil #_\"key is not present.\"")}
+                                      (meta/id :orders :quantity)]
+                                     30.0]]}]}
+              query')))))


### PR DESCRIPTION
Fixes #35341 

There were a few issues here

- QP results metadata comes back with `:binning_info` for binned columns, while `lib/binning` looks for `:metabase.lib.field/binning`. This PR updates the JS metadata provider to massage things into the expected MLv2 shape
- The underlying records drill did not check whether a column was binned and always generated a single `:=` filter; for binning it needs to calculate the bin's actual min max values (using the stuff recently backported from the QP code to power the `zoom-in-bins` drill) and generate a `:>=` and `:<` filter (`:between` is not appropriate here because `:between` is inclusive on both sides, like SQL `BETWEEN`. Since I already implemented this code for zoom-in bins recently I moved it in to `lib.binning` as a shared util function so it can be used here as well