### PR TITLE
Disable autofocus on SettingsSAMLForm

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm/SettingsSAMLForm.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm/SettingsSAMLForm.jsx
@@ -131,7 +131,6 @@ const SettingsSAMLForm = ({ elements = [], settingValues = {}, onSubmit }) => {
                 label={t`SAML Identity Provider URL`}
                 placeholder="https://your-org-name.yourIDP.com"
                 required
-                autoFocus
               />
               <FormTextarea
                 {...fields["saml-identity-provider-certificate"]}

--- a/enterprise/frontend/src/metabase-enterprise/auth/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/auth/index.js
@@ -91,7 +91,6 @@ PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections => ({
         placeholder: "https://example.com/app/my_saml_app/abc123/sso/saml",
         type: "string",
         required: true,
-        autoFocus: true,
       },
       {
         key: "saml-identity-provider-issuer",


### PR DESCRIPTION
From [slack](https://metaboat.slack.com/archives/C064EB1UE5P/p1701114094431349?thread_ts=1701109360.591559&cid=C064EB1UE5P):

> Q: If you go to Settings -> Authentication -> SAML -> "Set up" it auto focuses an input that's in the middle of the page, do you know if that's intentional? For some users it could even scroll the page (see video in replies)

> A: I think it was intentional to focus on this field when this page was first designed, but we redesigned this page on v44 (maybe) and it looks like a bug. We should just go to that page normally


