### PR TITLE
[Storybook] Build cljs with NODE_ENV=development to override default settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -306,7 +306,7 @@
     "build-static-viz:watch": "webpack --config webpack.static-viz.config.js --watch",
     "build-static-viz:watch-wait": "yarn wait:cljs; yarn build-static-viz:watch",
     "build-stats": "yarn && webpack --json > stats.json",
-    "build-storybook": "yarn build:cljs && NODE_OPTIONS=--max-old-space-size=8196 build-storybook",
+    "build-storybook": "NODE_ENV=development yarn build:cljs && NODE_OPTIONS=--max-old-space-size=8196 build-storybook",
     "build-watch": "yarn concurrently -n 'cljs,js' 'yarn build-watch:cljs' 'yarn build-watch:js'",
     "build-watch:cljs": "yarn && shadow-cljs watch app",
     "build-watch:js": "yarn && NODE_OPTIONS=--max-old-space-size=8196 webpack --watch",


### PR DESCRIPTION
### Description

Fix storybook build. After the [latest changes in chromatic](https://github.com/chromaui/chromatic-cli/pull/865), NODE_ENV value is "production" which is not something we support at CLJS 

### How to verify

chromatic shouldn't fail for this PR https://github.com/metabase/metabase/actions/runs/7084791101/job/19279903320
 