### PR TITLE
Support histogram X-axis, improve X-axis type inferrence

### DIFF
--- a/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
+++ b/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
@@ -16,7 +16,11 @@ import {
 } from "metabase/visualizations/shared/settings/series";
 import { getCommonStaticVizSettings } from "metabase/static-viz/lib/settings";
 import {
+  getDefaultIsHistogram,
+  getDefaultIsNumeric,
+  getDefaultIsTimeSeries,
   getDefaultStackingValue,
+  getDefaultXAxisScale,
   getDefaultXAxisTitle,
   getDefaultYAxisTitle,
   getIsXAxisLabelEnabledDefault,
@@ -94,7 +98,7 @@ export const computeStaticComboChartSettings = (
   dashcardSettings: VisualizationSettings,
   renderingContext: RenderingContext,
 ): ComputedVisualizationSettings => {
-  const mainCard = rawSeries[0].card;
+  const { card: mainCard, data: mainDataset } = rawSeries[0];
   const settings = getCommonStaticVizSettings(rawSeries, dashcardSettings);
 
   const cardsColumns = getCardsColumns(rawSeries, settings);
@@ -197,6 +201,28 @@ export const computeStaticComboChartSettings = (
   fillWithDefaultValue(settings, "graph.x_axis.axis_enabled", true);
 
   fillWithDefaultValue(settings, "graph.y_axis.axis_enabled", true);
+
+  fillWithDefaultValue(
+    settings,
+    "graph.x_axis._is_numeric",
+    getDefaultIsNumeric(mainDataset, dimensionModel.columnIndex),
+  );
+  fillWithDefaultValue(
+    settings,
+    "graph.x_axis._is_timeseries",
+    getDefaultIsTimeSeries(mainDataset, dimensionModel.columnIndex),
+  );
+  fillWithDefaultValue(
+    settings,
+    "graph.x_axis._is_histogram",
+    getDefaultIsHistogram(dimensionModel.column),
+  );
+
+  fillWithDefaultValue(
+    settings,
+    "graph.x_axis.scale",
+    getDefaultXAxisScale(settings),
+  );
 
   return settings;
 };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
@@ -224,7 +224,6 @@ const getXAxisType = (settings: ComputedVisualizationSettings) => {
     case "linear":
       return "value";
     default:
-      // TODO: implement histogram
       return "category";
   }
 };
@@ -251,6 +250,7 @@ export const buildDimensionAxis = (
 
   const boundaryGap =
     axisType === "value" ? undefined : ([0.02, 0.02] as [number, number]);
+  // const boundaryGap = false;
 
   const nameGap = getXAxisNameGap(
     chartModel,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/format.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/format.ts
@@ -39,11 +39,14 @@ const getXAxisFormatter = (
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
 ) => {
+  const isHistogram = settings["graph.x_axis.scale"] === "histogram";
+
   return (value: unknown) =>
     renderingContext.formatValue(value, {
       column,
       ...(settings.column?.(column) ?? {}),
       jsx: false,
+      noRange: isHistogram,
     });
 };
 

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -24,7 +24,9 @@ import {
 
 import { ChartSettingOrderedSimple } from "metabase/visualizations/components/settings/ChartSettingOrderedSimple";
 import {
+  getDefaultIsHistogram,
   getDefaultStackingValue,
+  getDefaultXAxisScale,
   getDefaultXAxisTitle,
   getDefaultYAxisTitle,
   getIsXAxisLabelEnabledDefault,
@@ -39,15 +41,6 @@ import {
   isNumeric,
   isAny,
 } from "metabase-lib/types/utils/isa";
-
-// NOTE: currently we don't consider any date extracts to be histgrams
-const HISTOGRAM_DATE_EXTRACTS = new Set([
-  // "minute-of-hour",
-  // "hour-of-day",
-  // "day-of-month",
-  // "day-of-year",
-  // "week-of-year",
-]);
 
 export function getDefaultDimensionLabel(multipleSeries) {
   return getDefaultXAxisTitle(multipleSeries[0]?.data.cols[0]);
@@ -453,12 +446,7 @@ export const GRAPH_AXIS_SETTINGS = {
         },
       ],
       vizSettings,
-    ) =>
-      // matches binned numeric columns
-      cols[0].binning_info != null ||
-      // matches certain date extracts like day-of-week, etc
-      // NOTE: currently disabled
-      HISTOGRAM_DATE_EXTRACTS.has(cols[0].unit),
+    ) => getDefaultIsHistogram(cols[0]),
   },
   "graph.x_axis.scale": {
     section: t`Axes`,
@@ -471,14 +459,7 @@ export const GRAPH_AXIS_SETTINGS = {
       "graph.x_axis._is_numeric",
       "graph.x_axis._is_histogram",
     ],
-    getDefault: (series, vizSettings) =>
-      vizSettings["graph.x_axis._is_histogram"]
-        ? "histogram"
-        : vizSettings["graph.x_axis._is_timeseries"]
-        ? "timeseries"
-        : vizSettings["graph.x_axis._is_numeric"]
-        ? "linear"
-        : "ordinal",
+    getDefault: (series, vizSettings) => getDefaultXAxisScale(vizSettings),
     getProps: (series, vizSettings) => {
       const options = [];
       if (vizSettings["graph.x_axis._is_timeseries"]) {

--- a/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
@@ -3,9 +3,12 @@ import type { ComputedVisualizationSettings } from "metabase/visualizations/type
 import type {
   Card,
   DatasetColumn,
+  DatasetData,
   SeriesOrderSetting,
 } from "metabase-types/api";
 import { getFriendlyName } from "metabase/visualizations/lib/utils";
+import { dimensionIsNumeric } from "metabase/visualizations/lib/numeric";
+import { dimensionIsTimeseries } from "metabase/visualizations/lib/timeseries";
 
 export const STACKABLE_DISPLAY_TYPES = new Set(["area", "bar"]);
 
@@ -111,3 +114,36 @@ export const getDefaultXAxisTitle = (
 };
 
 export const getIsXAxisLabelEnabledDefault = () => true;
+
+export const getDefaultIsHistogram = (dimensionColumn: DatasetColumn) => {
+  return dimensionColumn.binning_info != null;
+};
+
+export const getDefaultIsNumeric = (
+  data: DatasetData,
+  dimensionIndex: number,
+) => {
+  return dimensionIsNumeric(data, dimensionIndex);
+};
+
+export const getDefaultIsTimeSeries = (
+  data: DatasetData,
+  dimensionIndex: number,
+) => {
+  return dimensionIsTimeseries(data, dimensionIndex);
+};
+
+export const getDefaultXAxisScale = (
+  vizSettings: ComputedVisualizationSettings,
+) => {
+  if (vizSettings["graph.x_axis._is_histogram"]) {
+    return "histogram";
+  }
+  if (vizSettings["graph.x_axis._is_timeseries"]) {
+    return "timeseries";
+  }
+  if (vizSettings["graph.x_axis._is_numeric"]) {
+    return "linear";
+  }
+  return "ordinal";
+};


### PR DESCRIPTION
### Description

Adds the support of histogram X-axis.
It looks different from `dc.js` implementation because tick values are aligned at the center of a bar insead of being on the left. ECharts do not provide an option for that. Custom aligning requires the knowledge of bars width which is not available at the stage of building the `option` object.

### How to verify

Try sending test dashboard subscriptions with histograms.

### Demo

#### Histogram
<img width="598" alt="Screenshot 2023-11-17 at 1 39 26 PM" src="https://github.com/metabase/metabase/assets/14301985/d97d9edb-4090-4ed6-bb85-ef4c5c63916d">

#### Ordinal
<img width="599" alt="Screenshot 2023-11-17 at 1 39 13 PM" src="https://github.com/metabase/metabase/assets/14301985/4d3dec54-9a4b-4651-aea3-03e20cbe2f0c">


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
