### PR TITLE
Handle Release Notes for Release Candidates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -596,9 +596,14 @@ jobs:
       uses: actions/github-script@v6
       with:
         script: | # js
-          const { closeMilestone, openNextMilestones } = require('${{ github.workspace }}/release/dist/index.cjs');
+          const { closeMilestone, openNextMilestones, isRCVersion } = require('${{ github.workspace }}/release/dist/index.cjs');
 
           const version = '${{ inputs.version }}';
+
+          if (isRCVersion(version)) {
+            console.log("This is a release candidate, skipping milestone management");
+            return;
+          }
 
           await closeMilestone({
             github,

--- a/release/README.md
+++ b/release/README.md
@@ -52,3 +52,11 @@ yarn release-offline v0.77.77 1234567890abcdef1234567890abcdef12345678 --publish
 ```
 
 The order of the arguments matters, the script will yell at you if you put the flags in the wrong order. We could make this more robust, but it's probably not worth the effort since hopefully we won't ever have to use this :crossed_fingers:.
+
+## Utilities
+
+In case you want to preview release notes generation, or re-generate them after a release has been built, you can use this command. (the hash doesn't matter, it's just a placeholder)
+
+```sh
+yarn release-offline v0.77.0 1234567890abcdef1234567890abcdef12345678  --changelog > changelog.log
+```

--- a/release/release-offline.ts
+++ b/release/release-offline.ts
@@ -11,7 +11,6 @@ import "zx/globals";
 import { $ } from "zx";
 $.verbose = false;
 
-import { latest } from "immer/dist/internal";
 import {
   isValidVersionString,
   hasBeenReleased,
@@ -24,6 +23,7 @@ import {
   closeMilestone,
   openNextMilestones,
   versionRequirements,
+  getChangelog,
 } from "./src";
 
 const {
@@ -467,6 +467,19 @@ async function updateMilestones() {
 
   if (step === "release-notes") {
     await releaseNotes();
+  }
+
+  if (step === "changelog") {
+    // changelog preview only, doesn't publish anything
+    const { GITHUB_OWNER, GITHUB_REPO } = getGithubCredentials();
+    const notes = await getChangelog({
+      version, github,
+      owner: GITHUB_OWNER,
+      repo: GITHUB_REPO
+    });
+    // eslint-disable-next-line no-console -- allows piping to a file
+    console.log(notes);
+    return;
   }
 
   if (step === "update-milestones") {

--- a/release/src/github.ts
+++ b/release/src/github.ts
@@ -20,8 +20,8 @@ const findMilestone = async ({
     state: "open",
   });
 
-  // our milestones don't have the v prefix
-  const expectedMilestoneName = getOSSVersion(version).replace(/^v/, "");
+  // our milestones don't have the v prefix or a .0 suffix
+  const expectedMilestoneName = getOSSVersion(version).replace(/^v/, "").replace(/\.0$/, '');
 
   return milestones.data.find(
     (milestone: { title: string; number: number }) =>
@@ -83,14 +83,15 @@ export const getMilestoneIssues = async ({
     return [];
   }
 
-  const milestone = await github.rest.issues.listForRepo({
+  // we have to use paginate function or the issues will be truncated to 100
+  const issues = await github.paginate(github.rest.issues.listForRepo, {
     owner,
     repo,
     milestone: milestoneId.toString(),
     state: "closed",
   });
 
-  return (milestone?.data ?? []) as Issue[];
+  return (issues ?? []) as Issue[];
 };
 
 // latest for the purposes of github release notes

--- a/release/src/github.ts
+++ b/release/src/github.ts
@@ -21,7 +21,10 @@ const findMilestone = async ({
   });
 
   // our milestones don't have the v prefix or a .0 suffix
-  const expectedMilestoneName = getOSSVersion(version).replace(/^v/, "").replace(/\.0$/, '');
+  const expectedMilestoneName = getOSSVersion(version)
+    .replace(/^v/, "")
+    .replace(/-rc\d+$/i, "") // RC versions use the major version milestone
+    .replace(/\.0$/, '');
 
   return milestones.data.find(
     (milestone: { title: string; number: number }) =>

--- a/release/src/release-notes.ts
+++ b/release/src/release-notes.ts
@@ -110,3 +110,29 @@ export async function publishRelease({
 
   return github.rest.repos.createRelease(payload);
 }
+
+export async function getChangelog({
+  version,
+  owner,
+  repo,
+  github,
+}: ReleaseProps) {
+  if (!isValidVersionString(version)) {
+    throw new Error(`Invalid version string: ${version}`);
+  }
+  const issues = await getMilestoneIssues({ version, github, owner, repo });
+
+  const bugFixes = issues.filter(isBugIssue);
+  const enhancements = issues.filter(issue => !isBugIssue(issue));
+
+  const notes = `
+## Enhancements
+${enhancements?.map(formatIssue).join("\n") ?? ""}
+
+
+## Bug fixes
+${bugFixes?.map(formatIssue).join("\n") ?? ""}
+`;
+
+  return notes;
+}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase-private/issues/180

### Description

The release candidate release notes didn't quite generate as expected. This cleans up a few things discovered today.
- Do some version filtering so that RC versions grab the .0 release notes
- Update issue fetching logic to grab more than 100 issues in a milestone (this has probably been truncating the changelog in large releases for a while, even in the old release script)
- Don't auto-manage milestones for release candidates
- Exposes release notes generation via the local CLI to make previewing/fixing easier.

### How to verify

Load up a local .env file with the appropriate github variables and run this command in the release directory

```
yarn release-offline v0.48.0 1234567890abcdef1234567890abcdef12345678  --changelog > changelog.log
```

And you can generate your own personal set of v48 release notes.
