### PR TITLE
Ensure collections are loaded before showing entity copy form

### DIFF
--- a/frontend/src/metabase/entities/containers/EntityCopyModal.tsx
+++ b/frontend/src/metabase/entities/containers/EntityCopyModal.tsx
@@ -5,6 +5,7 @@ import EntityForm from "metabase/entities/containers/EntityForm";
 import ModalContent from "metabase/components/ModalContent";
 import { CreateCollectionOnTheGo } from "metabase/containers/CreateCollectionOnTheGo";
 import { useCollectionListQuery } from "metabase/common/hooks";
+import { Flex, Loader } from "metabase/ui";
 
 interface EntityCopyModalProps {
   entityType: string;
@@ -33,20 +34,26 @@ const EntityCopyModal = ({
           title={title || t`Duplicate "${entityObject.name}"`}
           onClose={onClose}
         >
-          <EntityForm
-            resumedValues={resumedValues}
-            entityType={entityType}
-            entityObject={{
-              ...dissoc(entityObject, "id"),
-              name: entityObject.name + " - " + t`Duplicate`,
-            }}
-            onSubmit={copy}
-            onClose={onClose}
-            onSaved={onSaved}
-            submitTitle={t`Duplicate`}
-            collections={collections}
-            {...props}
-          />
+          {!collections?.length ? (
+            <Flex justify="center" p="lg">
+              <Loader />
+            </Flex>
+          ) : (
+            <EntityForm
+              resumedValues={resumedValues}
+              entityType={entityType}
+              entityObject={{
+                ...dissoc(entityObject, "id"),
+                name: entityObject.name + " - " + t`Duplicate`,
+              }}
+              onSubmit={copy}
+              onClose={onClose}
+              onSaved={onSaved}
+              submitTitle={t`Duplicate`}
+              collections={collections}
+              {...props}
+            />
+          )}
         </ModalContent>
       )}
     </CreateCollectionOnTheGo>


### PR DESCRIPTION
### Description

Whoops, broke this test in master:

![Screen Shot 2023-12-01 at 3 03 20 PM](https://github.com/metabase/metabase/assets/30528226/af45e0b4-c212-4e14-84d7-c5de55c561ee)

Not sure why this test passed on the branch and broke in master, but it's definitely [broken in master](https://metaboat.slack.com/archives/C5XHN8GLW/p1701463848481349).

The issue is that if you load a question directly, without opening the sidebar, there's no collections list in local state, and we're not waiting on the collection api endpoint load before setting the form's initial state, so we can't find the correct custom reports collection, and that's why the test fails.

I have some deep misgivings about loading the full collections tree here, as it could be quite slow on instances with large numbers of collections. 😢 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR (the test is what caught it 😂 )
