### PR TITLE
Fetching specific collections for file upload toasts

### DIFF
--- a/frontend/src/metabase/redux/uploads.ts
+++ b/frontend/src/metabase/redux/uploads.ts
@@ -102,7 +102,7 @@ export const uploadFile = createThunkAction(
 interface UploadStartPayload {
   id: number;
   name: string;
-  collectionId: string;
+  collectionId: CollectionId;
 }
 
 interface UploadEndPayload {

--- a/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.tsx
@@ -1,39 +1,33 @@
+import _ from "underscore";
+
 import { useSelector, useDispatch } from "metabase/lib/redux";
 import { getAllUploads, clearAllUploads } from "metabase/redux/uploads";
-import Collections from "metabase/entities/collections/collections";
-import type { Collection } from "metabase-types/api";
+import type { CollectionId } from "metabase-types/api";
 import type { FileUpload } from "metabase-types/store/upload";
 import { isUploadAborted, isUploadInProgress } from "metabase/lib/uploads";
 
+import { useCollectionQuery } from "metabase/common/hooks";
 import useStatusVisibility from "../../hooks/use-status-visibility";
 import FileUploadStatusLarge from "../FileUploadStatusLarge";
 
-const FileUploadStatus = ({
-  collections = [],
-}: {
-  collections: Collection[];
-}) => {
+export const FileUploadStatus = () => {
   const uploads = useSelector(getAllUploads);
   const dispatch = useDispatch();
   const resetUploads = () => dispatch(clearAllUploads());
 
-  const uploadCollections = collections.filter(collection =>
-    uploads.some(upload => upload.collectionId === collection.id),
-  );
+  const groupedCollections = _.groupBy(uploads, "collectionId");
+
+  const collections = Object.keys(groupedCollections) as CollectionId[];
 
   return (
     <>
-      {uploadCollections.map(collection => {
-        const collectionUploads = uploads.filter(
-          ({ collectionId }) => collectionId === collection.id,
-        );
-
+      {collections.map(collectionId => {
         return (
           <FileUploadStatusContent
-            key={`uploads-${collection.id}`}
-            uploads={collectionUploads}
+            key={`uploads-${collectionId}`}
+            uploads={groupedCollections[collectionId]}
             resetUploads={resetUploads}
-            collection={collection}
+            collectionId={collectionId}
           />
         );
       })}
@@ -42,11 +36,11 @@ const FileUploadStatus = ({
 };
 
 const FileUploadStatusContent = ({
-  collection,
+  collectionId,
   uploads,
   resetUploads,
 }: {
-  collection: Collection;
+  collectionId: CollectionId;
   uploads: FileUpload[];
   resetUploads: () => void;
 }) => {
@@ -55,7 +49,11 @@ const FileUploadStatusContent = ({
   );
   const isVisible = useStatusVisibility(isActive);
 
-  if (!isVisible) {
+  const { data: collection, isLoading } = useCollectionQuery({
+    id: collectionId,
+  });
+
+  if (!isVisible || isLoading || !collection) {
     return null;
   }
 
@@ -67,8 +65,3 @@ const FileUploadStatusContent = ({
     />
   );
 };
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default Collections.loadList({ loadingAndErrorWrapper: false })(
-  FileUploadStatus,
-);

--- a/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.unit.spec.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.unit.spec.tsx
@@ -7,7 +7,7 @@ import { createMockUpload, createMockState } from "metabase-types/store/mocks";
 import { renderWithProviders } from "__support__/ui";
 import { createMockCollection } from "metabase-types/api/mocks";
 import CollectionHeader from "metabase/collections/containers/CollectionHeader";
-import FileUploadStatus from "./FileUploadStatus";
+import { FileUploadStatus } from "./FileUploadStatus";
 
 describe("FileUploadStatus", () => {
   const firstCollectionId = 1;
@@ -19,13 +19,15 @@ describe("FileUploadStatus", () => {
   const secondCollectionId = 2;
 
   beforeEach(() => {
-    fetchMock.get("path:/api/collection", [
-      firstCollection,
+    fetchMock.get("path:/api/collection/1", firstCollection);
+
+    fetchMock.get(
+      "path:/api/collection/2",
       createMockCollection({
-        id: secondCollectionId,
+        id: 2,
         name: "Second Collection",
       }),
-    ]);
+    );
   });
 
   afterEach(() => {

--- a/frontend/src/metabase/status/components/FileUploadStatus/index.ts
+++ b/frontend/src/metabase/status/components/FileUploadStatus/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./FileUploadStatus";
+export * from "./FileUploadStatus";

--- a/frontend/src/metabase/status/components/StatusListing/StatusListing.tsx
+++ b/frontend/src/metabase/status/components/StatusListing/StatusListing.tsx
@@ -7,7 +7,7 @@ import { getUserIsAdmin, getUser } from "metabase/selectors/user";
 import { hasActiveUploads } from "metabase/redux/uploads";
 
 import DatabaseStatus from "../../containers/DatabaseStatus";
-import FileUploadStatus from "../FileUploadStatus";
+import { FileUploadStatus } from "../FileUploadStatus";
 import { StatusListingRoot } from "./StatusListing.styled";
 
 const StatusListing = () => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/36215

### Description
The `<FileUploadStatus />` component was fetching the entire list of collections in order to determine the name of the collection to show in the toast. This can have a very negative effect on larger instances since all collections includes personal collections, as well as anything in `Out Analytics`. Locally, this request would take a couple seconds to complete for an instance with ~10,000 users, but would not result in anything showing on the screen for most people.

### How to verify
Go to the homepage and open up the network tab. You shouldn't see a request to `/collections`. If you do a CSV upload, you should only potentially see a request to the specific collection you're uploading to.

### Demo
![chrome_myeg8Qp8oE](https://github.com/metabase/metabase/assets/1328979/ae6cdc91-4b80-4c7a-b8f2-340d2eccb21a)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
