### PR TITLE
Cleaner hydration instrumentation

### DIFF
--- a/src/metabase/api/telemetry.clj
+++ b/src/metabase/api/telemetry.clj
@@ -1,0 +1,18 @@
+(ns metabase.api.telemetry
+  "Utilities for adding telemetry to our API endpoints."
+  (:require
+    [metabase.models.interface :as mi]
+    [steffan-westcott.clj-otel.api.trace.span :as span]
+    [toucan2.core :as t2]))
+
+(defmacro hydrate
+  "A telemetry-wrapped version of hydrate. Simply replace t2/hydrate with te/hydrate."
+  [entity & args]
+  `(let [entity# ~entity
+         model#  (mi/model entity#)]
+     (span/with-span!
+       {:name       "hydrate"
+        :attributes {:model model#
+                     (keyword (name model#) "id")
+                     (:id entity#)}}
+       (t2/hydrate entity# ~@args))))


### PR DESCRIPTION
The goal of this PR is to add instrumentation to `t2/hydrate` without manually adding pervasive spans everywhere in the code. This is part of the [Instrument dashboard endpoint performance #36274](https://github.com/metabase/metabase/issues/36274) effort.

This PR consists of two ideas to be considered:

## Instrument `hydrate-with-strategy`

This is a small change that adds tracing in a more global fashion to `hydrate-with-strategy`. Unfortunately, this doesn't really capture the top-level `hydrate` calls as we were hoping for. It does provide some additional insights, but not the kind of bulk spans that tell you where you're spending most of your time.

This change is done in `metabase.db` as:

```clojure
(methodical/defmethod t2.hydrate/hydrate-with-strategy :around :default
  "Add OpenTelemetry spans around calls to hydrate-with-strategy."
  [model strategy k instances]
  (span/with-span!
    {:name       "hydrate-with-strategy"
     :attributes {:hydrate/key k}}
    (next-method model strategy k instances)))
```
## Wrap `t2/hydrate` with a macro that auto-instruments it

The idea is to add a macro (tentatively in `metabase.api.telemetry`) around `hydrate` and then just use the aliased `te/hydrate` exactly as you would `t2/hydrate`. A few nice things about this approach:

- Easy to implement -- Just change the import
- Reflects the right calling location in instrumentation
- We can modify the macro if desired to dynamically add a different span name. Currently, it's just "hydrate". We could do "hydrate-${entity-type}", for example.
- It is bespoke, but trivial to add or remove. Find and replace the require alias in api nses we want to add spans to or find and replace to remove them.

This is the proposed macro:

```clojure
(defmacro hydrate
  "A telemetry-wrapped version of hydrate. Simply replace t2/hydrate with te/hydrate."
  [entity & args]
  `(let [entity# ~entity
         model#  (mi/model entity#)]
     (span/with-span!
       {:name       "hydrate"
        :attributes {:model model#
                     (keyword (name model#) "id")
                     (:id entity#)}}
       (t2/hydrate entity# ~@args))))
```

[Here's a Loom](https://www.loom.com/share/84dc0e79a6e24f66ad63dffb316f2bb9?sid=baede034-5f1c-48bc-bef9-7aeb18e835d8) describing the impact of both designs.