### PR TITLE
[E2E] Re-enable previously quarantined audit v1 schemas test

### DIFF
--- a/e2e/test/scenarios/admin-2/auditing/auditing.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/auditing/auditing.cy.spec.js
@@ -182,13 +182,12 @@ describeEE("audit > auditing", () => {
       cy.contains(year);
     });
 
-    // [quarantine] flaky
-    it.skip("should load both tabs in Schemas", () => {
-      // Overview tab
+    // Overview tab
+    it("should load both tabs in Schemas", () => {
       cy.visit("/admin/audit/schemas/overview");
-      cy.get("svg").should("have.length", 2);
       cy.findAllByText("Sample Database PUBLIC");
       cy.findAllByText("No results!").should("not.exist");
+      cy.findAllByTestId("dashcard").should("have.length", 2);
 
       // All schemas tab
       cy.visit("/admin/audit/schemas/all");

--- a/e2e/test/scenarios/admin-2/auditing/auditing.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/auditing/auditing.cy.spec.js
@@ -182,23 +182,32 @@ describeEE("audit > auditing", () => {
       cy.contains(year);
     });
 
-    // Overview tab
     it("should load both tabs in Schemas", () => {
+      cy.log("Overview tab");
       cy.visit("/admin/audit/schemas/overview");
-      cy.findAllByText("Sample Database PUBLIC");
-      cy.findAllByText("No results!").should("not.exist");
-      cy.findAllByTestId("dashcard").should("have.length", 2);
+      cy.findAllByTestId("dashcard")
+        .should("have.length", 2)
+        .and("contain", "Sample Database PUBLIC")
+        .and("not.contain", "No results!");
+      cy.findAllByTestId("legend-caption-title")
+        .first()
+        .should("have.text", "Most-queried schemas");
+      cy.findAllByTestId("legend-caption-title")
+        .last()
+        .should("have.text", "Slowest schemas");
 
-      // All schemas tab
+      cy.log("All schemas tab");
       cy.visit("/admin/audit/schemas/all");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("PUBLIC");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Saved Queries");
+      cy.findAllByRole("columnheader").eq(1).should("have.text", "Schema");
+      cy.findAllByRole("cell").eq(1).should("have.text", "PUBLIC");
+
+      cy.findAllByRole("columnheader")
+        .last()
+        .should("have.text", "Saved Queries");
+      cy.findAllByRole("cell").last().should("have.text", "4");
     });
 
     it("should load both tabs in Tables", () => {
-      // Overview tab
       cy.visit("/admin/audit/tables/overview");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Most-queried tables");


### PR DESCRIPTION
This test was quarantined a long time ago.
It was failing for me locally upon I unskipped it initially. The cause was [a wrong assertion](https://github.com/metabase/metabase/compare/e2e-re-enable-adutit-v1-schemas-test?expand=1#diff-31844e1bc7707f69b3bc0f4c25ddccb02d1d1330cd7f213eb1830b7e59c72c71L189).

The fix
```diff
- cy.get("svg").should("have.length", 2);
+ cy.findAllByTestId("dashcard").should("have.length", 2);
```

As with the other similar cases, I also tidied up a bit, removed lint errors and improved assertions.

Stress-tests show that the test is now stable:
- 20x ✅ https://github.com/metabase/metabase/actions/runs/6970094163
- 40x ✅ https://github.com/metabase/metabase/actions/runs/6970240752
- 40x ✅  https://github.com/metabase/metabase/actions/runs/6970298980