### PR TITLE
[MLv2] Include query, stage and column for quick filter drills

### DIFF
--- a/frontend/src/metabase-lib/drills.ts
+++ b/frontend/src/metabase-lib/drills.ts
@@ -5,6 +5,7 @@ import type {
   DataRow,
   Dimension,
   DrillThru,
+  FilterDrillDetails,
   Query,
 } from "./types";
 
@@ -36,4 +37,8 @@ export function drillThru(
   ...args: any[]
 ): Query {
   return ML.drill_thru(query, stageIndex, drillThru, ...args);
+}
+
+export function filterDrillDetails(drillThru: DrillThru): FilterDrillDetails {
+  return ML.filter_drill_details(drillThru);
 }

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -335,6 +335,12 @@ export type DrillThruDisplayInfo =
   | UnderlyingRecordsDrillThruInfo
   | ZoomTimeseriesDrillThruInfo;
 
+export type FilterDrillDetails = {
+  query: Query;
+  stageNumber: number;
+  column: ColumnMetadata;
+};
+
 export interface Dimension {
   column: DatasetColumn;
   value?: RowValue;

--- a/src/metabase/lib/drill_thru/column_filter.cljc
+++ b/src/metabase/lib/drill_thru/column_filter.cljc
@@ -8,10 +8,50 @@
    [metabase.lib.ref :as lib.ref]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
+   [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.stage :as lib.stage]
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.util :as lib.util]
    [metabase.util.malli :as mu]))
+
+(mu/defn filter-drill-adjusted-query :- [:map
+                                         [:query ::lib.schema/query]
+                                         [:stage-number :int]
+                                         [:column lib.filter/ColumnWithOperators]]
+  "If the column we're filtering on is an aggregation, the filtering must happen in a later stage. This function returns
+  a map with that possibly-updated `:query` and `:stage-number`, plus the `:column` for filtering in that stage (with
+  filter operators, as returned by [[lib.filter/filterable-columns]]).
+
+  If the column is an aggregation but the query already has a later stage, that stage is reused.
+  If the column is not an aggregation, the query and stage-number are returned unchanged, but the
+  [[lib.filter/filterable-columns]] counterpart of the input `column` is still returned.
+
+  This query and filterable column are exactly what the FE needs to render the filtering UI for a column filter drill,
+  or certain tricky cases of quick filter."
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   column       :- ::lib.schema.metadata/column]
+  (let [next-stage    (->> (lib.util/canonical-stage-index query stage-number)
+                           (lib.util/next-stage-number query))
+        base          (cond
+                        ;; Not an aggregation: just the input query and stage.
+                        (not= (:lib/source column) :source/aggregations)
+                        {:query        query
+                         :stage-number stage-number}
+
+                        ;; Aggregation column: if there's a later stage, use it.
+                        next-stage {:query        query
+                                    :stage-number next-stage}
+                        ;; Aggregation column with no later stage; append a stage.
+                        :else      {:query        (lib.stage/append-stage query)
+                                    :stage-number -1})
+        columns       (lib.filter/filterable-columns (:query base) (:stage-number base))
+        filter-column (or (lib.equality/find-matching-column
+                            (:query base) (:stage-number base) (lib.ref/ref column) columns)
+                          (and (:lib/source-uuid column)
+                               (m/find-first #(= (:lib/source-uuid %) (:lib/source-uuid column))
+                                             columns)))]
+    (assoc base :column filter-column)))
 
 (mu/defn column-filter-drill :- [:maybe ::lib.schema.drill-thru/drill-thru.column-filter]
   "Filtering at the column level, based on its type. Displays a submenu of eg. \"Today\", \"This Week\", etc. for date
@@ -37,27 +77,7 @@
          :type       :drill-thru/column-filter
          :initial-op initial-op}
         ;; When the column we would be filtering on is an aggregation, it can't be filtered without adding a stage.
-        (let [next-stage    (->> (lib.util/canonical-stage-index query stage-number)
-                                 (lib.util/next-stage-number query))
-              base          (cond
-                              ;; Not an aggregation: just the input query and stage.
-                              (not= (:lib/source column) :source/aggregations)
-                              {:query        query
-                               :stage-number stage-number}
-
-                              ;; Aggregation column: if there's a later stage, use it.
-                              next-stage {:query        query
-                                          :stage-number next-stage}
-                              ;; Aggregation column with no later stage; append a stage.
-                              :else      {:query        (lib.stage/append-stage query)
-                                          :stage-number -1})
-              columns       (lib.filter/filterable-columns (:query base) (:stage-number base))
-              filter-column (or (lib.equality/find-matching-column
-                                  (:query base) (:stage-number base) (lib.ref/ref column) columns)
-                                (and (:lib/source-uuid column)
-                                     (m/find-first #(= (:lib/source-uuid %) (:lib/source-uuid column))
-                                                   columns)))]
-          (assoc base :column filter-column))))))
+        (filter-drill-adjusted-query query stage-number column)))))
 
 (defmethod lib.drill-thru.common/drill-thru-info-method :drill-thru/column-filter
   [_query _stage-number {:keys [initial-op]}]

--- a/src/metabase/lib/drill_thru/quick_filter.cljc
+++ b/src/metabase/lib/drill_thru/quick_filter.cljc
@@ -1,6 +1,7 @@
 (ns metabase.lib.drill-thru.quick-filter
   (:require
    [medley.core :as m]
+   [metabase.lib.drill-thru.column-filter :as lib.drill-thru.column-filter]
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
    [metabase.lib.filter :as lib.filter]
    [metabase.lib.metadata :as lib.metadata]
@@ -9,7 +10,6 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
-   [metabase.lib.stage :as lib.stage]
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.util.malli :as mu]))
 
@@ -55,17 +55,13 @@
              (some? value) ; Deliberately allows value :null, only a missing value should fail this test.
              (not (lib.types.isa/primary-key? column))
              (not (lib.types.isa/foreign-key? column)))
-    ;; for aggregate columns, we want to introduce a new stage when applying the drill-thru, `:new-stage?` is used to
-    ;; track this. (#34346)
-    (let [{:keys [column new-stage?]} (if (= (:lib/source column) :source/aggregations)
-                                        {:column     (assoc column :lib/source :source/previous-stage)
-                                         :new-stage? true}
-                                        {:column    column
-                                         :new-stage? false})]
-      {:lib/type   :metabase.lib.drill-thru/drill-thru
-       :type       :drill-thru/quick-filter
-       :operators  (operators-for column value)
-       :new-stage? new-stage?})))
+    ;; For aggregate columns, we want to introduce a new stage when applying the drill-thru.
+    ;; [[lib.drill-thru.column-filter/filter-drill-adjusted-query]] handles this. (#34346)
+    (let [adjusted (lib.drill-thru.column-filter/filter-drill-adjusted-query query stage-number column)]
+      (merge {:lib/type   :metabase.lib.drill-thru/drill-thru
+              :type       :drill-thru/quick-filter
+              :operators  (operators-for (:column adjusted) value)}
+             adjusted))))
 
 (defmethod lib.drill-thru.common/drill-thru-info-method :drill-thru/quick-filter
   [_query _stage-number drill-thru]
@@ -73,16 +69,15 @@
    :operators (map :name (:operators drill-thru))})
 
 (mu/defmethod lib.drill-thru.common/drill-thru-method :drill-thru/quick-filter :- ::lib.schema/query
-  [query        :- ::lib.schema/query
-   stage-number :- :int
-   drill        :- ::lib.schema.drill-thru/drill-thru.quick-filter
-   filter-op    :- ::lib.schema.common/non-blank-string]
+  [_query                      :- ::lib.schema/query
+   _stage-number               :- :int
+   {:keys [query stage-number]
+    :as drill}                 :- ::lib.schema.drill-thru/drill-thru.quick-filter
+   filter-op                   :- ::lib.schema.common/non-blank-string]
   (let [quick-filter (or (m/find-first #(= (:name %) filter-op) (:operators drill))
                          (throw (ex-info (str "No matching filter for operator " filter-op)
                                          {:drill-thru   drill
                                           :operator     filter-op
                                           :query        query
-                                          :stage-number stage-number})))
-        query        (cond-> query
-                       (:new-stage? drill) lib.stage/append-stage)]
+                                          :stage-number stage-number})))]
     (lib.filter/filter query stage-number (:filter quick-filter))))

--- a/src/metabase/lib/drill_thru/quick_filter.cljc
+++ b/src/metabase/lib/drill_thru/quick_filter.cljc
@@ -60,7 +60,8 @@
     (let [adjusted (lib.drill-thru.column-filter/filter-drill-adjusted-query query stage-number column)]
       (merge {:lib/type   :metabase.lib.drill-thru/drill-thru
               :type       :drill-thru/quick-filter
-              :operators  (operators-for (:column adjusted) value)}
+              :operators  (operators-for (:column adjusted) value)
+              :value      value}
              adjusted))))
 
 (defmethod lib.drill-thru.common/drill-thru-info-method :drill-thru/quick-filter

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -994,11 +994,12 @@
   and some `quick-filter` drills. Since the query might need an extra stage appended, this returns a possibly updated
   `query` and `stageNumber`, as well as a `column` as returned by [[filterable-columns]]."
   [{a-query :query
-    :keys [column stage-number]
+    :keys [column stage-number value]
     :as _filter-drill}]
   #js {"column"      column
        "query"       a-query
-       "stageNumber" stage-number})
+       "stageNumber" stage-number
+       "value"       (if (= value :null) nil value)})
 
 (defn ^:export pivot-types
   "Returns an array of pivot types that are available in this drill-thru, which must be a pivot drill-thru."

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -989,13 +989,13 @@
   [a-query stage-number a-drill-thru & args]
   (apply lib.core/drill-thru a-query stage-number a-drill-thru args))
 
-(defn ^:export column-filter-drill-details
+(defn ^:export filter-drill-details
   "Returns a JS object with opaque CLJS things in it, which are needed to render the complex UI for `column-filter`
-  drills. Since the query might need an extra stage appended, this returns a possibly updated `query` and `stageNumber`,
-  as well as a `column` as returned by [[filterable-columns]]."
+  and some `quick-filter` drills. Since the query might need an extra stage appended, this returns a possibly updated
+  `query` and `stageNumber`, as well as a `column` as returned by [[filterable-columns]]."
   [{a-query :query
     :keys [column stage-number]
-    :as _column-filter-drill}]
+    :as _filter-drill}]
   #js {"column"      column
        "query"       a-query
        "stageNumber" stage-number})

--- a/src/metabase/lib/schema/drill_thru.cljc
+++ b/src/metabase/lib/schema/drill_thru.cljc
@@ -80,9 +80,10 @@
   [:merge
    ::drill-thru.common
    [:map
-    [:type       [:= :drill-thru/quick-filter]]
-    [:operators  [:sequential ::drill-thru.quick-filter.operator]]
+    [:type         [:= :drill-thru/quick-filter]]
+    [:operators    [:sequential ::drill-thru.quick-filter.operator]]
     [:column       [:ref ::lib.schema.metadata/column]]
+    [:value        [:maybe :any]]
     [:query        [:ref ::lib.schema/query]]
     [:stage-number number?]]])
 

--- a/src/metabase/lib/schema/drill_thru.cljc
+++ b/src/metabase/lib/schema/drill_thru.cljc
@@ -82,9 +82,9 @@
    [:map
     [:type       [:= :drill-thru/quick-filter]]
     [:operators  [:sequential ::drill-thru.quick-filter.operator]]
-    ;; whether applying this drill thru should introduce a new stage to the query. Filters on aggregate columns should
-    ;; introduce a new stage.
-    [:new-stage? :boolean]]])
+    [:column       [:ref ::lib.schema.metadata/column]]
+    [:query        [:ref ::lib.schema/query]]
+    [:stage-number number?]]])
 
 (mr/def ::drill-thru.fk-filter
   [:merge

--- a/test/metabase/lib/drill_thru/quick_filter_test.cljc
+++ b/test/metabase/lib/drill_thru/quick_filter_test.cljc
@@ -11,10 +11,12 @@
     :click-type  :cell
     :query-type  :unaggregated
     :column-name "SUBTOTAL"
-    :expected    {:type :drill-thru/quick-filter, :operators [{:name "<"}
-                                                              {:name ">"}
-                                                              {:name "="}
-                                                              {:name "≠"}]}}))
+    :expected    {:type      :drill-thru/quick-filter
+                  :value     (get-in lib.drill-thru.tu/test-queries ["ORDERS" :unaggregated :row "SUBTOTAL"])
+                  :operators [{:name "<"}
+                              {:name ">"}
+                              {:name "="}
+                              {:name "≠"}]}}))
 
 (deftest ^:parallel returns-quick-filter-test-2
   (lib.drill-thru.tu/test-returns-drill
@@ -22,8 +24,10 @@
     :click-type  :cell
     :query-type  :unaggregated
     :column-name "DISCOUNT"
-    :expected    {:type :drill-thru/quick-filter, :operators [{:name "="}
-                                                              {:name "≠"}]}}))
+    :expected    {:type      :drill-thru/quick-filter
+                  :value     :null
+                  :operators [{:name "="}
+                              {:name "≠"}]}}))
 
 (deftest ^:parallel returns-quick-filter-test-3
   (lib.drill-thru.tu/test-returns-drill
@@ -31,10 +35,12 @@
     :click-type  :cell
     :query-type  :unaggregated
     :column-name "CREATED_AT"
-    :expected    {:type :drill-thru/quick-filter, :operators [{:name "<"}
-                                                              {:name ">"}
-                                                              {:name "="}
-                                                              {:name "≠"}]}}))
+    :expected    {:type      :drill-thru/quick-filter
+                  :value     (get-in lib.drill-thru.tu/test-queries ["ORDERS" :unaggregated :row "CREATED_AT"])
+                  :operators [{:name "<"}
+                              {:name ">"}
+                              {:name "="}
+                              {:name "≠"}]}}))
 
 (deftest ^:parallel returns-quick-filter-test-4
   (lib.drill-thru.tu/test-returns-drill
@@ -42,22 +48,25 @@
     :click-type  :cell
     :query-type  :unaggregated
     :column-name "QUANTITY"
-    :expected    {:type :drill-thru/quick-filter, :operators [{:name "<"}
-                                                              {:name ">"}
-                                                              {:name "="}
-                                                              {:name "≠"}]}}))
+    :expected    {:type      :drill-thru/quick-filter
+                  :value     (get-in lib.drill-thru.tu/test-queries ["ORDERS" :unaggregated :row "QUANTITY"])
+                  :operators [{:name "<"}
+                              {:name ">"}
+                              {:name "="}
+                              {:name "≠"}]}}))
 
-;;; FIXME quick-filter doesn't get returned for CREATED_AT column in aggregated query (#34443)
 (deftest ^:parallel returns-quick-filter-test-5
-  #_(lib.drill-thru.tu/test-returns-drill
-     {:drill-type  :drill-thru/quick-filter
-      :click-type  :cell
-      :query-type  :aggregated
-      :column-name "CREATED_AT"
-      :expected    {:type :drill-thru/quick-filter, :operators [{:name "<"}
-                                                                {:name ">"}
-                                                                {:name "="}
-                                                                {:name "≠"}]}}))
+  (lib.drill-thru.tu/test-returns-drill
+    {:drill-type  :drill-thru/quick-filter
+     :click-type  :cell
+     :query-type  :aggregated
+     :column-name "CREATED_AT"
+     :expected    {:type      :drill-thru/quick-filter
+                   :value     (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "CREATED_AT"])
+                   :operators [{:name "<"}
+                               {:name ">"}
+                               {:name "="}
+                               {:name "≠"}]}}))
 
 (deftest ^:parallel returns-quick-filter-test-6
   (lib.drill-thru.tu/test-returns-drill
@@ -65,10 +74,12 @@
     :click-type  :cell
     :query-type  :aggregated
     :column-name "count"
-    :expected    {:type :drill-thru/quick-filter, :operators [{:name "<"}
-                                                              {:name ">"}
-                                                              {:name "="}
-                                                              {:name "≠"}]}}))
+    :expected    {:type      :drill-thru/quick-filter
+                  :value     (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "count"])
+                  :operators [{:name "<"}
+                              {:name ">"}
+                              {:name "="}
+                              {:name "≠"}]}}))
 
 (deftest ^:parallel returns-quick-filter-test-7
   (lib.drill-thru.tu/test-returns-drill
@@ -76,10 +87,12 @@
     :click-type  :cell
     :query-type  :aggregated
     :column-name "sum"
-    :expected    {:type :drill-thru/quick-filter, :operators [{:name "<"}
-                                                              {:name ">"}
-                                                              {:name "="}
-                                                              {:name "≠"}]}}))
+    :expected    {:type      :drill-thru/quick-filter
+                  :value     (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "sum"])
+                  :operators [{:name "<"}
+                              {:name ">"}
+                              {:name "="}
+                              {:name "≠"}]}}))
 
 (deftest ^:parallel returns-quick-filter-test-8
   (testing "quick-filter should not return < or > for cell with no value (#34445)"
@@ -88,8 +101,10 @@
       :click-type  :cell
       :query-type  :aggregated
       :column-name "max"
-      :expected    {:type :drill-thru/quick-filter, :operators [{:name "="}
-                                                                {:name "≠"}]}})))
+      :expected    {:type      :drill-thru/quick-filter
+                    :value     :null
+                    :operators [{:name "="}
+                                {:name "≠"}]}})))
 
 (deftest ^:parallel apply-quick-filter-on-correct-level-test
   (testing "quick-filter on an aggregation should introduce an new stage (#34346)"
@@ -104,7 +119,8 @@
                                       {:name "="}
                                       {:name "≠"}]
                        :query        {:stages [{} {}]}
-                       :stage-number -1}
+                       :stage-number -1
+                       :value        1}
       :drill-args     ["="]
       :expected-query {:stages [{}
                                 {:filters [[:= {}
@@ -124,7 +140,8 @@
                                       {:name "="}
                                       {:name "≠"}]
                        :query        {:stages [{}]}
-                       :stage-number -1}
+                       :stage-number -1
+                       :value        (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "CREATED_AT"])}
       :drill-args     ["<"]
       :expected-query {:stages [{:filters [[:< {}
                                             [:field {:temporal-unit :month} (meta/id :orders :created-at)]
@@ -141,7 +158,8 @@
                        :operators    [{:name "=", :filter [:is-null {} [:field {} "max"]]}
                                       {:name "≠", :filter [:not-null {} [:field {} "max"]]}]
                        :query        {:stages [{} {}]}
-                       :stage-number -1}
+                       :stage-number -1
+                       :value        :null}
       :drill-args     ["≠"]
       :expected-query {:stages [{}
                                 {:filters [[:not-null {} [:field {} "max"]]]}]}})))

--- a/test/metabase/lib/drill_thru/quick_filter_test.cljc
+++ b/test/metabase/lib/drill_thru/quick_filter_test.cljc
@@ -98,12 +98,13 @@
       :query-type     :aggregated
       :column-name    "sum"
       :drill-type     :drill-thru/quick-filter
-      :expected       {:type       :drill-thru/quick-filter
-                       :operators  [{:name "<"}
-                                    {:name ">"}
-                                    {:name "="}
-                                    {:name "≠"}]
-                       :new-stage? true}
+      :expected       {:type         :drill-thru/quick-filter
+                       :operators    [{:name "<"}
+                                      {:name ">"}
+                                      {:name "="}
+                                      {:name "≠"}]
+                       :query        {:stages [{} {}]}
+                       :stage-number -1}
       :drill-args     ["="]
       :expected-query {:stages [{}
                                 {:filters [[:= {}
@@ -117,12 +118,13 @@
       :query-type     :aggregated
       :column-name    "CREATED_AT"
       :drill-type     :drill-thru/quick-filter
-      :expected       {:type       :drill-thru/quick-filter
-                       :operators  [{:name "<"}
-                                    {:name ">"}
-                                    {:name "="}
-                                    {:name "≠"}]
-                       :new-stage? false}
+      :expected       {:type         :drill-thru/quick-filter
+                       :operators    [{:name "<"}
+                                      {:name ">"}
+                                      {:name "="}
+                                      {:name "≠"}]
+                       :query        {:stages [{}]}
+                       :stage-number -1}
       :drill-args     ["<"]
       :expected-query {:stages [{:filters [[:< {}
                                             [:field {:temporal-unit :month} (meta/id :orders :created-at)]
@@ -135,10 +137,11 @@
       :query-type     :aggregated
       :column-name    "max"
       :drill-type     :drill-thru/quick-filter
-      :expected       {:type      :drill-thru/quick-filter
-                       :operators [{:name "=", :filter [:is-null {} [:field {} "max"]]}
-                                   {:name "≠", :filter [:not-null {} [:field {} "max"]]}]
-                       :new-stage? true}
+      :expected       {:type         :drill-thru/quick-filter
+                       :operators    [{:name "=", :filter [:is-null {} [:field {} "max"]]}
+                                      {:name "≠", :filter [:not-null {} [:field {} "max"]]}]
+                       :query        {:stages [{} {}]}
+                       :stage-number -1}
       :drill-args     ["≠"]
       :expected-query {:stages [{}
                                 {:filters [[:not-null {} [:field {} "max"]]]}]}})))

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -153,3 +153,14 @@
       (is (=? [:> {} [:aggregation {} agg-uuid] 100] pmbql-expr)))
     (testing "from pMBQL expression"
       (is (= (js->clj legacy-expr) (js->clj legacy-expr'))))))
+
+(deftest ^:parallel filter-drill-details-test
+  (testing ":value field on the filter drill"
+    (testing "returns directly for most values"
+      (is (=? 7
+              (.-value (lib.js/filter-drill-details {:value 7}))))
+      (is (=? "some string"
+              (.-value (lib.js/filter-drill-details {:value "some string"})))))
+    (testing "converts :null keyword used by drill-thrus back to JS null"
+      (is (=? nil
+              (.-value (lib.js/filter-drill-details {:value :null})))))))


### PR DESCRIPTION
See #35878 which did the same for `column-filter` drills.

This reuses the logic from that PR to include the same information on
`quick-filter` drills as well. Most quick filters are a single click,
but there are a few special cases that are more involved and require
showing a complete filtering UI.

This renames `lib.js/column-filter-drill-details` to
`lib.js/filter-drill-details` as well.
