### PR TITLE
Fix failed E2E from 61f2b28dd62938ae4f66434b1678e227bb0c8d0d

### DIFF
--- a/frontend/src/metabase/entities/containers/EntityForm.jsx
+++ b/frontend/src/metabase/entities/containers/EntityForm.jsx
@@ -34,15 +34,18 @@ const EForm = ({
       ? entityObject.getPlainObject()
       : entityObject;
 
+  let isCustomCollectionLoaded = false;
   if (isInstanceAnalyticsCollection(entityObject?.collection)) {
     const customCollection = getInstanceAnalyticsCustomCollection(collections);
     if (customCollection) {
+      isCustomCollectionLoaded = true;
       initialValues.collection_id = customCollection.id;
     }
   }
 
   return (
     <FormikForm
+      key={isCustomCollectionLoaded}
       {...props}
       form={form}
       initialValues={{ ...initialValues, ...resumedValues }}


### PR DESCRIPTION
### Description

There is a test on `master` that [fails almost 100%](https://www.deploysentinel.com/ci/runs/656d57cdfcacf3cead661a6b).
![image](https://github.com/metabase/metabase/assets/1937582/ec0d0985-87cd-48ea-bfe2-ee8465f2d562)

I run `git bisect` and found 61f2b28dd62938ae4f66434b1678e227bb0c8d0d is the first commit that start to fail.

This PR fix the problem when the entity copy modal require `GET /api/collection` to be loaded bofore it could initialize the form. Otherwise, even if `initialValues` changes, the form won't rerender again.

![Screenshot 2023-12-04 at 3 26 56 PM](https://github.com/metabase/metabase/assets/1937582/048654b5-0454-434a-a9eb-764db4a145c6)


### How to verify

Run tests in `e2e/test/scenarios/collections/instance-analytics.cy.spec.js` and they should all pass.

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ No tests added, but the existing failing tests should pass now
