### PR TITLE
Manual backport: Adds logic and test for default SSH tunnel port (#32235)

### DIFF
--- a/src/metabase/util/ssh.clj
+++ b/src/metabase/util/ssh.clj
@@ -34,6 +34,10 @@
 
 (set! *warn-on-reflection* true)
 
+(def default-ssh-tunnel-port
+  "The default port for SSH tunnels (22) used if no port is specified"
+  22)
+
 (def ^:private ^Long default-ssh-timeout 30000)
 
 (def ^:private ^SshClient client
@@ -71,7 +75,8 @@
   [{:keys [^String tunnel-host ^Integer tunnel-port ^String tunnel-user tunnel-pass tunnel-private-key
            tunnel-private-key-passphrase host port]}]
   {:pre [(integer? port)]}
-  (let [^ConnectFuture conn-future (.connect client tunnel-user tunnel-host tunnel-port)
+  (let [^Integer tunnel-port       (or tunnel-port default-ssh-tunnel-port)
+        ^ConnectFuture conn-future (.connect client tunnel-user tunnel-host tunnel-port)
         ^SessionHolder conn-status (.verify conn-future default-ssh-timeout no-cancel-options)
         hb-sec                     (ssh-heartbeat-interval-sec)
         session                    (doto ^ClientSession (.getSession conn-status)

--- a/test/metabase/util/ssh_test.clj
+++ b/test/metabase/util/ssh_test.clj
@@ -190,6 +190,15 @@
          :host                          "127.0.0.1"
          :port                          1234}))))
 
+(deftest connects-with-default-tunnel-port-test
+  (with-redefs [ssh/default-ssh-tunnel-port ssh-mock-server-with-password-port]
+    (#'ssh/start-ssh-tunnel!
+     {:tunnel-user ssh-username
+      :tunnel-host "127.0.0.1"
+      :tunnel-pass ssh-password
+      :host        "127.0.0.1"
+      :port        1234})))
+
 (deftest ssh-tunnel-works
   (testing "ssh tunnel can properly tunnel"
     (with-open [server (doto (ServerSocket. 0) ; 0 -- let ServerSocket pick a random port


### PR DESCRIPTION
Manual backport of #32235 Adds logic and test for default SSH tunnel port.