### PR TITLE
Remove fromUrl parameter from QueryBuilder

### DIFF
--- a/e2e/test/scenarios/native/reproductions/35785-unexpected-redirect-after-question-save.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/35785-unexpected-redirect-after-question-save.cy.spec.js
@@ -1,0 +1,54 @@
+import { restore, modal } from "e2e/support/helpers";
+
+const nativeQuery =
+  "select * from products where created_at < {{max_date}} and created_at > {{from}} limit 5";
+
+const questionDetails = {
+  native: {
+    query: nativeQuery,
+    "template-tags": {
+      max_date: {
+        id: "32b7654f-38b1-2dfd-ded6-ed23c45ef5f6",
+        name: "max_date",
+        "display-name": "Max date",
+        type: "date",
+        default: "2030-01-01",
+        required: true,
+      },
+      from: {
+        id: "ddf7c404-38db-8b65-f90d-c6f4bd8127ec",
+        name: "from",
+        "display-name": "From",
+        type: "date",
+        default: "2022-10-02",
+        required: true,
+      },
+    },
+  },
+};
+
+describe("issue 35785", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+
+    cy.createNativeQuestion(questionDetails, { visitQuestion: true });
+
+    cy.intercept("GET", "/api/search?*").as("getSearchResults");
+  });
+
+  it("should not redirect to the value of 'from' URL parameter after saving (metabase#35785)", () => {
+    cy.findByTestId("native-query-editor-container")
+      .findByTestId("visibility-toggler")
+      .click();
+    cy.findByTestId("native-query-editor").type("{backspace}4");
+
+    cy.findByTestId("qb-header").findByRole("button", { name: "Save" }).click();
+
+    modal().findByRole("button", { name: "Save" }).click();
+
+    cy.wait("@getSearchResults");
+
+    cy.url().should("include", "/question");
+  });
+});

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { connect } from "react-redux";
-import { push } from "react-router-redux";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -104,7 +103,6 @@ const mapStateToProps = (state, props) => {
     user: getUser(state, props),
     canManageSubscriptions: canManageSubscriptions(state, props),
     isAdmin: getUserIsAdmin(state, props),
-    fromUrl: props.location.query?.from,
 
     mode: getMode(state),
 
@@ -188,7 +186,6 @@ const mapStateToProps = (state, props) => {
 const mapDispatchToProps = {
   ...actions,
   closeNavbar,
-  onChangeLocation: push,
   createBookmark: id => Bookmark.actions.create({ id, type: "card" }),
   deleteBookmark: id => Bookmark.actions.delete({ id, type: "card" }),
 };
@@ -199,7 +196,6 @@ function QueryBuilder(props) {
     originalQuestion,
     location,
     params,
-    fromUrl,
     uiControls,
     isNativeEditorOpen,
     isAnySidebarOpen,
@@ -209,7 +205,6 @@ function QueryBuilder(props) {
     apiUpdateQuestion,
     updateUrl,
     locationChanged,
-    onChangeLocation,
     setUIControls,
     cancelQuery,
     isBookmarked,
@@ -307,18 +302,12 @@ function QueryBuilder(props) {
           await updateUrl(updatedQuestion, { dirty: false });
         }
 
-        if (fromUrl) {
-          onChangeLocation(fromUrl);
-        } else {
-          setRecentlySaved("updated");
-        }
+        setRecentlySaved("updated");
       });
     },
     [
-      fromUrl,
       apiUpdateQuestion,
       updateUrl,
-      onChangeLocation,
       setRecentlySaved,
       setUIControls,
       scheduleCallback,

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { connect } from "react-redux";
+import { push } from "react-router-redux";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -186,6 +187,7 @@ const mapStateToProps = (state, props) => {
 const mapDispatchToProps = {
   ...actions,
   closeNavbar,
+  onChangeLocation: push,
   createBookmark: id => Bookmark.actions.create({ id, type: "card" }),
   deleteBookmark: id => Bookmark.actions.delete({ id, type: "card" }),
 };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/35785

### Description

There was an old parameter "fromUrl" in query builder which allowed to redirect to some previous page after question editing. But it looks like that functionality wasn't used. At the same time blacklisting of `from` keyword in the URL can conflict with named parameters. 

So, solution is to remove that old functionality seems nobody used.

### How to verify

Check e2e test:
- create sql question with  2 params, first is any, second should have name "from"
- save a question
- change anything in the question (e.g. add a comment on the top), save and "replace" the question
- there shouldn't be any URL redirect from the question

### Demo

example of the broken test (without changes in QB)
https://github.com/metabase/metabase/assets/125459446/d9f8023f-fb68-41ab-bf30-f003b87a3e04

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
