### PR TITLE
Timeseries chrome tests

### DIFF
--- a/frontend/src/metabase/common/components/DatePicker/DateOperatorPicker/DateOperatorPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/DateOperatorPicker/DateOperatorPicker.unit.spec.tsx
@@ -27,11 +27,6 @@ function setup({
 }
 
 describe("DateOperatorPicker", () => {
-  beforeAll(() => {
-    jest.useFakeTimers();
-    jest.setSystemTime(new Date(2020));
-  });
-
   it("should be able to change the option type", () => {
     const { onChange } = setup();
 

--- a/frontend/src/metabase/common/components/DatePicker/DateOperatorPicker/DateOperatorPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/DateOperatorPicker/DateOperatorPicker.unit.spec.tsx
@@ -1,0 +1,83 @@
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders, screen } from "__support__/ui";
+import { DATE_PICKER_OPERATORS } from "../constants";
+import type { DatePickerValue, DatePickerOperator } from "../types";
+import { DateOperatorPicker } from "./DateOperatorPicker";
+
+interface SetupOpts {
+  value?: DatePickerValue;
+  availableOperators?: ReadonlyArray<DatePickerOperator>;
+}
+
+function setup({
+  value,
+  availableOperators = DATE_PICKER_OPERATORS,
+}: SetupOpts = {}) {
+  const onChange = jest.fn();
+
+  renderWithProviders(
+    <DateOperatorPicker
+      value={value}
+      availableOperators={availableOperators}
+      onChange={onChange}
+    />,
+  );
+
+  return { onChange };
+}
+
+describe("DateOperatorPicker", () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2020));
+  });
+
+  it("should be able to change the option type", () => {
+    const { onChange } = setup();
+
+    userEvent.click(screen.getByDisplayValue("All time"));
+    userEvent.click(screen.getByText("Current"));
+
+    expect(onChange).toHaveBeenCalledWith({
+      type: "relative",
+      value: "current",
+      unit: "day",
+    });
+  });
+
+  it("should be able to change a specific date value", () => {
+    const { onChange } = setup({
+      value: {
+        type: "specific",
+        operator: "=",
+        values: [new Date(2015, 1, 10)],
+      },
+    });
+
+    userEvent.click(screen.getByText("15"));
+
+    expect(onChange).toHaveBeenCalledWith({
+      type: "specific",
+      operator: "=",
+      values: [new Date(2015, 1, 15)],
+    });
+  });
+
+  it("should be able to change a relative date value", () => {
+    const { onChange } = setup({
+      value: {
+        type: "relative",
+        value: 1,
+        unit: "month",
+      },
+    });
+
+    userEvent.type(screen.getByLabelText("Interval"), "2");
+
+    expect(onChange).toHaveBeenCalledWith({
+      type: "relative",
+      value: 12,
+      unit: "month",
+    });
+  });
+});

--- a/frontend/src/metabase/common/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
+++ b/frontend/src/metabase/common/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
@@ -1,0 +1,65 @@
+import type { DatePickerValue } from "../types";
+import { setOptionType } from "./utils";
+
+const DATE = new Date();
+
+const SPECIFIC_VALUES: DatePickerValue[] = [
+  { type: "specific", operator: "=", values: [DATE] },
+  { type: "specific", operator: ">", values: [DATE] },
+  { type: "specific", operator: "<", values: [DATE] },
+  { type: "specific", operator: "between", values: [DATE, DATE] },
+];
+
+const RELATIVE_VALUES: DatePickerValue[] = [
+  { type: "relative", value: 1, unit: "hour" },
+  { type: "relative", value: -1, unit: "minute" },
+  { type: "relative", value: "current", unit: "day" },
+];
+
+const EXCLUDE_VALUES: DatePickerValue[] = [
+  { type: "exclude", operator: "!=", values: [1], unit: "day-of-week" },
+  { type: "exclude", operator: "is-null", values: [] },
+  { type: "exclude", operator: "not-null", values: [] },
+];
+
+describe("setOptionType", () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2020, 0, 1));
+  });
+
+  describe("!=", () => {
+    it.each([...SPECIFIC_VALUES, ...RELATIVE_VALUES, ...EXCLUDE_VALUES])(
+      'should ignore "$operator" operator',
+      value => {
+        expect(setOptionType(value, "!=")).toBeUndefined();
+      },
+    );
+  });
+
+  describe("is-null", () => {
+    it.each([...SPECIFIC_VALUES, ...RELATIVE_VALUES, ...EXCLUDE_VALUES])(
+      'should return default value for "$operator" operator',
+      value => {
+        expect(setOptionType(value, "is-null")).toEqual({
+          type: "exclude",
+          operator: "is-null",
+          values: [],
+        });
+      },
+    );
+  });
+
+  describe("not-null", () => {
+    it.each([...SPECIFIC_VALUES, ...RELATIVE_VALUES, ...EXCLUDE_VALUES])(
+      'should return default value for "$operator" operator',
+      value => {
+        expect(setOptionType(value, "not-null")).toEqual({
+          type: "exclude",
+          operator: "not-null",
+          values: [],
+        });
+      },
+    );
+  });
+});

--- a/frontend/src/metabase/common/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
+++ b/frontend/src/metabase/common/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
@@ -86,6 +86,64 @@ describe("setOptionType", () => {
     });
   });
 
+  describe("next", () => {
+    it.each([...SPECIFIC_VALUES, ...EXCLUDE_VALUES])(
+      'should return default value for "$operator" operator',
+      value => {
+        expect(setOptionType(value, "next")).toEqual({
+          type: "relative",
+          value: -30,
+          unit: "day",
+        });
+      },
+    );
+
+    it.each<DatePickerTruncationUnit>([
+      "minute",
+      "hour",
+      "day",
+      "week",
+      "month",
+      "quarter",
+      "year",
+    ])(
+      'should preserve "%s" unit and use default value for "current" value',
+      unit => {
+        const value: DatePickerValue = {
+          type: "relative",
+          value: "current",
+          unit,
+        };
+        expect(setOptionType(value, "next")).toEqual({
+          type: "relative",
+          value: 30,
+          unit,
+        });
+      },
+    );
+
+    it.each<DatePickerTruncationUnit>([
+      "minute",
+      "hour",
+      "day",
+      "week",
+      "month",
+      "quarter",
+      "year",
+    ])('should preserve "%s" unit and value for "next" value', unit => {
+      const value: DatePickerValue = {
+        type: "relative",
+        value: -10,
+        unit,
+      };
+      expect(setOptionType(value, "next")).toEqual({
+        type: "relative",
+        value: 10,
+        unit,
+      });
+    });
+  });
+
   describe("current", () => {
     it.each([...SPECIFIC_VALUES, ...EXCLUDE_VALUES])(
       'should return default value for "$operator" operator',

--- a/frontend/src/metabase/common/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
+++ b/frontend/src/metabase/common/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
@@ -28,6 +28,64 @@ describe("setOptionType", () => {
     jest.setSystemTime(new Date(2020, 0, 1));
   });
 
+  describe("last", () => {
+    it.each([...SPECIFIC_VALUES, ...EXCLUDE_VALUES])(
+      'should return default value for "$operator" operator',
+      value => {
+        expect(setOptionType(value, "last")).toEqual({
+          type: "relative",
+          value: -30,
+          unit: "day",
+        });
+      },
+    );
+
+    it.each<DatePickerTruncationUnit>([
+      "minute",
+      "hour",
+      "day",
+      "week",
+      "month",
+      "quarter",
+      "year",
+    ])(
+      'should preserve "%s" unit and use default value for "current" value',
+      unit => {
+        const value: DatePickerValue = {
+          type: "relative",
+          value: "current",
+          unit,
+        };
+        expect(setOptionType(value, "last")).toEqual({
+          type: "relative",
+          value: -30,
+          unit,
+        });
+      },
+    );
+
+    it.each<DatePickerTruncationUnit>([
+      "minute",
+      "hour",
+      "day",
+      "week",
+      "month",
+      "quarter",
+      "year",
+    ])('should preserve "%s" unit and value for "next" value', unit => {
+      const value: DatePickerValue = {
+        type: "relative",
+        value: 10,
+        unit,
+      };
+      expect(setOptionType(value, "last")).toEqual({
+        type: "relative",
+        value: -10,
+        unit,
+      });
+    });
+  });
+
   describe("current", () => {
     it.each([...SPECIFIC_VALUES, ...EXCLUDE_VALUES])(
       'should return default value for "$operator" operator',

--- a/frontend/src/metabase/common/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
+++ b/frontend/src/metabase/common/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
@@ -1,9 +1,13 @@
 import type {
-  DatePickerValue,
   DatePickerTruncationUnit,
+  DatePickerValue,
+  ExcludeDatePickerValue,
+  RelativeDatePickerValue,
   SpecificDatePickerOperator,
+  SpecificDatePickerValue,
 } from "../types";
-import { setOptionType } from "./utils";
+import { getOptionType, setOptionType } from "./utils";
+import type { OptionType } from "./types";
 
 const TODAY = new Date(2020, 0, 1, 0, 0);
 const PAST_30DAYS = new Date(2019, 11, 2, 0, 0);
@@ -12,24 +16,42 @@ const DATE_PAST_30DAYS = new Date(2015, 9, 21, 0, 0);
 const DATE_NEXT_30DAYS = new Date(2015, 11, 20, 0, 0);
 const DATE_NEXT_YEAR = new Date(2016, 5, 15, 0, 0);
 
-const SPECIFIC_VALUES: DatePickerValue[] = [
+const SPECIFIC_VALUES: SpecificDatePickerValue[] = [
   { type: "specific", operator: "=", values: [DATE] },
   { type: "specific", operator: ">", values: [DATE] },
   { type: "specific", operator: "<", values: [DATE] },
   { type: "specific", operator: "between", values: [DATE, DATE] },
 ];
 
-const RELATIVE_VALUES: DatePickerValue[] = [
-  { type: "relative", value: 1, unit: "hour" },
+const RELATIVE_VALUES: RelativeDatePickerValue[] = [
   { type: "relative", value: -1, unit: "minute" },
+  { type: "relative", value: 1, unit: "hour" },
   { type: "relative", value: "current", unit: "day" },
 ];
 
-const EXCLUDE_VALUES: DatePickerValue[] = [
+const EXCLUDE_VALUES: ExcludeDatePickerValue[] = [
   { type: "exclude", operator: "!=", values: [1], unit: "day-of-week" },
   { type: "exclude", operator: "is-null", values: [] },
   { type: "exclude", operator: "not-null", values: [] },
 ];
+
+describe("getOptionType", () => {
+  it.each<[OptionType, DatePickerValue | undefined]>([
+    ["none", undefined],
+    ["=", SPECIFIC_VALUES[0]],
+    [">", SPECIFIC_VALUES[1]],
+    ["<", SPECIFIC_VALUES[2]],
+    ["between", SPECIFIC_VALUES[3]],
+    ["last", RELATIVE_VALUES[0]],
+    ["next", RELATIVE_VALUES[1]],
+    ["current", RELATIVE_VALUES[2]],
+    ["none", EXCLUDE_VALUES[0]],
+    ["is-null", EXCLUDE_VALUES[1]],
+    ["not-null", EXCLUDE_VALUES[2]],
+  ])('should compute "%s" type', (type, value) => {
+    expect(getOptionType(value)).toBe(type);
+  });
+});
 
 describe("setOptionType", () => {
   beforeAll(() => {

--- a/frontend/src/metabase/common/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
+++ b/frontend/src/metabase/common/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
@@ -1,3 +1,4 @@
+import { DATE_PICKER_OPERATORS } from "../constants";
 import type {
   DatePickerTruncationUnit,
   DatePickerValue,
@@ -6,7 +7,8 @@ import type {
   SpecificDatePickerOperator,
   SpecificDatePickerValue,
 } from "../types";
-import { getOptionType, setOptionType } from "./utils";
+import { OPERATOR_OPTIONS } from "./constants";
+import { getAvailableOptions, getOptionType, setOptionType } from "./utils";
 import type { OptionType } from "./types";
 
 const TODAY = new Date(2020, 0, 1, 0, 0);
@@ -34,6 +36,23 @@ const EXCLUDE_VALUES: ExcludeDatePickerValue[] = [
   { type: "exclude", operator: "is-null", values: [] },
   { type: "exclude", operator: "not-null", values: [] },
 ];
+
+describe("getAvailableOptions", () => {
+  it("should return options that don't require an operator", () => {
+    const options = getAvailableOptions([]);
+    expect(options.map(option => option.label)).toEqual([
+      "All time",
+      "Previous",
+      "Next",
+      "Current",
+    ]);
+  });
+
+  it("should return options for default operators", () => {
+    const options = getAvailableOptions(DATE_PICKER_OPERATORS);
+    expect(options).toEqual(OPERATOR_OPTIONS);
+  });
+});
 
 describe("getOptionType", () => {
   it.each<[OptionType, DatePickerValue | undefined]>([

--- a/frontend/src/metabase/common/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
+++ b/frontend/src/metabase/common/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
@@ -1,4 +1,4 @@
-import type { DatePickerValue } from "../types";
+import type { DatePickerValue, DatePickerTruncationUnit } from "../types";
 import { setOptionType } from "./utils";
 
 const DATE = new Date();
@@ -26,6 +26,58 @@ describe("setOptionType", () => {
   beforeAll(() => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date(2020, 0, 1));
+  });
+
+  describe("current", () => {
+    it.each([...SPECIFIC_VALUES, ...EXCLUDE_VALUES])(
+      'should return default value for "$operator" operator',
+      value => {
+        expect(setOptionType(value, "current")).toEqual({
+          type: "relative",
+          value: "current",
+          unit: "day",
+        });
+      },
+    );
+
+    describe.each<DatePickerTruncationUnit>(["minute", "hour"])(
+      'should use default unit for "%s" unit',
+      unit => {
+        it.each([-10, 10])('"%d" interval', interval => {
+          const value: DatePickerValue = {
+            type: "relative",
+            value: interval,
+            unit,
+          };
+          expect(setOptionType(value, "current")).toEqual({
+            type: "relative",
+            value: "current",
+            unit: "day",
+          });
+        });
+      },
+    );
+
+    describe.each<DatePickerTruncationUnit>([
+      "day",
+      "week",
+      "month",
+      "quarter",
+      "year",
+    ])('should preserve unit for "%s" unit', unit => {
+      it.each([-10, 10])('"%d" interval', interval => {
+        const value: DatePickerValue = {
+          type: "relative",
+          value: interval,
+          unit,
+        };
+        expect(setOptionType(value, "current")).toEqual({
+          type: "relative",
+          value: "current",
+          unit,
+        });
+      });
+    });
   });
 
   describe("!=", () => {

--- a/frontend/src/metabase/common/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
+++ b/frontend/src/metabase/common/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
@@ -118,6 +118,48 @@ describe("setOptionType", () => {
     });
   });
 
+  describe("<", () => {
+    it.each([...RELATIVE_VALUES, ...EXCLUDE_VALUES])(
+      'should return default value for "$operator" operator',
+      value => {
+        expect(setOptionType(value, "<")).toEqual({
+          type: "specific",
+          operator: "<",
+          values: [TODAY],
+        });
+      },
+    );
+
+    it.each<SpecificDatePickerOperator>(["=", ">"])(
+      'should preserve value for "%s" operator',
+      operator => {
+        const value: DatePickerValue = {
+          type: "specific",
+          operator,
+          values: [DATE],
+        };
+        expect(setOptionType(value, "<")).toEqual({
+          type: "specific",
+          operator: "<",
+          values: [DATE],
+        });
+      },
+    );
+
+    it('should preserve end date for "between" operator', () => {
+      const value: DatePickerValue = {
+        type: "specific",
+        operator: "between",
+        values: [DATE, DATE2],
+      };
+      expect(setOptionType(value, "<")).toEqual({
+        type: "specific",
+        operator: "<",
+        values: [DATE],
+      });
+    });
+  });
+
   describe("last", () => {
     it.each([...SPECIFIC_VALUES, ...EXCLUDE_VALUES])(
       'should return default value for "$operator" operator',

--- a/frontend/src/metabase/common/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
+++ b/frontend/src/metabase/common/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
@@ -1,7 +1,13 @@
-import type { DatePickerValue, DatePickerTruncationUnit } from "../types";
+import type {
+  DatePickerValue,
+  DatePickerTruncationUnit,
+  SpecificDatePickerOperator,
+} from "../types";
 import { setOptionType } from "./utils";
 
-const DATE = new Date();
+const TODAY = new Date(2020, 0, 1, 0, 0);
+const DATE = new Date(2015, 10, 20, 0, 0);
+const DATE2 = new Date(2016, 5, 15, 0, 0);
 
 const SPECIFIC_VALUES: DatePickerValue[] = [
   { type: "specific", operator: "=", values: [DATE] },
@@ -25,7 +31,91 @@ const EXCLUDE_VALUES: DatePickerValue[] = [
 describe("setOptionType", () => {
   beforeAll(() => {
     jest.useFakeTimers();
-    jest.setSystemTime(new Date(2020, 0, 1));
+    jest.setSystemTime(TODAY);
+  });
+
+  describe("=", () => {
+    it.each([...RELATIVE_VALUES, ...EXCLUDE_VALUES])(
+      'should return default value for "$operator" operator',
+      value => {
+        expect(setOptionType(value, "=")).toEqual({
+          type: "specific",
+          operator: "=",
+          values: [TODAY],
+        });
+      },
+    );
+
+    it.each<SpecificDatePickerOperator>([">", "<"])(
+      'should preserve value for "%s" operator',
+      operator => {
+        const value: DatePickerValue = {
+          type: "specific",
+          operator,
+          values: [DATE],
+        };
+        expect(setOptionType(value, "=")).toEqual({
+          type: "specific",
+          operator: "=",
+          values: [DATE],
+        });
+      },
+    );
+
+    it('should preserve end date for "between" operator', () => {
+      const value: DatePickerValue = {
+        type: "specific",
+        operator: "between",
+        values: [DATE, DATE2],
+      };
+      expect(setOptionType(value, "=")).toEqual({
+        type: "specific",
+        operator: "=",
+        values: [DATE2],
+      });
+    });
+  });
+
+  describe(">", () => {
+    it.each([...RELATIVE_VALUES, ...EXCLUDE_VALUES])(
+      'should return default value for "$operator" operator',
+      value => {
+        expect(setOptionType(value, ">")).toEqual({
+          type: "specific",
+          operator: ">",
+          values: [TODAY],
+        });
+      },
+    );
+
+    it.each<SpecificDatePickerOperator>(["=", "<"])(
+      'should preserve value for "%s" operator',
+      operator => {
+        const value: DatePickerValue = {
+          type: "specific",
+          operator,
+          values: [DATE],
+        };
+        expect(setOptionType(value, ">")).toEqual({
+          type: "specific",
+          operator: ">",
+          values: [DATE],
+        });
+      },
+    );
+
+    it('should preserve start date for "between" operator', () => {
+      const value: DatePickerValue = {
+        type: "specific",
+        operator: "between",
+        values: [DATE, DATE2],
+      };
+      expect(setOptionType(value, ">")).toEqual({
+        type: "specific",
+        operator: ">",
+        values: [DATE],
+      });
+    });
   });
 
   describe("last", () => {
@@ -92,7 +182,7 @@ describe("setOptionType", () => {
       value => {
         expect(setOptionType(value, "next")).toEqual({
           type: "relative",
-          value: -30,
+          value: 30,
           unit: "day",
         });
       },

--- a/frontend/src/metabase/common/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
+++ b/frontend/src/metabase/common/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
@@ -6,8 +6,11 @@ import type {
 import { setOptionType } from "./utils";
 
 const TODAY = new Date(2020, 0, 1, 0, 0);
+const PAST_30DAYS = new Date(2019, 11, 2, 0, 0);
 const DATE = new Date(2015, 10, 20, 0, 0);
-const DATE2 = new Date(2016, 5, 15, 0, 0);
+const DATE_PAST_30DAYS = new Date(2015, 9, 21, 0, 0);
+const DATE_NEXT_30DAYS = new Date(2015, 11, 20, 0, 0);
+const DATE_NEXT_YEAR = new Date(2016, 5, 15, 0, 0);
 
 const SPECIFIC_VALUES: DatePickerValue[] = [
   { type: "specific", operator: "=", values: [DATE] },
@@ -66,12 +69,12 @@ describe("setOptionType", () => {
       const value: DatePickerValue = {
         type: "specific",
         operator: "between",
-        values: [DATE, DATE2],
+        values: [DATE, DATE_NEXT_YEAR],
       };
       expect(setOptionType(value, "=")).toEqual({
         type: "specific",
         operator: "=",
-        values: [DATE2],
+        values: [DATE_NEXT_YEAR],
       });
     });
   });
@@ -108,7 +111,7 @@ describe("setOptionType", () => {
       const value: DatePickerValue = {
         type: "specific",
         operator: "between",
-        values: [DATE, DATE2],
+        values: [DATE, DATE_NEXT_YEAR],
       };
       expect(setOptionType(value, ">")).toEqual({
         type: "specific",
@@ -150,12 +153,54 @@ describe("setOptionType", () => {
       const value: DatePickerValue = {
         type: "specific",
         operator: "between",
-        values: [DATE, DATE2],
+        values: [DATE, DATE_NEXT_YEAR],
       };
       expect(setOptionType(value, "<")).toEqual({
         type: "specific",
         operator: "<",
+        values: [DATE_NEXT_YEAR],
+      });
+    });
+  });
+
+  describe("between", () => {
+    it.each([...RELATIVE_VALUES, ...EXCLUDE_VALUES])(
+      'should return default value for "$operator" operator',
+      value => {
+        expect(setOptionType(value, "between")).toEqual({
+          type: "specific",
+          operator: "between",
+          values: [PAST_30DAYS, TODAY],
+        });
+      },
+    );
+
+    it.each<SpecificDatePickerOperator>(["=", "<"])(
+      'should preserve end date for "%s" operator',
+      operator => {
+        const value: DatePickerValue = {
+          type: "specific",
+          operator,
+          values: [DATE],
+        };
+        expect(setOptionType(value, "between")).toEqual({
+          type: "specific",
+          operator: "between",
+          values: [DATE_PAST_30DAYS, DATE],
+        });
+      },
+    );
+
+    it('should preserve start date for ">" operator', () => {
+      const value: DatePickerValue = {
+        type: "specific",
+        operator: ">",
         values: [DATE],
+      };
+      expect(setOptionType(value, "between")).toEqual({
+        type: "specific",
+        operator: "between",
+        values: [DATE, DATE_NEXT_30DAYS],
       });
     });
   });

--- a/frontend/src/metabase/common/components/DatePicker/DatePicker.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/DatePicker.tsx
@@ -1,8 +1,5 @@
+import type { ReactNode } from "react";
 import { useState } from "react";
-import type { FormEvent, ReactNode } from "react";
-import { t } from "ttag";
-import { Button, Stack } from "metabase/ui";
-import { DateOperatorPicker } from "./DateOperatorPicker";
 import { DateShortcutPicker } from "./DateShortcutPicker";
 import { ExcludeDatePicker } from "./ExcludeDatePicker";
 import { RelativeDatePicker } from "./RelativeDatePicker";
@@ -89,36 +86,4 @@ export function DatePicker({
         />
       );
   }
-}
-
-interface SimpleDatePickerProps {
-  value?: DatePickerValue;
-  availableOperators?: ReadonlyArray<DatePickerOperator>;
-  onChange: (value: DatePickerValue | undefined) => void;
-}
-
-export function SimpleDatePicker({
-  value: initialValue,
-  availableOperators = DATE_PICKER_OPERATORS,
-  onChange,
-}: SimpleDatePickerProps) {
-  const [value, setValue] = useState(initialValue);
-
-  const handleSubmit = (event: FormEvent) => {
-    event.preventDefault();
-    onChange(value);
-  };
-
-  return (
-    <form onSubmit={handleSubmit}>
-      <Stack p="md">
-        <DateOperatorPicker
-          value={value}
-          availableOperators={availableOperators}
-          onChange={setValue}
-        />
-        <Button type="submit" variant="filled">{t`Apply`}</Button>
-      </Stack>
-    </form>
-  );
 }

--- a/frontend/src/metabase/common/components/DatePicker/RelativeDatePicker/CurrentDatePicker/SimpleCurrentDatePicker/SimpleCurrentDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/RelativeDatePicker/CurrentDatePicker/SimpleCurrentDatePicker/SimpleCurrentDatePicker.unit.spec.tsx
@@ -1,0 +1,44 @@
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { RelativeDatePickerValue } from "../../../types";
+import { SimpleCurrentDatePicker } from "./SimpleCurrentDatePicker";
+
+const DEFAULT_VALUE: RelativeDatePickerValue = {
+  type: "relative",
+  value: "current",
+  unit: "day",
+};
+
+interface SetupOpts {
+  value?: RelativeDatePickerValue;
+}
+
+function setup({ value = DEFAULT_VALUE }: SetupOpts = {}) {
+  const onChange = jest.fn();
+
+  renderWithProviders(
+    <SimpleCurrentDatePicker value={value} onChange={onChange} />,
+  );
+
+  return { onChange };
+}
+
+describe("SimpleCurrentDatePicker", () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2020, 0, 1));
+  });
+
+  it("should be able to filter by a current interval", () => {
+    const { onChange } = setup();
+
+    userEvent.click(screen.getByDisplayValue("Day"));
+    userEvent.click(screen.getByText("Week"));
+
+    expect(onChange).toHaveBeenCalledWith({
+      type: "relative",
+      value: "current",
+      unit: "week",
+    });
+  });
+});

--- a/frontend/src/metabase/common/components/DatePicker/RelativeDatePicker/DateIntervalPicker/SimpleDateIntervalPicker/SimpleDateIntervalPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/RelativeDatePicker/DateIntervalPicker/SimpleDateIntervalPicker/SimpleDateIntervalPicker.unit.spec.tsx
@@ -1,0 +1,132 @@
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { RelativeIntervalDirection } from "../../../types";
+import type { DateIntervalValue } from "../../types";
+import { SimpleDateIntervalPicker } from "./SimpleDateIntervalPicker";
+
+function getDefaultValue(
+  direction: RelativeIntervalDirection,
+): DateIntervalValue {
+  return {
+    type: "relative",
+    value: direction === "last" ? -30 : 30,
+    unit: "day",
+  };
+}
+
+interface SetupOpts {
+  value: DateIntervalValue;
+  isNew?: boolean;
+  canUseRelativeOffsets?: boolean;
+}
+
+function setup({ value }: SetupOpts) {
+  const onChange = jest.fn();
+
+  renderWithProviders(
+    <SimpleDateIntervalPicker value={value} onChange={onChange} />,
+  );
+
+  return { onChange };
+}
+
+describe("SimpleDateIntervalPicker", () => {
+  beforeAll(() => {
+    jest.useFakeTimers({ advanceTimers: true });
+    jest.setSystemTime(new Date(2020, 0, 1));
+  });
+
+  describe.each<RelativeIntervalDirection>(["last", "next"])(
+    "%s",
+    direction => {
+      const defaultValue = getDefaultValue(direction);
+
+      it("should change the interval", () => {
+        const { onChange } = setup({
+          value: defaultValue,
+        });
+
+        const input = screen.getByLabelText("Interval");
+        userEvent.clear(input);
+        userEvent.type(input, "20");
+
+        expect(onChange).toHaveBeenLastCalledWith({
+          ...defaultValue,
+          value: direction === "last" ? -20 : 20,
+        });
+      });
+
+      it("should change the interval with a negative value", () => {
+        const { onChange } = setup({
+          value: defaultValue,
+        });
+
+        const input = screen.getByLabelText("Interval");
+        userEvent.clear(input);
+        userEvent.type(input, "-10");
+
+        expect(onChange).toHaveBeenLastCalledWith({
+          ...defaultValue,
+          value: direction === "last" ? -10 : 10,
+        });
+      });
+
+      it("should coerce zero", () => {
+        const { onChange } = setup({
+          value: defaultValue,
+        });
+
+        const input = screen.getByLabelText("Interval");
+        userEvent.clear(input);
+        userEvent.type(input, "0");
+        userEvent.tab();
+
+        expect(onChange).toHaveBeenLastCalledWith({
+          ...defaultValue,
+          value: direction === "last" ? -1 : 1,
+        });
+      });
+
+      it("should ignore empty values", () => {
+        const { onChange } = setup({
+          value: defaultValue,
+        });
+
+        const input = screen.getByLabelText("Interval");
+        userEvent.clear(input);
+        userEvent.tab();
+
+        expect(input).toHaveValue("30");
+        expect(onChange).not.toHaveBeenCalled();
+      });
+
+      it("should ignore invalid values", () => {
+        const { onChange } = setup({
+          value: defaultValue,
+        });
+
+        const input = screen.getByLabelText("Interval");
+        userEvent.clear(input);
+        userEvent.type(input, "abc");
+        userEvent.tab();
+
+        expect(input).toHaveValue("30");
+        expect(onChange).not.toHaveBeenCalled();
+      });
+
+      it("should allow to change the unit", () => {
+        const { onChange } = setup({
+          value: defaultValue,
+        });
+
+        userEvent.click(screen.getByLabelText("Unit"));
+        userEvent.click(screen.getByText("years"));
+
+        expect(onChange).toHaveBeenCalledWith({
+          ...defaultValue,
+          unit: "year",
+        });
+      });
+    },
+  );
+});

--- a/frontend/src/metabase/common/components/DatePicker/RelativeDatePicker/utils.unit.spec.ts
+++ b/frontend/src/metabase/common/components/DatePicker/RelativeDatePicker/utils.unit.spec.ts
@@ -27,4 +27,96 @@ describe("setDirection", () => {
       });
     });
   });
+
+  describe("last", () => {
+    it("should convert a current value", () => {
+      const value: RelativeDatePickerValue = {
+        type: "relative",
+        value: "current",
+        unit: "week",
+      };
+      expect(setDirection(value, "last")).toEqual({
+        type: "relative",
+        value: -30,
+        unit: "week",
+      });
+    });
+
+    it("should convert an interval value", () => {
+      const value: RelativeDatePickerValue = {
+        type: "relative",
+        value: 20,
+        unit: "year",
+      };
+      expect(setDirection(value, "last")).toEqual({
+        type: "relative",
+        value: -20,
+        unit: "year",
+        offsetValue: undefined,
+      });
+    });
+
+    it("should convert an interval value with offset", () => {
+      const value: RelativeDatePickerValue = {
+        type: "relative",
+        value: 20,
+        unit: "day",
+        offsetValue: 10,
+        offsetUnit: "month",
+      };
+      expect(setDirection(value, "last")).toEqual({
+        type: "relative",
+        value: -20,
+        unit: "day",
+        offsetValue: -10,
+        offsetUnit: "month",
+      });
+    });
+  });
+
+  describe("next", () => {
+    it("should convert a current value", () => {
+      const value: RelativeDatePickerValue = {
+        type: "relative",
+        value: "current",
+        unit: "week",
+      };
+      expect(setDirection(value, "next")).toEqual({
+        type: "relative",
+        value: 30,
+        unit: "week",
+      });
+    });
+
+    it("should convert an interval value", () => {
+      const value: RelativeDatePickerValue = {
+        type: "relative",
+        value: -20,
+        unit: "year",
+      };
+      expect(setDirection(value, "next")).toEqual({
+        type: "relative",
+        value: 20,
+        unit: "year",
+        offsetValue: undefined,
+      });
+    });
+
+    it("should convert an interval value with offset", () => {
+      const value: RelativeDatePickerValue = {
+        type: "relative",
+        value: -20,
+        unit: "day",
+        offsetValue: -10,
+        offsetUnit: "month",
+      };
+      expect(setDirection(value, "next")).toEqual({
+        type: "relative",
+        value: 20,
+        unit: "day",
+        offsetValue: 10,
+        offsetUnit: "month",
+      });
+    });
+  });
 });

--- a/frontend/src/metabase/common/components/DatePicker/RelativeDatePicker/utils.unit.spec.ts
+++ b/frontend/src/metabase/common/components/DatePicker/RelativeDatePicker/utils.unit.spec.ts
@@ -1,0 +1,30 @@
+import type {
+  DatePickerTruncationUnit,
+  RelativeDatePickerValue,
+} from "../types";
+import { setDirection } from "./utils";
+
+describe("setDirection", () => {
+  describe("current", () => {
+    it.each<DatePickerTruncationUnit>([
+      "minute",
+      "hour",
+      "day",
+      "week",
+      "month",
+      "quarter",
+      "year",
+    ])('should fallback to "hour" for "%s" unit', unit => {
+      const value: RelativeDatePickerValue = {
+        type: "relative",
+        value: 1,
+        unit,
+      };
+      expect(setDirection(value, "current")).toEqual({
+        type: "relative",
+        value: "current",
+        unit: "hour",
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/common/components/DatePicker/SimpleDatePicker/SimpleDatePicker.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/SimpleDatePicker/SimpleDatePicker.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import type { FormEvent } from "react";
+import { t } from "ttag";
+import { Button, Stack } from "metabase/ui";
+import { DateOperatorPicker } from "../DateOperatorPicker";
+import { DATE_PICKER_OPERATORS } from "../constants";
+import type { DatePickerOperator, DatePickerValue } from "../types";
+
+interface SimpleDatePickerProps {
+  value?: DatePickerValue;
+  availableOperators?: ReadonlyArray<DatePickerOperator>;
+  onChange: (value: DatePickerValue | undefined) => void;
+}
+
+export function SimpleDatePicker({
+  value: initialValue,
+  availableOperators = DATE_PICKER_OPERATORS,
+  onChange,
+}: SimpleDatePickerProps) {
+  const [value, setValue] = useState(initialValue);
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    onChange(value);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Stack p="md">
+        <DateOperatorPicker
+          value={value}
+          availableOperators={availableOperators}
+          onChange={setValue}
+        />
+        <Button type="submit" variant="filled">{t`Apply`}</Button>
+      </Stack>
+    </form>
+  );
+}

--- a/frontend/src/metabase/common/components/DatePicker/SimpleDatePicker/SimpleDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/SimpleDatePicker/SimpleDatePicker.unit.spec.tsx
@@ -1,0 +1,45 @@
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders, screen } from "__support__/ui";
+import { DATE_PICKER_OPERATORS } from "../constants";
+import type { DatePickerOperator, DatePickerValue } from "../types";
+import { SimpleDatePicker } from "./SimpleDatePicker";
+
+interface SetupOpts {
+  value?: DatePickerValue;
+  availableOperators?: ReadonlyArray<DatePickerOperator>;
+}
+
+function setup({
+  value,
+  availableOperators = DATE_PICKER_OPERATORS,
+}: SetupOpts = {}) {
+  const onChange = jest.fn();
+
+  renderWithProviders(
+    <SimpleDatePicker
+      value={value}
+      availableOperators={availableOperators}
+      onChange={onChange}
+    />,
+  );
+
+  return { onChange };
+}
+
+describe("SimpleDatePicker", () => {
+  it("should be able change and submit the value", () => {
+    const { onChange } = setup();
+
+    userEvent.click(screen.getByDisplayValue("All time"));
+    userEvent.click(screen.getByText("Current"));
+    userEvent.click(screen.getByDisplayValue("Day"));
+    userEvent.click(screen.getByText("Month"));
+    userEvent.click(screen.getByText("Apply"));
+
+    expect(onChange).toHaveBeenCalledWith({
+      type: "relative",
+      value: "current",
+      unit: "month",
+    });
+  });
+});

--- a/frontend/src/metabase/common/components/DatePicker/SimpleDatePicker/index.ts
+++ b/frontend/src/metabase/common/components/DatePicker/SimpleDatePicker/index.ts
@@ -1,0 +1,1 @@
+export * from "./SimpleDatePicker";

--- a/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/DateRangePicker/SimpleDateRangePicker/SimpleDateRangePicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/DateRangePicker/SimpleDateRangePicker/SimpleDateRangePicker.unit.spec.tsx
@@ -1,0 +1,170 @@
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders, screen, within } from "__support__/ui";
+import { SimpleDateRangePicker } from "./SimpleDateRangePicker";
+
+const START_DATE = new Date(2020, 0, 10);
+const END_DATE = new Date(2020, 1, 9);
+
+const START_DATE_TIME = new Date(2020, 0, 10, 5, 20);
+const END_DATE_TIME = new Date(2020, 1, 9, 20, 30);
+
+interface SetupOpts {
+  value?: [Date, Date];
+}
+
+function setup({ value = [START_DATE, END_DATE] }: SetupOpts = {}) {
+  const onChange = jest.fn();
+
+  renderWithProviders(
+    <SimpleDateRangePicker value={value} onChange={onChange} />,
+  );
+
+  return { onChange };
+}
+
+describe("SimpleDateRangePicker", () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2020, 0, 15));
+  });
+
+  it("should be able to set the date range via the calendar", () => {
+    const { onChange } = setup();
+
+    const calendars = screen.getAllByRole("table");
+    userEvent.click(within(calendars[0]).getByText("12"));
+    userEvent.click(within(calendars[1]).getByText("5"));
+
+    expect(onChange).toHaveBeenCalledWith([
+      new Date(2020, 0, 12),
+      new Date(2020, 1, 5),
+    ]);
+  });
+
+  it("should be able to set the date range via the calendar when there is time", () => {
+    const { onChange } = setup({
+      value: [START_DATE_TIME, END_DATE_TIME],
+    });
+
+    const calendars = screen.getAllByRole("table");
+    userEvent.click(within(calendars[0]).getByText("12"));
+    userEvent.click(within(calendars[1]).getByText("5"));
+
+    expect(onChange).toHaveBeenLastCalledWith([
+      new Date(2020, 0, 12, 5, 20),
+      new Date(2020, 1, 5, 20, 30),
+    ]);
+  });
+
+  it("should be able to set the date range start via the input", () => {
+    const { onChange } = setup();
+
+    const input = screen.getByLabelText("Start date");
+    userEvent.clear(input);
+    userEvent.type(input, "Feb 15, 2020");
+
+    expect(onChange).toHaveBeenLastCalledWith([
+      new Date(2020, 1, 15),
+      END_DATE,
+    ]);
+  });
+
+  it("should be able to set the date range start via the input when there is time", () => {
+    const { onChange } = setup({
+      value: [START_DATE_TIME, END_DATE],
+    });
+
+    const input = screen.getByLabelText("Start date");
+    userEvent.clear(input);
+    userEvent.type(input, "Feb 15, 2020");
+
+    expect(onChange).toHaveBeenLastCalledWith([
+      new Date(2020, 1, 15, 5, 20),
+      END_DATE,
+    ]);
+  });
+
+  it("should be able to set the date range end via the input", () => {
+    const { onChange } = setup();
+
+    const input = screen.getByLabelText("End date");
+    userEvent.clear(input);
+    userEvent.type(input, "Jul 15, 2020");
+
+    expect(onChange).toHaveBeenLastCalledWith([
+      START_DATE,
+      new Date(2020, 6, 15),
+    ]);
+  });
+
+  it("should be able to set the date range end via the input when there is time", () => {
+    const { onChange } = setup({
+      value: [START_DATE, END_DATE_TIME],
+    });
+
+    const input = screen.getByLabelText("End date");
+    userEvent.clear(input);
+    userEvent.type(input, "Jul 15, 2020");
+
+    expect(onChange).toHaveBeenLastCalledWith([
+      START_DATE,
+      new Date(2020, 6, 15, 20, 30),
+    ]);
+  });
+
+  it("should be able to add time", () => {
+    const { onChange } = setup();
+
+    userEvent.click(screen.getByText("Add time"));
+    const input = screen.getByLabelText("Start time");
+    userEvent.clear(input);
+    userEvent.type(input, "11:20");
+
+    expect(onChange).toHaveBeenLastCalledWith([
+      new Date(2020, 0, 10, 11, 20),
+      END_DATE,
+    ]);
+  });
+
+  it("should be able to update the start time", () => {
+    const { onChange } = setup({
+      value: [START_DATE_TIME, END_DATE_TIME],
+    });
+
+    const input = screen.getByLabelText("Start time");
+    userEvent.clear(input);
+    userEvent.type(input, "11:20");
+
+    expect(onChange).toHaveBeenLastCalledWith([
+      new Date(2020, 0, 10, 11, 20),
+      END_DATE_TIME,
+    ]);
+  });
+
+  it("should be able to update the end time", () => {
+    const { onChange } = setup({
+      value: [START_DATE_TIME, END_DATE_TIME],
+    });
+
+    const input = screen.getByLabelText("End time");
+    userEvent.clear(input);
+    userEvent.type(input, "11:20");
+
+    expect(onChange).toHaveBeenLastCalledWith([
+      START_DATE_TIME,
+      new Date(2020, 1, 9, 11, 20),
+    ]);
+  });
+
+  it("should be able to remove time", () => {
+    const { onChange } = setup({
+      value: [START_DATE_TIME, END_DATE_TIME],
+    });
+
+    userEvent.click(screen.getByText("Remove time"));
+
+    expect(screen.queryByLabelText("Start time")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("End time")).not.toBeInTheDocument();
+    expect(onChange).toHaveBeenLastCalledWith([START_DATE, END_DATE]);
+  });
+});

--- a/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/SingleDatePicker/SimpleSingleDatePicker/SimpleSingleDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/DatePicker/SpecificDatePicker/SingleDatePicker/SimpleSingleDatePicker/SimpleSingleDatePicker.unit.spec.tsx
@@ -1,0 +1,103 @@
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders, screen } from "__support__/ui";
+import { SimpleSingleDatePicker } from "./SimpleSingleDatePicker";
+
+const DATE = new Date(2020, 0, 10);
+const DATE_TIME = new Date(2020, 0, 10, 10, 20);
+
+interface SetupOpts {
+  value?: Date;
+}
+
+function setup({ value = DATE }: SetupOpts = {}) {
+  const onChange = jest.fn();
+
+  renderWithProviders(
+    <SimpleSingleDatePicker value={value} onChange={onChange} />,
+  );
+
+  return { onChange };
+}
+
+describe("SimpleSingleDatePicker", () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2020, 0, 15));
+  });
+
+  it("should be able to set the date via the calendar", () => {
+    const { onChange } = setup();
+
+    userEvent.click(screen.getByText("12"));
+
+    expect(onChange).toHaveBeenCalledWith(new Date(2020, 0, 12));
+  });
+
+  it("should be able to set the date via the calendar when there is time", () => {
+    const { onChange } = setup({
+      value: DATE_TIME,
+    });
+
+    userEvent.click(screen.getByText("12"));
+
+    expect(onChange).toHaveBeenCalledWith(new Date(2020, 0, 12, 10, 20));
+  });
+
+  it("should be able to set the date via the input", () => {
+    const { onChange } = setup();
+
+    const input = screen.getByLabelText("Date");
+    userEvent.clear(input);
+    userEvent.type(input, "Feb 15, 2020");
+
+    expect(screen.getByText("February 2020")).toBeInTheDocument();
+    expect(onChange).toHaveBeenLastCalledWith(new Date(2020, 1, 15));
+  });
+
+  it("should be able to set the date via the input when there is time", () => {
+    const { onChange } = setup({
+      value: DATE_TIME,
+    });
+
+    const input = screen.getByLabelText("Date");
+    userEvent.clear(input);
+    userEvent.type(input, "Feb 15, 2020");
+
+    expect(screen.getByText("February 2020")).toBeInTheDocument();
+    expect(onChange).toHaveBeenLastCalledWith(new Date(2020, 1, 15, 10, 20));
+  });
+
+  it("should be able to add time", () => {
+    const { onChange } = setup();
+
+    userEvent.click(screen.getByText("Add time"));
+    const input = screen.getByLabelText("Time");
+    userEvent.clear(input);
+    userEvent.type(input, "10:20");
+
+    expect(onChange).toHaveBeenLastCalledWith(new Date(2020, 0, 10, 10, 20));
+  });
+
+  it("should be able to update the time", () => {
+    const { onChange } = setup({
+      value: DATE_TIME,
+    });
+
+    const input = screen.getByLabelText("Time");
+    userEvent.clear(input);
+    userEvent.type(input, "20:30");
+
+    expect(onChange).toHaveBeenLastCalledWith(new Date(2020, 0, 10, 20, 30));
+  });
+
+  it("should be able to remove time", () => {
+    const { onChange } = setup({
+      value: DATE_TIME,
+    });
+
+    userEvent.click(screen.getByText("Remove time"));
+
+    expect(screen.queryByLabelText("Time")).not.toBeInTheDocument();
+    expect(onChange).toHaveBeenLastCalledWith(new Date(2020, 0, 10));
+  });
+});

--- a/frontend/src/metabase/common/components/DatePicker/index.ts
+++ b/frontend/src/metabase/common/components/DatePicker/index.ts
@@ -1,3 +1,4 @@
 export * from "./DatePicker";
+export * from "./SimpleDatePicker";
 export * from "./types";
 export * from "./utils";


### PR DESCRIPTION
Changes:
- Moves `SimpleDatePicker` to a separate folder. I did that for other "simple" versions of the components but forgot about this one in one of previous PRs
- Adds missing unit tests to "Simple" date components 