### PR TITLE
fix backport comment command

### DIFF
--- a/.github/actions/verify-membership/action.yml
+++ b/.github/actions/verify-membership/action.yml
@@ -1,0 +1,22 @@
+name: 'Verify Organization Membership'
+description: 'Check if a user is a member of a GitHub organization'
+inputs:
+  github_token:
+    description: 'Token with access to the organization'
+    required: true
+  organization_name:
+    description: 'Organization name'
+    required: true
+  username:
+    description: 'Username'
+    required: true
+outputs:
+  is_member:
+    value: ${{ steps.verify-membership.outputs.is_member }}
+    description: "Is the user a member of the organization"
+runs:
+  using: "composite"
+  steps:
+    - run: bash ${{ github.action_path }}/verify_membership.sh ${{ inputs.github_token }} ${{ inputs.organization_name }} ${{ inputs.username }}
+      id: verify-membership
+      shell: bash

--- a/.github/actions/verify-membership/verify_membership.sh
+++ b/.github/actions/verify-membership/verify_membership.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+TOKEN=$1
+ORG_NAME=$2
+USERNAME=$3
+
+response=$(curl -L -o /dev/null -w "%{http_code}" \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "https://api.github.com/orgs/$ORG_NAME/members/$USERNAME")
+
+# Github returns an empty response with 204 status if user is a member and 404 status otherwise
+# See: https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
+if [ "$response" == "204" ]; then
+    echo "The user $USERNAME is a member of $ORG_NAME"
+    echo "is_member=true" >> $GITHUB_OUTPUT
+elif [ "$response" == "404" ]; then
+    echo "The user $USERNAME is not a member of $ORG_NAME"
+    echo "is_member=false" >> $GITHUB_OUTPUT
+else
+    echo "Failed to determine the membership status for $USERNAME in $ORG_NAME"
+    echo "is_member=false" >> $GITHUB_OUTPUT
+    exit 1
+fi

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: tibdex/github-app-token@v1.6.0
+      - uses: tibdex/github-app-token@v2.1.0
         id: generate-token
         with:
           app_id: ${{ secrets.METABASE_BOT_APP_ID }}

--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: tibdex/github-app-token@v1.6.0
+      - uses: tibdex/github-app-token@v2.1.0
         id: generate-token
         with:
           app_id: ${{ secrets.METABASE_BOT_APP_ID }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,19 +11,24 @@ jobs:
     if: contains(github.event.comment.body, '@metabase-bot backport')
     runs-on: ubuntu-22.04
     steps:
-      - uses: tibdex/github-app-token@v1.6.0
+      - uses: tibdex/github-app-token@v2.1.0
         id: generate-token
         with:
           app_id: ${{ secrets.METABASE_BOT_APP_ID }}
           private_key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
-      - id: is_organization_member
-        uses: JamesSingleton/is-organization-member@1.0.0
+      - uses: actions/checkout@v3
+        name: Cherry-pick commits and create PR
         with:
-          organization: metabase
-          username: ${{ github.event.issue.user.login }}
-          token: ${{ steps.generate-token.outputs.token }}
+          fetch-depth: 0
+      - name: Verify Membership
+        id: verify-membership
+        uses: ./.github/actions/verify-membership
+        with:
+          github_token: ${{ steps.generate-token.outputs.token }}
+          organization_name: metabase
+          username: ${{ github.event.comment.user.login }}
       - run: |
-          result=${{ steps.is_organization_member.outputs.result }}
+          result=${{ steps.verify-membership.outputs.is_member }}
           if [ $result == false ]; then
               echo User ${{ github.event.comment.user.login }} is not a member of Metabase organization
               exit 1
@@ -80,10 +85,6 @@ jobs:
               startSha: commits[0].sha,
               endSha: commits[commits.length - 1].sha
             }
-      - uses: actions/checkout@v3
-        name: Cherry-pick commits and create PR
-        with:
-          fetch-depth: 0
       - id: create_backport_pull_request
         name: Create backport pull request
         run: |

--- a/.github/workflows/percy-issue-comment.yml
+++ b/.github/workflows/percy-issue-comment.yml
@@ -14,19 +14,24 @@ jobs:
       branch_name: ${{ fromJson(steps.fetch_pr.outputs.data).head.ref }}
       commit_sha: ${{ fromJson(steps.fetch_pr.outputs.data).head.sha }}
     steps:
-      - uses: tibdex/github-app-token@v1.6.0
+      - uses: tibdex/github-app-token@v2.1.0
         id: generate-token
         with:
           app_id: ${{ secrets.METABASE_BOT_APP_ID }}
           private_key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
-      - id: is_organization_member
-        uses: JamesSingleton/is-organization-member@1.0.0
+      - uses: actions/checkout@v3
         with:
-          organization: metabase
-          username: ${{ github.event.issue.user.login }}
-          token: ${{ steps.generate-token.outputs.token }}
+          ref: ${{ needs.pr_info.outputs.branch_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify Membership
+        id: verify-membership
+        uses: ./.github/actions/verify-membership
+        with:
+          github_token: ${{ steps.generate-token.outputs.token }}
+          organization_name: metabase
+          username: ${{ github.event.comment.user.login }}
       - run: |
-          result=${{ steps.is_organization_member.outputs.result }}
+          result=${{ steps.verify-membership.outputs.is_member }}
           if [ $result == false ]; then
               echo User ${{ github.event.comment.user.login }} is not a member of Metabase organization
               exit 1

--- a/.github/workflows/require-percy-tests.yml
+++ b/.github/workflows/require-percy-tests.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
-      - uses: tibdex/github-app-token@v1.6.0
+      - uses: tibdex/github-app-token@v2.1.0
         id: generate-token
         with:
           app_id: ${{ secrets.METABASE_BOT_APP_ID }}


### PR DESCRIPTION
### Description

Fixes `@metabase-bot backport xxx` command which did not work for users who is hid their Metabase organization membership. The rest of the workflow is mostly the same.
I also updated github-app-token@v2.1.0 since the new version revokes generated tokens.

### How to verify

Check the result of the new verify-membership action [here](https://github.com/scarab-engineering/test-gha/actions/runs/7093127297/job/19305918408).

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
