### PR TITLE
Emotion: suppress SSR warnings

### DIFF
--- a/frontend/src/metabase/styled-components/components/EmotionCacheProvider/EmotionCacheProvider.tsx
+++ b/frontend/src/metabase/styled-components/components/EmotionCacheProvider/EmotionCacheProvider.tsx
@@ -14,6 +14,7 @@ export const EmotionCacheProvider = ({
     () => createCache({ key: "emotion", nonce: window.MetabaseNonce }),
     [],
   );
+  emotionCache.compat = true;
 
   return <CacheProvider value={emotionCache}>{children}</CacheProvider>;
 };

--- a/frontend/src/metabase/styled-components/components/EmotionCacheProvider/EmotionCacheProvider.tsx
+++ b/frontend/src/metabase/styled-components/components/EmotionCacheProvider/EmotionCacheProvider.tsx
@@ -10,11 +10,13 @@ interface EmotionCacheProviderProps {
 export const EmotionCacheProvider = ({
   children,
 }: EmotionCacheProviderProps) => {
-  const emotionCache = useMemo(
-    () => createCache({ key: "emotion", nonce: window.MetabaseNonce }),
-    [],
-  );
-  emotionCache.compat = true;
+  const emotionCache = useMemo(() => {
+    const cache = createCache({ key: "emotion", nonce: window.MetabaseNonce });
+    // This disables :first-child not working in SSR warnings
+    // Source: https://github.com/emotion-js/emotion/issues/1105#issuecomment-557726922
+    cache.compat = true;
+    return cache;
+  }, []);
 
   return <CacheProvider value={emotionCache}>{children}</CacheProvider>;
 };


### PR DESCRIPTION
### Description
While working on the https://github.com/metabase/metabase/pull/36128, we realised that emotion spits out useless warnings about `:first-child` being unsafe in SSR environments, which, I believe, we won't do. 

### How to verify
1. Create an SQL question
2. Open chrome dev tools, see the console tab
3. On master, you should see the `first-child` warning from emotion - on this branch, you shouldn't.

<img width="914" alt="Screenshot 2023-11-27 at 16 51 55" src="https://github.com/metabase/metabase/assets/2196347/186f5bbc-de3d-41ae-8ab5-0da609d90598">
