### PR TITLE
11x faster pretty printing

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -137,11 +137,13 @@
    clojure.pprint/pprint                              {:message "Use metabase.util.log instead of clojure.pprint/pprint"}
    clojure.string/lower-case                          {:message "Use metabase.util/lower-case-en instead of clojure.string/lower-case"}
    clojure.string/upper-case                          {:message "Use metabase.util/upper-case-en instead of clojure.string/upper-case"}
+   fipp.edn/pprint                                    {:message "Use metabase.util.log instead of fipp.edn/pprint"}
    honeysql.core/call                                 {:message "Use hx/call instead because it is Honey SQL 2 friendly"}
    honeysql.core/raw                                  {:message "Use hx/raw instead because it is Honey SQL 2 friendly"}
    java-time/with-clock                               {:message "Use mt/with-clock"}
    java.util.UUID/randomUUID                          {:message "Use clojure.core/random-uuid instead of java.util.UUID/randomUUID"}
    malli.core/explainer                               {:message "Use metabase.util.malli.registry/explainer instead of malli.core/explainer"}
+   me.flowthing.pp/pprint                             {:message "Use metabase.util.log instead of me.flowthing.pp/pprint"}
    medley.core/random-uuid                            {:message "Use clojure.core/random-uuid instead of medley.core/random-uuid"}
    metabase.lib.equality/find-column-indexes-for-refs {:message "Use lib.equality/closest-matches-in-metadata or lib.equality/find-closest-matches-for-refs instead of lib.equality/find-column-indexes-for-refs"}
    metabase.test/with-temp*                           {:message "Use mt/with-temp instead of mt/with-temp*"}

--- a/deps.edn
+++ b/deps.edn
@@ -74,6 +74,8 @@
   instaparse/instaparse                     {:mvn/version "1.4.12"}             ; Make your own parser
   clj-commons/clj-yaml                      {:mvn/version "1.0.27"}             ; Clojure wrapper for YAML library SnakeYAML
   io.github.camsaul/toucan2                 {:mvn/version "1.0.524"}
+  io.github.eerohele/pp                     {:git/tag "2023-10-05.5"            ; super fast pretty-printing library
+                                             :git/sha "7059eec"}
   ;; The 2.X line of Resilience4j requires Java 17, so we cannot upgrade this dependency until that is our minimum JVM version
   io.github.resilience4j/resilience4j-retry {:mvn/version "1.7.1"}              ; Support for retrying operations
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -17,6 +17,7 @@
    [net.cgrand.macrovich :as macros]
    [weavejester.dependency :as dep]
    #?@(:clj  ([clojure.math.numeric-tower :as math]
+              [me.flowthing.pp :as pp]
               [metabase.config :as config]
               #_{:clj-kondo/ignore [:discouraged-namespace]}
               [metabase.util.jvm :as u.jvm]
@@ -615,12 +616,19 @@
 
      (pprint-to-str 'green some-obj)"
   (^String [x]
-   ;; we try to set this permanently above, but it doesn't seem to work in Cljs, so just bind it every time. The
-   ;; default value wastes too much space, 120 is a little easier to read actually.
-   (#?@(:clj [do] :cljs [binding [pprint/*print-right-margin* 120]])
+   (#?@
+    (:clj
      (with-out-str
        #_{:clj-kondo/ignore [:discouraged-var]}
-       (pprint/pprint x))))
+       (pp/pprint x {:max-width 120}))
+
+     :cljs
+     ;; we try to set this permanently above, but it doesn't seem to work in Cljs, so just bind it every time. The
+     ;; default value wastes too much space, 120 is a little easier to read actually.
+     (binding [pprint/*print-right-margin* 120]
+       (with-out-str
+         #_{:clj-kondo/ignore [:discouraged-var]}
+         (pprint/pprint x))))))
 
   (^String [color-symb x]
    (u.format/colorize color-symb (pprint-to-str x))))


### PR DESCRIPTION
Resolves #1684

@markbastian discovered in #35895 that we're spending 3.5 seconds pretty printing something for a log message. Now, we shouldn't be logging mega objects in the first place, and we definitely should be no-opping there because it's at the `DEBUG` level which should be disabled, but either way the performance of `clojure.pprint/pprint` is terrible.

Way back in 2015 I opened #1684 to look into switching to [`fipp`](https://github.com/brandonbloom/fipp) since it's supposedly much faster. @escherize suggested we look at [`pp`](https://github.com/eerohele/pp) as well, which is even faster, but newer. Here are profiling results of printing the EDN definition of the sample dataset:

```clj
(pprint-to-str (metabase.test.data.interface/get-dataset-definition metabase.test.data.dataset-definitions/sample-dataset))
```

```
pprint (current code)
Evaluation count : 6 in 6 samples of 1 calls.
             Execution time mean : 7.322658 sec
    Execution time std-deviation : 27.342390 ms
   Execution time lower quantile : 7.285595 sec ( 2.5%)
   Execution time upper quantile : 7.352330 sec (97.5%)
                   Overhead used : 1.577346 ns

fipp
Evaluation count : 6 in 6 samples of 1 calls.
             Execution time mean : 5.620728 sec
    Execution time std-deviation : 629.796494 ms
   Execution time lower quantile : 4.728104 sec ( 2.5%)
   Execution time upper quantile : 6.211350 sec (97.5%)
                   Overhead used : 1.577346 ns

pp
Evaluation count : 6 in 6 samples of 1 calls.
             Execution time mean : 647.744193 ms
    Execution time std-deviation : 5.983942 ms
   Execution time lower quantile : 643.003141 ms ( 2.5%)
   Execution time upper quantile : 655.843870 ms (97.5%)
                   Overhead used : 1.577346 ns
```

So, about 11x faster for `pprint-to-str` which we use all over the place.

Since the output is basically the same, switching it is an easy win and a no-brainer.
