### PR TITLE
fix charts broken when there is right y-axis only

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
@@ -388,34 +388,37 @@ const buildMetricsAxes = (
   const hasLeftAxis = leftFormatter != null && leftExtent != null;
   const hasRightAxis = rightFormatter != null && rightExtent != null;
 
-  return [
-    ...(hasLeftAxis
-      ? [
-          buildMetricAxis(
-            settings,
-            "left",
-            leftRange,
-            leftExtent,
-            leftFormatter,
-            getYAxisName(chartModel, settings, "left"),
-            renderingContext,
-          ),
-        ]
-      : []),
-    ...(hasRightAxis
-      ? [
-          buildMetricAxis(
-            settings,
-            "right",
-            rightRange,
-            rightExtent,
-            rightFormatter,
-            getYAxisName(chartModel, settings, "right"),
-            renderingContext,
-          ),
-        ]
-      : []),
-  ];
+  const axes: CartesianAxisOption[] = [];
+
+  if (hasLeftAxis) {
+    axes.push(
+      buildMetricAxis(
+        settings,
+        "left",
+        leftRange,
+        leftExtent,
+        leftFormatter,
+        getYAxisName(chartModel, settings, "left"),
+        renderingContext,
+      ),
+    );
+  }
+
+  if (hasRightAxis) {
+    axes.push(
+      buildMetricAxis(
+        settings,
+        "right",
+        rightRange,
+        rightExtent,
+        rightFormatter,
+        getYAxisName(chartModel, settings, "right"),
+        renderingContext,
+      ),
+    );
+  }
+
+  return axes;
 };
 
 export const buildAxes = (

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -122,6 +122,23 @@ const buildEChartsLineAreaSeries = (
   };
 };
 
+const getSeriesYAxisIndex = (
+  seriesModel: SeriesModel,
+  chartModel: CartesianChartModel,
+): number => {
+  const hasSingleYAxis = chartModel.yAxisSplit.some(
+    yAxisKeys => yAxisKeys.length === 0,
+  );
+
+  if (hasSingleYAxis) {
+    return 0;
+  }
+
+  return chartModel.yAxisSplit.findIndex(yAxis =>
+    yAxis.includes(seriesModel.dataKey),
+  );
+};
+
 export const buildEChartsSeries = (
   chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
@@ -144,10 +161,7 @@ export const buildEChartsSeries = (
   return chartModel.seriesModels
     .map(seriesModel => {
       const seriesSettings = seriesSettingsByDataKey[seriesModel.dataKey];
-
-      const yAxisIndex = chartModel.yAxisSplit[0].includes(seriesModel.dataKey)
-        ? 0
-        : 1;
+      const yAxisIndex = getSeriesYAxisIndex(seriesModel, chartModel);
 
       switch (seriesSettings.display) {
         case "line":


### PR DESCRIPTION
### Description

Fixes when a combo chart has only right axis, it fails to render. It is caused by mistakingly setting `axisIndex=1` to series options that should be displayed on the right axis which is not true when there is no left axis at all.

This PR relies on changes that are done after https://github.com/metabase/metabase/pull/35307

### How to verify

1. Send a test subscription of a chart with only right Y-axis
2. Ensure it renders correctly

### Demo

<img width="586" alt="Screenshot 2023-11-17 at 5 33 54 PM" src="https://github.com/metabase/metabase/assets/14301985/3b169a86-5001-43de-a8a3-a55c4e76254a">

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
