### PR TITLE
Stress-test a single driver test in isolation

### DIFF
--- a/.github/workflows/drivers-stress-test.yml
+++ b/.github/workflows/drivers-stress-test.yml
@@ -1,0 +1,723 @@
+name: Driver Stress Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      test:
+        description: 'The exact test name with its namespace.'
+        type: string
+        required: true
+      times:
+        description: 'How many times do you want to run this test?'
+        type: number
+        required: true
+        default: 1
+      driver:
+        description: 'The driver against which you want to run this test.'
+        required: true
+        default: 'Postgres'
+        type: choice
+        options:
+          - Athena
+          - BigQuery
+          - Druid
+          - Google Analytics
+          - Google Classpath Test
+          - Maria DB
+          - Maria DB (latest)
+          - Mongo 4
+          - Mongo 4 (SSL)
+          - Mongo 5
+          - Mongo 5 (SSL)
+          - Mongo (latest)
+          - MySQL
+          - MySQL (latest)
+          - Oracle 18
+          - Oracle 21
+          - Postgres
+          - Postgres (latest)
+          - Presto JDBC
+          - Redshift
+          - Snowflake
+          - SparkSQL
+          - SQLite
+          - SQL Server 2017
+          - SQL Server 2022
+          - Vertica
+
+jobs:
+
+  be-tests-athena-ee:
+    if: inputs.driver == 'Athena'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: athena
+      MB_ATHENA_TEST_REGION: us-east-1
+      MB_ATHENA_TEST_ACCESS_KEY: ${{ secrets.MB_ATHENA_TEST_ACCESS_KEY }}
+      MB_ATHENA_TEST_SECRET_KEY: ${{ secrets.MB_ATHENA_TEST_SECRET_KEY }}
+      MB_ATHENA_TEST_S3_STAGING_DIR: ${{ secrets.MB_ATHENA_TEST_S3_STAGING_DIR }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test Athena driver
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-athena-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-tests-bigquery-cloud-sdk-ee:
+    if: inputs.driver == 'BigQuery'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: bigquery-cloud-sdk
+      MB_BIGQUERY_TEST_PROJECT_ID: ${{ secrets.BIGQUERY_TEST_PROJECT_ID }}
+      MB_BIGQUERY_TEST_CLIENT_ID: ${{ secrets.MB_BIGQUERY_TEST_CLIENT_ID }}
+      MB_BIGQUERY_TEST_CLIENT_SECRET: ${{ secrets.MB_BIGQUERY_TEST_CLIENT_SECRET }}
+      MB_BIGQUERY_TEST_ACCESS_TOKEN: ${{ secrets.MB_BIGQUERY_TEST_ACCESS_TOKEN }}
+      MB_BIGQUERY_TEST_REFRESH_TOKEN: ${{ secrets.MB_BIGQUERY_TEST_REFRESH_TOKEN }}
+      MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON: ${{ secrets.MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test BigQuery Cloud SDK driver
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-bigquery-cloud-sdk-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-tests-druid-ee:
+    if: inputs.driver == 'Druid'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: druid
+    services:
+      druid:
+        image: metabase/druid:0.20.2
+        ports:
+          - "8082:8082"
+        env:
+          CLUSTER_SIZE: nano-quickstart
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test Druid driver
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-druid-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-tests-googleanalytics-ee:
+    if: inputs.driver == 'Google Analytics'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: googleanalytics
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test Google Analytics driver
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-googleanalytics-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-google-related-drivers-classpath-test:
+    if: inputs.driver == 'Google Classpath Test'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: 'googleanalytics,bigquery-cloud-sdk'
+      MB_BIGQUERY_TEST_PROJECT_ID: ${{ secrets.BIGQUERY_TEST_PROJECT_ID }}
+      MB_BIGQUERY_TEST_CLIENT_ID: ${{ secrets.MB_BIGQUERY_TEST_CLIENT_ID }}
+      MB_BIGQUERY_TEST_CLIENT_SECRET: ${{ secrets.MB_BIGQUERY_TEST_CLIENT_SECRET }}
+      MB_BIGQUERY_TEST_ACCESS_TOKEN: ${{ secrets.MB_BIGQUERY_TEST_ACCESS_TOKEN }}
+      MB_BIGQUERY_TEST_REFRESH_TOKEN: ${{ secrets.MB_BIGQUERY_TEST_REFRESH_TOKEN }}
+      MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON: ${{ secrets.MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test Google Related Drivers Classpath
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-google-related-drivers-classpath-test'
+        test-args: ':only "[metabase.query-processor-test.expressions-test metabase.driver.google-test metabase.driver.googleanalytics-test ${{ inputs.test }}] :times ${{ inputs.times }}"'
+
+  be-tests-mariadb-10-2-ee:
+    if: inputs.driver == 'Maria DB'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: mysql
+      MB_DB_TYPE: mysql
+      MB_DB_HOST: localhost
+      MB_DB_PORT: 3306
+      MB_DB_DBNAME: circle_test
+      MB_DB_USER: root
+      MB_MYSQL_TEST_USER: root
+    services:
+      mariadb:
+        image: circleci/mariadb:10.2.23
+        ports:
+          - "3306:3306"
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test MariaDB driver (10.2)
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-mariadb-10-2-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-tests-mariadb-latest-ee:
+    if: inputs.driver == 'Maria DB (latest)'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: mysql
+      MB_DB_TYPE: mysql
+      MB_DB_HOST: localhost
+      MB_DB_PORT: 3306
+      MB_DB_DBNAME: circle_test
+      MB_DB_USER: root
+      MB_MYSQL_TEST_USER: root
+    services:
+      mariadb:
+        image: circleci/mariadb:latest
+        ports:
+          - "3306:3306"
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test MariaDB driver (latest)
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-mariadb-latest-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-tests-mongo-4-4-ee:
+    if: inputs.driver == 'Mongo 4'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: mongo
+      MB_MONGO_TEST_USER: metabase
+      MB_MONGO_TEST_PASSWORD: metasample123
+    services:
+      mongodb:
+        image: metabase/qa-databases:mongo-sample-4.4
+        ports:
+          - "27017:27017"
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test MongoDB driver (4.4)
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-mongo-4-4-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-tests-mongo-4-4-ssl-ee:
+    if: inputs.driver == 'Mongo 4 (SSL)'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: mongo
+      MB_MONGO_TEST_USER: metabase
+      MB_MONGO_TEST_PASSWORD: metasample123
+      MB_TEST_MONGO_REQUIRES_SSL: true
+    steps:
+      - uses: actions/checkout@v3
+      - name: Spin up Mongo docker container
+        run: docker run -d -p 27017:27017 --name metamongo metabase/qa-databases:mongo-sample-4.4 mongod --dbpath /data/db2/ --tlsMode requireTLS --tlsCertificateKeyFile /etc/mongo/metamongo.pem --tlsCAFile /etc/mongo/metaca.crt
+      - name: Wait until the port 27017 is ready
+        run: while ! nc -z localhost 27017; do sleep 1; done
+        timeout-minutes: 5
+      - name: Make SSL certificates for Mongo available
+        run: |
+          curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metabase.crt \
+          -o ./test_resources/ssl/mongo/metabase.crt
+
+          curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metabase.key \
+          -o ./test_resources/ssl/mongo/metabase.key
+
+          curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metaca.crt \
+          -o ./test_resources/ssl/mongo/metaca.crt
+
+      - name: Test MongoDB SSL driver (4.4)
+        uses: ./.github/actions/test-driver
+        with:
+          junit-name: 'be-tests-mongo-4-4-ee'
+          test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-tests-mongo-5-0-ee:
+    if: inputs.driver == 'Mongo 5'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: mongo
+      MB_MONGO_TEST_USER: metabase
+      MB_MONGO_TEST_PASSWORD: metasample123
+    services:
+      mongodb:
+        image: metabase/qa-databases:mongo-sample-5.0
+        ports:
+          - "27017:27017"
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test MongoDB driver (5.0)
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-mongo-5-0-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-tests-mongo-5-0-ssl-ee:
+    if: inputs.driver == 'Mongo 5 (SSL)'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: mongo
+      MB_MONGO_TEST_USER: metabase
+      MB_MONGO_TEST_PASSWORD: metasample123
+      MB_TEST_MONGO_REQUIRES_SSL: true
+    steps:
+    - uses: actions/checkout@v3
+    - name: Spin up Mongo docker container
+      run: docker run -d -p 27017:27017 --name metamongo metabase/qa-databases:mongo-sample-5.0 mongod --dbpath /data/db2/ --tlsMode requireTLS --tlsCertificateKeyFile /etc/mongo/metamongo.pem --tlsCAFile /etc/mongo/metaca.crt
+    - name: Wait until the port 27017 is ready
+      run: while ! nc -z localhost 27017; do sleep 1; done
+      timeout-minutes: 5
+    - name: Make SSL certificates for Mongo available
+      run: |
+        curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metabase.crt \
+        -o ./test_resources/ssl/mongo/metabase.crt
+
+        curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metabase.key \
+        -o ./test_resources/ssl/mongo/metabase.key
+
+        curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metaca.crt \
+        -o ./test_resources/ssl/mongo/metaca.crt
+
+    - name: Test MongoDB SSL driver (5.0)
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-mongo-5-0-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-tests-mongo-latest-ee:
+    if: inputs.driver == 'Mongo (latest)'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: mongo
+      MB_MONGO_TEST_USER: metabase
+      MB_MONGO_TEST_PASSWORD: metasample123
+    services:
+      mongodb:
+        image: circleci/mongo:latest
+        ports:
+          - "27017:27017"
+        env:
+          MONGO_INITDB_ROOT_USERNAME: metabase
+          MONGO_INITDB_ROOT_PASSWORD: metasample123
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test MongoDB driver (latest)
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-mongo-latest-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-tests-mysql-8-0-ee:
+    if: inputs.driver == 'MySQL'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: mysql
+      MB_DB_TYPE: mysql
+      MB_DB_HOST: localhost
+      MB_DB_PORT: 3306
+      MB_DB_DBNAME: circle_test
+      MB_DB_USER: root
+      MB_MYSQL_TEST_USER: root
+    services:
+      mysql:
+        image: cimg/mysql:8.0
+        ports:
+          - "3306:3306"
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test MySQL driver (8.0)
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-mysql-8-0-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-tests-mysql-latest-ee:
+    if: inputs.driver == 'MySQL (latest)'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: mysql
+      MB_DB_TYPE: mysql
+      MB_DB_HOST: localhost
+      MB_DB_PORT: 3306
+      MB_DB_DBNAME: circle_test
+      MB_DB_USER: root
+      MB_MYSQL_TEST_USER: root
+      # set up env vars for something named "MYSQL_SSL" to run MySQL SSL tests verifying connectivity with PEM cert
+      # they are deliberately given a different name to prevent them from affecting the regular test run against
+      # the configured MySQL instance, but there is one particular test (mysql-connect-with-ssl-and-pem-cert-test)
+      # that overrides the MB_MYSQL_TEST_* values with them
+      # the MYSQL_RDS_SSL_INSTANCE vars are defined as secrets and can be altered
+      MB_MYSQL_SSL_TEST_HOST: ${{ secrets.MYSQL_RDS_SSL_INSTANCE_HOST }}
+      MB_MYSQL_SSL_TEST_SSL: true
+      MB_MYSQL_SSL_TEST_ADDITIONAL_OPTIONS: 'verifyServerCertificate=true'
+      # the contents of the ./resources/certificates/rds-combined-ca-bundle.pem file
+      MB_MYSQL_SSL_TEST_SSL_CERT: ${{ secrets.MB_MYSQL_SSL_TEST_SSL_CERT }}
+      MB_MYSQL_SSL_TEST_USER: metabase
+      MB_MYSQL_SSL_TEST_PASSWORD: ${{ secrets.MYSQL_RDS_SSL_INSTANCE_PASSWORD }}
+    services:
+      mysql:
+        image: mysql:latest
+        ports:
+        - "3306:3306"
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test MySQL driver (latest)
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-mysql-latest-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-tests-oracle-18-4-ee:
+    if: inputs.driver == 'Oracle 18'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: oracle
+      MB_ORACLE_TEST_HOST: localhost
+      MB_ORACLE_TEST_USER: system
+      MB_ORACLE_TEST_PASSWORD: password
+      MB_ORACLE_TEST_SERVICE_NAME: XEPDB1
+    services:
+      oracle:
+        image: gvenzl/oracle-xe:18.4.0-slim
+        env:
+          ORACLE_PASSWORD: password
+        ports:
+          - "1521:1521"
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test Oracle driver (18.4)
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-oracle-18-4-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-tests-oracle-21-3-ee:
+    if: inputs.driver == 'Oracle 21'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: oracle
+      MB_ORACLE_TEST_HOST: localhost
+      MB_ORACLE_TEST_PORT: 2484
+      MB_ORACLE_TEST_SERVICE_NAME: XEPDB1
+      MB_ORACLE_TEST_SSL: true
+      MB_ORACLE_TEST_SSL_USE_TRUSTSTORE: true
+      MB_ORACLE_TEST_SSL_TRUSTSTORE_PATH: './test_resources/ssl/oracle/truststore.p12'
+      MB_ORACLE_TEST_SSL_TRUSTSTORE_OPTIONS: local
+      MB_ORACLE_TEST_SSL_TRUSTSTORE_PASSWORD_VALUE: 'PassworD_#1234'
+      MB_ORACLE_TEST_SSL_USE_KEYSTORE: true
+      MB_ORACLE_TEST_SSL_KEYSTORE_PATH: './test_resources/ssl/oracle/keystore.p12'
+      MB_ORACLE_TEST_SSL_KEYSTORE_OPTIONS: local
+      MB_ORACLE_TEST_SSL_KEYSTORE_PASSWORD_VALUE: 'PassworD_#1234'
+      MB_ORACLE_SSL_TEST_SSL: true
+    services:
+      oracle:
+        image: metabase/qa-databases:oracle-xe-21.3
+        env:
+          ORACLE_PASSWORD: password
+        ports:
+          - "2484:2484"
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test Oracle driver (21.3)
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-oracle-21-3-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-tests-postgres-ee:
+    if: inputs.driver == 'Postgres'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: postgres
+      MB_DB_TYPE: postgres
+      MB_DB_PORT: 5432
+      MB_DB_HOST: localhost
+      MB_DB_DBNAME: mb_test
+      MB_DB_USER: mb_test
+      MB_POSTGRESQL_TEST_USER: mb_test
+    services:
+      postgres:
+        image: postgres:12-alpine
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_USER: mb_test
+          POSTGRES_DB: mb_test
+          POSTGRES_HOST_AUTH_METHOD: trust
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test Postgres driver (12)
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-postgres-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-tests-postgres-latest-ee:
+    if: inputs.driver == 'Postgres (latest)'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: postgres
+      MB_DB_TYPE: postgres
+      MB_DB_PORT: 5432
+      MB_DB_HOST: localhost
+      MB_DB_DBNAME: circle_test
+      MB_DB_USER: circle_test
+      MB_POSTGRESQL_TEST_USER: circle_test
+      MB_POSTGRES_SSL_TEST_SSL: true
+      MB_POSTGRES_SSL_TEST_SSL_MODE: verify-full
+      MB_POSTGRES_SSL_TEST_SSL_ROOT_CERT_PATH: 'test-resources/certificates/us-east-2-bundle.pem'
+    services:
+      postgres:
+        image: circleci/postgres:latest
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_USER: circle_test
+          POSTGRES_DB: circle_test
+          POSTGRES_HOST_AUTH_METHOD: trust
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test Postgres driver (latest)
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-postgres-latest-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-tests-presto-jdbc-ee:
+    if: inputs.driver == 'Presto JDBC'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: presto-jdbc
+      MB_PRESTO_JDBC_TEST_CATALOG: test_data
+      MB_PRESTO_JDBC_TEST_HOST: localhost
+      MB_PRESTO_JDBC_TEST_PORT: 8443
+      MB_PRESTO_JDBC_TEST_SSL: true
+      MB_PRESTO_JDBC_TEST_USER: metabase
+      MB_PRESTO_JDBC_TEST_PASSWORD: metabase
+      MB_ENABLE_PRESTO_JDBC_DRIVER: true
+      MB_PRESTO_JDBC_TEST_ADDITIONAL_OPTIONS: 'SSLTrustStorePath=/tmp/cacerts-with-presto-ssl.jks&SSLTrustStorePassword=changeit'
+    services:
+      presto:
+        image: metabase/presto-mb-ci:latest # version 0.254
+        ports:
+          - "8443:8443"
+        env:
+          JAVA_TOOL_OPTIONS: "-Xmx2g"
+    steps:
+    - uses: actions/checkout@v3
+    - name: Wait for port ${{ env.MB_PRESTO_JDBC_TEST_PORT }} to be ready
+      run: while ! nc -z localhost ${{ env.MB_PRESTO_JDBC_TEST_PORT }}; do sleep 0.1; done
+      timeout-minutes: 15
+    - name: Create temp cacerts file based on bundled JDK one
+      run: cp $JAVA_HOME/lib/security/cacerts /tmp/cacerts-with-presto-ssl.jks
+    - name: Capture Presto server self signed CA
+      run: |
+          while [[ ! -s /tmp/presto-ssl-ca.pem ]];
+            do echo "Waiting to capture SSL CA" \
+              && openssl s_client -connect localhost:8443 2>/dev/null </dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > /tmp/presto-ssl-ca.pem \
+              && sleep 1; done
+    - name: Convert Presto CA from PEM to DER
+      run: openssl x509 -outform der -in /tmp/presto-ssl-ca.pem -out /tmp/presto-ssl-ca.der
+    - name: Add write permission on cacerts file
+      run: chmod u+w /tmp/cacerts-with-presto-ssl.jks
+    - name: Import Presto CA into temp cacerts file
+      run: |
+          keytool -noprompt -import -alias presto -keystore /tmp/cacerts-with-presto-ssl.jks \
+                  -storepass changeit -file /tmp/presto-ssl-ca.der -trustcacerts
+    - name: Test Presto JDBC driver
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-presto-jdbc-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-tests-redshift-ee:
+    if: inputs.driver == 'Redshift'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: redshift
+      MB_REDSHIFT_TEST_USER: metabase_ci
+      MB_REDSHIFT_TEST_DB: testdb
+      MB_REDSHIFT_TEST_HOST: ${{ secrets.MB_REDSHIFT_TEST_HOST }}
+      MB_REDSHIFT_TEST_PASSWORD: ${{ secrets.MB_REDSHIFT_TEST_PASSWORD }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test Redshift driver
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-redshift-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-tests-snowflake-ee:
+    if: inputs.driver == 'Snowflake'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: snowflake
+      MB_SNOWFLAKE_TEST_USER: METABASE CI
+      MB_SNOWFLAKE_TEST_ACCOUNT: ${{ secrets.MB_SNOWFLAKE_TEST_ACCOUNT }}
+      MB_SNOWFLAKE_TEST_PASSWORD: ${{ secrets.MB_SNOWFLAKE_TEST_PASSWORD }}
+      MB_SNOWFLAKE_TEST_WAREHOUSE: ${{ secrets.MB_SNOWFLAKE_TEST_WAREHOUSE }}
+      MB_SNOWFLAKE_TEST_PK_USER: METABASE PK
+      MB_SNOWFLAKE_TEST_PK_PRIVATE_KEY: ${{ secrets.MB_SNOWFLAKE_TEST_PK_PRIVATE_KEY }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test Snowflake driver
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-snowflake-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-tests-sparksql-ee:
+    if: inputs.driver == 'SparkSQL'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: sparksql
+    services:
+      sparksql:
+        image: metabase/spark:3.2.1
+        ports:
+          - "10000:10000"
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test Spark driver
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-sparksql-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-tests-sqlite-ee:
+    if: inputs.driver == 'SQLite'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: sqlite
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test SQLite driver
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-sqlite-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-tests-sqlserver-2017-ee:
+    if: inputs.driver == 'SQL Server 2017'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: sqlserver
+      MB_SQLSERVER_TEST_HOST: localhost
+      MB_SQLSERVER_TEST_PASSWORD: 'P@ssw0rd'
+      MB_SQLSERVER_TEST_USER: SA
+    services:
+      sqlserver:
+        image: mcr.microsoft.com/mssql/server:2017-latest
+        ports:
+          - "1433:1433"
+        env:
+          ACCEPT_EULA: Y
+          SA_PASSWORD: 'P@ssw0rd'
+          MSSQL_MEMORY_LIMIT_MB: 1024
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test MS SQL Server 2017 driver
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-sqlserver-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-tests-sqlserver-2022-ee:
+    if: inputs.driver == 'SQL Server 2022'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: sqlserver
+      MB_SQLSERVER_TEST_HOST: localhost
+      MB_SQLSERVER_TEST_PASSWORD: 'P@ssw0rd'
+      MB_SQLSERVER_TEST_USER: SA
+    services:
+      sqlserver:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        ports:
+          - "1433:1433"
+        env:
+          ACCEPT_EULA: Y
+          SA_PASSWORD: 'P@ssw0rd'
+          MSSQL_MEMORY_LIMIT_MB: 1024
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test MS SQL Server 2022 driver
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-sqlserver-2022-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"
+
+  be-tests-vertica-ee:
+    if: inputs.driver == 'Vertica'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: vertica
+    services:
+      vertica:
+        image: vertica/vertica-ce:12.0.2-0
+        ports:
+          - "5433:5433"
+    steps:
+    - uses: actions/checkout@v3
+    - name: Make plugins directory
+      run: mkdir plugins
+    - name: Test Vertica driver
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-vertica-ee'
+        test-args: ":only ${{ inputs.test }} :times ${{ inputs.times }}"


### PR DESCRIPTION
This PR introduces a driver stress-test workflow.
Resolves #32998.

It needs **three** input values:
1. Full test name with its namespace (e.g. `metabase.query-processor.streaming.csv-test/sqlite-datetime-test`
2. The number of times you want to run this test
3. Driver against which we want to test this (chosen from a dropdown menu)

Here's an example of a run from my fork where I ran the above mentioned test **forty times** against SQLite driver!
https://github.com/nemanjaglumac/metabase/actions/runs/7507569955/job/20441377658

![image](https://github.com/metabase/metabase/assets/31325167/7ac8578a-01f2-4c8c-9062-2e757fdd419b)

> [!important]
> This workflow needs to be kept in sync with the changes made to the (main) `drivers.yml`

### CLI
it should be easy to trigger this workflow from the CLI with Babashka, for example. I'm sure @escherize will be happy to cook something up quickly. In meantime, here's dumb (as in - not parameterized) NodeJS code that you can use in meantime. It can easily be parameterized, though.

```js
#!/usr/bin/node
const { Octokit } = require("@octokit/core");
const {
  restEndpointMethods,
} = require("@octokit/plugin-rest-endpoint-methods");

const MyOctokit = Octokit.plugin(restEndpointMethods);
const github = new MyOctokit({ auth: process.env["GITHUB_TOKEN"] });

const config = {
  owner: "metabase",
  repo: "metabase",
};

github.rest.actions.createWorkflowDispatch({
  ...config,
  workflow_id: "drivers-stress-test.yml",
  ref: "your-branch-here",
  inputs: {
    test: "test-name-with-namespace", // e.g. "metabase.query-processor.streaming.csv-test/sqlite-datetime-test"
    times: "40",
    driver: "SQLite" // or any other driver listed in the workflow
  },
});
```