### PR TITLE
Alert/Dashboard subscription: render question title as <a> tag

### DIFF
--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -26,6 +26,10 @@
   "Should the rendered pulse include a card description? (default: `false`)"
   false)
 
+(defn- card-href
+  [card]
+  (h (urls/card-url (:id card))))
+
 (s/defn ^:private make-title-if-needed :- (s/maybe common/RenderedPulseCard)
   [render-type card dashcard]
   (when *include-title*
@@ -42,7 +46,10 @@
                       [:tr
                        [:td {:style (style/style {:padding :0
                                                   :margin  :0})}
-                        [:span {:style (style/style (style/header-style))}
+                        [:a {:style  (style/style (style/header-style))
+                             :href   (card-href card)
+                             :target "_blank"
+                             :rel    "noopener noreferrer"}
                          (h card-name)]]
                        [:td {:style (style/style {:text-align :right})}
                         (when *include-buttons*
@@ -138,9 +145,6 @@
           (log/error e (trs "Pulse card render error"))
           (body/render :render-error nil nil nil nil nil))))))
 
-(defn- card-href
-  [card]
-  (h (urls/card-url (:id card))))
 
 (s/defn render-pulse-card :- common/RenderedPulseCard
   "Render a single `card` for a `Pulse` to Hiccup HTML. `result` is the QP results. Returns a map with keys

--- a/test/metabase/pulse/render_test.clj
+++ b/test/metabase/pulse/render_test.clj
@@ -198,3 +198,14 @@
             (is (= expected
                    (->> (get-in table [3 1])
                         (map #(peek (get (vec (get % 2)) tax-col))))))))))))
+
+(deftest title-should-be-an-a-tag-test
+  (testing "the title of the card should be an <a> tag so you can click on title using old outlook clients (#12901)"
+    (mt/with-temp [Card card {:name          "A Card"
+                              :dataset_query (mt/mbql-query venues {:limit 1})}]
+      (mt/with-temp-env-var-value [mb-site-url "https://mb.com"]
+        (let [rendered-card-content (:content (binding [render/*include-title* true]
+                                                (render/render-pulse-card :inline (pulse/defaulted-timezone card) card nil (qp/process-query (:dataset_query card))))
+                                              :content)]
+          (is (some? (mbql.u/match-one rendered-card-content
+                                       [:a (_ :guard #(= (format "https://mb.com/question/%d" (:id card)) (:href %))) "A Card"]))))))))

--- a/test/metabase/pulse/render_test.clj
+++ b/test/metabase/pulse/render_test.clj
@@ -205,7 +205,6 @@
                               :dataset_query (mt/mbql-query venues {:limit 1})}]
       (mt/with-temp-env-var-value [mb-site-url "https://mb.com"]
         (let [rendered-card-content (:content (binding [render/*include-title* true]
-                                                (render/render-pulse-card :inline (pulse/defaulted-timezone card) card nil (qp/process-query (:dataset_query card))))
-                                              :content)]
+                                                (render/render-pulse-card :inline (pulse/defaulted-timezone card) card nil (qp/process-query (:dataset_query card)))))]
           (is (some? (mbql.u/match-one rendered-card-content
                                        [:a (_ :guard #(= (format "https://mb.com/question/%d" (:id card)) (:href %))) "A Card"]))))))))


### PR DESCRIPTION
fixes #12901

On some versions of Outlook clients, `<a>` around `<table>` is not supported, so you can't click on the title/table to get directed to the question URL.

The fix is to make the title clickable by wrapping it with `<a>` tag, we only fix the title here because it'll probably solve the problem for most ppl.

about layout, it's probably fine to change from `<span>` to `<a>` because the title has its own line anyway.
Visually, there is no difference.
Before:
![Screenshot 2023-11-30 at 17 39 43](https://github.com/metabase/metabase/assets/25661381/33ef0877-0a92-4a51-9060-bacb9c83375e)
After:
![Screenshot 2023-11-30 at 17 39 54](https://github.com/metabase/metabase/assets/25661381/319ad6d6-759b-4244-bee1-16bc637eaf86)
