### PR TITLE
Adding more spans to understand stats `publish-event!`

### DIFF
--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -374,7 +374,10 @@
   [id]
   {id ms/PositiveInt}
   (let [dashboard (get-dashboard id)]
-    (events/publish-event! :event/dashboard-read {:object dashboard :user-id api/*current-user-id*})
+    (span/with-span!
+      {:name       "publish-event!.dashboard-read"
+       :attributes {:dashboard/id id}}
+      (events/publish-event! :event/dashboard-read {:object dashboard :user-id api/*current-user-id*}))
     (last-edit/with-last-edit-info dashboard :dashboard)))
 
 (defn- check-allowed-to-change-embedding

--- a/src/metabase/events.clj
+++ b/src/metabase/events.clj
@@ -118,16 +118,25 @@
         (initialize-events!)
         (publish-event! topic event))
       (do
-        (log/debugf "Publishing %s event:\n\n%s" (u/colorize :yellow (pr-str topic)) (u/pprint-to-str event))
-        (assert (and (qualified-keyword? topic)
-                     (isa? topic :metabase/event))
-                (format "Invalid event topic %s: events must derive from :metabase/event" (pr-str topic)))
-        (assert (map? event)
-                (format "Invalid event %s: event must be a map." (pr-str event)))
+        (span/with-span!
+          {:name       "publish-event!.logging"
+           :attributes {}}
+          (log/debugf "Publishing %s event:\n\n%s" (u/colorize :yellow (pr-str topic)) (u/pprint-to-str event))
+          (assert (and (qualified-keyword? topic)
+                       (isa? topic :metabase/event))
+                  (format "Invalid event topic %s: events must derive from :metabase/event" (pr-str topic)))
+          (assert (map? event)
+                  (format "Invalid event %s: event must be a map." (pr-str event))))
         (try
-          (when-let [schema (events.schema/topic->schema topic)]
-            (mu/validate-throw schema event))
-          (next-method topic event)
+          (span/with-span!
+            {:name       "publish-event!.schema-validation"
+             :attributes {}}
+            (when-let [schema (events.schema/topic->schema topic)]
+              (mu/validate-throw schema event)))
+          (span/with-span!
+            {:name       "publish-event!.next-method"
+             :attributes {}}
+            (next-method topic event))
           (catch Throwable e
             (throw (ex-info (i18n/tru "Error publishing {0} event: {1}" topic (ex-message e))
                             {:topic topic, :event event}

--- a/src/metabase/events/recent_views.clj
+++ b/src/metabase/events/recent_views.clj
@@ -7,7 +7,8 @@
    [metabase.models.recent-views :as recent-views]
    [metabase.util :as u]
    [metabase.util.log :as log]
-   [methodical.core :as m]))
+   [methodical.core :as m]
+   [steffan-westcott.clj-otel.api.trace.span :as span]))
 
 (derive ::event :metabase/event)
 
@@ -17,14 +18,19 @@
 (m/defmethod events/publish-event! ::event
   "Handle processing for a single event notification which should update the recent views for a user."
   [topic {:keys [object user-id] :as _event}]
-  (try
-    (when object
-      (let [model    (audit-log/model-name object)
-            model-id (u/id object)
-            user-id  (or user-id api/*current-user-id*)]
-        (recent-views/update-users-recent-views! user-id model model-id)))
-    (catch Throwable e
-      (log/warnf e "Failed to process recent_views event: %s" topic))))
+  (span/with-span!
+    {:name (str "recent-views-" (name topic))
+     :topic topic
+     :object object
+     :user-id user-id}
+    (try
+      (when object
+        (let [model    (audit-log/model-name object)
+              model-id (u/id object)
+              user-id  (or user-id api/*current-user-id*)]
+          (recent-views/update-users-recent-views! user-id model model-id)))
+      (catch Throwable e
+        (log/warnf e "Failed to process recent_views event: %s" topic)))))
 
 (derive ::card-query-event :metabase/event)
 (derive :event/card-query ::card-query-event)
@@ -32,11 +38,16 @@
 (m/defmethod events/publish-event! ::card-query-event
   "Handle processing for a single card query event."
   [topic {:keys [card-id user-id context] :as _event}]
-  (try
-    (let [model    "card"
-          user-id  (or user-id api/*current-user-id*)]
-      ;; we don't want to count pinned card views
-      (when-not (#{:collection :dashboard} context)
-        (recent-views/update-users-recent-views! user-id model card-id)))
-    (catch Throwable e
-      (log/warnf e "Failed to process recent_views event: %s" topic))))
+  (span/with-span!
+    {:name (str "recent-views-" (name topic))
+     :topic topic
+     :card-id card-id
+     :user-id user-id}
+    (try
+      (let [model    "card"
+            user-id  (or user-id api/*current-user-id*)]
+        ;; we don't want to count pinned card views
+        (when-not (#{:collection :dashboard} context)
+          (recent-views/update-users-recent-views! user-id model card-id)))
+      (catch Throwable e
+        (log/warnf e "Failed to process recent_views event: %s" topic)))))

--- a/src/metabase/events/recent_views.clj
+++ b/src/metabase/events/recent_views.clj
@@ -21,7 +21,6 @@
   (span/with-span!
     {:name (str "recent-views-" (name topic))
      :topic topic
-     :object object
      :user-id user-id}
     (try
       (when object

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -36,7 +36,6 @@
   (span/with-span!
     {:name "view-log-card-read"
      :topic topic
-     :object (:object event)
      :user-id (:user-id event)}
     (try
       (-> event
@@ -79,7 +78,6 @@
   (span/with-span!
     {:name "view-log-dashboard-read"
      :topic topic
-     :object object
      :user-id user-id}
     (try
       (let [dashcards (filter :card_id (:dashcards object)) ;; filter out link/text cards wtih no card_id
@@ -106,7 +104,6 @@
   (span/with-span!
     {:name "view-log-table-read"
      :topic topic
-     :object object
      :user-id user-id}
     (try
       (let [table-id    (u/id object)

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -33,13 +33,18 @@
 (m/defmethod events/publish-event! ::card-read-event
   "Handle processing for a generic read event notification"
   [topic event]
-  (try
-    (-> event
-        generate-view
-        (assoc :context "question")
-        record-views!)
-    (catch Throwable e
-      (log/warnf e "Failed to process view_log event. %s" topic))))
+  (span/with-span!
+    {:name "view-log-card-read"
+     :topic topic
+     :object (:object event)
+     :user-id (:user-id event)}
+    (try
+      (-> event
+          generate-view
+          (assoc :context "question")
+          record-views!)
+      (catch Throwable e
+        (log/warnf e "Failed to process view_log event. %s" topic)))))
 
 (derive ::read-permission-failure :metabase/event)
 (derive :event/read-permission-failure ::read-permission-failure)
@@ -71,20 +76,25 @@
   "Handle processing for the dashboard read event. Logs the dashboard view as well as card views for each card on the
   dashboard."
   [topic {:keys [object user-id] :as event}]
-  (try
-    (let [dashcards (filter :card_id (:dashcards object)) ;; filter out link/text cards wtih no card_id
-          user-id   (or user-id api/*current-user-id*)
-          views     (map (fn [dashcard]
-                           {:model      "card"
-                            :model_id   (u/id (:card_id dashcard))
-                            :user_id    user-id
-                            :has_access (readable-dashcard? dashcard)
-                            :context    "dashboard"})
-                         dashcards)
-          dash-view (generate-view event)]
-      (record-views! (cons dash-view views)))
-    (catch Throwable e
-       (log/warnf e "Failed to process view_log event. %s" topic))))
+  (span/with-span!
+    {:name "view-log-dashboard-read"
+     :topic topic
+     :object object
+     :user-id user-id}
+    (try
+      (let [dashcards (filter :card_id (:dashcards object)) ;; filter out link/text cards wtih no card_id
+            user-id   (or user-id api/*current-user-id*)
+            views     (map (fn [dashcard]
+                               {:model      "card"
+                                :model_id   (u/id (:card_id dashcard))
+                                :user_id    user-id
+                                :has_access (readable-dashcard? dashcard)
+                                :context    "dashboard"})
+                           dashcards)
+            dash-view (generate-view event)]
+        (record-views! (cons dash-view views)))
+      (catch Throwable e
+        (log/warnf e "Failed to process view_log event. %s" topic)))))
 
 (derive ::table-read :metabase/event)
 (derive :event/table-read ::table-read)
@@ -93,14 +103,19 @@
   "Handle processing for the table read event. Does a basic permissions check to see if the the user has data perms for
   the table."
   [topic {:keys [object user-id] :as event}]
-  (try
-    (let [table-id    (u/id object)
-          database-id (:db_id object)
-          has-access? (when (= api/*current-user-id* user-id)
-                        (query-perms/can-query-table? database-id table-id))]
-      (-> event
-          (assoc :has-access has-access?)
-          generate-view
-          record-views!))
-    (catch Throwable e
-      (log/warnf e "Failed to process view_log event. %s" topic))))
+  (span/with-span!
+    {:name "view-log-table-read"
+     :topic topic
+     :object object
+     :user-id user-id}
+    (try
+      (let [table-id    (u/id object)
+            database-id (:db_id object)
+            has-access? (when (= api/*current-user-id* user-id)
+                          (query-perms/can-query-table? database-id table-id))]
+        (-> event
+            (assoc :has-access has-access?)
+            generate-view
+            record-views!))
+      (catch Throwable e
+        (log/warnf e "Failed to process view_log event. %s" topic)))))


### PR DESCRIPTION
https://stats.metabase.com/dashboard/2117 still takes 4s to load and the current spans don't seem to provide fine granularity around the hot spot, but it seems to be happening in the early stages of `publish-event!`. These extra spans provide finer granularity.
