### PR TITLE
[MLv2] Filter modal — Reset changes when modal is closed

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/BulkFilterModal.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/BulkFilterModal.tsx
@@ -91,10 +91,15 @@ export function BulkFilterModal({
     [initialQuery, query],
   );
 
+  const resetUnsavedChanges = useCallback(
+    () => setQuery(initialQuery),
+    [initialQuery],
+  );
+
   const handleClose = useCallback(() => {
-    setQuery(initialQuery); // reset unsaved changes
+    resetUnsavedChanges();
     onClose();
-  }, [initialQuery, onClose]);
+  }, [resetUnsavedChanges, onClose]);
 
   const handleSubmit = useCallback(() => {
     onSubmit(query);

--- a/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/BulkFilterModal.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/BulkFilterModal.tsx
@@ -91,6 +91,11 @@ export function BulkFilterModal({
     [initialQuery, query],
   );
 
+  const handleClose = useCallback(() => {
+    setQuery(initialQuery); // reset unsaved changes
+    onClose();
+  }, [initialQuery, onClose]);
+
   const handleSubmit = useCallback(() => {
     onSubmit(query);
     onClose();
@@ -111,7 +116,7 @@ export function BulkFilterModal({
   const initialTab = defaultGroup.displayInfo.name || COMPUTED_COLUMN_GROUP_ID;
 
   return (
-    <Modal.Root opened={opened} size={modalWidth} onClose={onClose}>
+    <Modal.Root opened={opened} size={modalWidth} onClose={handleClose}>
       <Modal.Overlay />
       <Modal.Content>
         <ModalHeader p="lg">

--- a/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/BulkFilterModal.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/BulkFilterModal/BulkFilterModal.unit.spec.tsx
@@ -134,16 +134,19 @@ describe("BulkFilterModal", () => {
 
   it("should reset changes on close", async () => {
     const { onSubmit } = setup();
+    const applyButton = screen.getByRole("button", { name: "Apply filters" });
 
     let createdAtShortcut = screen.getByRole("button", { name: "Today" });
     userEvent.click(createdAtShortcut);
     expect(createdAtShortcut).toHaveAttribute("aria-selected", "true");
+    expect(applyButton).toBeEnabled();
 
     userEvent.click(screen.getByLabelText("Close"));
     userEvent.click(screen.getByRole("button", { name: "Show modal" }));
     createdAtShortcut = await screen.findByRole("button", { name: "Today" });
     expect(createdAtShortcut).toHaveAttribute("aria-selected", "false");
 
+    expect(applyButton).toBeDisabled();
     expect(onSubmit).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Resets bulk filter modal's `query` state to `initialQuery` if a modal gets closed by hitting Esc or the "Close" button

### To Verfiy

1. Open the Orders table
2. Open the filter modal
3. Add any filter
4. Click Esc
5. Open the modal again
6. Ensure your changes are not applied