### PR TITLE
Bug fix: remove divider in QueryBuilder/ViewHeader when it's not needed

### DIFF
--- a/frontend/src/metabase/query_builder/components/QuestionActions.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.styled.tsx
@@ -7,6 +7,10 @@ export const QuestionActionsDivider = styled.div`
   margin-left: 0.5rem;
   margin-right: 0.5rem;
   height: 1.25rem;
+
+  &:first-child {
+    display: none;
+  }
 `;
 
 export const StrengthIndicator = styled(DatasetMetadataStrengthIndicator)`

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -502,7 +502,6 @@ function ViewTitleHeaderRightSide(props) {
           />
         </ViewHeaderIconButtonContainer>
       )}
-      {/* TODO(oleggromov) remove divider when nothing else is shown to the left */}
       {isSaved && (
         <QuestionActions
           isShowingQuestionInfoSidebar={isShowingQuestionInfoSidebar}


### PR DESCRIPTION
### Description
There's a tiny issue with the header actions panel: when we don't have anything to the left from the action buttons, the divider is just dangling out there.

Before | After
---|---
<img width="758" alt="Screenshot 2023-11-27 at 14 10 52" src="https://github.com/metabase/metabase/assets/2196347/6ac53cdf-c76a-4eb7-8426-46cca59c4219"> | <img width="745" alt="Screenshot 2023-11-27 at 14 09 31" src="https://github.com/metabase/metabase/assets/2196347/ca72b1f5-7bd2-4e20-94bb-28edaee5dc21">

### How to verify

1. Create a new SQL question
2. Save it
3. You should see the "Explore results" button **and** a divider, which is correct
4. Add a parameter to it (`where id = {{id}}`) and you should see no button and no divider

### Tests
I don't think it's worth testing in an automated way.