### PR TITLE
[Auditv2] Don't show broken move and archive buttons for analytics collections

### DIFF
--- a/e2e/test/scenarios/collections/instance-analytics.cy.spec.js
+++ b/e2e/test/scenarios/collections/instance-analytics.cy.spec.js
@@ -131,7 +131,10 @@ describeEE("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
       },
     );
 
-    it("should not allow moving or archiving custom reports collection", () => {
+    it("should not allow moving or archiving analytics collections", () => {
+      cy.log(
+        "**-- Custom Reports collection should not be archivable or movable --**",
+      );
       navigationSidebar().within(() => {
         cy.findByText(ANALYTICS_COLLECTION_NAME).click();
         cy.findByText("Custom reports").click();
@@ -151,11 +154,46 @@ describeEE("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
         if (el.text() === "Custom reports") {
           cy.wrap(el).within(() => {
             cy.icon("ellipsis").click();
-            cy.contains("Archive").should("not.exist");
-            cy.contains("Move").should("not.exist");
           });
           return false; // stop iterating
         }
+      });
+
+      popover().within(() => {
+        cy.findByText("Bookmark").should("be.visible");
+        cy.findByText("Archive").should("not.exist");
+        cy.findByText("Move").should("not.exist");
+      });
+
+      cy.log(
+        "**-- Metabase Analytics collection should not be archivable or movable --**",
+      );
+      navigationSidebar().within(() => {
+        cy.findByText(ANALYTICS_COLLECTION_NAME).click();
+        cy.findByText("Our analytics").click();
+      });
+
+      cy.findByTestId("collection-menu").within(() => {
+        cy.icon("ellipsis").click();
+        cy.contains("Archive").should("not.exist");
+        cy.contains("Move").should("not.exist");
+      });
+
+      navigationSidebar().findByText("Our analytics").click();
+
+      cy.findAllByTestId("collection-entry").each(el => {
+        if (el.text() === ANALYTICS_COLLECTION_NAME) {
+          cy.wrap(el).within(() => {
+            cy.icon("ellipsis").click();
+          });
+          return false; // stop iterating
+        }
+      });
+
+      popover().within(() => {
+        cy.findByText("Bookmark").should("be.visible");
+        cy.findByText("Archive").should("not.exist");
+        cy.findByText("Move").should("not.exist");
       });
     });
   });

--- a/e2e/test/scenarios/collections/instance-analytics.cy.spec.js
+++ b/e2e/test/scenarios/collections/instance-analytics.cy.spec.js
@@ -9,7 +9,6 @@ import {
 
 const ANALYTICS_COLLECTION_NAME = "Metabase analytics";
 const PEOPLE_MODEL_NAME = "People";
-const METRICS_DASHBOARD_NAME = "Metabase metrics";
 
 describeEE("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
   describe("admin", () => {
@@ -157,87 +156,6 @@ describeEE("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
           });
           return false; // stop iterating
         }
-      });
-    });
-
-    it.skip("should not allow editing analytics content (#36228)", () => {
-      // dashboard
-      navigationSidebar().findByText(ANALYTICS_COLLECTION_NAME).click();
-      cy.findByTestId("pinned-items")
-        .findByText(METRICS_DASHBOARD_NAME)
-        .scrollIntoView()
-        .click();
-
-      cy.wait("@getDashboard");
-
-      cy.findByTestId("dashboard-header").within(() => {
-        cy.icon("pencil").should("not.exist");
-      });
-
-      // model
-      navigationSidebar().findByText(ANALYTICS_COLLECTION_NAME).click();
-      cy.findByTestId("pinned-items")
-        .findByText(PEOPLE_MODEL_NAME)
-        .scrollIntoView()
-        .click();
-
-      cy.wait("@getCard");
-
-      cy.findByTestId("qb-header").within(() => {
-        cy.icon("ellipsis").click();
-      });
-
-      popover().findByText("Edit query definition").should("not.exist");
-    });
-  });
-
-  describe("API tests", () => {
-    beforeEach(() => {
-      cy.intercept("GET", "/api/field/*/values").as("fieldValues");
-      cy.intercept("POST", "/api/dataset").as("datasetQuery");
-      cy.intercept("POST", "api/card").as("saveCard");
-      cy.intercept("POST", "api/dashboard/*/copy").as("copyDashboard");
-
-      restore();
-      cy.signInAsAdmin();
-      setTokenFeatures("all");
-    });
-
-    it.skip("should not allow editing analytics content (#36228)", () => {
-      // get the analytics collection
-      cy.request("GET", "/api/collection/root/items").then(({ body }) => {
-        const analyticsCollection = body.data.find(
-          ({ name }) => name === ANALYTICS_COLLECTION_NAME,
-        );
-        expect(analyticsCollection.can_write).to.be.false;
-
-        // get the items in the collection
-        cy.request(
-          "GET",
-          `/api/collection/${analyticsCollection.id}/items`,
-        ).then(({ body }) => {
-          const analyticsItems = body.data;
-
-          // check each collection item
-          const cards = analyticsItems.filter(
-            ({ model }) => model === "card" || model === "dataset",
-          );
-          const dashboards = analyticsItems.filter(
-            ({ model }) => model === "dashboard",
-          );
-
-          cards.forEach(({ id }) => {
-            cy.request("GET", `/api/card/${id}`).then(({ body }) => {
-              expect(body.can_write).to.be.false;
-            });
-          });
-
-          dashboards.forEach(({ id }) => {
-            cy.request("GET", `/api/dashboard/${id}`).then(({ body }) => {
-              expect(body.can_write).to.be.false;
-            });
-          });
-        });
       });
     });
   });

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.unit.spec.tsx
@@ -114,6 +114,7 @@ describe("ActionMenu", () => {
       const item = createMockCollectionItem({
         name: "Collection",
         model: "collection",
+        can_write: true,
         setCollection: jest.fn(),
         setArchived: jest.fn(),
       });
@@ -133,7 +134,24 @@ describe("ActionMenu", () => {
       const item = createMockCollectionItem({
         name: "My personal collection",
         model: "collection",
+        can_write: true,
         personal_owner_id: 1,
+        setCollection: jest.fn(),
+        setArchived: jest.fn(),
+      });
+
+      setup({ item });
+
+      userEvent.click(getIcon("ellipsis"));
+      expect(screen.queryByText("Move")).not.toBeInTheDocument();
+      expect(screen.queryByText("Archive")).not.toBeInTheDocument();
+    });
+
+    it("should not allow to move and archive read only collections", () => {
+      const item = createMockCollectionItem({
+        name: "My Read Only collection",
+        model: "collection",
+        can_write: false,
         setCollection: jest.fn(),
         setArchived: jest.fn(),
       });

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -129,6 +129,10 @@ export function isItemCollection(item: CollectionItem) {
   return item.model === "collection";
 }
 
+export function isReadOnlyCollection(collection: CollectionItem) {
+  return isItemCollection(collection) && !collection.can_write;
+}
+
 export function canPinItem(item: CollectionItem, collection: Collection) {
   return collection.can_write && item.setPinned != null;
 }
@@ -140,6 +144,7 @@ export function canPreviewItem(item: CollectionItem, collection: Collection) {
 export function canMoveItem(item: CollectionItem, collection: Collection) {
   return (
     collection.can_write &&
+    !isReadOnlyCollection(item) &&
     item.setCollection != null &&
     !(isItemCollection(item) && isRootPersonalCollection(item))
   );
@@ -148,6 +153,7 @@ export function canMoveItem(item: CollectionItem, collection: Collection) {
 export function canArchiveItem(item: CollectionItem, collection: Collection) {
   return (
     collection.can_write &&
+    !isReadOnlyCollection(item) &&
     !(isItemCollection(item) && isRootPersonalCollection(item))
   );
 }

--- a/frontend/src/metabase/collections/utils.unit.spec.ts
+++ b/frontend/src/metabase/collections/utils.unit.spec.ts
@@ -2,9 +2,14 @@ import {
   isRootPersonalCollection,
   canonicalCollectionId,
   isRootCollection,
+  isItemCollection,
+  isReadOnlyCollection,
 } from "metabase/collections/utils";
 
-import { createMockCollection } from "metabase-types/api/mocks";
+import {
+  createMockCollection,
+  createMockCollectionItem,
+} from "metabase-types/api/mocks";
 
 describe("Collections > utils", () => {
   describe("isRootPersonalCollection", () => {
@@ -68,6 +73,57 @@ describe("Collections > utils", () => {
       expect(isRootCollection(createMockCollection({ id: "foobar" }))).toBe(
         false,
       );
+    });
+  });
+
+  describe("isItemCollection", () => {
+    it("returns true if the item is a collection", () => {
+      expect(
+        isItemCollection(createMockCollectionItem({ model: "collection" })),
+      ).toBe(true);
+    });
+
+    it("returns false if the item is not a collection", () => {
+      expect(
+        isItemCollection(createMockCollectionItem({ model: "dashboard" })),
+      ).toBe(false);
+      expect(
+        isItemCollection(createMockCollectionItem({ model: "card" })),
+      ).toBe(false);
+      expect(
+        isItemCollection(createMockCollectionItem({ model: "dataset" })),
+      ).toBe(false);
+    });
+  });
+
+  describe("isReadOnlyCollection", () => {
+    it("returns true if the collection is read only", () => {
+      expect(
+        isReadOnlyCollection(
+          createMockCollectionItem({ model: "collection", can_write: false }),
+        ),
+      ).toBe(true);
+    });
+
+    it("returns false if the collection is not read only", () => {
+      expect(
+        isReadOnlyCollection(
+          createMockCollectionItem({ model: "collection", can_write: true }),
+        ),
+      ).toBe(false);
+    });
+
+    it("returns false if the item is not a collection", () => {
+      expect(
+        isReadOnlyCollection(
+          createMockCollectionItem({ model: "card", can_write: true }),
+        ),
+      ).toBe(false);
+      expect(
+        isReadOnlyCollection(
+          createMockCollectionItem({ model: "card", can_write: false }),
+        ),
+      ).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/35700 again? I don't think https://github.com/metabase/metabase/pull/35894 actually addressed this, which was caused by the UI not respecting `can_write` properties on collections in the collection list view.

### Description

Checks `can_write` for collections in the collection list view to determine whether we should show the move and archive buttons

Before | After
--- | ---
![Screen Shot 2023-11-30 at 8 54 45 AM](https://github.com/metabase/metabase/assets/30528226/29f4e5d8-51b8-417b-9e56-97b5668e7fbb) | ![Screen Shot 2023-11-30 at 8 54 21 AM](https://github.com/metabase/metabase/assets/30528226/efb0c8ec-bae7-414f-a0da-2eab383ff236)


### How to verify

Describe the steps to verify that the changes are working as expected.

1. visit the "our analytics collection"
2. click on the ... menu next to "metabase analytics"
3. do the same for "custom reports" within metabase analytics
4. see that you don't get the option to move or archive

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
