### PR TITLE
Add check for connection status before sync

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -29,12 +29,12 @@
    [metabase.util.honeysql-extensions :as hx]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
-(def ^:private test-db-name (bigquery.tx/normalize-name :db "test_data"))
+(def ^:private test-db-name (bigquery.tx/test-dataset-id "test_data"))
 
-(def ^:private sample-dataset-name (bigquery.tx/normalize-name :db "sample_dataset"))
+(def ^:private sample-dataset-name (bigquery.tx/test-dataset-id "sample_dataset"))
 
 (defn- with-test-db-name
-  "Replaces instances of v3_test_data with the full per-test-run DB name"
+  "Replaces instances of v3_test_data with the full per-test-run DB name (aka dataset ID)"
   [x]
   (cond
     (string? x) (str/replace x "v3_test_data" test-db-name)
@@ -659,7 +659,7 @@
                            :type       :native
                            :native     {:query         (str "SELECT count(*)\n"
                                                             (format "FROM `%s.attempts`\n"
-                                                                    (bigquery.tx/normalize-name :db "attempted_murders"))
+                                                                    (bigquery.tx/test-dataset-id "attempted_murders"))
                                                             "WHERE {{d}}")
                                         :template-tags {"d" {:name         "d"
                                                              :display-name "Date"

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -23,7 +23,7 @@
 
 (set! *warn-on-reflection* true)
 
-(def ^:private test-db-name (bigquery.tx/normalize-name :db "test_data"))
+(def ^:private test-db-name (bigquery.tx/test-dataset-id "test_data"))
 
 (deftest can-connect?-test
   (mt/test-driver :bigquery-cloud-sdk

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
@@ -320,27 +320,27 @@
     (log/info (u/format-color 'blue "Deleting temporary dataset more than two hours old: %s`." outdated))
     (u/ignore-exceptions
      (destroy-dataset! outdated)))
-  (let [database-name (normalize-name :db database-name)]
+  (let [dataset-id (normalize-name :db database-name)]
     (u/auto-retry 2
      (try
-       (log/infof "Creating dataset %s..." (pr-str database-name))
+       (log/infof "Creating dataset %s..." (pr-str dataset-id))
        ;; if the dataset failed to load successfully last time around, destroy whatever was loaded so we start
        ;; again from a blank slate
        (u/ignore-exceptions
-        (destroy-dataset! database-name))
-       (create-dataset! database-name)
+        (destroy-dataset! dataset-id))
+       (create-dataset! dataset-id)
        ;; now create tables and load data.
        (doseq [tabledef table-definitions]
-         (load-tabledef! database-name tabledef))
-       (log/info (u/format-color 'green "Successfully created %s." (pr-str database-name)))
+         (load-tabledef! dataset-id tabledef))
+       (log/info (u/format-color 'green "Successfully created %s." (pr-str dataset-id)))
        (catch Throwable e
-         (log/error (u/format-color 'red  "Failed to load BigQuery dataset %s." (pr-str database-name)))
+         (log/error (u/format-color 'red  "Failed to load BigQuery dataset %s." (pr-str dataset-id)))
          (log/error (u/pprint-to-str 'red (Throwable->map e)))
          (throw e))))))
 
 (defmethod tx/destroy-db! :bigquery-cloud-sdk
   [_ {:keys [database-name]}]
-  (destroy-dataset! database-name))
+  (destroy-dataset! (normalize-name :db database-name)))
 
 (defmethod tx/aggregate-column-info :bigquery-cloud-sdk
   ([driver aggregation-type]

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -58,9 +58,13 @@
     (let [db-stats (-> (cmd/db-stats conn)
                        (m.conversion/from-db-object :keywordize))
           db-names (mg/get-db-names mongo.util/*mongo-client*)]
-      (and (= (float (:ok db-stats))
-              1.0)
-           (contains? db-names (:db db-stats))))))
+      (and
+       ;; 1. check db.dbStats command completes successfully
+       (= (float (:ok db-stats))
+          1.0)
+       ;; 2. check the database is actually on the server
+       ;; (this is required because (1) is true even if the database doesn't exist)
+       (contains? db-names (:db db-stats))))))
 
 (defmethod driver/humanize-connection-error-message
   :mongo

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -56,10 +56,11 @@
   [_ details]
   (with-mongo-connection [^DB conn, details]
     (let [db-stats (-> (cmd/db-stats conn)
-                       (m.conversion/from-db-object :keywordize))]
+                       (m.conversion/from-db-object :keywordize))
+          db-names (mg/get-db-names mongo.util/*mongo-client*)]
       (and (= (float (:ok db-stats))
               1.0)
-           (contains? (mg/get-db-names mongo.util/*mongo-client*) (:db db-stats))))))
+           (contains? db-names (:db db-stats))))))
 
 (defmethod driver/humanize-connection-error-message
   :mongo

--- a/modules/drivers/mongo/src/metabase/driver/mongo/util.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/util.clj
@@ -18,12 +18,12 @@
 
 (set! *warn-on-reflection* true)
 
-(def ^:dynamic ^com.mongodb.MongoClient *mongo-client*
-  "Client used to connect to a Mongo database. Bound by top-level `with-mongo-connection` so it may be reused within its body."
-  nil)
-
 (def ^:dynamic ^com.mongodb.DB *mongo-connection*
   "Connection to a Mongo database. Bound by top-level `with-mongo-connection` so it may be reused within its body."
+  nil)
+
+(def ^:dynamic ^com.mongodb.MongoClient *mongo-client*
+  "Client used to connect to a Mongo database. Bound by top-level `with-mongo-connection` so it may be reused within its body."
   nil)
 
 ;; the code below is done to support "additional connection options" the way some of the JDBC drivers do.
@@ -223,7 +223,7 @@
 
 (defn do-with-mongo-connection
   "Run `f` with a new connection (bound to [[*mongo-connection*]]) to `database`. Don't use this directly; use
-  [[with-mongo-connection]]."
+  [[with-mongo-connection]]. Also dynamically binds the Mongo client to [[*mongo-client*]]."
   [f database]
   (let [details (database->details database)]
     (ssh/with-ssh-tunnel [details-with-tunnel details]
@@ -242,6 +242,8 @@
   "Open a new MongoDB connection to ``database-or-connection-string`, bind connection to `binding`, execute `body`, and
   close the connection. The DB connection is re-used by subsequent calls to [[with-mongo-connection]] within
   `body`. (We're smart about it: `database` isn't even evaluated if [[*mongo-connection*]] is already bound.)
+
+  [[*mongo-client*]] is also dynamically bound to the MongoClient instance.
 
     ;; delay isn't derefed if *mongo-connection* is already bound
     (with-mongo-connection [^com.mongodb.DB conn @(:db (sel :one Table ...))]

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -46,40 +46,42 @@
 (deftest can-connect-test?
   (mt/test-driver
    :mongo
-   (doseq [{:keys [details expected message]} [{:details  {:host   "localhost"
-                                                           :port   3000
-                                                           :dbname "bad-db-name"}
-                                                :expected false}
-                                               {:details  {}
-                                                :expected false}
-                                               {:details  {:host   "localhost"
-                                                           :port   27017
-                                                           :user   "metabase"
-                                                           :pass   "metasample123"
-                                                           :dbname "metabase-test"}
-                                                :expected true}
-                                               {:details  {:host   "localhost"
-                                                           :user   "metabase"
-                                                           :pass   "metasample123"
-                                                           :dbname "metabase-test"}
-                                                :expected true
-                                                :message  "should use default port 27017 if not specified"}
-                                               {:details  {:host   "123.4.5.6"
-                                                           :dbname "bad-db-name?connectTimeoutMS=50"}
-                                                :expected false}
-                                               {:details  {:host   "localhost"
-                                                           :port   3000
-                                                           :dbname "bad-db-name?connectTimeoutMS=50"}
-                                                :expected false}
-                                               {:details  {:conn-uri "mongodb://metabase:metasample123@localhost:27017/metabase-test?authSource=admin"}
-                                                :expected (not (tdm/ssl-required?))}
-                                               {:details  {:conn-uri "mongodb://localhost:3000/bad-db-name?connectTimeoutMS=50"}
-                                                :expected false}]
-           :let [ssl-details (tdm/conn-details details)]]
-     (testing (str "connect with " details)
-       (is (= expected
-              (driver.u/can-connect-with-details? :mongo ssl-details))
-           (str message))))))
+   (mt/dataset sample-dataset
+     (mt/db)
+     (doseq [{:keys [details expected message]} [{:details  {:host   "localhost"
+                                                             :port   3000
+                                                             :dbname "bad-db-name"}
+                                                  :expected false}
+                                                 {:details  {}
+                                                  :expected false}
+                                                 {:details  {:host   "localhost"
+                                                             :port   27017
+                                                             :user   "metabase"
+                                                             :pass   "metasample123"
+                                                             :dbname "sample-dataset"}
+                                                  :expected true}
+                                                 {:details  {:host   "localhost"
+                                                             :user   "metabase"
+                                                             :pass   "metasample123"
+                                                             :dbname "sample-dataset"}
+                                                  :expected true
+                                                  :message  "should use default port 27017 if not specified"}
+                                                 {:details  {:host   "123.4.5.6"
+                                                             :dbname "bad-db-name?connectTimeoutMS=50"}
+                                                  :expected false}
+                                                 {:details  {:host   "localhost"
+                                                             :port   3000
+                                                             :dbname "bad-db-name?connectTimeoutMS=50"}
+                                                  :expected false}
+                                                 {:details  {:conn-uri "mongodb://metabase:metasample123@localhost:27017/sample-dataset?authSource=admin"}
+                                                  :expected (not (tdm/ssl-required?))}
+                                                 {:details  {:conn-uri "mongodb://localhost:3000/bad-db-name?connectTimeoutMS=50"}
+                                                  :expected false}]
+             :let [ssl-details (tdm/conn-details details)]]
+       (testing (str "connect with " details)
+         (is (= expected
+                (driver.u/can-connect-with-details? :mongo ssl-details))
+             (str message)))))))
 
 (deftest database-supports?-test
   (mt/test-driver :mongo

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -67,7 +67,7 @@
    ;; Snowflake JDBC driver ignores this, but we do use it in the `query-db-name` function in
    ;; `metabase.driver.snowflake`
    (when (= context :db)
-     {:db (qualified-db-name (u/lower-case-en database-name))})))
+     {:db (qualified-db-name database-name)})))
 
 ;; Snowflake requires you identify an object with db-name.schema-name.table-name
 (defmethod sql.tx/qualified-name-components :snowflake

--- a/modules/drivers/sqlite/test/metabase/test/data/sqlite.clj
+++ b/modules/drivers/sqlite/test/metabase/test/data/sqlite.clj
@@ -1,16 +1,22 @@
 (ns metabase.test.data.sqlite
-  (:require [metabase.test.data.interface :as tx]
+  (:require [clojure.java.io :as io]
+            [metabase.test.data.interface :as tx]
             [metabase.test.data.sql :as sql.tx]
             [metabase.test.data.sql-jdbc :as sql-jdbc.tx]
             [metabase.test.data.sql-jdbc.execute :as execute]))
+
+(set! *warn-on-reflection* true)
 
 (sql-jdbc.tx/add-test-extensions! :sqlite)
 
 (defmethod tx/supports-timestamptz-type? :sqlite [_driver] false)
 
+(defn- file-name [dbdef]
+  (str (tx/escaped-database-name dbdef) ".sqlite"))
+
 (defmethod tx/dbdef->connection-details :sqlite
   [_driver _context dbdef]
-  {:db (str (tx/escaped-database-name dbdef) ".sqlite")})
+  {:db (file-name dbdef)})
 
 (doseq [[base-type sql-type] {:type/BigInteger "BIGINT"
                               :type/Boolean    "BOOLEAN"
@@ -44,3 +50,10 @@
 (defmethod sql.tx/drop-db-if-exists-sql :sqlite [& _] nil)
 (defmethod sql.tx/create-db-sql         :sqlite [& _] nil)
 (defmethod sql.tx/add-fk-sql            :sqlite [& _] nil) ; TODO - fix me
+
+(defmethod tx/destroy-db! :sqlite
+  [_driver dbdef]
+  (let [fname (file-name dbdef)
+        file  (io/file fname)]
+    (when (.exists file)
+      (.delete file))))

--- a/modules/drivers/sqlite/test/metabase/test/data/sqlite.clj
+++ b/modules/drivers/sqlite/test/metabase/test/data/sqlite.clj
@@ -11,12 +11,12 @@
 
 (defmethod tx/supports-timestamptz-type? :sqlite [_driver] false)
 
-(defn- file-name [dbdef]
+(defn- db-file-name [dbdef]
   (str (tx/escaped-database-name dbdef) ".sqlite"))
 
 (defmethod tx/dbdef->connection-details :sqlite
   [_driver _context dbdef]
-  {:db (file-name dbdef)})
+  {:db (db-file-name dbdef)})
 
 (doseq [[base-type sql-type] {:type/BigInteger "BIGINT"
                               :type/Boolean    "BOOLEAN"
@@ -53,7 +53,6 @@
 
 (defmethod tx/destroy-db! :sqlite
   [_driver dbdef]
-  (let [fname (file-name dbdef)
-        file  (io/file fname)]
+  (let [file (io/file (db-file-name dbdef))]
     (when (.exists file)
       (.delete file))))

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -992,8 +992,7 @@
                        nil)
                      (catch Throwable e
                        e))]
-
-      (throw ex)
+      (throw (ex-info (ex-message ex) {:status-code 422}))
       (do
         (future
           (sync-metadata/sync-db-metadata! db)

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -984,14 +984,14 @@
   ;; just wrap this in a future so it happens async
   (let [db (api/write-check (t2/select-one Database :id id))]
     (events/publish-event! :event/database-manual-sync {:object db :user-id api/*current-user-id*})
-    (if-let [ex (try (do
-                       ;; it's okay to allow testing H2 connections during sync. We only want to disallow you from testing them for the
-                       ;; purposes of creating a new H2 database.
-                       (binding [h2/*allow-testing-h2-connections* true]
-                         (driver.u/can-connect-with-details? (:engine db) (:details db) :throw-exceptions))
-                       nil)
-                     (catch Throwable e
-                       e))]
+    (if-let [ex (try
+                  ;; it's okay to allow testing H2 connections during sync. We only want to disallow you from testing them for the
+                  ;; purposes of creating a new H2 database.
+                  (binding [h2/*allow-testing-h2-connections* true]
+                    (driver.u/can-connect-with-details? (:engine db) (:details db) :throw-exceptions))
+                  nil
+                  (catch Throwable e
+                    e))]
       (throw (ex-info (ex-message ex) {:status-code 422}))
       (do
         (future

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -13,6 +13,7 @@
    [metabase.db.query :as mdb.query]
    [metabase.driver :as driver]
    [metabase.driver.ddl.interface :as ddl.i]
+   [metabase.driver.h2 :as h2]
    [metabase.driver.util :as driver.u]
    [metabase.events :as events]
    [metabase.lib.schema.id :as lib.schema.id]
@@ -983,10 +984,21 @@
   ;; just wrap this in a future so it happens async
   (let [db (api/write-check (t2/select-one Database :id id))]
     (events/publish-event! :event/database-manual-sync {:object db :user-id api/*current-user-id*})
-    (future
-      (sync-metadata/sync-db-metadata! db)
-      (analyze/analyze-db! db)))
-  {:status :ok})
+    (if-let [ex (try (do
+                       ;; it's okay to allow testing H2 connections during sync. We only want to disallow you from testing them for the
+                       ;; purposes of creating a new H2 database.
+                       (binding [h2/*allow-testing-h2-connections* true]
+                         (driver.u/can-connect-with-details? (:engine db) (:details db) :throw-exceptions))
+                       nil)
+                     (catch Throwable e
+                       e))]
+
+      (throw ex)
+      (do
+        (future
+          (sync-metadata/sync-db-metadata! db)
+          (analyze/analyze-db! db))
+        {:status :ok}))))
 
 (api/defendpoint POST "/:id/dismiss_spinner"
   "Manually set the initial sync status of the `Database` and corresponding

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -144,8 +144,8 @@
   (if throw-exceptions
     (try
       (u/with-timeout (db-connection-timeout-ms)
-        (when-not (driver/can-connect? driver details-map)
-          (throw (Exception. "Failed to connect to Database"))))
+        (or (driver/can-connect? driver details-map)
+            (throw (Exception. "Failed to connect to Database"))))
       ;; actually if we are going to `throw-exceptions` we'll rethrow the original but attempt to humanize the message
       ;; first
       (catch Throwable e

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -144,7 +144,8 @@
   (if throw-exceptions
     (try
       (u/with-timeout (db-connection-timeout-ms)
-        (driver/can-connect? driver details-map))
+        (when-not (driver/can-connect? driver details-map)
+          (throw (Exception. "Failed to connect to Database"))))
       ;; actually if we are going to `throw-exceptions` we'll rethrow the original but attempt to humanize the message
       ;; first
       (catch Throwable e

--- a/src/metabase/sync.clj
+++ b/src/metabase/sync.clj
@@ -48,7 +48,6 @@
   ([database                         :- i/DatabaseInstance
     {:keys [scan], :or {scan :full}} :- [:maybe [:map
                                                  [:scan {:optional true} [:maybe [:enum :schema :full]]]]]]
-   (driver.u/can-connect-with-details? (:engine database) (:details database) :throw-exceptions)
    (sync-util/sync-operation :sync database (format "Sync %s" (sync-util/name-for-logging database))
      (cond-> [(assoc (sync-metadata/sync-db-metadata! database) :name "metadata")]
        (= scan :full)

--- a/src/metabase/sync.clj
+++ b/src/metabase/sync.clj
@@ -48,20 +48,12 @@
   ([database                         :- i/DatabaseInstance
     {:keys [scan], :or {scan :full}} :- [:maybe [:map
                                                  [:scan {:optional true} [:maybe [:enum :schema :full]]]]]]
+   (driver.u/can-connect-with-details? (:engine database) (:details database) :throw-exceptions)
    (sync-util/sync-operation :sync database (format "Sync %s" (sync-util/name-for-logging database))
-     (into []
-           (keep (fn [[f step-name]]
-                   (when f
-                     (assoc (f database) :name step-name))))
-           [ ;; First make sure Tables, Fields, and FK information is up-to-date
-            [sync-metadata/sync-db-metadata! "metadata"]
-            ;; Next, run the 'analysis' step where we do things like scan values of fields and update semantic types
-            ;; accordingly
-            (when (= scan :full)
-              [analyze/analyze-db! "analyze"])
-            ;; Finally, update cached FieldValues
-            (when (= scan :full)
-              [field-values/update-field-values! "field-values"])]))))
+     (cond-> [(assoc (sync-metadata/sync-db-metadata! database) :name "metadata")]
+       (= scan :full)
+       (conj (assoc (analyze/analyze-db! database) :name "analyze")
+             (assoc (field-values/update-field-values! database) :name "field-values"))))))
 
 (mu/defn sync-table!
   "Perform all the different sync operations synchronously for a given `table`. Since often called on a sequence of

--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -89,7 +89,7 @@
                   nil
                   (catch Throwable e
                     e))]
-      (log/warnf ex "Cannot sync Database {0}: {1}" (:name database) (ex-message ex))
+      (log/warnf ex "Cannot sync Database %s: %s" (:name database) (ex-message ex))
       (do
         (sync-metadata/sync-db-metadata! database)
           ;; only run analysis if this is a "full sync" database

--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -74,7 +74,7 @@
          end-time
          (< (.toMinutes (t/duration start-time end-time)) analyze-duration-threshold-for-refingerprinting))))
 
-(defn- sync-and-analyze-database!*
+(defn- sync-and-analyze-database*!
   [database-id]
   (log/info (trs "Starting sync task for Database {0}." database-id))
   (when-let [database (or (t2/select-one Database :id database-id)
@@ -110,7 +110,7 @@
                           {:database-id database-id
                            :raw-job-context job-context
                            :job-context (pr-str job-context)}))))
-      (sync-and-analyze-database!* database-id))))
+      (sync-and-analyze-database*! database-id))))
 
 (jobs/defjob ^{org.quartz.DisallowConcurrentExecution true
                :doc "Sync and analyze the database"}

--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -12,6 +12,8 @@
    [malli.core :as mc]
    [metabase.config :as config]
    [metabase.db.query :as mdb.query]
+   [metabase.driver.h2 :as h2]
+   [metabase.driver.util :as driver.u]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.models.database :as database :refer [Database]]
    [metabase.models.interface :as mi]
@@ -72,6 +74,30 @@
          end-time
          (< (.toMinutes (t/duration start-time end-time)) analyze-duration-threshold-for-refingerprinting))))
 
+(defn- sync-and-analyze-database!*
+  [database-id]
+  (log/info (trs "Starting sync task for Database {0}." database-id))
+  (when-let [database (or (t2/select-one Database :id database-id)
+                          (do
+                            (unschedule-tasks-for-db! (mi/instance Database {:id database-id}))
+                            (log/warn (trs "Cannot sync Database {0}: Database does not exist." database-id))))]
+    (if-let [ex (try
+                  ;; it's okay to allow testing H2 connections during sync. We only want to disallow you from testing them for the
+                  ;; purposes of creating a new H2 database.
+                  (binding [h2/*allow-testing-h2-connections* true]
+                    (driver.u/can-connect-with-details? (:engine database) (:details database) :throw-exceptions))
+                  nil
+                  (catch Throwable e
+                    e))]
+      (log/warnf ex "Cannot sync Database {0}: {1}" (:name database) (ex-message ex))
+      (do
+        (sync-metadata/sync-db-metadata! database)
+          ;; only run analysis if this is a "full sync" database
+        (when (:is_full_sync database)
+          (let [results (analyze/analyze-db! database)]
+            (when (and (:refingerprint database) (should-refingerprint-fields? results))
+              (analyze/refingerprint-db! database))))))))
+
 (defn- sync-and-analyze-database!
   "The sync and analyze database job, as a function that can be used in a test"
   [job-context]
@@ -84,18 +110,7 @@
                           {:database-id database-id
                            :raw-job-context job-context
                            :job-context (pr-str job-context)}))))
-      (do
-        (log/info (trs "Starting sync task for Database {0}." database-id))
-        (when-let [database (or (t2/select-one Database :id database-id)
-                                (do
-                                  (unschedule-tasks-for-db! (mi/instance Database {:id database-id}))
-                                  (log/warn (trs "Cannot sync Database {0}: Database does not exist." database-id))))]
-          (sync-metadata/sync-db-metadata! database)
-          ;; only run analysis if this is a "full sync" database
-          (when (:is_full_sync database)
-            (let [results (analyze/analyze-db! database)]
-              (when (and (:refingerprint database) (should-refingerprint-fields? results))
-                (analyze/refingerprint-db! database)))))))))
+      (sync-and-analyze-database!* database-id))))
 
 (jobs/defjob ^{org.quartz.DisallowConcurrentExecution true
                :doc "Sync and analyze the database"}

--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -92,7 +92,7 @@
       (log/warnf ex "Cannot sync Database %s: %s" (:name database) (ex-message ex))
       (do
         (sync-metadata/sync-db-metadata! database)
-          ;; only run analysis if this is a "full sync" database
+        ;; only run analysis if this is a "full sync" database
         (when (:is_full_sync database)
           (let [results (analyze/analyze-db! database)]
             (when (and (:refingerprint database) (should-refingerprint-fields? results))

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -106,7 +106,7 @@
               (testing "sense check 2: triggering the sync via the POST /api/database/:id/sync_schema endpoint should succeed"
                 (is (= {:status "ok"}
                        (mt/user-http-request :crowberto :post 200 (str "/database/" (u/the-id db) "/sync_schema"))))))
-            ;; release db resources like connection pools we don't have to wait to finish syncing before destroying the db
+            ;; release db resources like connection pools so we don't have to wait to finish syncing before destroying the db
             (driver/notify-database-updated driver/*driver* db)
             ;; destroy the db
             (if (contains? #{:redshift :snowflake} driver/*driver*)

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -104,16 +104,16 @@
               (testing "2: triggering the sync via the POST /api/database/:id/sync_schema endpoint should succeed"
                 (is (= {:status "ok"}
                        (mt/user-http-request :crowberto :post 200 (str "/database/" (u/the-id db) "/sync_schema"))))))
-              ;; release db resources like connection pools we don't have to wait to finish syncing before destroying the db
+            ;; release db resources like connection pools we don't have to wait to finish syncing before destroying the db
             (driver/notify-database-updated driver/*driver* db)
-              ;; destroy the db
+            ;; destroy the db
             (tx/destroy-db! driver/*driver* dbdef)
             (testing "after deleting a database, sync should fail"
               (testing "1: sync-and-analyze-database! should log a warning and fail early"
                 (is (some? (find-log-match))))
               (testing "2: triggering the sync via the POST /api/database/:id/sync_schema endpoint should fail"
                 (mt/user-http-request :crowberto :post 422 (str "/database/" (u/the-id db) "/sync_schema"))))
-              ;; clean up the database
+            ;; clean up the database
             (t2/delete! :model/Database (u/the-id db))))))))
 
 (deftest supports-table-privileges-matches-implementations-test

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -115,7 +115,7 @@
                  (mt/with-log-messages-for-level :warn
                    (#'task.sync-databases/sync-and-analyze-database!* (u/the-id db))))))
           (testing "2: triggering the sync via the POST /api/database/:id/sync_schema endpoint should fail"
-            (mt/user-http-request :crowberto :post 500 (str "/database/" (u/the-id db) "/sync_schema"))))
+            (mt/user-http-request :crowberto :post 422 (str "/database/" (u/the-id db) "/sync_schema"))))
         ;; clean up the database
         (t2/delete! :model/Database (u/the-id db))))))
 

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -83,7 +83,10 @@
 
 (deftest check-can-connect-before-sync-test
   (testing "Database sync should short-circuit and fail if the database connection is not available"
-    (mt/test-drivers (mt/normal-drivers)
+    ;; TODO:
+    ;; This only works with this subset of drivers for now. We should expand it to all drivers once we
+    ;; correctly implement the can-connect? check.
+    (mt/test-drivers (filter #{:mongo :mysql :postgres :sqlite :sparksql :sqlserver} (mt/normal-drivers))
       (let [database-name (mt/random-name)
             dbdef         (basic-table-definition database-name)]
         (mt/dataset dbdef
@@ -95,7 +98,7 @@
                                          (instance? clojure.lang.ExceptionInfo throwable)
                                          (re-matches #"^Cannot sync Database (.+): (.+)" message)))
                                   (mt/with-log-messages-for-level :warn
-                                    (#'task.sync-databases/sync-and-analyze-database!* (u/the-id db)))))]
+                                    (#'task.sync-databases/sync-and-analyze-database*! (u/the-id db)))))]
             (binding [h2/*allow-testing-h2-connections* true]
               (sync/sync-database! db))
             (testing "sense checks before deleting the database"

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -86,7 +86,7 @@
                           ;; but to an S3 bucket that may contain many databases
                           ;; TODO: other drivers are still failing with this test. For these drivers there's a good chance there's a bug in
                           ;; test.data.<driver> code, and not with the driver itself.
-                          (remove #{:athena :oracle :vertica}))
+                          (remove #{:athena :oracle :vertica :presto-jdbc}))
       (let [database-name (mt/random-name)
             dbdef         (basic-db-definition database-name)]
         (mt/dataset dbdef
@@ -109,13 +109,11 @@
             ;; release db resources like connection pools so we don't have to wait to finish syncing before destroying the db
             (driver/notify-database-updated driver/*driver* db)
             ;; destroy the db
-            (if (contains? #{:redshift :snowflake :presto-jdbc} driver/*driver*)
+            (if (contains? #{:redshift :snowflake} driver/*driver*)
               ;; in the case of some cloud databases, the test database is never created, and shouldn't be destroyed.
               ;; so fake it by redefining the database name on the dbdef
               (t2/update! :model/Database (u/the-id db)
-                          {:details (case driver/*driver*
-                                      :presto-jdbc (assoc (:details (mt/db)) :catalog "fake-db-name-that-definitely-wont-be-used")
-                                      (assoc (:details (mt/db)) :db "fake-db-name-that-definitely-wont-be-used"))})
+                          {:details (assoc (:details (mt/db)) :db "fake-db-name-that-definitely-wont-be-used")})
               (tx/destroy-db! driver/*driver* dbdef))
             (testing "after deleting a database, sync should fail"
               (testing "1: sync-and-analyze-database! should log a warning and fail early"

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -1,7 +1,6 @@
 (ns metabase.driver-test
   (:require
    [cheshire.core :as json]
-   [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]
    [metabase.driver :as driver]
    [metabase.driver.h2 :as h2]
@@ -91,7 +90,6 @@
                                  (and (= log-level :warn)
                                       (instance? clojure.lang.ExceptionInfo throwable)
                                       (re-matches #"^Cannot sync Database (.+): (.+)" message)))]
-        (jdbc/execute! (sql-jdbc.conn/db->pooled-connection-spec db) ["create table foo (id int)"])
         (binding [h2/*allow-testing-h2-connections* true]
           (sync/sync-database! db))
         (testing "sense checks before deleting the database"


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/7526, except for oracle, vertica, and presto-jdbc.

It also fixes a few bugs in the driver `test.data` code.

Adds a check for valid connections in the following places: 
1. when handling a request to `POST /api/database/:id/sync_schema` (i.e. a manual trigger), we return a 422 status code
2. when a scheduled sync is triggered, we log a warning

In both cases if the connection fails we don't start any of the sync steps.

### Example with MySQL

**before a POST /api/database/:id/sync_schema with a deleted database would yield logs like this:**
```
2023-11-21 17:29:24,073 INFO metabase.events :: Publishing :event/database-manual-sync event (name and id):

{}

2023-11-21 17:29:24,093 DEBUG middleware.log :: POST /api/database/427/sync_schema 200 53.6 ms (7 DB calls) App DB connections: 0/10 Jetty threads: 5/50 (2 idle, 0 queued) (148 total active threads) Queries in flight: 0 (0 queued); mysql DB 427 connections: 0/1 (0 threads blocked)
2023-11-21 17:29:24,130 INFO metabase.events :: Publishing :event/sync-metadata-begin event (name and id):

{}

2023-11-21 17:29:24,130 INFO sync.util :: STARTING: Sync metadata for mysql Database 427 'foo'
2023-11-21 17:29:24,131 INFO sync.util :: STARTING: step 'sync-dbms-version' for mysql Database 427 'foo'
2023-11-21 17:29:24,133 INFO sync.util :: FINISHED: step 'sync-dbms-version' for mysql Database 427 'foo' (2.6 ms)
2023-11-21 17:29:24,134 INFO sync.util :: STARTING: step 'sync-timezone' for mysql Database 427 'foo'
2023-11-21 17:29:24,167 INFO sync-metadata.sync-timezone :: :mysql database 427 default timezone is "EET"
2023-11-21 17:29:24,167 INFO sync.util :: FINISHED: step 'sync-timezone' for mysql Database 427 'foo' (33.1 ms)
2023-11-21 17:29:24,167 INFO sync.util :: STARTING: step 'sync-tables' for mysql Database 427 'foo'
2023-11-21 17:29:24,170 INFO sync.util :: FINISHED: step 'sync-tables' for mysql Database 427 'foo' (3.2 ms)
2023-11-21 17:29:24,171 INFO sync.util :: STARTING: step 'sync-fields' for mysql Database 427 'foo'
2023-11-21 17:29:24,177 INFO sync.util :: FINISHED: step 'sync-fields' for mysql Database 427 'foo' (5.7 ms)
2023-11-21 17:29:24,177 INFO sync.util :: STARTING: step 'sync-fks' for mysql Database 427 'foo'
2023-11-21 17:29:24,178 INFO sync.util :: FINISHED: step 'sync-fks' for mysql Database 427 'foo' (1.2 ms)
2023-11-21 17:29:24,178 INFO sync.util :: STARTING: step 'sync-metabase-metadata' for mysql Database 427 'foo'
2023-11-21 17:29:24,178 INFO sync.util :: FINISHED: step 'sync-metabase-metadata' for mysql Database 427 'foo' (118.3 µs)
2023-11-21 17:29:24,178 INFO sync.util :: STARTING: step 'sync-table-privileges' for mysql Database 427 'foo'
2023-11-21 17:29:24,187 WARN sync.util :: Error running step 'sync-table-privileges' for mysql Database 427 'foo'
java.sql.SQLSyntaxErrorException: (conn=284871) Unknown database 'foo'
        at org.mariadb.jdbc.internal.util.exceptions.ExceptionFactory.createException(ExceptionFactory.java:62)
        at org.mariadb.jdbc.internal.util.exceptions.ExceptionFactory.create(ExceptionFactory.java:158)
        at org.mariadb.jdbc.MariaDbStatement.executeExceptionEpilogue(MariaDbStatement.java:262)
        at org.mariadb.jdbc.ClientSidePreparedStatement.executeInternal(ClientSidePreparedStatement.java:229)
        at org.mariadb.jdbc.ClientSidePreparedStatement.execute(ClientSidePreparedStatement.java:149)
        at org.mariadb.jdbc.ClientSidePreparedStatement.executeQuery(ClientSidePreparedStatement.java:163)
        at com.mchange.v2.c3p0.impl.NewProxyPreparedStatement.executeQuery(NewProxyPreparedStatement.java:1471)
        at clojure.java.jdbc$execute_query_with_params.invokeStatic(jdbc.clj:1090)
        at clojure.java.jdbc$execute_query_with_params.invoke(jdbc.clj:1084)
        at clojure.java.jdbc$db_query_with_resultset_STAR_.invokeStatic(jdbc.clj:1113)
        at clojure.java.jdbc$db_query_with_resultset_STAR_.invoke(jdbc.clj:1093)
        at clojure.java.jdbc$query.invokeStatic(jdbc.clj:1182)
        at clojure.java.jdbc$query.invoke(jdbc.clj:1144)
        at metabase.driver.mysql$eval114017$fn__114018.invoke(mysql.clj:871)
        at clojure.lang.MultiFn.invoke(MultiFn.java:234)
        at metabase.sync.sync_metadata.sync_table_privileges$sync_table_privileges_BANG_$fn__117231.invoke(sync_table_privileges.clj:18)
        at metabase.sync.sync_metadata.sync_table_privileges$sync_table_privileges_BANG_.invokeStatic(sync_table_privileges.clj:11)
        at metabase.sync.sync_metadata.sync_table_privileges$sync_table_privileges_BANG_.invoke(sync_table_privileges.clj:11)
        at clojure.lang.AFn.applyToHelper(AFn.java:154)
        at clojure.lang.AFn.applyTo(AFn.java:144)
        at clojure.core$apply.invokeStatic(core.clj:669)
        at clojure.core$apply.invoke(core.clj:662)
        at metabase.sync.util$run_step_with_metadata$fn__83649$fn__83651.doInvoke(util.clj:425)
        at clojure.lang.RestFn.invoke(RestFn.java:397)
        at metabase.sync.util$with_start_and_finish_logging_STAR_.invokeStatic(util.clj:132)
        at metabase.sync.util$with_start_and_finish_logging_STAR_.invoke(util.clj:126)
        at metabase.sync.util$with_start_and_finish_debug_logging.invokeStatic(util.clj:150)
        at metabase.sync.util$with_start_and_finish_debug_logging.invoke(util.clj:146)
        at metabase.sync.util$run_step_with_metadata$fn__83649.invoke(util.clj:420)
        at metabase.sync.util$run_step_with_metadata.invokeStatic(util.clj:415)
        at metabase.sync.util$run_step_with_metadata.invoke(util.clj:415)
        at metabase.sync.util$run_sync_operation$fn__83732$fn__83740.invoke(util.clj:531)
        at metabase.sync.util$run_sync_operation$fn__83732.invoke(util.clj:529)
        at metabase.sync.util$run_sync_operation.invokeStatic(util.clj:523)
        at metabase.sync.util$run_sync_operation.invoke(util.clj:523)
        at metabase.sync.sync_metadata$sync_db_metadata_BANG_$fn__117510$fn__117511.invoke(sync_metadata.clj:63)
        at metabase.sync.util$do_with_error_handling.invokeStatic(util.clj:191)
        at metabase.sync.util$do_with_error_handling.invoke(util.clj:184)
        at clojure.core$partial$fn__5910.invoke(core.clj:2647)
        at metabase.driver$eval65925$fn__65926.invoke(driver.clj:725)
        at clojure.lang.MultiFn.invoke(MultiFn.java:239)
        at metabase.sync.util$sync_in_context$fn__83563.invoke(util.clj:167)
        at metabase.sync.util$with_db_logging_disabled$fn__83560.invoke(util.clj:159)
        at metabase.sync.util$with_start_and_finish_logging_STAR_.invokeStatic(util.clj:132)
        at metabase.sync.util$with_start_and_finish_logging_STAR_.invoke(util.clj:126)
        at metabase.sync.util$with_start_and_finish_logging$fn__83547.invoke(util.clj:144)
        at metabase.sync.util$with_sync_events$fn__83537$fn__83541.invoke(util.clj:118)
        at metabase.sync.util$with_duplicate_ops_prevented$fn__83520.invoke(util.clj:90)
        at metabase.sync.util$do_sync_operation$fn__83582.invoke(util.clj:216)
        at metabase.sync.util$do_sync_operation.invokeStatic(util.clj:210)
        at metabase.sync.util$do_sync_operation.invoke(util.clj:210)
        at metabase.sync.sync_metadata$sync_db_metadata_BANG_$fn__117510.invoke(sync_metadata.clj:62)
        at metabase.sync.sync_metadata$sync_db_metadata_BANG_.invokeStatic(sync_metadata.clj:58)
        at metabase.sync.sync_metadata$sync_db_metadata_BANG_.invoke(sync_metadata.clj:58)
        at metabase.api.database$fn__210643$fn__210644.invoke(database.clj:998)
        at clojure.core$binding_conveyor_fn$fn__5823.invoke(core.clj:2047)
        at clojure.lang.AFn.call(AFn.java:18)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: org.mariadb.jdbc.internal.util.exceptions.MariaDbSqlException: Unknown database 'foo'
        at org.mariadb.jdbc.internal.util.exceptions.MariaDbSqlException.of(MariaDbSqlException.java:34)
        at org.mariadb.jdbc.internal.protocol.AbstractQueryProtocol.exceptionWithQuery(AbstractQueryProtocol.java:195)
        at org.mariadb.jdbc.internal.protocol.AbstractQueryProtocol.exceptionWithQuery(AbstractQueryProtocol.java:178)
        at org.mariadb.jdbc.internal.protocol.AbstractQueryProtocol.executeQuery(AbstractQueryProtocol.java:322)
        at org.mariadb.jdbc.ClientSidePreparedStatement.executeInternal(ClientSidePreparedStatement.java:220)
        ... 57 more
Caused by: java.sql.SQLException: Unknown database 'foo'
        at org.mariadb.jdbc.internal.protocol.AbstractQueryProtocol.readErrorPacket(AbstractQueryProtocol.java:1693)
        at org.mariadb.jdbc.internal.protocol.AbstractQueryProtocol.readPacket(AbstractQueryProtocol.java:1555)
        at org.mariadb.jdbc.internal.protocol.AbstractQueryProtocol.getResult(AbstractQueryProtocol.java:1518)
        at org.mariadb.jdbc.internal.protocol.AbstractQueryProtocol.executeQuery(AbstractQueryProtocol.java:319)
        ... 58 more
2023-11-21 17:29:24,188 INFO sync.util :: FINISHED: step 'sync-table-privileges' for mysql Database 427 'foo' (9.9 ms)
2023-11-21 17:29:24,214 INFO sync.util :: FINISHED: Sync metadata for mysql Database 427 'foo' (83.8 ms)
2023-11-21 17:29:24,214 INFO metabase.events :: Publishing :event/sync-metadata-end event (name and id):

{}

2023-11-21 17:29:24,215 INFO metabase.events :: Publishing :event/analyze-begin event (name and id):

{}

2023-11-21 17:29:24,215 INFO sync.util :: STARTING: Analyze data for mysql Database 427 'foo'
2023-11-21 17:29:24,216 INFO sync.util :: STARTING: step 'fingerprint-fields' for mysql Database 427 'foo'
2023-11-21 17:29:24,217 INFO sync.util :: FINISHED: step 'fingerprint-fields' for mysql Database 427 'foo' (1.5 ms)
2023-11-21 17:29:24,217 INFO sync.util :: STARTING: step 'classify-fields' for mysql Database 427 'foo'
2023-11-21 17:29:24,217 INFO sync.util :: FINISHED: step 'classify-fields' for mysql Database 427 'foo' (51.1 µs)
2023-11-21 17:29:24,218 INFO sync.util :: STARTING: step 'classify-tables' for mysql Database 427 'foo'
2023-11-21 17:29:24,218 INFO sync.util :: FINISHED: step 'classify-tables' for mysql Database 427 'foo' (83.0 µs)
2023-11-21 17:29:24,221 INFO sync.util :: FINISHED: Analyze data for mysql Database 427 'foo' (5.8 ms)
2023-11-21 17:29:24,221 INFO metabase.events :: Publishing :event/analyze-end event (name and id):

{}
```

**after these changes:**
```
2023-11-21 17:31:07,973 WARN middleware.log :: POST /api/database/427/sync_schema 422 94.1 ms (7 DB calls) 
"Could not connect to address=(host=localhost)(port=3306)(type=master) : (conn=284877) Unknown database 'foo'"
```