### PR TITLE
Fix event logging to print correct output

### DIFF
--- a/src/metabase/events.clj
+++ b/src/metabase/events.clj
@@ -122,12 +122,13 @@
         (span/with-span!
           {:name       "publish-event!.logging"
            :attributes {}}
-          (log/infof "Publishing %s event (name and id):\n\n%s"
-                      (u/colorize :yellow (pr-str topic))
-                      (u/pprint-to-str (let [model (mi/model event)]
-                                         (cond-> (select-keys event [:name :id])
-                                           model
-                                           (assoc :model model)))))
+          (let [{:keys [object]} event]
+            (log/infof "Publishing %s event (name and id):\n\n%s"
+                       (u/colorize :yellow (pr-str topic))
+                       (u/pprint-to-str (let [model (mi/model object)]
+                                          (cond-> (select-keys object [:name :id])
+                                            model
+                                            (assoc :model model))))))
           (assert (and (qualified-keyword? topic)
                        (isa? topic :metabase/event))
                   (format "Invalid event topic %s: events must derive from :metabase/event" (pr-str topic)))


### PR DESCRIPTION
The fix in #35895 included reducing the size of the printed object, but the drilled elements needed to be pulled from the object key in the event, not the event itself. This fixes that.
