### PR TITLE
Fix - Question editor does not work if model joins the same table more than once

### DIFF
--- a/e2e/test/scenarios/joins/reproductions/33427-joining-same-table-twice.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/33427-joining-same-table-twice.cy.spec.js
@@ -25,8 +25,6 @@ describe("issue 33427", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    cy.intercept("PUT", "/api/card/*").as("updateCard");
-    cy.intercept("POST", `/api/dataset`).as("dataset");
   });
 
   it("should display proper column names in the fields picker (metabase#33427)", () => {

--- a/e2e/test/scenarios/joins/reproductions/33427-joining-same-table-twice.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/33427-joining-same-table-twice.cy.spec.js
@@ -1,0 +1,82 @@
+import {
+  openNotebook,
+  openQuestionActions,
+  popover,
+  restore,
+  visitModel,
+} from "e2e/support/helpers";
+
+const MODEL_DETAILS = {
+  dataset: true,
+  native: {
+    query: `
+      SELECT o.ID, p1.TITLE AS CREATED_BY, p2.TITLE AS UPDATED_BY
+      FROM ORDERS o
+      JOIN PRODUCTS p1 ON p1.ID = o.PRODUCT_ID
+      JOIN PRODUCTS p2 ON p2.ID = o.USER_ID
+    `,
+  },
+};
+
+const CREATED_BY_NAME = "Title - created by";
+const UPDATED_BY_NAME = "Title - updated by";
+
+describe("issue 33427", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.intercept("PUT", "/api/card/*").as("updateCard");
+    cy.intercept("POST", `/api/dataset`).as("dataset");
+  });
+
+  it("should display proper column names in the fields picker (metabase#33427)", () => {
+    cy.createNativeQuestion(MODEL_DETAILS).then(({ body: card }) => {
+      visitModel(card.id);
+    });
+
+    cy.url().then(modelUrl => cy.wrap(modelUrl).as("modelUrl"));
+
+    openQuestionActions();
+    popover().findByText("Edit metadata").click();
+
+    cy.findAllByTestId("header-cell").contains("CREATED_BY").click();
+    mapColumnToProductsTitle();
+    changeColumnDisplayName("Title", CREATED_BY_NAME);
+
+    cy.findAllByTestId("header-cell").contains("UPDATED_BY").click();
+    mapColumnToProductsTitle();
+    changeColumnDisplayName("Title", UPDATED_BY_NAME);
+
+    cy.button("Save changes").click();
+    cy.get("@modelUrl").then(modelUrl => cy.url().should("equal", modelUrl));
+
+    openNotebook();
+    cy.findByTestId("fields-picker").click();
+    popover().within(() => {
+      cy.findByText("ID").should("exist");
+      cy.findByText(CREATED_BY_NAME).should("exist");
+      cy.findByText(UPDATED_BY_NAME).should("exist");
+    });
+  });
+});
+
+const mapColumnToProductsTitle = () => {
+  cy.findByTestId("sidebar-right")
+    .findByText("Database column this maps to")
+    .closest("#formField-id")
+    .findByTestId("select-button")
+    .click();
+  popover().findByText("Products").click();
+  popover().findByText("Title").click();
+};
+
+const changeColumnDisplayName = (currentName, newName) => {
+  cy.findByTestId("sidebar-right")
+    .findByTitle("Display name")
+    .should("have.value", currentName)
+    .clear()
+    .type(newName)
+    .blur();
+
+  cy.findAllByTestId("header-cell").contains(newName).should("exist");
+};

--- a/frontend/src/metabase-lib/metadata/utils/fields.ts
+++ b/frontend/src/metabase-lib/metadata/utils/fields.ts
@@ -45,9 +45,7 @@ export function getUniqueFieldId({
   const fieldIdentifier = getFieldIdentifier({ id, name });
 
   if (isVirtualCardId(table_id)) {
-    const isVirtual = typeof id !== "number";
-
-    if (isVirtual && name) {
+    if (name) {
       return `${table_id}:${fieldIdentifier}:${name}`;
     }
 

--- a/frontend/src/metabase-lib/metadata/utils/fields.ts
+++ b/frontend/src/metabase-lib/metadata/utils/fields.ts
@@ -45,6 +45,10 @@ export function getUniqueFieldId({
   const fieldIdentifier = getFieldIdentifier({ id, name });
 
   if (isVirtualCardId(table_id)) {
+    if (name) {
+      return `${table_id}:${fieldIdentifier}:${name}`;
+    }
+
     return `${table_id}:${fieldIdentifier}`;
   }
 

--- a/frontend/src/metabase-lib/metadata/utils/fields.ts
+++ b/frontend/src/metabase-lib/metadata/utils/fields.ts
@@ -45,7 +45,9 @@ export function getUniqueFieldId({
   const fieldIdentifier = getFieldIdentifier({ id, name });
 
   if (isVirtualCardId(table_id)) {
-    if (name) {
+    const isVirtual = typeof id !== "number";
+
+    if (isVirtual && name) {
       return `${table_id}:${fieldIdentifier}:${name}`;
     }
 

--- a/frontend/src/metabase-lib/metadata/utils/fields.unit.spec.ts
+++ b/frontend/src/metabase-lib/metadata/utils/fields.unit.spec.ts
@@ -29,15 +29,12 @@ const NESTED_DB_FIELD = createMockField({
 const CARD_FIELD = createMockField({
   id: CARD_FIELD_ID,
   table_id: CARD_TABLE_ID,
-  name: "foo",
-  display_name: "foo",
 });
 
 const NATIVE_CARD_FIELD = createMockField({
   id: NATIVE_CARD_FIELD_ID,
   table_id: CARD_TABLE_ID,
-  name: "foo",
-  display_name: "foo",
+  name: undefined,
 });
 
 const DB_TABLE = createMockTable({

--- a/frontend/src/metabase/entities/fields.js
+++ b/frontend/src/metabase/entities/fields.js
@@ -72,12 +72,12 @@ const Fields = createEntity({
     fetchFieldValues: compose(
       withAction(FETCH_FIELD_VALUES),
       withCachedDataAndRequestState(
-        ({ id, table_id }) => {
-          const uniqueId = getUniqueFieldId({ id, table_id });
+        ({ id, name, table_id }) => {
+          const uniqueId = getUniqueFieldId({ id, name, table_id });
           return [...Fields.getObjectStatePath(uniqueId)];
         },
-        ({ id, table_id }) => {
-          const uniqueId = getUniqueFieldId({ id, table_id });
+        ({ id, name, table_id }) => {
+          const uniqueId = getUniqueFieldId({ id, name, table_id });
           return [...Fields.getObjectStatePath(uniqueId), "values"];
         },
         field => {
@@ -86,13 +86,18 @@ const Fields = createEntity({
       ),
       withNormalize(FieldSchema),
     )(field => async () => {
+      const { id, table_id, name } = field;
       const { field_id, ...data } = await MetabaseApi.field_values({
-        fieldId: field.id,
+        fieldId: id,
       });
-      const table_id = field.table_id;
 
       // table_id is required for uniqueFieldId as it's a way to know if field is virtual
-      return { id: field_id, ...data, ...(table_id && { table_id }) };
+      return {
+        id: field_id,
+        ...data,
+        ...(table_id && { table_id }),
+        ...(name && { name }),
+      };
     }),
 
     updateField(field, values, opts) {

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -221,7 +221,7 @@ export class UnconnectedDataSelector extends Component {
     selectedDataBucketId: PropTypes.string,
     selectedDatabaseId: PropTypes.number,
     selectedSchemaId: PropTypes.string,
-    selectedTableId: PropTypes.number,
+    selectedTableId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     selectedFieldId: PropTypes.number,
     databases: PropTypes.array.isRequired,
     setDatabaseFn: PropTypes.func,


### PR DESCRIPTION
Fixes #33427

### Description

See [Slack discussion](https://metaboat.slack.com/archives/C04CYTEL9N2/p1699978395628049?thread_ts=1699902023.771949&cid=C04CYTEL9N2).

This PR fixes how the columns are displayed in the dropdown in GUI editor, but it does not fix what happens when you try to deselect/select these columns, see [video](https://github.com/metabase/metabase/assets/6830683/3f2b0d10-d1e3-430c-b3c5-25df61d04eeb) - it's been reported separately: #35290.



### How to verify

See demo below or follow steps from this comment: https://github.com/metabase/metabase/issues/33427#issuecomment-1690861463.

### Demo

#### Before

https://github.com/metabase/metabase/assets/6830683/d599fadd-3315-40ef-b19d-0b5f7cdba93a

#### After

https://github.com/metabase/metabase/assets/6830683/cf89f008-73ae-40e3-9152-f1fc38715a5d

### Discussions

- `getColumnGroups` now returns incorrect groups (e2e tests fail `table-column-settings.cy.spec.js`):
  - `should be able to show and hide fields from a nested query with joins and fields (metabase#32373)`
  - `should be able to show and hide implicitly joinable fields for a nested query with joins and fields`
  - `should be able to show and hide implicitly joinable fields for a nested query`
- `metadata.field` interface needs to receive `name` now, but there are 193 usages of this function
- `ChartSettingAddRemoveColumns.tsx` - `filteredColumns` are matched by `displayName` - this is incorrect