### PR TITLE
Backport: dashboard_tab.entity_id is nullable now, makes drop-entity-ids work 

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -15108,6 +15108,17 @@ databaseChangeLog:
                     nullable: true
                     unique: true
 
+  - changeSet:
+      id: v47.00-059
+      author: piranha
+      comment: 'Drops not null from dashboard_tab.entity_id since it breaks drop-entity-ids command'
+      changes:
+        - dropNotNullConstraint:
+            tableName: dashboard_tab
+            columnName: entity_id
+            columnDataType: char(21)
+      rollback: # noop, and 'drop not null' is a noop if it's dropped already
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################


### PR DESCRIPTION
Backport of #36401, for #36365