### PR TITLE
QueryBuilder and SQL questions: hide Explore results with parameters

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -1250,6 +1250,21 @@ class Question {
   }
 
   /**
+   * We can only "explore results" (i.e. create new questions based on this one)
+   * when question is a native query, which is saved, has no parameters
+   * and satisfies other conditionals below.
+   */
+  canExploreResults() {
+    return (
+      this.isNative() &&
+      this.isSaved() &&
+      this.parameters().length === 0 &&
+      this.query().canNest() &&
+      !this.query().readOnly() // originally "canRunAdhocQuery"
+    );
+  }
+
+  /**
    * TODO Atte Keinänen 6/13/17: Discussed with Tom that we could use the default Question constructor instead,
    * but it would require changing the constructor signature so that `card` is an optional parameter and has a default value
    */

--- a/frontend/src/metabase-lib/queries/AtomicQuery.ts
+++ b/frontend/src/metabase-lib/queries/AtomicQuery.ts
@@ -34,7 +34,7 @@ export default class AtomicQuery extends Query {
     return null;
   }
 
-  canNest() {
-    return this.database()?.hasFeature("nested-queries");
+  canNest(): boolean {
+    return Boolean(this.database()?.hasFeature("nested-queries"));
   }
 }

--- a/frontend/src/metabase-lib/question.unit.spec.ts
+++ b/frontend/src/metabase-lib/question.unit.spec.ts
@@ -8,6 +8,8 @@ import { createMockMetadata } from "__support__/metadata";
 import {
   createMockCard,
   createMockNativeDatasetQuery,
+  createMockParameter,
+  createMockTemplateTag,
 } from "metabase-types/api/mocks";
 import Question from "./Question";
 
@@ -33,23 +35,20 @@ describe("Question.canExploreResults", () => {
         native: {
           query: "select * from order where id > {{min_id}}",
           "template-tags": {
-            min_id: {
+            min_id: createMockTemplateTag({
               type: "text",
               name: "min_id",
-              id: "uuid",
               "display-name": "Min ID",
-            },
+            }),
           },
         },
       }),
       parameters: [
-        {
-          id: "uuid",
-          type: "category",
-          // target: ["variable", ["template-tag", "min_id"]],
+        createMockParameter({
           name: "Min ID",
           slug: "min_id",
-        },
+          type: "category",
+        }),
       ],
     });
     const q = new Question(card, metadata);

--- a/frontend/src/metabase-lib/question.unit.spec.ts
+++ b/frontend/src/metabase-lib/question.unit.spec.ts
@@ -1,0 +1,79 @@
+import {
+  createAdHocNativeCard,
+  createSampleDatabase,
+  createSavedStructuredCard,
+  createSavedNativeCard,
+} from "metabase-types/api/mocks/presets";
+import { createMockMetadata } from "__support__/metadata";
+import {
+  createMockCard,
+  createMockNativeDatasetQuery,
+} from "metabase-types/api/mocks";
+import Question from "./Question";
+
+describe("Question.canExploreResults", () => {
+  const metadata = createMockMetadata({
+    databases: [createSampleDatabase()],
+  });
+
+  it("should be false if not native", () => {
+    const q = new Question(createSavedStructuredCard(), metadata);
+    expect(q.canExploreResults()).toBe(false);
+  });
+
+  it("should be false when not saved", () => {
+    const q = new Question(createAdHocNativeCard(), metadata);
+    expect(q.canExploreResults()).toBe(false);
+  });
+
+  it("should be false with parameters", () => {
+    const card = createMockCard({
+      dataset_query: createMockNativeDatasetQuery({
+        type: "native",
+        native: {
+          query: "select * from order where id > {{min_id}}",
+          "template-tags": {
+            min_id: {
+              type: "text",
+              name: "min_id",
+              id: "uuid",
+              "display-name": "Min ID",
+            },
+          },
+        },
+      }),
+      parameters: [
+        {
+          id: "uuid",
+          type: "category",
+          // target: ["variable", ["template-tag", "min_id"]],
+          name: "Min ID",
+          slug: "min_id",
+        },
+      ],
+    });
+    const q = new Question(card, metadata);
+    expect(q.canExploreResults()).toBe(false);
+  });
+
+  it("should be false when not canNest", () => {
+    const metadata = createMockMetadata({
+      databases: [createSampleDatabase({ features: [] })],
+    });
+    const q = new Question(createSavedNativeCard(), metadata);
+    expect(q.canExploreResults()).toBe(false);
+  });
+
+  it("should be false when is readOnly", () => {
+    const metadata = createMockMetadata({
+      databases: [createSampleDatabase({ native_permissions: "none" })],
+    });
+    const q = new Question(createSavedNativeCard(), metadata);
+    expect(q.canExploreResults()).toBe(false);
+  });
+
+  it("should be true", () => {
+    const q = new Question(createSavedNativeCard(), metadata);
+    expect(q.canExploreResults()).toBe(true);
+  });
+});

--- a/frontend/src/metabase/query_builder/components/view/ExploreResultsLink.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ExploreResultsLink.tsx
@@ -4,11 +4,11 @@ import ViewButton from "metabase/query_builder/components/view/ViewButton";
 import type Question from "metabase-lib/Question";
 import { getUrl as ML_getUrl } from "metabase-lib/urls";
 
-type Props = {
+interface ExploreResultsLinkProps {
   question: Question;
-};
+}
 
-export function ExploreResultsLink({ question }: Props) {
+export function ExploreResultsLink({ question }: ExploreResultsLinkProps) {
   const query = question.composeThisQuery();
   const button = (
     <ViewButton disabled={!query} medium icon="insight" labelBreakpoint="sm">

--- a/frontend/src/metabase/query_builder/components/view/ExploreResultsLink.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ExploreResultsLink.tsx
@@ -1,0 +1,25 @@
+import { t } from "ttag";
+import Link from "metabase/core/components/Link";
+import ViewButton from "metabase/query_builder/components/view/ViewButton";
+import type Question from "metabase-lib/Question";
+import { getUrl as ML_getUrl } from "metabase-lib/urls";
+
+type Props = {
+  question: Question;
+};
+
+export function ExploreResultsLink({ question }: Props) {
+  const query = question.composeThisQuery();
+  const button = (
+    <ViewButton disabled={!query} medium icon="insight" labelBreakpoint="sm">
+      {t`Explore results`}
+    </ViewButton>
+  );
+
+  if (query) {
+    const url = ML_getUrl(query.setDisplay("table").setSettings({}));
+    return <Link to={url}>{button}</Link>;
+  }
+
+  return button;
+}

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -11,14 +11,13 @@ import { useToggle } from "metabase/hooks/use-toggle";
 import Link from "metabase/core/components/Link";
 import Tooltip from "metabase/core/components/Tooltip";
 
-import ViewButton from "metabase/query_builder/components/view/ViewButton";
 import SavedQuestionHeaderButton from "metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton";
 
 import { navigateBackToDashboard } from "metabase/query_builder/actions";
 import { MODAL_TYPES } from "metabase/query_builder/constants";
 import { getDashboard } from "metabase/query_builder/selectors";
-import * as ML_Urls from "metabase-lib/urls";
 import QuestionActions from "../QuestionActions";
+import { ExploreResultsLink } from "./ExploreResultsLink";
 import { FilterHeaderButton } from "./FilterHeaderButton";
 import { HeadBreadcrumbs } from "./HeaderBreadcrumbs";
 import QuestionDataSource from "./QuestionDataSource";
@@ -390,7 +389,6 @@ function ViewTitleHeaderRightSide(props) {
     toggleBookmark,
     isSaved,
     isDataset,
-    isNative,
     isRunnable,
     isRunning,
     isNativeEditorOpen,
@@ -414,19 +412,12 @@ function ViewTitleHeaderRightSide(props) {
     onModelPersistenceChange,
   } = props;
   const isShowingNotebook = queryBuilderMode === "notebook";
-  const query = question.query();
-  const isReadOnlyQuery = query.readOnly();
-  const canEditQuery = !isReadOnlyQuery;
-  const canRunAdhocQueries = !isReadOnlyQuery;
-  const canNest = query.canNest();
+  const canEditQuery = !question.query().readOnly();
   const hasExploreResultsLink =
-    isNative &&
-    canNest &&
-    isSaved &&
-    canRunAdhocQueries &&
+    question.canExploreResults() &&
     MetabaseSettings.get("enable-nested-queries");
 
-  const isNewQuery = !query.hasData();
+  const isNewQuery = !question.query().hasData();
   const hasSaveButton =
     !isDataset &&
     !!isDirty &&
@@ -511,6 +502,7 @@ function ViewTitleHeaderRightSide(props) {
           />
         </ViewHeaderIconButtonContainer>
       )}
+      {/* TODO(oleggromov) remove divider when nothing else is shown to the left */}
       {isSaved && (
         <QuestionActions
           isShowingQuestionInfoSidebar={isShowingQuestionInfoSidebar}
@@ -544,24 +536,6 @@ function ViewTitleHeaderRightSide(props) {
         </SaveButton>
       )}
     </ViewHeaderActionPanel>
-  );
-}
-
-ExploreResultsLink.propTypes = {
-  question: PropTypes.object.isRequired,
-};
-
-function ExploreResultsLink({ question }) {
-  const url = ML_Urls.getUrl(
-    question.composeThisQuery().setDisplay("table").setSettings({}),
-  );
-
-  return (
-    <Link to={url}>
-      <ViewButton medium p={[2, 1]} icon="insight" labelBreakpoint="sm">
-        {t`Explore results`}
-      </ViewButton>
-    </Link>
   );
 }
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/35476

### Description
Sometimes SQL-based questions could be used a data source for GUI questions, which is done by clicking "Explore results".

This is only possible though when a few conditions are met, and the missing one was that the question must have exactly 0 parameters (as per issue). 

This PR fixes it and does a bit of housekeeping. 

### How to verify

1. Create an SQL question without parameters, click save - you should see the "Explore results" button
2. Now add a parameter, for instance, `select * from orders where product_id = {{product_id}}`, click "Save" - the button must not show
3. There's a known bug: https://github.com/metabase/metabase/issues/36104 (see the last comment, there's a link to the one that supercedes it) 

### Demo

https://github.com/metabase/metabase/assets/2196347/c1d0da47-b8f8-436f-a001-56bb6016a01e

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
