### PR TITLE
fix bad merge around dashboard reducers

### DIFF
--- a/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.js
@@ -7,7 +7,7 @@ import {
 } from "metabase-types/api/mocks";
 import { createMockDashboardState } from "metabase-types/store/mocks";
 import { createMockEntitiesState } from "__support__/store";
-import dashboardReducer from "../reducers";
+import { dashboardReducers } from "../reducers";
 import { fetchDashboard } from "./data-fetching";
 
 describe("fetchDashboard", () => {
@@ -24,7 +24,7 @@ describe("fetchDashboard", () => {
 
     store = configureStore({
       reducer: {
-        dashboard: dashboardReducer,
+        dashboard: dashboardReducers,
         entities: (state = {}) => state,
         settings: (state = {}) => state,
       },


### PR DESCRIPTION
A file was added in this PR https://github.com/metabase/metabase/pull/35896 and it imported `dashboardReducers` assuming it is was exported as a default but it got changed in master