### PR TITLE
[E2E] Fix "slugify collection name" flake

### DIFF
--- a/e2e/test/scenarios/onboarding/urls.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/urls.cy.spec.js
@@ -71,7 +71,7 @@ describe("URLs", () => {
     });
   });
 
-  describe("collections", { tags: "@flaky" }, () => {
+  describe("collections", () => {
     it("should slugify collection name", () => {
       cy.visit("/collection/root");
       cy.findAllByTestId("collection-entry-name")

--- a/e2e/test/scenarios/onboarding/urls.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/urls.cy.spec.js
@@ -74,8 +74,9 @@ describe("URLs", () => {
   describe("collections", { tags: "@flaky" }, () => {
     it("should slugify collection name", () => {
       cy.visit("/collection/root");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("First collection").click();
+      cy.findAllByTestId("collection-entry-name")
+        .contains("First collection")
+        .click();
       cy.location("pathname").should(
         "eq",
         `/collection/${FIRST_COLLECTION_ID}-first-collection`,


### PR DESCRIPTION
### Stats (for the last 7 days on `master`)
This test has consistently been in the top 3-5 most flaky tests. Ironically, it also failed on `master` in the past 24h.
| type | %|
|-|-|
|Failure Rate|1.72%|
|Flake Rate|34.48%|

Examples of failed runs:
- https://www.deploysentinel.com/ci/runs/655720128e3aecf82054b472
- https://www.deploysentinel.com/ci/runs/65539de7c9fa8b50a4e6265b
- https://www.deploysentinel.com/ci/runs/655581c63afb6930b6c8fe74

![image](https://github.com/metabase/metabase/assets/31325167/290486bd-29c1-4c85-be01-22c658e7a8e1)

### The cause
We're using the unscoped `findByText()` helper.
Cypress finds the "First Collection" string first in the sidebar. Then the page loads and the sidebar most likely reloads by the time Cypress wants to click on that element.

### The solution
Scope the element we want to click on to the collection item. This also ensures page loaded.

### Stress-tests
1 x 30 ✅ ("should slugify collection name" - the actual flake)
- https://github.com/metabase/metabase/actions/runs/6903496830
1 x 30 ✅ (all tests in this spec - 10 x 30 = 300 runs passed)
- https://github.com/metabase/metabase/actions/runs/6903459862

### Additional Notes
Although @iethree tagged the whole describe block as `@flaky`, I couldn't find any other test from this spec in the Deploysentinel statistics, no matter which time period or branch I used to filter results. It was always just one and only "should slugify collection name" test. This PR fixes that test and removes the flaky tag from the whole block.

I wanted to go and clean things up in other tests but this whole spec shouldn't even exist. It's an overkill to use E2E tests to test "slugify" function. There's an issue opened back in August 2022 about this: https://github.com/metabase/metabase/issues/24960