### PR TITLE
[MLv2] Filters — Add bulk filter modal skeleton

### DIFF
--- a/frontend/src/metabase/query_builder/components/QueryModals.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.tsx
@@ -371,12 +371,14 @@ class QueryModals extends Component<QueryModalsProps> {
     return (
       <>
         {this.renderLegacyModal()}
-        <BulkFilterModal
-          opened={modal === MODAL_TYPES.FILTERS}
-          query={query}
-          onSubmit={this.onQueryChange}
-          onClose={onCloseModal}
-        />
+        {question.isStructured() && (
+          <BulkFilterModal
+            opened={modal === MODAL_TYPES.FILTERS}
+            query={query}
+            onSubmit={this.onQueryChange}
+            onClose={onCloseModal}
+          />
+        )}
       </>
     );
   }

--- a/frontend/src/metabase/query_builder/components/QueryModals.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.tsx
@@ -23,7 +23,7 @@ import { CreateAlertModalContent } from "metabase/query_builder/components/Alert
 import { ImpossibleToCreateModelModal } from "metabase/query_builder/components/ImpossibleToCreateModelModal";
 import NewDatasetModal from "metabase/query_builder/components/NewDatasetModal";
 import EntityCopyModal from "metabase/entities/containers/EntityCopyModal";
-import BulkFilterModal from "metabase/query_builder/components/filters/modals/BulkFilterModal";
+import { BulkFilterModal } from "metabase/query_builder/components/filters/BulkFilterModal";
 import NewEventModal from "metabase/timelines/questions/containers/NewEventModal";
 import EditEventModal from "metabase/timelines/questions/containers/EditEventModal";
 import MoveEventModal from "metabase/timelines/questions/containers/MoveEventModal";
@@ -37,7 +37,7 @@ import type {
   State,
 } from "metabase-types/store";
 import { getQuestionWithParameters } from "metabase/query_builder/selectors";
-import type StructuredQuery from "metabase-lib/queries/StructuredQuery";
+import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/Question";
 import type { UpdateQuestionOpts } from "../actions/core/updateQuestion";
 
@@ -98,12 +98,14 @@ class QueryModals extends Component<QueryModalsProps> {
     }
   };
 
-  onQueryChange = (query: StructuredQuery) => {
-    const question = query.question();
-    this.props.updateQuestion(question, { run: true });
+  onQueryChange = (query: Lib.Query) => {
+    const { question, updateQuestion } = this.props;
+    const nextLegacyQuery = Lib.toLegacyQuery(query);
+    const nextQuestion = question.setDatasetQuery(nextLegacyQuery);
+    updateQuestion(nextQuestion, { run: true });
   };
 
-  render() {
+  renderLegacyModal = () => {
     const {
       modal,
       modalContext,
@@ -230,16 +232,6 @@ class QueryModals extends Component<QueryModalsProps> {
               onClose={onCloseModal}
               multiStep
               initialCollectionId={this.props.initialCollectionId}
-            />
-          </Modal>
-        );
-      case MODAL_TYPES.FILTERS:
-        return (
-          <Modal fit onClose={onCloseModal}>
-            <BulkFilterModal
-              question={question}
-              onQueryChange={this.onQueryChange}
-              onClose={onCloseModal}
             />
           </Modal>
         );
@@ -370,6 +362,23 @@ class QueryModals extends Component<QueryModalsProps> {
       default:
         return null;
     }
+  };
+
+  render() {
+    const { question, modal, onCloseModal } = this.props;
+    const query = question._getMLv2Query();
+
+    return (
+      <>
+        {this.renderLegacyModal()}
+        <BulkFilterModal
+          opened={modal === MODAL_TYPES.FILTERS}
+          query={query}
+          onSubmit={this.onQueryChange}
+          onClose={onCloseModal}
+        />
+      </>
+    );
   }
 }
 

--- a/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/BulkFilterModal.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/BulkFilterModal.styled.tsx
@@ -1,0 +1,47 @@
+import styled from "@emotion/styled";
+import type { BoxProps } from "metabase/ui";
+import { Box, Flex, Modal, Tabs } from "metabase/ui";
+import { color } from "metabase/lib/colors";
+import { breakpointMaxSmall } from "metabase/styled-components/theme";
+
+export const ScrollableTabPanel = styled(Tabs.Panel)`
+  overflow-y: auto;
+`;
+
+export const ColumnFilterListItem = styled(Box)<BoxProps & { component?: any }>`
+  border-bottom: 1px solid ${color("border")};
+
+  &:last-of-type {
+    border-bottom: none;
+  }
+
+  &:hover,
+  :focus-within {
+    background-color: ${color("bg-light")};
+  }
+`;
+
+ColumnFilterListItem.defaultProps = {
+  component: "li",
+};
+
+export const ModalHeader = styled(Modal.Header)`
+  border-bottom: 1px solid ${color("border")};
+`;
+
+export const ModalBody = styled(Modal.Body)`
+  height: calc(90vh - 10rem);
+
+  ${breakpointMaxSmall} {
+    height: calc(98vh - 10rem);
+  }
+`;
+
+export const ModalFooter = styled(Flex)`
+  border-top: 1px solid ${color("border")};
+`;
+
+ModalFooter.defaultProps = {
+  p: "md",
+  direction: "row",
+};

--- a/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/BulkFilterModal.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/BulkFilterModal.tsx
@@ -1,0 +1,161 @@
+import { useCallback, useMemo, useState } from "react";
+import { t } from "ttag";
+
+import { Button, Flex, Modal, Tabs } from "metabase/ui";
+import { Icon } from "metabase/core/components/Icon";
+import {
+  getColumnGroupIcon,
+  getColumnGroupName,
+} from "metabase/common/utils/column-groups";
+
+import * as Lib from "metabase-lib";
+
+import { ColumnFilterSection } from "./ColumnFilterSection";
+import {
+  ColumnFilterListItem,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ScrollableTabPanel,
+} from "./BulkFilterModal.styled";
+
+interface BulkFilterModalProps {
+  query: Lib.Query;
+  opened: boolean;
+  onSubmit: (nextQuery: Lib.Query) => void;
+  onClose: () => void;
+}
+
+const STAGE_INDEX = -1;
+
+// Computed column groups have an empty `name`,
+// tab navigation components don't accept an empty `value` prop.
+const COMPUTED_COLUMN_GROUP_ID = "COMPUTED";
+
+export function BulkFilterModal({
+  query: initialQuery,
+  opened,
+  onSubmit,
+  onClose,
+}: BulkFilterModalProps) {
+  const [query] = useState(initialQuery);
+
+  const columnGroups = useMemo(() => {
+    const columns = Lib.filterableColumns(query, STAGE_INDEX);
+    return Lib.groupColumns(columns);
+  }, [query]);
+
+  const defaultGroupInfo = useMemo(() => {
+    const [firstGroup] = columnGroups;
+    return Lib.displayInfo(query, STAGE_INDEX, firstGroup);
+  }, [query, columnGroups]);
+
+  const handleSubmit = useCallback(() => {
+    onSubmit(query);
+    onClose();
+  }, [query, onSubmit, onClose]);
+
+  const hasNavigation = columnGroups.length > 1;
+
+  const unsafeModalWidth = hasNavigation ? "70rem" : "55rem";
+  const modalWidth = `min(98vw, ${unsafeModalWidth})`;
+
+  const modalTitle =
+    columnGroups.length === 1
+      ? t`Filter ${defaultGroupInfo.displayName} by`
+      : t`Filter by`;
+
+  const initialTab = defaultGroupInfo.name || COMPUTED_COLUMN_GROUP_ID;
+
+  return (
+    <Modal.Root opened={opened} size={modalWidth} onClose={onClose}>
+      <Modal.Overlay />
+      <Modal.Content>
+        <ModalHeader p="lg">
+          <Modal.Title>{modalTitle}</Modal.Title>
+          <Modal.CloseButton />
+        </ModalHeader>
+        <ModalBody p={0}>
+          <Tabs defaultValue={initialTab} orientation="vertical" h="100%">
+            <Flex direction="row" w="100%">
+              {hasNavigation && (
+                <ColumnGroupNavigation query={query} groups={columnGroups} />
+              )}
+              {columnGroups.map((group, index) => (
+                <FilterableColumnGroup
+                  key={index}
+                  query={query}
+                  group={group}
+                />
+              ))}
+            </Flex>
+          </Tabs>
+        </ModalBody>
+        <ModalFooter justify="flex-end">
+          <Button
+            variant="filled"
+            disabled
+            onClick={handleSubmit}
+          >{t`Apply filters`}</Button>
+        </ModalFooter>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}
+
+interface ColumnGroupNavigationProps {
+  query: Lib.Query;
+  groups: Lib.ColumnGroup[];
+}
+
+function ColumnGroupNavigation({ query, groups }: ColumnGroupNavigationProps) {
+  return (
+    <Tabs.List w="20%" pt="sm" pl="md">
+      {groups.map(group => {
+        const groupInfo = Lib.displayInfo(query, STAGE_INDEX, group);
+        const groupName = getColumnGroupName(groupInfo);
+        const groupIcon = getColumnGroupIcon(groupInfo);
+        const value = groupInfo.name || COMPUTED_COLUMN_GROUP_ID;
+        return (
+          <Tabs.Tab
+            key={value}
+            value={value}
+            aria-label={groupName}
+            icon={groupIcon && <Icon name={groupIcon} />}
+          >
+            {groupName}
+          </Tabs.Tab>
+        );
+      })}
+    </Tabs.List>
+  );
+}
+
+interface FilterableColumnGroupProps {
+  query: Lib.Query;
+  group: Lib.ColumnGroup;
+}
+
+function FilterableColumnGroup({ query, group }: FilterableColumnGroupProps) {
+  const groupInfo = Lib.displayInfo(query, STAGE_INDEX, group);
+  const groupColumns = Lib.getColumnsFromColumnGroup(group);
+  const value = groupInfo.name || COMPUTED_COLUMN_GROUP_ID;
+  return (
+    <ScrollableTabPanel key={value} value={value}>
+      <ul>
+        {groupColumns.map(column => {
+          const columnInfo = Lib.displayInfo(query, STAGE_INDEX, column);
+          return (
+            <ColumnFilterListItem key={columnInfo.name} pr="md">
+              <ColumnFilterSection
+                query={query}
+                stageIndex={STAGE_INDEX}
+                column={column}
+              />
+            </ColumnFilterListItem>
+          );
+        })}
+      </ul>
+    </ScrollableTabPanel>
+  );
+}

--- a/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/BulkFilterModal.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/BulkFilterModal.unit.spec.tsx
@@ -1,15 +1,28 @@
 import userEvent from "@testing-library/user-event";
+import { createMockMetadata } from "__support__/metadata";
 import { renderWithProviders, screen } from "__support__/ui";
-import { PRODUCTS_ID } from "metabase-types/api/mocks/presets";
+import type { FieldReference } from "metabase-types/api";
+import {
+  createSampleDatabase,
+  ORDERS,
+  ORDERS_ID,
+  PRODUCTS,
+  PRODUCTS_ID,
+  SAMPLE_DB_ID,
+} from "metabase-types/api/mocks/presets";
 import * as Lib from "metabase-lib";
 import { createQuery } from "metabase-lib/test-helpers";
 import { BulkFilterModal } from "./BulkFilterModal";
+
+const metadata = createMockMetadata({
+  databases: [createSampleDatabase()],
+});
 
 type SetupOpts = {
   query?: Lib.Query;
 };
 
-function setup({ query = createQuery() }: SetupOpts = {}) {
+function setup({ query = createQuery({ metadata }) }: SetupOpts = {}) {
   const onSubmit = jest.fn();
   const onClose = jest.fn();
 
@@ -105,4 +118,93 @@ describe("BulkFilterModal", () => {
     userEvent.click(screen.getByLabelText("Close"));
     expect(onClose).toHaveBeenCalled();
   });
+
+  describe("multi-stage query", () => {
+    it("should display a list of columns from last two stages", () => {
+      setup({ query: createTwoStageQuery() });
+
+      expect(screen.getByText("User ID")).toBeInTheDocument();
+      expect(screen.getByText("Discount")).toBeInTheDocument();
+      expect(screen.getByText("Stage 1 CC")).toBeInTheDocument();
+
+      expect(screen.queryByText("Rating")).not.toBeInTheDocument();
+      expect(screen.queryByText("Category")).not.toBeInTheDocument();
+
+      expect(screen.queryByText("Count")).not.toBeInTheDocument();
+      expect(screen.queryByText("Stage 2 CC")).not.toBeInTheDocument();
+    });
+
+    it("should call the second stage column group 'Summaries'", () => {
+      setup({ query: createTwoStageQuery() });
+      const tab = screen.getByRole("tab", { name: "Summaries" });
+
+      expect(tab).toHaveAttribute("aria-selected", "false");
+      userEvent.click(tab);
+
+      expect(screen.getByText("Count")).toBeInTheDocument();
+      expect(screen.getByText("Stage 2 CC")).toBeInTheDocument();
+
+      expect(tab).toHaveAttribute("aria-selected", "true");
+      expect(screen.getByRole("tab", { name: "Product" })).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
+    });
+
+    it("should list tables available in first stage", () => {
+      setup({ query: createTwoStageQuery() });
+
+      expect(screen.getByText("Order")).toBeInTheDocument();
+      expect(screen.getByText("Product")).toBeInTheDocument();
+      expect(screen.getByText("User")).toBeInTheDocument();
+
+      expect(screen.queryByText("Review")).not.toBeInTheDocument();
+    });
+  });
 });
+
+function createTwoStageQuery() {
+  const ORDERS_CREATED_AT_FIELD_REF: FieldReference = [
+    "field",
+    ORDERS.CREATED_AT,
+    {
+      "base-type": "type/DateTime",
+      "temporal-unit": "month",
+    },
+  ];
+
+  const PRODUCT_CATEGORY_FIELD_REF: FieldReference = [
+    "field",
+    PRODUCTS.CATEGORY,
+    {
+      "base-type": "type/Text",
+      "source-field": ORDERS.PRODUCT_ID,
+    },
+  ];
+
+  const COUNT_FIELD_REF: FieldReference = [
+    "field",
+    "count",
+    { "base-type": "type/Integer" },
+  ];
+
+  return Lib.fromLegacyQuery(SAMPLE_DB_ID, metadata, {
+    type: "query",
+    database: SAMPLE_DB_ID,
+    query: {
+      expressions: {
+        "Stage 2 CC": ["+", 2, 2],
+      },
+      filter: [">", COUNT_FIELD_REF, 5],
+      "source-query": {
+        "source-table": ORDERS_ID,
+        aggregation: [["count"]],
+        breakout: [ORDERS_CREATED_AT_FIELD_REF],
+        expressions: {
+          "Stage 1 CC": ["+", 1, 1],
+        },
+        filter: ["=", PRODUCT_CATEGORY_FIELD_REF, "Doohickey"],
+      },
+    },
+  });
+}

--- a/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/BulkFilterModal.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/BulkFilterModal.unit.spec.tsx
@@ -1,0 +1,108 @@
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders, screen } from "__support__/ui";
+import { PRODUCTS_ID } from "metabase-types/api/mocks/presets";
+import * as Lib from "metabase-lib";
+import { createQuery } from "metabase-lib/test-helpers";
+import { BulkFilterModal } from "./BulkFilterModal";
+
+type SetupOpts = {
+  query?: Lib.Query;
+};
+
+function setup({ query = createQuery() }: SetupOpts = {}) {
+  const onSubmit = jest.fn();
+  const onClose = jest.fn();
+
+  renderWithProviders(
+    <BulkFilterModal
+      query={query}
+      opened
+      onSubmit={onSubmit}
+      onClose={onClose}
+    />,
+  );
+
+  function getNextQuery() {
+    const [query] = onSubmit.mock.lastCall;
+    return query;
+  }
+
+  function getNextFilterParts(stageIndex = 0) {
+    const query = getNextQuery();
+    return Lib.filters(query, stageIndex).map(filter =>
+      Lib.filterParts(query, stageIndex, filter),
+    );
+  }
+
+  return { getNextFilterParts, onSubmit, onClose };
+}
+
+describe("BulkFilterModal", () => {
+  it("should display a list of columns", () => {
+    setup();
+
+    expect(screen.getByRole("heading")).toHaveTextContent("Filter by");
+
+    expect(screen.getByText("User ID")).toBeInTheDocument();
+    expect(screen.getByText("Discount")).toBeInTheDocument();
+
+    expect(screen.queryByText("Rating")).not.toBeInTheDocument();
+    expect(screen.queryByText("Category")).not.toBeInTheDocument();
+
+    userEvent.click(screen.getByRole("tab", { name: "Product" }));
+
+    expect(screen.getByText("Rating")).toBeInTheDocument();
+    expect(screen.getByText("Category")).toBeInTheDocument();
+
+    expect(screen.queryByText("User ID")).not.toBeInTheDocument();
+    expect(screen.queryByText("Discount")).not.toBeInTheDocument();
+  });
+
+  it("should navigate between column groups", () => {
+    setup();
+
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+
+    const orderTab = screen.getByRole("tab", { name: "Order" });
+    const userTab = screen.getByRole("tab", { name: "User" });
+    const productTab = screen.getByRole("tab", { name: "Product" });
+
+    expect(orderTab).toHaveAttribute("aria-selected", "true");
+    expect(productTab).toHaveAttribute("aria-selected", "false");
+    expect(userTab).toHaveAttribute("aria-selected", "false");
+
+    userEvent.click(productTab);
+
+    expect(orderTab).toHaveAttribute("aria-selected", "false");
+    expect(productTab).toHaveAttribute("aria-selected", "true");
+    expect(userTab).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("should not display navigation when there's only one column group", () => {
+    const query = Lib.withDifferentTable(createQuery(), PRODUCTS_ID);
+    setup({ query });
+
+    expect(screen.getByRole("heading")).toHaveTextContent("Filter Products by");
+
+    expect(screen.queryByRole("tablist")).not.toBeInTheDocument();
+    expect(screen.queryByRole("tab")).not.toBeInTheDocument();
+
+    expect(screen.queryByText(/Order(s?)/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Review(s?)/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Product")).not.toBeInTheDocument();
+    expect(screen.queryByText("User")).not.toBeInTheDocument();
+    expect(screen.queryByText("People")).not.toBeInTheDocument();
+  });
+
+  it("should disable submit when there're no changes", () => {
+    setup();
+    const applyButton = screen.getByRole("button", { name: "Apply filters" });
+    expect(applyButton).toBeDisabled();
+  });
+
+  it("should close", () => {
+    const { onClose } = setup();
+    userEvent.click(screen.getByLabelText("Close"));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/ColumnFilterSection.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/ColumnFilterSection.tsx
@@ -1,0 +1,28 @@
+import { Flex, Text } from "metabase/ui";
+import { Icon } from "metabase/core/components/Icon";
+import { getColumnIcon } from "metabase/common/utils/columns";
+import * as Lib from "metabase-lib";
+
+interface ColumnFilterSectionProps {
+  query: Lib.Query;
+  stageIndex: number;
+  column: Lib.ColumnMetadata;
+}
+
+export function ColumnFilterSection({
+  query,
+  stageIndex,
+  column,
+}: ColumnFilterSectionProps) {
+  const columnInfo = Lib.displayInfo(query, stageIndex, column);
+  const columnIcon = getColumnIcon(column);
+
+  return (
+    <Flex direction="row" align="center" px="2rem" py="1rem" gap="sm">
+      <Icon name={columnIcon} />
+      <Text color="text.2" weight="bold">
+        {columnInfo.displayName}
+      </Text>
+    </Flex>
+  );
+}

--- a/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/index.ts
+++ b/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/index.ts
@@ -1,0 +1,1 @@
+export * from "./BulkFilterModal";


### PR DESCRIPTION
Closes #35746

Adds a `BulkFilterModal` skeleton that displays filterable columns and their groups

### Demo

<details>
<summary>Orders table (3 column groups)</summary>

<img width="1284" alt="CleanShot 2023-11-16 at 18 06 40@2x" src="https://github.com/metabase/metabase/assets/17258145/6ef83b27-091c-41d5-9f80-161404a1a79c">

</details>

<details>
<summary>Products table (1 column group)</summary>

<img width="1287" alt="CleanShot 2023-11-16 at 18 07 11@2x" src="https://github.com/metabase/metabase/assets/17258145/63e0745e-09d3-4507-8b5e-5edb6a3e2784">

</details>

<details>
<summary>Multi-stage query (4 column groups)</summary>

<img width="1290" alt="CleanShot 2023-11-16 at 18 08 16@2x" src="https://github.com/metabase/metabase/assets/17258145/b60b36af-1709-47d6-af6c-f1ec9a3c93e7">


</details>