### PR TITLE
Change default log level for `publish-event!` to debug

### DIFF
--- a/src/metabase/events.clj
+++ b/src/metabase/events.clj
@@ -123,7 +123,7 @@
           {:name       "publish-event!.logging"
            :attributes {}}
           (let [{:keys [object]} event]
-            (log/infof "Publishing %s event (name and id):\n\n%s"
+            (log/debugf "Publishing %s event (name and id):\n\n%s"
                        (u/colorize :yellow (pr-str topic))
                        (u/pprint-to-str (let [model (mi/model object)]
                                           (cond-> (select-keys object [:name :id])


### PR DESCRIPTION
Logging every event sent to `publish-event!` by default creates extra logs for almost every action that occurs on the instance, which could be a lot of logging for large instances with a lot of activity. I also don't think this logging is very useful aside from debugging specific issues, so I don't think it needs to be turned on by default.

If anyone disagrees, we could maybe keep the basic logging at the `info` log level but only include the map with extra event details when we're at the `debug` log level. My main issue is that these logs take up a lot of space and stand out more than they probably should, e.g.
```
2023-11-29 20:24:03,864 INFO metabase.events :: Publishing :event/table-read event (name and id):

{:name "INVOICES", :id 6, :model :model/Table}

```