### PR TITLE
Automate (most of) updating translations

### DIFF
--- a/.github/workflows/translation-update.yml
+++ b/.github/workflows/translation-update.yml
@@ -58,7 +58,7 @@ jobs:
         gh pr create \
           --base "${CURRENT_BRANCH_NAME}" \
           --head "${BACKPORT_BRANCH}" \
-          --assignee "${GITHUB_ACTOR}" \
+          --reviewer "${GITHUB_ACTOR}" \
           --title "Import Translations for v${MAJOR_VERSION}" \
           --body "Imported translations from POEditor for v${MAJOR_VERSION}"
 

--- a/.github/workflows/translation-update.yml
+++ b/.github/workflows/translation-update.yml
@@ -1,0 +1,65 @@
+name: Update Translations
+on:
+  workflow_dispatch:
+    inputs:
+      step:
+        type: choice
+        description: Upload untranslated strings | Download translated strings
+        options:
+          - upload
+          - download
+
+jobs:
+  manage-translations:
+    name: Manage Translations
+    permissions: write-all
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    env:
+      POEDITOR_API_TOKEN: ${{ secrets.POEDITOR_API_TOKEN }}
+    steps:
+    - name: Prepare front-end environment
+      uses: ./.github/actions/prepare-frontend
+    - name: Prepare back-end environment
+      uses: ./.github/actions/prepare-backend
+      with:
+        m2-cache-key: manage-translations
+
+    # - name: Check for untranslated strings TODO
+
+    - name: Upload strings to be translated
+      if: ${{ inputs.step }} == 'upload'
+      run: | # sh
+        ./bin/i18n/update-translation-template
+        ./bin/i18n/export-pot-to-poeditor
+        echo "Strings uploaded to POEditor. Don't forget to notify contributors"
+
+    - name: Download translated strings
+      if: ${{ inputs.step }} == 'download'
+      run: | # sh
+        ./bin/i18n/import-po-from-poeditor
+        ./bin/i18n/build-translation-resources
+    - name: Commit changes
+      if: ${{ inputs.step }} == 'download'
+      run: | # sh
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+
+        CURRENT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+        MAJOR_VERSION=$(echo "${CURRENT_BRANCH_NAME}" | tr -d -c 0-9)
+        BRANCH_NAME="update-translations-v${MAJOR_VERSION}"
+
+        git checkout -b ${BRANCH_NAME}
+        git add locales/
+
+        git commit -m "Update translations"
+        git push -u origin ${BRANCH_NAME}
+
+        gh pr create \
+          --base "${CURRENT_BRANCH_NAME}" \
+          --head "${BACKPORT_BRANCH}" \
+          --assignee "${GITHUB_ACTOR}" \
+          --title "Import Translations for v${MAJOR_VERSION}" \
+          --body "Imported translations from POEditor for v${MAJOR_VERSION}"
+
+

--- a/.github/workflows/translation-update.yml
+++ b/.github/workflows/translation-update.yml
@@ -8,6 +8,11 @@ on:
         options:
           - upload
           - download
+        required: true
+      version:
+        type: string
+        description: The version number to update translations
+        required: true
 
 jobs:
   manage-translations:
@@ -46,8 +51,8 @@ jobs:
         git config user.email github-actions@github.com
 
         CURRENT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-        MAJOR_VERSION=$(echo "${CURRENT_BRANCH_NAME}" | tr -d -c 0-9)
-        BRANCH_NAME="update-translations-v${MAJOR_VERSION}"
+        VERSION="${{inputs.version}}"
+        BRANCH_NAME="update-translations-v${VERSION}"
 
         git checkout -b ${BRANCH_NAME}
         git add locales/
@@ -59,7 +64,7 @@ jobs:
           --base "${CURRENT_BRANCH_NAME}" \
           --head "${BACKPORT_BRANCH}" \
           --reviewer "${GITHUB_ACTOR}" \
-          --title "Import Translations for v${MAJOR_VERSION}" \
-          --body "Imported translations from POEditor for v${MAJOR_VERSION}"
+          --title "Import Translations for v${VERSION}" \
+          --body "Imported translations from POEditor for v${VERSION}"
 
 

--- a/.github/workflows/translation-update.yml
+++ b/.github/workflows/translation-update.yml
@@ -11,18 +11,25 @@ on:
         required: true
       version:
         type: string
-        description: The version number to update translations
+        description: "The version number for which to update translations (e.g. 43, 58.7)"
         required: true
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
-  manage-translations:
-    name: Manage Translations
-    permissions: write-all
+  upload-translations:
+    name: Upload Translations
+    if: ${{ inputs.step }} == 'upload'
     runs-on: ubuntu-22.04
-    timeout-minutes: 10
+    timeout-minutes: 20
     env:
       POEDITOR_API_TOKEN: ${{ secrets.POEDITOR_API_TOKEN }}
+      VERSION: ${{ inputs.version }}
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
     - name: Prepare front-end environment
       uses: ./.github/actions/prepare-frontend
     - name: Prepare back-end environment
@@ -30,41 +37,93 @@ jobs:
       with:
         m2-cache-key: manage-translations
 
-    # - name: Check for untranslated strings TODO
+    # TODO: check for untranslated strings
 
     - name: Upload strings to be translated
-      if: ${{ inputs.step }} == 'upload'
       run: | # sh
         ./bin/i18n/update-translation-template
         ./bin/i18n/export-pot-to-poeditor
-        echo "Strings uploaded to POEditor. Don't forget to notify contributors"
+        echo "Strings uploaded to POEditor. Don't forget to notify contributors and copy source strings to English language."
 
-    - name: Download translated strings
-      if: ${{ inputs.step }} == 'download'
-      run: | # sh
-        ./bin/i18n/import-po-from-poeditor
-        ./bin/i18n/build-translation-resources
     - name: Commit changes
-      if: ${{ inputs.step }} == 'download'
       run: | # sh
         git config user.name github-actions
         git config user.email github-actions@github.com
 
-        CURRENT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-        VERSION="${{inputs.version}}"
-        BRANCH_NAME="update-translations-v${VERSION}"
+        BRANCH_NAME="update-translations-v$VERSION"
 
-        git checkout -b ${BRANCH_NAME}
+        git checkout -b $BRANCH_NAME
+        git add locales/
+
+        git commit -m "Add new strings for v$VERSION"
+        git push -u origin $BRANCH_NAME
+
+        gh pr create \
+        --reviewer "${GITHUB_ACTOR}" \
+        --assignee "${GITHUB_ACTOR}" \
+        --title "Update Translations for v$VERSION" \
+        --body "Update translations from POEditor for v$VERSION
+
+        See [translation update documentation](https://www.notion.so/metabase/Process-for-updating-translations-421db70048fe400da1153ad0b61102f4)
+
+        ## To Do
+
+        - [x] Upload new strings to POEditor
+        - [ ] Message contributors on POEditor (manual)
+        - [ ] Copy source strings to english language (manual)
+        - [ ] Download translations from POEditor (github action)
+        - [ ] Merge this PR and backport to the release branch (manual)
+        "
+        --label "backport" \
+        --label "Customization/i18n"
+
+    # TODO: notify contributors
+    # TODO: copy source strings to english language
+
+  download-translations:
+    name: Upload Translations
+    if: ${{ inputs.step }} == 'download'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    env:
+      POEDITOR_API_TOKEN: ${{ secrets.POEDITOR_API_TOKEN }}
+      VERSION: ${{ inputs.version }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Prepare front-end environment
+      uses: ./.github/actions/prepare-frontend
+    - name: Prepare back-end environment
+      uses: ./.github/actions/prepare-backend
+      with:
+        m2-cache-key: manage-translations
+
+    - name: Prepare build scripts
+      run: cd ${{ github.workspace }}/release && yarn && yarn build
+    - name: Automatically translate untranslated strings
+      uses: actions/github-script@v7
+      with:
+        script: | # js
+          const { autoTranslateSupportedLanguages } = require('${{ github.workspace }}/release/dist/index.cjs');
+
+          await autoTranslateSupportedLanguages();
+
+    - name: Download translated strings
+      run: | # sh
+        cd ${{ github.workspace }}
+        ./bin/i18n/import-po-from-poeditor
+        ./bin/i18n/build-translation-resources
+    - name: Commit changes
+      run: | # sh
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+
+        BRANCH_NAME="update-translations-v$VERSION"
+
+        # assumes there's already a branch with that name from the upload step
+        git checkout $BRANCH_NAME
         git add locales/
 
         git commit -m "Update translations"
-        git push -u origin ${BRANCH_NAME}
-
-        gh pr create \
-          --base "${CURRENT_BRANCH_NAME}" \
-          --head "${BACKPORT_BRANCH}" \
-          --reviewer "${GITHUB_ACTOR}" \
-          --title "Import Translations for v${VERSION}" \
-          --body "Imported translations from POEditor for v${VERSION}"
-
+        git push -u origin $BRANCH_NAME
 

--- a/.github/workflows/translation-update.yml
+++ b/.github/workflows/translation-update.yml
@@ -99,7 +99,8 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        fetch-depth: 0 # get all branches
+        # assumes there's already a branch with that name from the upload step
+        ref: update-translations-v${{inputs.VERSION}}
     - name: Prepare back-end environment
       uses: ./.github/actions/prepare-backend
       with:
@@ -127,8 +128,6 @@ jobs:
 
         BRANCH_NAME="update-translations-v$VERSION"
 
-        # assumes there's already a branch with that name from the upload step
-        git checkout $BRANCH_NAME
         git add locales/
 
         git commit -m "Update translations"

--- a/.github/workflows/translation-update.yml
+++ b/.github/workflows/translation-update.yml
@@ -1,4 +1,5 @@
 name: Update Translations
+run-name: Update Translations for v${{ inputs.version }} - ${{ inputs.step }}
 on:
   workflow_dispatch:
     inputs:
@@ -21,11 +22,12 @@ permissions:
 jobs:
   upload-translations:
     name: Upload Translations
-    if: ${{ inputs.step }} == 'upload'
+    if: ${{ inputs.step  == 'upload' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     env:
       POEDITOR_API_TOKEN: ${{ secrets.POEDITOR_API_TOKEN }}
+      POEDITOR_PROJECT_ID: 200535
       VERSION: ${{ inputs.version }}
     steps:
     - name: Checkout code
@@ -36,6 +38,8 @@ jobs:
       uses: ./.github/actions/prepare-backend
       with:
         m2-cache-key: manage-translations
+    - name: install gettext
+      run: sudo apt-get install gettext
 
     # TODO: check for untranslated strings
 
@@ -43,9 +47,11 @@ jobs:
       run: | # sh
         ./bin/i18n/update-translation-template
         ./bin/i18n/export-pot-to-poeditor
-        echo "Strings uploaded to POEditor. Don't forget to notify contributors and copy source strings to English language."
+        echo "Strings uploaded to POEditor"
 
     - name: Commit changes
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: | # sh
         git config user.name github-actions
         git config user.email github-actions@github.com
@@ -73,7 +79,7 @@ jobs:
         - [ ] Copy source strings to english language (manual)
         - [ ] Download translations from POEditor (github action)
         - [ ] Merge this PR and backport to the release branch (manual)
-        "
+        " \
         --label "backport" \
         --label "Customization/i18n"
 
@@ -81,18 +87,19 @@ jobs:
     # TODO: copy source strings to english language
 
   download-translations:
-    name: Upload Translations
-    if: ${{ inputs.step }} == 'download'
+    name: Download Translations
+    if: ${{ inputs.step == 'download' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     env:
       POEDITOR_API_TOKEN: ${{ secrets.POEDITOR_API_TOKEN }}
+      POEDITOR_PROJECT_ID: 200535
       VERSION: ${{ inputs.version }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    - name: Prepare front-end environment
-      uses: ./.github/actions/prepare-frontend
+      with:
+        fetch-depth: 0 # get all branches
     - name: Prepare back-end environment
       uses: ./.github/actions/prepare-backend
       with:

--- a/.github/workflows/translation-update.yml
+++ b/.github/workflows/translation-update.yml
@@ -133,4 +133,3 @@ jobs:
 
         git commit -m "Update translations"
         git push -u origin $BRANCH_NAME
-

--- a/release/package.json
+++ b/release/package.json
@@ -15,6 +15,7 @@
     "copy-required-checks": "tsx ./src/required-checks.ts",
     "test:unit": "jest --testPathPattern unit",
     "test:integration": "jest --testPathPattern integration",
+    "auto-translate": "tsx src/auto-translate.ts",
     "type-check": "tsc --noEmit"
   },
   "author": "Metabase",

--- a/release/package.json
+++ b/release/package.json
@@ -8,14 +8,14 @@
     "node": ">=18.0.0"
   },
   "scripts": {
+    "auto-translate": "tsx src/auto-translate.ts",
     "build": "esbuild src/index.ts --bundle --outfile=dist/index.cjs --platform=node --target=node16",
+    "copy-required-checks": "tsx ./src/required-checks.ts",
+    "generate-changelog": "tsx generate-changelog.ts",
     "prettier": "prettier --write",
     "release-offline": "tsx release-offline.ts",
-    "generate-changelog": "tsx generate-changelog.ts",
-    "copy-required-checks": "tsx ./src/required-checks.ts",
     "test:unit": "jest --testPathPattern unit",
     "test:integration": "jest --testPathPattern integration",
-    "auto-translate": "tsx src/auto-translate.ts",
     "type-check": "tsc --noEmit"
   },
   "author": "Metabase",

--- a/release/src/auto-translate.ts
+++ b/release/src/auto-translate.ts
@@ -1,0 +1,49 @@
+import 'zx/globals';
+
+const baseUrl = 'https://api.poeditor.com/v2'
+const POEDITOR_API_TOKEN = process.env.POEDITOR_API_TOKEN;
+const POEDITOR_PROJECT_ID = "200535"; // Metabae POEditor project
+const SOURCE_LANGUAGE = "english";
+const PROVIDER = "deepl"; // TODO: fallback to google,
+
+const languages = [
+  'es',
+  'pl',
+];
+
+// https://poeditor.com/docs/api#translations_automatic
+const autoTranslate = async (language: string) => {
+  const url = `${baseUrl}/translations/automatic`;
+
+  // poeditor doesn't like the escaping that UrlSearchParams does
+  const encodedData = `api_token=${POEDITOR_API_TOKEN}&id=${POEDITOR_PROJECT_ID}&source_language="${SOURCE_LANGUAGE}"&provider_source_language="${SOURCE_LANGUAGE}"&provider="${PROVIDER}"`
+     + `&target_languages=${JSON.stringify([{
+        project_language: language,
+        provider_language: language,
+      }]).replaceAll('"', '\"')}`;
+
+  console.log(encodedData)
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: encodedData,
+  });
+
+  console.log(await response.json())
+}
+
+await autoTranslate('es');
+/**
+
+curl -X POST https://api.poeditor.com/v2/translations/automatic \
+     -d api_token="xxx" \
+     -d id="200535" \
+     -d source_language="en" \
+     -d provider_source_language="en" \
+     -d provider="deepl" \
+     -d target_languages="[{\"project_language\":\"es\",\"provider_language\":\"es\"}]"
+ */
+

--- a/release/src/auto-translate.ts
+++ b/release/src/auto-translate.ts
@@ -1,28 +1,65 @@
 import 'zx/globals';
+$.verbose = false;
 
 const baseUrl = 'https://api.poeditor.com/v2'
 const POEDITOR_API_TOKEN = process.env.POEDITOR_API_TOKEN;
-const POEDITOR_PROJECT_ID = "200535"; // Metabae POEditor project
-const SOURCE_LANGUAGE = "english";
-const PROVIDER = "deepl"; // TODO: fallback to google,
+const POEDITOR_PROJECT_ID = "200535"; // Metabase POEditor project
+const SOURCE_LANGUAGE = "en";
+const DEFAULT_PROVIDER = "deepl";
+const url = `${baseUrl}/translations/automatic`;
 
-const languages = [
-  'es',
-  'pl',
+// deepl doesn't support these languages
+const google_only_languages = [
+  'ar',
+  'ar-SA',
+  'ca',
+  'fa',
+  'he',
+  'id',
+  'sq',
+  'sr',
+  'vi',
 ];
+
+// alias from our file names to poeditor's language codes
+const aliases: Record<string, string> = {
+  "zh": 'zh-Hans',
+};
+
+// alias from poeditor's language codes to deepl or google's language codes
+const providerAliases: Record<string, string> = {
+  'he': 'iw', // google
+  "zh-CN": "zh", // deepl
+  "zh-HK": "zh", // deepl
+  "zh-TW": "zh", // deepl
+  "zh-Hans": "zh", // deepl
+};
 
 // https://poeditor.com/docs/api#translations_automatic
 const autoTranslate = async (language: string) => {
-  const url = `${baseUrl}/translations/automatic`;
+  if (language in aliases) {
+    language = aliases[language];
+  }
+
+  const provider = google_only_languages.includes(language) ? 'google' : DEFAULT_PROVIDER;
+
+  const config = {
+    source_language: SOURCE_LANGUAGE,
+    provider_source_language: provider === 'deepl'
+      ? SOURCE_LANGUAGE.toUpperCase() // deepl uses uppercase
+      : SOURCE_LANGUAGE,
+    provider,
+    target_languages: [{
+      project_language: language,
+      provider_language: provider === 'deepl'
+        ? (providerAliases[language] ?? language).toUpperCase() // deepl uses uppercase
+        : (providerAliases[language] ?? language),
+    }],
+  };
 
   // poeditor doesn't like the escaping that UrlSearchParams does
-  const encodedData = `api_token=${POEDITOR_API_TOKEN}&id=${POEDITOR_PROJECT_ID}&source_language="${SOURCE_LANGUAGE}"&provider_source_language="${SOURCE_LANGUAGE}"&provider="${PROVIDER}"`
-     + `&target_languages=${JSON.stringify([{
-        project_language: language,
-        provider_language: language,
-      }]).replaceAll('"', '\"')}`;
-
-  console.log(encodedData)
+  const encodedData = `api_token=${POEDITOR_API_TOKEN}&id=${POEDITOR_PROJECT_ID}&source_language=${config.source_language}&provider_source_language=${config.provider_source_language}&provider=${provider}`
+    + `&target_languages=${JSON.stringify(config.target_languages).replaceAll('"', '\"')}`;
 
   const response = await fetch(url, {
     method: 'POST',
@@ -32,18 +69,22 @@ const autoTranslate = async (language: string) => {
     body: encodedData,
   });
 
-  console.log(await response.json())
+  const message = (await response.json())?.result;
+
+  console.log(message);
 }
 
-await autoTranslate('es');
-/**
+function getExistingLanguages() {
+  const localeFiles = fs.readdirSync("../locales");
 
-curl -X POST https://api.poeditor.com/v2/translations/automatic \
-     -d api_token="xxx" \
-     -d id="200535" \
-     -d source_language="en" \
-     -d provider_source_language="en" \
-     -d provider="deepl" \
-     -d target_languages="[{\"project_language\":\"es\",\"provider_language\":\"es\"}]"
- */
+  return localeFiles.filter(f => /\.po$/.test(f))
+    .map(f => f.replace(/\.po$/, ""));
+}
 
+const supportedLanguages = getExistingLanguages();
+
+for (const language of supportedLanguages) {
+  // do this in a for/await loop to avoid rate limiting
+  console.log(chalk.blue(`\nTranslating ${language}`))
+  await autoTranslate(language);
+}

--- a/release/src/auto-translate.ts
+++ b/release/src/auto-translate.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import 'zx/globals';
 $.verbose = false;
 
@@ -28,6 +29,7 @@ const aliases: Record<string, string> = {
 
 // alias from poeditor's language codes to deepl or google's language codes
 const providerAliases: Record<string, string> = {
+  'ar-SA': 'ar', // google
   'he': 'iw', // google
   "zh-CN": "zh", // deepl
   "zh-HK": "zh", // deepl
@@ -35,6 +37,8 @@ const providerAliases: Record<string, string> = {
   "zh-Hans": "zh", // deepl
 };
 
+// for this to work you have to manually "copy terms to translations" in the english poeditor language
+// this also requires translations credits. it's like $34 every 6 months or so
 // https://poeditor.com/docs/api#translations_automatic
 const autoTranslate = async (language: string) => {
   if (language in aliases) {

--- a/release/src/auto-translate.ts
+++ b/release/src/auto-translate.ts
@@ -1,6 +1,5 @@
 import 'dotenv/config';
 import 'zx/globals';
-$.verbose = false;
 
 const baseUrl = 'https://api.poeditor.com/v2'
 const POEDITOR_API_TOKEN = process.env.POEDITOR_API_TOKEN;
@@ -85,10 +84,12 @@ function getExistingLanguages() {
     .map(f => f.replace(/\.po$/, ""));
 }
 
-const supportedLanguages = getExistingLanguages();
+export async function autoTranslateSupportedLanguages() {
+  const supportedLanguages = getExistingLanguages();
 
-for (const language of supportedLanguages) {
-  // do this in a for/await loop to avoid rate limiting
-  console.log(chalk.blue(`\nTranslating ${language}`))
-  await autoTranslate(language);
+  for (const language of supportedLanguages) {
+    // do this in a for/await loop to avoid rate limiting
+    console.log(chalk.blue(`\nTranslating ${language}`))
+    await autoTranslate(language);
+  }
 }

--- a/release/src/auto-translate.ts
+++ b/release/src/auto-translate.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import 'zx/globals';
+import fetch from 'node-fetch';
 
 const baseUrl = 'https://api.poeditor.com/v2'
 const POEDITOR_API_TOKEN = process.env.POEDITOR_API_TOKEN;
@@ -72,7 +72,7 @@ const autoTranslate = async (language: string) => {
     body: encodedData,
   });
 
-  const message = (await response.json())?.result;
+  const message = (await response.json() as { result?: string })?.result;
 
   console.log(message);
 }

--- a/release/src/backports.ts
+++ b/release/src/backports.ts
@@ -3,6 +3,7 @@ import type { Octokit } from "@octokit/rest";
 import dayjs from 'dayjs';
 
 import { sendBackportReminder } from "./slack";
+import type { Issue } from "./types";
 
 const RECENT_BACKPORT_THRESHOLD_HOURS = 8;
 
@@ -19,7 +20,7 @@ export const checkOpenBackports = async ({ github, owner, repo, channelName }: {
     repo,
     labels: "was-backported",
     state: "open",
-  });
+  }) as { data: Issue[] };
 
   console.log(`Found ${openBackports.length} open backports`);
 

--- a/release/src/index.ts
+++ b/release/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./auto-translate";
 export * from "./backports";
 export * from "./flakes";
 export * from "./github";

--- a/release/src/milestones.ts
+++ b/release/src/milestones.ts
@@ -1,5 +1,4 @@
 import _ from "underscore";
-import 'zx/globals';
 
 import {
   getMilestones,


### PR DESCRIPTION
> [!important]
> needs a new github actions secret: `POEDITOR_API_TOKEN`

Closes https://github.com/metabase/metabase-private/issues/187

### Description

This creates a github action with two "modes"

- Upload
  - pulls all strings out of the code and updates the .pot file
  - uploads the new .pot file to POEditor for translation
  - commits the updated .pot file and opens a PR like this
- Download
  - runs a script to cause POEditor to auto-translate all untranslated strings
  - downloads all translations from poeditor
  - adds all updated translation files to the PR created by the upload job


## Testing
This is not feasible to fully test, except during a release, for two reasons: 
  (1) we don't want to mess up the state of our POEditor account, and 
  (2) auto-translation is kind of expensive and we don't want to burn through our credits on tests

Nonetheless, the following tests were conducted:
- the auto-translation script was successfully used, locally, to do all auto-translations for v50, and it worked like a charm
- upload job test: https://github.com/iethree/metabase/actions/runs/9911919353
- download job test: https://github.com/iethree/metabase/actions/runs/9912029030
- sample PR: https://github.com/iethree/metabase/pull/32