### PR TITLE
Fix opening bookmarked dashboard shows an empty page

### DIFF
--- a/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.js
@@ -1,0 +1,70 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { setupDashboardEndpoints } from "__support__/server-mocks";
+import {
+  createMockDashboard,
+  createMockDatabase,
+  createMockSettings,
+} from "metabase-types/api/mocks";
+import { createMockDashboardState } from "metabase-types/store/mocks";
+import { createMockEntitiesState } from "__support__/store";
+import dashboardReducer from "../reducers";
+import { fetchDashboard } from "./data-fetching";
+
+describe("fetchDashboard", () => {
+  let store;
+
+  beforeEach(() => {
+    const state = {
+      dashboard: createMockDashboardState(),
+      entities: createMockEntitiesState({
+        databases: [createMockDatabase()],
+      }),
+      settings: createMockSettings(),
+    };
+
+    store = configureStore({
+      reducer: {
+        dashboard: dashboardReducer,
+        entities: (state = {}) => state,
+        settings: (state = {}) => state,
+      },
+      preloadedState: state,
+    });
+
+    setupDashboardEndpoints(createMockDashboard({ id: 1 }));
+    setupDashboardEndpoints(createMockDashboard({ id: 2 }));
+  });
+
+  it("should cancel previous dashboard fetch when a new one is initiated (metabase#35959)", async () => {
+    const firstFetch = store.dispatch(
+      fetchDashboard({
+        dashId: 1,
+        queryParams: {},
+        options: {},
+      }),
+    );
+
+    const secondFetch = store.dispatch(
+      fetchDashboard({
+        dashId: 2,
+        queryParams: {},
+        options: {},
+      }),
+    );
+
+    await expect(firstFetch).resolves.toHaveProperty(
+      "type",
+      "metabase/dashboard/FETCH_DASHBOARD/rejected",
+    );
+
+    await expect(secondFetch).resolves.toMatchObject({
+      type: "metabase/dashboard/FETCH_DASHBOARD/fulfilled",
+      payload: {
+        dashboardId: 2,
+        dashboard: {
+          id: 2,
+        },
+      },
+    });
+  });
+});

--- a/frontend/src/metabase/dashboard/actions/revisions.js
+++ b/frontend/src/metabase/dashboard/actions/revisions.js
@@ -9,7 +9,12 @@ export const revertToRevision = createThunkAction(
   revision => {
     return async dispatch => {
       await dispatch(Revision.objectActions.revert(revision));
-      await dispatch(fetchDashboard(revision.model_id, null));
+      await dispatch(
+        fetchDashboard({
+          dashId: revision.model_id,
+          queryParams: null,
+        }),
+      );
       await dispatch(
         fetchDashboardCardData({ reload: false, clearCache: true }),
       );

--- a/frontend/src/metabase/dashboard/actions/save.js
+++ b/frontend/src/metabase/dashboard/actions/save.js
@@ -132,7 +132,11 @@ export const updateDashboardAndCards = createThunkAction(
 
       // make sure that we've fully cleared out any dirty state from editing (this is overkill, but simple)
       dispatch(
-        fetchDashboard(dashboard.id, null, { preserveParameters: false }),
+        fetchDashboard({
+          dashId: dashboard.id,
+          queryParams: null,
+          options: { preserveParameters: false },
+        }),
       ); // disable using query parameters when saving
     };
   },
@@ -161,7 +165,11 @@ export const updateDashboard = createThunkAction(
 
       // make sure that we've fully cleared out any dirty state from editing (this is overkill, but simple)
       dispatch(
-        fetchDashboard(dashboard.id, null, { preserveParameters: true }),
+        fetchDashboard({
+          dashId: dashboard.id,
+          queryParam: null,
+          options: { preserveParameters: true },
+        }),
       );
     };
   },

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -100,11 +100,21 @@ class Dashboard extends Component {
 
     loadDashboardParams();
 
-    try {
-      await fetchDashboard(dashboardId, location.query, {
+    const result = await fetchDashboard({
+      dashId: dashboardId,
+      queryParams: location.query,
+      options: {
         clearCache: !isNavigatingBackToDashboard,
         preserveParameters: isNavigatingBackToDashboard,
-      });
+      },
+    });
+
+    if (result.error) {
+      setErrorPage(result.payload);
+      return;
+    }
+
+    try {
       if (editingOnLoad) {
         this.setEditing(this.props.dashboard);
       }

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.jsx
@@ -208,11 +208,11 @@ class DashboardHeaderContainer extends Component {
   }
 
   onRevert() {
-    this.props.fetchDashboard(
-      this.props.dashboard.id,
-      this.props.location.query,
-      { preserveParameters: true },
-    );
+    this.props.fetchDashboard({
+      dashId: this.props.dashboard.id,
+      queryParams: this.props.location.query,
+      options: { preserveParameters: true },
+    });
   }
 
   async onSave() {

--- a/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
+++ b/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
@@ -168,11 +168,11 @@ export default ComposedComponent =>
         const { refreshPeriod } = this.state;
         if (refreshPeriod && this._refreshElapsed >= refreshPeriod) {
           this._refreshElapsed = 0;
-          await this.props.fetchDashboard(
-            this.props.dashboardId,
-            this.props.location.query,
-            { preserveParameters: true },
-          );
+          await this.props.fetchDashboard({
+            dashId: this.props.dashboardId,
+            queryParams: this.props.location.query,
+            options: { preserveParameters: true },
+          });
           this.props.fetchDashboardCardData({
             isRefreshing: true,
             reload: true,

--- a/frontend/src/metabase/dashboard/hoc/DashboardData.jsx
+++ b/frontend/src/metabase/dashboard/hoc/DashboardData.jsx
@@ -58,10 +58,20 @@ export default ComposedComponent =>
 
         initialize({ clearCache: !isNavigatingBackToDashboard });
 
-        try {
-          await fetchDashboard(dashboardId, location && location.query, {
+        const result = await fetchDashboard({
+          dashId: dashboardId,
+          queryParams: location && location.query,
+          options: {
             clearCache: !isNavigatingBackToDashboard,
-          });
+          },
+        });
+
+        if (result.error) {
+          setErrorPage(result.payload);
+          return;
+        }
+
+        try {
           await fetchDashboardCardData({
             reload: false,
             clearCache: !isNavigatingBackToDashboard,

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -11,7 +11,6 @@ import { NAVIGATE_BACK_TO_DASHBOARD } from "metabase/query_builder/actions";
 
 import {
   INITIALIZE,
-  FETCH_DASHBOARD,
   SET_EDITING_DASHBOARD,
   SET_DASHBOARD_ATTRIBUTES,
   ADD_CARD_TO_DASH,
@@ -45,6 +44,7 @@ import {
   SHOW_AUTO_APPLY_FILTERS_TOAST,
   tabsReducer,
   FETCH_CARD_DATA_PENDING,
+  fetchDashboard,
 } from "./actions";
 import {
   calculateDashCardRowAfterUndo,
@@ -55,8 +55,10 @@ import { INITIAL_DASHBOARD_STATE } from "./constants";
 const dashboardId = handleActions(
   {
     [INITIALIZE]: { next: state => null },
-    [FETCH_DASHBOARD]: {
-      next: (state, { payload: { dashboardId } }) => dashboardId,
+    [fetchDashboard.fulfilled]: {
+      next: (state, { payload }) => {
+        return payload.dashboardId;
+      },
     },
     [RESET]: { next: state => null },
   },
@@ -100,7 +102,7 @@ function newDashboard(before, after, isDirty) {
 
 const dashboards = handleActions(
   {
-    [FETCH_DASHBOARD]: {
+    [fetchDashboard.fulfilled]: {
       next: (state, { payload }) => ({
         ...state,
         ...payload.entities.dashboard,
@@ -162,7 +164,7 @@ const dashboards = handleActions(
 
 const dashcards = handleActions(
   {
-    [FETCH_DASHBOARD]: {
+    [fetchDashboard.fulfilled]: {
       next: (state, { payload }) => ({
         ...state,
         ...payload.entities.dashcard,
@@ -323,7 +325,7 @@ const parameterValues = handleActions(
         return clearCache ? {} : state;
       },
     },
-    [FETCH_DASHBOARD]: {
+    [fetchDashboard.fulfilled]: {
       next: (state, { payload: { parameterValues } }) => parameterValues,
     },
     [SET_PARAMETER_VALUE]: {
@@ -352,7 +354,7 @@ const draftParameterValues = handleActions(
         return clearCache ? {} : state;
       },
     },
-    [FETCH_DASHBOARD]: {
+    [fetchDashboard.fulfilled]: {
       next: (
         state,
         { payload: { dashboard, parameterValues, preserveParameters } },

--- a/frontend/src/metabase/public/containers/PublicDashboard.jsx
+++ b/frontend/src/metabase/public/containers/PublicDashboard.jsx
@@ -82,8 +82,18 @@ class PublicDashboard extends Component {
     }
 
     initialize();
+
+    const result = await fetchDashboard({
+      dashId: uuid || token,
+      queryParams: location.query,
+    });
+
+    if (result.error) {
+      setErrorPage(result.payload);
+      return;
+    }
+
     try {
-      await fetchDashboard(uuid || token, location.query);
       if (this.props.dashboard.tabs.length === 0) {
         await fetchDashboardCardData({ reload: false, clearCache: true });
       }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/35959

### Description

When users had two bookmarked dashboards with at least two pages on them and they switched fast enough, the app rendered a blank dashboard. It can be reproduced on stats with ease but for local environment you need to enable "Fast 3G" throttling in dev tools.

The reason is that we did not discard the result of `fetchDashboard` if there was a newer call of `fetchDashboard`. It resulted in updating `state.dashboard.dashboardId` to the previously fetched dashboard id. This would still work without dashboard tabs but the tabs reducer `frontend/src/metabase/dashboard/actions/tabs.ts` initializes tabs based on the `dashboardId` from the state which can be incorrect if we do not cancel the first request so it led to an invalid `selectedTabId` and hence a blank dashboard.

### How to verify

1. Bookmark two dashboards with at least two tabs and a few questions
2. Enable "Fast 3G" throttling in dev tools
3. Switch fast between dashboards
4. Every time it shows the expected content of a selected dashboard, no blank pages

### Demo

#### Before

https://github.com/metabase/metabase/assets/14301985/28a831af-4f98-4857-9517-6ab916d14b3a

#### After

https://github.com/metabase/metabase/assets/14301985/49c850bb-52d9-4fce-ad52-1088736f910b

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
