### PR TITLE
[E2E] Fix pivot table sorting fields flake

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -487,21 +487,18 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
 
     // open settings and expand Total column settings
     cy.findByTestId("viz-settings-button").click();
-    openColumnSettings(/Total/);
 
-    // sort descending
-    cy.icon("arrow_down").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("158 – 160");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("8 – 10").should("not.exist");
+    sortColumnResults("Total", "descending");
+    cy.findAllByTestId("pivot-table").within(() => {
+      cy.findByText("158 – 160").should("be.visible");
+      cy.findByText("8 – 10").should("not.exist");
+    });
 
-    // sort ascending
-    cy.icon("arrow_up").realClick();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("8 – 10");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("158 – 160").should("not.exist");
+    sortColumnResults("Total", "ascending");
+    cy.findAllByTestId("pivot-table").within(() => {
+      cy.findByText("8 – 10").should("be.visible");
+      cy.findByText("158 – 160").should("not.exist");
+    });
   });
 
   it("should display an error message for native queries", () => {
@@ -1247,4 +1244,27 @@ function openColumnSettings(columnName) {
     .findByText(columnName)
     .siblings("[data-testid$=settings-button]")
     .click();
+}
+
+/**
+ * @param {string} column
+ * @param {("ascending"|"descending")} direction
+ */
+function sortColumnResults(column, direction) {
+  const iconName = direction === "ascending" ? "arrow_up" : "arrow_down";
+
+  cy.findByTestId("sidebar-content")
+    .findByTestId(`${column}-settings-button`)
+    .click();
+
+  popover().icon(iconName).click();
+  // Click anywhere to dismiss the popover from UI
+  cy.get("body").click("topLeft");
+
+  cy.location("hash").then(hash => {
+    // Get rid of the leading `#`
+    const base64EncodedQuery = hash.slice(1);
+    const decodedQuery = atob(base64EncodedQuery);
+    expect(decodedQuery).to.include(direction);
+  });
 }


### PR DESCRIPTION
### Stats (for the last 7 days on `master`)
This has been the flakiest test for a while. Regardless of the time period, it's always at about 50% flake rate.
| type | %|
|-|-|
|Failure Rate|0|
|Flake Rate|50.93%|

Examples of failed runs:
- https://www.deploysentinel.com/ci/runs/655731207a354ced6dd2c51a
- https://www.deploysentinel.com/ci/runs/65572a25a969b6143a2d69fa
- https://www.deploysentinel.com/ci/runs/65572816d41d0d719d43e86b

![image](https://github.com/metabase/metabase/assets/31325167/207e5766-7c69-4d68-a099-7fd5ac8065dc)

### The cause
It's really hard to debug this test because the popover is hovering table results. There's quite possibly some race condition in play here (between the click on the arrow and the time table results update).

What I've also noticed is that the existing `openColumnSettings` helper uses `sidebar()`, which yields two elements. At least one of which is not visible (as indicated by the crossed eye icon)
![image](https://github.com/metabase/metabase/assets/31325167/f583a65e-2159-4c7c-8340-c7da27d55db8)

### The solution
Wait for the table result to update after sorting, before we attempt to assert on anything. That's achieved with [the new helper](https://github.com/metabase/metabase/compare/e2e-fix-pivot-sorting-fields?expand=1#diff-af5719cf695b56de656582dfdfe06a84d74819769fde10f935a2d22ef0e8befaR1253-R1270) that makes sure URL updated **and** url hash (which is really a base 64 encoded query) contains the sort direction ("ascending" or "descending").

This helper also makes sure that the popover is not blocking/obscuring the table view. I don't think this contributed to the flake, but it definitely didn't help debug it.

### Stress-tests
1 x 30 ✅, 2 x 50 ✅ 
- https://github.com/metabase/metabase/actions/runs/6903496830
- https://github.com/metabase/metabase/actions/runs/6904258725
- https://github.com/metabase/metabase/actions/runs/6904448203

### Additional Notes
I also got rid of linting errors, and have made the assertion just a tiny bit more explicit and safe in the process.
```diff
- // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
- cy.findByText("158 – 160");
- // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
- cy.findByText("8 – 10").should("not.exist");
+ cy.findAllByTestId("pivot-table").within(() => {
+   cy.findByText("8 – 10").should("be.visible");
+   cy.findByText("158 – 160").should("not.exist");
+ }); 