### PR TITLE
Update parameter input styles

### DIFF
--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.css
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.css
@@ -37,20 +37,27 @@
   border-color: var(--color-brand);
 }
 
+:local(.parameter) input {
+  flex-basis: 142px;
+  flex-grow: 1;
+  border-radius: 0;
+}
+
 :local(.parameter.noPopover) input {
   width: 100%;
   font-size: 1em;
   font-weight: 600;
   border: none;
   background: none;
-}
 
-:local(.parameter.noPopover.isEditing) input {
-  width: 142px;
+  @media screen and (min-width: 440px) {
+    & {
+      padding: 0;
+    }
+  }
 }
 
 :local(.parameter.noPopover.selected) input {
-  width: 142px;
   font-weight: bold;
   color: var(--color-brand);
 }
@@ -58,7 +65,6 @@
 :local(.parameter.noPopover) input:focus {
   outline: none;
   color: var(--color-text-dark);
-  width: 142px;
 }
 :local(.parameter.noPopover) input::-webkit-input-placeholder {
   color: var(--color-text-medium);
@@ -119,12 +125,4 @@
 :local(.editNameIconContainer) > svg {
   position: absolute;
   top: -6px;
-}
-
-@media screen and (min-width: 440px) {
-  :local(.parameter.noPopover) input {
-    /* NOTE: Fixed with to circumvent issues with flexbox with container having a min-width */
-    width: 115px;
-    padding: 0;
-  }
 }

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.css
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.css
@@ -38,7 +38,6 @@
 }
 
 :local(.parameter) input {
-  flex-basis: 142px;
   flex-grow: 1;
   border-radius: 0;
 }

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -111,7 +111,6 @@ class ParameterValueWidget extends Component {
           ref={this.trigger}
           className={cx(S.parameter, S.noPopover, className, {
             [S.selected]: hasValue,
-            [S.isEditing]: isEditing,
           })}
         >
           {showTypeIcon && (


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/24988

### Description
The problem mentioned in the issue was with cutting text short in the parameter inputs. 
This was happening due to the `input`s being rendered within a flexbox container without explicitly set width, which was later changed to width in `px` and eventually "fixed" the bug by making inputs wide enough to fit the label.

However, this wasn't reliable and is unnecessarily verbose. And actually still had a bug that you see below.

This quick patch addresses a few issues:
- make inputs take all _available_ space within the flex container
- removes border-radius that cuts the caret


||Before|After|
|---|---|---|
|Text cut short, border-radius|<img width="338" alt="Screenshot 2023-11-22 at 16 23 10" src="https://github.com/metabase/metabase/assets/2196347/78643468-d9ac-4550-b0e8-3cf10de62051">|<img width="331" alt="Screenshot 2023-11-22 at 16 26 07" src="https://github.com/metabase/metabase/assets/2196347/e34c6cb3-3c05-4511-a07d-7c669eae8a2c">|

I have also noticed there was an [issue with smaller screen widths](https://github.com/metabase/metabase/pull/23043) and checked that all is good there as well:

Super narrow | Narrow
---|---
<img width="481" alt="Screenshot 2023-11-22 at 16 32 41" src="https://github.com/metabase/metabase/assets/2196347/e65fd0a7-06d6-431f-bcdb-45fee645d630">| <img width="636" alt="Screenshot 2023-11-22 at 16 32 35" src="https://github.com/metabase/metabase/assets/2196347/8334dfc9-d290-41b0-b812-6deec82f5263">


Of course it's not an ultimate solution. We would rather use components from the UI kit to build filters out of them.

### How to verify
1. Create an SQL question, add some parameters: `select * from people where email = {{filter}} and id in {{ids}}`
2. Click Settings, toggle the "Required switch"

<img width="1171" alt="Screenshot 2023-11-22 at 16 27 15" src="https://github.com/metabase/metabase/assets/2196347/40892625-158e-4bb6-a879-8ee40a1f5010">

To check the dashboard, open a dashboard, add a bunch of filters and shrink the screen size to ~600px and lower.

### Tests
Unless some visual regression tests already exist, I don't believe any new ones should be added.