### PR TITLE
[MLv2] Filter modal — Filter widget selection

### DIFF
--- a/frontend/src/metabase-lib/comparison.ts
+++ b/frontend/src/metabase-lib/comparison.ts
@@ -5,6 +5,7 @@ import type {
   FieldReference,
 } from "metabase-types/api";
 import type { ColumnMetadata, Query } from "./types";
+import { toLegacyQuery } from "./query";
 
 export function areLegacyQueriesEqual(
   query1: DatasetQuery,
@@ -12,6 +13,18 @@ export function areLegacyQueriesEqual(
   fieldIds?: number[],
 ): boolean {
   return ML.query_EQ_(query1, query2, fieldIds);
+}
+
+export function areQueriesEqual(
+  query1: Query,
+  query2: Query,
+  fieldIds?: number[],
+): boolean {
+  return areLegacyQueriesEqual(
+    toLegacyQuery(query1),
+    toLegacyQuery(query2),
+    fieldIds,
+  );
 }
 
 export function findMatchingColumn(

--- a/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/ColumnFilterSection.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/ColumnFilterSection.tsx
@@ -2,20 +2,27 @@ import { Flex, Text } from "metabase/ui";
 import { Icon } from "metabase/core/components/Icon";
 import { getColumnIcon } from "metabase/common/utils/columns";
 import * as Lib from "metabase-lib";
+import type { FilterPickerWidgetProps } from "./types";
 
 interface ColumnFilterSectionProps {
   query: Lib.Query;
   stageIndex: number;
   column: Lib.ColumnMetadata;
+  filter?: Lib.FilterClause;
+  onChange: (filter?: Lib.ExpressionClause) => void;
 }
 
 export function ColumnFilterSection({
   query,
   stageIndex,
   column,
+  filter,
+  onChange,
 }: ColumnFilterSectionProps) {
   const columnInfo = Lib.displayInfo(query, stageIndex, column);
   const columnIcon = getColumnIcon(column);
+
+  const FilterWidget = getFilterWidget(column);
 
   return (
     <Flex direction="row" align="center" px="2rem" py="1rem" gap="sm">
@@ -23,6 +30,39 @@ export function ColumnFilterSection({
       <Text color="text.2" weight="bold">
         {columnInfo.displayName}
       </Text>
+      <FilterWidget
+        query={query}
+        stageIndex={stageIndex}
+        column={column}
+        filter={filter}
+        onChange={onChange}
+      />
     </Flex>
   );
+}
+
+function NotImplementedWidget(props: FilterPickerWidgetProps) {
+  return null;
+}
+
+function getFilterWidget(column: Lib.ColumnMetadata) {
+  if (Lib.isBoolean(column)) {
+    return NotImplementedWidget;
+  }
+  if (Lib.isTime(column)) {
+    return NotImplementedWidget;
+  }
+  if (Lib.isDate(column)) {
+    return NotImplementedWidget;
+  }
+  if (Lib.isCoordinate(column)) {
+    return NotImplementedWidget;
+  }
+  if (Lib.isString(column)) {
+    return NotImplementedWidget;
+  }
+  if (Lib.isNumeric(column)) {
+    return NotImplementedWidget;
+  }
+  return NotImplementedWidget;
 }

--- a/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/types.ts
+++ b/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/types.ts
@@ -1,0 +1,9 @@
+import type * as Lib from "metabase-lib/types";
+
+export interface FilterPickerWidgetProps {
+  query: Lib.Query;
+  stageIndex: number;
+  column: Lib.ColumnMetadata;
+  filter?: Lib.FilterClause;
+  onChange: (filter?: Lib.ExpressionClause) => void;
+}

--- a/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/utils.ts
+++ b/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/utils.ts
@@ -1,0 +1,13 @@
+import * as Lib from "metabase-lib";
+
+export function findFilterClause(
+  query: Lib.Query,
+  stageIndex: number,
+  filterColumn: Lib.ColumnMetadata,
+): Lib.FilterClause | undefined {
+  const filters = Lib.filters(query, stageIndex);
+  const { filterPositions } = Lib.displayInfo(query, stageIndex, filterColumn);
+  return filterPositions != null && filterPositions.length > 0
+    ? filters[filterPositions[0]]
+    : undefined;
+}


### PR DESCRIPTION
Epic #34112

Adds placeholders for different filter widgets to the bulk filter modal. Also, adds the key parts to implement filter CRUD (mapping columns to filters, create/update/delete logic, etc.)

Tests will be added with the first PR implementing a specific kind of filters: #35908