### PR TITLE
Add error handling around creating new SSO user, and fix `with-model-cleanup` macro

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/sso_utils_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/sso_utils_test.clj
@@ -20,3 +20,30 @@
        "//example.com"
        "not a url"
        "http://localhost:3000?a=not a param"))))
+
+(deftest create-new-sso-user-test
+  (mt/with-model-cleanup [:model/User]
+    (testing "create-new-sso-user! creates a new user with the given attributes"
+      (let [user-attributes {:first_name       "Test"
+                             :last_name        "User"
+                             :email            "create-new-sso-user-test@metabase.com"
+                             :sso_source       :jwt
+                             :login_attributes {:foo "bar"}}
+            new-user (sso-utils/create-new-sso-user! user-attributes)]
+        (is (partial=
+             {:first_name "Test"
+              :last_name "User"
+              :email "create-new-sso-user-test@metabase.com"}
+             new-user))))
+
+    (testing "If a user with the given email already exists, a generic exception is thrown"
+      (let [user-attributes {:first_name       "Test"
+                             :last_name        "User"
+                             :email            "create-new-sso-user-test@metabase.com"
+                             :sso_source       :jwt
+                             :login_attributes {:foo "bar"}}]
+        (is
+         (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #"Error creating new SSO user"
+          (sso-utils/create-new-sso-user! user-attributes)))))))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -12,11 +12,20 @@
    [environ.core :as env]
    [java-time.api :as t]
    [mb.hawk.parallel]
+   [metabase.config :as config]
    [metabase.db.query :as mdb.query]
    [metabase.db.util :as mdb.u]
    [metabase.models
-    :refer [Card Collection Dimension Field FieldValues Permissions
-            PermissionsGroup PermissionsGroupMembership Setting Table User]]
+    :refer [Card
+            Dimension
+            Field
+            FieldValues
+            Permissions
+            PermissionsGroup
+            PermissionsGroupMembership
+            Setting
+            Table
+            User]]
    [metabase.models.collection :as collection]
    [metabase.models.interface :as mi]
    [metabase.models.moderation-review :as moderation-review]
@@ -635,7 +644,7 @@
   [_]
   nil)
 
-(defmethod with-model-cleanup-additional-conditions Collection
+(defmethod with-model-cleanup-additional-conditions :model/Collection
   [_]
   ;; NEVER delete personal collections for the test users.
   [:or
@@ -643,13 +652,42 @@
    [:not-in :personal_owner_id (set (map (requiring-resolve 'metabase.test.data.users/user->id)
                                          @(requiring-resolve 'metabase.test.data.users/usernames)))]])
 
+(defmethod with-model-cleanup-additional-conditions :model/User
+  [_]
+  ;; Don't delete the internal user
+  [:not= :id config/internal-mb-user-id])
+
+(defmethod with-model-cleanup-additional-conditions :model/Database
+  [_]
+  ;; Don't delete the audit database
+  [:not= :id perms/audit-db-id])
+
+(defmulti with-max-model-id-additional-conditions
+  "Additional conditions applied to the query to find the max ID for a model prior to a test run. This can be used to
+  exclude rows which intentionally use non-sequential IDs, like the internal user."
+  {:arglists '([model])}
+  mi/model)
+
+(defmethod with-max-model-id-additional-conditions :default
+  [_]
+  [:not= :id config/internal-mb-user-id])
+
+(defmethod with-max-model-id-additional-conditions :model/User
+  [_]
+  [:not= :id config/internal-mb-user-id])
+
+(defmethod with-max-model-id-additional-conditions :model/Database
+ [_]
+ [:not= :id perms/audit-db-id])
+
 (defn do-with-model-cleanup [models f]
   {:pre [(sequential? models) (every? mdb.u/toucan-model? models)]}
   (mb.hawk.parallel/assert-test-is-not-parallel "with-model-cleanup")
   (initialize/initialize-if-needed! :db)
   (let [model->old-max-id (into {} (for [model models]
                                      [model (:max-id (t2/select-one [model [(keyword (str "%max." (name (first (t2/primary-keys model)))))
-                                                                            :max-id]]))]))]
+                                                                            :max-id]]
+                                                                    {:where (with-max-model-id-additional-conditions model)}))]))]
     (try
       (testing (str "\n" (pr-str (cons 'with-model-cleanup (map name models))) "\n")
         (f))


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase-private/issues/184 by adding a try/catch around new user creation which throws a more generic `ex-info` which includes just the user attributes that were passed in.

Adds a unit test for `create-new-sso-user!`.

Fixes `with-model-cleanup` — it tries to determine the max ID of a row in the model's table, so that it can delete all rows with greater IDs when the test finishes. But this assumes that all IDs in a table are sequential, and our approach for the audit DB and the internal user break this assumption. I've fixed this by adding a condition to exclude these special IDs when the macro is being used for the Database or User models.