### PR TITLE
[E2E] Fix flaky reproduction for 29951

### DIFF
--- a/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
@@ -16,7 +16,7 @@ const questionDetails = {
       CC1: ["+", ["field", ORDERS.TOTAL], 1],
       CC2: ["+", ["field", ORDERS.TOTAL], 1],
     },
-    limit: 5,
+    limit: 2,
   },
   dataset: true,
 };
@@ -46,7 +46,7 @@ describe("issue 29951", { requestTimeout: 10000 }, () => {
     dragColumn(0, 100);
     cy.findByTestId("qb-header").button("Refresh").click();
     cy.wait("@dataset");
-    cy.findByTestId("view-footer").should("contain", "Showing 5 rows");
+    cy.findByTestId("view-footer").should("contain", "Showing 2 rows");
   });
 });
 

--- a/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
@@ -43,9 +43,12 @@ describe("issue 29951", { requestTimeout: 10000 }, () => {
     cy.button("Get Answer").should("be.visible");
     saveMetadataChanges();
 
+    cy.findAllByTestId("header-cell").last().should("have.text", "CC1");
+
     dragColumn(0, 100);
     cy.findByTestId("qb-header").button("Refresh").click();
     cy.wait("@dataset");
+    cy.get(".cellData").should("contain", "37.65");
     cy.findByTestId("view-footer").should("contain", "Showing 2 rows");
   });
 });

--- a/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
@@ -1,4 +1,8 @@
-import { getNotebookStep, restore } from "e2e/support/helpers";
+import {
+  getNotebookStep,
+  restore,
+  saveMetadataChanges,
+} from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 
@@ -37,8 +41,7 @@ describe("issue 29951", { requestTimeout: 10000 }, () => {
     // The UI shows us the "play" icon, indicating we should refresh the query,
     // but the point of this repro is to save without refreshing
     cy.button("Get Answer").should("be.visible");
-    cy.button("Save changes").click();
-    cy.wait(["@updateCard", "@dataset"]);
+    saveMetadataChanges();
 
     dragColumn(0, 100);
     cy.findByTestId("qb-header").button("Refresh").click();

--- a/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
@@ -21,7 +21,7 @@ const questionDetails = {
   dataset: true,
 };
 
-describe("issue 29951", { requestTimeout: 10000 }, () => {
+describe("issue 29951", { requestTimeout: 10000, viewportWidth: 1600 }, () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
@@ -1,9 +1,4 @@
-import {
-  getNotebookStep,
-  openQuestionActions,
-  popover,
-  restore,
-} from "e2e/support/helpers";
+import { getNotebookStep, restore } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 
@@ -33,11 +28,11 @@ describe("issue 29951", { requestTimeout: 10000 }, () => {
   });
 
   it("should allow to run the model query after changing custom columns (metabase#29951)", () => {
-    cy.createQuestion(questionDetails, { visitQuestion: true });
+    cy.createQuestion(questionDetails).then(({ body: { id } }) => {
+      cy.visit(`/model/${id}/query`);
+      cy.wait("@publicShema");
+    });
 
-    openQuestionActions();
-    popover().findByText("Edit query definition").click();
-    cy.wait("@publicShema");
     removeExpression("CC2");
     // The UI shows us the "play" icon, indicating we should refresh the query,
     // but the point of this repro is to save without refreshing


### PR DESCRIPTION
### Stats (for the last 7 days on `master`)
| type | %|
|-|-|
|Failure Rate|1.35%|
|Flake Rate|1.35%|

Examples of failed runs:
- https://www.deploysentinel.com/ci/runs/654e1dfe7bcc14868192bc86
- https://www.deploysentinel.com/ci/runs/654e99c8c9fa8b50a49740e6
- https://www.deploysentinel.com/ci/runs/654e1ddf7bcc14868192ba8f

![image](https://github.com/metabase/metabase/assets/31325167/47d40f9b-e44a-423e-a453-9a28ecbff73e)

### The cause
Not entirely sure what contributed to this, but it seems like a race condition. One thing I noticed in all failed recordings was that popover that contains "Edit model query" never fully rendered by the time Cypress clicks on that string.

https://github.com/metabase/metabase/assets/31325167/53e2138d-2615-45aa-9266-75ea65a96143

### The solution
1. [Navigate directly to the model query page](https://github.com/metabase/metabase/compare/e2e-fix-29951-flake?expand=1#diff-4f3b89aa6f745bf9fa183a2c7f288a1f391232932bf17a25ff15fc41ce50e932R35-R38)
2. [Use an existing helper to save changes](https://github.com/metabase/metabase/compare/e2e-fix-29951-flake?expand=1#diff-4f3b89aa6f745bf9fa183a2c7f288a1f391232932bf17a25ff15fc41ce50e932L45-R44) (comes with batteries included and waits for all the right requests)

Improvements:
- [Add an assertion](https://github.com/metabase/metabase/compare/e2e-fix-29951-flake?expand=1#diff-4f3b89aa6f745bf9fa183a2c7f288a1f391232932bf17a25ff15fc41ce50e932R46) to make sure the second custom column has actually been removed
    - This required a slightly wider viewport
- Make sure not only the footer renders and shows total number of rows, but also [check that the data in the table](https://github.com/metabase/metabase/compare/e2e-fix-29951-flake?expand=1#diff-4f3b89aa6f745bf9fa183a2c7f288a1f391232932bf17a25ff15fc41ce50e932R51) is present on the page

### Stress-tests
1 x 10 ✅, 2 x 30 ✅ , 1 x 50 
- https://github.com/metabase/metabase/actions/runs/6895246429
- https://github.com/metabase/metabase/actions/runs/6895340029
- https://github.com/metabase/metabase/actions/runs/6895671767
- https://github.com/metabase/metabase/actions/runs/6895954357
