### PR TITLE
Serialize missing settings for uploads

### DIFF
--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -205,7 +205,10 @@
      site-name
      source-address-header
      start-of-week
-     subscription-allowed-domains})
+     subscription-allowed-domains
+     uploads-enabled
+     uploads-database-id
+     uploads-schema-name})
 
 (defmethod serdes/extract-all "Setting" [_model _opts]
   (for [{:keys [key value]} (admin-writable-site-wide-settings


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/36232

We don't have to change the tests for this, the only serialization test we have for settings is [this](https://github.com/metabase/metabase/pull/29927).