### PR TITLE
Return `:pk` drills for non-PK values in rows with multiple PKs

### DIFF
--- a/src/metabase/lib/drill_thru/common.cljc
+++ b/src/metabase/lib/drill_thru/common.cljc
@@ -1,6 +1,7 @@
 (ns metabase.lib.drill-thru.common
   (:require
    [metabase.lib.hierarchy :as lib.hierarchy]
+   [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.util :as lib.util]))
 
 (defn mbql-stage?
@@ -35,3 +36,8 @@
   ;; Several drill-thrus are rendered as a fixed label for that type, with no reference to the column or value,
   ;; so the default is simply the drill-thru type.
   (select-keys drill-thru [:type :display-name]))
+
+(defn many-pks?
+  "Does the source table for this `query` have more than one primary key?"
+  [query]
+  (> (count (lib.metadata.calculation/primary-keys query)) 1))

--- a/src/metabase/lib/drill_thru/fk_details.cljc
+++ b/src/metabase/lib/drill_thru/fk_details.cljc
@@ -2,13 +2,33 @@
   "An FK details drill is one where you click a foreign key value in a table view e.g. ORDERS.USER_ID and choose the
   'View details' option, then it shows you the PEOPLE record in question (e.g. Person 5 if USER_ID was 5).
 
-  [[metabase.lib.drill-thru.object-details/object-detail-drill]] has the logic for determining whether to return this
-  drill as an option or not."
+  We will only possibly return one of the 'object details'
+  drills ([[metabase.lib.drill-thru.pk]], [[metabase.lib.drill-thru.fk-details]],
+  or [[metabase.lib.drill-thru.zoom]]); see [[metabase.lib.drill-thru.object-details]] for the high-level logic that
+  calls out to the individual implementations."
   (:require
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
    [metabase.lib.filter :as lib.filter]
    [metabase.lib.metadata :as lib.metadata]
-   [metabase.lib.query :as lib.query]))
+   [metabase.lib.query :as lib.query]
+   [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
+   [metabase.lib.types.isa :as lib.types.isa]
+   [metabase.util.malli :as mu]))
+
+(mu/defn fk-details-drill :- [:maybe ::lib.schema.drill-thru/drill-thru.fk-details]
+  "Return an `:fk-details` 'View details' drill when clicking on the value of a FK column."
+  [query                               :- ::lib.schema/query
+   _stage-number                       :- :int
+   {:keys [column value] :as _context} :- ::lib.schema.drill-thru/context]
+  (when (and (lib.types.isa/foreign-key? column)
+             (some? value)
+             (not= value :null))
+    {:lib/type  :metabase.lib.drill-thru/drill-thru
+     :type      :drill-thru/fk-details
+     :column    column
+     :object-id value
+     :many-pks? (lib.drill-thru.common/many-pks? query)}))
 
 (defmethod lib.drill-thru.common/drill-thru-info-method :drill-thru/fk-details
   [_query _stage-number drill-thru]

--- a/src/metabase/lib/drill_thru/pk.cljc
+++ b/src/metabase/lib/drill_thru/pk.cljc
@@ -1,15 +1,75 @@
 (ns metabase.lib.drill-thru.pk
-  "[[metabase.lib.drill-thru.object-details/object-detail-drill]] has the logic for determining whether to return this
-  drill as an option or not."
+  "A `:pk` drill is a 'View details' (AKA object details) drill that adds filter(s) for the value(s) of a PK(s). It is
+  only presented for Tables that have multiple PKs; for Tables with a single PK you'd instead
+  see [[metabase.lib.drill-thru.zoom]].
+
+  We will only possibly return one of the 'object details'
+  drills ([[metabase.lib.drill-thru.pk]], [[metabase.lib.drill-thru.fk-details]],
+  or [[metabase.lib.drill-thru.zoom]]); see [[metabase.lib.drill-thru.object-details]] for the high-level logic that
+  calls out to the individual implementations."
   (:require
+   [medley.core :as m]
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
-   [metabase.lib.filter :as lib.filter]))
+   [metabase.lib.filter :as lib.filter]
+   [metabase.lib.metadata.calculation :as lib.metadata.calculation]
+   [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
+   [metabase.lib.types.isa :as lib.types.isa]
+   [metabase.util.malli :as mu]))
+
+(mu/defn pk-drill :- [:maybe ::lib.schema.drill-thru/drill-thru.pk]
+  "'View details' drill when you click on a value in a table that has MULTIPLE PKs. There are two subtypes of PK
+  drills:
+
+  1) if you click on a PK column value, then we return a drill that will add a filter for that PK column/value
+
+  2) if you click a non-PK column value, then we return a drill that will add filters for the PK columns/values in the
+     row. This is never returned for FK columns; we return [[metabase.lib.drill-thru.fk-details]] drills instead."
+  [query                                   :- ::lib.schema/query
+   stage-number                            :- :int
+   {:keys [column value row] :as _context} :- ::lib.schema.drill-thru/context]
+  (when (and
+         ;; ignore column header clicks (value = nil). NULL values (value = :null) are ok if this is a click on a
+         ;; non-PK column.
+         (some? value)
+         (lib.drill-thru.common/mbql-stage? query stage-number)
+         ;; `:pk` drills are only for Tables with multiple PKs. For Tables with one PK, we do
+         ;; a [[metabase.lib.drill-thru.zoom]] drill instead.
+         (lib.drill-thru.common/many-pks? query)
+         ;; if this is an FK column we should return an [[metabase.lib.drill-thru.fk-details]] drill instead.
+         (not (lib.types.isa/foreign-key? column)))
+    (if (lib.types.isa/primary-key? column)
+      ;; 1) we clicked on a PK column: return a drill thru for that PK column + value. Ignore `nil` values.
+      (when (and (some? value)
+                 (not= value :null))
+        {:lib/type   :metabase.lib.drill-thru/drill-thru
+         :type       :drill-thru/pk
+         :dimensions [{:column column
+                       :value  value}]})
+      ;; 2) we clicked on a non-PK column: return a drill for ALL of the PK columns + values. Ignore any
+      ;;   `nil` (`:null`) values.
+      (let [pk-columns (lib.metadata.calculation/primary-keys query)
+            dimensions (for [pk-column pk-columns
+                             :let      [value (->> row
+                                                   (m/find-first #(-> % :column :name (= (:name pk-column))))
+                                                   :value)]
+                             ;; ignore any PKs that don't have a value in this row.
+                             :when     value]
+                         {:column pk-column, :value value})]
+        (when (seq dimensions)
+          {:lib/type   :metabase.lib.drill-thru/drill-thru
+           :type       :drill-thru/pk
+           ;; return the dimensions sorted by column ID so the return value is determinate.
+           :dimensions (vec (sort-by #(get-in % [:column :id]) dimensions))})))))
 
 (defmethod lib.drill-thru.common/drill-thru-info-method :drill-thru/pk
   [_query _stage-number drill-thru]
-  (select-keys drill-thru [:many-pks? :object-id :type]))
+  (select-keys drill-thru [:type :dimensions]))
 
 (defmethod lib.drill-thru.common/drill-thru-method :drill-thru/pk
-  [query stage-number {:keys [column object-id]} & _]
-  ;; This type is only used when there are multiple PKs and one was selected - [= pk x] filter.
-  (lib.filter/filter query stage-number (lib.filter/= column object-id)))
+  [query stage-number {:keys [dimensions], :as _pk-drill}]
+  (reduce
+   (fn [query {:keys [column value], :as _dimension}]
+     (lib.filter/filter query stage-number (lib.filter/= column value)))
+   query
+   dimensions))

--- a/src/metabase/lib/drill_thru/zoom.cljc
+++ b/src/metabase/lib/drill_thru/zoom.cljc
@@ -1,11 +1,50 @@
 (ns metabase.lib.drill-thru.zoom
-  "[[metabase.lib.drill-thru.object-details/object-detail-drill]] has the logic for determining whether to return this
-  drill as an option or not."
+  "A `:zoom` drill is a 'View details' drill when you click on the value of a PK column in a Table that has EXACTLY ONE
+  PK column. In MLv2, it is a no-op; in the frontend it changes the URL to take you to the 'object details' view for
+  the row in question. For Tables with multiple PK columns, a [[metabase.lib.drill-thru.pk]] drill is returned
+  instead.
+
+  We will only possibly return one of the 'object details'
+  drills ([[metabase.lib.drill-thru.pk]], [[metabase.lib.drill-thru.fk-details]],
+  or [[metabase.lib.drill-thru.zoom]]); see [[metabase.lib.drill-thru.object-details]] for the high-level logic that
+  calls out to the individual implementations."
   (:require
+   [medley.core :as m]
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
+   [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
+   [metabase.lib.types.isa :as lib.types.isa]
    [metabase.util.malli :as mu]))
+
+(defn- zoom-drill* [column value]
+  {:lib/type  :metabase.lib.drill-thru/drill-thru
+   :type      :drill-thru/zoom
+   :column    column
+   :object-id value
+   :many-pks? false})
+
+(mu/defn zoom-drill :- [:maybe ::lib.schema.drill-thru/drill-thru.zoom]
+  "Return a `:zoom` drill when clicking on the value of a PK column in a Table that has only one PK column."
+  [query                                   :- ::lib.schema/query
+   _stage-number                           :- :int
+   {:keys [column value row] :as _context} :- ::lib.schema.drill-thru/context]
+
+  (when (and
+         ;; ignore clicks on headers (value = nil rather than :null)
+         (some? value)
+         ;; if this table has more than one PK we should be returning a [[metabase.lib.drill-thru.pk]] instead.
+         (not (lib.drill-thru.common/many-pks? query)))
+    (if (lib.types.isa/primary-key? column)
+      ;; PK column was clicked. Ignore NULL values.
+      (when-not (= value :null)
+        (zoom-drill* column value))
+      ;; some other column was clicked. Find the PK column and create a filter for its value.
+      (let [[pk-column] (lib.metadata.calculation/primary-keys query)]
+        (when-let [pk-value (->> row
+                                 (m/find-first #(-> % :column :name (= (:name pk-column))))
+                                 :value)]
+          (zoom-drill* pk-column pk-value))))))
 
 (defmethod lib.drill-thru.common/drill-thru-info-method :drill-thru/zoom
   [_query _stage-number drill-thru]

--- a/src/metabase/lib/schema/drill_thru.cljc
+++ b/src/metabase/lib/schema/drill_thru.cljc
@@ -39,18 +39,30 @@
    [:map
     [:column [:ref ::lib.schema.metadata/column]]]])
 
-(mr/def ::drill-thru.object-details
-  [:merge
-   ::drill-thru.common.with-column
-   [:map
-    [:object-id :any]
-    [:many-pks? :boolean]]])
+;;; there are three "object details" drills: `:pk`, `:fk-details`, and `:zoom`. Originally, all three had `:column`
+;;; and `:object-id` (value), but since we want `:pk` to handle multiple PKs (thus multiple columns and values) we
+;;; changed it to instead have a list of `:dimensions` (similar in shape to `::context.row`, but without requiring
+;;; `:column-ref`). I didn't change the other ones so as to avoid unintentionally breaking something in the middle of
+;;; the drills epic. We should revisit these shapes in the future. See
+;;; https://metaboat.slack.com/archives/C04CYTEL9N2/p1701803047600169 for more information. -- Cam
+
+(mr/def ::drill-thru.object-details.dimension
+  [:map
+   [:column [:ref ::lib.schema.metadata/column]]
+   ;; we should ignore NULL values for PKs and FKs -- do not add filters on them.
+   [:value  [:and
+             :some
+             [:fn {:error/message "Non-NULL value"} #(not= % :null)]]]])
+
+(mr/def ::drill-thru.object-details.dimensions
+  [:sequential {:min 1} [:ref ::drill-thru.object-details.dimension]])
 
 (mr/def ::drill-thru.pk
   [:merge
-   ::drill-thru.object-details
+   ::drill-thru.common
    [:map
-    [:type [:= :drill-thru/pk]]]])
+    [:type       [:= :drill-thru/pk]]
+    [:dimensions [:ref ::drill-thru.object-details.dimensions]]]])
 
 (mr/def ::drill-thru.fk-details.fk-column
   [:merge
@@ -60,16 +72,22 @@
 
 (mr/def ::drill-thru.fk-details
   [:merge
-   ::drill-thru.object-details
+   ::drill-thru.common.with-column
    [:map
-    [:type   [:= :drill-thru/fk-details]]
-    [:column [:ref ::drill-thru.fk-details.fk-column]]]])
+    [:type      [:= :drill-thru/fk-details]]
+    [:column    [:ref ::drill-thru.fk-details.fk-column]]
+    [:object-id :any]
+    [:many-pks? :boolean]]])
 
 (mr/def ::drill-thru.zoom
   [:merge
-   ::drill-thru.object-details
+   ::drill-thru.common.with-column
    [:map
-    [:type [:= :drill-thru/zoom]]]])
+    [:type      [:= :drill-thru/zoom]]
+    [:object-id :any]
+    ;; TODO -- I don't think we really need this because there is no situation in which this isn't `false`, if it were
+    ;; true we'd return a `::drill-thru.pk` drill instead. See if we can remove this key without breaking the FE.
+    [:many-pks? [:= false]]]])
 
 (mr/def ::drill-thru.quick-filter.operator
   [:map
@@ -144,6 +162,8 @@
     [:query        [:ref ::lib.schema/query]]
     [:stage-number number?]]])
 
+;;; TODO FIXME -- it seems like underlying records drills also include `:dimensions` and `:column-ref`...
+;;; see [[metabase.lib.drill-thru.underlying-records/underlying-records-drill]]... this should be part of the schema
 (mr/def ::drill-thru.underlying-records
   [:merge
    ::drill-thru.common
@@ -279,7 +299,9 @@
   [:map
    [:column     [:ref ::lib.schema.metadata/column]]
    [:column-ref [:ref ::lib.schema.ref/ref]]
-   [:value      :any]])
+   [:value      [:fn
+                 {:error/message ":null should not be used in context row values, only for top-level context value"}
+                 #(not= % :null)]]])
 
 ;;; Sequence of maps with keys `:column`, `:column-ref`, and `:value`
 ;;;

--- a/test/metabase/lib/drill_thru/pk_test.cljc
+++ b/test/metabase/lib/drill_thru/pk_test.cljc
@@ -4,7 +4,8 @@
    [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.test-metadata :as meta]
-   [metabase.lib.test-util :as lib.tu]))
+   [metabase.lib.test-util :as lib.tu]
+   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))))
 
 (deftest ^:parallel do-not-return-pk-for-nil-test
   (testing "do not return pk drills for nil cell values (#36126)"
@@ -22,3 +23,61 @@
                                            :value      nil}]}]
       (is (not (m/find-first #(= (:type %) :drill-thru/pk)
                              (lib/available-drill-thrus query -1 context)))))))
+
+(deftest ^:parallel return-pk-drill-for-query-with-multiple-pks-on-non-pk-columns-click-test
+  (testing "should drill thru a non-PK and non-FK cell when there are multiple PK columns (#35618)"
+    ;; simulate a table with multiple PK columns: mark orders.product-id as a PK column
+    (let [metadata-provider   (lib.tu/merged-mock-metadata-provider
+                               meta/metadata-provider
+                               {:fields [{:id            (meta/id :orders :product-id)
+                                          :semantic-type :type/PK}]})
+          query               (lib/query metadata-provider (meta/table-metadata :orders))
+          context-with-values (fn [column-value pk-1-value pk-2-value]
+                                {:column     (meta/field-metadata :orders :total)
+                                 :value      column-value
+                                 :column-ref (lib/ref (meta/field-metadata :orders :total))
+                                 :row        [{:column     (meta/field-metadata :orders :id)
+                                               :column-ref (lib/ref (meta/field-metadata :orders :id))
+                                               :value      pk-1-value}
+                                              {:column     (meta/field-metadata :orders :product-id)
+                                               :column-ref (lib/ref (meta/field-metadata :orders :product-id))
+                                               :value      pk-2-value}
+                                              {:column     (meta/field-metadata :orders :total)
+                                               :column-ref (lib/ref (meta/field-metadata :orders :total))
+                                               :value      (when-not (= column-value :null)
+                                                             column-value)}]})
+          find-drill          (fn [query context]
+                                (m/find-first #(= (:type %) :drill-thru/pk)
+                                              (lib/available-drill-thrus query -1 context)))]
+      (testing "both PKs have values"
+        (doseq [column-value [10 :null]]
+          (let [context (context-with-values column-value 100 200)
+                drill   (find-drill query context)]
+            (is (=? {:lib/type   :metabase.lib.drill-thru/drill-thru
+                     :type       :drill-thru/pk
+                     :dimensions [{:column {:name "ID"}
+                                   :value  100}
+                                  {:column {:name "PRODUCT_ID"}
+                                   :value  200}]}
+                    drill))
+            (testing "Should add one filter for each PK column (#36426)"
+              (is (=? {:stages [{:filters [[:= {} [:field {} (meta/id :orders :id)] 100]
+                                           [:= {} [:field {} (meta/id :orders :product-id)] 200]]}]}
+                      (lib/drill-thru query -1 drill)))))))
+      (testing "only one PK has a value: ignore the PK without a value"
+        (let [context (context-with-values 10 100 nil)
+              drill   (find-drill query context)]
+          (is (=? {:lib/type   :metabase.lib.drill-thru/drill-thru
+                   :type       :drill-thru/pk
+                   :dimensions [{:column {:name "ID"}
+                                 :value  100}]}
+                  drill))
+          (testing "\nShould add one filter for each PK column (#36426)"
+            (is (=? {:stages [{:filters [[:= {} [:field {} (meta/id :orders :id)] 100]]}]}
+                    (lib/drill-thru query -1 drill))))))
+      (testing "neither PK has a value: don't return a drill at all"
+        (let [context (context-with-values 10 nil nil)]
+          (is (nil? (find-drill query context)))))
+      (testing "ignore header clicks (column value = nil, NOT :null)"
+        (let [context (context-with-values nil 100 200)]
+          (is (nil? (find-drill query context))))))))

--- a/test/metabase/lib/drill_thru/underlying_records_test.cljc
+++ b/test/metabase/lib/drill_thru/underlying_records_test.cljc
@@ -96,7 +96,11 @@
                            :column-ref (lib/ref breakout)
                            :value      value})
           context       (merge agg-dim
-                               {:row        (cons agg-dim breakout-dims)
+                               ;; rows aren't supposed to use `:null`, so change them to `nil` instead.
+                               {:row        (for [value (cons agg-dim breakout-dims)]
+                                              (update value :value (fn [v]
+                                                                     (when-not (= v :null)
+                                                                       v))))
                                 :dimensions breakout-dims})]
       (is (=? {:lib/type :mbql/query
                :stages [{:filters     (exp-filters-fn agg-dim breakout-dims)

--- a/test/metabase/lib/drill_thru/zoom_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_test.cljc
@@ -17,14 +17,15 @@
                   :many-pks? false}}))
 
 (deftest ^:parallel returns-zoom-test-2
-  (lib.drill-thru.tu/test-returns-drill
-   {:drill-type  :drill-thru/zoom
-    :click-type  :cell
-    :query-type  :unaggregated
-    :column-name "TAX"
-    :expected    {:type      :drill-thru/zoom
-                  :object-id (get-in lib.drill-thru.tu/test-queries ["ORDERS" :unaggregated :row "ID"])
-                  :many-pks? false}}))
+  (testing ":zoom drill should get returned when you click on a non-PK column in a Table with one PK"
+    (lib.drill-thru.tu/test-returns-drill
+     {:drill-type  :drill-thru/zoom
+      :click-type  :cell
+      :query-type  :unaggregated
+      :column-name "TAX"
+      :expected    {:type      :drill-thru/zoom
+                    :object-id (get-in lib.drill-thru.tu/test-queries ["ORDERS" :unaggregated :row "ID"])
+                    :many-pks? false}})))
 
 (deftest ^:parallel returns-zoom-test-3
   (lib.drill-thru.tu/test-returns-drill


### PR DESCRIPTION
If you have a Table with multiple PKs and click a non-PK column value cell, it should return a `:pk` filter drill. This drill should add one filter for each non-NULL PK value.

See discussion in https://metaboat.slack.com/archives/C04CYTEL9N2/p1701740553972049

As part of this I overhauled the schema for `:pk` drills, see discussion in https://metaboat.slack.com/archives/C04CYTEL9N2/p1701803047600169

I also refactored the `object-details` drill namespace a bit and moved the code for returning `:pk`, `:zoom`, and `:fk-details` drills into their respective namespaces -- it always seemed weird to have the tests there but then have the thing they're testing live somewhere else. Code is a little easier to follow now.

Fixes #35618
Fixes #36426