### PR TITLE
Update audit yamls new keyorder (with index migration fix)

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -13,6 +13,7 @@ import {
   popover,
   restore,
   saveDashboard,
+  setTokenFeatures,
   updateDashboardCards,
   visitDashboard,
   visitEmbeddedPage,
@@ -46,11 +47,10 @@ const COLUMN_INDEX = {
   COUNT: 1,
 };
 
-const FIRST_TAB = { id: 1, name: "first" };
-const FIRST_TAB_SLUG = `${FIRST_TAB.id}-${FIRST_TAB.name}`;
-const SECOND_TAB = { id: 2, name: "second" };
-const SECOND_TAB_SLUG = `${SECOND_TAB.id}-${SECOND_TAB.name}`;
-const THIRD_TAB = { id: 3, name: "third" };
+// these ids aren't real, but you have to provide unique ids 🙄
+const FIRST_TAB = { id: 900, name: "first" };
+const SECOND_TAB = { id: 901, name: "second" };
+const THIRD_TAB = { id: 902, name: "third" };
 
 const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
 
@@ -129,6 +129,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
+    setTokenFeatures("all");
   });
 
   describe("dashcards without click behavior", () => {
@@ -298,22 +299,28 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
     });
 
     it("allows setting dashboard tab with parameter as custom destination", () => {
-      cy.createDashboard(
-        {
-          ...TARGET_DASHBOARD,
-          parameters: [DASHBOARD_FILTER_TEXT],
-        },
-        {
-          wrapId: true,
-          idAlias: "targetDashboardId",
-        },
-      );
-      cy.get("@targetDashboardId").then(targetDashboardId => {
-        cy.request("PUT", `/api/dashboard/${targetDashboardId}/cards`, {
-          cards: [],
-          tabs: [FIRST_TAB, SECOND_TAB, THIRD_TAB],
+      const dashboard = {
+        ...TARGET_DASHBOARD,
+        parameters: [DASHBOARD_FILTER_TEXT],
+      };
+
+      const tabs = [FIRST_TAB, SECOND_TAB, THIRD_TAB];
+
+      const options = {
+        wrapId: true,
+        idAlias: "targetDashboardId",
+      };
+
+      createDashboardWithTabs({ dashboard, tabs, options });
+
+      const TAB_SLUG_MAP = {};
+
+      tabs.forEach(tab => {
+        cy.get(`@${tab.name}-id`).then(tabId => {
+          TAB_SLUG_MAP[tab.name] = `${tabId}-${tab.name}`;
         });
       });
+
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: card }) => {
           visitDashboard(card.dashboard_id);
@@ -344,22 +351,31 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         cy.location().should(({ pathname, search }) => {
           expect(pathname).to.equal(`/dashboard/${targetDashboardId}`);
           expect(search).to.equal(
-            `?tab=${SECOND_TAB_SLUG}&${DASHBOARD_FILTER_TEXT.slug}=${POINT_COUNT}`,
+            `?tab=${TAB_SLUG_MAP[SECOND_TAB.name]}&${
+              DASHBOARD_FILTER_TEXT.slug
+            }=${POINT_COUNT}`,
           );
         });
       });
     });
 
     it("should show error and disable the form after target dashboard tab has been removed and there is more than 1 tab left", () => {
-      cy.createDashboard(TARGET_DASHBOARD, {
+      const options = {
         wrapId: true,
         idAlias: "targetDashboardId",
-      });
-      cy.get("@targetDashboardId").then(targetDashboardId => {
-        cy.request("PUT", `/api/dashboard/${targetDashboardId}/cards`, {
-          cards: [],
-          tabs: [FIRST_TAB, SECOND_TAB, THIRD_TAB],
+      };
+      const tabs = [FIRST_TAB, SECOND_TAB, THIRD_TAB];
+
+      createDashboardWithTabs({ dashboard: TARGET_DASHBOARD, tabs, options });
+
+      const TAB_SLUG_MAP = {};
+      tabs.forEach(tab => {
+        cy.get(`@${tab.name}-id`).then(tabId => {
+          TAB_SLUG_MAP[tab.name] = `${tabId}-${tab.name}`;
         });
+      });
+
+      cy.get("@targetDashboardId").then(targetDashboardId => {
         const inexistingTabId = 999;
         const cardDetails = {
           visualization_settings: {
@@ -405,7 +421,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       cy.get("@targetDashboardId").then(targetDashboardId => {
         cy.location().should(({ pathname, search }) => {
           expect(pathname).to.equal(`/dashboard/${targetDashboardId}`);
-          expect(search).to.equal(`?tab=${SECOND_TAB_SLUG}`);
+          expect(search).to.equal(`?tab=${TAB_SLUG_MAP[SECOND_TAB.name]}`);
         });
       });
     });
@@ -454,15 +470,23 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
     });
 
     it("dashboard click behavior works without tabId previously saved", () => {
-      cy.createDashboard(TARGET_DASHBOARD, {
+      const tabs = [FIRST_TAB, SECOND_TAB, THIRD_TAB];
+
+      const options = {
         wrapId: true,
         idAlias: "targetDashboardId",
-      });
-      cy.get("@targetDashboardId").then(targetDashboardId => {
-        cy.request("PUT", `/api/dashboard/${targetDashboardId}/cards`, {
-          cards: [],
-          tabs: [FIRST_TAB, SECOND_TAB, THIRD_TAB],
+      };
+
+      createDashboardWithTabs({ dashboard: TARGET_DASHBOARD, tabs, options });
+
+      const TAB_SLUG_MAP = {};
+      tabs.forEach(tab => {
+        cy.get(`@${tab.name}-id`).then(tabId => {
+          TAB_SLUG_MAP[tab.name] = `${tabId}-${tab.name}`;
         });
+      });
+
+      cy.get("@targetDashboardId").then(targetDashboardId => {
         const cardDetails = {
           visualization_settings: {
             click_behavior: {
@@ -498,7 +522,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       cy.get("@targetDashboardId").then(targetDashboardId => {
         cy.location().should(({ pathname, search }) => {
           expect(pathname).to.equal(`/dashboard/${targetDashboardId}`);
-          expect(search).to.equal(`?tab=${FIRST_TAB_SLUG}`);
+          expect(search).to.equal(`?tab=${TAB_SLUG_MAP[FIRST_TAB.name]}`);
         });
       });
     });
@@ -1057,22 +1081,28 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
 
     it("should allow setting dashboard tab with parameter for a column", () => {
       cy.createQuestion(TARGET_QUESTION);
-      cy.createDashboard(
-        {
-          ...TARGET_DASHBOARD,
-          parameters: [DASHBOARD_FILTER_TEXT, DASHBOARD_FILTER_TIME],
-        },
-        {
-          wrapId: true,
-          idAlias: "targetDashboardId",
-        },
-      );
-      cy.get("@targetDashboardId").then(targetDashboardId => {
-        cy.request("PUT", `/api/dashboard/${targetDashboardId}/cards`, {
-          cards: [],
-          tabs: [FIRST_TAB, SECOND_TAB, THIRD_TAB],
+
+      const dashboard = {
+        ...TARGET_DASHBOARD,
+        parameters: [DASHBOARD_FILTER_TEXT, DASHBOARD_FILTER_TIME],
+      };
+
+      const tabs = [FIRST_TAB, SECOND_TAB, THIRD_TAB];
+
+      const options = {
+        wrapId: true,
+        idAlias: "targetDashboardId",
+      };
+
+      createDashboardWithTabs({ dashboard, tabs, options });
+
+      const TAB_SLUG_MAP = {};
+      tabs.forEach(tab => {
+        cy.get(`@${tab.name}-id`).then(tabId => {
+          TAB_SLUG_MAP[tab.name] = `${tabId}-${tab.name}`;
         });
       });
+
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: card }) => {
           visitDashboard(card.dashboard_id);
@@ -1112,7 +1142,9 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         cy.location().should(({ pathname, search }) => {
           expect(pathname).to.equal(`/dashboard/${targetDashboardId}`);
           expect(search).to.equal(
-            `?tab=${SECOND_TAB_SLUG}&${DASHBOARD_FILTER_TEXT.slug}=${POINT_COUNT}&${DASHBOARD_FILTER_TIME.slug}=`,
+            `?tab=${TAB_SLUG_MAP[SECOND_TAB.name]}&${
+              DASHBOARD_FILTER_TEXT.slug
+            }=${POINT_COUNT}&${DASHBOARD_FILTER_TIME.slug}=`,
           );
         });
       });
@@ -1622,4 +1654,23 @@ const getCountToDashboardFilterMapping = () => {
     .findByText(
       getBrokenUpTextMatcher(`${COUNT_COLUMN_NAME} updates 1 filter`),
     );
+};
+
+const createDashboardWithTabs = ({ dashboard, tabs, options }) => {
+  cy.createDashboard(dashboard, options);
+
+  cy.get(`@${options.idAlias}`)
+    .then(dashboardId => {
+      cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
+        cards: [],
+        tabs,
+      });
+    })
+    .then(({ body }) => {
+      // wrap tabs
+
+      body.tabs.forEach(tab => {
+        cy.wrap(tab.id).as(`${tab.name}-id`);
+      });
+    });
 };

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -62,7 +62,7 @@ describe("scenarios > dashboard > tabs", () => {
       cy.findByText("Orders, Count").click();
     });
     saveDashboard();
-    cy.url().should("include", "2-tab-2");
+    cy.url().should("match", /\d+\-tab\-2/); // id is not stable
 
     // Go back to first tab
     goToTab("Tab 1");
@@ -288,6 +288,7 @@ describe("scenarios > dashboard > tabs", () => {
 
     cy.wait("@saveDashboardCards").then(({ response }) => {
       cy.wrap(response.body.dashcards[1].id).as("secondTabDashcardId");
+      cy.wrap(response.body.tabs[0].id).as("firstTabId");
     });
 
     cy.intercept(
@@ -305,7 +306,9 @@ describe("scenarios > dashboard > tabs", () => {
     });
 
     // Visit first tab and confirm only first card was queried
-    visitDashboard(ORDERS_DASHBOARD_ID, { params: { tab: 1 } });
+    cy.get("@firstTabId").then(firstTabId => {
+      visitDashboard(ORDERS_DASHBOARD_ID, { params: { tab: firstTabId } });
+    });
     cy.get("@firstTabQuery").should("have.been.calledOnce");
     cy.get("@secondTabQuery").should("not.have.been.called");
 

--- a/enterprise/backend/src/metabase_enterprise/audit_app/permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/permissions.clj
@@ -24,6 +24,7 @@
     "v_fields"
     "v_query_log"
     "v_tables"
+    "v_tasks"
     "v_view_log"})
 
 (defenterprise check-audit-db-permissions

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/-19557ZnrWiDgG4h4cKxF_databases.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/-19557ZnrWiDgG4h4cKxF_databases.yaml
@@ -1,17 +1,41 @@
+name: Databases
 description: Information about your connected data sources.
+entity_id: -19557ZnrWiDgG4h4cKxF
+created_at: '2023-10-31T21:40:01.037564Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: 16
+query_type: query
+dataset: true
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_databases
+enable_embedding: false
+embedding_params: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
+dataset_query:
+  database: Internal Metabase Database
+  query:
+    source-table:
+    - Internal Metabase Database
+    - public
+    - v_databases
+  type: query
 result_metadata:
-- description: null
-  semantic_type: type/PK
+- base_type: type/Integer
   coercion_strategy: null
-  name: entity_id
-  settings: null
-  fk_target_field_id: null
+  description: null
+  display_name: Entity ID
+  effective_type: type/Integer
   field_ref:
   - field
   - - Internal Metabase Database
@@ -19,21 +43,21 @@ result_metadata:
     - v_databases
     - entity_id
   - null
-  effective_type: type/Integer
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_databases
   - entity_id
-  visibility_type: normal
-  display_name: Entity ID
-  base_type: type/Integer
-- description: null
+  name: entity_id
   semantic_type: type/PK
-  coercion_strategy: null
-  name: entity_qualified_id
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Entity Qualified ID
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -41,22 +65,21 @@ result_metadata:
     - v_databases
     - entity_qualified_id
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_databases
   - entity_qualified_id
-  visibility_type: normal
-  display_name: Entity Qualified ID
-  base_type: type/Text
-- description: null
-  semantic_type: type/CreationTimestamp
-  coercion_strategy: null
-  unit: default
-  name: created_at
+  name: entity_qualified_id
+  semantic_type: type/PK
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: null
+  display_name: Created At
+  effective_type: type/DateTimeWithLocalTZ
   field_ref:
   - field
   - - Internal Metabase Database
@@ -64,22 +87,22 @@ result_metadata:
     - v_databases
     - created_at
   - temporal-unit: default
-  effective_type: type/DateTimeWithLocalTZ
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_databases
   - created_at
-  visibility_type: normal
-  display_name: Created At
-  base_type: type/DateTimeWithLocalTZ
-- description: null
-  semantic_type: type/UpdatedTimestamp
-  coercion_strategy: null
-  unit: default
-  name: updated_at
+  name: created_at
+  semantic_type: type/CreationTimestamp
   settings: null
-  fk_target_field_id: null
+  unit: default
+  visibility_type: normal
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: null
+  display_name: Updated At
+  effective_type: type/DateTimeWithLocalTZ
   field_ref:
   - field
   - - Internal Metabase Database
@@ -87,21 +110,22 @@ result_metadata:
     - v_databases
     - updated_at
   - temporal-unit: default
-  effective_type: type/DateTimeWithLocalTZ
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_databases
   - updated_at
-  visibility_type: normal
-  display_name: Updated At
-  base_type: type/DateTimeWithLocalTZ
-- description: null
-  semantic_type: type/Name
-  coercion_strategy: null
-  name: name
+  name: updated_at
+  semantic_type: type/UpdatedTimestamp
   settings: null
-  fk_target_field_id: null
+  unit: default
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Name
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -109,21 +133,21 @@ result_metadata:
     - v_databases
     - name
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_databases
   - name
-  visibility_type: normal
-  display_name: Name
-  base_type: type/Text
-- description: null
-  semantic_type: type/Description
-  coercion_strategy: null
-  name: description
+  name: name
+  semantic_type: type/Name
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Description
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -131,21 +155,21 @@ result_metadata:
     - v_databases
     - description
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_databases
   - description
-  visibility_type: normal
-  display_name: Description
-  base_type: type/Text
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: database_type
+  name: description
+  semantic_type: type/Description
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Database Type
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -153,21 +177,21 @@ result_metadata:
     - v_databases
     - database_type
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_databases
   - database_type
-  visibility_type: normal
-  display_name: Database Type
-  base_type: type/Text
-- description: null
+  name: database_type
   semantic_type: type/Category
-  coercion_strategy: null
-  name: metadata_sync_schedule
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Metadata Sync Schedule
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -175,21 +199,21 @@ result_metadata:
     - v_databases
     - metadata_sync_schedule
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_databases
   - metadata_sync_schedule
-  visibility_type: normal
-  display_name: Metadata Sync Schedule
-  base_type: type/Text
-- description: null
+  name: metadata_sync_schedule
   semantic_type: type/Category
-  coercion_strategy: null
-  name: cache_field_values_schedule
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Cache Field Values Schedule
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -197,21 +221,21 @@ result_metadata:
     - v_databases
     - cache_field_values_schedule
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_databases
   - cache_field_values_schedule
-  visibility_type: normal
-  display_name: Cache Field Values Schedule
-  base_type: type/Text
-- description: null
+  name: cache_field_values_schedule
   semantic_type: type/Category
-  coercion_strategy: null
-  name: timezone
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Timezone
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -219,21 +243,21 @@ result_metadata:
     - v_databases
     - timezone
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_databases
   - timezone
-  visibility_type: normal
-  display_name: Timezone
-  base_type: type/Text
-- description: null
+  name: timezone
   semantic_type: type/Category
-  coercion_strategy: null
-  name: is_on_demand
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Boolean
+  coercion_strategy: null
+  description: null
+  display_name: Is On Demand
+  effective_type: type/Boolean
   field_ref:
   - field
   - - Internal Metabase Database
@@ -241,21 +265,21 @@ result_metadata:
     - v_databases
     - is_on_demand
   - null
-  effective_type: type/Boolean
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_databases
   - is_on_demand
-  visibility_type: normal
-  display_name: Is On Demand
-  base_type: type/Boolean
-- description: null
+  name: is_on_demand
   semantic_type: type/Category
-  coercion_strategy: null
-  name: auto_run_queries
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Boolean
+  coercion_strategy: null
+  description: null
+  display_name: Auto Run Queries
+  effective_type: type/Boolean
   field_ref:
   - field
   - - Internal Metabase Database
@@ -263,21 +287,21 @@ result_metadata:
     - v_databases
     - auto_run_queries
   - null
-  effective_type: type/Boolean
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_databases
   - auto_run_queries
-  visibility_type: normal
-  display_name: Auto Run Queries
-  base_type: type/Boolean
-- description: null
-  semantic_type: null
-  coercion_strategy: null
-  name: cache_ttl
+  name: auto_run_queries
+  semantic_type: type/Category
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Cache Ttl
+  effective_type: type/Integer
   field_ref:
   - field
   - - Internal Metabase Database
@@ -285,21 +309,21 @@ result_metadata:
     - v_databases
     - cache_ttl
   - null
-  effective_type: type/Integer
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_databases
   - cache_ttl
-  visibility_type: normal
-  display_name: Cache Ttl
-  base_type: type/Integer
-- description: null
-  semantic_type: type/FK
-  coercion_strategy: null
-  name: creator_id
+  name: cache_ttl
+  semantic_type: null
   settings: null
-  fk_target_field_id: 739
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Creator ID
+  effective_type: type/Integer
   field_ref:
   - field
   - - Internal Metabase Database
@@ -307,21 +331,21 @@ result_metadata:
     - v_databases
     - creator_id
   - null
-  effective_type: type/Integer
+  fk_target_field_id: 739
   id:
   - Internal Metabase Database
   - public
   - v_databases
   - creator_id
-  visibility_type: normal
-  display_name: Creator ID
-  base_type: type/Integer
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: db_version
+  name: creator_id
+  semantic_type: type/FK
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Db Version
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -329,43 +353,21 @@ result_metadata:
     - v_databases
     - db_version
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_databases
   - db_version
+  name: db_version
+  semantic_type: type/Category
+  settings: null
   visibility_type: normal
-  display_name: Db Version
-  base_type: type/Text
-database_id: Internal Metabase Database
-enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Databases
-creator_id: internal@metabase.com
-made_public_by_id: null
-embedding_params: null
-cache_ttl: null
-dataset_query:
-  database: Internal Metabase Database
-  type: query
-  query:
-    source-table:
-    - Internal Metabase Database
-    - public
-    - v_databases
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: -19557ZnrWiDgG4h4cKxF
-  label: databases
-display: table
-entity_id: -19557ZnrWiDgG4h4cKxF
-collection_preview: true
 visualization_settings:
+  column_settings: null
+  table.cell_column: cache_ttl
   table.columns:
-  - name: entity_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -373,8 +375,8 @@ visualization_settings:
       - v_databases
       - entity_id
     - null
-    enabled: true
-  - name: entity_qualified_id
+    name: entity_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -382,8 +384,8 @@ visualization_settings:
       - v_databases
       - entity_qualified_id
     - null
-    enabled: true
-  - name: created_at
+    name: entity_qualified_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -391,8 +393,8 @@ visualization_settings:
       - v_databases
       - created_at
     - temporal-unit: default
-    enabled: true
-  - name: updated_at
+    name: created_at
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -400,8 +402,8 @@ visualization_settings:
       - v_databases
       - updated_at
     - temporal-unit: default
-    enabled: true
-  - name: name
+    name: updated_at
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -409,8 +411,8 @@ visualization_settings:
       - v_databases
       - name
     - null
-    enabled: true
-  - name: database_type
+    name: name
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -418,8 +420,8 @@ visualization_settings:
       - v_databases
       - database_type
     - null
-    enabled: true
-  - name: metadata_sync_schedule
+    name: database_type
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -427,8 +429,8 @@ visualization_settings:
       - v_databases
       - metadata_sync_schedule
     - null
-    enabled: true
-  - name: description
+    name: metadata_sync_schedule
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -436,8 +438,8 @@ visualization_settings:
       - v_databases
       - description
     - null
-    enabled: true
-  - name: cache_field_values_schedule
+    name: description
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -445,8 +447,8 @@ visualization_settings:
       - v_databases
       - cache_field_values_schedule
     - null
-    enabled: true
-  - name: timezone
+    name: cache_field_values_schedule
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -454,8 +456,8 @@ visualization_settings:
       - v_databases
       - timezone
     - null
-    enabled: true
-  - name: is_on_demand
+    name: timezone
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -463,8 +465,8 @@ visualization_settings:
       - v_databases
       - is_on_demand
     - null
-    enabled: true
-  - name: auto_run_queries
+    name: is_on_demand
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -472,8 +474,8 @@ visualization_settings:
       - v_databases
       - auto_run_queries
     - null
-    enabled: true
-  - name: cache_ttl
+    name: auto_run_queries
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -481,8 +483,8 @@ visualization_settings:
       - v_databases
       - cache_ttl
     - null
-    enabled: true
-  - name: creator_id
+    name: cache_ttl
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -490,8 +492,8 @@ visualization_settings:
       - v_databases
       - creator_id
     - null
-    enabled: true
-  - name: db_version
+    name: creator_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -499,12 +501,10 @@ visualization_settings:
       - v_databases
       - db_version
     - null
-    enabled: true
+    name: db_version
   table.pivot_column: timezone
-  table.cell_column: cache_ttl
-  column_settings: null
+serdes/meta:
+- id: -19557ZnrWiDgG4h4cKxF
+  label: databases
+  model: Card
 metabase_version: vUNKNOWN (0e09ac7)
-parameters: []
-dataset: true
-created_at: '2023-10-31T21:40:01.037564Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/-_XgVaPuz7MY8jlG0wSEC_question_performance.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/-_XgVaPuz7MY8jlG0wSEC_question_performance.yaml
@@ -1,23 +1,29 @@
+name: Question performance
 description: null
+entity_id: -_XgVaPuz7MY8jlG0wSEC
+created_at: '2023-11-01T02:55:23.345772Z'
+creator_id: internal@metabase.com
+display: line
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Question performance
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
     aggregation:
     - - median
@@ -47,31 +53,25 @@ dataset_query:
       - base-type: type/DateTimeWithLocalTZ
         temporal-unit: week
     source-table: QOtZaiTLf2FDD4AT6Oinb
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: -_XgVaPuz7MY8jlG0wSEC
-  label: question_performance
-display: line
-entity_id: -_XgVaPuz7MY8jlG0wSEC
-collection_preview: true
+  type: query
+result_metadata: null
 visualization_settings:
-  table.pivot_column: error
-  table.cell_column: running_time_seconds
+  column_settings: null
   graph.dimensions:
   - started_at
+  graph.metrics:
+  - median
+  - Percentile 95 of load time (seconds)
+  graph.show_values: true
   series_settings:
     max:
       title: Max of load time (seconds)
     median:
       title: Median of load time (seconds)
-  graph.show_values: true
-  graph.metrics:
-  - median
-  - Percentile 95 of load time (seconds)
-  column_settings: null
+  table.cell_column: running_time_seconds
+  table.pivot_column: error
+serdes/meta:
+- id: -_XgVaPuz7MY8jlG0wSEC
+  label: question_performance
+  model: Card
 metabase_version: vUNKNOWN (13e6090)
-parameters: []
-dataset: false
-created_at: '2023-11-01T02:55:23.345772Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/-fFVxT-GLz6WO41bvw-Ar_dashboards_without_recent_views.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/-fFVxT-GLz6WO41bvw-Ar_dashboards_without_recent_views.yaml
@@ -1,25 +1,39 @@
+name: Dashboards without recent views
 description: null
+entity_id: -fFVxT-GLz6WO41bvw-Ar
+created_at: '2023-11-01T11:52:53.834059Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_content
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Dashboards without recent views
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    limit: 100
+    expressions:
+      Days since last view:
+      - datetime-diff
+      - - field
+        - max
+        - base-type: type/DateTimeWithLocalTZ
+          join-alias: Last content viewed at - Entity Qualified
+      - - now
+      - day
     fields:
     - - field
       - - Internal Metabase Database
@@ -41,40 +55,6 @@ dataset_query:
       - base-type: type/Text
     - - expression
       - Days since last view
-    joins:
-    - fields: none
-      strategy: left-join
-      alias: Last content viewed at - Entity Qualified
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - entity_qualified_id
-        - base-type: type/Text
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - entity_qualified_id
-        - base-type: type/Text
-          join-alias: Last content viewed at - Entity Qualified
-      source-table: tKEl86EXMyTDIoO9nyFTV
-    expressions:
-      Days since last view:
-      - datetime-diff
-      - - field
-        - max
-        - base-type: type/DateTimeWithLocalTZ
-          join-alias: Last content viewed at - Entity Qualified
-      - - now
-      - day
-    order-by:
-    - - desc
-      - - expression
-        - Days since last view
-    source-table: AxSackBiyXVRUzM_TyyQY
     filter:
     - and
     - - =
@@ -96,30 +76,50 @@ dataset_query:
           - archived
         - base-type: type/Boolean
       - false
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: -fFVxT-GLz6WO41bvw-Ar
-  label: dashboards_without_recent_views
-display: table
-entity_id: -fFVxT-GLz6WO41bvw-Ar
-collection_preview: true
+    joins:
+    - alias: Last content viewed at - Entity Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Last content viewed at - Entity Qualified
+      fields: none
+      source-table: tKEl86EXMyTDIoO9nyFTV
+      strategy: left-join
+    limit: 100
+    order-by:
+    - - desc
+      - - expression
+        - Days since last view
+    source-table: AxSackBiyXVRUzM_TyyQY
+  type: query
+result_metadata: null
 visualization_settings:
-  table.cell_column: Days since last view
   column_settings:
     '["ref",["expression","Days since last view"]]':
       show_mini_bar: true
     '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer"}]]':
       column_title: Dashboard ID
-      view_as: link
       link_text: ''
       link_url: /dashboard/{{entity_id}}
+      view_as: link
     '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text"}]]':
-      view_as: link
       link_text: ''
       link_url: /dashboard/{{entity_id}}
+      view_as: link
+  table.cell_column: Days since last view
+serdes/meta:
+- id: -fFVxT-GLz6WO41bvw-Ar
+  label: dashboards_without_recent_views
+  model: Card
 metabase_version: vUNKNOWN (901f705)
-parameters: []
-dataset: false
-created_at: '2023-11-01T11:52:53.834059Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/-lNDM3tJmuL5ltGbX0oyT_activity_log.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/-lNDM3tJmuL5ltGbX0oyT_activity_log.yaml
@@ -1,228 +1,30 @@
+name: Activity log
 description: Things that happened in your Metabase.
+entity_id: -lNDM3tJmuL5ltGbX0oyT
+created_at: '2023-06-14T18:39:19.328399Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: 9
+query_type: query
+dataset: true
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_audit_log
-result_metadata:
-- description: null
-  semantic_type: type/PK
-  coercion_strategy: null
-  name: id
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_audit_log
-    - id
-  - base-type: type/Integer
-  effective_type: type/Integer
-  id:
-  - Internal Metabase Database
-  - public
-  - v_audit_log
-  - id
-  visibility_type: normal
-  display_name: ID
-  base_type: type/Integer
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: topic
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_audit_log
-    - topic
-  - base-type: type/Text
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_audit_log
-  - topic
-  visibility_type: normal
-  display_name: Topic
-  base_type: type/Text
-- description: null
-  semantic_type: type/CreationTimestamp
-  coercion_strategy: null
-  unit: default
-  name: timestamp
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_audit_log
-    - timestamp
-  - base-type: type/DateTimeWithLocalTZ
-    temporal-unit: default
-  effective_type: type/DateTimeWithLocalTZ
-  id:
-  - Internal Metabase Database
-  - public
-  - v_audit_log
-  - timestamp
-  visibility_type: normal
-  display_name: Timestamp
-  base_type: type/DateTimeWithLocalTZ
-- description: null
-  semantic_type: null
-  coercion_strategy: null
-  name: end_timestamp
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_audit_log
-    - end_timestamp
-  - base-type: type/Text
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_audit_log
-  - end_timestamp
-  visibility_type: normal
-  display_name: End Timestamp
-  base_type: type/Text
-- description: null
-  semantic_type: null
-  coercion_strategy: null
-  name: user_id
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_audit_log
-    - user_id
-  - base-type: type/Integer
-  effective_type: type/Integer
-  id:
-  - Internal Metabase Database
-  - public
-  - v_audit_log
-  - user_id
-  visibility_type: normal
-  display_name: User ID
-  base_type: type/Integer
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: entity_type
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_audit_log
-    - entity_type
-  - base-type: type/Text
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_audit_log
-  - entity_type
-  visibility_type: normal
-  display_name: Entity Type
-  base_type: type/Text
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: entity_id
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_audit_log
-    - entity_id
-  - base-type: type/Integer
-  effective_type: type/Integer
-  id:
-  - Internal Metabase Database
-  - public
-  - v_audit_log
-  - entity_id
-  visibility_type: normal
-  display_name: Entity ID
-  base_type: type/Integer
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: entity_qualified_id
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_audit_log
-    - entity_qualified_id
-  - base-type: type/Text
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_audit_log
-  - entity_qualified_id
-  visibility_type: normal
-  display_name: Entity Qualified ID
-  base_type: type/Text
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: details
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_audit_log
-    - details
-  - base-type: type/Text
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_audit_log
-  - details
-  visibility_type: normal
-  display_name: Details
-  base_type: type/Text
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Activity log
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    source-table:
-    - Internal Metabase Database
-    - public
-    - v_audit_log
     fields:
     - - field
       - - Internal Metabase Database
@@ -286,20 +88,218 @@ dataset_query:
           - v_audit_log
           - timestamp
         - base-type: type/DateTimeWithLocalTZ
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: -lNDM3tJmuL5ltGbX0oyT
-  label: activity_log
-display: table
-entity_id: -lNDM3tJmuL5ltGbX0oyT
-collection_preview: true
+    source-table:
+    - Internal Metabase Database
+    - public
+    - v_audit_log
+  type: query
+result_metadata:
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: ID
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_audit_log
+    - id
+  - base-type: type/Integer
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_audit_log
+  - id
+  name: id
+  semantic_type: type/PK
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Topic
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_audit_log
+    - topic
+  - base-type: type/Text
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_audit_log
+  - topic
+  name: topic
+  semantic_type: type/Category
+  settings: null
+  visibility_type: normal
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: null
+  display_name: Timestamp
+  effective_type: type/DateTimeWithLocalTZ
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_audit_log
+    - timestamp
+  - base-type: type/DateTimeWithLocalTZ
+    temporal-unit: default
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_audit_log
+  - timestamp
+  name: timestamp
+  semantic_type: type/CreationTimestamp
+  settings: null
+  unit: default
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: End Timestamp
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_audit_log
+    - end_timestamp
+  - base-type: type/Text
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_audit_log
+  - end_timestamp
+  name: end_timestamp
+  semantic_type: null
+  settings: null
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: User ID
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_audit_log
+    - user_id
+  - base-type: type/Integer
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_audit_log
+  - user_id
+  name: user_id
+  semantic_type: null
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Entity Type
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_audit_log
+    - entity_type
+  - base-type: type/Text
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_audit_log
+  - entity_type
+  name: entity_type
+  semantic_type: type/Category
+  settings: null
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Entity ID
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_audit_log
+    - entity_id
+  - base-type: type/Integer
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_audit_log
+  - entity_id
+  name: entity_id
+  semantic_type: type/Category
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Entity Qualified ID
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_audit_log
+    - entity_qualified_id
+  - base-type: type/Text
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_audit_log
+  - entity_qualified_id
+  name: entity_qualified_id
+  semantic_type: type/Category
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Details
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_audit_log
+    - details
+  - base-type: type/Text
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_audit_log
+  - details
+  name: details
+  semantic_type: type/Category
+  settings: null
+  visibility_type: normal
 visualization_settings:
-  table.pivot_column: end_timestamp
-  table.cell_column: model_id
   column_settings: null
+  table.cell_column: model_id
+  table.pivot_column: end_timestamp
+serdes/meta:
+- id: -lNDM3tJmuL5ltGbX0oyT
+  label: activity_log
+  model: Card
 metabase_version: null
-parameters: []
-dataset: true
-created_at: '2023-06-14T18:39:19.328399Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/0wVIfjBJWclD0lKeABYYl_people.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/0wVIfjBJWclD0lKeABYYl_people.yaml
@@ -1,287 +1,27 @@
+name: People
 description: Everyone who's ever had an account in your Metabase, including both active and deactivated accounts.
+entity_id: 0wVIfjBJWclD0lKeABYYl
+created_at: '2023-06-08T14:18:48.912368Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: 11
+query_type: query
+dataset: true
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_users
-result_metadata:
-- description: null
-  semantic_type: type/PK
-  coercion_strategy: null
-  name: user_id
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_users
-    - user_id
-  - null
-  effective_type: type/Integer
-  id:
-  - Internal Metabase Database
-  - public
-  - v_users
-  - user_id
-  visibility_type: normal
-  display_name: User ID
-  base_type: type/Integer
-- description: null
-  semantic_type: type/Name
-  coercion_strategy: null
-  name: email
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_users
-    - email
-  - null
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_users
-  - email
-  visibility_type: normal
-  display_name: Email
-  base_type: type/Text
-- description: null
-  semantic_type: type/Name
-  coercion_strategy: null
-  name: first_name
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_users
-    - first_name
-  - null
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_users
-  - first_name
-  visibility_type: normal
-  display_name: First Name
-  base_type: type/Text
-- description: null
-  semantic_type: type/Name
-  coercion_strategy: null
-  name: last_name
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_users
-    - last_name
-  - null
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_users
-  - last_name
-  visibility_type: normal
-  display_name: Last Name
-  base_type: type/Text
-- description: null
-  semantic_type: type/Name
-  coercion_strategy: null
-  name: full_name
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_users
-    - full_name
-  - null
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_users
-  - full_name
-  visibility_type: normal
-  display_name: Full Name
-  base_type: type/Text
-- description: null
-  semantic_type: type/JoinTimestamp
-  coercion_strategy: null
-  unit: default
-  name: date_joined
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_users
-    - date_joined
-  - temporal-unit: default
-  effective_type: type/DateTimeWithLocalTZ
-  id:
-  - Internal Metabase Database
-  - public
-  - v_users
-  - date_joined
-  visibility_type: normal
-  display_name: Date Joined
-  base_type: type/DateTimeWithLocalTZ
-- description: null
-  semantic_type: null
-  coercion_strategy: null
-  unit: default
-  name: last_login
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_users
-    - last_login
-  - temporal-unit: default
-  effective_type: type/DateTimeWithLocalTZ
-  id:
-  - Internal Metabase Database
-  - public
-  - v_users
-  - last_login
-  visibility_type: normal
-  display_name: Last Login
-  base_type: type/DateTimeWithLocalTZ
-- description: null
-  semantic_type: type/UpdatedTimestamp
-  coercion_strategy: null
-  unit: default
-  name: updated_at
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_users
-    - updated_at
-  - temporal-unit: default
-  effective_type: type/DateTime
-  id:
-  - Internal Metabase Database
-  - public
-  - v_users
-  - updated_at
-  visibility_type: normal
-  display_name: Updated At
-  base_type: type/DateTime
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: is_admin
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_users
-    - is_admin
-  - null
-  effective_type: type/Boolean
-  id:
-  - Internal Metabase Database
-  - public
-  - v_users
-  - is_admin
-  visibility_type: normal
-  display_name: Is Admin
-  base_type: type/Boolean
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: is_active
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_users
-    - is_active
-  - null
-  effective_type: type/Boolean
-  id:
-  - Internal Metabase Database
-  - public
-  - v_users
-  - is_active
-  visibility_type: normal
-  display_name: Is Active
-  base_type: type/Boolean
-- description: null
-  semantic_type: type/Source
-  coercion_strategy: null
-  name: sso_source
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_users
-    - sso_source
-  - null
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_users
-  - sso_source
-  visibility_type: normal
-  display_name: Sso Source
-  base_type: type/Text
-- description: null
-  semantic_type: null
-  coercion_strategy: null
-  name: locale
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_users
-    - locale
-  - null
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_users
-  - locale
-  visibility_type: normal
-  display_name: Locale
-  base_type: type/Text
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: People
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
   query:
@@ -290,20 +30,280 @@ dataset_query:
     - public
     - v_users
   type: query
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: 0wVIfjBJWclD0lKeABYYl
-  label: people
-display: table
-entity_id: 0wVIfjBJWclD0lKeABYYl
-collection_preview: true
+result_metadata:
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: User ID
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_users
+    - user_id
+  - null
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_users
+  - user_id
+  name: user_id
+  semantic_type: type/PK
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Email
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_users
+    - email
+  - null
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_users
+  - email
+  name: email
+  semantic_type: type/Name
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: First Name
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_users
+    - first_name
+  - null
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_users
+  - first_name
+  name: first_name
+  semantic_type: type/Name
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Last Name
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_users
+    - last_name
+  - null
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_users
+  - last_name
+  name: last_name
+  semantic_type: type/Name
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Full Name
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_users
+    - full_name
+  - null
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_users
+  - full_name
+  name: full_name
+  semantic_type: type/Name
+  settings: null
+  visibility_type: normal
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: null
+  display_name: Date Joined
+  effective_type: type/DateTimeWithLocalTZ
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_users
+    - date_joined
+  - temporal-unit: default
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_users
+  - date_joined
+  name: date_joined
+  semantic_type: type/JoinTimestamp
+  settings: null
+  unit: default
+  visibility_type: normal
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: null
+  display_name: Last Login
+  effective_type: type/DateTimeWithLocalTZ
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_users
+    - last_login
+  - temporal-unit: default
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_users
+  - last_login
+  name: last_login
+  semantic_type: null
+  settings: null
+  unit: default
+  visibility_type: normal
+- base_type: type/DateTime
+  coercion_strategy: null
+  description: null
+  display_name: Updated At
+  effective_type: type/DateTime
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_users
+    - updated_at
+  - temporal-unit: default
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_users
+  - updated_at
+  name: updated_at
+  semantic_type: type/UpdatedTimestamp
+  settings: null
+  unit: default
+  visibility_type: normal
+- base_type: type/Boolean
+  coercion_strategy: null
+  description: null
+  display_name: Is Admin
+  effective_type: type/Boolean
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_users
+    - is_admin
+  - null
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_users
+  - is_admin
+  name: is_admin
+  semantic_type: type/Category
+  settings: null
+  visibility_type: normal
+- base_type: type/Boolean
+  coercion_strategy: null
+  description: null
+  display_name: Is Active
+  effective_type: type/Boolean
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_users
+    - is_active
+  - null
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_users
+  - is_active
+  name: is_active
+  semantic_type: type/Category
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Sso Source
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_users
+    - sso_source
+  - null
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_users
+  - sso_source
+  name: sso_source
+  semantic_type: type/Source
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Locale
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_users
+    - locale
+  - null
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_users
+  - locale
+  name: locale
+  semantic_type: null
+  settings: null
+  visibility_type: normal
 visualization_settings:
-  table.pivot_column: sso_source
-  table.cell_column: locale
   column_settings: null
+  table.cell_column: locale
+  table.pivot_column: sso_source
+serdes/meta:
+- id: 0wVIfjBJWclD0lKeABYYl
+  label: people
+  model: Card
 metabase_version: null
-parameters: []
-dataset: true
-created_at: '2023-06-08T14:18:48.912368Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/3CtVT_JDxNvMM5aFLtEHR_is_admin_.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/3CtVT_JDxNvMM5aFLtEHR_is_admin_.yaml
@@ -1,38 +1,38 @@
+name: Is admin?
 description: null
+entity_id: 3CtVT_JDxNvMM5aFLtEHR
+created_at: '2023-06-15T01:41:47.345244Z'
+creator_id: internal@metabase.com
+display: scalar
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_users
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Is admin?
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
   query:
     source-table: 0wVIfjBJWclD0lKeABYYl
   type: query
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: 3CtVT_JDxNvMM5aFLtEHR
-  label: is_admin_
-display: scalar
-entity_id: 3CtVT_JDxNvMM5aFLtEHR
-collection_preview: true
+result_metadata: null
 visualization_settings:
-  scalar.field: is_admin
   column_settings: null
+  scalar.field: is_admin
+serdes/meta:
+- id: 3CtVT_JDxNvMM5aFLtEHR
+  label: is_admin_
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-06-15T01:41:47.345244Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/4DlO-I7ry2OaVQy7-RGPU_median_load_time_in_seconds_for_questions_in_this_dashboard.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/4DlO-I7ry2OaVQy7-RGPU_median_load_time_in_seconds_for_questions_in_this_dashboard.yaml
@@ -1,23 +1,29 @@
+name: Median load time in seconds for questions in this dashboard
 description: null
+entity_id: 4DlO-I7ry2OaVQy7-RGPU
+created_at: '2023-11-01T02:58:31.067637Z'
+creator_id: internal@metabase.com
+display: line
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Median load time in seconds for questions in this dashboard
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
     aggregation:
     - - median
@@ -36,24 +42,18 @@ dataset_query:
       - base-type: type/DateTimeWithLocalTZ
         temporal-unit: week
     source-table: QOtZaiTLf2FDD4AT6Oinb
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: 4DlO-I7ry2OaVQy7-RGPU
-  label: median_load_time_in_seconds_for_questions_in_this_dashboard
-display: line
-entity_id: 4DlO-I7ry2OaVQy7-RGPU
-collection_preview: true
+  type: query
+result_metadata: null
 visualization_settings:
-  table.pivot_column: error
-  table.cell_column: running_time_seconds
+  column_settings: null
   graph.dimensions:
   - started_at
   graph.metrics:
   - median
-  column_settings: null
+  table.cell_column: running_time_seconds
+  table.pivot_column: error
+serdes/meta:
+- id: 4DlO-I7ry2OaVQy7-RGPU
+  label: median_load_time_in_seconds_for_questions_in_this_dashboard
+  model: Card
 metabase_version: vUNKNOWN (13e6090)
-parameters: []
-dataset: false
-created_at: '2023-11-01T02:58:31.067637Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/57V11my5MYVnSlaJYM8cX_most_viewed_models.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/57V11my5MYVnSlaJYM8cX_most_viewed_models.yaml
@@ -1,0 +1,239 @@
+name: Most viewed models
+description: null
+entity_id: 57V11my5MYVnSlaJYM8cX
+created_at: '2023-11-13T18:53:06.528775Z'
+creator_id: internal@metabase.com
+display: table
+archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
+collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
+table_id:
+- Internal Metabase Database
+- public
+- v_view_log
+enable_embedding: false
+embedding_params: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
+dataset_query:
+  database: Internal Metabase Database
+  query:
+    aggregation:
+    - - count
+    breakout:
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - name
+      - base-type: type/Text
+        join-alias: Content - Entity Qualified
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - entity_id
+      - base-type: type/Integer
+        join-alias: Content - Entity Qualified
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_databases
+        - name
+      - base-type: type/Text
+        join-alias: V Databases - Question Database
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_databases
+        - entity_id
+      - base-type: type/Integer
+        join-alias: V Databases - Question Database
+    filter:
+    - and
+    - - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - entity_type
+        - base-type: type/Text
+      - card
+    - - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_type
+        - base-type: type/Text
+          join-alias: Content - Entity Qualified
+      - model
+    joins:
+    - alias: Content - Entity Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - entity_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Content - Entity Qualified
+      source-table: AxSackBiyXVRUzM_TyyQY
+      strategy: left-join
+    - alias: People - Creator
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - creator_id
+        - base-type: type/Integer
+          join-alias: Content - Entity Qualified
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_users
+          - user_id
+        - base-type: type/Integer
+          join-alias: People - Creator
+      source-table: 0wVIfjBJWclD0lKeABYYl
+      strategy: left-join
+    - alias: Group Members - User
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - user_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_group_members
+          - user_id
+        - base-type: type/Integer
+          join-alias: Group Members - User
+      source-table: lTp-ATFsCUFEr9I0fMEaO
+      strategy: left-join
+    - alias: V Databases - Question Database
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - question_database_id
+        - base-type: type/Text
+          join-alias: Content - Entity Qualified
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_databases
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: V Databases - Question Database
+      fields: all
+      source-table:
+      - Internal Metabase Database
+      - public
+      - v_databases
+      strategy: left-join
+    limit: 100
+    order-by:
+    - - desc
+      - - aggregation
+        - 0
+    source-table: P6Ityjj7igswKh4NgZZjz
+  type: query
+result_metadata: null
+visualization_settings:
+  column_settings:
+    '["name","count"]':
+      show_mini_bar: true
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Question ID
+      link_url: question/{{entity_id}}
+      view_as: link
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Question name
+      link_text: ''
+      link_url: question/{{entity_id}}
+      view_as: link
+    ? '["ref",["field",["Internal Metabase Database","public","v_databases","name"],{"base-type":"type/Text","join-alias":"V Databases - Question Database"}]]'
+    : column_title: Database
+      link_url: /browse/{{entity_id_2}}
+      view_as: link
+  graph.dimensions:
+  - name
+  graph.metrics:
+  - count
+  graph.show_values: true
+  table.cell_column: count
+  table.columns:
+  - enabled: true
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_content
+      - name
+    - base-type: type/Text
+      join-alias: Content - Entity Qualified
+    name: name
+  - enabled: false
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_content
+      - entity_id
+    - base-type: type/Integer
+      join-alias: Content - Entity Qualified
+    name: entity_id
+  - enabled: true
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_databases
+      - name
+    - base-type: type/Text
+      join-alias: V Databases - Question Database
+    name: name_2
+  - enabled: false
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_databases
+      - entity_id
+    - base-type: type/Integer
+      join-alias: V Databases - Question Database
+    name: entity_id_2
+  - enabled: true
+    fieldRef:
+    - aggregation
+    - 0
+    name: count
+  table.pivot_column: name_2
+serdes/meta:
+- id: 57V11my5MYVnSlaJYM8cX
+  label: most_viewed_models
+  model: Card
+metabase_version: vUNKNOWN (1308cef)

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/5EsTAgs6Uu_xz69TsrUJ4_last_viewed_models.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/5EsTAgs6Uu_xz69TsrUJ4_last_viewed_models.yaml
@@ -1,0 +1,190 @@
+name: Last viewed models
+description: null
+entity_id: 5EsTAgs6Uu_xz69TsrUJ4
+created_at: '2023-11-13T20:22:56.420493Z'
+creator_id: internal@metabase.com
+display: table
+archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
+collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
+table_id:
+- Internal Metabase Database
+- public
+- v_view_log
+enable_embedding: false
+embedding_params: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
+dataset_query:
+  database: Internal Metabase Database
+  query:
+    fields:
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - timestamp
+      - base-type: type/DateTimeWithLocalTZ
+    filter:
+    - and
+    - - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - entity_type
+        - base-type: type/Text
+      - card
+    - - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_type
+        - base-type: type/Text
+          join-alias: Content - Entity Qualified
+      - model
+    joins:
+    - alias: Content - Entity Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - entity_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Content - Entity Qualified
+      fields:
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_id
+        - base-type: type/Integer
+          join-alias: Content - Entity Qualified
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - name
+        - base-type: type/Text
+          join-alias: Content - Entity Qualified
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - description
+        - base-type: type/Text
+          join-alias: Content - Entity Qualified
+      source-table: AxSackBiyXVRUzM_TyyQY
+      strategy: left-join
+    - alias: People - Creator
+      condition:
+      - =
+      - - field
+        - creator_id
+        - base-type: type/Integer
+          join-alias: Content - Entity Qualified
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_users
+          - user_id
+        - base-type: type/Integer
+          join-alias: People - Creator
+      fields: none
+      source-table: 0wVIfjBJWclD0lKeABYYl
+      strategy: left-join
+    limit: 200
+    order-by:
+    - - desc
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - timestamp
+        - base-type: type/DateTimeWithLocalTZ
+    source-table: P6Ityjj7igswKh4NgZZjz
+  type: query
+result_metadata: null
+visualization_settings:
+  column_settings:
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","description"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Description
+    '["ref",["field",["Internal Metabase Database","public","v_content","description"],{"join-alias":"Question 35"}]]':
+      column_title: Description
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Question ID
+    '["ref",["field",["Internal Metabase Database","public","v_content","id"],{"join-alias":"Question 35"}]]':
+      column_title: Dashboard ID
+      link_text: Dashboard {{id}}
+      link_url: ''
+      view_as: null
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Question name
+      link_url: /question/{{entity_id}}
+      view_as: link
+    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35"}]]':
+      column_title: Dashboard name
+  table.cell_column: model_id
+  table.columns:
+  - enabled: true
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_view_log
+      - timestamp
+    - base-type: type/DateTimeWithLocalTZ
+      temporal-unit: default
+    name: timestamp
+  - enabled: false
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_content
+      - entity_id
+    - base-type: type/Integer
+      join-alias: Content - Entity Qualified
+    name: entity_id
+  - enabled: true
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_content
+      - name
+    - base-type: type/Text
+      join-alias: Content - Entity Qualified
+    name: name
+  - enabled: true
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_content
+      - description
+    - base-type: type/Text
+      join-alias: Content - Entity Qualified
+    name: description
+  table.pivot_column: end_timestamp
+serdes/meta:
+- id: 5EsTAgs6Uu_xz69TsrUJ4
+  label: last_viewed_models
+  model: Card
+metabase_version: vUNKNOWN (a98530f)

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/5HQS2xXAPF4hOFudut_Tg_last_viewed_dashboards.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/5HQS2xXAPF4hOFudut_Tg_last_viewed_dashboards.yaml
@@ -1,26 +1,64 @@
+name: Last viewed dashboards
 description: null
+entity_id: 5HQS2xXAPF4hOFudut_Tg
+created_at: '2023-06-15T01:50:24.779399Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Last viewed dashboards
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
+    fields:
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - timestamp
+      - base-type: type/DateTimeWithLocalTZ
+    filter:
+    - =
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - entity_type
+      - base-type: type/Text
+    - dashboard
     joins:
-    - fields:
+    - alias: Content - Entity Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - entity_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Content - Entity Qualified
+      fields:
       - - field
         - - Internal Metabase Database
           - public
@@ -42,27 +80,9 @@ dataset_query:
           - description
         - base-type: type/Text
           join-alias: Content - Entity Qualified
-      strategy: left-join
-      alias: Content - Entity Qualified
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - entity_qualified_id
-        - base-type: type/Text
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - entity_qualified_id
-        - base-type: type/Text
-          join-alias: Content - Entity Qualified
       source-table: AxSackBiyXVRUzM_TyyQY
-    - fields: none
       strategy: left-join
-      alias: People - Creator
+    - alias: People - Creator
       condition:
       - =
       - - field
@@ -76,7 +96,10 @@ dataset_query:
           - user_id
         - base-type: type/Integer
           join-alias: People - Creator
+      fields: none
       source-table: 0wVIfjBJWclD0lKeABYYl
+      strategy: left-join
+    limit: 200
     order-by:
     - - desc
       - - field
@@ -85,32 +108,29 @@ dataset_query:
           - v_view_log
           - timestamp
         - base-type: type/DateTimeWithLocalTZ
-    fields:
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - timestamp
-      - base-type: type/DateTimeWithLocalTZ
     source-table: P6Ityjj7igswKh4NgZZjz
-    filter:
-    - =
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - entity_type
-      - base-type: type/Text
-    - dashboard
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: 5HQS2xXAPF4hOFudut_Tg
-  label: last_viewed_dashboards
-display: table
-entity_id: 5HQS2xXAPF4hOFudut_Tg
-collection_preview: true
+  type: query
+result_metadata: null
 visualization_settings:
+  column_settings:
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","description"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Description
+    '["ref",["field",["Internal Metabase Database","public","v_content","description"],{"join-alias":"Question 35"}]]':
+      column_title: Description
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Dashboard ID
+    '["ref",["field",["Internal Metabase Database","public","v_content","id"],{"join-alias":"Question 35"}]]':
+      column_title: Dashboard ID
+      link_text: Dashboard {{id}}
+      link_url: ''
+      view_as: null
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Dashboard name
+      link_text: ''
+      link_url: /dashboard/{{entity_id}}
+      view_as: link
+    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35"}]]':
+      column_title: Dashboard name
   table.cell_column: model_id
   table.columns:
   - enabled: true
@@ -118,20 +138,12 @@ visualization_settings:
     - field
     - - Internal Metabase Database
       - public
-      - v_content
-      - id
-    - join-alias: Question 35
-    name: id
+      - v_view_log
+      - timestamp
+    - base-type: type/DateTimeWithLocalTZ
+      temporal-unit: default
+    name: timestamp
   - enabled: false
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - user_id
-    - join-alias: Question 1
-    name: user_id
-  - name: entity_id_2
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -140,295 +152,8 @@ visualization_settings:
       - entity_id
     - base-type: type/Integer
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: entity_qualified_id_2
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - entity_qualified_id
-    - base-type: type/Text
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: entity_type_2
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - entity_type
-    - base-type: type/Text
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: created_at
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - created_at
-    - base-type: type/DateTimeWithLocalTZ
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: updated_at
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - updated_at
-    - base-type: type/DateTimeWithLocalTZ
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: creator_id
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - creator_id
-    - base-type: type/Integer
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: collection_id
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - collection_id
-    - base-type: type/Integer
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: made_public_by_user
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - made_public_by_user
-    - base-type: type/Integer
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: is_embedding_enabled
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - is_embedding_enabled
-    - base-type: type/Boolean
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: archived
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - archived
-    - base-type: type/Boolean
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: action_type
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - action_type
-    - base-type: type/Text
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: action_model_id
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - action_model_id
-    - base-type: type/Integer
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: collection_is_official
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - collection_is_official
-    - base-type: type/Boolean
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: collection_is_personal
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - collection_is_personal
-    - base-type: type/Boolean
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: question_viz_type
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - question_viz_type
-    - base-type: type/Text
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: question_database_id
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - question_database_id
-    - base-type: type/Text
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: question_is_native
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - question_is_native
-    - base-type: type/Boolean
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: event_timestamp
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - event_timestamp
-    - base-type: type/DateTimeWithLocalTZ
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: user_id_2
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - user_id
-    - join-alias: People - Creator
-    enabled: true
-  - name: email
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - email
-    - join-alias: People - Creator
-    enabled: true
-  - name: first_name
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - first_name
-    - join-alias: People - Creator
-    enabled: true
-  - name: last_name
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - last_name
-    - join-alias: People - Creator
-    enabled: true
-  - name: full_name
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - full_name
-    - join-alias: People - Creator
-    enabled: true
-  - name: date_joined
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - date_joined
-    - join-alias: People - Creator
-    enabled: true
-  - name: last_login
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - last_login
-    - join-alias: People - Creator
-    enabled: true
-  - name: updated_at_2
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - updated_at
-    - join-alias: People - Creator
-    enabled: true
-  - name: is_admin
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - is_admin
-    - join-alias: People - Creator
-    enabled: true
-  - name: is_active
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - is_active
-    - join-alias: People - Creator
-    enabled: true
-  - name: sso_source
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - sso_source
-    - join-alias: People - Creator
-    enabled: true
-  - name: locale
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - locale
-    - join-alias: People - Creator
-    enabled: true
-  - name: timestamp
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_view_log
-      - timestamp
-    - base-type: type/DateTimeWithLocalTZ
-    enabled: true
-  - name: name
+    name: entity_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -437,8 +162,8 @@ visualization_settings:
       - name
     - base-type: type/Text
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: description
+    name: name
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -447,36 +172,10 @@ visualization_settings:
       - description
     - base-type: type/Text
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: entity_id
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - entity_id
-    - base-type: type/Integer
-      join-alias: Content - Entity Qualified
-    enabled: true
+    name: description
   table.pivot_column: end_timestamp
-  column_settings:
-    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35"}]]':
-      column_title: Dashboard name
-    '["ref",["field",["Internal Metabase Database","public","v_content","id"],{"join-alias":"Question 35"}]]':
-      column_title: Dashboard ID
-      link_text: Dashboard {{id}}
-      link_url: ''
-      view_as: null
-    '["ref",["field",["Internal Metabase Database","public","v_content","description"],{"join-alias":"Question 35"}]]':
-      column_title: Description
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Entity Qualified"}]]'
-    : column_title: Dashboard ID
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
-    : column_title: Dashboard name
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","description"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
-    : column_title: Description
+serdes/meta:
+- id: 5HQS2xXAPF4hOFudut_Tg
+  label: last_viewed_dashboards
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-06-15T01:50:24.779399Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/5gASJxNKdQCmkiGXb5kRP_dashboards_consuming_most_resources.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/5gASJxNKdQCmkiGXb5kRP_dashboards_consuming_most_resources.yaml
@@ -1,64 +1,38 @@
+name: Dashboards consuming most resources
 description: Sum of all questions load time each week
+entity_id: 5gASJxNKdQCmkiGXb5kRP
+created_at: '2023-11-01T11:23:23.432274Z'
+creator_id: internal@metabase.com
+display: line
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Dashboards consuming most resources
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    limit: 300
-    joins:
-    - fields: all
-      strategy: left-join
-      alias: Content - Dashboard Qualified
-      condition:
-      - =
+    aggregation:
+    - - sum
       - - field
         - - Internal Metabase Database
           - public
           - v_query_log
-          - dashboard_qualified_id
-        - base-type: type/Text
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - entity_qualified_id
-        - base-type: type/Text
-          join-alias: Content - Dashboard Qualified
-      source-table: AxSackBiyXVRUzM_TyyQY
-    - fields: all
-      strategy: left-join
-      alias: Group Members - User
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_query_log
-          - user_id
-        - base-type: type/Integer
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_group_members
-          - user_id
-        - base-type: type/Integer
-          join-alias: Group Members - User
-      source-table: lTp-ATFsCUFEr9I0fMEaO
+          - running_time_seconds
+        - base-type: type/Float
     breakout:
     - - field
       - - Internal Metabase Database
@@ -80,19 +54,6 @@ dataset_query:
         - v_query_log
         - dashboard_id
       - base-type: type/Integer
-    order-by:
-    - - desc
-      - - aggregation
-        - 0
-    aggregation:
-    - - sum
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_query_log
-          - running_time_seconds
-        - base-type: type/Float
-    source-table: QOtZaiTLf2FDD4AT6Oinb
     filter:
     - and
     - - time-interval
@@ -112,25 +73,64 @@ dataset_query:
           - v_query_log
           - dashboard_qualified_id
         - base-type: type/Text
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: 5gASJxNKdQCmkiGXb5kRP
-  label: dashboards_consuming_most_resources
-display: line
-entity_id: 5gASJxNKdQCmkiGXb5kRP
-collection_preview: true
+    joins:
+    - alias: Content - Dashboard Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_query_log
+          - dashboard_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Content - Dashboard Qualified
+      fields: all
+      source-table: AxSackBiyXVRUzM_TyyQY
+      strategy: left-join
+    - alias: Group Members - User
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_query_log
+          - user_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_group_members
+          - user_id
+        - base-type: type/Integer
+          join-alias: Group Members - User
+      fields: all
+      source-table: lTp-ATFsCUFEr9I0fMEaO
+      strategy: left-join
+    limit: 300
+    order-by:
+    - - desc
+      - - aggregation
+        - 0
+    source-table: QOtZaiTLf2FDD4AT6Oinb
+  type: query
+result_metadata: null
 visualization_settings:
+  column_settings: null
   graph.dimensions:
   - started_at
   - name
-  graph.series_order_dimension: null
-  graph.series_order: null
   graph.metrics:
   - sum
-  column_settings: null
+  graph.series_order: null
+  graph.series_order_dimension: null
+serdes/meta:
+- id: 5gASJxNKdQCmkiGXb5kRP
+  label: dashboards_consuming_most_resources
+  model: Card
 metabase_version: vUNKNOWN (901f705)
-parameters: []
-dataset: false
-created_at: '2023-11-01T11:23:23.432274Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/5ojUtU9iE-DCggHdFPIll_dashboard_subscriptions.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/5ojUtU9iE-DCggHdFPIll_dashboard_subscriptions.yaml
@@ -1,17 +1,41 @@
+name: Dashboard subscriptions
 description: Which subscriptions are active, who created them, who's subscribed to them, when they're sent, and more.
+entity_id: 5ojUtU9iE-DCggHdFPIll
+created_at: '2023-06-08T14:36:00.472585Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: 13
+query_type: query
+dataset: true
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_subscriptions
+enable_embedding: false
+embedding_params: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
+dataset_query:
+  database: Internal Metabase Database
+  query:
+    source-table:
+    - Internal Metabase Database
+    - public
+    - v_subscriptions
+  type: query
 result_metadata:
-- description: null
-  semantic_type: type/PK
+- base_type: type/Integer
   coercion_strategy: null
-  name: entity_id
-  settings: null
-  fk_target_field_id: null
+  description: null
+  display_name: Entity ID
+  effective_type: type/Integer
   field_ref:
   - field
   - - Internal Metabase Database
@@ -19,21 +43,21 @@ result_metadata:
     - v_subscriptions
     - entity_id
   - null
-  effective_type: type/Integer
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_subscriptions
   - entity_id
-  visibility_type: normal
-  display_name: Entity ID
-  base_type: type/Integer
-- description: null
+  name: entity_id
   semantic_type: type/PK
-  coercion_strategy: null
-  name: entity_qualified_id
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Entity Qualified ID
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -41,22 +65,21 @@ result_metadata:
     - v_subscriptions
     - entity_qualified_id
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_subscriptions
   - entity_qualified_id
-  visibility_type: normal
-  display_name: Entity Qualified ID
-  base_type: type/Text
-- description: null
-  semantic_type: type/CreationTimestamp
-  coercion_strategy: null
-  unit: default
-  name: created_at
+  name: entity_qualified_id
+  semantic_type: type/PK
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: null
+  display_name: Created At
+  effective_type: type/DateTimeWithLocalTZ
   field_ref:
   - field
   - - Internal Metabase Database
@@ -64,22 +87,22 @@ result_metadata:
     - v_subscriptions
     - created_at
   - temporal-unit: default
-  effective_type: type/DateTimeWithLocalTZ
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_subscriptions
   - created_at
-  visibility_type: normal
-  display_name: Created At
-  base_type: type/DateTimeWithLocalTZ
-- description: null
-  semantic_type: type/UpdatedTimestamp
-  coercion_strategy: null
-  unit: default
-  name: updated_at
+  name: created_at
+  semantic_type: type/CreationTimestamp
   settings: null
-  fk_target_field_id: null
+  unit: default
+  visibility_type: normal
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: null
+  display_name: Updated At
+  effective_type: type/DateTimeWithLocalTZ
   field_ref:
   - field
   - - Internal Metabase Database
@@ -87,21 +110,22 @@ result_metadata:
     - v_subscriptions
     - updated_at
   - temporal-unit: default
-  effective_type: type/DateTimeWithLocalTZ
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_subscriptions
   - updated_at
-  visibility_type: normal
-  display_name: Updated At
-  base_type: type/DateTimeWithLocalTZ
-- description: null
-  semantic_type: type/FK
-  coercion_strategy: null
-  name: creator_id
+  name: updated_at
+  semantic_type: type/UpdatedTimestamp
   settings: null
-  fk_target_field_id: 739
+  unit: default
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Creator ID
+  effective_type: type/Integer
   field_ref:
   - field
   - - Internal Metabase Database
@@ -109,21 +133,21 @@ result_metadata:
     - v_subscriptions
     - creator_id
   - null
-  effective_type: type/Integer
+  fk_target_field_id: 739
   id:
   - Internal Metabase Database
   - public
   - v_subscriptions
   - creator_id
-  visibility_type: normal
-  display_name: Creator ID
-  base_type: type/Integer
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: archived
+  name: creator_id
+  semantic_type: type/FK
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Boolean
+  coercion_strategy: null
+  description: null
+  display_name: Archived
+  effective_type: type/Boolean
   field_ref:
   - field
   - - Internal Metabase Database
@@ -131,21 +155,21 @@ result_metadata:
     - v_subscriptions
     - archived
   - null
-  effective_type: type/Boolean
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_subscriptions
   - archived
-  visibility_type: normal
-  display_name: Archived
-  base_type: type/Boolean
-- description: null
-  semantic_type: type/FK
-  coercion_strategy: null
-  name: dashboard_qualified_id
+  name: archived
+  semantic_type: type/Category
   settings: null
-  fk_target_field_id: 1484
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Dashboard Qualified ID
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -153,21 +177,21 @@ result_metadata:
     - v_subscriptions
     - dashboard_qualified_id
   - null
-  effective_type: type/Text
+  fk_target_field_id: 1484
   id:
   - Internal Metabase Database
   - public
   - v_subscriptions
   - dashboard_qualified_id
-  visibility_type: normal
-  display_name: Dashboard Qualified ID
-  base_type: type/Text
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: schedule_type
+  name: dashboard_qualified_id
+  semantic_type: type/FK
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Schedule Type
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -175,21 +199,21 @@ result_metadata:
     - v_subscriptions
     - schedule_type
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_subscriptions
   - schedule_type
-  visibility_type: normal
-  display_name: Schedule Type
-  base_type: type/Text
-- description: null
+  name: schedule_type
   semantic_type: type/Category
-  coercion_strategy: null
-  name: schedule_day
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Schedule Day
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -197,21 +221,21 @@ result_metadata:
     - v_subscriptions
     - schedule_day
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_subscriptions
   - schedule_day
-  visibility_type: normal
-  display_name: Schedule Day
-  base_type: type/Text
-- description: null
+  name: schedule_day
   semantic_type: type/Category
-  coercion_strategy: null
-  name: schedule_hour
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Schedule Hour
+  effective_type: type/Integer
   field_ref:
   - field
   - - Internal Metabase Database
@@ -219,21 +243,21 @@ result_metadata:
     - v_subscriptions
     - schedule_hour
   - null
-  effective_type: type/Integer
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_subscriptions
   - schedule_hour
-  visibility_type: normal
-  display_name: Schedule Hour
-  base_type: type/Integer
-- description: null
+  name: schedule_hour
   semantic_type: type/Category
-  coercion_strategy: null
-  name: recipient_type
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Recipient Type
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -241,21 +265,21 @@ result_metadata:
     - v_subscriptions
     - recipient_type
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_subscriptions
   - recipient_type
-  visibility_type: normal
-  display_name: Recipient Type
-  base_type: type/Text
-- description: null
+  name: recipient_type
   semantic_type: type/Category
-  coercion_strategy: null
-  name: recipients
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Recipients
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -263,21 +287,21 @@ result_metadata:
     - v_subscriptions
     - recipients
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_subscriptions
   - recipients
-  visibility_type: normal
-  display_name: Recipients
-  base_type: type/Text
-- description: null
-  semantic_type: null
-  coercion_strategy: null
-  name: recipient_external
+  name: recipients
+  semantic_type: type/Category
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Recipient External
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -285,21 +309,21 @@ result_metadata:
     - v_subscriptions
     - recipient_external
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_subscriptions
   - recipient_external
-  visibility_type: normal
-  display_name: Recipient External
-  base_type: type/Text
-- description: null
-  semantic_type: type/SerializedJSON
-  coercion_strategy: null
-  name: parameters
+  name: recipient_external
+  semantic_type: null
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Parameters
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -307,42 +331,18 @@ result_metadata:
     - v_subscriptions
     - parameters
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_subscriptions
   - parameters
+  name: parameters
+  semantic_type: type/SerializedJSON
+  settings: null
   visibility_type: normal
-  display_name: Parameters
-  base_type: type/Text
-database_id: Internal Metabase Database
-enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Dashboard subscriptions
-creator_id: internal@metabase.com
-made_public_by_id: null
-embedding_params: null
-cache_ttl: null
-dataset_query:
-  database: Internal Metabase Database
-  type: query
-  query:
-    source-table:
-    - Internal Metabase Database
-    - public
-    - v_subscriptions
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: 5ojUtU9iE-DCggHdFPIll
-  label: dashboard_subscriptions
-display: table
-entity_id: 5ojUtU9iE-DCggHdFPIll
-collection_preview: true
 visualization_settings:
-  table.pivot_column: name
+  column_settings: null
   table.cell_column: recipient_external
   table.column_widths:
   - null
@@ -350,9 +350,9 @@ visualization_settings:
   - null
   - null
   - 136
-  column_settings: null
+  table.pivot_column: name
+serdes/meta:
+- id: 5ojUtU9iE-DCggHdFPIll
+  label: dashboard_subscriptions
+  model: Card
 metabase_version: null
-parameters: []
-dataset: true
-created_at: '2023-06-08T14:36:00.472585Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/613VT_7b325t9FBAJZcU8_question_views_per_month.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/613VT_7b325t9FBAJZcU8_question_views_per_month.yaml
@@ -1,23 +1,29 @@
+name: Question views per month
 description: null
+entity_id: 613VT_7b325t9FBAJZcU8
+created_at: '2023-11-01T02:35:24.053968Z'
+creator_id: internal@metabase.com
+display: line
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Question views per month
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
     aggregation:
     - - count
@@ -29,9 +35,17 @@ dataset_query:
         - timestamp
       - base-type: type/DateTimeWithLocalTZ
         temporal-unit: month
+    filter:
+    - =
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - entity_type
+      - base-type: type/Text
+    - card
     joins:
     - alias: Content - Entity Qualified
-      strategy: left-join
       condition:
       - =
       - - field
@@ -48,8 +62,8 @@ dataset_query:
         - base-type: type/Text
           join-alias: Content - Entity Qualified
       source-table: AxSackBiyXVRUzM_TyyQY
-    - alias: Group Members - User
       strategy: left-join
+    - alias: Group Members - User
       condition:
       - =
       - - field
@@ -66,35 +80,21 @@ dataset_query:
         - base-type: type/Integer
           join-alias: Group Members - User
       source-table: lTp-ATFsCUFEr9I0fMEaO
+      strategy: left-join
     source-table: P6Ityjj7igswKh4NgZZjz
-    filter:
-    - =
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - entity_type
-      - base-type: type/Text
-    - card
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: 613VT_7b325t9FBAJZcU8
-  label: question_views_per_month
-display: line
-entity_id: 613VT_7b325t9FBAJZcU8
-collection_preview: true
+  type: query
+result_metadata: null
 visualization_settings:
-  table.pivot_column: end_timestamp
-  table.cell_column: model_id
+  column_settings: null
   graph.dimensions:
   - timestamp
-  graph.show_values: true
   graph.metrics:
   - count
-  column_settings: null
+  graph.show_values: true
+  table.cell_column: model_id
+  table.pivot_column: end_timestamp
+serdes/meta:
+- id: 613VT_7b325t9FBAJZcU8
+  label: question_views_per_month
+  model: Card
 metabase_version: vUNKNOWN (13e6090)
-parameters: []
-dataset: false
-created_at: '2023-11-01T02:35:24.053968Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/7FLoE9kUELG4Ess6DsSEY_last_downloads.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/7FLoE9kUELG4Ess6DsSEY_last_downloads.yaml
@@ -1,0 +1,388 @@
+name: Last downloads
+description: Most recently downloaded content.
+entity_id: 7FLoE9kUELG4Ess6DsSEY
+created_at: '2023-11-13T20:33:32.875659Z'
+creator_id: internal@metabase.com
+display: table
+archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
+collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
+table_id:
+- Internal Metabase Database
+- public
+- v_query_log
+enable_embedding: false
+embedding_params: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
+dataset_query:
+  database: Internal Metabase Database
+  query:
+    fields:
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_query_log
+        - started_at
+      - base-type: type/DateTimeWithLocalTZ
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_query_log
+        - running_time_seconds
+      - base-type: type/Float
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_query_log
+        - result_rows
+      - base-type: type/Integer
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_query_log
+        - is_native
+      - base-type: type/Boolean
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_query_log
+        - query_source
+      - base-type: type/Text
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_query_log
+        - error
+      - base-type: type/Text
+    filter:
+    - =
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_query_log
+        - query_source
+      - base-type: type/Text
+    - csv-download
+    - json-download
+    - xlsx-download
+    joins:
+    - alias: Content - Card Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_query_log
+          - card_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Content - Card Qualified
+      fields:
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - name
+        - base-type: type/Text
+          join-alias: Content - Card Qualified
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_id
+        - base-type: type/Integer
+          join-alias: Content - Card Qualified
+      source-table: AxSackBiyXVRUzM_TyyQY
+      strategy: left-join
+    - alias: Content - Dashboard Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_query_log
+          - dashboard_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Content - Dashboard Qualified
+      fields:
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - name
+        - base-type: type/Text
+          join-alias: Content - Dashboard Qualified
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_id
+        - base-type: type/Integer
+          join-alias: Content - Dashboard Qualified
+      source-table: AxSackBiyXVRUzM_TyyQY
+      strategy: left-join
+    - alias: Databases - Database Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_query_log
+          - database_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_databases
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Databases - Database Qualified
+      fields:
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_databases
+          - entity_id
+        - base-type: type/Integer
+          join-alias: Databases - Database Qualified
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_databases
+          - name
+        - base-type: type/Text
+          join-alias: Databases - Database Qualified
+      source-table: -19557ZnrWiDgG4h4cKxF
+      strategy: left-join
+    - alias: People - User
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_query_log
+          - user_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_users
+          - user_id
+        - base-type: type/Integer
+          join-alias: People - User
+      fields:
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_users
+          - user_id
+        - base-type: type/Integer
+          join-alias: People - User
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_users
+          - full_name
+        - base-type: type/Text
+          join-alias: People - User
+      source-table: 0wVIfjBJWclD0lKeABYYl
+      strategy: left-join
+    limit: 200
+    order-by:
+    - - desc
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_query_log
+          - started_at
+        - base-type: type/DateTimeWithLocalTZ
+    source-table: QOtZaiTLf2FDD4AT6Oinb
+  type: query
+result_metadata: null
+visualization_settings:
+  column_settings:
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Card Qualified"}]]'
+    : column_title: Question ID
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Dashboard Qualified"}]]'
+    : column_title: Dashboard ID
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Card Qualified"}]]'
+    : column_title: Question name
+      link_text: ''
+      link_url: /question/{{entity_id}}
+      view_as: link
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Dashboard Qualified"}]]'
+    : column_title: Dashboard name
+      link_url: /dashboard/{{entity_id_2}}
+      view_as: link
+    ? '["ref",["field",["Internal Metabase Database","public","v_databases","entity_id"],{"base-type":"type/Integer","join-alias":"Databases - Database Qualified"}]]'
+    : column_title: Database ID
+    ? '["ref",["field",["Internal Metabase Database","public","v_databases","name"],{"base-type":"type/Text","join-alias":"Databases - Database Qualified"}]]'
+    : column_title: Database name
+      link_url: /browse/{{entity_id_3}}
+      view_as: link
+    ? '["ref",["field",["Internal Metabase Database","public","v_users","full_name"],{"base-type":"type/Text","join-alias":"People - User"}]]'
+    : column_title: User name
+    ? '["ref",["field",["Internal Metabase Database","public","v_users","user_id"],{"base-type":"type/Integer","join-alias":"People - User"}]]'
+    : column_title: User ID
+  table.cell_column: running_time_seconds
+  table.columns:
+  - enabled: true
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_query_log
+      - started_at
+    - base-type: type/DateTimeWithLocalTZ
+      temporal-unit: default
+    name: started_at
+  - enabled: true
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_users
+      - full_name
+    - base-type: type/Text
+      join-alias: People - User
+    name: full_name
+  - enabled: true
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_query_log
+      - query_source
+    - base-type: type/Text
+    name: query_source
+  - enabled: true
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_content
+      - name
+    - base-type: type/Text
+      join-alias: Content - Card Qualified
+    name: name
+  - enabled: true
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_content
+      - name
+    - base-type: type/Text
+      join-alias: Content - Dashboard Qualified
+    name: name_2
+  - enabled: true
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_databases
+      - name
+    - base-type: type/Text
+      join-alias: Databases - Database Qualified
+    name: name_3
+  - enabled: true
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_query_log
+      - is_native
+    - base-type: type/Boolean
+    name: is_native
+  - enabled: true
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_query_log
+      - running_time_seconds
+    - base-type: type/Float
+    name: running_time_seconds
+  - enabled: true
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_query_log
+      - result_rows
+    - base-type: type/Integer
+    name: result_rows
+  - enabled: false
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_content
+      - entity_id
+    - base-type: type/Integer
+      join-alias: Content - Card Qualified
+    name: entity_id
+  - enabled: false
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_content
+      - entity_id
+    - base-type: type/Integer
+      join-alias: Content - Dashboard Qualified
+    name: entity_id_2
+  - enabled: false
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_databases
+      - entity_id
+    - base-type: type/Integer
+      join-alias: Databases - Database Qualified
+    name: entity_id_3
+  - enabled: true
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_query_log
+      - error
+    - base-type: type/Text
+    name: error
+  - enabled: false
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_users
+      - user_id
+    - base-type: type/Integer
+      join-alias: People - User
+    name: user_id
+  table.pivot_column: error
+serdes/meta:
+- id: 7FLoE9kUELG4Ess6DsSEY
+  label: last_downloads
+  model: Card
+metabase_version: vUNKNOWN (a98530f)

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/95Om4AllyfyB5wtl6TeGi_last_viewed_tables.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/95Om4AllyfyB5wtl6TeGi_last_viewed_tables.yaml
@@ -1,30 +1,30 @@
+name: Last viewed tables
 description: null
+entity_id: 95Om4AllyfyB5wtl6TeGi
+created_at: '2023-11-01T01:02:00.637304Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Last viewed tables
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
+  database: Internal Metabase Database
   query:
-    order-by:
-    - - desc
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - timestamp
-        - base-type: type/DateTimeWithLocalTZ
     fields:
     - - field
       - - Internal Metabase Database
@@ -32,8 +32,33 @@ dataset_query:
         - v_view_log
         - timestamp
       - base-type: type/DateTimeWithLocalTZ
+    filter:
+    - =
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - entity_type
+      - base-type: type/Text
+    - table
     joins:
-    - fields:
+    - alias: Tables - Entity Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - entity_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_tables
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Tables - Entity Qualified
+      fields:
       - - field
         - - Internal Metabase Database
           - public
@@ -55,27 +80,16 @@ dataset_query:
           - description
         - base-type: type/Text
           join-alias: Tables - Entity Qualified
-      strategy: left-join
-      alias: Tables - Entity Qualified
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - entity_qualified_id
-        - base-type: type/Text
       - - field
         - - Internal Metabase Database
           - public
           - v_tables
-          - entity_qualified_id
-        - base-type: type/Text
+          - database_id
+        - base-type: type/Integer
           join-alias: Tables - Entity Qualified
       source-table: x7GwgNdjfzrpQkKTraaqo
-    - fields: none
       strategy: left-join
-      alias: People - User
+    - alias: People - User
       condition:
       - =
       - - field
@@ -91,210 +105,51 @@ dataset_query:
           - user_id
         - base-type: type/Integer
           join-alias: People - User
+      fields: none
       source-table: 0wVIfjBJWclD0lKeABYYl
+      strategy: left-join
+    limit: 200
+    order-by:
+    - - desc
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - timestamp
+        - base-type: type/DateTimeWithLocalTZ
     source-table: P6Ityjj7igswKh4NgZZjz
-    filter:
-    - =
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - entity_type
-      - base-type: type/Text
-    - table
   type: query
-  database: Internal Metabase Database
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: 95Om4AllyfyB5wtl6TeGi
-  label: last_viewed_tables
-display: table
-entity_id: 95Om4AllyfyB5wtl6TeGi
-collection_preview: true
+result_metadata: null
 visualization_settings:
-  table.pivot_column: end_timestamp
+  column_settings:
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","description"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Description
+    '["ref",["field",["Internal Metabase Database","public","v_content","description"],{"join-alias":"Question 35"}]]':
+      column_title: Description
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Question ID
+    '["ref",["field",["Internal Metabase Database","public","v_content","id"],{"join-alias":"Question 35"}]]':
+      column_title: Dashboard ID
+      link_text: Dashboard {{id}}
+      link_url: ''
+      view_as: null
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Question name
+    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35"}]]':
+      column_title: Dashboard name
+    ? '["ref",["field",["Internal Metabase Database","public","v_tables","database_id"],{"base-type":"type/Integer","join-alias":"Tables - Entity Qualified"}]]'
+    : column_title: Database ID
+    ? '["ref",["field",["Internal Metabase Database","public","v_tables","description"],{"base-type":"type/Text","join-alias":"Tables - Entity Qualified"}]]'
+    : column_title: Description
+    ? '["ref",["field",["Internal Metabase Database","public","v_tables","entity_id"],{"base-type":"type/Integer","join-alias":"Tables - Entity Qualified"}]]'
+    : column_title: Table ID
+    ? '["ref",["field",["Internal Metabase Database","public","v_tables","name"],{"base-type":"type/Text","join-alias":"Tables - Entity Qualified"}]]'
+    : column_title: Table name
+      link_url: /question#?db={{database_id}}&table={{entity_id}}
+      view_as: link
   table.cell_column: model_id
   table.columns:
-  - name: id
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - id
-    - join-alias: Question 35
-    enabled: true
-  - name: entity_id_2
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - entity_id
-    - base-type: type/Integer
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: entity_qualified_id_2
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - entity_qualified_id
-    - base-type: type/Text
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: entity_type_2
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - entity_type
-    - base-type: type/Text
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: creator_id
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - creator_id
-    - base-type: type/Integer
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: collection_id
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - collection_id
-    - base-type: type/Integer
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: made_public_by_user
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - made_public_by_user
-    - base-type: type/Integer
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: is_embedding_enabled
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - is_embedding_enabled
-    - base-type: type/Boolean
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: archived
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - archived
-    - base-type: type/Boolean
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: action_type
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - action_type
-    - base-type: type/Text
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: action_model_id
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - action_model_id
-    - base-type: type/Integer
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: collection_is_official
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - collection_is_official
-    - base-type: type/Boolean
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: collection_is_personal
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - collection_is_personal
-    - base-type: type/Boolean
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: question_viz_type
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - question_viz_type
-    - base-type: type/Text
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: question_database_id
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - question_database_id
-    - base-type: type/Text
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: question_is_native
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - question_is_native
-    - base-type: type/Boolean
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: event_timestamp
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - event_timestamp
-    - base-type: type/DateTimeWithLocalTZ
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: user_id_2
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - user_id
-    - join-alias: People - Creator
-    enabled: true
-  - name: timestamp
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -302,8 +157,9 @@ visualization_settings:
       - v_view_log
       - timestamp
     - base-type: type/DateTimeWithLocalTZ
-    enabled: true
-  - name: false
+      temporal-unit: default
+    name: timestamp
+  - enabled: false
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -312,8 +168,8 @@ visualization_settings:
       - entity_id
     - base-type: type/Integer
       join-alias: Tables - Entity Qualified
-    enabled: true
-  - name: false_2
+    name: entity_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -322,8 +178,8 @@ visualization_settings:
       - name
     - base-type: type/Text
       join-alias: Tables - Entity Qualified
-    enabled: true
-  - name: false_3
+    name: name
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -332,31 +188,20 @@ visualization_settings:
       - description
     - base-type: type/Text
       join-alias: Tables - Entity Qualified
-    enabled: true
-  column_settings:
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
-    : column_title: Question name
-    ? '["ref",["field",["Internal Metabase Database","public","v_tables","entity_id"],{"base-type":"type/Integer","join-alias":"Tables - Entity Qualified"}]]'
-    : column_title: Table ID
-    '["ref",["field",["Internal Metabase Database","public","v_content","description"],{"join-alias":"Question 35"}]]':
-      column_title: Description
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Entity Qualified"}]]'
-    : column_title: Question ID
-    ? '["ref",["field",["Internal Metabase Database","public","v_tables","description"],{"base-type":"type/Text","join-alias":"Tables - Entity Qualified"}]]'
-    : column_title: Description
-    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35"}]]':
-      column_title: Dashboard name
-    '["ref",["field",["Internal Metabase Database","public","v_content","id"],{"join-alias":"Question 35"}]]':
-      view_as: null
-      column_title: Dashboard ID
-      link_text: Dashboard {{id}}
-      link_url: ''
-    ? '["ref",["field",["Internal Metabase Database","public","v_tables","name"],{"base-type":"type/Text","join-alias":"Tables - Entity Qualified"}]]'
-    : column_title: Table name
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","description"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
-    : column_title: Description
+    name: description
+  - enabled: false
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_tables
+      - database_id
+    - base-type: type/Integer
+      join-alias: Tables - Entity Qualified
+    name: database_id
+  table.pivot_column: end_timestamp
+serdes/meta:
+- id: 95Om4AllyfyB5wtl6TeGi
+  label: last_viewed_tables
+  model: Card
 metabase_version: vUNKNOWN (ad99d37)
-parameters: []
-dataset: false
-created_at: '2023-11-01T01:02:00.637304Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/9shJ0y29V5o1lOSDL4ImJ_most_viewed_questions.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/9shJ0y29V5o1lOSDL4ImJ_most_viewed_questions.yaml
@@ -1,59 +1,30 @@
+name: Most viewed questions
 description: null
+entity_id: 9shJ0y29V5o1lOSDL4ImJ
+created_at: '2023-06-15T02:29:28.716686Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Most viewed questions
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    joins:
-    - strategy: left-join
-      alias: Content - Entity Qualified
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - entity_qualified_id
-        - base-type: type/Text
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - entity_qualified_id
-        - base-type: type/Text
-          join-alias: Content - Entity Qualified
-      source-table: AxSackBiyXVRUzM_TyyQY
-    - strategy: left-join
-      alias: People - Creator
-      condition:
-      - =
-      - - field
-        - creator_id
-        - base-type: type/Integer
-          join-alias: Content - Entity Qualified
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_users
-          - user_id
-        - base-type: type/Integer
-          join-alias: People - Creator
-      source-table: 0wVIfjBJWclD0lKeABYYl
     aggregation:
     - - count
     breakout:
@@ -71,11 +42,6 @@ dataset_query:
         - entity_id
       - base-type: type/Integer
         join-alias: Content - Entity Qualified
-    order-by:
-    - - desc
-      - - aggregation
-        - 0
-    source-table: P6Ityjj7igswKh4NgZZjz
     filter:
     - =
     - - field
@@ -85,17 +51,69 @@ dataset_query:
         - entity_type
       - base-type: type/Text
     - card
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: 9shJ0y29V5o1lOSDL4ImJ
-  label: most_viewed_questions
-display: table
-entity_id: 9shJ0y29V5o1lOSDL4ImJ
-collection_preview: true
+    joins:
+    - alias: Content - Entity Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - entity_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Content - Entity Qualified
+      source-table: AxSackBiyXVRUzM_TyyQY
+      strategy: left-join
+    - alias: People - Creator
+      condition:
+      - =
+      - - field
+        - creator_id
+        - base-type: type/Integer
+          join-alias: Content - Entity Qualified
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_users
+          - user_id
+        - base-type: type/Integer
+          join-alias: People - Creator
+      source-table: 0wVIfjBJWclD0lKeABYYl
+      strategy: left-join
+    order-by:
+    - - desc
+      - - aggregation
+        - 0
+    source-table: P6Ityjj7igswKh4NgZZjz
+  type: query
+result_metadata: null
 visualization_settings:
+  column_settings:
+    '["name","count"]':
+      show_mini_bar: true
+    '["ref",["field",["Internal Metabase Database","public","v_content","description"],{"join-alias":"Question 35"}]]':
+      column_title: Description
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Question ID
+    '["ref",["field",["Internal Metabase Database","public","v_content","id"],{"join-alias":"Question 35"}]]':
+      column_title: Dashboard ID
+      link_text: Dashboard {{id}}
+      link_url: ''
+      view_as: null
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Question name
+    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35"}]]':
+      column_title: Dashboard name
   graph.dimensions:
   - name
+  graph.metrics:
+  - count
   table.cell_column: model_id
   table.columns:
   - enabled: true
@@ -125,7 +143,7 @@ visualization_settings:
       - user_id
     - join-alias: Question 1
     name: user_id
-  - name: entity_id_2
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -134,8 +152,8 @@ visualization_settings:
       - entity_id
     - base-type: type/Integer
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: entity_qualified_id_2
+    name: entity_id_2
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -144,8 +162,8 @@ visualization_settings:
       - entity_qualified_id
     - base-type: type/Text
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: entity_type_2
+    name: entity_qualified_id_2
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -154,8 +172,8 @@ visualization_settings:
       - entity_type
     - base-type: type/Text
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: created_at
+    name: entity_type_2
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -164,8 +182,8 @@ visualization_settings:
       - created_at
     - base-type: type/DateTimeWithLocalTZ
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: updated_at
+    name: created_at
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -174,8 +192,8 @@ visualization_settings:
       - updated_at
     - base-type: type/DateTimeWithLocalTZ
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: creator_id
+    name: updated_at
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -184,8 +202,8 @@ visualization_settings:
       - creator_id
     - base-type: type/Integer
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: description
+    name: creator_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -194,8 +212,8 @@ visualization_settings:
       - description
     - base-type: type/Text
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: collection_id
+    name: description
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -204,8 +222,8 @@ visualization_settings:
       - collection_id
     - base-type: type/Integer
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: made_public_by_user
+    name: collection_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -214,8 +232,8 @@ visualization_settings:
       - made_public_by_user
     - base-type: type/Integer
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: is_embedding_enabled
+    name: made_public_by_user
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -224,8 +242,8 @@ visualization_settings:
       - is_embedding_enabled
     - base-type: type/Boolean
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: archived
+    name: is_embedding_enabled
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -234,8 +252,8 @@ visualization_settings:
       - archived
     - base-type: type/Boolean
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: action_type
+    name: archived
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -244,8 +262,8 @@ visualization_settings:
       - action_type
     - base-type: type/Text
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: action_model_id
+    name: action_type
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -254,8 +272,8 @@ visualization_settings:
       - action_model_id
     - base-type: type/Integer
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: collection_is_official
+    name: action_model_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -264,8 +282,8 @@ visualization_settings:
       - collection_is_official
     - base-type: type/Boolean
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: collection_is_personal
+    name: collection_is_official
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -274,8 +292,8 @@ visualization_settings:
       - collection_is_personal
     - base-type: type/Boolean
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: question_viz_type
+    name: collection_is_personal
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -284,8 +302,8 @@ visualization_settings:
       - question_viz_type
     - base-type: type/Text
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: question_database_id
+    name: question_viz_type
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -294,8 +312,8 @@ visualization_settings:
       - question_database_id
     - base-type: type/Text
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: question_is_native
+    name: question_database_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -304,8 +322,8 @@ visualization_settings:
       - question_is_native
     - base-type: type/Boolean
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: event_timestamp
+    name: question_is_native
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -314,8 +332,8 @@ visualization_settings:
       - event_timestamp
     - base-type: type/DateTimeWithLocalTZ
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: user_id_2
+    name: event_timestamp
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -323,8 +341,8 @@ visualization_settings:
       - v_users
       - user_id
     - join-alias: People - Creator
-    enabled: true
-  - name: email
+    name: user_id_2
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -332,8 +350,8 @@ visualization_settings:
       - v_users
       - email
     - join-alias: People - Creator
-    enabled: true
-  - name: first_name
+    name: email
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -341,8 +359,8 @@ visualization_settings:
       - v_users
       - first_name
     - join-alias: People - Creator
-    enabled: true
-  - name: last_name
+    name: first_name
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -350,8 +368,8 @@ visualization_settings:
       - v_users
       - last_name
     - join-alias: People - Creator
-    enabled: true
-  - name: date_joined
+    name: last_name
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -359,8 +377,8 @@ visualization_settings:
       - v_users
       - date_joined
     - join-alias: People - Creator
-    enabled: true
-  - name: last_login
+    name: date_joined
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -368,8 +386,8 @@ visualization_settings:
       - v_users
       - last_login
     - join-alias: People - Creator
-    enabled: true
-  - name: updated_at_2
+    name: last_login
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -377,8 +395,8 @@ visualization_settings:
       - v_users
       - updated_at
     - join-alias: People - Creator
-    enabled: true
-  - name: is_admin
+    name: updated_at_2
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -386,8 +404,8 @@ visualization_settings:
       - v_users
       - is_admin
     - join-alias: People - Creator
-    enabled: true
-  - name: is_active
+    name: is_admin
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -395,8 +413,8 @@ visualization_settings:
       - v_users
       - is_active
     - join-alias: People - Creator
-    enabled: true
-  - name: sso_source
+    name: is_active
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -404,8 +422,8 @@ visualization_settings:
       - v_users
       - sso_source
     - join-alias: People - Creator
-    enabled: true
-  - name: locale
+    name: sso_source
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -413,8 +431,8 @@ visualization_settings:
       - v_users
       - locale
     - join-alias: People - Creator
-    enabled: true
-  - name: full_name
+    name: locale
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -423,8 +441,8 @@ visualization_settings:
       - full_name
     - base-type: type/Text
       join-alias: People - Creator
-    enabled: true
-  - name: name
+    name: full_name
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -433,8 +451,8 @@ visualization_settings:
       - name
     - base-type: type/Text
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: entity_id
+    name: name
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -443,28 +461,10 @@ visualization_settings:
       - entity_id
     - base-type: type/Integer
       join-alias: Content - Entity Qualified
-    enabled: true
+    name: entity_id
   table.pivot_column: end_timestamp
-  column_settings:
-    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35"}]]':
-      column_title: Dashboard name
-    '["ref",["field",["Internal Metabase Database","public","v_content","id"],{"join-alias":"Question 35"}]]':
-      column_title: Dashboard ID
-      link_text: Dashboard {{id}}
-      link_url: ''
-      view_as: null
-    '["ref",["field",["Internal Metabase Database","public","v_content","description"],{"join-alias":"Question 35"}]]':
-      column_title: Description
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
-    : column_title: Question name
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Entity Qualified"}]]'
-    : column_title: Question ID
-    '["name","count"]':
-      show_mini_bar: true
-  graph.metrics:
-  - count
+serdes/meta:
+- id: 9shJ0y29V5o1lOSDL4ImJ
+  label: most_viewed_questions
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-06-15T02:29:28.716686Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/AxSackBiyXVRUzM_TyyQY_content.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/AxSackBiyXVRUzM_TyyQY_content.yaml
@@ -1,474 +1,30 @@
+name: Content
 description: All Metabase content, including questions, models, dashboards, events, and collections.
+entity_id: AxSackBiyXVRUzM_TyyQY
+created_at: '2023-06-08T14:33:12.546414Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: 12
+query_type: query
+dataset: true
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_content
-result_metadata:
-- description: null
-  semantic_type: type/PK
-  coercion_strategy: null
-  name: entity_id
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_content
-    - entity_id
-  - base-type: type/Integer
-  effective_type: type/Integer
-  id:
-  - Internal Metabase Database
-  - public
-  - v_content
-  - entity_id
-  visibility_type: normal
-  display_name: Entity ID
-  base_type: type/Integer
-- description: null
-  semantic_type: type/PK
-  coercion_strategy: null
-  name: entity_qualified_id
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_content
-    - entity_qualified_id
-  - base-type: type/Text
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_content
-  - entity_qualified_id
-  visibility_type: normal
-  display_name: Entity Qualified ID
-  base_type: type/Text
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: entity_type
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_content
-    - entity_type
-  - base-type: type/Text
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_content
-  - entity_type
-  visibility_type: normal
-  display_name: Entity Type
-  base_type: type/Text
-- description: null
-  semantic_type: type/CreationTimestamp
-  coercion_strategy: null
-  unit: default
-  name: created_at
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_content
-    - created_at
-  - base-type: type/DateTimeWithLocalTZ
-    temporal-unit: default
-  effective_type: type/DateTimeWithLocalTZ
-  id:
-  - Internal Metabase Database
-  - public
-  - v_content
-  - created_at
-  visibility_type: normal
-  display_name: Created At
-  base_type: type/DateTimeWithLocalTZ
-- description: null
-  semantic_type: type/UpdatedTimestamp
-  coercion_strategy: null
-  unit: default
-  name: updated_at
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_content
-    - updated_at
-  - base-type: type/DateTimeWithLocalTZ
-    temporal-unit: default
-  effective_type: type/DateTimeWithLocalTZ
-  id:
-  - Internal Metabase Database
-  - public
-  - v_content
-  - updated_at
-  visibility_type: normal
-  display_name: Updated At
-  base_type: type/DateTimeWithLocalTZ
-- description: null
-  semantic_type: type/FK
-  coercion_strategy: null
-  name: creator_id
-  settings: null
-  fk_target_field_id: 739
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_content
-    - creator_id
-  - base-type: type/Integer
-  effective_type: type/Integer
-  id:
-  - Internal Metabase Database
-  - public
-  - v_content
-  - creator_id
-  visibility_type: normal
-  display_name: Creator ID
-  base_type: type/Integer
-- description: null
-  semantic_type: type/Name
-  coercion_strategy: null
-  name: name
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_content
-    - name
-  - base-type: type/Text
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_content
-  - name
-  visibility_type: normal
-  display_name: Name
-  base_type: type/Text
-- description: null
-  semantic_type: type/Description
-  coercion_strategy: null
-  name: description
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_content
-    - description
-  - base-type: type/Text
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_content
-  - description
-  visibility_type: normal
-  display_name: Description
-  base_type: type/Text
-- description: null
-  semantic_type: type/FK
-  coercion_strategy: null
-  name: collection_id
-  settings: null
-  fk_target_field_id: 919
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_content
-    - collection_id
-  - base-type: type/Integer
-  effective_type: type/Integer
-  id:
-  - Internal Metabase Database
-  - public
-  - v_content
-  - collection_id
-  visibility_type: normal
-  display_name: Collection ID
-  base_type: type/Integer
-- description: null
-  semantic_type: type/FK
-  coercion_strategy: null
-  name: made_public_by_user
-  settings: null
-  fk_target_field_id: 739
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_content
-    - made_public_by_user
-  - base-type: type/Integer
-  effective_type: type/Integer
-  id:
-  - Internal Metabase Database
-  - public
-  - v_content
-  - made_public_by_user
-  visibility_type: normal
-  display_name: Made Public By User
-  base_type: type/Integer
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: is_embedding_enabled
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_content
-    - is_embedding_enabled
-  - base-type: type/Boolean
-  effective_type: type/Boolean
-  id:
-  - Internal Metabase Database
-  - public
-  - v_content
-  - is_embedding_enabled
-  visibility_type: normal
-  display_name: Is Embedding Enabled
-  base_type: type/Boolean
-- description: null
-  semantic_type: type/Enum
-  coercion_strategy: null
-  name: archived
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_content
-    - archived
-  - base-type: type/Boolean
-  effective_type: type/Boolean
-  id:
-  - Internal Metabase Database
-  - public
-  - v_content
-  - archived
-  visibility_type: normal
-  display_name: Archived
-  base_type: type/Boolean
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: action_type
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_content
-    - action_type
-  - base-type: type/Text
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_content
-  - action_type
-  visibility_type: normal
-  display_name: Action Type
-  base_type: type/Text
-- description: null
-  semantic_type: type/FK
-  coercion_strategy: null
-  name: action_model_id
-  settings: null
-  fk_target_field_id: 919
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_content
-    - action_model_id
-  - base-type: type/Integer
-  effective_type: type/Integer
-  id:
-  - Internal Metabase Database
-  - public
-  - v_content
-  - action_model_id
-  visibility_type: normal
-  display_name: Action Model ID
-  base_type: type/Integer
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: collection_is_official
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_content
-    - collection_is_official
-  - base-type: type/Boolean
-  effective_type: type/Boolean
-  id:
-  - Internal Metabase Database
-  - public
-  - v_content
-  - collection_is_official
-  visibility_type: normal
-  display_name: Collection Is Official
-  base_type: type/Boolean
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: collection_is_personal
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_content
-    - collection_is_personal
-  - base-type: type/Boolean
-  effective_type: type/Boolean
-  id:
-  - Internal Metabase Database
-  - public
-  - v_content
-  - collection_is_personal
-  visibility_type: normal
-  display_name: Collection Is Personal
-  base_type: type/Boolean
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: question_viz_type
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_content
-    - question_viz_type
-  - base-type: type/Text
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_content
-  - question_viz_type
-  visibility_type: normal
-  display_name: Question Viz Type
-  base_type: type/Text
-- description: null
-  semantic_type: type/FK
-  coercion_strategy: null
-  name: question_database_id
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_content
-    - question_database_id
-  - base-type: type/Text
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_content
-  - question_database_id
-  visibility_type: normal
-  display_name: Question Database ID
-  base_type: type/Text
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: question_is_native
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_content
-    - question_is_native
-  - base-type: type/Boolean
-  effective_type: type/Boolean
-  id:
-  - Internal Metabase Database
-  - public
-  - v_content
-  - question_is_native
-  visibility_type: normal
-  display_name: Question Is Native
-  base_type: type/Boolean
-- description: null
-  semantic_type: null
-  coercion_strategy: null
-  unit: default
-  name: event_timestamp
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_content
-    - event_timestamp
-  - base-type: type/DateTimeWithLocalTZ
-    temporal-unit: default
-  effective_type: type/DateTimeWithLocalTZ
-  id:
-  - Internal Metabase Database
-  - public
-  - v_content
-  - event_timestamp
-  visibility_type: normal
-  display_name: Event Timestamp
-  base_type: type/DateTimeWithLocalTZ
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Content
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    source-table:
-    - Internal Metabase Database
-    - public
-    - v_content
     fields:
     - - field
       - - Internal Metabase Database
@@ -590,20 +146,464 @@ dataset_query:
         - v_content
         - event_timestamp
       - base-type: type/DateTimeWithLocalTZ
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: AxSackBiyXVRUzM_TyyQY
-  label: content
-display: table
-entity_id: AxSackBiyXVRUzM_TyyQY
-collection_preview: true
+    source-table:
+    - Internal Metabase Database
+    - public
+    - v_content
+  type: query
+result_metadata:
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Entity ID
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_content
+    - entity_id
+  - base-type: type/Integer
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_content
+  - entity_id
+  name: entity_id
+  semantic_type: type/PK
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Entity Qualified ID
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_content
+    - entity_qualified_id
+  - base-type: type/Text
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_content
+  - entity_qualified_id
+  name: entity_qualified_id
+  semantic_type: type/PK
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Entity Type
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_content
+    - entity_type
+  - base-type: type/Text
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_content
+  - entity_type
+  name: entity_type
+  semantic_type: type/Category
+  settings: null
+  visibility_type: normal
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: null
+  display_name: Created At
+  effective_type: type/DateTimeWithLocalTZ
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_content
+    - created_at
+  - base-type: type/DateTimeWithLocalTZ
+    temporal-unit: default
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_content
+  - created_at
+  name: created_at
+  semantic_type: type/CreationTimestamp
+  settings: null
+  unit: default
+  visibility_type: normal
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: null
+  display_name: Updated At
+  effective_type: type/DateTimeWithLocalTZ
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_content
+    - updated_at
+  - base-type: type/DateTimeWithLocalTZ
+    temporal-unit: default
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_content
+  - updated_at
+  name: updated_at
+  semantic_type: type/UpdatedTimestamp
+  settings: null
+  unit: default
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Creator ID
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_content
+    - creator_id
+  - base-type: type/Integer
+  fk_target_field_id: 739
+  id:
+  - Internal Metabase Database
+  - public
+  - v_content
+  - creator_id
+  name: creator_id
+  semantic_type: type/FK
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Name
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_content
+    - name
+  - base-type: type/Text
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_content
+  - name
+  name: name
+  semantic_type: type/Name
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Description
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_content
+    - description
+  - base-type: type/Text
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_content
+  - description
+  name: description
+  semantic_type: type/Description
+  settings: null
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Collection ID
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_content
+    - collection_id
+  - base-type: type/Integer
+  fk_target_field_id: 919
+  id:
+  - Internal Metabase Database
+  - public
+  - v_content
+  - collection_id
+  name: collection_id
+  semantic_type: type/FK
+  settings: null
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Made Public By User
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_content
+    - made_public_by_user
+  - base-type: type/Integer
+  fk_target_field_id: 739
+  id:
+  - Internal Metabase Database
+  - public
+  - v_content
+  - made_public_by_user
+  name: made_public_by_user
+  semantic_type: type/FK
+  settings: null
+  visibility_type: normal
+- base_type: type/Boolean
+  coercion_strategy: null
+  description: null
+  display_name: Is Embedding Enabled
+  effective_type: type/Boolean
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_content
+    - is_embedding_enabled
+  - base-type: type/Boolean
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_content
+  - is_embedding_enabled
+  name: is_embedding_enabled
+  semantic_type: type/Category
+  settings: null
+  visibility_type: normal
+- base_type: type/Boolean
+  coercion_strategy: null
+  description: null
+  display_name: Archived
+  effective_type: type/Boolean
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_content
+    - archived
+  - base-type: type/Boolean
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_content
+  - archived
+  name: archived
+  semantic_type: type/Enum
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Action Type
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_content
+    - action_type
+  - base-type: type/Text
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_content
+  - action_type
+  name: action_type
+  semantic_type: type/Category
+  settings: null
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Action Model ID
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_content
+    - action_model_id
+  - base-type: type/Integer
+  fk_target_field_id: 919
+  id:
+  - Internal Metabase Database
+  - public
+  - v_content
+  - action_model_id
+  name: action_model_id
+  semantic_type: type/FK
+  settings: null
+  visibility_type: normal
+- base_type: type/Boolean
+  coercion_strategy: null
+  description: null
+  display_name: Collection Is Official
+  effective_type: type/Boolean
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_content
+    - collection_is_official
+  - base-type: type/Boolean
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_content
+  - collection_is_official
+  name: collection_is_official
+  semantic_type: type/Category
+  settings: null
+  visibility_type: normal
+- base_type: type/Boolean
+  coercion_strategy: null
+  description: null
+  display_name: Collection Is Personal
+  effective_type: type/Boolean
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_content
+    - collection_is_personal
+  - base-type: type/Boolean
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_content
+  - collection_is_personal
+  name: collection_is_personal
+  semantic_type: type/Category
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Question Viz Type
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_content
+    - question_viz_type
+  - base-type: type/Text
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_content
+  - question_viz_type
+  name: question_viz_type
+  semantic_type: type/Category
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Question Database ID
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_content
+    - question_database_id
+  - base-type: type/Text
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_content
+  - question_database_id
+  name: question_database_id
+  semantic_type: type/FK
+  settings: null
+  visibility_type: normal
+- base_type: type/Boolean
+  coercion_strategy: null
+  description: null
+  display_name: Question Is Native
+  effective_type: type/Boolean
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_content
+    - question_is_native
+  - base-type: type/Boolean
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_content
+  - question_is_native
+  name: question_is_native
+  semantic_type: type/Category
+  settings: null
+  visibility_type: normal
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: null
+  display_name: Event Timestamp
+  effective_type: type/DateTimeWithLocalTZ
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_content
+    - event_timestamp
+  - base-type: type/DateTimeWithLocalTZ
+    temporal-unit: default
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_content
+  - event_timestamp
+  name: event_timestamp
+  semantic_type: null
+  settings: null
+  unit: default
+  visibility_type: normal
 visualization_settings:
-  table.pivot_column: action_type
-  table.cell_column: event_timestamp
   column_settings: null
+  table.cell_column: event_timestamp
+  table.pivot_column: action_type
+serdes/meta:
+- id: AxSackBiyXVRUzM_TyyQY
+  label: content
+  model: Card
 metabase_version: null
-parameters: []
-dataset: true
-created_at: '2023-06-08T14:33:12.546414Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/Bp2r19P5a9HjDTR4-VuZa_subscriptions_on_this_dashboard.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/Bp2r19P5a9HjDTR4-VuZa_subscriptions_on_this_dashboard.yaml
@@ -1,23 +1,29 @@
+name: Subscriptions on this dashboard
 description: null
+entity_id: Bp2r19P5a9HjDTR4-VuZa
+created_at: '2023-08-18T19:02:09.768319Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_subscriptions
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Subscriptions on this dashboard
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
     fields:
     - - field
@@ -69,9 +75,7 @@ dataset_query:
         - parameters
       - base-type: type/Text
     joins:
-    - fields: none
-      strategy: left-join
-      alias: Content - Dashboard Qualified
+    - alias: Content - Dashboard Qualified
       condition:
       - =
       - - field
@@ -87,10 +91,10 @@ dataset_query:
           - entity_qualified_id
         - base-type: type/Text
           join-alias: Content - Dashboard Qualified
+      fields: none
       source-table: AxSackBiyXVRUzM_TyyQY
-    - fields: none
       strategy: left-join
-      alias: People - Creator
+    - alias: People - Creator
       condition:
       - =
       - - field
@@ -106,20 +110,21 @@ dataset_query:
           - user_id
         - base-type: type/Integer
           join-alias: People - Creator
+      fields: none
       source-table: 0wVIfjBJWclD0lKeABYYl
+      strategy: left-join
     source-table: 5ojUtU9iE-DCggHdFPIll
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: Bp2r19P5a9HjDTR4-VuZa
-  label: subscriptions_on_this_dashboard
-display: table
-entity_id: Bp2r19P5a9HjDTR4-VuZa
-collection_preview: true
+  type: query
+result_metadata: null
 visualization_settings:
+  column_settings:
+    ? '["ref",["field",["Internal Metabase Database","public","v_users","full_name"],{"base-type":"type/Text","join-alias":"People - Creator"}]]'
+    : column_title: User
+    ? '["ref",["field",["Internal Metabase Database","public","v_users","user_id"],{"base-type":"type/Integer","join-alias":"People - Creator"}]]'
+    : column_title: User ID
   table.cell_column: recipient_external
   table.columns:
-  - name: created_at
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -127,8 +132,8 @@ visualization_settings:
       - v_subscriptions
       - created_at
     - base-type: type/DateTimeWithLocalTZ
-    enabled: true
-  - name: schedule_type
+    name: created_at
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -136,8 +141,8 @@ visualization_settings:
       - v_subscriptions
       - schedule_type
     - base-type: type/Text
-    enabled: true
-  - name: schedule_hour
+    name: schedule_type
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -145,8 +150,8 @@ visualization_settings:
       - v_subscriptions
       - schedule_hour
     - base-type: type/Integer
-    enabled: true
-  - name: recipient_type
+    name: schedule_hour
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -154,8 +159,8 @@ visualization_settings:
       - v_subscriptions
       - recipient_type
     - base-type: type/Text
-    enabled: true
-  - name: recipients
+    name: recipient_type
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -163,8 +168,8 @@ visualization_settings:
       - v_subscriptions
       - recipients
     - base-type: type/Text
-    enabled: true
-  - name: recipient_external
+    name: recipients
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -172,8 +177,8 @@ visualization_settings:
       - v_subscriptions
       - recipient_external
     - base-type: type/Text
-    enabled: true
-  - name: parameters
+    name: recipient_external
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -181,15 +186,10 @@ visualization_settings:
       - v_subscriptions
       - parameters
     - base-type: type/Text
-    enabled: true
+    name: parameters
   table.pivot_column: archived
-  column_settings:
-    ? '["ref",["field",["Internal Metabase Database","public","v_users","user_id"],{"base-type":"type/Integer","join-alias":"People - Creator"}]]'
-    : column_title: User ID
-    ? '["ref",["field",["Internal Metabase Database","public","v_users","full_name"],{"base-type":"type/Text","join-alias":"People - Creator"}]]'
-    : column_title: User
+serdes/meta:
+- id: Bp2r19P5a9HjDTR4-VuZa
+  label: subscriptions_on_this_dashboard
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-08-18T19:02:09.768319Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/DnNyT6EtIn-Zx8bHRFHbV_questions_created_last_week.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/DnNyT6EtIn-Zx8bHRFHbV_questions_created_last_week.yaml
@@ -1,43 +1,30 @@
+name: Questions created last week
 description: null
+entity_id: DnNyT6EtIn-Zx8bHRFHbV
+created_at: '2023-06-14T19:50:43.33191Z'
+creator_id: internal@metabase.com
+display: smartscalar
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_content
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Questions created last week
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    joins:
-    - fields: all
-      alias: Question 34
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - creator_id
-        - base-type: type/Integer
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_group_members
-          - user_id
-        - base-type: type/Integer
-          join-alias: Question 34
-      source-table: lTp-ATFsCUFEr9I0fMEaO
     aggregation:
     - - count
     breakout:
@@ -45,7 +32,6 @@ dataset_query:
       - created_at
       - base-type: type/DateTimeWithLocalTZ
         temporal-unit: week
-    source-table: AxSackBiyXVRUzM_TyyQY
     filter:
     - and
     - - =
@@ -66,23 +52,37 @@ dataset_query:
       - -2
       - week
       - include-current: false
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: DnNyT6EtIn-Zx8bHRFHbV
-  label: questions_created_last_week
-display: smartscalar
-entity_id: DnNyT6EtIn-Zx8bHRFHbV
-collection_preview: true
+    joins:
+    - alias: Question 34
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - creator_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_group_members
+          - user_id
+        - base-type: type/Integer
+          join-alias: Question 34
+      fields: all
+      source-table: lTp-ATFsCUFEr9I0fMEaO
+    source-table: AxSackBiyXVRUzM_TyyQY
+  type: query
+result_metadata: null
 visualization_settings:
+  column_settings: null
   graph.dimensions:
   - created_at
   - group_name
   graph.metrics:
   - count
-  column_settings: null
+serdes/meta:
+- id: DnNyT6EtIn-Zx8bHRFHbV
+  label: questions_created_last_week
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-06-14T19:50:43.33191Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/DuL1yrlkmnqOgz4drGiG4_users_consuming_most_resources.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/DuL1yrlkmnqOgz4drGiG4_users_consuming_most_resources.yaml
@@ -1,64 +1,38 @@
+name: Users consuming most resources
 description: null
+entity_id: DuL1yrlkmnqOgz4drGiG4
+created_at: '2023-11-01T11:34:51.583773Z'
+creator_id: internal@metabase.com
+display: line
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Users consuming most resources
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    limit: 200
-    joins:
-    - fields: all
-      strategy: left-join
-      alias: People - User
-      condition:
-      - =
+    aggregation:
+    - - sum
       - - field
         - - Internal Metabase Database
           - public
           - v_query_log
-          - user_id
-        - base-type: type/Integer
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_users
-          - user_id
-        - base-type: type/Integer
-          join-alias: People - User
-      source-table: 0wVIfjBJWclD0lKeABYYl
-    - fields: all
-      strategy: left-join
-      alias: Group Members - User
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_query_log
-          - user_id
-        - base-type: type/Integer
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_group_members
-          - user_id
-        - base-type: type/Integer
-          join-alias: Group Members - User
-      source-table: lTp-ATFsCUFEr9I0fMEaO
+          - running_time_seconds
+        - base-type: type/Float
     breakout:
     - - field
       - - Internal Metabase Database
@@ -80,19 +54,6 @@ dataset_query:
         - full_name
       - base-type: type/Text
         join-alias: People - User
-    order-by:
-    - - desc
-      - - aggregation
-        - 0
-    aggregation:
-    - - sum
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_query_log
-          - running_time_seconds
-        - base-type: type/Float
-    source-table: QOtZaiTLf2FDD4AT6Oinb
     filter:
     - and
     - - time-interval
@@ -112,25 +73,64 @@ dataset_query:
           - v_query_log
           - dashboard_qualified_id
         - base-type: type/Text
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: DuL1yrlkmnqOgz4drGiG4
-  label: users_consuming_most_resources
-display: line
-entity_id: DuL1yrlkmnqOgz4drGiG4
-collection_preview: true
+    joins:
+    - alias: People - User
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_query_log
+          - user_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_users
+          - user_id
+        - base-type: type/Integer
+          join-alias: People - User
+      fields: all
+      source-table: 0wVIfjBJWclD0lKeABYYl
+      strategy: left-join
+    - alias: Group Members - User
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_query_log
+          - user_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_group_members
+          - user_id
+        - base-type: type/Integer
+          join-alias: Group Members - User
+      fields: all
+      source-table: lTp-ATFsCUFEr9I0fMEaO
+      strategy: left-join
+    limit: 200
+    order-by:
+    - - desc
+      - - aggregation
+        - 0
+    source-table: QOtZaiTLf2FDD4AT6Oinb
+  type: query
+result_metadata: null
 visualization_settings:
+  column_settings: null
   graph.dimensions:
   - started_at
   - full_name
-  graph.series_order_dimension: null
-  graph.series_order: null
   graph.metrics:
   - sum
-  column_settings: null
+  graph.series_order: null
+  graph.series_order_dimension: null
+serdes/meta:
+- id: DuL1yrlkmnqOgz4drGiG4
+  label: users_consuming_most_resources
+  model: Card
 metabase_version: vUNKNOWN (901f705)
-parameters: []
-dataset: false
-created_at: '2023-11-01T11:34:51.583773Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/FUuJSuFo7wM6EoddmNsHf_most_active_viewers.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/FUuJSuFo7wM6EoddmNsHf_most_active_viewers.yaml
@@ -1,61 +1,30 @@
+name: Most active viewers
 description: null
+entity_id: FUuJSuFo7wM6EoddmNsHf
+created_at: '2023-06-15T02:19:04.741672Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Most active viewers
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    joins:
-    - strategy: left-join
-      alias: People - User
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - user_id
-        - base-type: type/Integer
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_users
-          - user_id
-        - base-type: type/Integer
-          join-alias: People - User
-      source-table: 0wVIfjBJWclD0lKeABYYl
-    - strategy: left-join
-      alias: Group Members - User
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - user_id
-        - base-type: type/Integer
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_group_members
-          - user_id
-        - base-type: type/Integer
-          join-alias: Group Members - User
-      source-table: lTp-ATFsCUFEr9I0fMEaO
     aggregation:
     - - count
     breakout:
@@ -72,11 +41,6 @@ dataset_query:
         - v_view_log
         - user_id
       - base-type: type/Integer
-    order-by:
-    - - desc
-      - - aggregation
-        - 0
-    source-table: P6Ityjj7igswKh4NgZZjz
     filter:
     - =
     - - field
@@ -86,15 +50,57 @@ dataset_query:
         - entity_type
       - base-type: type/Text
     - card
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: FUuJSuFo7wM6EoddmNsHf
-  label: most_active_viewers
-display: table
-entity_id: FUuJSuFo7wM6EoddmNsHf
-collection_preview: true
+    joins:
+    - alias: People - User
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - user_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_users
+          - user_id
+        - base-type: type/Integer
+          join-alias: People - User
+      source-table: 0wVIfjBJWclD0lKeABYYl
+      strategy: left-join
+    - alias: Group Members - User
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - user_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_group_members
+          - user_id
+        - base-type: type/Integer
+          join-alias: Group Members - User
+      source-table: lTp-ATFsCUFEr9I0fMEaO
+      strategy: left-join
+    order-by:
+    - - desc
+      - - aggregation
+        - 0
+    source-table: P6Ityjj7igswKh4NgZZjz
+  type: query
+result_metadata: null
 visualization_settings:
+  column_settings:
+    '["name","count"]':
+      column_title: Question views
+      show_mini_bar: true
+    ? '["ref",["field",["Internal Metabase Database","public","v_users","full_name"],{"base-type":"type/Text","join-alias":"Question 1"}]]'
+    : column_title: User
   table.cell_column: model_id
   table.columns:
   - enabled: true
@@ -102,7 +108,7 @@ visualization_settings:
     - aggregation
     - 0
     name: count
-  - name: user_id_2
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -110,8 +116,8 @@ visualization_settings:
       - v_users
       - user_id
     - join-alias: People - User
-    enabled: true
-  - name: email
+    name: user_id_2
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -119,8 +125,8 @@ visualization_settings:
       - v_users
       - email
     - join-alias: People - User
-    enabled: true
-  - name: first_name
+    name: email
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -128,8 +134,8 @@ visualization_settings:
       - v_users
       - first_name
     - join-alias: People - User
-    enabled: true
-  - name: last_name
+    name: first_name
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -137,8 +143,8 @@ visualization_settings:
       - v_users
       - last_name
     - join-alias: People - User
-    enabled: true
-  - name: date_joined
+    name: last_name
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -146,8 +152,8 @@ visualization_settings:
       - v_users
       - date_joined
     - join-alias: People - User
-    enabled: true
-  - name: last_login
+    name: date_joined
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -155,8 +161,8 @@ visualization_settings:
       - v_users
       - last_login
     - join-alias: People - User
-    enabled: true
-  - name: updated_at
+    name: last_login
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -164,8 +170,8 @@ visualization_settings:
       - v_users
       - updated_at
     - join-alias: People - User
-    enabled: true
-  - name: is_admin
+    name: updated_at
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -173,8 +179,8 @@ visualization_settings:
       - v_users
       - is_admin
     - join-alias: People - User
-    enabled: true
-  - name: is_active
+    name: is_admin
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -182,8 +188,8 @@ visualization_settings:
       - v_users
       - is_active
     - join-alias: People - User
-    enabled: true
-  - name: sso_source
+    name: is_active
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -191,8 +197,8 @@ visualization_settings:
       - v_users
       - sso_source
     - join-alias: People - User
-    enabled: true
-  - name: locale
+    name: sso_source
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -200,8 +206,8 @@ visualization_settings:
       - v_users
       - locale
     - join-alias: People - User
-    enabled: true
-  - name: user_id_3
+    name: locale
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -209,8 +215,8 @@ visualization_settings:
       - v_group_members
       - user_id
     - join-alias: Group Members - User
-    enabled: true
-  - name: group_id
+    name: user_id_3
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -218,8 +224,8 @@ visualization_settings:
       - v_group_members
       - group_id
     - join-alias: Group Members - User
-    enabled: true
-  - name: group_name
+    name: group_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -227,8 +233,8 @@ visualization_settings:
       - v_group_members
       - group_name
     - join-alias: Group Members - User
-    enabled: true
-  - name: full_name
+    name: group_name
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -237,8 +243,8 @@ visualization_settings:
       - full_name
     - base-type: type/Text
       join-alias: People - User
-    enabled: true
-  - name: entity_id
+    name: full_name
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -246,16 +252,10 @@ visualization_settings:
       - v_view_log
       - entity_id
     - base-type: type/Integer
-    enabled: true
+    name: entity_id
   table.pivot_column: end_timestamp
-  column_settings:
-    '["name","count"]':
-      column_title: Question views
-      show_mini_bar: true
-    ? '["ref",["field",["Internal Metabase Database","public","v_users","full_name"],{"base-type":"type/Text","join-alias":"Question 1"}]]'
-    : column_title: User
+serdes/meta:
+- id: FUuJSuFo7wM6EoddmNsHf
+  label: most_active_viewers
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-06-15T02:19:04.741672Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/Fnu5Kh0gYPN6P8A_fvICu_dashboard_with_this_question.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/Fnu5Kh0gYPN6P8A_fvICu_dashboard_with_this_question.yaml
@@ -1,23 +1,29 @@
+name: Dashboard with this question
 description: null
+entity_id: Fnu5Kh0gYPN6P8A_fvICu
+created_at: '2023-09-21T13:30:15.777835Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_dashboardcard
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Dashboard with this question
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
     fields:
     - - field
@@ -28,19 +34,6 @@ dataset_query:
       - base-type: type/DateTimeWithLocalTZ
     joins:
     - alias: Question 35_2
-      fields:
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - id
-        - join-alias: Question 35_2
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - name
-        - join-alias: Question 35_2
       condition:
       - =
       - - field
@@ -55,20 +48,38 @@ dataset_query:
           - v_content
           - id
         - join-alias: Question 35_2
+      fields:
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - id
+        - join-alias: Question 35_2
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - name
+        - join-alias: Question 35_2
       source-table: AxSackBiyXVRUzM_TyyQY
     source-table: pKdvc0pwu1zDi8NqnyJkt
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: Fnu5Kh0gYPN6P8A_fvICu
-  label: dashboard_with_this_question
-display: table
-entity_id: Fnu5Kh0gYPN6P8A_fvICu
-collection_preview: true
+  type: query
+result_metadata: null
 visualization_settings:
+  column_settings:
+    '["ref",["field",["Internal Metabase Database","public","v_content","created_at"],{"join-alias":"Question 35_2"}]]':
+      column_title: Added At
+    '["ref",["field",["Internal Metabase Database","public","v_content","id"],{"join-alias":"Question 35_2"}]]':
+      column_title: Dashboard ID
+    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35"}]]':
+      column_title: Question Name
+    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35_2"}]]':
+      column_title: Dashboard Name
+    ? '["ref",["field",["Internal Metabase Database","public","v_dashboardcard","created_at"],{"base-type":"type/DateTimeWithLocalTZ"}]]'
+    : column_title: Added At
   table.cell_column: name
   table.columns:
-  - name: id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -76,8 +87,8 @@ visualization_settings:
       - v_content
       - id
     - join-alias: Question 35_2
-    enabled: true
-  - name: name
+    name: id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -85,8 +96,8 @@ visualization_settings:
       - v_content
       - name
     - join-alias: Question 35_2
-    enabled: true
-  - name: created_at
+    name: name
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -95,21 +106,10 @@ visualization_settings:
       - created_at
     - base-type: type/DateTimeWithLocalTZ
       temporal-unit: default
-    enabled: true
+    name: created_at
   table.pivot_column: name_2
-  column_settings:
-    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35_2"}]]':
-      column_title: Dashboard Name
-    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35"}]]':
-      column_title: Question Name
-    '["ref",["field",["Internal Metabase Database","public","v_content","id"],{"join-alias":"Question 35_2"}]]':
-      column_title: Dashboard ID
-    '["ref",["field",["Internal Metabase Database","public","v_content","created_at"],{"join-alias":"Question 35_2"}]]':
-      column_title: Added At
-    ? '["ref",["field",["Internal Metabase Database","public","v_dashboardcard","created_at"],{"base-type":"type/DateTimeWithLocalTZ"}]]'
-    : column_title: Added At
+serdes/meta:
+- id: Fnu5Kh0gYPN6P8A_fvICu
+  label: dashboard_with_this_question
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-09-21T13:30:15.777835Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/G7fFejjb7cgwYlUXSvf3K_dashboards_created_last_week.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/G7fFejjb7cgwYlUXSvf3K_dashboards_created_last_week.yaml
@@ -1,43 +1,30 @@
+name: Dashboards created last week
 description: null
+entity_id: G7fFejjb7cgwYlUXSvf3K
+created_at: '2023-06-14T19:54:26.670515Z'
+creator_id: internal@metabase.com
+display: smartscalar
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_content
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Dashboards created last week
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    joins:
-    - fields: all
-      alias: Question 34
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - creator_id
-        - base-type: type/Integer
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_group_members
-          - user_id
-        - base-type: type/Integer
-          join-alias: Question 34
-      source-table: lTp-ATFsCUFEr9I0fMEaO
     aggregation:
     - - count
     breakout:
@@ -45,7 +32,6 @@ dataset_query:
       - created_at
       - base-type: type/DateTimeWithLocalTZ
         temporal-unit: week
-    source-table: AxSackBiyXVRUzM_TyyQY
     filter:
     - and
     - - =
@@ -66,23 +52,37 @@ dataset_query:
       - -2
       - week
       - include-current: false
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: G7fFejjb7cgwYlUXSvf3K
-  label: dashboards_created_last_week
-display: smartscalar
-entity_id: G7fFejjb7cgwYlUXSvf3K
-collection_preview: true
+    joins:
+    - alias: Question 34
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - creator_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_group_members
+          - user_id
+        - base-type: type/Integer
+          join-alias: Question 34
+      fields: all
+      source-table: lTp-ATFsCUFEr9I0fMEaO
+    source-table: AxSackBiyXVRUzM_TyyQY
+  type: query
+result_metadata: null
 visualization_settings:
+  column_settings: null
   graph.dimensions:
   - created_at
   - group_name
   graph.metrics:
   - count
-  column_settings: null
+serdes/meta:
+- id: G7fFejjb7cgwYlUXSvf3K
+  label: dashboards_created_last_week
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-06-14T19:54:26.670515Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/ItdtatOMd0uUEpvx7tDAC_most_viewed_tables.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/ItdtatOMd0uUEpvx7tDAC_most_viewed_tables.yaml
@@ -1,103 +1,32 @@
+name: Most viewed tables
 description: null
+entity_id: ItdtatOMd0uUEpvx7tDAC
+created_at: '2023-11-01T12:01:42.296181Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Most viewed tables
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    limit: 100
-    joins:
-    - alias: Group Members - User
-      strategy: left-join
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - user_id
-        - base-type: type/Integer
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_group_members
-          - user_id
-        - base-type: type/Integer
-          join-alias: Group Members - User
-      source-table: lTp-ATFsCUFEr9I0fMEaO
-    - fields: all
-      strategy: left-join
-      alias: Tables - Entity Qualified
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - entity_qualified_id
-        - base-type: type/Text
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_tables
-          - entity_qualified_id
-        - base-type: type/Text
-          join-alias: Tables - Entity Qualified
-      source-table: x7GwgNdjfzrpQkKTraaqo
-    - fields: all
-      strategy: left-join
-      alias: People - User
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_group_members
-          - user_id
-        - base-type: type/Integer
-          join-alias: Group Members - User
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_users
-          - user_id
-        - base-type: type/Integer
-          join-alias: People - User
-      source-table: 0wVIfjBJWclD0lKeABYYl
-    - fields: all
-      strategy: left-join
-      alias: Databases
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_tables
-          - database_id
-        - base-type: type/Integer
-          join-alias: Tables - Entity Qualified
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_databases
-          - entity_id
-        - base-type: type/Integer
-          join-alias: Databases
-      source-table: -19557ZnrWiDgG4h4cKxF
+    aggregation:
+    - - count
     breakout:
     - - field
       - - Internal Metabase Database
@@ -113,13 +42,20 @@ dataset_query:
         - name
       - base-type: type/Text
         join-alias: Databases
-    order-by:
-    - - desc
-      - - aggregation
-        - 0
-    aggregation:
-    - - count
-    source-table: P6Ityjj7igswKh4NgZZjz
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_databases
+        - entity_id
+      - base-type: type/Integer
+        join-alias: Databases
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_tables
+        - entity_id
+      - base-type: type/Integer
+        join-alias: Tables - Entity Qualified
     filter:
     - and
     - - =
@@ -138,36 +74,164 @@ dataset_query:
           - name
         - base-type: type/Text
           join-alias: Tables - Entity Qualified
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: ItdtatOMd0uUEpvx7tDAC
-  label: most_viewed_tables
-display: table
-entity_id: ItdtatOMd0uUEpvx7tDAC
-collection_preview: true
+    joins:
+    - alias: Group Members - User
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - user_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_group_members
+          - user_id
+        - base-type: type/Integer
+          join-alias: Group Members - User
+      source-table: lTp-ATFsCUFEr9I0fMEaO
+      strategy: left-join
+    - alias: Tables - Entity Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - entity_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_tables
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Tables - Entity Qualified
+      fields: all
+      source-table: x7GwgNdjfzrpQkKTraaqo
+      strategy: left-join
+    - alias: People - User
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_group_members
+          - user_id
+        - base-type: type/Integer
+          join-alias: Group Members - User
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_users
+          - user_id
+        - base-type: type/Integer
+          join-alias: People - User
+      fields: all
+      source-table: 0wVIfjBJWclD0lKeABYYl
+      strategy: left-join
+    - alias: Databases
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_tables
+          - database_id
+        - base-type: type/Integer
+          join-alias: Tables - Entity Qualified
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_databases
+          - entity_id
+        - base-type: type/Integer
+          join-alias: Databases
+      fields: all
+      source-table: -19557ZnrWiDgG4h4cKxF
+      strategy: left-join
+    limit: 100
+    order-by:
+    - - desc
+      - - aggregation
+        - 0
+    source-table: P6Ityjj7igswKh4NgZZjz
+  type: query
+result_metadata: null
 visualization_settings:
-  graph.dimensions:
-  - name
-  graph.show_values: true
-  table.cell_column: count
-  table.pivot: false
-  table.pivot_column: name_2
   column_settings:
     '["name","count"]':
       show_mini_bar: true
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
-    : column_title: Dashboard name
     ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Entity Qualified"}]]'
     : column_title: Dashboard ID
-    ? '["ref",["field",["Internal Metabase Database","public","v_tables","name"],{"base-type":"type/Text","join-alias":"Tables - Entity Qualified"}]]'
-    : column_title: Table name
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Dashboard name
     ? '["ref",["field",["Internal Metabase Database","public","v_databases","name"],{"base-type":"type/Text","join-alias":"Databases"}]]'
     : column_title: Database
+      link_url: /browse/{{entity_id}}
+      view_as: link
+    ? '["ref",["field",["Internal Metabase Database","public","v_tables","name"],{"base-type":"type/Text","join-alias":"Tables - Entity Qualified"}]]'
+    : column_title: Table name
+      link_url: /question#?db={{entity_id_2}}&table={{entity_id}}
+      view_as: link
+  graph.dimensions:
+  - name
   graph.metrics:
   - count
+  graph.show_values: true
+  table.cell_column: count
+  table.columns:
+  - enabled: true
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_tables
+      - name
+    - base-type: type/Text
+      join-alias: Tables - Entity Qualified
+    name: name
+  - enabled: true
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_databases
+      - name
+    - base-type: type/Text
+      join-alias: Databases
+    name: name_2
+  - enabled: false
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_databases
+      - entity_id
+    - base-type: type/Integer
+      join-alias: Databases
+    name: entity_id
+  - enabled: true
+    fieldRef:
+    - aggregation
+    - 0
+    name: count
+  - enabled: false
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_tables
+      - entity_id
+    - base-type: type/Integer
+      join-alias: Tables - Entity Qualified
+    name: false_2
+  table.pivot: false
+  table.pivot_column: name_2
+serdes/meta:
+- id: ItdtatOMd0uUEpvx7tDAC
+  label: most_viewed_tables
+  model: Card
 metabase_version: vUNKNOWN (901f705)
-parameters: []
-dataset: false
-created_at: '2023-11-01T12:01:42.296181Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/JPERH6xYVcj3m2Zw0YVY1_active_alerts.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/JPERH6xYVcj3m2Zw0YVY1_active_alerts.yaml
@@ -1,23 +1,30 @@
+name: Active alerts
 description: null
+entity_id: JPERH6xYVcj3m2Zw0YVY1
+created_at: '2023-06-15T01:56:06.29029Z'
+creator_id: internal@metabase.com
+display: scalar
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts_subscriptions
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Active alerts
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
+  database: Internal Metabase Database
   query:
-    source-table: 5ojUtU9iE-DCggHdFPIll
     aggregation:
     - - count
     filter:
@@ -38,22 +45,15 @@ dataset_query:
           - entity_type
         - null
       - alert
-  database: Internal Metabase Database
+    source-table: 5ojUtU9iE-DCggHdFPIll
   type: query
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: JPERH6xYVcj3m2Zw0YVY1
-  label: active_alerts
-display: scalar
-entity_id: JPERH6xYVcj3m2Zw0YVY1
-collection_preview: true
+result_metadata: null
 visualization_settings:
-  table.pivot_column: name
-  table.cell_column: recipient_external
   column_settings: null
+  table.cell_column: recipient_external
+  table.pivot_column: name
+serdes/meta:
+- id: JPERH6xYVcj3m2Zw0YVY1
+  label: active_alerts
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-06-15T01:56:06.29029Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/KXNGLyYyS1pO_9wMguHIB_total_time_spent_on_sync_per_day.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/KXNGLyYyS1pO_9wMguHIB_total_time_spent_on_sync_per_day.yaml
@@ -1,0 +1,96 @@
+name: Total time spent on sync per day
+description: null
+entity_id: KXNGLyYyS1pO_9wMguHIB
+created_at: '2023-11-13T20:43:59.158137Z'
+creator_id: internal@metabase.com
+display: line
+archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
+collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
+table_id:
+- Internal Metabase Database
+- public
+- v_tasks
+enable_embedding: false
+embedding_params: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
+dataset_query:
+  database: Internal Metabase Database
+  query:
+    aggregation:
+    - - sum
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_tasks
+          - duration_seconds
+        - base-type: type/Float
+    breakout:
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_tasks
+        - started_at
+      - base-type: type/DateTimeWithLocalTZ
+        temporal-unit: day
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_databases
+        - name
+      - base-type: type/Text
+        join-alias: Databases - Database Qualified
+    filter:
+    - =
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_tasks
+        - task
+      - base-type: type/Text
+    - sync
+    joins:
+    - alias: Databases - Database Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_tasks
+          - database_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_databases
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Databases - Database Qualified
+      fields: all
+      source-table: -19557ZnrWiDgG4h4cKxF
+      strategy: left-join
+    source-table: PKhlEfegdbTozSMfj0aLB
+  type: query
+result_metadata: null
+visualization_settings:
+  column_settings: null
+  graph.dimensions:
+  - started_at
+  - name
+  graph.metrics:
+  - sum
+  graph.series_order: null
+  graph.series_order_dimension: null
+serdes/meta:
+- id: KXNGLyYyS1pO_9wMguHIB
+  label: total_time_spent_on_sync_per_day
+  model: Card
+metabase_version: vUNKNOWN (a98530f)

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/LN9YtKcxZk_kybyRjJx1J_total_time_looking_for_field_values_per_day.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/LN9YtKcxZk_kybyRjJx1J_total_time_looking_for_field_values_per_day.yaml
@@ -1,0 +1,97 @@
+name: Total time looking for field values per day
+description: null
+entity_id: LN9YtKcxZk_kybyRjJx1J
+created_at: '2023-11-13T20:45:10.662006Z'
+creator_id: internal@metabase.com
+display: line
+archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
+collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
+table_id:
+- Internal Metabase Database
+- public
+- v_tasks
+enable_embedding: false
+embedding_params: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
+dataset_query:
+  database: Internal Metabase Database
+  query:
+    aggregation:
+    - - sum
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_tasks
+          - duration_seconds
+        - base-type: type/Float
+    breakout:
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_tasks
+        - started_at
+      - base-type: type/DateTimeWithLocalTZ
+        temporal-unit: day
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_databases
+        - name
+      - base-type: type/Text
+        join-alias: Databases - Database Qualified
+    filter:
+    - =
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_tasks
+        - task
+      - base-type: type/Text
+    - field values scanning
+    - update-field-values
+    joins:
+    - alias: Databases - Database Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_tasks
+          - database_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_databases
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Databases - Database Qualified
+      fields: all
+      source-table: -19557ZnrWiDgG4h4cKxF
+      strategy: left-join
+    source-table: PKhlEfegdbTozSMfj0aLB
+  type: query
+result_metadata: null
+visualization_settings:
+  column_settings: null
+  graph.dimensions:
+  - started_at
+  - name
+  graph.metrics:
+  - sum
+  graph.series_order: null
+  graph.series_order_dimension: null
+serdes/meta:
+- id: LN9YtKcxZk_kybyRjJx1J
+  label: total_time_looking_for_field_values_per_day
+  model: Card
+metabase_version: vUNKNOWN (a98530f)

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/LXu_IZa1EDg3QOhlwunGy_sso_source.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/LXu_IZa1EDg3QOhlwunGy_sso_source.yaml
@@ -1,38 +1,38 @@
+name: SSO source
 description: null
+entity_id: LXu_IZa1EDg3QOhlwunGy
+created_at: '2023-06-15T01:41:01.562671Z'
+creator_id: internal@metabase.com
+display: scalar
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_users
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: SSO source
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
   query:
     source-table: 0wVIfjBJWclD0lKeABYYl
   type: query
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: LXu_IZa1EDg3QOhlwunGy
-  label: sso_source
-display: scalar
-entity_id: LXu_IZa1EDg3QOhlwunGy
-collection_preview: true
+result_metadata: null
 visualization_settings:
-  scalar.field: sso_source
   column_settings: null
+  scalar.field: sso_source
+serdes/meta:
+- id: LXu_IZa1EDg3QOhlwunGy
+  label: sso_source
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-06-15T01:41:01.562671Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/MOAq881VSlM2BhVUv5e_K_last_activity_on_question.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/MOAq881VSlM2BhVUv5e_K_last_activity_on_question.yaml
@@ -1,23 +1,29 @@
+name: Last activity on question
 description: null
+entity_id: MOAq881VSlM2BhVUv5e_K
+created_at: '2023-11-01T02:47:25.64266Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_audit_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Last activity on question
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
     fields:
     - - field
@@ -26,16 +32,19 @@ dataset_query:
     - - field
       - timestamp
       - base-type: type/DateTimeWithLocalTZ
+    filter:
+    - =
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_audit_log
+        - topic
+      - base-type: type/Text
+    - card-create
+    - card-delete
+    - card-update
     joins:
     - alias: Question 1
-      fields:
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_users
-          - full_name
-        - base-type: type/Text
-          join-alias: Question 1
       condition:
       - =
       - - field
@@ -51,9 +60,23 @@ dataset_query:
           - user_id
         - base-type: type/Integer
           join-alias: Question 1
+      fields:
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_users
+          - user_id
+        - base-type: type/Integer
+          join-alias: Question 1
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_users
+          - full_name
+        - base-type: type/Text
+          join-alias: Question 1
       source-table: 0wVIfjBJWclD0lKeABYYl
     - alias: Question 35
-      fields: none
       condition:
       - =
       - - field
@@ -69,6 +92,7 @@ dataset_query:
           - entity_qualified_id
         - base-type: type/Text
           join-alias: Question 35
+      fields: none
       source-table: AxSackBiyXVRUzM_TyyQY
     order-by:
     - - desc
@@ -79,26 +103,12 @@ dataset_query:
           - timestamp
         - base-type: type/DateTimeWithLocalTZ
     source-table: -lNDM3tJmuL5ltGbX0oyT
-    filter:
-    - =
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_audit_log
-        - topic
-      - base-type: type/Text
-    - card-create
-    - card-delete
-    - card-update
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: MOAq881VSlM2BhVUv5e_K
-  label: last_activity_on_question
-display: table
-entity_id: MOAq881VSlM2BhVUv5e_K
-collection_preview: true
+  type: query
+result_metadata: null
 visualization_settings:
+  column_settings:
+    ? '["ref",["field",["Internal Metabase Database","public","v_users","full_name"],{"base-type":"type/Text","join-alias":"Question 1"}]]'
+    : column_title: Person
   table.cell_column: model_id
   table.columns:
   - enabled: true
@@ -107,9 +117,29 @@ visualization_settings:
     - - Internal Metabase Database
       - public
       - v_audit_log
+      - topic
+    - base-type: type/Text
+    name: topic
+  - enabled: true
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_audit_log
       - timestamp
-    - temporal-unit: default
+    - base-type: type/DateTimeWithLocalTZ
+      temporal-unit: default
     name: timestamp
+  - enabled: false
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_users
+      - user_id
+    - base-type: type/Integer
+      join-alias: Question 1
+    name: user_id
   - enabled: true
     fieldRef:
     - field
@@ -117,218 +147,12 @@ visualization_settings:
       - public
       - v_users
       - full_name
-    - join-alias: Question 1
-    name: full_name
-  - enabled: true
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - id
-    - join-alias: Question 35
-    name: id
-  - enabled: true
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - entity_type
-    - join-alias: Question 35
-    name: entity_type
-  - enabled: true
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - created_at
-    - join-alias: Question 35
-    name: created_at
-  - enabled: true
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - updated_at
-    - join-alias: Question 35
-    name: updated_at
-  - enabled: true
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - creator_id
-    - join-alias: Question 35
-    name: creator_id
-  - enabled: true
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - name
-    - join-alias: Question 35
-    name: name
-  - enabled: true
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - description
-    - join-alias: Question 35
-    name: description
-  - enabled: true
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - collection_id
-    - join-alias: Question 35
-    name: collection_id
-  - enabled: true
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - made_public_by_user
-    - join-alias: Question 35
-    name: made_public_by_user
-  - enabled: true
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - is_embedding_enabled
-    - join-alias: Question 35
-    name: is_embedding_enabled
-  - enabled: true
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - archived
-    - join-alias: Question 35
-    name: archived
-  - enabled: true
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - action_type
-    - join-alias: Question 35
-    name: action_type
-  - enabled: true
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - action_model_id
-    - join-alias: Question 35
-    name: action_model_id
-  - enabled: true
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - collection_is_official
-    - join-alias: Question 35
-    name: collection_is_official
-  - enabled: true
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - collection_is_personal
-    - join-alias: Question 35
-    name: collection_is_personal
-  - enabled: true
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - question_viz_type
-    - join-alias: Question 35
-    name: question_viz_type
-  - enabled: true
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - question_database_id
-    - join-alias: Question 35
-    name: question_database_id
-  - enabled: true
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - question_is_native
-    - join-alias: Question 35
-    name: question_is_native
-  - enabled: true
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - event_timestamp
-    - join-alias: Question 35
-    name: event_timestamp
-  - enabled: true
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_group_members
-      - user_id
-    - join-alias: Question 34
-    name: user_id
-  - enabled: true
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_group_members
-      - group_id
-    - join-alias: Question 34
-    name: group_id
-  - enabled: true
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_group_members
-      - group_name
-    - join-alias: Question 34
-    name: group_name
-  - enabled: true
-    fieldRef:
-    - field
-    - topic
     - base-type: type/Text
-    name: topic
+      join-alias: Question 1
+    name: full_name
   table.pivot_column: end_timestamp
-  column_settings:
-    ? '["ref",["field",["Internal Metabase Database","public","v_users","full_name"],{"base-type":"type/Text","join-alias":"Question 1"}]]'
-    : column_title: Person
+serdes/meta:
+- id: MOAq881VSlM2BhVUv5e_K
+  label: last_activity_on_question
+  model: Card
 metabase_version: vUNKNOWN (13e6090)
-parameters: []
-dataset: false
-created_at: '2023-11-01T02:47:25.64266Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/MUXrck2HHcd2TIRuPfK0v_most_viewed_dashboards.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/MUXrck2HHcd2TIRuPfK0v_most_viewed_dashboards.yaml
@@ -1,28 +1,58 @@
+name: Most viewed dashboards
 description: null
+entity_id: MUXrck2HHcd2TIRuPfK0v
+created_at: '2023-08-18T19:09:18.119167Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Most viewed dashboards
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    limit: 100
+    aggregation:
+    - - count
+    breakout:
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - name
+      - base-type: type/Text
+        join-alias: Content - Entity Qualified
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - entity_id
+      - base-type: type/Integer
+        join-alias: Content - Entity Qualified
+    filter:
+    - =
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - entity_type
+      - base-type: type/Text
+    - dashboard
     joins:
     - alias: Content - Entity Qualified
-      strategy: left-join
       condition:
       - =
       - - field
@@ -39,8 +69,8 @@ dataset_query:
         - base-type: type/Text
           join-alias: Content - Entity Qualified
       source-table: AxSackBiyXVRUzM_TyyQY
-    - alias: People - Creator
       strategy: left-join
+    - alias: People - Creator
       condition:
       - =
       - - field
@@ -55,8 +85,8 @@ dataset_query:
         - base-type: type/Integer
           join-alias: People - Creator
       source-table: 0wVIfjBJWclD0lKeABYYl
-    - alias: Group Members - User
       strategy: left-join
+    - alias: Group Members - User
       condition:
       - =
       - - field
@@ -73,61 +103,35 @@ dataset_query:
         - base-type: type/Integer
           join-alias: Group Members - User
       source-table: lTp-ATFsCUFEr9I0fMEaO
-    breakout:
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_content
-        - name
-      - base-type: type/Text
-        join-alias: Content - Entity Qualified
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_content
-        - entity_id
-      - base-type: type/Integer
-        join-alias: Content - Entity Qualified
+      strategy: left-join
+    limit: 100
     order-by:
     - - desc
       - - aggregation
         - 0
-    aggregation:
-    - - count
     source-table: P6Ityjj7igswKh4NgZZjz
-    filter:
-    - =
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - entity_type
-      - base-type: type/Text
-    - dashboard
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: MUXrck2HHcd2TIRuPfK0v
-  label: most_viewed_dashboards
-display: table
-entity_id: MUXrck2HHcd2TIRuPfK0v
-collection_preview: true
+  type: query
+result_metadata: null
 visualization_settings:
-  graph.dimensions:
-  - name
-  graph.show_values: true
-  table.cell_column: count
   column_settings:
     '["name","count"]':
       show_mini_bar: true
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
-    : column_title: Dashboard name
     ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Entity Qualified"}]]'
     : column_title: Dashboard ID
+      link_url: dashboard/{{entity_id}}
+      view_as: link
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Dashboard name
+      link_url: dashboard/{{entity_id}}
+      view_as: link
+  graph.dimensions:
+  - name
   graph.metrics:
   - count
+  graph.show_values: true
+  table.cell_column: count
+serdes/meta:
+- id: MUXrck2HHcd2TIRuPfK0v
+  label: most_viewed_dashboards
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-08-18T19:09:18.119167Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/OCkxXZM5KPJ9zOjYVEnqY_slowest_questions.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/OCkxXZM5KPJ9zOjYVEnqY_slowest_questions.yaml
@@ -1,64 +1,38 @@
+name: Slowest questions
 description: null
+entity_id: OCkxXZM5KPJ9zOjYVEnqY
+created_at: '2023-11-01T11:31:50.756543Z'
+creator_id: internal@metabase.com
+display: line
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Slowest questions
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    limit: 200
-    joins:
-    - fields: all
-      strategy: left-join
-      alias: Content - Dashboard Qualified
-      condition:
-      - =
+    aggregation:
+    - - max
       - - field
         - - Internal Metabase Database
           - public
           - v_query_log
-          - card_qualified_id
-        - base-type: type/Text
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - entity_qualified_id
-        - base-type: type/Text
-          join-alias: Content - Dashboard Qualified
-      source-table: AxSackBiyXVRUzM_TyyQY
-    - fields: all
-      strategy: left-join
-      alias: Group Members - Entity
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_query_log
-          - user_id
-        - base-type: type/Integer
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_group_members
-          - user_id
-        - base-type: type/Integer
-          join-alias: Group Members - Entity
-      source-table: lTp-ATFsCUFEr9I0fMEaO
+          - running_time_seconds
+        - base-type: type/Float
     breakout:
     - - field
       - - Internal Metabase Database
@@ -81,19 +55,6 @@ dataset_query:
         - entity_id
       - base-type: type/Integer
         join-alias: Content - Dashboard Qualified
-    order-by:
-    - - desc
-      - - aggregation
-        - 0
-    aggregation:
-    - - max
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_query_log
-          - running_time_seconds
-        - base-type: type/Float
-    source-table: QOtZaiTLf2FDD4AT6Oinb
     filter:
     - and
     - - time-interval
@@ -113,25 +74,64 @@ dataset_query:
           - v_query_log
           - dashboard_qualified_id
         - base-type: type/Text
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: OCkxXZM5KPJ9zOjYVEnqY
-  label: slowest_questions
-display: line
-entity_id: OCkxXZM5KPJ9zOjYVEnqY
-collection_preview: true
+    joins:
+    - alias: Content - Dashboard Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_query_log
+          - card_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Content - Dashboard Qualified
+      fields: all
+      source-table: AxSackBiyXVRUzM_TyyQY
+      strategy: left-join
+    - alias: Group Members - Entity
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_query_log
+          - user_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_group_members
+          - user_id
+        - base-type: type/Integer
+          join-alias: Group Members - Entity
+      fields: all
+      source-table: lTp-ATFsCUFEr9I0fMEaO
+      strategy: left-join
+    limit: 200
+    order-by:
+    - - desc
+      - - aggregation
+        - 0
+    source-table: QOtZaiTLf2FDD4AT6Oinb
+  type: query
+result_metadata: null
 visualization_settings:
+  column_settings: null
   graph.dimensions:
   - started_at
   - name
-  graph.series_order_dimension: null
-  graph.series_order: null
   graph.metrics:
   - max
-  column_settings: null
+  graph.series_order: null
+  graph.series_order_dimension: null
+serdes/meta:
+- id: OCkxXZM5KPJ9zOjYVEnqY
+  label: slowest_questions
+  model: Card
 metabase_version: vUNKNOWN (901f705)
-parameters: []
-dataset: false
-created_at: '2023-11-01T11:31:50.756543Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/P6Ityjj7igswKh4NgZZjz_view_log.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/P6Ityjj7igswKh4NgZZjz_view_log.yaml
@@ -1,170 +1,30 @@
+name: View log
 description: Each row describes a question, model, table or dashboard view
+entity_id: P6Ityjj7igswKh4NgZZjz
+created_at: '2023-10-31T13:40:12.944134Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: 3
+query_type: query
+dataset: true
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
-result_metadata:
-- description: null
-  semantic_type: type/PK
-  coercion_strategy: null
-  name: id
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_view_log
-    - id
-  - base-type: type/Integer
-  effective_type: type/Integer
-  id:
-  - Internal Metabase Database
-  - public
-  - v_view_log
-  - id
-  visibility_type: normal
-  display_name: ID
-  base_type: type/Integer
-- description: null
-  semantic_type: null
-  coercion_strategy: null
-  unit: default
-  name: timestamp
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_view_log
-    - timestamp
-  - base-type: type/DateTimeWithLocalTZ
-    temporal-unit: default
-  effective_type: type/DateTimeWithLocalTZ
-  id:
-  - Internal Metabase Database
-  - public
-  - v_view_log
-  - timestamp
-  visibility_type: normal
-  display_name: Timestamp
-  base_type: type/DateTimeWithLocalTZ
-- description: null
-  semantic_type: type/FK
-  coercion_strategy: null
-  name: user_id
-  settings: null
-  fk_target_field_id: 739
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_view_log
-    - user_id
-  - base-type: type/Integer
-  effective_type: type/Integer
-  id:
-  - Internal Metabase Database
-  - public
-  - v_view_log
-  - user_id
-  visibility_type: normal
-  display_name: User ID
-  base_type: type/Integer
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: entity_type
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_view_log
-    - entity_type
-  - base-type: type/Text
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_view_log
-  - entity_type
-  visibility_type: normal
-  display_name: Entity Type
-  base_type: type/Text
-- description: null
-  semantic_type: null
-  coercion_strategy: null
-  name: entity_id
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_view_log
-    - entity_id
-  - base-type: type/Integer
-  effective_type: type/Integer
-  id:
-  - Internal Metabase Database
-  - public
-  - v_view_log
-  - entity_id
-  visibility_type: normal
-  display_name: Entity ID
-  base_type: type/Integer
-- description: null
-  semantic_type: type/FK
-  coercion_strategy: null
-  name: entity_qualified_id
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_view_log
-    - entity_qualified_id
-  - base-type: type/Text
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_view_log
-  - entity_qualified_id
-  visibility_type: normal
-  display_name: Entity Qualified ID
-  base_type: type/Text
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: View log
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    source-table:
-    - Internal Metabase Database
-    - public
-    - v_view_log
-    order-by:
-    - - desc
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - timestamp
-        - base-type: type/DateTimeWithLocalTZ
     fields:
     - - field
       - - Internal Metabase Database
@@ -202,20 +62,160 @@ dataset_query:
         - v_view_log
         - entity_qualified_id
       - base-type: type/Text
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: P6Ityjj7igswKh4NgZZjz
-  label: view_log
-display: table
-entity_id: P6Ityjj7igswKh4NgZZjz
-collection_preview: true
+    order-by:
+    - - desc
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - timestamp
+        - base-type: type/DateTimeWithLocalTZ
+    source-table:
+    - Internal Metabase Database
+    - public
+    - v_view_log
+  type: query
+result_metadata:
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: ID
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_view_log
+    - id
+  - base-type: type/Integer
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_view_log
+  - id
+  name: id
+  semantic_type: type/PK
+  settings: null
+  visibility_type: normal
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: null
+  display_name: Timestamp
+  effective_type: type/DateTimeWithLocalTZ
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_view_log
+    - timestamp
+  - base-type: type/DateTimeWithLocalTZ
+    temporal-unit: default
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_view_log
+  - timestamp
+  name: timestamp
+  semantic_type: null
+  settings: null
+  unit: default
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: User ID
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_view_log
+    - user_id
+  - base-type: type/Integer
+  fk_target_field_id: 739
+  id:
+  - Internal Metabase Database
+  - public
+  - v_view_log
+  - user_id
+  name: user_id
+  semantic_type: type/FK
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Entity Type
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_view_log
+    - entity_type
+  - base-type: type/Text
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_view_log
+  - entity_type
+  name: entity_type
+  semantic_type: type/Category
+  settings: null
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Entity ID
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_view_log
+    - entity_id
+  - base-type: type/Integer
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_view_log
+  - entity_id
+  name: entity_id
+  semantic_type: null
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Entity Qualified ID
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_view_log
+    - entity_qualified_id
+  - base-type: type/Text
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_view_log
+  - entity_qualified_id
+  name: entity_qualified_id
+  semantic_type: type/FK
+  settings: null
+  visibility_type: normal
 visualization_settings:
-  table.pivot_column: details
-  table.cell_column: user_id
   column_settings: null
+  table.cell_column: user_id
+  table.pivot_column: details
+serdes/meta:
+- id: P6Ityjj7igswKh4NgZZjz
+  label: view_log
+  model: Card
 metabase_version: vUNKNOWN (7c47e04)
-parameters: []
-dataset: true
-created_at: '2023-10-31T13:40:12.944134Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/PKhlEfegdbTozSMfj0aLB_system_tasks.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/PKhlEfegdbTozSMfj0aLB_system_tasks.yaml
@@ -1,0 +1,197 @@
+name: System tasks
+description: Describes the last 14 days of Metabase internal processes tasks
+entity_id: PKhlEfegdbTozSMfj0aLB
+created_at: '2023-11-13T18:43:58.096941Z'
+creator_id: internal@metabase.com
+display: table
+archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
+collection_position: 19
+query_type: query
+dataset: true
+cache_ttl: null
+database_id: Internal Metabase Database
+table_id:
+- Internal Metabase Database
+- public
+- v_tasks
+enable_embedding: false
+embedding_params: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
+dataset_query:
+  database: Internal Metabase Database
+  query:
+    source-table:
+    - Internal Metabase Database
+    - public
+    - v_tasks
+  type: query
+result_metadata:
+- base_type: type/Integer
+  coercion_strategy: null
+  description: ''
+  display_name: ID
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_tasks
+    - id
+  - null
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_tasks
+  - id
+  name: id
+  semantic_type: type/PK
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Task
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_tasks
+    - task
+  - null
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_tasks
+  - task
+  name: task
+  semantic_type: type/Category
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Database Qualified ID
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_tasks
+    - database_qualified_id
+  - null
+  fk_target_field_id: 1048
+  id:
+  - Internal Metabase Database
+  - public
+  - v_tasks
+  - database_qualified_id
+  name: database_qualified_id
+  semantic_type: type/FK
+  settings: null
+  visibility_type: normal
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: null
+  display_name: Started At
+  effective_type: type/DateTimeWithLocalTZ
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_tasks
+    - started_at
+  - temporal-unit: default
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_tasks
+  - started_at
+  name: started_at
+  semantic_type: type/CreationTimestamp
+  settings: null
+  unit: default
+  visibility_type: normal
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: null
+  display_name: Ended At
+  effective_type: type/DateTimeWithLocalTZ
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_tasks
+    - ended_at
+  - temporal-unit: default
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_tasks
+  - ended_at
+  name: ended_at
+  semantic_type: null
+  settings: null
+  unit: default
+  visibility_type: normal
+- base_type: type/Float
+  coercion_strategy: null
+  description: null
+  display_name: Duration Seconds
+  effective_type: type/Float
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_tasks
+    - duration_seconds
+  - null
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_tasks
+  - duration_seconds
+  name: duration_seconds
+  semantic_type: type/Quantity
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Details
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_tasks
+    - details
+  - null
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_tasks
+  - details
+  name: details
+  semantic_type: null
+  settings: null
+  visibility_type: normal
+visualization_settings:
+  column_settings: null
+  table.cell_column: duration_seconds
+serdes/meta:
+- id: PKhlEfegdbTozSMfj0aLB
+  label: system_tasks
+  model: Card
+metabase_version: vUNKNOWN (1308cef)

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/PkIueKBME3DfRFwBsYjuE_list_of_dashboards.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/PkIueKBME3DfRFwBsYjuE_list_of_dashboards.yaml
@@ -1,23 +1,29 @@
+name: List of dashboards
 description: null
+entity_id: PkIueKBME3DfRFwBsYjuE
+created_at: '2023-11-01T01:37:47.173914Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_content
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: List of dashboards
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
     fields:
     - - field
@@ -38,7 +44,6 @@ dataset_query:
         - v_content
         - name
       - base-type: type/Text
-    source-table: AxSackBiyXVRUzM_TyyQY
     filter:
     - =
     - - field
@@ -48,19 +53,14 @@ dataset_query:
         - entity_type
       - base-type: type/Text
     - dashboard
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: PkIueKBME3DfRFwBsYjuE
-  label: list_of_dashboards
-display: table
-entity_id: PkIueKBME3DfRFwBsYjuE
-collection_preview: true
+    source-table: AxSackBiyXVRUzM_TyyQY
+  type: query
+result_metadata: null
 visualization_settings:
-  table.cell_column: entity_id
   column_settings: null
+  table.cell_column: entity_id
+serdes/meta:
+- id: PkIueKBME3DfRFwBsYjuE
+  label: list_of_dashboards
+  model: Card
 metabase_version: vUNKNOWN (ad99d37)
-parameters: []
-dataset: false
-created_at: '2023-11-01T01:37:47.173914Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/QOtZaiTLf2FDD4AT6Oinb_query_log.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/QOtZaiTLf2FDD4AT6Oinb_query_log.yaml
@@ -1,17 +1,41 @@
+name: Query log
 description: Information about all queries Metabase ran across all dashboards
+entity_id: QOtZaiTLf2FDD4AT6Oinb
+created_at: '2023-10-31T21:50:16.833016Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: 10
+query_type: query
+dataset: true
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
+enable_embedding: false
+embedding_params: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
+dataset_query:
+  database: Internal Metabase Database
+  query:
+    source-table:
+    - Internal Metabase Database
+    - public
+    - v_query_log
+  type: query
 result_metadata:
-- description: null
-  semantic_type: type/PK
+- base_type: type/Integer
   coercion_strategy: null
-  name: entity_id
-  settings: null
-  fk_target_field_id: null
+  description: null
+  display_name: Entity ID
+  effective_type: type/Integer
   field_ref:
   - field
   - - Internal Metabase Database
@@ -19,22 +43,21 @@ result_metadata:
     - v_query_log
     - entity_id
   - null
-  effective_type: type/Integer
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_query_log
   - entity_id
-  visibility_type: normal
-  display_name: Entity ID
-  base_type: type/Integer
-- description: null
-  semantic_type: type/CreationTimestamp
-  coercion_strategy: null
-  unit: default
-  name: started_at
+  name: entity_id
+  semantic_type: type/PK
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: null
+  display_name: Started At
+  effective_type: type/DateTimeWithLocalTZ
   field_ref:
   - field
   - - Internal Metabase Database
@@ -42,21 +65,22 @@ result_metadata:
     - v_query_log
     - started_at
   - temporal-unit: default
-  effective_type: type/DateTimeWithLocalTZ
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_query_log
   - started_at
-  visibility_type: normal
-  display_name: Started At
-  base_type: type/DateTimeWithLocalTZ
-- description: null
-  semantic_type: null
-  coercion_strategy: null
-  name: running_time_seconds
+  name: started_at
+  semantic_type: type/CreationTimestamp
   settings: null
-  fk_target_field_id: null
+  unit: default
+  visibility_type: normal
+- base_type: type/Float
+  coercion_strategy: null
+  description: null
+  display_name: Running Time Seconds
+  effective_type: type/Float
   field_ref:
   - field
   - - Internal Metabase Database
@@ -64,21 +88,21 @@ result_metadata:
     - v_query_log
     - running_time_seconds
   - null
-  effective_type: type/Float
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_query_log
   - running_time_seconds
-  visibility_type: normal
-  display_name: Running Time Seconds
-  base_type: type/Float
-- description: null
+  name: running_time_seconds
   semantic_type: null
-  coercion_strategy: null
-  name: result_rows
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Result Rows
+  effective_type: type/Integer
   field_ref:
   - field
   - - Internal Metabase Database
@@ -86,21 +110,21 @@ result_metadata:
     - v_query_log
     - result_rows
   - null
-  effective_type: type/Integer
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_query_log
   - result_rows
-  visibility_type: normal
-  display_name: Result Rows
-  base_type: type/Integer
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: is_native
+  name: result_rows
+  semantic_type: null
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Boolean
+  coercion_strategy: null
+  description: null
+  display_name: Is Native
+  effective_type: type/Boolean
   field_ref:
   - field
   - - Internal Metabase Database
@@ -108,21 +132,21 @@ result_metadata:
     - v_query_log
     - is_native
   - null
-  effective_type: type/Boolean
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_query_log
   - is_native
-  visibility_type: normal
-  display_name: Is Native
-  base_type: type/Boolean
-- description: null
-  semantic_type: type/Source
-  coercion_strategy: null
-  name: query_source
+  name: is_native
+  semantic_type: type/Category
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Query Source
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -130,21 +154,21 @@ result_metadata:
     - v_query_log
     - query_source
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_query_log
   - query_source
-  visibility_type: normal
-  display_name: Query Source
-  base_type: type/Text
-- description: null
-  semantic_type: null
-  coercion_strategy: null
-  name: error
+  name: query_source
+  semantic_type: type/Source
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Error
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -152,21 +176,21 @@ result_metadata:
     - v_query_log
     - error
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_query_log
   - error
-  visibility_type: normal
-  display_name: Error
-  base_type: type/Text
-- description: null
-  semantic_type: type/FK
-  coercion_strategy: null
-  name: user_id
+  name: error
+  semantic_type: null
   settings: null
-  fk_target_field_id: 739
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: User ID
+  effective_type: type/Integer
   field_ref:
   - field
   - - Internal Metabase Database
@@ -174,21 +198,21 @@ result_metadata:
     - v_query_log
     - user_id
   - null
-  effective_type: type/Integer
+  fk_target_field_id: 739
   id:
   - Internal Metabase Database
   - public
   - v_query_log
   - user_id
-  visibility_type: normal
-  display_name: User ID
-  base_type: type/Integer
-- description: null
-  semantic_type: null
-  coercion_strategy: null
-  name: card_id
+  name: user_id
+  semantic_type: type/FK
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Card ID
+  effective_type: type/Integer
   field_ref:
   - field
   - - Internal Metabase Database
@@ -196,21 +220,21 @@ result_metadata:
     - v_query_log
     - card_id
   - null
-  effective_type: type/Integer
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_query_log
   - card_id
-  visibility_type: details-only
-  display_name: Card ID
-  base_type: type/Integer
-- description: null
-  semantic_type: type/FK
-  coercion_strategy: null
-  name: card_qualified_id
+  name: card_id
+  semantic_type: null
   settings: null
-  fk_target_field_id: 1484
+  visibility_type: details-only
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Card Qualified ID
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -218,21 +242,21 @@ result_metadata:
     - v_query_log
     - card_qualified_id
   - null
-  effective_type: type/Text
+  fk_target_field_id: 1484
   id:
   - Internal Metabase Database
   - public
   - v_query_log
   - card_qualified_id
-  visibility_type: normal
-  display_name: Card Qualified ID
-  base_type: type/Text
-- description: null
-  semantic_type: null
-  coercion_strategy: null
-  name: dashboard_id
+  name: card_qualified_id
+  semantic_type: type/FK
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Dashboard ID
+  effective_type: type/Integer
   field_ref:
   - field
   - - Internal Metabase Database
@@ -240,21 +264,21 @@ result_metadata:
     - v_query_log
     - dashboard_id
   - null
-  effective_type: type/Integer
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_query_log
   - dashboard_id
-  visibility_type: details-only
-  display_name: Dashboard ID
-  base_type: type/Integer
-- description: null
-  semantic_type: type/FK
-  coercion_strategy: null
-  name: dashboard_qualified_id
+  name: dashboard_id
+  semantic_type: null
   settings: null
-  fk_target_field_id: 1484
+  visibility_type: details-only
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Dashboard Qualified ID
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -262,21 +286,21 @@ result_metadata:
     - v_query_log
     - dashboard_qualified_id
   - null
-  effective_type: type/Text
+  fk_target_field_id: 1484
   id:
   - Internal Metabase Database
   - public
   - v_query_log
   - dashboard_qualified_id
-  visibility_type: normal
-  display_name: Dashboard Qualified ID
-  base_type: type/Text
-- description: null
-  semantic_type: null
-  coercion_strategy: null
-  name: pulse_id
+  name: dashboard_qualified_id
+  semantic_type: type/FK
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Pulse ID
+  effective_type: type/Integer
   field_ref:
   - field
   - - Internal Metabase Database
@@ -284,21 +308,21 @@ result_metadata:
     - v_query_log
     - pulse_id
   - null
-  effective_type: type/Integer
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_query_log
   - pulse_id
-  visibility_type: normal
-  display_name: Pulse ID
-  base_type: type/Integer
-- description: null
+  name: pulse_id
   semantic_type: null
-  coercion_strategy: null
-  name: database_id
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Database ID
+  effective_type: type/Integer
   field_ref:
   - field
   - - Internal Metabase Database
@@ -306,21 +330,21 @@ result_metadata:
     - v_query_log
     - database_id
   - null
-  effective_type: type/Integer
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_query_log
   - database_id
-  visibility_type: details-only
-  display_name: Database ID
-  base_type: type/Integer
-- description: null
-  semantic_type: type/FK
-  coercion_strategy: null
-  name: database_qualified_id
+  name: database_id
+  semantic_type: null
   settings: null
-  fk_target_field_id: 1556
+  visibility_type: details-only
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Database Qualified ID
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -328,21 +352,21 @@ result_metadata:
     - v_query_log
     - database_qualified_id
   - null
-  effective_type: type/Text
+  fk_target_field_id: 1556
   id:
   - Internal Metabase Database
   - public
   - v_query_log
   - database_qualified_id
-  visibility_type: normal
-  display_name: Database Qualified ID
-  base_type: type/Text
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: cache_hit
+  name: database_qualified_id
+  semantic_type: type/FK
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Boolean
+  coercion_strategy: null
+  description: null
+  display_name: Cache Hit
+  effective_type: type/Boolean
   field_ref:
   - field
   - - Internal Metabase Database
@@ -350,21 +374,21 @@ result_metadata:
     - v_query_log
     - cache_hit
   - null
-  effective_type: type/Boolean
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_query_log
   - cache_hit
-  visibility_type: normal
-  display_name: Cache Hit
-  base_type: type/Boolean
-- description: null
-  semantic_type: null
-  coercion_strategy: null
-  name: action_id
+  name: cache_hit
+  semantic_type: type/Category
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Action ID
+  effective_type: type/Integer
   field_ref:
   - field
   - - Internal Metabase Database
@@ -372,46 +396,22 @@ result_metadata:
     - v_query_log
     - action_id
   - null
-  effective_type: type/Integer
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_query_log
   - action_id
+  name: action_id
+  semantic_type: null
+  settings: null
   visibility_type: details-only
-  display_name: Action ID
-  base_type: type/Integer
-database_id: Internal Metabase Database
-enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Query log
-creator_id: internal@metabase.com
-made_public_by_id: null
-embedding_params: null
-cache_ttl: null
-dataset_query:
-  database: Internal Metabase Database
-  type: query
-  query:
-    source-table:
-    - Internal Metabase Database
-    - public
-    - v_query_log
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: QOtZaiTLf2FDD4AT6Oinb
-  label: query_log
-display: table
-entity_id: QOtZaiTLf2FDD4AT6Oinb
-collection_preview: true
 visualization_settings:
-  table.pivot_column: error
-  table.cell_column: running_time_seconds
   column_settings: null
+  table.cell_column: running_time_seconds
+  table.pivot_column: error
+serdes/meta:
+- id: QOtZaiTLf2FDD4AT6Oinb
+  label: query_log
+  model: Card
 metabase_version: vUNKNOWN (0e09ac7)
-parameters: []
-dataset: true
-created_at: '2023-10-31T21:50:16.833016Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/T1vsVJUAfg30Fqiw4Dywa_most_viewed_cards.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/T1vsVJUAfg30Fqiw4Dywa_most_viewed_cards.yaml
@@ -1,61 +1,30 @@
+name: Most viewed cards
 description: null
+entity_id: T1vsVJUAfg30Fqiw4Dywa
+created_at: '2023-06-14T20:04:09.381118Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Most viewed cards
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    joins:
-    - strategy: left-join
-      alias: Group Members - User
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - user_id
-        - base-type: type/Integer
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_group_members
-          - user_id
-        - base-type: type/Integer
-          join-alias: Group Members - User
-      source-table: lTp-ATFsCUFEr9I0fMEaO
-    - strategy: left-join
-      alias: Content - Entity Qualified
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - entity_qualified_id
-        - base-type: type/Text
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - entity_qualified_id
-        - base-type: type/Text
-          join-alias: Content - Entity Qualified
-      source-table: AxSackBiyXVRUzM_TyyQY
     aggregation:
     - - count
     breakout:
@@ -72,11 +41,6 @@ dataset_query:
         - name
       - base-type: type/Text
         join-alias: Content - Entity Qualified
-    order-by:
-    - - desc
-      - - aggregation
-        - 0
-    source-table: P6Ityjj7igswKh4NgZZjz
     filter:
     - =
     - - field
@@ -86,20 +50,73 @@ dataset_query:
         - entity_type
       - base-type: type/Text
     - card
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: T1vsVJUAfg30Fqiw4Dywa
-  label: most_viewed_cards
-display: table
-entity_id: T1vsVJUAfg30Fqiw4Dywa
-collection_preview: true
+    joins:
+    - alias: Group Members - User
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - user_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_group_members
+          - user_id
+        - base-type: type/Integer
+          join-alias: Group Members - User
+      source-table: lTp-ATFsCUFEr9I0fMEaO
+      strategy: left-join
+    - alias: Content - Entity Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - entity_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Content - Entity Qualified
+      source-table: AxSackBiyXVRUzM_TyyQY
+      strategy: left-join
+    order-by:
+    - - desc
+      - - aggregation
+        - 0
+    source-table: P6Ityjj7igswKh4NgZZjz
+  type: query
+result_metadata: null
 visualization_settings:
+  column_settings:
+    '["name","count"]':
+      show_mini_bar: true
+    '["ref",["field",["Internal Metabase Database","public","v_audit_log","model_id"],null]]':
+      column_title: Question ID
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Question name
+      link_url: /question/{{entity_id}}
+      view_as: link
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Question 35"}]]'
+    : column_title: Question Name
+    '["ref",["field",["Internal Metabase Database","public","v_view_log","entity_id"],{"base-type":"type/Integer"}]]':
+      column_title: Question ID
+  graph.dimensions:
+  - model_id
+  graph.metrics:
+  - count
   graph.show_goal: false
   graph.show_values: true
-  table.pivot: false
+  table.cell_column: count
   table.columns:
-  - name: name
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -108,8 +125,8 @@ visualization_settings:
       - name
     - base-type: type/Text
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: entity_id
+    name: name
+  - enabled: false
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -117,31 +134,16 @@ visualization_settings:
       - v_view_log
       - entity_id
     - base-type: type/Integer
-    enabled: true
-  - name: count
+    name: entity_id
+  - enabled: true
     fieldRef:
     - aggregation
     - 0
-    enabled: true
-  table.cell_column: count
-  graph.metrics:
-  - count
+    name: count
+  table.pivot: false
   table.pivot_column: model_id
-  column_settings:
-    '["name","count"]':
-      show_mini_bar: true
-    '["ref",["field",["Internal Metabase Database","public","v_audit_log","model_id"],null]]':
-      column_title: Question ID
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Question 35"}]]'
-    : column_title: Question Name
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
-    : column_title: Question name
-    '["ref",["field",["Internal Metabase Database","public","v_view_log","entity_id"],{"base-type":"type/Integer"}]]':
-      column_title: Question ID
-  graph.dimensions:
-  - model_id
+serdes/meta:
+- id: T1vsVJUAfg30Fqiw4Dywa
+  label: most_viewed_cards
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-06-14T20:04:09.381118Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/UEK1JfYa3ZBp6W7F-Ui5i_questions_without_recent_views.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/UEK1JfYa3ZBp6W7F-Ui5i_questions_without_recent_views.yaml
@@ -1,25 +1,39 @@
+name: Questions without recent views
 description: null
+entity_id: UEK1JfYa3ZBp6W7F-Ui5i
+created_at: '2023-11-01T11:53:36.842975Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_content
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Questions without recent views
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    limit: 100
+    expressions:
+      Days since last view:
+      - datetime-diff
+      - - field
+        - max
+        - base-type: type/DateTimeWithLocalTZ
+          join-alias: Last content viewed at - Entity Qualified
+      - - now
+      - day
     fields:
     - - field
       - - Internal Metabase Database
@@ -41,40 +55,6 @@ dataset_query:
       - base-type: type/Text
     - - expression
       - Days since last view
-    joins:
-    - fields: none
-      strategy: left-join
-      alias: Last content viewed at - Entity Qualified
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - entity_qualified_id
-        - base-type: type/Text
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - entity_qualified_id
-        - base-type: type/Text
-          join-alias: Last content viewed at - Entity Qualified
-      source-table: tKEl86EXMyTDIoO9nyFTV
-    expressions:
-      Days since last view:
-      - datetime-diff
-      - - field
-        - max
-        - base-type: type/DateTimeWithLocalTZ
-          join-alias: Last content viewed at - Entity Qualified
-      - - now
-      - day
-    order-by:
-    - - desc
-      - - expression
-        - Days since last view
-    source-table: AxSackBiyXVRUzM_TyyQY
     filter:
     - and
     - - =
@@ -96,30 +76,50 @@ dataset_query:
           - archived
         - base-type: type/Boolean
       - false
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: UEK1JfYa3ZBp6W7F-Ui5i
-  label: questions_without_recent_views
-display: table
-entity_id: UEK1JfYa3ZBp6W7F-Ui5i
-collection_preview: true
+    joins:
+    - alias: Last content viewed at - Entity Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Last content viewed at - Entity Qualified
+      fields: none
+      source-table: tKEl86EXMyTDIoO9nyFTV
+      strategy: left-join
+    limit: 100
+    order-by:
+    - - desc
+      - - expression
+        - Days since last view
+    source-table: AxSackBiyXVRUzM_TyyQY
+  type: query
+result_metadata: null
 visualization_settings:
-  table.cell_column: Days since last view
   column_settings:
     '["ref",["expression","Days since last view"]]':
       show_mini_bar: true
     '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer"}]]':
       column_title: Question ID
-      view_as: link
       link_text: ''
       link_url: /question/{{entity_id}}
+      view_as: link
     '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text"}]]':
-      view_as: link
       link_text: ''
       link_url: /question/{{entity_id}}
+      view_as: link
+  table.cell_column: Days since last view
+serdes/meta:
+- id: UEK1JfYa3ZBp6W7F-Ui5i
+  label: questions_without_recent_views
+  model: Card
 metabase_version: vUNKNOWN (901f705)
-parameters: []
-dataset: false
-created_at: '2023-11-01T11:53:36.842975Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/Vm-4GYORvVbGu9jHVLfg1_question_views_per_month.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/Vm-4GYORvVbGu9jHVLfg1_question_views_per_month.yaml
@@ -1,27 +1,51 @@
+name: Question views per month
 description: null
+entity_id: Vm-4GYORvVbGu9jHVLfg1
+created_at: '2023-06-15T02:08:19.283932Z'
+creator_id: internal@metabase.com
+display: line
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Question views per month
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
+    aggregation:
+    - - count
+    breakout:
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - timestamp
+      - base-type: type/DateTimeWithLocalTZ
+        temporal-unit: month
+    filter:
+    - =
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - entity_type
+      - base-type: type/Text
+    - card
     joins:
-    - strategy: left-join
-      alias: People - User
+    - alias: People - User
       condition:
       - =
       - - field
@@ -38,43 +62,19 @@ dataset_query:
         - base-type: type/Integer
           join-alias: People - User
       source-table: 0wVIfjBJWclD0lKeABYYl
-    aggregation:
-    - - count
-    breakout:
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - timestamp
-      - base-type: type/DateTimeWithLocalTZ
-        temporal-unit: month
+      strategy: left-join
     source-table: P6Ityjj7igswKh4NgZZjz
-    filter:
-    - =
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - entity_type
-      - base-type: type/Text
-    - card
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: Vm-4GYORvVbGu9jHVLfg1
-  label: question_views_per_month
-display: line
-entity_id: Vm-4GYORvVbGu9jHVLfg1
-collection_preview: true
+  type: query
+result_metadata: null
 visualization_settings:
+  column_settings: null
   graph.dimensions:
   - timestamp
-  graph.show_values: true
   graph.metrics:
   - count
-  column_settings: null
+  graph.show_values: true
+serdes/meta:
+- id: Vm-4GYORvVbGu9jHVLfg1
+  label: question_views_per_month
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-06-15T02:08:19.283932Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/W34-Nzp-T3-SPdZwGvLeB_dashboard_metadata.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/W34-Nzp-T3-SPdZwGvLeB_dashboard_metadata.yaml
@@ -1,23 +1,29 @@
+name: Dashboard metadata
 description: null
+entity_id: W34-Nzp-T3-SPdZwGvLeB
+created_at: '2023-08-17T21:47:25.11498Z'
+creator_id: internal@metabase.com
+display: object
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_content
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Dashboard metadata
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
     fields:
     - - field
@@ -80,7 +86,6 @@ dataset_query:
         - v_content
         - archived
       - base-type: type/Boolean
-    source-table: AxSackBiyXVRUzM_TyyQY
     filter:
     - =
     - - field
@@ -90,19 +95,24 @@ dataset_query:
         - entity_type
       - base-type: type/Text
     - dashboard
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: W34-Nzp-T3-SPdZwGvLeB
-  label: dashboard_metadata
-display: object
-entity_id: W34-Nzp-T3-SPdZwGvLeB
-collection_preview: true
+    source-table: AxSackBiyXVRUzM_TyyQY
+  type: query
+result_metadata: null
 visualization_settings:
-  table.pivot_column: full_name
+  column_settings:
+    '["ref",["field",["Internal Metabase Database","public","v_audit_log","model_id"],null]]':
+      column_title: Content ID
+    '["ref",["field",["Internal Metabase Database","public","v_audit_log","timestamp"],null]]':
+      column_title: Creation Date
+    '["ref",["field",["Internal Metabase Database","public","v_content","description"],{"join-alias":"Question 35"}]]':
+      column_title: Description
+    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35"}]]':
+      column_title: Name
+    '["ref",["field",["Internal Metabase Database","public","v_users","full_name"],{"join-alias":"Question 1"}]]':
+      column_title: Creator Name
   table.cell_column: model_id
   table.columns:
-  - name: entity_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -110,8 +120,8 @@ visualization_settings:
       - v_content
       - entity_id
     - base-type: type/Integer
-    enabled: true
-  - name: name
+    name: entity_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -119,8 +129,8 @@ visualization_settings:
       - v_content
       - name
     - base-type: type/Text
-    enabled: true
-  - name: entity_type
+    name: name
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -128,8 +138,8 @@ visualization_settings:
       - v_content
       - entity_type
     - base-type: type/Text
-    enabled: true
-  - name: created_at
+    name: entity_type
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -138,8 +148,8 @@ visualization_settings:
       - created_at
     - base-type: type/DateTimeWithLocalTZ
       temporal-unit: default
-    enabled: true
-  - name: updated_at
+    name: created_at
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -148,8 +158,8 @@ visualization_settings:
       - updated_at
     - base-type: type/DateTimeWithLocalTZ
       temporal-unit: default
-    enabled: true
-  - name: creator_id
+    name: updated_at
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -157,8 +167,8 @@ visualization_settings:
       - v_content
       - creator_id
     - base-type: type/Integer
-    enabled: true
-  - name: description
+    name: creator_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -166,8 +176,8 @@ visualization_settings:
       - v_content
       - description
     - base-type: type/Text
-    enabled: true
-  - name: made_public_by_user
+    name: description
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -175,8 +185,8 @@ visualization_settings:
       - v_content
       - made_public_by_user
     - base-type: type/Integer
-    enabled: true
-  - name: is_embedding_enabled
+    name: made_public_by_user
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -184,8 +194,8 @@ visualization_settings:
       - v_content
       - is_embedding_enabled
     - base-type: type/Boolean
-    enabled: true
-  - name: archived
+    name: is_embedding_enabled
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -193,20 +203,10 @@ visualization_settings:
       - v_content
       - archived
     - base-type: type/Boolean
-    enabled: true
-  column_settings:
-    '["ref",["field",["Internal Metabase Database","public","v_users","full_name"],{"join-alias":"Question 1"}]]':
-      column_title: Creator Name
-    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35"}]]':
-      column_title: Name
-    '["ref",["field",["Internal Metabase Database","public","v_content","description"],{"join-alias":"Question 35"}]]':
-      column_title: Description
-    '["ref",["field",["Internal Metabase Database","public","v_audit_log","model_id"],null]]':
-      column_title: Content ID
-    '["ref",["field",["Internal Metabase Database","public","v_audit_log","timestamp"],null]]':
-      column_title: Creation Date
+    name: archived
+  table.pivot_column: full_name
+serdes/meta:
+- id: W34-Nzp-T3-SPdZwGvLeB
+  label: dashboard_metadata
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-08-17T21:47:25.11498Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/WlQ-en2l-iRRCvO2-v5j1_recent_activity.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/WlQ-en2l-iRRCvO2-v5j1_recent_activity.yaml
@@ -1,23 +1,29 @@
+name: Recent activity
 description: null
+entity_id: WlQ-en2l-iRRCvO2-v5j1
+created_at: '2023-11-01T01:06:15.554648Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_audit_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Recent activity
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
     fields:
     - - field
@@ -44,18 +50,8 @@ dataset_query:
         - v_audit_log
         - details
       - base-type: type/Text
-    order-by:
-    - - desc
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_audit_log
-          - timestamp
-        - base-type: type/DateTimeWithLocalTZ
     joins:
-    - fields: none
-      strategy: left-join
-      alias: People - User
+    - alias: People - User
       condition:
       - =
       - - field
@@ -71,21 +67,70 @@ dataset_query:
           - user_id
         - base-type: type/Integer
           join-alias: People - User
+      fields: none
       source-table: 0wVIfjBJWclD0lKeABYYl
+      strategy: left-join
+    - alias: Content - Entity Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_audit_log
+          - entity_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Content - Entity Qualified
+      fields:
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_id
+        - base-type: type/Integer
+          join-alias: Content - Entity Qualified
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_type
+        - base-type: type/Text
+          join-alias: Content - Entity Qualified
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - name
+        - base-type: type/Text
+          join-alias: Content - Entity Qualified
+      source-table: AxSackBiyXVRUzM_TyyQY
+      strategy: left-join
+    limit: 200
+    order-by:
+    - - desc
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_audit_log
+          - timestamp
+        - base-type: type/DateTimeWithLocalTZ
     source-table: -lNDM3tJmuL5ltGbX0oyT
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: WlQ-en2l-iRRCvO2-v5j1
-  label: recent_activity
-display: table
-entity_id: WlQ-en2l-iRRCvO2-v5j1
-collection_preview: true
+  type: query
+result_metadata: null
 visualization_settings:
-  table.pivot_column: topic
+  column_settings:
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Content name
+      link_url: /{{entity_type}}/{{entity_id}}
+      view_as: link
   table.cell_column: details
   table.columns:
-  - name: timestamp
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -94,8 +139,8 @@ visualization_settings:
       - timestamp
     - base-type: type/DateTimeWithLocalTZ
       temporal-unit: default
-    enabled: true
-  - name: topic
+    name: timestamp
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -103,8 +148,18 @@ visualization_settings:
       - v_audit_log
       - topic
     - base-type: type/Text
-    enabled: true
-  - name: entity_qualified_id
+    name: topic
+  - enabled: true
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_content
+      - name
+    - base-type: type/Text
+      join-alias: Content - Entity Qualified
+    name: name
+  - enabled: false
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -112,8 +167,8 @@ visualization_settings:
       - v_audit_log
       - entity_qualified_id
     - base-type: type/Text
-    enabled: true
-  - name: details
+    name: entity_qualified_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -121,10 +176,30 @@ visualization_settings:
       - v_audit_log
       - details
     - base-type: type/Text
-    enabled: true
-  column_settings: null
+    name: details
+  - enabled: false
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_content
+      - entity_id
+    - base-type: type/Integer
+      join-alias: Content - Entity Qualified
+    name: entity_id
+  - enabled: false
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_content
+      - entity_type
+    - base-type: type/Text
+      join-alias: Content - Entity Qualified
+    name: entity_type
+  table.pivot_column: topic
+serdes/meta:
+- id: WlQ-en2l-iRRCvO2-v5j1
+  label: recent_activity
+  model: Card
 metabase_version: vUNKNOWN (ad99d37)
-parameters: []
-dataset: false
-created_at: '2023-11-01T01:06:15.554648Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/WoQnk12nwOaJ1pcb1wsr4_new_dashboards_per_month.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/WoQnk12nwOaJ1pcb1wsr4_new_dashboards_per_month.yaml
@@ -1,32 +1,30 @@
+name: New dashboards per month
 description: null
+entity_id: WoQnk12nwOaJ1pcb1wsr4
+created_at: '2023-06-08T14:37:36.024095Z'
+creator_id: internal@metabase.com
+display: line
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_content
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: New dashboards per month
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
+  database: Internal Metabase Database
   query:
-    source-table: AxSackBiyXVRUzM_TyyQY
-    filter:
-    - =
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_content
-        - entity_type
-      - null
-    - dashboard
     aggregation:
     - - count
     breakout:
@@ -36,27 +34,29 @@ dataset_query:
         - v_content
         - created_at
       - temporal-unit: month
-  database: Internal Metabase Database
+    filter:
+    - =
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - entity_type
+      - null
+    - dashboard
+    source-table: AxSackBiyXVRUzM_TyyQY
   type: query
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: WoQnk12nwOaJ1pcb1wsr4
-  label: new_dashboards_per_month
-display: line
-entity_id: WoQnk12nwOaJ1pcb1wsr4
-collection_preview: true
+result_metadata: null
 visualization_settings:
-  table.pivot_column: action_type
-  table.cell_column: event_timestamp
-  graph.show_values: true
+  column_settings: null
   graph.dimensions:
   - created_at
   graph.metrics:
   - count
-  column_settings: null
+  graph.show_values: true
+  table.cell_column: event_timestamp
+  table.pivot_column: action_type
+serdes/meta:
+- id: WoQnk12nwOaJ1pcb1wsr4
+  label: new_dashboards_per_month
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-06-08T14:37:36.024095Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/XIiIsCNMk9gg-eO2hkl8S_dashboard_views_per_month.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/XIiIsCNMk9gg-eO2hkl8S_dashboard_views_per_month.yaml
@@ -1,23 +1,29 @@
+name: Dashboard views per month
 description: null
+entity_id: XIiIsCNMk9gg-eO2hkl8S
+created_at: '2023-08-17T21:55:45.764868Z'
+creator_id: internal@metabase.com
+display: line
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Dashboard views per month
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
     aggregation:
     - - count
@@ -29,9 +35,17 @@ dataset_query:
         - timestamp
       - base-type: type/DateTimeWithLocalTZ
         temporal-unit: month
+    filter:
+    - =
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - entity_type
+      - base-type: type/Text
+    - dashboard
     joins:
     - alias: Content - Entity Qualified
-      strategy: left-join
       condition:
       - =
       - - field
@@ -48,8 +62,8 @@ dataset_query:
         - base-type: type/Text
           join-alias: Content - Entity Qualified
       source-table: AxSackBiyXVRUzM_TyyQY
-    - alias: Group Members - User
       strategy: left-join
+    - alias: Group Members - User
       condition:
       - =
       - - field
@@ -66,35 +80,21 @@ dataset_query:
         - base-type: type/Integer
           join-alias: Group Members - User
       source-table: lTp-ATFsCUFEr9I0fMEaO
+      strategy: left-join
     source-table: P6Ityjj7igswKh4NgZZjz
-    filter:
-    - =
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - entity_type
-      - base-type: type/Text
-    - dashboard
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: XIiIsCNMk9gg-eO2hkl8S
-  label: dashboard_views_per_month
-display: line
-entity_id: XIiIsCNMk9gg-eO2hkl8S
-collection_preview: true
+  type: query
+result_metadata: null
 visualization_settings:
-  table.pivot_column: end_timestamp
-  table.cell_column: model_id
+  column_settings: null
   graph.dimensions:
   - timestamp
-  graph.show_values: true
   graph.metrics:
   - count
-  column_settings: null
+  graph.show_values: true
+  table.cell_column: model_id
+  table.pivot_column: end_timestamp
+serdes/meta:
+- id: XIiIsCNMk9gg-eO2hkl8S
+  label: dashboard_views_per_month
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-08-17T21:55:45.764868Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/XLzhOnMmk3DkefFAMx_Vg_question_metadata.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/XLzhOnMmk3DkefFAMx_Vg_question_metadata.yaml
@@ -1,21 +1,29 @@
+name: Question metadata
 description: null
+entity_id: XLzhOnMmk3DkefFAMx_Vg
+created_at: '2023-11-01T02:34:12.158577Z'
+creator_id: internal@metabase.com
+display: object
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_content
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Question metadata
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
+  database: Internal Metabase Database
   query:
     fields:
     - - field
@@ -78,7 +86,6 @@ dataset_query:
         - v_content
         - archived
       - base-type: type/Boolean
-    source-table: AxSackBiyXVRUzM_TyyQY
     filter:
     - =
     - - field
@@ -88,21 +95,24 @@ dataset_query:
         - entity_type
       - base-type: type/Text
     - question
+    source-table: AxSackBiyXVRUzM_TyyQY
   type: query
-  database: Internal Metabase Database
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: XLzhOnMmk3DkefFAMx_Vg
-  label: question_metadata
-display: object
-entity_id: XLzhOnMmk3DkefFAMx_Vg
-collection_preview: true
+result_metadata: null
 visualization_settings:
-  table.pivot_column: full_name
+  column_settings:
+    '["ref",["field",["Internal Metabase Database","public","v_audit_log","model_id"],null]]':
+      column_title: Content ID
+    '["ref",["field",["Internal Metabase Database","public","v_audit_log","timestamp"],null]]':
+      column_title: Creation Date
+    '["ref",["field",["Internal Metabase Database","public","v_content","description"],{"join-alias":"Question 35"}]]':
+      column_title: Description
+    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35"}]]':
+      column_title: Name
+    '["ref",["field",["Internal Metabase Database","public","v_users","full_name"],{"join-alias":"Question 1"}]]':
+      column_title: Creator Name
   table.cell_column: model_id
   table.columns:
-  - name: entity_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -110,8 +120,8 @@ visualization_settings:
       - v_content
       - entity_id
     - base-type: type/Integer
-    enabled: true
-  - name: name
+    name: entity_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -119,8 +129,8 @@ visualization_settings:
       - v_content
       - name
     - base-type: type/Text
-    enabled: true
-  - name: entity_type
+    name: name
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -128,8 +138,8 @@ visualization_settings:
       - v_content
       - entity_type
     - base-type: type/Text
-    enabled: true
-  - name: created_at
+    name: entity_type
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -138,8 +148,8 @@ visualization_settings:
       - created_at
     - base-type: type/DateTimeWithLocalTZ
       temporal-unit: default
-    enabled: true
-  - name: updated_at
+    name: created_at
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -148,8 +158,8 @@ visualization_settings:
       - updated_at
     - base-type: type/DateTimeWithLocalTZ
       temporal-unit: default
-    enabled: true
-  - name: creator_id
+    name: updated_at
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -157,8 +167,8 @@ visualization_settings:
       - v_content
       - creator_id
     - base-type: type/Integer
-    enabled: true
-  - name: description
+    name: creator_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -166,8 +176,8 @@ visualization_settings:
       - v_content
       - description
     - base-type: type/Text
-    enabled: true
-  - name: made_public_by_user
+    name: description
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -175,8 +185,8 @@ visualization_settings:
       - v_content
       - made_public_by_user
     - base-type: type/Integer
-    enabled: true
-  - name: is_embedding_enabled
+    name: made_public_by_user
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -184,8 +194,8 @@ visualization_settings:
       - v_content
       - is_embedding_enabled
     - base-type: type/Boolean
-    enabled: true
-  - name: archived
+    name: is_embedding_enabled
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -193,20 +203,10 @@ visualization_settings:
       - v_content
       - archived
     - base-type: type/Boolean
-    enabled: true
-  column_settings:
-    '["ref",["field",["Internal Metabase Database","public","v_users","full_name"],{"join-alias":"Question 1"}]]':
-      column_title: Creator Name
-    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35"}]]':
-      column_title: Name
-    '["ref",["field",["Internal Metabase Database","public","v_content","description"],{"join-alias":"Question 35"}]]':
-      column_title: Description
-    '["ref",["field",["Internal Metabase Database","public","v_audit_log","model_id"],null]]':
-      column_title: Content ID
-    '["ref",["field",["Internal Metabase Database","public","v_audit_log","timestamp"],null]]':
-      column_title: Creation Date
+    name: archived
+  table.pivot_column: full_name
+serdes/meta:
+- id: XLzhOnMmk3DkefFAMx_Vg
+  label: question_metadata
+  model: Card
 metabase_version: vUNKNOWN (13e6090)
-parameters: []
-dataset: false
-created_at: '2023-11-01T02:34:12.158577Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/Y0ZykgQ64HHwAW_MYx-dW_first_login_date.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/Y0ZykgQ64HHwAW_MYx-dW_first_login_date.yaml
@@ -1,41 +1,41 @@
+name: First login date
 description: null
+entity_id: Y0ZykgQ64HHwAW_MYx-dW
+created_at: '2023-06-15T01:39:03.628078Z'
+creator_id: internal@metabase.com
+display: scalar
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_users
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: First login date
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
   query:
     source-table: 0wVIfjBJWclD0lKeABYYl
   type: query
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: Y0ZykgQ64HHwAW_MYx-dW
-  label: first_login_date
-display: scalar
-entity_id: Y0ZykgQ64HHwAW_MYx-dW
-collection_preview: true
+result_metadata: null
 visualization_settings:
-  scalar.field: date_joined
   column_settings:
     '["ref",["field",["Internal Metabase Database","public","v_users","date_joined"],null]]':
-      time_enabled: null
       date_abbreviate: true
+      time_enabled: null
+  scalar.field: date_joined
+serdes/meta:
+- id: Y0ZykgQ64HHwAW_MYx-dW
+  label: first_login_date
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-06-15T01:39:03.628078Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/YiHMsA2dv3iQob11DLTIz_alerts_on_this_question.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/YiHMsA2dv3iQob11DLTIz_alerts_on_this_question.yaml
@@ -1,63 +1,30 @@
+name: Alerts on this question
 description: null
+entity_id: YiHMsA2dv3iQob11DLTIz
+created_at: '2023-11-01T02:51:15.092627Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Alerts on this question
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    joins:
-    - fields: none
-      strategy: left-join
-      alias: Content - Card Qualified
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_alerts
-          - card_qualified_id
-        - base-type: type/Text
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - entity_qualified_id
-        - base-type: type/Text
-          join-alias: Content - Card Qualified
-      source-table: AxSackBiyXVRUzM_TyyQY
-    - fields: none
-      strategy: left-join
-      alias: People - Creator
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_alerts
-          - creator_id
-        - base-type: type/Integer
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_users
-          - user_id
-        - base-type: type/Integer
-          join-alias: People - Creator
-      source-table: 0wVIfjBJWclD0lKeABYYl
     fields:
     - - field
       - - Internal Metabase Database
@@ -113,7 +80,6 @@ dataset_query:
         - v_alerts
         - recipient_external
       - base-type: type/Text
-    source-table: skoPT2xiuEcUV8vFkHE6S
     filter:
     - =
     - - field
@@ -123,20 +89,54 @@ dataset_query:
         - archived
       - base-type: type/Boolean
     - false
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: YiHMsA2dv3iQob11DLTIz
-  label: alerts_on_this_question
-display: table
-entity_id: YiHMsA2dv3iQob11DLTIz
-collection_preview: true
+    joins:
+    - alias: Content - Card Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_alerts
+          - card_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Content - Card Qualified
+      fields: none
+      source-table: AxSackBiyXVRUzM_TyyQY
+      strategy: left-join
+    - alias: People - Creator
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_alerts
+          - creator_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_users
+          - user_id
+        - base-type: type/Integer
+          join-alias: People - Creator
+      fields: none
+      source-table: 0wVIfjBJWclD0lKeABYYl
+      strategy: left-join
+    source-table: skoPT2xiuEcUV8vFkHE6S
+  type: query
+result_metadata: null
 visualization_settings:
-  table.pivot_column: schedule_day
-  table.cell_column: card_id
   column_settings: null
+  table.cell_column: card_id
+  table.pivot_column: schedule_day
+serdes/meta:
+- id: YiHMsA2dv3iQob11DLTIz
+  label: alerts_on_this_question
+  model: Card
 metabase_version: vUNKNOWN (13e6090)
-parameters: []
-dataset: false
-created_at: '2023-11-01T02:51:15.092627Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/YxCC6fQfHOPVvBtUkjFCN_questions_that_don_t_belong_to_a_dashboard.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/YxCC6fQfHOPVvBtUkjFCN_questions_that_don_t_belong_to_a_dashboard.yaml
@@ -1,25 +1,39 @@
+name: Questions that don't belong to a dashboard
 description: null
+entity_id: YxCC6fQfHOPVvBtUkjFCN
+created_at: '2023-11-01T11:56:37.486175Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_content
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Questions that don't belong to a dashboard
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    limit: 100
+    expressions:
+      Days since last view:
+      - datetime-diff
+      - - field
+        - max
+        - base-type: type/DateTimeWithLocalTZ
+          join-alias: Last content viewed at - Entity Qualified
+      - - now
+      - day
     fields:
     - - field
       - - Internal Metabase Database
@@ -41,59 +55,6 @@ dataset_query:
       - base-type: type/Text
     - - expression
       - Days since last view
-    joins:
-    - fields: none
-      strategy: left-join
-      alias: Last content viewed at - Entity Qualified
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - entity_qualified_id
-        - base-type: type/Text
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - entity_qualified_id
-        - base-type: type/Text
-          join-alias: Last content viewed at - Entity Qualified
-      source-table: tKEl86EXMyTDIoO9nyFTV
-    - fields: none
-      strategy: left-join
-      alias: Dashboard cards - Entity Qualified
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - entity_qualified_id
-        - base-type: type/Text
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_dashboardcard
-          - card_qualified_id
-        - base-type: type/Text
-          join-alias: Dashboard cards - Entity Qualified
-      source-table: pKdvc0pwu1zDi8NqnyJkt
-    expressions:
-      Days since last view:
-      - datetime-diff
-      - - field
-        - max
-        - base-type: type/DateTimeWithLocalTZ
-          join-alias: Last content viewed at - Entity Qualified
-      - - now
-      - day
-    order-by:
-    - - desc
-      - - expression
-        - Days since last view
-    source-table: AxSackBiyXVRUzM_TyyQY
     filter:
     - and
     - - =
@@ -123,31 +84,70 @@ dataset_query:
           - entity_id
         - base-type: type/Integer
           join-alias: Dashboard cards - Entity Qualified
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: YxCC6fQfHOPVvBtUkjFCN
-  label: questions_that_don_t_belong_to_a_dashboard
-display: table
-entity_id: YxCC6fQfHOPVvBtUkjFCN
-collection_preview: true
+    joins:
+    - alias: Last content viewed at - Entity Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Last content viewed at - Entity Qualified
+      fields: none
+      source-table: tKEl86EXMyTDIoO9nyFTV
+      strategy: left-join
+    - alias: Dashboard cards - Entity Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_dashboardcard
+          - card_qualified_id
+        - base-type: type/Text
+          join-alias: Dashboard cards - Entity Qualified
+      fields: none
+      source-table: pKdvc0pwu1zDi8NqnyJkt
+      strategy: left-join
+    limit: 100
+    order-by:
+    - - desc
+      - - expression
+        - Days since last view
+    source-table: AxSackBiyXVRUzM_TyyQY
+  type: query
+result_metadata: null
 visualization_settings:
-  table.cell_column: Days since last view
-  table.pivot_column: dashboardtab_id
   column_settings:
     '["ref",["expression","Days since last view"]]':
       show_mini_bar: true
     '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer"}]]':
       column_title: Question ID
-      view_as: link
       link_text: ''
       link_url: /question/{{entity_id}}
+      view_as: link
     '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text"}]]':
-      view_as: link
       link_text: ''
       link_url: /question/{{entity_id}}
+      view_as: link
+  table.cell_column: Days since last view
+  table.pivot_column: dashboardtab_id
+serdes/meta:
+- id: YxCC6fQfHOPVvBtUkjFCN
+  label: questions_that_don_t_belong_to_a_dashboard
+  model: Card
 metabase_version: vUNKNOWN (901f705)
-parameters: []
-dataset: false
-created_at: '2023-11-01T11:56:37.486175Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/Z18i0B5CgOe66-YScAZdx_questions_created_per_month.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/Z18i0B5CgOe66-YScAZdx_questions_created_per_month.yaml
@@ -1,24 +1,30 @@
+name: Questions created per month
 description: null
+entity_id: Z18i0B5CgOe66-YScAZdx
+created_at: '2023-06-15T02:12:55.658594Z'
+creator_id: internal@metabase.com
+display: line
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_audit_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Questions created per month
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
   query:
-    source-table: -lNDM3tJmuL5ltGbX0oyT
     aggregation:
     - - count
     breakout:
@@ -28,9 +34,17 @@ dataset_query:
         - v_audit_log
         - timestamp
       - temporal-unit: month
+    filter:
+    - =
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_audit_log
+        - topic
+      - null
+    - card-create
     joins:
-    - fields: all
-      source-table: 0wVIfjBJWclD0lKeABYYl
+    - alias: Question 1
       condition:
       - =
       - - field
@@ -45,34 +59,20 @@ dataset_query:
           - v_users
           - user_id
         - join-alias: Question 1
-      alias: Question 1
-    filter:
-    - =
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_audit_log
-        - topic
-      - null
-    - card-create
+      fields: all
+      source-table: 0wVIfjBJWclD0lKeABYYl
+    source-table: -lNDM3tJmuL5ltGbX0oyT
   type: query
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: Z18i0B5CgOe66-YScAZdx
-  label: questions_created_per_month
-display: line
-entity_id: Z18i0B5CgOe66-YScAZdx
-collection_preview: true
+result_metadata: null
 visualization_settings:
+  column_settings: null
   graph.dimensions:
   - timestamp
-  graph.show_values: true
   graph.metrics:
   - count
-  column_settings: null
+  graph.show_values: true
+serdes/meta:
+- id: Z18i0B5CgOe66-YScAZdx
+  label: questions_created_per_month
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-06-15T02:12:55.658594Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/ZmDKwRQBuRwfXfGipg7-k_fields.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/ZmDKwRQBuRwfXfGipg7-k_fields.yaml
@@ -1,17 +1,41 @@
+name: Fields
 description: All fields from all connected data sources.
+entity_id: ZmDKwRQBuRwfXfGipg7-k
+created_at: '2023-10-31T21:45:31.793133Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: 18
+query_type: query
+dataset: true
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_fields
+enable_embedding: false
+embedding_params: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
+dataset_query:
+  database: Internal Metabase Database
+  query:
+    source-table:
+    - Internal Metabase Database
+    - public
+    - v_fields
+  type: query
 result_metadata:
-- description: null
-  semantic_type: type/PK
+- base_type: type/Integer
   coercion_strategy: null
-  name: entity_id
-  settings: null
-  fk_target_field_id: null
+  description: null
+  display_name: Entity ID
+  effective_type: type/Integer
   field_ref:
   - field
   - - Internal Metabase Database
@@ -19,21 +43,21 @@ result_metadata:
     - v_fields
     - entity_id
   - null
-  effective_type: type/Integer
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_fields
   - entity_id
-  visibility_type: normal
-  display_name: Entity ID
-  base_type: type/Integer
-- description: null
+  name: entity_id
   semantic_type: type/PK
-  coercion_strategy: null
-  name: entity_qualified_id
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Entity Qualified ID
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -41,22 +65,21 @@ result_metadata:
     - v_fields
     - entity_qualified_id
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_fields
   - entity_qualified_id
-  visibility_type: normal
-  display_name: Entity Qualified ID
-  base_type: type/Text
-- description: null
-  semantic_type: type/CreationTimestamp
-  coercion_strategy: null
-  unit: default
-  name: created_at
+  name: entity_qualified_id
+  semantic_type: type/PK
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: null
+  display_name: Created At
+  effective_type: type/DateTimeWithLocalTZ
   field_ref:
   - field
   - - Internal Metabase Database
@@ -64,22 +87,22 @@ result_metadata:
     - v_fields
     - created_at
   - temporal-unit: default
-  effective_type: type/DateTimeWithLocalTZ
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_fields
   - created_at
-  visibility_type: normal
-  display_name: Created At
-  base_type: type/DateTimeWithLocalTZ
-- description: null
-  semantic_type: type/UpdatedTimestamp
-  coercion_strategy: null
-  unit: default
-  name: updated_at
+  name: created_at
+  semantic_type: type/CreationTimestamp
   settings: null
-  fk_target_field_id: null
+  unit: default
+  visibility_type: normal
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: null
+  display_name: Updated At
+  effective_type: type/DateTimeWithLocalTZ
   field_ref:
   - field
   - - Internal Metabase Database
@@ -87,21 +110,22 @@ result_metadata:
     - v_fields
     - updated_at
   - temporal-unit: default
-  effective_type: type/DateTimeWithLocalTZ
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_fields
   - updated_at
-  visibility_type: normal
-  display_name: Updated At
-  base_type: type/DateTimeWithLocalTZ
-- description: null
-  semantic_type: type/Name
-  coercion_strategy: null
-  name: name
+  name: updated_at
+  semantic_type: type/UpdatedTimestamp
   settings: null
-  fk_target_field_id: null
+  unit: default
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Name
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -109,21 +133,21 @@ result_metadata:
     - v_fields
     - name
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_fields
   - name
-  visibility_type: normal
-  display_name: Name
-  base_type: type/Text
-- description: null
-  semantic_type: null
-  coercion_strategy: null
-  name: display_name
+  name: name
+  semantic_type: type/Name
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Display Name
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -131,21 +155,21 @@ result_metadata:
     - v_fields
     - display_name
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_fields
   - display_name
-  visibility_type: normal
-  display_name: Display Name
-  base_type: type/Text
-- description: null
-  semantic_type: type/Description
-  coercion_strategy: null
-  name: description
+  name: display_name
+  semantic_type: null
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Description
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -153,21 +177,21 @@ result_metadata:
     - v_fields
     - description
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_fields
   - description
-  visibility_type: normal
-  display_name: Description
-  base_type: type/Text
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: base_type
+  name: description
+  semantic_type: type/Description
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Base Type
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -175,21 +199,21 @@ result_metadata:
     - v_fields
     - base_type
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_fields
   - base_type
-  visibility_type: normal
-  display_name: Base Type
-  base_type: type/Text
-- description: null
+  name: base_type
   semantic_type: type/Category
-  coercion_strategy: null
-  name: visibility_type
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Visibility Type
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -197,21 +221,21 @@ result_metadata:
     - v_fields
     - visibility_type
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_fields
   - visibility_type
-  visibility_type: normal
-  display_name: Visibility Type
-  base_type: type/Text
-- description: null
-  semantic_type: type/FK
-  coercion_strategy: null
-  name: fk_target_field_id
+  name: visibility_type
+  semantic_type: type/Category
   settings: null
-  fk_target_field_id: 1546
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Fk Target Field ID
+  effective_type: type/Integer
   field_ref:
   - field
   - - Internal Metabase Database
@@ -219,21 +243,21 @@ result_metadata:
     - v_fields
     - fk_target_field_id
   - null
-  effective_type: type/Integer
+  fk_target_field_id: 1546
   id:
   - Internal Metabase Database
   - public
   - v_fields
   - fk_target_field_id
-  visibility_type: normal
-  display_name: Fk Target Field ID
-  base_type: type/Integer
-- description: null
-  semantic_type: null
-  coercion_strategy: null
-  name: has_field_values
+  name: fk_target_field_id
+  semantic_type: type/FK
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Has Field Values
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -241,21 +265,21 @@ result_metadata:
     - v_fields
     - has_field_values
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_fields
   - has_field_values
-  visibility_type: normal
-  display_name: Has Field Values
-  base_type: type/Text
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: active
+  name: has_field_values
+  semantic_type: null
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Boolean
+  coercion_strategy: null
+  description: null
+  display_name: Active
+  effective_type: type/Boolean
   field_ref:
   - field
   - - Internal Metabase Database
@@ -263,21 +287,21 @@ result_metadata:
     - v_fields
     - active
   - null
-  effective_type: type/Boolean
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_fields
   - active
-  visibility_type: normal
-  display_name: Active
-  base_type: type/Boolean
-- description: null
-  semantic_type: type/FK
-  coercion_strategy: null
-  name: table_id
+  name: active
+  semantic_type: type/Category
   settings: null
-  fk_target_field_id: 1534
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Table ID
+  effective_type: type/Integer
   field_ref:
   - field
   - - Internal Metabase Database
@@ -285,46 +309,22 @@ result_metadata:
     - v_fields
     - table_id
   - null
-  effective_type: type/Integer
+  fk_target_field_id: 1534
   id:
   - Internal Metabase Database
   - public
   - v_fields
   - table_id
+  name: table_id
+  semantic_type: type/FK
+  settings: null
   visibility_type: normal
-  display_name: Table ID
-  base_type: type/Integer
-database_id: Internal Metabase Database
-enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Fields
-creator_id: internal@metabase.com
-made_public_by_id: null
-embedding_params: null
-cache_ttl: null
-dataset_query:
-  database: Internal Metabase Database
-  type: query
-  query:
-    source-table:
-    - Internal Metabase Database
-    - public
-    - v_fields
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: ZmDKwRQBuRwfXfGipg7-k
-  label: fields
-display: table
-entity_id: ZmDKwRQBuRwfXfGipg7-k
-collection_preview: true
 visualization_settings:
-  table.pivot_column: visibility_type
-  table.cell_column: table_id
   column_settings: null
+  table.cell_column: table_id
+  table.pivot_column: visibility_type
+serdes/meta:
+- id: ZmDKwRQBuRwfXfGipg7-k
+  label: fields
+  model: Card
 metabase_version: vUNKNOWN (0e09ac7)
-parameters: []
-dataset: true
-created_at: '2023-10-31T21:45:31.793133Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/_lfXwss_MckZBidbcJsgk_most_viewed_questions.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/_lfXwss_MckZBidbcJsgk_most_viewed_questions.yaml
@@ -1,28 +1,68 @@
+name: Most viewed questions
 description: null
+entity_id: _lfXwss_MckZBidbcJsgk
+created_at: '2023-08-18T19:13:04.917177Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Most viewed questions
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    limit: 100
+    aggregation:
+    - - count
+    breakout:
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - name
+      - base-type: type/Text
+        join-alias: Content - Entity Qualified
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - entity_id
+      - base-type: type/Integer
+        join-alias: Content - Entity Qualified
+    filter:
+    - and
+    - - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - entity_type
+        - base-type: type/Text
+      - card
+    - - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_type
+        - base-type: type/Text
+          join-alias: Content - Entity Qualified
+      - question
     joins:
-    - strategy: left-join
-      alias: Content - Entity Qualified
+    - alias: Content - Entity Qualified
       condition:
       - =
       - - field
@@ -39,8 +79,8 @@ dataset_query:
         - base-type: type/Text
           join-alias: Content - Entity Qualified
       source-table: AxSackBiyXVRUzM_TyyQY
-    - strategy: left-join
-      alias: People - Creator
+      strategy: left-join
+    - alias: People - Creator
       condition:
       - =
       - - field
@@ -58,8 +98,8 @@ dataset_query:
         - base-type: type/Integer
           join-alias: People - Creator
       source-table: 0wVIfjBJWclD0lKeABYYl
-    - strategy: left-join
-      alias: Group Members - User
+      strategy: left-join
+    - alias: Group Members - User
       condition:
       - =
       - - field
@@ -76,61 +116,36 @@ dataset_query:
         - base-type: type/Integer
           join-alias: Group Members - User
       source-table: lTp-ATFsCUFEr9I0fMEaO
-    breakout:
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_content
-        - name
-      - base-type: type/Text
-        join-alias: Content - Entity Qualified
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_content
-        - entity_id
-      - base-type: type/Integer
-        join-alias: Content - Entity Qualified
+      strategy: left-join
+    limit: 100
     order-by:
     - - desc
       - - aggregation
         - 0
-    aggregation:
-    - - count
     source-table: P6Ityjj7igswKh4NgZZjz
-    filter:
-    - =
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - entity_type
-      - base-type: type/Text
-    - card
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: _lfXwss_MckZBidbcJsgk
-  label: most_viewed_questions
-display: table
-entity_id: _lfXwss_MckZBidbcJsgk
-collection_preview: true
+  type: query
+result_metadata: null
 visualization_settings:
-  graph.show_values: true
-  graph.dimensions:
-  - name
-  table.cell_column: count
   column_settings:
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
-    : column_title: Question name
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Entity Qualified"}]]'
-    : column_title: Question ID
     '["name","count"]':
       show_mini_bar: true
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Question ID
+      link_url: question/{{entity_id}}
+      view_as: link
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Question name
+      link_text: ''
+      link_url: question/{{entity_id}}
+      view_as: link
+  graph.dimensions:
+  - name
   graph.metrics:
   - count
+  graph.show_values: true
+  table.cell_column: count
+serdes/meta:
+- id: _lfXwss_MckZBidbcJsgk
+  label: most_viewed_questions
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-08-18T19:13:04.917177Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/_p6UGMWOQn5-yf03uGsaN_most_active_people_on_this_dashboard.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/_p6UGMWOQn5-yf03uGsaN_most_active_people_on_this_dashboard.yaml
@@ -1,79 +1,30 @@
+name: Most active people on this dashboard
 description: null
+entity_id: _p6UGMWOQn5-yf03uGsaN
+created_at: '2023-08-17T22:03:07.64817Z'
+creator_id: internal@metabase.com
+display: row
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Most active people on this dashboard
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    joins:
-    - strategy: left-join
-      alias: Content - Entity Qualified
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - entity_qualified_id
-        - base-type: type/Text
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - entity_qualified_id
-        - base-type: type/Text
-          join-alias: Content - Entity Qualified
-      source-table: AxSackBiyXVRUzM_TyyQY
-    - strategy: left-join
-      alias: Group Members - User
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - user_id
-        - base-type: type/Integer
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_group_members
-          - user_id
-        - base-type: type/Integer
-          join-alias: Group Members - User
-      source-table: lTp-ATFsCUFEr9I0fMEaO
-    - strategy: left-join
-      alias: People - Creator
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - user_id
-        - base-type: type/Integer
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_users
-          - user_id
-        - base-type: type/Integer
-          join-alias: People - Creator
-      source-table: 0wVIfjBJWclD0lKeABYYl
     aggregation:
     - - count
     breakout:
@@ -90,11 +41,6 @@ dataset_query:
         - full_name
       - base-type: type/Text
         join-alias: People - Creator
-    order-by:
-    - - desc
-      - - aggregation
-        - 0
-    source-table: P6Ityjj7igswKh4NgZZjz
     filter:
     - =
     - - field
@@ -104,26 +50,80 @@ dataset_query:
         - entity_type
       - null
     - dashboard
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: _p6UGMWOQn5-yf03uGsaN
-  label: most_active_people_on_this_dashboard
-display: row
-entity_id: _p6UGMWOQn5-yf03uGsaN
-collection_preview: true
+    joins:
+    - alias: Content - Entity Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - entity_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Content - Entity Qualified
+      source-table: AxSackBiyXVRUzM_TyyQY
+      strategy: left-join
+    - alias: Group Members - User
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - user_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_group_members
+          - user_id
+        - base-type: type/Integer
+          join-alias: Group Members - User
+      source-table: lTp-ATFsCUFEr9I0fMEaO
+      strategy: left-join
+    - alias: People - Creator
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - user_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_users
+          - user_id
+        - base-type: type/Integer
+          join-alias: People - Creator
+      source-table: 0wVIfjBJWclD0lKeABYYl
+      strategy: left-join
+    order-by:
+    - - desc
+      - - aggregation
+        - 0
+    source-table: P6Ityjj7igswKh4NgZZjz
+  type: query
+result_metadata: null
 visualization_settings:
-  table.pivot: false
+  column_settings: null
   graph.dimensions:
   - full_name
-  graph.series_order_dimension: null
-  graph.series_order: null
-  graph.show_values: true
   graph.metrics:
   - count
-  column_settings: null
+  graph.series_order: null
+  graph.series_order_dimension: null
+  graph.show_values: true
+  table.pivot: false
+serdes/meta:
+- id: _p6UGMWOQn5-yf03uGsaN
+  label: most_active_people_on_this_dashboard
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-08-17T22:03:07.64817Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/ezcT88-OmH-5HFOFNqmX7_last_viewed_questions.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/ezcT88-OmH-5HFOFNqmX7_last_viewed_questions.yaml
@@ -1,26 +1,74 @@
+name: Last viewed questions
 description: null
+entity_id: ezcT88-OmH-5HFOFNqmX7
+created_at: '2023-06-15T01:53:38.323579Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Last viewed questions
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
+    fields:
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - timestamp
+      - base-type: type/DateTimeWithLocalTZ
+    filter:
+    - and
+    - - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - entity_type
+        - base-type: type/Text
+      - card
+    - - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_type
+        - base-type: type/Text
+          join-alias: Content - Entity Qualified
+      - question
     joins:
-    - fields:
+    - alias: Content - Entity Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - entity_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Content - Entity Qualified
+      fields:
       - - field
         - - Internal Metabase Database
           - public
@@ -42,27 +90,9 @@ dataset_query:
           - description
         - base-type: type/Text
           join-alias: Content - Entity Qualified
-      strategy: left-join
-      alias: Content - Entity Qualified
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - entity_qualified_id
-        - base-type: type/Text
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - entity_qualified_id
-        - base-type: type/Text
-          join-alias: Content - Entity Qualified
       source-table: AxSackBiyXVRUzM_TyyQY
-    - fields: none
       strategy: left-join
-      alias: People - Creator
+    - alias: People - Creator
       condition:
       - =
       - - field
@@ -76,7 +106,10 @@ dataset_query:
           - user_id
         - base-type: type/Integer
           join-alias: People - Creator
+      fields: none
       source-table: 0wVIfjBJWclD0lKeABYYl
+      strategy: left-join
+    limit: 200
     order-by:
     - - desc
       - - field
@@ -85,342 +118,31 @@ dataset_query:
           - v_view_log
           - timestamp
         - base-type: type/DateTimeWithLocalTZ
-    fields:
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - timestamp
-      - base-type: type/DateTimeWithLocalTZ
     source-table: P6Ityjj7igswKh4NgZZjz
-    filter:
-    - =
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - entity_type
-      - base-type: type/Text
-    - card
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: ezcT88-OmH-5HFOFNqmX7
-  label: last_viewed_questions
-display: table
-entity_id: ezcT88-OmH-5HFOFNqmX7
-collection_preview: true
+  type: query
+result_metadata: null
 visualization_settings:
-  table.pivot_column: end_timestamp
+  column_settings:
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","description"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Description
+    '["ref",["field",["Internal Metabase Database","public","v_content","description"],{"join-alias":"Question 35"}]]':
+      column_title: Description
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Question ID
+    '["ref",["field",["Internal Metabase Database","public","v_content","id"],{"join-alias":"Question 35"}]]':
+      column_title: Dashboard ID
+      link_text: Dashboard {{id}}
+      link_url: ''
+      view_as: null
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Question name
+      link_url: /question/{{entity_id}}
+      view_as: link
+    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35"}]]':
+      column_title: Dashboard name
   table.cell_column: model_id
   table.columns:
-  - name: id
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - id
-    - join-alias: Question 35
-    enabled: true
-  - name: user_id
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - user_id
-    - join-alias: Question 1
-    enabled: false
-  - name: entity_id_2
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - entity_id
-    - base-type: type/Integer
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: entity_qualified_id_2
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - entity_qualified_id
-    - base-type: type/Text
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: entity_type_2
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - entity_type
-    - base-type: type/Text
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: created_at
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - created_at
-    - base-type: type/DateTimeWithLocalTZ
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: updated_at
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - updated_at
-    - base-type: type/DateTimeWithLocalTZ
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: creator_id
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - creator_id
-    - base-type: type/Integer
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: collection_id
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - collection_id
-    - base-type: type/Integer
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: made_public_by_user
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - made_public_by_user
-    - base-type: type/Integer
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: is_embedding_enabled
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - is_embedding_enabled
-    - base-type: type/Boolean
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: archived
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - archived
-    - base-type: type/Boolean
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: action_type
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - action_type
-    - base-type: type/Text
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: action_model_id
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - action_model_id
-    - base-type: type/Integer
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: collection_is_official
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - collection_is_official
-    - base-type: type/Boolean
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: collection_is_personal
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - collection_is_personal
-    - base-type: type/Boolean
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: question_viz_type
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - question_viz_type
-    - base-type: type/Text
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: question_database_id
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - question_database_id
-    - base-type: type/Text
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: question_is_native
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - question_is_native
-    - base-type: type/Boolean
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: event_timestamp
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - event_timestamp
-    - base-type: type/DateTimeWithLocalTZ
-      join-alias: Content - Entity Qualified
-    enabled: true
-  - name: user_id_2
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - user_id
-    - join-alias: People - Creator
-    enabled: true
-  - name: email
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - email
-    - join-alias: People - Creator
-    enabled: true
-  - name: first_name
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - first_name
-    - join-alias: People - Creator
-    enabled: true
-  - name: last_name
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - last_name
-    - join-alias: People - Creator
-    enabled: true
-  - name: full_name
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - full_name
-    - join-alias: People - Creator
-    enabled: true
-  - name: date_joined
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - date_joined
-    - join-alias: People - Creator
-    enabled: true
-  - name: last_login
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - last_login
-    - join-alias: People - Creator
-    enabled: true
-  - name: updated_at_2
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - updated_at
-    - join-alias: People - Creator
-    enabled: true
-  - name: is_admin
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - is_admin
-    - join-alias: People - Creator
-    enabled: true
-  - name: is_active
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - is_active
-    - join-alias: People - Creator
-    enabled: true
-  - name: sso_source
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - sso_source
-    - join-alias: People - Creator
-    enabled: true
-  - name: locale
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_users
-      - locale
-    - join-alias: People - Creator
-    enabled: true
-  - name: timestamp
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -428,8 +150,9 @@ visualization_settings:
       - v_view_log
       - timestamp
     - base-type: type/DateTimeWithLocalTZ
-    enabled: true
-  - name: entity_id
+      temporal-unit: default
+    name: timestamp
+  - enabled: false
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -438,8 +161,8 @@ visualization_settings:
       - entity_id
     - base-type: type/Integer
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: name
+    name: entity_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -448,8 +171,8 @@ visualization_settings:
       - name
     - base-type: type/Text
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: description
+    name: name
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -458,25 +181,10 @@ visualization_settings:
       - description
     - base-type: type/Text
       join-alias: Content - Entity Qualified
-    enabled: true
-  column_settings:
-    '["ref",["field",["Internal Metabase Database","public","v_content","id"],{"join-alias":"Question 35"}]]':
-      view_as: null
-      column_title: Dashboard ID
-      link_text: Dashboard {{id}}
-      link_url: ''
-    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35"}]]':
-      column_title: Dashboard name
-    '["ref",["field",["Internal Metabase Database","public","v_content","description"],{"join-alias":"Question 35"}]]':
-      column_title: Description
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Entity Qualified"}]]'
-    : column_title: Question ID
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
-    : column_title: Question name
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","description"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
-    : column_title: Description
+    name: description
+  table.pivot_column: end_timestamp
+serdes/meta:
+- id: ezcT88-OmH-5HFOFNqmX7
+  label: last_viewed_questions
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-06-15T01:53:38.323579Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/fBr2cU-86t14YWbaS3r6-_most_viewed_dashboards.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/fBr2cU-86t14YWbaS3r6-_most_viewed_dashboards.yaml
@@ -1,61 +1,30 @@
+name: Most viewed dashboards
 description: null
+entity_id: fBr2cU-86t14YWbaS3r6-
+created_at: '2023-06-14T20:01:20.69398Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Most viewed dashboards
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    joins:
-    - strategy: left-join
-      alias: Group Members - User
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - user_id
-        - base-type: type/Integer
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_group_members
-          - user_id
-        - base-type: type/Integer
-          join-alias: Group Members - User
-      source-table: lTp-ATFsCUFEr9I0fMEaO
-    - strategy: left-join
-      alias: Content - Entity Qualified
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - entity_qualified_id
-        - base-type: type/Text
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - entity_qualified_id
-        - base-type: type/Text
-          join-alias: Content - Entity Qualified
-      source-table: AxSackBiyXVRUzM_TyyQY
     aggregation:
     - - count
     breakout:
@@ -72,11 +41,6 @@ dataset_query:
         - name
       - base-type: type/Text
         join-alias: Content - Entity Qualified
-    order-by:
-    - - desc
-      - - aggregation
-        - 0
-    source-table: P6Ityjj7igswKh4NgZZjz
     filter:
     - =
     - - field
@@ -86,20 +50,76 @@ dataset_query:
         - entity_type
       - base-type: type/Text
     - dashboard
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: fBr2cU-86t14YWbaS3r6-
-  label: most_viewed_dashboards
-display: table
-entity_id: fBr2cU-86t14YWbaS3r6-
-collection_preview: true
+    joins:
+    - alias: Group Members - User
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - user_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_group_members
+          - user_id
+        - base-type: type/Integer
+          join-alias: Group Members - User
+      source-table: lTp-ATFsCUFEr9I0fMEaO
+      strategy: left-join
+    - alias: Content - Entity Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - entity_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Content - Entity Qualified
+      source-table: AxSackBiyXVRUzM_TyyQY
+      strategy: left-join
+    order-by:
+    - - desc
+      - - aggregation
+        - 0
+    source-table: P6Ityjj7igswKh4NgZZjz
+  type: query
+result_metadata: null
 visualization_settings:
+  column_settings:
+    '["name","count"]':
+      show_mini_bar: true
+    '["ref",["field",["Internal Metabase Database","public","v_audit_log","model_id"],null]]':
+      column_title: Dashboard ID
+      link_text: ''
+      view_as: link
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Dashboard name
+      link_text: ''
+      link_url: /dashboard/{{entity_id}}
+      view_as: link
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Question 35"}]]'
+    : column_title: Dashboard Name
+    '["ref",["field",["Internal Metabase Database","public","v_view_log","entity_id"],{"base-type":"type/Integer"}]]':
+      column_title: Dashboard ID
+  graph.dimensions:
+  - model_id
+  graph.metrics:
+  - count
   graph.show_goal: false
   graph.show_values: true
-  table.pivot: false
+  table.cell_column: count
   table.columns:
-  - name: name
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -108,8 +128,8 @@ visualization_settings:
       - name
     - base-type: type/Text
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: entity_id
+    name: name
+  - enabled: false
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -117,33 +137,16 @@ visualization_settings:
       - v_view_log
       - entity_id
     - base-type: type/Integer
-    enabled: true
-  - name: count
+    name: entity_id
+  - enabled: true
     fieldRef:
     - aggregation
     - 0
-    enabled: true
-  table.cell_column: count
-  graph.metrics:
-  - count
+    name: count
+  table.pivot: false
   table.pivot_column: model_id
-  column_settings:
-    '["name","count"]':
-      show_mini_bar: true
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Question 35"}]]'
-    : column_title: Dashboard Name
-    '["ref",["field",["Internal Metabase Database","public","v_audit_log","model_id"],null]]':
-      column_title: Dashboard ID
-      view_as: link
-      link_text: ''
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
-    : column_title: Dashboard name
-    '["ref",["field",["Internal Metabase Database","public","v_view_log","entity_id"],{"base-type":"type/Integer"}]]':
-      column_title: Dashboard ID
-  graph.dimensions:
-  - model_id
+serdes/meta:
+- id: fBr2cU-86t14YWbaS3r6-
+  label: most_viewed_dashboards
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-06-14T20:01:20.69398Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/gTeYI2eJtQUh63sZurc3z_last_queries.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/gTeYI2eJtQUh63sZurc3z_last_queries.yaml
@@ -1,122 +1,30 @@
+name: Last queries
 description: Most recently run queries.
+entity_id: gTeYI2eJtQUh63sZurc3z
+created_at: '2023-11-01T01:13:52.012276Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Last queries
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
+  database: Internal Metabase Database
   query:
-    joins:
-    - fields:
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - name
-        - base-type: type/Text
-          join-alias: Content - Card Qualified
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - entity_id
-        - base-type: type/Integer
-          join-alias: Content - Card Qualified
-      strategy: left-join
-      alias: Content - Card Qualified
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_query_log
-          - card_qualified_id
-        - base-type: type/Text
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - entity_qualified_id
-        - base-type: type/Text
-          join-alias: Content - Card Qualified
-      source-table: AxSackBiyXVRUzM_TyyQY
-    - fields:
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - name
-        - base-type: type/Text
-          join-alias: Content - Dashboard Qualified
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - entity_id
-        - base-type: type/Integer
-          join-alias: Content - Dashboard Qualified
-      strategy: left-join
-      alias: Content - Dashboard Qualified
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_query_log
-          - dashboard_qualified_id
-        - base-type: type/Text
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - entity_qualified_id
-        - base-type: type/Text
-          join-alias: Content - Dashboard Qualified
-      source-table: AxSackBiyXVRUzM_TyyQY
-    - fields:
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_databases
-          - entity_id
-        - base-type: type/Integer
-          join-alias: Databases - Database Qualified
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_databases
-          - name
-        - base-type: type/Text
-          join-alias: Databases - Database Qualified
-      strategy: left-join
-      alias: Databases - Database Qualified
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_query_log
-          - database_qualified_id
-        - base-type: type/Text
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_databases
-          - entity_qualified_id
-        - base-type: type/Text
-          join-alias: Databases - Database Qualified
-      source-table: -19557ZnrWiDgG4h4cKxF
     fields:
     - - field
       - - Internal Metabase Database
@@ -154,6 +62,107 @@ dataset_query:
         - v_query_log
         - error
       - base-type: type/Text
+    joins:
+    - alias: Content - Card Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_query_log
+          - card_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Content - Card Qualified
+      fields:
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - name
+        - base-type: type/Text
+          join-alias: Content - Card Qualified
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_id
+        - base-type: type/Integer
+          join-alias: Content - Card Qualified
+      source-table: AxSackBiyXVRUzM_TyyQY
+      strategy: left-join
+    - alias: Content - Dashboard Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_query_log
+          - dashboard_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Content - Dashboard Qualified
+      fields:
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - name
+        - base-type: type/Text
+          join-alias: Content - Dashboard Qualified
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_id
+        - base-type: type/Integer
+          join-alias: Content - Dashboard Qualified
+      source-table: AxSackBiyXVRUzM_TyyQY
+      strategy: left-join
+    - alias: Databases - Database Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_query_log
+          - database_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_databases
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Databases - Database Qualified
+      fields:
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_databases
+          - entity_id
+        - base-type: type/Integer
+          join-alias: Databases - Database Qualified
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_databases
+          - name
+        - base-type: type/Text
+          join-alias: Databases - Database Qualified
+      source-table: -19557ZnrWiDgG4h4cKxF
+      strategy: left-join
+    limit: 200
     order-by:
     - - desc
       - - field
@@ -164,18 +173,31 @@ dataset_query:
         - base-type: type/DateTimeWithLocalTZ
     source-table: QOtZaiTLf2FDD4AT6Oinb
   type: query
-  database: Internal Metabase Database
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: gTeYI2eJtQUh63sZurc3z
-  label: last_queries
-display: table
-entity_id: gTeYI2eJtQUh63sZurc3z
-collection_preview: true
+result_metadata: null
 visualization_settings:
+  column_settings:
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Card Qualified"}]]'
+    : column_title: Question ID
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Dashboard Qualified"}]]'
+    : column_title: Dashboard ID
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Card Qualified"}]]'
+    : column_title: Question name
+      link_text: ''
+      link_url: /question/{{entity_id}}
+      view_as: link
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Dashboard Qualified"}]]'
+    : column_title: Dashboard name
+      link_url: /dashboard/{{entity_id_2}}
+      view_as: link
+    ? '["ref",["field",["Internal Metabase Database","public","v_databases","entity_id"],{"base-type":"type/Integer","join-alias":"Databases - Database Qualified"}]]'
+    : column_title: Database ID
+    ? '["ref",["field",["Internal Metabase Database","public","v_databases","name"],{"base-type":"type/Text","join-alias":"Databases - Database Qualified"}]]'
+    : column_title: Database name
+      link_url: /browse/{{entity_id_3}}
+      view_as: link
+  table.cell_column: running_time_seconds
   table.columns:
-  - name: started_at
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -184,8 +206,8 @@ visualization_settings:
       - started_at
     - base-type: type/DateTimeWithLocalTZ
       temporal-unit: default
-    enabled: true
-  - name: query_source
+    name: started_at
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -193,8 +215,8 @@ visualization_settings:
       - v_query_log
       - query_source
     - base-type: type/Text
-    enabled: true
-  - name: name
+    name: query_source
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -203,8 +225,8 @@ visualization_settings:
       - name
     - base-type: type/Text
       join-alias: Content - Card Qualified
-    enabled: true
-  - name: name_2
+    name: name
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -213,8 +235,8 @@ visualization_settings:
       - name
     - base-type: type/Text
       join-alias: Content - Dashboard Qualified
-    enabled: true
-  - name: name_3
+    name: name_2
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -223,8 +245,8 @@ visualization_settings:
       - name
     - base-type: type/Text
       join-alias: Databases - Database Qualified
-    enabled: true
-  - name: is_native
+    name: name_3
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -232,8 +254,8 @@ visualization_settings:
       - v_query_log
       - is_native
     - base-type: type/Boolean
-    enabled: true
-  - name: running_time_seconds
+    name: is_native
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -241,8 +263,8 @@ visualization_settings:
       - v_query_log
       - running_time_seconds
     - base-type: type/Float
-    enabled: true
-  - name: result_rows
+    name: running_time_seconds
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -250,8 +272,8 @@ visualization_settings:
       - v_query_log
       - result_rows
     - base-type: type/Integer
-    enabled: true
-  - name: entity_id
+    name: result_rows
+  - enabled: false
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -260,8 +282,8 @@ visualization_settings:
       - entity_id
     - base-type: type/Integer
       join-alias: Content - Card Qualified
-    enabled: true
-  - name: entity_id_2
+    name: entity_id
+  - enabled: false
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -270,8 +292,8 @@ visualization_settings:
       - entity_id
     - base-type: type/Integer
       join-alias: Content - Dashboard Qualified
-    enabled: true
-  - name: entity_id_3
+    name: entity_id_2
+  - enabled: false
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -280,8 +302,8 @@ visualization_settings:
       - entity_id
     - base-type: type/Integer
       join-alias: Databases - Database Qualified
-    enabled: true
-  - name: error
+    name: entity_id_3
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -289,24 +311,10 @@ visualization_settings:
       - v_query_log
       - error
     - base-type: type/Text
-    enabled: true
+    name: error
   table.pivot_column: error
-  table.cell_column: running_time_seconds
-  column_settings:
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Card Qualified"}]]'
-    : column_title: Question ID
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Card Qualified"}]]'
-    : column_title: Question name
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Dashboard Qualified"}]]'
-    : column_title: Dashboard ID
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Dashboard Qualified"}]]'
-    : column_title: Dashboard name
-    ? '["ref",["field",["Internal Metabase Database","public","v_databases","entity_id"],{"base-type":"type/Integer","join-alias":"Databases - Database Qualified"}]]'
-    : column_title: Database ID
-    ? '["ref",["field",["Internal Metabase Database","public","v_databases","name"],{"base-type":"type/Text","join-alias":"Databases - Database Qualified"}]]'
-    : column_title: Database name
+serdes/meta:
+- id: gTeYI2eJtQUh63sZurc3z
+  label: last_queries
+  model: Card
 metabase_version: vUNKNOWN (ad99d37)
-parameters: []
-dataset: false
-created_at: '2023-11-01T01:13:52.012276Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/gYt6bo9DFKz6tSeDLxYVs_active_users_last_week.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/gYt6bo9DFKz6tSeDLxYVs_active_users_last_week.yaml
@@ -1,43 +1,30 @@
+name: Active users last week
 description: null
+entity_id: gYt6bo9DFKz6tSeDLxYVs
+created_at: '2023-06-14T19:18:24.731067Z'
+creator_id: internal@metabase.com
+display: smartscalar
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Active users last week
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    joins:
-    - strategy: left-join
-      alias: Group Members - User
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - user_id
-        - base-type: type/Integer
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_group_members
-          - user_id
-        - base-type: type/Integer
-          join-alias: Group Members - User
-      source-table: lTp-ATFsCUFEr9I0fMEaO
     aggregation:
     - - distinct
       - - field
@@ -54,7 +41,6 @@ dataset_query:
         - timestamp
       - base-type: type/DateTimeWithLocalTZ
         temporal-unit: week
-    source-table: P6Ityjj7igswKh4NgZZjz
     filter:
     - time-interval
     - - field
@@ -66,24 +52,38 @@ dataset_query:
     - -2
     - week
     - include-current: false
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: gYt6bo9DFKz6tSeDLxYVs
-  label: active_users_last_week
-display: smartscalar
-entity_id: gYt6bo9DFKz6tSeDLxYVs
-collection_preview: true
+    joins:
+    - alias: Group Members - User
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - user_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_group_members
+          - user_id
+        - base-type: type/Integer
+          join-alias: Group Members - User
+      source-table: lTp-ATFsCUFEr9I0fMEaO
+      strategy: left-join
+    source-table: P6Ityjj7igswKh4NgZZjz
+  type: query
+result_metadata: null
 visualization_settings:
-  table.pivot_column: end_timestamp
-  table.cell_column: model_id
+  column_settings: null
   graph.dimensions:
   - timestamp
   graph.metrics:
   - count
-  column_settings: null
+  table.cell_column: model_id
+  table.pivot_column: end_timestamp
+serdes/meta:
+- id: gYt6bo9DFKz6tSeDLxYVs
+  label: active_users_last_week
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-06-14T19:18:24.731067Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/hFpp3c-7Y-CtMOrs3zeyn_last_login_date.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/hFpp3c-7Y-CtMOrs3zeyn_last_login_date.yaml
@@ -1,44 +1,44 @@
+name: Last login date
 description: null
+entity_id: hFpp3c-7Y-CtMOrs3zeyn
+created_at: '2023-06-15T01:39:31.195008Z'
+creator_id: internal@metabase.com
+display: scalar
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_users
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Last login date
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
   query:
     source-table: 0wVIfjBJWclD0lKeABYYl
   type: query
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: hFpp3c-7Y-CtMOrs3zeyn
-  label: last_login_date
-display: scalar
-entity_id: hFpp3c-7Y-CtMOrs3zeyn
-collection_preview: true
+result_metadata: null
 visualization_settings:
-  scalar.field: last_login
   column_settings:
     '["ref",["field",["Internal Metabase Database","public","v_users","date_joined"],null]]':
-      time_enabled: null
       date_abbreviate: true
+      time_enabled: null
     '["ref",["field",["Internal Metabase Database","public","v_users","last_login"],null]]':
-      time_enabled: null
       date_abbreviate: true
+      time_enabled: null
+  scalar.field: last_login
+serdes/meta:
+- id: hFpp3c-7Y-CtMOrs3zeyn
+  label: last_login_date
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-06-15T01:39:31.195008Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/kd1-A_wWOvlSuLDTFUpyb_question_views_per_week.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/kd1-A_wWOvlSuLDTFUpyb_question_views_per_week.yaml
@@ -1,43 +1,30 @@
+name: Question views per week
 description: null
+entity_id: kd1-A_wWOvlSuLDTFUpyb
+created_at: '2023-06-14T19:38:02.91541Z'
+creator_id: internal@metabase.com
+display: line
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Question views per week
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    joins:
-    - strategy: left-join
-      alias: Group Members - User
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - user_id
-        - base-type: type/Integer
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_group_members
-          - user_id
-        - base-type: type/Integer
-          join-alias: Group Members - User
-      source-table: lTp-ATFsCUFEr9I0fMEaO
     aggregation:
     - - count
     breakout:
@@ -55,7 +42,6 @@ dataset_query:
         - group_name
       - base-type: type/Text
         join-alias: Group Members - User
-    source-table: P6Ityjj7igswKh4NgZZjz
     filter:
     - =
     - - field
@@ -65,24 +51,38 @@ dataset_query:
         - entity_type
       - base-type: type/Text
     - card
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: kd1-A_wWOvlSuLDTFUpyb
-  label: question_views_per_week
-display: line
-entity_id: kd1-A_wWOvlSuLDTFUpyb
-collection_preview: true
+    joins:
+    - alias: Group Members - User
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - user_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_group_members
+          - user_id
+        - base-type: type/Integer
+          join-alias: Group Members - User
+      source-table: lTp-ATFsCUFEr9I0fMEaO
+      strategy: left-join
+    source-table: P6Ityjj7igswKh4NgZZjz
+  type: query
+result_metadata: null
 visualization_settings:
+  column_settings: null
   graph.dimensions:
   - timestamp
   - group_name
-  graph.show_values: true
   graph.metrics:
   - count
-  column_settings: null
+  graph.show_values: true
+serdes/meta:
+- id: kd1-A_wWOvlSuLDTFUpyb
+  label: question_views_per_week
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-06-14T19:38:02.91541Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/lTp-ATFsCUFEr9I0fMEaO_group_members.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/lTp-ATFsCUFEr9I0fMEaO_group_members.yaml
@@ -1,83 +1,27 @@
+name: Group Members
 description: Metabase group membership
+entity_id: lTp-ATFsCUFEr9I0fMEaO
+created_at: '2023-06-08T14:32:26.114293Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: true
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_group_members
-result_metadata:
-- description: null
-  semantic_type: type/FK
-  coercion_strategy: null
-  name: user_id
-  settings: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_group_members
-    - user_id
-  - null
-  effective_type: type/Integer
-  id:
-  - Internal Metabase Database
-  - public
-  - v_group_members
-  - user_id
-  visibility_type: normal
-  display_name: User ID
-  base_type: type/Integer
-- description: null
-  semantic_type: type/PK
-  coercion_strategy: null
-  name: group_id
-  settings: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_group_members
-    - group_id
-  - null
-  effective_type: type/Integer
-  id:
-  - Internal Metabase Database
-  - public
-  - v_group_members
-  - group_id
-  visibility_type: normal
-  display_name: Group ID
-  base_type: type/Integer
-- description: null
-  semantic_type: type/Name
-  coercion_strategy: null
-  name: group_name
-  settings: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_group_members
-    - group_name
-  - null
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_group_members
-  - group_name
-  visibility_type: normal
-  display_name: Group Name
-  base_type: type/Text
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Group Members
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
   query:
@@ -86,20 +30,76 @@ dataset_query:
     - public
     - v_group_members
   type: query
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: lTp-ATFsCUFEr9I0fMEaO
-  label: group_members
-display: table
-entity_id: lTp-ATFsCUFEr9I0fMEaO
-collection_preview: true
+result_metadata:
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: User ID
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_group_members
+    - user_id
+  - null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_group_members
+  - user_id
+  name: user_id
+  semantic_type: type/FK
+  settings: null
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Group ID
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_group_members
+    - group_id
+  - null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_group_members
+  - group_id
+  name: group_id
+  semantic_type: type/PK
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Group Name
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_group_members
+    - group_name
+  - null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_group_members
+  - group_name
+  name: group_name
+  semantic_type: type/Name
+  settings: null
+  visibility_type: normal
 visualization_settings:
-  table.pivot_column: group_id
-  table.cell_column: group_name
   column_settings: null
+  table.cell_column: group_name
+  table.pivot_column: group_id
+serdes/meta:
+- id: lTp-ATFsCUFEr9I0fMEaO
+  label: group_members
+  model: Card
 metabase_version: null
-parameters: []
-dataset: true
-created_at: '2023-06-08T14:32:26.114293Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/lh0sbjKcm9BhiiHPpPxRa_most_viewed_dashboards.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/lh0sbjKcm9BhiiHPpPxRa_most_viewed_dashboards.yaml
@@ -1,59 +1,30 @@
+name: Most viewed dashboards
 description: null
+entity_id: lh0sbjKcm9BhiiHPpPxRa
+created_at: '2023-06-15T02:28:28.441363Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Most viewed dashboards
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    joins:
-    - strategy: left-join
-      alias: Content - Entity Qualified
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - entity_qualified_id
-        - base-type: type/Text
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - entity_qualified_id
-        - base-type: type/Text
-          join-alias: Content - Entity Qualified
-      source-table: AxSackBiyXVRUzM_TyyQY
-    - strategy: left-join
-      alias: People - Creator
-      condition:
-      - =
-      - - field
-        - creator_id
-        - base-type: type/Integer
-          join-alias: Content - Entity Qualified
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_users
-          - user_id
-        - base-type: type/Integer
-          join-alias: People - Creator
-      source-table: 0wVIfjBJWclD0lKeABYYl
     aggregation:
     - - count
     breakout:
@@ -71,11 +42,6 @@ dataset_query:
         - entity_id
       - base-type: type/Integer
         join-alias: Content - Entity Qualified
-    order-by:
-    - - desc
-      - - aggregation
-        - 0
-    source-table: P6Ityjj7igswKh4NgZZjz
     filter:
     - =
     - - field
@@ -85,19 +51,72 @@ dataset_query:
         - entity_type
       - base-type: type/Text
     - dashboard
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: lh0sbjKcm9BhiiHPpPxRa
-  label: most_viewed_dashboards
-display: table
-entity_id: lh0sbjKcm9BhiiHPpPxRa
-collection_preview: true
+    joins:
+    - alias: Content - Entity Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - entity_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Content - Entity Qualified
+      source-table: AxSackBiyXVRUzM_TyyQY
+      strategy: left-join
+    - alias: People - Creator
+      condition:
+      - =
+      - - field
+        - creator_id
+        - base-type: type/Integer
+          join-alias: Content - Entity Qualified
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_users
+          - user_id
+        - base-type: type/Integer
+          join-alias: People - Creator
+      source-table: 0wVIfjBJWclD0lKeABYYl
+      strategy: left-join
+    order-by:
+    - - desc
+      - - aggregation
+        - 0
+    source-table: P6Ityjj7igswKh4NgZZjz
+  type: query
+result_metadata: null
 visualization_settings:
-  table.pivot_column: end_timestamp
+  column_settings:
+    '["name","count"]':
+      show_mini_bar: true
+    '["ref",["field",["Internal Metabase Database","public","v_content","description"],{"join-alias":"Question 35"}]]':
+      column_title: Description
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Dashboard ID
+    '["ref",["field",["Internal Metabase Database","public","v_content","id"],{"join-alias":"Question 35"}]]':
+      column_title: Dashboard ID
+      link_text: Dashboard {{id}}
+      link_url: ''
+      view_as: null
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
+    : column_title: Dashboard name
+    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35"}]]':
+      column_title: Dashboard name
+  graph.dimensions:
+  - name
+  graph.metrics:
+  - count
   table.cell_column: model_id
   table.columns:
-  - name: timestamp
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -105,8 +124,8 @@ visualization_settings:
       - v_audit_log
       - timestamp
     - temporal-unit: default
-    enabled: true
-  - name: id
+    name: timestamp
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -114,8 +133,8 @@ visualization_settings:
       - v_content
       - id
     - join-alias: Question 35
-    enabled: true
-  - name: user_id
+    name: id
+  - enabled: false
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -123,8 +142,8 @@ visualization_settings:
       - v_users
       - user_id
     - join-alias: Question 1
-    enabled: false
-  - name: entity_id_2
+    name: user_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -133,8 +152,8 @@ visualization_settings:
       - entity_id
     - base-type: type/Integer
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: entity_qualified_id_2
+    name: entity_id_2
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -143,8 +162,8 @@ visualization_settings:
       - entity_qualified_id
     - base-type: type/Text
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: entity_type_2
+    name: entity_qualified_id_2
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -153,8 +172,8 @@ visualization_settings:
       - entity_type
     - base-type: type/Text
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: created_at
+    name: entity_type_2
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -163,8 +182,8 @@ visualization_settings:
       - created_at
     - base-type: type/DateTimeWithLocalTZ
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: updated_at
+    name: created_at
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -173,8 +192,8 @@ visualization_settings:
       - updated_at
     - base-type: type/DateTimeWithLocalTZ
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: creator_id
+    name: updated_at
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -183,8 +202,8 @@ visualization_settings:
       - creator_id
     - base-type: type/Integer
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: description
+    name: creator_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -193,8 +212,8 @@ visualization_settings:
       - description
     - base-type: type/Text
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: collection_id
+    name: description
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -203,8 +222,8 @@ visualization_settings:
       - collection_id
     - base-type: type/Integer
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: made_public_by_user
+    name: collection_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -213,8 +232,8 @@ visualization_settings:
       - made_public_by_user
     - base-type: type/Integer
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: is_embedding_enabled
+    name: made_public_by_user
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -223,8 +242,8 @@ visualization_settings:
       - is_embedding_enabled
     - base-type: type/Boolean
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: archived
+    name: is_embedding_enabled
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -233,8 +252,8 @@ visualization_settings:
       - archived
     - base-type: type/Boolean
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: action_type
+    name: archived
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -243,8 +262,8 @@ visualization_settings:
       - action_type
     - base-type: type/Text
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: action_model_id
+    name: action_type
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -253,8 +272,8 @@ visualization_settings:
       - action_model_id
     - base-type: type/Integer
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: collection_is_official
+    name: action_model_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -263,8 +282,8 @@ visualization_settings:
       - collection_is_official
     - base-type: type/Boolean
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: collection_is_personal
+    name: collection_is_official
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -273,8 +292,8 @@ visualization_settings:
       - collection_is_personal
     - base-type: type/Boolean
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: question_viz_type
+    name: collection_is_personal
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -283,8 +302,8 @@ visualization_settings:
       - question_viz_type
     - base-type: type/Text
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: question_database_id
+    name: question_viz_type
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -293,8 +312,8 @@ visualization_settings:
       - question_database_id
     - base-type: type/Text
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: question_is_native
+    name: question_database_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -303,8 +322,8 @@ visualization_settings:
       - question_is_native
     - base-type: type/Boolean
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: event_timestamp
+    name: question_is_native
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -313,8 +332,8 @@ visualization_settings:
       - event_timestamp
     - base-type: type/DateTimeWithLocalTZ
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: user_id_2
+    name: event_timestamp
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -322,8 +341,8 @@ visualization_settings:
       - v_users
       - user_id
     - join-alias: People - Creator
-    enabled: true
-  - name: email
+    name: user_id_2
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -331,8 +350,8 @@ visualization_settings:
       - v_users
       - email
     - join-alias: People - Creator
-    enabled: true
-  - name: first_name
+    name: email
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -340,8 +359,8 @@ visualization_settings:
       - v_users
       - first_name
     - join-alias: People - Creator
-    enabled: true
-  - name: last_name
+    name: first_name
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -349,8 +368,8 @@ visualization_settings:
       - v_users
       - last_name
     - join-alias: People - Creator
-    enabled: true
-  - name: full_name
+    name: last_name
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -358,8 +377,8 @@ visualization_settings:
       - v_users
       - full_name
     - join-alias: People - Creator
-    enabled: true
-  - name: date_joined
+    name: full_name
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -367,8 +386,8 @@ visualization_settings:
       - v_users
       - date_joined
     - join-alias: People - Creator
-    enabled: true
-  - name: last_login
+    name: date_joined
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -376,8 +395,8 @@ visualization_settings:
       - v_users
       - last_login
     - join-alias: People - Creator
-    enabled: true
-  - name: updated_at_2
+    name: last_login
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -385,8 +404,8 @@ visualization_settings:
       - v_users
       - updated_at
     - join-alias: People - Creator
-    enabled: true
-  - name: is_admin
+    name: updated_at_2
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -394,8 +413,8 @@ visualization_settings:
       - v_users
       - is_admin
     - join-alias: People - Creator
-    enabled: true
-  - name: is_active
+    name: is_admin
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -403,8 +422,8 @@ visualization_settings:
       - v_users
       - is_active
     - join-alias: People - Creator
-    enabled: true
-  - name: sso_source
+    name: is_active
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -412,8 +431,8 @@ visualization_settings:
       - v_users
       - sso_source
     - join-alias: People - Creator
-    enabled: true
-  - name: locale
+    name: sso_source
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -421,8 +440,8 @@ visualization_settings:
       - v_users
       - locale
     - join-alias: People - Creator
-    enabled: true
-  - name: name
+    name: locale
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -431,8 +450,8 @@ visualization_settings:
       - name
     - base-type: type/Text
       join-alias: Content - Entity Qualified
-    enabled: true
-  - name: entity_id
+    name: name
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -441,29 +460,10 @@ visualization_settings:
       - entity_id
     - base-type: type/Integer
       join-alias: Content - Entity Qualified
-    enabled: true
-  graph.dimensions:
-  - name
-  column_settings:
-    '["ref",["field",["Internal Metabase Database","public","v_content","id"],{"join-alias":"Question 35"}]]':
-      view_as: null
-      column_title: Dashboard ID
-      link_text: Dashboard {{id}}
-      link_url: ''
-    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35"}]]':
-      column_title: Dashboard name
-    '["ref",["field",["Internal Metabase Database","public","v_content","description"],{"join-alias":"Question 35"}]]':
-      column_title: Description
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
-    : column_title: Dashboard name
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Entity Qualified"}]]'
-    : column_title: Dashboard ID
-    '["name","count"]':
-      show_mini_bar: true
-  graph.metrics:
-  - count
+    name: entity_id
+  table.pivot_column: end_timestamp
+serdes/meta:
+- id: lh0sbjKcm9BhiiHPpPxRa
+  label: most_viewed_dashboards
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-06-15T02:28:28.441363Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/mm8k37Rgk7ChMNwAUdXK2_slowest_dashboards.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/mm8k37Rgk7ChMNwAUdXK2_slowest_dashboards.yaml
@@ -1,64 +1,38 @@
+name: Slowest dashboards
 description: Time (seconds) to run the slowest query in a dashboard
+entity_id: mm8k37Rgk7ChMNwAUdXK2
+created_at: '2023-11-01T11:20:54.119762Z'
+creator_id: internal@metabase.com
+display: line
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Slowest dashboards
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    limit: 300
-    joins:
-    - fields: all
-      strategy: left-join
-      alias: Content - Dashboard Qualified
-      condition:
-      - =
+    aggregation:
+    - - max
       - - field
         - - Internal Metabase Database
           - public
           - v_query_log
-          - dashboard_qualified_id
-        - base-type: type/Text
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - entity_qualified_id
-        - base-type: type/Text
-          join-alias: Content - Dashboard Qualified
-      source-table: AxSackBiyXVRUzM_TyyQY
-    - fields: all
-      strategy: left-join
-      alias: Group Members - User
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_query_log
-          - user_id
-        - base-type: type/Integer
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_group_members
-          - user_id
-        - base-type: type/Integer
-          join-alias: Group Members - User
-      source-table: lTp-ATFsCUFEr9I0fMEaO
+          - running_time_seconds
+        - base-type: type/Float
     breakout:
     - - field
       - - Internal Metabase Database
@@ -80,19 +54,6 @@ dataset_query:
         - v_query_log
         - dashboard_id
       - base-type: type/Integer
-    order-by:
-    - - desc
-      - - aggregation
-        - 0
-    aggregation:
-    - - max
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_query_log
-          - running_time_seconds
-        - base-type: type/Float
-    source-table: QOtZaiTLf2FDD4AT6Oinb
     filter:
     - and
     - - time-interval
@@ -112,25 +73,64 @@ dataset_query:
           - v_query_log
           - dashboard_qualified_id
         - base-type: type/Text
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: mm8k37Rgk7ChMNwAUdXK2
-  label: slowest_dashboards
-display: line
-entity_id: mm8k37Rgk7ChMNwAUdXK2
-collection_preview: true
+    joins:
+    - alias: Content - Dashboard Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_query_log
+          - dashboard_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Content - Dashboard Qualified
+      fields: all
+      source-table: AxSackBiyXVRUzM_TyyQY
+      strategy: left-join
+    - alias: Group Members - User
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_query_log
+          - user_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_group_members
+          - user_id
+        - base-type: type/Integer
+          join-alias: Group Members - User
+      fields: all
+      source-table: lTp-ATFsCUFEr9I0fMEaO
+      strategy: left-join
+    limit: 300
+    order-by:
+    - - desc
+      - - aggregation
+        - 0
+    source-table: QOtZaiTLf2FDD4AT6Oinb
+  type: query
+result_metadata: null
 visualization_settings:
+  column_settings: null
   graph.dimensions:
   - started_at
   - name
-  graph.series_order_dimension: null
-  graph.series_order: null
   graph.metrics:
   - max
-  column_settings: null
+  graph.series_order: null
+  graph.series_order_dimension: null
+serdes/meta:
+- id: mm8k37Rgk7ChMNwAUdXK2
+  label: slowest_dashboards
+  model: Card
 metabase_version: vUNKNOWN (901f705)
-parameters: []
-dataset: false
-created_at: '2023-11-01T11:20:54.119762Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/p-z74CSp1IOs1rXwAcwcS_most_active_creators.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/p-z74CSp1IOs1rXwAcwcS_most_active_creators.yaml
@@ -1,40 +1,57 @@
+name: Most active creators
 description: null
+entity_id: p-z74CSp1IOs1rXwAcwcS
+created_at: '2023-06-15T02:22:17.198967Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_audit_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Most active creators
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
     aggregation:
     - - count
-    order-by:
-    - - desc
-      - - aggregation
-        - 0
+    breakout:
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - full_name
+      - base-type: type/Text
+        join-alias: Question 1
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_audit_log
+        - user_id
+      - base-type: type/Integer
+    filter:
+    - =
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_audit_log
+        - topic
+      - base-type: type/Text
+    - card-create
     joins:
-    - fields:
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_users
-          - full_name
-        - base-type: type/Text
-          join-alias: Question 1
-      alias: Question 1
+    - alias: Question 1
       condition:
       - =
       - - field
@@ -50,9 +67,16 @@ dataset_query:
           - user_id
         - base-type: type/Integer
           join-alias: Question 1
+      fields:
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_users
+          - full_name
+        - base-type: type/Text
+          join-alias: Question 1
       source-table: 0wVIfjBJWclD0lKeABYYl
-    - fields: all
-      alias: Question 34
+    - alias: Question 34
       condition:
       - =
       - - field
@@ -68,44 +92,25 @@ dataset_query:
           - user_id
         - base-type: type/Integer
           join-alias: Question 34
+      fields: all
       source-table: lTp-ATFsCUFEr9I0fMEaO
-    breakout:
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - full_name
-      - base-type: type/Text
-        join-alias: Question 1
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_audit_log
-        - user_id
-      - base-type: type/Integer
+    order-by:
+    - - desc
+      - - aggregation
+        - 0
     source-table: -lNDM3tJmuL5ltGbX0oyT
-    filter:
-    - =
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_audit_log
-        - topic
-      - base-type: type/Text
-    - card-create
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: p-z74CSp1IOs1rXwAcwcS
-  label: most_active_creators
-display: table
-entity_id: p-z74CSp1IOs1rXwAcwcS
-collection_preview: true
+  type: query
+result_metadata: null
 visualization_settings:
-  table.pivot_column: end_timestamp
+  column_settings:
+    '["name","count"]':
+      column_title: Questions created
+      show_mini_bar: true
+    ? '["ref",["field",["Internal Metabase Database","public","v_users","full_name"],{"base-type":"type/Text","join-alias":"Question 1"}]]'
+    : column_title: User
   table.cell_column: model_id
   table.columns:
-  - name: full_name
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -114,8 +119,8 @@ visualization_settings:
       - full_name
     - base-type: type/Text
       join-alias: Question 1
-    enabled: true
-  - name: user_id
+    name: full_name
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -123,20 +128,15 @@ visualization_settings:
       - v_audit_log
       - user_id
     - base-type: type/Integer
-    enabled: true
-  - name: count
+    name: user_id
+  - enabled: true
     fieldRef:
     - aggregation
     - 0
-    enabled: true
-  column_settings:
-    ? '["ref",["field",["Internal Metabase Database","public","v_users","full_name"],{"base-type":"type/Text","join-alias":"Question 1"}]]'
-    : column_title: User
-    '["name","count"]':
-      column_title: Questions created
-      show_mini_bar: true
+    name: count
+  table.pivot_column: end_timestamp
+serdes/meta:
+- id: p-z74CSp1IOs1rXwAcwcS
+  label: most_active_creators
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-06-15T02:22:17.198967Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/p8ZML2ebd3ItzCyWsKXLa_weekly_active_users.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/p8ZML2ebd3ItzCyWsKXLa_weekly_active_users.yaml
@@ -1,43 +1,30 @@
+name: Weekly active users
 description: null
+entity_id: p8ZML2ebd3ItzCyWsKXLa
+created_at: '2023-06-14T19:39:07.960966Z'
+creator_id: internal@metabase.com
+display: line
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Weekly active users
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    joins:
-    - strategy: left-join
-      alias: Group Members - User
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - user_id
-        - base-type: type/Integer
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_group_members
-          - user_id
-        - base-type: type/Integer
-          join-alias: Group Members - User
-      source-table: lTp-ATFsCUFEr9I0fMEaO
     aggregation:
     - - distinct
       - - field
@@ -61,26 +48,39 @@ dataset_query:
         - group_name
       - base-type: type/Text
         join-alias: Group Members - User
+    joins:
+    - alias: Group Members - User
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - user_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_group_members
+          - user_id
+        - base-type: type/Integer
+          join-alias: Group Members - User
+      source-table: lTp-ATFsCUFEr9I0fMEaO
+      strategy: left-join
     source-table: P6Ityjj7igswKh4NgZZjz
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: p8ZML2ebd3ItzCyWsKXLa
-  label: weekly_active_users
-display: line
-entity_id: p8ZML2ebd3ItzCyWsKXLa
-collection_preview: true
+  type: query
+result_metadata: null
 visualization_settings:
+  column_settings: null
   graph.dimensions:
   - timestamp
-  table.cell_column: model_id
-  table.pivot_column: end_timestamp
-  graph.show_values: true
   graph.metrics:
   - count
-  column_settings: null
+  graph.show_values: true
+  table.cell_column: model_id
+  table.pivot_column: end_timestamp
+serdes/meta:
+- id: p8ZML2ebd3ItzCyWsKXLa
+  label: weekly_active_users
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-06-14T19:39:07.960966Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/pKdvc0pwu1zDi8NqnyJkt_dashboard_cards.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/pKdvc0pwu1zDi8NqnyJkt_dashboard_cards.yaml
@@ -1,230 +1,30 @@
+name: Dashboard cards
 description: Records of all dashboard cards (including text cards).
+entity_id: pKdvc0pwu1zDi8NqnyJkt
+created_at: '2023-09-21T13:24:15.758371Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: 14
+query_type: query
+dataset: true
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_dashboardcard
-result_metadata:
-- description: null
-  semantic_type: null
-  coercion_strategy: null
-  name: entity_id
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_dashboardcard
-    - entity_id
-  - base-type: type/Integer
-  effective_type: type/Integer
-  id:
-  - Internal Metabase Database
-  - public
-  - v_dashboardcard
-  - entity_id
-  visibility_type: normal
-  display_name: Entity ID
-  base_type: type/Integer
-- description: null
-  semantic_type: null
-  coercion_strategy: null
-  name: entity_qualified_id
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_dashboardcard
-    - entity_qualified_id
-  - base-type: type/Text
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_dashboardcard
-  - entity_qualified_id
-  visibility_type: normal
-  display_name: Entity Qualified ID
-  base_type: type/Text
-- description: null
-  semantic_type: type/FK
-  coercion_strategy: null
-  name: dashboard_qualified_id
-  settings: null
-  fk_target_field_id: 1484
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_dashboardcard
-    - dashboard_qualified_id
-  - base-type: type/Text
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_dashboardcard
-  - dashboard_qualified_id
-  visibility_type: normal
-  display_name: Dashboard Qualified ID
-  base_type: type/Text
-- description: null
-  semantic_type: null
-  coercion_strategy: null
-  name: dashboardtab_id
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_dashboardcard
-    - dashboardtab_id
-  - base-type: type/Text
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_dashboardcard
-  - dashboardtab_id
-  visibility_type: normal
-  display_name: Dashboardtab ID
-  base_type: type/Text
-- description: null
-  semantic_type: type/FK
-  coercion_strategy: null
-  name: card_qualified_id
-  settings: null
-  fk_target_field_id: 1484
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_dashboardcard
-    - card_qualified_id
-  - base-type: type/Text
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_dashboardcard
-  - card_qualified_id
-  visibility_type: normal
-  display_name: Card Qualified ID
-  base_type: type/Text
-- description: null
-  semantic_type: type/CreationTimestamp
-  coercion_strategy: null
-  unit: default
-  name: created_at
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_dashboardcard
-    - created_at
-  - base-type: type/DateTimeWithLocalTZ
-    temporal-unit: default
-  effective_type: type/DateTimeWithLocalTZ
-  id:
-  - Internal Metabase Database
-  - public
-  - v_dashboardcard
-  - created_at
-  visibility_type: normal
-  display_name: Created At
-  base_type: type/DateTimeWithLocalTZ
-- description: null
-  semantic_type: type/UpdatedTimestamp
-  coercion_strategy: null
-  unit: default
-  name: updated_at
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_dashboardcard
-    - updated_at
-  - base-type: type/DateTimeWithLocalTZ
-    temporal-unit: default
-  effective_type: type/DateTimeWithLocalTZ
-  id:
-  - Internal Metabase Database
-  - public
-  - v_dashboardcard
-  - updated_at
-  visibility_type: normal
-  display_name: Updated At
-  base_type: type/DateTimeWithLocalTZ
-- description: null
-  semantic_type: type/SerializedJSON
-  coercion_strategy: null
-  name: visualization_settings
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_dashboardcard
-    - visualization_settings
-  - base-type: type/Text
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_dashboardcard
-  - visualization_settings
-  visibility_type: normal
-  display_name: Visualization Settings
-  base_type: type/Text
-- description: null
-  semantic_type: type/SerializedJSON
-  coercion_strategy: null
-  name: parameter_mappings
-  settings: null
-  fk_target_field_id: null
-  field_ref:
-  - field
-  - - Internal Metabase Database
-    - public
-    - v_dashboardcard
-    - parameter_mappings
-  - base-type: type/Text
-  effective_type: type/Text
-  id:
-  - Internal Metabase Database
-  - public
-  - v_dashboardcard
-  - parameter_mappings
-  visibility_type: normal
-  display_name: Parameter Mappings
-  base_type: type/Text
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Dashboard cards
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    source-table:
-    - Internal Metabase Database
-    - public
-    - v_dashboardcard
     fields:
     - - field
       - - Internal Metabase Database
@@ -280,20 +80,220 @@ dataset_query:
         - v_dashboardcard
         - parameter_mappings
       - base-type: type/Text
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: pKdvc0pwu1zDi8NqnyJkt
-  label: dashboard_cards
-display: table
-entity_id: pKdvc0pwu1zDi8NqnyJkt
-collection_preview: true
+    source-table:
+    - Internal Metabase Database
+    - public
+    - v_dashboardcard
+  type: query
+result_metadata:
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Entity ID
+  effective_type: type/Integer
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_dashboardcard
+    - entity_id
+  - base-type: type/Integer
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_dashboardcard
+  - entity_id
+  name: entity_id
+  semantic_type: null
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Entity Qualified ID
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_dashboardcard
+    - entity_qualified_id
+  - base-type: type/Text
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_dashboardcard
+  - entity_qualified_id
+  name: entity_qualified_id
+  semantic_type: null
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Dashboard Qualified ID
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_dashboardcard
+    - dashboard_qualified_id
+  - base-type: type/Text
+  fk_target_field_id: 1484
+  id:
+  - Internal Metabase Database
+  - public
+  - v_dashboardcard
+  - dashboard_qualified_id
+  name: dashboard_qualified_id
+  semantic_type: type/FK
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Dashboardtab ID
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_dashboardcard
+    - dashboardtab_id
+  - base-type: type/Text
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_dashboardcard
+  - dashboardtab_id
+  name: dashboardtab_id
+  semantic_type: null
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Card Qualified ID
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_dashboardcard
+    - card_qualified_id
+  - base-type: type/Text
+  fk_target_field_id: 1484
+  id:
+  - Internal Metabase Database
+  - public
+  - v_dashboardcard
+  - card_qualified_id
+  name: card_qualified_id
+  semantic_type: type/FK
+  settings: null
+  visibility_type: normal
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: null
+  display_name: Created At
+  effective_type: type/DateTimeWithLocalTZ
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_dashboardcard
+    - created_at
+  - base-type: type/DateTimeWithLocalTZ
+    temporal-unit: default
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_dashboardcard
+  - created_at
+  name: created_at
+  semantic_type: type/CreationTimestamp
+  settings: null
+  unit: default
+  visibility_type: normal
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: null
+  display_name: Updated At
+  effective_type: type/DateTimeWithLocalTZ
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_dashboardcard
+    - updated_at
+  - base-type: type/DateTimeWithLocalTZ
+    temporal-unit: default
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_dashboardcard
+  - updated_at
+  name: updated_at
+  semantic_type: type/UpdatedTimestamp
+  settings: null
+  unit: default
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Visualization Settings
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_dashboardcard
+    - visualization_settings
+  - base-type: type/Text
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_dashboardcard
+  - visualization_settings
+  name: visualization_settings
+  semantic_type: type/SerializedJSON
+  settings: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Parameter Mappings
+  effective_type: type/Text
+  field_ref:
+  - field
+  - - Internal Metabase Database
+    - public
+    - v_dashboardcard
+    - parameter_mappings
+  - base-type: type/Text
+  fk_target_field_id: null
+  id:
+  - Internal Metabase Database
+  - public
+  - v_dashboardcard
+  - parameter_mappings
+  name: parameter_mappings
+  semantic_type: type/SerializedJSON
+  settings: null
+  visibility_type: normal
 visualization_settings:
-  table.pivot_column: dashboardtab_id
-  table.cell_column: size_x
   column_settings: null
+  table.cell_column: size_x
+  table.pivot_column: dashboardtab_id
+serdes/meta:
+- id: pKdvc0pwu1zDi8NqnyJkt
+  label: dashboard_cards
+  model: Card
 metabase_version: null
-parameters: []
-dataset: true
-created_at: '2023-09-21T13:24:15.758371Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/r8r6O1VedjAjSD2MPxJs6_dashboards_with_more_questions_in_the_same_tab.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/r8r6O1VedjAjSD2MPxJs6_dashboards_with_more_questions_in_the_same_tab.yaml
@@ -1,45 +1,32 @@
+name: Dashboards with more questions in the same tab
 description: Try to keep fewer than 25 questions per tab
+entity_id: r8r6O1VedjAjSD2MPxJs6
+created_at: '2023-11-01T11:28:39.771028Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_dashboardcard
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Dashboards with more questions in the same tab
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    limit: 100
-    joins:
-    - fields: all
-      strategy: left-join
-      alias: Content - Dashboard Qualified
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_dashboardcard
-          - dashboard_qualified_id
-        - base-type: type/Text
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - entity_qualified_id
-        - base-type: type/Text
-          join-alias: Content - Dashboard Qualified
-      source-table: AxSackBiyXVRUzM_TyyQY
+    aggregation:
+    - - count
     breakout:
     - - field
       - - Internal Metabase Database
@@ -61,13 +48,6 @@ dataset_query:
         - v_dashboardcard
         - dashboardtab_id
       - base-type: type/Text
-    order-by:
-    - - desc
-      - - aggregation
-        - 0
-    aggregation:
-    - - count
-    source-table: pKdvc0pwu1zDi8NqnyJkt
     filter:
     - not-empty
     - - field
@@ -76,27 +56,47 @@ dataset_query:
         - v_dashboardcard
         - card_qualified_id
       - base-type: type/Text
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: r8r6O1VedjAjSD2MPxJs6
-  label: dashboards_with_more_questions_in_the_same_tab
-display: table
-entity_id: r8r6O1VedjAjSD2MPxJs6
-collection_preview: true
+    joins:
+    - alias: Content - Dashboard Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_dashboardcard
+          - dashboard_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Content - Dashboard Qualified
+      fields: all
+      source-table: AxSackBiyXVRUzM_TyyQY
+      strategy: left-join
+    limit: 100
+    order-by:
+    - - desc
+      - - aggregation
+        - 0
+    source-table: pKdvc0pwu1zDi8NqnyJkt
+  type: query
+result_metadata: null
 visualization_settings:
-  table.pivot_column: dashboardtab_id
-  table.cell_column: size_x
   column_settings:
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Dashboard Qualified"}]]'
-    : column_title: Dashboard name
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Dashboard Qualified"}]]'
-    : column_title: Question ID
     '["name","count"]':
       column_title: Count of questions
       show_mini_bar: true
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Dashboard Qualified"}]]'
+    : column_title: Question ID
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Dashboard Qualified"}]]'
+    : column_title: Dashboard name
+  table.cell_column: size_x
+  table.pivot_column: dashboardtab_id
+serdes/meta:
+- id: r8r6O1VedjAjSD2MPxJs6
+  label: dashboards_with_more_questions_in_the_same_tab
+  model: Card
 metabase_version: vUNKNOWN (901f705)
-parameters: []
-dataset: false
-created_at: '2023-11-01T11:28:39.771028Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/skoPT2xiuEcUV8vFkHE6S_alerts.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/skoPT2xiuEcUV8vFkHE6S_alerts.yaml
@@ -1,17 +1,41 @@
+name: Alerts
 description: All alerts, both active and archived.
+entity_id: skoPT2xiuEcUV8vFkHE6S
+created_at: '2023-11-01T02:49:36.532503Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: 15
+query_type: query
+dataset: true
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts
+enable_embedding: false
+embedding_params: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
+dataset_query:
+  database: Internal Metabase Database
+  query:
+    source-table:
+    - Internal Metabase Database
+    - public
+    - v_alerts
+  type: query
 result_metadata:
-- description: null
-  semantic_type: type/PK
+- base_type: type/Integer
   coercion_strategy: null
-  name: entity_id
-  settings: null
-  fk_target_field_id: null
+  description: null
+  display_name: Entity ID
+  effective_type: type/Integer
   field_ref:
   - field
   - - Internal Metabase Database
@@ -19,21 +43,21 @@ result_metadata:
     - v_alerts
     - entity_id
   - null
-  effective_type: type/Integer
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_alerts
   - entity_id
-  visibility_type: normal
-  display_name: Entity ID
-  base_type: type/Integer
-- description: null
+  name: entity_id
   semantic_type: type/PK
-  coercion_strategy: null
-  name: entity_qualified_id
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Entity Qualified ID
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -41,22 +65,21 @@ result_metadata:
     - v_alerts
     - entity_qualified_id
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_alerts
   - entity_qualified_id
-  visibility_type: normal
-  display_name: Entity Qualified ID
-  base_type: type/Text
-- description: null
-  semantic_type: type/CreationTimestamp
-  coercion_strategy: null
-  unit: default
-  name: created_at
+  name: entity_qualified_id
+  semantic_type: type/PK
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: null
+  display_name: Created At
+  effective_type: type/DateTimeWithLocalTZ
   field_ref:
   - field
   - - Internal Metabase Database
@@ -64,22 +87,22 @@ result_metadata:
     - v_alerts
     - created_at
   - temporal-unit: default
-  effective_type: type/DateTimeWithLocalTZ
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_alerts
   - created_at
-  visibility_type: normal
-  display_name: Created At
-  base_type: type/DateTimeWithLocalTZ
-- description: null
-  semantic_type: type/UpdatedTimestamp
-  coercion_strategy: null
-  unit: default
-  name: updated_at
+  name: created_at
+  semantic_type: type/CreationTimestamp
   settings: null
-  fk_target_field_id: null
+  unit: default
+  visibility_type: normal
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: null
+  display_name: Updated At
+  effective_type: type/DateTimeWithLocalTZ
   field_ref:
   - field
   - - Internal Metabase Database
@@ -87,21 +110,22 @@ result_metadata:
     - v_alerts
     - updated_at
   - temporal-unit: default
-  effective_type: type/DateTimeWithLocalTZ
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_alerts
   - updated_at
-  visibility_type: normal
-  display_name: Updated At
-  base_type: type/DateTimeWithLocalTZ
-- description: null
-  semantic_type: type/FK
-  coercion_strategy: null
-  name: creator_id
+  name: updated_at
+  semantic_type: type/UpdatedTimestamp
   settings: null
-  fk_target_field_id: 739
+  unit: default
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Creator ID
+  effective_type: type/Integer
   field_ref:
   - field
   - - Internal Metabase Database
@@ -109,21 +133,21 @@ result_metadata:
     - v_alerts
     - creator_id
   - null
-  effective_type: type/Integer
+  fk_target_field_id: 739
   id:
   - Internal Metabase Database
   - public
   - v_alerts
   - creator_id
-  visibility_type: normal
-  display_name: Creator ID
-  base_type: type/Integer
-- description: null
-  semantic_type: null
-  coercion_strategy: null
-  name: card_id
+  name: creator_id
+  semantic_type: type/FK
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Card ID
+  effective_type: type/Integer
   field_ref:
   - field
   - - Internal Metabase Database
@@ -131,21 +155,21 @@ result_metadata:
     - v_alerts
     - card_id
   - null
-  effective_type: type/Integer
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_alerts
   - card_id
-  visibility_type: normal
-  display_name: Card ID
-  base_type: type/Integer
-- description: null
-  semantic_type: type/FK
-  coercion_strategy: null
-  name: card_qualified_id
+  name: card_id
+  semantic_type: null
   settings: null
-  fk_target_field_id: 1484
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Card Qualified ID
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -153,21 +177,21 @@ result_metadata:
     - v_alerts
     - card_qualified_id
   - null
-  effective_type: type/Text
+  fk_target_field_id: 1484
   id:
   - Internal Metabase Database
   - public
   - v_alerts
   - card_qualified_id
-  visibility_type: normal
-  display_name: Card Qualified ID
-  base_type: type/Text
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: alert_condition
+  name: card_qualified_id
+  semantic_type: type/FK
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Alert Condition
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -175,21 +199,21 @@ result_metadata:
     - v_alerts
     - alert_condition
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_alerts
   - alert_condition
-  visibility_type: normal
-  display_name: Alert Condition
-  base_type: type/Text
-- description: null
+  name: alert_condition
   semantic_type: type/Category
-  coercion_strategy: null
-  name: schedule_type
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Schedule Type
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -197,21 +221,21 @@ result_metadata:
     - v_alerts
     - schedule_type
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_alerts
   - schedule_type
-  visibility_type: normal
-  display_name: Schedule Type
-  base_type: type/Text
-- description: null
+  name: schedule_type
   semantic_type: type/Category
-  coercion_strategy: null
-  name: schedule_day
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Schedule Day
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -219,21 +243,21 @@ result_metadata:
     - v_alerts
     - schedule_day
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_alerts
   - schedule_day
-  visibility_type: normal
-  display_name: Schedule Day
-  base_type: type/Text
-- description: null
+  name: schedule_day
   semantic_type: type/Category
-  coercion_strategy: null
-  name: schedule_hour
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Schedule Hour
+  effective_type: type/Integer
   field_ref:
   - field
   - - Internal Metabase Database
@@ -241,21 +265,21 @@ result_metadata:
     - v_alerts
     - schedule_hour
   - null
-  effective_type: type/Integer
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_alerts
   - schedule_hour
-  visibility_type: normal
-  display_name: Schedule Hour
-  base_type: type/Integer
-- description: null
+  name: schedule_hour
   semantic_type: type/Category
-  coercion_strategy: null
-  name: archived
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Boolean
+  coercion_strategy: null
+  description: null
+  display_name: Archived
+  effective_type: type/Boolean
   field_ref:
   - field
   - - Internal Metabase Database
@@ -263,21 +287,21 @@ result_metadata:
     - v_alerts
     - archived
   - null
-  effective_type: type/Boolean
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_alerts
   - archived
-  visibility_type: normal
-  display_name: Archived
-  base_type: type/Boolean
-- description: null
+  name: archived
   semantic_type: type/Category
-  coercion_strategy: null
-  name: recipient_type
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Recipient Type
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -285,21 +309,21 @@ result_metadata:
     - v_alerts
     - recipient_type
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_alerts
   - recipient_type
-  visibility_type: normal
-  display_name: Recipient Type
-  base_type: type/Text
-- description: null
+  name: recipient_type
   semantic_type: type/Category
-  coercion_strategy: null
-  name: recipients
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Recipients
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -307,21 +331,21 @@ result_metadata:
     - v_alerts
     - recipients
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_alerts
   - recipients
-  visibility_type: normal
-  display_name: Recipients
-  base_type: type/Text
-- description: null
+  name: recipients
   semantic_type: type/Category
-  coercion_strategy: null
-  name: recipient_external
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Recipient External
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -329,46 +353,22 @@ result_metadata:
     - v_alerts
     - recipient_external
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_alerts
   - recipient_external
+  name: recipient_external
+  semantic_type: type/Category
+  settings: null
   visibility_type: normal
-  display_name: Recipient External
-  base_type: type/Text
-database_id: Internal Metabase Database
-enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Alerts
-creator_id: internal@metabase.com
-made_public_by_id: null
-embedding_params: null
-cache_ttl: null
-dataset_query:
-  database: Internal Metabase Database
-  type: query
-  query:
-    source-table:
-    - Internal Metabase Database
-    - public
-    - v_alerts
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: skoPT2xiuEcUV8vFkHE6S
-  label: alerts
-display: table
-entity_id: skoPT2xiuEcUV8vFkHE6S
-collection_preview: true
 visualization_settings:
-  table.pivot_column: schedule_day
-  table.cell_column: card_id
   column_settings: null
+  table.cell_column: card_id
+  table.pivot_column: schedule_day
+serdes/meta:
+- id: skoPT2xiuEcUV8vFkHE6S
+  label: alerts
+  model: Card
 metabase_version: vUNKNOWN (13e6090)
-parameters: []
-dataset: true
-created_at: '2023-11-01T02:49:36.532503Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/t-4MnpU-Nn7Ph9GQT6zYb_question_views_last_week.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/t-4MnpU-Nn7Ph9GQT6zYb_question_views_last_week.yaml
@@ -1,43 +1,30 @@
+name: Question views last week
 description: null
+entity_id: t-4MnpU-Nn7Ph9GQT6zYb
+created_at: '2023-06-14T19:34:18.446212Z'
+creator_id: internal@metabase.com
+display: smartscalar
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Question views last week
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    joins:
-    - strategy: left-join
-      alias: Group Members - User
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - user_id
-        - base-type: type/Integer
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_group_members
-          - user_id
-        - base-type: type/Integer
-          join-alias: Group Members - User
-      source-table: lTp-ATFsCUFEr9I0fMEaO
     aggregation:
     - - count
     breakout:
@@ -48,7 +35,6 @@ dataset_query:
         - timestamp
       - base-type: type/DateTimeWithLocalTZ
         temporal-unit: week
-    source-table: P6Ityjj7igswKh4NgZZjz
     filter:
     - and
     - - =
@@ -69,22 +55,36 @@ dataset_query:
       - -2
       - week
       - include-current: false
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: t-4MnpU-Nn7Ph9GQT6zYb
-  label: question_views_last_week
-display: smartscalar
-entity_id: t-4MnpU-Nn7Ph9GQT6zYb
-collection_preview: true
+    joins:
+    - alias: Group Members - User
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - user_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_group_members
+          - user_id
+        - base-type: type/Integer
+          join-alias: Group Members - User
+      source-table: lTp-ATFsCUFEr9I0fMEaO
+      strategy: left-join
+    source-table: P6Ityjj7igswKh4NgZZjz
+  type: query
+result_metadata: null
 visualization_settings:
+  column_settings: null
   graph.dimensions:
   - timestamp
   graph.metrics:
   - count
-  column_settings: null
+serdes/meta:
+- id: t-4MnpU-Nn7Ph9GQT6zYb
+  label: question_views_last_week
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-06-14T19:34:18.446212Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/tKEl86EXMyTDIoO9nyFTV_last_content_viewed_at.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/tKEl86EXMyTDIoO9nyFTV_last_content_viewed_at.yaml
@@ -1,23 +1,29 @@
+name: Last content viewed at
 description: null
+entity_id: tKEl86EXMyTDIoO9nyFTV
+created_at: '2023-11-01T11:47:58.374394Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Last content viewed at
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
     aggregation:
     - - max
@@ -36,19 +42,13 @@ dataset_query:
         - entity_qualified_id
       - base-type: type/Text
     source-table: P6Ityjj7igswKh4NgZZjz
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: tKEl86EXMyTDIoO9nyFTV
-  label: last_content_viewed_at
-display: table
-entity_id: tKEl86EXMyTDIoO9nyFTV
-collection_preview: true
+  type: query
+result_metadata: null
 visualization_settings:
-  table.cell_column: max
   column_settings: null
+  table.cell_column: max
+serdes/meta:
+- id: tKEl86EXMyTDIoO9nyFTV
+  label: last_content_viewed_at
+  model: Card
 metabase_version: vUNKNOWN (901f705)
-parameters: []
-dataset: false
-created_at: '2023-11-01T11:47:58.374394Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/uEf4gbDzXkj9q1uvkaTny_person_detail.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/uEf4gbDzXkj9q1uvkaTny_person_detail.yaml
@@ -1,23 +1,29 @@
+name: Person detail
 description: null
+entity_id: uEf4gbDzXkj9q1uvkaTny
+created_at: '2023-11-01T01:27:12.07356Z'
+creator_id: internal@metabase.com
+display: object
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_users
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Person detail
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
     fields:
     - - field
@@ -75,18 +81,12 @@ dataset_query:
         - sso_source
       - base-type: type/Text
     source-table: 0wVIfjBJWclD0lKeABYYl
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: uEf4gbDzXkj9q1uvkaTny
-  label: person_detail
-display: object
-entity_id: uEf4gbDzXkj9q1uvkaTny
-collection_preview: true
+  type: query
+result_metadata: null
 visualization_settings:
   column_settings: null
+serdes/meta:
+- id: uEf4gbDzXkj9q1uvkaTny
+  label: person_detail
+  model: Card
 metabase_version: vUNKNOWN (ad99d37)
-parameters: []
-dataset: false
-created_at: '2023-11-01T01:27:12.07356Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/vrez-ciNppijhELOxLJOY_dashboards_with_this_question.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/vrez-ciNppijhELOxLJOY_dashboards_with_this_question.yaml
@@ -1,23 +1,29 @@
+name: Dashboards with this question
 description: null
+entity_id: vrez-ciNppijhELOxLJOY
+created_at: '2023-11-01T02:39:26.690027Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_dashboardcard
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Dashboards with this question
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
     fields:
     - - field
@@ -27,9 +33,7 @@ dataset_query:
         - created_at
       - base-type: type/DateTimeWithLocalTZ
     joins:
-    - fields: none
-      strategy: left-join
-      alias: Content - Card Qualified
+    - alias: Content - Card Qualified
       condition:
       - =
       - - field
@@ -45,24 +49,10 @@ dataset_query:
           - entity_qualified_id
         - base-type: type/Text
           join-alias: Content - Card Qualified
+      fields: none
       source-table: AxSackBiyXVRUzM_TyyQY
-    - fields:
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - entity_id
-        - base-type: type/Integer
-          join-alias: Content - Dashboard Qualified
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - name
-        - base-type: type/Text
-          join-alias: Content - Dashboard Qualified
       strategy: left-join
-      alias: Content - Dashboard Qualified
+    - alias: Content - Dashboard Qualified
       condition:
       - =
       - - field
@@ -78,7 +68,23 @@ dataset_query:
           - entity_qualified_id
         - base-type: type/Text
           join-alias: Content - Dashboard Qualified
+      fields:
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_id
+        - base-type: type/Integer
+          join-alias: Content - Dashboard Qualified
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - name
+        - base-type: type/Text
+          join-alias: Content - Dashboard Qualified
       source-table: AxSackBiyXVRUzM_TyyQY
+      strategy: left-join
     order-by:
     - - desc
       - - field
@@ -89,18 +95,31 @@ dataset_query:
         - base-type: type/DateTimeWithLocalTZ
           temporal-unit: default
     source-table: pKdvc0pwu1zDi8NqnyJkt
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: vrez-ciNppijhELOxLJOY
-  label: dashboards_with_this_question
-display: table
-entity_id: vrez-ciNppijhELOxLJOY
-collection_preview: true
+  type: query
+result_metadata: null
 visualization_settings:
+  column_settings:
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Card Qualified"}]]'
+    : column_title: Card ID
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Dashboard Qualified"}]]'
+    : column_title: Dashboard ID
+      view_as: link
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Card Qualified"}]]'
+    : column_title: Question name
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Dashboard Qualified"}]]'
+    : column_title: Dashboard name
+      link_text: ''
+      link_url: /dashboard/{{entity_id}}
+      view_as: link
+    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35"}]]':
+      column_title: Question Name
+    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35_2"}]]':
+      column_title: Dashboard Name
+    ? '["ref",["field",["Internal Metabase Database","public","v_dashboardcard","created_at"],{"base-type":"type/DateTimeWithLocalTZ"}]]'
+    : column_title: Added At
   table.cell_column: name
   table.columns:
-  - name: created_at
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -109,18 +128,8 @@ visualization_settings:
       - created_at
     - base-type: type/DateTimeWithLocalTZ
       temporal-unit: default
-    enabled: true
-  - name: entity_id
-    fieldRef:
-    - field
-    - - Internal Metabase Database
-      - public
-      - v_content
-      - entity_id
-    - base-type: type/Integer
-      join-alias: Content - Card Qualified
-    enabled: true
-  - name: name
+    name: created_at
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -129,26 +138,20 @@ visualization_settings:
       - name
     - base-type: type/Text
       join-alias: Content - Dashboard Qualified
-    enabled: true
+    name: name
+  - enabled: true
+    fieldRef:
+    - field
+    - - Internal Metabase Database
+      - public
+      - v_content
+      - entity_id
+    - base-type: type/Integer
+      join-alias: Content - Card Qualified
+    name: entity_id
   table.pivot_column: name_2
-  column_settings:
-    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35_2"}]]':
-      column_title: Dashboard Name
-    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35"}]]':
-      column_title: Question Name
-    ? '["ref",["field",["Internal Metabase Database","public","v_dashboardcard","created_at"],{"base-type":"type/DateTimeWithLocalTZ"}]]'
-    : column_title: Added At
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Card Qualified"}]]'
-    : column_title: Card ID
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Card Qualified"}]]'
-    : column_title: Question name
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Dashboard Qualified"}]]'
-    : column_title: Dashboard ID
-      view_as: link
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Dashboard Qualified"}]]'
-    : column_title: Dashboard name
+serdes/meta:
+- id: vrez-ciNppijhELOxLJOY
+  label: dashboards_with_this_question
+  model: Card
 metabase_version: vUNKNOWN (13e6090)
-parameters: []
-dataset: false
-created_at: '2023-11-01T02:39:26.690027Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/x7GwgNdjfzrpQkKTraaqo_tables.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/x7GwgNdjfzrpQkKTraaqo_tables.yaml
@@ -1,17 +1,41 @@
+name: Tables
 description: List of all tables across all connected data sources.
+entity_id: x7GwgNdjfzrpQkKTraaqo
+created_at: '2023-10-31T21:46:14.039531Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: 17
+query_type: query
+dataset: true
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_tables
+enable_embedding: false
+embedding_params: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
+dataset_query:
+  database: Internal Metabase Database
+  query:
+    source-table:
+    - Internal Metabase Database
+    - public
+    - v_tables
+  type: query
 result_metadata:
-- description: null
-  semantic_type: type/PK
+- base_type: type/Integer
   coercion_strategy: null
-  name: entity_id
-  settings: null
-  fk_target_field_id: null
+  description: null
+  display_name: Entity ID
+  effective_type: type/Integer
   field_ref:
   - field
   - - Internal Metabase Database
@@ -19,21 +43,21 @@ result_metadata:
     - v_tables
     - entity_id
   - null
-  effective_type: type/Integer
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_tables
   - entity_id
-  visibility_type: normal
-  display_name: Entity ID
-  base_type: type/Integer
-- description: null
+  name: entity_id
   semantic_type: type/PK
-  coercion_strategy: null
-  name: entity_qualified_id
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Entity Qualified ID
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -41,22 +65,21 @@ result_metadata:
     - v_tables
     - entity_qualified_id
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_tables
   - entity_qualified_id
-  visibility_type: normal
-  display_name: Entity Qualified ID
-  base_type: type/Text
-- description: null
-  semantic_type: type/CreationTimestamp
-  coercion_strategy: null
-  unit: default
-  name: created_at
+  name: entity_qualified_id
+  semantic_type: type/PK
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: null
+  display_name: Created At
+  effective_type: type/DateTimeWithLocalTZ
   field_ref:
   - field
   - - Internal Metabase Database
@@ -64,22 +87,22 @@ result_metadata:
     - v_tables
     - created_at
   - temporal-unit: default
-  effective_type: type/DateTimeWithLocalTZ
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_tables
   - created_at
-  visibility_type: normal
-  display_name: Created At
-  base_type: type/DateTimeWithLocalTZ
-- description: null
-  semantic_type: type/UpdatedTimestamp
-  coercion_strategy: null
-  unit: default
-  name: updated_at
+  name: created_at
+  semantic_type: type/CreationTimestamp
   settings: null
-  fk_target_field_id: null
+  unit: default
+  visibility_type: normal
+- base_type: type/DateTimeWithLocalTZ
+  coercion_strategy: null
+  description: null
+  display_name: Updated At
+  effective_type: type/DateTimeWithLocalTZ
   field_ref:
   - field
   - - Internal Metabase Database
@@ -87,21 +110,22 @@ result_metadata:
     - v_tables
     - updated_at
   - temporal-unit: default
-  effective_type: type/DateTimeWithLocalTZ
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_tables
   - updated_at
-  visibility_type: normal
-  display_name: Updated At
-  base_type: type/DateTimeWithLocalTZ
-- description: null
-  semantic_type: type/Name
-  coercion_strategy: null
-  name: name
+  name: updated_at
+  semantic_type: type/UpdatedTimestamp
   settings: null
-  fk_target_field_id: null
+  unit: default
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Name
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -109,21 +133,21 @@ result_metadata:
     - v_tables
     - name
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_tables
   - name
-  visibility_type: normal
-  display_name: Name
-  base_type: type/Text
-- description: null
+  name: name
   semantic_type: type/Name
-  coercion_strategy: null
-  name: display_name
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Display Name
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -131,21 +155,21 @@ result_metadata:
     - v_tables
     - display_name
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_tables
   - display_name
-  visibility_type: normal
-  display_name: Display Name
-  base_type: type/Text
-- description: null
-  semantic_type: type/Description
-  coercion_strategy: null
-  name: description
+  name: display_name
+  semantic_type: type/Name
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Description
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -153,21 +177,21 @@ result_metadata:
     - v_tables
     - description
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_tables
   - description
-  visibility_type: normal
-  display_name: Description
-  base_type: type/Text
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: active
+  name: description
+  semantic_type: type/Description
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Boolean
+  coercion_strategy: null
+  description: null
+  display_name: Active
+  effective_type: type/Boolean
   field_ref:
   - field
   - - Internal Metabase Database
@@ -175,21 +199,21 @@ result_metadata:
     - v_tables
     - active
   - null
-  effective_type: type/Boolean
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_tables
   - active
-  visibility_type: normal
-  display_name: Active
-  base_type: type/Boolean
-- description: null
-  semantic_type: type/FK
-  coercion_strategy: null
-  name: database_id
+  name: active
+  semantic_type: type/Category
   settings: null
-  fk_target_field_id: 1559
+  visibility_type: normal
+- base_type: type/Integer
+  coercion_strategy: null
+  description: null
+  display_name: Database ID
+  effective_type: type/Integer
   field_ref:
   - field
   - - Internal Metabase Database
@@ -197,21 +221,21 @@ result_metadata:
     - v_tables
     - database_id
   - null
-  effective_type: type/Integer
+  fk_target_field_id: 1559
   id:
   - Internal Metabase Database
   - public
   - v_tables
   - database_id
-  visibility_type: normal
-  display_name: Database ID
-  base_type: type/Integer
-- description: null
-  semantic_type: null
-  coercion_strategy: null
-  name: schema
+  name: database_id
+  semantic_type: type/FK
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Text
+  coercion_strategy: null
+  description: null
+  display_name: Schema
+  effective_type: type/Text
   field_ref:
   - field
   - - Internal Metabase Database
@@ -219,21 +243,21 @@ result_metadata:
     - v_tables
     - schema
   - null
-  effective_type: type/Text
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_tables
   - schema
-  visibility_type: normal
-  display_name: Schema
-  base_type: type/Text
-- description: null
-  semantic_type: type/Category
-  coercion_strategy: null
-  name: is_upload
+  name: schema
+  semantic_type: null
   settings: null
-  fk_target_field_id: null
+  visibility_type: normal
+- base_type: type/Boolean
+  coercion_strategy: null
+  description: null
+  display_name: Is Upload
+  effective_type: type/Boolean
   field_ref:
   - field
   - - Internal Metabase Database
@@ -241,46 +265,22 @@ result_metadata:
     - v_tables
     - is_upload
   - null
-  effective_type: type/Boolean
+  fk_target_field_id: null
   id:
   - Internal Metabase Database
   - public
   - v_tables
   - is_upload
+  name: is_upload
+  semantic_type: type/Category
+  settings: null
   visibility_type: normal
-  display_name: Is Upload
-  base_type: type/Boolean
-database_id: Internal Metabase Database
-enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Tables
-creator_id: internal@metabase.com
-made_public_by_id: null
-embedding_params: null
-cache_ttl: null
-dataset_query:
-  database: Internal Metabase Database
-  type: query
-  query:
-    source-table:
-    - Internal Metabase Database
-    - public
-    - v_tables
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: x7GwgNdjfzrpQkKTraaqo
-  label: tables
-display: table
-entity_id: x7GwgNdjfzrpQkKTraaqo
-collection_preview: true
 visualization_settings:
-  table.pivot_column: is_upload
-  table.cell_column: schema
   column_settings: null
+  table.cell_column: schema
+  table.pivot_column: is_upload
+serdes/meta:
+- id: x7GwgNdjfzrpQkKTraaqo
+  label: tables
+  model: Card
 metabase_version: vUNKNOWN (0e09ac7)
-parameters: []
-dataset: true
-created_at: '2023-10-31T21:46:14.039531Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/xrgv7nzXe_v8ORWIbq839_recent_activity_on_dashboard.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/xrgv7nzXe_v8ORWIbq839_recent_activity_on_dashboard.yaml
@@ -1,22 +1,29 @@
+name: Recent activity on dashboard
 description: null
+entity_id: xrgv7nzXe_v8ORWIbq839
+created_at: '2023-08-18T18:52:13.025952Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_audit_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Recent activity on dashboard
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
-  type: query
+  database: Internal Metabase Database
   query:
     fields:
     - - field
@@ -108,16 +115,12 @@ dataset_query:
           - timestamp
         - base-type: type/DateTimeWithLocalTZ
     source-table: -lNDM3tJmuL5ltGbX0oyT
-  database: Internal Metabase Database
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: xrgv7nzXe_v8ORWIbq839
-  label: recent_activity_on_dashboard
-display: table
-entity_id: xrgv7nzXe_v8ORWIbq839
-collection_preview: true
+  type: query
+result_metadata: null
 visualization_settings:
+  column_settings:
+    ? '["ref",["field",["Internal Metabase Database","public","v_users","full_name"],{"base-type":"type/Text","join-alias":"Question 1"}]]'
+    : column_title: Person
   table.cell_column: model_id
   table.columns:
   - enabled: true
@@ -343,11 +346,8 @@ visualization_settings:
     - base-type: type/Text
     name: topic
   table.pivot_column: end_timestamp
-  column_settings:
-    ? '["ref",["field",["Internal Metabase Database","public","v_users","full_name"],{"base-type":"type/Text","join-alias":"Question 1"}]]'
-    : column_title: Person
+serdes/meta:
+- id: xrgv7nzXe_v8ORWIbq839
+  label: recent_activity_on_dashboard
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-08-18T18:52:13.025952Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/y-_5bBl0fXY9XlEbpJkrj_most_active_people_on_this_question.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/y-_5bBl0fXY9XlEbpJkrj_most_active_people_on_this_question.yaml
@@ -1,79 +1,30 @@
+name: Most active people on this question
 description: null
+entity_id: y-_5bBl0fXY9XlEbpJkrj
+created_at: '2023-11-01T02:46:05.025998Z'
+creator_id: internal@metabase.com
+display: row
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Most active people on this question
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    joins:
-    - strategy: left-join
-      alias: Content - Entity Qualified
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - entity_qualified_id
-        - base-type: type/Text
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - entity_qualified_id
-        - base-type: type/Text
-          join-alias: Content - Entity Qualified
-      source-table: AxSackBiyXVRUzM_TyyQY
-    - strategy: left-join
-      alias: Group Members - User
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - user_id
-        - base-type: type/Integer
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_group_members
-          - user_id
-        - base-type: type/Integer
-          join-alias: Group Members - User
-      source-table: lTp-ATFsCUFEr9I0fMEaO
-    - strategy: left-join
-      alias: People - Creator
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_view_log
-          - user_id
-        - base-type: type/Integer
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_users
-          - user_id
-        - base-type: type/Integer
-          join-alias: People - Creator
-      source-table: 0wVIfjBJWclD0lKeABYYl
     aggregation:
     - - count
     breakout:
@@ -90,11 +41,6 @@ dataset_query:
         - full_name
       - base-type: type/Text
         join-alias: People - Creator
-    order-by:
-    - - desc
-      - - aggregation
-        - 0
-    source-table: P6Ityjj7igswKh4NgZZjz
     filter:
     - =
     - - field
@@ -104,26 +50,80 @@ dataset_query:
         - entity_type
       - null
     - card
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: y-_5bBl0fXY9XlEbpJkrj
-  label: most_active_people_on_this_question
-display: row
-entity_id: y-_5bBl0fXY9XlEbpJkrj
-collection_preview: true
+    joins:
+    - alias: Content - Entity Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - entity_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Content - Entity Qualified
+      source-table: AxSackBiyXVRUzM_TyyQY
+      strategy: left-join
+    - alias: Group Members - User
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - user_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_group_members
+          - user_id
+        - base-type: type/Integer
+          join-alias: Group Members - User
+      source-table: lTp-ATFsCUFEr9I0fMEaO
+      strategy: left-join
+    - alias: People - Creator
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_view_log
+          - user_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_users
+          - user_id
+        - base-type: type/Integer
+          join-alias: People - Creator
+      source-table: 0wVIfjBJWclD0lKeABYYl
+      strategy: left-join
+    order-by:
+    - - desc
+      - - aggregation
+        - 0
+    source-table: P6Ityjj7igswKh4NgZZjz
+  type: query
+result_metadata: null
 visualization_settings:
-  table.pivot: false
+  column_settings: null
   graph.dimensions:
   - full_name
-  graph.series_order_dimension: null
-  graph.series_order: null
-  graph.show_values: true
   graph.metrics:
   - count
-  column_settings: null
+  graph.series_order: null
+  graph.series_order_dimension: null
+  graph.show_values: true
+  table.pivot: false
+serdes/meta:
+- id: y-_5bBl0fXY9XlEbpJkrj
+  label: most_active_people_on_this_question
+  model: Card
 metabase_version: vUNKNOWN (13e6090)
-parameters: []
-dataset: false
-created_at: '2023-11-01T02:46:05.025998Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/yVr4oMzxq8BPWf5HLbdwL_questions_in_this_dashboard.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/yVr4oMzxq8BPWf5HLbdwL_questions_in_this_dashboard.yaml
@@ -1,23 +1,29 @@
+name: Questions in this dashboard
 description: null
+entity_id: yVr4oMzxq8BPWf5HLbdwL
+created_at: '2023-09-21T13:27:39.768277Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_dashboardcard
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Questions in this dashboard
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
     fields:
     - - field
@@ -34,22 +40,6 @@ dataset_query:
       - base-type: type/Text
     joins:
     - alias: Content - Card Qualified
-      fields:
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - entity_id
-        - base-type: type/Integer
-          join-alias: Content - Card Qualified
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - name
-        - base-type: type/Text
-          join-alias: Content - Card Qualified
-      strategy: left-join
       condition:
       - =
       - - field
@@ -65,10 +55,24 @@ dataset_query:
           - entity_qualified_id
         - base-type: type/Text
           join-alias: Content - Card Qualified
+      fields:
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_id
+        - base-type: type/Integer
+          join-alias: Content - Card Qualified
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - name
+        - base-type: type/Text
+          join-alias: Content - Card Qualified
       source-table: AxSackBiyXVRUzM_TyyQY
-    - fields: none
       strategy: left-join
-      alias: Content - Dashboard Qualified
+    - alias: Content - Dashboard Qualified
       condition:
       - =
       - - field
@@ -84,7 +88,9 @@ dataset_query:
           - entity_qualified_id
         - base-type: type/Text
           join-alias: Content - Dashboard Qualified
+      fields: none
       source-table: AxSackBiyXVRUzM_TyyQY
+      strategy: left-join
     order-by:
     - - desc
       - - field
@@ -95,15 +101,20 @@ dataset_query:
         - base-type: type/DateTimeWithLocalTZ
           temporal-unit: default
     source-table: pKdvc0pwu1zDi8NqnyJkt
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: yVr4oMzxq8BPWf5HLbdwL
-  label: questions_in_this_dashboard
-display: table
-entity_id: yVr4oMzxq8BPWf5HLbdwL
-collection_preview: true
+  type: query
+result_metadata: null
 visualization_settings:
+  column_settings:
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Card Qualified"}]]'
+    : column_title: Card ID
+    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Card Qualified"}]]'
+    : column_title: Question name
+    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35"}]]':
+      column_title: Question Name
+    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35_2"}]]':
+      column_title: Dashboard Name
+    ? '["ref",["field",["Internal Metabase Database","public","v_dashboardcard","created_at"],{"base-type":"type/DateTimeWithLocalTZ"}]]'
+    : column_title: Added At
   table.cell_column: name
   table.columns:
   - enabled: true
@@ -146,19 +157,8 @@ visualization_settings:
     - base-type: type/Text
     name: visualization_settings
   table.pivot_column: name_2
-  column_settings:
-    ? '["ref",["field",["Internal Metabase Database","public","v_dashboardcard","created_at"],{"base-type":"type/DateTimeWithLocalTZ"}]]'
-    : column_title: Added At
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Card Qualified"}]]'
-    : column_title: Card ID
-    ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Card Qualified"}]]'
-    : column_title: Question name
-    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35_2"}]]':
-      column_title: Dashboard Name
-    '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35"}]]':
-      column_title: Question Name
+serdes/meta:
+- id: yVr4oMzxq8BPWf5HLbdwL
+  label: questions_in_this_dashboard
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-09-21T13:27:39.768277Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/ybsNZp-876qEMoA1U51dc_alerts_and_subscriptions_created_last_week.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/ybsNZp-876qEMoA1U51dc_alerts_and_subscriptions_created_last_week.yaml
@@ -1,23 +1,29 @@
+name: Alerts and subscriptions created last week
 description: null
+entity_id: ybsNZp-876qEMoA1U51dc
+created_at: '2023-06-14T19:55:26.986705Z'
+creator_id: internal@metabase.com
+display: smartscalar
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts_subscriptions
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Alerts and subscriptions created last week
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
     aggregation:
     - - count
@@ -26,26 +32,6 @@ dataset_query:
       - created_at
       - base-type: type/DateTimeWithLocalTZ
         temporal-unit: week
-    joins:
-    - alias: Question 34
-      fields: all
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_alerts_subscriptions
-          - creator_id
-        - base-type: type/Integer
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_group_members
-          - user_id
-        - base-type: type/Integer
-          join-alias: Question 34
-      source-table: lTp-ATFsCUFEr9I0fMEaO
-    source-table: 5ojUtU9iE-DCggHdFPIll
     filter:
     - and
     - - =
@@ -67,23 +53,37 @@ dataset_query:
       - -2
       - week
       - include-current: false
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: ybsNZp-876qEMoA1U51dc
-  label: alerts_and_subscriptions_created_last_week
-display: smartscalar
-entity_id: ybsNZp-876qEMoA1U51dc
-collection_preview: true
+    joins:
+    - alias: Question 34
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_alerts_subscriptions
+          - creator_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_group_members
+          - user_id
+        - base-type: type/Integer
+          join-alias: Question 34
+      fields: all
+      source-table: lTp-ATFsCUFEr9I0fMEaO
+    source-table: 5ojUtU9iE-DCggHdFPIll
+  type: query
+result_metadata: null
 visualization_settings:
+  column_settings: null
   graph.dimensions:
   - created_at
   - group_name
   graph.metrics:
   - count
-  column_settings: null
+serdes/meta:
+- id: ybsNZp-876qEMoA1U51dc
+  label: alerts_and_subscriptions_created_last_week
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-06-14T19:55:26.986705Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/zdVQGoMs__No_3l_amEWV_questions_consuming_most_resources.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/zdVQGoMs__No_3l_amEWV_questions_consuming_most_resources.yaml
@@ -1,64 +1,38 @@
+name: Questions consuming most resources
 description: null
+entity_id: zdVQGoMs__No_3l_amEWV
+created_at: '2023-11-01T11:33:05.288724Z'
+creator_id: internal@metabase.com
+display: line
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Questions consuming most resources
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
   database: Internal Metabase Database
-  type: query
   query:
-    limit: 200
-    joins:
-    - fields: all
-      strategy: left-join
-      alias: Content - Dashboard Qualified
-      condition:
-      - =
+    aggregation:
+    - - sum
       - - field
         - - Internal Metabase Database
           - public
           - v_query_log
-          - card_qualified_id
-        - base-type: type/Text
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_content
-          - entity_qualified_id
-        - base-type: type/Text
-          join-alias: Content - Dashboard Qualified
-      source-table: AxSackBiyXVRUzM_TyyQY
-    - fields: all
-      strategy: left-join
-      alias: Group Members - User
-      condition:
-      - =
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_query_log
-          - user_id
-        - base-type: type/Integer
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_group_members
-          - user_id
-        - base-type: type/Integer
-          join-alias: Group Members - User
-      source-table: lTp-ATFsCUFEr9I0fMEaO
+          - running_time_seconds
+        - base-type: type/Float
     breakout:
     - - field
       - - Internal Metabase Database
@@ -81,19 +55,6 @@ dataset_query:
         - entity_id
       - base-type: type/Integer
         join-alias: Content - Dashboard Qualified
-    order-by:
-    - - desc
-      - - aggregation
-        - 0
-    aggregation:
-    - - sum
-      - - field
-        - - Internal Metabase Database
-          - public
-          - v_query_log
-          - running_time_seconds
-        - base-type: type/Float
-    source-table: QOtZaiTLf2FDD4AT6Oinb
     filter:
     - and
     - - time-interval
@@ -113,25 +74,64 @@ dataset_query:
           - v_query_log
           - dashboard_qualified_id
         - base-type: type/Text
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: zdVQGoMs__No_3l_amEWV
-  label: questions_consuming_most_resources
-display: line
-entity_id: zdVQGoMs__No_3l_amEWV
-collection_preview: true
+    joins:
+    - alias: Content - Dashboard Qualified
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_query_log
+          - card_qualified_id
+        - base-type: type/Text
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_content
+          - entity_qualified_id
+        - base-type: type/Text
+          join-alias: Content - Dashboard Qualified
+      fields: all
+      source-table: AxSackBiyXVRUzM_TyyQY
+      strategy: left-join
+    - alias: Group Members - User
+      condition:
+      - =
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_query_log
+          - user_id
+        - base-type: type/Integer
+      - - field
+        - - Internal Metabase Database
+          - public
+          - v_group_members
+          - user_id
+        - base-type: type/Integer
+          join-alias: Group Members - User
+      fields: all
+      source-table: lTp-ATFsCUFEr9I0fMEaO
+      strategy: left-join
+    limit: 200
+    order-by:
+    - - desc
+      - - aggregation
+        - 0
+    source-table: QOtZaiTLf2FDD4AT6Oinb
+  type: query
+result_metadata: null
 visualization_settings:
+  column_settings: null
   graph.dimensions:
   - started_at
   - name
-  graph.series_order_dimension: null
-  graph.series_order: null
   graph.metrics:
   - sum
-  column_settings: null
+  graph.series_order: null
+  graph.series_order_dimension: null
+serdes/meta:
+- id: zdVQGoMs__No_3l_amEWV
+  label: questions_consuming_most_resources
+  model: Card
 metabase_version: vUNKNOWN (901f705)
-parameters: []
-dataset: false
-created_at: '2023-11-01T11:33:05.288724Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/zn_VtBXm5-teZmXpwGcNu_member_of.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/zn_VtBXm5-teZmXpwGcNu_member_of.yaml
@@ -1,24 +1,30 @@
+name: Member of
 description: null
+entity_id: zn_VtBXm5-teZmXpwGcNu
+created_at: '2023-06-15T02:00:12.773345Z'
+creator_id: internal@metabase.com
+display: table
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+collection_preview: true
 collection_position: null
+query_type: query
+dataset: false
+cache_ttl: null
+database_id: Internal Metabase Database
 table_id:
 - Internal Metabase Database
 - public
 - v_group_members
-result_metadata: null
-database_id: Internal Metabase Database
 enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-query_type: query
-name: Member of
-creator_id: internal@metabase.com
-made_public_by_id: null
 embedding_params: null
-cache_ttl: null
+made_public_by_id: null
+public_uuid: null
+parameters: []
+parameter_mappings: []
 dataset_query:
-  type: query
+  database: Internal Metabase Database
   query:
-    source-table: lTp-ATFsCUFEr9I0fMEaO
     fields:
     - - field
       - - Internal Metabase Database
@@ -32,18 +38,14 @@ dataset_query:
         - v_group_members
         - group_name
       - null
-  database: Internal Metabase Database
-parameter_mappings: []
-serdes/meta:
-- model: Card
-  id: zn_VtBXm5-teZmXpwGcNu
-  label: member_of
-display: table
-entity_id: zn_VtBXm5-teZmXpwGcNu
-collection_preview: true
+    source-table: lTp-ATFsCUFEr9I0fMEaO
+  type: query
+result_metadata: null
 visualization_settings:
+  column_settings: null
+  table.cell_column: group_name
   table.columns:
-  - name: user_id
+  - enabled: false
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -51,8 +53,8 @@ visualization_settings:
       - v_group_members
       - user_id
     - null
-    enabled: false
-  - name: group_id
+    name: user_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -60,8 +62,8 @@ visualization_settings:
       - v_group_members
       - group_id
     - null
-    enabled: true
-  - name: group_name
+    name: group_id
+  - enabled: true
     fieldRef:
     - field
     - - Internal Metabase Database
@@ -69,12 +71,10 @@ visualization_settings:
       - v_group_members
       - group_name
     - null
-    enabled: true
+    name: group_name
   table.pivot_column: group_id
-  table.cell_column: group_name
-  column_settings: null
+serdes/meta:
+- id: zn_VtBXm5-teZmXpwGcNu
+  label: member_of
+  model: Card
 metabase_version: null
-parameters: []
-dataset: false
-created_at: '2023-06-15T02:00:12.773345Z'
-public_uuid: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/dashboards/BHyad8ZHCbeiBZpQxDwsP_content_with_cobwebs.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/dashboards/BHyad8ZHCbeiBZpQxDwsP_content_with_cobwebs.yaml
@@ -1,86 +1,86 @@
+name: Content with cobwebs
 description: Dashboards and questions that you could consider archiving.
+entity_id: BHyad8ZHCbeiBZpQxDwsP
+created_at: '2023-11-01T11:45:19.282195Z'
+creator_id: internal@metabase.com
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+auto_apply_filters: true
+cache_ttl: null
 collection_position: 8
+position: null
+enable_embedding: false
+embedding_params: null
+made_public_by_id: null
+public_uuid: null
+show_in_getting_started: false
+caveats: null
+points_of_interest: null
+parameters:
+- default:
+  - 90
+  id: bdcf71b1
+  name: Days since last view (greater than)
+  sectionId: number
+  slug: days_since_last_view_(greater_than)
+  type: number/>=
+serdes/meta:
+- id: BHyad8ZHCbeiBZpQxDwsP
+  label: content_with_cobwebs
+  model: Dashboard
 dashcards:
-- size_x: 12
-  dashboard_tab_id: null
-  action_id: null
-  col: 0
-  parameter_mappings:
-  - parameter_id: bdcf71b1
-    card_id: -fFVxT-GLz6WO41bvw-Ar
-    target:
-    - dimension
-    - - expression
-      - Days since last view
+- entity_id: mO1Hmv7RPBY81C-HiGBVl
   card_id: -fFVxT-GLz6WO41bvw-Ar
-  entity_id: mO1Hmv7RPBY81C-HiGBVl
-  visualization_settings:
-    column_settings: null
-  size_y: 8
   created_at: '2023-11-01T11:53:04.927382Z'
   row: 0
-- size_x: 12
-  dashboard_tab_id: null
+  col: 0
+  size_x: 12
+  size_y: 8
   action_id: null
-  col: 12
+  dashboard_tab_id: null
   parameter_mappings:
-  - parameter_id: bdcf71b1
-    card_id: UEK1JfYa3ZBp6W7F-Ui5i
+  - card_id: -fFVxT-GLz6WO41bvw-Ar
+    parameter_id: bdcf71b1
     target:
     - dimension
     - - expression
       - Days since last view
-  card_id: UEK1JfYa3ZBp6W7F-Ui5i
-  entity_id: mxTQVlyG8xLO1U3c0miCm
   visualization_settings:
     column_settings: null
-  size_y: 8
+- entity_id: mxTQVlyG8xLO1U3c0miCm
+  card_id: UEK1JfYa3ZBp6W7F-Ui5i
   created_at: '2023-11-01T11:54:12.111068Z'
   row: 0
-- size_x: 12
-  dashboard_tab_id: null
+  col: 12
+  size_x: 12
+  size_y: 8
   action_id: null
-  col: 0
+  dashboard_tab_id: null
   parameter_mappings:
-  - parameter_id: bdcf71b1
-    card_id: YxCC6fQfHOPVvBtUkjFCN
+  - card_id: UEK1JfYa3ZBp6W7F-Ui5i
+    parameter_id: bdcf71b1
     target:
     - dimension
     - - expression
       - Days since last view
-  card_id: YxCC6fQfHOPVvBtUkjFCN
-  entity_id: LWnMbIRc4ei2M70S-ow37
   visualization_settings:
     column_settings: null
-  size_y: 8
+- entity_id: LWnMbIRc4ei2M70S-ow37
+  card_id: YxCC6fQfHOPVvBtUkjFCN
   created_at: '2023-11-01T11:56:53.296305Z'
   row: 8
+  col: 0
+  size_x: 12
+  size_y: 8
+  action_id: null
+  dashboard_tab_id: null
+  parameter_mappings:
+  - card_id: YxCC6fQfHOPVvBtUkjFCN
+    parameter_id: bdcf71b1
+    target:
+    - dimension
+    - - expression
+      - Days since last view
+  visualization_settings:
+    column_settings: null
 tabs: []
-enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-show_in_getting_started: false
-name: Content with cobwebs
-caveats: null
-creator_id: internal@metabase.com
-made_public_by_id: null
-embedding_params: null
-cache_ttl: null
-serdes/meta:
-- model: Dashboard
-  id: BHyad8ZHCbeiBZpQxDwsP
-  label: content_with_cobwebs
-position: null
-entity_id: BHyad8ZHCbeiBZpQxDwsP
-parameters:
-- name: Days since last view (greater than)
-  slug: days_since_last_view_(greater_than)
-  id: bdcf71b1
-  type: number/>=
-  sectionId: number
-  default:
-  - 90
-auto_apply_filters: true
-created_at: '2023-11-01T11:45:19.282195Z'
-public_uuid: null
-points_of_interest: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/dashboards/DHMhMa1FYxiyIgM7_xdgR_person_overview.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/dashboards/DHMhMa1FYxiyIgM7_xdgR_person_overview.yaml
@@ -1,208 +1,159 @@
+name: Person overview
 description: See what someone's been up to in your Metabase.
+entity_id: DHMhMa1FYxiyIgM7_xdgR
+created_at: '2023-06-15T01:31:06.523478Z'
+creator_id: internal@metabase.com
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+auto_apply_filters: false
+cache_ttl: null
 collection_position: 4
+position: null
+enable_embedding: false
+embedding_params: null
+made_public_by_id: null
+public_uuid: null
+show_in_getting_started: false
+caveats: null
+points_of_interest: null
+parameters:
+- filteringParameters:
+  - 50670f9e
+  id: 6b3da96f
+  isMultiSelect: false
+  name: User ID
+  sectionId: id
+  slug: user_id
+  type: id
+- filteringParameters:
+  - 50670f9e
+  id: 4a221c3a
+  isMultiSelect: false
+  name: User Name
+  sectionId: string
+  slug: user_name
+  type: string/=
+- filteringParameters:
+  - 50670f9e
+  id: d53443e8
+  isMultiSelect: false
+  name: User Email
+  sectionId: string
+  slug: user_email
+  type: string/=
+- default:
+  - true
+  id: 50670f9e
+  isMultiSelect: false
+  name: Is User Active?
+  sectionId: string
+  slug: is_user_active%3F
+  type: string/=
+- default: past52weeks~
+  id: ba4cf986
+  name: Date Filter
+  sectionId: date
+  slug: date_filter
+  type: date/all-options
+- id: dad0245c
+  name: Activity Type
+  sectionId: string
+  slug: activity_type
+  type: string/=
+- id: a4b3b4ff
+  name: Query Source
+  sectionId: string
+  slug: query_source
+  type: string/=
+serdes/meta:
+- id: DHMhMa1FYxiyIgM7_xdgR
+  label: person_overview
+  model: Dashboard
 dashcards:
-- size_x: 8
-  dashboard_tab_id: null
-  action_id: null
-  col: 0
-  parameter_mappings:
-  - parameter_id: 4a221c3a
-    card_id: 5HQS2xXAPF4hOFudut_Tg
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - full_name
-      - join-alias: People - Creator
-  - parameter_id: d53443e8
-    card_id: 5HQS2xXAPF4hOFudut_Tg
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - email
-      - join-alias: People - Creator
-  - parameter_id: 50670f9e
-    card_id: 5HQS2xXAPF4hOFudut_Tg
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - is_active
-      - join-alias: People - Creator
-  - parameter_id: 6b3da96f
-    card_id: 5HQS2xXAPF4hOFudut_Tg
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - user_id
-      - base-type: type/Integer
-  - parameter_id: ba4cf986
-    card_id: 5HQS2xXAPF4hOFudut_Tg
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - timestamp
-      - base-type: type/DateTimeWithLocalTZ
-        temporal-unit: default
-  card_id: 5HQS2xXAPF4hOFudut_Tg
-  entity_id: rjbN3tiJO78esor3syTMS
-  visualization_settings:
-    column_settings: null
-  size_y: 7
-  created_at: '2023-06-15T01:50:45.976511Z'
-  row: 14
-- size_x: 8
-  dashboard_tab_id: null
-  action_id: null
-  col: 8
-  parameter_mappings:
-  - parameter_id: 4a221c3a
-    card_id: ezcT88-OmH-5HFOFNqmX7
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - full_name
-      - join-alias: People - Creator
-  - parameter_id: d53443e8
-    card_id: ezcT88-OmH-5HFOFNqmX7
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - email
-      - join-alias: People - Creator
-  - parameter_id: 50670f9e
-    card_id: ezcT88-OmH-5HFOFNqmX7
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - is_active
-      - join-alias: People - Creator
-  - parameter_id: 6b3da96f
-    card_id: ezcT88-OmH-5HFOFNqmX7
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - user_id
-      - base-type: type/Integer
-  - parameter_id: ba4cf986
-    card_id: ezcT88-OmH-5HFOFNqmX7
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - timestamp
-      - base-type: type/DateTimeWithLocalTZ
-        temporal-unit: default
-  card_id: ezcT88-OmH-5HFOFNqmX7
-  entity_id: ZF3MvfX0yADr4LKv33dy3
-  visualization_settings:
-    column_settings: null
-  size_y: 7
-  created_at: '2023-06-15T01:54:16.820341Z'
-  row: 14
-- size_x: 6
-  dashboard_tab_id: null
-  action_id: null
-  col: 18
-  parameter_mappings:
-  - parameter_id: 6b3da96f
-    card_id: JPERH6xYVcj3m2Zw0YVY1
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - user_id
-      - source-field:
-        - Internal Metabase Database
-        - public
-        - v_subscriptions
-        - creator_id
-  - parameter_id: 4a221c3a
-    card_id: JPERH6xYVcj3m2Zw0YVY1
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - full_name
-      - source-field:
-        - Internal Metabase Database
-        - public
-        - v_subscriptions
-        - creator_id
-  - parameter_id: d53443e8
-    card_id: JPERH6xYVcj3m2Zw0YVY1
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - email
-      - source-field:
-        - Internal Metabase Database
-        - public
-        - v_subscriptions
-        - creator_id
-  - parameter_id: 50670f9e
-    card_id: JPERH6xYVcj3m2Zw0YVY1
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - is_active
-      - source-field:
-        - Internal Metabase Database
-        - public
-        - v_subscriptions
-        - creator_id
+- entity_id: GciAp1qdJrTUEX1rv9wVy
   card_id: JPERH6xYVcj3m2Zw0YVY1
-  entity_id: GciAp1qdJrTUEX1rv9wVy
-  visualization_settings:
-    column_settings: null
-  size_y: 4
   created_at: '2023-06-15T01:56:53.613044Z'
   row: 0
-- size_x: 6
-  dashboard_tab_id: null
+  col: 18
+  size_x: 6
+  size_y: 4
   action_id: null
-  col: 12
+  dashboard_tab_id:
+  - DHMhMa1FYxiyIgM7_xdgR
+  - VLzpbzPlShrECFp-dG4pH
   parameter_mappings:
-  - parameter_id: 6b3da96f
-    card_id: zn_VtBXm5-teZmXpwGcNu
+  - card_id: JPERH6xYVcj3m2Zw0YVY1
+    parameter_id: 6b3da96f
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - user_id
+      - source-field:
+        - Internal Metabase Database
+        - public
+        - v_subscriptions
+        - creator_id
+  - card_id: JPERH6xYVcj3m2Zw0YVY1
+    parameter_id: 4a221c3a
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - full_name
+      - source-field:
+        - Internal Metabase Database
+        - public
+        - v_subscriptions
+        - creator_id
+  - card_id: JPERH6xYVcj3m2Zw0YVY1
+    parameter_id: d53443e8
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - email
+      - source-field:
+        - Internal Metabase Database
+        - public
+        - v_subscriptions
+        - creator_id
+  - card_id: JPERH6xYVcj3m2Zw0YVY1
+    parameter_id: 50670f9e
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - is_active
+      - source-field:
+        - Internal Metabase Database
+        - public
+        - v_subscriptions
+        - creator_id
+  visualization_settings:
+    column_settings: null
+- entity_id: wOrRB7IdN-LE7vDvBziuE
+  card_id: zn_VtBXm5-teZmXpwGcNu
+  created_at: '2023-06-15T02:00:30.798995Z'
+  row: 0
+  col: 12
+  size_x: 6
+  size_y: 4
+  action_id: null
+  dashboard_tab_id:
+  - DHMhMa1FYxiyIgM7_xdgR
+  - VLzpbzPlShrECFp-dG4pH
+  parameter_mappings:
+  - card_id: zn_VtBXm5-teZmXpwGcNu
+    parameter_id: 6b3da96f
     target:
     - dimension
     - - field
@@ -215,8 +166,8 @@ dashcards:
         - public
         - v_group_members
         - user_id
-  - parameter_id: 4a221c3a
-    card_id: zn_VtBXm5-teZmXpwGcNu
+  - card_id: zn_VtBXm5-teZmXpwGcNu
+    parameter_id: 4a221c3a
     target:
     - dimension
     - - field
@@ -229,8 +180,8 @@ dashcards:
         - public
         - v_group_members
         - user_id
-  - parameter_id: d53443e8
-    card_id: zn_VtBXm5-teZmXpwGcNu
+  - card_id: zn_VtBXm5-teZmXpwGcNu
+    parameter_id: d53443e8
     target:
     - dimension
     - - field
@@ -243,8 +194,8 @@ dashcards:
         - public
         - v_group_members
         - user_id
-  - parameter_id: 50670f9e
-    card_id: zn_VtBXm5-teZmXpwGcNu
+  - card_id: zn_VtBXm5-teZmXpwGcNu
+    parameter_id: 50670f9e
     target:
     - dimension
     - - field
@@ -257,84 +208,23 @@ dashcards:
         - public
         - v_group_members
         - user_id
-  card_id: zn_VtBXm5-teZmXpwGcNu
-  entity_id: wOrRB7IdN-LE7vDvBziuE
   visualization_settings:
     column_settings:
       '["ref",["field",["Internal Metabase Database","public","v_group_members","group_id"],null]]': {}
-  size_y: 4
-  created_at: '2023-06-15T02:00:30.798995Z'
-  row: 0
-- size_x: 6
-  dashboard_tab_id: null
-  action_id: null
-  col: 18
-  parameter_mappings:
-  - parameter_id: 6b3da96f
-    card_id: Vm-4GYORvVbGu9jHVLfg1
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - user_id
-      - join-alias: People - User
-  - parameter_id: 4a221c3a
-    card_id: Vm-4GYORvVbGu9jHVLfg1
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - full_name
-      - join-alias: People - User
-  - parameter_id: d53443e8
-    card_id: Vm-4GYORvVbGu9jHVLfg1
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - email
-      - join-alias: People - User
-  - parameter_id: 50670f9e
-    card_id: Vm-4GYORvVbGu9jHVLfg1
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - is_active
-      - join-alias: People - User
-  - parameter_id: ba4cf986
-    card_id: Vm-4GYORvVbGu9jHVLfg1
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - timestamp
-      - base-type: type/DateTimeWithLocalTZ
-        temporal-unit: default
+- entity_id: Ttn9QEiWRHlNEOga_EHEq
   card_id: Vm-4GYORvVbGu9jHVLfg1
-  entity_id: Ttn9QEiWRHlNEOga_EHEq
-  visualization_settings:
-    column_settings: null
-  size_y: 4
   created_at: '2023-06-15T02:08:35.62614Z'
   row: 4
-- size_x: 6
-  dashboard_tab_id: null
+  col: 18
+  size_x: 6
+  size_y: 4
   action_id: null
-  col: 12
+  dashboard_tab_id:
+  - DHMhMa1FYxiyIgM7_xdgR
+  - VLzpbzPlShrECFp-dG4pH
   parameter_mappings:
-  - parameter_id: 6b3da96f
-    card_id: Z18i0B5CgOe66-YScAZdx
+  - card_id: Vm-4GYORvVbGu9jHVLfg1
+    parameter_id: 6b3da96f
     target:
     - dimension
     - - field
@@ -342,9 +232,9 @@ dashcards:
         - public
         - v_users
         - user_id
-      - join-alias: Question 1
-  - parameter_id: 4a221c3a
-    card_id: Z18i0B5CgOe66-YScAZdx
+      - join-alias: People - User
+  - card_id: Vm-4GYORvVbGu9jHVLfg1
+    parameter_id: 4a221c3a
     target:
     - dimension
     - - field
@@ -352,9 +242,9 @@ dashcards:
         - public
         - v_users
         - full_name
-      - join-alias: Question 1
-  - parameter_id: d53443e8
-    card_id: Z18i0B5CgOe66-YScAZdx
+      - join-alias: People - User
+  - card_id: Vm-4GYORvVbGu9jHVLfg1
+    parameter_id: d53443e8
     target:
     - dimension
     - - field
@@ -362,9 +252,9 @@ dashcards:
         - public
         - v_users
         - email
-      - join-alias: Question 1
-  - parameter_id: 50670f9e
-    card_id: Z18i0B5CgOe66-YScAZdx
+      - join-alias: People - User
+  - card_id: Vm-4GYORvVbGu9jHVLfg1
+    parameter_id: 50670f9e
     target:
     - dimension
     - - field
@@ -372,95 +262,44 @@ dashcards:
         - public
         - v_users
         - is_active
-      - join-alias: Question 1
-  - parameter_id: ba4cf986
-    card_id: Z18i0B5CgOe66-YScAZdx
+      - join-alias: People - User
+  - card_id: Vm-4GYORvVbGu9jHVLfg1
+    parameter_id: ba4cf986
     target:
     - dimension
     - - field
       - - Internal Metabase Database
         - public
-        - v_audit_log
+        - v_view_log
         - timestamp
       - base-type: type/DateTimeWithLocalTZ
         temporal-unit: default
-  card_id: Z18i0B5CgOe66-YScAZdx
-  entity_id: Hl9iWmzW05hbW9efp0-Ya
   visualization_settings:
     column_settings: null
-  size_y: 4
+- entity_id: Hl9iWmzW05hbW9efp0-Ya
+  card_id: Z18i0B5CgOe66-YScAZdx
   created_at: '2023-06-15T02:13:22.483217Z'
   row: 4
-- size_x: 12
-  dashboard_tab_id: null
-  action_id: null
-  col: 0
-  parameter_mappings:
-  - parameter_id: 4a221c3a
-    card_id: lh0sbjKcm9BhiiHPpPxRa
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - full_name
-      - join-alias: People - Creator
-  - parameter_id: d53443e8
-    card_id: lh0sbjKcm9BhiiHPpPxRa
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - email
-      - join-alias: People - Creator
-  - parameter_id: 50670f9e
-    card_id: lh0sbjKcm9BhiiHPpPxRa
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - is_active
-      - join-alias: People - Creator
-  - parameter_id: 6b3da96f
-    card_id: lh0sbjKcm9BhiiHPpPxRa
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - user_id
-      - base-type: type/Integer
-  - parameter_id: ba4cf986
-    card_id: lh0sbjKcm9BhiiHPpPxRa
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - timestamp
-      - base-type: type/DateTimeWithLocalTZ
-        temporal-unit: default
-  card_id: lh0sbjKcm9BhiiHPpPxRa
-  entity_id: ag9MAUxcnGPdRs6NlANoA
-  visualization_settings:
-    column_settings: null
-  size_y: 6
-  created_at: '2023-06-15T02:29:03.42306Z'
-  row: 8
-- size_x: 12
-  dashboard_tab_id: null
-  action_id: null
   col: 12
+  size_x: 6
+  size_y: 4
+  action_id: null
+  dashboard_tab_id:
+  - DHMhMa1FYxiyIgM7_xdgR
+  - VLzpbzPlShrECFp-dG4pH
   parameter_mappings:
-  - parameter_id: 4a221c3a
-    card_id: 9shJ0y29V5o1lOSDL4ImJ
+  - card_id: Z18i0B5CgOe66-YScAZdx
+    parameter_id: 6b3da96f
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - user_id
+      - join-alias: Question 1
+  - card_id: Z18i0B5CgOe66-YScAZdx
+    parameter_id: 4a221c3a
     target:
     - dimension
     - - field
@@ -468,9 +307,9 @@ dashcards:
         - public
         - v_users
         - full_name
-      - join-alias: People - Creator
-  - parameter_id: d53443e8
-    card_id: 9shJ0y29V5o1lOSDL4ImJ
+      - join-alias: Question 1
+  - card_id: Z18i0B5CgOe66-YScAZdx
+    parameter_id: d53443e8
     target:
     - dimension
     - - field
@@ -478,9 +317,9 @@ dashcards:
         - public
         - v_users
         - email
-      - join-alias: People - Creator
-  - parameter_id: 50670f9e
-    card_id: 9shJ0y29V5o1lOSDL4ImJ
+      - join-alias: Question 1
+  - card_id: Z18i0B5CgOe66-YScAZdx
+    parameter_id: 50670f9e
     target:
     - dimension
     - - field
@@ -488,178 +327,614 @@ dashcards:
         - public
         - v_users
         - is_active
-      - join-alias: People - Creator
-  - parameter_id: 6b3da96f
-    card_id: 9shJ0y29V5o1lOSDL4ImJ
+      - join-alias: Question 1
+  - card_id: Z18i0B5CgOe66-YScAZdx
+    parameter_id: ba4cf986
     target:
     - dimension
     - - field
       - - Internal Metabase Database
         - public
-        - v_view_log
-        - user_id
-      - base-type: type/Integer
-  - parameter_id: ba4cf986
-    card_id: 9shJ0y29V5o1lOSDL4ImJ
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
+        - v_audit_log
         - timestamp
       - base-type: type/DateTimeWithLocalTZ
         temporal-unit: default
-  card_id: 9shJ0y29V5o1lOSDL4ImJ
-  entity_id: qovKiMT2Y5xTOMp1I_Pxr
   visualization_settings:
     column_settings: null
-  size_y: 6
-  created_at: '2023-06-15T02:29:55.706733Z'
-  row: 8
-- size_x: 8
-  dashboard_tab_id: null
-  action_id: null
-  col: 16
-  parameter_mappings:
-  - parameter_id: 4a221c3a
-    card_id: 95Om4AllyfyB5wtl6TeGi
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - full_name
-      - join-alias: People - User
-  - parameter_id: d53443e8
-    card_id: 95Om4AllyfyB5wtl6TeGi
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - email
-      - join-alias: People - User
-  - parameter_id: 50670f9e
-    card_id: 95Om4AllyfyB5wtl6TeGi
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - is_active
-      - join-alias: People - User
-  - parameter_id: 6b3da96f
-    card_id: 95Om4AllyfyB5wtl6TeGi
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - user_id
-      - base-type: type/Integer
-  - parameter_id: ba4cf986
-    card_id: 95Om4AllyfyB5wtl6TeGi
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - timestamp
-      - base-type: type/DateTimeWithLocalTZ
-        temporal-unit: default
-  card_id: 95Om4AllyfyB5wtl6TeGi
-  entity_id: J1GfPRy1ajRKeAkji2KdP
-  visualization_settings:
-    column_settings: null
-  size_y: 7
-  created_at: '2023-11-01T01:03:22.895074Z'
-  row: 14
-- size_x: 24
-  dashboard_tab_id: null
-  action_id: null
+- entity_id: 44ekjEv02wPsWKcE9BYl0
+  card_id: uEf4gbDzXkj9q1uvkaTny
+  created_at: '2023-11-01T01:28:23.514406Z'
+  row: 0
   col: 0
-  parameter_mappings:
-  - parameter_id: 6b3da96f
-    card_id: WlQ-en2l-iRRCvO2-v5j1
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - user_id
-      - join-alias: People - User
-  - parameter_id: 4a221c3a
-    card_id: WlQ-en2l-iRRCvO2-v5j1
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - full_name
-      - join-alias: People - User
-  - parameter_id: d53443e8
-    card_id: WlQ-en2l-iRRCvO2-v5j1
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - email
-      - join-alias: People - User
-  - parameter_id: 50670f9e
-    card_id: WlQ-en2l-iRRCvO2-v5j1
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - is_active
-      - join-alias: People - User
-  - parameter_id: ba4cf986
-    card_id: WlQ-en2l-iRRCvO2-v5j1
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_audit_log
-        - timestamp
-      - base-type: type/DateTimeWithLocalTZ
-        temporal-unit: default
-  - parameter_id: dad0245c
-    card_id: WlQ-en2l-iRRCvO2-v5j1
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_audit_log
-        - topic
-      - base-type: type/Text
-  card_id: WlQ-en2l-iRRCvO2-v5j1
-  entity_id: PnISN8uUdOyj_-A0N3V32
-  visualization_settings:
-    column_settings: null
+  size_x: 12
   size_y: 8
-  created_at: '2023-11-01T01:06:44.484556Z'
-  row: 21
-- size_x: 24
-  dashboard_tab_id: null
   action_id: null
-  col: 0
+  dashboard_tab_id:
+  - DHMhMa1FYxiyIgM7_xdgR
+  - VLzpbzPlShrECFp-dG4pH
   parameter_mappings:
-  - parameter_id: 6b3da96f
-    card_id: gTeYI2eJtQUh63sZurc3z
+  - card_id: uEf4gbDzXkj9q1uvkaTny
+    parameter_id: 6b3da96f
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - user_id
+      - null
+  - card_id: uEf4gbDzXkj9q1uvkaTny
+    parameter_id: 4a221c3a
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - full_name
+      - null
+  - card_id: uEf4gbDzXkj9q1uvkaTny
+    parameter_id: d53443e8
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - email
+      - null
+  - card_id: uEf4gbDzXkj9q1uvkaTny
+    parameter_id: 50670f9e
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - is_active
+      - null
+  visualization_settings:
+    column_settings: null
+- entity_id: W-Dah8wiwi3_DRg_VDSP6
+  card_id: 95Om4AllyfyB5wtl6TeGi
+  created_at: '2023-11-13T20:15:30.366828Z'
+  row: 16
+  col: 0
+  size_x: 24
+  size_y: 8
+  action_id: null
+  dashboard_tab_id:
+  - DHMhMa1FYxiyIgM7_xdgR
+  - O0vWXzcQX97NAp_KlupRD
+  parameter_mappings:
+  - card_id: 95Om4AllyfyB5wtl6TeGi
+    parameter_id: 6b3da96f
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - user_id
+      - base-type: type/Integer
+  - card_id: 95Om4AllyfyB5wtl6TeGi
+    parameter_id: 4a221c3a
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - full_name
+      - join-alias: People - User
+  - card_id: 95Om4AllyfyB5wtl6TeGi
+    parameter_id: d53443e8
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - email
+      - join-alias: People - User
+  - card_id: 95Om4AllyfyB5wtl6TeGi
+    parameter_id: 50670f9e
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - is_active
+      - join-alias: People - User
+  - card_id: 95Om4AllyfyB5wtl6TeGi
+    parameter_id: ba4cf986
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - timestamp
+      - base-type: type/DateTimeWithLocalTZ
+        temporal-unit: default
+  visualization_settings:
+    column_settings: null
+- entity_id: hsKfpF3yEcMhoD-o_Zdn0
+  card_id: 5HQS2xXAPF4hOFudut_Tg
+  created_at: '2023-11-13T20:15:30.366828Z'
+  row: 0
+  col: 0
+  size_x: 24
+  size_y: 8
+  action_id: null
+  dashboard_tab_id:
+  - DHMhMa1FYxiyIgM7_xdgR
+  - O0vWXzcQX97NAp_KlupRD
+  parameter_mappings:
+  - card_id: 5HQS2xXAPF4hOFudut_Tg
+    parameter_id: 6b3da96f
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - user_id
+      - base-type: type/Integer
+  - card_id: 5HQS2xXAPF4hOFudut_Tg
+    parameter_id: 4a221c3a
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - full_name
+      - join-alias: People - Creator
+  - card_id: 5HQS2xXAPF4hOFudut_Tg
+    parameter_id: d53443e8
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - email
+      - join-alias: People - Creator
+  - card_id: 5HQS2xXAPF4hOFudut_Tg
+    parameter_id: 50670f9e
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - is_active
+      - join-alias: People - Creator
+  - card_id: 5HQS2xXAPF4hOFudut_Tg
+    parameter_id: ba4cf986
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - timestamp
+      - base-type: type/DateTimeWithLocalTZ
+        temporal-unit: default
+  visualization_settings:
+    column_settings:
+      ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Entity Qualified"}]]'
+      : click_behavior:
+          linkTemplate: /dashboard/{{entity_id}}
+          linkType: url
+          targetId: null
+          type: link
+- entity_id: o3Trjmdzp8iKpQDhuYUtG
+  card_id: ezcT88-OmH-5HFOFNqmX7
+  created_at: '2023-11-13T20:15:30.366828Z'
+  row: 8
+  col: 0
+  size_x: 24
+  size_y: 8
+  action_id: null
+  dashboard_tab_id:
+  - DHMhMa1FYxiyIgM7_xdgR
+  - O0vWXzcQX97NAp_KlupRD
+  parameter_mappings:
+  - card_id: ezcT88-OmH-5HFOFNqmX7
+    parameter_id: 6b3da96f
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - user_id
+      - base-type: type/Integer
+  - card_id: ezcT88-OmH-5HFOFNqmX7
+    parameter_id: 4a221c3a
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - full_name
+      - join-alias: People - Creator
+  - card_id: ezcT88-OmH-5HFOFNqmX7
+    parameter_id: d53443e8
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - email
+      - join-alias: People - Creator
+  - card_id: ezcT88-OmH-5HFOFNqmX7
+    parameter_id: 50670f9e
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - is_active
+      - join-alias: People - Creator
+  - card_id: ezcT88-OmH-5HFOFNqmX7
+    parameter_id: ba4cf986
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - timestamp
+      - base-type: type/DateTimeWithLocalTZ
+        temporal-unit: default
+  visualization_settings:
+    column_settings: null
+- entity_id: 2qDp6z4ZWNaWAtXbk-0i8
+  card_id: 5EsTAgs6Uu_xz69TsrUJ4
+  created_at: '2023-11-13T20:23:23.603367Z'
+  row: 24
+  col: 0
+  size_x: 24
+  size_y: 9
+  action_id: null
+  dashboard_tab_id:
+  - DHMhMa1FYxiyIgM7_xdgR
+  - O0vWXzcQX97NAp_KlupRD
+  parameter_mappings:
+  - card_id: 5EsTAgs6Uu_xz69TsrUJ4
+    parameter_id: 6b3da96f
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - user_id
+      - base-type: type/Integer
+  - card_id: 5EsTAgs6Uu_xz69TsrUJ4
+    parameter_id: 4a221c3a
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - full_name
+      - join-alias: People - Creator
+  - card_id: 5EsTAgs6Uu_xz69TsrUJ4
+    parameter_id: d53443e8
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - email
+      - join-alias: People - Creator
+  - card_id: 5EsTAgs6Uu_xz69TsrUJ4
+    parameter_id: 50670f9e
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - is_active
+      - join-alias: People - Creator
+  - card_id: 5EsTAgs6Uu_xz69TsrUJ4
+    parameter_id: ba4cf986
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - timestamp
+      - base-type: type/DateTimeWithLocalTZ
+        temporal-unit: default
+  visualization_settings:
+    column_settings: null
+- entity_id: 4CWPmm-zMHuFVXoWEwRIk
+  card_id: ItdtatOMd0uUEpvx7tDAC
+  created_at: '2023-11-13T20:26:15.603024Z'
+  row: 9
+  col: 0
+  size_x: 12
+  size_y: 9
+  action_id: null
+  dashboard_tab_id:
+  - DHMhMa1FYxiyIgM7_xdgR
+  - 1PNg7EqqaSdPhPyQYpDxp
+  parameter_mappings:
+  - card_id: ItdtatOMd0uUEpvx7tDAC
+    parameter_id: 6b3da96f
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - user_id
+      - base-type: type/Integer
+  - card_id: ItdtatOMd0uUEpvx7tDAC
+    parameter_id: 4a221c3a
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - full_name
+      - join-alias: People - User
+  - card_id: ItdtatOMd0uUEpvx7tDAC
+    parameter_id: d53443e8
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - email
+      - join-alias: People - User
+  - card_id: ItdtatOMd0uUEpvx7tDAC
+    parameter_id: 50670f9e
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - is_active
+      - join-alias: People - User
+  - card_id: ItdtatOMd0uUEpvx7tDAC
+    parameter_id: ba4cf986
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - timestamp
+      - base-type: type/DateTimeWithLocalTZ
+        temporal-unit: default
+  visualization_settings:
+    column_settings: null
+- entity_id: ZqFAsLNhQJc5RJnLC8mGv
+  card_id: 57V11my5MYVnSlaJYM8cX
+  created_at: '2023-11-13T20:26:15.603024Z'
+  row: 9
+  col: 12
+  size_x: 12
+  size_y: 9
+  action_id: null
+  dashboard_tab_id:
+  - DHMhMa1FYxiyIgM7_xdgR
+  - 1PNg7EqqaSdPhPyQYpDxp
+  parameter_mappings:
+  - card_id: 57V11my5MYVnSlaJYM8cX
+    parameter_id: 6b3da96f
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - user_id
+      - base-type: type/Integer
+  - card_id: 57V11my5MYVnSlaJYM8cX
+    parameter_id: 4a221c3a
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - full_name
+      - join-alias: People - Creator
+  - card_id: 57V11my5MYVnSlaJYM8cX
+    parameter_id: d53443e8
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - email
+      - join-alias: People - Creator
+  - card_id: 57V11my5MYVnSlaJYM8cX
+    parameter_id: 50670f9e
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - is_active
+      - join-alias: People - Creator
+  - card_id: 57V11my5MYVnSlaJYM8cX
+    parameter_id: ba4cf986
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - timestamp
+      - base-type: type/DateTimeWithLocalTZ
+        temporal-unit: default
+  visualization_settings:
+    column_settings: null
+- entity_id: IdUPTWiWUbCGmQOpKxGOI
+  card_id: _lfXwss_MckZBidbcJsgk
+  created_at: '2023-11-13T20:26:15.603024Z'
+  row: 0
+  col: 0
+  size_x: 12
+  size_y: 9
+  action_id: null
+  dashboard_tab_id:
+  - DHMhMa1FYxiyIgM7_xdgR
+  - 1PNg7EqqaSdPhPyQYpDxp
+  parameter_mappings:
+  - card_id: _lfXwss_MckZBidbcJsgk
+    parameter_id: 6b3da96f
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - user_id
+      - base-type: type/Integer
+  - card_id: _lfXwss_MckZBidbcJsgk
+    parameter_id: 4a221c3a
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - full_name
+      - join-alias: People - Creator
+  - card_id: _lfXwss_MckZBidbcJsgk
+    parameter_id: d53443e8
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - email
+      - join-alias: People - Creator
+  - card_id: _lfXwss_MckZBidbcJsgk
+    parameter_id: 50670f9e
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - is_active
+      - join-alias: People - Creator
+  - card_id: _lfXwss_MckZBidbcJsgk
+    parameter_id: ba4cf986
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - timestamp
+      - base-type: type/DateTimeWithLocalTZ
+        temporal-unit: default
+  visualization_settings:
+    column_settings: null
+- entity_id: FwTaMeuSVnrwEuD6CMpp6
+  card_id: MUXrck2HHcd2TIRuPfK0v
+  created_at: '2023-11-13T20:26:15.603024Z'
+  row: 0
+  col: 12
+  size_x: 12
+  size_y: 9
+  action_id: null
+  dashboard_tab_id:
+  - DHMhMa1FYxiyIgM7_xdgR
+  - 1PNg7EqqaSdPhPyQYpDxp
+  parameter_mappings:
+  - card_id: MUXrck2HHcd2TIRuPfK0v
+    parameter_id: 6b3da96f
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - user_id
+      - base-type: type/Integer
+  - card_id: MUXrck2HHcd2TIRuPfK0v
+    parameter_id: 4a221c3a
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - full_name
+      - join-alias: People - Creator
+  - card_id: MUXrck2HHcd2TIRuPfK0v
+    parameter_id: d53443e8
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - email
+      - join-alias: People - Creator
+  - card_id: MUXrck2HHcd2TIRuPfK0v
+    parameter_id: 50670f9e
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - is_active
+      - join-alias: People - Creator
+  - card_id: MUXrck2HHcd2TIRuPfK0v
+    parameter_id: ba4cf986
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - timestamp
+      - base-type: type/DateTimeWithLocalTZ
+        temporal-unit: default
+  visualization_settings:
+    column_settings: null
+- entity_id: lgRO8HWcyVqRky2JaL92G
+  card_id: gTeYI2eJtQUh63sZurc3z
+  created_at: '2023-11-13T20:29:14.682883Z'
+  row: 0
+  col: 0
+  size_x: 24
+  size_y: 9
+  action_id: null
+  dashboard_tab_id:
+  - DHMhMa1FYxiyIgM7_xdgR
+  - sOD2E2oTJE-j-YB5ltBts
+  parameter_mappings:
+  - card_id: gTeYI2eJtQUh63sZurc3z
+    parameter_id: 6b3da96f
     target:
     - dimension
     - - field
@@ -668,8 +943,8 @@ dashcards:
         - v_query_log
         - user_id
       - null
-  - parameter_id: 4a221c3a
-    card_id: gTeYI2eJtQUh63sZurc3z
+  - card_id: gTeYI2eJtQUh63sZurc3z
+    parameter_id: 4a221c3a
     target:
     - dimension
     - - field
@@ -682,8 +957,8 @@ dashcards:
         - public
         - v_query_log
         - user_id
-  - parameter_id: d53443e8
-    card_id: gTeYI2eJtQUh63sZurc3z
+  - card_id: gTeYI2eJtQUh63sZurc3z
+    parameter_id: d53443e8
     target:
     - dimension
     - - field
@@ -696,8 +971,8 @@ dashcards:
         - public
         - v_query_log
         - user_id
-  - parameter_id: 50670f9e
-    card_id: gTeYI2eJtQUh63sZurc3z
+  - card_id: gTeYI2eJtQUh63sZurc3z
+    parameter_id: 50670f9e
     target:
     - dimension
     - - field
@@ -710,8 +985,8 @@ dashcards:
         - public
         - v_query_log
         - user_id
-  - parameter_id: ba4cf986
-    card_id: gTeYI2eJtQUh63sZurc3z
+  - card_id: gTeYI2eJtQUh63sZurc3z
+    parameter_id: ba4cf986
     target:
     - dimension
     - - field
@@ -720,8 +995,8 @@ dashcards:
         - v_query_log
         - started_at
       - temporal-unit: default
-  - parameter_id: a4b3b4ff
-    card_id: gTeYI2eJtQUh63sZurc3z
+  - card_id: gTeYI2eJtQUh63sZurc3z
+    parameter_id: a4b3b4ff
     target:
     - dimension
     - - field
@@ -730,12 +1005,110 @@ dashcards:
         - v_query_log
         - query_source
       - null
-  card_id: gTeYI2eJtQUh63sZurc3z
-  entity_id: Lyf_W155PRLz5IgWeon8t
   visualization_settings:
+    column_settings: null
+- entity_id: _jzOzy43czLDogU6ILzaF
+  card_id: 7FLoE9kUELG4Ess6DsSEY
+  created_at: '2023-11-13T20:34:07.43949Z'
+  row: 9
+  col: 0
+  size_x: 24
+  size_y: 9
+  action_id: null
+  dashboard_tab_id:
+  - DHMhMa1FYxiyIgM7_xdgR
+  - sOD2E2oTJE-j-YB5ltBts
+  parameter_mappings:
+  - card_id: 7FLoE9kUELG4Ess6DsSEY
+    parameter_id: 6b3da96f
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_query_log
+        - user_id
+      - null
+  - card_id: 7FLoE9kUELG4Ess6DsSEY
+    parameter_id: 4a221c3a
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - full_name
+      - source-field:
+        - Internal Metabase Database
+        - public
+        - v_query_log
+        - user_id
+  - card_id: 7FLoE9kUELG4Ess6DsSEY
+    parameter_id: d53443e8
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - email
+      - source-field:
+        - Internal Metabase Database
+        - public
+        - v_query_log
+        - user_id
+  - card_id: 7FLoE9kUELG4Ess6DsSEY
+    parameter_id: 50670f9e
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - is_active
+      - source-field:
+        - Internal Metabase Database
+        - public
+        - v_query_log
+        - user_id
+  - card_id: 7FLoE9kUELG4Ess6DsSEY
+    parameter_id: ba4cf986
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_query_log
+        - started_at
+      - temporal-unit: default
+  visualization_settings:
+    column_settings:
+      ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Card Qualified"}]]'
+      : column_title: Question ID
+      ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Dashboard Qualified"}]]'
+      : column_title: Dashboard ID
+      ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Card Qualified"}]]'
+      : column_title: Question name
+        link_text: ''
+        link_url: /question/{{entity_id}}
+        view_as: link
+      ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Dashboard Qualified"}]]'
+      : column_title: Dashboard name
+        link_url: /dashboard/{{entity_id_2}}
+        view_as: link
+      ? '["ref",["field",["Internal Metabase Database","public","v_databases","entity_id"],{"base-type":"type/Integer","join-alias":"Databases - Database Qualified"}]]'
+      : column_title: Database ID
+      ? '["ref",["field",["Internal Metabase Database","public","v_databases","name"],{"base-type":"type/Text","join-alias":"Databases - Database Qualified"}]]'
+      : column_title: Database name
+        link_url: /browse/{{entity_id_3}}
+        view_as: link
+      ? '["ref",["field",["Internal Metabase Database","public","v_users","full_name"],{"base-type":"type/Text","join-alias":"People - User"}]]'
+      : column_title: User name
+      ? '["ref",["field",["Internal Metabase Database","public","v_users","user_id"],{"base-type":"type/Integer","join-alias":"People - User"}]]'
+      : column_title: User ID
     table.cell_column: running_time_seconds
     table.columns:
-    - name: started_at
+    - enabled: true
       fieldRef:
       - field
       - - Internal Metabase Database
@@ -744,8 +1117,18 @@ dashcards:
         - started_at
       - base-type: type/DateTimeWithLocalTZ
         temporal-unit: default
-      enabled: true
-    - name: query_source
+      name: started_at
+    - enabled: false
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - full_name
+      - base-type: type/Text
+        join-alias: People - User
+      name: full_name
+    - enabled: true
       fieldRef:
       - field
       - - Internal Metabase Database
@@ -753,8 +1136,8 @@ dashcards:
         - v_query_log
         - query_source
       - base-type: type/Text
-      enabled: true
-    - name: name
+      name: query_source
+    - enabled: true
       fieldRef:
       - field
       - - Internal Metabase Database
@@ -763,8 +1146,8 @@ dashcards:
         - name
       - base-type: type/Text
         join-alias: Content - Card Qualified
-      enabled: true
-    - name: name_2
+      name: name
+    - enabled: true
       fieldRef:
       - field
       - - Internal Metabase Database
@@ -773,8 +1156,8 @@ dashcards:
         - name
       - base-type: type/Text
         join-alias: Content - Dashboard Qualified
-      enabled: true
-    - name: name_3
+      name: name_2
+    - enabled: true
       fieldRef:
       - field
       - - Internal Metabase Database
@@ -783,8 +1166,8 @@ dashcards:
         - name
       - base-type: type/Text
         join-alias: Databases - Database Qualified
-      enabled: true
-    - name: is_native
+      name: name_3
+    - enabled: true
       fieldRef:
       - field
       - - Internal Metabase Database
@@ -792,8 +1175,8 @@ dashcards:
         - v_query_log
         - is_native
       - base-type: type/Boolean
-      enabled: true
-    - name: running_time_seconds
+      name: is_native
+    - enabled: true
       fieldRef:
       - field
       - - Internal Metabase Database
@@ -801,8 +1184,8 @@ dashcards:
         - v_query_log
         - running_time_seconds
       - base-type: type/Float
-      enabled: true
-    - name: result_rows
+      name: running_time_seconds
+    - enabled: true
       fieldRef:
       - field
       - - Internal Metabase Database
@@ -810,8 +1193,8 @@ dashcards:
         - v_query_log
         - result_rows
       - base-type: type/Integer
-      enabled: true
-    - name: entity_id
+      name: result_rows
+    - enabled: false
       fieldRef:
       - field
       - - Internal Metabase Database
@@ -820,8 +1203,8 @@ dashcards:
         - entity_id
       - base-type: type/Integer
         join-alias: Content - Card Qualified
-      enabled: false
-    - name: entity_id_2
+      name: entity_id
+    - enabled: false
       fieldRef:
       - field
       - - Internal Metabase Database
@@ -830,8 +1213,8 @@ dashcards:
         - entity_id
       - base-type: type/Integer
         join-alias: Content - Dashboard Qualified
-      enabled: false
-    - name: entity_id_3
+      name: entity_id_2
+    - enabled: false
       fieldRef:
       - field
       - - Internal Metabase Database
@@ -840,8 +1223,8 @@ dashcards:
         - entity_id
       - base-type: type/Integer
         join-alias: Databases - Database Qualified
-      enabled: false
-    - name: error
+      name: entity_id_3
+    - enabled: true
       fieldRef:
       - field
       - - Internal Metabase Database
@@ -849,43 +1232,32 @@ dashcards:
         - v_query_log
         - error
       - base-type: type/Text
-      enabled: true
+      name: error
+    - enabled: false
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - user_id
+      - base-type: type/Integer
+        join-alias: People - User
+      name: user_id
     table.pivot_column: error
-    column_settings:
-      ? '["ref",["field",["Internal Metabase Database","public","v_databases","name"],{"base-type":"type/Text","join-alias":"Databases - Database Qualified"}]]'
-      : column_title: Database name
-        click_behavior:
-          type: link
-          linkType: url
-          linkTemplate: /browse/{{entity_id_3}}
-      ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Dashboard Qualified"}]]'
-      : column_title: Dashboard name
-        click_behavior:
-          type: link
-          linkType: url
-          linkTemplate: /dashboard/{{entity_id_2}}
-      ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Card Qualified"}]]'
-      : column_title: Question name
-        click_behavior:
-          type: link
-          linkType: url
-          linkTemplate: /question/{{entity_id}}
-      ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Card Qualified"}]]'
-      : column_title: Question ID
-      ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Dashboard Qualified"}]]'
-      : column_title: Dashboard ID
-      ? '["ref",["field",["Internal Metabase Database","public","v_databases","entity_id"],{"base-type":"type/Integer","join-alias":"Databases - Database Qualified"}]]'
-      : column_title: Database ID
-  size_y: 13
-  created_at: '2023-11-01T01:15:19.403379Z'
-  row: 29
-- size_x: 12
-  dashboard_tab_id: null
-  action_id: null
+- entity_id: JAd9PU848J24nq7stgYc1
+  card_id: WlQ-en2l-iRRCvO2-v5j1
+  created_at: '2023-11-13T20:35:02.81769Z'
+  row: 0
   col: 0
+  size_x: 24
+  size_y: 11
+  action_id: null
+  dashboard_tab_id:
+  - DHMhMa1FYxiyIgM7_xdgR
+  - pN3kDqlZ16MCaKLxv4hH2
   parameter_mappings:
-  - parameter_id: 6b3da96f
-    card_id: uEf4gbDzXkj9q1uvkaTny
+  - card_id: WlQ-en2l-iRRCvO2-v5j1
+    parameter_id: 6b3da96f
     target:
     - dimension
     - - field
@@ -893,9 +1265,9 @@ dashcards:
         - public
         - v_users
         - user_id
-      - null
-  - parameter_id: 4a221c3a
-    card_id: uEf4gbDzXkj9q1uvkaTny
+      - join-alias: People - User
+  - card_id: WlQ-en2l-iRRCvO2-v5j1
+    parameter_id: 4a221c3a
     target:
     - dimension
     - - field
@@ -903,9 +1275,9 @@ dashcards:
         - public
         - v_users
         - full_name
-      - null
-  - parameter_id: d53443e8
-    card_id: uEf4gbDzXkj9q1uvkaTny
+      - join-alias: People - User
+  - card_id: WlQ-en2l-iRRCvO2-v5j1
+    parameter_id: d53443e8
     target:
     - dimension
     - - field
@@ -913,9 +1285,9 @@ dashcards:
         - public
         - v_users
         - email
-      - null
-  - parameter_id: 50670f9e
-    card_id: uEf4gbDzXkj9q1uvkaTny
+      - join-alias: People - User
+  - card_id: WlQ-en2l-iRRCvO2-v5j1
+    parameter_id: 50670f9e
     target:
     - dimension
     - - field
@@ -923,80 +1295,48 @@ dashcards:
         - public
         - v_users
         - is_active
-      - null
-  card_id: uEf4gbDzXkj9q1uvkaTny
-  entity_id: 44ekjEv02wPsWKcE9BYl0
+      - join-alias: People - User
+  - card_id: WlQ-en2l-iRRCvO2-v5j1
+    parameter_id: ba4cf986
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_audit_log
+        - timestamp
+      - base-type: type/DateTimeWithLocalTZ
+        temporal-unit: default
+  - card_id: WlQ-en2l-iRRCvO2-v5j1
+    parameter_id: dad0245c
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_audit_log
+        - topic
+      - base-type: type/Text
   visualization_settings:
     column_settings: null
-  size_y: 8
-  created_at: '2023-11-01T01:28:23.514406Z'
-  row: 0
-tabs: []
-enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-show_in_getting_started: false
-name: Person overview
-caveats: null
-creator_id: internal@metabase.com
-made_public_by_id: null
-embedding_params: null
-cache_ttl: null
-serdes/meta:
-- model: Dashboard
-  id: DHMhMa1FYxiyIgM7_xdgR
-  label: person_overview
-position: null
-entity_id: DHMhMa1FYxiyIgM7_xdgR
-parameters:
-- name: User ID
-  slug: user_id
-  id: 6b3da96f
-  type: id
-  sectionId: id
-  isMultiSelect: false
-  filteringParameters:
-  - 50670f9e
-- name: User Name
-  slug: user_name
-  id: 4a221c3a
-  type: string/=
-  sectionId: string
-  isMultiSelect: false
-  filteringParameters:
-  - 50670f9e
-- name: User Email
-  slug: user_email
-  id: d53443e8
-  type: string/=
-  sectionId: string
-  isMultiSelect: false
-  filteringParameters:
-  - 50670f9e
-- name: Is Active?
-  slug: is_active%3F
-  id: 50670f9e
-  type: string/=
-  sectionId: string
-  default:
-  - true
-  isMultiSelect: false
-- name: Date Filter
-  slug: date_filter
-  id: ba4cf986
-  type: date/all-options
-  sectionId: date
-  default: past52weeks~
-- name: Activity type
-  slug: activity_type
-  id: dad0245c
-  type: string/=
-  sectionId: string
-- name: Query source
-  slug: query_source
-  id: a4b3b4ff
-  type: string/=
-  sectionId: string
-auto_apply_filters: false
-created_at: '2023-06-15T01:31:06.523478Z'
-public_uuid: null
-points_of_interest: null
+tabs:
+- created_at: '2023-11-13T20:15:30.366828Z'
+  entity_id: VLzpbzPlShrECFp-dG4pH
+  name: Overview
+  position: 0
+- created_at: '2023-11-13T20:15:30.366828Z'
+  entity_id: O0vWXzcQX97NAp_KlupRD
+  name: Recently viewed
+  position: 1
+- created_at: '2023-11-13T20:24:02.939513Z'
+  entity_id: 1PNg7EqqaSdPhPyQYpDxp
+  name: Most viewed
+  position: 2
+- created_at: '2023-11-13T20:29:14.682883Z'
+  entity_id: sOD2E2oTJE-j-YB5ltBts
+  name: Queries and downloads
+  position: 3
+- created_at: '2023-11-13T20:35:02.81769Z'
+  entity_id: pN3kDqlZ16MCaKLxv4hH2
+  name: Activity
+  position: 4

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/dashboards/Glqmoytsnu0n6rfLUjock_performance_overview.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/dashboards/Glqmoytsnu0n6rfLUjock_performance_overview.yaml
@@ -1,50 +1,54 @@
+name: Performance overview
 description: Question, dashboard and database performance.
+entity_id: Glqmoytsnu0n6rfLUjock
+created_at: '2023-11-01T11:13:09.170935Z'
+creator_id: internal@metabase.com
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+auto_apply_filters: true
+cache_ttl: null
 collection_position: 7
+position: null
+enable_embedding: false
+embedding_params: null
+made_public_by_id: null
+public_uuid: null
+show_in_getting_started: false
+caveats: null
+points_of_interest: null
+parameters:
+- id: cbef6d30
+  name: Database
+  sectionId: string
+  slug: database
+  type: string/=
+- default:
+  - All Users
+  id: dbeeb776
+  isMultiSelect: false
+  name: Group
+  sectionId: string
+  slug: group
+  type: string/=
+serdes/meta:
+- id: Glqmoytsnu0n6rfLUjock
+  label: performance_overview
+  model: Dashboard
 dashcards:
-- size_x: 12
-  dashboard_tab_id: null
-  action_id: null
-  col: 0
-  parameter_mappings:
-  - parameter_id: cbef6d30
-    card_id: mm8k37Rgk7ChMNwAUdXK2
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_databases
-        - name
-      - source-field:
-        - Internal Metabase Database
-        - public
-        - v_query_log
-        - database_qualified_id
-  - parameter_id: dbeeb776
-    card_id: mm8k37Rgk7ChMNwAUdXK2
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_group_members
-        - group_name
-      - join-alias: Group Members - User
+- entity_id: iJ6TElSxr9vyZm6PgNn9s
   card_id: mm8k37Rgk7ChMNwAUdXK2
-  entity_id: iJ6TElSxr9vyZm6PgNn9s
-  visualization_settings:
-    column_settings: null
-  size_y: 6
   created_at: '2023-11-01T11:21:03.166953Z'
   row: 0
-- size_x: 12
-  dashboard_tab_id: null
+  col: 0
+  size_x: 12
+  size_y: 6
   action_id: null
-  col: 12
+  dashboard_tab_id:
+  - Glqmoytsnu0n6rfLUjock
+  - jBvRp7n8EAyim_aK6rCnP
   parameter_mappings:
-  - parameter_id: cbef6d30
-    card_id: 5gASJxNKdQCmkiGXb5kRP
+  - card_id: mm8k37Rgk7ChMNwAUdXK2
+    parameter_id: cbef6d30
     target:
     - dimension
     - - field
@@ -57,8 +61,8 @@ dashcards:
         - public
         - v_query_log
         - database_qualified_id
-  - parameter_id: dbeeb776
-    card_id: 5gASJxNKdQCmkiGXb5kRP
+  - card_id: mm8k37Rgk7ChMNwAUdXK2
+    parameter_id: dbeeb776
     target:
     - dimension
     - - field
@@ -67,32 +71,22 @@ dashcards:
         - v_group_members
         - group_name
       - join-alias: Group Members - User
-  card_id: 5gASJxNKdQCmkiGXb5kRP
-  entity_id: 8EOwPHjMTyhK7RNA65eRE
   visualization_settings:
     column_settings: null
-  size_y: 6
+- entity_id: 8EOwPHjMTyhK7RNA65eRE
+  card_id: 5gASJxNKdQCmkiGXb5kRP
   created_at: '2023-11-01T11:23:28.898047Z'
   row: 0
-- size_x: 12
-  dashboard_tab_id: null
-  action_id: null
-  col: 0
-  parameter_mappings: []
-  card_id: r8r6O1VedjAjSD2MPxJs6
-  entity_id: I6pKZnuNRduK6inlhtJG8
-  visualization_settings:
-    column_settings: null
+  col: 12
+  size_x: 12
   size_y: 6
-  created_at: '2023-11-01T11:29:58.249212Z'
-  row: 12
-- size_x: 12
-  dashboard_tab_id: null
   action_id: null
-  col: 0
+  dashboard_tab_id:
+  - Glqmoytsnu0n6rfLUjock
+  - jBvRp7n8EAyim_aK6rCnP
   parameter_mappings:
-  - parameter_id: cbef6d30
-    card_id: OCkxXZM5KPJ9zOjYVEnqY
+  - card_id: 5gASJxNKdQCmkiGXb5kRP
+    parameter_id: cbef6d30
     target:
     - dimension
     - - field
@@ -105,8 +99,84 @@ dashcards:
         - public
         - v_query_log
         - database_qualified_id
-  - parameter_id: dbeeb776
-    card_id: OCkxXZM5KPJ9zOjYVEnqY
+  - card_id: 5gASJxNKdQCmkiGXb5kRP
+    parameter_id: dbeeb776
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_group_members
+        - group_name
+      - join-alias: Group Members - User
+  visualization_settings:
+    column_settings: null
+- entity_id: I6pKZnuNRduK6inlhtJG8
+  card_id: r8r6O1VedjAjSD2MPxJs6
+  created_at: '2023-11-01T11:29:58.249212Z'
+  row: 6
+  col: 0
+  size_x: 24
+  size_y: 8
+  action_id: null
+  dashboard_tab_id:
+  - Glqmoytsnu0n6rfLUjock
+  - jBvRp7n8EAyim_aK6rCnP
+  parameter_mappings: []
+  visualization_settings:
+    column_settings: null
+- entity_id: GuplD3L8-SZv_or20dYNI
+  card_id: zdVQGoMs__No_3l_amEWV
+  created_at: '2023-11-13T20:40:42.614766Z'
+  row: 0
+  col: 12
+  size_x: 12
+  size_y: 7
+  action_id: null
+  dashboard_tab_id:
+  - Glqmoytsnu0n6rfLUjock
+  - 4cbECWHJ2N1_nIPXQ186S
+  parameter_mappings:
+  - card_id: zdVQGoMs__No_3l_amEWV
+    parameter_id: dbeeb776
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_group_members
+        - group_name
+      - join-alias: Group Members - User
+  - card_id: zdVQGoMs__No_3l_amEWV
+    parameter_id: cbef6d30
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_databases
+        - name
+      - source-field:
+        - Internal Metabase Database
+        - public
+        - v_query_log
+        - database_qualified_id
+  visualization_settings:
+    column_settings: null
+- entity_id: YmdWBHC1EHgN0VI06DiDP
+  card_id: OCkxXZM5KPJ9zOjYVEnqY
+  created_at: '2023-11-13T20:40:42.614766Z'
+  row: 0
+  col: 0
+  size_x: 12
+  size_y: 7
+  action_id: null
+  dashboard_tab_id:
+  - Glqmoytsnu0n6rfLUjock
+  - 4cbECWHJ2N1_nIPXQ186S
+  parameter_mappings:
+  - card_id: OCkxXZM5KPJ9zOjYVEnqY
+    parameter_id: dbeeb776
     target:
     - dimension
     - - field
@@ -115,20 +185,8 @@ dashcards:
         - v_group_members
         - group_name
       - join-alias: Group Members - Entity
-  card_id: OCkxXZM5KPJ9zOjYVEnqY
-  entity_id: HVh-W4SbKVwfOaw9pWg87
-  visualization_settings:
-    column_settings: null
-  size_y: 6
-  created_at: '2023-11-01T11:32:05.272167Z'
-  row: 6
-- size_x: 12
-  dashboard_tab_id: null
-  action_id: null
-  col: 12
-  parameter_mappings:
-  - parameter_id: cbef6d30
-    card_id: zdVQGoMs__No_3l_amEWV
+  - card_id: OCkxXZM5KPJ9zOjYVEnqY
+    parameter_id: cbef6d30
     target:
     - dimension
     - - field
@@ -141,90 +199,108 @@ dashcards:
         - public
         - v_query_log
         - database_qualified_id
-  - parameter_id: dbeeb776
-    card_id: zdVQGoMs__No_3l_amEWV
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_group_members
-        - group_name
-      - join-alias: Group Members - User
-  card_id: zdVQGoMs__No_3l_amEWV
-  entity_id: zClrjPJO--ZktPNLs02nb
   visualization_settings:
     column_settings: null
-  size_y: 6
-  created_at: '2023-11-01T11:33:19.539758Z'
-  row: 6
-- size_x: 12
-  dashboard_tab_id: null
-  action_id: null
-  col: 12
-  parameter_mappings:
-  - parameter_id: cbef6d30
-    card_id: DuL1yrlkmnqOgz4drGiG4
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_databases
-        - name
-      - source-field:
-        - Internal Metabase Database
-        - public
-        - v_query_log
-        - database_qualified_id
-  - parameter_id: dbeeb776
-    card_id: DuL1yrlkmnqOgz4drGiG4
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_group_members
-        - group_name
-      - join-alias: Group Members - User
+- entity_id: aBpCVPlOAxucmmKrdx9VM
   card_id: DuL1yrlkmnqOgz4drGiG4
-  entity_id: 6im_kqIIunL0spceL4KLP
+  created_at: '2023-11-13T20:40:42.614766Z'
+  row: 0
+  col: 0
+  size_x: 24
+  size_y: 9
+  action_id: null
+  dashboard_tab_id:
+  - Glqmoytsnu0n6rfLUjock
+  - w4-8vby2KqplrfPXB_vIf
+  parameter_mappings:
+  - card_id: DuL1yrlkmnqOgz4drGiG4
+    parameter_id: dbeeb776
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_group_members
+        - group_name
+      - join-alias: Group Members - User
+  - card_id: DuL1yrlkmnqOgz4drGiG4
+    parameter_id: cbef6d30
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_databases
+        - name
+      - source-field:
+        - Internal Metabase Database
+        - public
+        - v_query_log
+        - database_qualified_id
   visualization_settings:
     column_settings: null
-  size_y: 6
-  created_at: '2023-11-01T11:35:17.773595Z'
-  row: 12
-tabs: []
-enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-show_in_getting_started: false
-name: Performance overview
-caveats: null
-creator_id: internal@metabase.com
-made_public_by_id: null
-embedding_params: null
-cache_ttl: null
-serdes/meta:
-- model: Dashboard
-  id: Glqmoytsnu0n6rfLUjock
-  label: performance_overview
-position: null
-entity_id: Glqmoytsnu0n6rfLUjock
-parameters:
-- name: Database
-  slug: database
-  id: cbef6d30
-  type: string/=
-  sectionId: string
-- name: Group
-  slug: group
-  id: dbeeb776
-  type: string/=
-  sectionId: string
-  isMultiSelect: false
-  default:
-  - All Users
-auto_apply_filters: true
-created_at: '2023-11-01T11:13:09.170935Z'
-public_uuid: null
-points_of_interest: null
+- entity_id: K2iosE8HMewiHs5tJAKIB
+  card_id: KXNGLyYyS1pO_9wMguHIB
+  created_at: '2023-11-13T20:44:16.084445Z'
+  row: 0
+  col: 0
+  size_x: 12
+  size_y: 7
+  action_id: null
+  dashboard_tab_id:
+  - Glqmoytsnu0n6rfLUjock
+  - m7yuefui-NMfdMQmhW0ML
+  parameter_mappings:
+  - card_id: KXNGLyYyS1pO_9wMguHIB
+    parameter_id: cbef6d30
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_databases
+        - name
+      - join-alias: Databases - Database Qualified
+  visualization_settings:
+    column_settings: null
+- entity_id: rSsdJlI3VVC8zjbpMZarM
+  card_id: LN9YtKcxZk_kybyRjJx1J
+  created_at: '2023-11-13T20:45:22.149233Z'
+  row: 0
+  col: 12
+  size_x: 12
+  size_y: 7
+  action_id: null
+  dashboard_tab_id:
+  - Glqmoytsnu0n6rfLUjock
+  - m7yuefui-NMfdMQmhW0ML
+  parameter_mappings:
+  - card_id: LN9YtKcxZk_kybyRjJx1J
+    parameter_id: cbef6d30
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_databases
+        - name
+      - join-alias: Databases - Database Qualified
+  visualization_settings:
+    column_settings: null
+tabs:
+- created_at: '2023-11-13T20:40:42.614766Z'
+  entity_id: jBvRp7n8EAyim_aK6rCnP
+  name: Dashboards
+  position: 0
+- created_at: '2023-11-13T20:40:42.614766Z'
+  entity_id: 4cbECWHJ2N1_nIPXQ186S
+  name: Questions
+  position: 1
+- created_at: '2023-11-13T20:40:42.614766Z'
+  entity_id: m7yuefui-NMfdMQmhW0ML
+  name: Databases
+  position: 2
+- created_at: '2023-11-13T20:40:42.614766Z'
+  entity_id: w4-8vby2KqplrfPXB_vIf
+  name: Users
+  position: 3

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/dashboards/IW64bVIFFkpldy410Pe5F_most_viewed_content.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/dashboards/IW64bVIFFkpldy410Pe5F_most_viewed_content.yaml
@@ -1,56 +1,63 @@
+name: Most viewed content
 description: Most viewed dashboards, questions, and tables in your Metabase.
+entity_id: IW64bVIFFkpldy410Pe5F
+created_at: '2023-08-18T19:07:51.157584Z'
+creator_id: internal@metabase.com
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+auto_apply_filters: true
+cache_ttl: null
 collection_position: 2
+position: null
+enable_embedding: false
+embedding_params: null
+made_public_by_id: null
+public_uuid: null
+show_in_getting_started: false
+caveats: null
+points_of_interest: null
+parameters:
+- default:
+  - All Users
+  id: 27bf158b
+  isMultiSelect: false
+  name: Group name
+  sectionId: string
+  slug: group_name
+  type: string/=
+- filteringParameters:
+  - '5e162806'
+  id: 124adfb8
+  isMultiSelect: true
+  name: User
+  sectionId: string
+  slug: user
+  type: string/=
+- default:
+  - 'true'
+  id: '5e162806'
+  isMultiSelect: false
+  name: Is user active
+  sectionId: string
+  slug: is_user_active
+  type: string/=
+serdes/meta:
+- id: IW64bVIFFkpldy410Pe5F
+  label: most_viewed_content
+  model: Dashboard
 dashcards:
-- size_x: 12
-  dashboard_tab_id: null
-  action_id: null
-  col: 0
-  parameter_mappings:
-  - parameter_id: 27bf158b
-    card_id: MUXrck2HHcd2TIRuPfK0v
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_group_members
-        - group_name
-      - join-alias: Group Members - User
-  - parameter_id: 124adfb8
-    card_id: MUXrck2HHcd2TIRuPfK0v
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - full_name
-      - join-alias: People - Creator
-  - parameter_id: '5e162806'
-    card_id: MUXrck2HHcd2TIRuPfK0v
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_users
-        - is_active
-      - join-alias: People - Creator
+- entity_id: 9Lnv8dgtICiNt2yl2WV0x
   card_id: MUXrck2HHcd2TIRuPfK0v
-  entity_id: 9Lnv8dgtICiNt2yl2WV0x
-  visualization_settings:
-    column_settings: null
-  size_y: 9
   created_at: '2023-08-18T19:09:24.116624Z'
   row: 0
-- size_x: 12
-  dashboard_tab_id: null
+  col: 0
+  size_x: 12
+  size_y: 9
   action_id: null
-  col: 12
+  dashboard_tab_id: null
   parameter_mappings:
-  - parameter_id: 27bf158b
-    card_id: _lfXwss_MckZBidbcJsgk
+  - card_id: MUXrck2HHcd2TIRuPfK0v
+    parameter_id: 27bf158b
     target:
     - dimension
     - - field
@@ -59,8 +66,8 @@ dashcards:
         - v_group_members
         - group_name
       - join-alias: Group Members - User
-  - parameter_id: 124adfb8
-    card_id: _lfXwss_MckZBidbcJsgk
+  - card_id: MUXrck2HHcd2TIRuPfK0v
+    parameter_id: 124adfb8
     target:
     - dimension
     - - field
@@ -69,8 +76,8 @@ dashcards:
         - v_users
         - full_name
       - join-alias: People - Creator
-  - parameter_id: '5e162806'
-    card_id: _lfXwss_MckZBidbcJsgk
+  - card_id: MUXrck2HHcd2TIRuPfK0v
+    parameter_id: '5e162806'
     target:
     - dimension
     - - field
@@ -79,20 +86,62 @@ dashcards:
         - v_users
         - is_active
       - join-alias: People - Creator
-  card_id: _lfXwss_MckZBidbcJsgk
-  entity_id: mtP6yOJW7VaU9DV5lxwAw
   visualization_settings:
-    column_settings: null
-  size_y: 9
+    column_settings:
+      '["name","count"]':
+        show_mini_bar: true
+      ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Entity Qualified"}]]'
+      : column_title: Dashboard ID
+        link_url: dashboard/{{entity_id}}
+        view_as: link
+      ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
+      : column_title: Dashboard name
+        link_url: dashboard/{{entity_id}}
+        view_as: link
+    graph.dimensions:
+    - name
+    graph.metrics:
+    - count
+    graph.show_values: true
+    table.cell_column: count
+    table.columns:
+    - enabled: true
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - name
+      - base-type: type/Text
+        join-alias: Content - Entity Qualified
+      name: name
+    - enabled: false
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - entity_id
+      - base-type: type/Integer
+        join-alias: Content - Entity Qualified
+      name: entity_id
+    - enabled: true
+      fieldRef:
+      - aggregation
+      - 0
+      name: count
+- entity_id: mtP6yOJW7VaU9DV5lxwAw
+  card_id: _lfXwss_MckZBidbcJsgk
   created_at: '2023-08-18T19:13:18.392443Z'
   row: 0
-- size_x: 12
-  dashboard_tab_id: null
+  col: 12
+  size_x: 12
+  size_y: 9
   action_id: null
-  col: 0
+  dashboard_tab_id: null
   parameter_mappings:
-  - parameter_id: 27bf158b
-    card_id: ItdtatOMd0uUEpvx7tDAC
+  - card_id: _lfXwss_MckZBidbcJsgk
+    parameter_id: 27bf158b
     target:
     - dimension
     - - field
@@ -101,8 +150,93 @@ dashcards:
         - v_group_members
         - group_name
       - join-alias: Group Members - User
-  - parameter_id: 124adfb8
-    card_id: ItdtatOMd0uUEpvx7tDAC
+  - card_id: _lfXwss_MckZBidbcJsgk
+    parameter_id: 124adfb8
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - full_name
+      - join-alias: People - Creator
+  - card_id: _lfXwss_MckZBidbcJsgk
+    parameter_id: '5e162806'
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - is_active
+      - join-alias: People - Creator
+  visualization_settings:
+    column_settings:
+      '["name","count"]':
+        show_mini_bar: true
+      ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Entity Qualified"}]]'
+      : column_title: Question ID
+        link_url: question/{{entity_id}}
+        view_as: link
+      ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
+      : column_title: Question name
+        link_text: ''
+        link_url: question/{{entity_id}}
+        view_as: link
+    graph.dimensions:
+    - name
+    graph.metrics:
+    - count
+    graph.show_values: true
+    table.cell_column: count
+    table.columns:
+    - enabled: true
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - name
+      - base-type: type/Text
+        join-alias: Content - Entity Qualified
+      name: name
+    - enabled: false
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - entity_id
+      - base-type: type/Integer
+        join-alias: Content - Entity Qualified
+      name: entity_id
+    - enabled: true
+      fieldRef:
+      - aggregation
+      - 0
+      name: count
+- entity_id: QkKyZ0hyV3s5T8UERDFOI
+  card_id: ItdtatOMd0uUEpvx7tDAC
+  created_at: '2023-11-01T12:02:06.300855Z'
+  row: 9
+  col: 0
+  size_x: 12
+  size_y: 9
+  action_id: null
+  dashboard_tab_id: null
+  parameter_mappings:
+  - card_id: ItdtatOMd0uUEpvx7tDAC
+    parameter_id: 27bf158b
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_group_members
+        - group_name
+      - join-alias: Group Members - User
+  - card_id: ItdtatOMd0uUEpvx7tDAC
+    parameter_id: 124adfb8
     target:
     - dimension
     - - field
@@ -111,8 +245,8 @@ dashcards:
         - v_users
         - full_name
       - join-alias: People - User
-  - parameter_id: '5e162806'
-    card_id: ItdtatOMd0uUEpvx7tDAC
+  - card_id: ItdtatOMd0uUEpvx7tDAC
+    parameter_id: '5e162806'
     target:
     - dimension
     - - field
@@ -121,55 +255,104 @@ dashcards:
         - v_users
         - is_active
       - join-alias: People - User
-  card_id: ItdtatOMd0uUEpvx7tDAC
-  entity_id: QkKyZ0hyV3s5T8UERDFOI
   visualization_settings:
     column_settings: null
-  size_y: 9
-  created_at: '2023-11-01T12:02:06.300855Z'
+- entity_id: q2TAw8RtBJbvTfeZYGKyw
+  card_id: 57V11my5MYVnSlaJYM8cX
+  created_at: '2023-11-13T18:53:17.090069Z'
   row: 9
+  col: 12
+  size_x: 12
+  size_y: 9
+  action_id: null
+  dashboard_tab_id: null
+  parameter_mappings:
+  - card_id: 57V11my5MYVnSlaJYM8cX
+    parameter_id: '5e162806'
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - is_active
+      - join-alias: People - Creator
+  - card_id: 57V11my5MYVnSlaJYM8cX
+    parameter_id: 124adfb8
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - full_name
+      - join-alias: People - Creator
+  - card_id: 57V11my5MYVnSlaJYM8cX
+    parameter_id: 27bf158b
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_group_members
+        - group_name
+      - join-alias: Group Members - User
+  visualization_settings:
+    column_settings:
+      '["name","count"]':
+        show_mini_bar: true
+      ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Entity Qualified"}]]'
+      : column_title: Question ID
+        link_url: question/{{entity_id}}
+        view_as: link
+      ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Entity Qualified"}]]'
+      : column_title: Question name
+        link_text: ''
+        link_url: question/{{entity_id}}
+        view_as: link
+      ? '["ref",["field",["Internal Metabase Database","public","v_databases","name"],{"base-type":"type/Text","join-alias":"V Databases - Question Database"}]]'
+      : column_title: Database
+    graph.dimensions:
+    - name
+    graph.metrics:
+    - count
+    graph.show_values: true
+    table.cell_column: count
+    table.columns:
+    - enabled: true
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - name
+      - base-type: type/Text
+        join-alias: Content - Entity Qualified
+      name: name
+    - enabled: false
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - entity_id
+      - base-type: type/Integer
+        join-alias: Content - Entity Qualified
+      name: entity_id
+    - enabled: true
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_databases
+        - name
+      - base-type: type/Text
+        join-alias: V Databases - Question Database
+      name: name_2
+    - enabled: true
+      fieldRef:
+      - aggregation
+      - 0
+      name: count
+    table.pivot_column: name_2
 tabs: []
-enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-show_in_getting_started: false
-name: Most viewed content
-caveats: null
-creator_id: internal@metabase.com
-made_public_by_id: null
-embedding_params: null
-cache_ttl: null
-serdes/meta:
-- model: Dashboard
-  id: IW64bVIFFkpldy410Pe5F
-  label: most_viewed_content
-position: null
-entity_id: IW64bVIFFkpldy410Pe5F
-parameters:
-- name: Group name
-  slug: group_name
-  id: 27bf158b
-  type: string/=
-  sectionId: string
-  isMultiSelect: false
-  default:
-  - All Users
-- name: User
-  slug: user
-  id: 124adfb8
-  type: string/=
-  sectionId: string
-  isMultiSelect: true
-  filteringParameters:
-  - '5e162806'
-- name: Is user active
-  slug: is_user_active
-  id: '5e162806'
-  type: string/=
-  sectionId: string
-  default:
-  - 'true'
-  isMultiSelect: false
-auto_apply_filters: true
-created_at: '2023-08-18T19:07:51.157584Z'
-public_uuid: null
-points_of_interest: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/dashboards/bJEYb0o5CXlfWFcIztDwJ_dashboard_overview.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/dashboards/bJEYb0o5CXlfWFcIztDwJ_dashboard_overview.yaml
@@ -1,344 +1,28 @@
-description: Information on the performance, views, activity, and more for a particular dashboard.
-archived: false
-collection_position: 5
-dashcards:
-- size_x: 12
-  dashboard_tab_id: null
-  action_id: null
-  col: 0
-  parameter_mappings:
-  - parameter_id: c02bd3d3
-    card_id: W34-Nzp-T3-SPdZwGvLeB
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_content
-        - name
-      - base-type: type/Text
-  - parameter_id: 4b39cd95
-    card_id: W34-Nzp-T3-SPdZwGvLeB
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_content
-        - entity_id
-      - base-type: type/Integer
-  card_id: W34-Nzp-T3-SPdZwGvLeB
-  entity_id: 1d46RUV7YxaRBwo9Yks_6
-  visualization_settings:
-    column_settings: null
-  size_y: 6
-  created_at: '2023-08-17T21:51:54.863964Z'
-  row: 0
-- size_x: 12
-  dashboard_tab_id: null
-  action_id: null
-  col: 12
-  parameter_mappings:
-  - parameter_id: c02bd3d3
-    card_id: XIiIsCNMk9gg-eO2hkl8S
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_content
-        - name
-      - base-type: type/Text
-        join-alias: Content - Entity Qualified
-  - parameter_id: 2ea1dae2
-    card_id: XIiIsCNMk9gg-eO2hkl8S
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_group_members
-        - group_name
-      - join-alias: Group Members - User
-  - parameter_id: 25f8871e
-    card_id: XIiIsCNMk9gg-eO2hkl8S
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - timestamp
-      - temporal-unit: default
-  - parameter_id: 4b39cd95
-    card_id: XIiIsCNMk9gg-eO2hkl8S
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_content
-        - entity_id
-      - base-type: type/Integer
-        join-alias: Content - Entity Qualified
-  card_id: XIiIsCNMk9gg-eO2hkl8S
-  entity_id: bvo3bHzsPRHm4yNdGLkRD
-  visualization_settings:
-    column_settings: null
-  size_y: 6
-  created_at: '2023-08-17T21:56:01.551685Z'
-  row: 0
-- size_x: 12
-  dashboard_tab_id: null
-  action_id: null
-  col: 12
-  parameter_mappings:
-  - parameter_id: c02bd3d3
-    card_id: _p6UGMWOQn5-yf03uGsaN
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_content
-        - name
-      - base-type: type/Text
-        join-alias: Content - Entity Qualified
-  - parameter_id: 2ea1dae2
-    card_id: _p6UGMWOQn5-yf03uGsaN
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_group_members
-        - group_name
-      - join-alias: Group Members - User
-  - parameter_id: 25f8871e
-    card_id: _p6UGMWOQn5-yf03uGsaN
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - timestamp
-      - temporal-unit: default
-  - parameter_id: 4b39cd95
-    card_id: _p6UGMWOQn5-yf03uGsaN
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_content
-        - entity_id
-      - base-type: type/Integer
-        join-alias: Content - Entity Qualified
-  card_id: _p6UGMWOQn5-yf03uGsaN
-  entity_id: 8-R___ABOFNA--DmJNq_H
-  visualization_settings:
-    column_settings: null
-  size_y: 7
-  created_at: '2023-08-17T22:03:45.266592Z'
-  row: 6
-- size_x: 12
-  dashboard_tab_id: null
-  action_id: null
-  col: 12
-  parameter_mappings:
-  - parameter_id: 2ea1dae2
-    card_id: xrgv7nzXe_v8ORWIbq839
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_group_members
-        - group_name
-      - join-alias: Question 34
-  - parameter_id: 25f8871e
-    card_id: xrgv7nzXe_v8ORWIbq839
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_audit_log
-        - timestamp
-      - base-type: type/DateTimeWithLocalTZ
-        temporal-unit: default
-  - parameter_id: 4b39cd95
-    card_id: xrgv7nzXe_v8ORWIbq839
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_content
-        - entity_id
-      - base-type: type/Integer
-        join-alias: Question 35
-  - parameter_id: c02bd3d3
-    card_id: xrgv7nzXe_v8ORWIbq839
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_content
-        - name
-      - base-type: type/Text
-        join-alias: Question 35
-  card_id: xrgv7nzXe_v8ORWIbq839
-  entity_id: _8MUvI8zFhQ2_vzIf5kw3
-  visualization_settings:
-    column_settings: null
-  size_y: 14
-  created_at: '2023-08-18T18:53:47.157159Z'
-  row: 13
-- size_x: 24
-  dashboard_tab_id: null
-  action_id: null
-  col: 0
-  parameter_mappings:
-  - parameter_id: c02bd3d3
-    card_id: Bp2r19P5a9HjDTR4-VuZa
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_content
-        - name
-      - base-type: type/Text
-        join-alias: Content - Dashboard Qualified
-  - parameter_id: 4b39cd95
-    card_id: Bp2r19P5a9HjDTR4-VuZa
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_content
-        - entity_id
-      - base-type: type/Integer
-        join-alias: Content - Dashboard Qualified
-  card_id: Bp2r19P5a9HjDTR4-VuZa
-  entity_id: cKFQR4ATKoLlhHiQ1Kd1b
-  visualization_settings:
-    column_settings: null
-  size_y: 7
-  created_at: '2023-11-01T02:17:51.755215Z'
-  row: 27
-- size_x: 12
-  dashboard_tab_id: null
-  action_id: null
-  col: 0
-  parameter_mappings:
-  - parameter_id: 4b39cd95
-    card_id: yVr4oMzxq8BPWf5HLbdwL
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_content
-        - entity_id
-      - base-type: type/Integer
-        join-alias: Content - Dashboard Qualified
-  - parameter_id: c02bd3d3
-    card_id: yVr4oMzxq8BPWf5HLbdwL
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_content
-        - name
-      - base-type: type/Text
-        join-alias: Content - Dashboard Qualified
-  card_id: yVr4oMzxq8BPWf5HLbdwL
-  entity_id: U1rsHOTwmxXbOTsfOixVj
-  visualization_settings:
-    column_settings: null
-  size_y: 14
-  created_at: '2023-11-01T02:30:58.105138Z'
-  row: 13
-- size_x: 12
-  dashboard_tab_id: null
-  action_id: null
-  col: 0
-  parameter_mappings:
-  - parameter_id: c02bd3d3
-    card_id: -_XgVaPuz7MY8jlG0wSEC
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_content
-        - name
-      - source-field:
-        - Internal Metabase Database
-        - public
-        - v_query_log
-        - dashboard_qualified_id
-  - parameter_id: 4b39cd95
-    card_id: -_XgVaPuz7MY8jlG0wSEC
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_content
-        - entity_id
-      - source-field:
-        - Internal Metabase Database
-        - public
-        - v_query_log
-        - dashboard_qualified_id
-  - parameter_id: 25f8871e
-    card_id: -_XgVaPuz7MY8jlG0wSEC
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_query_log
-        - started_at
-      - temporal-unit: default
-  card_id: -_XgVaPuz7MY8jlG0wSEC
-  entity_id: 7gEN7hoqAUs0fTygAXIHU
-  visualization_settings:
-    column_settings: null
-  size_y: 7
-  created_at: '2023-11-01T02:56:07.756716Z'
-  row: 6
-tabs: []
-enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-show_in_getting_started: false
 name: Dashboard overview
-caveats: null
-creator_id: internal@metabase.com
-made_public_by_id: null
-embedding_params: null
-cache_ttl: null
-serdes/meta:
-- model: Dashboard
-  id: bJEYb0o5CXlfWFcIztDwJ
-  label: dashboard_overview
-position: null
+description: Information on the performance, views, activity, and more for a particular dashboard.
 entity_id: bJEYb0o5CXlfWFcIztDwJ
+created_at: '2023-08-17T21:40:01.620493Z'
+creator_id: internal@metabase.com
+archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+auto_apply_filters: true
+cache_ttl: null
+collection_position: 5
+position: null
+enable_embedding: false
+embedding_params: null
+made_public_by_id: null
+public_uuid: null
+show_in_getting_started: false
+caveats: null
+points_of_interest: null
 parameters:
-- name: Dashboard name
-  slug: dashboard_name
-  id: c02bd3d3
-  type: string/=
-  sectionId: string
+- id: c02bd3d3
   isMultiSelect: false
-  values_source_type: card
+  name: Dashboard name
+  sectionId: string
+  slug: dashboard_name
+  type: string/=
   values_source_config:
     card_id: PkIueKBME3DfRFwBsYjuE
     value_field:
@@ -348,26 +32,342 @@ parameters:
       - v_content
       - name
     - base-type: type/Text
-- name: Dashboard ID
-  slug: dashboard_id
-  id: 4b39cd95
-  type: id
+  values_source_type: card
+- id: 4b39cd95
+  name: Dashboard ID
   sectionId: id
-- name: Group Name
-  slug: group_name
-  id: 2ea1dae2
-  type: string/=
-  sectionId: string
-  isMultiSelect: false
-  default:
+  slug: dashboard_id
+  type: id
+- default:
   - All Users
-- name: Date Filter
-  slug: date_filter
+  id: 2ea1dae2
+  isMultiSelect: false
+  name: Group Name
+  sectionId: string
+  slug: group_name
+  type: string/=
+- default: past12months~
   id: 25f8871e
-  type: date/all-options
+  name: Date Filter
   sectionId: date
-  default: past12months~
-auto_apply_filters: true
-created_at: '2023-08-17T21:40:01.620493Z'
-public_uuid: null
-points_of_interest: null
+  slug: date_filter
+  type: date/all-options
+serdes/meta:
+- id: bJEYb0o5CXlfWFcIztDwJ
+  label: dashboard_overview
+  model: Dashboard
+dashcards:
+- entity_id: 1d46RUV7YxaRBwo9Yks_6
+  card_id: W34-Nzp-T3-SPdZwGvLeB
+  created_at: '2023-08-17T21:51:54.863964Z'
+  row: 0
+  col: 0
+  size_x: 12
+  size_y: 6
+  action_id: null
+  dashboard_tab_id: null
+  parameter_mappings:
+  - card_id: W34-Nzp-T3-SPdZwGvLeB
+    parameter_id: c02bd3d3
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - name
+      - base-type: type/Text
+  - card_id: W34-Nzp-T3-SPdZwGvLeB
+    parameter_id: 4b39cd95
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - entity_id
+      - base-type: type/Integer
+  visualization_settings:
+    column_settings: null
+- entity_id: bvo3bHzsPRHm4yNdGLkRD
+  card_id: XIiIsCNMk9gg-eO2hkl8S
+  created_at: '2023-08-17T21:56:01.551685Z'
+  row: 0
+  col: 12
+  size_x: 12
+  size_y: 6
+  action_id: null
+  dashboard_tab_id: null
+  parameter_mappings:
+  - card_id: XIiIsCNMk9gg-eO2hkl8S
+    parameter_id: c02bd3d3
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - name
+      - base-type: type/Text
+        join-alias: Content - Entity Qualified
+  - card_id: XIiIsCNMk9gg-eO2hkl8S
+    parameter_id: 2ea1dae2
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_group_members
+        - group_name
+      - join-alias: Group Members - User
+  - card_id: XIiIsCNMk9gg-eO2hkl8S
+    parameter_id: 25f8871e
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - timestamp
+      - temporal-unit: default
+  - card_id: XIiIsCNMk9gg-eO2hkl8S
+    parameter_id: 4b39cd95
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - entity_id
+      - base-type: type/Integer
+        join-alias: Content - Entity Qualified
+  visualization_settings:
+    column_settings: null
+- entity_id: 8-R___ABOFNA--DmJNq_H
+  card_id: _p6UGMWOQn5-yf03uGsaN
+  created_at: '2023-08-17T22:03:45.266592Z'
+  row: 6
+  col: 12
+  size_x: 12
+  size_y: 7
+  action_id: null
+  dashboard_tab_id: null
+  parameter_mappings:
+  - card_id: _p6UGMWOQn5-yf03uGsaN
+    parameter_id: c02bd3d3
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - name
+      - base-type: type/Text
+        join-alias: Content - Entity Qualified
+  - card_id: _p6UGMWOQn5-yf03uGsaN
+    parameter_id: 2ea1dae2
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_group_members
+        - group_name
+      - join-alias: Group Members - User
+  - card_id: _p6UGMWOQn5-yf03uGsaN
+    parameter_id: 25f8871e
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - timestamp
+      - temporal-unit: default
+  - card_id: _p6UGMWOQn5-yf03uGsaN
+    parameter_id: 4b39cd95
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - entity_id
+      - base-type: type/Integer
+        join-alias: Content - Entity Qualified
+  visualization_settings:
+    column_settings: null
+- entity_id: _8MUvI8zFhQ2_vzIf5kw3
+  card_id: xrgv7nzXe_v8ORWIbq839
+  created_at: '2023-08-18T18:53:47.157159Z'
+  row: 13
+  col: 12
+  size_x: 12
+  size_y: 14
+  action_id: null
+  dashboard_tab_id: null
+  parameter_mappings:
+  - card_id: xrgv7nzXe_v8ORWIbq839
+    parameter_id: 2ea1dae2
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_group_members
+        - group_name
+      - join-alias: Question 34
+  - card_id: xrgv7nzXe_v8ORWIbq839
+    parameter_id: 25f8871e
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_audit_log
+        - timestamp
+      - base-type: type/DateTimeWithLocalTZ
+        temporal-unit: default
+  - card_id: xrgv7nzXe_v8ORWIbq839
+    parameter_id: 4b39cd95
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - entity_id
+      - base-type: type/Integer
+        join-alias: Question 35
+  - card_id: xrgv7nzXe_v8ORWIbq839
+    parameter_id: c02bd3d3
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - name
+      - base-type: type/Text
+        join-alias: Question 35
+  visualization_settings:
+    column_settings: null
+- entity_id: cKFQR4ATKoLlhHiQ1Kd1b
+  card_id: Bp2r19P5a9HjDTR4-VuZa
+  created_at: '2023-11-01T02:17:51.755215Z'
+  row: 27
+  col: 0
+  size_x: 24
+  size_y: 7
+  action_id: null
+  dashboard_tab_id: null
+  parameter_mappings:
+  - card_id: Bp2r19P5a9HjDTR4-VuZa
+    parameter_id: c02bd3d3
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - name
+      - base-type: type/Text
+        join-alias: Content - Dashboard Qualified
+  - card_id: Bp2r19P5a9HjDTR4-VuZa
+    parameter_id: 4b39cd95
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - entity_id
+      - base-type: type/Integer
+        join-alias: Content - Dashboard Qualified
+  visualization_settings:
+    column_settings: null
+- entity_id: U1rsHOTwmxXbOTsfOixVj
+  card_id: yVr4oMzxq8BPWf5HLbdwL
+  created_at: '2023-11-01T02:30:58.105138Z'
+  row: 13
+  col: 0
+  size_x: 12
+  size_y: 14
+  action_id: null
+  dashboard_tab_id: null
+  parameter_mappings:
+  - card_id: yVr4oMzxq8BPWf5HLbdwL
+    parameter_id: 4b39cd95
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - entity_id
+      - base-type: type/Integer
+        join-alias: Content - Dashboard Qualified
+  - card_id: yVr4oMzxq8BPWf5HLbdwL
+    parameter_id: c02bd3d3
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - name
+      - base-type: type/Text
+        join-alias: Content - Dashboard Qualified
+  visualization_settings:
+    column_settings: null
+- entity_id: 7gEN7hoqAUs0fTygAXIHU
+  card_id: -_XgVaPuz7MY8jlG0wSEC
+  created_at: '2023-11-01T02:56:07.756716Z'
+  row: 6
+  col: 0
+  size_x: 12
+  size_y: 7
+  action_id: null
+  dashboard_tab_id: null
+  parameter_mappings:
+  - card_id: -_XgVaPuz7MY8jlG0wSEC
+    parameter_id: c02bd3d3
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - name
+      - source-field:
+        - Internal Metabase Database
+        - public
+        - v_query_log
+        - dashboard_qualified_id
+  - card_id: -_XgVaPuz7MY8jlG0wSEC
+    parameter_id: 4b39cd95
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - entity_id
+      - source-field:
+        - Internal Metabase Database
+        - public
+        - v_query_log
+        - dashboard_qualified_id
+  - card_id: -_XgVaPuz7MY8jlG0wSEC
+    parameter_id: 25f8871e
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_query_log
+        - started_at
+      - temporal-unit: default
+  visualization_settings:
+    column_settings: null
+tabs: []

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/dashboards/jm7KgY6IuS6pQjkBZ7WUI_question_overview.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/dashboards/jm7KgY6IuS6pQjkBZ7WUI_question_overview.yaml
@@ -1,14 +1,45 @@
+name: Question overview
 description: Views, performance, activity, and other data for a particular question.
+entity_id: jm7KgY6IuS6pQjkBZ7WUI
+created_at: '2023-06-15T19:16:35.989393Z'
+creator_id: internal@metabase.com
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+auto_apply_filters: true
+cache_ttl: null
 collection_position: 6
+position: null
+enable_embedding: false
+embedding_params: null
+made_public_by_id: null
+public_uuid: null
+show_in_getting_started: false
+caveats: null
+points_of_interest: null
+parameters:
+- id: 81d22d7f
+  isMultiSelect: false
+  name: Question ID
+  sectionId: id
+  slug: question_id
+  type: id
+serdes/meta:
+- id: jm7KgY6IuS6pQjkBZ7WUI
+  label: question_overview
+  model: Dashboard
 dashcards:
-- size_x: 12
-  dashboard_tab_id: null
-  action_id: null
+- entity_id: ejJ8SwwOs7vpmHsgPqq0r
+  card_id: XLzhOnMmk3DkefFAMx_Vg
+  created_at: '2023-11-01T02:34:20.626451Z'
+  row: 0
   col: 0
+  size_x: 12
+  size_y: 7
+  action_id: null
+  dashboard_tab_id: null
   parameter_mappings:
-  - parameter_id: 81d22d7f
-    card_id: XLzhOnMmk3DkefFAMx_Vg
+  - card_id: XLzhOnMmk3DkefFAMx_Vg
+    parameter_id: 81d22d7f
     target:
     - dimension
     - - field
@@ -17,20 +48,20 @@ dashcards:
         - v_content
         - entity_id
       - base-type: type/Integer
-  card_id: XLzhOnMmk3DkefFAMx_Vg
-  entity_id: ejJ8SwwOs7vpmHsgPqq0r
   visualization_settings:
     column_settings: null
-  size_y: 7
-  created_at: '2023-11-01T02:34:20.626451Z'
+- entity_id: jeaMN8dAMxu8cQrKT28nz
+  card_id: 613VT_7b325t9FBAJZcU8
+  created_at: '2023-11-01T02:35:42.541237Z'
   row: 0
-- size_x: 12
-  dashboard_tab_id: null
-  action_id: null
   col: 12
+  size_x: 12
+  size_y: 7
+  action_id: null
+  dashboard_tab_id: null
   parameter_mappings:
-  - parameter_id: 81d22d7f
-    card_id: 613VT_7b325t9FBAJZcU8
+  - card_id: 613VT_7b325t9FBAJZcU8
+    parameter_id: 81d22d7f
     target:
     - dimension
     - - field
@@ -40,20 +71,20 @@ dashcards:
         - entity_id
       - base-type: type/Integer
         join-alias: Content - Entity Qualified
-  card_id: 613VT_7b325t9FBAJZcU8
-  entity_id: jeaMN8dAMxu8cQrKT28nz
   visualization_settings:
     column_settings: null
-  size_y: 7
-  created_at: '2023-11-01T02:35:42.541237Z'
-  row: 0
-- size_x: 12
-  dashboard_tab_id: null
-  action_id: null
+- entity_id: ZW-Zh5fCsudRWuc_5-ebV
+  card_id: vrez-ciNppijhELOxLJOY
+  created_at: '2023-11-01T02:41:00.615638Z'
+  row: 13
   col: 0
+  size_x: 12
+  size_y: 8
+  action_id: null
+  dashboard_tab_id: null
   parameter_mappings:
-  - parameter_id: 81d22d7f
-    card_id: vrez-ciNppijhELOxLJOY
+  - card_id: vrez-ciNppijhELOxLJOY
+    parameter_id: 81d22d7f
     target:
     - dimension
     - - field
@@ -63,20 +94,71 @@ dashcards:
         - entity_id
       - base-type: type/Integer
         join-alias: Content - Card Qualified
-  card_id: vrez-ciNppijhELOxLJOY
-  entity_id: ZW-Zh5fCsudRWuc_5-ebV
   visualization_settings:
-    column_settings: null
-  size_y: 12
-  created_at: '2023-11-01T02:41:00.615638Z'
-  row: 13
-- size_x: 12
-  dashboard_tab_id: null
-  action_id: null
+    column_settings:
+      ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Card Qualified"}]]'
+      : column_title: Card ID
+      ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Dashboard Qualified"}]]'
+      : column_title: Dashboard ID
+        view_as: link
+      ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Card Qualified"}]]'
+      : column_title: Question name
+      ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Dashboard Qualified"}]]'
+      : column_title: Dashboard name
+        link_text: ''
+        link_url: /dashboard/{{entity_id}}
+        view_as: link
+      '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35"}]]':
+        column_title: Question Name
+      '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"join-alias":"Question 35_2"}]]':
+        column_title: Dashboard Name
+      ? '["ref",["field",["Internal Metabase Database","public","v_dashboardcard","created_at"],{"base-type":"type/DateTimeWithLocalTZ"}]]'
+      : column_title: Added At
+    table.cell_column: name
+    table.columns:
+    - enabled: true
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_dashboardcard
+        - created_at
+      - base-type: type/DateTimeWithLocalTZ
+        temporal-unit: default
+      name: created_at
+    - enabled: true
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - name
+      - base-type: type/Text
+        join-alias: Content - Dashboard Qualified
+      name: name
+    - enabled: false
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - entity_id
+      - base-type: type/Integer
+        join-alias: Content - Card Qualified
+      name: entity_id
+    table.pivot_column: name_2
+- entity_id: t94BPUqDcK5f5_WEuTP-S
+  card_id: y-_5bBl0fXY9XlEbpJkrj
+  created_at: '2023-11-01T02:46:22.129198Z'
+  row: 7
   col: 12
+  size_x: 12
+  size_y: 6
+  action_id: null
+  dashboard_tab_id: null
   parameter_mappings:
-  - parameter_id: 81d22d7f
-    card_id: y-_5bBl0fXY9XlEbpJkrj
+  - card_id: y-_5bBl0fXY9XlEbpJkrj
+    parameter_id: 81d22d7f
     target:
     - dimension
     - - field
@@ -86,20 +168,20 @@ dashcards:
         - entity_id
       - base-type: type/Integer
         join-alias: Content - Entity Qualified
-  card_id: y-_5bBl0fXY9XlEbpJkrj
-  entity_id: t94BPUqDcK5f5_WEuTP-S
   visualization_settings:
     column_settings: null
-  size_y: 6
-  created_at: '2023-11-01T02:46:22.129198Z'
-  row: 7
-- size_x: 12
-  dashboard_tab_id: null
-  action_id: null
+- entity_id: d6fgUU6_hAqWj_ngoJea_
+  card_id: MOAq881VSlM2BhVUv5e_K
+  created_at: '2023-11-01T02:47:47.57613Z'
+  row: 13
   col: 12
+  size_x: 12
+  size_y: 8
+  action_id: null
+  dashboard_tab_id: null
   parameter_mappings:
-  - parameter_id: 81d22d7f
-    card_id: MOAq881VSlM2BhVUv5e_K
+  - card_id: MOAq881VSlM2BhVUv5e_K
+    parameter_id: 81d22d7f
     target:
     - dimension
     - - field
@@ -109,20 +191,36 @@ dashcards:
         - entity_id
       - base-type: type/Integer
         join-alias: Question 35
-  card_id: MOAq881VSlM2BhVUv5e_K
-  entity_id: d6fgUU6_hAqWj_ngoJea_
   visualization_settings:
-    column_settings: null
-  size_y: 12
-  created_at: '2023-11-01T02:47:47.57613Z'
-  row: 13
-- size_x: 24
-  dashboard_tab_id: null
-  action_id: null
+    column_settings:
+      ? '["ref",["field",["Internal Metabase Database","public","v_users","full_name"],{"base-type":"type/Text","join-alias":"Question 1"}]]'
+      : click_behavior:
+          linkType: dashboard
+          parameterMapping:
+            6b3da96f:
+              id: 6b3da96f
+              source:
+                id: user_id
+                name: Question 1 → User ID
+                type: column
+              target:
+                id: 6b3da96f
+                type: parameter
+          tabId: 1
+          targetId: DHMhMa1FYxiyIgM7_xdgR
+          type: link
+- entity_id: PljXyyyfScG10byiLANCg
+  card_id: YiHMsA2dv3iQob11DLTIz
+  created_at: '2023-11-01T02:51:46.409464Z'
+  row: 21
   col: 0
+  size_x: 24
+  size_y: 6
+  action_id: null
+  dashboard_tab_id: null
   parameter_mappings:
-  - parameter_id: 81d22d7f
-    card_id: YiHMsA2dv3iQob11DLTIz
+  - card_id: YiHMsA2dv3iQob11DLTIz
+    parameter_id: 81d22d7f
     target:
     - dimension
     - - field
@@ -132,20 +230,20 @@ dashcards:
         - entity_id
       - base-type: type/Integer
         join-alias: Content - Card Qualified
-  card_id: YiHMsA2dv3iQob11DLTIz
-  entity_id: PljXyyyfScG10byiLANCg
   visualization_settings:
     column_settings: null
-  size_y: 6
-  created_at: '2023-11-01T02:51:46.409464Z'
-  row: 25
-- size_x: 12
-  dashboard_tab_id: null
-  action_id: null
+- entity_id: 8qi2lYbU4119zouFP9f6M
+  card_id: -_XgVaPuz7MY8jlG0wSEC
+  created_at: '2023-11-01T03:01:10.764008Z'
+  row: 7
   col: 0
+  size_x: 12
+  size_y: 6
+  action_id: null
+  dashboard_tab_id: null
   parameter_mappings:
-  - parameter_id: 81d22d7f
-    card_id: -_XgVaPuz7MY8jlG0wSEC
+  - card_id: -_XgVaPuz7MY8jlG0wSEC
+    parameter_id: 81d22d7f
     target:
     - dimension
     - - field
@@ -158,37 +256,190 @@ dashcards:
         - public
         - v_query_log
         - card_qualified_id
-  card_id: -_XgVaPuz7MY8jlG0wSEC
-  entity_id: 8qi2lYbU4119zouFP9f6M
   visualization_settings:
     column_settings: null
-  size_y: 6
-  created_at: '2023-11-01T03:01:10.764008Z'
-  row: 7
+- entity_id: e_bl-8XvvXVu7iAA79eCb
+  card_id: 7FLoE9kUELG4Ess6DsSEY
+  created_at: '2023-11-13T21:40:46.417186Z'
+  row: 27
+  col: 0
+  size_x: 24
+  size_y: 8
+  action_id: null
+  dashboard_tab_id: null
+  parameter_mappings:
+  - card_id: 7FLoE9kUELG4Ess6DsSEY
+    parameter_id: 81d22d7f
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - entity_id
+      - base-type: type/Integer
+        join-alias: Content - Card Qualified
+  visualization_settings:
+    column_settings:
+      ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Card Qualified"}]]'
+      : column_title: Question ID
+      ? '["ref",["field",["Internal Metabase Database","public","v_content","entity_id"],{"base-type":"type/Integer","join-alias":"Content - Dashboard Qualified"}]]'
+      : column_title: Dashboard ID
+      ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Card Qualified"}]]'
+      : column_title: Question name
+        link_text: ''
+        link_url: /question/{{entity_id}}
+        view_as: link
+      ? '["ref",["field",["Internal Metabase Database","public","v_content","name"],{"base-type":"type/Text","join-alias":"Content - Dashboard Qualified"}]]'
+      : column_title: Dashboard name
+        link_url: /dashboard/{{entity_id_2}}
+        view_as: link
+      ? '["ref",["field",["Internal Metabase Database","public","v_databases","entity_id"],{"base-type":"type/Integer","join-alias":"Databases - Database Qualified"}]]'
+      : column_title: Database ID
+      ? '["ref",["field",["Internal Metabase Database","public","v_databases","name"],{"base-type":"type/Text","join-alias":"Databases - Database Qualified"}]]'
+      : column_title: Database name
+        link_url: /browse/{{entity_id_3}}
+        view_as: link
+      ? '["ref",["field",["Internal Metabase Database","public","v_users","full_name"],{"base-type":"type/Text","join-alias":"People - User"}]]'
+      : column_title: User name
+      ? '["ref",["field",["Internal Metabase Database","public","v_users","user_id"],{"base-type":"type/Integer","join-alias":"People - User"}]]'
+      : column_title: User ID
+    table.cell_column: running_time_seconds
+    table.columns:
+    - enabled: true
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_query_log
+        - started_at
+      - base-type: type/DateTimeWithLocalTZ
+        temporal-unit: default
+      name: started_at
+    - enabled: true
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - full_name
+      - base-type: type/Text
+        join-alias: People - User
+      name: full_name
+    - enabled: true
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_query_log
+        - query_source
+      - base-type: type/Text
+      name: query_source
+    - enabled: true
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - name
+      - base-type: type/Text
+        join-alias: Content - Card Qualified
+      name: name
+    - enabled: true
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - name
+      - base-type: type/Text
+        join-alias: Content - Dashboard Qualified
+      name: name_2
+    - enabled: false
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_databases
+        - name
+      - base-type: type/Text
+        join-alias: Databases - Database Qualified
+      name: name_3
+    - enabled: false
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_query_log
+        - is_native
+      - base-type: type/Boolean
+      name: is_native
+    - enabled: true
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_query_log
+        - running_time_seconds
+      - base-type: type/Float
+      name: running_time_seconds
+    - enabled: true
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_query_log
+        - result_rows
+      - base-type: type/Integer
+      name: result_rows
+    - enabled: false
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - entity_id
+      - base-type: type/Integer
+        join-alias: Content - Card Qualified
+      name: entity_id
+    - enabled: false
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_content
+        - entity_id
+      - base-type: type/Integer
+        join-alias: Content - Dashboard Qualified
+      name: entity_id_2
+    - enabled: false
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_databases
+        - entity_id
+      - base-type: type/Integer
+        join-alias: Databases - Database Qualified
+      name: entity_id_3
+    - enabled: true
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_query_log
+        - error
+      - base-type: type/Text
+      name: error
+    - enabled: false
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - user_id
+      - base-type: type/Integer
+        join-alias: People - User
+      name: user_id
+    table.pivot_column: error
 tabs: []
-enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-show_in_getting_started: false
-name: Question overview
-caveats: null
-creator_id: internal@metabase.com
-made_public_by_id: null
-embedding_params: null
-cache_ttl: null
-serdes/meta:
-- model: Dashboard
-  id: jm7KgY6IuS6pQjkBZ7WUI
-  label: question_overview
-position: null
-entity_id: jm7KgY6IuS6pQjkBZ7WUI
-parameters:
-- name: Question ID
-  slug: question_id
-  id: 81d22d7f
-  type: id
-  sectionId: id
-  isMultiSelect: false
-auto_apply_filters: true
-created_at: '2023-06-15T19:16:35.989393Z'
-public_uuid: null
-points_of_interest: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/dashboards/vFnGZMNN2K_KW1I0B52bq_metabase_metrics.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/dashboards/vFnGZMNN2K_KW1I0B52bq_metabase_metrics.yaml
@@ -1,36 +1,53 @@
+name: Metabase metrics
 description: General information about people viewing and creating dashboards, questions, subscriptions, and alerts.
+entity_id: vFnGZMNN2K_KW1I0B52bq
+created_at: '2023-06-14T19:20:57.472354Z'
+creator_id: internal@metabase.com
 archived: false
+collection_id: vG58R8k-QddHWA7_47umn
+auto_apply_filters: true
+cache_ttl: null
 collection_position: 1
+position: null
+enable_embedding: false
+embedding_params: null
+made_public_by_id: null
+public_uuid: null
+show_in_getting_started: false
+caveats: null
+points_of_interest: null
+parameters:
+- default: past52weeks
+  id: 9112df7d
+  name: Date Filter
+  sectionId: date
+  slug: date_filter
+  type: date/all-options
+- default:
+  - All Users
+  id: ab0252fc
+  isMultiSelect: false
+  name: User Group
+  sectionId: string
+  slug: user_group
+  type: string/=
+serdes/meta:
+- id: vFnGZMNN2K_KW1I0B52bq
+  label: metabase_metrics
+  model: Dashboard
 dashcards:
-- size_x: 6
-  dashboard_tab_id: null
-  action_id: null
-  col: 0
-  parameter_mappings:
-  - parameter_id: ab0252fc
-    card_id: gYt6bo9DFKz6tSeDLxYVs
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_group_members
-        - group_name
-      - join-alias: Group Members - User
+- entity_id: Qv9D3jXGGbsyLURLlKoIG
   card_id: gYt6bo9DFKz6tSeDLxYVs
-  entity_id: Qv9D3jXGGbsyLURLlKoIG
-  visualization_settings:
-    column_settings: null
-  size_y: 3
   created_at: '2023-06-14T19:21:05.326917Z'
   row: 0
-- size_x: 6
-  dashboard_tab_id: null
+  col: 0
+  size_x: 6
+  size_y: 3
   action_id: null
-  col: 6
+  dashboard_tab_id: null
   parameter_mappings:
-  - parameter_id: ab0252fc
-    card_id: t-4MnpU-Nn7Ph9GQT6zYb
+  - card_id: gYt6bo9DFKz6tSeDLxYVs
+    parameter_id: ab0252fc
     target:
     - dimension
     - - field
@@ -39,20 +56,20 @@ dashcards:
         - v_group_members
         - group_name
       - join-alias: Group Members - User
-  card_id: t-4MnpU-Nn7Ph9GQT6zYb
-  entity_id: 8KV2R5mzQZ5ZqcSBAZhpi
   visualization_settings:
     column_settings: null
-  size_y: 3
+- entity_id: 8KV2R5mzQZ5ZqcSBAZhpi
+  card_id: t-4MnpU-Nn7Ph9GQT6zYb
   created_at: '2023-06-14T19:34:35.785887Z'
   row: 0
-- size_x: 12
-  dashboard_tab_id: null
+  col: 6
+  size_x: 6
+  size_y: 3
   action_id: null
-  col: 12
+  dashboard_tab_id: null
   parameter_mappings:
-  - parameter_id: ab0252fc
-    card_id: kd1-A_wWOvlSuLDTFUpyb
+  - card_id: t-4MnpU-Nn7Ph9GQT6zYb
+    parameter_id: ab0252fc
     target:
     - dimension
     - - field
@@ -61,31 +78,20 @@ dashcards:
         - v_group_members
         - group_name
       - join-alias: Group Members - User
-  - parameter_id: 9112df7d
-    card_id: kd1-A_wWOvlSuLDTFUpyb
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - timestamp
-      - base-type: type/DateTimeWithLocalTZ
-        temporal-unit: default
-  card_id: kd1-A_wWOvlSuLDTFUpyb
-  entity_id: eMu8T8shqP6OiB_orPQb8
   visualization_settings:
     column_settings: null
-  size_y: 7
+- entity_id: eMu8T8shqP6OiB_orPQb8
+  card_id: kd1-A_wWOvlSuLDTFUpyb
   created_at: '2023-06-14T19:38:20.75091Z'
   row: 3
-- size_x: 12
-  dashboard_tab_id: null
+  col: 12
+  size_x: 12
+  size_y: 7
   action_id: null
-  col: 0
+  dashboard_tab_id: null
   parameter_mappings:
-  - parameter_id: ab0252fc
-    card_id: p8ZML2ebd3ItzCyWsKXLa
+  - card_id: kd1-A_wWOvlSuLDTFUpyb
+    parameter_id: ab0252fc
     target:
     - dimension
     - - field
@@ -94,8 +100,8 @@ dashcards:
         - v_group_members
         - group_name
       - join-alias: Group Members - User
-  - parameter_id: 9112df7d
-    card_id: p8ZML2ebd3ItzCyWsKXLa
+  - card_id: kd1-A_wWOvlSuLDTFUpyb
+    parameter_id: 9112df7d
     target:
     - dimension
     - - field
@@ -105,20 +111,20 @@ dashcards:
         - timestamp
       - base-type: type/DateTimeWithLocalTZ
         temporal-unit: default
-  card_id: p8ZML2ebd3ItzCyWsKXLa
-  entity_id: vIa5qU52qmci1wnR4rYWm
   visualization_settings:
     column_settings: null
-  size_y: 7
+- entity_id: vIa5qU52qmci1wnR4rYWm
+  card_id: p8ZML2ebd3ItzCyWsKXLa
   created_at: '2023-06-14T19:39:23.643935Z'
   row: 3
-- size_x: 4
-  dashboard_tab_id: null
+  col: 0
+  size_x: 12
+  size_y: 7
   action_id: null
-  col: 12
+  dashboard_tab_id: null
   parameter_mappings:
-  - parameter_id: ab0252fc
-    card_id: DnNyT6EtIn-Zx8bHRFHbV
+  - card_id: p8ZML2ebd3ItzCyWsKXLa
+    parameter_id: ab0252fc
     target:
     - dimension
     - - field
@@ -126,21 +132,32 @@ dashcards:
         - public
         - v_group_members
         - group_name
-      - join-alias: Question 34
-  card_id: DnNyT6EtIn-Zx8bHRFHbV
-  entity_id: cbYziqfyj3Vo_-TDwjB_y
+      - join-alias: Group Members - User
+  - card_id: p8ZML2ebd3ItzCyWsKXLa
+    parameter_id: 9112df7d
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - timestamp
+      - base-type: type/DateTimeWithLocalTZ
+        temporal-unit: default
   visualization_settings:
     column_settings: null
-  size_y: 3
+- entity_id: cbYziqfyj3Vo_-TDwjB_y
+  card_id: DnNyT6EtIn-Zx8bHRFHbV
   created_at: '2023-06-14T19:51:12.234537Z'
   row: 0
-- size_x: 4
-  dashboard_tab_id: null
+  col: 12
+  size_x: 4
+  size_y: 3
   action_id: null
-  col: 16
+  dashboard_tab_id: null
   parameter_mappings:
-  - parameter_id: ab0252fc
-    card_id: G7fFejjb7cgwYlUXSvf3K
+  - card_id: DnNyT6EtIn-Zx8bHRFHbV
+    parameter_id: ab0252fc
     target:
     - dimension
     - - field
@@ -149,20 +166,20 @@ dashcards:
         - v_group_members
         - group_name
       - join-alias: Question 34
-  card_id: G7fFejjb7cgwYlUXSvf3K
-  entity_id: ttTLsz8CSqwKhpabUPhX4
   visualization_settings:
     column_settings: null
-  size_y: 3
+- entity_id: ttTLsz8CSqwKhpabUPhX4
+  card_id: G7fFejjb7cgwYlUXSvf3K
   created_at: '2023-06-14T19:54:37.614341Z'
   row: 0
-- size_x: 4
-  dashboard_tab_id: null
+  col: 16
+  size_x: 4
+  size_y: 3
   action_id: null
-  col: 20
+  dashboard_tab_id: null
   parameter_mappings:
-  - parameter_id: ab0252fc
-    card_id: ybsNZp-876qEMoA1U51dc
+  - card_id: G7fFejjb7cgwYlUXSvf3K
+    parameter_id: ab0252fc
     target:
     - dimension
     - - field
@@ -171,119 +188,20 @@ dashcards:
         - v_group_members
         - group_name
       - join-alias: Question 34
-  card_id: ybsNZp-876qEMoA1U51dc
-  entity_id: KOytsZjicYh1zDDRGbzeM
   visualization_settings:
     column_settings: null
-  size_y: 3
+- entity_id: KOytsZjicYh1zDDRGbzeM
+  card_id: ybsNZp-876qEMoA1U51dc
   created_at: '2023-06-14T19:55:41.37213Z'
   row: 0
-- size_x: 12
-  dashboard_tab_id: null
+  col: 20
+  size_x: 4
+  size_y: 3
   action_id: null
-  col: 0
-  parameter_mappings:
-  - parameter_id: ab0252fc
-    card_id: fBr2cU-86t14YWbaS3r6-
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_group_members
-        - group_name
-      - join-alias: Group Members - User
-  - parameter_id: 9112df7d
-    card_id: fBr2cU-86t14YWbaS3r6-
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - timestamp
-      - base-type: type/DateTimeWithLocalTZ
-        temporal-unit: default
-  card_id: fBr2cU-86t14YWbaS3r6-
-  entity_id: GlI9CJywLBzdGgNkmhVWn
-  visualization_settings:
-    column_settings: null
-  size_y: 8
-  created_at: '2023-06-14T20:01:45.178516Z'
-  row: 17
-- size_x: 12
   dashboard_tab_id: null
-  action_id: null
-  col: 12
   parameter_mappings:
-  - parameter_id: ab0252fc
-    card_id: T1vsVJUAfg30Fqiw4Dywa
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_group_members
-        - group_name
-      - join-alias: Group Members - User
-  - parameter_id: 9112df7d
-    card_id: T1vsVJUAfg30Fqiw4Dywa
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - timestamp
-      - base-type: type/DateTimeWithLocalTZ
-        temporal-unit: default
-  card_id: T1vsVJUAfg30Fqiw4Dywa
-  entity_id: 9QohNXoERBN4aKd--9LS7
-  visualization_settings:
-    column_settings: null
-  size_y: 8
-  created_at: '2023-06-14T20:04:21.059679Z'
-  row: 17
-- size_x: 12
-  dashboard_tab_id: null
-  action_id: null
-  col: 0
-  parameter_mappings:
-  - parameter_id: ab0252fc
-    card_id: FUuJSuFo7wM6EoddmNsHf
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_group_members
-        - group_name
-      - join-alias: Group Members - User
-  - parameter_id: 9112df7d
-    card_id: FUuJSuFo7wM6EoddmNsHf
-    target:
-    - dimension
-    - - field
-      - - Internal Metabase Database
-        - public
-        - v_view_log
-        - timestamp
-      - base-type: type/DateTimeWithLocalTZ
-        temporal-unit: default
-  card_id: FUuJSuFo7wM6EoddmNsHf
-  entity_id: Z4dzLFWHFKEEymbqcM2PA
-  visualization_settings:
-    column_settings: null
-  size_y: 7
-  created_at: '2023-06-15T02:19:50.336395Z'
-  row: 10
-- size_x: 12
-  dashboard_tab_id: null
-  action_id: null
-  col: 12
-  parameter_mappings:
-  - parameter_id: ab0252fc
-    card_id: p-z74CSp1IOs1rXwAcwcS
+  - card_id: ybsNZp-876qEMoA1U51dc
+    parameter_id: ab0252fc
     target:
     - dimension
     - - field
@@ -292,8 +210,161 @@ dashcards:
         - v_group_members
         - group_name
       - join-alias: Question 34
-  - parameter_id: 9112df7d
-    card_id: p-z74CSp1IOs1rXwAcwcS
+  visualization_settings:
+    column_settings: null
+- entity_id: GlI9CJywLBzdGgNkmhVWn
+  card_id: fBr2cU-86t14YWbaS3r6-
+  created_at: '2023-06-14T20:01:45.178516Z'
+  row: 17
+  col: 0
+  size_x: 12
+  size_y: 8
+  action_id: null
+  dashboard_tab_id: null
+  parameter_mappings:
+  - card_id: fBr2cU-86t14YWbaS3r6-
+    parameter_id: ab0252fc
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_group_members
+        - group_name
+      - join-alias: Group Members - User
+  - card_id: fBr2cU-86t14YWbaS3r6-
+    parameter_id: 9112df7d
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - timestamp
+      - base-type: type/DateTimeWithLocalTZ
+        temporal-unit: default
+  visualization_settings:
+    column_settings: null
+- entity_id: 9QohNXoERBN4aKd--9LS7
+  card_id: T1vsVJUAfg30Fqiw4Dywa
+  created_at: '2023-06-14T20:04:21.059679Z'
+  row: 17
+  col: 12
+  size_x: 12
+  size_y: 8
+  action_id: null
+  dashboard_tab_id: null
+  parameter_mappings:
+  - card_id: T1vsVJUAfg30Fqiw4Dywa
+    parameter_id: ab0252fc
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_group_members
+        - group_name
+      - join-alias: Group Members - User
+  - card_id: T1vsVJUAfg30Fqiw4Dywa
+    parameter_id: 9112df7d
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - timestamp
+      - base-type: type/DateTimeWithLocalTZ
+        temporal-unit: default
+  visualization_settings:
+    column_settings: null
+- entity_id: Z4dzLFWHFKEEymbqcM2PA
+  card_id: FUuJSuFo7wM6EoddmNsHf
+  created_at: '2023-06-15T02:19:50.336395Z'
+  row: 10
+  col: 0
+  size_x: 12
+  size_y: 7
+  action_id: null
+  dashboard_tab_id: null
+  parameter_mappings:
+  - card_id: FUuJSuFo7wM6EoddmNsHf
+    parameter_id: ab0252fc
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_group_members
+        - group_name
+      - join-alias: Group Members - User
+  - card_id: FUuJSuFo7wM6EoddmNsHf
+    parameter_id: 9112df7d
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - timestamp
+      - base-type: type/DateTimeWithLocalTZ
+        temporal-unit: default
+  visualization_settings:
+    column_settings:
+      '["name","count"]':
+        column_title: Question views
+        show_mini_bar: true
+      ? '["ref",["field",["Internal Metabase Database","public","v_users","full_name"],{"base-type":"type/Text","join-alias":"Question 1"}]]'
+      : column_title: User
+    table.cell_column: model_id
+    table.columns:
+    - enabled: true
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_users
+        - full_name
+      - base-type: type/Text
+        join-alias: People - User
+      name: full_name
+    - enabled: false
+      fieldRef:
+      - field
+      - - Internal Metabase Database
+        - public
+        - v_view_log
+        - user_id
+      - base-type: type/Integer
+      name: user_id
+    - enabled: true
+      fieldRef:
+      - aggregation
+      - 0
+      name: count
+    table.pivot_column: end_timestamp
+- entity_id: _iLvtXz7cnTL6NrcNxEtQ
+  card_id: p-z74CSp1IOs1rXwAcwcS
+  created_at: '2023-06-15T02:23:27.106361Z'
+  row: 10
+  col: 12
+  size_x: 12
+  size_y: 7
+  action_id: null
+  dashboard_tab_id: null
+  parameter_mappings:
+  - card_id: p-z74CSp1IOs1rXwAcwcS
+    parameter_id: ab0252fc
+    target:
+    - dimension
+    - - field
+      - - Internal Metabase Database
+        - public
+        - v_group_members
+        - group_name
+      - join-alias: Question 34
+  - card_id: p-z74CSp1IOs1rXwAcwcS
+    parameter_id: 9112df7d
     target:
     - dimension
     - - field
@@ -303,45 +374,6 @@ dashcards:
         - timestamp
       - base-type: type/DateTimeWithLocalTZ
         temporal-unit: default
-  card_id: p-z74CSp1IOs1rXwAcwcS
-  entity_id: _iLvtXz7cnTL6NrcNxEtQ
   visualization_settings:
     column_settings: null
-  size_y: 7
-  created_at: '2023-06-15T02:23:27.106361Z'
-  row: 10
 tabs: []
-enable_embedding: false
-collection_id: vG58R8k-QddHWA7_47umn
-show_in_getting_started: false
-name: Metabase metrics
-caveats: null
-creator_id: internal@metabase.com
-made_public_by_id: null
-embedding_params: null
-cache_ttl: null
-serdes/meta:
-- model: Dashboard
-  id: vFnGZMNN2K_KW1I0B52bq
-  label: metabase_metrics
-position: null
-entity_id: vFnGZMNN2K_KW1I0B52bq
-parameters:
-- name: Date Filter
-  slug: date_filter
-  id: 9112df7d
-  type: date/all-options
-  sectionId: date
-  default: past52weeks
-- name: User Group
-  slug: user_group
-  id: ab0252fc
-  type: string/=
-  sectionId: string
-  isMultiSelect: false
-  default:
-  - All Users
-auto_apply_filters: true
-created_at: '2023-06-14T19:20:57.472354Z'
-public_uuid: null
-points_of_interest: null

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/vG58R8k-QddHWA7_47umn_metabase_analytics.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/vG58R8k-QddHWA7_47umn_metabase_analytics.yaml
@@ -1,15 +1,15 @@
-authority_level: null
-description: Your instance data. To customize these questions and dashboards, you can duplicate them and save them in the custom reports collection.
-archived: false
-slug: metabase_analytics
 name: Metabase analytics
-personal_owner_id: null
-type: instance-analytics
-parent_id: null
-serdes/meta:
-- model: Collection
-  id: vG58R8k-QddHWA7_47umn
-  label: metabase_analytics
+description: Your instance data. To customize these questions and dashboards, you can duplicate them and save them in the custom reports collection.
 entity_id: vG58R8k-QddHWA7_47umn
-namespace: "analytics"
+slug: metabase_analytics
 created_at: '2023-06-08T14:12:32.4457Z'
+archived: false
+parent_id: null
+personal_owner_id: null
+namespace: "analytics"
+type: instance-analytics
+authority_level: null
+serdes/meta:
+- id: vG58R8k-QddHWA7_47umn
+  label: metabase_analytics
+  model: Collection

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/alert_condition.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/alert_condition.yaml
@@ -1,39 +1,39 @@
+name: alert_condition
+display_name: Alert Condition
 description: null
-database_type: varchar
-semantic_type: type/Category
+created_at: '2023-11-01T02:10:34.168342Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: alert_condition
+preview_display: true
+position: 7
+custom_position: 0
+database_position: 7
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts
-- model: Field
-  id: alert_condition
-database_is_auto_increment: false
-json_unfolding: false
-position: 7
-visibility_type: normal
-preview_display: true
-display_name: Alert Condition
-database_position: 7
-database_required: false
-created_at: '2023-11-01T02:10:34.168342Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts
+  model: Table
+- id: alert_condition
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/archived.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/archived.yaml
@@ -1,39 +1,39 @@
+name: archived
+display_name: Archived
 description: null
-database_type: bool
-semantic_type: type/Category
+created_at: '2023-11-01T02:10:34.168342Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts
+database_type: bool
+base_type: type/Boolean
+effective_type: type/Boolean
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: archived
+preview_display: true
+position: 11
+custom_position: 0
+database_position: 11
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Boolean
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts
-- model: Field
-  id: archived
-database_is_auto_increment: false
-json_unfolding: false
-position: 11
-visibility_type: normal
-preview_display: true
-display_name: Archived
-database_position: 11
-database_required: false
-created_at: '2023-11-01T02:10:34.168342Z'
-base_type: type/Boolean
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts
+  model: Table
+- id: archived
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/card_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/card_id.yaml
@@ -1,39 +1,39 @@
+name: card_id
+display_name: Card ID
 description: null
-database_type: int4
-semantic_type: null
+created_at: '2023-11-01T02:10:34.168342Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: card_id
+preview_display: true
+position: 5
+custom_position: 0
+database_position: 5
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts
-- model: Field
-  id: card_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 5
-visibility_type: normal
-preview_display: true
-display_name: Card ID
-database_position: 5
-database_required: false
-created_at: '2023-11-01T02:10:34.168342Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts
+  model: Table
+- id: card_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/card_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/card_qualified_id.yaml
@@ -1,43 +1,43 @@
+name: card_qualified_id
+display_name: Card Qualified ID
 description: null
-database_type: text
-semantic_type: type/FK
+created_at: '2023-11-01T02:10:34.168342Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts
-coercion_strategy: null
-name: card_qualified_id
-has_field_values: auto-list
-settings: null
-caveats: null
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
 fk_target_field_id:
 - Internal Metabase Database
 - public
 - v_content
 - entity_qualified_id
 dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts
-- model: Field
-  id: card_qualified_id
-database_is_auto_increment: false
 json_unfolding: false
-position: 6
-visibility_type: normal
+parent_id: null
+coercion_strategy: null
 preview_display: true
-display_name: Card Qualified ID
+position: 6
+custom_position: 0
 database_position: 6
-database_required: false
-created_at: '2023-11-01T02:10:34.168342Z'
-base_type: type/Text
+has_field_values: auto-list
+settings: null
+caveats: null
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts
+  model: Table
+- id: card_qualified_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/created_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/created_at.yaml
@@ -1,39 +1,39 @@
+name: created_at
+display_name: Created At
 description: null
-database_type: timestamptz
-semantic_type: type/CreationTimestamp
+created_at: '2023-11-01T02:10:34.168342Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts
+database_type: timestamptz
+base_type: type/DateTimeWithLocalTZ
+effective_type: type/DateTimeWithLocalTZ
+semantic_type: type/CreationTimestamp
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: created_at
+preview_display: true
+position: 2
+custom_position: 0
+database_position: 2
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/DateTimeWithLocalTZ
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts
-- model: Field
-  id: created_at
-database_is_auto_increment: false
-json_unfolding: false
-position: 2
-visibility_type: normal
-preview_display: true
-display_name: Created At
-database_position: 2
-database_required: false
-created_at: '2023-11-01T02:10:34.168342Z'
-base_type: type/DateTimeWithLocalTZ
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts
+  model: Table
+- id: created_at
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/creator_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/creator_id.yaml
@@ -1,43 +1,43 @@
+name: creator_id
+display_name: Creator ID
 description: null
-database_type: int4
-semantic_type: type/FK
+created_at: '2023-11-01T02:10:34.168342Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts
-coercion_strategy: null
-name: creator_id
-has_field_values: auto-list
-settings: null
-caveats: null
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
 fk_target_field_id:
 - Internal Metabase Database
 - public
 - v_users
 - user_id
 dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts
-- model: Field
-  id: creator_id
-database_is_auto_increment: false
 json_unfolding: false
-position: 4
-visibility_type: normal
+parent_id: null
+coercion_strategy: null
 preview_display: true
-display_name: Creator ID
+position: 4
+custom_position: 0
 database_position: 4
-database_required: false
-created_at: '2023-11-01T02:10:34.168342Z'
-base_type: type/Integer
+has_field_values: auto-list
+settings: null
+caveats: null
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts
+  model: Table
+- id: creator_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/dashboard_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/dashboard_qualified_id.yaml
@@ -1,39 +1,39 @@
+name: dashboard_qualified_id
+display_name: Dashboard Qualified ID
 description: null
-database_type: text
-semantic_type: null
+created_at: '2023-11-01T02:10:34.168342Z'
+active: false
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: dashboard_qualified_id
+preview_display: true
+position: 12
+custom_position: 0
+database_position: 12
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: false
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts
-- model: Field
-  id: dashboard_qualified_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 12
-visibility_type: normal
-preview_display: true
-display_name: Dashboard Qualified ID
-database_position: 12
-database_required: false
-created_at: '2023-11-01T02:10:34.168342Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts
+  model: Table
+- id: dashboard_qualified_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/entity_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/entity_id.yaml
@@ -1,39 +1,39 @@
+name: entity_id
+display_name: Entity ID
 description: null
-database_type: int4
-semantic_type: type/PK
+created_at: '2023-11-01T02:10:34.168342Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_id
+preview_display: true
+position: 0
+custom_position: 0
+database_position: 0
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts
-- model: Field
-  id: entity_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 0
-visibility_type: normal
-preview_display: true
-display_name: Entity ID
-database_position: 0
-database_required: false
-created_at: '2023-11-01T02:10:34.168342Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts
+  model: Table
+- id: entity_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/entity_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/entity_qualified_id.yaml
@@ -1,39 +1,39 @@
+name: entity_qualified_id
+display_name: Entity Qualified ID
 description: null
-database_type: text
-semantic_type: type/PK
+created_at: '2023-11-01T02:10:34.168342Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_qualified_id
+preview_display: true
+position: 1
+custom_position: 0
+database_position: 1
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts
-- model: Field
-  id: entity_qualified_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 1
-visibility_type: normal
-preview_display: true
-display_name: Entity Qualified ID
-database_position: 1
-database_required: false
-created_at: '2023-11-01T02:10:34.168342Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts
+  model: Table
+- id: entity_qualified_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/recipient_external.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/recipient_external.yaml
@@ -1,39 +1,39 @@
+name: recipient_external
+display_name: Recipient External
 description: null
-database_type: text
-semantic_type: type/Category
+created_at: '2023-11-01T02:10:34.168342Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: recipient_external
+preview_display: true
+position: 14
+custom_position: 0
+database_position: 14
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts
-- model: Field
-  id: recipient_external
-database_is_auto_increment: false
-json_unfolding: false
-position: 14
-visibility_type: normal
-preview_display: true
-display_name: Recipient External
-database_position: 14
-database_required: false
-created_at: '2023-11-01T02:10:34.168342Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts
+  model: Table
+- id: recipient_external
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/recipient_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/recipient_type.yaml
@@ -1,39 +1,39 @@
+name: recipient_type
+display_name: Recipient Type
 description: null
-database_type: varchar
-semantic_type: type/Category
+created_at: '2023-11-01T02:10:34.168342Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: recipient_type
+preview_display: true
+position: 12
+custom_position: 0
+database_position: 12
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts
-- model: Field
-  id: recipient_type
-database_is_auto_increment: false
-json_unfolding: false
-position: 12
-visibility_type: normal
-preview_display: true
-display_name: Recipient Type
-database_position: 12
-database_required: false
-created_at: '2023-11-01T02:10:34.168342Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts
+  model: Table
+- id: recipient_type
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/recipients.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/recipients.yaml
@@ -1,39 +1,39 @@
+name: recipients
+display_name: Recipients
 description: null
-database_type: text
-semantic_type: type/Category
+created_at: '2023-11-01T02:10:34.168342Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: recipients
+preview_display: true
+position: 13
+custom_position: 0
+database_position: 13
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts
-- model: Field
-  id: recipients
-database_is_auto_increment: false
-json_unfolding: false
-position: 13
-visibility_type: normal
-preview_display: true
-display_name: Recipients
-database_position: 13
-database_required: false
-created_at: '2023-11-01T02:10:34.168342Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts
+  model: Table
+- id: recipients
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/schedule_day.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/schedule_day.yaml
@@ -1,39 +1,39 @@
+name: schedule_day
+display_name: Schedule Day
 description: null
-database_type: varchar
-semantic_type: type/Category
+created_at: '2023-11-01T02:10:34.168342Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: schedule_day
+preview_display: true
+position: 9
+custom_position: 0
+database_position: 9
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts
-- model: Field
-  id: schedule_day
-database_is_auto_increment: false
-json_unfolding: false
-position: 9
-visibility_type: normal
-preview_display: true
-display_name: Schedule Day
-database_position: 9
-database_required: false
-created_at: '2023-11-01T02:10:34.168342Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts
+  model: Table
+- id: schedule_day
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/schedule_hour.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/schedule_hour.yaml
@@ -1,39 +1,39 @@
+name: schedule_hour
+display_name: Schedule Hour
 description: null
-database_type: int4
-semantic_type: type/Category
+created_at: '2023-11-01T02:10:34.168342Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: schedule_hour
+preview_display: true
+position: 10
+custom_position: 0
+database_position: 10
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts
-- model: Field
-  id: schedule_hour
-database_is_auto_increment: false
-json_unfolding: false
-position: 10
-visibility_type: normal
-preview_display: true
-display_name: Schedule Hour
-database_position: 10
-database_required: false
-created_at: '2023-11-01T02:10:34.168342Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts
+  model: Table
+- id: schedule_hour
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/schedule_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/schedule_type.yaml
@@ -1,39 +1,39 @@
+name: schedule_type
+display_name: Schedule Type
 description: null
-database_type: varchar
-semantic_type: type/Category
+created_at: '2023-11-01T02:10:34.168342Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: schedule_type
+preview_display: true
+position: 8
+custom_position: 0
+database_position: 8
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts
-- model: Field
-  id: schedule_type
-database_is_auto_increment: false
-json_unfolding: false
-position: 8
-visibility_type: normal
-preview_display: true
-display_name: Schedule Type
-database_position: 8
-database_required: false
-created_at: '2023-11-01T02:10:34.168342Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts
+  model: Table
+- id: schedule_type
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/updated_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/updated_at.yaml
@@ -1,39 +1,39 @@
+name: updated_at
+display_name: Updated At
 description: null
-database_type: timestamptz
-semantic_type: type/UpdatedTimestamp
+created_at: '2023-11-01T02:10:34.168342Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts
+database_type: timestamptz
+base_type: type/DateTimeWithLocalTZ
+effective_type: type/DateTimeWithLocalTZ
+semantic_type: type/UpdatedTimestamp
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: updated_at
+preview_display: true
+position: 3
+custom_position: 0
+database_position: 3
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/DateTimeWithLocalTZ
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts
-- model: Field
-  id: updated_at
-database_is_auto_increment: false
-json_unfolding: false
-position: 3
-visibility_type: normal
-preview_display: true
-display_name: Updated At
-database_position: 3
-database_required: false
-created_at: '2023-11-01T02:10:34.168342Z'
-base_type: type/DateTimeWithLocalTZ
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts
+  model: Table
+- id: updated_at
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/v_alerts.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/v_alerts.yaml
@@ -1,22 +1,22 @@
-description: null
-entity_type: entity/GenericTable
-schema: public
-show_in_getting_started: false
 name: v_alerts
-caveats: null
-active: true
-db_id: Internal Metabase Database
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts
-visibility_type: null
-field_order: database
-is_upload: false
-initial_sync_status: complete
 display_name: V Alerts
+description: null
 created_at: '2023-11-01T02:10:33.263249Z'
+db_id: Internal Metabase Database
+schema: public
+entity_type: entity/GenericTable
+active: true
+is_upload: false
+field_order: database
+visibility_type: null
+show_in_getting_started: false
+initial_sync_status: complete
 points_of_interest: null
+caveats: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts
+  model: Table

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/action_model_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/action_model_id.yaml
@@ -1,39 +1,39 @@
+name: action_model_id
+display_name: Action Model ID
 description: null
-database_type: text
-semantic_type: null
+created_at: '2023-06-08T14:05:44.460794Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts_subscriptions
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: action_model_id
+preview_display: true
+position: 12
+custom_position: 0
+database_position: 12
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: false
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts_subscriptions
-- model: Field
-  id: action_model_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 12
-visibility_type: normal
-preview_display: true
-display_name: Action Model ID
-database_position: 12
-database_required: false
-created_at: '2023-06-08T14:05:44.460794Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts_subscriptions
+  model: Table
+- id: action_model_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/action_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/action_type.yaml
@@ -1,39 +1,39 @@
+name: action_type
+display_name: Action Type
 description: null
-database_type: text
-semantic_type: type/Category
+created_at: '2023-06-08T14:05:44.460794Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts_subscriptions
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: action_type
+preview_display: true
+position: 11
+custom_position: 0
+database_position: 11
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: false
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts_subscriptions
-- model: Field
-  id: action_type
-database_is_auto_increment: false
-json_unfolding: false
-position: 11
-visibility_type: normal
-preview_display: true
-display_name: Action Type
-database_position: 11
-database_required: false
-created_at: '2023-06-08T14:05:44.460794Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts_subscriptions
+  model: Table
+- id: action_type
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/alert_question_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/alert_question_id.yaml
@@ -1,43 +1,43 @@
+name: alert_question_id
+display_name: Alert Question ID
 description: null
-database_type: int4
-semantic_type: type/FK
+created_at: '2023-06-08T14:05:44.460794Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts_subscriptions
-coercion_strategy: null
-name: alert_question_id
-has_field_values: null
-settings: null
-caveats: null
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
 fk_target_field_id:
 - Internal Metabase Database
 - public
 - v_content
 - id
 dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: false
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts_subscriptions
-- model: Field
-  id: alert_question_id
-database_is_auto_increment: false
 json_unfolding: false
-position: 15
-visibility_type: normal
+parent_id: null
+coercion_strategy: null
 preview_display: true
-display_name: Alert Question ID
+position: 15
+custom_position: 0
 database_position: 15
-database_required: false
-created_at: '2023-06-08T14:05:44.460794Z'
-base_type: type/Integer
+has_field_values: null
+settings: null
+caveats: null
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts_subscriptions
+  model: Table
+- id: alert_question_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/archived.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/archived.yaml
@@ -1,39 +1,39 @@
+name: archived
+display_name: Archived
 description: null
-database_type: bool
-semantic_type: type/Category
+created_at: '2023-06-08T14:05:44.460794Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts_subscriptions
+database_type: bool
+base_type: type/Boolean
+effective_type: type/Boolean
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: archived
+preview_display: true
+position: 9
+custom_position: 0
+database_position: 9
 has_field_values: list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Boolean
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts_subscriptions
-- model: Field
-  id: archived
-database_is_auto_increment: false
-json_unfolding: false
-position: 8
-visibility_type: normal
-preview_display: true
-display_name: Archived
-database_position: 8
-database_required: false
-created_at: '2023-06-08T14:05:44.460794Z'
-base_type: type/Boolean
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts_subscriptions
+  model: Table
+- id: archived
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/collection_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/collection_id.yaml
@@ -1,39 +1,39 @@
+name: collection_id
+display_name: Collection ID
 description: null
-database_type: int4
-semantic_type: type/Category
+created_at: '2023-06-08T14:05:44.460794Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts_subscriptions
+database_type: text
+base_type: type/Text
+effective_type: type/Integer
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: collection_id
+preview_display: true
+position: 7
+custom_position: 0
+database_position: 7
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts_subscriptions
-- model: Field
-  id: collection_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 7
-visibility_type: normal
-preview_display: true
-display_name: Collection ID
-database_position: 7
-database_required: false
-created_at: '2023-06-08T14:05:44.460794Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts_subscriptions
+  model: Table
+- id: collection_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/collection_is_personal.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/collection_is_personal.yaml
@@ -1,39 +1,39 @@
+name: collection_is_personal
+display_name: Collection Is Personal
 description: null
-database_type: text
-semantic_type: null
+created_at: '2023-06-08T14:05:44.460794Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts_subscriptions
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: collection_is_personal
+preview_display: true
+position: 13
+custom_position: 0
+database_position: 13
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: false
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts_subscriptions
-- model: Field
-  id: collection_is_personal
-database_is_auto_increment: false
-json_unfolding: false
-position: 13
-visibility_type: normal
-preview_display: true
-display_name: Collection Is Personal
-database_position: 13
-database_required: false
-created_at: '2023-06-08T14:05:44.460794Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts_subscriptions
+  model: Table
+- id: collection_is_personal
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/created_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/created_at.yaml
@@ -1,39 +1,39 @@
+name: created_at
+display_name: Created At
 description: null
-database_type: timestamptz
-semantic_type: type/CreationTimestamp
+created_at: '2023-06-08T14:05:44.460794Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts_subscriptions
+database_type: timestamptz
+base_type: type/DateTimeWithLocalTZ
+effective_type: type/DateTimeWithLocalTZ
+semantic_type: type/CreationTimestamp
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: created_at
+preview_display: true
+position: 2
+custom_position: 0
+database_position: 2
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/DateTimeWithLocalTZ
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts_subscriptions
-- model: Field
-  id: created_at
-database_is_auto_increment: false
-json_unfolding: false
-position: 3
-visibility_type: normal
-preview_display: true
-display_name: Created At
-database_position: 3
-database_required: false
-created_at: '2023-06-08T14:05:44.460794Z'
-base_type: type/DateTimeWithLocalTZ
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts_subscriptions
+  model: Table
+- id: created_at
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/creator_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/creator_id.yaml
@@ -1,43 +1,43 @@
+name: creator_id
+display_name: Creator ID
 description: null
-database_type: int4
-semantic_type: type/FK
+created_at: '2023-06-08T14:05:44.460794Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts_subscriptions
-coercion_strategy: null
-name: creator_id
-has_field_values: null
-settings: null
-caveats: null
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
 fk_target_field_id:
 - Internal Metabase Database
 - public
 - v_users
 - user_id
 dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts_subscriptions
-- model: Field
-  id: creator_id
-database_is_auto_increment: false
 json_unfolding: false
-position: 5
-visibility_type: normal
+parent_id: null
+coercion_strategy: null
 preview_display: true
-display_name: Creator ID
-database_position: 5
-database_required: false
-created_at: '2023-06-08T14:05:44.460794Z'
-base_type: type/Integer
+position: 4
+custom_position: 0
+database_position: 4
+has_field_values: null
+settings: null
+caveats: null
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts_subscriptions
+  model: Table
+- id: creator_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/description.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/description.yaml
@@ -1,39 +1,39 @@
+name: description
+display_name: Description
 description: null
-database_type: text
-semantic_type: type/Description
+created_at: '2023-06-08T14:05:44.460794Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts_subscriptions
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Description
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: description
+preview_display: true
+position: 6
+custom_position: 0
+database_position: 6
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: false
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts_subscriptions
-- model: Field
-  id: description
-database_is_auto_increment: false
-json_unfolding: false
-position: 6
-visibility_type: normal
-preview_display: true
-display_name: Description
-database_position: 6
-database_required: false
-created_at: '2023-06-08T14:05:44.460794Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts_subscriptions
+  model: Table
+- id: description
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/entity_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/entity_id.yaml
@@ -1,39 +1,39 @@
+name: entity_id
+display_name: Entity ID
 description: null
-database_type: int4
-semantic_type: type/PK
+created_at: '2023-10-31T13:16:53.841144Z'
+active: false
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts_subscriptions
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_id
+preview_display: true
+position: 0
+custom_position: 0
+database_position: 0
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts_subscriptions
-- model: Field
-  id: entity_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 0
-visibility_type: normal
-preview_display: true
-display_name: Entity ID
-database_position: 0
-database_required: false
-created_at: '2023-10-31T13:16:53.841144Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts_subscriptions
+  model: Table
+- id: entity_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/entity_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/entity_qualified_id.yaml
@@ -1,39 +1,39 @@
+name: entity_qualified_id
+display_name: Entity Qualified ID
 description: null
-database_type: text
-semantic_type: type/PK
+created_at: '2023-10-31T13:16:53.841144Z'
+active: false
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts_subscriptions
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_qualified_id
+preview_display: true
+position: 1
+custom_position: 0
+database_position: 1
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts_subscriptions
-- model: Field
-  id: entity_qualified_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 1
-visibility_type: normal
-preview_display: true
-display_name: Entity Qualified ID
-database_position: 1
-database_required: false
-created_at: '2023-10-31T13:16:53.841144Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts_subscriptions
+  model: Table
+- id: entity_qualified_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/entity_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/entity_type.yaml
@@ -1,39 +1,39 @@
+name: entity_type
+display_name: Entity Type
 description: null
-database_type: text
-semantic_type: type/Category
+created_at: '2023-06-08T14:05:44.460794Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts_subscriptions
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_type
+preview_display: true
+position: 1
+custom_position: 0
+database_position: 1
 has_field_values: list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts_subscriptions
-- model: Field
-  id: entity_type
-database_is_auto_increment: false
-json_unfolding: false
-position: 2
-visibility_type: normal
-preview_display: true
-display_name: Entity Type
-database_position: 2
-database_required: false
-created_at: '2023-06-08T14:05:44.460794Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts_subscriptions
+  model: Table
+- id: entity_type
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/id.yaml
@@ -1,39 +1,39 @@
+name: id
+display_name: ID
 description: null
-database_type: text
-semantic_type: type/PK
+created_at: '2023-06-08T14:05:44.460794Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts_subscriptions
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: id
+preview_display: true
+position: 0
+custom_position: 0
+database_position: 0
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: false
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts_subscriptions
-- model: Field
-  id: id
-database_is_auto_increment: false
-json_unfolding: false
-position: 0
-visibility_type: normal
-preview_display: true
-display_name: ID
-database_position: 0
-database_required: false
-created_at: '2023-06-08T14:05:44.460794Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts_subscriptions
+  model: Table
+- id: id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/is_official.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/is_official.yaml
@@ -1,39 +1,39 @@
+name: is_official
+display_name: Is Official
 description: null
-database_type: text
-semantic_type: null
+created_at: '2023-06-08T14:05:44.460794Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts_subscriptions
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: is_official
+preview_display: true
+position: 10
+custom_position: 0
+database_position: 10
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: false
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts_subscriptions
-- model: Field
-  id: is_official
-database_is_auto_increment: false
-json_unfolding: false
-position: 10
-visibility_type: normal
-preview_display: true
-display_name: Is Official
-database_position: 10
-database_required: false
-created_at: '2023-06-08T14:05:44.460794Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts_subscriptions
+  model: Table
+- id: is_official
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/made_public_by_user.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/made_public_by_user.yaml
@@ -1,43 +1,43 @@
+name: made_public_by_user
+display_name: Made Public By User
 description: null
-database_type: text
-semantic_type: type/FK
+created_at: '2023-06-08T14:05:44.460794Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts_subscriptions
-coercion_strategy: null
-name: made_public_by_user
-has_field_values: null
-settings: null
-caveats: null
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
 fk_target_field_id:
 - Internal Metabase Database
 - public
 - v_users
 - user_id
 dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: false
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts_subscriptions
-- model: Field
-  id: made_public_by_user
-database_is_auto_increment: false
 json_unfolding: false
-position: 8
-visibility_type: normal
+parent_id: null
+coercion_strategy: null
 preview_display: true
-display_name: Made Public By User
+position: 8
+custom_position: 0
 database_position: 8
-database_required: false
-created_at: '2023-06-08T14:05:44.460794Z'
-base_type: type/Text
+has_field_values: null
+settings: null
+caveats: null
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts_subscriptions
+  model: Table
+- id: made_public_by_user
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/name.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/name.yaml
@@ -1,39 +1,39 @@
+name: name
+display_name: Name
 description: null
-database_type: varchar
-semantic_type: type/Name
+created_at: '2023-06-08T14:05:44.460794Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts_subscriptions
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Name
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: name
+preview_display: true
+position: 5
+custom_position: 0
+database_position: 5
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts_subscriptions
-- model: Field
-  id: name
-database_is_auto_increment: false
-json_unfolding: false
-position: 6
-visibility_type: normal
-preview_display: true
-display_name: Name
-database_position: 6
-database_required: false
-created_at: '2023-06-08T14:05:44.460794Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts_subscriptions
+  model: Table
+- id: name
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/recipient_external.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/recipient_external.yaml
@@ -1,39 +1,39 @@
+name: recipient_external
+display_name: Recipient External
 description: null
-database_type: text
-semantic_type: type/Category
+created_at: '2023-06-08T14:05:44.460794Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts_subscriptions
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: recipient_external
+preview_display: true
+position: 17
+custom_position: 0
+database_position: 17
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts_subscriptions
-- model: Field
-  id: recipient_external
-database_is_auto_increment: false
-json_unfolding: false
-position: 12
-visibility_type: normal
-preview_display: true
-display_name: Recipient External
-database_position: 12
-database_required: false
-created_at: '2023-06-08T14:05:44.460794Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts_subscriptions
+  model: Table
+- id: recipient_external
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/recipient_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/recipient_type.yaml
@@ -1,39 +1,39 @@
+name: recipient_type
+display_name: Recipient Type
 description: null
-database_type: varchar
-semantic_type: type/Category
+created_at: '2023-06-08T14:05:44.460794Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts_subscriptions
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: recipient_type
+preview_display: true
+position: 16
+custom_position: 0
+database_position: 16
 has_field_values: list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts_subscriptions
-- model: Field
-  id: recipient_type
-database_is_auto_increment: false
-json_unfolding: false
-position: 10
-visibility_type: normal
-preview_display: true
-display_name: Recipient Type
-database_position: 10
-database_required: false
-created_at: '2023-06-08T14:05:44.460794Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts_subscriptions
+  model: Table
+- id: recipient_type
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/recipients.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/recipients.yaml
@@ -1,39 +1,39 @@
+name: recipients
+display_name: Recipients
 description: null
-database_type: text
-semantic_type: type/Category
+created_at: '2023-10-31T13:16:53.841144Z'
+active: false
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts_subscriptions
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: recipients
+preview_display: true
+position: 11
+custom_position: 0
+database_position: 11
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts_subscriptions
-- model: Field
-  id: recipients
-database_is_auto_increment: false
-json_unfolding: false
-position: 11
-visibility_type: normal
-preview_display: true
-display_name: Recipients
-database_position: 11
-database_required: false
-created_at: '2023-10-31T13:16:53.841144Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts_subscriptions
+  model: Table
+- id: recipients
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/subscription_dashboard_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/subscription_dashboard_id.yaml
@@ -1,43 +1,43 @@
+name: subscription_dashboard_id
+display_name: Subscription Dashboard ID
 description: null
-database_type: text
-semantic_type: type/FK
+created_at: '2023-06-08T14:05:44.460794Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts_subscriptions
-coercion_strategy: null
-name: subscription_dashboard_id
-has_field_values: null
-settings: null
-caveats: null
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
 fk_target_field_id:
 - Internal Metabase Database
 - public
 - v_content
 - id
 dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: false
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts_subscriptions
-- model: Field
-  id: subscription_dashboard_id
-database_is_auto_increment: false
 json_unfolding: false
-position: 14
-visibility_type: normal
+parent_id: null
+coercion_strategy: null
 preview_display: true
-display_name: Subscription Dashboard ID
+position: 14
+custom_position: 0
 database_position: 14
-database_required: false
-created_at: '2023-06-08T14:05:44.460794Z'
-base_type: type/Text
+has_field_values: null
+settings: null
+caveats: null
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts_subscriptions
+  model: Table
+- id: subscription_dashboard_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/tracked_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/tracked_qualified_id.yaml
@@ -1,43 +1,43 @@
+name: tracked_qualified_id
+display_name: Tracked Qualified ID
 description: null
-database_type: text
-semantic_type: type/FK
+created_at: '2023-10-31T15:02:37.442949Z'
+active: false
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts_subscriptions
-coercion_strategy: null
-name: tracked_qualified_id
-has_field_values: auto-list
-settings: null
-caveats: null
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
 fk_target_field_id:
 - Internal Metabase Database
 - public
 - v_content
 - entity_qualified_id
 dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts_subscriptions
-- model: Field
-  id: tracked_qualified_id
-database_is_auto_increment: false
 json_unfolding: false
-position: 9
-visibility_type: normal
+parent_id: null
+coercion_strategy: null
 preview_display: true
-display_name: Tracked Qualified ID
+position: 9
+custom_position: 0
 database_position: 9
-database_required: false
-created_at: '2023-10-31T15:02:37.442949Z'
-base_type: type/Text
+has_field_values: auto-list
+settings: null
+caveats: null
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts_subscriptions
+  model: Table
+- id: tracked_qualified_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/updated_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/fields/updated_at.yaml
@@ -1,39 +1,39 @@
+name: updated_at
+display_name: Updated At
 description: null
-database_type: timestamptz
-semantic_type: type/UpdatedTimestamp
+created_at: '2023-06-08T14:05:44.460794Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_alerts_subscriptions
+database_type: timestamptz
+base_type: type/DateTimeWithLocalTZ
+effective_type: type/DateTimeWithLocalTZ
+semantic_type: type/UpdatedTimestamp
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: updated_at
+preview_display: true
+position: 3
+custom_position: 0
+database_position: 3
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/DateTimeWithLocalTZ
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts_subscriptions
-- model: Field
-  id: updated_at
-database_is_auto_increment: false
-json_unfolding: false
-position: 4
-visibility_type: normal
-preview_display: true
-display_name: Updated At
-database_position: 4
-database_required: false
-created_at: '2023-06-08T14:05:44.460794Z'
-base_type: type/DateTimeWithLocalTZ
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts_subscriptions
+  model: Table
+- id: updated_at
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/v_alerts_subscriptions.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts_subscriptions/v_alerts_subscriptions.yaml
@@ -1,22 +1,22 @@
-description: null
-entity_type: entity/SubscriptionTable
-schema: public
-show_in_getting_started: false
 name: v_alerts_subscriptions
-caveats: null
-active: false
-db_id: Internal Metabase Database
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_alerts_subscriptions
-visibility_type: null
-field_order: database
-is_upload: false
-initial_sync_status: complete
 display_name: V Alerts Subscriptions
+description: null
 created_at: '2023-06-08T14:05:39.484164Z'
+db_id: Internal Metabase Database
+schema: public
+entity_type: entity/SubscriptionTable
+active: true
+is_upload: false
+field_order: database
+visibility_type: null
+show_in_getting_started: false
+initial_sync_status: complete
 points_of_interest: null
+caveats: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_alerts_subscriptions
+  model: Table

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/details.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/details.yaml
@@ -1,39 +1,39 @@
+name: details
+display_name: Details
 description: null
-database_type: text
-semantic_type: type/Category
+created_at: '2023-06-14T14:56:02.702697Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_audit_log
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: details
+preview_display: true
+position: 8
+custom_position: 0
+database_position: 8
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_audit_log
-- model: Field
-  id: details
-database_is_auto_increment: false
-json_unfolding: false
-position: 8
-visibility_type: normal
-preview_display: true
-display_name: Details
-database_position: 8
-database_required: false
-created_at: '2023-06-14T14:56:02.702697Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_audit_log
+  model: Table
+- id: details
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/end_timestamp.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/end_timestamp.yaml
@@ -1,39 +1,39 @@
+name: end_timestamp
+display_name: End Timestamp
 description: null
-database_type: text
-semantic_type: null
+created_at: '2023-06-14T14:56:02.702697Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_audit_log
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: end_timestamp
+preview_display: true
+position: 3
+custom_position: 0
+database_position: 3
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_audit_log
-- model: Field
-  id: end_timestamp
-database_is_auto_increment: false
-json_unfolding: false
-position: 3
-visibility_type: normal
-preview_display: true
-display_name: End Timestamp
-database_position: 3
-database_required: false
-created_at: '2023-06-14T14:56:02.702697Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_audit_log
+  model: Table
+- id: end_timestamp
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/entity_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/entity_id.yaml
@@ -1,39 +1,39 @@
+name: entity_id
+display_name: Entity ID
 description: null
-database_type: int4
-semantic_type: type/Category
+created_at: '2023-10-31T13:16:53.749017Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_audit_log
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_id
+preview_display: true
+position: 6
+custom_position: 0
+database_position: 6
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_audit_log
-- model: Field
-  id: entity_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 6
-visibility_type: normal
-preview_display: true
-display_name: Entity ID
-database_position: 6
-database_required: false
-created_at: '2023-10-31T13:16:53.749017Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_audit_log
+  model: Table
+- id: entity_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/entity_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/entity_qualified_id.yaml
@@ -1,39 +1,39 @@
+name: entity_qualified_id
+display_name: Entity Qualified ID
 description: null
-database_type: text
-semantic_type: type/Category
+created_at: '2023-10-31T13:16:53.749017Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_audit_log
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_qualified_id
+preview_display: true
+position: 7
+custom_position: 0
+database_position: 7
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_audit_log
-- model: Field
-  id: entity_qualified_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 7
-visibility_type: normal
-preview_display: true
-display_name: Entity Qualified ID
-database_position: 7
-database_required: false
-created_at: '2023-10-31T13:16:53.749017Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_audit_log
+  model: Table
+- id: entity_qualified_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/entity_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/entity_type.yaml
@@ -1,39 +1,39 @@
+name: entity_type
+display_name: Entity Type
 description: null
-database_type: text
-semantic_type: type/Category
+created_at: '2023-10-31T13:16:53.749017Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_audit_log
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_type
+preview_display: true
+position: 5
+custom_position: 0
+database_position: 5
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_audit_log
-- model: Field
-  id: entity_type
-database_is_auto_increment: false
-json_unfolding: false
-position: 5
-visibility_type: normal
-preview_display: true
-display_name: Entity Type
-database_position: 5
-database_required: false
-created_at: '2023-10-31T13:16:53.749017Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_audit_log
+  model: Table
+- id: entity_type
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/id.yaml
@@ -1,39 +1,39 @@
+name: id
+display_name: ID
 description: null
-database_type: int4
-semantic_type: type/PK
+created_at: '2023-06-14T14:56:02.702697Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_audit_log
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: id
+preview_display: true
+position: 0
+custom_position: 0
+database_position: 0
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_audit_log
-- model: Field
-  id: id
-database_is_auto_increment: false
-json_unfolding: false
-position: 0
-visibility_type: normal
-preview_display: true
-display_name: ID
-database_position: 0
-database_required: false
-created_at: '2023-06-14T14:56:02.702697Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_audit_log
+  model: Table
+- id: id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/model.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/model.yaml
@@ -1,39 +1,39 @@
+name: model
+display_name: Model
 description: null
-database_type: varchar
-semantic_type: type/Category
+created_at: '2023-06-14T14:56:02.702697Z'
+active: false
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_audit_log
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: model
+preview_display: true
+position: 5
+custom_position: 0
+database_position: 5
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: false
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_audit_log
-- model: Field
-  id: model
-database_is_auto_increment: false
-json_unfolding: false
-position: 5
-visibility_type: normal
-preview_display: true
-display_name: Model
-database_position: 5
-database_required: false
-created_at: '2023-06-14T14:56:02.702697Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_audit_log
+  model: Table
+- id: model
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/model_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/model_id.yaml
@@ -1,43 +1,43 @@
+name: model_id
+display_name: Model ID
 description: null
-database_type: text
-semantic_type: type/FK
+created_at: '2023-06-14T14:56:02.702697Z'
+active: false
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_audit_log
-coercion_strategy: null
-name: model_id
-has_field_values: null
-settings: null
-caveats: null
+database_type: text
+base_type: type/Text
+effective_type: type/Integer
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
 fk_target_field_id:
 - Internal Metabase Database
 - public
 - v_content
 - id
 dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: false
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_audit_log
-- model: Field
-  id: model_id
-database_is_auto_increment: false
 json_unfolding: false
-position: 6
-visibility_type: normal
+parent_id: null
+coercion_strategy: null
 preview_display: true
-display_name: Model ID
+position: 6
+custom_position: 0
 database_position: 6
-database_required: false
-created_at: '2023-06-14T14:56:02.702697Z'
-base_type: type/Text
+has_field_values: null
+settings: null
+caveats: null
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_audit_log
+  model: Table
+- id: model_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/timestamp.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/timestamp.yaml
@@ -1,39 +1,39 @@
+name: timestamp
+display_name: Timestamp
 description: null
-database_type: timestamptz
-semantic_type: type/CreationTimestamp
+created_at: '2023-06-14T14:56:02.702697Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_audit_log
+database_type: timestamptz
+base_type: type/DateTimeWithLocalTZ
+effective_type: type/DateTimeWithLocalTZ
+semantic_type: type/CreationTimestamp
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: timestamp
+preview_display: true
+position: 2
+custom_position: 0
+database_position: 2
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/DateTimeWithLocalTZ
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_audit_log
-- model: Field
-  id: timestamp
-database_is_auto_increment: false
-json_unfolding: false
-position: 2
-visibility_type: normal
-preview_display: true
-display_name: Timestamp
-database_position: 2
-database_required: false
-created_at: '2023-06-14T14:56:02.702697Z'
-base_type: type/DateTimeWithLocalTZ
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_audit_log
+  model: Table
+- id: timestamp
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/topic.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/topic.yaml
@@ -1,39 +1,39 @@
+name: topic
+display_name: Topic
 description: null
-database_type: varchar
-semantic_type: type/Category
+created_at: '2023-06-14T14:56:02.702697Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_audit_log
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: topic
+preview_display: true
+position: 1
+custom_position: 0
+database_position: 1
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_audit_log
-- model: Field
-  id: topic
-database_is_auto_increment: false
-json_unfolding: false
-position: 1
-visibility_type: normal
-preview_display: true
-display_name: Topic
-database_position: 1
-database_required: false
-created_at: '2023-06-14T14:56:02.702697Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_audit_log
+  model: Table
+- id: topic
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/user_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/user_id.yaml
@@ -1,39 +1,39 @@
+name: user_id
+display_name: User ID
 description: null
-database_type: int4
-semantic_type: null
+created_at: '2023-06-14T14:56:02.702697Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_audit_log
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: user_id
+preview_display: true
+position: 4
+custom_position: 0
+database_position: 4
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_audit_log
-- model: Field
-  id: user_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 4
-visibility_type: normal
-preview_display: true
-display_name: User ID
-database_position: 4
-database_required: false
-created_at: '2023-06-14T14:56:02.702697Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_audit_log
+  model: Table
+- id: user_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/v_audit_log.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/v_audit_log.yaml
@@ -1,22 +1,22 @@
-description: null
-entity_type: entity/EventTable
-schema: public
-show_in_getting_started: false
 name: v_audit_log
-caveats: null
-active: true
-db_id: Internal Metabase Database
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_audit_log
-visibility_type: null
-field_order: database
-is_upload: false
-initial_sync_status: complete
 display_name: V Audit Log
+description: null
 created_at: '2023-06-14T14:56:00.312438Z'
+db_id: Internal Metabase Database
+schema: public
+entity_type: entity/EventTable
+active: true
+is_upload: false
+field_order: database
+visibility_type: null
+show_in_getting_started: false
+initial_sync_status: complete
 points_of_interest: null
+caveats: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_audit_log
+  model: Table

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/action_model_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/action_model_id.yaml
@@ -1,43 +1,43 @@
+name: action_model_id
+display_name: Action Model ID
 description: null
-database_type: int4
-semantic_type: type/FK
+created_at: '2023-06-08T14:05:43.635833Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_content
-coercion_strategy: null
-name: action_model_id
-has_field_values: null
-settings: null
-caveats: null
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
 fk_target_field_id:
 - Internal Metabase Database
 - public
 - v_content
 - id
 dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_content
-- model: Field
-  id: action_model_id
-database_is_auto_increment: false
 json_unfolding: false
-position: 13
-visibility_type: normal
+parent_id: null
+coercion_strategy: null
 preview_display: true
-display_name: Action Model ID
+position: 13
+custom_position: 0
 database_position: 13
-database_required: false
-created_at: '2023-06-08T14:05:43.635833Z'
-base_type: type/Integer
+has_field_values: null
+settings: null
+caveats: null
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_content
+  model: Table
+- id: action_model_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/action_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/action_type.yaml
@@ -1,39 +1,39 @@
+name: action_type
+display_name: Action Type
 description: null
-database_type: text
-semantic_type: type/Category
+created_at: '2023-06-08T14:05:43.635833Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_content
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: action_type
+preview_display: true
+position: 12
+custom_position: 0
+database_position: 12
 has_field_values: list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_content
-- model: Field
-  id: action_type
-database_is_auto_increment: false
-json_unfolding: false
-position: 12
-visibility_type: normal
-preview_display: true
-display_name: Action Type
-database_position: 12
-database_required: false
-created_at: '2023-06-08T14:05:43.635833Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_content
+  model: Table
+- id: action_type
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/archived.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/archived.yaml
@@ -1,39 +1,39 @@
+name: archived
+display_name: Archived
 description: null
-database_type: bool
-semantic_type: type/Enum
+created_at: '2023-06-08T14:05:43.635833Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_content
+database_type: bool
+base_type: type/Boolean
+effective_type: type/Boolean
+semantic_type: type/Enum
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: archived
+preview_display: true
+position: 11
+custom_position: 0
+database_position: 11
 has_field_values: list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Boolean
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_content
-- model: Field
-  id: archived
-database_is_auto_increment: false
-json_unfolding: false
-position: 11
-visibility_type: normal
-preview_display: true
-display_name: Archived
-database_position: 11
-database_required: false
-created_at: '2023-06-08T14:05:43.635833Z'
-base_type: type/Boolean
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_content
+  model: Table
+- id: archived
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/collection_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/collection_id.yaml
@@ -1,43 +1,43 @@
+name: collection_id
+display_name: Collection ID
 description: null
-database_type: int4
-semantic_type: type/FK
+created_at: '2023-06-08T14:05:43.635833Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_content
-coercion_strategy: null
-name: collection_id
-has_field_values: null
-settings: null
-caveats: null
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
 fk_target_field_id:
 - Internal Metabase Database
 - public
 - v_content
 - id
 dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_content
-- model: Field
-  id: collection_id
-database_is_auto_increment: false
 json_unfolding: false
-position: 8
-visibility_type: normal
+parent_id: null
+coercion_strategy: null
 preview_display: true
-display_name: Collection ID
+position: 8
+custom_position: 0
 database_position: 8
-database_required: false
-created_at: '2023-06-08T14:05:43.635833Z'
-base_type: type/Integer
+has_field_values: null
+settings: null
+caveats: null
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_content
+  model: Table
+- id: collection_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/collection_is_official.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/collection_is_official.yaml
@@ -1,39 +1,39 @@
+name: collection_is_official
+display_name: Collection Is Official
 description: null
-database_type: bool
-semantic_type: type/Category
+created_at: '2023-06-08T14:05:43.635833Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_content
+database_type: bool
+base_type: type/Boolean
+effective_type: type/Boolean
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: collection_is_official
+preview_display: true
+position: 14
+custom_position: 0
+database_position: 14
 has_field_values: list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Boolean
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_content
-- model: Field
-  id: collection_is_official
-database_is_auto_increment: false
-json_unfolding: false
-position: 14
-visibility_type: normal
-preview_display: true
-display_name: Collection Is Official
-database_position: 14
-database_required: false
-created_at: '2023-06-08T14:05:43.635833Z'
-base_type: type/Boolean
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_content
+  model: Table
+- id: collection_is_official
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/collection_is_personal.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/collection_is_personal.yaml
@@ -1,39 +1,39 @@
+name: collection_is_personal
+display_name: Collection Is Personal
 description: null
-database_type: bool
-semantic_type: type/Category
+created_at: '2023-06-08T14:05:43.635833Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_content
+database_type: bool
+base_type: type/Boolean
+effective_type: type/Boolean
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: collection_is_personal
+preview_display: true
+position: 15
+custom_position: 0
+database_position: 15
 has_field_values: list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Boolean
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_content
-- model: Field
-  id: collection_is_personal
-database_is_auto_increment: false
-json_unfolding: false
-position: 15
-visibility_type: normal
-preview_display: true
-display_name: Collection Is Personal
-database_position: 15
-database_required: false
-created_at: '2023-06-08T14:05:43.635833Z'
-base_type: type/Boolean
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_content
+  model: Table
+- id: collection_is_personal
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/created_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/created_at.yaml
@@ -1,39 +1,39 @@
+name: created_at
+display_name: Created At
 description: null
-database_type: timestamptz
-semantic_type: type/CreationTimestamp
+created_at: '2023-06-08T14:05:43.635833Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_content
+database_type: timestamptz
+base_type: type/DateTimeWithLocalTZ
+effective_type: type/DateTimeWithLocalTZ
+semantic_type: type/CreationTimestamp
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: created_at
+preview_display: true
+position: 3
+custom_position: 0
+database_position: 3
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/DateTimeWithLocalTZ
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_content
-- model: Field
-  id: created_at
-database_is_auto_increment: false
-json_unfolding: false
-position: 3
-visibility_type: normal
-preview_display: true
-display_name: Created At
-database_position: 3
-database_required: false
-created_at: '2023-06-08T14:05:43.635833Z'
-base_type: type/DateTimeWithLocalTZ
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_content
+  model: Table
+- id: created_at
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/creator_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/creator_id.yaml
@@ -1,43 +1,43 @@
+name: creator_id
+display_name: Creator ID
 description: null
-database_type: int4
-semantic_type: type/FK
+created_at: '2023-06-08T14:05:43.635833Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_content
-coercion_strategy: null
-name: creator_id
-has_field_values: null
-settings: null
-caveats: null
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
 fk_target_field_id:
 - Internal Metabase Database
 - public
 - v_users
 - user_id
 dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_content
-- model: Field
-  id: creator_id
-database_is_auto_increment: false
 json_unfolding: false
-position: 5
-visibility_type: normal
+parent_id: null
+coercion_strategy: null
 preview_display: true
-display_name: Creator ID
+position: 5
+custom_position: 0
 database_position: 5
-database_required: false
-created_at: '2023-06-08T14:05:43.635833Z'
-base_type: type/Integer
+has_field_values: null
+settings: null
+caveats: null
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_content
+  model: Table
+- id: creator_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/description.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/description.yaml
@@ -1,39 +1,39 @@
+name: description
+display_name: Description
 description: null
-database_type: text
-semantic_type: type/Description
+created_at: '2023-06-08T14:05:43.635833Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_content
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Description
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: description
+preview_display: true
+position: 7
+custom_position: 0
+database_position: 7
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_content
-- model: Field
-  id: description
-database_is_auto_increment: false
-json_unfolding: false
-position: 7
-visibility_type: normal
-preview_display: true
-display_name: Description
-database_position: 7
-database_required: false
-created_at: '2023-06-08T14:05:43.635833Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_content
+  model: Table
+- id: description
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/entity_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/entity_id.yaml
@@ -1,39 +1,39 @@
+name: entity_id
+display_name: Entity ID
 description: null
-database_type: int4
-semantic_type: type/PK
+created_at: '2023-10-31T13:16:53.593285Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_content
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_id
+preview_display: true
+position: 0
+custom_position: 0
+database_position: 0
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_content
-- model: Field
-  id: entity_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 0
-visibility_type: normal
-preview_display: true
-display_name: Entity ID
-database_position: 0
-database_required: false
-created_at: '2023-10-31T13:16:53.593285Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_content
+  model: Table
+- id: entity_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/entity_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/entity_qualified_id.yaml
@@ -1,39 +1,39 @@
+name: entity_qualified_id
+display_name: Entity Qualified ID
 description: null
-database_type: text
-semantic_type: type/PK
+created_at: '2023-10-31T13:16:53.593285Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_content
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_qualified_id
+preview_display: true
+position: 1
+custom_position: 0
+database_position: 1
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_content
-- model: Field
-  id: entity_qualified_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 1
-visibility_type: normal
-preview_display: true
-display_name: Entity Qualified ID
-database_position: 1
-database_required: false
-created_at: '2023-10-31T13:16:53.593285Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_content
+  model: Table
+- id: entity_qualified_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/entity_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/entity_type.yaml
@@ -1,39 +1,39 @@
+name: entity_type
+display_name: Entity Type
 description: null
-database_type: text
-semantic_type: type/Category
+created_at: '2023-06-08T14:05:43.635833Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_content
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_type
+preview_display: true
+position: 2
+custom_position: 0
+database_position: 2
 has_field_values: list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_content
-- model: Field
-  id: entity_type
-database_is_auto_increment: false
-json_unfolding: false
-position: 2
-visibility_type: normal
-preview_display: true
-display_name: Entity Type
-database_position: 2
-database_required: false
-created_at: '2023-06-08T14:05:43.635833Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_content
+  model: Table
+- id: entity_type
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/event_timestamp.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/event_timestamp.yaml
@@ -1,39 +1,39 @@
+name: event_timestamp
+display_name: Event Timestamp
 description: null
-database_type: timestamptz
-semantic_type: null
+created_at: '2023-06-08T14:05:43.635833Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_content
+database_type: timestamptz
+base_type: type/DateTimeWithLocalTZ
+effective_type: type/DateTimeWithLocalTZ
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: event_timestamp
+preview_display: true
+position: 19
+custom_position: 0
+database_position: 19
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/DateTimeWithLocalTZ
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_content
-- model: Field
-  id: event_timestamp
-database_is_auto_increment: false
-json_unfolding: false
-position: 19
-visibility_type: normal
-preview_display: true
-display_name: Event Timestamp
-database_position: 19
-database_required: false
-created_at: '2023-06-08T14:05:43.635833Z'
-base_type: type/DateTimeWithLocalTZ
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_content
+  model: Table
+- id: event_timestamp
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/id.yaml
@@ -1,39 +1,39 @@
+name: id
+display_name: ID
 description: null
-database_type: text
-semantic_type: type/PK
+created_at: '2023-06-08T14:05:43.635833Z'
+active: false
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_content
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: id
+preview_display: true
+position: 0
+custom_position: 0
+database_position: 0
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: false
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_content
-- model: Field
-  id: id
-database_is_auto_increment: false
-json_unfolding: false
-position: 0
-visibility_type: normal
-preview_display: true
-display_name: ID
-database_position: 0
-database_required: false
-created_at: '2023-06-08T14:05:43.635833Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_content
+  model: Table
+- id: id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/is_embedding_enabled.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/is_embedding_enabled.yaml
@@ -1,39 +1,39 @@
+name: is_embedding_enabled
+display_name: Is Embedding Enabled
 description: null
-database_type: bool
-semantic_type: type/Category
+created_at: '2023-06-08T14:05:43.635833Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_content
+database_type: bool
+base_type: type/Boolean
+effective_type: type/Boolean
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: is_embedding_enabled
+preview_display: true
+position: 10
+custom_position: 0
+database_position: 10
 has_field_values: list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Boolean
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_content
-- model: Field
-  id: is_embedding_enabled
-database_is_auto_increment: false
-json_unfolding: false
-position: 10
-visibility_type: normal
-preview_display: true
-display_name: Is Embedding Enabled
-database_position: 10
-database_required: false
-created_at: '2023-06-08T14:05:43.635833Z'
-base_type: type/Boolean
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_content
+  model: Table
+- id: is_embedding_enabled
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/made_public_by_user.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/made_public_by_user.yaml
@@ -1,43 +1,43 @@
+name: made_public_by_user
+display_name: Made Public By User
 description: null
-database_type: int4
-semantic_type: type/FK
+created_at: '2023-06-08T14:05:43.635833Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_content
-coercion_strategy: null
-name: made_public_by_user
-has_field_values: null
-settings: null
-caveats: null
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
 fk_target_field_id:
 - Internal Metabase Database
 - public
 - v_users
 - user_id
 dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_content
-- model: Field
-  id: made_public_by_user
-database_is_auto_increment: false
 json_unfolding: false
-position: 9
-visibility_type: normal
+parent_id: null
+coercion_strategy: null
 preview_display: true
-display_name: Made Public By User
+position: 9
+custom_position: 0
 database_position: 9
-database_required: false
-created_at: '2023-06-08T14:05:43.635833Z'
-base_type: type/Integer
+has_field_values: null
+settings: null
+caveats: null
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_content
+  model: Table
+- id: made_public_by_user
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/name.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/name.yaml
@@ -1,39 +1,39 @@
+name: name
+display_name: Name
 description: null
-database_type: varchar
-semantic_type: type/Name
+created_at: '2023-06-08T14:05:43.635833Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_content
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Name
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: name
+preview_display: true
+position: 6
+custom_position: 0
+database_position: 6
 has_field_values: list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_content
-- model: Field
-  id: name
-database_is_auto_increment: false
-json_unfolding: false
-position: 6
-visibility_type: normal
-preview_display: true
-display_name: Name
-database_position: 6
-database_required: false
-created_at: '2023-06-08T14:05:43.635833Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_content
+  model: Table
+- id: name
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/question_database_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/question_database_id.yaml
@@ -1,39 +1,39 @@
+name: question_database_id
+display_name: Question Database ID
 description: null
-database_type: text
-semantic_type: type/FK
+created_at: '2023-06-08T14:05:43.635833Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_content
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: question_database_id
+preview_display: true
+position: 17
+custom_position: 0
+database_position: 17
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_content
-- model: Field
-  id: question_database_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 17
-visibility_type: normal
-preview_display: true
-display_name: Question Database ID
-database_position: 17
-database_required: false
-created_at: '2023-06-08T14:05:43.635833Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_content
+  model: Table
+- id: question_database_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/question_is_native.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/question_is_native.yaml
@@ -1,39 +1,39 @@
+name: question_is_native
+display_name: Question Is Native
 description: null
-database_type: bool
-semantic_type: type/Category
+created_at: '2023-06-08T14:05:43.635833Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_content
+database_type: bool
+base_type: type/Boolean
+effective_type: type/Boolean
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: question_is_native
+preview_display: true
+position: 18
+custom_position: 0
+database_position: 18
 has_field_values: list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Boolean
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_content
-- model: Field
-  id: question_is_native
-database_is_auto_increment: false
-json_unfolding: false
-position: 18
-visibility_type: normal
-preview_display: true
-display_name: Question Is Native
-database_position: 18
-database_required: false
-created_at: '2023-06-08T14:05:43.635833Z'
-base_type: type/Boolean
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_content
+  model: Table
+- id: question_is_native
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/question_viz_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/question_viz_type.yaml
@@ -1,39 +1,39 @@
+name: question_viz_type
+display_name: Question Viz Type
 description: null
-database_type: text
-semantic_type: type/Category
+created_at: '2023-06-08T14:05:43.635833Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_content
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: question_viz_type
+preview_display: true
+position: 16
+custom_position: 0
+database_position: 16
 has_field_values: list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_content
-- model: Field
-  id: question_viz_type
-database_is_auto_increment: false
-json_unfolding: false
-position: 16
-visibility_type: normal
-preview_display: true
-display_name: Question Viz Type
-database_position: 16
-database_required: false
-created_at: '2023-06-08T14:05:43.635833Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_content
+  model: Table
+- id: question_viz_type
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/updated_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/updated_at.yaml
@@ -1,39 +1,39 @@
+name: updated_at
+display_name: Updated At
 description: null
-database_type: timestamptz
-semantic_type: type/UpdatedTimestamp
+created_at: '2023-06-08T14:05:43.635833Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_content
+database_type: timestamptz
+base_type: type/DateTimeWithLocalTZ
+effective_type: type/DateTimeWithLocalTZ
+semantic_type: type/UpdatedTimestamp
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: updated_at
+preview_display: true
+position: 4
+custom_position: 0
+database_position: 4
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/DateTimeWithLocalTZ
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_content
-- model: Field
-  id: updated_at
-database_is_auto_increment: false
-json_unfolding: false
-position: 4
-visibility_type: normal
-preview_display: true
-display_name: Updated At
-database_position: 4
-database_required: false
-created_at: '2023-06-08T14:05:43.635833Z'
-base_type: type/DateTimeWithLocalTZ
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_content
+  model: Table
+- id: updated_at
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/v_content.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/v_content.yaml
@@ -1,22 +1,22 @@
-description: null
-entity_type: entity/GenericTable
-schema: public
-show_in_getting_started: false
 name: v_content
-caveats: null
-active: true
-db_id: Internal Metabase Database
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_content
-visibility_type: null
-field_order: database
-is_upload: false
-initial_sync_status: complete
 display_name: V Content
+description: null
 created_at: '2023-06-08T14:05:39.120813Z'
+db_id: Internal Metabase Database
+schema: public
+entity_type: entity/GenericTable
+active: true
+is_upload: false
+field_order: database
+visibility_type: null
+show_in_getting_started: false
+initial_sync_status: complete
 points_of_interest: null
+caveats: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_content
+  model: Table

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/card_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/card_qualified_id.yaml
@@ -1,43 +1,43 @@
+name: card_qualified_id
+display_name: Card Qualified ID
 description: null
-database_type: text
-semantic_type: type/FK
+created_at: '2023-11-01T02:26:19.956545Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_dashboardcard
-coercion_strategy: null
-name: card_qualified_id
-has_field_values: null
-settings: null
-caveats: null
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
 fk_target_field_id:
 - Internal Metabase Database
 - public
 - v_content
 - entity_qualified_id
 dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_dashboardcard
-- model: Field
-  id: card_qualified_id
-database_is_auto_increment: false
 json_unfolding: false
-position: 4
-visibility_type: normal
+parent_id: null
+coercion_strategy: null
 preview_display: true
-display_name: Card Qualified ID
+position: 4
+custom_position: 0
 database_position: 4
-database_required: false
-created_at: '2023-11-01T02:26:19.956545Z'
-base_type: type/Text
+has_field_values: null
+settings: null
+caveats: null
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_dashboardcard
+  model: Table
+- id: card_qualified_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/col.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/col.yaml
@@ -1,39 +1,39 @@
+name: col
+display_name: Col
 description: null
-database_type: int4
-semantic_type: type/Category
+created_at: '2023-09-21T13:22:50.069446Z'
+active: false
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_dashboardcard
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: col
+preview_display: true
+position: 9
+custom_position: 0
+database_position: 9
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: false
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_dashboardcard
-- model: Field
-  id: col
-database_is_auto_increment: false
-json_unfolding: false
-position: 9
-visibility_type: normal
-preview_display: true
-display_name: Col
-database_position: 9
-database_required: false
-created_at: '2023-09-21T13:22:50.069446Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_dashboardcard
+  model: Table
+- id: col
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/created_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/created_at.yaml
@@ -1,39 +1,39 @@
+name: created_at
+display_name: Created At
 description: null
-database_type: timestamptz
-semantic_type: type/CreationTimestamp
+created_at: '2023-09-21T13:22:50.069446Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_dashboardcard
+database_type: timestamptz
+base_type: type/DateTimeWithLocalTZ
+effective_type: type/DateTimeWithLocalTZ
+semantic_type: type/CreationTimestamp
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: created_at
+preview_display: true
+position: 5
+custom_position: 0
+database_position: 5
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/DateTimeWithLocalTZ
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_dashboardcard
-- model: Field
-  id: created_at
-database_is_auto_increment: false
-json_unfolding: false
-position: 5
-visibility_type: normal
-preview_display: true
-display_name: Created At
-database_position: 5
-database_required: false
-created_at: '2023-09-21T13:22:50.069446Z'
-base_type: type/DateTimeWithLocalTZ
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_dashboardcard
+  model: Table
+- id: created_at
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/dashboard_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/dashboard_id.yaml
@@ -1,39 +1,39 @@
+name: dashboard_id
+display_name: Dashboard ID
 description: null
-database_type: text
-semantic_type: null
+created_at: '2023-09-21T13:22:50.069446Z'
+active: false
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_dashboardcard
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: dashboard_id
+preview_display: true
+position: 2
+custom_position: 0
+database_position: 2
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: false
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_dashboardcard
-- model: Field
-  id: dashboard_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 2
-visibility_type: normal
-preview_display: true
-display_name: Dashboard ID
-database_position: 2
-database_required: false
-created_at: '2023-09-21T13:22:50.069446Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_dashboardcard
+  model: Table
+- id: dashboard_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/dashboard_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/dashboard_qualified_id.yaml
@@ -1,43 +1,43 @@
+name: dashboard_qualified_id
+display_name: Dashboard Qualified ID
 description: null
-database_type: text
-semantic_type: type/FK
+created_at: '2023-11-01T02:26:19.956545Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_dashboardcard
-coercion_strategy: null
-name: dashboard_qualified_id
-has_field_values: auto-list
-settings: null
-caveats: null
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
 fk_target_field_id:
 - Internal Metabase Database
 - public
 - v_content
 - entity_qualified_id
 dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_dashboardcard
-- model: Field
-  id: dashboard_qualified_id
-database_is_auto_increment: false
 json_unfolding: false
-position: 2
-visibility_type: normal
+parent_id: null
+coercion_strategy: null
 preview_display: true
-display_name: Dashboard Qualified ID
+position: 2
+custom_position: 0
 database_position: 2
-database_required: false
-created_at: '2023-11-01T02:26:19.956545Z'
-base_type: type/Text
+has_field_values: auto-list
+settings: null
+caveats: null
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_dashboardcard
+  model: Table
+- id: dashboard_qualified_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/dashboardtab_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/dashboardtab_id.yaml
@@ -1,39 +1,39 @@
+name: dashboardtab_id
+display_name: Dashboardtab ID
 description: null
-database_type: text
-semantic_type: null
+created_at: '2023-09-21T13:22:50.069446Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_dashboardcard
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: dashboardtab_id
+preview_display: true
+position: 3
+custom_position: 0
+database_position: 3
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_dashboardcard
-- model: Field
-  id: dashboardtab_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 3
-visibility_type: normal
-preview_display: true
-display_name: Dashboardtab ID
-database_position: 3
-database_required: false
-created_at: '2023-09-21T13:22:50.069446Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_dashboardcard
+  model: Table
+- id: dashboardtab_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/entity_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/entity_id.yaml
@@ -1,39 +1,39 @@
+name: entity_id
+display_name: Entity ID
 description: null
-database_type: int4
-semantic_type: type/PK
+created_at: '2023-10-31T13:16:53.995137Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_dashboardcard
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_id
+preview_display: true
+position: 0
+custom_position: 0
+database_position: 0
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_dashboardcard
-- model: Field
-  id: entity_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 0
-visibility_type: normal
-preview_display: true
-display_name: Entity ID
-database_position: 0
-database_required: false
-created_at: '2023-10-31T13:16:53.995137Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_dashboardcard
+  model: Table
+- id: entity_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/entity_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/entity_qualified_id.yaml
@@ -1,39 +1,39 @@
+name: entity_qualified_id
+display_name: Entity Qualified ID
 description: null
-database_type: text
-semantic_type: type/PK
+created_at: '2023-10-31T13:16:53.995137Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_dashboardcard
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_qualified_id
+preview_display: true
+position: 1
+custom_position: 0
+database_position: 1
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_dashboardcard
-- model: Field
-  id: entity_qualified_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 1
-visibility_type: normal
-preview_display: true
-display_name: Entity Qualified ID
-database_position: 1
-database_required: false
-created_at: '2023-10-31T13:16:53.995137Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_dashboardcard
+  model: Table
+- id: entity_qualified_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/id.yaml
@@ -1,39 +1,39 @@
+name: id
+display_name: ID
 description: null
-database_type: text
-semantic_type: type/PK
+created_at: '2023-09-21T13:22:50.069446Z'
+active: false
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_dashboardcard
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: id
+preview_display: true
+position: 0
+custom_position: 0
+database_position: 0
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: false
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_dashboardcard
-- model: Field
-  id: id
-database_is_auto_increment: false
-json_unfolding: false
-position: 0
-visibility_type: normal
-preview_display: true
-display_name: ID
-database_position: 0
-database_required: false
-created_at: '2023-09-21T13:22:50.069446Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_dashboardcard
+  model: Table
+- id: id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/parameter_mappings.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/parameter_mappings.yaml
@@ -1,39 +1,39 @@
+name: parameter_mappings
+display_name: Parameter Mappings
 description: null
-database_type: text
-semantic_type: type/SerializedJSON
+created_at: '2023-09-21T13:22:50.069446Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_dashboardcard
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/SerializedJSON
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: parameter_mappings
+preview_display: false
+position: 10
+custom_position: 0
+database_position: 10
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_dashboardcard
-- model: Field
-  id: parameter_mappings
-database_is_auto_increment: false
-json_unfolding: false
-position: 10
-visibility_type: normal
-preview_display: false
-display_name: Parameter Mappings
-database_position: 10
-database_required: false
-created_at: '2023-09-21T13:22:50.069446Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_dashboardcard
+  model: Table
+- id: parameter_mappings
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/question_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/question_id.yaml
@@ -1,39 +1,39 @@
+name: question_id
+display_name: Question ID
 description: null
-database_type: text
-semantic_type: null
+created_at: '2023-09-21T13:22:50.069446Z'
+active: false
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_dashboardcard
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: question_id
+preview_display: true
+position: 4
+custom_position: 0
+database_position: 4
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: false
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_dashboardcard
-- model: Field
-  id: question_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 4
-visibility_type: normal
-preview_display: true
-display_name: Question ID
-database_position: 4
-database_required: false
-created_at: '2023-09-21T13:22:50.069446Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_dashboardcard
+  model: Table
+- id: question_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/row.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/row.yaml
@@ -1,39 +1,39 @@
+name: row
+display_name: Row
 description: null
-database_type: int4
-semantic_type: null
+created_at: '2023-09-21T13:22:50.069446Z'
+active: false
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_dashboardcard
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: row
+preview_display: true
+position: 8
+custom_position: 0
+database_position: 8
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: false
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_dashboardcard
-- model: Field
-  id: row
-database_is_auto_increment: false
-json_unfolding: false
-position: 8
-visibility_type: normal
-preview_display: true
-display_name: Row
-database_position: 8
-database_required: false
-created_at: '2023-09-21T13:22:50.069446Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_dashboardcard
+  model: Table
+- id: row
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/size_x.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/size_x.yaml
@@ -1,39 +1,39 @@
+name: size_x
+display_name: Size X
 description: null
-database_type: int4
-semantic_type: null
+created_at: '2023-09-21T13:22:50.069446Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_dashboardcard
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: size_x
+preview_display: true
+position: 7
+custom_position: 0
+database_position: 7
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_dashboardcard
-- model: Field
-  id: size_x
-database_is_auto_increment: false
-json_unfolding: false
-position: 7
-visibility_type: normal
-preview_display: true
-display_name: Size X
-database_position: 7
-database_required: false
-created_at: '2023-09-21T13:22:50.069446Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_dashboardcard
+  model: Table
+- id: size_x
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/size_y.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/size_y.yaml
@@ -1,39 +1,39 @@
+name: size_y
+display_name: Size Y
 description: null
-database_type: int4
-semantic_type: null
+created_at: '2023-09-21T13:22:50.069446Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_dashboardcard
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: size_y
+preview_display: true
+position: 8
+custom_position: 0
+database_position: 8
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_dashboardcard
-- model: Field
-  id: size_y
-database_is_auto_increment: false
-json_unfolding: false
-position: 8
-visibility_type: normal
-preview_display: true
-display_name: Size Y
-database_position: 8
-database_required: false
-created_at: '2023-09-21T13:22:50.069446Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_dashboardcard
+  model: Table
+- id: size_y
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/updated_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/updated_at.yaml
@@ -1,39 +1,39 @@
+name: updated_at
+display_name: Updated At
 description: null
-database_type: timestamptz
-semantic_type: type/UpdatedTimestamp
+created_at: '2023-09-21T13:22:50.069446Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_dashboardcard
+database_type: timestamptz
+base_type: type/DateTimeWithLocalTZ
+effective_type: type/DateTimeWithLocalTZ
+semantic_type: type/UpdatedTimestamp
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: updated_at
+preview_display: true
+position: 6
+custom_position: 0
+database_position: 6
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/DateTimeWithLocalTZ
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_dashboardcard
-- model: Field
-  id: updated_at
-database_is_auto_increment: false
-json_unfolding: false
-position: 6
-visibility_type: normal
-preview_display: true
-display_name: Updated At
-database_position: 6
-database_required: false
-created_at: '2023-09-21T13:22:50.069446Z'
-base_type: type/DateTimeWithLocalTZ
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_dashboardcard
+  model: Table
+- id: updated_at
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/visualization_settings.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/visualization_settings.yaml
@@ -1,39 +1,39 @@
+name: visualization_settings
+display_name: Visualization Settings
 description: null
-database_type: text
-semantic_type: type/SerializedJSON
+created_at: '2023-09-21T13:22:50.069446Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_dashboardcard
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/SerializedJSON
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: visualization_settings
+preview_display: false
+position: 9
+custom_position: 0
+database_position: 9
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_dashboardcard
-- model: Field
-  id: visualization_settings
-database_is_auto_increment: false
-json_unfolding: false
-position: 9
-visibility_type: normal
-preview_display: false
-display_name: Visualization Settings
-database_position: 9
-database_required: false
-created_at: '2023-09-21T13:22:50.069446Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_dashboardcard
+  model: Table
+- id: visualization_settings
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/v_dashboardcard.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/v_dashboardcard.yaml
@@ -1,22 +1,22 @@
-description: null
-entity_type: entity/GenericTable
-schema: public
-show_in_getting_started: false
 name: v_dashboardcard
-caveats: null
-active: true
-db_id: Internal Metabase Database
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_dashboardcard
-visibility_type: null
-field_order: database
-is_upload: false
-initial_sync_status: complete
 display_name: V Dashboardcard
+description: null
 created_at: '2023-09-21T13:22:49.746681Z'
+db_id: Internal Metabase Database
+schema: public
+entity_type: entity/GenericTable
+active: true
+is_upload: false
+field_order: database
+visibility_type: null
+show_in_getting_started: false
+initial_sync_status: complete
 points_of_interest: null
+caveats: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_dashboardcard
+  model: Table

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/auto_run_queries.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/auto_run_queries.yaml
@@ -1,39 +1,39 @@
+name: auto_run_queries
+display_name: Auto Run Queries
 description: null
-database_type: bool
-semantic_type: type/Category
+created_at: '2023-10-31T21:26:33.02415Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_databases
+database_type: bool
+base_type: type/Boolean
+effective_type: type/Boolean
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: auto_run_queries
+preview_display: true
+position: 11
+custom_position: 0
+database_position: 11
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Boolean
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_databases
-- model: Field
-  id: auto_run_queries
-database_is_auto_increment: false
-json_unfolding: false
-position: 11
-visibility_type: normal
-preview_display: true
-display_name: Auto Run Queries
-database_position: 11
-database_required: false
-created_at: '2023-10-31T21:26:33.02415Z'
-base_type: type/Boolean
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_databases
+  model: Table
+- id: auto_run_queries
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/cache_field_values_schedule.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/cache_field_values_schedule.yaml
@@ -1,39 +1,39 @@
+name: cache_field_values_schedule
+display_name: Cache Field Values Schedule
 description: null
-database_type: varchar
-semantic_type: type/Category
+created_at: '2023-10-31T21:26:33.02415Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_databases
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: cache_field_values_schedule
+preview_display: true
+position: 8
+custom_position: 0
+database_position: 8
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_databases
-- model: Field
-  id: cache_field_values_schedule
-database_is_auto_increment: false
-json_unfolding: false
-position: 8
-visibility_type: normal
-preview_display: true
-display_name: Cache Field Values Schedule
-database_position: 8
-database_required: false
-created_at: '2023-10-31T21:26:33.02415Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_databases
+  model: Table
+- id: cache_field_values_schedule
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/cache_ttl.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/cache_ttl.yaml
@@ -1,39 +1,39 @@
+name: cache_ttl
+display_name: Cache Ttl
 description: null
-database_type: int4
-semantic_type: null
+created_at: '2023-10-31T21:26:33.02415Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_databases
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: cache_ttl
+preview_display: true
+position: 12
+custom_position: 0
+database_position: 12
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_databases
-- model: Field
-  id: cache_ttl
-database_is_auto_increment: false
-json_unfolding: false
-position: 12
-visibility_type: normal
-preview_display: true
-display_name: Cache Ttl
-database_position: 12
-database_required: false
-created_at: '2023-10-31T21:26:33.02415Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_databases
+  model: Table
+- id: cache_ttl
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/created_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/created_at.yaml
@@ -1,39 +1,39 @@
+name: created_at
+display_name: Created At
 description: null
-database_type: timestamptz
-semantic_type: type/CreationTimestamp
+created_at: '2023-10-31T21:26:33.02415Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_databases
+database_type: timestamptz
+base_type: type/DateTimeWithLocalTZ
+effective_type: type/DateTimeWithLocalTZ
+semantic_type: type/CreationTimestamp
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: created_at
+preview_display: true
+position: 2
+custom_position: 0
+database_position: 2
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/DateTimeWithLocalTZ
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_databases
-- model: Field
-  id: created_at
-database_is_auto_increment: false
-json_unfolding: false
-position: 2
-visibility_type: normal
-preview_display: true
-display_name: Created At
-database_position: 2
-database_required: false
-created_at: '2023-10-31T21:26:33.02415Z'
-base_type: type/DateTimeWithLocalTZ
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_databases
+  model: Table
+- id: created_at
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/creator_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/creator_id.yaml
@@ -1,43 +1,43 @@
+name: creator_id
+display_name: Creator ID
 description: null
-database_type: int4
-semantic_type: type/FK
+created_at: '2023-10-31T21:26:33.02415Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_databases
-coercion_strategy: null
-name: creator_id
-has_field_values: auto-list
-settings: null
-caveats: null
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
 fk_target_field_id:
 - Internal Metabase Database
 - public
 - v_users
 - user_id
 dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_databases
-- model: Field
-  id: creator_id
-database_is_auto_increment: false
 json_unfolding: false
-position: 13
-visibility_type: normal
+parent_id: null
+coercion_strategy: null
 preview_display: true
-display_name: Creator ID
+position: 13
+custom_position: 0
 database_position: 13
-database_required: false
-created_at: '2023-10-31T21:26:33.02415Z'
-base_type: type/Integer
+has_field_values: auto-list
+settings: null
+caveats: null
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_databases
+  model: Table
+- id: creator_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/database_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/database_type.yaml
@@ -1,39 +1,39 @@
+name: database_type
+display_name: Database Type
 description: null
-database_type: varchar
-semantic_type: type/Category
+created_at: '2023-10-31T21:26:33.02415Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_databases
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: database_type
+preview_display: true
+position: 6
+custom_position: 0
+database_position: 6
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_databases
-- model: Field
-  id: database_type
-database_is_auto_increment: false
-json_unfolding: false
-position: 6
-visibility_type: normal
-preview_display: true
-display_name: Database Type
-database_position: 6
-database_required: false
-created_at: '2023-10-31T21:26:33.02415Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_databases
+  model: Table
+- id: database_type
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/db_version.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/db_version.yaml
@@ -1,39 +1,39 @@
+name: db_version
+display_name: Db Version
 description: null
-database_type: text
-semantic_type: type/Category
+created_at: '2023-10-31T21:26:33.02415Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_databases
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: db_version
+preview_display: true
+position: 14
+custom_position: 0
+database_position: 14
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_databases
-- model: Field
-  id: db_version
-database_is_auto_increment: false
-json_unfolding: false
-position: 14
-visibility_type: normal
-preview_display: true
-display_name: Db Version
-database_position: 14
-database_required: false
-created_at: '2023-10-31T21:26:33.02415Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_databases
+  model: Table
+- id: db_version
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/description.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/description.yaml
@@ -1,39 +1,39 @@
+name: description
+display_name: Description
 description: null
-database_type: text
-semantic_type: type/Description
+created_at: '2023-10-31T21:26:33.02415Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_databases
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Description
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: description
+preview_display: true
+position: 5
+custom_position: 0
+database_position: 5
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_databases
-- model: Field
-  id: description
-database_is_auto_increment: false
-json_unfolding: false
-position: 5
-visibility_type: normal
-preview_display: true
-display_name: Description
-database_position: 5
-database_required: false
-created_at: '2023-10-31T21:26:33.02415Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_databases
+  model: Table
+- id: description
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/entity_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/entity_id.yaml
@@ -1,39 +1,39 @@
+name: entity_id
+display_name: Entity ID
 description: null
-database_type: int4
-semantic_type: type/PK
+created_at: '2023-10-31T21:26:33.02415Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_databases
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_id
+preview_display: true
+position: 0
+custom_position: 0
+database_position: 0
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_databases
-- model: Field
-  id: entity_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 0
-visibility_type: normal
-preview_display: true
-display_name: Entity ID
-database_position: 0
-database_required: false
-created_at: '2023-10-31T21:26:33.02415Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_databases
+  model: Table
+- id: entity_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/entity_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/entity_qualified_id.yaml
@@ -1,39 +1,39 @@
+name: entity_qualified_id
+display_name: Entity Qualified ID
 description: null
-database_type: text
-semantic_type: type/PK
+created_at: '2023-10-31T21:26:33.02415Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_databases
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_qualified_id
+preview_display: true
+position: 1
+custom_position: 0
+database_position: 1
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_databases
-- model: Field
-  id: entity_qualified_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 1
-visibility_type: normal
-preview_display: true
-display_name: Entity Qualified ID
-database_position: 1
-database_required: false
-created_at: '2023-10-31T21:26:33.02415Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_databases
+  model: Table
+- id: entity_qualified_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/is_on_demand.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/is_on_demand.yaml
@@ -1,39 +1,39 @@
+name: is_on_demand
+display_name: Is On Demand
 description: null
-database_type: bool
-semantic_type: type/Category
+created_at: '2023-10-31T21:26:33.02415Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_databases
+database_type: bool
+base_type: type/Boolean
+effective_type: type/Boolean
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: is_on_demand
+preview_display: true
+position: 10
+custom_position: 0
+database_position: 10
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Boolean
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_databases
-- model: Field
-  id: is_on_demand
-database_is_auto_increment: false
-json_unfolding: false
-position: 10
-visibility_type: normal
-preview_display: true
-display_name: Is On Demand
-database_position: 10
-database_required: false
-created_at: '2023-10-31T21:26:33.02415Z'
-base_type: type/Boolean
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_databases
+  model: Table
+- id: is_on_demand
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/metadata_sync_schedule.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/metadata_sync_schedule.yaml
@@ -1,39 +1,39 @@
+name: metadata_sync_schedule
+display_name: Metadata Sync Schedule
 description: null
-database_type: varchar
-semantic_type: type/Category
+created_at: '2023-10-31T21:26:33.02415Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_databases
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: metadata_sync_schedule
+preview_display: true
+position: 7
+custom_position: 0
+database_position: 7
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_databases
-- model: Field
-  id: metadata_sync_schedule
-database_is_auto_increment: false
-json_unfolding: false
-position: 7
-visibility_type: normal
-preview_display: true
-display_name: Metadata Sync Schedule
-database_position: 7
-database_required: false
-created_at: '2023-10-31T21:26:33.02415Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_databases
+  model: Table
+- id: metadata_sync_schedule
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/name.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/name.yaml
@@ -1,39 +1,39 @@
+name: name
+display_name: Name
 description: null
-database_type: varchar
-semantic_type: type/Name
+created_at: '2023-10-31T21:26:33.02415Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_databases
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Name
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: name
+preview_display: true
+position: 4
+custom_position: 0
+database_position: 4
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_databases
-- model: Field
-  id: name
-database_is_auto_increment: false
-json_unfolding: false
-position: 4
-visibility_type: normal
-preview_display: true
-display_name: Name
-database_position: 4
-database_required: false
-created_at: '2023-10-31T21:26:33.02415Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_databases
+  model: Table
+- id: name
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/timezone.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/timezone.yaml
@@ -1,39 +1,39 @@
+name: timezone
+display_name: Timezone
 description: null
-database_type: varchar
-semantic_type: type/Category
+created_at: '2023-10-31T21:26:33.02415Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_databases
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: timezone
+preview_display: true
+position: 9
+custom_position: 0
+database_position: 9
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_databases
-- model: Field
-  id: timezone
-database_is_auto_increment: false
-json_unfolding: false
-position: 9
-visibility_type: normal
-preview_display: true
-display_name: Timezone
-database_position: 9
-database_required: false
-created_at: '2023-10-31T21:26:33.02415Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_databases
+  model: Table
+- id: timezone
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/updated_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/updated_at.yaml
@@ -1,39 +1,39 @@
+name: updated_at
+display_name: Updated At
 description: null
-database_type: timestamptz
-semantic_type: type/UpdatedTimestamp
+created_at: '2023-10-31T21:26:33.02415Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_databases
+database_type: timestamptz
+base_type: type/DateTimeWithLocalTZ
+effective_type: type/DateTimeWithLocalTZ
+semantic_type: type/UpdatedTimestamp
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: updated_at
+preview_display: true
+position: 3
+custom_position: 0
+database_position: 3
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/DateTimeWithLocalTZ
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_databases
-- model: Field
-  id: updated_at
-database_is_auto_increment: false
-json_unfolding: false
-position: 3
-visibility_type: normal
-preview_display: true
-display_name: Updated At
-database_position: 3
-database_required: false
-created_at: '2023-10-31T21:26:33.02415Z'
-base_type: type/DateTimeWithLocalTZ
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_databases
+  model: Table
+- id: updated_at
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/v_databases.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/v_databases.yaml
@@ -1,22 +1,22 @@
-description: null
-entity_type: entity/GenericTable
-schema: public
-show_in_getting_started: false
 name: v_databases
-caveats: null
-active: true
-db_id: Internal Metabase Database
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_databases
-visibility_type: null
-field_order: database
-is_upload: false
-initial_sync_status: complete
 display_name: V Databases
+description: null
 created_at: '2023-10-31T21:26:32.246512Z'
+db_id: Internal Metabase Database
+schema: public
+entity_type: entity/GenericTable
+active: true
+is_upload: false
+field_order: database
+visibility_type: null
+show_in_getting_started: false
+initial_sync_status: complete
 points_of_interest: null
+caveats: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_databases
+  model: Table

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/active.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/active.yaml
@@ -1,39 +1,39 @@
+name: active
+display_name: Active
 description: null
-database_type: bool
-semantic_type: type/Category
+created_at: '2023-10-31T21:26:32.933732Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_fields
+database_type: bool
+base_type: type/Boolean
+effective_type: type/Boolean
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: active
+preview_display: true
+position: 11
+custom_position: 0
+database_position: 11
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Boolean
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_fields
-- model: Field
-  id: active
-database_is_auto_increment: false
-json_unfolding: false
-position: 11
-visibility_type: normal
-preview_display: true
-display_name: Active
-database_position: 11
-database_required: false
-created_at: '2023-10-31T21:26:32.933732Z'
-base_type: type/Boolean
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_fields
+  model: Table
+- id: active
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/base_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/base_type.yaml
@@ -1,39 +1,39 @@
+name: base_type
+display_name: Base Type
 description: null
-database_type: varchar
-semantic_type: type/Category
+created_at: '2023-10-31T21:26:32.933732Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_fields
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: base_type
+preview_display: true
+position: 7
+custom_position: 0
+database_position: 7
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_fields
-- model: Field
-  id: base_type
-database_is_auto_increment: false
-json_unfolding: false
-position: 7
-visibility_type: normal
-preview_display: true
-display_name: Base Type
-database_position: 7
-database_required: false
-created_at: '2023-10-31T21:26:32.933732Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_fields
+  model: Table
+- id: base_type
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/created_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/created_at.yaml
@@ -1,39 +1,39 @@
+name: created_at
+display_name: Created At
 description: null
-database_type: timestamptz
-semantic_type: type/CreationTimestamp
+created_at: '2023-10-31T21:26:32.933732Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_fields
+database_type: timestamptz
+base_type: type/DateTimeWithLocalTZ
+effective_type: type/DateTimeWithLocalTZ
+semantic_type: type/CreationTimestamp
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: created_at
+preview_display: true
+position: 2
+custom_position: 0
+database_position: 2
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/DateTimeWithLocalTZ
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_fields
-- model: Field
-  id: created_at
-database_is_auto_increment: false
-json_unfolding: false
-position: 2
-visibility_type: normal
-preview_display: true
-display_name: Created At
-database_position: 2
-database_required: false
-created_at: '2023-10-31T21:26:32.933732Z'
-base_type: type/DateTimeWithLocalTZ
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_fields
+  model: Table
+- id: created_at
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/description.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/description.yaml
@@ -1,39 +1,39 @@
+name: description
+display_name: Description
 description: null
-database_type: text
-semantic_type: type/Description
+created_at: '2023-10-31T21:26:32.933732Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_fields
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Description
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: description
+preview_display: true
+position: 6
+custom_position: 0
+database_position: 6
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_fields
-- model: Field
-  id: description
-database_is_auto_increment: false
-json_unfolding: false
-position: 6
-visibility_type: normal
-preview_display: true
-display_name: Description
-database_position: 6
-database_required: false
-created_at: '2023-10-31T21:26:32.933732Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_fields
+  model: Table
+- id: description
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/display_name.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/display_name.yaml
@@ -1,39 +1,39 @@
+name: display_name
+display_name: Display Name
 description: null
-database_type: varchar
-semantic_type: null
+created_at: '2023-10-31T21:26:32.933732Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_fields
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: display_name
+preview_display: true
+position: 5
+custom_position: 0
+database_position: 5
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_fields
-- model: Field
-  id: display_name
-database_is_auto_increment: false
-json_unfolding: false
-position: 5
-visibility_type: normal
-preview_display: true
-display_name: Display Name
-database_position: 5
-database_required: false
-created_at: '2023-10-31T21:26:32.933732Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_fields
+  model: Table
+- id: display_name
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/entity_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/entity_id.yaml
@@ -1,39 +1,39 @@
+name: entity_id
+display_name: Entity ID
 description: null
-database_type: int4
-semantic_type: type/PK
+created_at: '2023-10-31T21:26:32.933732Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_fields
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_id
+preview_display: true
+position: 0
+custom_position: 0
+database_position: 0
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_fields
-- model: Field
-  id: entity_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 0
-visibility_type: normal
-preview_display: true
-display_name: Entity ID
-database_position: 0
-database_required: false
-created_at: '2023-10-31T21:26:32.933732Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_fields
+  model: Table
+- id: entity_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/entity_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/entity_qualified_id.yaml
@@ -1,39 +1,39 @@
+name: entity_qualified_id
+display_name: Entity Qualified ID
 description: null
-database_type: text
-semantic_type: type/PK
+created_at: '2023-10-31T21:26:32.933732Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_fields
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_qualified_id
+preview_display: true
+position: 1
+custom_position: 0
+database_position: 1
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_fields
-- model: Field
-  id: entity_qualified_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 1
-visibility_type: normal
-preview_display: true
-display_name: Entity Qualified ID
-database_position: 1
-database_required: false
-created_at: '2023-10-31T21:26:32.933732Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_fields
+  model: Table
+- id: entity_qualified_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/fk_target_field_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/fk_target_field_id.yaml
@@ -1,39 +1,39 @@
+name: fk_target_field_id
+display_name: Fk Target Field ID
 description: null
-database_type: int4
-semantic_type: null
+created_at: '2023-10-31T21:26:32.933732Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_fields
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: fk_target_field_id
+preview_display: true
+position: 9
+custom_position: 0
+database_position: 9
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_fields
-- model: Field
-  id: fk_target_field_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 9
-visibility_type: normal
-preview_display: true
-display_name: Fk Target Field ID
-database_position: 9
-database_required: false
-created_at: '2023-10-31T21:26:32.933732Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_fields
+  model: Table
+- id: fk_target_field_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/has_field_values.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/has_field_values.yaml
@@ -1,39 +1,39 @@
+name: has_field_values
+display_name: Has Field Values
 description: null
-database_type: text
-semantic_type: null
+created_at: '2023-10-31T21:26:32.933732Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_fields
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: has_field_values
+preview_display: true
+position: 10
+custom_position: 0
+database_position: 10
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_fields
-- model: Field
-  id: has_field_values
-database_is_auto_increment: false
-json_unfolding: false
-position: 10
-visibility_type: normal
-preview_display: true
-display_name: Has Field Values
-database_position: 10
-database_required: false
-created_at: '2023-10-31T21:26:32.933732Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_fields
+  model: Table
+- id: has_field_values
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/name.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/name.yaml
@@ -1,39 +1,39 @@
+name: name
+display_name: Name
 description: null
-database_type: varchar
-semantic_type: type/Name
+created_at: '2023-10-31T21:26:32.933732Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_fields
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Name
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: name
+preview_display: true
+position: 4
+custom_position: 0
+database_position: 4
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_fields
-- model: Field
-  id: name
-database_is_auto_increment: false
-json_unfolding: false
-position: 4
-visibility_type: normal
-preview_display: true
-display_name: Name
-database_position: 4
-database_required: false
-created_at: '2023-10-31T21:26:32.933732Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_fields
+  model: Table
+- id: name
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/table_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/table_id.yaml
@@ -1,43 +1,43 @@
+name: table_id
+display_name: Table ID
 description: null
-database_type: int4
-semantic_type: type/FK
+created_at: '2023-10-31T21:26:32.933732Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_fields
-coercion_strategy: null
-name: table_id
-has_field_values: null
-settings: null
-caveats: null
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
 fk_target_field_id:
 - Internal Metabase Database
 - public
 - v_tables
 - entity_id
 dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_fields
-- model: Field
-  id: table_id
-database_is_auto_increment: false
 json_unfolding: false
-position: 12
-visibility_type: normal
+parent_id: null
+coercion_strategy: null
 preview_display: true
-display_name: Table ID
+position: 12
+custom_position: 0
 database_position: 12
-database_required: false
-created_at: '2023-10-31T21:26:32.933732Z'
-base_type: type/Integer
+has_field_values: null
+settings: null
+caveats: null
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_fields
+  model: Table
+- id: table_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/updated_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/updated_at.yaml
@@ -1,39 +1,39 @@
+name: updated_at
+display_name: Updated At
 description: null
-database_type: timestamptz
-semantic_type: type/UpdatedTimestamp
+created_at: '2023-10-31T21:26:32.933732Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_fields
+database_type: timestamptz
+base_type: type/DateTimeWithLocalTZ
+effective_type: type/DateTimeWithLocalTZ
+semantic_type: type/UpdatedTimestamp
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: updated_at
+preview_display: true
+position: 3
+custom_position: 0
+database_position: 3
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/DateTimeWithLocalTZ
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_fields
-- model: Field
-  id: updated_at
-database_is_auto_increment: false
-json_unfolding: false
-position: 3
-visibility_type: normal
-preview_display: true
-display_name: Updated At
-database_position: 3
-database_required: false
-created_at: '2023-10-31T21:26:32.933732Z'
-base_type: type/DateTimeWithLocalTZ
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_fields
+  model: Table
+- id: updated_at
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/visibility_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/visibility_type.yaml
@@ -1,39 +1,39 @@
+name: visibility_type
+display_name: Visibility Type
 description: null
-database_type: varchar
-semantic_type: type/Category
+created_at: '2023-10-31T21:26:32.933732Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_fields
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: visibility_type
+preview_display: true
+position: 8
+custom_position: 0
+database_position: 8
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_fields
-- model: Field
-  id: visibility_type
-database_is_auto_increment: false
-json_unfolding: false
-position: 8
-visibility_type: normal
-preview_display: true
-display_name: Visibility Type
-database_position: 8
-database_required: false
-created_at: '2023-10-31T21:26:32.933732Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_fields
+  model: Table
+- id: visibility_type
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/v_fields.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/v_fields.yaml
@@ -1,22 +1,22 @@
-description: null
-entity_type: entity/GenericTable
-schema: public
-show_in_getting_started: false
 name: v_fields
-caveats: null
-active: true
-db_id: Internal Metabase Database
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_fields
-visibility_type: null
-field_order: database
-is_upload: false
-initial_sync_status: complete
 display_name: V Fields
+description: null
 created_at: '2023-10-31T21:26:32.235861Z'
+db_id: Internal Metabase Database
+schema: public
+entity_type: entity/GenericTable
+active: true
+is_upload: false
+field_order: database
+visibility_type: null
+show_in_getting_started: false
+initial_sync_status: complete
 points_of_interest: null
+caveats: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_fields
+  model: Table

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_group_members/fields/group_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_group_members/fields/group_id.yaml
@@ -1,39 +1,39 @@
+name: group_id
+display_name: Group ID
 description: null
-database_type: int4
-semantic_type: type/PK
+created_at: '2023-06-08T14:05:41.30338Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_group_members
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: group_id
+preview_display: true
+position: 1
+custom_position: 0
+database_position: 1
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_group_members
-- model: Field
-  id: group_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 1
-visibility_type: normal
-preview_display: true
-display_name: Group ID
-database_position: 1
-database_required: false
-created_at: '2023-06-08T14:05:41.30338Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_group_members
+  model: Table
+- id: group_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_group_members/fields/group_name.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_group_members/fields/group_name.yaml
@@ -1,39 +1,39 @@
+name: group_name
+display_name: Group Name
 description: null
-database_type: varchar
-semantic_type: type/Name
+created_at: '2023-06-08T14:05:41.30338Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_group_members
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Name
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: group_name
+preview_display: true
+position: 2
+custom_position: 0
+database_position: 2
 has_field_values: list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_group_members
-- model: Field
-  id: group_name
-database_is_auto_increment: false
-json_unfolding: false
-position: 2
-visibility_type: normal
-preview_display: true
-display_name: Group Name
-database_position: 2
-database_required: false
-created_at: '2023-06-08T14:05:41.30338Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_group_members
+  model: Table
+- id: group_name
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_group_members/fields/user_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_group_members/fields/user_id.yaml
@@ -1,43 +1,43 @@
+name: user_id
+display_name: User ID
 description: null
-database_type: int4
-semantic_type: type/FK
+created_at: '2023-06-08T14:05:41.30338Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_group_members
-coercion_strategy: null
-name: user_id
-has_field_values: null
-settings: null
-caveats: null
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
 fk_target_field_id:
 - Internal Metabase Database
 - public
 - v_users
 - user_id
 dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_group_members
-- model: Field
-  id: user_id
-database_is_auto_increment: false
 json_unfolding: false
-position: 0
-visibility_type: normal
+parent_id: null
+coercion_strategy: null
 preview_display: true
-display_name: User ID
+position: 0
+custom_position: 0
 database_position: 0
-database_required: false
-created_at: '2023-06-08T14:05:41.30338Z'
-base_type: type/Integer
+has_field_values: null
+settings: null
+caveats: null
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_group_members
+  model: Table
+- id: user_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_group_members/v_group_members.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_group_members/v_group_members.yaml
@@ -1,22 +1,22 @@
-description: null
-entity_type: entity/GenericTable
-schema: public
-show_in_getting_started: false
 name: v_group_members
-caveats: null
-active: true
-db_id: Internal Metabase Database
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_group_members
-visibility_type: null
-field_order: database
-is_upload: false
-initial_sync_status: complete
 display_name: V Group Members
+description: null
 created_at: '2023-06-08T14:05:38.973247Z'
+db_id: Internal Metabase Database
+schema: public
+entity_type: entity/GenericTable
+active: true
+is_upload: false
+field_order: database
+visibility_type: null
+show_in_getting_started: false
+initial_sync_status: complete
 points_of_interest: null
+caveats: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_group_members
+  model: Table

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/action_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/action_id.yaml
@@ -1,39 +1,39 @@
+name: action_id
+display_name: Action ID
 description: null
-database_type: int4
-semantic_type: null
+created_at: '2023-10-31T21:26:33.12521Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: action_id
+preview_display: true
+position: 16
+custom_position: 0
+database_position: 16
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_query_log
-- model: Field
-  id: action_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 16
-visibility_type: normal
-preview_display: true
-display_name: Action ID
-database_position: 16
-database_required: false
-created_at: '2023-10-31T21:26:33.12521Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_query_log
+  model: Table
+- id: action_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/action_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/action_qualified_id.yaml
@@ -1,39 +1,39 @@
+name: action_qualified_id
+display_name: Action Qualified ID
 description: null
-database_type: text
-semantic_type: type/Category
+created_at: '2023-10-31T21:56:01.797264Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: action_qualified_id
+preview_display: true
+position: 17
+custom_position: 0
+database_position: 17
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_query_log
-- model: Field
-  id: action_qualified_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 17
-visibility_type: normal
-preview_display: true
-display_name: Action Qualified ID
-database_position: 17
-database_required: false
-created_at: '2023-10-31T21:56:01.797264Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_query_log
+  model: Table
+- id: action_qualified_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/cache_hit.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/cache_hit.yaml
@@ -1,39 +1,39 @@
+name: cache_hit
+display_name: Cache Hit
 description: null
-database_type: bool
-semantic_type: type/Category
+created_at: '2023-10-31T21:26:33.12521Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
+database_type: bool
+base_type: type/Boolean
+effective_type: type/Boolean
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: cache_hit
+preview_display: true
+position: 15
+custom_position: 0
+database_position: 15
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Boolean
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_query_log
-- model: Field
-  id: cache_hit
-database_is_auto_increment: false
-json_unfolding: false
-position: 15
-visibility_type: normal
-preview_display: true
-display_name: Cache Hit
-database_position: 15
-database_required: false
-created_at: '2023-10-31T21:26:33.12521Z'
-base_type: type/Boolean
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_query_log
+  model: Table
+- id: cache_hit
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/card_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/card_id.yaml
@@ -1,39 +1,39 @@
+name: card_id
+display_name: Card ID
 description: null
-database_type: int4
-semantic_type: null
+created_at: '2023-10-31T21:26:33.12521Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: card_id
+preview_display: true
+position: 8
+custom_position: 0
+database_position: 8
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_query_log
-- model: Field
-  id: card_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 8
-visibility_type: normal
-preview_display: true
-display_name: Card ID
-database_position: 8
-database_required: false
-created_at: '2023-10-31T21:26:33.12521Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_query_log
+  model: Table
+- id: card_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/card_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/card_qualified_id.yaml
@@ -1,43 +1,43 @@
+name: card_qualified_id
+display_name: Card Qualified ID
 description: null
-database_type: text
-semantic_type: type/FK
+created_at: '2023-10-31T21:26:33.12521Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
-coercion_strategy: null
-name: card_qualified_id
-has_field_values: null
-settings: null
-caveats: null
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
 fk_target_field_id:
 - Internal Metabase Database
 - public
 - v_content
 - entity_qualified_id
 dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_query_log
-- model: Field
-  id: card_qualified_id
-database_is_auto_increment: false
 json_unfolding: false
-position: 9
-visibility_type: normal
+parent_id: null
+coercion_strategy: null
 preview_display: true
-display_name: Card Qualified ID
+position: 9
+custom_position: 0
 database_position: 9
-database_required: false
-created_at: '2023-10-31T21:26:33.12521Z'
-base_type: type/Text
+has_field_values: null
+settings: null
+caveats: null
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_query_log
+  model: Table
+- id: card_qualified_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/dashboard_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/dashboard_id.yaml
@@ -1,39 +1,39 @@
+name: dashboard_id
+display_name: Dashboard ID
 description: null
-database_type: int4
-semantic_type: null
+created_at: '2023-10-31T21:26:33.12521Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: dashboard_id
+preview_display: true
+position: 10
+custom_position: 0
+database_position: 10
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_query_log
-- model: Field
-  id: dashboard_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 10
-visibility_type: normal
-preview_display: true
-display_name: Dashboard ID
-database_position: 10
-database_required: false
-created_at: '2023-10-31T21:26:33.12521Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_query_log
+  model: Table
+- id: dashboard_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/dashboard_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/dashboard_qualified_id.yaml
@@ -1,43 +1,43 @@
+name: dashboard_qualified_id
+display_name: Dashboard Qualified ID
 description: null
-database_type: text
-semantic_type: type/FK
+created_at: '2023-10-31T21:26:33.12521Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
-coercion_strategy: null
-name: dashboard_qualified_id
-has_field_values: auto-list
-settings: null
-caveats: null
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
 fk_target_field_id:
 - Internal Metabase Database
 - public
 - v_content
 - entity_qualified_id
 dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_query_log
-- model: Field
-  id: dashboard_qualified_id
-database_is_auto_increment: false
 json_unfolding: false
-position: 11
-visibility_type: normal
+parent_id: null
+coercion_strategy: null
 preview_display: true
-display_name: Dashboard Qualified ID
+position: 11
+custom_position: 0
 database_position: 11
-database_required: false
-created_at: '2023-10-31T21:26:33.12521Z'
-base_type: type/Text
+has_field_values: auto-list
+settings: null
+caveats: null
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_query_log
+  model: Table
+- id: dashboard_qualified_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/database_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/database_id.yaml
@@ -1,39 +1,39 @@
+name: database_id
+display_name: Database ID
 description: null
-database_type: int4
-semantic_type: null
+created_at: '2023-10-31T21:26:33.12521Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: database_id
+preview_display: true
+position: 13
+custom_position: 0
+database_position: 13
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_query_log
-- model: Field
-  id: database_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 13
-visibility_type: normal
-preview_display: true
-display_name: Database ID
-database_position: 13
-database_required: false
-created_at: '2023-10-31T21:26:33.12521Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_query_log
+  model: Table
+- id: database_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/database_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/database_qualified_id.yaml
@@ -1,43 +1,43 @@
+name: database_qualified_id
+display_name: Database Qualified ID
 description: null
-database_type: text
-semantic_type: type/FK
+created_at: '2023-10-31T21:26:33.12521Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
-coercion_strategy: null
-name: database_qualified_id
-has_field_values: auto-list
-settings: null
-caveats: null
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
 fk_target_field_id:
 - Internal Metabase Database
 - public
 - v_databases
 - entity_qualified_id
 dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_query_log
-- model: Field
-  id: database_qualified_id
-database_is_auto_increment: false
 json_unfolding: false
-position: 14
-visibility_type: normal
+parent_id: null
+coercion_strategy: null
 preview_display: true
-display_name: Database Qualified ID
+position: 14
+custom_position: 0
 database_position: 14
-database_required: false
-created_at: '2023-10-31T21:26:33.12521Z'
-base_type: type/Text
+has_field_values: auto-list
+settings: null
+caveats: null
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_query_log
+  model: Table
+- id: database_qualified_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/entity_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/entity_id.yaml
@@ -1,39 +1,39 @@
+name: entity_id
+display_name: Entity ID
 description: null
-database_type: int4
-semantic_type: type/PK
+created_at: '2023-10-31T21:26:33.12521Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_id
+preview_display: true
+position: 0
+custom_position: 0
+database_position: 0
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_query_log
-- model: Field
-  id: entity_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 0
-visibility_type: normal
-preview_display: true
-display_name: Entity ID
-database_position: 0
-database_required: false
-created_at: '2023-10-31T21:26:33.12521Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_query_log
+  model: Table
+- id: entity_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/error.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/error.yaml
@@ -1,39 +1,39 @@
+name: error
+display_name: Error
 description: null
-database_type: text
-semantic_type: null
+created_at: '2023-10-31T21:26:33.12521Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: error
+preview_display: true
+position: 6
+custom_position: 0
+database_position: 6
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_query_log
-- model: Field
-  id: error
-database_is_auto_increment: false
-json_unfolding: false
-position: 6
-visibility_type: normal
-preview_display: true
-display_name: Error
-database_position: 6
-database_required: false
-created_at: '2023-10-31T21:26:33.12521Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_query_log
+  model: Table
+- id: error
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/is_native.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/is_native.yaml
@@ -1,39 +1,39 @@
+name: is_native
+display_name: Is Native
 description: null
-database_type: bool
-semantic_type: type/Category
+created_at: '2023-10-31T21:26:33.12521Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
+database_type: bool
+base_type: type/Boolean
+effective_type: type/Boolean
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: is_native
+preview_display: true
+position: 4
+custom_position: 0
+database_position: 4
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Boolean
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_query_log
-- model: Field
-  id: is_native
-database_is_auto_increment: false
-json_unfolding: false
-position: 4
-visibility_type: normal
-preview_display: true
-display_name: Is Native
-database_position: 4
-database_required: false
-created_at: '2023-10-31T21:26:33.12521Z'
-base_type: type/Boolean
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_query_log
+  model: Table
+- id: is_native
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/pulse_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/pulse_id.yaml
@@ -1,39 +1,39 @@
+name: pulse_id
+display_name: Pulse ID
 description: null
-database_type: int4
-semantic_type: null
+created_at: '2023-10-31T21:26:33.12521Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: pulse_id
+preview_display: true
+position: 12
+custom_position: 0
+database_position: 12
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_query_log
-- model: Field
-  id: pulse_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 12
-visibility_type: normal
-preview_display: true
-display_name: Pulse ID
-database_position: 12
-database_required: false
-created_at: '2023-10-31T21:26:33.12521Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_query_log
+  model: Table
+- id: pulse_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/query_source.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/query_source.yaml
@@ -1,39 +1,39 @@
+name: query_source
+display_name: Query Source
 description: null
-database_type: varchar
-semantic_type: type/Source
+created_at: '2023-10-31T21:26:33.12521Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Source
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: query_source
+preview_display: true
+position: 5
+custom_position: 0
+database_position: 5
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_query_log
-- model: Field
-  id: query_source
-database_is_auto_increment: false
-json_unfolding: false
-position: 5
-visibility_type: normal
-preview_display: true
-display_name: Query Source
-database_position: 5
-database_required: false
-created_at: '2023-10-31T21:26:33.12521Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_query_log
+  model: Table
+- id: query_source
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/result_rows.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/result_rows.yaml
@@ -1,39 +1,39 @@
+name: result_rows
+display_name: Result Rows
 description: null
-database_type: int4
-semantic_type: null
+created_at: '2023-10-31T21:26:33.12521Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: result_rows
+preview_display: true
+position: 3
+custom_position: 0
+database_position: 3
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_query_log
-- model: Field
-  id: result_rows
-database_is_auto_increment: false
-json_unfolding: false
-position: 3
-visibility_type: normal
-preview_display: true
-display_name: Result Rows
-database_position: 3
-database_required: false
-created_at: '2023-10-31T21:26:33.12521Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_query_log
+  model: Table
+- id: result_rows
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/running_time_seconds.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/running_time_seconds.yaml
@@ -1,39 +1,39 @@
+name: running_time_seconds
+display_name: Running Time Seconds
 description: null
-database_type: float8
-semantic_type: null
+created_at: '2023-10-31T21:26:33.12521Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
+database_type: float8
+base_type: type/Float
+effective_type: type/Float
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: running_time_seconds
+preview_display: true
+position: 2
+custom_position: 0
+database_position: 2
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Float
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_query_log
-- model: Field
-  id: running_time_seconds
-database_is_auto_increment: false
-json_unfolding: false
-position: 2
-visibility_type: normal
-preview_display: true
-display_name: Running Time Seconds
-database_position: 2
-database_required: false
-created_at: '2023-10-31T21:26:33.12521Z'
-base_type: type/Float
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_query_log
+  model: Table
+- id: running_time_seconds
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/started_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/started_at.yaml
@@ -1,39 +1,39 @@
+name: started_at
+display_name: Started At
 description: null
-database_type: timestamptz
-semantic_type: type/CreationTimestamp
+created_at: '2023-10-31T21:26:33.12521Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
+database_type: timestamptz
+base_type: type/DateTimeWithLocalTZ
+effective_type: type/DateTimeWithLocalTZ
+semantic_type: type/CreationTimestamp
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: started_at
+preview_display: true
+position: 1
+custom_position: 0
+database_position: 1
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/DateTimeWithLocalTZ
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_query_log
-- model: Field
-  id: started_at
-database_is_auto_increment: false
-json_unfolding: false
-position: 1
-visibility_type: normal
-preview_display: true
-display_name: Started At
-database_position: 1
-database_required: false
-created_at: '2023-10-31T21:26:33.12521Z'
-base_type: type/DateTimeWithLocalTZ
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_query_log
+  model: Table
+- id: started_at
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/user_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/user_id.yaml
@@ -1,43 +1,43 @@
+name: user_id
+display_name: User ID
 description: null
-database_type: int4
-semantic_type: type/FK
+created_at: '2023-10-31T21:26:33.12521Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_query_log
-coercion_strategy: null
-name: user_id
-has_field_values: auto-list
-settings: null
-caveats: null
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
 fk_target_field_id:
 - Internal Metabase Database
 - public
 - v_users
 - user_id
 dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_query_log
-- model: Field
-  id: user_id
-database_is_auto_increment: false
 json_unfolding: false
-position: 7
-visibility_type: normal
+parent_id: null
+coercion_strategy: null
 preview_display: true
-display_name: User ID
+position: 7
+custom_position: 0
 database_position: 7
-database_required: false
-created_at: '2023-10-31T21:26:33.12521Z'
-base_type: type/Integer
+has_field_values: auto-list
+settings: null
+caveats: null
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_query_log
+  model: Table
+- id: user_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/v_query_log.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/v_query_log.yaml
@@ -1,22 +1,22 @@
-description: null
-entity_type: entity/EventTable
-schema: public
-show_in_getting_started: false
 name: v_query_log
-caveats: null
-active: true
-db_id: Internal Metabase Database
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_query_log
-visibility_type: null
-field_order: database
-is_upload: false
-initial_sync_status: complete
 display_name: V Query Log
+description: null
 created_at: '2023-10-31T21:26:32.257395Z'
+db_id: Internal Metabase Database
+schema: public
+entity_type: entity/EventTable
+active: true
+is_upload: false
+field_order: database
+visibility_type: null
+show_in_getting_started: false
+initial_sync_status: complete
 points_of_interest: null
+caveats: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_query_log
+  model: Table

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/archived.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/archived.yaml
@@ -1,39 +1,39 @@
+name: archived
+display_name: Archived
 description: null
-database_type: bool
-semantic_type: type/Category
+created_at: '2023-11-01T02:10:34.257547Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_subscriptions
+database_type: bool
+base_type: type/Boolean
+effective_type: type/Boolean
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: archived
+preview_display: true
+position: 5
+custom_position: 0
+database_position: 5
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Boolean
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_subscriptions
-- model: Field
-  id: archived
-database_is_auto_increment: false
-json_unfolding: false
-position: 5
-visibility_type: normal
-preview_display: true
-display_name: Archived
-database_position: 5
-database_required: false
-created_at: '2023-11-01T02:10:34.257547Z'
-base_type: type/Boolean
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_subscriptions
+  model: Table
+- id: archived
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/created_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/created_at.yaml
@@ -1,39 +1,39 @@
+name: created_at
+display_name: Created At
 description: null
-database_type: timestamptz
-semantic_type: type/CreationTimestamp
+created_at: '2023-11-01T02:10:34.257547Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_subscriptions
+database_type: timestamptz
+base_type: type/DateTimeWithLocalTZ
+effective_type: type/DateTimeWithLocalTZ
+semantic_type: type/CreationTimestamp
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: created_at
+preview_display: true
+position: 2
+custom_position: 0
+database_position: 2
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/DateTimeWithLocalTZ
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_subscriptions
-- model: Field
-  id: created_at
-database_is_auto_increment: false
-json_unfolding: false
-position: 2
-visibility_type: normal
-preview_display: true
-display_name: Created At
-database_position: 2
-database_required: false
-created_at: '2023-11-01T02:10:34.257547Z'
-base_type: type/DateTimeWithLocalTZ
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_subscriptions
+  model: Table
+- id: created_at
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/creator_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/creator_id.yaml
@@ -1,43 +1,43 @@
+name: creator_id
+display_name: Creator ID
 description: null
-database_type: int4
-semantic_type: type/FK
+created_at: '2023-11-01T02:10:34.257547Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_subscriptions
-coercion_strategy: null
-name: creator_id
-has_field_values: auto-list
-settings: null
-caveats: null
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
 fk_target_field_id:
 - Internal Metabase Database
 - public
 - v_users
 - user_id
 dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_subscriptions
-- model: Field
-  id: creator_id
-database_is_auto_increment: false
 json_unfolding: false
-position: 4
-visibility_type: normal
+parent_id: null
+coercion_strategy: null
 preview_display: true
-display_name: Creator ID
+position: 4
+custom_position: 0
 database_position: 4
-database_required: false
-created_at: '2023-11-01T02:10:34.257547Z'
-base_type: type/Integer
+has_field_values: auto-list
+settings: null
+caveats: null
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_subscriptions
+  model: Table
+- id: creator_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/dashboard_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/dashboard_qualified_id.yaml
@@ -1,43 +1,43 @@
+name: dashboard_qualified_id
+display_name: Dashboard Qualified ID
 description: null
-database_type: text
-semantic_type: type/FK
+created_at: '2023-11-01T02:10:34.257547Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_subscriptions
-coercion_strategy: null
-name: dashboard_qualified_id
-has_field_values: auto-list
-settings: null
-caveats: null
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
 fk_target_field_id:
 - Internal Metabase Database
 - public
 - v_content
 - entity_qualified_id
 dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_subscriptions
-- model: Field
-  id: dashboard_qualified_id
-database_is_auto_increment: false
 json_unfolding: false
-position: 6
-visibility_type: normal
+parent_id: null
+coercion_strategy: null
 preview_display: true
-display_name: Dashboard Qualified ID
+position: 6
+custom_position: 0
 database_position: 6
-database_required: false
-created_at: '2023-11-01T02:10:34.257547Z'
-base_type: type/Text
+has_field_values: auto-list
+settings: null
+caveats: null
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_subscriptions
+  model: Table
+- id: dashboard_qualified_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/entity_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/entity_id.yaml
@@ -1,39 +1,39 @@
+name: entity_id
+display_name: Entity ID
 description: null
-database_type: int4
-semantic_type: type/PK
+created_at: '2023-11-01T02:10:34.257547Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_subscriptions
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_id
+preview_display: true
+position: 0
+custom_position: 0
+database_position: 0
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_subscriptions
-- model: Field
-  id: entity_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 0
-visibility_type: normal
-preview_display: true
-display_name: Entity ID
-database_position: 0
-database_required: false
-created_at: '2023-11-01T02:10:34.257547Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_subscriptions
+  model: Table
+- id: entity_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/entity_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/entity_qualified_id.yaml
@@ -1,39 +1,39 @@
+name: entity_qualified_id
+display_name: Entity Qualified ID
 description: null
-database_type: text
-semantic_type: type/PK
+created_at: '2023-11-01T02:10:34.257547Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_subscriptions
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_qualified_id
+preview_display: true
+position: 1
+custom_position: 0
+database_position: 1
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_subscriptions
-- model: Field
-  id: entity_qualified_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 1
-visibility_type: normal
-preview_display: true
-display_name: Entity Qualified ID
-database_position: 1
-database_required: false
-created_at: '2023-11-01T02:10:34.257547Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_subscriptions
+  model: Table
+- id: entity_qualified_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/parameters.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/parameters.yaml
@@ -1,39 +1,39 @@
+name: parameters
+display_name: Parameters
 description: null
-database_type: text
-semantic_type: type/SerializedJSON
+created_at: '2023-11-01T02:10:34.257547Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_subscriptions
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/SerializedJSON
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: parameters
+preview_display: true
+position: 13
+custom_position: 0
+database_position: 13
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_subscriptions
-- model: Field
-  id: parameters
-database_is_auto_increment: false
-json_unfolding: false
-position: 13
-visibility_type: normal
-preview_display: true
-display_name: Parameters
-database_position: 13
-database_required: false
-created_at: '2023-11-01T02:10:34.257547Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_subscriptions
+  model: Table
+- id: parameters
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/recipient_external.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/recipient_external.yaml
@@ -1,39 +1,39 @@
+name: recipient_external
+display_name: Recipient External
 description: null
-database_type: text
-semantic_type: null
+created_at: '2023-11-01T02:10:34.257547Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_subscriptions
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: recipient_external
+preview_display: true
+position: 12
+custom_position: 0
+database_position: 12
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_subscriptions
-- model: Field
-  id: recipient_external
-database_is_auto_increment: false
-json_unfolding: false
-position: 12
-visibility_type: normal
-preview_display: true
-display_name: Recipient External
-database_position: 12
-database_required: false
-created_at: '2023-11-01T02:10:34.257547Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_subscriptions
+  model: Table
+- id: recipient_external
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/recipient_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/recipient_type.yaml
@@ -1,39 +1,39 @@
+name: recipient_type
+display_name: Recipient Type
 description: null
-database_type: varchar
-semantic_type: type/Category
+created_at: '2023-11-01T02:10:34.257547Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_subscriptions
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: recipient_type
+preview_display: true
+position: 10
+custom_position: 0
+database_position: 10
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_subscriptions
-- model: Field
-  id: recipient_type
-database_is_auto_increment: false
-json_unfolding: false
-position: 10
-visibility_type: normal
-preview_display: true
-display_name: Recipient Type
-database_position: 10
-database_required: false
-created_at: '2023-11-01T02:10:34.257547Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_subscriptions
+  model: Table
+- id: recipient_type
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/recipients.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/recipients.yaml
@@ -1,39 +1,39 @@
+name: recipients
+display_name: Recipients
 description: null
-database_type: text
-semantic_type: type/Category
+created_at: '2023-11-01T02:10:34.257547Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_subscriptions
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: recipients
+preview_display: true
+position: 11
+custom_position: 0
+database_position: 11
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_subscriptions
-- model: Field
-  id: recipients
-database_is_auto_increment: false
-json_unfolding: false
-position: 11
-visibility_type: normal
-preview_display: true
-display_name: Recipients
-database_position: 11
-database_required: false
-created_at: '2023-11-01T02:10:34.257547Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_subscriptions
+  model: Table
+- id: recipients
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/schedule_day.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/schedule_day.yaml
@@ -1,39 +1,39 @@
+name: schedule_day
+display_name: Schedule Day
 description: null
-database_type: varchar
-semantic_type: type/Category
+created_at: '2023-11-01T02:10:34.257547Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_subscriptions
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: schedule_day
+preview_display: true
+position: 8
+custom_position: 0
+database_position: 8
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_subscriptions
-- model: Field
-  id: schedule_day
-database_is_auto_increment: false
-json_unfolding: false
-position: 8
-visibility_type: normal
-preview_display: true
-display_name: Schedule Day
-database_position: 8
-database_required: false
-created_at: '2023-11-01T02:10:34.257547Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_subscriptions
+  model: Table
+- id: schedule_day
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/schedule_hour.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/schedule_hour.yaml
@@ -1,39 +1,39 @@
+name: schedule_hour
+display_name: Schedule Hour
 description: null
-database_type: int4
-semantic_type: type/Category
+created_at: '2023-11-01T02:10:34.257547Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_subscriptions
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: schedule_hour
+preview_display: true
+position: 9
+custom_position: 0
+database_position: 9
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_subscriptions
-- model: Field
-  id: schedule_hour
-database_is_auto_increment: false
-json_unfolding: false
-position: 9
-visibility_type: normal
-preview_display: true
-display_name: Schedule Hour
-database_position: 9
-database_required: false
-created_at: '2023-11-01T02:10:34.257547Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_subscriptions
+  model: Table
+- id: schedule_hour
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/schedule_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/schedule_type.yaml
@@ -1,39 +1,39 @@
+name: schedule_type
+display_name: Schedule Type
 description: null
-database_type: varchar
-semantic_type: type/Category
+created_at: '2023-11-01T02:10:34.257547Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_subscriptions
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: schedule_type
+preview_display: true
+position: 7
+custom_position: 0
+database_position: 7
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_subscriptions
-- model: Field
-  id: schedule_type
-database_is_auto_increment: false
-json_unfolding: false
-position: 7
-visibility_type: normal
-preview_display: true
-display_name: Schedule Type
-database_position: 7
-database_required: false
-created_at: '2023-11-01T02:10:34.257547Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_subscriptions
+  model: Table
+- id: schedule_type
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/updated_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/updated_at.yaml
@@ -1,39 +1,39 @@
+name: updated_at
+display_name: Updated At
 description: null
-database_type: timestamptz
-semantic_type: type/UpdatedTimestamp
+created_at: '2023-11-01T02:10:34.257547Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_subscriptions
+database_type: timestamptz
+base_type: type/DateTimeWithLocalTZ
+effective_type: type/DateTimeWithLocalTZ
+semantic_type: type/UpdatedTimestamp
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: updated_at
+preview_display: true
+position: 3
+custom_position: 0
+database_position: 3
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/DateTimeWithLocalTZ
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_subscriptions
-- model: Field
-  id: updated_at
-database_is_auto_increment: false
-json_unfolding: false
-position: 3
-visibility_type: normal
-preview_display: true
-display_name: Updated At
-database_position: 3
-database_required: false
-created_at: '2023-11-01T02:10:34.257547Z'
-base_type: type/DateTimeWithLocalTZ
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_subscriptions
+  model: Table
+- id: updated_at
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/v_subscriptions.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/v_subscriptions.yaml
@@ -1,22 +1,22 @@
-description: null
-entity_type: entity/SubscriptionTable
-schema: public
-show_in_getting_started: false
 name: v_subscriptions
-caveats: null
-active: true
-db_id: Internal Metabase Database
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_subscriptions
-visibility_type: null
-field_order: database
-is_upload: false
-initial_sync_status: complete
 display_name: V Subscriptions
+description: null
 created_at: '2023-11-01T02:10:33.27391Z'
+db_id: Internal Metabase Database
+schema: public
+entity_type: entity/SubscriptionTable
+active: true
+is_upload: false
+field_order: database
+visibility_type: null
+show_in_getting_started: false
+initial_sync_status: complete
 points_of_interest: null
+caveats: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_subscriptions
+  model: Table

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/active.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/active.yaml
@@ -1,39 +1,39 @@
+name: active
+display_name: Active
 description: null
-database_type: bool
-semantic_type: type/Category
+created_at: '2023-10-31T21:26:32.847751Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_tables
+database_type: bool
+base_type: type/Boolean
+effective_type: type/Boolean
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: active
+preview_display: true
+position: 7
+custom_position: 0
+database_position: 7
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Boolean
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_tables
-- model: Field
-  id: active
-database_is_auto_increment: false
-json_unfolding: false
-position: 7
-visibility_type: normal
-preview_display: true
-display_name: Active
-database_position: 7
-database_required: false
-created_at: '2023-10-31T21:26:32.847751Z'
-base_type: type/Boolean
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_tables
+  model: Table
+- id: active
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/created_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/created_at.yaml
@@ -1,39 +1,39 @@
+name: created_at
+display_name: Created At
 description: null
-database_type: timestamptz
-semantic_type: type/CreationTimestamp
+created_at: '2023-10-31T21:26:32.847751Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_tables
+database_type: timestamptz
+base_type: type/DateTimeWithLocalTZ
+effective_type: type/DateTimeWithLocalTZ
+semantic_type: type/CreationTimestamp
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: created_at
+preview_display: true
+position: 2
+custom_position: 0
+database_position: 2
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/DateTimeWithLocalTZ
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_tables
-- model: Field
-  id: created_at
-database_is_auto_increment: false
-json_unfolding: false
-position: 2
-visibility_type: normal
-preview_display: true
-display_name: Created At
-database_position: 2
-database_required: false
-created_at: '2023-10-31T21:26:32.847751Z'
-base_type: type/DateTimeWithLocalTZ
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_tables
+  model: Table
+- id: created_at
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/database_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/database_id.yaml
@@ -1,43 +1,43 @@
+name: database_id
+display_name: Database ID
 description: null
-database_type: int4
-semantic_type: type/FK
+created_at: '2023-10-31T21:26:32.847751Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_tables
-coercion_strategy: null
-name: database_id
-has_field_values: auto-list
-settings: null
-caveats: null
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
 fk_target_field_id:
 - Internal Metabase Database
 - public
 - v_databases
 - entity_id
 dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_tables
-- model: Field
-  id: database_id
-database_is_auto_increment: false
 json_unfolding: false
-position: 8
-visibility_type: normal
+parent_id: null
+coercion_strategy: null
 preview_display: true
-display_name: Database ID
+position: 8
+custom_position: 0
 database_position: 8
-database_required: false
-created_at: '2023-10-31T21:26:32.847751Z'
-base_type: type/Integer
+has_field_values: auto-list
+settings: null
+caveats: null
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_tables
+  model: Table
+- id: database_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/description.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/description.yaml
@@ -1,39 +1,39 @@
+name: description
+display_name: Description
 description: null
-database_type: text
-semantic_type: type/Description
+created_at: '2023-10-31T21:26:32.847751Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_tables
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Description
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: description
+preview_display: true
+position: 6
+custom_position: 0
+database_position: 6
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_tables
-- model: Field
-  id: description
-database_is_auto_increment: false
-json_unfolding: false
-position: 6
-visibility_type: normal
-preview_display: true
-display_name: Description
-database_position: 6
-database_required: false
-created_at: '2023-10-31T21:26:32.847751Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_tables
+  model: Table
+- id: description
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/display_name.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/display_name.yaml
@@ -1,39 +1,39 @@
+name: display_name
+display_name: Display Name
 description: null
-database_type: varchar
-semantic_type: null
+created_at: '2023-10-31T21:26:32.847751Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_tables
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: display_name
+preview_display: true
+position: 5
+custom_position: 0
+database_position: 5
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_tables
-- model: Field
-  id: display_name
-database_is_auto_increment: false
-json_unfolding: false
-position: 5
-visibility_type: normal
-preview_display: true
-display_name: Display Name
-database_position: 5
-database_required: false
-created_at: '2023-10-31T21:26:32.847751Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_tables
+  model: Table
+- id: display_name
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/entity_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/entity_id.yaml
@@ -1,39 +1,39 @@
+name: entity_id
+display_name: Entity ID
 description: null
-database_type: int4
-semantic_type: type/PK
+created_at: '2023-10-31T21:26:32.847751Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_tables
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_id
+preview_display: true
+position: 0
+custom_position: 0
+database_position: 0
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_tables
-- model: Field
-  id: entity_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 0
-visibility_type: normal
-preview_display: true
-display_name: Entity ID
-database_position: 0
-database_required: false
-created_at: '2023-10-31T21:26:32.847751Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_tables
+  model: Table
+- id: entity_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/entity_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/entity_qualified_id.yaml
@@ -1,39 +1,39 @@
+name: entity_qualified_id
+display_name: Entity Qualified ID
 description: null
-database_type: text
-semantic_type: type/PK
+created_at: '2023-10-31T21:26:32.847751Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_tables
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_qualified_id
+preview_display: true
+position: 1
+custom_position: 0
+database_position: 1
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_tables
-- model: Field
-  id: entity_qualified_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 1
-visibility_type: normal
-preview_display: true
-display_name: Entity Qualified ID
-database_position: 1
-database_required: false
-created_at: '2023-10-31T21:26:32.847751Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_tables
+  model: Table
+- id: entity_qualified_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/is_upload.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/is_upload.yaml
@@ -1,39 +1,39 @@
+name: is_upload
+display_name: Is Upload
 description: null
-database_type: bool
-semantic_type: type/Category
+created_at: '2023-10-31T21:26:32.847751Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_tables
+database_type: bool
+base_type: type/Boolean
+effective_type: type/Boolean
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: is_upload
+preview_display: true
+position: 10
+custom_position: 0
+database_position: 10
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Boolean
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_tables
-- model: Field
-  id: is_upload
-database_is_auto_increment: false
-json_unfolding: false
-position: 10
-visibility_type: normal
-preview_display: true
-display_name: Is Upload
-database_position: 10
-database_required: false
-created_at: '2023-10-31T21:26:32.847751Z'
-base_type: type/Boolean
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_tables
+  model: Table
+- id: is_upload
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/name.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/name.yaml
@@ -1,39 +1,39 @@
+name: name
+display_name: Name
 description: null
-database_type: varchar
-semantic_type: type/Name
+created_at: '2023-10-31T21:26:32.847751Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_tables
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Name
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: name
+preview_display: true
+position: 4
+custom_position: 0
+database_position: 4
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_tables
-- model: Field
-  id: name
-database_is_auto_increment: false
-json_unfolding: false
-position: 4
-visibility_type: normal
-preview_display: true
-display_name: Name
-database_position: 4
-database_required: false
-created_at: '2023-10-31T21:26:32.847751Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_tables
+  model: Table
+- id: name
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/schema.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/schema.yaml
@@ -1,39 +1,39 @@
+name: schema
+display_name: Schema
 description: null
-database_type: varchar
-semantic_type: null
+created_at: '2023-10-31T21:26:32.847751Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_tables
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: schema
+preview_display: true
+position: 9
+custom_position: 0
+database_position: 9
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_tables
-- model: Field
-  id: schema
-database_is_auto_increment: false
-json_unfolding: false
-position: 9
-visibility_type: normal
-preview_display: true
-display_name: Schema
-database_position: 9
-database_required: false
-created_at: '2023-10-31T21:26:32.847751Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_tables
+  model: Table
+- id: schema
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/updated_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/updated_at.yaml
@@ -1,39 +1,39 @@
+name: updated_at
+display_name: Updated At
 description: null
-database_type: timestamptz
-semantic_type: type/UpdatedTimestamp
+created_at: '2023-10-31T21:26:32.847751Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_tables
+database_type: timestamptz
+base_type: type/DateTimeWithLocalTZ
+effective_type: type/DateTimeWithLocalTZ
+semantic_type: type/UpdatedTimestamp
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: updated_at
+preview_display: true
+position: 3
+custom_position: 0
+database_position: 3
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/DateTimeWithLocalTZ
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_tables
-- model: Field
-  id: updated_at
-database_is_auto_increment: false
-json_unfolding: false
-position: 3
-visibility_type: normal
-preview_display: true
-display_name: Updated At
-database_position: 3
-database_required: false
-created_at: '2023-10-31T21:26:32.847751Z'
-base_type: type/DateTimeWithLocalTZ
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_tables
+  model: Table
+- id: updated_at
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/v_tables.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/v_tables.yaml
@@ -1,22 +1,22 @@
-description: null
-entity_type: entity/GenericTable
-schema: public
-show_in_getting_started: false
 name: v_tables
-caveats: null
-active: true
-db_id: Internal Metabase Database
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_tables
-visibility_type: null
-field_order: database
-is_upload: false
-initial_sync_status: complete
 display_name: V Tables
+description: null
 created_at: '2023-10-31T21:26:32.221044Z'
+db_id: Internal Metabase Database
+schema: public
+entity_type: entity/GenericTable
+active: true
+is_upload: false
+field_order: database
+visibility_type: null
+show_in_getting_started: false
+initial_sync_status: complete
 points_of_interest: null
+caveats: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_tables
+  model: Table

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/database_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/database_id.yaml
@@ -1,0 +1,39 @@
+name: database_id
+display_name: Database ID
+description: null
+created_at: '2023-11-13T18:40:43.716586Z'
+active: false
+visibility_type: normal
+table_id:
+- Internal Metabase Database
+- public
+- v_tasks
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/Description
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
+coercion_strategy: null
+preview_display: true
+position: 2
+custom_position: 0
+database_position: 2
+has_field_values: auto-list
+settings: null
+caveats: null
+points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_tasks
+  model: Table
+- id: database_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/database_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/database_qualified_id.yaml
@@ -1,0 +1,43 @@
+name: database_qualified_id
+display_name: Database Qualified ID
+description: null
+created_at: '2023-11-13T18:40:43.716586Z'
+active: true
+visibility_type: normal
+table_id:
+- Internal Metabase Database
+- public
+- v_tasks
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/FK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id:
+- Internal Metabase Database
+- public
+- v_databases
+- entity_qualified_id
+dimensions: []
+json_unfolding: false
+parent_id: null
+coercion_strategy: null
+preview_display: true
+position: 2
+custom_position: 0
+database_position: 2
+has_field_values: auto-list
+settings: null
+caveats: null
+points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_tasks
+  model: Table
+- id: database_qualified_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/details.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/details.yaml
@@ -1,0 +1,39 @@
+name: details
+display_name: Details
+description: null
+created_at: '2023-11-13T18:40:43.716586Z'
+active: true
+visibility_type: normal
+table_id:
+- Internal Metabase Database
+- public
+- v_tasks
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
+coercion_strategy: null
+preview_display: true
+position: 6
+custom_position: 0
+database_position: 6
+has_field_values: auto-list
+settings: null
+caveats: null
+points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_tasks
+  model: Table
+- id: details
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/duration_seconds.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/duration_seconds.yaml
@@ -1,0 +1,39 @@
+name: duration_seconds
+display_name: Duration Seconds
+description: null
+created_at: '2023-11-13T18:40:43.716586Z'
+active: true
+visibility_type: normal
+table_id:
+- Internal Metabase Database
+- public
+- v_tasks
+database_type: float8
+base_type: type/Float
+effective_type: type/Float
+semantic_type: type/Quantity
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
+coercion_strategy: null
+preview_display: true
+position: 5
+custom_position: 0
+database_position: 5
+has_field_values: null
+settings: null
+caveats: null
+points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_tasks
+  model: Table
+- id: duration_seconds
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/ended_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/ended_at.yaml
@@ -1,0 +1,39 @@
+name: ended_at
+display_name: Ended At
+description: null
+created_at: '2023-11-13T18:40:43.716586Z'
+active: true
+visibility_type: normal
+table_id:
+- Internal Metabase Database
+- public
+- v_tasks
+database_type: timestamptz
+base_type: type/DateTimeWithLocalTZ
+effective_type: type/DateTimeWithLocalTZ
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
+coercion_strategy: null
+preview_display: true
+position: 4
+custom_position: 0
+database_position: 4
+has_field_values: null
+settings: null
+caveats: null
+points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_tasks
+  model: Table
+- id: ended_at
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/id.yaml
@@ -1,0 +1,39 @@
+name: id
+display_name: ID
+description: null
+created_at: '2023-11-13T18:40:43.716586Z'
+active: true
+visibility_type: normal
+table_id:
+- Internal Metabase Database
+- public
+- v_tasks
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
+coercion_strategy: null
+preview_display: true
+position: 0
+custom_position: 0
+database_position: 0
+has_field_values: null
+settings: null
+caveats: null
+points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_tasks
+  model: Table
+- id: id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/started_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/started_at.yaml
@@ -1,0 +1,39 @@
+name: started_at
+display_name: Started At
+description: null
+created_at: '2023-11-13T18:40:43.716586Z'
+active: true
+visibility_type: normal
+table_id:
+- Internal Metabase Database
+- public
+- v_tasks
+database_type: timestamptz
+base_type: type/DateTimeWithLocalTZ
+effective_type: type/DateTimeWithLocalTZ
+semantic_type: type/CreationTimestamp
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
+coercion_strategy: null
+preview_display: true
+position: 3
+custom_position: 0
+database_position: 3
+has_field_values: null
+settings: null
+caveats: null
+points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_tasks
+  model: Table
+- id: started_at
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/task.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/task.yaml
@@ -1,0 +1,39 @@
+name: task
+display_name: Task
+description: null
+created_at: '2023-11-13T18:40:43.716586Z'
+active: true
+visibility_type: normal
+table_id:
+- Internal Metabase Database
+- public
+- v_tasks
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
+coercion_strategy: null
+preview_display: true
+position: 1
+custom_position: 0
+database_position: 1
+has_field_values: auto-list
+settings: null
+caveats: null
+points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_tasks
+  model: Table
+- id: task
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/v_tasks.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/v_tasks.yaml
@@ -1,0 +1,22 @@
+name: v_tasks
+display_name: V Tasks
+description: null
+created_at: '2023-11-13T18:40:43.213898Z'
+db_id: Internal Metabase Database
+schema: public
+entity_type: entity/GenericTable
+active: true
+is_upload: false
+field_order: database
+visibility_type: null
+show_in_getting_started: false
+initial_sync_status: complete
+points_of_interest: null
+caveats: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_tasks
+  model: Table

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/date_joined.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/date_joined.yaml
@@ -1,39 +1,39 @@
+name: date_joined
+display_name: Date Joined
 description: null
-database_type: timestamptz
-semantic_type: type/JoinTimestamp
+created_at: '2023-06-08T14:05:41.008036Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_users
+database_type: timestamptz
+base_type: type/DateTimeWithLocalTZ
+effective_type: type/DateTimeWithLocalTZ
+semantic_type: type/JoinTimestamp
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: date_joined
+preview_display: true
+position: 6
+custom_position: 0
+database_position: 6
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/DateTimeWithLocalTZ
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_users
-- model: Field
-  id: date_joined
-database_is_auto_increment: false
-json_unfolding: false
-position: 6
-visibility_type: normal
-preview_display: true
-display_name: Date Joined
-database_position: 6
-database_required: false
-created_at: '2023-06-08T14:05:41.008036Z'
-base_type: type/DateTimeWithLocalTZ
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_users
+  model: Table
+- id: date_joined
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/email.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/email.yaml
@@ -1,39 +1,39 @@
+name: email
+display_name: Email
 description: null
-database_type: citext
-semantic_type: type/Email
+created_at: '2023-06-08T14:05:41.008036Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_users
+database_type: citext
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Email
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: email
+preview_display: true
+position: 2
+custom_position: 0
+database_position: 2
 has_field_values: list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_users
-- model: Field
-  id: email
-database_is_auto_increment: false
-json_unfolding: false
-position: 2
-visibility_type: normal
-preview_display: true
-display_name: Email
-database_position: 2
-database_required: false
-created_at: '2023-06-08T14:05:41.008036Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_users
+  model: Table
+- id: email
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/entity_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/entity_qualified_id.yaml
@@ -1,39 +1,39 @@
+name: entity_qualified_id
+display_name: Entity Qualified ID
 description: null
-database_type: text
-semantic_type: null
+created_at: '2023-10-31T13:16:53.421308Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_users
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_qualified_id
+preview_display: true
+position: 1
+custom_position: 0
+database_position: 1
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_users
-- model: Field
-  id: entity_qualified_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 1
-visibility_type: normal
-preview_display: true
-display_name: Entity Qualified ID
-database_position: 1
-database_required: false
-created_at: '2023-10-31T13:16:53.421308Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_users
+  model: Table
+- id: entity_qualified_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/first_name.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/first_name.yaml
@@ -1,39 +1,39 @@
+name: first_name
+display_name: First Name
 description: null
-database_type: varchar
-semantic_type: type/Name
+created_at: '2023-06-08T14:05:41.008036Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_users
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Name
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: first_name
+preview_display: true
+position: 3
+custom_position: 0
+database_position: 3
 has_field_values: list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_users
-- model: Field
-  id: first_name
-database_is_auto_increment: false
-json_unfolding: false
-position: 3
-visibility_type: normal
-preview_display: true
-display_name: First Name
-database_position: 3
-database_required: false
-created_at: '2023-06-08T14:05:41.008036Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_users
+  model: Table
+- id: first_name
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/full_name.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/full_name.yaml
@@ -1,39 +1,39 @@
+name: full_name
+display_name: Full Name
 description: null
-database_type: text
-semantic_type: type/Name
+created_at: '2023-06-08T14:05:41.008036Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_users
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Name
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: full_name
+preview_display: true
+position: 5
+custom_position: 0
+database_position: 5
 has_field_values: list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_users
-- model: Field
-  id: full_name
-database_is_auto_increment: false
-json_unfolding: false
-position: 5
-visibility_type: normal
-preview_display: true
-display_name: Full Name
-database_position: 5
-database_required: false
-created_at: '2023-06-08T14:05:41.008036Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_users
+  model: Table
+- id: full_name
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/is_active.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/is_active.yaml
@@ -1,39 +1,39 @@
+name: is_active
+display_name: Is Active
 description: null
-database_type: bool
-semantic_type: type/Category
+created_at: '2023-06-08T14:05:41.008036Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_users
+database_type: bool
+base_type: type/Boolean
+effective_type: type/Boolean
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: is_active
+preview_display: true
+position: 10
+custom_position: 0
+database_position: 10
 has_field_values: list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Boolean
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_users
-- model: Field
-  id: is_active
-database_is_auto_increment: false
-json_unfolding: false
-position: 10
-visibility_type: normal
-preview_display: true
-display_name: Is Active
-database_position: 10
-database_required: false
-created_at: '2023-06-08T14:05:41.008036Z'
-base_type: type/Boolean
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_users
+  model: Table
+- id: is_active
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/is_admin.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/is_admin.yaml
@@ -1,39 +1,39 @@
+name: is_admin
+display_name: Is Admin
 description: null
-database_type: bool
-semantic_type: type/Category
+created_at: '2023-06-08T14:05:41.008036Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_users
+database_type: bool
+base_type: type/Boolean
+effective_type: type/Boolean
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: is_admin
+preview_display: true
+position: 9
+custom_position: 0
+database_position: 9
 has_field_values: list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Boolean
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_users
-- model: Field
-  id: is_admin
-database_is_auto_increment: false
-json_unfolding: false
-position: 9
-visibility_type: normal
-preview_display: true
-display_name: Is Admin
-database_position: 9
-database_required: false
-created_at: '2023-06-08T14:05:41.008036Z'
-base_type: type/Boolean
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_users
+  model: Table
+- id: is_admin
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/last_login.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/last_login.yaml
@@ -1,39 +1,39 @@
+name: last_login
+display_name: Last Login
 description: null
-database_type: timestamptz
-semantic_type: null
+created_at: '2023-06-08T14:05:41.008036Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_users
+database_type: timestamptz
+base_type: type/DateTimeWithLocalTZ
+effective_type: type/DateTimeWithLocalTZ
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: last_login
+preview_display: true
+position: 7
+custom_position: 0
+database_position: 7
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/DateTimeWithLocalTZ
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_users
-- model: Field
-  id: last_login
-database_is_auto_increment: false
-json_unfolding: false
-position: 7
-visibility_type: normal
-preview_display: true
-display_name: Last Login
-database_position: 7
-database_required: false
-created_at: '2023-06-08T14:05:41.008036Z'
-base_type: type/DateTimeWithLocalTZ
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_users
+  model: Table
+- id: last_login
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/last_name.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/last_name.yaml
@@ -1,39 +1,39 @@
+name: last_name
+display_name: Last Name
 description: null
-database_type: varchar
-semantic_type: type/Name
+created_at: '2023-06-08T14:05:41.008036Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_users
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Name
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: last_name
+preview_display: true
+position: 4
+custom_position: 0
+database_position: 4
 has_field_values: list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_users
-- model: Field
-  id: last_name
-database_is_auto_increment: false
-json_unfolding: false
-position: 4
-visibility_type: normal
-preview_display: true
-display_name: Last Name
-database_position: 4
-database_required: false
-created_at: '2023-06-08T14:05:41.008036Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_users
+  model: Table
+- id: last_name
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/locale.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/locale.yaml
@@ -1,39 +1,39 @@
+name: locale
+display_name: Locale
 description: null
-database_type: varchar
-semantic_type: null
+created_at: '2023-06-08T14:05:41.008036Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_users
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: locale
+preview_display: true
+position: 12
+custom_position: 0
+database_position: 12
 has_field_values: list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_users
-- model: Field
-  id: locale
-database_is_auto_increment: false
-json_unfolding: false
-position: 12
-visibility_type: normal
-preview_display: true
-display_name: Locale
-database_position: 12
-database_required: false
-created_at: '2023-06-08T14:05:41.008036Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_users
+  model: Table
+- id: locale
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/sso_source.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/sso_source.yaml
@@ -1,39 +1,39 @@
+name: sso_source
+display_name: Sso Source
 description: null
-database_type: varchar
-semantic_type: type/Source
+created_at: '2023-06-08T14:05:41.008036Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_users
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Source
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: sso_source
+preview_display: true
+position: 11
+custom_position: 0
+database_position: 11
 has_field_values: list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_users
-- model: Field
-  id: sso_source
-database_is_auto_increment: false
-json_unfolding: false
-position: 11
-visibility_type: normal
-preview_display: true
-display_name: Sso Source
-database_position: 11
-database_required: false
-created_at: '2023-06-08T14:05:41.008036Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_users
+  model: Table
+- id: sso_source
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/updated_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/updated_at.yaml
@@ -1,39 +1,39 @@
+name: updated_at
+display_name: Updated At
 description: null
-database_type: timestamp
-semantic_type: type/UpdatedTimestamp
+created_at: '2023-06-08T14:05:41.008036Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_users
+database_type: timestamp
+base_type: type/DateTime
+effective_type: type/DateTime
+semantic_type: type/UpdatedTimestamp
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: updated_at
+preview_display: true
+position: 8
+custom_position: 0
+database_position: 8
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/DateTime
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_users
-- model: Field
-  id: updated_at
-database_is_auto_increment: false
-json_unfolding: false
-position: 8
-visibility_type: normal
-preview_display: true
-display_name: Updated At
-database_position: 8
-database_required: false
-created_at: '2023-06-08T14:05:41.008036Z'
-base_type: type/DateTime
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_users
+  model: Table
+- id: updated_at
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/user_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/user_id.yaml
@@ -1,39 +1,39 @@
+name: user_id
+display_name: User ID
 description: null
-database_type: int4
-semantic_type: type/PK
+created_at: '2023-06-08T14:05:41.008036Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_users
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: user_id
+preview_display: true
+position: 0
+custom_position: 0
+database_position: 0
 has_field_values: none
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_users
-- model: Field
-  id: user_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 0
-visibility_type: normal
-preview_display: true
-display_name: User ID
-database_position: 0
-database_required: false
-created_at: '2023-06-08T14:05:41.008036Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_users
+  model: Table
+- id: user_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/v_users.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/v_users.yaml
@@ -1,22 +1,22 @@
-description: null
-entity_type: entity/UserTable
-schema: public
-show_in_getting_started: false
 name: v_users
-caveats: null
-active: true
-db_id: Internal Metabase Database
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_users
-visibility_type: null
-field_order: database
-is_upload: false
-initial_sync_status: complete
 display_name: V Users
+description: null
 created_at: '2023-06-08T14:05:38.871348Z'
+db_id: Internal Metabase Database
+schema: public
+entity_type: entity/UserTable
+active: true
+is_upload: false
+field_order: database
+visibility_type: null
+show_in_getting_started: false
+initial_sync_status: complete
 points_of_interest: null
+caveats: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_users
+  model: Table

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/details.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/details.yaml
@@ -1,39 +1,39 @@
+name: details
+display_name: Details
 description: null
-database_type: text
-semantic_type: type/Category
+created_at: '2023-10-31T13:16:54.089514Z'
+active: false
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: details
+preview_display: true
+position: 6
+custom_position: 0
+database_position: 6
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_view_log
-- model: Field
-  id: details
-database_is_auto_increment: false
-json_unfolding: false
-position: 6
-visibility_type: normal
-preview_display: true
-display_name: Details
-database_position: 6
-database_required: false
-created_at: '2023-10-31T13:16:54.089514Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_view_log
+  model: Table
+- id: details
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/entity_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/entity_id.yaml
@@ -1,39 +1,39 @@
+name: entity_id
+display_name: Entity ID
 description: null
-database_type: int4
-semantic_type: null
+created_at: '2023-10-31T13:16:54.089514Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_id
+preview_display: true
+position: 4
+custom_position: 0
+database_position: 4
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_view_log
-- model: Field
-  id: entity_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 4
-visibility_type: normal
-preview_display: true
-display_name: Entity ID
-database_position: 4
-database_required: false
-created_at: '2023-10-31T13:16:54.089514Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_view_log
+  model: Table
+- id: entity_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/entity_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/entity_qualified_id.yaml
@@ -1,39 +1,39 @@
+name: entity_qualified_id
+display_name: Entity Qualified ID
 description: null
-database_type: text
-semantic_type: null
+created_at: '2023-10-31T13:16:54.089514Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
+database_type: text
+base_type: type/Text
+effective_type: type/Text
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_qualified_id
+preview_display: true
+position: 5
+custom_position: 0
+database_position: 5
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_view_log
-- model: Field
-  id: entity_qualified_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 5
-visibility_type: normal
-preview_display: true
-display_name: Entity Qualified ID
-database_position: 5
-database_required: false
-created_at: '2023-10-31T13:16:54.089514Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_view_log
+  model: Table
+- id: entity_qualified_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/entity_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/entity_type.yaml
@@ -1,39 +1,39 @@
+name: entity_type
+display_name: Entity Type
 description: null
-database_type: varchar
-semantic_type: type/Category
+created_at: '2023-10-31T13:16:54.089514Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
+database_type: varchar
+base_type: type/Text
+effective_type: type/Text
+semantic_type: type/Category
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: entity_type
+preview_display: true
+position: 3
+custom_position: 0
+database_position: 3
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Text
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_view_log
-- model: Field
-  id: entity_type
-database_is_auto_increment: false
-json_unfolding: false
-position: 3
-visibility_type: normal
-preview_display: true
-display_name: Entity Type
-database_position: 3
-database_required: false
-created_at: '2023-10-31T13:16:54.089514Z'
-base_type: type/Text
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_view_log
+  model: Table
+- id: entity_type
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/id.yaml
@@ -1,39 +1,39 @@
+name: id
+display_name: ID
 description: null
-database_type: int4
-semantic_type: type/PK
+created_at: '2023-10-31T13:16:54.089514Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: type/PK
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: id
+preview_display: true
+position: 0
+custom_position: 0
+database_position: 0
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_view_log
-- model: Field
-  id: id
-database_is_auto_increment: false
-json_unfolding: false
-position: 0
-visibility_type: normal
-preview_display: true
-display_name: ID
-database_position: 0
-database_required: false
-created_at: '2023-10-31T13:16:54.089514Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_view_log
+  model: Table
+- id: id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/timestamp.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/timestamp.yaml
@@ -1,39 +1,39 @@
+name: timestamp
+display_name: Timestamp
 description: null
-database_type: timestamptz
-semantic_type: null
+created_at: '2023-10-31T13:16:54.089514Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
+database_type: timestamptz
+base_type: type/DateTimeWithLocalTZ
+effective_type: type/DateTimeWithLocalTZ
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: timestamp
+preview_display: true
+position: 1
+custom_position: 0
+database_position: 1
 has_field_values: null
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/DateTimeWithLocalTZ
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_view_log
-- model: Field
-  id: timestamp
-database_is_auto_increment: false
-json_unfolding: false
-position: 1
-visibility_type: normal
-preview_display: true
-display_name: Timestamp
-database_position: 1
-database_required: false
-created_at: '2023-10-31T13:16:54.089514Z'
-base_type: type/DateTimeWithLocalTZ
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_view_log
+  model: Table
+- id: timestamp
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/user_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/user_id.yaml
@@ -1,39 +1,39 @@
+name: user_id
+display_name: User ID
 description: null
-database_type: int4
-semantic_type: null
+created_at: '2023-10-31T13:16:54.089514Z'
+active: true
+visibility_type: normal
 table_id:
 - Internal Metabase Database
 - public
 - v_view_log
+database_type: int4
+base_type: type/Integer
+effective_type: type/Integer
+semantic_type: null
+database_is_auto_increment: false
+database_required: false
+fk_target_field_id: null
+dimensions: []
+json_unfolding: false
+parent_id: null
 coercion_strategy: null
-name: user_id
+preview_display: true
+position: 2
+custom_position: 0
+database_position: 2
 has_field_values: auto-list
 settings: null
 caveats: null
-fk_target_field_id: null
-dimensions: []
-custom_position: 0
-effective_type: type/Integer
-active: true
-nfc_path: null
-parent_id: null
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_view_log
-- model: Field
-  id: user_id
-database_is_auto_increment: false
-json_unfolding: false
-position: 2
-visibility_type: normal
-preview_display: true
-display_name: User ID
-database_position: 2
-database_required: false
-created_at: '2023-10-31T13:16:54.089514Z'
-base_type: type/Integer
 points_of_interest: null
+nfc_path: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_view_log
+  model: Table
+- id: user_id
+  model: Field

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/v_view_log.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/v_view_log.yaml
@@ -1,22 +1,22 @@
-description: null
-entity_type: entity/EventTable
-schema: public
-show_in_getting_started: false
 name: v_view_log
-caveats: null
-active: true
-db_id: Internal Metabase Database
-serdes/meta:
-- model: Database
-  id: Internal Metabase Database
-- model: Schema
-  id: public
-- model: Table
-  id: v_view_log
-visibility_type: null
-field_order: database
-is_upload: false
-initial_sync_status: complete
 display_name: V View Log
+description: null
 created_at: '2023-10-31T13:16:53.281011Z'
+db_id: Internal Metabase Database
+schema: public
+entity_type: entity/EventTable
+active: true
+is_upload: false
+field_order: database
+visibility_type: null
+show_in_getting_started: false
+initial_sync_status: complete
 points_of_interest: null
+caveats: null
+serdes/meta:
+- id: Internal Metabase Database
+  model: Database
+- id: public
+  model: Schema
+- id: v_view_log
+  model: Table

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -4145,6 +4145,18 @@ databaseChangeLog:
             sql: UPDATE collection SET namespace = 'analytics' WHERE entity_id = 'okNLSZKdSxaoG58JSQY54' OR entity_id = 'vG58R8k-QddHWA7_47umn'
       rollback: # not necessary
 
+  - changeSet:
+      id: v48.00-060
+      author: noahmoss
+      comment: Added 0.48.0 - task_history.started_at
+      changes:
+        - createIndex:
+            indexName: idx_task_history_started_at
+            tableName: task_history
+            columns:
+              - column:
+                  name: started_at
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -4085,6 +4085,28 @@ databaseChangeLog:
         - sql: DELETE FROM core_user WHERE id = 13371338;
 
   - changeSet:
+
+      id: v48.00-055
+      author: noahmoss
+      comment: Added 0.48.0 - new view v_tasks
+      changes:
+        - sqlFile:
+            dbms: postgresql
+            path: instance_analytics_views/tasks/v1/postgres-tasks.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: instance_analytics_views/tasks/v1/mysql-tasks.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: h2
+            path: instance_analytics_views/tasks/v1/h2-tasks.sql
+            relativeToChangelogFile: true
+      rollback:
+        - sql:
+            sql: drop view if exists v_tasks;
+
+  - changeSet:
       id: v48.00-056
       author: noahmoss
       comment: 'Adjust view_log schema for Audit Log v2'

--- a/resources/migrations/instance_analytics_views/indexes/v1/h2-indexes.sql
+++ b/resources/migrations/instance_analytics_views/indexes/v1/h2-indexes.sql
@@ -5,3 +5,6 @@ create index if not exists idx_view_log_model_id
 
 create index if not exists idx_view_log_timestamp
     on view_log(timestamp);
+
+create index if not exists idx_task_history_started_at
+    on task_history(started_at);

--- a/resources/migrations/instance_analytics_views/indexes/v1/h2-indexes.sql
+++ b/resources/migrations/instance_analytics_views/indexes/v1/h2-indexes.sql
@@ -5,6 +5,3 @@ create index if not exists idx_view_log_model_id
 
 create index if not exists idx_view_log_timestamp
     on view_log(timestamp);
-
-create index if not exists idx_task_history_started_at
-    on task_history(started_at);

--- a/resources/migrations/instance_analytics_views/indexes/v1/mysql-indexes.sql
+++ b/resources/migrations/instance_analytics_views/indexes/v1/mysql-indexes.sql
@@ -30,3 +30,6 @@ create index idx_view_log_timestamp on view_log (timestamp);
 
 create index idx_view_log_entity_qualified_id
     on view_log ((concat(model, '_', model_id)));
+
+create index idx_task_history_started_at
+    on task_history(started_at);

--- a/resources/migrations/instance_analytics_views/indexes/v1/mysql-indexes.sql
+++ b/resources/migrations/instance_analytics_views/indexes/v1/mysql-indexes.sql
@@ -30,6 +30,3 @@ create index idx_view_log_timestamp on view_log (timestamp);
 
 create index idx_view_log_entity_qualified_id
     on view_log ((concat(model, '_', model_id)));
-
-create index idx_task_history_started_at
-    on task_history(started_at);

--- a/resources/migrations/instance_analytics_views/indexes/v1/mysql-rollback.sql
+++ b/resources/migrations/instance_analytics_views/indexes/v1/mysql-rollback.sql
@@ -9,3 +9,4 @@ drop index idx_view_log_model_id on view_log;
 drop index idx_view_log_timestamp on view_log;
 create index idx_view_log_timestamp on view_log (model_id);
 drop index idx_view_log_entity_qualified_id on view_log;
+drop index idx_task_history_started_at on task_history;

--- a/resources/migrations/instance_analytics_views/indexes/v1/mysql-rollback.sql
+++ b/resources/migrations/instance_analytics_views/indexes/v1/mysql-rollback.sql
@@ -9,4 +9,3 @@ drop index idx_view_log_model_id on view_log;
 drop index idx_view_log_timestamp on view_log;
 create index idx_view_log_timestamp on view_log (model_id);
 drop index idx_view_log_entity_qualified_id on view_log;
-drop index idx_task_history_started_at on task_history;

--- a/resources/migrations/instance_analytics_views/indexes/v1/postgres-indexes.sql
+++ b/resources/migrations/instance_analytics_views/indexes/v1/postgres-indexes.sql
@@ -36,3 +36,7 @@ create index if not exists idx_view_log_timestamp
 
 create index if not exists idx_view_log_entity_qualified_id
     on view_log((model || '_' || model_id));
+
+-- tasks
+create index if not exists idx_task_history_started_at
+    on task_history(started_at);

--- a/resources/migrations/instance_analytics_views/indexes/v1/postgres-indexes.sql
+++ b/resources/migrations/instance_analytics_views/indexes/v1/postgres-indexes.sql
@@ -36,7 +36,3 @@ create index if not exists idx_view_log_timestamp
 
 create index if not exists idx_view_log_entity_qualified_id
     on view_log((model || '_' || model_id));
-
--- tasks
-create index if not exists idx_task_history_started_at
-    on task_history(started_at);

--- a/resources/migrations/instance_analytics_views/tasks/v1/h2-tasks.sql
+++ b/resources/migrations/instance_analytics_views/tasks/v1/h2-tasks.sql
@@ -1,0 +1,12 @@
+drop view if exists v_tasks;
+
+create or replace view v_tasks as
+select
+    id,
+    task,
+    'database_' || db_id as database_qualified_id,
+    started_at,
+    ended_at,
+    cast(duration as double) / 1000 as duration_seconds,
+    task_details as details
+from task_history;

--- a/resources/migrations/instance_analytics_views/tasks/v1/mysql-tasks.sql
+++ b/resources/migrations/instance_analytics_views/tasks/v1/mysql-tasks.sql
@@ -1,0 +1,12 @@
+drop view if exists v_tasks;
+
+create or replace view v_tasks as
+select
+    id,
+    task,
+    concat('database_', db_id) as database_qualified_id,
+    started_at,
+    ended_at,
+    cast(duration as double) / 1000 as duration_seconds,
+    task_details as details
+from task_history;

--- a/resources/migrations/instance_analytics_views/tasks/v1/postgres-tasks.sql
+++ b/resources/migrations/instance_analytics_views/tasks/v1/postgres-tasks.sql
@@ -1,0 +1,12 @@
+drop view if exists v_tasks;
+
+create or replace view v_tasks as
+select
+    id,
+    task,
+    'database_' || db_id as database_qualified_id,
+    started_at,
+    ended_at,
+    cast(duration as double precision) / 1000 as duration_seconds,
+    task_details as details
+from task_history;


### PR DESCRIPTION
The same as https://github.com/metabase/metabase/pull/35634 but the new index (`idx_task_history_started_at`) is added using Liquibase's yaml syntax instead of using a SQL migration (since it's a simple column index).