### PR TITLE
[webpack] Do not restore yarn cache twice

### DIFF
--- a/.github/actions/prepare-frontend/action.yml
+++ b/.github/actions/prepare-frontend/action.yml
@@ -5,8 +5,7 @@ runs:
     - name: Prepare Node.js
       uses: actions/setup-node@v3
       with:
-        node-version-file: '.nvmrc'
-        cache: 'yarn'
+        node-version-file: ".nvmrc"
     - name: Check to see if dependencies should be cached
       if: ${{ contains(github.event.head_commit.message, '[ci nocache]') }}
       run: |


### PR DESCRIPTION
closes #36338

### Description

Do not restore yarn cache twice, frontend cache is already restored at https://github.com/metabase/metabase/blob/master/.github/actions/prepare-frontend/action.yml#L22-L27