### PR TITLE
[InfoText] Mock date in test for moment

### DIFF
--- a/frontend/src/metabase/search/components/InfoText/InfoText.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/InfoText/InfoText.unit.spec.tsx
@@ -71,6 +71,8 @@ async function setup({
   isCompact?: boolean;
   resultProps?: Partial<SearchResult>;
 } = {}) {
+  jest.spyOn(Date, "now").mockReturnValue(new Date(2023, 10, 1).getTime());
+
   setupTableEndpoints(MOCK_TABLE);
   setupDatabaseEndpoints(MOCK_DATABASE);
   setupUsersEndpoints([MOCK_USER, MOCK_OTHER_USER]);
@@ -107,7 +109,6 @@ async function setup({
     ).not.toBeInTheDocument(),
   );
 
-  // await waitforAssetLinkLoadingTextToBeRemoved()
   await waitForLoadingTextToBeRemoved();
 
   return {


### PR DESCRIPTION
### Description

Fixes date diff for moment usage in `InfoText.unit.spec.tsx` - moment calculated `fromNow` using date of running test as a base