### PR TITLE
docs - max retention

### DIFF
--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -191,7 +191,7 @@ Only available on Metabase [Pro](https://www.metabase.com/product/pro) and [Ente
 Type: integer<br>
 Default: 0 (Metabase keeps all rows)<br>
 
-Sets the maximum number of days Metabase preserves rows in the following application database tables:
+Sets the maximum number of days Metabase preserves rows for the following application database tables:
 
 - `query_execution`
 - `audit_log`

--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -191,7 +191,11 @@ Only available on Metabase [Pro](https://www.metabase.com/product/pro) and [Ente
 Type: integer<br>
 Default: 0 (Metabase keeps all rows)<br>
 
-Sets the maximum number of days Metabase preserves rows in the `query_execution` table in the application database.
+Sets the maximum number of days Metabase preserves rows in the following application database tables:
+
+- `query_execution`
+- `audit_log`
+- `view_log`
 
 Twice a day, Metabase will delete rows older than this threshold.
 

--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -189,7 +189,7 @@ Maximum number of async Jetty threads. If not set, then [MB_JETTY_MAXTHREADS](#m
 
 Only available on Metabase [Pro](https://www.metabase.com/product/pro) and [Enterprise](https://www.metabase.com/product/enterprise) plans.<br>
 Type: integer<br>
-Default: 0 (Metabase keeps all rows)<br>
+Default: 720 (Metabase keeps all rows)<br>
 
 Sets the maximum number of days Metabase preserves rows for the following application database tables:
 


### PR DESCRIPTION
Updates list of tables for `MB_AUDIT_MAX_RETENTION_DAYS`.

See https://github.com/metabase/metabase/issues/34985.