### PR TITLE
[E2E] Fix recent-views flake(s)

### DIFF
--- a/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
@@ -39,7 +39,7 @@ describe("search > recently viewed", () => {
     cy.findByTestId("loading-spinner").should("not.exist");
   });
 
-  it("shows list of recently viewed items", { tags: "@flaky" }, () => {
+  it("shows list of recently viewed items", () => {
     assertRecentlyViewedItem(0, "Orders in a dashboard", "Dashboard");
     assertRecentlyViewedItem(1, "Orders", "Question");
     assertRecentlyViewedItem(2, "People", "Table");

--- a/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
@@ -30,11 +30,11 @@ describe("search > recently viewed", () => {
     // inside the "Orders in a dashboard" dashboard, the order is queried again,
     // which elicits a ViewLog entry
 
-    cy.visit("/");
-
     cy.intercept(`/api/activity/recent_views`).as("recent");
-    cy.findByPlaceholderText("Search…").click();
+    cy.visit("/");
     cy.wait("@recent");
+
+    cy.findByPlaceholderText("Search…").click();
 
     cy.findByTestId("loading-spinner").should("not.exist");
   });


### PR DESCRIPTION
### Stats (for the last 7 days on `master`)
| type | %|
|-|-|
|Failure Rate|2.67%|
|Flake Rate|14.67%|

Examples of failed runs:
- https://www.deploysentinel.com/ci/runs/654e06607bcc1486818ec8c7
- https://www.deploysentinel.com/ci/runs/655326527bcc148681eac24a
- https://www.deploysentinel.com/ci/runs/655326707bcc148681eac795

![image](https://github.com/metabase/metabase/assets/31325167/a6bcf507-3dac-4b3d-b6ca-9cbe265064c8)

### The cause
Intercept and wait are placed in a wrong place. The request to get `/api/activity/recent_views` happens upon a home page visit, not when we click on the search. You can check this by doing a hard refresh on the home page. Observe the network tab. Then click on "Search..." - nothing happens.

### The solution
Wait for the response from this request upon the home page load.

### Stress-tests
3 x 20 ✅ 
- https://github.com/metabase/metabase/actions/runs/6887773655
- https://github.com/metabase/metabase/actions/runs/6887955037
- https://github.com/metabase/metabase/actions/runs/6888000135

### Additional Notes
This also seems to have fixed the other related flake (they are sharing the same `describe` block where the failure occurred). 
`"allows to select an item from keyboard`

Stress tests for it also reveal 3 x 20 ✅ 
- https://github.com/metabase/metabase/actions/runs/6888275796
- https://github.com/metabase/metabase/actions/runs/6888258557
- https://github.com/metabase/metabase/actions/runs/6888164373