### PR TITLE
 Fix card filter connected to a field not causing an update

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -42,10 +42,6 @@ class DashboardInner extends Component {
     isSharing: false,
   };
 
-  constructor(props) {
-    super(props);
-  }
-
   static getDerivedStateFromProps({ parameters }, { parametersListLength }) {
     const visibleParameters = getVisibleParameters(parameters);
     return visibleParameters.length !== parametersListLength
@@ -54,14 +50,14 @@ class DashboardInner extends Component {
   }
 
   async componentDidMount() {
-    await this.loadDashboard(this.props.dashboardId);
+    await this.loadDashboard();
   }
 
   async componentDidUpdate(prevProps) {
     updateParametersWidgetStickiness(this);
 
     if (prevProps.dashboardId !== this.props.dashboardId) {
-      await this.loadDashboard(this.props.dashboardId);
+      await this.loadDashboard();
       return;
     }
 
@@ -84,29 +80,17 @@ class DashboardInner extends Component {
     this.props.cancelFetchDashboardCardData();
   }
 
-  async loadDashboard(dashboardId) {
-    const {
-      editingOnLoad,
-      addCardOnLoad,
-      addCardToDashboard,
-      fetchDashboard,
-      initialize,
-      loadDashboardParams,
-      location,
-      setErrorPage,
-      isNavigatingBackToDashboard,
-    } = this.props;
+  async loadDashboard() {
+    const p = this.props;
+    p.initialize({ clearCache: !p.isNavigatingBackToDashboard });
+    p.loadDashboardParams();
 
-    initialize({ clearCache: !isNavigatingBackToDashboard });
-
-    loadDashboardParams();
-
-    const result = await fetchDashboard({
-      dashId: dashboardId,
-      queryParams: location.query,
+    const result = await p.fetchDashboard({
+      dashId: p.dashboardId,
+      queryParams: p.location.query,
       options: {
-        clearCache: !isNavigatingBackToDashboard,
-        preserveParameters: isNavigatingBackToDashboard,
+        clearCache: !p.isNavigatingBackToDashboard,
+        preserveParameters: p.isNavigatingBackToDashboard,
       },
     });
 
@@ -119,16 +103,16 @@ class DashboardInner extends Component {
       if (editingOnLoad) {
         this.setEditing(this.props.dashboard);
       }
-      if (addCardOnLoad != null) {
-        addCardToDashboard({
-          dashId: dashboardId,
-          cardId: addCardOnLoad,
-          tabId: this.props.dashboard.tabs[0]?.id ?? null,
+      if (p.addCardOnLoad != null) {
+        p.addCardToDashboard({
+          dashId: p.dashboardId,
+          cardId: p.addCardOnLoad,
+          tabId: p.dashboard.tabs[0]?.id ?? null,
         });
       }
     } catch (error) {
       if (error.status === 404) {
-        setErrorPage({ ...error, context: "dashboard" });
+        p.setErrorPage({ ...error, context: "dashboard" });
       } else {
         console.error(error);
         this.setState({ error });
@@ -157,133 +141,113 @@ class DashboardInner extends Component {
   };
 
   onAddQuestion = () => {
-    const { dashboard } = this.props;
-    this.setEditing(dashboard);
+    this.setEditing(this.props.dashboard);
     this.props.toggleSidebar(SIDEBAR_NAME.addQuestion);
   };
 
+  shouldRenderAsNightMode() {
+    return this.props.isNightMode && this.props.isFullscreen;
+  }
+
   renderContent = () => {
-    const { dashboard, selectedTabId, isNightMode, isFullscreen } = this.props;
-
-    const canWrite = dashboard?.can_write ?? false;
-
-    const dashboardHasCards = dashboard?.dashcards.length > 0 ?? false;
-
+    const p = this.props;
+    const canWrite = p.dashboard?.can_write ?? false;
+    const dashboardHasCards = p.dashboard?.dashcards.length > 0 ?? false;
     const tabHasCards =
-      dashboard?.dashcards.filter(
+      p.dashboard?.dashcards.filter(
         c =>
-          selectedTabId !== undefined && c.dashboard_tab_id === selectedTabId,
+          p.selectedTabId !== undefined &&
+          c.dashboard_tab_id === p.selectedTabId,
       ).length > 0 ?? false;
-
-    const shouldRenderAsNightMode = isNightMode && isFullscreen;
 
     if (!dashboardHasCards && !canWrite) {
       return (
         <DashboardEmptyStateWithoutAddPrompt
-          isNightMode={shouldRenderAsNightMode}
+          isNightMode={this.shouldRenderAsNightMode()}
         />
       );
     }
+
     if (!dashboardHasCards) {
       return (
         <DashboardEmptyState
-          dashboard={dashboard}
-          isNightMode={shouldRenderAsNightMode}
+          dashboard={p.dashboard}
+          isNightMode={this.shouldRenderAsNightMode()}
           addQuestion={this.onAddQuestion}
-          closeNavbar={this.props.closeNavbar}
+          closeNavbar={p.closeNavbar}
         />
       );
     }
+
     if (dashboardHasCards && !tabHasCards) {
       return (
         <DashboardEmptyStateWithoutAddPrompt
-          isNightMode={shouldRenderAsNightMode}
+          isNightMode={this.shouldRenderAsNightMode()}
         />
       );
     }
+
     return (
       <DashboardGridConnected
         {...this.props}
-        dashboard={this.props.dashboard}
-        isNightMode={shouldRenderAsNightMode}
+        dashboard={p.dashboard}
+        isNightMode={this.shouldRenderAsNightMode()}
         onEditingChange={this.setEditing}
       />
     );
   };
 
   render() {
-    const {
-      addParameter,
-      dashboard,
-      isEditing,
-      isEditingParameter,
-      isFullscreen,
-      isNightMode,
-      isSharing,
-      parameters,
-      parameterValues,
-      draftParameterValues,
-      editingParameter,
-      setParameterValue,
-      setParameterIndex,
-      setEditingParameter,
-      isHeaderVisible,
-      isAutoApplyFilters,
-    } = this.props;
-
-    const { error, isParametersWidgetSticky } = this.state;
-
-    const shouldRenderAsNightMode = isNightMode && isFullscreen;
-
-    const visibleParameters = getVisibleParameters(parameters);
+    const p = this.props;
+    const visibleParameters = getVisibleParameters(p.parameters);
 
     const parametersWidget = (
       <SyncedParametersList
         parameters={getValuePopulatedParameters(
-          parameters,
-          isAutoApplyFilters ? parameterValues : draftParameterValues,
+          p.parameters,
+          p.isAutoApplyFilters ? p.parameterValues : p.draftParameterValues,
         )}
-        editingParameter={editingParameter}
-        dashboard={dashboard}
-        isFullscreen={isFullscreen}
-        isNightMode={shouldRenderAsNightMode}
-        isEditing={isEditing}
-        setParameterValue={setParameterValue}
-        setParameterIndex={setParameterIndex}
-        setEditingParameter={setEditingParameter}
+        editingParameter={p.editingParameter}
+        dashboard={p.dashboard}
+        isFullscreen={p.isFullscreen}
+        isNightMode={this.shouldRenderAsNightMode()}
+        isEditing={p.isEditing}
+        setParameterValue={p.setParameterValue}
+        setParameterIndex={p.setParameterIndex}
+        setEditingParameter={p.setEditingParameter}
       />
     );
 
     const shouldRenderParametersWidgetInViewMode =
-      !isEditing && !isFullscreen && visibleParameters.length > 0;
+      !p.isEditing && !p.isFullscreen && visibleParameters.length > 0;
 
     const shouldRenderParametersWidgetInEditMode =
-      isEditing && visibleParameters.length > 0;
+      p.isEditing && visibleParameters.length > 0;
 
     const cardsContainerShouldHaveMarginTop =
       !shouldRenderParametersWidgetInViewMode &&
-      (!isEditing || isEditingParameter);
+      (!p.isEditing || p.isEditingParameter);
 
     return (
       <DashboardLoadingAndErrorWrapper
-        isFullHeight={isEditing || isSharing}
-        isFullscreen={isFullscreen}
-        isNightMode={shouldRenderAsNightMode}
-        loading={!dashboard}
-        error={error}
+        isFullHeight={p.isEditing || p.isSharing}
+        isFullscreen={p.isFullscreen}
+        isNightMode={this.shouldRenderAsNightMode()}
+        loading={!p.dashboard}
+        error={this.state.error}
       >
         {() => (
           <DashboardStyled>
-            {isHeaderVisible && (
+            {p.isHeaderVisible && (
               <DashboardHeaderContainer
-                isFullscreen={isFullscreen}
-                isNightMode={shouldRenderAsNightMode}
+                isFullscreen={p.isFullscreen}
+                isNightMode={this.shouldRenderAsNightMode()}
               >
                 <DashboardHeader
                   {...this.props}
                   onEditingChange={this.setEditing}
                   setDashboardAttribute={this.setDashboardAttribute}
-                  addParameter={addParameter}
+                  addParameter={p.addParameter}
                   parametersWidget={parametersWidget}
                   onSharingClick={this.onSharingClick}
                 />
@@ -291,7 +255,7 @@ class DashboardInner extends Component {
                 {shouldRenderParametersWidgetInEditMode && (
                   <ParametersWidgetContainer
                     data-testid="edit-dashboard-parameters-widget-container"
-                    isEditing={isEditing}
+                    isEditing={p.isEditing}
                   >
                     {parametersWidget}
                   </ParametersWidgetContainer>
@@ -299,17 +263,17 @@ class DashboardInner extends Component {
               </DashboardHeaderContainer>
             )}
 
-            <DashboardBody isEditingOrSharing={isEditing || isSharing}>
+            <DashboardBody isEditingOrSharing={p.isEditing || p.isSharing}>
               <ParametersAndCardsContainer
                 data-testid="dashboard-parameters-and-cards"
                 shouldMakeDashboardHeaderStickyAfterScrolling={
-                  !isFullscreen && (isEditing || isSharing)
+                  !p.isFullscreen && (p.isEditing || p.isSharing)
                 }
               >
                 {shouldRenderParametersWidgetInViewMode && (
                   <ParametersWidgetContainer
                     data-testid="dashboard-parameters-widget-container"
-                    isSticky={isParametersWidgetSticky}
+                    isSticky={this.state.isParametersWidgetSticky}
                   >
                     {parametersWidget}
                     <FilterApplyButton />

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -69,7 +69,8 @@ class DashboardInner extends Component {
 
     if (
       !_.isEqual(prevProps.parameterValues, this.props.parameterValues) ||
-      !_.isEqual(prevProps.parameters, this.props.parameters)
+      !_.isEqual(prevProps.parameters, this.props.parameters) ||
+      (!prevProps.dashboard && this.props.dashboard)
     ) {
       this.props.fetchDashboardCardData({ reload: false, clearCache: true });
     }

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -107,7 +107,7 @@ class DashboardInner extends Component {
         p.addCardToDashboard({
           dashId: p.dashboardId,
           cardId: p.addCardOnLoad,
-          tabId: p.dashboard.tabs[0]?.id ?? null,
+          tabId: p.dashboard?.tabs[0]?.id ?? null,
         });
       }
     } catch (error) {

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -73,6 +73,7 @@ class DashboardInner extends Component {
 
     if (
       !_.isEqual(prevProps.parameterValues, this.props.parameterValues) ||
+      !_.isEqual(prevProps.parameters, this.props.parameters) ||
       (!prevProps.dashboard && this.props.dashboard)
     ) {
       this.props.fetchDashboardCardData({ reload: false, clearCache: true });

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -69,8 +69,7 @@ class DashboardInner extends Component {
 
     if (
       !_.isEqual(prevProps.parameterValues, this.props.parameterValues) ||
-      !_.isEqual(prevProps.parameters, this.props.parameters) ||
-      (!prevProps.dashboard && this.props.dashboard)
+      !_.isEqual(prevProps.parameters, this.props.parameters)
     ) {
       this.props.fetchDashboardCardData({ reload: false, clearCache: true });
     }

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -95,12 +95,12 @@ class DashboardInner extends Component {
     });
 
     if (result.error) {
-      setErrorPage(result.payload);
+      p.setErrorPage(result.payload);
       return;
     }
 
     try {
-      if (editingOnLoad) {
+      if (p.editingOnLoad) {
         this.setEditing(this.props.dashboard);
       }
       if (p.addCardOnLoad != null) {

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.unit.spec.tsx
@@ -1,0 +1,171 @@
+import { renderWithProviders, waitForLoaderToBeRemoved } from "__support__/ui";
+import {
+  createMockActionDashboardCard as _createMockActionDashboardCard,
+  createMockActionParameter,
+  createMockDashboard,
+} from "metabase-types/api/mocks";
+import type { Parameter } from "metabase-types/api";
+import { Dashboard as DashboardComponent } from "./Dashboard";
+
+type TestedProps = {
+  dashboardId: number;
+  selectedTabId: number | null; // when there's no tabs, is null
+  parameters: Parameter[]; // when empty, is an empty array
+  parameterValues?: Record<string, any>; // when empty, is undefined
+};
+
+type SetupReturn = {
+  rerender: (props: TestedProps) => void;
+  mockLoadDashboardParams: jest.Mock;
+  mockFetchDashboard: jest.Mock;
+  mockFetchDashboardCardData: jest.Mock;
+  mockFetchDashboardCardMetadata: jest.Mock;
+};
+
+async function setup(props: TestedProps): Promise<SetupReturn> {
+  const mockDashboard = createMockDashboard({ id: 10 }); // value is irrelevant
+  const mockLoadDashboardParams = jest.fn();
+  const mockFetchDashboard = jest.fn(() => mockDashboard);
+  const mockFetchDashboardCardData = jest.fn();
+  const mockFetchDashboardCardMetadata = jest.fn();
+
+  function TestComponent(props: TestedProps) {
+    return (
+      <DashboardComponent
+        dashboard={mockDashboard}
+        dashboardId={props.dashboardId}
+        parameters={props.parameters}
+        parameterValues={props.parameterValues}
+        loadDashboardParams={mockLoadDashboardParams}
+        fetchDashboard={mockFetchDashboard}
+        fetchDashboardCardData={mockFetchDashboardCardData}
+        fetchDashboardCardMetadata={mockFetchDashboardCardMetadata}
+        // stuff below doesn't change
+        location={global.location}
+        isAdmin={false}
+        isFullscreen={false}
+        isNightMode={false}
+        isSharing={false}
+        isEditing={false}
+        isEditingParameter={false}
+        isNavbarOpen={false}
+        isHeaderVisible={false}
+        isAdditionalInfoVisible={false}
+        isNavigatingBackToDashboard={false}
+        editingOnLoad={false}
+        addCardOnLoad={null}
+        isAutoApplyFilters={false} // TODO true or false?
+        dashcardData={{}}
+        selectedTabId={props.selectedTabId}
+        draftParameterValues={{}}
+        editingParameter={{}}
+        sidebar={{ name: "any", props: {} }}
+        addCardToDashboard={jest.fn()}
+        addParameter={jest.fn()}
+        archiveDashboard={jest.fn()}
+        cancelFetchDashboardCardData={jest.fn()}
+        initialize={jest.fn()}
+        onRefreshPeriodChange={jest.fn()}
+        updateDashboardAndCards={jest.fn()}
+        setDashboardAttributes={jest.fn()}
+        setEditingDashboard={jest.fn()}
+        setErrorPage={jest.fn()}
+        setSharing={jest.fn()}
+        setParameterValue={jest.fn()}
+        setEditingParameter={jest.fn()}
+        setParameterIndex={jest.fn()}
+        onUpdateDashCardVisualizationSettings={jest.fn()}
+        onUpdateDashCardColumnSettings={jest.fn()}
+        onReplaceAllDashCardVisualizationSettings={jest.fn()}
+        onChangeLocation={jest.fn()}
+        onSharingClick={jest.fn()}
+        onEmbeddingClick={jest.fn()}
+        toggleSidebar={jest.fn()}
+        closeSidebar={jest.fn()}
+        closeNavbar={jest.fn()}
+      />
+    );
+  }
+
+  const { rerender } = renderWithProviders(
+    <TestComponent
+      dashboardId={props.dashboardId}
+      selectedTabId={props.selectedTabId}
+      parameters={props.parameters}
+      parameterValues={props.parameterValues}
+    />,
+  );
+
+  await waitForLoaderToBeRemoved();
+
+  return {
+    rerender: (props: TestedProps) => rerender(<TestComponent {...props} />),
+    mockLoadDashboardParams,
+    mockFetchDashboard,
+    mockFetchDashboardCardData,
+    mockFetchDashboardCardMetadata,
+  };
+}
+
+describe("Dashboard data fetching", () => {
+  const DEFAULT_PROPS: TestedProps = {
+    dashboardId: 10,
+    selectedTabId: null,
+    parameters: [],
+    parameterValues: undefined,
+  };
+
+  afterEach(() => jest.clearAllMocks());
+
+  it("should fetch dashboard on first load", async () => {
+    const mocks = await setup(DEFAULT_PROPS);
+    expect(mocks.mockFetchDashboard).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not fetch anything on re-render", async () => {
+    const mocks = await setup(DEFAULT_PROPS);
+    jest.clearAllMocks();
+    mocks.rerender(DEFAULT_PROPS);
+    expect(mocks.mockFetchDashboard).toHaveBeenCalledTimes(0);
+    expect(mocks.mockFetchDashboardCardData).toHaveBeenCalledTimes(0);
+    expect(mocks.mockFetchDashboardCardMetadata).toHaveBeenCalledTimes(0);
+  });
+
+  it("should fetch dashboard on dashboard id change", async () => {
+    const mocks = await setup(DEFAULT_PROPS);
+    mocks.rerender({ ...DEFAULT_PROPS, dashboardId: 20 });
+    expect(mocks.mockFetchDashboard).toHaveBeenCalledTimes(2);
+  });
+
+  it("should fetch card data and metadata when tab id changes", async () => {
+    const mocks = await setup(DEFAULT_PROPS);
+    mocks.rerender({ ...DEFAULT_PROPS, selectedTabId: 1 });
+    expect(mocks.mockFetchDashboardCardData).toHaveBeenCalledTimes(1);
+    expect(mocks.mockFetchDashboardCardMetadata).toHaveBeenCalledTimes(1);
+  });
+
+  it("should fetch card data when parameters change", async () => {
+    const mocks = await setup(DEFAULT_PROPS);
+    jest.clearAllMocks();
+    mocks.rerender({
+      ...DEFAULT_PROPS,
+      parameters: [createMockActionParameter()],
+    });
+    expect(mocks.mockFetchDashboardCardMetadata).toHaveBeenCalledTimes(0);
+    expect(mocks.mockFetchDashboardCardData).toHaveBeenCalledTimes(1);
+  });
+
+  it("should fetch card data when parameter properties change", async () => {
+    const mocks = await setup({
+      ...DEFAULT_PROPS,
+      parameters: [createMockActionParameter()],
+    });
+    jest.clearAllMocks();
+    mocks.rerender({
+      ...DEFAULT_PROPS,
+      parameters: [createMockActionParameter({ id: "another" })],
+    });
+    expect(mocks.mockFetchDashboardCardMetadata).toHaveBeenCalledTimes(0);
+    expect(mocks.mockFetchDashboardCardData).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.jsx
@@ -46,7 +46,7 @@ import Link from "metabase/core/components/Link/Link";
 import Collections from "metabase/entities/collections/collections";
 import { isInstanceAnalyticsCollection } from "metabase/collections/utils";
 import { SIDEBAR_NAME } from "../../constants";
-import { DashboardHeaderComponent } from "./DashboardHeaderView";
+import { DashboardHeaderView } from "./DashboardHeaderView";
 import {
   DashboardHeaderButton,
   DashboardHeaderActionDivider,
@@ -565,7 +565,7 @@ class DashboardHeaderContainer extends Component {
 
     return (
       <>
-        <DashboardHeaderComponent
+        <DashboardHeaderView
           headerClassName="wrapper"
           objectType="dashboard"
           analyticsContext="Dashboard"

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.tsx
@@ -44,7 +44,7 @@ interface DashboardHeaderViewProps {
   setDashboardAttribute: (prop: string, value: string) => null;
 }
 
-export function DashboardHeaderComponent({
+export function DashboardHeaderView({
   editingTitle = "",
   editingSubtitle = "",
   editingButtons = [],

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
@@ -34,21 +34,6 @@ import {
 import { createMockEntitiesState } from "__support__/store";
 import { callMockEvent } from "__support__/events";
 
-const TEST_COLLECTION = createMockCollection();
-
-const TEST_DATABASE_WITH_ACTIONS = createMockDatabase({
-  settings: { "database-enable-actions": true },
-});
-
-const TEST_COLLECTION_ITEM = createMockCollectionItem({
-  collection: TEST_COLLECTION,
-  model: "dataset",
-});
-
-const TEST_CARD = createMockCard();
-
-const TEST_TABLE = createMockTable();
-
 const TestHome = () => <div />;
 
 interface Options {
@@ -56,6 +41,12 @@ interface Options {
 }
 
 async function setup({ dashboard }: Options = {}) {
+  const TEST_COLLECTION = createMockCollection();
+
+  const TEST_DATABASE_WITH_ACTIONS = createMockDatabase({
+    settings: { "database-enable-actions": true },
+  });
+
   const mockDashboard = createMockDashboard(dashboard);
   const dashboardId = mockDashboard.id;
 
@@ -69,9 +60,14 @@ async function setup({ dashboard }: Options = {}) {
     collection: TEST_COLLECTION,
     collectionItems: [],
   });
-  setupSearchEndpoints([TEST_COLLECTION_ITEM]);
-  setupCardsEndpoints([TEST_CARD]);
-  setupTableEndpoints(TEST_TABLE);
+  setupSearchEndpoints([
+    createMockCollectionItem({
+      collection: TEST_COLLECTION,
+      model: "dataset",
+    }),
+  ]);
+  setupCardsEndpoints([createMockCard()]);
+  setupTableEndpoints(createMockTable());
 
   setupBookmarksEndpoints([]);
   setupActionsEndpoints([]);
@@ -115,15 +111,9 @@ async function setup({ dashboard }: Options = {}) {
 }
 
 describe("DashboardApp", function () {
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
+  afterEach(() => jest.clearAllMocks());
 
   describe("beforeunload events", () => {
-    afterEach(() => {
-      jest.clearAllMocks();
-    });
-
     it("should have a beforeunload event when the user tries to leave a dirty dashboard", async function () {
       const { mockEventListener } = await setup();
 

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
@@ -41,9 +41,9 @@ interface Options {
 }
 
 async function setup({ dashboard }: Options = {}) {
-  const TEST_COLLECTION = createMockCollection();
+  const testCollection = createMockCollection();
 
-  const TEST_DATABASE_WITH_ACTIONS = createMockDatabase({
+  const testDatabaseWithActions = createMockDatabase({
     settings: { "database-enable-actions": true },
   });
 
@@ -53,16 +53,16 @@ async function setup({ dashboard }: Options = {}) {
   const channelData = { channels: {} };
   fetchMock.get("path:/api/pulse/form_input", channelData);
 
-  setupDatabasesEndpoints([TEST_DATABASE_WITH_ACTIONS]);
+  setupDatabasesEndpoints([testDatabaseWithActions]);
   setupDashboardEndpoints(mockDashboard);
   setupCollectionsEndpoints({ collections: [] });
   setupCollectionItemsEndpoint({
-    collection: TEST_COLLECTION,
+    collection: testCollection,
     collectionItems: [],
   });
   setupSearchEndpoints([
     createMockCollectionItem({
-      collection: TEST_COLLECTION,
+      collection: testCollection,
       model: "dataset",
     }),
   ]);
@@ -95,7 +95,7 @@ async function setup({ dashboard }: Options = {}) {
       storeInitialState: {
         dashboard: createMockDashboardState(),
         entities: createMockEntitiesState({
-          databases: [TEST_DATABASE_WITH_ACTIONS],
+          databases: [testDatabaseWithActions],
         }),
       },
     },


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/35503

### Description

The problem was that for some reason in `Dashboard.componentDidUpdate`, the method that decides whether to fetch new data, only parameter _values_ where checked — but not parameters themselves.

I have fixed that, removing garbage code along the way, and added "unit tests" for the `Dashboard` component. Net change (without the test code) is `-46` sloc, which I think is worth it.

### Test approach evolution
1. I have tried to implement an e2e test suite, which is pure madness in my opinion — I would've to recreate the entire page in a browser and click through 10 times to cover a tiny conditional way down in the function call tree.
2. Then I tried to extract a real unit from a react component (which hardly is a "unit" itself), but realised that I would still need to invoke the component itself to make sure the integration of the component and this unit with conditionals is covered too.
3. Finally I have found a happy middle ground, which I am quite satisfied with, but the setup part is ugly anyways. 

PS Certainly the tests we produce with react testing library aren't _unit_ tests because they require a rich environment, so much mocking, and are **slow**. 

### How to verify
Repeat after what I do in the screencast.

#### Before it didn't work 
https://github.com/metabase/metabase/assets/2196347/2a825b5e-8840-471d-8213-60d81321f561

#### Now it works 
https://github.com/metabase/metabase/assets/2196347/a8aa503f-9fdf-49e4-9cd8-fb8f7ec02505


### Checklist
- [x] Tests have been added/updated to cover changes in this PR
