### PR TITLE
Fixing bad performance due to massive pprint statements

### DIFF
--- a/src/metabase/events.clj
+++ b/src/metabase/events.clj
@@ -10,6 +10,7 @@
   (:require
    [clojure.spec.alpha :as s]
    [metabase.events.schema :as events.schema]
+   [metabase.models.interface :as mi]
    [metabase.plugins.classloader :as classloader]
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
@@ -121,7 +122,12 @@
         (span/with-span!
           {:name       "publish-event!.logging"
            :attributes {}}
-          (log/debugf "Publishing %s event:\n\n%s" (u/colorize :yellow (pr-str topic)) (u/pprint-to-str event))
+          (log/infof "Publishing %s event (name and id):\n\n%s"
+                      (u/colorize :yellow (pr-str topic))
+                      (u/pprint-to-str (let [model (mi/model event)]
+                                         (cond-> (select-keys event [:name :id])
+                                           model
+                                           (assoc :model model)))))
           (assert (and (qualified-keyword? topic)
                        (isa? topic :metabase/event))
                   (format "Invalid event topic %s: events must derive from :metabase/event" (pr-str topic)))


### PR DESCRIPTION
Spans on stats for massive models are very long, on the order of 4s.

The bad span seems to encompass a small amount of logging and assertion logic, including a with-out-str pprint, which I've found to be notoriously slow for large objects. This PR slims down the logged object.

If this is the culprit we should see a substantial performance improvement.

For reference, this is the offending span.

![image](https://github.com/metabase/metabase/assets/8381441/8aaad79a-cffb-4e6f-80dd-d2a865419dff)
