### PR TITLE
[MLv2] Strip question marks off of keys in JS version of display info

### DIFF
--- a/frontend/src/metabase-lib/drills.unit.spec.ts
+++ b/frontend/src/metabase-lib/drills.unit.spec.ts
@@ -318,7 +318,7 @@ describe("availableDrillThrus", () => {
         {
           type: "drill-thru/zoom",
           objectId: ORDERS_ROW_VALUES.ID as string,
-          "manyPks?": false,
+          isManyPks: false,
         },
       ],
     },
@@ -333,7 +333,7 @@ describe("availableDrillThrus", () => {
         {
           type: "drill-thru/fk-details",
           objectId: ORDERS_ROW_VALUES.USER_ID as string,
-          "manyPks?": false,
+          isManyPks: false,
         },
       ],
     },
@@ -345,7 +345,7 @@ describe("availableDrillThrus", () => {
         {
           type: "drill-thru/zoom",
           objectId: ORDERS_ROW_VALUES.ID as string,
-          "manyPks?": false,
+          isManyPks: false,
         },
         {
           type: "drill-thru/quick-filter",
@@ -361,7 +361,7 @@ describe("availableDrillThrus", () => {
         {
           type: "drill-thru/zoom",
           objectId: ORDERS_ROW_VALUES.ID as string,
-          "manyPks?": false,
+          isManyPks: false,
         },
         {
           type: "drill-thru/quick-filter",
@@ -507,7 +507,7 @@ describe("availableDrillThrus", () => {
     //     {
     //       type: "drill-thru/fk-details",
     //       objectId: AGGREGATED_ORDERS_ROW_VALUES.PRODUCT_ID as number,
-    //       "manyPks?": false,
+    //       isManyPks: false,
     //     },
     //     {
     //       rowCount: 2, // FIXME: (metabase#32108) this should return real count of rows
@@ -1189,7 +1189,7 @@ describe("availableDrillThrus", () => {
       expectedParameters: {
         type: "drill-thru/zoom",
         objectId: ORDERS_ROW_VALUES.ID as string,
-        "manyPks?": false,
+        isManyPks: false,
       },
     },
     {
@@ -1200,7 +1200,7 @@ describe("availableDrillThrus", () => {
       expectedParameters: {
         type: "drill-thru/zoom",
         objectId: ORDERS_ROW_VALUES.ID as string,
-        "manyPks?": false,
+        isManyPks: false,
       },
     },
     {
@@ -1211,7 +1211,7 @@ describe("availableDrillThrus", () => {
       expectedParameters: {
         type: "drill-thru/zoom",
         objectId: ORDERS_ROW_VALUES.ID as string,
-        "manyPks?": false,
+        isManyPks: false,
       },
     },
     {
@@ -1222,7 +1222,7 @@ describe("availableDrillThrus", () => {
       expectedParameters: {
         type: "drill-thru/zoom",
         objectId: ORDERS_ROW_VALUES.ID as string,
-        "manyPks?": false,
+        isManyPks: false,
       },
     },
     {
@@ -1233,7 +1233,7 @@ describe("availableDrillThrus", () => {
       expectedParameters: {
         type: "drill-thru/zoom",
         objectId: ORDERS_ROW_VALUES.ID as string,
-        "manyPks?": false,
+        isManyPks: false,
       },
     },
     // endregion
@@ -1251,7 +1251,7 @@ describe("availableDrillThrus", () => {
       expectedParameters: {
         type: "drill-thru/fk-details",
         objectId: ORDERS_ROW_VALUES.PRODUCT_ID as string,
-        "manyPks?": false,
+        isManyPks: false,
       },
     },
     {
@@ -1262,7 +1262,7 @@ describe("availableDrillThrus", () => {
       expectedParameters: {
         type: "drill-thru/fk-details",
         objectId: ORDERS_ROW_VALUES.USER_ID as string,
-        "manyPks?": false,
+        isManyPks: false,
       },
     },
     // endregion

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -275,7 +275,7 @@ export type QuickFilterDrillThruInfo =
 type ObjectDetailsDrillThruInfo<Type extends DrillThruType> =
   BaseDrillThruInfo<Type> & {
     objectId: string | number;
-    "manyPks?": boolean; // TODO [33479]: this should be "manyPks"
+    isManyPks: boolean;
   };
 export type PKDrillThruInfo = ObjectDetailsDrillThruInfo<"drill-thru/pk">;
 export type ZoomDrillThruInfo = ObjectDetailsDrillThruInfo<"drill-thru/zoom">;

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -133,3 +133,7 @@
 (deftest ^:parallel is-column-metadata-test
   (is (true? (lib.js/is-column-metadata (meta/field-metadata :venues :id))))
   (is (false? (lib.js/is-column-metadata 1))))
+
+(deftest ^:parallel cljs-key->js-key-test
+  (is (= "isManyPks"
+         (#'lib.js/cljs-key->js-key :many-pks?))))


### PR DESCRIPTION
Fixes #35725

The key `:many-pks?` in drill thru display info did not get converted to something JS-friendly -- it got converted to `manyPks?`, which is hard to use in JS. This PR changes our JS-specific display name key logic so anything ending with a question mark changes from `x?` to `isX` e.g. `:many-pks?` now becomes `isManyPks`.

I know `hasManyPks` is probably better grammar here but I didn't want to go down that rabbit hole of trying to decide when to use `is` vs `has`, and one general rule is easier to keep in your head anyway.