### PR TITLE
[MLv2] Add `ColumnGroupDisplayInfo` type

### DIFF
--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -17,6 +17,7 @@ import type {
   ClauseDisplayInfo,
   ColumnDisplayInfo,
   ColumnGroup,
+  ColumnGroupDisplayInfo,
   ColumnMetadata,
   DrillThru,
   DrillThruDisplayInfo,
@@ -58,7 +59,7 @@ declare function DisplayInfoFn(
   query: Query,
   stageIndex: number,
   columnGroup: ColumnGroup,
-): ColumnDisplayInfo | TableDisplayInfo;
+): ColumnGroupDisplayInfo;
 declare function DisplayInfoFn(
   query: Query,
   stageIndex: number,

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -130,7 +130,6 @@ export type ColumnDisplayInfo = {
   displayName: string;
   longDisplayName: string;
 
-  fkReferenceName?: string;
   isCalculated: boolean;
   isFromJoin: boolean;
   isImplicitlyJoinable: boolean;
@@ -140,6 +139,10 @@ export type ColumnDisplayInfo = {
   filterPositions?: number[];
   orderByPosition?: number;
   selected?: boolean; // used in aggregation and field clauses
+};
+
+export type ColumnGroupDisplayInfo = TableDisplayInfo & {
+  fkReferenceName?: string;
 };
 
 export type SegmentDisplayInfo = {

--- a/frontend/src/metabase/common/utils/column-groups.ts
+++ b/frontend/src/metabase/common/utils/column-groups.ts
@@ -1,19 +1,15 @@
 import { singularize } from "metabase/lib/formatting";
 import type { IconName } from "metabase/core/components/Icon";
-import type { ColumnDisplayInfo, TableDisplayInfo } from "metabase-lib/types";
+import type { ColumnGroupDisplayInfo } from "metabase-lib/types";
 
-export function getColumnGroupName(
-  groupInfo: ColumnDisplayInfo | TableDisplayInfo,
-) {
-  const columnInfo = groupInfo as ColumnDisplayInfo;
-  const tableInfo = groupInfo as TableDisplayInfo;
-  return columnInfo.fkReferenceName || singularize(tableInfo.displayName);
+export function getColumnGroupName(groupInfo: ColumnGroupDisplayInfo) {
+  return groupInfo.fkReferenceName || singularize(groupInfo.displayName);
 }
 
 export function getColumnGroupIcon(
-  groupInfo: ColumnDisplayInfo | TableDisplayInfo,
+  groupInfo: ColumnGroupDisplayInfo,
 ): IconName | undefined {
-  if ((groupInfo as TableDisplayInfo).isSourceTable) {
+  if (groupInfo.isSourceTable) {
     return "table";
   }
   if (groupInfo.isFromJoin) {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnList.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnList.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import _ from "underscore";
 import { t } from "ttag";
 import Input from "metabase/core/components/Input";
-import { singularize } from "metabase/lib/formatting";
+import { getColumnGroupName } from "metabase/common/utils/column-groups";
 import { useDebouncedValue } from "metabase/hooks/use-debounced-value";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/lib/constants";
 import * as Lib from "metabase-lib";
@@ -166,12 +166,6 @@ export function BreakoutColumnList({
   );
 }
 
-function getGroupName(groupInfo: Lib.ColumnDisplayInfo | Lib.TableDisplayInfo) {
-  const columnInfo = groupInfo as Lib.ColumnDisplayInfo;
-  const tableInfo = groupInfo as Lib.TableDisplayInfo;
-  return columnInfo.fkReferenceName || singularize(tableInfo.displayName);
-}
-
 function getColumnListItem(
   query: Lib.Query,
   breakouts: Lib.BreakoutClause[],
@@ -213,7 +207,7 @@ function getColumnSections(
     );
 
     return {
-      name: getGroupName(groupInfo),
+      name: getColumnGroupName(groupInfo),
       items,
     };
   });

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/utils.ts
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/utils.ts
@@ -126,13 +126,8 @@ export const getAdditionalMetadataColumns = (
   return Array.from(additionalColumns);
 };
 
-const getColumnGroupName = (
-  displayInfo: Lib.ColumnDisplayInfo | Lib.TableDisplayInfo,
-) => {
-  const columnInfo = displayInfo as Lib.ColumnDisplayInfo;
-  const tableInfo = displayInfo as Lib.TableDisplayInfo;
-  return columnInfo.fkReferenceName || tableInfo.displayName;
-};
+const getColumnGroupName = (displayInfo: Lib.ColumnGroupDisplayInfo) =>
+  displayInfo.fkReferenceName || displayInfo.displayName;
 
 export const getColumnGroups = (
   query: Lib.Query,


### PR DESCRIPTION
Extracted from bulk filter modal work

Carrying `ColumnDisplayInfo | TableDisplayInfo` type for column groups is pretty annoying, so let's just give it its own type