### PR TITLE
[MLv2] Filter modal — Sync `BulkFilterModal` with initial query

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/BulkFilterModal.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/BulkFilterModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { t } from "ttag";
 
 import { Button, Flex, Modal, Tabs } from "metabase/ui";
@@ -56,6 +56,10 @@ export function BulkFilterModal({
   onClose,
 }: BulkFilterModalProps) {
   const [query, setQuery] = useState(initialQuery);
+
+  useEffect(() => {
+    setQuery(initialQuery);
+  }, [initialQuery]);
 
   const columnGroups: ColumnGroupListItem[] = useMemo(() => {
     const stageCount = Lib.stageCount(query);


### PR DESCRIPTION
`BulkFilterModal` uses Mantine-based `Modal` and, as opposed to our legacy modals, stays mounted when the `opened` prop is `false`. We copy the initial query into the filter modal's state so we can apply filters in bulk and rerun the query only once. That means that we either need a `useEffect` to sync outer and inner queries, or that we need to unmount the filter modal's content when the modal gets closed. This PR adds the `useEffect`