### PR TITLE
Add test-unit-watch:debug script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -359,6 +359,7 @@
     "test-unit-keep-cljs": "jest --maxWorkers=2",
     "test-unit-watch": "yarn test-unit --watch",
     "test-unit-watch:cljs": "yarn concurrently -n 'cljs,tests' 'yarn build-watch:cljs' 'yarn test-unit-keep-cljs --watch'",
+    "test-unit-watch:debug": "node --inspect-brk node_modules/.bin/jest --runInBand --watch",
     "test-visual": "yarn build && ./bin/build-for-test && yarn test-visual-run",
     "test-visual-open": "percy exec -- yarn test-cypress-open",
     "test-visual-run": "percy exec -- yarn test-cypress-run --spec \"./e2e/test/visual/**/*.cy.spec.js\"",

--- a/package.json
+++ b/package.json
@@ -359,7 +359,7 @@
     "test-unit-keep-cljs": "jest --maxWorkers=2",
     "test-unit-watch": "yarn test-unit --watch",
     "test-unit-watch:cljs": "yarn concurrently -n 'cljs,tests' 'yarn build-watch:cljs' 'yarn test-unit-keep-cljs --watch'",
-    "test-unit-watch:debug": "node --inspect-brk node_modules/.bin/jest --runInBand --watch",
+    "test-unit-watch:debug": "node --inspect-brk node_modules/.bin/jest --runInBand --no-cache --watch",
     "test-visual": "yarn build && ./bin/build-for-test && yarn test-visual-run",
     "test-visual-open": "percy exec -- yarn test-cypress-open",
     "test-visual-run": "percy exec -- yarn test-cypress-run --spec \"./e2e/test/visual/**/*.cy.spec.js\"",


### PR DESCRIPTION
I needed to debug unit tests today and figured this is a useful little script to have in `package.json`.

See https://jestjs.io/docs/troubleshooting.