### PR TITLE
Remove `getBrokenUpTextMatcher` helper from E2E tests

### DIFF
--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -304,23 +304,3 @@ export function visitPublicDashboard(id, { params = {} } = {}) {
     },
   );
 }
-
-/**
- * Returns a matcher function to find text content that is broken up by multiple elements
- * There is also a version of this for unit tests - frontend/test/__support__/ui.tsx
- * In case of changes, please, add them there as well
- *
- * @param {string} textToFind
- * @example
- * cy.findByText(getBrokenUpTextMatcher("my text with a styled word"))
- */
-export function getBrokenUpTextMatcher(textToFind) {
-  return (content, element) => {
-    const hasText = node => node?.textContent === textToFind;
-    const childrenDoNotHaveText = element
-      ? Array.from(element.children).every(child => !hasText(child))
-      : true;
-
-    return hasText(element) && childrenDoNotHaveText;
-  };
-}

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -4,7 +4,6 @@ import {
   addOrUpdateDashboardCard,
   editDashboard,
   getActionCardDetails,
-  getBrokenUpTextMatcher,
   getDashboardCard,
   getHeadingCardDetails,
   getLinkCardDetails,
@@ -1623,37 +1622,21 @@ const getTableCell = index => {
 const getCreatedAtToQuestionMapping = () => {
   return cy
     .get("aside")
-    .findByText(
-      getBrokenUpTextMatcher(
-        `${CREATED_AT_COLUMN_NAME} goes to "${TARGET_QUESTION.name}"`,
-      ),
-    );
+    .contains(`${CREATED_AT_COLUMN_NAME} goes to "${TARGET_QUESTION.name}"`);
 };
 
 const getCountToDashboardMapping = () => {
   return cy
     .get("aside")
-    .findByText(
-      getBrokenUpTextMatcher(
-        `${COUNT_COLUMN_NAME} goes to "${TARGET_DASHBOARD.name}"`,
-      ),
-    );
+    .contains(`${COUNT_COLUMN_NAME} goes to "${TARGET_DASHBOARD.name}"`);
 };
 
 const getCreatedAtToUrlMapping = () => {
-  return cy
-    .get("aside")
-    .findByText(
-      getBrokenUpTextMatcher(`${CREATED_AT_COLUMN_NAME} goes to URL`),
-    );
+  return cy.get("aside").contains(`${CREATED_AT_COLUMN_NAME} goes to URL`);
 };
 
 const getCountToDashboardFilterMapping = () => {
-  return cy
-    .get("aside")
-    .findByText(
-      getBrokenUpTextMatcher(`${COUNT_COLUMN_NAME} updates 1 filter`),
-    );
+  return cy.get("aside").contains(`${COUNT_COLUMN_NAME} updates 1 filter`);
 };
 
 const createDashboardWithTabs = ({ dashboard, tabs, options }) => {

--- a/e2e/test/scenarios/filters/reproductions/31340-long-column-name-search-results.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/31340-long-column-name-search-results.cy.spec.js
@@ -1,7 +1,6 @@
 import {
   assertDescendantNotOverflowsContainer,
   assertIsEllipsified,
-  getBrokenUpTextMatcher,
   popover,
   restore,
 } from "e2e/support/helpers";
@@ -55,9 +54,7 @@ describe("issue 31340", function () {
 
       cy.wait("@search");
 
-      cy.findByText(
-        getBrokenUpTextMatcher(`No matching ${LONG_COLUMN_NAME} found.`),
-      )
+      cy.contains(`No matching ${LONG_COLUMN_NAME} found.`)
         .should("be.visible")
         .then($container => {
           cy.findByText(LONG_COLUMN_NAME).then(([columnTextEl]) => {


### PR DESCRIPTION
Cypress already has `cy.contains()` that is doing the exact same thing.