### PR TITLE
Print inputs in stress-test workflow summary

### DIFF
--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -17,6 +17,22 @@ on:
         required: false
 
 jobs:
+  workflow-summary:
+    name: Stress test inputs
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - name: Generate workflow summary
+        run: |
+          echo '**Inputs:**' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo '- `branch`: ${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
+          echo '- `spec`: ${{ inputs.spec }}' >> $GITHUB_STEP_SUMMARY
+          echo '- `burn_in`: ${{ inputs.burn_in }}' >> $GITHUB_STEP_SUMMARY
+          echo '- `grep`: "${{ inputs.grep }}"' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo 'triggered by: @${{ github.event.sender.login }}' >> $GITHUB_STEP_SUMMARY
+
   stress-test-flake-fix:
     runs-on: ubuntu-22.04
     timeout-minutes: 60


### PR DESCRIPTION
This is a small QoL improvement for people who rely on the "stress-test" workflow, and for the ones who need to review some [flaky test fix](https://github.com/metabase/metabase/pulls?q=is%3Aopen+is%3Apr+label%3Aflaky-test-fix) PRs.

It simply prints the inputs passed to the workflow on a manual trigger.
Makes it easier to see what was triggered just by glancing at the summary, and makes it easier to trigger another run with the same inputs if needed.

**Before**
https://github.com/metabase/metabase/actions/runs/6904258725

No easy way of knowing what was tested
![image](https://github.com/metabase/metabase/assets/31325167/50f514d6-0f33-45e4-8f19-555f3181aea4)

**After**
https://github.com/metabase/metabase/actions/runs/6931494205

It will print inputs even during the test run
![image](https://github.com/metabase/metabase/assets/31325167/7d07d4d4-88e1-43ef-9fab-095c30bda052)
