### PR TITLE
Support the Percentage semantic type

### DIFF
--- a/frontend/src/metabase-lib/types/utils/isa.js
+++ b/frontend/src/metabase-lib/types/utils/isa.js
@@ -181,6 +181,9 @@ export const isLongitude = field =>
 export const isCurrency = field =>
   field && isa(field.semantic_type, TYPE.Currency);
 
+export const isPercentage = field =>
+  field && isa(field.semantic_type, TYPE.Percentage);
+
 export const isDescription = field =>
   field && isa(field.semantic_type, TYPE.Description);
 

--- a/frontend/src/metabase/lib/core.js
+++ b/frontend/src/metabase/lib/core.js
@@ -146,6 +146,12 @@ export const field_semantic_types = [
     section: t`Numeric`,
     icon: "int",
   },
+  {
+    id: TYPE.Percentage,
+    name: t`Percentage`,
+    section: t`Numeric`,
+    icon: "int",
+  },
 
   /* Profile */
   {

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -52,6 +52,7 @@ import {
   isCoordinate,
   isCurrency,
   isDateWithoutTime,
+  isPercentage,
 } from "metabase-lib/types/utils/isa";
 import { findColumnIndexForColumnSetting } from "metabase-lib/queries/utils/dataset";
 import { getColumnKey } from "metabase-lib/queries/utils/get-column-key";
@@ -265,8 +266,17 @@ export const NUMBER_COLUMN_SETTINGS = {
         { name: t`Currency`, value: "currency" },
       ],
     },
-    getDefault: (column, settings) =>
-      isCurrency(column) && settings["currency"] ? "currency" : "decimal",
+    getDefault: (column, settings) => {
+      if (isCurrency(column) && settings["currency"]) {
+        return "currency";
+      }
+
+      if (isPercentage(column)) {
+        return "percent";
+      }
+
+      return "decimal";
+    },
     // hide this for currency
     getHidden: (column, settings) =>
       isCurrency(column) && settings["number_style"] === "currency",

--- a/frontend/src/metabase/visualizations/lib/settings/column.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.unit.spec.js
@@ -97,4 +97,13 @@ describe("column settings", () => {
     expect(time_style).toEqual("h:mm A");
     expect(date_style).toEqual("");
   });
+  it("should set a percentage style to a column with percentage type in its metadata", () => {
+    const series = seriesWithColumn({
+      semantic_type: "type/Percentage",
+    });
+    const defs = { ...columnSettings() };
+    const computed = getComputedSettings(defs, series, {});
+    const { number_style } = computed.column(series[0].data.cols[0]);
+    expect(number_style).toBe("percent");
+  });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/35124

### Description

Adds column formatting default settings inferrence from the Percentage semantic type.

### How to verify

1. Create a new model from Orders where Tax has semantic type `Percentage`
2. Ensure it renders as percentage
3. In Admin -> Table Metadata change the Tax column semantic type to `Percentage`
4. Ensure it renders as percentage

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
