### PR TITLE
Update visitDashboard e2e helper to be tabs-aware

### DIFF
--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -163,7 +163,7 @@ export function visitDashboard(dashboard_id, { params = {} } = {}) {
     url: `/api/dashboard/${dashboard_id}`,
     // That's why we have to ignore failures
     failOnStatusCode: false,
-  }).then(({ status, body: { dashcards } }) => {
+  }).then(({ status, body: { dashcards, tabs } }) => {
     const dashboardAlias = "getDashboard" + dashboard_id;
 
     cy.intercept("GET", `/api/dashboard/${dashboard_id}`).as(dashboardAlias);
@@ -171,9 +171,12 @@ export function visitDashboard(dashboard_id, { params = {} } = {}) {
     const canViewDashboard = hasAccess(status);
 
     let validQuestions = dashboardHasQuestions(dashcards);
-    if (params.tab != null) {
+
+    // if dashboard has tabs, only expect cards on the first tab
+    if (tabs?.length > 0) {
+      const firstTab = tabs[0];
       validQuestions = validQuestions.filter(
-        card => card.dashboard_tab_id === params.tab,
+        card => card.dashboard_tab_id === firstTab.id,
       );
     }
 

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -288,7 +288,6 @@ describe("scenarios > dashboard > tabs", () => {
 
     cy.wait("@saveDashboardCards").then(({ response }) => {
       cy.wrap(response.body.dashcards[1].id).as("secondTabDashcardId");
-      cy.wrap(response.body.tabs[0].id).as("firstTabId");
     });
 
     cy.intercept(
@@ -306,9 +305,8 @@ describe("scenarios > dashboard > tabs", () => {
     });
 
     // Visit first tab and confirm only first card was queried
-    cy.get("@firstTabId").then(firstTabId => {
-      visitDashboard(ORDERS_DASHBOARD_ID, { params: { tab: firstTabId } });
-    });
+    visitDashboard(ORDERS_DASHBOARD_ID);
+
     cy.get("@firstTabQuery").should("have.been.calledOnce");
     cy.get("@secondTabQuery").should("not.have.been.called");
 


### PR DESCRIPTION
### Description

Currently the `visitDashboard` helper will cause a test failure if you visit any tabbed dashboard with dashcards on tabs other than the first tab.  This updates the helper to only expect dashcard loads from the first tab.

Previously, we used a passed parameter to accomplish this, but it's really hard to do correctly because the ids of dashcard tabs are globally unique, and may change across test runs due to changing state in the db (especially with auditv2 dashboards having tabs now).

### How to verify

All e2e tests should pass

