### PR TITLE
Upload test results to S3

### DIFF
--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -1,0 +1,39 @@
+name: Upload Test Results to s3
+description: Uploads test results files to s3
+
+inputs:
+  input-path:
+    required: true
+  output-dir:
+    required: true
+    default: test
+  aws-access-key-id:
+    required: true
+  aws-secret-access-key:
+    required: true
+  aws-region:
+    required: true
+    default: us-east-1
+  bucket:
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Configure AWS credentials
+      if: always()
+      uses: aws-actions/configure-aws-credentials@v3
+      with:
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-region: ${{ inputs.aws-region }}
+    - name: Upload test results to S3
+      if: always()
+      env:
+        BUCKET: ${{ inputs.bucket }}
+        INPUT: ${{ inputs.input-path }}
+        OUTPUT_DIR: ${{ inputs.output-dir }}
+      shell: bash
+      run: | # sh
+        DATE=$(date '+%Y-%m-%d')
+        aws s3 cp $INPUT s3://$BUCKET/$DATE/$GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT/$OUTPUT_DIR/ --exclude "*" --include "*.xml" --recursive

--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -4,7 +4,7 @@ description: Uploads test results files to s3
 inputs:
   input-path:
     required: true
-  output-dir:
+  output-name:
     required: true
     default: test
   aws-access-key-id:
@@ -21,19 +21,23 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS credentials
-      if: always()
       uses: aws-actions/configure-aws-credentials@v3
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
         aws-region: ${{ inputs.aws-region }}
+    - name: zip test results
+      env:
+        INPUT_DIR: ${{ inputs.input-path }}
+        OUTPUT_FILE: ${{ inputs.output-name }}
+      shell: bash
+      run: | # sh
+        zip ${OUTPUT_FILE}.zip $INPUT_DIR/*.xml
     - name: Upload test results to S3
-      if: always()
       env:
         BUCKET: ${{ inputs.bucket }}
-        INPUT: ${{ inputs.input-path }}
-        OUTPUT_DIR: ${{ inputs.output-dir }}
+        OUTPUT_FILE: ${{ inputs.output-name }}
       shell: bash
       run: | # sh
         DATE=$(date '+%Y-%m-%d')
-        aws s3 cp $INPUT s3://$BUCKET/$DATE/$GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT/$OUTPUT_DIR/ --exclude "*" --include "*.xml" --recursive
+        aws s3 cp ${OUTPUT_FILE}.zip s3://$BUCKET/$DATE/$GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT/

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -202,16 +202,18 @@ jobs:
           path: resources/frontend_client/app/dist
 
       - name: Run tests
+        id: run-java-tests
         if: matrix.java-version != 21
         run: clojure -X:dev:ci:test:${{ matrix.edition }}:${{ matrix.edition }}-dev
 
       - name: Run tests using Java 21 on `master` only
+        id: run-java-tests-21
         if: matrix.java-version == 21 && github.ref_name == 'master'
         run: clojure -X:dev:ci:test:${{ matrix.edition }}:${{ matrix.edition }}-dev
 
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
-        if: always()
+        if: always() && (steps.run-java-tests.conclusion != 'skipped' || steps.run-java-tests-21.conclusion != 'skipped')
         with:
           input-path: ./target/junit/
           output-dir: be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -216,7 +216,7 @@ jobs:
         if: always() && (steps.run-java-tests.conclusion != 'skipped' || steps.run-java-tests-21.conclusion != 'skipped')
         with:
           input-path: ./target/junit/
-          output-dir: be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}
+          output-name: be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}
           bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
           aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -209,6 +209,17 @@ jobs:
         if: matrix.java-version == 21 && github.ref_name == 'master'
         run: clojure -X:dev:ci:test:${{ matrix.edition }}:${{ matrix.edition }}-dev
 
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit/
+          output-dir: be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+
       - name: Publish Test Report (JUnit)
         uses: dorny/test-reporter@v1
         if: failure()

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -47,6 +47,16 @@ jobs:
       with:
         junit-name: 'be-tests-athena-ee'
         test-args: ":exclude-tags '[:mb/once]'"
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-dir: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
 
   be-tests-bigquery-cloud-sdk-ee:
     needs: files-changed
@@ -69,6 +79,16 @@ jobs:
       with:
         junit-name: 'be-tests-bigquery-cloud-sdk-ee'
         test-args: ":exclude-tags '[:mb/once]'"
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-dir: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
 
   be-tests-druid-ee:
     needs: files-changed
@@ -92,6 +112,16 @@ jobs:
       with:
         junit-name: 'be-tests-druid-ee'
         test-args: ":exclude-tags '[:mb/once]'"
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-dir: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
 
   be-tests-googleanalytics-ee:
     needs: files-changed
@@ -108,6 +138,16 @@ jobs:
       with:
         junit-name: 'be-tests-googleanalytics-ee'
         test-args: ":exclude-tags '[:mb/once]'"
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-dir: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
 
   be-google-related-drivers-classpath-test:
     needs: files-changed
@@ -130,6 +170,16 @@ jobs:
       with:
         junit-name: 'be-google-related-drivers-classpath-test'
         test-args: ':only "[metabase.query-processor-test.expressions-test metabase.driver.google-test metabase.driver.googleanalytics-test]"'
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-dir: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
 
   be-tests-mariadb-10-2-ee:
     needs: files-changed
@@ -156,6 +206,16 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-mariadb-10-2-ee'
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-dir: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
 
   be-tests-mariadb-latest-ee:
     needs: files-changed
@@ -182,6 +242,16 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-mariadb-latest-ee'
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-dir: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
 
   be-tests-mongo-4-4-ee:
     needs: files-changed
@@ -205,6 +275,16 @@ jobs:
       with:
         junit-name: 'be-tests-mongo-4-4-ee'
         test-args: ":exclude-tags '[:mb/once]'"
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-dir: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
 
   be-tests-mongo-4-4-ssl-ee:
     needs: files-changed
@@ -240,6 +320,16 @@ jobs:
         with:
           junit-name: 'be-tests-mongo-4-4-ee'
           test-args: ":exclude-tags '[:mb/once]'"
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit/
+          output-dir: ${{ github.job }}
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
 
   be-tests-mongo-5-0-ee:
     needs: files-changed
@@ -263,6 +353,16 @@ jobs:
       with:
         junit-name: 'be-tests-mongo-5-0-ee'
         test-args: ":exclude-tags '[:mb/once]'"
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-dir: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
 
   be-tests-mongo-5-0-ssl-ee:
     needs: files-changed
@@ -298,6 +398,16 @@ jobs:
       with:
         junit-name: 'be-tests-mongo-5-0-ee'
         test-args: ":exclude-tags '[:mb/once]'"
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-dir: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
 
   be-tests-mongo-latest-ee:
     needs: files-changed
@@ -324,6 +434,16 @@ jobs:
       with:
         junit-name: 'be-tests-mongo-latest-ee'
         test-args: ":exclude-tags '[:mb/once]'"
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-dir: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
 
   be-tests-mysql-8-0-ee:
     needs: files-changed
@@ -391,6 +511,16 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-mysql-latest-ee'
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-dir: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
 
   be-tests-oracle-18-4-ee:
     needs: files-changed
@@ -418,6 +548,16 @@ jobs:
       with:
         junit-name: 'be-tests-oracle-18-4-ee'
         test-args: ":exclude-tags '[:mb/once]'"
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-dir: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
 
   be-tests-oracle-21-3-ee:
     needs: files-changed
@@ -454,6 +594,16 @@ jobs:
       with:
         junit-name: 'be-tests-oracle-21-3-ee'
         test-args: ":exclude-tags '[:mb/once]'"
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-dir: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
 
   be-tests-postgres-ee:
     needs: files-changed
@@ -517,6 +667,16 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-postgres-latest-ee'
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-dir: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
 
   be-tests-presto-jdbc-ee:
     needs: files-changed
@@ -567,6 +727,16 @@ jobs:
       with:
         junit-name: 'be-tests-presto-jdbc-ee'
         test-args: ":exclude-tags '[:mb/once]'"
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-dir: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
 
   be-tests-redshift-ee:
     needs: files-changed
@@ -587,6 +757,16 @@ jobs:
       with:
         junit-name: 'be-tests-redshift-ee'
         test-args: ":exclude-tags '[:mb/once]'"
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-dir: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
 
   be-tests-snowflake-ee:
     needs: files-changed
@@ -609,6 +789,16 @@ jobs:
       with:
         junit-name: 'be-tests-snowflake-ee'
         test-args: ":exclude-tags '[:mb/once]'"
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-dir: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
 
   be-tests-sparksql-ee:
     needs: files-changed
@@ -630,6 +820,16 @@ jobs:
       with:
         junit-name: 'be-tests-sparksql-ee'
         test-args: ":exclude-tags '[:mb/once]'"
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-dir: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
 
   be-tests-sqlite-ee:
     needs: files-changed
@@ -646,6 +846,16 @@ jobs:
       with:
         junit-name: 'be-tests-sqlite-ee'
         test-args: ":exclude-tags '[:mb/once]'"
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-dir: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
 
   be-tests-sqlserver-2017-ee:
     needs: files-changed
@@ -674,6 +884,16 @@ jobs:
       with:
         junit-name: 'be-tests-sqlserver-ee'
         test-args: ":exclude-tags '[:mb/once]'"
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-dir: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
 
   be-tests-sqlserver-2022-ee:
     needs: files-changed
@@ -702,6 +922,16 @@ jobs:
       with:
         junit-name: 'be-tests-sqlserver-2022-ee'
         test-args: ":exclude-tags '[:mb/once]'"
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-dir: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
 
   be-tests-vertica-ee:
     needs: files-changed
@@ -725,3 +955,13 @@ jobs:
       with:
         junit-name: 'be-tests-vertica-ee'
         test-args: ":exclude-tags '[:mb/once]'"
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-dir: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -52,7 +52,7 @@ jobs:
       if: always()
       with:
         input-path: ./target/junit/
-        output-dir: ${{ github.job }}
+        output-name: ${{ github.job }}
         bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
         aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
@@ -84,7 +84,7 @@ jobs:
       if: always()
       with:
         input-path: ./target/junit/
-        output-dir: ${{ github.job }}
+        output-name: ${{ github.job }}
         bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
         aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
@@ -117,7 +117,7 @@ jobs:
       if: always()
       with:
         input-path: ./target/junit/
-        output-dir: ${{ github.job }}
+        output-name: ${{ github.job }}
         bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
         aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
@@ -143,7 +143,7 @@ jobs:
       if: always()
       with:
         input-path: ./target/junit/
-        output-dir: ${{ github.job }}
+        output-name: ${{ github.job }}
         bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
         aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
@@ -175,7 +175,7 @@ jobs:
       if: always()
       with:
         input-path: ./target/junit/
-        output-dir: ${{ github.job }}
+        output-name: ${{ github.job }}
         bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
         aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
@@ -211,7 +211,7 @@ jobs:
       if: always()
       with:
         input-path: ./target/junit/
-        output-dir: ${{ github.job }}
+        output-name: ${{ github.job }}
         bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
         aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
@@ -247,7 +247,7 @@ jobs:
       if: always()
       with:
         input-path: ./target/junit/
-        output-dir: ${{ github.job }}
+        output-name: ${{ github.job }}
         bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
         aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
@@ -280,7 +280,7 @@ jobs:
       if: always()
       with:
         input-path: ./target/junit/
-        output-dir: ${{ github.job }}
+        output-name: ${{ github.job }}
         bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
         aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
@@ -325,7 +325,7 @@ jobs:
         if: always()
         with:
           input-path: ./target/junit/
-          output-dir: ${{ github.job }}
+          output-name: ${{ github.job }}
           bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
           aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
@@ -358,7 +358,7 @@ jobs:
       if: always()
       with:
         input-path: ./target/junit/
-        output-dir: ${{ github.job }}
+        output-name: ${{ github.job }}
         bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
         aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
@@ -403,7 +403,7 @@ jobs:
       if: always()
       with:
         input-path: ./target/junit/
-        output-dir: ${{ github.job }}
+        output-name: ${{ github.job }}
         bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
         aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
@@ -439,7 +439,7 @@ jobs:
       if: always()
       with:
         input-path: ./target/junit/
-        output-dir: ${{ github.job }}
+        output-name: ${{ github.job }}
         bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
         aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
@@ -516,7 +516,7 @@ jobs:
       if: always()
       with:
         input-path: ./target/junit/
-        output-dir: ${{ github.job }}
+        output-name: ${{ github.job }}
         bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
         aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
@@ -553,7 +553,7 @@ jobs:
       if: always()
       with:
         input-path: ./target/junit/
-        output-dir: ${{ github.job }}
+        output-name: ${{ github.job }}
         bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
         aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
@@ -599,7 +599,7 @@ jobs:
       if: always()
       with:
         input-path: ./target/junit/
-        output-dir: ${{ github.job }}
+        output-name: ${{ github.job }}
         bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
         aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
@@ -672,7 +672,7 @@ jobs:
       if: always()
       with:
         input-path: ./target/junit/
-        output-dir: ${{ github.job }}
+        output-name: ${{ github.job }}
         bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
         aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
@@ -732,7 +732,7 @@ jobs:
       if: always()
       with:
         input-path: ./target/junit/
-        output-dir: ${{ github.job }}
+        output-name: ${{ github.job }}
         bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
         aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
@@ -762,7 +762,7 @@ jobs:
       if: always()
       with:
         input-path: ./target/junit/
-        output-dir: ${{ github.job }}
+        output-name: ${{ github.job }}
         bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
         aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
@@ -794,7 +794,7 @@ jobs:
       if: always()
       with:
         input-path: ./target/junit/
-        output-dir: ${{ github.job }}
+        output-name: ${{ github.job }}
         bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
         aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
@@ -825,7 +825,7 @@ jobs:
       if: always()
       with:
         input-path: ./target/junit/
-        output-dir: ${{ github.job }}
+        output-name: ${{ github.job }}
         bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
         aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
@@ -851,7 +851,7 @@ jobs:
       if: always()
       with:
         input-path: ./target/junit/
-        output-dir: ${{ github.job }}
+        output-name: ${{ github.job }}
         bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
         aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
@@ -889,7 +889,7 @@ jobs:
       if: always()
       with:
         input-path: ./target/junit/
-        output-dir: ${{ github.job }}
+        output-name: ${{ github.job }}
         bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
         aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
@@ -927,7 +927,7 @@ jobs:
       if: always()
       with:
         input-path: ./target/junit/
-        output-dir: ${{ github.job }}
+        output-name: ${{ github.job }}
         bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
         aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
@@ -960,7 +960,7 @@ jobs:
       if: always()
       with:
         input-path: ./target/junit/
-        output-dir: ${{ github.job }}
+        output-name: ${{ github.job }}
         bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
         aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -179,6 +179,17 @@ jobs:
         env:
           CYPRESS_QA_DB_MONGO: true
 
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit
+          output-dir: e2e-${{ matrix.name }}
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+
       - name: Upload Cypress Artifacts upon failure
         uses: actions/upload-artifact@v3
         if: failure()

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -184,7 +184,7 @@ jobs:
         if: always()
         with:
           input-path: ./target/junit
-          output-dir: e2e-${{ matrix.name }}
+          output-name: e2e-${{ matrix.name }}
           bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
           aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -72,6 +72,9 @@ jobs:
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.frontend_all == 'true'
     runs-on: buildjet-2vcpu-ubuntu-2204
     timeout-minutes: 60
+    env:
+      JEST_JUNIT_OUTPUT_DIR: ./target/junit
+      JEST_JUNIT_OUTPUT_NAME: test-report-frontend-unit.xml
     steps:
       - uses: actions/checkout@v3
       - name: Prepare front-end environment
@@ -92,6 +95,16 @@ jobs:
         with:
           files: ./coverage/lcov.info
           flags: front-end
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit
+          output-dir: frontend-unit
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
 
   fe-tests-timezones:
     needs: files-changed

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -100,7 +100,7 @@ jobs:
         if: always()
         with:
           input-path: ./target/junit
-          output-dir: frontend-unit
+          output-name: frontend-unit
           bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
           aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}

--- a/e2e/runner/cypress-runner-run-tests.js
+++ b/e2e/runner/cypress-runner-run-tests.js
@@ -39,13 +39,7 @@ const runCypress = async (baseUrl, exitFunction) => {
       ? await cypress.open(finalConfig)
       : await cypress.run(finalConfig);
 
-    // At least one test failed, so let's generate HTML report that helps us determine what went wrong
     if (totalFailed > 0) {
-      await executeYarnCommand({
-        command: "yarn run generate-cypress-html-report",
-        message: "Generating Mochawesome HTML report\n",
-      });
-
       await exitFunction(1);
     }
 

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -126,13 +126,10 @@ const mainConfig = {
   viewportHeight: 800,
   viewportWidth: 1280,
   numTestsKeptInMemory: process.env["CI"] ? 1 : 50,
-  reporter: "mochawesome",
+  reporter: "junit",
   reporterOptions: {
-    reportDir: "cypress/reports/mochareports",
-    reportFilename: "[status]-[name]",
-    quiet: true,
-    html: false,
-    json: true,
+    mochaFile: "./target/junit/[hash].xml",
+    toConsole: true,
   },
   retries: {
     runMode: 2,

--- a/jest.config.js
+++ b/jest.config.js
@@ -45,6 +45,7 @@ const config = {
     ace: {},
     ga: {},
   },
+  reporters: ['default', 'jest-junit'],
   coverageDirectory: "./coverage",
   coverageReporters: ["html", "lcov"],
   collectCoverageFrom: [

--- a/package.json
+++ b/package.json
@@ -243,6 +243,7 @@
     "jest": "^29.5.0",
     "jest-canvas-mock": "^2.4.0",
     "jest-environment-jsdom": "^29.5.0",
+    "jest-junit": "^16.0.0",
     "jest-localstorage-mock": "^2.4.22",
     "jest-watch-typeahead": "^2.2.1",
     "json-to-pretty-yaml": "^1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13973,6 +13973,16 @@ jest-haste-map@^29.5.0:
   optionalDependencies:
     fsevents "^2.3.2"
 
+jest-junit@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-16.0.0.tgz#d838e8c561cf9fdd7eb54f63020777eee4136785"
+  integrity sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==
+  dependencies:
+    mkdirp "^1.0.4"
+    strip-ansi "^6.0.1"
+    uuid "^8.3.2"
+    xml "^1.0.1"
+
 jest-leak-detector@^29.5.0:
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-29.5.0.tgz#cf4bdea9615c72bac4a3a7ba7e7930f9c0610c8c"
@@ -22897,6 +22907,11 @@ xml-name-validator@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
   integrity sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/35682

### Description

Uploads junit test results to an s3 bucket for all tests we run. This will allow us to detect failures, flakes, and run time on a per-test basis for our entire test suite, which we cannot currently do.

The four groups of tests we have are
- frontend unit tests
- backend unit tests
- driver tests
- e2e tests

All of which now output junit test files which get zipped within each job and uploaded to s3 with this path structure:
- format: `s3://{bucket}/{date}/{runId}/{runAttempt}/{jobName}.zip`
- example: `s3://my-test-bucket/2023-11-30/7049572755/1/be-tests-bigquery-cloud-sdk-ee.zip`

## New Environment Variables Needed

✅  Added by Nemanja on 11/28

```sh
# secret (secrets)
AWS_TEST_RESULTS_ACCESS_KEY_ID
AWS_TEST_RESULTS_SECRET_ACCESS_KEY

# not secret (vars)
AWS_S3_TEST_RESULTS_BUCKET
```

