### PR TITLE
Updating default `number-formatter` for percents

### DIFF
--- a/src/metabase/pulse/render/common.clj
+++ b/src/metabase/pulse/render/common.clj
@@ -107,15 +107,12 @@
     (fn [value]
       (if (number? value)
         (let [scaled-value (* value (or scale 1))
-              percent-scaled-value (* 100 scaled-value)
               decimals-in-value (digits-after-decimal (if percent? (* 100 scaled-value) scaled-value))
               decimal-digits (cond
                                decimals decimals ;; if user ever specifies # of decimals, use that
                                integral? 0
                                currency? (get-in currency/currency [(keyword (or currency "USD")) :decimal_digits])
-                               (and percent? (> percent-scaled-value 100))   (min 2 decimals-in-value) ;; 5.5432 -> %554.32
-                               ;; This needs configuration. I don't see why we don't keep more significant digits.
-                               (and percent? (> 100 percent-scaled-value 1)) (min 0 decimals-in-value) ;; 0.2555 -> %26
+                               percent?  (min 2 decimals-in-value) ;; 5.5432 -> %554.32
                                :else (if (>= scaled-value 1)
                                        (min 2 decimals-in-value) ;; values greater than 1 round to 2 decimal places
                                        (let [n-figs (sig-figs-after-decimal scaled-value decimal)]

--- a/test/metabase/pulse/render/common_test.clj
+++ b/test/metabase/pulse/render/common_test.clj
@@ -64,7 +64,11 @@
                    ::mb.viz/number-separators ",."})))
       (is (= "10%" (format 0.1 {::mb.viz/number-style "percent"})))
       (is (= "1%" (format 0.01 {::mb.viz/number-style "percent"})))
-      (is (= "0.00001%" (format 0.0000001 {::mb.viz/number-style "percent"}))))
+      (is (= "0%" (format 0.000000 {::mb.viz/number-style "percent"})))
+      ;; This is not zero, so should show decimal places
+      (is (= "0.00%" (format 0.0000001 {::mb.viz/number-style "percent"})))
+      (is (= "0.00001%" (format 0.0000001 {::mb.viz/number-style "percent"
+                                           ::mb.viz/decimals          5}))))
     (testing "Match UI 'natural formatting' behavior for decimal values with no column formatting present"
       ;; basically, for numbers greater than 1, round to 2 decimal places,
       ;; and do not display decimals if they end up as zeroes

--- a/test/metabase/pulse/render_test.clj
+++ b/test/metabase/pulse/render_test.clj
@@ -200,7 +200,7 @@
         ;; the significant digits in the formatter, we'll need to modify this test as well.
         (letfn [(create-comparison-results [query-results card]
                   (let [expected      (mapv (fn [row]
-                                              (format "%s%%" (Math/round ^float (* 100 (peek row)))))
+                                              (format "%.2f%%" (* 100 (peek row))))
                                             (get-in query-results [:data :rows]))
                         rendered-card (render/render-pulse-card :inline (pulse/defaulted-timezone card) card nil query-results)
                         table         (-> rendered-card


### PR DESCRIPTION
The number formatter used in some static viz rendering (e.g. tables) in `metabase.pulse.render.common/number-formatter` had logic to render only integer-valued percents for values between 1 and 100 and render two significant digits otherwise.

The FE default formatter uses 2 significant digits consistently in `frontend/src/metabase/lib/formatting/numbers.tsx`:

```js
const PRECISION_NUMBER_FORMATTER = d3.format(".2f");
```

This change modifies `number-formatter` to consistenly use 2 significant digits for percentage types.

Note that this does NOT apply to fields with custom formatting. Presently, custom column formatting does not appear to be applied for HTML tables at all for BE rendering while it is applied on the FE. This is a separate issue. This PR just brings the baseline behaviors based on typing into alignment.