### PR TITLE
remove e2e test with cy.wait

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -835,56 +835,7 @@ describe("scenarios > dashboard > parameters", () => {
           getDashboardCard(i).findByText("Select…").should("exist");
         }
       });
-
-      it("in case of two autowiring undo toast, the second one should last the default timeout of 5s", () => {
-        // The autowiring undo toasts use the same id, a bug in the undo logic caused the second toast to be dismissed by the
-        // timeout set by the first. See https://github.com/metabase/metabase/pull/35461#pullrequestreview-1731776862
-        const cardTemplate = {
-          card_id: ORDERS_BY_YEAR_QUESTION_ID,
-          row: 0,
-          col: 0,
-          size_x: 5,
-          size_y: 4,
-        };
-        const cards = [
-          {
-            ...cardTemplate,
-            col: 0,
-          },
-          {
-            ...cardTemplate,
-            col: 5,
-          },
-          {
-            ...cardTemplate,
-            col: 10,
-          },
-        ];
-
-        createDashboardWithCards(cards).then(dashboardId => {
-          visitDashboard(dashboardId);
-        });
-
-        editDashboard();
-
-        setFilter("Text or Category", "Is");
-
-        selectDashboardFilter(getDashboardCard(0), "Name");
-
-        removeFilterFromDashCard(0);
-        removeFilterFromDashCard(1);
-
-        cy.wait(2000);
-
-        selectDashboardFilter(getDashboardCard(0), "Name");
-
-        // since we waited 2 seconds earlier, if the toast is still visible after this other delay of 4s,
-        // it means the first timeout of 5s was cleared correctly
-        cy.wait(4000);
-        undoToast().should("exist");
-      });
     });
-
     describe("wiring parameters when adding a card", () => {
       it("should automatically wire a parameters to cards that are added to the dashboard", () => {
         const cards = [
@@ -1053,8 +1004,4 @@ function goToFilterMapping(name = "Text") {
   cy.findByTestId("edit-dashboard-parameters-widget-container")
     .findByText("Text")
     .click();
-}
-
-function removeFilterFromDashCard(dashcardIndex = 0) {
-  getDashboardCard(dashcardIndex).icon("close").click();
 }

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -867,6 +867,8 @@ describe("scenarios > dashboard > parameters", () => {
 
         editDashboard();
 
+        cy.clock();
+
         setFilter("Text or Category", "Is");
 
         selectDashboardFilter(getDashboardCard(0), "Name");
@@ -874,14 +876,18 @@ describe("scenarios > dashboard > parameters", () => {
         removeFilterFromDashCard(0);
         removeFilterFromDashCard(1);
 
-        cy.wait(2000);
+        cy.tick(2000);
 
         selectDashboardFilter(getDashboardCard(0), "Name");
 
         // since we waited 2 seconds earlier, if the toast is still visible after this other delay of 4s,
         // it means the first timeout of 5s was cleared correctly
-        cy.wait(4000);
+        cy.tick(4000);
         undoToast().should("exist");
+
+        cy.tick(2000);
+
+        undoToast().should("not.exist");
       });
     });
 


### PR DESCRIPTION
### Description

In [Add explanatory toast and Undo when auto-applying filters](https://github.com/metabase/metabase/pull/35461) I added both a [e2e test](https://github.com/metabase/metabase/pull/35461/commits/ce529c9a97288393ddd246fd81e8b21937c9ee31) and some [unit test](https://github.com/metabase/metabase/pull/35461/commits/ccd410993b94847ceb7adda91af57b364d02fe09).

~The e2e test require cy.wait to work, as I didn't find any other way of testing the feature.~

~If we're ok with testing the setTimeout/clearInterval issue only at the unit test level, then we could remove the e2e one.~

`cy.clock` does the trick

