### PR TITLE
Add an E2E test for Filter dropdown does not work in embedded applications when params is not an object

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -5,6 +5,7 @@ import {
   visitEmbeddedPage,
   filterWidget,
   visitIframe,
+  getDashboardCard,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
@@ -220,6 +221,32 @@ describe("scenarios > embedding > dashboard parameters", () => {
       );
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains(".ScalarValue", "2");
+    });
+  });
+
+  it("should render error message when `params` is not an object (metabase#14474)", () => {
+    cy.get("@dashboardId").then(dashboardId => {
+      cy.request("PUT", `/api/dashboard/${dashboardId}`, {
+        embedding_params: {
+          id: "enabled",
+          name: "enabled",
+          source: "enabled",
+          user_id: "enabled",
+        },
+        enable_embedding: true,
+      });
+
+      const invalidParamsValue = [];
+      const payload = {
+        resource: { dashboard: dashboardId },
+        params: invalidParamsValue,
+      };
+
+      visitEmbeddedPage(payload);
+
+      getDashboardCard()
+        .findByText("There was a problem displaying this chart.")
+        .should("be.visible");
     });
   });
 });


### PR DESCRIPTION
Closes #14474

#14474 is already solved i.e. when `params` isn't an object that isn't supported by design, we already show that in [server error log](https://github.com/metabase/metabase/issues/14474#issuecomment-1812555466). And now we're showing an error instead of showing results with broken filter autocompletion.

This PR adds a test to verify that when `params` isn't an object we show an error message instead.


### How to verify

Describe the steps to verify that the changes are working as expected.

Follow the reproduce steps from [this comment](https://github.com/metabase/metabase/issues/14474#issuecomment-764724524).

You can use [this Next JS app](https://github.com/WiNloSt/metabase-embeddings-101/blob/main/app/page.tsx) to test which makes it easy to test static embeddings, or use any setup of your choice.

### Demo

![image](https://github.com/metabase/metabase/assets/1937582/f5b504d2-36e2-4559-b22a-7f30acab75ce)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

