### PR TITLE
Allow toggling of the dashboard subscription sidebar from the icon

### DIFF
--- a/e2e/support/helpers/e2e-email-helpers.js
+++ b/e2e/support/helpers/e2e-email-helpers.js
@@ -97,7 +97,6 @@ export const setupSubscriptionWithRecipient = recipient => {
 };
 
 export const openPulseSubscription = () => {
-  cy.findByLabelText("subscriptions").click();
   sidebar().findByLabelText("Pulse Card").click();
 };
 

--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -69,13 +69,13 @@ describe("scenarios > dashboard > subscriptions", () => {
   describe("sidebar toggling behavior", () => {
     it("should allow toggling the sidebar", () => {
       openDashboardSubscriptions();
-      cy.findByLabelText("subscriptions").click();
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Email it");
       cy.findByLabelText("subscriptions").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Email it").should("not.exist");
+      cy.findByLabelText("subscriptions").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Email it");
     });
   });
 

--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -66,6 +66,19 @@ describe("scenarios > dashboard > subscriptions", () => {
     cy.findByText(/Share this dashboard with people *./i);
   });
 
+  describe("sidebar toggling behavior", () => {
+    it("should allow toggling the sidebar", () => {
+      openDashboardSubscriptions();
+      cy.findByLabelText("subscriptions").click();
+
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Email it");
+      cy.findByLabelText("subscriptions").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Email it").should("not.exist");
+    });
+  });
+
   describe("with no channels set up", () => {
     it("should instruct user to connect email or slack", () => {
       openDashboardSubscriptions();

--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -70,12 +70,9 @@ describe("scenarios > dashboard > subscriptions", () => {
     it("should allow toggling the sidebar", () => {
       openDashboardSubscriptions();
 
+      // The sidebar starts open after the method there, so test that clicking the icon closes it
       cy.findByLabelText("subscriptions").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Email it").should("not.exist");
-      cy.findByLabelText("subscriptions").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Email it");
+      sidebar().should("not.exist");
     });
   });
 

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -142,7 +142,7 @@ class DashboardInner extends Component {
   };
 
   onSharingClick = () => {
-    this.props.setSharing(true);
+    this.props.setSharing(this.props.isSharing ? false : true);
   };
 
   onAddQuestion = () => {

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -142,7 +142,7 @@ class DashboardInner extends Component {
   };
 
   onSharingClick = () => {
-    this.props.setSharing(this.props.isSharing ? false : true);
+    this.props.setSharing(!this.props.isSharing);
   };
 
   onAddQuestion = () => {


### PR DESCRIPTION
### What
Updates the behavior of clicking the subscriptions icon in the dashboard header so that the sidebar gets toggled, instead of you having to go all the way down to `Cancel.` This now matches the behavior of the info panel.

### Demo
https://www.loom.com/share/465134c0f6ba4ffd9408a4dade4d9d67?sid=246a8af4-3112-4c88-b502-d8260d3de8cd

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
