### PR TITLE
Increase the number of Cypress snapshots locally

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -125,7 +125,7 @@ const mainConfig = {
   ...defaultConfig,
   viewportHeight: 800,
   viewportWidth: 1280,
-  numTestsKeptInMemory: 1,
+  numTestsKeptInMemory: process.env["CI"] ? 1 : 50,
   reporter: "mochawesome",
   reporterOptions: {
     reportDir: "cypress/reports/mochareports",


### PR DESCRIPTION
https://docs.cypress.io/guides/references/configuration#Global

`numTestsKeptInMemory` can affect memory and performance. But it's also useful when running a series of tests locally. When it's set to `1`, you'll have snapshots only for the test that ran last. More often than not, you want to examine the other tests as well.

This PR keeps the setting unchanged for the CI context, and increases it to 50 tests locally.