### PR TITLE
[MLv2] [BE] - return query, stage index and column for `column-filter` drill

### DIFF
--- a/src/metabase/lib/drill_thru/column_filter.cljc
+++ b/src/metabase/lib/drill_thru/column_filter.cljc
@@ -1,16 +1,24 @@
 (ns metabase.lib.drill-thru.column-filter
   (:require
+   [medley.core :as m]
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
+   [metabase.lib.equality :as lib.equality]
    [metabase.lib.filter :as lib.filter]
    [metabase.lib.filter.operator :as lib.filter.operator]
+   [metabase.lib.ref :as lib.ref]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
+   [metabase.lib.stage :as lib.stage]
    [metabase.lib.types.isa :as lib.types.isa]
+   [metabase.lib.util :as lib.util]
    [metabase.util.malli :as mu]))
 
 (mu/defn column-filter-drill :- [:maybe ::lib.schema.drill-thru/drill-thru.column-filter]
   "Filtering at the column level, based on its type. Displays a submenu of eg. \"Today\", \"This Week\", etc. for date
-  columns."
+  columns.
+
+  Note that if the clicked column is an aggregation, filtering by it will require a new stage. Therefore this drill
+  returns a possibly-updated `:query` and `:stage-number` along with a `:column` referencing that later stage."
   [query                  :- ::lib.schema/query
    stage-number           :- :int
    {:keys [column value]} :- ::lib.schema.drill-thru/context]
@@ -23,10 +31,33 @@
                        (-> (lib.filter.operator/filter-operators column)
                            first
                            (assoc :lib/type :operator/filter)))]
-      {:lib/type   :metabase.lib.drill-thru/drill-thru
-       :type       :drill-thru/column-filter
-       :column     column
-       :initial-op initial-op})))
+
+      (merge
+        {:lib/type   :metabase.lib.drill-thru/drill-thru
+         :type       :drill-thru/column-filter
+         :initial-op initial-op}
+        ;; When the column we would be filtering on is an aggregation, it can't be filtered without adding a stage.
+        (let [next-stage    (->> (lib.util/canonical-stage-index query stage-number)
+                                 (lib.util/next-stage-number query))
+              base          (cond
+                              ;; Not an aggregation: just the input query and stage.
+                              (not= (:lib/source column) :source/aggregations)
+                              {:query        query
+                               :stage-number stage-number}
+
+                              ;; Aggregation column: if there's a later stage, use it.
+                              next-stage {:query        query
+                                          :stage-number next-stage}
+                              ;; Aggregation column with no later stage; append a stage.
+                              :else      {:query        (lib.stage/append-stage query)
+                                          :stage-number -1})
+              columns       (lib.filter/filterable-columns (:query base) (:stage-number base))
+              filter-column (or (lib.equality/find-matching-column
+                                  (:query base) (:stage-number base) (lib.ref/ref column) columns)
+                                (and (:lib/source-uuid column)
+                                     (m/find-first #(= (:lib/source-uuid %) (:lib/source-uuid column))
+                                                   columns)))]
+          (assoc base :column filter-column))))))
 
 (defmethod lib.drill-thru.common/drill-thru-info-method :drill-thru/column-filter
   [_query _stage-number {:keys [initial-op]}]

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -989,6 +989,17 @@
   [a-query stage-number a-drill-thru & args]
   (apply lib.core/drill-thru a-query stage-number a-drill-thru args))
 
+(defn ^:export column-filter-drill-details
+  "Returns a JS object with opaque CLJS things in it, which are needed to render the complex UI for `column-filter`
+  drills. Since the query might need an extra stage appended, this returns a possibly updated `query` and `stageNumber`,
+  as well as a `column` as returned by [[filterable-columns]]."
+  [{a-query :query
+    :keys [column stage-number]
+    :as _column-filter-drill}]
+  #js {"column"      column
+       "query"       a-query
+       "stageNumber" stage-number})
+
 (defn ^:export pivot-types
   "Returns an array of pivot types that are available in this drill-thru, which must be a pivot drill-thru."
   [a-drill-thru]

--- a/src/metabase/lib/schema/drill_thru.cljc
+++ b/src/metabase/lib/schema/drill_thru.cljc
@@ -4,6 +4,7 @@
   Drill-thrus are not part of MBQL; they are a set of actions one can take to transform a query.
   For example, adding a filter like `created_at < 2022-01-01`, or following a foreign key."
   (:require
+   [metabase.lib.schema :as-alias lib.schema]
    [metabase.lib.schema.binning :as lib.schema.binning]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.expression :as lib.schema.expression]
@@ -134,8 +135,11 @@
   [:merge
    ::drill-thru.common.with-column
    [:map
-    [:type       [:= :drill-thru/column-filter]]
-    [:initial-op [:maybe ::lib.schema.filter/operator]]]])
+    [:type         [:= :drill-thru/column-filter]]
+    [:initial-op   [:maybe ::lib.schema.filter/operator]]
+    [:column       [:ref ::lib.schema.metadata/column]]
+    [:query        [:ref ::lib.schema/query]]
+    [:stage-number number?]]])
 
 (mr/def ::drill-thru.underlying-records
   [:merge

--- a/test/metabase/lib/drill_thru/column_filter_test.cljc
+++ b/test/metabase/lib/drill_thru/column_filter_test.cljc
@@ -1,7 +1,13 @@
 (ns metabase.lib.drill-thru.column-filter-test
   (:require
-   [clojure.test :refer [deftest]]
-   [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]))
+   [clojure.test :refer [deftest is testing]]
+   [medley.core :as m]
+   [metabase.lib.core :as lib]
+   [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
+   [metabase.lib.test-metadata :as meta]
+   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))))
+
+#?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
 (deftest ^:parallel returns-column-filter-test-1
   (lib.drill-thru.tu/test-returns-drill
@@ -92,3 +98,64 @@
       :query-type  :aggregated
       :column-name "max"
       :expected    {:type :drill-thru/column-filter, :initial-op {:short :=}}}))
+
+(deftest ^:parallel aggregation-adds-extra-stage-test
+  (testing "filtering an aggregation column adds an extra stage"
+    (let [query       (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                          (lib/aggregate (lib/count))
+                          (lib/breakout (meta/field-metadata :products :category)))
+          [_category
+           count-col] (lib/returned-columns query)
+          new-stage   (lib/append-stage query)]
+      (is (=? {:lib/type     :metabase.lib.drill-thru/drill-thru
+               :type         :drill-thru/column-filter
+               :query        new-stage
+               :stage-number -1
+               :column       (->> new-stage
+                                  lib/filterable-columns
+                                  (m/find-first #(= (:name %) "count")))}
+              (->> {:column     count-col
+                    :column-ref (lib/ref count-col)
+                    :value      nil}
+                   (lib/available-drill-thrus query -1)
+                   (m/find-first #(= (:type %) :drill-thru/column-filter))))))))
+
+(deftest ^:parallel aggregation-existing-extra-stage-test
+  (testing "filtering an aggregation column uses an existing later stage"
+    (let [query       (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                          (lib/aggregate (lib/count))
+                          (lib/breakout (meta/field-metadata :products :category))
+                          (lib/append-stage))
+          [_category
+           count-col] (lib/returned-columns query 0 (-> query :stages first))] ;; NOTE: columns of the first stage
+      (is (=? {:lib/type     :metabase.lib.drill-thru/drill-thru
+               :type         :drill-thru/column-filter
+               :query        query
+               :stage-number 1
+               :column       (-> query lib/returned-columns second)}
+              (->> {:column     count-col
+                    :column-ref (lib/ref count-col)
+                    :value      nil}
+                   (lib/available-drill-thrus query 0)
+                   (m/find-first #(= (:type %) :drill-thru/column-filter))))))))
+
+(deftest ^:parallel no-aggregation-no-extra-stage-test
+  (testing "filtering a non-aggregation column does not add another stage"
+    (let [query      (lib/query meta/metadata-provider (meta/table-metadata :orders))
+          subtotal   (m/find-first #(= (:name %) "SUBTOTAL")
+                                   (lib/returned-columns query))]
+      (is (=? {:lib/type     :metabase.lib.drill-thru/drill-thru
+               :type         :drill-thru/column-filter
+               :query        query
+               :stage-number -1
+               ;; The filterable-columns counterpart is returned, not the plain column.
+               :column       {:lib/type  :metadata/column
+                              :name      "SUBTOTAL"
+                              :id        (meta/id :orders :subtotal)
+                              :operators (fn [ops]
+                                           (every? (every-pred map? #(= (:lib/type %) :operator/filter)) ops))}}
+              (->> {:column     subtotal
+                    :column-ref (lib/ref subtotal)
+                    :value      nil}
+                   (lib/available-drill-thrus query -1)
+                   (m/find-first #(= (:type %) :drill-thru/column-filter))))))))


### PR DESCRIPTION
 If this drill is targeting an aggregation column, the query needs an
    extra stage added. To enable the custom filtering UI, this updated
    query, stage number, and the correct column *in that new stage* are
    returned as part of the opaque `column-filter` drill.
    
`lib.js/column-filter-drill-details` is added to hand those details
    to the FE as a JS object containing opaque CLJS values.