### PR TITLE
disable can-write for cards and dashboards in default audit collection

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
@@ -129,25 +129,11 @@
     (binding [api/*current-user-permissions-set* (delay #{"/"})]
       (is (true? (mi/can-write? root-child-dashboard))))))
 
-;; for all cards + dashboards:
-;; instead of temp card, lookup the real audit cards, and call can-write? on them
-
 (deftest can-write-is-false-for-audit-content-dashboards-test
   (let [audit-dashboards (t2/select :model/Dashboard :collection_id (:id (perms/default-audit-collection)))]
     (is (= #{false} (set (map mi/can-write? audit-dashboards))))))
-
-;; for a random one:
-;; API tests -- try to edit the card and/or the dashboard
 
 (deftest cannot-edit-audit-content-dashboards-over-api
   (let [dashboard (t2/select-one :model/Dashboard :collection_id (:id (perms/default-audit-collection)))]
     (is (= "You don't have permissions to do that."
            (mt/user-http-request :rasta :put 403 (str "dashboard/" (u/the-id dashboard)) {:name "My new title"})))))
-
-
-
-
-(comment
-
-  (can-write-false-for-audit-card-content-test)
-  )

--- a/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
@@ -6,6 +6,7 @@
    [metabase-enterprise.audit-db :as audit-db]
    [metabase-enterprise.audit-db-test :as audit-db-test]
    [metabase.api.common :as api]
+   [metabase.core :as mbc]
    [metabase.models.collection :refer [Collection]]
    [metabase.models.collection.graph :refer [update-graph!]]
    [metabase.models.collection.graph-test :refer [graph]]
@@ -102,7 +103,15 @@
                #"Unable to make audit collections writable."
                (update-graph! (assoc-in (graph :clear-revisions? true) [:groups group-id (:id collection)] :write)))))))))
 
+(defn- install-audit-db-if-needed!
+  "Checks if there's an audit-db. if not, it will create it and serialize audit content, including the
+  `default-audit-collection`. If the audit-db is there, this does nothing."
+  []
+  (when-not (t2/select-one :model/Database :is_audit true)
+    (mbc/ensure-audit-db-installed!)))
+
 (deftest can-write-false-for-audit-card-content-test
+  (install-audit-db-if-needed!)
   (t2.with-temp/with-temp [:model/Card audit-child-card {:collection_id (:id (perms/default-audit-collection))}
                            :model/Card root-child-card {:collection_id nil}]
     (is (false? (mi/can-write? audit-child-card)))
@@ -112,15 +121,18 @@
       (is (true? (mi/can-write? root-child-card))))))
 
 (deftest can-write-is-false-for-audit-content-cards-test
+  (install-audit-db-if-needed!)
   (let [audit-cards (t2/select :model/Card :collection_id (:id (perms/default-audit-collection)))]
     (is (= #{false} (set (map mi/can-write? audit-cards))))))
 
 (deftest cannot-edit-audit-content-cards-over-api
+  (install-audit-db-if-needed!)
   (let [card (t2/select-one :model/Card :collection_id (:id (perms/default-audit-collection)))]
     (is (= "You don't have permissions to do that."
            (mt/user-http-request :rasta :put 403 (str "card/" (u/the-id card)) {:name "My new title"})))))
 
 (deftest can-write-false-for-audit-dashboard-content-test
+  (install-audit-db-if-needed!)
   (t2.with-temp/with-temp [:model/Dashboard audit-child-dashboard {:collection_id (:id (perms/default-audit-collection))}
                            :model/Dashboard root-child-dashboard {:collection_id nil}]
     (is (false? (mi/can-write? audit-child-dashboard)))
@@ -130,10 +142,12 @@
       (is (true? (mi/can-write? root-child-dashboard))))))
 
 (deftest can-write-is-false-for-audit-content-dashboards-test
+  (install-audit-db-if-needed!)
   (let [audit-dashboards (t2/select :model/Dashboard :collection_id (:id (perms/default-audit-collection)))]
     (is (= #{false} (set (map mi/can-write? audit-dashboards))))))
 
 (deftest cannot-edit-audit-content-dashboards-over-api
+  (install-audit-db-if-needed!)
   (let [dashboard (t2/select-one :model/Dashboard :collection_id (:id (perms/default-audit-collection)))]
     (is (= "You don't have permissions to do that."
            (mt/user-http-request :rasta :put 403 (str "dashboard/" (u/the-id dashboard)) {:name "My new title"})))))

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -83,7 +83,12 @@
 (defmethod mi/can-write? Card
   ([instance]
    ;; Cards in audit collection should not be writable.
-   (if (= (:collection_id instance) perms/audit-db-id)
+   (if (and
+        ;; We want to make sure there's an existing audit collection before doing the equality check below.
+        ;; If there is no audit collection, this will be nil:
+        (perms/default-audit-collection)
+        ;; Is a direct descendant of audit collection
+        (= (:collection_id instance) (:id (perms/default-audit-collection))))
      false
      (mi/current-user-has-full-permissions? (perms/perms-objects-set-for-parent-collection instance :write))))
   ([_ pk]

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -86,7 +86,7 @@
    (if (and
         ;; We want to make sure there's an existing audit collection before doing the equality check below.
         ;; If there is no audit collection, this will be nil:
-        (perms/default-audit-collection)
+        (some? (:id (perms/default-audit-collection)))
         ;; Is a direct descendant of audit collection
         (= (:collection_id instance) (:id (perms/default-audit-collection))))
      false

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -55,12 +55,11 @@
    (if (and
         ;; We want to make sure there's an existing audit collection before doing the equality check below.
         ;; If there is no audit collection, this will be nil:
-        (perms/default-audit-collection)
+        (some? (:id (perms/default-audit-collection)))
         ;; Is a direct descendant of audit collection
         (= (:collection_id instance) (:id (perms/default-audit-collection))))
      false
-     (mi/current-user-has-full-permissions? (perms/perms-objects-set-for-parent-collection instance :write)))
-   )
+     (mi/current-user-has-full-permissions? (perms/perms-objects-set-for-parent-collection instance :write))))
   ([_ pk]
    (mi/can-write? (t2/select-one :model/Dashboard :id pk))))
 

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -52,9 +52,15 @@
 (defmethod mi/can-write? Dashboard
   ([instance]
    ;; Dashboards in audit collection should be read only
-   (if (= (:collection_id instance) perms/audit-db-id)
+   (if (and
+        ;; We want to make sure there's an existing audit collection before doing the equality check below.
+        ;; If there is no audit collection, this will be nil:
+        (perms/default-audit-collection)
+        ;; Is a direct descendant of audit collection
+        (= (:collection_id instance) (:id (perms/default-audit-collection))))
      false
-     (mi/current-user-has-full-permissions? (perms/perms-objects-set-for-parent-collection instance :write))))
+     (mi/current-user-has-full-permissions? (perms/perms-objects-set-for-parent-collection instance :write)))
+   )
   ([_ pk]
    (mi/can-write? (t2/select-one :model/Dashboard :id pk))))
 

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -1088,7 +1088,7 @@
 (defenterprise default-audit-collection
   "OSS implementation of `audit-db/default-audit-collection`, which is an enterprise feature, so does nothing in the OSS
   version."
-  metabase-enterprise.audit-db [] ::noop)
+  metabase-enterprise.audit-db [] nil)
 
 (defenterprise default-custom-reports-collection
   "OSS implementation of `audit-db/default-custom-reports-collection`, which is an enterprise feature, so does nothing in the OSS

--- a/test/metabase/models/collection/root_test.clj
+++ b/test/metabase/models/collection/root_test.clj
@@ -11,7 +11,7 @@
                                #{"/"}                 true
                                #{"/db/1/"}            false
                                #{"/collection/root/"} true}
-          ;; Audit content shouldn't affect can-read/can-write lookups on the root collection.
+          ;; Audit content should not affect can-read?/can-write? on the root collection.
           premium-feature-set [#{} #{:audit-app}]
           f                   [#'mi/can-read? #'mi/can-write?]]
     (testing (format "%s with perms %s and features %s"

--- a/test/metabase/models/collection/root_test.clj
+++ b/test/metabase/models/collection/root_test.clj
@@ -3,15 +3,19 @@
    [clojure.test :refer :all]
    [metabase.api.common :as api]
    [metabase.models.collection.root :as collection.root]
-   [metabase.models.interface :as mi]))
+   [metabase.models.interface :as mi]
+   [metabase.public-settings.premium-features-test :as premium-features-test]))
 
 (deftest perms-test
-  (doseq [[perms expected] {nil                    false
-                            #{"/"}                 true
-                            #{"/db/1/"}            false
-                            #{"/collection/root/"} true}
-          f                [#'mi/can-read? #'mi/can-write?]]
-    (testing (format "%s with perms %s" f (pr-str perms))
-      (binding [api/*current-user-permissions-set* (atom perms)]
-        (is (= expected
-               (f collection.root/root-collection)))))))
+  (doseq [[perms expected]    {nil                    false
+                               #{"/"}                 true
+                               #{"/db/1/"}            false
+                               #{"/collection/root/"} true}
+          premium-feature-set [#{} #{:audit-app}]
+          f                   [#'mi/can-read? #'mi/can-write?]]
+    (testing (format "%s with perms %s and features %s"
+                     f (pr-str perms) (pr-str premium-feature-set))
+      (premium-features-test/with-premium-features premium-feature-set
+        (binding [api/*current-user-permissions-set* (atom perms)]
+          (is (= expected
+                 (f collection.root/root-collection))))))))

--- a/test/metabase/models/collection/root_test.clj
+++ b/test/metabase/models/collection/root_test.clj
@@ -11,6 +11,7 @@
                                #{"/"}                 true
                                #{"/db/1/"}            false
                                #{"/collection/root/"} true}
+          ;; Audit content shouldn't affect can-read/can-write lookups on the root collection.
           premium-feature-set [#{} #{:audit-app}]
           f                   [#'mi/can-read? #'mi/can-write?]]
     (testing (format "%s with perms %s and features %s"

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -1681,7 +1681,7 @@
 
 (deftest instance-analytics-collections-test
   (testing "Instance analytics and it's contents isn't writable, even for admins."
-    (t2.with-temp/with-temp [Collection audit-collection {:id perms/audit-db-id :type "instance-analytics"}
+    (t2.with-temp/with-temp [Collection audit-collection {:type "instance-analytics"}
                              Card       audit-card       {:collection_id (:id audit-collection)}
                              Dashboard  audit-dashboard  {:collection_id (:id audit-collection)}
                              Collection cr-collection    {}


### PR DESCRIPTION
What's wrong: Cards and Dashboards that are in the Metabase Analytics collection are writable, but they shouldn't be.

Why was it happening: We were checking the instance's collection-id against the audit-db-id (which is 13371337).

What is the fix: we should compare it to the default audit collection's id.
