### PR TITLE
API Keys: add AuthCard and listing page

### DIFF
--- a/e2e/test/scenarios/admin-2/api-keys.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/api-keys.cy.spec.ts
@@ -1,0 +1,309 @@
+import type { CyHttpMessages } from "cypress/types/net-stubbing";
+
+import { popover, restore } from "e2e/support/helpers";
+import type { ApiKey } from "metabase-types/api";
+
+const MOCK_ROWS: ApiKey[] = [
+  {
+    name: "Development API Key",
+    id: 1,
+    group: {
+      id: 1,
+      name: "All Users",
+    },
+    creator_id: 1,
+    masked_key: "asdfasdfa",
+    created_at: "2010 Aug 10",
+    updated_at: "2010 Aug 10",
+    updated_by: {
+      id: 10,
+      common_name: "John Doe",
+    },
+  },
+  {
+    name: "Production API Key",
+    id: 2,
+    group: {
+      id: 2,
+      name: "Administrators",
+    },
+    creator_id: 1,
+    masked_key: "asdfasdfa",
+    created_at: "2010 Aug 10",
+    updated_at: "2010 Aug 10",
+    updated_by: {
+      id: 11,
+      common_name: "Jane Doe",
+    },
+  },
+  {
+    name: "Personal API Key",
+    id: 3,
+    group: {
+      id: 3,
+      name: "collection",
+    },
+    creator_id: 1,
+    masked_key: "asdfasdfa",
+    created_at: "2010 Aug 10",
+    updated_at: "2010 Aug 10",
+    updated_by: {
+      id: 12,
+      common_name: "Jane Doe",
+    },
+  },
+];
+
+const MOCK_GROUPS = [
+  // NOTE: this is only here temporarily (remove when backend is working)
+  {
+    id: 2,
+    name: "Administrators",
+    member_count: 1,
+  },
+  {
+    id: 1,
+    name: "All Users",
+    member_count: 9,
+  },
+  {
+    id: 3,
+    name: "collection",
+    member_count: 4,
+  },
+  {
+    id: 4,
+    name: "data",
+    member_count: 2,
+  },
+  {
+    id: 6,
+    name: "nosql",
+    member_count: 1,
+  },
+  {
+    id: 5,
+    name: "readonly",
+    member_count: 1,
+  },
+];
+
+const getRequestId = (req: CyHttpMessages.IncomingHttpRequest) =>
+  parseInt(req.url.match(/api-key\/(\d+)/)?.[1] ?? "", 10);
+
+describe("scenarios > admin > settings > API keys", () => {
+  // TODO: replace intercepts below with actual requests to test backend
+  let mockRows: ApiKey[] = [];
+
+  beforeEach(() => {
+    restore();
+    mockRows = [...MOCK_ROWS];
+    cy.signInAsAdmin();
+  });
+
+  it("should show number of API keys on auth card", () => {
+    cy.intercept("GET", "/api/api-key/count", req => req.reply(200, "5"));
+    cy.visit("/admin/settings/authentication");
+    getApiKeysCard()
+      .findByTestId("card-badge")
+      .should("have.text", "5 API Keys");
+
+    cy.intercept("GET", "/api/api-key/count", req => req.reply(200, "1"));
+    cy.reload();
+    getApiKeysCard()
+      .findByTestId("card-badge")
+      .should("have.text", "1 API Key");
+
+    cy.intercept("GET", "/api/api-key/count", req => req.reply(200, "0"));
+    cy.reload();
+    getApiKeysCard().findByTestId("card-badge").should("not.exist");
+  });
+
+  it("should list existing API keys", () => {
+    cy.intercept("GET", "/api/api-key", req => req.reply(200, mockRows));
+    cy.visit("/admin/settings/authentication/api-keys");
+    getApiKeysRows()
+      .should("contain", "Development API Key")
+      .and("contain", "Production API Key")
+      .and("contain", "Personal API Key");
+  });
+
+  it("should allow creating an API key", () => {
+    cy.intercept("GET", "/api/api-key", req => req.reply(200, mockRows)).as(
+      "fetchKeys",
+    );
+    cy.intercept("POST", "/api/api-key", req => {
+      mockRows.push(req.body);
+      req.reply(200);
+    });
+
+    cy.visit("/admin/settings/authentication/api-keys");
+    cy.wait("@fetchKeys");
+    cy.findByTestId("api-keys-settings-header")
+      .button("Create API Key")
+      .click();
+    cy.findByLabelText(/Key name/).type("New key");
+    cy.findByLabelText(/Select a group/).click();
+    cy.findByRole("listbox").findByText("Administrators").click();
+    cy.button("Create").click();
+    cy.wait("@fetchKeys");
+    cy.button("Done").click();
+    getApiKeysRows().contains("New key").should("exist");
+    cy.reload();
+    getApiKeysRows().contains("New key").should("exist");
+  });
+
+  it("should allow deleting an API key", () => {
+    cy.intercept("GET", "/api/api-key", req => req.reply(200, mockRows)).as(
+      "fetchKeys",
+    );
+    cy.intercept("DELETE", "/api/api-key/*", req => {
+      const id = getRequestId(req);
+      mockRows = mockRows.filter(row => row.id !== id);
+      req.reply(200);
+    }).as("deleteKey");
+    cy.visit("/admin/settings/authentication/api-keys");
+    cy.wait("@fetchKeys");
+    getApiKeysRows()
+      .contains("Development API Key")
+      .closest("tr")
+      .icon("trash")
+      .click();
+    cy.button("Delete API Key").click();
+    cy.wait("@deleteKey");
+    cy.wait("@fetchKeys");
+    getApiKeysRows().should("not.contain", "Development API Key");
+    cy.reload();
+    getApiKeysRows().should("not.contain", "Development API Key");
+  });
+
+  it("should allow editing an API key", () => {
+    cy.intercept("GET", "/api/api-key", req => req.reply(200, mockRows)).as(
+      "fetchKeys",
+    );
+    cy.intercept("PUT", "/api/api-key/*", req => {
+      const id = getRequestId(req);
+      const rowI = mockRows.findIndex(row => row.id === id);
+      mockRows[rowI] = {
+        ...mockRows[rowI],
+        ...req.body,
+        group_name: MOCK_GROUPS.find(group => group.id === req.body.group_id)
+          ?.name,
+      };
+      req.reply(200);
+    }).as("saveKey");
+    cy.visit("/admin/settings/authentication/api-keys");
+    cy.wait("@fetchKeys");
+
+    getApiKeysRows()
+      .contains("Development API Key")
+      .closest("tr")
+      .icon("pencil")
+      .click();
+
+    cy.findByLabelText(/Key name/)
+      .clear()
+      .type("Different key name");
+    cy.findByLabelText(/Select a group/).click();
+    cy.findByRole("listbox").findByText("collection").click();
+    cy.button("Save").click();
+    cy.wait("@saveKey");
+    cy.wait("@fetchKeys");
+
+    getApiKeysRows()
+      .should("not.contain", "Development API Key")
+      .contains("Different key name")
+      .closest("tr")
+      .should("contain", "collection");
+    cy.reload();
+    getApiKeysRows()
+      .contains("Different key name")
+      .closest("tr")
+      .should("contain", "collection");
+  });
+
+  it("should allow regenerating an API key", () => {
+    cy.intercept("GET", "/api/api-key", req => req.reply(200, mockRows)).as(
+      "fetchKeys",
+    );
+    cy.intercept("PUT", "/api/api-key/*/regenerate", req => {
+      const id = getRequestId(req);
+      const rowI = mockRows.findIndex(row => row.id === id);
+      const masked_key = "qwerty";
+      const unmasked_key = "qwertyuiop";
+      mockRows[rowI] = {
+        ...mockRows[rowI],
+        masked_key: "qwerty",
+      };
+      req.reply(200, { masked_key, unmasked_key });
+    }).as("regenKey");
+    cy.visit("/admin/settings/authentication/api-keys");
+    cy.wait("@fetchKeys");
+    getApiKeysRows()
+      .contains("Personal API Key")
+      .closest("tr")
+      .icon("pencil")
+      .click();
+    cy.button("Regenerate API Key").click();
+    cy.button("Regenerate").click();
+    cy.wait("@regenKey");
+    cy.findByLabelText("The API key").should("have.value", "qwertyuiop");
+    cy.wait("@fetchKeys");
+    cy.button("Done").click();
+    getApiKeysRows()
+      .contains("Personal API Key")
+      .closest("tr")
+      .should("contain", "qwerty")
+      .and("not.contain", "qwertyuiop");
+    cy.reload();
+    getApiKeysRows()
+      .contains("Personal API Key")
+      .closest("tr")
+      .should("contain", "qwerty")
+      .and("not.contain", "qwertyuiop");
+  });
+
+  it("should warn before deleting a group with API keys", () => {
+    cy.intercept("GET", "/api/api-key", req => req.reply(200, mockRows)).as(
+      "fetchKeys",
+    );
+    cy.visit("/admin/people/groups");
+    cy.wait("@fetchKeys");
+    cy.get(".ContentTable")
+      .contains("collection")
+      .closest("tr")
+      .should("contain", "(Includes 1 API Key")
+      .icon("ellipsis")
+      .click();
+    popover().findByText("Remove Group").click();
+    cy.get(".Modal")
+      .findByText(/move the API Keys/)
+      .click();
+    cy.url().should("match", /\/admin\/settings\/authentication\/api-keys$/);
+  });
+
+  it("should show API keys when viewing Group details", () => {
+    cy.intercept("GET", "/api/api-key", req => req.reply(200, mockRows)).as(
+      "fetchKeys",
+    );
+    cy.visit("/admin/people/groups/3");
+    cy.wait("@fetchKeys");
+    cy.get(".ContentTable")
+      .findByText("Personal API Key")
+      .closest("tr")
+      .icon("link")
+      .as("apiKeysLink")
+      .realHover();
+    cy.findByRole("tooltip").should("contain", "Manage API keys");
+    cy.get("@apiKeysLink").click();
+    cy.url().should("match", /\/admin\/settings\/authentication\/api-keys$/);
+  });
+
+  it("should show when a question was last edited by an API key", () => {
+    // TODO: write this when backend is ready
+  });
+});
+const getApiKeysCard = () => cy.findByText("API Keys").parent().parent();
+
+const getApiKeysRows = () =>
+  cy.findByTestId("api-keys-table").find("tbody > tr");

--- a/frontend/src/metabase-types/api/admin.ts
+++ b/frontend/src/metabase-types/api/admin.ts
@@ -1,0 +1,16 @@
+export type ApiKey = {
+  name: string;
+  id: number;
+  group: {
+    id: number;
+    name: string;
+  };
+  creator_id: number;
+  masked_key: string;
+  created_at: string;
+  updated_at: string;
+  updated_by: {
+    id: number;
+    common_name: string;
+  };
+};

--- a/frontend/src/metabase-types/api/index.ts
+++ b/frontend/src/metabase-types/api/index.ts
@@ -1,5 +1,6 @@
 export * from "./actions";
 export * from "./activity";
+export * from "./admin";
 export * from "./alert";
 export * from "./automagic-dashboards";
 export * from "./bookmark";

--- a/frontend/src/metabase/admin/settings/auth/components/ApiKeysAuthCard.tsx
+++ b/frontend/src/metabase/admin/settings/auth/components/ApiKeysAuthCard.tsx
@@ -1,0 +1,38 @@
+import { t } from "ttag";
+import { useEffect, useState } from "react";
+import { Link } from "react-router";
+import Button from "metabase/core/components/Button";
+import { ApiKeysApi } from "metabase/services";
+import {
+  CardBadge,
+  CardDescription,
+  CardHeader,
+  CardRoot,
+  CardTitle,
+} from "./AuthCard/AuthCard.styled";
+
+export const ApiKeysAuthCard = () => {
+  const [keyCount, setKeyCount] = useState(0);
+
+  useEffect(() => {
+    ApiKeysApi.count().then(setKeyCount);
+  }, []);
+
+  const isConfigured = keyCount > 0;
+  return (
+    <CardRoot>
+      <CardHeader>
+        <CardTitle>{t`API Keys`}</CardTitle>
+        {isConfigured && (
+          <CardBadge isEnabled data-testid="card-badge">
+            {keyCount === 1 ? t`1 API Key` : t`${keyCount} API Keys`}
+          </CardBadge>
+        )}
+      </CardHeader>
+      <CardDescription>{t`Allow users to use the API keys to authenticate their API calls.`}</CardDescription>
+      <Button as={Link} to={`/admin/settings/authentication/api-keys`}>
+        {isConfigured ? t`Manage` : t`Set up`}
+      </Button>
+    </CardRoot>
+  );
+};

--- a/frontend/src/metabase/admin/settings/auth/components/AuthCard/AuthCard.styled.tsx
+++ b/frontend/src/metabase/admin/settings/auth/components/AuthCard/AuthCard.styled.tsx
@@ -14,7 +14,7 @@ export const CardRoot = styled.div`
 export const CardHeader = styled.div`
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 1rem;
   margin-bottom: 1rem;
 `;
 
@@ -39,7 +39,7 @@ interface CardBadgeProps {
 export const CardBadge = styled.div<CardBadgeProps>`
   color: ${props => color(props.isEnabled ? "brand" : "danger")};
   background-color: ${props =>
-    color(props.isEnabled ? "brand-light" : "bg-light")};
+    color(props.isEnabled ? "brand-lighter" : "bg-light")};
   padding: 0.25rem 0.375rem;
   border-radius: 0.25rem;
   font-weight: bold;

--- a/frontend/src/metabase/admin/settings/components/ApiKeys/CreateApiKeyModal.tsx
+++ b/frontend/src/metabase/admin/settings/components/ApiKeys/CreateApiKeyModal.tsx
@@ -1,0 +1,81 @@
+import { t } from "ttag";
+import { useCallback, useState } from "react";
+
+import { Text, Button, Group, Modal, Stack } from "metabase/ui";
+import {
+  Form,
+  FormErrorMessage,
+  FormProvider,
+  FormGroupWidget,
+  FormSubmitButton,
+  FormTextInput,
+} from "metabase/forms";
+import { ApiKeysApi } from "metabase/services";
+
+import { SecretKeyModal } from "./SecretKeyModal";
+
+export const CreateApiKeyModal = ({
+  onClose,
+  refreshList,
+}: {
+  onClose: () => void;
+  refreshList: () => void;
+}) => {
+  const [modal, setModal] = useState<"create" | "secretKey">("create");
+  const [secretKey, setSecretKey] = useState<string>("");
+
+  const handleSubmit = useCallback(
+    async vals => {
+      const response = await ApiKeysApi.create(vals);
+      setSecretKey(response.unmasked_key);
+      setModal("secretKey");
+      refreshList();
+    },
+    [refreshList],
+  );
+
+  if (modal === "secretKey") {
+    return <SecretKeyModal secretKey={secretKey} onClose={onClose} />;
+  }
+
+  if (modal === "create") {
+    return (
+      <Modal
+        size="30rem"
+        padding="xl"
+        opened
+        onClose={onClose}
+        title={t`Create a new API Key`}
+      >
+        <FormProvider initialValues={{}} onSubmit={handleSubmit}>
+          <Form>
+            <Stack spacing="md">
+              <FormTextInput
+                name="name"
+                label={t`Key name`}
+                size="sm"
+                required
+              />
+              <FormGroupWidget
+                name="group_id"
+                label={t`Select a group to inherit its permissions`}
+                size="sm"
+                required
+              />
+              <Text
+                my="sm"
+                size="sm"
+              >{t`We don’t version the Metabase API. We rarely change API endpoints, and almost never remove them, but if you write code that relies on the API, there’s a chance you might have to update your code in the future.`}</Text>
+              <FormErrorMessage />
+              <Group position="right">
+                <Button onClick={onClose}>{t`Cancel`}</Button>
+                <FormSubmitButton variant="filled" label={t`Create`} />
+              </Group>
+            </Stack>
+          </Form>
+        </FormProvider>
+      </Modal>
+    );
+  }
+  return null;
+};

--- a/frontend/src/metabase/admin/settings/components/ApiKeys/DeleteApiKeyModal.tsx
+++ b/frontend/src/metabase/admin/settings/components/ApiKeys/DeleteApiKeyModal.tsx
@@ -1,0 +1,60 @@
+import { t } from "ttag";
+import { useCallback } from "react";
+
+import type { ApiKey } from "metabase-types/api";
+
+import {
+  FormProvider,
+  Form,
+  FormSubmitButton,
+  FormErrorMessage,
+} from "metabase/forms";
+
+import { Text, Button, Group, Modal, Stack } from "metabase/ui";
+import { ApiKeysApi } from "metabase/services";
+
+export const DeleteApiKeyModal = ({
+  onClose,
+  refreshList,
+  apiKey,
+}: {
+  onClose: () => void;
+  refreshList: () => void;
+  apiKey: ApiKey;
+}) => {
+  const handleDelete = useCallback(async () => {
+    await ApiKeysApi.delete({ id: apiKey.id });
+    refreshList();
+    onClose();
+  }, [refreshList, onClose, apiKey.id]);
+
+  return (
+    <Modal
+      size="30rem"
+      padding="xl"
+      opened
+      onClose={onClose}
+      title={t`Delete API Key`}
+    >
+      <FormProvider initialValues={{}} onSubmit={handleDelete}>
+        <Form>
+          <Stack spacing="lg">
+            <Text>{t`API key deleted can’t be recovered. You have to create a new key.`}</Text>
+            <FormErrorMessage />
+            <Group position="right">
+              <Button
+                color="error.0"
+                onClick={onClose}
+              >{t`No, don’t delete`}</Button>
+              <FormSubmitButton
+                label={t`Delete API Key`}
+                variant="filled"
+                color="error.0"
+              />
+            </Group>
+          </Stack>
+        </Form>
+      </FormProvider>
+    </Modal>
+  );
+};

--- a/frontend/src/metabase/admin/settings/components/ApiKeys/EditApiKeyModal.tsx
+++ b/frontend/src/metabase/admin/settings/components/ApiKeys/EditApiKeyModal.tsx
@@ -1,0 +1,184 @@
+import { t } from "ttag";
+import { useCallback, useState } from "react";
+
+import type { ApiKey } from "metabase-types/api";
+
+import { Text, Button, Group, Modal, Stack } from "metabase/ui";
+import {
+  Form,
+  FormErrorMessage,
+  FormGroupWidget,
+  FormProvider,
+  FormSubmitButton,
+  FormTextInput,
+} from "metabase/forms";
+import { ApiKeysApi } from "metabase/services";
+
+import { SecretKeyModal } from "./SecretKeyModal";
+
+type EditModalName = "edit" | "regenerate" | "secretKey";
+
+const RegenerateKeyModal = ({
+  apiKey,
+  setModal,
+  setSecretKey,
+  refreshList,
+}: {
+  apiKey: ApiKey;
+  setModal: (name: EditModalName) => void;
+  setSecretKey: (key: string) => void;
+  refreshList: () => void;
+}) => {
+  const handleRegenerate = useCallback(async () => {
+    const result = await ApiKeysApi.regenerate({ id: apiKey.id });
+    setSecretKey(result.unmasked_key);
+    setModal("secretKey");
+    refreshList();
+  }, [apiKey.id, refreshList, setModal, setSecretKey]);
+
+  return (
+    <Modal
+      size="30rem"
+      padding="xl"
+      opened
+      onClose={() => setModal("edit")}
+      title={t`Regenerate API key`}
+    >
+      <FormProvider initialValues={{}} onSubmit={handleRegenerate}>
+        <Form>
+          <Stack spacing="lg">
+            <Stack spacing="xs">
+              <Text
+                component="label"
+                weight="bold"
+                color="text.0"
+                size="sm"
+              >{t`Key name`}</Text>
+              <Text weight="bold" size="sm">
+                {apiKey.name}
+              </Text>
+            </Stack>
+            <Stack spacing="xs">
+              <Text
+                component="label"
+                weight="bold"
+                color="text.0"
+                size="sm"
+              >{t`Group`}</Text>
+              <Text weight="bold" size="sm">
+                {apiKey.group.name}
+              </Text>
+            </Stack>
+            <Text>{t`The existing API key will be deleted and cannot be recovered. It will be replaced with a new key.`}</Text>
+            <FormErrorMessage />
+            <Group position="right">
+              <Button
+                onClick={() => setModal("edit")}
+              >{t`No, don’t regenerate`}</Button>
+              <FormSubmitButton variant="filled" label={t`Regenerate`} />
+            </Group>
+          </Stack>
+        </Form>
+      </FormProvider>
+    </Modal>
+  );
+};
+
+export const EditApiKeyModal = ({
+  onClose,
+  refreshList,
+  apiKey,
+}: {
+  onClose: () => void;
+  refreshList: () => void;
+  apiKey: ApiKey;
+}) => {
+  const [modal, setModal] = useState<EditModalName>("edit");
+  const [secretKey, setSecretKey] = useState<string>("");
+
+  const handleSubmit = useCallback(
+    async vals => {
+      await ApiKeysApi.edit({
+        id: vals.id,
+        group_id: vals.group_id,
+        name: vals.name,
+      });
+      refreshList();
+      onClose();
+    },
+    [onClose, refreshList],
+  );
+
+  if (modal === "secretKey") {
+    return <SecretKeyModal secretKey={secretKey} onClose={onClose} />;
+  }
+
+  if (modal === "regenerate") {
+    return (
+      <RegenerateKeyModal
+        apiKey={apiKey}
+        setModal={setModal}
+        setSecretKey={setSecretKey}
+        refreshList={refreshList}
+      />
+    );
+  }
+
+  if (modal === "edit") {
+    return (
+      <Modal
+        size="30rem"
+        padding="xl"
+        opened
+        onClose={onClose}
+        title={t`Edit API Key`}
+      >
+        <FormProvider
+          initialValues={{ ...apiKey, group_id: apiKey.group.id }}
+          onSubmit={handleSubmit}
+        >
+          {({ dirty }) => (
+            <Form>
+              <Stack spacing="md">
+                <FormTextInput
+                  name="name"
+                  label={t`Key name`}
+                  size="sm"
+                  required
+                  withAsterisk={false}
+                />
+                <FormGroupWidget
+                  name="group_id"
+                  label={t`Select a group to inherit its permissions`}
+                  size="sm"
+                />
+                <FormTextInput
+                  name="masked_key"
+                  label={t`API Key`}
+                  size="sm"
+                  styles={{ input: { fontFamily: "Monaco, monospace" } }}
+                  disabled
+                />
+                <FormErrorMessage />
+                <Group position="apart" mt="lg">
+                  <Button
+                    onClick={() => setModal("regenerate")}
+                  >{t`Regenerate API Key`}</Button>
+                  <Group position="right">
+                    <Button onClick={onClose}>{t`Cancel`}</Button>
+                    <FormSubmitButton
+                      disabled={!dirty}
+                      variant="filled"
+                      label={t`Save`}
+                    />
+                  </Group>
+                </Group>
+              </Stack>
+            </Form>
+          )}
+        </FormProvider>
+      </Modal>
+    );
+  }
+  return null;
+};

--- a/frontend/src/metabase/admin/settings/components/ApiKeys/ManageApiKeys.tsx
+++ b/frontend/src/metabase/admin/settings/components/ApiKeys/ManageApiKeys.tsx
@@ -1,0 +1,177 @@
+import { t } from "ttag";
+import { useEffect, useState } from "react";
+import { useAsyncFn } from "react-use";
+
+import { Stack, Title, Text, Button, Group } from "metabase/ui";
+
+import Breadcrumbs from "metabase/components/Breadcrumbs";
+import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
+
+import { ApiKeysApi } from "metabase/services";
+import { Icon } from "metabase/core/components/Icon";
+
+import type { ApiKey } from "metabase-types/api";
+import { formatDateTimeWithUnit } from "metabase/lib/formatting/date";
+
+import { CreateApiKeyModal } from "./CreateApiKeyModal";
+import { EditApiKeyModal } from "./EditApiKeyModal";
+import { DeleteApiKeyModal } from "./DeleteApiKeyModal";
+
+type Modal = null | "create" | "edit" | "delete";
+
+function formatMaskedKey(maskedKey: string) {
+  return maskedKey.substring(0, 4) + "...";
+}
+
+function EmptyTableWarning() {
+  return (
+    <Stack
+      h="40rem" // TODO: how to make this fill only available window height?
+      align="center"
+      justify="center"
+      spacing="sm"
+    >
+      <Title>{t`No API keys here yet`}</Title>
+      <Text color="text.1">{t`Create API keys to programmatically authenticate their API calls.`}</Text>
+    </Stack>
+  );
+}
+
+function ApiKeysTable({
+  apiKeys,
+  setActiveApiKey,
+  setModal,
+  loading,
+  error,
+}: {
+  apiKeys?: ApiKey[];
+  setActiveApiKey: (apiKey: ApiKey) => void;
+  setModal: (modal: Modal) => void;
+  loading: boolean;
+  error?: Error;
+}) {
+  return (
+    <Stack>
+      <table
+        className="ContentTable border-bottom"
+        data-testid="api-keys-table"
+      >
+        <thead>
+          <tr>
+            <th>{t`Key name`}</th>
+            <th>{t`Group`}</th>
+            <th>{t`Key`}</th>
+            <th>{t`Last Modified By`}</th>
+            <th>{t`Last Modified On`}</th>
+            <th />
+          </tr>
+        </thead>
+        <tbody>
+          {apiKeys?.map(apiKey => (
+            <tr key={apiKey.id} className="border-bottom">
+              <td className="text-bold">{apiKey.name}</td>
+              <td>{apiKey.group.name}</td>
+              <td className="text-monospace">
+                {formatMaskedKey(apiKey.masked_key)}
+              </td>
+              <td>{apiKey.updated_by.common_name}</td>
+              <td>{formatDateTimeWithUnit(apiKey.updated_at, "minute")}</td>
+              <td>
+                <Group spacing="md">
+                  <Icon
+                    name="pencil"
+                    className="cursor-pointer"
+                    onClick={() => {
+                      setActiveApiKey(apiKey);
+                      setModal("edit");
+                    }}
+                  />
+                  <Icon
+                    name="trash"
+                    className="cursor-pointer"
+                    onClick={() => {
+                      setActiveApiKey(apiKey);
+                      setModal("delete");
+                    }}
+                  />
+                </Group>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <LoadingAndErrorWrapper loading={loading} error={error}>
+        {apiKeys?.length === 0 && <EmptyTableWarning />}
+      </LoadingAndErrorWrapper>
+    </Stack>
+  );
+}
+
+export const ManageApiKeys = () => {
+  const [modal, setModal] = useState<Modal>(null);
+  const [activeApiKey, setActiveApiKey] = useState<null | ApiKey>(null);
+
+  const [{ value: apiKeys, loading, error }, refreshList] = useAsyncFn(
+    (): Promise<ApiKey[]> => ApiKeysApi.list(),
+    [],
+  );
+
+  const handleClose = () => setModal(null);
+
+  useEffect(() => {
+    refreshList();
+  }, [refreshList]);
+
+  const isShowingEmptyTable = !loading && !error && apiKeys?.length === 0;
+
+  return (
+    <>
+      {modal === "create" ? (
+        <CreateApiKeyModal onClose={handleClose} refreshList={refreshList} />
+      ) : modal === "edit" && activeApiKey ? (
+        <EditApiKeyModal
+          onClose={handleClose}
+          refreshList={refreshList}
+          apiKey={activeApiKey}
+        />
+      ) : modal === "delete" && activeApiKey ? (
+        <DeleteApiKeyModal
+          apiKey={activeApiKey}
+          onClose={handleClose}
+          refreshList={refreshList}
+        />
+      ) : null}
+      <Stack pl="md" spacing="lg">
+        <Breadcrumbs
+          crumbs={[
+            [t`Authentication`, "/admin/settings/authentication"],
+            [t`API Keys`],
+          ]}
+        />
+        <Group
+          align="end"
+          position="apart"
+          data-testid="api-keys-settings-header"
+        >
+          <Stack>
+            <Title>{t`Manage API Keys`}</Title>
+            {!isShowingEmptyTable && (
+              <Text color="text.1">{t`Allow users to use the API keys to authenticate their API calls.`}</Text>
+            )}
+          </Stack>
+          <Button
+            variant="filled"
+            onClick={() => setModal("create")}
+          >{t`Create API Key`}</Button>
+        </Group>
+        <ApiKeysTable
+          loading={loading}
+          error={error}
+          apiKeys={apiKeys}
+          setActiveApiKey={setActiveApiKey}
+          setModal={setModal}
+        />
+      </Stack>
+    </>
+  );
+};

--- a/frontend/src/metabase/admin/settings/components/ApiKeys/ManageApiKeys.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/ApiKeys/ManageApiKeys.unit.spec.tsx
@@ -1,0 +1,185 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
+import {
+  setupApiKeyEndpoints,
+  setupGroupsEndpoint,
+} from "__support__/server-mocks";
+import { ManageApiKeys } from "metabase/admin/settings/components/ApiKeys/ManageApiKeys";
+import { createMockGroup } from "metabase-types/api/mocks";
+
+const GROUPS = [
+  createMockGroup(),
+  createMockGroup({ id: 2, name: "Administrators" }),
+  createMockGroup({ id: 3, name: "foo" }),
+  createMockGroup({ id: 4, name: "bar" }),
+  createMockGroup({ id: 5, name: "flamingos" }),
+];
+
+async function setup() {
+  setupGroupsEndpoint(GROUPS);
+  setupApiKeyEndpoints([
+    {
+      name: "Development API Key",
+      id: 1,
+      group: {
+        id: 1,
+        name: "All Users",
+      },
+      creator_id: 1,
+      masked_key: "asdfasdfa",
+      created_at: "2010 Aug 10",
+      updated_at: "2010 Aug 10",
+      updated_by: {
+        common_name: "John Doe",
+        id: 10,
+      },
+    },
+    {
+      name: "Production API Key",
+      id: 2,
+      group: {
+        id: 2,
+        name: "Administrators",
+      },
+      creator_id: 1,
+      masked_key: "asdfasdfa",
+      created_at: "2010 Aug 10",
+      updated_at: "2010 Aug 10",
+      updated_by: {
+        common_name: "Jane Doe",
+        id: 10,
+      },
+    },
+  ]);
+  renderWithProviders(<ManageApiKeys />);
+  await waitFor(async () => {
+    expect(
+      await fetchMock.calls("path:/api/api-key", { method: "GET" }),
+    ).toHaveLength(1);
+  });
+}
+describe("ManageApiKeys", () => {
+  it("should render the component", async () => {
+    await setup();
+    expect(screen.getByText("Manage API Keys")).toBeInTheDocument();
+  });
+  it("should load API keys from api", async () => {
+    await setup();
+    expect(await screen.findByText("Development API Key")).toBeInTheDocument();
+  });
+  it("should create a new API key", async () => {
+    await setup();
+    userEvent.click(screen.getByText("Create API Key"));
+    expect(await screen.findByText("Create a new API Key")).toBeInTheDocument();
+    userEvent.type(screen.getByLabelText(/Key name/), "New key");
+    userEvent.click(await screen.findByLabelText(/Select a group/));
+    userEvent.click(await screen.findByText("flamingos"));
+    userEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(
+      await screen.findByText("Copy and save the API key"),
+    ).toBeInTheDocument();
+    expect(
+      await fetchMock
+        .lastCall("path:/api/api-key", { method: "POST" })
+        ?.request?.json(),
+    ).toEqual({ name: "New key", group_id: 5 });
+
+    userEvent.click(screen.getByRole("button", { name: "Done" }));
+    await waitFor(async () =>
+      expect(
+        await fetchMock.calls("path:/api/api-key", { method: "GET" }),
+      ).toHaveLength(2),
+    );
+  });
+  it("should regenerate an API key", async () => {
+    await setup();
+    const REGEN_URL = "path:/api/api-key/1/regenerate";
+    fetchMock.put(REGEN_URL, 200);
+
+    userEvent.click(
+      within(
+        await screen.findByRole("row", {
+          name: /development api key/i,
+        }),
+      ).getByRole("img", { name: /pencil/i }),
+    );
+    await screen.findByText("Edit API Key");
+    userEvent.click(screen.getByRole("button", { name: "Regenerate API Key" }));
+    userEvent.click(await screen.findByRole("button", { name: "Regenerate" }));
+
+    await screen.findByText("Copy and save the API key");
+    expect(
+      await fetchMock.lastCall(REGEN_URL, { method: "PUT" })?.request?.json(),
+    ).toEqual({});
+    await waitFor(async () => {
+      expect(
+        await fetchMock.calls("path:/api/api-key", { method: "GET" }),
+      ).toHaveLength(2);
+    });
+  });
+  it("should edit API key", async () => {
+    await setup();
+    const EDIT_URL = "path:/api/api-key/1";
+    fetchMock.put(EDIT_URL, 200);
+
+    userEvent.click(
+      within(
+        await screen.findByRole("row", {
+          name: /development api key/i,
+        }),
+      ).getByRole("img", { name: /pencil/i }),
+    );
+    await screen.findByText("Edit API Key");
+
+    const group = await screen.findByLabelText(
+      "Select a group to inherit its permissions",
+    );
+    userEvent.click(group);
+    userEvent.click(await screen.findByText("flamingos"));
+
+    const keyName = screen.getByLabelText("Key name");
+    userEvent.clear(keyName);
+    userEvent.type(keyName, "My Key");
+
+    userEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(async () => {
+      expect(
+        await fetchMock.lastCall(EDIT_URL, { method: "PUT" })?.request?.json(),
+      ).toEqual({ group_id: 5, name: "My Key" });
+    });
+    await waitFor(async () => {
+      expect(
+        await fetchMock.calls("path:/api/api-key", { method: "GET" }),
+      ).toHaveLength(2);
+    });
+  });
+  it("should delete API key", async () => {
+    await setup();
+    const DELETE_URL = "path:/api/api-key/1";
+    fetchMock.delete(DELETE_URL, 200);
+
+    userEvent.click(
+      within(
+        await screen.findByRole("row", {
+          name: /development api key/i,
+        }),
+      ).getByRole("img", { name: /trash/i }),
+    );
+    userEvent.click(
+      await screen.findByRole("button", { name: "Delete API Key" }),
+    );
+    await waitFor(async () => {
+      expect(
+        await fetchMock.calls(DELETE_URL, { method: "DELETE" }),
+      ).toHaveLength(1);
+    });
+    await waitFor(async () => {
+      expect(
+        await fetchMock.calls("path:/api/api-key", { method: "GET" }),
+      ).toHaveLength(2);
+    });
+  });
+});

--- a/frontend/src/metabase/admin/settings/components/ApiKeys/SecretKeyModal.tsx
+++ b/frontend/src/metabase/admin/settings/components/ApiKeys/SecretKeyModal.tsx
@@ -1,0 +1,54 @@
+import { t } from "ttag";
+
+import { Text, Button, Flex, Group, Modal, Stack } from "metabase/ui";
+import { DEFAULT_Z_INDEX } from "metabase/components/Popover/constants";
+import { Icon } from "metabase/core/components/Icon";
+import { CopyTextInput } from "metabase/components/CopyTextInput";
+
+export const SecretKeyModal = ({
+  secretKey,
+  onClose,
+}: {
+  secretKey: string;
+  onClose: () => void;
+}) => (
+  <Modal
+    size="30rem"
+    padding="xl"
+    zIndex={DEFAULT_Z_INDEX} // prevents CopyWidgetButton’s Tippy popover from being obscured
+    opened
+    onClose={onClose}
+    title={t`Copy and save the API key`}
+  >
+    <Stack spacing="xl">
+      <CopyTextInput
+        label={t`The API key`}
+        size="sm"
+        value={secretKey}
+        readOnly
+        disabled
+        styles={{
+          input: {
+            color: `black !important`,
+            fontFamily: "Monaco, monospace",
+          },
+        }}
+      />
+      <Flex direction="row" gap="md">
+        <Icon
+          name="info_filled"
+          size={22}
+          className="text-medium"
+          style={{ marginTop: "-4px" }}
+        />
+        <Text
+          size="sm"
+          color="text.1"
+        >{t`Please copy this key and save it somewhere safe. For security reasons, we can’t show it to you again.`}</Text>
+      </Flex>
+      <Group position="right">
+        <Button onClick={onClose} variant="filled">{t`Done`}</Button>
+      </Group>
+    </Stack>
+  </Modal>
+);

--- a/frontend/src/metabase/forms/components/FormGroupWidget/FormGroupWidget.tsx
+++ b/frontend/src/metabase/forms/components/FormGroupWidget/FormGroupWidget.tsx
@@ -1,0 +1,63 @@
+import { forwardRef, useCallback } from "react";
+import type { FocusEvent, Ref } from "react";
+import { useField } from "formik";
+import { Select } from "metabase/ui";
+import type { SelectProps } from "metabase/ui";
+
+import type { GroupId } from "metabase-types/api";
+import { useGroupListQuery } from "metabase/common/hooks";
+
+interface FormGroupWidgetProps
+  extends Omit<SelectProps, "value" | "error" | "data"> {
+  name: string;
+  nullable?: boolean;
+}
+
+export const FormGroupWidget = forwardRef(function FormGroupWidget(
+  { name, nullable, onChange, onBlur, ...props }: FormGroupWidgetProps,
+  ref: Ref<HTMLInputElement>,
+) {
+  const [{ value }, { error, touched }, { setValue, setTouched }] = useField<
+    GroupId | null | undefined
+  >(name);
+
+  const handleChange = useCallback(
+    (newValue: string) => {
+      const newGroupId = parseInt(newValue, 10);
+      setValue(newGroupId);
+    },
+    [setValue],
+  );
+
+  const handleBlur = useCallback(
+    (event: FocusEvent<HTMLInputElement>) => {
+      setTouched(true);
+      onBlur?.(event);
+    },
+    [setTouched, onBlur],
+  );
+
+  const { data: groups, isLoading } = useGroupListQuery();
+  if (isLoading || !groups) {
+    // TODO: display a disabled Select when loading?
+    // TODO: display error when group list query fails?
+    return null;
+  }
+  const groupOptions = groups.map(({ id, name }) => ({
+    value: String(id),
+    label: name,
+  }));
+
+  return (
+    <Select
+      {...props}
+      ref={ref}
+      name={name}
+      value={value == null ? value : String(value)}
+      error={touched ? error : null}
+      data={groupOptions}
+      onChange={handleChange}
+      onBlur={handleBlur}
+    />
+  );
+});

--- a/frontend/src/metabase/forms/components/FormGroupWidget/index.ts
+++ b/frontend/src/metabase/forms/components/FormGroupWidget/index.ts
@@ -1,0 +1,1 @@
+export * from "./FormGroupWidget";

--- a/frontend/src/metabase/forms/components/FormSelect/FormSelect.tsx
+++ b/frontend/src/metabase/forms/components/FormSelect/FormSelect.tsx
@@ -9,7 +9,7 @@ export interface FormSelectProps extends Omit<SelectProps, "value" | "error"> {
   nullable?: boolean;
 }
 
-export const FormSelect = forwardRef(function FormNumberInput(
+export const FormSelect = forwardRef(function FormSelect(
   { name, nullable, onChange, onBlur, ...props }: FormSelectProps,
   ref: Ref<HTMLInputElement>,
 ) {

--- a/frontend/src/metabase/forms/components/index.ts
+++ b/frontend/src/metabase/forms/components/index.ts
@@ -3,6 +3,7 @@ export * from "./FormCheckbox";
 export * from "./FormCheckboxGroup";
 export * from "./FormErrorMessage";
 export * from "./FormGroupsWidget";
+export * from "./FormGroupWidget";
 export * from "./FormNumberInput";
 export * from "./FormProvider";
 export * from "./FormRadioGroup";

--- a/frontend/src/metabase/plugins/builtin.js
+++ b/frontend/src/metabase/plugins/builtin.js
@@ -3,3 +3,4 @@ import "metabase/plugins/builtin/auth/google";
 import "metabase/plugins/builtin/auth/ldap";
 import "metabase/plugins/builtin/auth/jwt";
 import "metabase/plugins/builtin/auth/saml";
+import "metabase/plugins/builtin/auth/apiKeys";

--- a/frontend/src/metabase/plugins/builtin/auth/apiKeys.js
+++ b/frontend/src/metabase/plugins/builtin/auth/apiKeys.js
@@ -1,0 +1,25 @@
+import { updateIn } from "icepick";
+
+import { PLUGIN_ADMIN_SETTINGS_UPDATES } from "metabase/plugins";
+import { ApiKeysAuthCard } from "metabase/admin/settings/auth/components/ApiKeysAuthCard";
+import { ManageApiKeys } from "metabase/admin/settings/components/ApiKeys/ManageApiKeys";
+
+PLUGIN_ADMIN_SETTINGS_UPDATES.push(
+  sections =>
+    updateIn(sections, ["authentication", "settings"], settings => [
+      ...settings,
+      {
+        key: "api-keys",
+        description: null,
+        noHeader: true,
+        widget: ApiKeysAuthCard,
+      },
+    ]),
+  sections => ({
+    ...sections,
+    "authentication/api-keys": {
+      component: ManageApiKeys,
+      settings: [],
+    },
+  }),
+);

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -600,3 +600,12 @@ export const MetabotApi = {
   databasePromptQuery: POST("/api/metabot/database/:databaseId/query"),
   sendFeedback: POST("/api/metabot/feedback"),
 };
+
+export const ApiKeysApi = {
+  list: GET("/api/api-key"),
+  create: POST("/api/api-key"),
+  count: GET("/api/api-key/count"),
+  delete: DELETE("/api/api-key/:id"),
+  edit: PUT("/api/api-key/:id"),
+  regenerate: PUT("/api/api-key/:id/regenerate"),
+};

--- a/frontend/test/__support__/server-mocks/api-key.ts
+++ b/frontend/test/__support__/server-mocks/api-key.ts
@@ -1,0 +1,7 @@
+import fetchMock from "fetch-mock";
+import type { ApiKey } from "metabase-types/api";
+
+export function setupApiKeyEndpoints(apiKeys: ApiKey[]) {
+  fetchMock.get("path:/api/api-key", apiKeys);
+  fetchMock.post("path:/api/api-key", 200);
+}

--- a/frontend/test/__support__/server-mocks/index.ts
+++ b/frontend/test/__support__/server-mocks/index.ts
@@ -1,6 +1,7 @@
 export * from "./action";
 export * from "./activity";
 export * from "./alert";
+export * from "./api-key";
 export * from "./automagic-dashboards";
 export * from "./bookmark";
 export * from "./card";


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/36805

Adding the entry point for managing API Keys at <http://localhost:3000/admin/settings/authentication>

## Summary

1. Added `ApiKey` type to “metabase-types/api/admin”
1. Added `ApiKeysApi` entry to “metabase/services”
1. Added `AuthCard` for API Keys
1. Added `ManageApiKeys` page
    * Added CRUD modals for creating, editing, and deleting keys.
    * Added secondary modals for regenerating a key and copying an unmasked key.
1. Edited `GroupListing` page to show number of API keys belonging to each group
1. Edited `GroupDetails` page to show each API key belonging the group

I also created some reusable components:
1. Added `FormGroupWidget` component for selecting a single Group.