### PR TITLE
Cleanup of extra spans when diagnosing 33499

### DIFF
--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -374,10 +374,7 @@
   [id]
   {id ms/PositiveInt}
   (let [dashboard (get-dashboard id)]
-    (span/with-span!
-      {:name       "publish-event!.dashboard-read"
-       :attributes {:dashboard/id id}}
-      (events/publish-event! :event/dashboard-read {:object dashboard :user-id api/*current-user-id*}))
+    (events/publish-event! :event/dashboard-read {:object dashboard :user-id api/*current-user-id*})
     (last-edit/with-last-edit-info dashboard :dashboard)))
 
 (defn- check-allowed-to-change-embedding

--- a/src/metabase/events.clj
+++ b/src/metabase/events.clj
@@ -134,11 +134,8 @@
           (assert (map? event)
                   (format "Invalid event %s: event must be a map." (pr-str event))))
         (try
-          (span/with-span!
-            {:name       "publish-event!.schema-validation"
-             :attributes {}}
-            (when-let [schema (events.schema/topic->schema topic)]
-              (mu/validate-throw schema event)))
+          (when-let [schema (events.schema/topic->schema topic)]
+            (mu/validate-throw schema event))
           (span/with-span!
             {:name       "publish-event!.next-method"
              :attributes {}}


### PR DESCRIPTION
Fixes #33499

We added a bunch of OTEL spans to figure out what was going on with super long page loads. Turns out it was a slow pprint of massive objects.

This PR removes a few spans, but not all. The ones removed are either redundant or almost certainly not needed (I did remove the one around the offending code, but the negative space that would show if it happened again would reveal the issue -- LMK if we think we should put that one back).

One important thing to consider when reviewing this PR is if we like the current coverage level around the `metabase.events` code (plus a couple extra things that were instrumented). It feels right, but if it seems too onerous we could remove some.

As an observation, it _might_ make sense to add instrumentation to the high level functions in toucan2 itself, such as hydrate, select, etc. This would give us transparent instrumentation on the library and we could easily view traces to see the bounds of our db hot spots.
