### PR TITLE
[MLv2] Disambiguate columns: `:field` ref(:filter drill-thru))))s shouldn't match expressions

### DIFF
--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -158,15 +158,36 @@
         (not-empty (filter #(clojure.core/= (:id %) ref-id) columns)))
       []))
 
+(defn- ambiguous-match-error [a-ref columns]
+  (ex-info "Ambiguous match! Implement more logic in disambiguate-matches."
+           {:ref a-ref
+            :columns columns}))
+
+(mu/defn ^:private expression-column? [column]
+  (or (= (:lib/source column) :source/expressions)
+      (:lib/expression-name column)))
+
+(mu/defn ^:private disambiguate-matches-dislike-field-refs-to-expressions :- [:maybe ::lib.schema.metadata/column]
+  "If a custom column is a simple wrapper for a field, that column gets `:id`, `:table_id`, etc.
+  A custom column should get a ref like `[:expression {} \"expr name\"]`, not `[:field {} 17]`.
+  If we got a `:field` ref, prefer matches which are not `:lib/source :source/expressions`."
+  [a-ref   :- ::lib.schema.ref/ref
+   columns :- [:sequential ::lib.schema.metadata/column]]
+  (or (when (= (first a-ref) :field)
+        (when-let [non-exprs (not-empty (remove expression-column? columns))]
+          (when-not (next non-exprs)
+            (first non-exprs))))
+      ;; In all other cases, this is an ambiguous match.
+      (throw (ambiguous-match-error a-ref columns))))
+
 (mu/defn ^:private disambiguate-matches-prefer-explicit :- [:maybe ::lib.schema.metadata/column]
+  "Prefers table-default or explicitly joined columns over implicitly joinable ones."
   [a-ref   :- ::lib.schema.ref/ref
    columns :- [:sequential ::lib.schema.metadata/column]]
   (if-let [no-implicit (not-empty (remove :fk-field-id columns))]
     (if-not (next no-implicit)
       (first no-implicit)
-      (throw (ex-info "Ambiguous match! Implement more logic in disambiguate-matches."
-                      {:ref a-ref
-                       :columns columns})))
+      (disambiguate-matches-dislike-field-refs-to-expressions a-ref no-implicit))
     nil))
 
 (mu/defn ^:private disambiguate-matches-no-alias :- [:maybe ::lib.schema.metadata/column]


### PR DESCRIPTION
Expressions which just wrap a real Field get `:id`, `:table_id` etc. so
they match a `[:field {} 7]` ref. If that real field exists (table
default or joined), prefer that over the expressions.

Fixes #35839.
