### PR TITLE
[E2E] Re-enable previously quarantined approved domains test

### DIFF
--- a/e2e/test/scenarios/sharing/approved-domains.cy.spec.js
+++ b/e2e/test/scenarios/sharing/approved-domains.cy.spec.js
@@ -50,8 +50,8 @@ describeEE(
     it("should validate approved email domains for a dashboard subscription (metabase#17977)", () => {
       visitDashboard(ORDERS_DASHBOARD_ID);
       cy.icon("subscription").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Email it").click();
+
+      cy.findByRole("heading", { name: "Email it" }).click();
 
       sidebar().within(() => {
         addEmailRecipient(deniedEmail);

--- a/e2e/test/scenarios/sharing/approved-domains.cy.spec.js
+++ b/e2e/test/scenarios/sharing/approved-domains.cy.spec.js
@@ -47,8 +47,7 @@ describeEE(
       cy.findByText(alertError);
     });
 
-    // Adding test on Quarantine to understand a bit better some H2 Lock issue.
-    it.skip("should validate approved email domains for a dashboard subscription (metabase#17977)", () => {
+    it("should validate approved email domains for a dashboard subscription (metabase#17977)", () => {
       visitDashboard(ORDERS_DASHBOARD_ID);
       cy.icon("subscription").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/sharing/approved-domains.cy.spec.js
+++ b/e2e/test/scenarios/sharing/approved-domains.cy.spec.js
@@ -34,17 +34,15 @@ describeEE(
       visitQuestion(ORDERS_QUESTION_ID);
 
       cy.icon("bell").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Set up an alert").click();
+      cy.button("Set up an alert").click();
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Email alerts to:")
-        .parent()
-        .within(() => addEmailRecipient(deniedEmail));
-
+      cy.findByRole("heading", { name: "Email" })
+        .closest("li")
+        .within(() => {
+          addEmailRecipient(deniedEmail);
+          cy.findByText(alertError);
+        });
       cy.button("Done").should("be.disabled");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText(alertError);
     });
 
     it("should validate approved email domains for a dashboard subscription (metabase#17977)", () => {


### PR DESCRIPTION
There wasn't anything that's really needed fixing here, as this initial stress-test shows. I merely unskipped the test and it was passing:
https://github.com/metabase/metabase/actions/runs/6958127001

While I was already in the spec, I cleaned up a bit and got rid of eslint warnings.
Two newer stress-test runs confirm that both tests are passing after the cleanup:
- https://github.com/metabase/metabase/actions/runs/6958958292
- https://github.com/metabase/metabase/actions/runs/6958959526