### PR TITLE
Mapping editor update

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/LoginAttributesWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/LoginAttributesWidget.tsx
@@ -21,7 +21,7 @@ export const LoginAttributesWidget = ({
 
   const handleError = (error: boolean) => {
     if (error) {
-      setError("bad");
+      setError(t`Duplicate login attribute keys`);
     }
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/LoginAttributesWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/LoginAttributesWidget.tsx
@@ -17,13 +17,20 @@ export const LoginAttributesWidget = ({
   className,
   style,
 }: Props) => {
-  const [{ value }, , { setValue }] = useField(name);
+  const [{ value }, , { setValue, setError }] = useField(name);
+
+  const handleError = (error: boolean) => {
+    if (error) {
+      setError("bad");
+    }
+  };
 
   return (
     <FormField className={className} style={style} title={title}>
       <MappingEditor
         value={value || {}}
         onChange={setValue}
+        onError={handleError}
         addText={t`Add an attribute`}
       />
     </FormField>

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/MappingEditor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/MappingEditor.tsx
@@ -137,14 +137,14 @@ export const MappingEditor = ({
               <td className="pb1" style={{ verticalAlign: "bottom" }}>
                 {!swapKeyAndValue ? keyInput : valueInput}
               </td>
-              <td className="pb1 px1" style={{ verticalAlign: "bottom" }}>
+              <td className="pb1 px1" style={{ verticalAlign: "middle" }}>
                 {divider}
               </td>
               <td className="pb1" style={{ verticalAlign: "bottom" }}>
                 {!swapKeyAndValue ? valueInput : keyInput}
               </td>
               {canDelete && (
-                <td style={{ verticalAlign: "middle" }}>
+                <td className="pb1" style={{ verticalAlign: "bottom" }}>
                   <Button
                     leftIcon={<Icon name="close" />}
                     variant="subtle"

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/MappingEditor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/MappingEditor.tsx
@@ -2,6 +2,7 @@ import _ from "underscore";
 import { t } from "ttag";
 
 import type React from "react";
+import { useState } from "react";
 import { Button, TextInput } from "metabase/ui";
 import { Icon } from "metabase/core/components/Icon";
 
@@ -9,26 +10,30 @@ type DefaultRenderInputProps = {
   value: MappingValue;
   onChange: (val: string) => void;
   placeholder: string;
+  error?: boolean | string;
 };
 
 const DefaultRenderInput = ({
   value,
   onChange,
   placeholder,
+  error = false,
 }: DefaultRenderInputProps) => (
   <TextInput
     value={value || ""}
     placeholder={placeholder}
     onChange={e => onChange(e.target.value)}
+    error={error}
   />
 );
 
-type MappingValue = string | null;
+type MappingValue = string;
 type MappingType = Record<string, MappingValue>;
 
 interface MappingEditorProps {
   value: MappingType;
   onChange: (val: MappingType) => void;
+  onError?: (val: boolean) => void;
   className?: string;
   style?: React.CSSProperties;
   keyHeader?: JSX.Element;
@@ -44,9 +49,38 @@ interface MappingEditorProps {
   swapKeyAndValue?: boolean;
 }
 
+type Entry = {
+  key: string;
+  value: string;
+};
+
+const buildEntries = (mapping: MappingType): Entry[] =>
+  Object.entries(mapping).map(([key, value]) => ({ key, value }));
+
+const buildMapping = (entries: Entry[]): MappingType =>
+  entries.reduce((memo: MappingType, { key, value }) => {
+    if (key) {
+      memo[key] = value;
+    }
+    return memo;
+  }, {});
+
+const entryError = (entries: Entry[], key: string) =>
+  entries.filter(e => e.key === key).length > 1
+    ? t`Attribute keys must be unique`
+    : false;
+
+const hasError = (entries: Entry[]) => {
+  const entryKeys = entries.map(({ key }) => key);
+  const entrySet = new Set(entryKeys);
+
+  return entryKeys.length !== entrySet.size;
+};
+
 export const MappingEditor = ({
   value: mapping,
   onChange,
+  onError,
   className = "",
   style = {},
   keyHeader,
@@ -61,7 +95,17 @@ export const MappingEditor = ({
   addText = "Add",
   swapKeyAndValue,
 }: MappingEditorProps) => {
-  const entries = Object.entries(mapping);
+  const [entries, setEntries] = useState<Entry[]>(buildEntries(mapping));
+
+  const handleChange = (newEntries: Entry[]) => {
+    setEntries(newEntries);
+    if (onError && hasError(newEntries)) {
+      onError(hasError(newEntries));
+    } else {
+      onChange(buildMapping(newEntries));
+    }
+  };
+
   return (
     <table className={className} style={style}>
       {keyHeader || valueHeader ? (
@@ -74,34 +118,37 @@ export const MappingEditor = ({
         </thead>
       ) : null}
       <tbody>
-        {entries.map(([key, value], index) => {
+        {entries.map(({ key, value }, index) => {
           const keyInput = renderKeyInput({
             value: key,
             placeholder: keyPlaceholder,
             onChange: newKey =>
-              onChange(replaceMappingKey(mapping, key, newKey)),
+              handleChange(replaceEntryKey(entries, index, newKey)),
+            error: entryError(entries, key),
           });
           const valueInput = renderValueInput({
             value: value,
             placeholder: valuePlaceholder,
             onChange: newValue =>
-              onChange(replaceMappingValue(mapping, key, newValue)),
+              handleChange(replaceEntryValue(entries, index, newValue)),
           });
           return (
             <tr key={index}>
-              <td className="pb1">
+              <td className="pb1" style={{ verticalAlign: "bottom" }}>
                 {!swapKeyAndValue ? keyInput : valueInput}
               </td>
-              <td className="pb1 px1">{divider}</td>
-              <td className="pb1">
+              <td className="pb1 px1" style={{ verticalAlign: "bottom" }}>
+                {divider}
+              </td>
+              <td className="pb1" style={{ verticalAlign: "bottom" }}>
                 {!swapKeyAndValue ? valueInput : keyInput}
               </td>
               {canDelete && (
-                <td>
+                <td style={{ verticalAlign: "middle" }}>
                   <Button
                     leftIcon={<Icon name="close" />}
                     variant="subtle"
-                    onClick={() => onChange(removeMapping(mapping, key))}
+                    onClick={() => handleChange(removeEntry(entries, index))}
                     color={"text"}
                     data-testId="remove-mapping"
                   />
@@ -110,15 +157,14 @@ export const MappingEditor = ({
             </tr>
           );
         })}
-        {!("" in mapping) &&
-          _.every(mapping, value => value != null) &&
+        {_.every(entries, entry => entry.value !== "" && entry.key !== "") &&
           canAdd && (
             <tr>
               <td colSpan={2}>
                 <Button
                   leftIcon={<Icon name="add" />}
                   variant="subtle"
-                  onClick={() => onChange(addMapping(mapping))}
+                  onClick={() => handleChange(addEntry(entries))}
                 >
                   {addText}
                 </Button>
@@ -130,32 +176,26 @@ export const MappingEditor = ({
   );
 };
 
-const addMapping = (mappings: MappingType) => {
-  return { ...mappings, "": null };
+const addEntry = (entries: Entry[]) => {
+  return [...entries, { key: "", value: "" }];
 };
 
-const removeMapping = (mappings: MappingType, prevKey: string) => {
-  mappings = { ...mappings };
-  delete mappings[prevKey];
-  return mappings;
+const removeEntry = (entries: Entry[], index: number) => {
+  return entries.toSpliced(index, 1);
 };
 
-const replaceMappingValue = (
-  mappings: MappingType,
-  oldKey: string,
+const replaceEntryValue = (
+  entries: Entry[],
+  index: number,
   newValue: MappingValue,
 ) => {
-  return { ...mappings, [oldKey]: newValue };
+  const newEntries = [...entries];
+  newEntries[index].value = newValue;
+  return newEntries;
 };
 
-const replaceMappingKey = (
-  mappings: MappingType,
-  oldKey: string,
-  newKey: string,
-) => {
-  const newMappings: MappingType = {};
-  for (const key in mappings) {
-    newMappings[key === oldKey ? newKey : key] = mappings[key];
-  }
-  return newMappings;
+const replaceEntryKey = (entries: Entry[], index: number, newKey: string) => {
+  const newEntries = [...entries];
+  newEntries[index].key = newKey;
+  return newEntries;
 };

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/MappingEditor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/MappingEditor.tsx
@@ -67,7 +67,7 @@ const buildMapping = (entries: Entry[]): MappingType =>
 
 const entryError = (entries: Entry[], key: string) =>
   entries.filter(e => e.key === key).length > 1
-    ? t`Attribute keys must be unique`
+    ? t`Attribute keys can't have the same name`
     : false;
 
 const hasError = (entries: Entry[]) => {
@@ -181,7 +181,9 @@ const addEntry = (entries: Entry[]) => {
 };
 
 const removeEntry = (entries: Entry[], index: number) => {
-  return entries.toSpliced(index, 1);
+  const entriesCopy = [...entries];
+  entriesCopy.splice(index, 1);
+  return entriesCopy;
 };
 
 const replaceEntryValue = (

--- a/frontend/src/metabase/admin/people/forms/UserForm.unit.spec.tsx
+++ b/frontend/src/metabase/admin/people/forms/UserForm.unit.spec.tsx
@@ -230,5 +230,51 @@ describe("UserForm", () => {
         );
       });
     });
+
+    it("should should not change the order of the inputs when working with numbers (#35316)", async () => {
+      setup({
+        hasEnterprisePlugins: true,
+        initialValues: eeUser,
+      });
+
+      userEvent.click(await screen.findByText("Add an attribute"));
+
+      userEvent.type((await screen.findAllByPlaceholderText("Key"))[1], "1");
+
+      expect((await screen.findAllByPlaceholderText("Key"))[1]).toHaveValue(
+        "1",
+      );
+    });
+
+    it("should show errors messages and disable form submit when 2 login attributes have the same key (#30196)", async () => {
+      setup({
+        hasEnterprisePlugins: true,
+        initialValues: eeUser,
+      });
+
+      userEvent.click(await screen.findByText("Add an attribute"));
+
+      // We need a delay in typing into the form so that the error
+      // state is handled apropriately. Formik clears errors when you call
+      // setValue, so we need to ensure that no other setValue calls are in
+      // flight before typing the letter can causes the error.
+      await userEvent.type(
+        (
+          await screen.findAllByPlaceholderText("Key")
+        )[1],
+        "team",
+        { delay: 100 },
+      );
+
+      expect(
+        await screen.findAllByText("Attribute keys can't have the same name"),
+      ).toHaveLength(2);
+
+      await waitFor(async () =>
+        expect(
+          await screen.findByRole("button", { name: "Update" }),
+        ).toBeDisabled(),
+      );
+    });
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/35316
Closes https://github.com/metabase/metabase/issues/30196

### Description
This PR re-works the <MappingEditor /> component to not directly edit an object, but instead deconstruct the object into entries on mount, and as changes are made reconstruct the object and pass it through `onChange`. This allows us to be able to work around some of the nuances of JS objects, like the order of `Objects.Entries` not being based on insertion, and keys not being immediately overwritten when there are duplicates. Admittedly, adding state to this component doesn't feel amazing, but this does allow us to get around the 2 bugs above.

We also add an `onError` prop, which is called when 2 keys have the same value. This allows a parent component to disable the submit button in a form if needed. If no `onError` prop is passed, we simply call `onChange`

### How to verify
1. Go to Admin -> People -> Invite User. Fill out the names and email
2. Click "Add an Attribute", give it a key of "foo" and a value of "bar"
3. Click "Add an attribute" again, and give it a key of 1. The attributes should remain in the correct order (#35316)
4. Clear the 1, and type "foo". You should be prompted with an error message, and the update button should be disabled. Both attributes should remain on the screen (#30196)

### Demo
![chrome_bKrnFdq5nu](https://github.com/metabase/metabase/assets/1328979/e510a613-4db4-442f-9a3f-f4591a613d81)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
