### PR TITLE
Fix erroring migration and add test to exercise MB_DB_AUTOMIGRATE=false option

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -2291,8 +2291,11 @@ databaseChangeLog:
       id: v46.00-090
       author: noahmoss
       comment: Add foreign key constraint on sandboxes.permission_id
-      # This is a revised version of a prior migration (v46.00-075) so it may fail due to the FK constriant already existing
-      failOnError: false
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - foreignKeyConstraintExists:
+                - foreignKeyName: fk_sandboxes_ref_permissions
       changes:
         - addForeignKeyConstraint:
             baseTableName: sandboxes

--- a/test_resources/error-migration.yaml
+++ b/test_resources/error-migration.yaml
@@ -1,0 +1,33 @@
+# This migration intentionally fails but is set with `failOnError: false` to avoid stopping startup. However,
+# this means it won't be logged in the `databasechangelog` table,  causing issues with the `MB_DB_AUTOMIGRATE`
+# env variable as it will still consider this migration as pending. Migrations that have an expected chance of
+# failure should generally use preConditions to detect these cases and mark the migration as ran.
+databaseChangeLog:
+  - changeSet:
+      id: '1'
+      author: noahmoss
+      changes:
+        - createTable:
+            tableName: migration_error_test
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+
+  - changeSet:
+      id: '2'
+      author: noahmoss
+      failOnError: false
+      changes:
+        - createTable:
+            tableName: migration_error_test
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true


### PR DESCRIPTION
Edit: [here's a perhaps clearer description of the issue on Slack](https://metaboat.slack.com/archives/C04K1LEUPC5/p1701790374596419?thread_ts=1701722431.070349&cid=C04K1LEUPC5)

Migration `v46.00-090` had a chance of failing for some customers because it was creating a foreign key constraint that had already been created conditionally in an earlier migration, so it needed to guard against the case where the constraint already exists and ignore it. I did this using `failOnError: false` which allows the app to continue starting up, but this results in a "dirty" migration state where there are migrations which still need to be run successfully. This, then, prevents the app from starting successfully with the `MB_DB_AUTOMIGRATE=false` env var—instead it detects that there's an unrun migration, prints it out for inspection, and exits.

I've fixed this by changing the migration to use a `preCondition` instead, which marks the migration as ran if the condition fails. Did some manual testing to ensure this fixes the `MB_DB_AUTOMIGRATE` options for instances that were previously seeing it fail.

I've also added a test that exercises `MB_DB_AUTOMIGRATE=false` on a fully migrated app DB and ensures it passes, as well as tests that it catches the specific case where `failOnError: false` on a migration which intentionally fails. I think it's hard to be foolproof here but this will catch most of these potential issues.

Closes https://github.com/metabase/metabase/issues/36374 