### PR TITLE
Uploads: Make the display name for the _mb_row_id column "_mb_row_id"

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -888,8 +888,13 @@
           stats             (upload/load-from-csv! driver db-id schema+table-name csv-file)
           ;; Sync immediately to create the Table and its Fields; the scan is settings-dependent and can be async
           table             (sync-tables/create-or-reactivate-table! database {:name table-name :schema (not-empty schema-name)})
-          _set_is_upload    (t2/update! Table (u/the-id table) {:is_upload true})
+          _set_is_upload    (t2/update! :model/Table (u/the-id table) {:is_upload true})
           _sync             (scan-and-sync-table! database table)
+          ;; Set the display_name of the auto-generated primary key column to the same as its name, so that if users
+          ;; download results from the table as a CSV and reupload, we'll recognize it as the same column
+          auto-pk-field     (t2/select-one :model/Field :table_id (u/the-id table)
+                                           :%lower.name upload/auto-pk-column-name)
+          _  (t2/update! :model/Field (u/the-id auto-pk-field) {:display_name (:name auto-pk-field)})
           card              (card/create-card!
                              {:collection_id          collection-id,
                               :dataset                true

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -894,7 +894,7 @@
           ;; download results from the table as a CSV and reupload, we'll recognize it as the same column
           auto-pk-field     (t2/select-one :model/Field :table_id (u/the-id table)
                                            :%lower.name upload/auto-pk-column-name)
-          _  (t2/update! :model/Field (u/the-id auto-pk-field) {:display_name (:name auto-pk-field)})
+          _                 (t2/update! :model/Field (u/the-id auto-pk-field) {:display_name (:name auto-pk-field)})
           card              (card/create-card!
                              {:collection_id          collection-id,
                               :dataset                true

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -195,8 +195,8 @@
     "unnamed_column"
     (u/slugify (str/trim raw-name))))
 
-(def ^:private auto-pk-column-name
-  "The name of the auto-incrementing PK column."
+(def auto-pk-column-name
+  "The lower-case name of the auto-incrementing PK column. The actual name in the database could be in upper-case."
   "_mb_row_id")
 
 (defn- remove-indices

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2932,18 +2932,17 @@
                                              uploads-schema-name  nil
                                              uploads-table-prefix "uploaded_magic_"]
             (if (supports-schemas? driver/*driver*)
+              (is (thrown-with-msg?
+                    java.lang.Exception
+                    #"^A schema has not been set."
+                    (upload-example-csv! nil)))
               (let [new-model (upload-example-csv! nil)
                     new-table (t2/select-one Table :db_id db-id)]
                 (is (=? {:name #"(?i)example csv file(.*)"}
                         new-model))
                 (is (=? {:name #"(?i)uploaded_magic_example(.*)"}
                         new-table))
-                (is (nil? (:schema new-table))))
-              ;; Else, for drivers that support schemas
-              (is (thrown-with-msg?
-                   java.lang.Exception
-                   #"^A schema has not been set."
-                   (upload-example-csv! nil))))))))))
+                (is (nil? (:schema new-table)))))))))))
 
 (deftest upload-csv!-auto-pk-column-display-name-test
   (testing "The auto-generated column display_name should be the same as its name"

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2840,6 +2840,10 @@
                  :values_source_config {:values ["BBQ" "Bakery" "Bar"]}}]
                (:parameters card)))))))
 
+;; Cal TODO: move this to driver test multimethod
+(defn- supports-schemas? [driver]
+  (not= driver :mysql))
+
 (defn upload-example-csv!
   "Upload a small CSV file to the given collection ID"
   ([collection-id]
@@ -2864,7 +2868,7 @@
            (perms/revoke-data-perms! group-id (mt/id))))))))
 
 (deftest upload-csv!-schema-test
-  (mt/test-drivers (disj (mt/normal-drivers-with-feature :uploads) :mysql) ; MySQL doesn't support schemas
+  (mt/test-drivers (filter supports-schemas? (mt/normal-drivers-with-feature :uploads))
     (mt/with-empty-db
       (let [db                   (mt/db)
             db-id                (u/the-id db)
@@ -2927,21 +2931,41 @@
                                              uploads-database-id  db-id
                                              uploads-schema-name  nil
                                              uploads-table-prefix "uploaded_magic_"]
-            (if (= driver/*driver* :mysql)
+            (if (supports-schemas? driver/*driver*)
               (let [new-model (upload-example-csv! nil)
                     new-table (t2/select-one Table :db_id db-id)]
                 (is (=? {:name #"(?i)example csv file(.*)"}
                         new-model))
                 (is (=? {:name #"(?i)uploaded_magic_example(.*)"}
                         new-table))
-                (if (= driver/*driver* :mysql)
-                  (is (nil? (:schema new-table)))
-                  (is (=? {:schema #"(?i)public"} new-table))))
+                (is (nil? (:schema new-table))))
               ;; Else, for drivers that support schemas
               (is (thrown-with-msg?
                    java.lang.Exception
                    #"^A schema has not been set."
                    (upload-example-csv! nil))))))))))
+
+(deftest upload-csv!-auto-pk-column-display-name-test
+  (testing "The auto-generated column display_name should be the same as its name"
+   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
+     (mt/with-empty-db
+       (let [db-id (u/the-id (mt/db))]
+         (when (supports-schemas? driver/*driver*)
+           (let [details (mt/dbdef->connection-details driver/*driver* :db {:database-name (:name (mt/db))})]
+             (jdbc/execute! (sql-jdbc.conn/connection-details->spec driver/*driver* details)
+                            ["CREATE SCHEMA \"not_public\";"])))
+         (mt/with-temporary-setting-values [uploads-enabled      true
+                                            uploads-database-id  db-id
+                                            uploads-schema-name  (if (supports-schemas? driver/*driver*)
+                                                                   "not_public"
+                                                                   nil)
+                                            uploads-table-prefix "uploads_"]
+           (upload-example-csv! nil)
+           (let [new-table (t2/select-one Table :db_id db-id)
+                 new-field (t2/select-one Field :table_id (:id new-table) :name "_mb_row_id")]
+             (is (= "_mb_row_id"
+                    (:name new-field)
+                    (:display_name new-field))))))))))
 
 (deftest upload-csv!-failure-test
   ;; Just test with postgres because failure should be independent of the driver


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/36354

After syncing the newly created table and its fields, we change the display name to match the name.