### PR TITLE
Fix E2E replay stray job dependency

### DIFF
--- a/.github/workflows/e2e-tests-replay.yml
+++ b/.github/workflows/e2e-tests-replay.yml
@@ -3,7 +3,7 @@ name: E2E Tests using Replay.io browser
 on:
   # We'll record runs using Replay.io and their browser on a schedule as an experiment
   schedule:
-    - cron: '0 */3 * * *'
+    - cron: '0 */2 * * *'
 
 jobs:
   e2e-matrix-builder:

--- a/.github/workflows/e2e-tests-replay.yml
+++ b/.github/workflows/e2e-tests-replay.yml
@@ -19,7 +19,7 @@ jobs:
 
 
   e2e-tests:
-    needs: [test-run-id, e2e-matrix-builder]
+    needs: e2e-matrix-builder
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     name: e2e-tests-${{ matrix.name }}-${{ matrix.edition }}


### PR DESCRIPTION
I left a stray job dependency in #36138 which makes the workflow fail at startup.

https://github.com/metabase/metabase/actions/runs/7042641389
<img width="995" alt="image" src="https://github.com/metabase/metabase/assets/31325167/4e4448f7-5a45-4234-81d3-ae0879649028">

This PR fixes that and increases the frequency of a schedule to run every two hours (to compensate for the lost time).