### PR TITLE
Fix deadlock when running api tests in the repl

### DIFF
--- a/src/metabase/db/connection.clj
+++ b/src/metabase/db/connection.clj
@@ -6,11 +6,14 @@
    [metabase.db.env :as mdb.env]
    [methodical.core :as methodical]
    [potemkin :as p]
-   [toucan2.connection :as t2.conn])
+   [toucan2.connection :as t2.conn]
+   [toucan2.jdbc.connection :as t2.jdbc.conn])
   (:import
    (java.util.concurrent.locks ReentrantReadWriteLock)))
 
 (set! *warn-on-reflection* true)
+
+
 
 (defonce ^{:doc "Counter for [[unique-identifier]] -- this is a simple counter rather that [[java.util.UUID/randomUUID]]
   so we don't waste precious entropy on launch generating something that doesn't need to be random (it just needs to be
@@ -160,6 +163,11 @@
         (finally
           (.setAutoCommit connection true)))
       (thunk))))
+
+(comment
+ ;; in toucan2.jdbc.connection, there is a 'defmethod' for t2.conn/do-with-transaction java.sql.Connection
+ ;; since we don't want our implementation to be overwritten, we need to require it here first before defininng ours
+ t2.jdbc.conn/keepme)
 
 (methodical/defmethod t2.conn/do-with-transaction java.sql.Connection
   "Support nested transactions without introducing a lock like `next.jdbc` does, as that can cause deadlocks -- see

--- a/src/metabase/db/connection.clj
+++ b/src/metabase/db/connection.clj
@@ -13,8 +13,6 @@
 
 (set! *warn-on-reflection* true)
 
-
-
 (defonce ^{:doc "Counter for [[unique-identifier]] -- this is a simple counter rather that [[java.util.UUID/randomUUID]]
   so we don't waste precious entropy on launch generating something that doesn't need to be random (it just needs to be
   unique)"}


### PR DESCRIPTION
The problem was that if you're in a transaction and you spawn a thread to run queries, you'll get a deadlock. See https://github.com/seancorfield/next-jdbc/issues/244 for details.

We've fixed that by having our own `t2.conn/do-with-transaction` [implementation](https://github.com/metabase/metabase/blob/0bb85bf4aef2fe0dd64a3b6ddcbfd11f31460aa1/src/metabase/db/connection.clj#L164) .

But with the recent changes from toucan2, our implementation got overwritten by the default implementation from [toucan2](https://github.com/camsaul/toucan2/blob/c5346586c85f8dcd25573696d3e2f976b6ac0550/src/toucan2/jdbc/connection.clj#L36).

The fix is to make sure we load the default implementation before defining ours.

How to verify: 
1. open up your repl
2. try to run this simple test
```clojure
(deftest deadlock-test
  (mt/with-temp [:model/Card {card-id :id}]
    (mt/user-http-request :crowberto 200 (str "card/" card-id))))
```
3. if it doesn't give you a time out, we're good

