### PR TITLE
Fix widget border in StringInputWidget, NumberInputWidget (n arity)

### DIFF
--- a/frontend/src/metabase/parameters/components/widgets/Widget.styled.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/Widget.styled.tsx
@@ -34,5 +34,4 @@ UpdateButton.defaultProps = {
 
 export const TokenFieldWrapper = styled.div`
   margin: ${space(1)};
-  border: 1px solid ${color("border")};
 `;


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/27365.

### Description

Originally it occurred to me that the bug is not reproducible on the current version. 
However, due to [the change in the widget type selection conditional](https://github.com/metabase/metabase/commit/16353290e6318dd6ba8cb6bdbb349646b5a4d559#diff-fb656618096d3e68aee4f568170da19f7a853e0480ae22f8b40c28d04e1c692fR252) this particular parameter became rendered as `ParameterFieldWidget` instead `StringInputWidget`, which obscured the bug.

### How to verify

1. Run storybook `yarn storybook`
2. Find `StringInputWidget` and `NumberInputWidget` with N args
3. Make sure you don't see thin grey border around them

|Before|After|
|---|---|
|<img width="645" alt="Screenshot 2023-11-21 at 19 49 47" src="https://github.com/metabase/metabase/assets/2196347/40ba5997-24a2-4638-a6b6-460583da1036">|<img width="644" alt="Screenshot 2023-11-21 at 19 50 08" src="https://github.com/metabase/metabase/assets/2196347/bc753048-b344-40a5-b00f-b064714f6a3f">|

### Testing
I doubt such a small thing requires a test. At best, an overall visual regression test suite might be added/updated but certainly not a single border on a tiny component.