### PR TITLE
skip milestone check if docs PR

### DIFF
--- a/.github/workflows/check-milestone.yml
+++ b/.github/workflows/check-milestone.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   milestone-reminder:
-    if: github.event.pull_request.merged == true
+    if: |
+      github.event.pull_request.merged == true &&
+      github.event.label.name != 'Type:Documentation'
     name: Remind to set milestone
     runs-on: ubuntu-22.04
     timeout-minutes: 5


### PR DESCRIPTION
Updates milestone check to skip if the PR has the `Type:Documentation` label.