### PR TITLE
Use swcMinify to speedup bundle minification

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "@storybook/manager-webpack5": "6.5.15",
     "@storybook/react": "6.5.15",
     "@svgr/webpack": "^8.0.1",
+    "@swc/core": "^1.3.99",
     "@testing-library/cypress": "^9.0.0",
     "@testing-library/dom": "^7.29.0",
     "@testing-library/jest-dom": "^5.16.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -199,6 +199,13 @@ const config = (module.exports = {
         },
       },
     },
+    minimizer: [
+      new TerserPlugin({
+        minify: TerserPlugin.swcMinify,
+        parallel: true,
+        test: /\.(tsx?|jsx?)($|\?)/i,
+      }),
+    ],
   },
 
   plugins: [
@@ -341,9 +348,5 @@ if (WEBPACK_BUNDLE !== "production") {
     }),
   );
 } else {
-  config.plugins.push(
-    new TerserPlugin({ parallel: true, test: /\.(tsx?|jsx?)($|\?)/i }),
-  );
-
   config.devtool = "source-map";
 }

--- a/webpack.static-viz.config.js
+++ b/webpack.static-viz.config.js
@@ -1,5 +1,7 @@
 const YAML = require("json-to-pretty-yaml");
+const TerserPlugin = require("terser-webpack-plugin");
 const { StatsWriterPlugin } = require("webpack-stats-plugin");
+
 const SRC_PATH = __dirname + "/frontend/src/metabase";
 const BUILD_PATH = __dirname + "/resources/frontend_client";
 const CLJS_SRC_PATH = __dirname + "/target/cljs_release";
@@ -60,6 +62,11 @@ module.exports = env => {
     },
     optimization: {
       minimize: !shouldDisableMinimization,
+      minimizer: [
+        new TerserPlugin({
+          minify: TerserPlugin.swcMinify,
+        }),
+      ],
     },
     plugins: [
       new StatsWriterPlugin({

--- a/yarn.lock
+++ b/yarn.lock
@@ -4210,6 +4210,79 @@
     "@svgr/plugin-jsx" "8.0.1"
     "@svgr/plugin-svgo" "8.0.1"
 
+"@swc/core-darwin-arm64@1.3.99":
+  version "1.3.99"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.99.tgz#def204349ac645b8de21a800fa784907642a6c91"
+  integrity sha512-Qj7Jct68q3ZKeuJrjPx7k8SxzWN6PqLh+VFxzA+KwLDpQDPzOlKRZwkIMzuFjLhITO4RHgSnXoDk/Syz0ZeN+Q==
+
+"@swc/core-darwin-x64@1.3.99":
+  version "1.3.99"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.3.99.tgz#2633f1ac1668ec569f34f86eb5250d56fcacd952"
+  integrity sha512-wR7m9QVJjgiBu1PSOHy7s66uJPa45Kf9bZExXUL+JAa9OQxt5y+XVzr+n+F045VXQOwdGWplgPnWjgbUUHEVyw==
+
+"@swc/core-linux-arm64-gnu@1.3.99":
+  version "1.3.99"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.99.tgz#871c2f049a3a5d88bcc7317ac004230517a08ba4"
+  integrity sha512-gcGv1l5t0DScEONmw5OhdVmEI/o49HCe9Ik38zzH0NtDkc+PDYaCcXU5rvfZP2qJFaAAr8cua8iJcOunOSLmnA==
+
+"@swc/core-linux-arm64-musl@1.3.99":
+  version "1.3.99"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.99.tgz#28ed1622e92bc13aab4b650f2af695af8695289b"
+  integrity sha512-XL1/eUsTO8BiKsWq9i3iWh7H99iPO61+9HYiWVKhSavknfj4Plbn+XyajDpxsauln5o8t+BRGitymtnAWJM4UQ==
+
+"@swc/core-linux-x64-gnu@1.3.99":
+  version "1.3.99"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.99.tgz#8e07add9cc8b76d542959e3240340effa6c6e446"
+  integrity sha512-fGrXYE6DbTfGNIGQmBefYxSk3rp/1lgbD0nVg4rl4mfFRQPi7CgGhrrqSuqZ/ezXInUIgoCyvYGWFSwjLXt/Qg==
+
+"@swc/core-linux-x64-musl@1.3.99":
+  version "1.3.99"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.99.tgz#677eb82d6862605cb0a81ec5b732bef2a9861b16"
+  integrity sha512-kvgZp/mqf3IJ806gUOL6gN6VU15+DfzM1Zv4Udn8GqgXiUAvbQehrtruid4Snn5pZTLj4PEpSCBbxgxK1jbssA==
+
+"@swc/core-win32-arm64-msvc@1.3.99":
+  version "1.3.99"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.99.tgz#6c9bf96dd4cb81b5960884906766dc47a49efb0d"
+  integrity sha512-yt8RtZ4W/QgFF+JUemOUQAkVW58cCST7mbfKFZ1v16w3pl3NcWd9OrtppFIXpbjU1rrUX2zp2R7HZZzZ2Zk/aQ==
+
+"@swc/core-win32-ia32-msvc@1.3.99":
+  version "1.3.99"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.99.tgz#6940a602b65137eee30f09ced7cd9fcb6e162b88"
+  integrity sha512-62p5fWnOJR/rlbmbUIpQEVRconICy5KDScWVuJg1v3GPLBrmacjphyHiJC1mp6dYvvoEWCk/77c/jcQwlXrDXw==
+
+"@swc/core-win32-x64-msvc@1.3.99":
+  version "1.3.99"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.99.tgz#7fcdfe6577f015604f7e69f71dda99822e946385"
+  integrity sha512-PdppWhkoS45VGdMBxvClVgF1hVjqamtvYd82Gab1i4IV45OSym2KinoDCKE1b6j3LwBLOn2J9fvChGSgGfDCHQ==
+
+"@swc/core@^1.3.99":
+  version "1.3.99"
+  resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.3.99.tgz#24a2ff0aaa1096b31046c8099b043936db0c4ca6"
+  integrity sha512-8O996RfuPC4ieb4zbYMfbyCU9k4gSOpyCNnr7qBQ+o7IEmh8JCV6B8wwu+fT/Om/6Lp34KJe1IpJ/24axKS6TQ==
+  dependencies:
+    "@swc/counter" "^0.1.1"
+    "@swc/types" "^0.1.5"
+  optionalDependencies:
+    "@swc/core-darwin-arm64" "1.3.99"
+    "@swc/core-darwin-x64" "1.3.99"
+    "@swc/core-linux-arm64-gnu" "1.3.99"
+    "@swc/core-linux-arm64-musl" "1.3.99"
+    "@swc/core-linux-x64-gnu" "1.3.99"
+    "@swc/core-linux-x64-musl" "1.3.99"
+    "@swc/core-win32-arm64-msvc" "1.3.99"
+    "@swc/core-win32-ia32-msvc" "1.3.99"
+    "@swc/core-win32-x64-msvc" "1.3.99"
+
+"@swc/counter@^0.1.1":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@swc/counter/-/counter-0.1.2.tgz#bf06d0770e47c6f1102270b744e17b934586985e"
+  integrity sha512-9F4ys4C74eSTEUNndnER3VJ15oru2NumfQxS8geE+f3eB5xvfxpWyqE5XlVnxb/R14uoXi6SLbBwwiDSkv+XEw==
+
+"@swc/types@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@swc/types/-/types-0.1.5.tgz#043b731d4f56a79b4897a3de1af35e75d56bc63a"
+  integrity sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==
+
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"


### PR DESCRIPTION
### Description

Our build process includes building jars, which is one of the slowest parts. Webpack in the production mode takes a significant part of the time to bundle and minify code.
Modern frontend tools written in rust show substantial perf improvements, one of it is swc.
We already had an attempt to [migrate to swc loader once](https://github.com/metabase/metabase/pull/29628), it didn't work out and requires additional investigation and time.

However we can benefit from using swc in code minification. Historically Terser plugin is a default choice for webpack, it provides one of the smallest final bundle sizes.

There are several others: https://github.com/privatenumber/minification-benchmarks#-results

`esbuild` seems to be the fastest minificator, but with our app it provides much bigger final bundle (5.7Mb vs 5.3Mb with terser).

At the same time `swc` shows great speed improvement and resulted bundle size is approximately the same as with terser.

Luckily terser provides a [built in option to enable swc](https://webpack.js.org/plugins/terser-webpack-plugin/#swc) (as esbuild) for minification.

So before we migrate to Rspack to make build process way faster, swc can save some time for us.

This is the result of building jar oss - [job](https://github.com/metabase/metabase/actions/runs/6954030719/job/18920135054?pr=36022) - you can compare with results before [deduplication PR](https://github.com/metabase/metabase/pull/35712) -  [job](https://github.com/metabase/metabase/actions/runs/6745784982/job/18340327029)


### Results

| $~~~~~~~~~~~~~$ | main | static viz |
| :-: |- |-|
| before | <img width="507" alt="Screenshot 2023-11-22 at 10 25 26" src="https://github.com/metabase/metabase/assets/125459446/989d3ab2-ec17-4dc0-87d3-516b5c3bb28a"> | <img width="622" alt="Screenshot 2023-11-22 at 10 25 18" src="https://github.com/metabase/metabase/assets/125459446/a951c2f7-e756-40ba-93ce-d4d60fe5a4bf"> |
| after | <img width="561" alt="Screenshot 2023-11-22 at 10 25 39" src="https://github.com/metabase/metabase/assets/125459446/c9f5e429-575e-4099-8f91-ff8a3a1fd91b"> | <img width="680" alt="Screenshot 2023-11-22 at 10 25 47" src="https://github.com/metabase/metabase/assets/125459446/2b82d3c9-1b8f-4145-8f57-6d9a493c04e1"> | 

### How to test

There is a little chance to break something using different minizer, so probably we can rely on e2e tests and need to verify locally, if there are any unexpected errors during prod build.

I use locally
```
NODE_ENV=production WEBPACK_BUNDLE=production NODE_OPTIONS=--max-old-space-size=8196 yarn webpack --bail
```
