### PR TITLE
fix dashcard table visual lag

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
@@ -548,11 +548,7 @@ describe(
             .should("not.be.checked");
           filterWidget().findByText("Gadget").should("be.visible");
 
-          // Card height isn't updated because we're mocking clock, this is because
-          // dashcard visualizations are wrapped within `ExplicitSize` HoC which uses
-          // either `setTimeout` or `setInterval` under the hood.
-          // That's why this dashcard is only showing 1 result per page.
-          getDashboardCard().findByText("Rows 1-1 of 53").should("be.visible");
+          getDashboardCard().findByText("Rows 1-5 of 53").should("be.visible");
 
           // Card result should be updated after manually updating the filter
           filterWidget().icon("close").click();
@@ -561,11 +557,7 @@ describe(
             .should("be.visible")
             .click();
 
-          // Card height isn't updated because we're mocking clock, this is because
-          // dashcard visualizations are wrapped within `ExplicitSize` HoC which uses
-          // either `setTimeout` or `setInterval` under the hood.
-          // That's why this dashcard is only showing 1 result per page.
-          getDashboardCard().findByText("Rows 1-1 of 200").should("be.visible");
+          getDashboardCard().findByText("Rows 1-5 of 200").should("be.visible");
         });
 
         it("should not display a toast when a dashboard takes longer than 15s to load if users have no write access to a dashboard", () => {
@@ -583,11 +575,7 @@ describe(
           // so to make sure callback in `setTimeout` is called, we need to advance the clock using cy.tick().
           cy.tick();
 
-          // Card height isn't updated because we're mocking clock, this is because
-          // dashcard visualizations are wrapped within `ExplicitSize` HoC which uses
-          // either `setTimeout` or `setInterval` under the hood.
-          // That's why this dashcard is only showing 1 result per page.
-          getDashboardCard().findByText("Rows 1-1 of 53").should("be.visible");
+          getDashboardCard().findByText("Rows 1-5 of 53").should("be.visible");
         });
       });
     });

--- a/frontend/src/metabase/visualizations/components/TableSimple/TableSimple.jsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple/TableSimple.jsx
@@ -219,5 +219,5 @@ function TableSimple({
 
 export default ExplicitSize({
   refreshMode: props =>
-    props.isDashboard && !props.isEditing ? "debounce" : "throttle",
+    props.isDashboard && !props.isEditing ? "debounceLeading" : "throttle",
 })(TableSimple);


### PR DESCRIPTION
### Description

There is a visual lag on the dashcard table, it initially renders 1 row and then after about ~200ms it renders others. This is due to debounce of the `ExplicitSize` hoc which do not provide element dimensions until there is no change in them for 200ms affects the initial rendering. By changing resizeMode to `debounceLeading` we can solve this problem.

### How to verify

- Create a dashboard with a table
- Reload the page and ensure it initially renders rows for all available space in the card 

### Demo

#### Before

https://github.com/metabase/metabase/assets/14301985/408a428d-ec87-4157-8915-ed29df2bc140

#### After

https://github.com/metabase/metabase/assets/14301985/29d97595-5826-4648-a062-c3ee9a0a40d7

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
