### PR TITLE
Attach dashcard's viz settings to the card's :data :viz-settings key

### DIFF
--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -267,7 +267,7 @@
 (defn dashcard-results-async
   "Return results for running the query belonging to a DashboardCard. Returns a `StreamingResponse`."
   {:style/indent 0}
-  [& {:keys [dashboard-id dashcard-id card-id export-format embedding-params token-params
+  [& {:keys [dashboard-id dashcard-id card-id export-format embedding-params token-params middleware
              query-params constraints qp-runner]
       :or   {constraints (qp.constraints/default-query-constraints)
              qp-runner   qp/process-query-and-save-execution!}}]
@@ -283,7 +283,8 @@
      :parameters    parameters
      :qp-runner     qp-runner
      :context       :embedded-dashboard
-     :constraints   constraints)))
+     :constraints   constraints
+     :middleware    middleware)))
 
 
 ;;; ------------------------------------- Other /api/embed-specific utility fns --------------------------------------
@@ -392,7 +393,7 @@
   Returns a `StreamingResponse`."
   {:style/indent 1}
   [token dashcard-id card-id export-format query-params
-   & {:keys [constraints qp-runner]
+   & {:keys [constraints qp-runner middleware]
       :or   {constraints (qp.constraints/default-query-constraints)
              qp-runner   qp/process-query-and-save-execution!}}]
   (let [unsigned-token (embed/unsign token)
@@ -407,7 +408,8 @@
       :token-params     (embed/get-in-unsigned-token-or-throw unsigned-token [:params])
       :query-params     query-params
       :constraints      constraints
-      :qp-runner        qp-runner)))
+      :qp-runner        qp-runner
+      :middleware       middleware)))
 
 (api/defendpoint GET "/dashboard/:token/dashcard/:dashcard-id/card/:card-id"
   "Fetch the results of running a Card belonging to a Dashboard using a JSON Web Token signed with the

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -24,7 +24,6 @@
    [metabase.query-processor.dashboard :as qp.dashboard]
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.server.middleware.session :as mw.session]
-   [metabase.shared.models.visualization-settings :as mb.viz]
    [metabase.shared.parameters.parameters :as shared.params]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru trs tru]]
@@ -87,12 +86,7 @@
       (when-not (and (get-in dashcard [:visualization_settings :card.hide_empty]) (is-card-empty? result))
         {:card     card
          :dashcard dashcard
-         :result   (update-in result
-                              [:data :viz-settings]
-                              (fn [viz-settings]
-                                (merge viz-settings
-                                       (mb.viz/db->norm
-                                        (:visualization_settings dashcard)))))
+         :result   result
          :type     :card}))
     (catch Throwable e
       (log/warn e (trs "Error running query for Card {0}" card-or-id)))))

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -191,33 +191,38 @@
   Question) or `:dashboard` (from a Saved Question in a Dashboard). See [[metabase.mbql.schema/Context]] for all valid
   options."
   [card-id export-format
-   & {:keys [parameters constraints context dashboard-id middleware qp-runner run ignore_cache]
+   & {:keys [parameters constraints context dashboard-id dashcard-id middleware qp-runner run ignore_cache]
       :or   {constraints (qp.constraints/default-query-constraints)
              context     :question
              qp-runner   qp/process-query-and-save-execution!}}]
   {:pre [(int? card-id) (u/maybe? sequential? parameters)]}
-  (let [run   (or run
-                  ;; param `run` can be used to control how the query is ran, e.g. if you need to
-                  ;; customize the `context` passed to the QP
-                  (^:once fn* [query info]
-                   (qp.streaming/streaming-response [{:keys [rff context]} export-format (u/slugify (:card-name info))]
-                     (qp-runner query info rff context))))
-        card  (api/read-check (t2/select-one [Card :id :name :dataset_query :database_id :cache_ttl :collection_id
-                                              :dataset :result_metadata :visualization_settings]
-                                             :id card-id))
-        query (-> (assoc (query-for-card card parameters constraints middleware {:dashboard-id dashboard-id}) :async? true)
-                  (update :middleware (fn [middleware]
-                                        (merge
-                                         {:js-int-to-string? true :ignore-cached-results? ignore_cache}
-                                         middleware))))
-        info  (cond-> {:executed-by            api/*current-user-id*
-                       :context                context
-                       :card-id                card-id
-                       :card-name              (:name card)
-                       :dashboard-id           dashboard-id
-                       :visualization-settings (:visualization_settings card)}
-                (and (:dataset card) (seq (:result_metadata card)))
-                (assoc :metadata/dataset-metadata (:result_metadata card)))]
+  (let [run       (or run
+                      ;; param `run` can be used to control how the query is ran, e.g. if you need to
+                      ;; customize the `context` passed to the QP
+                      (^:once fn* [query info]
+                       (qp.streaming/streaming-response [{:keys [rff context]} export-format (u/slugify (:card-name info))]
+                         (qp-runner query info rff context))))
+        dash-viz  (when (not= context :question)
+                    (t2/select-one-fn :visualization_settings :model/DashboardCard :id dashcard-id))
+        card      (api/read-check (t2/select-one [Card :id :name :dataset_query :database_id :cache_ttl :collection_id
+                                                  :dataset :result_metadata :visualization_settings]
+                                                 :id card-id))
+        query     (-> (query-for-card card parameters constraints middleware {:dashboard-id dashboard-id})
+                      (update :viz-settings (fn [viz] (when (or (seq viz) (seq dash-viz))
+                                                        (merge viz dash-viz))))
+                      (assoc :async? true)
+                      (update :middleware (fn [middleware]
+                                            (merge
+                                             {:js-int-to-string? true :ignore-cached-results? ignore_cache}
+                                             middleware))))
+        info      (cond-> {:executed-by            api/*current-user-id*
+                           :context                context
+                           :card-id                card-id
+                           :card-name              (:name card)
+                           :dashboard-id           dashboard-id
+                           :visualization-settings (:visualization_settings card)}
+                    (and (:dataset card) (seq (:result_metadata card)))
+                    (assoc :metadata/dataset-metadata (:result_metadata card)))]
     (api/check-not-archived card)
     (when (seq parameters)
       (validate-card-parameters card-id (mbql.normalize/normalize-fragment [:parameters] parameters)))

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -208,8 +208,7 @@
                                                   :dataset :result_metadata :visualization_settings]
                                                  :id card-id))
         query     (-> (query-for-card card parameters constraints middleware {:dashboard-id dashboard-id})
-                      (update :viz-settings (fn [viz] (when (or (seq viz) (seq dash-viz))
-                                                        (merge viz dash-viz))))
+                      (update :viz-settings (fn [viz] (merge viz dash-viz)))
                       (assoc :async? true)
                       (update :middleware (fn [middleware]
                                             (merge

--- a/src/metabase/query_processor/middleware/visualization_settings.clj
+++ b/src/metabase/query_processor/middleware/visualization_settings.clj
@@ -27,7 +27,8 @@
 (defn- viz-settings
   "Pull viz settings from either the query map or the DB"
   [query]
-  (or (-> query :viz-settings)
+  (or (let [viz (-> query :viz-settings)]
+        (when (seq viz) viz))
       (when-let [card-id (-> query :info :card-id)]
         (mb.viz/db->norm (:visualization-settings (lib.metadata.protocols/card (qp.store/metadata-provider) card-id))))))
 

--- a/src/metabase/query_processor/middleware/visualization_settings.clj
+++ b/src/metabase/query_processor/middleware/visualization_settings.clj
@@ -44,19 +44,20 @@
   Processed viz settings are added to the metadata under the key :viz-settings."
   [{{:keys [process-viz-settings?]} :middleware, :as query} rff]
   (if process-viz-settings?
-    (let [card-viz-settings           (viz-settings query)
-          column-viz-settings         (::mb.viz/column-settings card-viz-settings)
-          fields                      (or (-> query :query :fields)
-                                          (-> query :query :source-query :fields))
-          field-ids                   (filter int? (map second fields))
-          updated-column-viz-settings (if (= (:type query) :query)
-                                        (update-card-viz-settings column-viz-settings field-ids)
-                                        column-viz-settings)
-          global-settings             (m/map-vals mb.viz/db->norm-column-settings-entries
-                                                  (public-settings/custom-formatting))
-          updated-card-viz-settings   (-> card-viz-settings
-                                          (assoc ::mb.viz/column-settings updated-column-viz-settings)
-                                          (assoc ::mb.viz/global-column-settings global-settings))]
+    (let [card-viz-settings            (viz-settings query)
+          normalized-card-viz-settings (mb.viz/db->norm card-viz-settings)
+          column-viz-settings          (::mb.viz/column-settings card-viz-settings)
+          fields                       (or (-> query :query :fields)
+                                           (-> query :query :source-query :fields))
+          field-ids                    (filter int? (map second fields))
+          updated-column-viz-settings  (if (= (:type query) :query)
+                                         (update-card-viz-settings column-viz-settings field-ids)
+                                         column-viz-settings)
+          global-settings              (m/map-vals mb.viz/db->norm-column-settings-entries
+                                                   (public-settings/custom-formatting))
+          updated-card-viz-settings    (-> normalized-card-viz-settings
+                                           (assoc ::mb.viz/column-settings updated-column-viz-settings)
+                                           (assoc ::mb.viz/global-column-settings global-settings))]
       (fn update-viz-settings-rff* [metadata]
         (rff (assoc metadata :viz-settings updated-card-viz-settings))))
     rff))

--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -1,6 +1,9 @@
 (ns metabase.dashboard-subscription-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase.dashboard-subscription-test :as dashboard-subscription-test]
+   [metabase.email.messages :as messages]
    [metabase.models
     :refer [Card
             Collection
@@ -24,6 +27,8 @@
    [metabase.util :as u]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))
+
+(set! *warn-on-reflection* true)
 
 (defn- do-with-dashboard-sub-for-card
   "Creates a Pulse, Dashboard, and other relevant rows for a `card` (using `pulse` and `pulse-card` properties if
@@ -881,7 +886,58 @@
                   [{:type "divider"}
                    {:type "context",
                     :elements
-                    [{:type "mrkdwn",
+                    [{:type "mrkdwn"
                       :text
                       #"<https://metabase\.com/testmb/dashboard/\d+\?state=CA&state=NY&state=NJ&quarter_and_year=Q1-2021\|\*Sent from Metabase Test\*>"}]}]}]}
                (pulse.test-util/thunk->boolean pulse-results))))}}))
+
+(defn- result-attachment
+  [{{{:keys [rows]} :data, :as result} :result}]
+  (when (seq rows)
+    [(let [^java.io.ByteArrayOutputStream baos (java.io.ByteArrayOutputStream.)]
+       (with-open [os baos]
+         (#'messages/stream-api-results-to-export-format :csv os result)
+         (let [output-string (.toString baos "UTF-8")]
+           {:type         :attachment
+            :content-type :csv
+            :content      output-string})))]))
+
+(deftest dashboard-subscription-attachments-test
+  (testing "Dashboard subscription attachments respect viz-settings"
+    (mt/with-fake-inbox
+      (mt/with-temp [Card          {card-id :id}
+                     {:dataset_query {:type     :native,
+                                      :native
+                                      {:query "SELECT 'a' AS column1, 1 AS column2;"}
+                                      :database (mt/id)}}
+                     Dashboard     {dashboard-id :id, :as dashboard} {:name "just dash"}
+                     DashboardCard {dashboard-card-id :id}
+                     {:dashboard_id dashboard-id
+                      :card_id      card-id
+                      :visualization_settings
+                      {:table.columns
+                       [{:name "column1" :fieldRef [:field "column1" {:base-type :type/Text}] :enabled true}
+                        {:name "column2" :fieldRef [:field "column2" {:base-type :type/Integer}] :enabled false}]}}
+                     Pulse         {pulse-id :id, :as pulse}  {:name         "just pulse"
+                                                               :dashboard_id (u/the-id dashboard)}
+                     PulseCard     _ {:pulse_id          pulse-id
+                                      :card_id           card-id
+                                      :position          0
+                                      :dashboard_card_id dashboard-card-id
+                                      :include_csv       true}
+                     PulseChannel  {pc-id :id} {:pulse_id pulse-id}
+                     PulseChannelRecipient _ {:user_id          (pulse.test-util/rasta-id)
+                                              :pulse_channel_id pc-id}]
+        (with-redefs [messages/result-attachment result-attachment]
+          (metabase.pulse/send-pulse! pulse)
+          (is (= 1
+                 (-> @mt/inbox
+                     (get (:email (mt/fetch-user :rasta)))
+                     last
+                     :body
+                     last
+                     :content
+                     str/split-lines
+                     (->> (mapv #(str/split % #",")))
+                     first
+                     count))))))))

--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -910,7 +910,9 @@
     (mt/with-fake-inbox
       (mt/with-temp [Card {card-id :id :as c} (pulse.test-util/checkins-query-card {:breakout [!day.date]})
                      Dashboard     {dash-id :id} {:name "just dash"}]
-        (let [viz {:table.columns (mapv metadata->field-ref (:result_metadata c) [true false])}]
+        (let [;; with the helper `metadata->field-ref` we turn column metadata into column field refs
+              ;; with an additional key `:enabled`. Here the 1st col is enabled, and the 2nd is disabled
+              viz {:table.columns (mapv metadata->field-ref (:result_metadata c) [true false])}]
           (mt/with-temp [DashboardCard {dash-card-id :id} {:dashboard_id           dash-id
                                                            :card_id                card-id
                                                            :visualization_settings viz}

--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -911,10 +911,9 @@
       (mt/with-temp [Card {card-id :id :as c} (pulse.test-util/checkins-query-card {:breakout [!day.date]})
                      Dashboard     {dash-id :id} {:name "just dash"}]
         (let [viz {:table.columns (mapv metadata->field-ref (:result_metadata c) [true false])}]
-          (mt/with-temp [DashboardCard {dash-card-id :id}
-                         {:dashboard_id           dash-id
-                          :card_id                card-id
-                          :visualization_settings viz}
+          (mt/with-temp [DashboardCard {dash-card-id :id} {:dashboard_id           dash-id
+                                                           :card_id                card-id
+                                                           :visualization_settings viz}
                          Pulse         {pulse-id :id, :as pulse}  {:name         "just pulse"
                                                                    :dashboard_id dash-id}
                          PulseCard     _ {:pulse_id          pulse-id


### PR DESCRIPTION
Closes: https://github.com/metabase/metabase/issues/35437
partially fixes: https://github.com/metabase/metabase/issues/33727 (solves column order/hiding but not other formatting issues yet)

The linked issues had similarities: csv/xlsx exports did not respect column settings (like hidden columns). 

In the case of dashboard subscription attachments, there were 2 issues:
 - the dashcard viz settings were not being incorporated into the call to `metabase.query-processor.card/run-query-for-card-async`, which is ultimately run for each dashcard (excluding virtual cards)
 - even when they were merged into the card viz-settings, they weren't normalized and so downstream fns didn't incorporate the settings, because the keys weren't actually in the viz-settings (this is an opportunity for schemas + cleaning up the viz-settings throughout the codebase in future PRs)

Why merge the dashcard viz settings and card viz settings? When the query processor runs the `process-viz-settings` middleware, it is unaware of any dashcards related to the cards, and no dashcard-ids or data get passed through the qp, so the settings are unavailable unless they're merged. In this PR they get merged onto the `:viz-settings` key of the query map that gets passed through the query processor. (Another thing worth cleaning up is sensible and consistent naming (viz-settings vs. visualization_settings for example)

In the case of the embedding, there were 2 issues:
 - the middleware map was not properly being passed through the embed API to the `run-query-for-card-async` function
 - similarly to above, the viz-settings were not normalized, so column order/hidden settings were not respected

## After this PR
<img width="1319" alt="image" src="https://github.com/metabase/metabase/assets/21064735/9aa0c9dd-eafe-4af5-9e5f-61392a957a9d">

The exports/downloaded csv (and xlsx) looked like the table on the left before. After, they look like on the right. (Hidden columns are not visible and the column order set in the dashboard is also applied properly).

There are now 2 additional tests:
 - the dashboard subscription test namespace now sends an email with .csv attachment and looks at the contents of the csv to assert that not all columns are shown
 - the api/embed test namespace adds a function that similarly asserts that column order / hidden state is respected in the csv exports.