### PR TITLE
Fix BE flake 36089: metabase.api.search-test/search-db-call-count-test

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -350,6 +350,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-mysql-8-0-ee'
+        test-args: ":only metabase.api.search-test/search-db-call-count-test"
 
   be-tests-mysql-latest-ee:
     needs: files-changed
@@ -388,6 +389,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-mysql-latest-ee'
+        test-args: ":only metabase.api.search-test/search-db-call-count-test"
 
   be-tests-oracle-18-4-ee:
     needs: files-changed

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -350,7 +350,6 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-mysql-8-0-ee'
-        test-args: ":only metabase.api.search-test/search-db-call-count-test"
 
   be-tests-mysql-latest-ee:
     needs: files-changed
@@ -389,7 +388,6 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-mysql-latest-ee'
-        test-args: ":only metabase.api.search-test/search-db-call-count-test"
 
   be-tests-oracle-18-4-ee:
     needs: files-changed

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -819,7 +819,7 @@
         ;; the call count number here are expected to change if we change the search api
         ;; we have this test here just to keep tracks this number to remind us to put effort
         ;; into keep this number as low as we can
-         (is (= 11 (call-count))))))))
+         (is (= 9 (call-count))))))))
 
 (deftest snowplow-new-search-query-event-test
   (testing "Send a snowplow event when a search query is triggered and context is passed"

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -779,41 +779,42 @@
               (is (= nil (search-for-pulses pulse))))))))))
 
 (deftest search-db-call-count-test
-  (t2.with-temp/with-temp
-    [Card      _              {:name "card db count test 1"}
-     Card      _              {:name "card db count test 2"}
-     Card      _              {:name "card db count test 3"}
-     Dashboard _              {:name "dash count test 1"}
-     Dashboard _              {:name "dash count test 2"}
-     Dashboard _              {:name "dash count test 3"}
-     Database  {db-id :id}    {:name "database count test 1"}
-     Database  _              {:name "database count test 2"}
-     Database  _              {:name "database count test 3"}
-     Table     {table-id :id} {:db_id  db-id
-                               :schema nil}
-     Metric    _              {:table_id table-id
-                               :name     "metric count test 1"}
-     Metric    _              {:table_id table-id
-                               :name     "metric count test 1"}
-     Metric    _              {:table_id table-id
-                               :name     "metric count test 2"}
-     Segment   _              {:table_id table-id
-                               :name     "segment count test 1"}
-     Segment   _              {:table_id table-id
-                               :name     "segment count test 2"}
-     Segment   _              {:table_id table-id
-                               :name     "segment count test 3"}]
-    (mt/with-current-user (mt/user->id :crowberto)
-      (t2.execute/with-call-count [call-count]
-        (#'api.search/search {:search-string      "count test"
-                              :archived?          false
-                              :models             search.config/all-models
-                              :current-user-perms #{"/"}
-                              :limit-int          100})
+  (dotimes [_ 20]
+   (t2.with-temp/with-temp
+     [Card      _              {:name "card db count test 1"}
+      Card      _              {:name "card db count test 2"}
+      Card      _              {:name "card db count test 3"}
+      Dashboard _              {:name "dash count test 1"}
+      Dashboard _              {:name "dash count test 2"}
+      Dashboard _              {:name "dash count test 3"}
+      Database  {db-id :id}    {:name "database count test 1"}
+      Database  _              {:name "database count test 2"}
+      Database  _              {:name "database count test 3"}
+      Table     {table-id :id} {:db_id  db-id
+                                :schema nil}
+      Metric    _              {:table_id table-id
+                                :name     "metric count test 1"}
+      Metric    _              {:table_id table-id
+                                :name     "metric count test 1"}
+      Metric    _              {:table_id table-id
+                                :name     "metric count test 2"}
+      Segment   _              {:table_id table-id
+                                :name     "segment count test 1"}
+      Segment   _              {:table_id table-id
+                                :name     "segment count test 2"}
+      Segment   _              {:table_id table-id
+                                :name     "segment count test 3"}]
+     (mt/with-current-user (mt/user->id :crowberto)
+       (t2.execute/with-call-count [call-count]
+         (#'api.search/search {:search-string      "count test"
+                               :archived?          false
+                               :models             search.config/all-models
+                               :current-user-perms #{"/"}
+                               :limit-int          100})
         ;; the call count number here are expected to change if we change the search api
         ;; we have this test here just to keep tracks this number to remind us to put effort
         ;; into keep this number as low as we can
-        (is (= 11 (call-count)))))))
+         (is (= 11 (call-count))))))))
 
 (deftest snowplow-new-search-query-event-test
   (testing "Send a snowplow event when a search query is triggered and context is passed"

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -779,47 +779,48 @@
 
 (deftest search-db-call-count-test
   (dotimes [_ 20]
-   (t2.with-temp/with-temp
-     [Card      _              {:name "card db count test 1"}
-      Card      _              {:name "card db count test 2"}
-      Card      _              {:name "card db count test 3"}
-      Dashboard _              {:name "dash count test 1"}
-      Dashboard _              {:name "dash count test 2"}
-      Dashboard _              {:name "dash count test 3"}
-      Database  {db-id :id}    {:name "database count test 1"}
-      Database  _              {:name "database count test 2"}
-      Database  _              {:name "database count test 3"}
-      Table     {table-id :id} {:db_id  db-id
-                                :schema nil}
-      Metric    _              {:table_id table-id
-                                :name     "metric count test 1"}
-      Metric    _              {:table_id table-id
-                                :name     "metric count test 1"}
-      Metric    _              {:table_id table-id
-                                :name     "metric count test 2"}
-      Segment   _              {:table_id table-id
-                                :name     "segment count test 1"}
-      Segment   _              {:table_id table-id
-                                :name     "segment count test 2"}
-      Segment   _              {:table_id table-id
-                                :name     "segment count test 3"}]
-     (mt/with-current-user (mt/user->id :crowberto)
-       ;; try warming it up
-       (#'api.search/search {:search-string      "count test"
-                             :archived?          false
-                             :models             search.config/all-models
-                             :current-user-perms #{"/"}
-                             :limit-int          100})
-       (t2/with-call-count [call-count]
-         (#'api.search/search {:search-string      "count test"
-                               :archived?          false
-                               :models             search.config/all-models
-                               :current-user-perms #{"/"}
-                               :limit-int          100})
+    (let [search-string (mt/random-name)]
+      (t2.with-temp/with-temp
+        [Card      _              {:name (str "card db 1 " search-string)}
+         Card      _              {:name (str "card db 2 " search-string)}
+         Card      _              {:name (str "card db 3 " search-string)}
+         Dashboard _              {:name (str "dash 1 " search-string)}
+         Dashboard _              {:name (str "dash 2 " search-string)}
+         Dashboard _              {:name (str "dash 3 " search-string)}
+         Database  {db-id :id}    {:name (str "database 1 " search-string)}
+         Database  _              {:name (str "database 2 " search-string)}
+         Database  _              {:name (str "database 3 " search-string)}
+         Table     {table-id :id} {:db_id  db-id
+                                   :schema nil}
+         Metric    _              {:table_id table-id
+                                   :name     (str "metric 1 " search-string)}
+         Metric    _              {:table_id table-id
+                                   :name     (str "metric 1 " search-string)}
+         Metric    _              {:table_id table-id
+                                   :name     (str "metric 2 " search-string)}
+         Segment   _              {:table_id table-id
+                                   :name     (str "segment 1 " search-string)}
+         Segment   _              {:table_id table-id
+                                   :name     (str "segment 2 " search-string)}
+         Segment   _              {:table_id table-id
+                                   :name     (str "segment 3 " search-string)}]
+        (mt/with-current-user (mt/user->id :crowberto)
+       ;; try warming it up, just to make sure there's no caching
+          (#'api.search/search {:search-string      search-string
+                                :archived?          false
+                                :models             search.config/all-models
+                                :current-user-perms #{"/"}
+                                :limit-int          100})
+          (t2/with-call-count [call-count]
+            (#'api.search/search {:search-string      search-string
+                                  :archived?          false
+                                  :models             search.config/all-models
+                                  :current-user-perms #{"/"}
+                                  :limit-int          100})
         ;; the call count number here are expected to change if we change the search api
         ;; we have this test here just to keep tracks this number to remind us to put effort
         ;; into keep this number as low as we can
-         (is (= 9 (call-count))))))))
+            (is (= 11 (call-count)))))))))
 
 (deftest snowplow-new-search-query-event-test
   (testing "Send a snowplow event when a search query is triggered and context is passed"

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -24,7 +24,6 @@
    [metabase.test :as mt]
    [metabase.util :as u]
    [toucan2.core :as t2]
-   [toucan2.execute :as t2.execute]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
 (defn- ordered-subset?
@@ -805,7 +804,13 @@
       Segment   _              {:table_id table-id
                                 :name     "segment count test 3"}]
      (mt/with-current-user (mt/user->id :crowberto)
-       (t2.execute/with-call-count [call-count]
+       ;; try warming it up
+       (#'api.search/search {:search-string      "count test"
+                             :archived?          false
+                             :models             search.config/all-models
+                             :current-user-perms #{"/"}
+                             :limit-int          100})
+       (t2/with-call-count [call-count]
          (#'api.search/search {:search-string      "count test"
                                :archived?          false
                                :models             search.config/all-models


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/36089

The problem was there could be other objects in the database that matched the search query, depending on the order that the tests were run.

I stress tested this on this commit [c76bc03](https://github.com/metabase/metabase/actions/runs/6983209131/job/19003936431?pr=36100), running the test 20 times for each driver.