### PR TITLE
[MLv2] Underlying records: show drills on clicks with no `:column`

### DIFF
--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -19,7 +19,10 @@
 (mu/defn underlying-records-drill :- [:maybe ::lib.schema.drill-thru/drill-thru.underlying-records]
   "When clicking on a particular broken-out group, offer a look at the details of all the rows that went into this
   bucket. Eg. distribution of People by State, then click New York and see the table of all People filtered by
-  `STATE = 'New York'`."
+  `STATE = 'New York'`.
+
+  There is another quite different case: clicking the legend of a chart with multiple bars or lines broken out by
+  category. Then `column` is nil!"
   [query                                        :- ::lib.schema/query
    stage-number                                 :- :int
    {:keys [column column-ref dimensions value]} :- ::lib.schema.drill-thru/context]
@@ -31,11 +34,18 @@
   ;; - value: the aggregated value (the count, the sum, etc.)
   ;; So dimensions is exactly what we want.
   ;; It returns the table name and row count, since that's used for pluralization of the name.
+
+  ;; Clicking on a chart legend for eg. COUNT(Orders) by Products.CATEGORY and Orders.CREATED_AT has a context like:
+  ;; - column is nil
+  ;; - value is nil
+  ;; - dimensions holds only the legend's column, eg. Products.CATEGORY.
   (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
-             column
-             (some? value)
              (not-empty dimensions)
-             (not (lib.types.isa/structured? column)))
+             ;; Either we need both column and value (cell/map/data point click) or neither (chart legend click).
+             (or (and column (some? value))
+                 (and (nil? column) (nil? value)))
+             ;; If the column exists, it must not be a structured column like JSON.
+             (not (and column (lib.types.isa/structured? column))))
     {:lib/type   :metabase.lib.drill-thru/drill-thru
      :type       :drill-thru/underlying-records
      ;; TODO: This is a bit confused for non-COUNT aggregations. Perhaps it should just always be 10 or something?

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -964,15 +964,19 @@
 
 (defn ^:export available-drill-thrus
   "Return an array (possibly empty) of drill-thrus given:
-  - Required column
+  - Nullable column
   - Nullable value
   - Nullable data row (the array of `{col, value}` pairs from `clicked.data`)
-  - Nullable dimensions list (`{column, value}` pairs from `clicked.dimensions`)"
+  - Nullable dimensions list (`{column, value}` pairs from `clicked.dimensions`)
+
+  Column can be nil for a \"chart legend\" click, eg. clicking a category in the legend explaining the colours in a
+  multiple bar or line chart. Underlying records drills apply in that case!"
   [a-query stage-number column value row dimensions]
   (lib.convert/with-aggregation-list (lib.core/aggregations a-query stage-number)
-    (let [column-ref (when-let [a-ref (.-field_ref ^js column)]
+    (let [column-ref (when-let [a-ref (and column (.-field_ref ^js column))]
                        (legacy-ref->pMBQL a-ref))]
-      (->> (merge {:column     (fix-column-with-ref column-ref (js.metadata/parse-column column))
+      (->> (merge {:column     (when column
+                                 (fix-column-with-ref column-ref (js.metadata/parse-column column)))
                    :column-ref column-ref
                    :value      (cond
                                  (undefined? value) nil   ; Missing a value, ie. a column click

--- a/src/metabase/lib/schema/drill_thru.cljc
+++ b/src/metabase/lib/schema/drill_thru.cljc
@@ -287,8 +287,8 @@
 
 (mr/def ::context
   [:map
-   [:column     [:ref ::lib.schema.metadata/column]]
-   [:column-ref [:ref ::lib.schema.ref/ref]]
+   [:column     [:maybe [:ref ::lib.schema.metadata/column]]]
+   [:column-ref [:maybe [:ref ::lib.schema.ref/ref]]]
    [:value      [:maybe :any]]
    [:row        {:optional true} [:ref ::context.row]]
    [:dimensions {:optional true} [:maybe [:ref ::context.row]]]])

--- a/test/metabase/lib/drill_thru/underlying_records_test.cljc
+++ b/test/metabase/lib/drill_thru/underlying_records_test.cljc
@@ -268,3 +268,32 @@
                                       (meta/id :orders :quantity)]
                                      30.0]]}]}
               query')))))
+
+(deftest ^:parallel chart-legend-click-test
+  (testing "chart legend clicks have no `column` set, but shoudl still work (#35343)"
+    (let [query    (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                       (lib/aggregate (lib/count))
+                       (lib/breakout (meta/field-metadata :products :category))
+                       (lib/breakout (meta/field-metadata :orders :created-at)))
+          columns  (lib/returned-columns query)
+          category (m/find-first #(= (:name %) "CATEGORY") columns)
+          context  {:column     nil
+                    :column-ref nil
+                    :value      nil
+                    :dimensions [{:column     category
+                                  :column-ref (lib/ref category)
+                                  :value      "Gadget"}]}
+          drills   (lib.drill-thru/available-drill-thrus query context)
+          drill    (m/find-first #(= (:type %) :drill-thru/underlying-records)
+                                 drills)]
+      (is (=? {:type       :drill-thru/underlying-records
+               :row-count  2
+               :table-name "Orders"
+               :dimensions [{}]}
+              drill))
+      (is (=? {:lib/type :mbql/query
+               :stages [{:filters     [[:= {} [:field {} (meta/id :products :category)] "Gadget"]]
+                         :aggregation (symbol "nil #_\"key is not present.\"")
+                         :breakout    (symbol "nil #_\"key is not present.\"")
+                         :fields      (symbol "nil #_\"key is not present.\"")}]}
+              (lib.drill-thru/drill-thru query -1 drill))))))

--- a/test/metabase/lib/drill_thru/underlying_records_test.cljc
+++ b/test/metabase/lib/drill_thru/underlying_records_test.cljc
@@ -270,7 +270,7 @@
               query')))))
 
 (deftest ^:parallel chart-legend-click-test
-  (testing "chart legend clicks have no `column` set, but shoudl still work (#35343)"
+  (testing "chart legend clicks have no `column` set, but should still work (#35343)"
     (let [query    (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
                        (lib/aggregate (lib/count))
                        (lib/breakout (meta/field-metadata :products :category))


### PR DESCRIPTION
Fixes #35343 and #35394 by fixing `available-drill-thrus` and `underlying-records-drill` for cases
where there is no `:column` defined, only `:dimensions`.
