### PR TITLE
Set embedding visual settings before initial render

### DIFF
--- a/e2e/support/helpers/e2e-embedding-helpers.js
+++ b/e2e/support/helpers/e2e-embedding-helpers.js
@@ -114,3 +114,17 @@ export function visitIframe() {
     cy.visit(iframe.src);
   });
 }
+
+/**
+ * Get page iframe body wrapped in `cy` helper
+ * @param {string} [selector]
+ */
+export function getIframeBody(selector = "iframe") {
+  return cy
+    .get(selector)
+    .its("0.contentDocument")
+    .should("exist")
+    .its("body")
+    .should("not.be.null")
+    .then(cy.wrap);
+}

--- a/e2e/test/scenarios/sharing/reproductions/26988-embedding-dynamic-settings.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/26988-embedding-dynamic-settings.cy.spec.js
@@ -1,0 +1,50 @@
+import { restore } from "e2e/support/helpers";
+import { ORDERS_ID } from "metabase-types/api/mocks/presets";
+
+describe("issue 26988", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should apply embedding settings passed in URL on load", () => {
+    cy.createDashboardWithQuestions({
+      questions: [
+        {
+          name: "Q1",
+          query: {
+            "source-table": ORDERS_ID,
+            limit: 3,
+          },
+        },
+      ],
+    }).then(({ dashboard }) => {
+      cy.request("POST", `/api/dashboard/${dashboard.id}/public_link`).then(
+        ({ body: { uuid } }) => {
+          cy.signOut();
+
+          cy.visit({
+            url: `/public/dashboard/${uuid}`,
+            qs: { enableCypressIframe: true },
+          });
+
+          // default font
+          cy.get("body").should("have.css", "font-family", `Lato, sans-serif`);
+
+          cy.wait(1000);
+
+          cy.visit({
+            url: `/public/dashboard/${uuid}`,
+            qs: { enableCypressIframe: true, font: "Oswald" },
+          });
+
+          cy.get("body").should(
+            "have.css",
+            "font-family",
+            `Oswald, sans-serif`,
+          );
+        },
+      );
+    });
+  });
+});

--- a/e2e/test/scenarios/sharing/reproductions/26988-embedding-dynamic-settings.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/26988-embedding-dynamic-settings.cy.spec.js
@@ -39,12 +39,12 @@ describeEE("issue 26988", () => {
 
     getIframeBody().should("have.css", "font-family", `Lato, sans-serif`);
 
-    cy.findByTestId("embedding-settings").findByText("Font").siblings().click();
+    cy.findByTestId("embedding-settings").findByLabelText("Font").click();
     popover().findByText("Oswald").click();
     cy.wait("@dashboard");
     getIframeBody().should("have.css", "font-family", `Oswald, sans-serif`);
 
-    cy.findByTestId("embedding-settings").findByText("Font").siblings().click();
+    cy.findByTestId("embedding-settings").findByLabelText("Font").click();
     popover().findByText("Slabo 27px").click();
     cy.wait("@dashboard");
     getIframeBody().should(

--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -10,6 +10,7 @@ import {
   leftSidebar,
   main,
   modal,
+  getIframeBody,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
@@ -1239,16 +1240,6 @@ function dragColumnHeader(el, xDistance = 50) {
       })
       .trigger("mouseup");
   });
-}
-
-function getIframeBody(selector = "iframe") {
-  return cy
-    .get(selector)
-    .its("0.contentDocument")
-    .should("exist")
-    .its("body")
-    .should("not.be.null")
-    .then(cy.wrap);
 }
 
 function openColumnSettings(columnName) {

--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -73,6 +73,8 @@ function _init(reducers, getRoutes, callback) {
 
   createTracker(store);
 
+  initializeEmbedding(store);
+
   ReactDOM.render(
     <Provider store={store} ref={ref => (root = ref)}>
       <EmotionCacheProvider>
@@ -88,8 +90,6 @@ function _init(reducers, getRoutes, callback) {
   );
 
   registerVisualizations();
-
-  initializeEmbedding(store);
 
   store.dispatch(refreshSiteSettings());
 

--- a/frontend/src/metabase/lib/browser.js
+++ b/frontend/src/metabase/lib/browser.js
@@ -7,7 +7,14 @@ function parseQueryStringOptions(s) {
     if (options[name] === "") {
       options[name] = true;
     } else if (/^(true|false|-?\d+(\.\d+)?)$/.test(options[name])) {
-      options[name] = JSON.parse(options[name]);
+      let parsed;
+
+      try {
+        parsed = JSON.parse(options[name]);
+        options[name] = parsed;
+      } catch (e) {
+        console.warn("Failed to parse queryString option", name, options[name]);
+      }
     }
   }
 

--- a/frontend/src/metabase/lib/browser.js
+++ b/frontend/src/metabase/lib/browser.js
@@ -7,14 +7,7 @@ function parseQueryStringOptions(s) {
     if (options[name] === "") {
       options[name] = true;
     } else if (/^(true|false|-?\d+(\.\d+)?)$/.test(options[name])) {
-      let parsed;
-
-      try {
-        parsed = JSON.parse(options[name]);
-        options[name] = parsed;
-      } catch (e) {
-        console.warn("Failed to parse queryString option", name, options[name]);
-      }
+      options[name] = JSON.parse(options[name]);
     }
   }
 

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -13,6 +13,13 @@ export const getScrollY = () =>
 // Cypress renders the whole app within an iframe, but we want to exlude it from this check to avoid certain components (like Nav bar) not rendering
 export const isWithinIframe = function () {
   try {
+    if (
+      isCypressActive &&
+      window.location.search.includes("enableCypressIframe=true")
+    ) {
+      return true;
+    }
+
     return !isCypressActive && window.self !== window.top;
   } catch (e) {
     return true;

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -13,13 +13,6 @@ export const getScrollY = () =>
 // Cypress renders the whole app within an iframe, but we want to exlude it from this check to avoid certain components (like Nav bar) not rendering
 export const isWithinIframe = function () {
   try {
-    if (
-      isCypressActive &&
-      window.location.search.includes("enableCypressIframe=true")
-    ) {
-      return true;
-    }
-
     return !isCypressActive && window.self !== window.top;
   } catch (e) {
     return true;

--- a/frontend/src/metabase/lib/embed.js
+++ b/frontend/src/metabase/lib/embed.js
@@ -1,6 +1,5 @@
 import { push } from "react-router-redux";
 import _ from "underscore";
-import { parseSearchOptions, parseHashOptions } from "metabase/lib/browser";
 import { isWithinIframe, IFRAMED_IN_SELF } from "metabase/lib/dom";
 import { setOptions } from "metabase/redux/embed";
 import { isFitViewportMode } from "metabase/hoc/FitViewPort";
@@ -41,12 +40,24 @@ export function initializeEmbedding(store) {
         }
       }
     });
-    store.dispatch(
-      setOptions({
-        ...parseSearchOptions(window.location.search),
-        ...parseHashOptions(window.location.hash),
-      }),
-    );
+
+    if (IS_EMBED_PREVIEW) {
+      let currentLocation;
+      store.subscribe(() => {
+        const previousLocation = currentLocation;
+        currentLocation = store.getState().routing.locationBeforeTransitions;
+
+        if (
+          previousLocation &&
+          (currentLocation.search !== previousLocation.search ||
+            currentLocation.hash !== previousLocation.hash)
+        ) {
+          store.dispatch(setOptions(currentLocation));
+        }
+      });
+    }
+
+    store.dispatch(setOptions(window.location));
   }
 }
 

--- a/frontend/src/metabase/lib/embed.js
+++ b/frontend/src/metabase/lib/embed.js
@@ -41,22 +41,6 @@ export function initializeEmbedding(store) {
       }
     });
 
-    if (IS_EMBED_PREVIEW) {
-      let currentLocation;
-      store.subscribe(() => {
-        const previousLocation = currentLocation;
-        currentLocation = store.getState().routing.locationBeforeTransitions;
-
-        if (
-          previousLocation &&
-          (currentLocation.search !== previousLocation.search ||
-            currentLocation.hash !== previousLocation.hash)
-        ) {
-          store.dispatch(setOptions(currentLocation));
-        }
-      });
-    }
-
     store.dispatch(setOptions(window.location));
   }
 }

--- a/frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx
+++ b/frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx
@@ -37,6 +37,7 @@ const DisplayOptionsPane = ({
   showDownloadDataButtonVisibilityToggle,
 }) => {
   const toggleId = useUniqueId("show-download-data-button");
+  const fontControlLabelId = useUniqueId("display-option");
 
   return (
     <div className={className}>
@@ -78,7 +79,7 @@ const DisplayOptionsPane = ({
       </DisplayOptionSection>
       {canWhitelabel && (
         <>
-          <DisplayOptionSection title={t`Font`}>
+          <DisplayOptionSection title={t`Font`} titleId={fontControlLabelId}>
             <Select
               value={displayOptions.font}
               options={[
@@ -91,6 +92,9 @@ const DisplayOptionsPane = ({
                   value: font,
                 })),
               ]}
+              buttonProps={{
+                "aria-labelledby": fontControlLabelId,
+              }}
               onChange={e => {
                 onChangeDisplayOptions({
                   ...displayOptions,
@@ -126,9 +130,9 @@ const DisplayOptionsPane = ({
   );
 };
 
-const DisplayOptionSection = ({ title, children }) => (
+const DisplayOptionSection = ({ title, titleId, children }) => (
   <DisplayOption>
-    <DisplayOptionTitle>{title}</DisplayOptionTitle>
+    <DisplayOptionTitle id={titleId}>{title}</DisplayOptionTitle>
     {children}
   </DisplayOption>
 );

--- a/frontend/src/metabase/redux/embed.ts
+++ b/frontend/src/metabase/redux/embed.ts
@@ -3,6 +3,7 @@ import {
   createAction,
   handleActions,
 } from "metabase/lib/redux";
+import { parseHashOptions, parseSearchOptions } from "metabase/lib/browser";
 
 export const DEFAULT_EMBED_OPTIONS = {
   top_nav: true,
@@ -17,7 +18,15 @@ export const DEFAULT_EMBED_OPTIONS = {
 } as const;
 
 export const SET_OPTIONS = "metabase/embed/SET_OPTIONS";
-export const setOptions = createAction(SET_OPTIONS);
+export const setOptions = createAction(
+  SET_OPTIONS,
+  ({ search, hash }: { search: string; hash: string }) => {
+    return {
+      ...parseSearchOptions(search),
+      ...parseHashOptions(hash),
+    };
+  },
+);
 
 const options = handleActions(
   {


### PR DESCRIPTION
Relates https://github.com/metabase/metabase/issues/26988

### Description

This moves embedding settings preparation to happen before the rendering. 
This way we set the state first and then render global styles and content. We avoid extra rerender and possible race conditions with font being applied to a page.

Also we add a code that should dynamically apply embedding settings to the app in "preview mode", which will be used soon in https://github.com/metabase/metabase/issues/35961

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
