### PR TITLE
Move upload-csv! to metabase.upload

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -721,13 +721,13 @@
               (with-all-users-data-perms {db-id {:data {:native :none, :schemas {"public"     :all
                                                                                  "not_public" schema-perms}}}}
                 (if can-upload?
-                  (is (some? (api.card-test/upload-example-csv! nil false)))
+                  (is (some? (api.card-test/upload-example-csv-via-api! :grant-permission? false)))
                   (is (thrown-with-msg?
                        clojure.lang.ExceptionInfo
                        #"You don't have permissions to do that\."
-                       (api.card-test/upload-example-csv! nil false)))))
+                       (api.card-test/upload-example-csv-via-api! :grant-permission? false)))))
               (with-all-users-data-perms {db-id {:data {:native :write, :schemas ["not_public"]}}}
-                (is (some? (api.card-test/upload-example-csv! nil false)))))))))))
+                (is (some? (api.card-test/upload-example-csv-via-api! :grant-permission? false)))))))))))
 
 (deftest get-database-can-upload-test
   (mt/test-drivers (disj (mt/normal-drivers-with-feature :uploads) :mysql) ; MySQL doesn't support schemas

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -4,7 +4,6 @@
    [clojure.core.memoize :as memoize]
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]
-   [metabase.api.card-test :as api.card-test]
    [metabase.api.database :as api.database]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.models :refer [Dashboard DashboardCard Database Field FieldValues
@@ -17,6 +16,7 @@
    [metabase.sync :as sync]
    [metabase.sync.concurrent :as sync.concurrent]
    [metabase.test :as mt]
+   [metabase.upload-test :as upload-test]
    [metabase.util :as u]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))
@@ -710,22 +710,24 @@
           (jdbc/execute! conn-spec "CREATE SCHEMA \"not_public\"; CREATE TABLE \"not_public\".\"table_name\" (id INTEGER)"))
         (sync/sync-database! (mt/db))
         (let [db-id    (u/the-id (mt/db))
-              table-id (t2/select-one-pk :model/Table :db_id db-id)]
-          (mt/with-temporary-setting-values [uploads-enabled      true
-                                             uploads-database-id  db-id
-                                             uploads-schema-name  "not_public"
-                                             uploads-table-prefix "uploaded_magic_"]
-            (doseq [[schema-perms can-upload?] {:all            true
-                                                :none           false
-                                                {table-id :all} false}]
-              (with-all-users-data-perms {db-id {:data {:native :none, :schemas {"public"     :all
-                                                                                 "not_public" schema-perms}}}}
-                (if can-upload?
-                  (is (some? (api.card-test/upload-example-csv-via-api! :grant-permission? false)))
-                  (is (= {:status 403, :body {:message "You don't have permissions to do that."}}
-                         (api.card-test/upload-example-csv-via-api! :grant-permission? false)))))
-              (with-all-users-data-perms {db-id {:data {:native :write, :schemas ["not_public"]}}}
-                (is (some? (api.card-test/upload-example-csv-via-api! :grant-permission? false)))))))))))
+              table-id (t2/select-one-pk :model/Table :db_id db-id)
+              upload-csv! (fn []
+                            (upload-test/upload-example-csv! {:grant-permission? false
+                                                              :schema-name       "not_public"
+                                                              :table-prefix      "uploaded_magic_"}))]
+          (doseq [[schema-perms can-upload?] {:all            true
+                                              :none           false
+                                              {table-id :all} false}]
+            (with-all-users-data-perms {db-id {:data {:native :none, :schemas {"public"     :all
+                                                                               "not_public" schema-perms}}}}
+              (if can-upload?
+                (is (some? (upload-csv!)))
+                (is (thrown-with-msg?
+                      clojure.lang.ExceptionInfo
+                      #"You don't have permissions to do that\."
+                      (upload-csv!)))))
+            (with-all-users-data-perms {db-id {:data {:native :write, :schemas ["not_public"]}}}
+              (is (some? (upload-csv!))))))))))
 
 (deftest get-database-can-upload-test
   (mt/test-drivers (disj (mt/normal-drivers-with-feature :uploads) :mysql) ; MySQL doesn't support schemas

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -722,10 +722,8 @@
                                                                                  "not_public" schema-perms}}}}
                 (if can-upload?
                   (is (some? (api.card-test/upload-example-csv-via-api! :grant-permission? false)))
-                  (is (thrown-with-msg?
-                       clojure.lang.ExceptionInfo
-                       #"You don't have permissions to do that\."
-                       (api.card-test/upload-example-csv-via-api! :grant-permission? false)))))
+                  (is (= {:status 403, :body {:message "You don't have permissions to do that."}}
+                         (api.card-test/upload-example-csv-via-api! :grant-permission? false)))))
               (with-all-users-data-perms {db-id {:data {:native :write, :schemas ["not_public"]}}}
                 (is (some? (api.card-test/upload-example-csv-via-api! :grant-permission? false)))))))))))
 

--- a/enterprise/backend/test/metabase_enterprise/upload_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/upload_test.clj
@@ -2,18 +2,13 @@
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.test :as met]
-   [metabase.api.card :as api.card]
    [metabase.test :as mt]
    [metabase.upload-test :as upload-test]))
 
 (deftest uploads-disabled-for-sandboxed-user-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-    (mt/with-temporary-setting-values [uploads-enabled true]
-      (met/with-gtaps-for-user :rasta {:gtaps {:venues {}}}
-        (is (= {:status 403, :body {:message "Uploads are not permitted for sandboxed users."}}
-               (@#'api.card/from-csv!
-                {:collection-id nil
-                 :filename      "star_wars.csv"
-                 :file          (upload-test/csv-file-with ["id,ship,captain"
-                                                            "1,Serenity,Malcolm Reynolds"
-                                                            "2,Millennium Falcon,Han Solo"])})))))))
+    (met/with-gtaps-for-user :rasta {:gtaps {:venues {}}}
+      (is (thrown-with-msg? Exception #"Uploads are not permitted for sandboxed users\."
+            (upload-test/upload-example-csv! {:grant-permission? false
+                                              :schema-name       "not_public"
+                                              :table-prefix      "uploaded_magic_"}))))))

--- a/enterprise/backend/test/metabase_enterprise/upload_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/upload_test.clj
@@ -10,10 +10,10 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
     (mt/with-temporary-setting-values [uploads-enabled true]
       (met/with-gtaps-for-user :rasta {:gtaps {:venues {}}}
-        (is (thrown-with-msg? Exception #"Uploads are not permitted for sandboxed users\."
-                              (api.card/upload-csv!
-                               nil
-                               "star_wars.csv"
-                               (upload-test/csv-file-with ["id,ship,captain"
-                                                           "1,Serenity,Malcolm Reynolds"
-                                                           "2,Millennium Falcon,Han Solo"]))))))))
+        (is (= {:status 403, :body {:message "Uploads are not permitted for sandboxed users."}}
+               (@#'api.card/from-csv!
+                {:collection-id nil
+                 :filename      "star_wars.csv"
+                 :file          (upload-test/csv-file-with ["id,ship,captain"
+                                                            "1,Serenity,Malcolm Reynolds"
+                                                            "2,Millennium Falcon,Han Solo"])})))))))

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -808,7 +808,9 @@
                                      :file          file
                                      :schema-name   (public-settings/uploads-schema-name)
                                      :table-prefix  (public-settings/uploads-table-prefix)
-                                     :db-id         (public-settings/uploads-database-id)})]
+                                     :db-id         (or (public-settings/uploads-database-id)
+                                                        (throw (ex-info (tru "The uploads database is not configured.")
+                                                                        {:status-code 422})))})]
       {:status 200
        :body   (:id model)})
     (catch Throwable e

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -802,9 +802,6 @@
    query     ms/NonBlankString}
   (param-values (api/read-check Card card-id) param-key query))
 
-;;
-;;
-
 (defn- can-upload-error
   "Returns an ExceptionInfo object if the user cannot upload to the given database and schema. Returns nil otherwise."
   [db schema-name]

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -806,7 +806,6 @@
     (let [model (upload/upload-csv! {:collection-id collection-id
                                      :filename      filename
                                      :file          file
-                                     :user-id       @api/*current-user*
                                      :schema-name   (public-settings/uploads-schema-name)
                                      :table-prefix  (public-settings/uploads-table-prefix)
                                      :db-id         (public-settings/uploads-database-id)})]

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -843,7 +843,8 @@
   [db schema-name]
   (nil? (can-upload-error db schema-name)))
 
-(defn- upload-csv!
+(defn- from-csv!
+  "This helper function exists to make testing the POST /api/card/from-csv endpoint easier."
   [{:keys [collection-id filename file]}]
   (try
     (collection/check-write-perms-for-collection collection-id)
@@ -871,8 +872,8 @@
   "Create a table and model populated with the values from the attached CSV. Returns the model ID if successful."
   [:as {raw-params :params}]
   ;; parse-long returns nil with "root" as the collection ID, which is what we want anyway
-  (upload-csv! {:collection-id (parse-long (get raw-params "collection_id"))
-                :filename      (get-in raw-params ["file" :filename])
-                :file          (get-in raw-params ["file" :tempfile])}))
+  (from-csv! {:collection-id (parse-long (get raw-params "collection_id"))
+              :filename      (get-in raw-params ["file" :filename])
+              :file          (get-in raw-params ["file" :tempfile])}))
 
 (api/define-routes)

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -5,7 +5,6 @@
    [compojure.core :refer [DELETE GET POST PUT]]
    [medley.core :as m]
    [metabase.analytics.snowplow :as snowplow]
-   [metabase.api.card :as api.card]
    [metabase.api.common :as api]
    [metabase.api.table :as api.table]
    [metabase.config :as config]
@@ -40,6 +39,7 @@
    [metabase.sync.sync-metadata :as sync-metadata]
    [metabase.sync.util :as sync-util]
    [metabase.task.persist-refresh :as task.persist-refresh]
+   [metabase.upload :as upload]
    [metabase.util :as u]
    [metabase.util.cron :as u.cron]
    [metabase.util.honey-sql-2 :as h2x]
@@ -239,7 +239,7 @@
   (let [uploads-db-id (public-settings/uploads-database-id)]
     (for [db dbs]
       (assoc db :can_upload (and (= (:id db) uploads-db-id)
-                                 (api.card/can-upload? db (public-settings/uploads-schema-name)))))))
+                                 (upload/can-upload? db (public-settings/uploads-schema-name)))))))
 
 (defn- dbs-list
   [& {:keys [include-tables?
@@ -336,7 +336,7 @@
   "Add an entry about whether the user can upload to this DB."
   [db]
   (assoc db :can_upload (and (= (u/the-id db) (public-settings/uploads-database-id))
-                             (api.card/can-upload? db (public-settings/uploads-schema-name)))))
+                             (upload/can-upload? db (public-settings/uploads-schema-name)))))
 
 (api/defendpoint GET "/:id"
   "Get a single Database with `id`. Optionally pass `?include=tables` or `?include=tables.fields` to include the Tables

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -17,7 +17,6 @@
    [metabase.plugins.classloader :as classloader]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.store :as qp.store]
-   [metabase.upload :as upload]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [deferred-tru tru]]
@@ -573,15 +572,15 @@
 (defmethod driver/upload-type->database-type :h2
   [_driver upload-type]
   (case upload-type
-    ::upload/varchar-255              [:varchar]
-    ::upload/text                     [:varchar]
-    ::upload/int                      [:bigint]
-    ::upload/auto-incrementing-int-pk [:bigint :generated-always :as :identity :primary-key]
-    ::upload/float                    [(keyword "DOUBLE PRECISION")]
-    ::upload/boolean                  [:boolean]
-    ::upload/date                     [:date]
-    ::upload/datetime                 [:timestamp]
-    ::upload/offset-datetime          [:timestamp-with-time-zone]))
+    :metabase.upload/varchar-255              [:varchar]
+    :metabase.upload/text                     [:varchar]
+    :metabase.upload/int                      [:bigint]
+    :metabase.upload/auto-incrementing-int-pk [:bigint :generated-always :as :identity :primary-key]
+    :metabase.upload/float                    [(keyword "DOUBLE PRECISION")]
+    :metabase.upload/boolean                  [:boolean]
+    :metabase.upload/date                     [:date]
+    :metabase.upload/datetime                 [:timestamp]
+    :metabase.upload/offset-datetime          [:timestamp-with-time-zone]))
 
 (defmethod driver/table-name-length-limit :h2
   [_driver]

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -10,12 +10,16 @@
    [metabase.analytics.snowplow :as snowplow]
    [metabase.api.common :as api]
    [metabase.driver :as driver]
+   [metabase.driver.sync :as driver.s]
    [metabase.driver.util :as driver.u]
    [metabase.mbql.util :as mbql.u]
    [metabase.models :refer [Database]]
    [metabase.models.card :as card]
+   [metabase.models.collection :as collection]
    [metabase.models.humanization :as humanization]
+   [metabase.models.permissions :as perms]
    [metabase.public-settings :as public-settings]
+   [metabase.public-settings.premium-features :as premium-features]
    [metabase.sync :as sync]
    [metabase.sync.sync-metadata.fields :as sync-fields]
    [metabase.sync.sync-metadata.tables :as sync-tables]
@@ -345,85 +349,129 @@
         (driver/drop-table! driver db-id table-name)
         (throw (ex-info (ex-message e) {:status-code 400}))))))
 
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                                 public interface                                               |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
 (defn- scan-and-sync-table!
   [database table]
   (sync-fields/sync-fields-for-table! database table)
   (future
     (sync/sync-table! table)))
 
+(defn- can-upload-error
+  "Returns an ExceptionInfo object if the user cannot upload to the given database and schema. Returns nil otherwise."
+  [db schema-name]
+  (let [driver (driver.u/database->driver db)]
+    (cond
+      (not (public-settings/uploads-enabled))
+      (ex-info (tru "Uploads are not enabled.")
+               {:status-code 422})
+      (premium-features/sandboxed-user?)
+      (ex-info (tru "Uploads are not permitted for sandboxed users.")
+               {:status-code 403})
+      (not (driver/database-supports? driver :uploads nil))
+      (ex-info (tru "Uploads are not supported on {0} databases." (str/capitalize (name driver)))
+               {:status-code 422})
+      (and (str/blank? schema-name)
+           (driver/database-supports? driver :schemas db))
+      (ex-info (tru "A schema has not been set.")
+               {:status-code 422})
+      (not (perms/set-has-full-permissions? @api/*current-user-permissions-set*
+                                            (perms/data-perms-path (u/the-id db) schema-name)))
+      (ex-info (tru "You don''t have permissions to do that.")
+               {:status-code 403})
+      (and (some? schema-name)
+           (not (driver.s/include-schema? db schema-name)))
+      (ex-info (tru "The schema {0} is not syncable." schema-name)
+               {:status-code 422}))))
 
-;;; +----------------------------------------------------------------------------------------------------------------+
-;;; |                                                 Public Interface                                               |
-;;; +----------------------------------------------------------------------------------------------------------------+
+(defn- check-can-upload
+  "Throws an error if the user cannot upload to the given database and schema."
+  [db schema-name]
+  (when-let [error (can-upload-error db schema-name)]
+    (throw error)))
+
+(defn can-upload?
+  "Returns true if the user can upload to the given database and schema, and false otherwise."
+  [db schema-name]
+  (nil? (can-upload-error db schema-name)))
 
 (defn upload-csv!
   "Main entry point for CSV uploading.
 
   What it does:
+  - throws an error if the user cannot upload to the given database and schema (see [[can-upload-error]] for reasons)
+  - throws an error if the user has write permissions to the given collection
   - detects the schema of the CSV file
   - inserts the data into a new table with a unique name, along with an extra auto-generated primary key column
   - syncs and scans the table
   - creates a model which wraps the table
 
-  Requires that current-user dynamic vars in [[metabase.api.common]] are bound as if by API middleware.
-  Returns the newly created model. May throw validation or DB errors.
+  Requires that current-user dynamic vars in [[metabase.api.common]] are bound as if by API middleware (this is
+  needed for QP permissions checks).
+  Returns the newly created model. May throw validation, permimissions, or DB errors.
 
   Args:
   - `collection-id`: the ID of the collection to create the model in.
   - `filename`: the name of the file being uploaded.
-  - `file`: the file being uploaded. This will be deleted after the upload is complete.
+  - `file`: the file being uploaded.
   - `database`: the database to upload to.
   - `schema-name`: the name of the schema to create the table in (optional).
   - `table-prefix`: the prefix to use for the table name (optional)."
-  [{:keys [collection-id filename ^File file database schema-name table-prefix]}]
-  (try
-    (let [start-time        (System/currentTimeMillis)
-          driver            (driver.u/database->driver database)
-          filename-prefix   (or (second (re-matches #"(.*)\.csv$" filename))
-                                filename)
-          table-name        (->> (str table-prefix filename-prefix)
-                                 (unique-table-name driver)
-                                 (u/lower-case-en))
-          schema+table-name (if (str/blank? schema-name)
-                              table-name
-                              (str schema-name "." table-name))
-          stats             (load-from-csv! driver (:id database) schema+table-name file)
+  [{:keys [collection-id filename ^File file db-id schema-name table-prefix]}]
+  (let [database (or (t2/select-one Database :id db-id)
+                     (throw (ex-info (tru "The uploads database does not exist.")
+                                     {:status-code 422})))]
+    (check-can-upload database schema-name)
+    (collection/check-write-perms-for-collection collection-id)
+    (try
+      (let [start-time        (System/currentTimeMillis)
+            driver            (driver.u/database->driver database)
+            filename-prefix   (or (second (re-matches #"(.*)\.csv$" filename))
+                                  filename)
+            table-name        (->> (str table-prefix filename-prefix)
+                                   (unique-table-name driver)
+                                   (u/lower-case-en))
+            schema+table-name (if (str/blank? schema-name)
+                                table-name
+                                (str schema-name "." table-name))
+            stats             (load-from-csv! driver (:id database) schema+table-name file)
           ;; Sync immediately to create the Table and its Fields; the scan is settings-dependent and can be async
-          table             (sync-tables/create-or-reactivate-table! database {:name table-name :schema (not-empty schema-name)})
-          _set_is_upload    (t2/update! :model/Table (:id table) {:is_upload true})
-          _sync             (scan-and-sync-table! database table)
+            table             (sync-tables/create-or-reactivate-table! database {:name table-name :schema (not-empty schema-name)})
+            _set_is_upload    (t2/update! :model/Table (:id table) {:is_upload true})
+            _sync             (scan-and-sync-table! database table)
           ;; Set the display_name of the auto-generated primary key column to the same as its name, so that if users
           ;; download results from the table as a CSV and reupload, we'll recognize it as the same column
-          auto-pk-field     (t2/select-one :model/Field :table_id (:id table)
-                                           :%lower.name auto-pk-column-name)
-          _                 (t2/update! :model/Field (:id auto-pk-field) {:display_name (:name auto-pk-field)})
-          card              (card/create-card!
-                             {:collection_id          collection-id,
-                              :dataset                true
-                              :database_id            (:id database)
-                              :dataset_query          {:database (:id database)
-                                                       :query    {:source-table (:id table)}
-                                                       :type     :query}
-                              :display                :table
-                              :name                   (humanization/name->human-readable-name filename-prefix)
-                              :visualization_settings {}}
-                             @api/*current-user*)
-          upload-seconds    (/ (- (System/currentTimeMillis) start-time)
-                               1000.0)]
-      (snowplow/track-event! ::snowplow/csv-upload-successful
-                             api/*current-user-id*
-                             (merge
-                              {:model-id       (:id card)
-                               :upload-seconds upload-seconds}
-                              stats))
-      card)
-    (catch Throwable e
-      (let [fail-stats (with-open [reader (bom/bom-reader file)]
-                         (let [rows (csv/read-csv reader)]
-                           {:size-mb     (/ (.length file) 1048576.0)
-                            :num-columns (count (first rows))
-                            :num-rows    (count (rest rows))}))]
-        (snowplow/track-event! ::snowplow/csv-upload-failed api/*current-user-id* fail-stats))
+            auto-pk-field     (t2/select-one :model/Field :table_id (:id table)
+                                             :%lower.name auto-pk-column-name)
+            _                 (t2/update! :model/Field (:id auto-pk-field) {:display_name (:name auto-pk-field)})
+            card              (card/create-card!
+                               {:collection_id          collection-id,
+                                :dataset                true
+                                :database_id            (:id database)
+                                :dataset_query          {:database (:id database)
+                                                         :query    {:source-table (:id table)}
+                                                         :type     :query}
+                                :display                :table
+                                :name                   (humanization/name->human-readable-name filename-prefix)
+                                :visualization_settings {}}
+                               @api/*current-user*)
+            upload-seconds    (/ (- (System/currentTimeMillis) start-time)
+                                 1000.0)]
+        (snowplow/track-event! ::snowplow/csv-upload-successful
+                               api/*current-user-id*
+                               (merge
+                                {:model-id       (:id card)
+                                 :upload-seconds upload-seconds}
+                                stats))
+        card)
+      (catch Throwable e
+        (let [fail-stats (with-open [reader (bom/bom-reader file)]
+                           (let [rows (csv/read-csv reader)]
+                             {:size-mb     (/ (.length file) 1048576.0)
+                              :num-columns (count (first rows))
+                              :num-rows    (count (rest rows))}))]
+          (snowplow/track-event! ::snowplow/csv-upload-failed api/*current-user-id* fail-stats))
 
-      (throw e))
-    (finally (.delete file))))
+        (throw e)))))

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -361,15 +361,15 @@
 
   What it does:
   - detects the schema of the CSV file
-  - inserts the data it into the database
-  - syncs and scans the new table
-  - creates a model
+  - inserts the data into a new table with a unique name, along with an extra auto-generated primary key column
+  - syncs and scans the table
+  - creates a model which wraps the table
 
   Requires that current-user dynamic vars in [[metabase.api.common]] are bound as if by API middleware.
   Returns the newly created model. May throw validation or DB errors.
 
   Args:
-  - `collection-id`: the ID of the collection to upload to.
+  - `collection-id`: the ID of the collection to create the model in.
   - `filename`: the name of the file being uploaded.
   - `file`: the file being uploaded. This will be deleted after the upload is complete.
   - `database`: the database to upload to.

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -16,8 +16,17 @@
    [metabase.events.view-log-test :as view-log-test]
    [metabase.http-client :as client]
    [metabase.models
-    :refer [CardBookmark Collection Dashboard Database ModerationReview
-            Pulse PulseCard PulseChannel PulseChannelRecipient Table Timeline
+    :refer [CardBookmark
+            Collection
+            Dashboard
+            Database
+            ModerationReview
+            Pulse
+            PulseCard
+            PulseChannel
+            PulseChannelRecipient
+            Table
+            Timeline
             TimelineEvent]]
    [metabase.models.moderation-review :as moderation-review]
    [metabase.models.permissions :as perms]

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2863,10 +2863,17 @@
                    (t2/select-one-pk :model/Card :database_id (mt/id)))))))
       (testing "Failure paths return an appropriate status code and a message in the body"
         (mt/with-temporary-setting-values [uploads-enabled true
+                                           uploads-database-id nil
+                                           uploads-table-prefix nil
+                                           uploads-schema-name "PUBLIC"]
+          (is (= {:body   {:message "The uploads database is not configured."},
+                  :status 422}
+                 (upload-example-csv-via-api!))))
+        (mt/with-temporary-setting-values [uploads-enabled true
                                            uploads-database-id Integer/MAX_VALUE
                                            uploads-table-prefix nil
                                            uploads-schema-name "PUBLIC"]
-          (is (= {:body {:message "The uploads database does not exist."},
+          (is (= {:body   {:message "The uploads database does not exist."},
                   :status 422}
                  (upload-example-csv-via-api!))))))))
 

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2847,7 +2847,7 @@
                                  grant-permission?)]
       (when grant?
         (perms/grant-permissions! group-id (perms/data-perms-path (mt/id))))
-      (u/prog1 (@#'api.card/upload-csv! {:collection-id collection-id
+      (u/prog1 (@#'api.card/from-csv! {:collection-id collection-id
                                          :filename      filename
                                          :file          file})
         (when grant?

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2853,16 +2853,17 @@
   (mt/test-driver :h2
     (mt/with-empty-db
       (testing "Happy path"
-        (mt/with-temporary-setting-values [uploads-database-id (mt/id)
+        (mt/with-temporary-setting-values [uploads-enabled true
+                                           uploads-database-id (mt/id)
                                            uploads-table-prefix nil
-                                           uploads-schema-name "PUBLIC"]
-          (let [{:keys [status body]} (upload-example-csv-via-api!)]
+                                           uploads-schema-name "PUBLIC"]          (let [{:keys [status body]} (upload-example-csv-via-api!)]
             (is (= 200
                    status))
             (is (= body
                    (t2/select-one-pk :model/Card :database_id (mt/id)))))))
       (testing "Failure paths return an appropriate status code and a message in the body"
-        (mt/with-temporary-setting-values [uploads-database-id Integer/MAX_VALUE
+        (mt/with-temporary-setting-values [uploads-enabled true
+                                           uploads-database-id Integer/MAX_VALUE
                                            uploads-table-prefix nil
                                            uploads-schema-name "PUBLIC"]
           (is (= {:body {:message "The uploads database does not exist."},

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2848,8 +2848,8 @@
       (when grant?
         (perms/grant-permissions! group-id (perms/data-perms-path (mt/id))))
       (u/prog1 (@#'api.card/from-csv! {:collection-id collection-id
-                                         :filename      filename
-                                         :file          file})
+                                       :filename      filename
+                                       :file          file})
         (when grant?
           (perms/revoke-data-perms! group-id (mt/id)))))))
 

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -6,9 +6,13 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [java-time.api :as t]
+   [metabase.analytics.snowplow-test :as snowplow-test]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.models :refer [Field Table]]
+   [metabase.models.interface :as mi]
+   [metabase.models.permissions :as perms]
+   [metabase.models.permissions-group :as perms-group]
    [metabase.query-processor :as qp]
    [metabase.sync :as sync]
    [metabase.test :as mt]
@@ -230,7 +234,7 @@
       (is (=? (with-ai-id {:name             vchar-type
                            :age              int-type
                            :favorite_pokemon vchar-type})
-              (upload/detect-schema
+              (@#'upload/detect-schema
                (csv-file-with ["Name, Age, Favorite Pokémon"
                                "Tim, 12, Haunter"
                                "Ryan, 97, Paras"])))))
@@ -238,7 +242,7 @@
       (is (=? (with-ai-id {:name       vchar-type
                            :height     int-type
                            :birth_year float-type})
-              (upload/detect-schema
+              (@#'upload/detect-schema
                (csv-file-with ["Name, Height, Birth Year"
                                "Luke Skywalker, 172, -19"
                                "Darth Vader, 202, -41.9"
@@ -248,7 +252,7 @@
       (is (=? (with-ai-id {:name       vchar-type
                            :height     float-type
                            :birth_year vchar-type})
-              (upload/detect-schema
+              (@#'upload/detect-schema
                (csv-file-with ["Name, Height, Birth Year"
                                "Rey Skywalker, 170, 15"
                                "Darth Vader, 202.0, 41.9BBY"])))))
@@ -257,7 +261,7 @@
                            :is_jedi_      bool-type
                            :is_jedi__int_ int-type
                            :is_jedi__vc_  vchar-type})
-              (upload/detect-schema
+              (@#'upload/detect-schema
                (csv-file-with ["Name, Is Jedi?, Is Jedi (int), Is Jedi (VC)"
                                "Rey Skywalker, yes, true, t"
                                "Darth Vader, YES, TRUE, Y"
@@ -268,23 +272,23 @@
         (is (= (map keyword (str/split header #","))
                (keys
                 (:extant-columns
-                 (upload/detect-schema
+                 (@#'upload/detect-schema
                   (csv-file-with [header
                                   "Luke,ah'm,yer,da,,,missing,columns,should,not,matter"]))))))))
     (testing "Empty contents (with header) are okay"
       (is (=? (with-ai-id {:name     text-type
                            :is_jedi_ text-type})
-              (upload/detect-schema
+              (@#'upload/detect-schema
                (csv-file-with ["Name, Is Jedi?"])))))
     (testing "Completely empty contents are okay"
       (is (=? (with-ai-id {})
-              (upload/detect-schema
+              (@#'upload/detect-schema
                (csv-file-with [""])))))
     (testing "CSV missing data in the top row"
       (is (=? (with-ai-id {:name       vchar-type
                            :height     int-type
                            :birth_year float-type})
-              (upload/detect-schema
+              (@#'upload/detect-schema
                (csv-file-with ["Name, Height, Birth Year"
                               ;; missing column
                                "Watto, 137"
@@ -297,7 +301,7 @@
                                    :name       vchar-type
                                    :weapon     vchar-type}
                :generated-columns {:_mb_row_id auto-pk-type}}
-              (upload/detect-schema
+              (@#'upload/detect-schema
                (csv-file-with ["_mb_row_id,ship,name,weapon"
                                "1,Serenity,Malcolm Reynolds,Pistol"
                                "2,Millennium Falcon, Han Solo,Blaster"])))))
@@ -307,7 +311,7 @@
                                    :name       vchar-type
                                    :weapon     vchar-type}
                :generated-columns {:_mb_row_id auto-pk-type}}
-              (upload/detect-schema
+              (@#'upload/detect-schema
                (csv-file-with ["id,ship,name,weapon"
                                "1,Serenity,Malcolm Reynolds,Pistol"
                                "2,Millennium Falcon, Han Solo,Blaster"])))))))
@@ -319,7 +323,7 @@
                            :not_date     vchar-type
                            :datetime     datetime-type
                            :not_datetime vchar-type})
-              (upload/detect-schema
+              (@#'upload/detect-schema
                (csv-file-with ["Date      ,Not Date  ,Datetime           ,Not datetime       "
                                "2022-01-01,2023-02-28,2022-01-01T00:00:00,2023-02-28T00:00:00"
                                "2022-02-01,2023-02-29,2022-01-01T00:00:00,2023-02-29T00:00:00"])))))))
@@ -329,7 +333,7 @@
     (testing "Dates"
       (is (=? (with-ai-id {:offset_datetime offset-dt-type
                            :not_datetime   vchar-type})
-              (upload/detect-schema
+              (@#'upload/detect-schema
                (csv-file-with ["Offset Datetime,Not Datetime"
                                "2022-01-01T00:00:00-01:00,2023-02-28T00:00:00-01:00"
                                "2022-01-01T00:00:00-01:00,2023-02-29T00:00:00-01:00"
@@ -338,9 +342,9 @@
 (deftest ^:parallel unique-table-name-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
     (testing "File name is slugified"
-      (is (=? #"my_file_name_\d+" (#'upload/unique-table-name driver/*driver* "my file name"))))
+      (is (=? #"my_file_name_\d+" (@#'upload/unique-table-name driver/*driver* "my file name"))))
     (testing "semicolons are removed"
-      (is (nil? (re-find #";" (#'upload/unique-table-name driver/*driver* "some text; -- DROP TABLE.csv")))))))
+      (is (nil? (re-find #";" (@#'upload/unique-table-name driver/*driver* "some text; -- DROP TABLE.csv")))))))
 
 (deftest load-from-csv-table-name-test
   (testing "Upload a CSV file"
@@ -348,8 +352,8 @@
       (mt/with-empty-db
         (let [file       (csv-file-with ["id" "2" "3"])]
           (testing "Can upload two files with the same name"
-            (is (some? (upload/load-from-csv! driver/*driver* (mt/id) (format "table_name_%s" driver/*driver*) file)))
-            (is (some? (upload/load-from-csv! driver/*driver* (mt/id) (format "table_name_2_%s" driver/*driver*) file)))))))))
+            (is (some? (@#'upload/load-from-csv! driver/*driver* (mt/id) (format "table_name_%s" driver/*driver*) file)))
+            (is (some? (@#'upload/load-from-csv! driver/*driver* (mt/id) (format "table_name_2_%s" driver/*driver*) file)))))))))
 
 (defn- query-table
   [table]
@@ -372,7 +376,7 @@
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (with-mysql-local-infile-on-and-off
         (mt/with-empty-db
-          (upload/load-from-csv!
+          (@#'upload/load-from-csv!
            driver/*driver*
            (mt/id)
            "upload_test"
@@ -420,7 +424,7 @@
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (with-mysql-local-infile-on-and-off
         (mt/with-empty-db
-          (upload/load-from-csv!
+          (@#'upload/load-from-csv!
            driver/*driver*
            (mt/id)
            "upload_test"
@@ -455,7 +459,7 @@
                                   ["2022-01-01T12:00:00+07"    "2022-01-01T05:00:00Z"]
                                   ["2022-01-01T12:00:00+07:00" "2022-01-01T05:00:00Z"]
                                   ["2022-01-01T12:00:00+07:30" "2022-01-01T04:30:00Z"]]]
-              (upload/load-from-csv!
+              (@#'upload/load-from-csv!
                driver/*driver*
                (mt/id)
                "upload_test"
@@ -477,7 +481,7 @@
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (with-mysql-local-infile-on-and-off
         (mt/with-empty-db
-          (upload/load-from-csv!
+          (@#'upload/load-from-csv!
            driver/*driver*
            (mt/id)
            "upload_test"
@@ -522,10 +526,10 @@
         (is (pos? length-limit) "driver/table-name-length-limit has been set")
         (with-mysql-local-infile-on-and-off
           (mt/with-empty-db
-            (upload/load-from-csv!
+            (@#'upload/load-from-csv!
              driver/*driver*
              (mt/id)
-             (upload/unique-table-name driver/*driver* long-name)
+             (@#'upload/unique-table-name driver/*driver* long-name)
              (csv-file-with ["number,bool"
                              "1,true"
                              "2,false"
@@ -545,7 +549,7 @@
   (testing "Upload a CSV file with a blank column name"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (mt/with-empty-db
-        (upload/load-from-csv!
+        (@#'upload/load-from-csv!
          driver/*driver*
          (mt/id)
          "upload_test"
@@ -565,7 +569,7 @@
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (with-mysql-local-infile-on-and-off
         (mt/with-empty-db
-          (upload/load-from-csv!
+          (@#'upload/load-from-csv!
            driver/*driver*
            (mt/id)
            "upload_test"
@@ -585,7 +589,7 @@
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (with-mysql-local-infile-on-and-off
         (mt/with-empty-db
-          (upload/load-from-csv!
+          (@#'upload/load-from-csv!
            driver/*driver*
            (mt/id)
            "upload_test"
@@ -612,7 +616,7 @@
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (with-mysql-local-infile-on-and-off
         (mt/with-empty-db
-          (upload/load-from-csv!
+          (@#'upload/load-from-csv!
            driver/*driver*
            (mt/id)
            "upload_test"
@@ -638,7 +642,7 @@
       (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
         (with-mysql-local-infile-on-and-off
           (mt/with-empty-db
-            (upload/load-from-csv!
+            (@#'upload/load-from-csv!
              driver/*driver*
              (mt/id)
              "upload_test"
@@ -659,7 +663,7 @@
       (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
         (with-mysql-local-infile-on-and-off
           (mt/with-empty-db
-            (upload/load-from-csv!
+            (@#'upload/load-from-csv!
              driver/*driver*
              (mt/id)
              "upload_test"
@@ -680,7 +684,7 @@
       (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
         (with-mysql-local-infile-on-and-off
           (mt/with-empty-db
-            (upload/load-from-csv!
+            (@#'upload/load-from-csv!
              driver/*driver*
              (mt/id)
              "upload_test"
@@ -703,7 +707,7 @@
     (with-mysql-local-infile-on-and-off
       (mt/with-empty-db
         (testing "Can upload a CSV with missing values"
-          (upload/load-from-csv!
+          (@#'upload/load-from-csv!
            driver/*driver*
            (mt/id)
            "upload_test"
@@ -726,7 +730,7 @@
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (with-mysql-local-infile-on-and-off
         (mt/with-empty-db
-          (upload/load-from-csv!
+          (@#'upload/load-from-csv!
            driver/*driver*
            (mt/id)
            "upload_test"
@@ -749,7 +753,7 @@
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (with-mysql-local-infile-on-and-off
         (mt/with-empty-db
-          (upload/load-from-csv!
+          (@#'upload/load-from-csv!
            driver/*driver*
            (mt/id)
            "upload_test"
@@ -772,7 +776,7 @@
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (with-mysql-local-infile-on-and-off
         (mt/with-empty-db
-          (upload/load-from-csv!
+          (@#'upload/load-from-csv!
            driver/*driver*
            (mt/id)
            "upload_test"
@@ -794,7 +798,7 @@
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (with-mysql-local-infile-on-and-off
         (mt/with-empty-db
-          (upload/load-from-csv!
+          (@#'upload/load-from-csv!
            driver/*driver*
            (mt/id)
            "upload_test"
@@ -817,7 +821,7 @@
   (testing "Upload a CSV file with Postgres's 'end of input' marker"
     (mt/test-drivers [:postgres]
       (mt/with-empty-db
-        (upload/load-from-csv!
+        (@#'upload/load-from-csv!
          driver/*driver*
          (mt/id)
          "upload_test"
@@ -850,3 +854,144 @@
                           (jdbc/query "show global variables like 'local_infile'")
                           first
                           :value))))))))
+
+;; Cal TODO: move this to driver test multimethod
+(defn- supports-schemas? [driver]
+  (not= driver :mysql))
+
+(defn- upload-example-csv!
+  "Upload a small CSV file to the given collection ID"
+  [& {:keys [schema-name table-prefix collection-id grant-permission?]
+      :or {collection-id     nil ;; root collection
+           grant-permission? true}}]
+  (mt/with-temporary-setting-values [uploads-enabled true]
+    (mt/with-current-user (mt/user->id :rasta)
+      (let [;; Make the file-name unique so the table names don't collide
+            csv-file-name     (str "example csv file " (random-uuid) ".csv")
+            file              (csv-file-with
+                               ["id, name"
+                                "1, Luke Skywalker"
+                                "2, Darth Vader"]
+                               csv-file-name)
+            group-id          (u/the-id (perms-group/all-users))
+            can-already-read? (mi/can-read? (mt/db))
+            grant?            (and (not can-already-read?)
+                                   grant-permission?)]
+        (when grant?
+          (perms/grant-permissions! group-id (perms/data-perms-path (mt/id))))
+        (u/prog1 (upload/upload-csv! {:collection-id collection-id
+                                      :filename      csv-file-name
+                                      :file          file
+                                      :database      (mt/db)
+                                      :schema-name   schema-name
+                                      :table-prefix  table-prefix})
+          (when grant?
+            (perms/revoke-data-perms! group-id (mt/id))))))))
+
+(deftest upload-csv!-schema-test
+  (mt/test-drivers (filter supports-schemas? (mt/normal-drivers-with-feature :uploads))
+    (mt/with-empty-db
+      (let [db                   (mt/db)
+            db-id                (u/the-id db)
+            original-sync-values (select-keys db [:is_on_demand :is_full_sync])
+            in-future?           (atom false)
+            _                    (t2/update! :model/Database db-id {:is_on_demand false
+                                                                    :is_full_sync false})]
+        (try
+          (with-redefs [ ;; do away with the `future` invocation since we don't want race conditions in a test
+                        future-call (fn [thunk]
+                                      (swap! in-future? (constantly true))
+                                      (thunk))]
+            (testing "Happy path with schema, and without table-prefix"
+              ;; create not_public schema in the db
+              (let [details (mt/dbdef->connection-details driver/*driver* :db {:database-name (:name (mt/db))})]
+                (jdbc/execute! (sql-jdbc.conn/connection-details->spec driver/*driver* details)
+                               ["CREATE SCHEMA \"not_public\";"]))
+              (let [new-model (upload-example-csv! :schema-name "not_public")
+                    new-table (t2/select-one Table :db_id db-id)]
+                (is (=? {:display          :table
+                         :database_id      db-id
+                         :dataset_query    {:database db-id
+                                            :query    {:source-table (:id new-table)}
+                                            :type     :query}
+                         :creator_id       (mt/user->id :rasta)
+                         :name             #"(?i)example csv file(.*)"
+                         :collection_id    nil} new-model)
+                    "A new model is created")
+                (is (=? {:name      #"(?i)example(.*)"
+                         :schema    #"(?i)not_public"
+                         :is_upload true}
+                        new-table)
+                    "A new table is created")
+                (is (= "complete"
+                       (:initial_sync_status new-table))
+                    "The table is synced and marked as complete")
+                (is (= #{["_mb_row_id" :type/PK]
+                         ["id"   :type/PK]
+                         ["name" :type/Name]}
+                       (->> (t2/select Field :table_id (:id new-table))
+                            (map (fn [field] [(u/lower-case-en (:name field))
+                                              (:semantic_type field)]))
+                            set))
+                    "The sync actually runs")
+                (is (true? @in-future?)
+                    "Table has been synced in a separate thread"))))
+          (finally
+            (t2/update! :model/Database db-id original-sync-values)))))))
+
+(deftest upload-csv!-table-prefix-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
+    (mt/with-empty-db
+      (let [db-id (u/the-id (mt/db))]
+        (testing "Happy path with table prefix, and without schema"
+          (let [new-model (upload-example-csv! :schema-name nil, :table-prefix "uploaded_magic_")
+                new-table (t2/select-one Table :db_id db-id)]
+            (is (=? {:name #"(?i)example csv file(.*)"}
+                    new-model))
+            (is (=? {:name #"(?i)uploaded_magic_example(.*)"}
+                    new-table))
+            (is (nil? (:schema new-table)))))))))
+
+(deftest upload-csv!-auto-pk-column-display-name-test
+  (testing "The auto-generated column display_name should be the same as its name"
+   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
+     (mt/with-empty-db
+       (let [db-id (u/the-id (mt/db))]
+         (when (supports-schemas? driver/*driver*)
+           (let [details (mt/dbdef->connection-details driver/*driver* :db {:database-name (:name (mt/db))})]
+             (jdbc/execute! (sql-jdbc.conn/connection-details->spec driver/*driver* details)
+                            ["CREATE SCHEMA \"not_public\";"])))
+         (upload-example-csv! {:schema-name (if (supports-schemas? driver/*driver*)
+                                              "not_public"
+                                              nil)
+                               :table-prefix "uploads_"})
+         (let [new-table (t2/select-one Table :db_id db-id)
+               new-field (t2/select-one Field :table_id (:id new-table) :name "_mb_row_id")]
+           (is (= "_mb_row_id"
+                  (:name new-field)
+                  (:display_name new-field)))))))))
+
+(deftest csv-upload-snowplow-test
+  (mt/test-driver :h2
+    (mt/with-empty-db
+      (snowplow-test/with-fake-snowplow-collector
+        (upload-example-csv!)
+        (is (=? {:data {"model_id"        pos?
+                        "size_mb"         3.910064697265625E-5
+                        "num_columns"     2
+                        "num_rows"        2
+                        "upload_seconds"  pos?
+                        "event"           "csv_upload_successful"}
+                 :user-id (str (mt/user->id :rasta))}
+                (last (snowplow-test/pop-event-data-and-user-id!))))
+        (with-redefs [upload/load-from-csv! (fn [_ _ _ _]
+                                              (throw (Exception.)))]
+          (try (upload-example-csv! :schema-name "PUBLIC")
+               (catch Throwable _
+                 nil))
+          (is (= {:data {"size_mb"     3.910064697265625E-5
+                         "num_columns" 2
+                         "num_rows"    2
+                         "event"       "csv_upload_failed"}
+                  :user-id (str (mt/user->id :rasta))}
+                 (last (snowplow-test/pop-event-data-and-user-id!)))))))))

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1016,15 +1016,6 @@
                 java.lang.Exception
                 #"^Uploads are not enabled\.$"
                 (upload-example-csv! :uploads-enabled uploads-enabled-value :schema-name "public", :table-prefix "uploaded_magic_")))))
-      (testing "Database ID must be set"
-        (mt/with-temporary-setting-values [uploads-enabled      true
-                                           uploads-database-id  nil
-                                           uploads-schema-name  "public"
-                                           uploads-table-prefix "uploaded_magic_"]
-          (is (thrown-with-msg?
-                java.lang.Exception
-                #"^The uploads database does not exist\.$"
-                (upload-example-csv! :db-id nil, :schema-name "public", :table-prefix "uploaded_magic_")))))
       (testing "Database ID must be valid"
         (is (thrown-with-msg?
               java.lang.Exception


### PR DESCRIPTION
This PR is a refactoring of the interface to the upload code. It moves most of the logic from `metabase.api.card/upload-csv!` to `metabase.upload/upload-csv!`. Reading settings values is kept in the api namespace to minimise the amount of global state `metabase.upload/upload-csv!` depends on.

The purpose of this refactoring is to allow adding new interfaces for the uploads model such as appending or replacing data, which can reuse some of the implementation of the `upload-csv!` function.