### PR TITLE
Install clojure before running clj-kondo

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -95,6 +95,11 @@ jobs:
       DOWNLOAD_URL: https://github.com/clj-kondo/clj-kondo/releases/download
     steps:
       - uses: actions/checkout@v3
+      - name: Install Clojure CLI
+        shell: bash
+        run: |
+          curl -O https://download.clojure.org/install/linux-install-1.11.1.1262.sh &&
+          sudo bash ./linux-install-1.11.1.1262.sh
       - name: Install clj-kondo
         run: |
           curl -OL ${DOWNLOAD_URL}/v${CLJ_KONDO_VERSION}/clj-kondo-${CLJ_KONDO_VERSION}-linux-static-amd64.zip

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -95,11 +95,10 @@ jobs:
       DOWNLOAD_URL: https://github.com/clj-kondo/clj-kondo/releases/download
     steps:
       - uses: actions/checkout@v3
-      - name: Install Clojure CLI
-        shell: bash
-        run: |
-          curl -O https://download.clojure.org/install/linux-install-1.11.1.1262.sh &&
-          sudo bash ./linux-install-1.11.1.1262.sh
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+        with:
+          m2-cache-key: 'kondo'
       - name: Install clj-kondo
         run: |
           curl -OL ${DOWNLOAD_URL}/v${CLJ_KONDO_VERSION}/clj-kondo-${CLJ_KONDO_VERSION}-linux-static-amd64.zip


### PR DESCRIPTION
running `bin/kondo.sh` requires `clojure` but we didn't install it during the kondo job

job: https://github.com/metabase/metabase/actions/runs/7045318501/job/19174789904?pr=36220#step:5:8