### PR TITLE
Delete tables should clean data, download permissions

### DIFF
--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -63,7 +63,7 @@
 
 (t2/define-before-delete :model/Table
   [{:keys [db_id schema id]}]
-  (t2/delete! Permissions :object [:like (str (perms/data-perms-path db_id schema id) "%")]))
+  (t2/delete! Permissions :object [:like (str "%" (perms/data-perms-path db_id schema id) "%")]))
 
 (defmethod mi/perms-objects-set :model/Table
   [{db-id :db_id, schema :schema, table-id :id, :as table} read-or-write]


### PR DESCRIPTION
this is from https://github.com/metabase/metabase/pull/35443 but that PR has been reverted, since this is a meaningfull change we should keep it