### PR TITLE
feat: basic validation for help-link custom destination

### DIFF
--- a/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
@@ -1,6 +1,7 @@
 import {
   appBar,
   describeEE,
+  main,
   popover,
   restore,
   setTokenFeatures,
@@ -240,6 +241,25 @@ describeEE("formatting > whitelabel", () => {
       helpLink()
         .should("have.attr", "href")
         .and("include", "https://www.metabase.com/help?");
+    });
+
+    it("it should validate the url", () => {
+      cy.signInAsAdmin();
+      cy.visit("/admin/settings/whitelabel");
+
+      cy.findByTestId("help-link-setting")
+        .findByText("Go to a custom destination...")
+        .click();
+
+      helpLinkCustomDestinationInput().clear().type("ftp://something").blur();
+      main()
+        .findByText("This needs to be an http, https or mailto URL.")
+        .should("exist");
+
+      helpLinkCustomDestinationInput().clear().type("https://").blur();
+      main()
+        .findByText(/Invalid URL/i)
+        .should("exist");
     });
 
     it("should not create a race condition - scenario 1: default ->  custom  -> non custom", () => {

--- a/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
@@ -192,7 +192,7 @@ describeEE("formatting > whitelabel", () => {
         .findByText("Go to a custom destination...")
         .click();
 
-      cy.findByLabelText("Help link custom destination")
+      helpLinkCustomDestinationInput()
         .should("have.focus")
         .type("https://example.org/custom-destination")
         .blur();
@@ -204,9 +204,7 @@ describeEE("formatting > whitelabel", () => {
       cy.log("Check that on page load the text field is not focused");
       cy.reload();
 
-      cy.findByLabelText("Help link custom destination").should(
-        "not.have.focus",
-      );
+      helpLinkCustomDestinationInput().should("not.have.focus");
 
       cy.signInAsNormalUser();
       cy.visit("/");
@@ -252,7 +250,7 @@ describeEE("formatting > whitelabel", () => {
         .findByText("Go to a custom destination...")
         .click();
 
-      cy.findByLabelText("Help link custom destination").type(
+      helpLinkCustomDestinationInput().type(
         "https://example.org/custom-destination",
       );
 
@@ -274,7 +272,7 @@ describeEE("formatting > whitelabel", () => {
         .findByText("Go to a custom destination...")
         .click();
 
-      cy.findByLabelText("Help link custom destination").type(
+      helpLinkCustomDestinationInput().type(
         "https://example.org/custom-destination",
       );
 
@@ -307,3 +305,6 @@ function setApplicationFontTo(font) {
 const openSettingsMenu = () => appBar().icon("gear").click();
 
 const helpLink = () => popover().findByRole("link", { name: "Help" });
+
+const helpLinkCustomDestinationInput = () =>
+  cy.findByPlaceholderText("Enter a URL it should go to");

--- a/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
@@ -193,7 +193,7 @@ describeEE("formatting > whitelabel", () => {
         .findByText("Go to a custom destination...")
         .click();
 
-      helpLinkCustomDestinationInput()
+      getHelpLinkCustomDestinationInput()
         .should("have.focus")
         .type("https://example.org/custom-destination")
         .blur();
@@ -205,7 +205,7 @@ describeEE("formatting > whitelabel", () => {
       cy.log("Check that on page load the text field is not focused");
       cy.reload();
 
-      helpLinkCustomDestinationInput().should("not.have.focus");
+      getHelpLinkCustomDestinationInput().should("not.have.focus");
 
       cy.signInAsNormalUser();
       cy.visit("/");
@@ -251,12 +251,15 @@ describeEE("formatting > whitelabel", () => {
         .findByText("Go to a custom destination...")
         .click();
 
-      helpLinkCustomDestinationInput().clear().type("ftp://something").blur();
+      getHelpLinkCustomDestinationInput()
+        .clear()
+        .type("ftp://something")
+        .blur();
       main()
         .findByText("This needs to be an http, https or mailto URL.")
         .should("exist");
 
-      helpLinkCustomDestinationInput().clear().type("https://").blur();
+      getHelpLinkCustomDestinationInput().clear().type("https://").blur();
       main()
         .findByText(/Invalid URL/i)
         .should("exist");
@@ -270,7 +273,7 @@ describeEE("formatting > whitelabel", () => {
         .findByText("Go to a custom destination...")
         .click();
 
-      helpLinkCustomDestinationInput().type(
+      getHelpLinkCustomDestinationInput().type(
         "https://example.org/custom-destination",
       );
 
@@ -292,7 +295,7 @@ describeEE("formatting > whitelabel", () => {
         .findByText("Go to a custom destination...")
         .click();
 
-      helpLinkCustomDestinationInput().type(
+      getHelpLinkCustomDestinationInput().type(
         "https://example.org/custom-destination",
       );
 
@@ -326,5 +329,5 @@ const openSettingsMenu = () => appBar().icon("gear").click();
 
 const helpLink = () => popover().findByRole("link", { name: "Help" });
 
-const helpLinkCustomDestinationInput = () =>
+const getHelpLinkCustomDestinationInput = () =>
   cy.findByPlaceholderText("Enter a URL it should go to");

--- a/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
@@ -256,7 +256,7 @@ describeEE("formatting > whitelabel", () => {
         .type("ftp://something")
         .blur();
       main()
-        .findByText("This needs to be an http, https or mailto URL.")
+        .findByText(/This needs to be/i)
         .should("exist");
 
       getHelpLinkCustomDestinationInput().clear().type("https://").blur();

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/HelpLinkSettings/HelpLinkRadio.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/HelpLinkSettings/HelpLinkRadio.tsx
@@ -43,7 +43,7 @@ export const HelpLinkRadio = ({
     if (value === "") {
       setError(t`This field can't be left empty.`);
     } else if (!supportedPrefixes.some(prefix => value.startsWith(prefix))) {
-      setError(t`This needs to be an http, https or mailto URL.`);
+      setError(t`This needs to be an "http://", "https://" or "mailto:" URL.`);
     } else {
       setError("");
       try {

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -130,7 +130,7 @@
             (str "http://" s))]
     ;; check that the URL is valid
     (when-not (u/url? s)
-      (throw (ex-info (tru "Invalid site URL: {0}" (pr-str s)) {:url (pr-str s)})))
+      (throw (ex-info (tru "Invalid URL: {0}" (pr-str s)) {:url (pr-str s)})))
     s))
 
 (defsetting help-link-custom-destination

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -114,18 +114,32 @@
   :audit      :getter)
 
   ;; TODO: the settings on the BE will be done at the end, with help from the backend team
-  (defsetting help-link
+(defsetting help-link
   (deferred-tru "TODO")
-  :default    :metabase_default
+  :default    :default
   :type       :keyword
   :audit      :getter
   :visibility :public)
+
+(defn- normalize-help-link-custom-destination [^String s]
+  (let [;; remove trailing slashes
+        s (str/replace s #"/$" "")
+        ;; add protocol if missing
+        s (if (str/starts-with? s "http")
+            s
+            (str "http://" s))]
+    ;; check that the URL is valid
+    (when-not (u/url? s)
+      (throw (ex-info (tru "Invalid site URL: {0}" (pr-str s)) {:url (pr-str s)})))
+    s))
 
 (defsetting help-link-custom-destination
   (deferred-tru "TODO")
   :type       :string
   :visibility :public
-  :audit      :getter)
+  :setter     (fn [new-value]
+                (let [new-value (some-> new-value normalize-help-link-custom-destination)]
+                  (setting/set-value-of-type! :string :help-link-custom-destination new-value))))
 
 (defsetting dismissed-custom-dashboard-toast
   (deferred-tru "Toggle which is true after a user has dismissed the custom dashboard toast.")


### PR DESCRIPTION
[🛠️ Epic](https://github.com/metabase/metabase/issues/35915)
[📝 Product Doc](https://www.notion.so/metabase/White-labeling-Customizing-or-hiding-Help-link-8840fbdfd3c743ccaff9301a835ec81c?pvs=4)

### Description

This PR adds the validation to the url input.
It combine very basic validation on the FE with just displaying whatever error the backend returns us.

The backend code is copy pasted from the site-url validation, we'll get support from the BE team for the real code.


### Demo

https://github.com/metabase/metabase/assets/1914270/94baa5c5-6d5c-4c3b-874b-1d766b36097b


