### PR TITLE
Remove flaky remove-collection-color-test

### DIFF
--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -551,11 +551,7 @@
 
         (migrate!)
         (testing "should drop the existing color column"
-          (is (not (contains? (t2/select-one :model/Collection :id collection-id) :color))))
-
-        (migrate! :down 47)
-        (testing "Rollback to the previous version should restore the column column, and set the default color value"
-          (is (= "#31698A" (:color (t2/select-one :model/Collection :id collection-id)))))))))
+          (is (not (contains? (t2/select-one :model/Collection :id collection-id) :color))))))))
 
 (deftest audit-v2-views-test
   (testing "Migrations v48.00-029 - v48.00-040"


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/35576

This PR removes the part of `metabase.db.schema-migrations-test/remove-collection-color-test
` that keeps flaking on MySQL 8.0.

Obviously it would be ideal to fix the problem so it doesn't happen again, but at least in this way we can at least solve the CI flake first so others don't have to re-run CI in the meantime.

The risk introduced by removing this test is relatively low. This is a migration rollback test that's realistically unlikely to be broken by future changes, because we never change migrations.

We did the same thing in the past here with another migration flake [here](https://github.com/metabase/metabase/pull/35654/commits/36f644b02c9fc42f8ac14f7bd0d78609ec14b374).