### PR TITLE
Housekeeping: remove default exports from dashboard/*

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditDashboard.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditDashboard.jsx
@@ -4,7 +4,7 @@ import { push } from "react-router-redux";
 import { getMetadata } from "metabase/selectors/metadata";
 
 import { Dashboard } from "metabase/dashboard/containers/Dashboard";
-import DashboardData from "metabase/dashboard/hoc/DashboardData";
+import { DashboardData } from "metabase/dashboard/hoc/DashboardData";
 
 const DashboardWithData = DashboardData(Dashboard);
 

--- a/frontend/src/metabase/App.styled.tsx
+++ b/frontend/src/metabase/App.styled.tsx
@@ -1,12 +1,12 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 
-export const AppContainer = styled.div`
+export const AppStyled = styled.div`
   display: flex;
   flex-direction: column;
 `;
 
-export const AppContentContainer = styled.div<{
+export const AppContentWrapStyled = styled.div<{
   isAdminApp: boolean;
 }>`
   flex-grow: 1;
@@ -23,7 +23,7 @@ export const AppContentContainer = styled.div<{
   }
 `;
 
-export const AppContent = styled.main`
+export const AppContentStyled = styled.main`
   width: 100%;
   height: 100%;
   overflow: auto;

--- a/frontend/src/metabase/App.styled.tsx
+++ b/frontend/src/metabase/App.styled.tsx
@@ -1,12 +1,12 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 
-export const AppStyled = styled.div`
+export const AppContainer = styled.div`
   display: flex;
   flex-direction: column;
 `;
 
-export const AppContentWrapStyled = styled.div<{
+export const AppContentContainer = styled.div<{
   isAdminApp: boolean;
 }>`
   flex-grow: 1;
@@ -23,7 +23,7 @@ export const AppContentWrapStyled = styled.div<{
   }
 `;
 
-export const AppContentStyled = styled.main`
+export const AppContent = styled.main`
   width: 100%;
   height: 100%;
   overflow: auto;

--- a/frontend/src/metabase/App.tsx
+++ b/frontend/src/metabase/App.tsx
@@ -29,7 +29,11 @@ import { ContentViewportContext } from "metabase/core/context/ContentViewportCon
 
 import type { AppErrorDescriptor, State } from "metabase-types/store";
 
-import { AppContainer, AppContent, AppContentContainer } from "./App.styled";
+import {
+  AppStyled,
+  AppContentStyled,
+  AppContentWrapStyled,
+} from "./App.styled";
 import ErrorBoundary from "./ErrorBoundary";
 
 const getErrorComponent = ({ status, data, context }: AppErrorDescriptor) => {
@@ -99,20 +103,20 @@ function App({
   return (
     <ErrorBoundary onError={onError}>
       <ScrollToTop>
-        <AppContainer className="spread">
+        <AppStyled className="spread">
           <AppBanner location={location} />
           {isAppBarVisible && <AppBar />}
-          <AppContentContainer isAdminApp={isAdminApp}>
+          <AppContentWrapStyled isAdminApp={isAdminApp}>
             {isNavBarEnabled && <Navbar />}
-            <AppContent ref={setViewportElement}>
+            <AppContentStyled ref={setViewportElement}>
               <ContentViewportContext.Provider value={viewportElement ?? null}>
                 {errorPage ? getErrorComponent(errorPage) : children}
               </ContentViewportContext.Provider>
-            </AppContent>
+            </AppContentStyled>
             <UndoListing />
             <StatusListing />
-          </AppContentContainer>
-        </AppContainer>
+          </AppContentWrapStyled>
+        </AppStyled>
       </ScrollToTop>
     </ErrorBoundary>
   );

--- a/frontend/src/metabase/App.tsx
+++ b/frontend/src/metabase/App.tsx
@@ -29,11 +29,7 @@ import { ContentViewportContext } from "metabase/core/context/ContentViewportCon
 
 import type { AppErrorDescriptor, State } from "metabase-types/store";
 
-import {
-  AppStyled,
-  AppContentStyled,
-  AppContentWrapStyled,
-} from "./App.styled";
+import { AppContainer, AppContent, AppContentContainer } from "./App.styled";
 import ErrorBoundary from "./ErrorBoundary";
 
 const getErrorComponent = ({ status, data, context }: AppErrorDescriptor) => {
@@ -103,20 +99,20 @@ function App({
   return (
     <ErrorBoundary onError={onError}>
       <ScrollToTop>
-        <AppStyled className="spread">
+        <AppContainer className="spread">
           <AppBanner location={location} />
           {isAppBarVisible && <AppBar />}
-          <AppContentWrapStyled isAdminApp={isAdminApp}>
+          <AppContentContainer isAdminApp={isAdminApp}>
             {isNavBarEnabled && <Navbar />}
-            <AppContentStyled ref={setViewportElement}>
+            <AppContent ref={setViewportElement}>
               <ContentViewportContext.Provider value={viewportElement ?? null}>
                 {errorPage ? getErrorComponent(errorPage) : children}
               </ContentViewportContext.Provider>
-            </AppContentStyled>
+            </AppContent>
             <UndoListing />
             <StatusListing />
-          </AppContentWrapStyled>
-        </AppStyled>
+          </AppContentContainer>
+        </AppContainer>
       </ScrollToTop>
     </ErrorBoundary>
   );

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -10,7 +10,7 @@ import * as Urls from "metabase/lib/urls";
 
 import ActionCreator from "metabase/actions/containers/ActionCreator";
 import CreateCollectionModal from "metabase/collections/containers/CreateCollectionModal";
-import CreateDashboardModal from "metabase/dashboard/containers/CreateDashboardModal";
+import { CreateDashboardModalConnected } from "metabase/dashboard/containers/CreateDashboardModal";
 
 import type { CollectionId, WritebackAction } from "metabase-types/api";
 
@@ -170,7 +170,7 @@ const NewItemMenu = ({
             </Modal>
           ) : modal === "new-dashboard" ? (
             <Modal onClose={handleModalClose}>
-              <CreateDashboardModal
+              <CreateDashboardModalConnected
                 collectionId={collectionId}
                 onClose={handleModalClose}
               />

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.tsx
@@ -8,7 +8,7 @@ import Link from "metabase/core/components/Link";
 import ModalContent from "metabase/components/ModalContent";
 import DashboardPicker from "metabase/containers/DashboardPicker";
 import * as Urls from "metabase/lib/urls";
-import CreateDashboardModal from "metabase/dashboard/containers/CreateDashboardModal";
+import { CreateDashboardModalConnected } from "metabase/dashboard/containers/CreateDashboardModal";
 import { useCollectionQuery } from "metabase/common/hooks";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import type { State } from "metabase-types/store";
@@ -91,7 +91,7 @@ const AddToDashSelectDashModal = ({
 
   if (shouldCreateDashboard) {
     return (
-      <CreateDashboardModal
+      <CreateDashboardModalConnected
         filterPersonalCollections={
           isQuestionInPersonalCollection ? "only" : undefined
         }

--- a/frontend/src/metabase/dashboard/components/ActionSidebar/ActionSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/ActionSidebar/ActionSidebar.tsx
@@ -19,7 +19,7 @@ import {
 } from "metabase/core/components/FormField/FormField.styled";
 
 import ModalWithTrigger from "metabase/components/ModalWithTrigger";
-import Sidebar from "metabase/dashboard/components/Sidebar";
+import { Sidebar } from "metabase/dashboard/components/Sidebar";
 
 import { ConnectedActionDashcardSettings } from "metabase/actions/components/ActionViz/ActionDashcardSettings";
 import ActionViz from "metabase/actions/components/ActionViz";
@@ -48,7 +48,7 @@ interface ActionSidebarProps {
   onClose: () => void;
 }
 
-export function ActionSidebarFn({
+export function ActionSidebar({
   dashboard,
   dashcardId,
   onUpdateVisualizationSettings,
@@ -150,4 +150,7 @@ export function ActionSidebarFn({
   );
 }
 
-export const ActionSidebar = connect(null, mapDispatchToProps)(ActionSidebarFn);
+export const ActionSidebarConnected = connect(
+  null,
+  mapDispatchToProps,
+)(ActionSidebar);

--- a/frontend/src/metabase/dashboard/components/ActionSidebar/ActionSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/ActionSidebar/ActionSidebar.unit.spec.tsx
@@ -23,7 +23,7 @@ import {
   setupDatabasesEndpoints,
   setupSearchEndpoints,
 } from "__support__/server-mocks";
-import { ActionSidebarFn } from "./ActionSidebar";
+import { ActionSidebar } from "./ActionSidebar";
 
 const dashcard = createMockDashboardCard();
 const actionDashcard = createMockActionDashboardCard({ id: 2 });
@@ -44,7 +44,7 @@ const dashboard = createMockDashboard({
 });
 
 const setup = (
-  options?: Partial<React.ComponentProps<typeof ActionSidebarFn>>,
+  options?: Partial<React.ComponentProps<typeof ActionSidebar>>,
 ) => {
   setupDatabasesEndpoints([actionsDatabase]);
   setupSearchEndpoints([collectionItem]);
@@ -55,7 +55,7 @@ const setup = (
   const closeSpy = jest.fn();
 
   renderWithProviders(
-    <ActionSidebarFn
+    <ActionSidebar
       onUpdateVisualizationSettings={vizUpdateSpy}
       onClose={closeSpy}
       dashboard={dashboard}

--- a/frontend/src/metabase/dashboard/components/AddSeriesModal/index.ts
+++ b/frontend/src/metabase/dashboard/components/AddSeriesModal/index.ts
@@ -1,1 +1,0 @@
-export { AddSeriesModal } from "./AddSeriesModal";

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.tsx
@@ -4,7 +4,7 @@ import { getIn } from "icepick";
 import { useMount, usePrevious } from "react-use";
 
 import { useDashboardQuery } from "metabase/common/hooks";
-import Sidebar from "metabase/dashboard/components/Sidebar";
+import { Sidebar } from "metabase/dashboard/components/Sidebar";
 
 import type {
   Dashboard,
@@ -24,7 +24,7 @@ import {
 
 import { getColumnKey } from "metabase-lib/queries/utils/get-column-key";
 import { getClickBehaviorForColumn } from "./utils";
-import ClickBehaviorSidebarContent from "./ClickBehaviorSidebarContent";
+import { ClickBehaviorSidebarContent } from "./ClickBehaviorSidebarContent";
 import { ClickBehaviorSidebarHeader } from "./ClickBehaviorSidebarHeader";
 
 function shouldShowTypeSelector(clickBehavior?: ClickBehavior) {
@@ -54,7 +54,7 @@ interface Props {
   ) => void;
 }
 
-function ClickBehaviorSidebar({
+export function ClickBehaviorSidebar({
   dashboard,
   dashcard,
   dashcardData,
@@ -225,6 +225,3 @@ function ClickBehaviorSidebar({
     </Sidebar>
   );
 }
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default ClickBehaviorSidebar;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.tsx
@@ -25,7 +25,7 @@ import {
 import { getColumnKey } from "metabase-lib/queries/utils/get-column-key";
 import { getClickBehaviorForColumn } from "./utils";
 import { ClickBehaviorSidebarContent } from "./ClickBehaviorSidebarContent";
-import { ClickBehaviorSidebarHeader } from "./ClickBehaviorSidebarHeader";
+import { ClickBehaviorSidebarHeader } from "./ClickBehaviorSidebarHeader/ClickBehaviorSidebarHeader";
 
 function shouldShowTypeSelector(clickBehavior?: ClickBehavior) {
   return !clickBehavior || clickBehavior.type == null;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarContent.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarContent.tsx
@@ -14,9 +14,9 @@ import type {
 import { isTableDisplay } from "metabase/lib/click-behavior";
 import type { UiParameter } from "metabase-lib/parameters/types";
 import { getClickBehaviorForColumn } from "./utils";
-import { ClickBehaviorSidebarMainView } from "./ClickBehaviorSidebarMainView";
-import { TableClickBehaviorView } from "./TableClickBehaviorView";
-import { TypeSelector } from "./TypeSelector";
+import { ClickBehaviorSidebarMainView } from "./ClickBehaviorSidebarMainView/ClickBehaviorSidebarMainView";
+import { TableClickBehaviorView } from "./TableClickBehaviorView/TableClickBehaviorView";
+import { TypeSelector } from "./TypeSelector/TypeSelector";
 import { SidebarContent } from "./ClickBehaviorSidebar.styled";
 
 interface Props {

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarContent.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarContent.tsx
@@ -14,9 +14,9 @@ import type {
 import { isTableDisplay } from "metabase/lib/click-behavior";
 import type { UiParameter } from "metabase-lib/parameters/types";
 import { getClickBehaviorForColumn } from "./utils";
-import ClickBehaviorSidebarMainView from "./ClickBehaviorSidebarMainView";
-import TableClickBehaviorView from "./TableClickBehaviorView";
-import TypeSelector from "./TypeSelector";
+import { ClickBehaviorSidebarMainView } from "./ClickBehaviorSidebarMainView";
+import { TableClickBehaviorView } from "./TableClickBehaviorView";
+import { TypeSelector } from "./TypeSelector";
 import { SidebarContent } from "./ClickBehaviorSidebar.styled";
 
 interface Props {
@@ -32,7 +32,7 @@ interface Props {
   onTypeSelectorVisibilityChange: (isVisible: boolean) => void;
 }
 
-function ClickBehaviorSidebarContent({
+export function ClickBehaviorSidebarContent({
   dashboard,
   dashcard,
   dashcardData,
@@ -90,6 +90,3 @@ function ClickBehaviorSidebarContent({
     />
   );
 }
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default ClickBehaviorSidebarContent;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarHeader/index.ts
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarHeader/index.ts
@@ -1,1 +1,0 @@
-export { ClickBehaviorSidebarHeader } from "./ClickBehaviorSidebarHeader";

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarMainView/ClickBehaviorSidebarMainView.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarMainView/ClickBehaviorSidebarMainView.tsx
@@ -8,7 +8,7 @@ import type { UiParameter } from "metabase-lib/parameters/types";
 
 import { clickBehaviorOptions, getClickBehaviorOptionName } from "../utils";
 import { CrossfilterOptions } from "../CrossfilterOptions";
-import { LinkOptions } from "../LinkOptions";
+import { LinkOptions } from "../LinkOptions/LinkOptions";
 import { SidebarItem } from "../SidebarItem";
 import {
   SidebarContentBordered,

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarMainView/ClickBehaviorSidebarMainView.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarMainView/ClickBehaviorSidebarMainView.tsx
@@ -7,8 +7,8 @@ import type {
 import type { UiParameter } from "metabase-lib/parameters/types";
 
 import { clickBehaviorOptions, getClickBehaviorOptionName } from "../utils";
-import CrossfilterOptions from "../CrossfilterOptions";
-import LinkOptions from "../LinkOptions";
+import { CrossfilterOptions } from "../CrossfilterOptions";
+import { LinkOptions } from "../LinkOptions";
 import { SidebarItem } from "../SidebarItem";
 import {
   SidebarContentBordered,
@@ -62,7 +62,7 @@ interface ClickBehaviorSidebarMainViewProps {
   updateSettings: (settings: Partial<ClickBehavior>) => void;
 }
 
-function ClickBehaviorSidebarMainView({
+export function ClickBehaviorSidebarMainView({
   clickBehavior,
   dashboard,
   dashcard,
@@ -106,6 +106,3 @@ function ClickBehaviorSidebarMainView({
     </>
   );
 }
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default ClickBehaviorSidebarMainView;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarMainView/index.ts
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarMainView/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./ClickBehaviorSidebarMainView";
+export { ClickBehaviorSidebarMainView } from "./ClickBehaviorSidebarMainView";

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarMainView/index.ts
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarMainView/index.ts
@@ -1,1 +1,0 @@
-export { ClickBehaviorSidebarMainView } from "./ClickBehaviorSidebarMainView";

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/CrossfilterOptions.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/CrossfilterOptions.tsx
@@ -1,6 +1,6 @@
 import { t } from "ttag";
 
-import ClickMappings from "metabase/dashboard/components/ClickMappings";
+import { ClickMappingsConnected } from "metabase/dashboard/components/ClickMappings";
 
 import type {
   ClickBehavior,
@@ -17,7 +17,7 @@ interface Props {
   updateSettings: (settings: ClickBehavior) => void;
 }
 
-function CrossfilterOptions({
+export function CrossfilterOptions({
   clickBehavior,
   dashboard,
   dashcard,
@@ -26,7 +26,7 @@ function CrossfilterOptions({
   return (
     <SidebarContent>
       <Heading className="text-medium">{t`Pick one or more filters to update`}</Heading>
-      <ClickMappings
+      <ClickMappingsConnected
         object={dashboard}
         dashcard={dashcard}
         isDashboard
@@ -37,6 +37,3 @@ function CrossfilterOptions({
     </SidebarContent>
   );
 }
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default CrossfilterOptions;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/CustomLinkText.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/CustomLinkText.tsx
@@ -15,7 +15,7 @@ interface Props {
   updateSettings: (settings: ClickBehavior) => void;
 }
 
-const CustomLinkText = ({ clickBehavior, updateSettings }: Props) => {
+export const CustomLinkText = ({ clickBehavior, updateSettings }: Props) => {
   const handleChange = useCallback(
     (e: { target: HTMLInputElement }) => {
       updateSettings({
@@ -38,6 +38,3 @@ const CustomLinkText = ({ clickBehavior, updateSettings }: Props) => {
     </div>
   );
 };
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default CustomLinkText;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/CustomURLPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/CustomURLPicker.tsx
@@ -15,9 +15,9 @@ import type { UiParameter } from "metabase-lib/parameters/types";
 import { clickBehaviorIsValid } from "metabase-lib/parameters/utils/click-behavior";
 
 import { SidebarItem } from "../SidebarItem";
-import CustomLinkText from "./CustomLinkText";
+import { CustomLinkText } from "./CustomLinkText";
 
-import ValuesYouCanReference from "./ValuesYouCanReference";
+import { ValuesYouCanReference } from "./ValuesYouCanReference";
 import {
   FormDescription,
   DoneButton,
@@ -32,7 +32,7 @@ interface Props {
   updateSettings: (settings: ClickBehavior) => void;
 }
 
-function CustomURLPicker({
+export function CustomURLPicker({
   clickBehavior,
   updateSettings,
   dashcard,
@@ -117,6 +117,3 @@ function CustomURLPicker({
     </ModalWithTrigger>
   );
 }
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default CustomURLPicker;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkOption.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkOption.tsx
@@ -3,7 +3,7 @@ import { color } from "metabase/lib/colors";
 import type { IconName } from "metabase/core/components/Icon";
 import { SidebarItem } from "../SidebarItem";
 
-const LinkOption = ({
+export const LinkOption = ({
   option,
   icon,
   onClick,
@@ -19,6 +19,3 @@ const LinkOption = ({
     </div>
   </SidebarItem>
 );
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default LinkOption;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkOptions.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkOptions.tsx
@@ -12,12 +12,12 @@ import { isTableDisplay } from "metabase/lib/click-behavior";
 import type { IconName } from "metabase/core/components/Icon";
 import type { UiParameter } from "metabase-lib/parameters/types";
 import { SidebarContent } from "../ClickBehaviorSidebar.styled";
-import CustomLinkText from "./CustomLinkText";
+import { CustomLinkText } from "./CustomLinkText";
 import { LinkedEntityPicker } from "./LinkedEntityPicker";
 
-import CustomURLPicker from "./CustomURLPicker";
-import LinkOption from "./LinkOption";
-import ValuesYouCanReference from "./ValuesYouCanReference";
+import { CustomURLPicker } from "./CustomURLPicker";
+import { LinkOption } from "./LinkOption";
+import { ValuesYouCanReference } from "./ValuesYouCanReference";
 
 type LinkTypeOption = {
   type: CustomDestinationClickBehaviorLinkType;
@@ -56,7 +56,7 @@ interface Props {
   updateSettings: (settings: Partial<ClickBehavior>) => void;
 }
 
-function LinkOptions({
+export function LinkOptions({
   clickBehavior,
   dashcard,
   parameters,
@@ -112,6 +112,3 @@ function LinkOptions({
     </SidebarContent>
   );
 }
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default LinkOptions;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkOptions.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkOptions.tsx
@@ -13,7 +13,7 @@ import type { IconName } from "metabase/core/components/Icon";
 import type { UiParameter } from "metabase-lib/parameters/types";
 import { SidebarContent } from "../ClickBehaviorSidebar.styled";
 import { CustomLinkText } from "./CustomLinkText";
-import { LinkedEntityPicker } from "./LinkedEntityPicker";
+import { LinkedEntityPicker } from "./LinkedEntityPicker/LinkedEntityPicker";
 
 import { CustomURLPicker } from "./CustomURLPicker";
 import { LinkOption } from "./LinkOption";

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.tsx
@@ -130,7 +130,7 @@ function TargetClickMappings({
   );
 }
 
-function LinkedEntityPicker({
+export function LinkedEntityPicker({
   dashcard,
   clickBehavior,
   updateSettings,
@@ -313,5 +313,3 @@ function LinkedEntityPicker({
     </div>
   );
 }
-
-export { LinkedEntityPicker };

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.tsx
@@ -13,7 +13,8 @@ import Questions from "metabase/entities/questions";
 import DashboardPicker from "metabase/containers/DashboardPicker";
 import QuestionPicker from "metabase/containers/QuestionPicker";
 
-import ClickMappings, {
+import {
+  ClickMappingsConnected,
   clickTargetObjectType,
 } from "metabase/dashboard/components/ClickMappings";
 
@@ -116,7 +117,7 @@ function TargetClickMappings({
       {({ object }: { object: Question | Dashboard }) => (
         <div className="pt1">
           <Heading>{getTargetClickMappingsHeading(object)}</Heading>
-          <ClickMappings
+          <ClickMappingsConnected
             object={object}
             dashcard={dashcard}
             isDashboard={isDashboard}

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/index.ts
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/index.ts
@@ -1,1 +1,0 @@
-export { LinkedEntityPicker } from "./LinkedEntityPicker";

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/ValuesYouCanReference.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/ValuesYouCanReference.jsx
@@ -17,7 +17,7 @@ function prefixIfNeeded(values, prefix, otherLists) {
   );
 }
 
-const ValuesYouCanReference = withUserAttributes(
+export const ValuesYouCanReference = withUserAttributes(
   ({ dashcard, parameters, userAttributes }) => {
     const columnMetadata = dashcard.card.result_metadata || [];
     const columns = columnMetadata?.filter(isMappableColumn).map(c => c.name);
@@ -69,5 +69,3 @@ const ValuesYouCanReference = withUserAttributes(
     );
   },
 );
-
-export default ValuesYouCanReference;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/index.ts
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/index.ts
@@ -1,1 +1,0 @@
-export { LinkOptions } from "./LinkOptions";

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/index.ts
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./LinkOptions";
+export { LinkOptions } from "./LinkOptions";

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TableClickBehaviorView/Column.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TableClickBehaviorView/Column.tsx
@@ -84,7 +84,7 @@ interface ColumnProps {
   onClick: () => void;
 }
 
-const Column = ({ column, clickBehavior, onClick }: ColumnProps) => (
+export const Column = ({ column, clickBehavior, onClick }: ColumnProps) => (
   <SidebarItem onClick={onClick}>
     <SidebarItem.Icon
       name={getIconForField(column) as unknown as IconName}
@@ -98,6 +98,3 @@ const Column = ({ column, clickBehavior, onClick }: ColumnProps) => (
     </div>
   </SidebarItem>
 );
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default Column;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TableClickBehaviorView/TableClickBehaviorView.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TableClickBehaviorView/TableClickBehaviorView.tsx
@@ -10,7 +10,7 @@ import type {
 } from "metabase-types/api";
 
 import { hasActionsMenu } from "metabase/lib/click-behavior";
-import Column from "./Column";
+import { Column } from "./Column";
 
 const COLUMN_SORTING_ORDER_BY_CLICK_BEHAVIOR_TYPE = [
   "link",
@@ -41,7 +41,7 @@ interface Props {
   onColumnClick: (column: DatasetColumn) => void;
 }
 
-function TableClickBehaviorView({
+export function TableClickBehaviorView({
   columns,
   dashcard,
   getClickBehaviorForColumn,
@@ -96,6 +96,3 @@ function TableClickBehaviorView({
 
   return <>{groupedColumns.map(renderColumnGroup)}</>;
 }
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default TableClickBehaviorView;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TableClickBehaviorView/index.ts
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TableClickBehaviorView/index.ts
@@ -1,1 +1,0 @@
-export { TableClickBehaviorView } from "./TableClickBehaviorView";

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TableClickBehaviorView/index.ts
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TableClickBehaviorView/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./TableClickBehaviorView";
+export { TableClickBehaviorView } from "./TableClickBehaviorView";

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TypeSelector/TypeSelector.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TypeSelector/TypeSelector.tsx
@@ -58,7 +58,7 @@ interface TypeSelectorProps {
   moveToNextPage: () => void;
 }
 
-function TypeSelector({
+export function TypeSelector({
   dashcard,
   clickBehavior,
   parameters,
@@ -97,6 +97,3 @@ function TypeSelector({
     </div>
   );
 }
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default TypeSelector;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TypeSelector/index.ts
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TypeSelector/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./TypeSelector";
+export { TypeSelector } from "./TypeSelector";

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TypeSelector/index.ts
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TypeSelector/index.ts
@@ -1,1 +1,0 @@
-export { TypeSelector } from "./TypeSelector";

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/index.ts
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./ClickBehaviorSidebar";
+export { ClickBehaviorSidebar } from "./ClickBehaviorSidebar";

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/index.ts
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/index.ts
@@ -1,1 +1,0 @@
-export { ClickBehaviorSidebar } from "./ClickBehaviorSidebar";

--- a/frontend/src/metabase/dashboard/components/ClickMappings.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickMappings.jsx
@@ -21,7 +21,7 @@ import {
 import Question from "metabase-lib/Question";
 import { TargetTrigger } from "./ClickMappings.styled";
 
-class ClickMappingsInner extends Component {
+class ClickMappings extends Component {
   render() {
     const { setTargets, unsetTargets } = this.props;
     const sourceOptions = {
@@ -116,7 +116,7 @@ class ClickMappingsInner extends Component {
   }
 }
 
-const ClickMappings = _.compose(
+export const ClickMappingsConnected = _.compose(
   loadQuestionMetadata((state, props) =>
     props.isDashboard ? null : props.object,
   ),
@@ -151,7 +151,7 @@ const ClickMappings = _.compose(
     };
     return { setTargets, unsetTargets, sourceOptions };
   }),
-)(ClickMappingsInner);
+)(ClickMappings);
 
 const getKeyForSource = o => (o.type == null ? null : `${o.type}-${o.id}`);
 const getSourceOption = {
@@ -339,5 +339,3 @@ export function clickTargetObjectType(object) {
     return "gui";
   }
 }
-
-export default ClickMappings;

--- a/frontend/src/metabase/dashboard/components/DashCard/ClickBehaviorSidebarOverlay/ClickBehaviorSidebarOverlay.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/ClickBehaviorSidebarOverlay/ClickBehaviorSidebarOverlay.tsx
@@ -22,7 +22,7 @@ interface Props {
 
 const MIN_WIDTH_FOR_ON_CLICK_LABEL = 330;
 
-function ClickBehaviorSidebarOverlay({
+export function ClickBehaviorSidebarOverlay({
   dashcard,
   dashcardWidth,
   showClickBehaviorSidebar,
@@ -52,6 +52,3 @@ function ClickBehaviorSidebarOverlay({
     </Root>
   );
 }
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default ClickBehaviorSidebarOverlay;

--- a/frontend/src/metabase/dashboard/components/DashCard/ClickBehaviorSidebarOverlay/index.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/ClickBehaviorSidebarOverlay/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./ClickBehaviorSidebarOverlay";
+export { ClickBehaviorSidebarOverlay } from "./ClickBehaviorSidebarOverlay";

--- a/frontend/src/metabase/dashboard/components/DashCard/ClickBehaviorSidebarOverlay/index.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/ClickBehaviorSidebarOverlay/index.ts
@@ -1,1 +1,0 @@
-export { ClickBehaviorSidebarOverlay } from "./ClickBehaviorSidebarOverlay";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -43,7 +43,7 @@ import type {
   DashCardOnChangeCardAndRunHandler,
 } from "./types";
 import { DashCardActionsPanel } from "./DashCardActionsPanel";
-import DashCardVisualization from "./DashCardVisualization";
+import { DashCardVisualization } from "./DashCardVisualization";
 import { DashCardRoot } from "./DashCard.styled";
 
 function preventDragging(event: React.SyntheticEvent) {
@@ -85,7 +85,7 @@ export interface DashCardProps {
   onChangeLocation: (location: LocationDescriptor) => void;
 }
 
-function DashCard({
+function DashCardInner({
   dashcard,
   dashcardData,
   dashboard,
@@ -317,7 +317,6 @@ function DashCard({
   );
 }
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default Object.assign(DashCard, {
+export const DashCard = Object.assign(DashCardInner, {
   root: DashCardRoot,
 });

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -42,7 +42,7 @@ import type {
   NavigateToNewCardFromDashboardOpts,
   DashCardOnChangeCardAndRunHandler,
 } from "./types";
-import { DashCardActionsPanel } from "./DashCardActionsPanel";
+import { DashCardActionsPanel } from "./DashCardActionsPanel/DashCardActionsPanel";
 import { DashCardVisualization } from "./DashCardVisualization";
 import { DashCardRoot } from "./DashCard.styled";
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ActionSettingsButton/ActionSettingsButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ActionSettingsButton/ActionSettingsButton.tsx
@@ -35,5 +35,7 @@ function ActionSettingsButton({ dashcard, setEditingDashcardId }: Props) {
   );
 }
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default connect(null, mapDispatchToProps)(ActionSettingsButton);
+export const ActionSettingsButtonConnected = connect(
+  null,
+  mapDispatchToProps,
+)(ActionSettingsButton);

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ActionSettingsButton/ActionSettingsButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ActionSettingsButton/ActionSettingsButton.tsx
@@ -6,7 +6,7 @@ import type { ActionDashboardCard, Dashboard } from "metabase-types/api";
 
 import { setEditingDashcardId } from "metabase/dashboard/actions";
 
-import { DashCardActionButton } from "../DashCardActionButton";
+import { DashActionButton } from "../DashCardActionButton/DashCardActionButton";
 
 const mapDispatchToProps = {
   setEditingDashcardId,
@@ -26,12 +26,12 @@ function ActionSettingsButton({ dashcard, setEditingDashcardId }: Props) {
   }, [dashcard.id, dashcard.justAdded, setEditingDashcardId]);
 
   return (
-    <DashCardActionButton
+    <DashActionButton
       tooltip={t`Action Settings`}
       onClick={() => setEditingDashcardId(dashcard.id)}
     >
-      <DashCardActionButton.Icon name="gear" />
-    </DashCardActionButton>
+      <DashActionButton.Icon name="gear" />
+    </DashActionButton>
   );
 }
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ActionSettingsButton/ActionSettingsButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ActionSettingsButton/ActionSettingsButton.tsx
@@ -6,7 +6,7 @@ import type { ActionDashboardCard, Dashboard } from "metabase-types/api";
 
 import { setEditingDashcardId } from "metabase/dashboard/actions";
 
-import { DashActionButton } from "../DashCardActionButton/DashCardActionButton";
+import { DashCardActionButton } from "../DashCardActionButton/DashCardActionButton";
 
 const mapDispatchToProps = {
   setEditingDashcardId,
@@ -26,12 +26,12 @@ function ActionSettingsButton({ dashcard, setEditingDashcardId }: Props) {
   }, [dashcard.id, dashcard.justAdded, setEditingDashcardId]);
 
   return (
-    <DashActionButton
+    <DashCardActionButton
       tooltip={t`Action Settings`}
       onClick={() => setEditingDashcardId(dashcard.id)}
     >
-      <DashActionButton.Icon name="gear" />
-    </DashActionButton>
+      <DashCardActionButton.Icon name="gear" />
+    </DashCardActionButton>
   );
 }
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ActionSettingsButton/index.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ActionSettingsButton/index.ts
@@ -1,1 +1,1 @@
-export { default as ActionSettingsButton } from "./ActionSettingsButton";
+export { ActionSettingsButtonConnected } from "./ActionSettingsButton";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ActionSettingsButton/index.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ActionSettingsButton/index.ts
@@ -1,1 +1,0 @@
-export { ActionSettingsButtonConnected } from "./ActionSettingsButton";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/AddSeriesButton/AddSeriesButton.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/AddSeriesButton/AddSeriesButton.styled.tsx
@@ -1,8 +1,8 @@
 import styled from "@emotion/styled";
 
-import { DashCardActionButton } from "../DashCardActionButton";
+import { DashActionButton } from "../DashCardActionButton/DashCardActionButton";
 
-export const ActionButton = styled(DashCardActionButton)`
+export const ActionButton = styled(DashActionButton)`
   position: relative;
 `;
 
@@ -10,7 +10,7 @@ export const IconContainer = styled.span`
   display: flex;
 `;
 
-export const PlusIcon = styled(DashCardActionButton.Icon)`
+export const PlusIcon = styled(DashActionButton.Icon)`
   top: 0;
   left: 1;
 `;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/AddSeriesButton/AddSeriesButton.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/AddSeriesButton/AddSeriesButton.styled.tsx
@@ -1,8 +1,8 @@
 import styled from "@emotion/styled";
 
-import { DashActionButton } from "../DashCardActionButton/DashCardActionButton";
+import { DashCardActionButton } from "../DashCardActionButton/DashCardActionButton";
 
-export const ActionButton = styled(DashActionButton)`
+export const ActionButton = styled(DashCardActionButton)`
   position: relative;
 `;
 
@@ -10,7 +10,7 @@ export const IconContainer = styled.span`
   display: flex;
 `;
 
-export const PlusIcon = styled(DashActionButton.Icon)`
+export const PlusIcon = styled(DashCardActionButton.Icon)`
   top: 0;
   left: 1;
 `;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/AddSeriesButton/AddSeriesButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/AddSeriesButton/AddSeriesButton.tsx
@@ -5,14 +5,14 @@ import { Icon } from "metabase/core/components/Icon";
 import visualizations from "metabase/visualizations";
 import type { Series } from "metabase-types/api";
 
-import { DashCardActionButton } from "../DashCardActionButton";
+import { DashActionButton } from "../DashCardActionButton/DashCardActionButton";
 import {
   ActionButton,
   IconContainer,
   PlusIcon,
 } from "./AddSeriesButton.styled";
 
-const { ICON_SIZE } = DashCardActionButton;
+const { ICON_SIZE } = DashActionButton;
 
 function getSeriesIconName(series: Series) {
   const display = series[0]?.card.display;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/AddSeriesButton/AddSeriesButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/AddSeriesButton/AddSeriesButton.tsx
@@ -5,14 +5,14 @@ import { Icon } from "metabase/core/components/Icon";
 import visualizations from "metabase/visualizations";
 import type { Series } from "metabase-types/api";
 
-import { DashActionButton } from "../DashCardActionButton/DashCardActionButton";
+import { DashCardActionButton } from "../DashCardActionButton/DashCardActionButton";
 import {
   ActionButton,
   IconContainer,
   PlusIcon,
 } from "./AddSeriesButton.styled";
 
-const { ICON_SIZE } = DashActionButton;
+const { ICON_SIZE } = DashCardActionButton;
 
 function getSeriesIconName(series: Series) {
   const display = series[0]?.card.display;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/AddSeriesButton/AddSeriesButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/AddSeriesButton/AddSeriesButton.tsx
@@ -22,7 +22,7 @@ function getSeriesIconName(series: Series) {
   );
 }
 
-function AddSeriesButton({
+export function AddSeriesButton({
   series,
   onClick,
 }: {
@@ -43,5 +43,3 @@ function AddSeriesButton({
     </ActionButton>
   );
 }
-
-export { AddSeriesButton };

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/AddSeriesButton/index.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/AddSeriesButton/index.ts
@@ -1,1 +1,0 @@
-export { AddSeriesButton } from "./AddSeriesButton";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ChartSettingsButton/ChartSettingsButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ChartSettingsButton/ChartSettingsButton.tsx
@@ -11,7 +11,7 @@ import type {
   VisualizationSettings,
 } from "metabase-types/api";
 
-import { DashActionButton } from "../DashCardActionButton/DashCardActionButton";
+import { DashCardActionButton } from "../DashCardActionButton/DashCardActionButton";
 
 interface Props {
   series: Series;
@@ -31,12 +31,12 @@ export function ChartSettingsButton({
       wide
       tall
       triggerElement={
-        <DashActionButton
+        <DashCardActionButton
           tooltip={t`Visualization options`}
           aria-label={t`Show visualization options`}
         >
-          <DashActionButton.Icon name="palette" />
-        </DashActionButton>
+          <DashCardActionButton.Icon name="palette" />
+        </DashCardActionButton>
       }
       enableMouseEvents
     >

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ChartSettingsButton/ChartSettingsButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ChartSettingsButton/ChartSettingsButton.tsx
@@ -20,7 +20,7 @@ interface Props {
   onReplaceAllVisualizationSettings: (settings: VisualizationSettings) => void;
 }
 
-function ChartSettingsButton({
+export function ChartSettingsButton({
   series,
   dashboard,
   dashcard,
@@ -51,6 +51,3 @@ function ChartSettingsButton({
     </ModalWithTrigger>
   );
 }
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default ChartSettingsButton;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ChartSettingsButton/ChartSettingsButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ChartSettingsButton/ChartSettingsButton.tsx
@@ -11,7 +11,7 @@ import type {
   VisualizationSettings,
 } from "metabase-types/api";
 
-import { DashCardActionButton } from "../DashCardActionButton";
+import { DashActionButton } from "../DashCardActionButton/DashCardActionButton";
 
 interface Props {
   series: Series;
@@ -31,12 +31,12 @@ export function ChartSettingsButton({
       wide
       tall
       triggerElement={
-        <DashCardActionButton
+        <DashActionButton
           tooltip={t`Visualization options`}
           aria-label={t`Show visualization options`}
         >
-          <DashCardActionButton.Icon name="palette" />
-        </DashCardActionButton>
+          <DashActionButton.Icon name="palette" />
+        </DashActionButton>
       }
       enableMouseEvents
     >

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ChartSettingsButton/index.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ChartSettingsButton/index.ts
@@ -1,1 +1,1 @@
-export { default as ChartSettingsButton } from "./ChartSettingsButton";
+export { ChartSettingsButton } from "./ChartSettingsButton";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ChartSettingsButton/index.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ChartSettingsButton/index.ts
@@ -1,1 +1,0 @@
-export { ChartSettingsButton } from "./ChartSettingsButton";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionButton/DashCardActionButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionButton/DashCardActionButton.tsx
@@ -13,7 +13,7 @@ interface Props extends React.HTMLAttributes<HTMLAnchorElement> {
   analyticsEvent?: string;
 }
 
-const DashActionButtonWrap = React.forwardRef<HTMLAnchorElement, Props>(
+const DashActionButton = React.forwardRef<HTMLAnchorElement, Props>(
   function DashActionButton(
     { tooltip, analyticsEvent, children, ...props },
     ref,
@@ -26,7 +26,7 @@ const DashActionButtonWrap = React.forwardRef<HTMLAnchorElement, Props>(
   },
 );
 
-export const DashActionButton = Object.assign(DashActionButtonWrap, {
+export const DashCardActionButton = Object.assign(DashActionButton, {
   Icon: ActionIcon,
   ICON_SIZE: HEADER_ICON_SIZE,
 });

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionButton/DashCardActionButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionButton/DashCardActionButton.tsx
@@ -13,7 +13,7 @@ interface Props extends React.HTMLAttributes<HTMLAnchorElement> {
   analyticsEvent?: string;
 }
 
-const DashActionButton = React.forwardRef<HTMLAnchorElement, Props>(
+const DashActionButtonWrap = React.forwardRef<HTMLAnchorElement, Props>(
   function DashActionButton(
     { tooltip, analyticsEvent, children, ...props },
     ref,
@@ -26,8 +26,7 @@ const DashActionButton = React.forwardRef<HTMLAnchorElement, Props>(
   },
 );
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default Object.assign(DashActionButton, {
+export const DashActionButton = Object.assign(DashActionButtonWrap, {
   Icon: ActionIcon,
   ICON_SIZE: HEADER_ICON_SIZE,
 });

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionButton/index.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionButton/index.ts
@@ -1,1 +1,1 @@
-export { default as DashCardActionButton } from "./DashCardActionButton";
+export { DashActionButton as DashCardActionButton } from "./DashCardActionButton";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionButton/index.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionButton/index.ts
@@ -1,1 +1,0 @@
-export { DashActionButton as DashCardActionButton } from "./DashCardActionButton";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
@@ -16,12 +16,12 @@ import type {
 import { isActionDashCard } from "metabase/actions/utils";
 import { isLinkDashCard } from "metabase/dashboard/utils";
 
-import { ChartSettingsButton } from "./ChartSettingsButton";
-import { DashCardTabMenu } from "./DashCardTabMenu";
-import { DashCardActionButton } from "./DashCardActionButton";
-import { AddSeriesButton } from "./AddSeriesButton";
-import { ActionSettingsButtonConnected } from "./ActionSettingsButton";
-import { LinkCardEditButton } from "./LinkCardEditButton";
+import { ChartSettingsButton } from "./ChartSettingsButton/ChartSettingsButton";
+import { DashCardTabMenu } from "./DashCardTabMenu/DashCardTabMenu";
+import { DashActionButton } from "./DashCardActionButton/DashCardActionButton";
+import { AddSeriesButton } from "./AddSeriesButton/AddSeriesButton";
+import { ActionSettingsButtonConnected } from "./ActionSettingsButton/ActionSettingsButton";
+import { LinkCardEditButton } from "./LinkCardEditButton/LinkCardEditButton";
 import {
   DashCardActionButtonsContainer,
   DashCardActionsPanelContainer,
@@ -88,7 +88,7 @@ export function DashCardActionsPanel({
 
   if (supportPreviewing) {
     buttons.push(
-      <DashCardActionButton
+      <DashActionButton
         key="preview"
         onClick={onPreviewToggle}
         tooltip={isPreviewing ? t`Edit` : t`Preview`}
@@ -96,11 +96,11 @@ export function DashCardActionsPanel({
         analyticsEvent="Dashboard;Text;edit"
       >
         {isPreviewing ? (
-          <DashCardActionButton.Icon name="edit_document" />
+          <DashActionButton.Icon name="edit_document" />
         ) : (
-          <DashCardActionButton.Icon name="eye" size={18} />
+          <DashActionButton.Icon name="eye" size={18} />
         )}
-      </DashCardActionButton>,
+      </DashActionButton>,
     );
   }
 
@@ -119,14 +119,14 @@ export function DashCardActionsPanel({
 
     if (!isVirtualDashCard && !disableClickBehavior) {
       buttons.push(
-        <DashCardActionButton
+        <DashActionButton
           key="click-behavior-tooltip"
           tooltip={t`Click behavior`}
           analyticsEvent="Dashboard;Open Click Behavior Sidebar"
           onClick={showClickBehaviorSidebar}
         >
           <Icon name="click" />
-        </DashCardActionButton>,
+        </DashActionButton>,
       );
     }
 
@@ -170,13 +170,13 @@ export function DashCardActionsPanel({
     >
       <DashCardActionButtonsContainer>
         {buttons}
-        <DashCardActionButton
+        <DashActionButton
           onClick={onRemove}
           tooltip={t`Remove`}
           analyticsEvent="Dashboard;Remove Card Modal"
         >
-          <DashCardActionButton.Icon name="close" />
-        </DashCardActionButton>
+          <DashActionButton.Icon name="close" />
+        </DashActionButton>
       </DashCardActionButtonsContainer>
     </DashCardActionsPanelContainer>
   );

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
@@ -18,7 +18,7 @@ import { isLinkDashCard } from "metabase/dashboard/utils";
 
 import { ChartSettingsButton } from "./ChartSettingsButton/ChartSettingsButton";
 import { DashCardTabMenu } from "./DashCardTabMenu/DashCardTabMenu";
-import { DashActionButton } from "./DashCardActionButton/DashCardActionButton";
+import { DashCardActionButton } from "./DashCardActionButton/DashCardActionButton";
 import { AddSeriesButton } from "./AddSeriesButton/AddSeriesButton";
 import { ActionSettingsButtonConnected } from "./ActionSettingsButton/ActionSettingsButton";
 import { LinkCardEditButton } from "./LinkCardEditButton/LinkCardEditButton";
@@ -88,7 +88,7 @@ export function DashCardActionsPanel({
 
   if (supportPreviewing) {
     buttons.push(
-      <DashActionButton
+      <DashCardActionButton
         key="preview"
         onClick={onPreviewToggle}
         tooltip={isPreviewing ? t`Edit` : t`Preview`}
@@ -96,11 +96,11 @@ export function DashCardActionsPanel({
         analyticsEvent="Dashboard;Text;edit"
       >
         {isPreviewing ? (
-          <DashActionButton.Icon name="edit_document" />
+          <DashCardActionButton.Icon name="edit_document" />
         ) : (
-          <DashActionButton.Icon name="eye" size={18} />
+          <DashCardActionButton.Icon name="eye" size={18} />
         )}
-      </DashActionButton>,
+      </DashCardActionButton>,
     );
   }
 
@@ -119,14 +119,14 @@ export function DashCardActionsPanel({
 
     if (!isVirtualDashCard && !disableClickBehavior) {
       buttons.push(
-        <DashActionButton
+        <DashCardActionButton
           key="click-behavior-tooltip"
           tooltip={t`Click behavior`}
           analyticsEvent="Dashboard;Open Click Behavior Sidebar"
           onClick={showClickBehaviorSidebar}
         >
           <Icon name="click" />
-        </DashActionButton>,
+        </DashCardActionButton>,
       );
     }
 
@@ -170,13 +170,13 @@ export function DashCardActionsPanel({
     >
       <DashCardActionButtonsContainer>
         {buttons}
-        <DashActionButton
+        <DashCardActionButton
           onClick={onRemove}
           tooltip={t`Remove`}
           analyticsEvent="Dashboard;Remove Card Modal"
         >
-          <DashActionButton.Icon name="close" />
-        </DashActionButton>
+          <DashCardActionButton.Icon name="close" />
+        </DashCardActionButton>
       </DashCardActionButtonsContainer>
     </DashCardActionsPanelContainer>
   );

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
@@ -20,7 +20,7 @@ import { ChartSettingsButton } from "./ChartSettingsButton";
 import { DashCardTabMenu } from "./DashCardTabMenu";
 import { DashCardActionButton } from "./DashCardActionButton";
 import { AddSeriesButton } from "./AddSeriesButton";
-import { ActionSettingsButton } from "./ActionSettingsButton";
+import { ActionSettingsButtonConnected } from "./ActionSettingsButton";
 import { LinkCardEditButton } from "./LinkCardEditButton";
 import {
   DashCardActionButtonsContainer,
@@ -142,7 +142,7 @@ export function DashCardActionsPanel({
 
     if (dashcard && isActionDashCard(dashcard)) {
       buttons.push(
-        <ActionSettingsButton
+        <ActionSettingsButtonConnected
           key="action-settings-button"
           dashboard={dashboard}
           dashcard={dashcard}

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardTabMenu/DashCardTabMenu.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardTabMenu/DashCardTabMenu.styled.tsx
@@ -1,11 +1,11 @@
 import styled from "@emotion/styled";
-import { DashActionButton } from "../DashCardActionButton/DashCardActionButton";
+import { DashCardActionButton } from "../DashCardActionButton/DashCardActionButton";
 
 /**
  * This is a button with a bigger "hover area" to make it easier
  * for the user to go to the menu without the menu closing.
  */
-export const MoveDashCardActionStyled = styled(DashActionButton)`
+export const MoveDashCardActionStyled = styled(DashCardActionButton)`
   position: relative;
   &:hover::before {
     content: "";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardTabMenu/DashCardTabMenu.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardTabMenu/DashCardTabMenu.styled.tsx
@@ -5,7 +5,7 @@ import { DashCardActionButton } from "../DashCardActionButton";
  * This is a button with a bigger "hover area" to make it easier
  * for the user to go to the menu without the menu closing.
  */
-export const MoveDashCardActionContainer = styled(DashCardActionButton)`
+export const MoveDashCardActionStyled = styled(DashCardActionButton)`
   position: relative;
   &:hover::before {
     content: "";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardTabMenu/DashCardTabMenu.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardTabMenu/DashCardTabMenu.styled.tsx
@@ -1,11 +1,11 @@
 import styled from "@emotion/styled";
-import { DashCardActionButton } from "../DashCardActionButton";
+import { DashActionButton } from "../DashCardActionButton/DashCardActionButton";
 
 /**
  * This is a button with a bigger "hover area" to make it easier
  * for the user to go to the menu without the menu closing.
  */
-export const MoveDashCardActionStyled = styled(DashCardActionButton)`
+export const MoveDashCardActionStyled = styled(DashActionButton)`
   position: relative;
   &:hover::before {
     content: "";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardTabMenu/DashCardTabMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardTabMenu/DashCardTabMenu.tsx
@@ -5,7 +5,7 @@ import { Divider, Menu } from "metabase/ui";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { getSelectedTabId, getTabs } from "metabase/dashboard/selectors";
 import { moveDashCardToTab } from "metabase/dashboard/actions";
-import { DashCardActionButton } from "../DashCardActionButton";
+import { DashActionButton } from "../DashCardActionButton/DashCardActionButton";
 import { MoveDashCardActionStyled } from "./DashCardTabMenu.styled";
 
 interface DashCardTabMenuProps {
@@ -45,7 +45,7 @@ export function DashCardTabMenu({
       <Menu trigger="hover" onOpen={onOpen} onClose={onClose}>
         <Menu.Target>
           <MoveDashCardActionStyled>
-            <DashCardActionButton.Icon name="move_card" />
+            <DashActionButton.Icon name="move_card" />
           </MoveDashCardActionStyled>
         </Menu.Target>
         <Menu.Dropdown>

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardTabMenu/DashCardTabMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardTabMenu/DashCardTabMenu.tsx
@@ -6,7 +6,7 @@ import { useDispatch, useSelector } from "metabase/lib/redux";
 import { getSelectedTabId, getTabs } from "metabase/dashboard/selectors";
 import { moveDashCardToTab } from "metabase/dashboard/actions";
 import { DashCardActionButton } from "../DashCardActionButton";
-import { MoveDashCardActionContainer } from "./DashCardTabMenu.styled";
+import { MoveDashCardActionStyled } from "./DashCardTabMenu.styled";
 
 interface DashCardTabMenuProps {
   dashCardId: DashCardId;
@@ -44,9 +44,9 @@ export function DashCardTabMenu({
     <>
       <Menu trigger="hover" onOpen={onOpen} onClose={onClose}>
         <Menu.Target>
-          <MoveDashCardActionContainer>
+          <MoveDashCardActionStyled>
             <DashCardActionButton.Icon name="move_card" />
-          </MoveDashCardActionContainer>
+          </MoveDashCardActionStyled>
         </Menu.Target>
         <Menu.Dropdown>
           <Menu.Label>{t`Move to tab`}</Menu.Label>

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardTabMenu/DashCardTabMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardTabMenu/DashCardTabMenu.tsx
@@ -5,7 +5,7 @@ import { Divider, Menu } from "metabase/ui";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { getSelectedTabId, getTabs } from "metabase/dashboard/selectors";
 import { moveDashCardToTab } from "metabase/dashboard/actions";
-import { DashActionButton } from "../DashCardActionButton/DashCardActionButton";
+import { DashCardActionButton } from "../DashCardActionButton/DashCardActionButton";
 import { MoveDashCardActionStyled } from "./DashCardTabMenu.styled";
 
 interface DashCardTabMenuProps {
@@ -45,7 +45,7 @@ export function DashCardTabMenu({
       <Menu trigger="hover" onOpen={onOpen} onClose={onClose}>
         <Menu.Target>
           <MoveDashCardActionStyled>
-            <DashActionButton.Icon name="move_card" />
+            <DashCardActionButton.Icon name="move_card" />
           </MoveDashCardActionStyled>
         </Menu.Target>
         <Menu.Dropdown>

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardTabMenu/index.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardTabMenu/index.ts
@@ -1,1 +1,0 @@
-export * from "./DashCardTabMenu";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/LinkCardEditButton/LinkCardEditButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/LinkCardEditButton/LinkCardEditButton.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 import type { DashboardCard, VisualizationSettings } from "metabase-types/api";
 import { isRestrictedLinkEntity } from "metabase-types/guards/dashboard";
 
-import { DashCardActionButton } from "../DashCardActionButton";
+import { DashActionButton } from "../DashCardActionButton/DashCardActionButton";
 
 interface Props {
   dashcard: DashboardCard;
@@ -31,8 +31,8 @@ export function LinkCardEditButton({
   };
 
   return (
-    <DashCardActionButton tooltip={t`Edit Link`} onClick={handleClick}>
-      <DashCardActionButton.Icon name="pencil" />
-    </DashCardActionButton>
+    <DashActionButton tooltip={t`Edit Link`} onClick={handleClick}>
+      <DashActionButton.Icon name="pencil" />
+    </DashActionButton>
   );
 }

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/LinkCardEditButton/LinkCardEditButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/LinkCardEditButton/LinkCardEditButton.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 import type { DashboardCard, VisualizationSettings } from "metabase-types/api";
 import { isRestrictedLinkEntity } from "metabase-types/guards/dashboard";
 
-import { DashActionButton } from "../DashCardActionButton/DashCardActionButton";
+import { DashCardActionButton } from "../DashCardActionButton/DashCardActionButton";
 
 interface Props {
   dashcard: DashboardCard;
@@ -31,8 +31,8 @@ export function LinkCardEditButton({
   };
 
   return (
-    <DashActionButton tooltip={t`Edit Link`} onClick={handleClick}>
-      <DashActionButton.Icon name="pencil" />
-    </DashActionButton>
+    <DashCardActionButton tooltip={t`Edit Link`} onClick={handleClick}>
+      <DashCardActionButton.Icon name="pencil" />
+    </DashCardActionButton>
   );
 }

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/LinkCardEditButton/index.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/LinkCardEditButton/index.ts
@@ -1,1 +1,0 @@
-export { LinkCardEditButton } from "./LinkCardEditButton";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/index.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/index.ts
@@ -1,1 +1,0 @@
-export { DashCardActionsPanel } from "./DashCardActionsPanel";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
@@ -167,5 +167,7 @@ DashCardMenu.shouldRender = ({
   );
 };
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default connect(null, mapDispatchToProps)(DashCardMenu);
+export const DashCardMenuConnected = connect(
+  null,
+  mapDispatchToProps,
+)(DashCardMenu);

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.unit.spec.tsx
@@ -18,7 +18,7 @@ import { createMockState } from "metabase-types/store/mocks";
 import { setupCardQueryDownloadEndpoint } from "__support__/server-mocks";
 import { createMockEntitiesState } from "__support__/store";
 import { getIcon, renderWithProviders, screen } from "__support__/ui";
-import DashCardMenu from "./DashCardMenu";
+import { DashCardMenuConnected } from "./DashCardMenu";
 
 const TEST_CARD = createMockCard({
   can_write: true,
@@ -88,7 +88,9 @@ const setup = ({ card = TEST_CARD, result = TEST_RESULT }: SetupOpts = {}) => {
     <>
       <Route
         path="dashboard/:slug"
-        component={() => <DashCardMenu question={question} result={result} />}
+        component={() => (
+          <DashCardMenuConnected question={question} result={result} />
+        )}
       />
       <Route path="question/:slug" component={() => <div />} />
       <Route path="question/:slug/notebook" component={() => <div />} />

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/index.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/index.ts
@@ -1,1 +1,0 @@
-export { DashCardMenuConnected } from "./DashCardMenu";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/index.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./DashCardMenu";
+export { DashCardMenuConnected } from "./DashCardMenu";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
@@ -303,7 +303,7 @@ export function DashCardCardParameterMapper({
   );
 }
 
-export default connect(
+export const DashCardCardParameterMapperConnected = connect(
   mapStateToProps,
   mapDispatchToProps,
 )(DashCardCardParameterMapper);

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardParameterMapper.jsx
@@ -3,10 +3,10 @@ import { t } from "ttag";
 
 import { color } from "metabase/lib/colors";
 
-import DashCardCardParameterMapper from "./DashCardCardParameterMapper";
+import { DashCardCardParameterMapperConnected } from "./DashCardCardParameterMapper";
 import { MapperSettingsContainer } from "./DashCardParameterMapper.styled";
 
-const DashCardParameterMapper = ({ dashcard, isMobile }) => (
+export const DashCardParameterMapper = ({ dashcard, isMobile }) => (
   <div className="relative flex-full flex flex-column layout-centered">
     {dashcard.series && dashcard.series.length > 0 && (
       <div
@@ -22,7 +22,7 @@ const DashCardParameterMapper = ({ dashcard, isMobile }) => (
     )}
     <MapperSettingsContainer>
       {[dashcard.card].concat(dashcard.series || []).map(card => (
-        <DashCardCardParameterMapper
+        <DashCardCardParameterMapperConnected
           key={`${dashcard.id},${card.id}`}
           dashcard={dashcard}
           card={card}
@@ -32,5 +32,3 @@ const DashCardParameterMapper = ({ dashcard, isMobile }) => (
     </MapperSettingsContainer>
   </div>
 );
-
-export default DashCardParameterMapper;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/index.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/index.ts
@@ -1,1 +1,0 @@
-export { DashCardParameterMapper } from "./DashCardParameterMapper";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/index.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./DashCardParameterMapper";
+export { DashCardParameterMapper } from "./DashCardParameterMapper";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -7,7 +7,7 @@ import type { LocationDescriptor } from "history";
 import type { IconName, IconProps } from "metabase/core/components/Icon";
 
 import Visualization from "metabase/visualizations/components/Visualization";
-import WithVizSettingsData from "metabase/dashboard/hoc/WithVizSettingsData";
+import { WithVizSettingsData } from "metabase/dashboard/hoc/WithVizSettingsData";
 import { getVisualizationRaw } from "metabase/visualizations";
 
 import {
@@ -36,9 +36,9 @@ import type {
   CardSlownessStatus,
   DashCardOnChangeCardAndRunHandler,
 } from "./types";
-import ClickBehaviorSidebarOverlay from "./ClickBehaviorSidebarOverlay";
-import DashCardMenu from "./DashCardMenu";
-import DashCardParameterMapper from "./DashCardParameterMapper";
+import { ClickBehaviorSidebarOverlay } from "./ClickBehaviorSidebarOverlay";
+import { DashCardMenuConnected } from "./DashCardMenu";
+import { DashCardParameterMapper } from "./DashCardParameterMapper";
 import {
   VirtualDashCardOverlayRoot,
   VirtualDashCardOverlayText,
@@ -96,7 +96,7 @@ const WrappedVisualization = WithVizSettingsData(
   connect(null, mapDispatchToProps)(Visualization),
 );
 
-function DashCardVisualization({
+export function DashCardVisualization({
   dashcard,
   dashboard,
   series,
@@ -188,7 +188,7 @@ function DashCardVisualization({
   const renderActionButtons = useCallback(() => {
     const mainSeries = series[0] as unknown as Dataset;
 
-    const shouldShowDashCardMenu = DashCardMenu.shouldRender({
+    const shouldShowDashCardMenu = DashCardMenuConnected.shouldRender({
       question,
       result: mainSeries,
       isXray,
@@ -202,7 +202,7 @@ function DashCardVisualization({
     }
 
     return (
-      <DashCardMenu
+      <DashCardMenuConnected
         question={question}
         result={mainSeries}
         dashcardId={dashcard.id}
@@ -265,6 +265,3 @@ function DashCardVisualization({
     />
   );
 }
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default DashCardVisualization;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -36,9 +36,9 @@ import type {
   CardSlownessStatus,
   DashCardOnChangeCardAndRunHandler,
 } from "./types";
-import { ClickBehaviorSidebarOverlay } from "./ClickBehaviorSidebarOverlay";
-import { DashCardMenuConnected } from "./DashCardMenu";
-import { DashCardParameterMapper } from "./DashCardParameterMapper";
+import { ClickBehaviorSidebarOverlay } from "./ClickBehaviorSidebarOverlay/ClickBehaviorSidebarOverlay";
+import { DashCardMenuConnected } from "./DashCardMenu/DashCardMenu";
+import { DashCardParameterMapper } from "./DashCardParameterMapper/DashCardParameterMapper";
 import {
   VirtualDashCardOverlayRoot,
   VirtualDashCardOverlayText,

--- a/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
@@ -15,7 +15,7 @@ import { createMockMetadata } from "__support__/metadata";
 
 import { createMockState } from "metabase-types/store/mocks";
 import type { DashCardProps } from "./DashCard";
-import Dashcard from "./DashCard";
+import { DashCard } from "./DashCard";
 
 registerVisualizations();
 
@@ -37,7 +37,7 @@ function setup(
   storeOptions?: Partial<typeof store>,
 ) {
   return renderWithProviders(
-    <Dashcard
+    <DashCard
       dashboard={dashboard}
       dashcard={tableDashcard}
       gridItemWidth={4}

--- a/frontend/src/metabase/dashboard/components/DashCard/index.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/index.ts
@@ -1,1 +1,0 @@
-export { DashCard } from "./DashCard";

--- a/frontend/src/metabase/dashboard/components/DashCard/index.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./DashCard";
+export { DashCard } from "./DashCard";

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -7,11 +7,11 @@ import { DashboardHeader } from "metabase/dashboard/components/DashboardHeader";
 import SyncedParametersList from "metabase/parameters/components/SyncedParametersList/SyncedParametersList";
 import { FilterApplyButton } from "metabase/parameters/components/FilterApplyButton";
 import { getVisibleParameters } from "metabase/parameters/utils/ui";
-import DashboardControls from "metabase/dashboard/hoc/DashboardControls";
+import { DashboardControls } from "metabase/dashboard/hoc/DashboardControls";
 import { getValuePopulatedParameters } from "metabase-lib/parameters/utils/parameter-values";
 
 import { DashboardSidebars } from "../DashboardSidebars";
-import DashboardGrid from "../DashboardGrid";
+import { DashboardGridConnected } from "../DashboardGrid";
 import { SIDEBAR_NAME } from "../../constants";
 
 import {
@@ -19,7 +19,7 @@ import {
   DashboardStyled,
   DashboardLoadingAndErrorWrapper,
   DashboardBody,
-  HeaderContainer,
+  DashboardHeaderContainer,
   ParametersAndCardsContainer,
   ParametersWidgetContainer,
 } from "./Dashboard.styled";
@@ -31,7 +31,7 @@ import { updateParametersWidgetStickiness } from "./stickyParameters";
 
 // NOTE: move DashboardControls HoC to container
 
-class Dashboard extends Component {
+class DashboardInner extends Component {
   state = {
     error: null,
     isParametersWidgetSticky: false,
@@ -191,7 +191,7 @@ class Dashboard extends Component {
       );
     }
     return (
-      <DashboardGrid
+      <DashboardGridConnected
         {...this.props}
         dashboard={this.props.dashboard}
         isNightMode={shouldRenderAsNightMode}
@@ -264,7 +264,7 @@ class Dashboard extends Component {
         {() => (
           <DashboardStyled>
             {isHeaderVisible && (
-              <HeaderContainer
+              <DashboardHeaderContainer
                 isFullscreen={isFullscreen}
                 isNightMode={shouldRenderAsNightMode}
               >
@@ -285,7 +285,7 @@ class Dashboard extends Component {
                     {parametersWidget}
                   </ParametersWidgetContainer>
                 )}
-              </HeaderContainer>
+              </DashboardHeaderContainer>
             )}
 
             <DashboardBody isEditingOrSharing={isEditing || isSharing}>
@@ -326,7 +326,7 @@ class Dashboard extends Component {
   }
 }
 
-Dashboard.propTypes = {
+DashboardInner.propTypes = {
   loadDashboardParams: PropTypes.func,
   location: PropTypes.object,
 
@@ -387,4 +387,4 @@ Dashboard.propTypes = {
   isAutoApplyFilters: PropTypes.bool,
 };
 
-export default DashboardControls(Dashboard);
+export const Dashboard = DashboardControls(DashboardInner);

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.tsx
@@ -10,7 +10,7 @@ import { FullWidthContainer } from "metabase/styled-components/layout/FullWidthC
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
 import { SAVING_DOM_IMAGE_CLASS } from "metabase/visualizations/lib/save-chart-image";
-import { DashCard } from "../DashCard";
+import { DashCard } from "../DashCard/DashCard";
 
 // Class names are added here because we still use traditional css,
 // see dashboard.css

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.tsx
@@ -10,7 +10,7 @@ import { FullWidthContainer } from "metabase/styled-components/layout/FullWidthC
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
 import { SAVING_DOM_IMAGE_CLASS } from "metabase/visualizations/lib/save-chart-image";
-import Dashcard from "../DashCard";
+import { DashCard } from "../DashCard";
 
 // Class names are added here because we still use traditional css,
 // see dashboard.css
@@ -63,7 +63,7 @@ export const DashboardBody = styled.div<{ isEditingOrSharing: boolean }>`
     `}
 `;
 
-export const HeaderContainer = styled.header<{
+export const DashboardHeaderContainer = styled.header<{
   isFullscreen: boolean;
   isNightMode: boolean;
 }>`
@@ -148,7 +148,7 @@ export const CardsContainer = styled(FullWidthContainer)<{
   &.${SAVING_DOM_IMAGE_CLASS} {
     padding-bottom: 20px;
 
-    ${Dashcard.root} {
+    ${DashCard.root} {
       box-shadow: none;
       border: 1px solid ${color("border")};
     }

--- a/frontend/src/metabase/dashboard/components/DashboardActions.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardActions.jsx
@@ -4,7 +4,7 @@ import MetabaseSettings from "metabase/lib/settings";
 import Tooltip from "metabase/core/components/Tooltip";
 
 import { DashboardHeaderButton } from "metabase/dashboard/components/DashboardHeader/DashboardHeader.styled";
-import DashboardSharingEmbeddingModal from "../containers/DashboardSharingEmbeddingModal.jsx";
+import { DashboardSharingEmbeddingModalConnected } from "../containers/DashboardSharingEmbeddingModal.jsx";
 import {
   FullScreenButtonIcon,
   NightModeButtonIcon,
@@ -79,7 +79,7 @@ export const getDashboardActions = (
 
     if (canShareDashboard) {
       buttons.push(
-        <DashboardSharingEmbeddingModal
+        <DashboardSharingEmbeddingModalConnected
           key="dashboard-embed"
           additionalClickActions={() => self.refs.popover.close()}
           dashboard={dashboard}

--- a/frontend/src/metabase/dashboard/components/DashboardActions.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardActions.styled.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import FullscreenIcon from "metabase/components/icons/FullscreenIcon";
 import NightModeIcon from "metabase/components/icons/NightModeIcon";
-import RefreshWidget from "metabase/dashboard/components/RefreshWidget";
+import { RefreshWidget } from "metabase/dashboard/components/RefreshWidget";
 import { DashboardHeaderButton } from "metabase/dashboard/components/DashboardHeader/DashboardHeader.styled";
 
 interface ShareButtonProps {

--- a/frontend/src/metabase/dashboard/components/DashboardBookmark.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardBookmark.tsx
@@ -9,7 +9,7 @@ export interface DashboardBookmarkProps {
   onDeleteBookmark: (dashboard: Dashboard) => void;
 }
 
-const DashboardBookmark = ({
+export const DashboardBookmark = ({
   dashboard,
   isBookmarked,
   onCreateBookmark,
@@ -31,6 +31,3 @@ const DashboardBookmark = ({
     />
   );
 };
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default DashboardBookmark;

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
@@ -42,7 +42,7 @@ const getTitle = (dashboard, isShallowCopy) => {
   }
 };
 
-const DashboardCopyModalInner = ({
+const DashboardCopyModal = ({
   onClose,
   onReplaceLocation,
   copyDashboard,
@@ -81,9 +81,7 @@ const DashboardCopyModalInner = ({
   );
 };
 
-const DashboardCopyModal = _.compose(
+export const DashboardCopyModalConnected = _.compose(
   withRouter,
   connect(mapStateToProps, mapDispatchToProps),
-)(DashboardCopyModalInner);
-
-export default DashboardCopyModal;
+)(DashboardCopyModal);

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal/DashboardCopyModalShallowCheckboxLabel/DashboardCopyModalShallowCheckboxLabel.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal/DashboardCopyModalShallowCheckboxLabel/DashboardCopyModalShallowCheckboxLabel.tsx
@@ -5,7 +5,7 @@ import Tooltip from "metabase/core/components/Tooltip";
 
 import { CheckboxLabelRoot } from "./DashboardCopyModalShallowCheckboxLabel.styled";
 
-const DashboardCopyModalShallowCheckboxLabel = () => (
+export const DashboardCopyModalShallowCheckboxLabel = () => (
   <CheckboxLabelRoot>
     {t`Only duplicate the dashboard`}
     <Tooltip
@@ -15,6 +15,3 @@ const DashboardCopyModalShallowCheckboxLabel = () => (
     </Tooltip>
   </CheckboxLabelRoot>
 );
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default DashboardCopyModalShallowCheckboxLabel;

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal/DashboardCopyModalShallowCheckboxLabel/index.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal/DashboardCopyModalShallowCheckboxLabel/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./DashboardCopyModalShallowCheckboxLabel";
+export { DashboardCopyModalShallowCheckboxLabel } from "./DashboardCopyModalShallowCheckboxLabel";

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal/DashboardCopyModalShallowCheckboxLabel/index.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal/DashboardCopyModalShallowCheckboxLabel/index.ts
@@ -1,1 +1,0 @@
-export { DashboardCopyModalShallowCheckboxLabel } from "./DashboardCopyModalShallowCheckboxLabel";

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -37,8 +37,8 @@ import { DashboardCard } from "./DashboardGrid.styled";
 import { GridLayout } from "./grid/GridLayout";
 import { generateMobileLayout } from "./grid/utils";
 
-import { AddSeriesModal } from "./AddSeriesModal";
-import { DashCard } from "./DashCard";
+import { AddSeriesModal } from "./AddSeriesModal/AddSeriesModal";
+import { DashCard } from "./DashCard/DashCard";
 
 const mapDispatchToProps = { addUndo };
 

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -34,11 +34,11 @@ import {
 
 import { DashboardCard } from "./DashboardGrid.styled";
 
-import GridLayout from "./grid/GridLayout";
+import { GridLayout } from "./grid/GridLayout";
 import { generateMobileLayout } from "./grid/utils";
 
 import { AddSeriesModal } from "./AddSeriesModal";
-import DashCard from "./DashCard";
+import { DashCard } from "./DashCard";
 
 const mapDispatchToProps = { addUndo };
 
@@ -465,7 +465,7 @@ function isEditingTextOrHeadingCard(display, isEditing) {
   return isEditing && isTextOrHeadingCard;
 }
 
-export default _.compose(
+export const DashboardGridConnected = _.compose(
   ExplicitSize(),
   connect(null, mapDispatchToProps),
 )(DashboardGrid);

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.jsx
@@ -22,8 +22,8 @@ import Bookmark from "metabase/entities/bookmarks";
 import { getDashboardActions } from "metabase/dashboard/components/DashboardActions";
 
 import { TextOptionsButton } from "metabase/dashboard/components/TextOptions/TextOptionsButton";
-import ParametersPopover from "metabase/dashboard/components/ParametersPopover";
-import DashboardBookmark from "metabase/dashboard/components/DashboardBookmark";
+import { ParametersPopover } from "metabase/dashboard/components/ParametersPopover";
+import { DashboardBookmark } from "metabase/dashboard/components/DashboardBookmark";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
 
 import { getPulseFormInput } from "metabase/pulse/selectors";

--- a/frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx
@@ -18,7 +18,7 @@ const mapDispatchToProps = {
   setDashboardCollection: Dashboards.actions.setCollection,
 };
 
-class DashboardMoveModalInner extends Component {
+class DashboardMoveModal extends Component {
   render() {
     const { dashboard, onClose, setDashboardCollection } = this.props;
     const title = t`Move dashboard to…`;
@@ -43,15 +43,6 @@ class DashboardMoveModalInner extends Component {
   }
 }
 
-const DashboardMoveModal = _.compose(
-  connect(null, mapDispatchToProps),
-  Dashboards.load({
-    id: (state, props) => Urls.extractCollectionId(props.params.slug),
-  }),
-)(DashboardMoveModalInner);
-
-export default DashboardMoveModal;
-
 const DashboardMoveToast = ({ collectionId }) => (
   <ToastRoot>
     <Icon name="collection" className="mr1" color="white" />
@@ -64,3 +55,10 @@ const DashboardMoveToast = ({ collectionId }) => (
     )}`}
   </ToastRoot>
 );
+
+export const DashboardMoveModalConnected = _.compose(
+  connect(null, mapDispatchToProps),
+  Dashboards.load({
+    id: (state, props) => Urls.extractCollectionId(props.params.slug),
+  }),
+)(DashboardMoveModal);

--- a/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
@@ -7,10 +7,10 @@ import { SIDEBAR_NAME } from "metabase/dashboard/constants";
 import ParameterSidebar from "metabase/parameters/components/ParameterSidebar";
 import SharingSidebar from "metabase/sharing/components/SharingSidebar";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
-import ClickBehaviorSidebar from "./ClickBehaviorSidebar";
+import { ClickBehaviorSidebar } from "./ClickBehaviorSidebar";
 import { DashboardInfoSidebar } from "./DashboardInfoSidebar";
 import { AddCardSidebar } from "./add-card-sidebar/AddCardSidebar";
-import { ActionSidebar } from "./ActionSidebar";
+import { ActionSidebarConnected } from "./ActionSidebar";
 
 DashboardSidebars.propTypes = {
   dashboard: PropTypes.object,
@@ -101,7 +101,7 @@ export function DashboardSidebars({
         );
 
       return (
-        <ActionSidebar
+        <ActionSidebarConnected
           dashboard={dashboard}
           dashcardId={sidebar.props.dashcardId}
           onUpdateVisualizationSettings={onUpdateVisualizationSettings}

--- a/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
@@ -7,9 +7,9 @@ import { SIDEBAR_NAME } from "metabase/dashboard/constants";
 import ParameterSidebar from "metabase/parameters/components/ParameterSidebar";
 import SharingSidebar from "metabase/sharing/components/SharingSidebar";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
-import { ClickBehaviorSidebar } from "./ClickBehaviorSidebar";
+import { ClickBehaviorSidebar } from "./ClickBehaviorSidebar/ClickBehaviorSidebar";
 import { DashboardInfoSidebar } from "./DashboardInfoSidebar";
-import { AddCardSidebar } from "./add-card-sidebar/AddCardSidebar";
+import { AddCardSidebar } from "./add-card-sidebar/AddCardSidebar/AddCardSidebar";
 import { ActionSidebarConnected } from "./ActionSidebar";
 
 DashboardSidebars.propTypes = {

--- a/frontend/src/metabase/dashboard/components/ParametersPopover.jsx
+++ b/frontend/src/metabase/dashboard/components/ParametersPopover.jsx
@@ -16,7 +16,7 @@ const PopoverBody = styled.div`
   max-width: 300px;
 `;
 
-export default class ParametersPopover extends Component {
+export class ParametersPopover extends Component {
   constructor(props, context) {
     super(props, context);
     this.state = {};

--- a/frontend/src/metabase/dashboard/components/RefreshWidget.jsx
+++ b/frontend/src/metabase/dashboard/components/RefreshWidget.jsx
@@ -24,7 +24,7 @@ const OPTIONS = [
   { name: t`60 minutes`, period: 60 * 60 },
 ];
 
-export default class RefreshWidget extends Component {
+export class RefreshWidget extends Component {
   constructor(props) {
     super(props);
 

--- a/frontend/src/metabase/dashboard/components/Sidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.jsx
@@ -12,7 +12,7 @@ const propTypes = {
   "data-testid": PropTypes.string,
 };
 
-function Sidebar({
+export function Sidebar({
   closeIsDisabled,
   children,
   onClose,
@@ -57,5 +57,3 @@ function Sidebar({
 }
 
 Sidebar.propTypes = propTypes;
-
-export default Sidebar;

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/AddCardSidebar/AddCardSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/AddCardSidebar/AddCardSidebar.jsx
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 
-import Sidebar from "metabase/dashboard/components/Sidebar";
-import QuestionPicker from "../QuestionPicker";
+import { Sidebar } from "metabase/dashboard/components/Sidebar";
+import { QuestionPickerConnected } from "../QuestionPicker";
 
 AddCardSidebar.propTypes = {
   onSelect: PropTypes.func.isRequired,
@@ -11,7 +11,7 @@ AddCardSidebar.propTypes = {
 export function AddCardSidebar(props) {
   return (
     <Sidebar data-testid="add-card-sidebar">
-      <QuestionPicker {...props} />
+      <QuestionPickerConnected {...props} />
     </Sidebar>
   );
 }

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/AddCardSidebar/index.ts
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/AddCardSidebar/index.ts
@@ -1,1 +1,0 @@
-export { AddCardSidebar } from "./AddCardSidebar";

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionPicker.jsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionPicker.jsx
@@ -115,7 +115,7 @@ function QuestionPicker({ onSelect, collectionsById, getCollectionIcon }) {
   );
 }
 
-export default _.compose(
+export const QuestionPickerConnected = _.compose(
   entityObjectLoader({
     id: () => "root",
     entityType: "collections",

--- a/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
@@ -7,7 +7,7 @@ import "react-resizable/css/styles.css";
 
 import { generateGridBackground } from "./utils";
 
-function GridLayout({
+export function GridLayout({
   items,
   itemRenderer,
   breakpoints,
@@ -133,5 +133,3 @@ function GridLayout({
     </ReactGridLayout>
   );
 }
-
-export default GridLayout;

--- a/frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx
+++ b/frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx
@@ -57,7 +57,7 @@ class ArchiveDashboardModal extends Component {
   }
 }
 
-export default _.compose(
+export const ArchiveDashboardModalConnected = _.compose(
   connect(null, mapDispatchToProps),
   Dashboard.load({
     id: (state, props) => Urls.extractCollectionId(props.params.slug),

--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
@@ -8,7 +8,7 @@ import _ from "underscore";
 import { dissoc } from "icepick";
 import title from "metabase/hoc/Title";
 import withToast from "metabase/hoc/Toast";
-import DashboardData from "metabase/dashboard/hoc/DashboardData";
+import { DashboardData } from "metabase/dashboard/hoc/DashboardData";
 
 import ActionButton from "metabase/components/ActionButton";
 import Button from "metabase/core/components/Button";
@@ -204,7 +204,7 @@ class AutomaticDashboardAppInner extends Component {
   }
 }
 
-const AutomaticDashboardApp = _.compose(
+export const AutomaticDashboardAppConnected = _.compose(
   connect(mapStateToProps, mapDispatchToProps),
   DashboardData,
   withToast,
@@ -331,5 +331,3 @@ const SuggestionsSidebar = ({ related }) => (
     <SuggestionsList suggestions={related} />
   </SidebarRoot>
 );
-
-export default AutomaticDashboardApp;

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
@@ -138,8 +138,7 @@ function CreateDashboardForm({
   );
 }
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default _.compose(
+export const CreateDashboardFormConnected = _.compose(
   withRouter,
   connect(mapStateToProps, mapDispatchToProps),
 )(CreateDashboardForm);

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.tsx
@@ -13,7 +13,7 @@ import type { Dashboard } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
 import type { CreateDashboardFormOwnProps } from "./CreateDashboardForm";
-import CreateDashboardForm from "./CreateDashboardForm";
+import { CreateDashboardFormConnected } from "./CreateDashboardForm";
 
 interface CreateDashboardModalOwnProps
   extends Omit<CreateDashboardFormOwnProps, "onCancel"> {
@@ -52,7 +52,7 @@ function CreateDashboardModal({
     <CreateCollectionOnTheGo>
       {({ resumedValues }) => (
         <ModalContent title={t`New dashboard`} onClose={onClose}>
-          <CreateDashboardForm
+          <CreateDashboardFormConnected
             {...props}
             onCreate={handleCreate}
             onCancel={onClose}
@@ -64,8 +64,7 @@ function CreateDashboardModal({
   );
 }
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default connect<
+export const CreateDashboardModalConnected = connect<
   unknown,
   CreateDashboardModalDispatchProps,
   CreateDashboardModalOwnProps,

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
@@ -10,7 +10,7 @@ import { createMockEntitiesState } from "__support__/store";
 import { createMockCollection } from "metabase-types/api/mocks";
 import { ROOT_COLLECTION } from "metabase/entities/collections";
 import { openCollection } from "metabase/containers/ItemPicker/test-utils";
-import CreateDashboardModal from "./CreateDashboardModal";
+import { CreateDashboardModalConnected } from "./CreateDashboardModal";
 
 const COLLECTION = {
   ROOT: createMockCollection({
@@ -51,7 +51,7 @@ function setup({
     .filter(c => c.id !== "root")
     .forEach(c => fetchMock.get(`path:/api/collection/${c.id}`, c));
 
-  renderWithProviders(<CreateDashboardModal onClose={onClose} />, {
+  renderWithProviders(<CreateDashboardModalConnected onClose={onClose} />, {
     storeInitialState: {
       entities: createMockEntitiesState({ collections }),
       settings,

--- a/frontend/src/metabase/dashboard/containers/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/containers/Dashboard.jsx
@@ -5,8 +5,7 @@ import { Component } from "react";
 import cx from "classnames";
 
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
-import DashboardGrid from "metabase/dashboard/components/DashboardGrid";
-import DashboardData from "metabase/dashboard/hoc/DashboardData";
+import { DashboardGridConnected } from "metabase/dashboard/components/DashboardGrid";
 
 export class Dashboard extends Component {
   render() {
@@ -20,11 +19,13 @@ export class Dashboard extends Component {
         noBackground
       >
         {() => (
-          <DashboardGrid dashboard={dashboard} {...props} className="spread" />
+          <DashboardGridConnected
+            dashboard={dashboard}
+            {...props}
+            className="spread"
+          />
         )}
       </LoadingAndErrorWrapper>
     );
   }
 }
-
-export default DashboardData(Dashboard);

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.jsx
@@ -11,7 +11,7 @@ import title from "metabase/hoc/Title";
 import favicon from "metabase/hoc/Favicon";
 import titleWithLoadingTime from "metabase/hoc/TitleWithLoadingTime";
 
-import Dashboard from "metabase/dashboard/components/Dashboard/Dashboard";
+import { Dashboard } from "metabase/dashboard/components/Dashboard/Dashboard";
 
 import { useLoadingTimer } from "metabase/hooks/use-loading-timer";
 import { useWebNotification } from "metabase/hooks/use-web-notification";
@@ -233,7 +233,7 @@ DashboardApp.propTypes = {
   route: PropTypes.object,
 };
 
-export default _.compose(
+export const DashboardAppConnected = _.compose(
   connect(mapStateToProps, mapDispatchToProps),
   favicon(({ pageFavicon }) => pageFavicon),
   title(({ dashboard, documentTitle }) => ({

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
@@ -8,7 +8,7 @@ import {
   waitForLoaderToBeRemoved,
 } from "__support__/ui";
 import { checkNotNull } from "metabase/lib/types";
-import { DashboardAppConnected } from "metabase/dashboard/containers/DashboardApp";
+import { DashboardAppConnected } from "metabase/dashboard/containers/DashboardApp/DashboardApp";
 import { BEFORE_UNLOAD_UNSAVED_MESSAGE } from "metabase/hooks/use-before-unload";
 import type { Dashboard } from "metabase-types/api";
 import {

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
@@ -8,7 +8,7 @@ import {
   waitForLoaderToBeRemoved,
 } from "__support__/ui";
 import { checkNotNull } from "metabase/lib/types";
-import DashboardApp from "metabase/dashboard/containers/DashboardApp";
+import { DashboardAppConnected } from "metabase/dashboard/containers/DashboardApp";
 import { BEFORE_UNLOAD_UNSAVED_MESSAGE } from "metabase/hooks/use-before-unload";
 import type { Dashboard } from "metabase-types/api";
 import {
@@ -83,7 +83,7 @@ async function setup({ dashboard }: Options = {}) {
     return (
       <main>
         <link rel="icon" />
-        <DashboardApp {...props} />
+        <DashboardAppConnected {...props} />
       </main>
     );
   };

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/index.js
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/index.js
@@ -1,1 +1,1 @@
-export { default } from "./DashboardApp";
+export { DashboardAppConnected } from "./DashboardApp";

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/index.js
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/index.js
@@ -1,1 +1,0 @@
-export { DashboardAppConnected } from "./DashboardApp";

--- a/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal.jsx
@@ -107,7 +107,7 @@ class DashboardSharingEmbeddingModal extends Component {
 
 DashboardSharingEmbeddingModal.defaultProps = defaultProps;
 
-export default connect(
+export const DashboardSharingEmbeddingModalConnected = connect(
   mapStateToProps,
   mapDispatchToProps,
 )(DashboardSharingEmbeddingModal);

--- a/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
+++ b/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
@@ -15,7 +15,7 @@ const TICK_PERIOD = 1; // seconds
  *
  * @deprecated HOCs are deprecated
  */
-export default ComposedComponent =>
+export const DashboardControls = ComposedComponent =>
   connect(null, { replace })(
     class extends Component {
       static displayName =

--- a/frontend/src/metabase/dashboard/hoc/DashboardData.jsx
+++ b/frontend/src/metabase/dashboard/hoc/DashboardData.jsx
@@ -39,12 +39,12 @@ const mapDispatchToProps = {
 /**
  * @deprecated HOCs are deprecated
  */
-export default ComposedComponent =>
+export const DashboardData = ComposedComponent =>
   connect(
     mapStateToProps,
     mapDispatchToProps,
   )(
-    class DashboardContainer extends Component {
+    class DashboardDataInner extends Component {
       async load(props) {
         const {
           initialize,

--- a/frontend/src/metabase/dashboard/hoc/WithVizSettingsData.js
+++ b/frontend/src/metabase/dashboard/hoc/WithVizSettingsData.js
@@ -10,7 +10,7 @@ import { getLinkTargets } from "metabase/lib/click-behavior";
  * This HOC gives access to data referenced in viz settings.
  * @deprecated HOCs are deprecated
  */
-const WithVizSettingsData = ComposedComponent => {
+export const WithVizSettingsData = ComposedComponent => {
   return withRouter(
     connect(
       (state, props) => ({
@@ -50,5 +50,3 @@ const WithVizSettingsData = ComposedComponent => {
     ),
   );
 };
-
-export default WithVizSettingsData;

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -489,7 +489,7 @@ export const autoApplyFilters = handleActions(
   INITIAL_DASHBOARD_STATE.autoApplyFilters,
 );
 
-export default reduceReducers(
+export const dashboardReducers = reduceReducers(
   INITIAL_DASHBOARD_STATE,
   combineReducers({
     dashboardId,

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.js
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.js
@@ -1,4 +1,4 @@
-import reducer from "./reducers";
+import { dashboardReducers as reducer } from "./reducers";
 import {
   INITIALIZE,
   SET_EDITING_DASHBOARD,

--- a/frontend/src/metabase/entities/dashboards/forms.jsx
+++ b/frontend/src/metabase/entities/dashboards/forms.jsx
@@ -2,7 +2,7 @@ import { t } from "ttag";
 import MetabaseSettings from "metabase/lib/settings";
 import { PLUGIN_CACHING } from "metabase/plugins";
 
-import DashboardCopyModalShallowCheckboxLabel from "metabase/dashboard/components/DashboardCopyModal/DashboardCopyModalShallowCheckboxLabel";
+import { DashboardCopyModalShallowCheckboxLabel } from "metabase/dashboard/components/DashboardCopyModal/DashboardCopyModalShallowCheckboxLabel";
 
 function createNameField() {
   return {

--- a/frontend/src/metabase/entities/dashboards/forms.jsx
+++ b/frontend/src/metabase/entities/dashboards/forms.jsx
@@ -2,7 +2,7 @@ import { t } from "ttag";
 import MetabaseSettings from "metabase/lib/settings";
 import { PLUGIN_CACHING } from "metabase/plugins";
 
-import { DashboardCopyModalShallowCheckboxLabel } from "metabase/dashboard/components/DashboardCopyModal/DashboardCopyModalShallowCheckboxLabel";
+import { DashboardCopyModalShallowCheckboxLabel } from "metabase/dashboard/components/DashboardCopyModal/DashboardCopyModalShallowCheckboxLabel/DashboardCopyModalShallowCheckboxLabel";
 
 function createNameField() {
   return {

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 import Radio from "metabase/core/components/Radio";
-import Sidebar from "metabase/dashboard/components/Sidebar";
+import { Sidebar } from "metabase/dashboard/components/Sidebar";
 import type {
   Parameter,
   ParameterId,

--- a/frontend/src/metabase/public/containers/PublicDashboard.jsx
+++ b/frontend/src/metabase/public/containers/PublicDashboard.jsx
@@ -8,8 +8,8 @@ import _ from "underscore";
 import { isWithinIframe } from "metabase/lib/dom";
 
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
-import DashboardGrid from "metabase/dashboard/components/DashboardGrid";
-import DashboardControls from "metabase/dashboard/hoc/DashboardControls";
+import { DashboardGridConnected } from "metabase/dashboard/components/DashboardGrid";
+import { DashboardControls } from "metabase/dashboard/hoc/DashboardControls";
 import { getDashboardActions } from "metabase/dashboard/components/DashboardActions";
 import title from "metabase/hoc/Title";
 
@@ -156,7 +156,7 @@ class PublicDashboard extends Component {
               <DashboardTabs location={this.props.location} />
               <Separator />
               <DashboardGridContainer>
-                <DashboardGrid
+                <DashboardGridConnected
                   {...this.props}
                   isPublic
                   className="spread"

--- a/frontend/src/metabase/reducers-main.js
+++ b/frontend/src/metabase/reducers-main.js
@@ -11,7 +11,7 @@ import admin from "metabase/admin/admin";
 import { reducer as setup } from "metabase/setup/reducers";
 
 /* dashboards */
-import dashboard from "metabase/dashboard/reducers";
+import { dashboardReducers as dashboard } from "metabase/dashboard/reducers";
 
 /* parameters */
 import * as parameters from "metabase/parameters/reducers";

--- a/frontend/src/metabase/reducers-public.js
+++ b/frontend/src/metabase/reducers-public.js
@@ -1,6 +1,6 @@
 // Reducers needed for public questions and dashboards
 import { combineReducers } from "@reduxjs/toolkit";
-import dashboard from "metabase/dashboard/reducers";
+import { dashboardReducers as dashboard } from "metabase/dashboard/reducers";
 import * as parameters from "metabase/parameters/reducers";
 import commonReducers from "./reducers-common";
 

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -19,7 +19,7 @@ import { Logout } from "metabase/auth/components/Logout";
 import { ResetPassword } from "metabase/auth/components/ResetPassword";
 
 /* Dashboards */
-import { DashboardAppConnected } from "metabase/dashboard/containers/DashboardApp";
+import { DashboardAppConnected } from "metabase/dashboard/containers/DashboardApp/DashboardApp";
 import { AutomaticDashboardAppConnected } from "metabase/dashboard/containers/AutomaticDashboardApp";
 
 /* Browse data */

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -19,8 +19,8 @@ import { Logout } from "metabase/auth/components/Logout";
 import { ResetPassword } from "metabase/auth/components/ResetPassword";
 
 /* Dashboards */
-import DashboardApp from "metabase/dashboard/containers/DashboardApp";
-import AutomaticDashboardApp from "metabase/dashboard/containers/AutomaticDashboardApp";
+import { DashboardAppConnected } from "metabase/dashboard/containers/DashboardApp";
+import { AutomaticDashboardAppConnected } from "metabase/dashboard/containers/AutomaticDashboardApp";
 
 /* Browse data */
 import BrowseApp from "metabase/browse/components/BrowseApp";
@@ -74,9 +74,9 @@ import { getRoutes as getModelRoutes } from "metabase/models/routes";
 
 import { PublicQuestion } from "metabase/public/containers/PublicQuestion";
 import PublicDashboard from "metabase/public/containers/PublicDashboard";
-import ArchiveDashboardModal from "metabase/dashboard/containers/ArchiveDashboardModal";
-import DashboardMoveModal from "metabase/dashboard/components/DashboardMoveModal";
-import DashboardCopyModal from "metabase/dashboard/components/DashboardCopyModal";
+import { ArchiveDashboardModalConnected } from "metabase/dashboard/containers/ArchiveDashboardModal";
+import { DashboardMoveModalConnected } from "metabase/dashboard/components/DashboardMoveModal";
+import { DashboardCopyModalConnected } from "metabase/dashboard/components/DashboardCopyModal";
 import { ModalRoute } from "metabase/hoc/ModalRoute";
 
 import { HomePage } from "metabase/home/components/HomePage";
@@ -172,11 +172,11 @@ export const getRoutes = store => (
         <Route
           path="dashboard/:slug"
           title={t`Dashboard`}
-          component={DashboardApp}
+          component={DashboardAppConnected}
         >
-          <ModalRoute path="move" modal={DashboardMoveModal} />
-          <ModalRoute path="copy" modal={DashboardCopyModal} />
-          <ModalRoute path="archive" modal={ArchiveDashboardModal} />
+          <ModalRoute path="move" modal={DashboardMoveModalConnected} />
+          <ModalRoute path="copy" modal={DashboardCopyModalConnected} />
+          <ModalRoute path="archive" modal={ArchiveDashboardModalConnected} />
         </Route>
 
         <Route path="/question">
@@ -218,7 +218,10 @@ export const getRoutes = store => (
 
         {/* INDIVIDUAL DASHBOARDS */}
 
-        <Route path="/auto/dashboard/*" component={AutomaticDashboardApp} />
+        <Route
+          path="/auto/dashboard/*"
+          component={AutomaticDashboardAppConnected}
+        />
 
         {/* REFERENCE */}
         <Route path="/reference" title={t`Data Reference`}>

--- a/frontend/src/metabase/sharing/components/AddEditSidebar/AddEditEmailSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/AddEditSidebar/AddEditEmailSidebar.jsx
@@ -8,7 +8,7 @@ import { dashboardPulseIsValid } from "metabase/lib/pulse";
 import { Icon } from "metabase/core/components/Icon";
 import Toggle from "metabase/core/components/Toggle";
 import SchedulePicker from "metabase/containers/SchedulePicker";
-import Sidebar from "metabase/dashboard/components/Sidebar";
+import { Sidebar } from "metabase/dashboard/components/Sidebar";
 import EmailAttachmentPicker from "metabase/sharing/components/EmailAttachmentPicker";
 import RecipientPicker from "metabase/pulse/components/RecipientPicker";
 import SendTestPulse from "metabase/components/SendTestPulse";

--- a/frontend/src/metabase/sharing/components/AddEditSidebar/AddEditSlackSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/AddEditSidebar/AddEditSlackSidebar.jsx
@@ -5,7 +5,7 @@ import _ from "underscore";
 import { Icon } from "metabase/core/components/Icon";
 import SchedulePicker from "metabase/containers/SchedulePicker";
 import SendTestPulse from "metabase/components/SendTestPulse";
-import Sidebar from "metabase/dashboard/components/Sidebar";
+import { Sidebar } from "metabase/dashboard/components/Sidebar";
 import Toggle from "metabase/core/components/Toggle";
 
 import { dashboardPulseIsValid } from "metabase/lib/pulse";

--- a/frontend/src/metabase/sharing/components/NewPulseSidebar.tsx
+++ b/frontend/src/metabase/sharing/components/NewPulseSidebar.tsx
@@ -3,7 +3,7 @@ import { t, jt } from "ttag";
 import { Icon } from "metabase/core/components/Icon";
 import Text from "metabase/components/type/Text";
 import Link from "metabase/core/components/Link";
-import Sidebar from "metabase/dashboard/components/Sidebar";
+import { Sidebar } from "metabase/dashboard/components/Sidebar";
 import { ChannelCard } from "metabase/sharing/components/NewPulseSidebar.styled";
 
 interface NewPulseSidebarProps {

--- a/frontend/src/metabase/sharing/components/PulsesListSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/PulsesListSidebar.jsx
@@ -9,7 +9,7 @@ import { t, ngettext, msgid } from "ttag";
 import { Icon } from "metabase/core/components/Icon";
 import Label from "metabase/components/type/Label";
 import Subhead from "metabase/components/type/Subhead";
-import Sidebar from "metabase/dashboard/components/Sidebar";
+import { Sidebar } from "metabase/dashboard/components/Sidebar";
 import Tooltip from "metabase/core/components/Tooltip";
 
 import {

--- a/frontend/src/metabase/sharing/components/SharingSidebar/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar/SharingSidebar.jsx
@@ -12,7 +12,7 @@ import {
   AddEditEmailSidebar,
 } from "metabase/sharing/components/AddEditSidebar/AddEditSidebar";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
-import Sidebar from "metabase/dashboard/components/Sidebar";
+import { Sidebar } from "metabase/dashboard/components/Sidebar";
 import Pulses from "metabase/entities/pulses";
 
 import {


### PR DESCRIPTION
### Description
I was working on fixing a bug in Dashboard and noticed lots of `export default`s and deprecation notices. Thought that it would make sense to clean them up as I am passing by.

Another thing I am removing are re-exports from `index.(js|ts)`, which add an unnecessary level of nesting _and_ are [bad for build performance at scale](https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7/). 

<img width="936" alt="Screenshot 2023-11-29 at 11 52 07" src="https://github.com/metabase/metabase/assets/2196347/73732824-e89d-4efe-937f-7828a9a1b130">

