### PR TITLE
Pass step as only parameter with query, legacyQuery and stageIndex

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/metrics.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/metrics.cy.spec.js
@@ -122,7 +122,10 @@ describe("scenarios > admin > datamodel > metrics", () => {
       cy.button("Done").click();
       cy.wait("@dataset");
 
-      // The test should fail on this step first
+      // verify popover is closed, otherwise its state will reset
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Custom Expression").should("not.exist");
+
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Result: 93.8");
 

--- a/e2e/test/scenarios/admin/datamodel/metrics.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/metrics.cy.spec.js
@@ -107,8 +107,7 @@ describe("scenarios > admin > datamodel > metrics", () => {
       // `data`, `filtered by` and `view`
       cy.wait(["@dataset", "@dataset", "@dataset"]);
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Count").click();
+      cy.get(".GuiBuilder").findByText("Count").click();
       popover().contains("Custom Expression").click();
 
       cy.get(".ace_text-input")
@@ -123,15 +122,12 @@ describe("scenarios > admin > datamodel > metrics", () => {
       cy.wait("@dataset");
 
       // verify popover is closed, otherwise its state will reset
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Custom Expression").should("not.exist");
+      cy.findByRole("grid").findByText("Custom Expression").should("not.exist");
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Result: 93.8");
+      cy.get(".GuiBuilder").findByText("Result: 93.8");
 
       // Let's make sure the custom expression is still preserved
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Foo").click();
+      cy.get(".GuiBuilder").findByText("Foo").click();
       cy.get(".ace_content").should("contain", customExpression);
     });
   });

--- a/frontend/src/metabase-lib/expressions/__support__/expressions.js
+++ b/frontend/src/metabase-lib/expressions/__support__/expressions.js
@@ -6,104 +6,118 @@ import {
   createMockTable,
 } from "metabase-types/api/mocks";
 import { createMockMetadata } from "__support__/metadata";
+import { SAMPLE_DB_ID } from "metabase-types/api/mocks/presets";
 import { TYPE } from "metabase-lib/types/constants";
+import { SAMPLE_DATABASE } from "metabase-lib/test-helpers";
 
-const DB_ID = 1;
+const DB_ID = SAMPLE_DB_ID;
 const TABLE_ID = 1;
 
-const metadata = createMockMetadata({
-  databases: [
-    createMockDatabase({
-      id: DB_ID,
-      name: "db",
-      tables: [
-        createMockTable({
-          db: DB_ID,
-          fields: [
-            createMockField({
-              id: 1,
-              table_id: TABLE_ID,
-              display_name: "A",
-              base_type: TYPE.Float,
-            }),
-            createMockField({
-              id: 2,
-              table_id: TABLE_ID,
-              display_name: "B",
-              base_type: TYPE.Float,
-            }),
-            createMockField({
-              id: 3,
-              table_id: TABLE_ID,
-              display_name: "C",
-              base_type: TYPE.Float,
-            }),
-            createMockField({
-              id: 10,
-              table_id: TABLE_ID,
-              display_name: "Toucan Sam",
-              base_type: TYPE.Float,
-            }),
-            createMockField({
-              id: 11,
-              table_id: TABLE_ID,
-              display_name: "Sum",
-              base_type: TYPE.Float,
-            }),
-            createMockField({
-              id: 12,
-              table_id: TABLE_ID,
-              display_name: "count",
-              base_type: TYPE.Float,
-            }),
-            createMockField({
-              id: 13,
-              table_id: TABLE_ID,
-              display_name: "text",
-              base_type: TYPE.Text,
-            }),
-            createMockField({
-              id: 14,
-              table_id: TABLE_ID,
-              display_name: "date",
-              base_type: TYPE.DateTime,
-            }),
-          ],
-          segments: [
-            createMockSegment({
-              id: 1,
-              name: "segment",
-            }),
-          ],
-          metrics: [
-            createMockMetric({
-              id: 1,
-              name: "metric",
-            }),
-            createMockMetric({
-              id: 2,
-              name: "metric",
-            }),
-          ],
+export const DEFAULT_QUERY = {
+  database: SAMPLE_DATABASE.id,
+  type: "query",
+  query: {
+    "source-table": TABLE_ID,
+  },
+};
+
+const database = createMockDatabase({
+  id: SAMPLE_DB_ID,
+  name: "db",
+  tables: [
+    createMockTable({
+      db: DB_ID,
+      id: TABLE_ID,
+      fields: [
+        createMockField({
+          id: 1,
+          table_id: TABLE_ID,
+          display_name: "A",
+          base_type: TYPE.Float,
+        }),
+        createMockField({
+          id: 2,
+          table_id: TABLE_ID,
+          display_name: "B",
+          base_type: TYPE.Float,
+        }),
+        createMockField({
+          id: 3,
+          table_id: TABLE_ID,
+          display_name: "C",
+          base_type: TYPE.Float,
+        }),
+        createMockField({
+          id: 10,
+          table_id: TABLE_ID,
+          display_name: "Toucan Sam",
+          base_type: TYPE.Float,
+        }),
+        createMockField({
+          id: 11,
+          table_id: TABLE_ID,
+          display_name: "Sum",
+          base_type: TYPE.Float,
+        }),
+        createMockField({
+          id: 12,
+          table_id: TABLE_ID,
+          display_name: "count",
+          base_type: TYPE.Float,
+        }),
+        createMockField({
+          id: 13,
+          table_id: TABLE_ID,
+          display_name: "text",
+          base_type: TYPE.Text,
+        }),
+        createMockField({
+          id: 14,
+          table_id: TABLE_ID,
+          display_name: "date",
+          base_type: TYPE.DateTime,
         }),
       ],
-      features: [
-        "basic-aggregations",
-        "standard-deviation-aggregations",
-        "expression-aggregations",
-        "percentile-aggregations",
-        "foreign-keys",
-        "native-parameters",
-        "expressions",
-        "advanced-math-expressions",
-        "right-join",
-        "left-join",
-        "inner-join",
-        "nested-queries",
-        "advanced-math-expressions",
+      segments: [
+        createMockSegment({
+          id: 1,
+          name: "segment",
+          table_id: TABLE_ID,
+        }),
+      ],
+      metrics: [
+        createMockMetric({
+          id: 1,
+          name: "metric",
+          table_id: TABLE_ID,
+        }),
+        createMockMetric({
+          id: 2,
+          name: "metric",
+          table_id: TABLE_ID,
+        }),
       ],
     }),
   ],
+  features: [
+    "basic-aggregations",
+    "standard-deviation-aggregations",
+    "expression-aggregations",
+    "percentile-aggregations",
+    "foreign-keys",
+    "native-parameters",
+    "expressions",
+    "advanced-math-expressions",
+    "right-join",
+    "left-join",
+    "inner-join",
+    "nested-queries",
+    "advanced-math-expressions",
+  ],
+});
+
+export const metadata = createMockMetadata({
+  databases: [database],
 });
 
 export const legacyQuery = metadata.table(TABLE_ID).query();

--- a/frontend/src/metabase-lib/expressions/__support__/shared.js
+++ b/frontend/src/metabase-lib/expressions/__support__/shared.js
@@ -27,6 +27,7 @@ const metadata = createMockMetadata({
             createMockSegment({
               id: SEGMENT_ID,
               name: "Expensive Things",
+              table_id: ORDERS_ID,
               definition: {
                 filter: [">", ["field", ORDERS.TOTAL, null], 30],
                 "source-table": ORDERS_ID,
@@ -37,6 +38,7 @@ const metadata = createMockMetadata({
             createMockMetric({
               id: METRIC_ID,
               name: "Total Order Value",
+              table_id: ORDERS_ID,
               definition: {
                 aggregation: [["sum", ["field", ORDERS.TOTAL, null]]],
                 "source-table": ORDERS_ID,
@@ -301,3 +303,5 @@ export const ordersTable = metadata.table(ORDERS_ID);
  * @type {import("metabase-lib/metadata/Field").default}
  */
 export const ordersTotalField = metadata.field(ORDERS.TOTAL);
+
+export const sharedMetadata = metadata;

--- a/frontend/src/metabase-lib/expressions/index.js
+++ b/frontend/src/metabase-lib/expressions/index.js
@@ -120,7 +120,7 @@ export function formatDimensionName(dimension, options) {
 }
 
 /**
- * TODO -- this doesn't really return the dimension *name*, does it? It returns the 'rendered' dimension decscription
+ * TODO -- this doesn't really return the dimension *name*, does it? It returns the 'rendered' dimension description
  * with the FK symbol (→) replaced with a different character.
  */
 export function getDimensionName(
@@ -128,6 +128,13 @@ export function getDimensionName(
   separator = EDITOR_FK_SYMBOLS.default,
 ) {
   return dimension.render().replace(` ${FK_SYMBOL} `, separator);
+}
+
+export function getDisplayNameWithSeparator(
+  displayName,
+  separator = EDITOR_FK_SYMBOLS.default,
+) {
+  return displayName.replace(` ${FK_SYMBOL} `, separator);
 }
 
 // STRING LITERALS

--- a/frontend/src/metabase-lib/expressions/suggest.ts
+++ b/frontend/src/metabase-lib/expressions/suggest.ts
@@ -184,7 +184,7 @@ export function suggest({
           return {
             type: "segments",
             name: displayInfo.displayName,
-            text: formatIdentifier(displayInfo.displayName),
+            text: formatIdentifier(displayInfo.longDisplayName),
             index: targetOffset,
             icon: "segment",
             order: 3,

--- a/frontend/src/metabase-lib/expressions/suggest.ts
+++ b/frontend/src/metabase-lib/expressions/suggest.ts
@@ -178,12 +178,7 @@ export function suggest({
     if (segments) {
       suggestions.push(
         ...segments.map(segment => {
-          // TODO: fix type
-          const displayInfo = Lib.displayInfo(
-            query,
-            stageIndex,
-            segment as any,
-          );
+          const displayInfo = Lib.displayInfo(query, stageIndex, segment);
 
           return {
             type: "segments",

--- a/frontend/src/metabase-lib/expressions/suggest.ts
+++ b/frontend/src/metabase-lib/expressions/suggest.ts
@@ -1,9 +1,11 @@
 import _ from "underscore";
 
+import * as Lib from "metabase-lib";
 import {
   enclosingFunction,
   partialMatch,
 } from "metabase-lib/expressions/completer";
+import type Metadata from "metabase-lib/metadata/Metadata";
 import {
   AGGREGATION_FUNCTIONS,
   EDITOR_FK_SYMBOLS,
@@ -12,17 +14,14 @@ import {
   MBQL_CLAUSES as MBQL_CLAUSES_CONFIG,
 } from "metabase-lib/expressions/config";
 import {
-  formatDimensionName,
-  formatMetricName,
-  formatSegmentName,
-  getDimensionName,
+  formatIdentifier,
+  getDisplayNameWithSeparator,
 } from "metabase-lib/expressions";
 import type {
   HelpText,
   MBQLClauseFunctionConfig,
   MBQLClauseMap,
 } from "metabase-lib/expressions/types";
-import type StructuredQuery from "metabase-lib/queries/StructuredQuery";
 import { getHelpText } from "metabase-lib/expressions/helper-text-strings";
 
 const MBQL_CLAUSES = MBQL_CLAUSES_CONFIG as MBQLClauseMap;
@@ -46,15 +45,21 @@ const suggestionText = (func: MBQLClauseFunctionConfig) => {
 
 type SuggestArgs = {
   source: string;
-  legacyQuery: StructuredQuery;
+  query: Lib.Query;
+  stageIndex: number;
+  metadata: Metadata;
   reportTimezone?: string;
   startRule: string;
   targetOffset?: number;
+  getColumnIcon: (column: Lib.ColumnMetadata) => string;
 };
 
 export function suggest({
   source,
-  legacyQuery,
+  query,
+  stageIndex,
+  getColumnIcon,
+  metadata,
   reportTimezone,
   startRule,
   targetOffset = source.length,
@@ -72,7 +77,7 @@ export function suggest({
     const functionDisplayName = enclosingFunction(partialSource);
     if (functionDisplayName) {
       const name = getMBQLName(functionDisplayName);
-      const database = legacyQuery.database();
+      const database = getDatabase(query, metadata);
 
       if (name && database) {
         const helpText = getHelpText(name, database, reportTimezone);
@@ -103,7 +108,7 @@ export function suggest({
     },
   );
 
-  const database = legacyQuery.database();
+  const database = getDatabase(query, metadata);
   if (_.first(matchPrefix) !== "[") {
     suggestions.push({
       type: "functions",
@@ -149,49 +154,66 @@ export function suggest({
 
   if (_.last(matchPrefix) !== "]") {
     suggestions.push(
-      ...legacyQuery
-        .dimensionOptions(() => true)
-        .all()
-        .map(dimension => ({
-          type: "fields",
-          name: getDimensionName(dimension),
-          text: formatDimensionName(dimension) + " ",
-          alternates: EDITOR_FK_SYMBOLS.symbols.map(symbol =>
-            getDimensionName(dimension, symbol),
-          ),
-          index: targetOffset,
-          icon: dimension.icon(),
-          order: 2,
-          dimension,
-        })),
+      ...Lib.expressionableColumns(query, stageIndex, targetOffset).map(
+        column => {
+          const displayInfo = Lib.displayInfo(query, stageIndex, column);
+          return {
+            type: "fields",
+            name: displayInfo.longDisplayName,
+            text: formatIdentifier(displayInfo.displayName) + " ",
+            alternates: EDITOR_FK_SYMBOLS.symbols.map(symbol =>
+              getDisplayNameWithSeparator(displayInfo.longDisplayName, symbol),
+            ),
+            index: targetOffset,
+            icon: getColumnIcon(column),
+            order: 2,
+            ...column,
+          };
+        },
+      ),
     );
 
-    const segments = legacyQuery.table()?.segments;
+    const segments = Lib.availableSegments(query, stageIndex);
+
     if (segments) {
       suggestions.push(
-        ...segments.map(segment => ({
-          type: "segments",
-          name: segment.name,
-          text: formatSegmentName(segment),
-          index: targetOffset,
-          icon: "segment",
-          order: 3,
-        })),
+        ...segments.map(segment => {
+          // TODO: fix type
+          const displayInfo = Lib.displayInfo(
+            query,
+            stageIndex,
+            segment as any,
+          );
+
+          return {
+            type: "segments",
+            name: displayInfo.displayName,
+            text: formatIdentifier(displayInfo.displayName),
+            index: targetOffset,
+            icon: "segment",
+            order: 3,
+          };
+        }),
       );
     }
 
     if (startRule === "aggregation") {
-      const metrics = legacyQuery.table()?.metrics;
+      const metrics = Lib.availableMetrics(query);
+
       if (metrics) {
         suggestions.push(
-          ...metrics.map(metric => ({
-            type: "metrics",
-            name: metric.name,
-            text: formatMetricName(metric),
-            index: targetOffset,
-            icon: "insight",
-            order: 4,
-          })),
+          ...metrics.map(metric => {
+            const displayInfo = Lib.displayInfo(query, stageIndex, metric);
+
+            return {
+              type: "metrics",
+              name: displayInfo.displayName,
+              text: formatIdentifier(displayInfo.displayName),
+              index: targetOffset,
+              icon: "insight",
+              order: 4,
+            };
+          }),
         );
       }
     }
@@ -236,7 +258,7 @@ export function suggest({
     const { icon } = suggestions[0];
     if (icon === "function") {
       const name = getMBQLName(matchPrefix);
-      const database = legacyQuery.database();
+      const database = getDatabase(query, metadata);
 
       if (name && database) {
         const helpText = getHelpText(name, database, reportTimezone);
@@ -249,4 +271,10 @@ export function suggest({
   }
 
   return { suggestions };
+}
+
+function getDatabase(query: Lib.Query, metadata: Metadata) {
+  const databaseId = Lib.databaseID(query);
+
+  return metadata.database(databaseId);
 }

--- a/frontend/src/metabase-lib/expressions/suggest.ts
+++ b/frontend/src/metabase-lib/expressions/suggest.ts
@@ -157,10 +157,11 @@ export function suggest({
       ...Lib.expressionableColumns(query, stageIndex, targetOffset).map(
         column => {
           const displayInfo = Lib.displayInfo(query, stageIndex, column);
+
           return {
             type: "fields",
             name: displayInfo.longDisplayName,
-            text: formatIdentifier(displayInfo.displayName) + " ",
+            text: formatIdentifier(displayInfo.longDisplayName) + " ",
             alternates: EDITOR_FK_SYMBOLS.symbols.map(symbol =>
               getDisplayNameWithSeparator(displayInfo.longDisplayName, symbol),
             ),
@@ -202,8 +203,8 @@ export function suggest({
 
             return {
               type: "metrics",
-              name: displayInfo.displayName,
-              text: formatIdentifier(displayInfo.displayName),
+              name: displayInfo.longDisplayName,
+              text: formatIdentifier(displayInfo.longDisplayName),
               index: targetOffset,
               icon: "insight",
               order: 4,

--- a/frontend/src/metabase-lib/expressions/suggest.unit.spec.ts
+++ b/frontend/src/metabase-lib/expressions/suggest.unit.spec.ts
@@ -1,7 +1,24 @@
 import _ from "underscore";
-import { REVIEWS_ID } from "metabase-types/api/mocks/presets";
-import { ordersTable, ordersTotalField } from "./__support__/shared";
-import { aggregationOpts, expressionOpts } from "./__support__/expressions";
+import {
+  ORDERS,
+  ORDERS_ID,
+  REVIEWS,
+  REVIEWS_ID,
+} from "metabase-types/api/mocks/presets";
+import type { DatasetQuery, Join } from "metabase-types/api";
+import * as Lib from "metabase-lib";
+import {
+  SAMPLE_DATABASE,
+  SAMPLE_METADATA,
+  createQuery,
+} from "metabase-lib/test-helpers";
+import { sharedMetadata } from "./__support__/shared";
+import {
+  aggregationOpts,
+  expressionOpts,
+  metadata,
+  DEFAULT_QUERY as DEFAULT_EXPRESSION_QUERY,
+} from "./__support__/expressions";
 import type { Suggestion } from "./suggest";
 import { suggest as suggest_ } from "./suggest";
 
@@ -61,6 +78,8 @@ const FIELDS_CUSTOM_NON_NUMERIC = [
   { type: "fields", text: "[text] " },
 ];
 
+const DEFAULT_QUERY = DEFAULT_EXPRESSION_QUERY as DatasetQuery;
+
 describe("metabase/lib/expression/suggest", () => {
   describe("suggest()", () => {
     function suggest(...args: Parameters<typeof suggest_>) {
@@ -73,7 +92,19 @@ describe("metabase/lib/expression/suggest", () => {
 
     describe("expression", () => {
       it("should suggest partial matches in expression", () => {
-        expect(suggest({ source: "1 + C", ...expressionOpts })).toEqual([
+        expect(
+          suggest({
+            source: "1 + C",
+            ...expressionOpts,
+            query: createQuery({
+              metadata,
+              query: DEFAULT_QUERY,
+            }),
+            stageIndex: -1,
+            metadata,
+            getColumnIcon: () => "icon",
+          }),
+        ).toEqual([
           { type: "fields", text: "[C] " },
           { type: "fields", text: "[count] " },
           { type: "functions", text: "case(" },
@@ -86,7 +117,19 @@ describe("metabase/lib/expression/suggest", () => {
       });
 
       it("should suggest partial matches in unterminated quoted string", () => {
-        expect(suggest({ source: "1 + [C", ...expressionOpts })).toEqual([
+        expect(
+          suggest({
+            source: "1 + [C",
+            ...expressionOpts,
+            query: createQuery({
+              metadata,
+              query: DEFAULT_QUERY,
+            }),
+            stageIndex: -1,
+            metadata,
+            getColumnIcon: () => "icon",
+          }),
+        ).toEqual([
           { type: "fields", text: "[C] " },
           { type: "fields", text: "[count] " },
         ]);
@@ -96,8 +139,11 @@ describe("metabase/lib/expression/suggest", () => {
         expect(
           suggest({
             source: "User",
-            legacyQuery: ordersTable.query(),
+            query: createQuery(),
             startRule: "expression",
+            stageIndex: -1,
+            metadata: SAMPLE_METADATA,
+            getColumnIcon: () => "icon",
           }),
         ).toEqual([
           { text: "[User ID] ", type: "fields" },
@@ -118,13 +164,36 @@ describe("metabase/lib/expression/suggest", () => {
       });
 
       it("should suggest joined fields", () => {
+        const JOIN_CLAUSE: Join = {
+          alias: "Foo",
+          "source-table": REVIEWS_ID,
+          condition: [
+            "=",
+            ["field", REVIEWS.PRODUCT_ID, null],
+            ["field", ORDERS.PRODUCT_ID, null],
+          ],
+        };
+        const queryWithJoins: DatasetQuery = {
+          database: SAMPLE_DATABASE.id,
+          type: "query",
+          query: {
+            "source-table": ORDERS_ID,
+            joins: [JOIN_CLAUSE],
+          },
+        };
+
+        const query = createQuery({
+          metadata: sharedMetadata,
+          query: queryWithJoins,
+        });
+
         expect(
           suggest({
             source: "Foo",
-            legacyQuery: ordersTable.query().join({
-              alias: "Foo",
-              "source-table": REVIEWS_ID,
-            }),
+            query,
+            stageIndex: -1,
+            metadata: sharedMetadata,
+            getColumnIcon: () => "icon",
             startRule: "expression",
           }),
         ).toEqual([
@@ -138,20 +207,40 @@ describe("metabase/lib/expression/suggest", () => {
       });
 
       it("should suggest nested query fields", () => {
+        const datasetQuery: DatasetQuery = {
+          database: SAMPLE_DATABASE.id,
+          type: "query",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [["count"]],
+            breakout: [["field", ORDERS.TOTAL, null]],
+          },
+        };
+
+        const queryWithAggregation = createQuery({
+          metadata: sharedMetadata,
+          query: datasetQuery,
+        });
+
+        const query = Lib.appendStage(queryWithAggregation);
+        const stageIndexAfterNesting = 1;
+
         expect(
           suggest({
             source: "T",
-            legacyQuery: ordersTable
-              .query()
-              .aggregate(["count"])
-              .breakout(ordersTotalField)
-              .nest(),
+            query,
+            stageIndex: stageIndexAfterNesting,
+            metadata: sharedMetadata,
+            getColumnIcon: () => "icon",
             startRule: "expression",
           }),
         ).toEqual(
           [
             { text: "True", type: "literal" },
             { text: "[Total] ", type: "fields" },
+            // TODO: uladzimir, it looks like segments should not be returned by BE
+            // https://github.com/metabase/metabase/issues/36196
+            { text: "[Expensive Things]", type: "segments" },
             { text: "timeSpan(", type: "functions" },
             { text: "trim(", type: "functions" },
           ].sort(suggestionSort),
@@ -162,8 +251,11 @@ describe("metabase/lib/expression/suggest", () => {
         expect(
           helpText({
             source: "substring(",
-            legacyQuery: ordersTable.query(),
+            query: createQuery(),
             startRule: "expression",
+            metadata: SAMPLE_METADATA,
+            getColumnIcon: () => "icon",
+            stageIndex: -1,
           }),
         ).toMatchObject({
           structure: "substring",
@@ -176,8 +268,11 @@ describe("metabase/lib/expression/suggest", () => {
         expect(
           helpText({
             source: "lower", // doesn't need to be "lower(" since it's a unique match
-            legacyQuery: ordersTable.query(),
+            query: createQuery(),
+            metadata: SAMPLE_METADATA,
             startRule: "expression",
+            stageIndex: -1,
+            getColumnIcon: () => "icon",
           }),
         ).toMatchObject({
           structure: "lower",
@@ -190,7 +285,10 @@ describe("metabase/lib/expression/suggest", () => {
         expect(
           helpText({
             source: "trim(Total ",
-            legacyQuery: ordersTable.query(),
+            query: createQuery(),
+            metadata: SAMPLE_METADATA,
+            stageIndex: -1,
+            getColumnIcon: () => "icon",
             startRule: "expression",
           })?.name,
         ).toEqual("trim");
@@ -200,7 +298,10 @@ describe("metabase/lib/expression/suggest", () => {
         expect(
           helpText({
             source: "coalesce(Total ",
-            legacyQuery: ordersTable.query(),
+            query: createQuery(),
+            metadata: SAMPLE_METADATA,
+            stageIndex: -1,
+            getColumnIcon: () => "icon",
             startRule: "expression",
           })?.name,
         ).toEqual("coalesce");
@@ -209,7 +310,20 @@ describe("metabase/lib/expression/suggest", () => {
 
     describe("aggregation", () => {
       it("should suggest aggregations and metrics", () => {
-        expect(suggest({ source: "case([", ...aggregationOpts })).toEqual(
+        const { startRule } = aggregationOpts;
+        expect(
+          suggest({
+            source: "case([",
+            query: createQuery({
+              metadata,
+              query: DEFAULT_QUERY,
+            }),
+            stageIndex: -1,
+            metadata,
+            getColumnIcon: () => "icon",
+            startRule,
+          }),
+        ).toEqual(
           [
             ...FIELDS_CUSTOM,
             ...METRICS_CUSTOM,
@@ -220,7 +334,19 @@ describe("metabase/lib/expression/suggest", () => {
       });
 
       it("should suggest partial matches after an aggregation", () => {
-        expect(suggest({ source: "average(c", ...aggregationOpts })).toEqual([
+        expect(
+          suggest({
+            source: "average(c",
+            ...aggregationOpts,
+            query: createQuery({
+              metadata,
+              query: DEFAULT_QUERY,
+            }),
+            stageIndex: -1,
+            metadata,
+            getColumnIcon: () => "icon",
+          }),
+        ).toEqual([
           // FIXME: the next four should not appear
           { type: "aggregations", text: "Count " },
           { type: "aggregations", text: "CountIf(" },
@@ -237,7 +363,19 @@ describe("metabase/lib/expression/suggest", () => {
       });
 
       it("should suggest partial matches in aggregation", () => {
-        expect(suggest({ source: "1 + C", ...aggregationOpts })).toEqual([
+        expect(
+          suggest({
+            source: "1 + C",
+            ...aggregationOpts,
+            query: createQuery({
+              metadata,
+              query: DEFAULT_QUERY,
+            }),
+            stageIndex: -1,
+            metadata,
+            getColumnIcon: () => "icon",
+          }),
+        ).toEqual([
           { type: "aggregations", text: "Count " },
           { type: "aggregations", text: "CountIf(" },
           { type: "aggregations", text: "CumulativeCount " },
@@ -256,7 +394,10 @@ describe("metabase/lib/expression/suggest", () => {
         expect(
           suggest({
             source: "to",
-            legacyQuery: ordersTable.query(),
+            query: createQuery({ metadata: sharedMetadata }),
+            stageIndex: -1,
+            getColumnIcon: () => "icon",
+            metadata: sharedMetadata,
             startRule: "aggregation",
           }),
         ).toEqual([
@@ -269,7 +410,10 @@ describe("metabase/lib/expression/suggest", () => {
         expect(
           suggest({
             source: "cou",
-            legacyQuery: ordersTable.query(),
+            query: createQuery(),
+            metadata: SAMPLE_METADATA,
+            stageIndex: -1,
+            getColumnIcon: () => "icon",
             startRule: "aggregation",
           }),
         ).toEqual([
@@ -282,7 +426,10 @@ describe("metabase/lib/expression/suggest", () => {
         expect(
           helpText({
             source: "Sum(",
-            legacyQuery: ordersTable.query(),
+            query: createQuery(),
+            stageIndex: -1,
+            getColumnIcon: () => "icon",
+            metadata: sharedMetadata,
             startRule: "aggregation",
           }),
         ).toMatchObject({ name: "sum", example: "Sum([Subtotal])" });
@@ -294,7 +441,10 @@ describe("metabase/lib/expression/suggest", () => {
         expect(
           suggest({
             source: "c",
-            legacyQuery: ordersTable.query(),
+            query: createQuery(),
+            metadata: SAMPLE_METADATA,
+            stageIndex: -1,
+            getColumnIcon: () => "icon",
             startRule: "boolean",
           }),
         ).toEqual([
@@ -315,7 +465,10 @@ describe("metabase/lib/expression/suggest", () => {
         expect(
           suggest({
             source: "ca",
-            legacyQuery: ordersTable.query(),
+            query: createQuery(),
+            metadata: SAMPLE_METADATA,
+            stageIndex: -1,
+            getColumnIcon: () => "icon",
             startRule: "boolean",
           }),
         ).toEqual([
@@ -328,7 +481,10 @@ describe("metabase/lib/expression/suggest", () => {
         expect(
           suggest({
             source: "[",
-            legacyQuery: ordersTable.query(),
+            query: createQuery({ metadata: sharedMetadata }),
+            stageIndex: -1,
+            getColumnIcon: () => "icon",
+            metadata: sharedMetadata,
             startRule: "boolean",
           }),
         ).toEqual([...FIELDS_ORDERS, ...SEGMENTS_ORDERS].sort(suggestionSort));
@@ -338,7 +494,10 @@ describe("metabase/lib/expression/suggest", () => {
         expect(
           helpText({
             source: "Contains(Total ",
-            legacyQuery: ordersTable.query(),
+            query: createQuery(),
+            metadata: SAMPLE_METADATA,
+            stageIndex: -1,
+            getColumnIcon: () => "icon",
             startRule: "boolean",
           }),
         ).toMatchObject({

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -32,6 +32,8 @@ import type {
   TableDisplayInfo,
   TableMetadata,
   Query,
+  SegmentMetadata,
+  SegmentDisplayInfo,
 } from "./types";
 
 export function metadataProvider(
@@ -120,6 +122,11 @@ declare function DisplayInfoFn(
   stageIndex: number,
   drillThru: DrillThru,
 ): DrillThruDisplayInfo;
+declare function DisplayInfoFn(
+  query: Query,
+  stageIndex: number,
+  segment: SegmentMetadata,
+): SegmentDisplayInfo;
 
 // x can be any sort of opaque object, e.g. a clause or metadata map. Values returned depend on what you pass in, but it
 // should always have display_name... see :metabase.lib.metadata.calculation/display-info schema

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -128,6 +128,14 @@ export type MetricDisplayInfo = {
   selected?: boolean;
 };
 
+export type SegmentDisplayInfo = {
+  name: string;
+  displayName: string;
+  longDisplayName: string;
+  description: string;
+  effectiveType: string;
+};
+
 export type ClauseDisplayInfo = Pick<
   ColumnDisplayInfo,
   "name" | "displayName" | "longDisplayName" | "table"

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -214,6 +214,8 @@ export function AggregationPicker({
     return (
       <ExpressionWidget
         legacyQuery={legacyQuery}
+        query={query}
+        stageIndex={stageIndex}
         name={AGGREGATION.getName(legacyClause)}
         expression={AGGREGATION.getContent(legacyClause)}
         withName

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -1,7 +1,7 @@
 import _ from "underscore";
 import userEvent from "@testing-library/user-event";
 import { createMockMetadata } from "__support__/metadata";
-import { render, screen, waitFor, within } from "__support__/ui";
+import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
 import { checkNotNull } from "metabase/lib/types";
 
 import type { Metric, StructuredDatasetQuery } from "metabase-types/api";
@@ -150,7 +150,7 @@ function setup({
     onSelect(Lib.displayInfo(nextQuery, 0, recentAggregation));
   }
 
-  render(
+  renderWithProviders(
     <AggregationPicker
       query={query}
       legacyQuery={legacyQuery}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -415,7 +415,6 @@ class ExpressionEditorTextfield extends React.Component<
 
     const {
       query,
-      legacyQuery,
       reportTimezone,
       stageIndex,
       metadata,
@@ -427,8 +426,13 @@ class ExpressionEditorTextfield extends React.Component<
       startRule,
       source,
       targetOffset: cursor.column,
-      query: query ?? legacyQuery.question()._getMLv2Query(),
-      stageIndex: stageIndex ?? -1,
+      // TODO: uladzimir
+      // using stage index apart from -1 is possible only in the notebook editor, filter pills, and the filter modal
+      // first 2 are migrated in the filters integration branch. The latter is in progress
+      // query: query ?? legacyQuery.question()._getMLv2Query(),
+      // stageIndex: stageIndex ?? -1,
+      query,
+      stageIndex,
       metadata,
       getColumnIcon,
     });

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -414,8 +414,9 @@ class ExpressionEditorTextfield extends React.Component<
     const cursor = selection.getCursor();
 
     const {
-      legacyQuery,
+      query,
       reportTimezone,
+      stageIndex,
       metadata,
       startRule = ExpressionEditorTextfield.defaultProps.startRule,
     } = this.props;
@@ -425,8 +426,8 @@ class ExpressionEditorTextfield extends React.Component<
       startRule,
       source,
       targetOffset: cursor.column,
-      query: legacyQuery.question()._getMLv2Query(),
-      stageIndex: legacyQuery.getQueryStageIndex(),
+      query,
+      stageIndex,
       metadata,
       getColumnIcon,
     });

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -415,6 +415,7 @@ class ExpressionEditorTextfield extends React.Component<
 
     const {
       query,
+      legacyQuery,
       reportTimezone,
       stageIndex,
       metadata,
@@ -426,8 +427,8 @@ class ExpressionEditorTextfield extends React.Component<
       startRule,
       source,
       targetOffset: cursor.column,
-      query,
-      stageIndex,
+      query: query ?? legacyQuery.question()._getMLv2Query(),
+      stageIndex: stageIndex ?? -1,
       metadata,
       getColumnIcon,
     });

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { useRef, useState } from "react";
 import { t } from "ttag";
 import { isNotNull } from "metabase/lib/types";
+import type * as Lib from "metabase-lib";
 import Button from "metabase/core/components/Button";
 import Input from "metabase/core/components/Input/Input";
 import Tooltip from "metabase/core/components/Tooltip";
@@ -29,6 +30,8 @@ const EXPRESSIONS_DOCUMENTATION_URL = MetabaseSettings.docsUrl(
 
 export interface ExpressionWidgetProps {
   legacyQuery: StructuredQuery;
+  query: Lib.Query | null;
+  stageIndex: number;
   expression: Expression | undefined;
   name?: string;
   withName?: boolean;
@@ -44,6 +47,8 @@ export interface ExpressionWidgetProps {
 export const ExpressionWidget = (props: ExpressionWidgetProps): JSX.Element => {
   const {
     legacyQuery,
+    query,
+    stageIndex,
     name: initialName,
     expression: initialExpression,
     withName = false,
@@ -106,6 +111,8 @@ export const ExpressionWidget = (props: ExpressionWidgetProps): JSX.Element => {
             expression={expression}
             startRule={startRule}
             name={name}
+            query={query}
+            stageIndex={stageIndex}
             legacyQuery={legacyQuery}
             reportTimezone={reportTimezone}
             textAreaId="expression-content"

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.tsx
@@ -28,10 +28,18 @@ const EXPRESSIONS_DOCUMENTATION_URL = MetabaseSettings.docsUrl(
   "questions/query-builder/expressions",
 );
 
-export interface ExpressionWidgetProps {
-  legacyQuery: StructuredQuery;
-  query: Lib.Query | null;
+interface LegacyQueryProps {
+  query?: never;
+  stageIndex?: never;
+}
+
+interface QueryProps {
+  query: Lib.Query;
   stageIndex: number;
+}
+
+export type ExpressionWidgetProps = {
+  legacyQuery: StructuredQuery;
   expression: Expression | undefined;
   name?: string;
   withName?: boolean;
@@ -42,7 +50,7 @@ export interface ExpressionWidgetProps {
   onChangeExpression: (name: string, expression: Expression) => void;
   onRemoveExpression?: (name: string) => void;
   onClose?: () => void;
-}
+} & (QueryProps | LegacyQueryProps);
 
 export const ExpressionWidget = (props: ExpressionWidgetProps): JSX.Element => {
   const {

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.unit.spec.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { checkNotNull } from "metabase/lib/types";
-import { getIcon, render, screen } from "__support__/ui";
+import { getIcon, renderWithProviders, screen } from "__support__/ui";
 import { createMockEntitiesState } from "__support__/store";
 import { getMetadata } from "metabase/selectors/metadata";
 import type { Expression } from "metabase-types/api";
@@ -173,7 +173,7 @@ function setup(additionalProps?: Partial<ExpressionWidgetProps>) {
     ...additionalProps,
   };
 
-  render(<ExpressionWidget {...props} />);
+  renderWithProviders(<ExpressionWidget {...props} />);
 
   return mocks;
 }

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.unit.spec.tsx
@@ -163,7 +163,8 @@ function setup(additionalProps?: Partial<ExpressionWidgetProps>) {
     onChangeExpression: jest.fn(),
   };
 
-  const props = {
+  // we test only legacy queries for now
+  const props: Omit<ExpressionWidgetProps, "query" | "stageIndex"> = {
     expression: undefined,
     name: undefined,
     legacyQuery: createMockQueryForExpressions(),

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
@@ -142,6 +142,7 @@ function NotebookStep({
                 step={step}
                 topLevelQuery={step.topLevelQuery}
                 query={step.query}
+                stageIndex={step.stageIndex}
                 sourceQuestion={sourceQuestion}
                 updateQuery={updateQuery}
                 isLastOpened={isLastOpened}

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
@@ -140,9 +140,6 @@ function NotebookStep({
               <NotebookStepComponent
                 color={color}
                 step={step}
-                topLevelQuery={step.topLevelQuery}
-                query={step.query}
-                stageIndex={step.stageIndex}
                 sourceQuestion={sourceQuestion}
                 updateQuery={updateQuery}
                 isLastOpened={isLastOpened}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
@@ -19,15 +19,13 @@ const aggTetherOptions = {
 };
 
 export function AggregateStep({
-  query: legacyQuery,
-  topLevelQuery,
   step,
   color,
   isLastOpened,
   readOnly,
   updateQuery,
 }: NotebookStepUiComponentProps) {
-  const { stageIndex } = step;
+  const { stageIndex, topLevelQuery, query: legacyQuery } = step;
 
   const clauses = useMemo(() => {
     return Lib.aggregations(topLevelQuery, stageIndex);

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.unit.spec.tsx
@@ -30,9 +30,6 @@ function setup(step = createMockNotebookStep()) {
   render(
     <AggregateStep
       step={step}
-      query={step.query}
-      stageIndex={step.stageIndex}
-      topLevelQuery={step.topLevelQuery}
       color="summarize"
       isLastOpened={false}
       reportTimezone="UTC"

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.unit.spec.tsx
@@ -31,6 +31,7 @@ function setup(step = createMockNotebookStep()) {
     <AggregateStep
       step={step}
       query={step.query}
+      stageIndex={step.stageIndex}
       topLevelQuery={step.topLevelQuery}
       color="summarize"
       isLastOpened={false}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.tsx
@@ -18,14 +18,13 @@ const breakoutTetherOptions = {
 };
 
 function BreakoutStep({
-  topLevelQuery,
   step,
   color,
   isLastOpened,
   readOnly,
   updateQuery,
 }: NotebookStepUiComponentProps) {
-  const { stageIndex } = step;
+  const { stageIndex, topLevelQuery } = step;
 
   const breakouts = useMemo(() => {
     return Lib.breakouts(topLevelQuery, stageIndex);

--- a/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.unit.spec.tsx
@@ -56,9 +56,6 @@ function setup(step = createMockNotebookStep()) {
   render(
     <BreakoutStep
       step={step}
-      stageIndex={step.stageIndex}
-      query={step.query}
-      topLevelQuery={step.topLevelQuery}
       color="summarize"
       isLastOpened={false}
       reportTimezone="UTC"

--- a/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.unit.spec.tsx
@@ -56,6 +56,7 @@ function setup(step = createMockNotebookStep()) {
   render(
     <BreakoutStep
       step={step}
+      stageIndex={step.stageIndex}
       query={step.query}
       topLevelQuery={step.topLevelQuery}
       color="summarize"

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
@@ -14,19 +14,17 @@ import { FieldsPickerIcon, FIELDS_PICKER_STYLES } from "../../FieldsPickerIcon";
 import { DataStepCell } from "./DataStep.styled";
 
 export const DataStep = ({
-  topLevelQuery,
-  query,
   step,
   readOnly,
   color,
   updateQuery,
 }: NotebookStepUiComponentProps) => {
-  const { stageIndex } = step;
+  const { stageIndex, query: legacyQuery, topLevelQuery } = step;
 
-  const question = query.question();
+  const question = legacyQuery.question();
   const metadata = question.metadata();
   const collectionId = question.collectionId();
-  const tableId = query.sourceTableId();
+  const tableId = legacyQuery.sourceTableId();
 
   const databaseId = Lib.databaseID(topLevelQuery);
   const table = tableId

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.unit.spec.tsx
@@ -53,6 +53,7 @@ const setup = async (
     <DataStep
       step={step}
       topLevelQuery={step.topLevelQuery}
+      stageIndex={step.stageIndex}
       query={step.query}
       readOnly={readOnly}
       color="brand"

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.unit.spec.tsx
@@ -52,9 +52,6 @@ const setup = async (
   renderWithProviders(
     <DataStep
       step={step}
-      topLevelQuery={step.topLevelQuery}
-      stageIndex={step.stageIndex}
-      query={step.query}
       readOnly={readOnly}
       color="brand"
       isLastOpened={false}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.tsx
@@ -5,14 +5,14 @@ import ClauseStep from "./ClauseStep";
 
 const ExpressionStep = ({
   color,
-  query: legacyQuery,
-  topLevelQuery: query,
-  stageIndex,
   updateQuery,
   isLastOpened,
   reportTimezone,
   readOnly,
+  step,
 }: NotebookStepUiComponentProps): JSX.Element => {
+  const { stageIndex, topLevelQuery: query, query: legacyQuery } = step;
+
   const items = Object.entries(legacyQuery.expressions()).map(
     ([name, expression]) => ({ name, expression }),
   );

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.tsx
@@ -5,13 +5,15 @@ import ClauseStep from "./ClauseStep";
 
 const ExpressionStep = ({
   color,
-  query,
+  query: legacyQuery,
+  topLevelQuery: query,
+  stageIndex,
   updateQuery,
   isLastOpened,
   reportTimezone,
   readOnly,
 }: NotebookStepUiComponentProps): JSX.Element => {
-  const items = Object.entries(query.expressions()).map(
+  const items = Object.entries(legacyQuery.expressions()).map(
     ([name, expression]) => ({ name, expression }),
   );
 
@@ -23,22 +25,28 @@ const ExpressionStep = ({
       readOnly={readOnly}
       renderPopover={item => (
         <ExpressionWidget
-          legacyQuery={query}
+          legacyQuery={legacyQuery}
+          query={query}
+          stageIndex={stageIndex}
           name={item?.name}
           expression={item?.expression}
           withName
           onChangeExpression={(newName, newExpression) => {
             item?.expression
               ? updateQuery(
-                  query.updateExpression(newName, newExpression, item.name),
+                  legacyQuery.updateExpression(
+                    newName,
+                    newExpression,
+                    item.name,
+                  ),
                 )
-              : updateQuery(query.addExpression(newName, newExpression));
+              : updateQuery(legacyQuery.addExpression(newName, newExpression));
           }}
           reportTimezone={reportTimezone}
         />
       )}
       isLastOpened={isLastOpened}
-      onRemove={({ name }) => updateQuery(query.removeExpression(name))}
+      onRemove={({ name }) => updateQuery(legacyQuery.removeExpression(name))}
     />
   );
 };

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.unit.spec.tsx
@@ -111,6 +111,7 @@ function setup(
     step,
     color: "#93A1AB",
     query,
+    stageIndex: step.stageIndex,
     topLevelQuery: step.topLevelQuery,
     updateQuery,
     isLastOpened: false,

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.unit.spec.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { checkNotNull } from "metabase/lib/types";
-import { render, screen, within } from "__support__/ui";
+import { renderWithProviders, screen, within } from "__support__/ui";
 import { createMockEntitiesState } from "__support__/store";
 import { getMetadata } from "metabase/selectors/metadata";
 
@@ -119,7 +119,7 @@ function setup(
     ...additionalProps,
   };
 
-  render(<ExpressionStep {...props} />);
+  renderWithProviders(<ExpressionStep {...props} />);
 
   return {
     props,

--- a/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.tsx
@@ -6,27 +6,28 @@ import type { NotebookStepUiComponentProps } from "../types";
 import ClauseStep from "./ClauseStep";
 
 function FilterStep({
-  query,
+  step,
   color,
   isLastOpened,
   readOnly,
   updateQuery,
 }: NotebookStepUiComponentProps) {
+  const { query: legacyQuery } = step;
   return (
     <ClauseStep
       color={color}
       initialAddText={t`Add filters to narrow your answer`}
-      items={query.filters()}
+      items={legacyQuery.filters()}
       renderName={item => item.displayName()}
       readOnly={readOnly}
       renderPopover={filter => (
         <FilterPopover
-          query={query}
+          query={legacyQuery}
           filter={filter}
           onChangeFilter={newFilter =>
             filter
               ? updateQuery(filter.replace(newFilter))
-              : updateQuery(query.filter(newFilter))
+              : updateQuery(legacyQuery.filter(newFilter))
           }
         />
       )}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
@@ -26,14 +26,13 @@ import {
 } from "./JoinStep.styled";
 
 export function JoinStep({
-  topLevelQuery: query,
   step,
   color,
   readOnly,
   sourceQuestion,
   updateQuery,
 }: NotebookStepUiComponentProps) {
-  const { stageIndex, itemIndex } = step;
+  const { stageIndex, itemIndex, topLevelQuery: query } = step;
 
   const joins = Lib.joins(query, stageIndex);
   const join = typeof itemIndex === "number" ? joins[itemIndex] : undefined;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -136,6 +136,7 @@ function setup(step = createMockNotebookStep(), { readOnly = false } = {}) {
       <JoinStep
         step={step}
         query={step.query}
+        stageIndex={step.stageIndex}
         topLevelQuery={query}
         color="brand"
         isLastOpened={false}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -134,10 +134,10 @@ function setup(step = createMockNotebookStep(), { readOnly = false } = {}) {
 
     return (
       <JoinStep
-        step={step}
-        query={step.query}
-        stageIndex={step.stageIndex}
-        topLevelQuery={query}
+        step={{
+          ...step,
+          topLevelQuery: query,
+        }}
         color="brand"
         isLastOpened={false}
         readOnly={readOnly}
@@ -560,7 +560,7 @@ describe("Notebook Editor > Join Step", () => {
         column => Lib.displayInfo(query, 0, column).name === "PRICE",
       );
       expect(columns).not.toHaveLength(0);
-      expect(vendor).not.toBeUndefined();
+      expect(vendor).toBeDefined();
       expect(category).toBeUndefined();
       expect(price).toBeUndefined();
     });

--- a/frontend/src/metabase/query_builder/components/notebook/steps/LimitStep/LimitStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/LimitStep/LimitStep.tsx
@@ -7,13 +7,8 @@ import * as Lib from "metabase-lib";
 import type { NotebookStepUiComponentProps } from "../../types";
 import { NotebookCell } from "../../NotebookCell";
 
-function LimitStep({
-  topLevelQuery,
-  step,
-  color,
-  updateQuery,
-}: NotebookStepUiComponentProps) {
-  const { stageIndex } = step;
+function LimitStep({ step, color, updateQuery }: NotebookStepUiComponentProps) {
+  const { stageIndex, topLevelQuery } = step;
 
   const limit = Lib.currentLimit(topLevelQuery, stageIndex);
   const value = typeof limit === "number" ? limit : "";

--- a/frontend/src/metabase/query_builder/components/notebook/steps/LimitStep/LimitStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/LimitStep/LimitStep.unit.spec.tsx
@@ -17,6 +17,7 @@ function setup(step = createMockNotebookStep()) {
       query={step.query}
       topLevelQuery={step.topLevelQuery}
       color="brand"
+      stageIndex={step.stageIndex}
       isLastOpened={false}
       reportTimezone="UTC"
       updateQuery={updateQuery}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/LimitStep/LimitStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/LimitStep/LimitStep.unit.spec.tsx
@@ -14,10 +14,7 @@ function setup(step = createMockNotebookStep()) {
   render(
     <LimitStep
       step={step}
-      query={step.query}
-      topLevelQuery={step.topLevelQuery}
       color="brand"
-      stageIndex={step.stageIndex}
       isLastOpened={false}
       reportTimezone="UTC"
       updateQuery={updateQuery}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.tsx
@@ -8,14 +8,13 @@ import ClauseStep from "../ClauseStep";
 import { SortDirectionButton } from "./SortStep.styled";
 
 function SortStep({
-  topLevelQuery,
   step,
   color,
   isLastOpened,
   readOnly,
   updateQuery,
 }: NotebookStepUiComponentProps) {
-  const { stageIndex } = step;
+  const { stageIndex, topLevelQuery } = step;
 
   const clauses = useMemo(() => {
     return Lib.orderBys(topLevelQuery, stageIndex);

--- a/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.unit.spec.tsx
@@ -22,6 +22,7 @@ function setup(step = createMockNotebookStep()) {
     <SortStep
       step={step}
       query={step.query}
+      stageIndex={step.stageIndex}
       topLevelQuery={step.topLevelQuery}
       color="brand"
       isLastOpened={false}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.unit.spec.tsx
@@ -21,9 +21,6 @@ function setup(step = createMockNotebookStep()) {
   render(
     <SortStep
       step={step}
-      query={step.query}
-      stageIndex={step.stageIndex}
-      topLevelQuery={step.topLevelQuery}
       color="brand"
       isLastOpened={false}
       reportTimezone="UTC"

--- a/frontend/src/metabase/query_builder/components/notebook/steps/SummarizeStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/SummarizeStep.tsx
@@ -7,7 +7,7 @@ import { StepContainer, StepLabel, StepRoot } from "./SummarizeStep.styled";
 
 function SummarizeStep({
   color,
-  query,
+  step,
   isLastOpened,
   ...props
 }: NotebookStepUiComponentProps) {
@@ -16,7 +16,7 @@ function SummarizeStep({
       <StepContainer>
         <AggregateStep
           color={color}
-          query={query}
+          step={step}
           isLastOpened={isLastOpened}
           {...props}
         />
@@ -25,7 +25,7 @@ function SummarizeStep({
       <StepContainer>
         <BreakoutStep
           color={color}
-          query={query}
+          step={step}
           isLastOpened={false}
           {...props}
         />

--- a/frontend/src/metabase/query_builder/components/notebook/types.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/types.ts
@@ -52,6 +52,7 @@ export interface NotebookStepAction {
 export interface NotebookStepUiComponentProps {
   step: NotebookStep;
   topLevelQuery: Query;
+  stageIndex: number;
   query: StructuredQuery;
   sourceQuestion?: Question;
   color: string;

--- a/frontend/src/metabase/query_builder/components/notebook/types.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/types.ts
@@ -51,9 +51,6 @@ export interface NotebookStepAction {
 
 export interface NotebookStepUiComponentProps {
   step: NotebookStep;
-  topLevelQuery: Query;
-  stageIndex: number;
-  query: StructuredQuery;
   sourceQuestion?: Question;
   color: string;
   isLastOpened: boolean;


### PR DESCRIPTION
`step` already has query, topLevelQuery and stageIndex, so why do we need to duplicate this info using other props?