### PR TITLE
Update node and java versions for v48 release

### DIFF
--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -114,6 +114,7 @@ export const versionRequirements: Record<
   45: { java: 11, node: 14 },
   46: { java: 11, node: 16 },
   47: { java: 11, node: 18 },
+  48: { java: 11, node: 18 },
 };
 
 export const getBuildRequirements = (version: string) => {


### PR DESCRIPTION
### Description

This doesn't matter at all now, but if our supported version change in v49, it will be necessary to make sure we get the right versions for v48.


