### PR TITLE
Handle CVE in commons-compress and org.json/json

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -99,8 +99,8 @@
   net.sf.cssbox/cssbox                      {:mvn/version "5.0.1"               ; HTML / CSS rendering
                                              :exclusions  [org.slf4j/slf4j-api]}
   net.thisptr/jackson-jq                    {:mvn/version "1.0.0-preview.20230409"} ; Java implementation of the JQ json query language
-  org.apache.commons/commons-compress       {:mvn/version "1.23.0"}             ; compression utils
-  org.apache.commons/commons-lang3          {:mvn/version "3.13.0"}             ; helper methods for working with java.lang stuff
+  org.apache.commons/commons-compress       {:mvn/version "1.25.0"}             ; compression utils
+  org.apache.commons/commons-lang3          {:mvn/version "3.14.0"}             ; helper methods for working with java.lang stuff
   org.apache.logging.log4j/log4j-1.2-api    {:mvn/version "2.20.0"}             ; apache logging framework
   org.apache.logging.log4j/log4j-api        {:mvn/version "2.20.0"}             ; add compatibility with log4j 1.2
   org.apache.logging.log4j/log4j-core       {:mvn/version "2.20.0"}             ; apache logging framework

--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -3,6 +3,6 @@
 
  :deps
  ;; TODO: figure out how to be able to leave off this version string and use the version from the BOM
- {com.google.cloud/google-cloud-bigquery      {:mvn/version "2.31.1"}
+ {com.google.cloud/google-cloud-bigquery      {:mvn/version "2.34.2"}
   com.google.code.gson/gson                   {:mvn/version "2.10.1"}
   com.google.oauth-client/google-oauth-client {:mvn/version "1.34.1"}}}


### PR DESCRIPTION
Github has [two complaints](https://github.com/metabase/metabase/security/code-scanning) for us
<img width="703" alt="image" src="https://github.com/metabase/metabase/assets/6553/a7cc9424-3d8d-4fad-a8be-976e46cb9578">
