### PR TITLE
Rollback mbqlv2 drills - sort, fk-filter, summarize-column-by-time

### DIFF
--- a/frontend/src/metabase/visualizations/click-actions/Mode/Mode.ts
+++ b/frontend/src/metabase/visualizations/click-actions/Mode/Mode.ts
@@ -1,12 +1,9 @@
-import * as Lib from "metabase-lib";
-import type { DrillThru } from "metabase-lib";
 import type Question from "metabase-lib/Question";
 import type {
   ClickAction,
   ClickObject,
   QueryClickActionsMode,
 } from "../../types";
-import { DRILL_TYPE_TO_HANDLER_MAP } from "./constants";
 
 export class Mode {
   _question: Question;
@@ -34,58 +31,7 @@ export class Mode {
     const question = this._question;
     const props = { question, settings, clicked, extraData };
 
-    let drills: ClickAction[] = [];
-
-    // FIXME: this try catch is needed to mitigate Lib runtime error, it doesn't work properly with custom columns. Remove when this gets fixed
-    try {
-      const query = question._getMLv2Query();
-      const stageIndex = -1;
-
-      const applyDrillAndGetNewQuestion = (
-        drill: DrillThru,
-        ...args: any[]
-      ) => {
-        const updatedQuery = Lib.drillThru(query, stageIndex, drill, ...args);
-        return question.setDatasetQuery(Lib.toLegacyQuery(updatedQuery));
-      };
-
-      // TODO: those calculations are really expensive and must be memoized at some level
-      // check `_visualizationIsClickableCached` from TableInteractive
-      const availableDrillThrus = Lib.availableDrillThrus(
-        query,
-        stageIndex,
-        clicked?.column,
-        clicked?.value,
-        clicked?.data,
-        clicked?.dimensions,
-      );
-
-      drills = availableDrillThrus
-        .flatMap(drill => {
-          const drillDisplayInfo = Lib.displayInfo(query, stageIndex, drill);
-
-          const drillHandler = DRILL_TYPE_TO_HANDLER_MAP[drillDisplayInfo.type];
-
-          if (!drillHandler) {
-            return null;
-          }
-
-          return drillHandler({
-            ...props,
-            drill,
-            drillDisplayInfo,
-            applyDrill: applyDrillAndGetNewQuestion,
-          });
-        })
-        .filter(Boolean) as ClickAction[]; // TODO [31004]: remove this after all drills have been added
-    } catch (e) {
-      console.error("error getting available drills from MLv2", e);
-    }
-
-    const additionalClickActions =
-      mode.clickActions?.flatMap(drill => drill(props)) || [];
-
-    const actions = [...drills, ...additionalClickActions];
+    const actions = mode.clickActions.flatMap(drill => drill(props));
 
     if (!actions.length && mode.fallback) {
       return mode.fallback(props);

--- a/frontend/src/metabase/visualizations/click-actions/Mode/Mode.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/click-actions/Mode/Mode.unit.spec.ts
@@ -72,7 +72,9 @@ describe("Mode", function () {
             type: "query",
             query: {
               "source-table": ORDERS_ID,
-              "order-by": [["asc", ["field", ORDERS.ID, null]]],
+              "order-by": [
+                ["asc", ["field", ORDERS.ID, { "base-type": "type/Integer" }]],
+              ],
             },
           },
         });

--- a/frontend/src/metabase/visualizations/click-actions/actions/HideColumnAction/HideColumnAction.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/HideColumnAction/HideColumnAction.tsx
@@ -25,7 +25,7 @@ export const HideColumnAction: LegacyDrill = ({
 
   return [
     {
-      name: "formatting",
+      name: "formatting-hide",
       title: t`Hide column`,
       section: "sort",
       buttonType: "sort",

--- a/frontend/src/metabase/visualizations/click-actions/drills/SortDrill.ts
+++ b/frontend/src/metabase/visualizations/click-actions/drills/SortDrill.ts
@@ -1,0 +1,46 @@
+import { t } from "ttag";
+import type {
+  ClickActionBase,
+  ClickActionProps,
+  QuestionChangeClickAction,
+} from "metabase/visualizations/types";
+import {
+  sortDrill,
+  sortDrillQuestion,
+} from "metabase-lib/queries/drills/sort-drill";
+
+const ACTIONS: Record<string, ClickActionBase> = {
+  asc: {
+    name: "sort-ascending",
+    icon: "arrow_up",
+    section: "sort",
+    buttonType: "sort",
+    tooltip: t`Sort ascending`,
+  },
+  desc: {
+    name: "sort-descending",
+    icon: "arrow_down",
+    section: "sort",
+    buttonType: "sort",
+    tooltip: t`Sort descending`,
+  },
+};
+
+const SortDrill = ({
+  question,
+  clicked,
+}: ClickActionProps): QuestionChangeClickAction[] => {
+  const drill = sortDrill({ question, clicked });
+  if (!drill) {
+    return [];
+  }
+
+  const { sortDirections } = drill;
+  return sortDirections.map(sortDirection => ({
+    ...ACTIONS[sortDirection],
+    question: () => sortDrillQuestion({ question, clicked, sortDirection }),
+  }));
+};
+
+// eslint-disable-next-line import/no-default-export -- deprecated usage
+export default SortDrill;

--- a/frontend/src/metabase/visualizations/click-actions/modes/DefaultMode.ts
+++ b/frontend/src/metabase/visualizations/click-actions/modes/DefaultMode.ts
@@ -4,6 +4,8 @@ import { QuickFilterDrill } from "metabase/visualizations/click-actions/drills/Q
 import { ObjectDetailDrill } from "metabase/visualizations/click-actions/drills/ObjectDetailDrill";
 import ZoomDrill from "metabase/visualizations/click-actions/drills/ZoomDrill";
 import { ColumnFilterDrill } from "metabase/visualizations/click-actions/drills/ColumnFilterDrill";
+import SortDrill from "metabase/visualizations/click-actions/drills/SortDrill";
+import ForeignKeyDrill from "metabase/visualizations/click-actions/drills/ForeignKeyDrill";
 import type { QueryClickActionsMode } from "../../types";
 import { ColumnFormattingAction } from "../actions/ColumnFormattingAction";
 import { HideColumnAction } from "../actions/HideColumnAction";
@@ -14,8 +16,10 @@ export const DefaultMode: QueryClickActionsMode = {
   clickActions: [
     UnderlyingRecordsDrill,
     ZoomDrill,
+    SortDrill,
     ObjectDetailDrill,
     QuickFilterDrill,
+    ForeignKeyDrill,
     ColumnFilterDrill,
     AutomaticInsightsDrill,
     HideColumnAction,

--- a/frontend/src/metabase/visualizations/click-actions/modes/SegmentMode.ts
+++ b/frontend/src/metabase/visualizations/click-actions/modes/SegmentMode.ts
@@ -1,5 +1,6 @@
 import SummarizeColumnDrill from "metabase/visualizations/click-actions/drills/SummarizeColumnDrill";
 import DistributionDrill from "metabase/visualizations/click-actions/drills/DistributionDrill";
+import SummarizeColumnByTimeDrill from "metabase/visualizations/click-actions/drills/SummarizeColumnByTimeDrill";
 import type { QueryClickActionsMode } from "../../types";
 import { DefaultMode } from "./DefaultMode";
 
@@ -8,6 +9,7 @@ export const SegmentMode: QueryClickActionsMode = {
   clickActions: [
     ...DefaultMode.clickActions,
     SummarizeColumnDrill,
+    SummarizeColumnByTimeDrill,
     DistributionDrill,
   ],
 };

--- a/frontend/src/metabase/visualizations/click-actions/modes/TimeseriesMode.ts
+++ b/frontend/src/metabase/visualizations/click-actions/modes/TimeseriesMode.ts
@@ -6,8 +6,8 @@ import { DefaultMode } from "./DefaultMode";
 export const TimeseriesMode: QueryClickActionsMode = {
   name: "timeseries",
   clickActions: [
-    ...DefaultMode.clickActions,
     getPivotDrill({ withTime: false }),
+    ...DefaultMode.clickActions,
   ],
   ModeFooter: TimeseriesModeFooter,
 };

--- a/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsPopover.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsPopover.unit.spec.tsx
@@ -144,7 +144,12 @@ describe("ClickActionsPopover", function () {
               ...ORDERS_DATASET_QUERY,
               query: {
                 ...ORDERS_DATASET_QUERY.query,
-                "order-by": [["asc", ["field", ORDERS.ID, null]]],
+                "order-by": [
+                  [
+                    "asc",
+                    ["field", ORDERS.ID, { "base-type": "type/Integer" }],
+                  ],
+                ],
               },
             },
           }),
@@ -152,6 +157,7 @@ describe("ClickActionsPopover", function () {
             column: ORDERS_COLUMNS.ID,
             value: undefined,
           },
+          rowValues: undefined,
         });
 
         expect(queryIcon("arrow_up")).not.toBeInTheDocument();
@@ -185,7 +191,7 @@ describe("ClickActionsPopover", function () {
                       "field",
                       ORDERS.ID,
                       {
-                        "base-type": "type/BigInteger",
+                        "base-type": "type/Integer",
                       },
                     ],
                   ],
@@ -208,7 +214,7 @@ describe("ClickActionsPopover", function () {
               ORDERS.TOTAL,
               "type/Float",
             ),
-            display: "table",
+            display: "line",
           },
         },
         {
@@ -219,7 +225,7 @@ describe("ClickActionsPopover", function () {
               ORDERS.QUANTITY,
               "type/Integer",
             ),
-            display: "table",
+            display: "line",
           },
         },
       ])(
@@ -508,7 +514,6 @@ function getSummarizedOverTimeResultDatasetQuery(
           "field",
           ORDERS.CREATED_AT,
           {
-            "base-type": "type/DateTime",
             "temporal-unit": "month",
           },
         ],


### PR DESCRIPTION
### Description

This rolls back mbqlv2 drills implementation added in:
https://github.com/metabase/metabase/pull/34460 - SortDrill
https://github.com/metabase/metabase/pull/32402 - FKFilterDrill, SummarizeColumnByTimeDrill

We don't remove all added code, just restore original drlls and remove MBQLv2 api usage.

We should revert this changes in 49 version.

### How to verify
CI should pass

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
