### PR TITLE
[MLv2] Underlying records: use card name as label for nested queries

### DIFF
--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -41,9 +41,9 @@
      ;; TODO: This is a bit confused for non-COUNT aggregations. Perhaps it should just always be 10 or something?
      ;; Note that some languages have different plurals for exactly 2, or for 1, 2-5, and 6+.
      :row-count  (if (number? value) value 2)
-     :table-name (some->> (lib.util/source-table-id query)
-                          (lib.metadata/table query)
-                          (lib.metadata.calculation/display-name query stage-number))
+     :table-name (when-let [table-or-card (or (some->> query lib.util/source-table-id (lib.metadata/table query))
+                                              (some->> query lib.util/source-card-id  (lib.metadata/card  query)))]
+                   (lib.metadata.calculation/display-name query stage-number table-or-card))
      :dimensions dimensions
      :column-ref column-ref}))
 


### PR DESCRIPTION
Fixes #35340 by using the card's name if this question's source is a card.
