### PR TITLE
rename help-link default value

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/HelpLinkSettings/HelpLinkRadio.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/HelpLinkSettings/HelpLinkRadio.tsx
@@ -24,7 +24,7 @@ export const HelpLinkRadio = ({
   settingValues,
 }: Props) => {
   const [helpLinkSetting, setHelpLinkType] = useState(
-    settingValues["help-link"] || "metabase_default",
+    settingValues["help-link"] || "default",
   );
 
   const handleRadioChange = (value: HelpLinkSetting) => {
@@ -39,7 +39,7 @@ export const HelpLinkRadio = ({
     <Stack>
       <Radio.Group value={helpLinkSetting} onChange={handleRadioChange}>
         <Stack>
-          <Radio label={t`Link to Metabase help`} value="metabase_default" />
+          <Radio label={t`Link to Metabase help`} value="default" />
           <Radio label={t`Hide it`} value="hidden" />
           <Radio label={t`Go to a custom destination...`} value="custom" />
         </Stack>

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/index.js
@@ -91,7 +91,7 @@ if (hasPremiumFeature("whitelabel")) {
           ),
 
           widget: HelpLinkRadio,
-          defaultValue: "metabase_default",
+          defaultValue: "default",
         },
         {
           key: "show-metabot",

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -143,7 +143,7 @@ export const createMockSettings = (opts?: Partial<Settings>): Settings => ({
   "custom-formatting": {},
   "custom-homepage": false,
   "custom-homepage-dashboard": null,
-  "help-link": "metabase_default",
+  "help-link": "default",
   "help-link-custom-destination": "",
   "deprecation-notice-version": undefined,
   "email-configured?": false,

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -187,7 +187,7 @@ export interface OpenAiModel {
   owned_by: string;
 }
 
-export type HelpLinkSetting = "metabase_default" | "hidden" | "custom";
+export type HelpLinkSetting = "default" | "hidden" | "custom";
 
 export interface Settings {
   "active-users-count"?: number;

--- a/frontend/src/metabase/nav/components/ProfileLink/ProfileLink.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/ProfileLink/ProfileLink.unit.spec.tsx
@@ -36,7 +36,7 @@ function setup({
   isAdmin = false,
   isHosted = false,
   isPaidPlan = true,
-  helpLinkSetting = "metabase_default",
+  helpLinkSetting = "default",
   helpLinkCustomDestinationSetting = "https://custom-destination.com/help",
 }: {
   isAdmin?: boolean;
@@ -150,13 +150,13 @@ describe("ProfileLink", () => {
       });
     });
 
-    describe("when the setting is `metabase_default`", () => {
+    describe("when the setting is `default`", () => {
       describe("when admin on paid plan", () => {
         it("should return the default /help-premium link", async () => {
           setup({
             isAdmin: true,
             isPaidPlan: true,
-            helpLinkSetting: "metabase_default",
+            helpLinkSetting: "default",
           });
           openMenu();
           const link = screen.getByRole("link", { name: /help/i });
@@ -177,7 +177,7 @@ describe("ProfileLink", () => {
           setup({
             isAdmin: false,
             isPaidPlan: true,
-            helpLinkSetting: "metabase_default",
+            helpLinkSetting: "default",
           });
           openMenu();
           const link = screen.getByRole("link", { name: /help/i });


### PR DESCRIPTION
### Description

Notion doc mentioned both `metabase_default` (for the analytics) and `default`. [We agreed](https://www.notion.so/White-labeling-Customizing-or-hiding-Help-link-8840fbdfd3c743ccaff9301a835ec81c?d=511f1f59e19f43c0900c04eb5b7d1d3c&pvs=4#9d2f37d1e55b48df85c9735866d36b6a) to use `default` for both

