### PR TITLE
[MLv2] Filter modal — Add "Clear all filters" button

### DIFF
--- a/frontend/src/metabase-lib/filter.ts
+++ b/frontend/src/metabase-lib/filter.ts
@@ -30,6 +30,7 @@ import {
   temporalBucket,
   withTemporalBucket,
 } from "./temporal_bucket";
+import { removeClause } from "./query";
 import type {
   BooleanFilterOperatorName,
   BooleanFilterParts,
@@ -87,6 +88,14 @@ export function filter(
 
 export function filters(query: Query, stageIndex: number): FilterClause[] {
   return ML.filters(query, stageIndex);
+}
+
+export function clearFilters(query: Query, stageIndex: number): Query {
+  let current = query;
+  filters(query, stageIndex).forEach(clause => {
+    current = removeClause(current, stageIndex, clause);
+  });
+  return current;
 }
 
 export function stringFilterClause({

--- a/frontend/src/metabase-types/api/mocks/presets/sample_database.ts
+++ b/frontend/src/metabase-types/api/mocks/presets/sample_database.ts
@@ -88,6 +88,17 @@ export const PRODUCT_VENDOR_VALUES: FieldValuesResult = {
   has_more_values: true,
 };
 
+export const PRODUCT_TITLE_VALUES: FieldValuesResult = {
+  field_id: PRODUCTS.TITLE,
+  values: [
+    ["Aerodynamic Bronze Hat"],
+    ["Durable Copper Clock"],
+    ["Mediocre Paper Car"],
+    ["Sleek Plastic Toucan"],
+  ],
+  has_more_values: false,
+};
+
 export const PEOPLE_SOURCE_VALUES: FieldValuesResult = {
   field_id: PEOPLE.SOURCE,
   values: [["Affiliate"], ["Facebook"], ["Google"], ["Organic"], ["Twitter"]],

--- a/frontend/src/metabase/common/hooks/filters/use-number-filter/use-number-filter.ts
+++ b/frontend/src/metabase/common/hooks/filters/use-number-filter/use-number-filter.ts
@@ -1,4 +1,5 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { usePrevious } from "react-use";
 import * as Lib from "metabase-lib";
 import { getAvailableOperatorOptions } from "../utils";
 import type { NumberPickerOperator } from "./types";
@@ -20,6 +21,8 @@ export function useNumberFilter({
   filter,
   defaultOperator = "=",
 }: UseNumberFilterOpts) {
+  const previousFilter = usePrevious(filter);
+
   const filterParts = useMemo(
     () => (filter ? Lib.numberFilterParts(query, stageIndex, filter) : null),
     [query, stageIndex, filter],
@@ -38,6 +41,13 @@ export function useNumberFilter({
   const [values, setValues] = useState(() =>
     getDefaultValues(operator, filterParts?.values),
   );
+
+  useEffect(() => {
+    if (previousFilter && !filter) {
+      _setOperator(defaultOperator);
+      setValues(getDefaultValues(defaultOperator));
+    }
+  }, [filter, previousFilter, defaultOperator]);
 
   const { valueCount, hasMultipleValues } = OPERATOR_OPTIONS[operator];
   const isValid = hasValidValues(operator, values);

--- a/frontend/src/metabase/common/hooks/filters/use-string-filter/use-string-filter.ts
+++ b/frontend/src/metabase/common/hooks/filters/use-string-filter/use-string-filter.ts
@@ -1,4 +1,5 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { usePrevious } from "react-use";
 import * as Lib from "metabase-lib";
 import { getAvailableOperatorOptions } from "../utils";
 import type { StringPickerOperator } from "./types";
@@ -20,6 +21,8 @@ export function useStringFilter({
   filter,
   defaultOperator = "=",
 }: UseStringFilterOpts) {
+  const previousFilter = usePrevious(filter);
+
   const filterParts = useMemo(
     () => (filter ? Lib.stringFilterParts(query, stageIndex, filter) : null),
     [query, stageIndex, filter],
@@ -42,6 +45,14 @@ export function useStringFilter({
   const [options, setOptions] = useState(
     filterParts ? filterParts.options : {},
   );
+
+  useEffect(() => {
+    if (previousFilter && !filter) {
+      _setOperator(defaultOperator);
+      setValues(getDefaultValues(defaultOperator));
+      setOptions({});
+    }
+  }, [filter, previousFilter, defaultOperator]);
 
   const { valueCount, hasMultipleValues, hasCaseSensitiveOption } =
     OPERATOR_OPTIONS[operator];

--- a/frontend/src/metabase/common/hooks/filters/use-time-filter/use-time-filter.ts
+++ b/frontend/src/metabase/common/hooks/filters/use-time-filter/use-time-filter.ts
@@ -1,4 +1,5 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { usePrevious } from "react-use";
 import * as Lib from "metabase-lib";
 import { getAvailableOperatorOptions } from "../utils";
 import type { TimePickerOperator } from "./types";
@@ -20,6 +21,8 @@ export function useTimeFilter({
   filter,
   defaultOperator = "<",
 }: UseTimeFilterOpts) {
+  const previousFilter = usePrevious(filter);
+
   const filterParts = useMemo(() => {
     return filter ? Lib.timeFilterParts(query, stageIndex, filter) : null;
   }, [query, stageIndex, filter]);
@@ -37,6 +40,13 @@ export function useTimeFilter({
   const [values, setValues] = useState(() =>
     getDefaultValues(operator, filterParts?.values),
   );
+
+  useEffect(() => {
+    if (previousFilter && !filter) {
+      _setOperator(defaultOperator);
+      setValues(getDefaultValues(defaultOperator));
+    }
+  }, [filter, previousFilter, defaultOperator]);
 
   const { valueCount } = OPERATOR_OPTIONS[operator];
 

--- a/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/BulkFilterModal.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/BulkFilterModal.tsx
@@ -61,11 +61,11 @@ export function BulkFilterModal({
     setQuery(initialQuery);
   }, [initialQuery]);
 
-  const columnGroups: ColumnGroupListItem[] = useMemo(() => {
-    const stageCount = Lib.stageCount(query);
-    const lastStageIndex = stageCount - 1;
-    const hasPreviousStage = stageCount > 1;
+  const stageCount = Lib.stageCount(query);
+  const lastStageIndex = stageCount - 1;
+  const hasPreviousStage = stageCount > 1;
 
+  const columnGroups: ColumnGroupListItem[] = useMemo(() => {
     const lastStageColumns = Lib.filterableColumns(query, lastStageIndex);
     const previousStageColumns = hasPreviousStage
       ? Lib.filterableColumns(query, lastStageIndex - 1)
@@ -84,7 +84,22 @@ export function BulkFilterModal({
         toGroupListItem(query, lastStageIndex, group),
       ),
     ];
-  }, [query]);
+  }, [query, lastStageIndex, hasPreviousStage]);
+
+  const hasFilters = useMemo(() => {
+    const hasLastStageFilters = Lib.filters(query, lastStageIndex).length > 0;
+
+    if (hasLastStageFilters) {
+      return true;
+    }
+    if (!hasPreviousStage) {
+      return false;
+    }
+
+    const hasPreviousStageFilters =
+      Lib.filters(query, lastStageIndex - 1).length > 0;
+    return hasLastStageFilters && hasPreviousStageFilters;
+  }, [query, lastStageIndex, hasPreviousStage]);
 
   const canSubmit = useMemo(
     () => !Lib.areQueriesEqual(initialQuery, query),
@@ -95,6 +110,14 @@ export function BulkFilterModal({
     onSubmit(query);
     onClose();
   }, [query, onSubmit, onClose]);
+
+  const handleClearAll = useCallback(() => {
+    let nextQuery = Lib.clearFilters(query, lastStageIndex);
+    nextQuery = hasPreviousStage
+      ? Lib.clearFilters(nextQuery, lastStageIndex - 1)
+      : nextQuery;
+    setQuery(nextQuery);
+  }, [query, lastStageIndex, hasPreviousStage]);
 
   const hasNavigation = columnGroups.length > 1;
 
@@ -133,7 +156,13 @@ export function BulkFilterModal({
             </Flex>
           </Tabs>
         </ModalBody>
-        <ModalFooter justify="flex-end">
+        <ModalFooter justify="space-between">
+          <Button
+            variant="subtle"
+            color="text.1"
+            disabled={!hasFilters}
+            onClick={handleClearAll}
+          >{t`Clear all filters`}</Button>
           <Button
             variant="filled"
             disabled={!canSubmit}

--- a/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/BulkFilterModal.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/BulkFilterModal.unit.spec.tsx
@@ -1,6 +1,8 @@
 import userEvent from "@testing-library/user-event";
-import { createMockMetadata } from "__support__/metadata";
 import { renderWithProviders, screen } from "__support__/ui";
+import { setupFieldsValuesEndpoints } from "__support__/server-mocks";
+import { createMockEntitiesState } from "__support__/store";
+import { getMetadata } from "metabase/selectors/metadata";
 import type { FieldReference } from "metabase-types/api";
 import {
   createSampleDatabase,
@@ -9,14 +11,24 @@ import {
   PRODUCTS,
   PRODUCTS_ID,
   SAMPLE_DB_ID,
+  PRODUCT_CATEGORY_VALUES,
+  PRODUCT_TITLE_VALUES,
+  PRODUCT_VENDOR_VALUES,
 } from "metabase-types/api/mocks/presets";
+import { createMockState } from "metabase-types/store/mocks";
 import * as Lib from "metabase-lib";
 import { createQuery } from "metabase-lib/test-helpers";
 import { BulkFilterModal } from "./BulkFilterModal";
 
-const metadata = createMockMetadata({
-  databases: [createSampleDatabase()],
+const db = createSampleDatabase();
+
+const storeInitialState = createMockState({
+  entities: createMockEntitiesState({
+    databases: [db],
+  }),
 });
+
+const metadata = getMetadata(storeInitialState);
 
 type SetupOpts = {
   query?: Lib.Query;
@@ -26,6 +38,12 @@ function setup({ query = createQuery({ metadata }) }: SetupOpts = {}) {
   const onSubmit = jest.fn();
   const onClose = jest.fn();
 
+  setupFieldsValuesEndpoints([
+    PRODUCT_CATEGORY_VALUES,
+    PRODUCT_TITLE_VALUES,
+    PRODUCT_VENDOR_VALUES,
+  ]);
+
   renderWithProviders(
     <BulkFilterModal
       query={query}
@@ -33,6 +51,7 @@ function setup({ query = createQuery({ metadata }) }: SetupOpts = {}) {
       onSubmit={onSubmit}
       onClose={onClose}
     />,
+    { storeInitialState },
   );
 
   function getNextQuery() {
@@ -47,7 +66,7 @@ function setup({ query = createQuery({ metadata }) }: SetupOpts = {}) {
     );
   }
 
-  return { getNextFilterParts, onSubmit, onClose };
+  return { getNextQuery, getNextFilterParts, onSubmit, onClose };
 }
 
 describe("BulkFilterModal", () => {
@@ -113,10 +132,40 @@ describe("BulkFilterModal", () => {
     expect(applyButton).toBeDisabled();
   });
 
+  it("should disable the clear filters button when there're no filters", () => {
+    setup();
+    const clearButton = screen.getByRole("button", {
+      name: "Clear all filters",
+    });
+    expect(clearButton).toBeDisabled();
+  });
+
   it("should close", () => {
     const { onClose } = setup();
     userEvent.click(screen.getByLabelText("Close"));
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("should clean all filters", async () => {
+    const { getNextQuery } = setup({ query: createTwoStageQuery() });
+
+    userEvent.click(screen.getByText("Product"));
+    expect(await screen.findByLabelText("Doohickey")).toBeChecked();
+    userEvent.click(screen.getByText("Summaries"));
+    // There's a "Count > 5" filter
+    expect(screen.getByDisplayValue("5")).toBeInTheDocument();
+
+    userEvent.click(screen.getByText("Clear all filters"));
+
+    expect(screen.queryByLabelText("5")).not.toBeInTheDocument();
+    userEvent.click(screen.getByText("Product"));
+    expect(screen.getByLabelText("Doohickey")).not.toBeChecked();
+
+    userEvent.click(screen.getByText("Apply filters"));
+
+    const nextQuery = getNextQuery();
+    expect(Lib.filters(nextQuery, 0)).toHaveLength(0);
+    expect(Lib.filters(nextQuery, 1)).toHaveLength(0);
   });
 
   describe("multi-stage query", () => {


### PR DESCRIPTION
Closes #36052

Adds a "Clear all filters" button to the bulk filter modal:

* enabled if a query has at least one filter on stages -1 or -2 (the last stage or the one before it)
* removes all filters from stages -1 or -2 (the last stage or the one before it)
* notice it doesn't care if a filter was added while the modal was open or closed

### Demo

https://github.com/metabase/metabase/assets/17258145/85108b61-dbaa-47db-92a1-8741300ee75f

