### PR TITLE
Fix embedding not getting hot reloading

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -226,12 +226,14 @@ const config = (module.exports = {
       chunksSortMode: "manual",
       chunks: ["vendor", "styles", "app-public"],
       template: __dirname + "/resources/frontend_client/index_template.html",
+      alwaysWriteToDisk: true,
     }),
     new HtmlWebpackPlugin({
       filename: "../../embed.html",
       chunksSortMode: "manual",
       chunks: ["vendor", "styles", "app-embed"],
       template: __dirname + "/resources/frontend_client/index_template.html",
+      alwaysWriteToDisk: true,
     }),
     new HtmlWebpackHarddiskPlugin({
       outputPath: __dirname + "/resources/frontend_client/app/dist",
@@ -308,9 +310,7 @@ if (WEBPACK_BUNDLE === "hot") {
   };
 
   config.watchOptions = {
-    ignored: [
-      CLJS_SRC_PATH_DEV + "/**",
-    ],
+    ignored: [CLJS_SRC_PATH_DEV + "/**"],
   };
 
   config.plugins.unshift(


### PR DESCRIPTION
> [!note]
> This PR is superseded by https://github.com/metabase/metabase/pull/36335

@npretto was the first person to report this problem: [Slack](https://metaboat.slack.com/archives/C063Q3F1HPF/p1701436191828889)

### Description

I believe this was a mistake from https://github.com/metabase/metabase/pull/34473. You can see in the diff on that PR that it removed `inject` and `scripLoading` from `app-main`, but it also [removed `alwaysWriteToDisk` in addition](https://github.com/metabase/metabase/pull/34473/files#diff-1fb26bc12ac780c7ad7325730ed09fc4c2c3d757c276c3dacc44bfe20faf166fL227) from `app-public` and `app-embed`.

### How to verify

1. Share a dashboard or a question via public link.
1. Visit the public link
1. Edit `frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx` e.g. adding a markup
1. You should see the new change on public page
1. Go back to the previous dashboard/question and select embed in your application to see the embed preview
1. Edit `frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx` e.g. adding a markup
1. You should see the new change in the embed preview

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ No test because this is only webpack change
