### PR TITLE
Do not return zoom/pk/fk-details drills for null cell values

### DIFF
--- a/src/metabase/lib/drill_thru/object_details.cljc
+++ b/src/metabase/lib/drill_thru/object_details.cljc
@@ -19,7 +19,8 @@
     (cond
       (and (lib.types.isa/primary-key? column)
            many-pks?
-           mbql-stage?)
+           mbql-stage?
+           (not= value :null))
       (assoc base :type :drill-thru/pk)
 
       ;; TODO: Figure out clicked.extraData and the dashboard flow.
@@ -27,7 +28,8 @@
            (not= value :null))
       (assoc base :type :drill-thru/zoom)
 
-      (lib.types.isa/foreign-key? column)
+      (and (lib.types.isa/foreign-key? column)
+           (not= value :null))
       (assoc base :type :drill-thru/fk-details)
 
       (and (not many-pks?)

--- a/src/metabase/lib/drill_thru/object_details.cljc
+++ b/src/metabase/lib/drill_thru/object_details.cljc
@@ -23,7 +23,8 @@
       (assoc base :type :drill-thru/pk)
 
       ;; TODO: Figure out clicked.extraData and the dashboard flow.
-      (lib.types.isa/primary-key? column)
+      (and (lib.types.isa/primary-key? column)
+           (not= value :null))
       (assoc base :type :drill-thru/zoom)
 
       (lib.types.isa/foreign-key? column)

--- a/test/metabase/lib/drill_thru/fk_details_test.cljc
+++ b/test/metabase/lib/drill_thru/fk_details_test.cljc
@@ -118,3 +118,15 @@
                                           [:field {} (meta/id :people :id)]
                                           1]]}]}
                     (lib/drill-thru query -1 fk-details-drill)))))))))
+
+(deftest ^:parallel do-not-return-fk-details-for-nil-test
+  (testing "do not return fk-details drills for nil cell values (#36133)"
+    (let [query   (lib/query meta/metadata-provider (meta/table-metadata :orders))
+          context {:column     (meta/field-metadata :orders :product-id)
+                   :column-ref (lib/ref (meta/field-metadata :orders :product-id))
+                   :value      :null
+                   :row        [{:column     (meta/field-metadata :orders :product-id)
+                                 :column-ref (lib/ref (meta/field-metadata :orders :product-id))
+                                 :value      nil}]}]
+      (is (not (m/find-first #(= (:type %) :drill-thru/fk-details)
+                             (lib/available-drill-thrus query -1 context)))))))

--- a/test/metabase/lib/drill_thru/pk_test.cljc
+++ b/test/metabase/lib/drill_thru/pk_test.cljc
@@ -1,0 +1,24 @@
+(ns metabase.lib.drill-thru.pk-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [medley.core :as m]
+   [metabase.lib.core :as lib]
+   [metabase.lib.test-metadata :as meta]
+   [metabase.lib.test-util :as lib.tu]))
+
+(deftest ^:parallel do-not-return-pk-for-nil-test
+  (testing "do not return pk drills for nil cell values (#36126)"
+    ;; simulate a table with multiple PK columns: mark orders.product-id as a PK column
+    (let [metadata-provider (lib.tu/merged-mock-metadata-provider
+                             meta/metadata-provider
+                             {:fields [{:id            (meta/id :orders :product-id)
+                                        :semantic-type :type/PK}]})
+          query             (lib/query metadata-provider (meta/table-metadata :orders))
+          context           {:column     (meta/field-metadata :orders :id)
+                             :column-ref (lib/ref (meta/field-metadata :orders :id))
+                             :value      :null
+                             :row        [{:column     (meta/field-metadata :orders :id)
+                                           :column-ref (lib/ref (meta/field-metadata :orders :id))
+                                           :value      nil}]}]
+      (is (not (m/find-first #(= (:type %) :drill-thru/pk)
+                             (lib/available-drill-thrus query -1 context)))))))

--- a/test/metabase/lib/drill_thru/zoom_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_test.cljc
@@ -1,7 +1,10 @@
 (ns metabase.lib.drill-thru.zoom-test
   (:require
-   [clojure.test :refer [deftest]]
-   [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]))
+   [clojure.test :refer [deftest is testing]]
+   [medley.core :as m]
+   [metabase.lib.core :as lib]
+   [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
+   [metabase.lib.test-metadata :as meta]))
 
 (deftest ^:parallel returns-zoom-test-1
   (lib.drill-thru.tu/test-returns-drill
@@ -52,3 +55,15 @@
     :expected    {:type      :drill-thru/zoom
                   :object-id (get-in lib.drill-thru.tu/test-queries ["ORDERS" :unaggregated :row "ID"])
                   :many-pks? false}}))
+
+(deftest ^:parallel do-not-return-zoom-for-nil-test
+  (testing "do not return zoom drills for nil cell values (#36130)"
+    (let [query   (lib/query meta/metadata-provider (meta/table-metadata :orders))
+          context {:column     (meta/field-metadata :orders :id)
+                   :column-ref (lib/ref (meta/field-metadata :orders :id))
+                   :value      :null
+                   :row        [{:column     (meta/field-metadata :orders :id)
+                                 :column-ref (lib/ref (meta/field-metadata :orders :id))
+                                 :value      nil}]}]
+      (is (not (m/find-first #(= (:type %) :drill-thru/zoom)
+                             (lib/available-drill-thrus query -1 context)))))))


### PR DESCRIPTION
Fixes #36126
Fixes #36130
Fixes #36133

All three issues were basically the same problem, with the same one-line fix for each; I verified that the skipped tests in #35952 for these issues are now passing. I adapted those tests to Clojure by logging for the query and context that got passed in when running the JS unit tests. So the new tests are Clojure versions of those tests.
