### PR TITLE
Remove non-existent input for `download-uberjar`

### DIFF
--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -51,7 +51,6 @@ jobs:
         uses: ./.github/actions/e2e-download-uberjar
         with:
           edition: 'ee'
-          was-built: false
 
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend


### PR DESCRIPTION
There is a warning in each stress-test workflow summary about an unexpected input
![image](https://github.com/metabase/metabase/assets/31325167/6877431f-eeb5-4ac8-b932-2809d0454e73)

Composite action "download-uberjar" doesn't accept `was-built` input ever since #35079. In particular, lines that removed this are [here](https://github.com/metabase/metabase/pull/35079/files#diff-3bc24e13e2aa6c3d50d79dc4bb5d819de9ac09c969da26abfa1ad86569fd89f1L7-L9).

This PR is just a cleanup.
After we merge this, the warning shouldn't appear anymore.
