### PR TITLE
Remove stray (misleading) audit readme

### DIFF
--- a/e2e/test/scenarios/admin-2/auditing/README.md
+++ b/e2e/test/scenarios/admin-2/auditing/README.md
@@ -1,6 +1,0 @@
-# IMPORTANT:
-We are not running these tests in CI!
-
-You can still run them locally using the following command:
-
-`yarn test-cypress-run --folder auditing`


### PR DESCRIPTION
We started running audit tests in the CI again, but forgot to remove this file.