### PR TITLE
Uploads: Make empty values NULL for MySQL

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -682,6 +682,10 @@
   [_driver val]
   (str val))
 
+(defmethod value->string nil
+  [_driver _val]
+  nil)
+
 (defmethod value->string Boolean
   [_driver val]
   (if val
@@ -712,10 +716,12 @@
   ;; you must specify two backslashes for the value to be interpreted as a single backslash. The escape sequences
   ;; '\t' and '\n' specify tab and newline characters, respectively.
   [v]
-  (str/replace v #"\\|\n|\r|\t" {"\\" "\\\\"
-                                 "\n" "\\n"
-                                 "\r" "\\r"
-                                 "\t" "\\t"}))
+  (if (nil? v)
+    "\\N"
+    (str/replace v #"\\|\n|\r|\t" {"\\" "\\\\"
+                                   "\n" "\\n"
+                                   "\r" "\\r"
+                                   "\t" "\\t"})))
 
 (defn- row->tsv
   [driver column-count row]

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -169,15 +169,15 @@
            [" 2022-01-01T01:00:00.00Z "       (t/offset-date-time "2022-01-01T01:00+00:00") offset-dt-type]
            [" 2022-01-01t01:00:00.00Z "       (t/offset-date-time "2022-01-01T01:00+00:00") offset-dt-type]
            [" 2022-01-01 01:00:00.00Z "       (t/offset-date-time "2022-01-01T01:00+00:00") offset-dt-type]]]
-    (let [settings {:number-separators (or seps ".,")}
-          type     (#'upload/value->type string-value settings)
-          parser   (upload-parsing/upload-type->parser type settings)]
-      (testing (format "\"%s\" is a %s" string-value type)
-        (is (= expected-type
-               type)))
-      (testing (format "\"%s\" is parsed into %s" string-value expected-value)
-        (is (= expected-value
-               (parser string-value)))))))
+    (mt/with-temporary-setting-values [custom-formatting (when seps {:type/Number {:number_separators seps}})]
+      (let [type   (upload/value->type string-value)
+            parser (#'upload-parsing/upload-type->parser type)]
+        (testing (format "\"%s\" is a %s" string-value type)
+          (is (= expected-type
+                 type)))
+        (testing (format "\"%s\" is parsed into %s" string-value expected-value)
+          (is (= expected-value
+                 (parser string-value))))))))
 
 (deftest ^:parallel type-coalescing-test
   (doseq [[type-a          type-b        expected]

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -69,7 +69,7 @@
     (thunk)
     (do
       (testing "with local_infile on"
-        (do-with-mysql-local-infile-off thunk))
+        (do-with-mysql-local-infile-on thunk))
       (testing "with local_infile off"
         (do-with-mysql-local-infile-off thunk)))))
 

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -709,7 +709,7 @@
            "upload_test"
            (csv-file-with ["id,column_that_has_one_value,column_that_doesnt_have_a_value"
                            "1,2"
-                           "2,,"]))
+                           "2,  ,\n"]))
           (testing "Table and Fields exist after sync"
             (sync/sync-database! (mt/db))
             (let [table (t2/select-one Table :db_id (mt/id))]

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -7,7 +7,6 @@
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.driver :as driver]
-   [metabase.driver.mysql :as mysql]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.models :refer [Field Table]]
    [metabase.query-processor :as qp]
@@ -34,30 +33,51 @@
 (def ^:private ai-int-pk-type ::upload/auto-incrementing-int-pk)
 (def ^:private string-pk-type ::upload/string-pk)
 
-(defn- do-with-mysql-local-infile-activated
-  "Helper for [[with-mysql-local-infile-activated]]"
-  [thunk]
-  (if (or
-       (not= :mysql driver/*driver*)
-       (= "ON" (-> (sql-jdbc.conn/db->pooled-connection-spec (mt/db))
-                   (jdbc/query
-                    ["show global variables like 'local_infile'"])
-                   first
-                   :value)))
-    (thunk)
-    (let [conn-spec (sql-jdbc.conn/db->pooled-connection-spec (mt/db))]
-      (try
-        (jdbc/query conn-spec
-                    "set global local_infile = 1")
-        (thunk)
-        (finally
-          (jdbc/query conn-spec
-                      "set global local_infile = 0"))))))
+(defn- local-infile-on? []
+  (= "ON" (-> (sql-jdbc.conn/db->pooled-connection-spec (mt/db))
+              (jdbc/query ["show global variables like 'local_infile'"])
+              first
+              :value)))
 
-(defmacro ^:private with-mysql-local-infile-activated
-  "Turn on local_infile for MySQL"
+(defn- set-local-infile! [on?]
+  (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec (mt/db))
+              (str "set global local_infile = " (if on? 1 0))))
+
+(defn- do-with-mysql-local-infile-on
+  [thunk]
+  (if (local-infile-on?)
+    (thunk)
+    (try
+      (set-local-infile! true)
+      (thunk)
+      (finally
+        (set-local-infile! false)))))
+
+(defn- do-with-mysql-local-infile-off
+  [thunk]
+  (if (local-infile-on?)
+    (thunk)
+    (try
+      (set-local-infile! false)
+      (thunk)
+      (finally
+        (set-local-infile! true)))))
+
+(defn- do-with-mysql-local-infile-on-and-off
+  "Helper for [[with-mysql-local-infile-on-and-off]]"
+  [thunk]
+  (if (not= driver/*driver* :mysql)
+    (thunk)
+    (do
+      (testing "with local_infile on"
+        (do-with-mysql-local-infile-off thunk))
+      (testing "with local_infile off"
+        (do-with-mysql-local-infile-off thunk)))))
+
+(defmacro ^:private with-mysql-local-infile-on-and-off
+  "Exectute the body with local_infile on, and then again with local_infile off"
   [& body]
-  `(do-with-mysql-local-infile-activated (fn [] ~@body)))
+  `(do-with-mysql-local-infile-on-and-off (fn [] ~@body)))
 
 (deftest type-detection-and-parse-test
   (doseq [[string-value  expected-value expected-type seps]
@@ -149,15 +169,15 @@
            [" 2022-01-01T01:00:00.00Z "       (t/offset-date-time "2022-01-01T01:00+00:00") offset-dt-type]
            [" 2022-01-01t01:00:00.00Z "       (t/offset-date-time "2022-01-01T01:00+00:00") offset-dt-type]
            [" 2022-01-01 01:00:00.00Z "       (t/offset-date-time "2022-01-01T01:00+00:00") offset-dt-type]]]
-    (mt/with-temporary-setting-values [custom-formatting (when seps {:type/Number {:number_separators seps}})]
-      (let [type   (upload/value->type string-value)
-            parser (#'upload-parsing/upload-type->parser type)]
-        (testing (format "\"%s\" is a %s" string-value type)
-          (is (= expected-type
-                 type)))
-        (testing (format "\"%s\" is parsed into %s" string-value expected-value)
-          (is (= expected-value
-                 (parser string-value))))))))
+    (let [settings {:number-separators (or seps ".,")}
+          type     (#'upload/value->type string-value settings)
+          parser   (upload-parsing/upload-type->parser type settings)]
+      (testing (format "\"%s\" is a %s" string-value type)
+        (is (= expected-type
+               type)))
+      (testing (format "\"%s\" is parsed into %s" string-value expected-value)
+        (is (= expected-value
+               (parser string-value)))))))
 
 (deftest ^:parallel type-coalescing-test
   (doseq [[type-a          type-b        expected]
@@ -401,7 +421,7 @@
   (testing "Upload a CSV file"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (mt/with-empty-db
-        (with-mysql-local-infile-activated
+        (with-mysql-local-infile-on-and-off
           (upload/load-from-csv!
            driver/*driver*
            (mt/id)
@@ -444,8 +464,8 @@
 (deftest load-from-csv-date-test
   (testing "Upload a CSV file with a datetime column"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-      (mt/with-empty-db
-        (with-mysql-local-infile-activated
+      (with-mysql-local-infile-on-and-off
+        (mt/with-empty-db
           (upload/load-from-csv!
            driver/*driver*
            (mt/id)
@@ -454,55 +474,55 @@
                            "2022-01-01"
                            "2022-01-01 00:00"
                            "2022-01-01T00:00:00"
-                           "2022-01-01T00:00"])))
-        (testing "Fields exists after sync"
-          (sync/sync-database! (mt/db))
-          (let [table (t2/select-one Table :db_id (mt/id))]
-            (is (=? {:name #"(?i)upload_test"} table))
-            (testing "Check the datetime column the correct base_type"
-              (is (=? {:name      #"(?i)datetime"
-                       :base_type (if (= driver/*driver* :mysql) :type/DateTimeWithLocalTZ :type/DateTime)}
+                           "2022-01-01T00:00"]))
+          (testing "Fields exists after sync"
+            (sync/sync-database! (mt/db))
+            (let [table (t2/select-one Table :db_id (mt/id))]
+              (is (=? {:name #"(?i)upload_test"} table))
+              (testing "Check the datetime column the correct base_type"
+                (is (=? {:name      #"(?i)datetime"
+                         :base_type (if (= driver/*driver* :mysql) :type/DateTimeWithLocalTZ :type/DateTime)}
                       ;; db position is 1; 0 is for the auto-inserted ID
-                      (t2/select-one Field :database_position 1 :table_id (:id table)))))
-            (is (some? table))))))))
+                        (t2/select-one Field :database_position 1 :table_id (:id table)))))
+              (is (some? table)))))))))
 
 (deftest load-from-csv-offset-datetime-test
   (testing "Upload a CSV file with a datetime column"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-      (mt/with-empty-db
-        (with-redefs [driver/db-default-timezone (constantly "Z")
-                      upload/current-database    (constantly (mt/db))]
-          (let [datetime-pairs [["2022-01-01T12:00:00-07"    "2022-01-01T19:00:00Z"]
-                                ["2022-01-01T12:00:00-07:00" "2022-01-01T19:00:00Z"]
-                                ["2022-01-01T12:00:00-07:30" "2022-01-01T19:30:00Z"]
-                                ["2022-01-01T12:00:00Z"      "2022-01-01T12:00:00Z"]
-                                ["2022-01-01T12:00:00-00:00" "2022-01-01T12:00:00Z"]
-                                ["2022-01-01T12:00:00+07"    "2022-01-01T05:00:00Z"]
-                                ["2022-01-01T12:00:00+07:00" "2022-01-01T05:00:00Z"]
-                                ["2022-01-01T12:00:00+07:30" "2022-01-01T04:30:00Z"]]]
-            (with-mysql-local-infile-activated
+      (with-mysql-local-infile-on-and-off
+        (mt/with-empty-db
+          (with-redefs [driver/db-default-timezone (constantly "Z")
+                        upload/current-database    (constantly (mt/db))]
+            (let [datetime-pairs [["2022-01-01T12:00:00-07"    "2022-01-01T19:00:00Z"]
+                                  ["2022-01-01T12:00:00-07:00" "2022-01-01T19:00:00Z"]
+                                  ["2022-01-01T12:00:00-07:30" "2022-01-01T19:30:00Z"]
+                                  ["2022-01-01T12:00:00Z"      "2022-01-01T12:00:00Z"]
+                                  ["2022-01-01T12:00:00-00:00" "2022-01-01T12:00:00Z"]
+                                  ["2022-01-01T12:00:00+07"    "2022-01-01T05:00:00Z"]
+                                  ["2022-01-01T12:00:00+07:00" "2022-01-01T05:00:00Z"]
+                                  ["2022-01-01T12:00:00+07:30" "2022-01-01T04:30:00Z"]]]
               (upload/load-from-csv!
                driver/*driver*
                (mt/id)
                "upload_test"
-               (csv-file-with (into ["offset_datetime"] (map first datetime-pairs)))))
-            (testing "Fields exists after sync"
-              (sync/sync-database! (mt/db))
-              (let [table (t2/select-one Table :db_id (mt/id))]
-                (is (=? {:name #"(?i)upload_test"} table))
-                (testing "Check the offset datetime column the correct base_type"
-                  (is (=? {:name      #"(?i)offset_datetime"
-                           :base_type :type/DateTimeWithLocalTZ}
+               (csv-file-with (into ["offset_datetime"] (map first datetime-pairs))))
+              (testing "Fields exists after sync"
+                (sync/sync-database! (mt/db))
+                (let [table (t2/select-one Table :db_id (mt/id))]
+                  (is (=? {:name #"(?i)upload_test"} table))
+                  (testing "Check the offset datetime column the correct base_type"
+                    (is (=? {:name      #"(?i)offset_datetime"
+                             :base_type :type/DateTimeWithLocalTZ}
                           ;; db position is 1; 0 is for the auto-inserted ID
-                          (t2/select-one Field :database_position 1 :table_id (:id table)))))
-                (is (= (map second datetime-pairs)
-                       (map second (rows-for-table table))))))))))))
+                            (t2/select-one Field :database_position 1 :table_id (:id table)))))
+                  (is (= (map second datetime-pairs)
+                         (map second (rows-for-table table)))))))))))))
 
 (deftest load-from-csv-boolean-test
   (testing "Upload a CSV file"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-      (mt/with-empty-db
-        (with-mysql-local-infile-activated
+      (with-mysql-local-infile-on-and-off
+        (mt/with-empty-db
           (upload/load-from-csv!
            driver/*driver*
            (mt/id)
@@ -525,19 +545,19 @@
                            "15,YES"
                            "16,NO"
                            "17,1"
-                           "18,0"])))
-        (testing "Table and Fields exist after sync"
-          (sync/sync-database! (mt/db))
-          (let [table (t2/select-one Table :db_id (mt/id))]
-            (is (=? {:name #"(?i)upload_test"} table))
-            (testing "Check the boolean column has a boolean base_type"
-              (is (=? {:name      #"(?i)bool"
-                       :base_type :type/Boolean}
-                      (t2/select-one Field :database_position 1 :table_id (:id table)))))
-            (testing "Check the data was uploaded into the table correctly"
-              (let [bool-column (map second (rows-for-table table))
-                    alternating (map even? (range (count bool-column)))]
-                (is (= alternating bool-column))))))))))
+                           "18,0"]))
+          (testing "Table and Fields exist after sync"
+            (sync/sync-database! (mt/db))
+            (let [table (t2/select-one Table :db_id (mt/id))]
+              (is (=? {:name #"(?i)upload_test"} table))
+              (testing "Check the boolean column has a boolean base_type"
+                (is (=? {:name      #"(?i)bool"
+                         :base_type :type/Boolean}
+                        (t2/select-one Field :database_position 1 :table_id (:id table)))))
+              (testing "Check the data was uploaded into the table correctly"
+                (let [bool-column (map second (rows-for-table table))
+                      alternating (map even? (range (count bool-column)))]
+                  (is (= alternating bool-column)))))))))))
 
 (deftest load-from-csv-length-test
   (testing "Upload a CSV file with large names and numbers"
@@ -546,8 +566,8 @@
             long-name    (apply str (repeat 33 "abcdefgh")) ; 33×8 = 264. Max is H2 at 256
             short-name   (subs long-name 0 (- length-limit (count "_yyyyMMddHHmmss")))]
         (is (pos? length-limit) "driver/table-name-length-limit has been set")
-        (mt/with-empty-db
-          (with-mysql-local-infile-activated
+        (with-mysql-local-infile-on-and-off
+          (mt/with-empty-db
             (upload/load-from-csv!
              driver/*driver*
              (mt/id)
@@ -555,17 +575,17 @@
              (csv-file-with ["number,bool"
                              "1,true"
                              "2,false"
-                             (format "%d,true" Long/MAX_VALUE)])))
-          (testing "It truncates it to the right number of characters, allowing for the timestamp"
-            (sync/sync-database! (mt/db))
-            (let [table    (t2/select-one Table :db_id (mt/id) :%lower.name [:like (str short-name "%")])
-                  table-re (re-pattern (str "(?i)" short-name "_\\d{14}"))]
-              (is (re-matches table-re (:name table)))
-              (testing "Check the data was uploaded into the table correctly"
-                (is (= [[1 1 true]
-                        [2 2 false]
-                        [3 Long/MAX_VALUE true]]
-                       (rows-for-table table)))))))))))
+                             (format "%d,true" Long/MAX_VALUE)]))
+            (testing "It truncates it to the right number of characters, allowing for the timestamp"
+              (sync/sync-database! (mt/db))
+              (let [table    (t2/select-one Table :db_id (mt/id) :%lower.name [:like (str short-name "%")])
+                    table-re (re-pattern (str "(?i)" short-name "_\\d{14}"))]
+                (is (re-matches table-re (:name table)))
+                (testing "Check the data was uploaded into the table correctly"
+                  (is (= [[1 1 true]
+                          [2 2 false]
+                          [3 Long/MAX_VALUE true]]
+                         (rows-for-table table))))))))))))
 
 (deftest load-from-csv-empty-header-test
   (testing "Upload a CSV file with a blank column name"
@@ -589,28 +609,28 @@
 (deftest load-from-csv-duplicate-names-test
   (testing "Upload a CSV file with duplicate column names"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-      (mt/with-empty-db
-        (with-mysql-local-infile-activated
+      (with-mysql-local-infile-on-and-off
+        (mt/with-empty-db
           (upload/load-from-csv!
            driver/*driver*
            (mt/id)
            "upload_test"
            (csv-file-with ["unknown,unknown,unknown,unknown_2"
                            "1,Serenity,Malcolm Reynolds,Pistol"
-                           "2,Millennium Falcon, Han Solo,Blaster"])))
-        (testing "Table and Fields exist after sync"
-          (sync/sync-database! (mt/db))
-          (let [table (t2/select-one Table :db_id (mt/id))]
-            (is (=? {:name #"(?i)upload_test"} table))
-            (testing "Check the data was uploaded into the table correctly"
-              (is (= ["id" "unknown" "unknown_2" "unknown_3" "unknown_2_2"]
-                     (column-names-for-table table))))))))))
+                           "2,Millennium Falcon, Han Solo,Blaster"]))
+          (testing "Table and Fields exist after sync"
+            (sync/sync-database! (mt/db))
+            (let [table (t2/select-one Table :db_id (mt/id))]
+              (is (=? {:name #"(?i)upload_test"} table))
+              (testing "Check the data was uploaded into the table correctly"
+                (is (= ["id" "unknown" "unknown_2" "unknown_3" "unknown_2_2"]
+                       (column-names-for-table table)))))))))))
 
 (deftest load-from-csv-existing-id-column-test
   (testing "Upload a CSV file with an existing ID column"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-      (mt/with-empty-db
-        (with-mysql-local-infile-activated
+      (with-mysql-local-infile-on-and-off
+        (mt/with-empty-db
           (upload/load-from-csv!
            driver/*driver*
            (mt/id)
@@ -619,136 +639,139 @@
                            "1,Serenity,Malcolm Reynolds,Pistol"
                            "2,Millennium Falcon,Han Solo,Blaster"
                            ;; A huge ID to make extra sure we're using bigints
-                           "9000000000,Razor Crest,Din Djarin,Spear"])))
-        (testing "Table and Fields exist after sync"
-          (sync/sync-database! (mt/db))
-          (let [table (t2/select-one Table :db_id (mt/id))]
-            (is (=? {:name #"(?i)upload_test"} table))
-            (testing "Check the data was uploaded into the table correctly"
-              (is (= ["id" "ship" "name" "weapon"]
-                     (column-names-for-table table)))
-              (is (=? {:name                       #"(?i)id"
-                       :semantic_type              :type/PK
-                       :base_type                  :type/BigInteger
-                       :database_is_auto_increment false}
-                      (t2/select-one Field :database_position 0 :table_id (:id table)))))))))))
+                           "9000000000,Razor Crest,Din Djarin,Spear"]))
+          (testing "Table and Fields exist after sync"
+            (sync/sync-database! (mt/db))
+            (let [table (t2/select-one Table :db_id (mt/id))]
+              (is (=? {:name #"(?i)upload_test"} table))
+              (testing "Check the data was uploaded into the table correctly"
+                (is (= ["id" "ship" "name" "weapon"]
+                       (column-names-for-table table)))
+                (is (=? {:name                       #"(?i)id"
+                         :semantic_type              :type/PK
+                         :base_type                  :type/BigInteger
+                         :database_is_auto_increment false}
+                        (t2/select-one Field :database_position 0 :table_id (:id table))))))))))))
 
 (deftest load-from-csv-existing-string-id-column-test
   (testing "Upload a CSV file with an existing string ID column"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-      (mt/with-empty-db
-        (with-mysql-local-infile-activated
+      (with-mysql-local-infile-on-and-off
+        (mt/with-empty-db
           (upload/load-from-csv!
            driver/*driver*
            (mt/id)
            "upload_test"
            (csv-file-with ["id,ship,name,weapon"
                            "a,Serenity,Malcolm Reynolds,Pistol"
-                           "b,Millennium Falcon,Han Solo,Blaster"])))
-        (testing "Table and Fields exist after sync"
-          (sync/sync-database! (mt/db))
-          (let [table (t2/select-one Table :db_id (mt/id))]
-            (is (=? {:name #"(?i)upload_test"} table))
-            (testing "Check the data was uploaded into the table correctly"
-              (is (= ["id" "ship" "name" "weapon"]
-                     (column-names-for-table table)))
-              (is (=? {:name                       #"(?i)id"
-                       :semantic_type              :type/PK
-                       :base_type                  :type/Text
-                       :database_is_auto_increment false}
-                      (t2/select-one Field :database_position 0 :table_id (:id table)))))))))))
+                           "b,Millennium Falcon,Han Solo,Blaster"]))
+          (testing "Table and Fields exist after sync"
+            (sync/sync-database! (mt/db))
+            (let [table (t2/select-one Table :db_id (mt/id))]
+              (is (=? {:name #"(?i)upload_test"} table))
+              (testing "Check the data was uploaded into the table correctly"
+                (is (= ["id" "ship" "name" "weapon"]
+                       (column-names-for-table table)))
+                (is (=? {:name                       #"(?i)id"
+                         :semantic_type              :type/PK
+                         :base_type                  :type/Text
+                         :database_is_auto_increment false}
+                        (t2/select-one Field :database_position 0 :table_id (:id table))))))))))))
 
 (deftest load-from-csv-reserved-db-words-test
   (testing "Upload a CSV file with column names that are reserved by the DB"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-      (mt/with-empty-db
-        (with-mysql-local-infile-activated
+      (with-mysql-local-infile-on-and-off
+        (mt/with-empty-db
           (upload/load-from-csv!
            driver/*driver*
            (mt/id)
            "upload_test"
            (csv-file-with ["id,ship,captain"
                            "1,Serenity,Malcolm Reynolds"
-                           "2,Millennium Falcon, Han Solo"])))
-        (testing "Table and Fields exist after sync"
-          (sync/sync-database! (mt/db))
-          (let [table (t2/select-one Table :db_id (mt/id))]
-            (is (=? {:name #"(?i)upload_test"} table))
-            (testing "Check the data was uploaded into the table correctly"
-              (is (= ["id", "ship", "captain"]
-                     (column-names-for-table table))))))))))
-
-(deftest load-from-csv-missing-values-test
-  (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-    (mt/with-empty-db
-      (with-mysql-local-infile-activated
-        (testing "Can upload a CSV with missing values"
-          (upload/load-from-csv!
-           driver/*driver*
-           (mt/id)
-           "upload_test"
-           (csv-file-with ["id,column_that_doesnt_have_a_value" "2"]))
+                           "2,Millennium Falcon, Han Solo"]))
           (testing "Table and Fields exist after sync"
             (sync/sync-database! (mt/db))
             (let [table (t2/select-one Table :db_id (mt/id))]
               (is (=? {:name #"(?i)upload_test"} table))
               (testing "Check the data was uploaded into the table correctly"
-                (is (= ["id", "column_that_doesnt_have_a_value"]
+                (is (= ["id", "ship", "captain"]
+                       (column-names-for-table table)))))))))))
+
+(deftest load-from-csv-missing-values-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
+    (with-mysql-local-infile-on-and-off
+      (mt/with-empty-db
+        (testing "Can upload a CSV with missing values"
+          (upload/load-from-csv!
+           driver/*driver*
+           (mt/id)
+           "upload_test"
+           (csv-file-with ["id,column_that_has_one_value,column_that_doesnt_have_a_value"
+                           "1,2"
+                           "2,,"]))
+          (testing "Table and Fields exist after sync"
+            (sync/sync-database! (mt/db))
+            (let [table (t2/select-one Table :db_id (mt/id))]
+              (is (=? {:name #"(?i)upload_test"} table))
+              (testing "Check the data was uploaded into the table correctly"
+                (is (= ["id" "column_that_has_one_value", "column_that_doesnt_have_a_value"]
                        (column-names-for-table table)))
-                (is (= [[2 nil]]
+                (is (= [[1 2 nil]
+                        [2 nil nil]]
                        (rows-for-table table)))))))))))
 
 (deftest load-from-csv-tab-test
   (testing "Upload a CSV file with tabs in the values"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-      (mt/with-empty-db
-        (with-mysql-local-infile-activated
+      (with-mysql-local-infile-on-and-off
+        (mt/with-empty-db
           (upload/load-from-csv!
            driver/*driver*
            (mt/id)
            "upload_test"
            (csv-file-with ["id,ship,captain"
                            "1,Serenity,Malcolm\tReynolds"
-                           "2,Millennium\tFalcon,Han\tSolo"])))
-        (testing "Table and Fields exist after sync"
-          (sync/sync-database! (mt/db))
-          (let [table (t2/select-one Table :db_id (mt/id))]
-            (is (=? {:name #"(?i)upload_test"} table))
-            (testing "Check the data was uploaded into the table correctly"
-              (is (= ["id", "ship", "captain"]
-                     (column-names-for-table table)))
-              (is (= [[1 "Serenity" "Malcolm\tReynolds"]
-                      [2 "Millennium\tFalcon" "Han\tSolo"]]
-                     (rows-for-table table))))))))))
+                           "2,Millennium\tFalcon,Han\tSolo"]))
+          (testing "Table and Fields exist after sync"
+            (sync/sync-database! (mt/db))
+            (let [table (t2/select-one Table :db_id (mt/id))]
+              (is (=? {:name #"(?i)upload_test"} table))
+              (testing "Check the data was uploaded into the table correctly"
+                (is (= ["id", "ship", "captain"]
+                       (column-names-for-table table)))
+                (is (= [[1 "Serenity" "Malcolm\tReynolds"]
+                        [2 "Millennium\tFalcon" "Han\tSolo"]]
+                       (rows-for-table table)))))))))))
 
 (deftest load-from-csv-carriage-return-test
   (testing "Upload a CSV file with carriage returns in the values"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-      (mt/with-empty-db
-        (with-mysql-local-infile-activated
+      (with-mysql-local-infile-on-and-off
+        (mt/with-empty-db
           (upload/load-from-csv!
            driver/*driver*
            (mt/id)
            "upload_test"
            (csv-file-with ["id,ship,captain"
                            "1,Serenity,\"Malcolm\rReynolds\""
-                           "2,\"Millennium\rFalcon\",\"Han\rSolo\""])))
-        (testing "Table and Fields exist after sync"
-          (sync/sync-database! (mt/db))
-          (let [table (t2/select-one Table :db_id (mt/id))]
-            (is (=? {:name #"(?i)upload_test"} table))
-            (testing "Check the data was uploaded into the table correctly"
-              (is (= ["id", "ship", "captain"]
-                     (column-names-for-table table)))
-              (is (= [[1 "Serenity" "Malcolm\rReynolds"]
-                      [2 "Millennium\rFalcon" "Han\rSolo"]]
-                     (rows-for-table table))))))))))
+                           "2,\"Millennium\rFalcon\",\"Han\rSolo\""]))
+          (testing "Table and Fields exist after sync"
+            (sync/sync-database! (mt/db))
+            (let [table (t2/select-one Table :db_id (mt/id))]
+              (is (=? {:name #"(?i)upload_test"} table))
+              (testing "Check the data was uploaded into the table correctly"
+                (is (= ["id", "ship", "captain"]
+                       (column-names-for-table table)))
+                (is (= [[1 "Serenity" "Malcolm\rReynolds"]
+                        [2 "Millennium\rFalcon" "Han\rSolo"]]
+                       (rows-for-table table)))))))))))
 
 (deftest load-from-csv-BOM-test
   (testing "Upload a CSV file with a byte-order mark (BOM)"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-      (mt/with-empty-db
-        (with-mysql-local-infile-activated
+      (with-mysql-local-infile-on-and-off
+        (mt/with-empty-db
           (upload/load-from-csv!
            driver/*driver*
            (mt/id)
@@ -757,20 +780,20 @@
                            "1,Serenity,Malcolm Reynolds"
                            "2,Millennium Falcon, Han Solo"]
                           "star-wars"
-                          (partial bom/bom-writer "UTF-8"))))
-        (testing "Table and Fields exist after sync"
-          (sync/sync-database! (mt/db))
-          (let [table (t2/select-one Table :db_id (mt/id))]
-            (is (=? {:name #"(?i)upload_test"} table))
-            (testing "Check the data was uploaded into the table correctly"
-              (is (= ["id", "ship", "captain"]
-                     (column-names-for-table table))))))))))
+                          (partial bom/bom-writer "UTF-8")))
+          (testing "Table and Fields exist after sync"
+            (sync/sync-database! (mt/db))
+            (let [table (t2/select-one Table :db_id (mt/id))]
+              (is (=? {:name #"(?i)upload_test"} table))
+              (testing "Check the data was uploaded into the table correctly"
+                (is (= ["id", "ship", "captain"]
+                       (column-names-for-table table)))))))))))
 
 (deftest load-from-csv-injection-test
   (testing "Upload a CSV file with very rude values"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-      (mt/with-empty-db
-        (with-mysql-local-infile-activated
+      (with-mysql-local-infile-on-and-off
+        (mt/with-empty-db
           (upload/load-from-csv!
            driver/*driver*
            (mt/id)
@@ -778,17 +801,17 @@
            (csv-file-with ["id integer); --,ship,captain"
                            "1,Serenity,--Malcolm Reynolds"
                            "2,;Millennium Falcon,Han Solo\""]
-                          "\"; -- Very rude filename")))
-        (testing "Table and Fields exist after sync"
-          (sync/sync-database! (mt/db))
-          (let [table (t2/select-one Table :db_id (mt/id))]
-            (is (=? {:name #"(?i)upload_test"} table))
-            (testing "Check the data was uploaded into the table correctly"
-              (is (= ["id" "id_integer_____" "ship" "captain"]
-                     (column-names-for-table table)))
-              (is (= [[1 1 "Serenity"           "--Malcolm Reynolds"]
-                      [2 2 ";Millennium Falcon" "Han Solo\""]]
-                     (rows-for-table table))))))))))
+                          "\"; -- Very rude filename"))
+          (testing "Table and Fields exist after sync"
+            (sync/sync-database! (mt/db))
+            (let [table (t2/select-one Table :db_id (mt/id))]
+              (is (=? {:name #"(?i)upload_test"} table))
+              (testing "Check the data was uploaded into the table correctly"
+                (is (= ["id" "id_integer_____" "ship" "captain"]
+                       (column-names-for-table table)))
+                (is (= [[1 1 "Serenity"           "--Malcolm Reynolds"]
+                        [2 2 ";Millennium Falcon" "Han Solo\""]]
+                       (rows-for-table table)))))))))))
 
 (deftest load-from-csv-eof-marker-test
   (testing "Upload a CSV file with Postgres's 'end of input' marker"
@@ -813,32 +836,19 @@
 (deftest mysql-settings-test
   (testing "Ensure that local_infile is set to true for better MySQL testing"
     (mt/test-drivers [:mysql]
-      (with-mysql-local-infile-activated
-        (is (= "ON" (-> (sql-jdbc.conn/db->pooled-connection-spec (mt/db))
-                        (jdbc/query
-                         ["show global variables like 'local_infile'"])
-                        first
-                        :value)))))))
-
-(deftest load-from-csv-mysql-slow-way-test
-  (testing "MySQL upload should work fine with local_infile disabled"
+      (do-with-mysql-local-infile-on
+       (fn []
+         (is (= "ON" (-> (sql-jdbc.conn/db->pooled-connection-spec (mt/db))
+                         (jdbc/query
+                          ["show global variables like 'local_infile'"])
+                         first
+                         :value)))))))
+  (testing "Ensure that local_infile is set to false for better MySQL testing"
     (mt/test-drivers [:mysql]
-      (mt/with-empty-db
-        (with-redefs [mysql/get-global-variable (constantly "OFF")]
-          (upload/load-from-csv!
-           driver/*driver*
-           (mt/id)
-           "upload_test"
-           (csv-file-with ["id,ship,captain"
-                           "1,Serenity,Malcolm Reynolds"
-                           "2,Millennium Falcon,Han Solo"])))
-        (testing "Table and Fields exist after sync"
-          (sync/sync-database! (mt/db))
-          (let [table (t2/select-one Table :db_id (mt/id))]
-            (is (=? {:name #"(?i)upload_test"} table))
-            (testing "Check the data was uploaded into the table correctly"
-              (is (= ["id", "ship", "captain"]
-                     (column-names-for-table table)))
-              (is (= [[1 "Serenity" "Malcolm Reynolds"]
-                      [2 "Millennium Falcon" "Han Solo"]]
-                     (rows-for-table table))))))))))
+      (do-with-mysql-local-infile-off
+       (fn []
+         (is (= "OFF" (-> (sql-jdbc.conn/db->pooled-connection-spec (mt/db))
+                          (jdbc/query
+                           ["show global variables like 'local_infile'"])
+                          first
+                          :value))))))))


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/35606

It also makes an improvement to the testing code. Now all CSV upload tests that write the upload data to the database run with [local_infile](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_local_infile) both set to on and off. Before most tests just ran with it on.