### PR TITLE
[MLv2] Implement `automatic-insights` drill

### DIFF
--- a/src/metabase/lib/drill_thru/automatic_insights.cljc
+++ b/src/metabase/lib/drill_thru/automatic_insights.cljc
@@ -1,16 +1,41 @@
-(ns metabase.lib.drill-thru.automatic-insights)
+(ns metabase.lib.drill-thru.automatic-insights
+  (:require
+   [metabase.lib.drill-thru.common :as lib.drill-thru.common]
+   [metabase.lib.drill-thru.underlying-records :as lib.drill-thru.underlying-records]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
+   [metabase.lib.util :as lib.util]
+   [metabase.util.malli :as mu]))
 
-;; (mu/defn ^:private automatic-insights-drill :- [:maybe ::lib.schema.drill-thru/drill-thru]
-;;   ""
-;;   [query        :- ::lib.schema/query
-;;    stage-number :- :int
-;;    column       :- lib.metadata/ColumnMetadata
-;;    value]
-;;   (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
-;;              (lib.metadata/setting query :enable-xrays)
-;;              column
-;;              (nil? value)
-;;              (not (lib.types.isa/structured? column)))
-;;     ;; TODO: Check for expression dimensions; don't show if so, they don't work see metabase#16680.
-;;     ;; TODO: Implement this - it's actually a URL in v1 rather than a click handler.
-;;     ))
+(mu/defn automatic-insights-drill :- [:maybe ::lib.schema.drill-thru/drill-thru]
+  "Automatic insights appears:
+  - When clicking on a value with a breakout - eg. a point in a time series, a cell of a table, a bar or pie slice
+  - Or when clicking a pivot cell, with a value but no column.
+  - Or when clicking a chart legend, in which case there's no column or value set.
+  - There must be at least 1 breakout
+  - X-rays must be enabled (check the settings)
+
+  There are two forms: X-ray, and \"Compare to the rest\". This is a simple user choice and does not need extra data."
+  [query                                        :- ::lib.schema/query
+   stage-number                                 :- :int
+   {:keys [column column-ref dimensions value]} :- ::lib.schema.drill-thru/context]
+  (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
+             ;; Column with no value is not allowed - that's a column header click. Other combinations are allowed.
+             (or (not column) (some? value))
+             (lib.metadata/setting query :enable-xrays)
+             (not-empty dimensions))
+    {:lib/type   :metabase.lib.drill-thru/drill-thru
+     :type       :drill-thru/automatic-insights
+     :column-ref column-ref
+     :dimensions dimensions}))
+
+(defmethod lib.drill-thru.common/drill-thru-method :drill-thru/automatic-insights
+  [query _stage-number drill-thru & _]
+  ;; Returns a dummy query with the right filters for the underlying query. Rather than using this query directly, the
+  ;; FE logic for this drill will grab the filters and build a URL with them.
+  (-> query
+      ;; Drop any existing filters so they aren't duplicated.
+      (lib.util/update-query-stage -1 dissoc :filter)
+      ;; Then transform the aggregations and selected breakouts into filters.
+      (lib.drill-thru.underlying-records/drill-underlying-records drill-thru)))

--- a/src/metabase/lib/drill_thru/automatic_insights.cljc
+++ b/src/metabase/lib/drill_thru/automatic_insights.cljc
@@ -36,6 +36,6 @@
   ;; FE logic for this drill will grab the filters and build a URL with them.
   (-> query
       ;; Drop any existing filters so they aren't duplicated.
-      (lib.util/update-query-stage -1 dissoc :filter)
+      (lib.util/update-query-stage -1 dissoc :filters)
       ;; Then transform the aggregations and selected breakouts into filters.
       (lib.drill-thru.underlying-records/drill-underlying-records drill-thru)))

--- a/src/metabase/lib/drill_thru/quick_filter.cljc
+++ b/src/metabase/lib/drill_thru/quick_filter.cljc
@@ -50,7 +50,6 @@
    stage-number           :- :int
    {:keys [column value]} :- ::lib.schema.drill-thru/context]
   (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
-             ;; (editable? query stage-number)
              column
              (some? value) ; Deliberately allows value :null, only a missing value should fail this test.
              (not (lib.types.isa/primary-key? column))

--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -80,27 +80,27 @@
      query
      filter-clauses)))
 
-(defmethod lib.drill-thru.common/drill-thru-method :drill-thru/underlying-records
-  [query _stage-number {:keys [column-ref dimensions]} & _]
-  (let [top-query   (lib.underlying/top-level-query query)
-        ;; Drop all aggregations, breakouts, sort orders, etc. to get the underlying records.
-        ;; Note that the input _stage-number is deliberately ignored. The top-level query may have fewer stages than the
-        ;; input query; all operations are performed on the final stage of the top-level query.
-        base-query  (lib.util/update-query-stage top-query -1
-                                                 dissoc :aggregation :breakout :order-by :limit :fields)
+(defn drill-underlying-records
+  "Drops aggregations, breakouts, orders, limits and field, then applies a filter for each of the dimensions (including
+  for metrics, and aggregations that imply a filter like `:sum-where`).
+
+  Extracted to a helper since it's reused by automatic-insights drill."
+  [query {:keys [column-ref dimensions] :as _context}]
+  (let [;; Drop all aggregations, breakouts, sort orders, etc. to get the underlying records.
+        ;; Note that all operations are performed on the final stage of input query.
+        base-query  (lib.util/update-query-stage query -1 dissoc :aggregation :breakout :order-by :limit :fields)
         ;; Turn any non-aggregation dimensions into filters.
         ;; eg. if we drilled into a temporal bucket, add a filter for the [:= breakout-column that-month].
         filtered    (reduce (fn [q {:keys [column value]}]
                               (drill-filter q -1 column value))
                             base-query
                             (for [dimension dimensions
-                                  :let [top (update dimension :column #(lib.underlying/top-level-column query %))]
-                                  :when (-> top :column :lib/source (not= :source/aggregations))]
-                              top))
+                                  :when (-> dimension :column :lib/source (not= :source/aggregations))]
+                              dimension))
         ;; The column-ref should be an aggregation ref - look up the full aggregation.
         aggregation (when-let [agg-uuid (last column-ref)]
                       (m/find-first #(= (lib.options/uuid %) agg-uuid)
-                                    (lib.aggregation/aggregations top-query -1)))]
+                                    (lib.aggregation/aggregations query -1)))]
     ;; Apply the filters derived from the aggregation.
     (reduce #(lib.filter/filter %1 -1 %2)
             filtered
@@ -122,3 +122,13 @@
 
                 ;; Default: no filters to add.
                 nil)))))
+
+(defmethod lib.drill-thru.common/drill-thru-method :drill-thru/underlying-records
+  [query _stage-number context & _]
+  ;; Note that the input _stage-number is deliberately ignored. The top-level query may have fewer stages than the
+  ;; input query; all operations are performed on the final stage of the top-level query.
+  (drill-underlying-records (lib.underlying/top-level-query query)
+                            (update context :dimensions
+                                    (fn [dims]
+                                      (for [dim dims]
+                                        (update dim :column #(lib.underlying/top-level-column query %)))))))

--- a/src/metabase/lib/js/metadata.cljs
+++ b/src/metabase/lib/js/metadata.cljs
@@ -442,8 +442,14 @@
         :when              (and a-segment (= (:table-id a-segment) table-id))]
     a-segment))
 
-(defn- setting [setting-key]
-  (.get js/__metabaseSettings (name setting-key)))
+(defn- setting [setting-key unparsed-metadata]
+  (if (and js/describe js/it)
+    ;; Trust the metadata's settings in tests.
+    (-> unparsed-metadata
+        (.-settings)
+        (aget (name setting-key)))
+    ;; And use the global, async-updated one in prod.
+    (.get js/__metabaseSettings (name setting-key))))
 
 (defn metadata-provider
   "Use a `metabase-lib/metadata/Metadata` as a [[metabase.lib.metadata.protocols/MetadataProvider]]."
@@ -461,7 +467,7 @@
       (fields   [_this table-id]    (fields   metadata table-id))
       (metrics  [_this table-id]    (metrics  metadata table-id))
       (segments [_this table-id]    (segments metadata table-id))
-      (setting  [_this setting-key] (setting  setting-key))
+      (setting  [_this setting-key] (setting  setting-key unparsed-metadata))
 
       ;; for debugging: call [[clojure.datafy/datafy]] on one of these to parse all of our metadata and see the whole
       ;; thing at once.

--- a/src/metabase/lib/metadata.cljc
+++ b/src/metabase/lib/metadata.cljc
@@ -1,6 +1,7 @@
 (ns metabase.lib.metadata
   (:require
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
+   [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
@@ -208,3 +209,17 @@
   (if-let [card-id (lib.util/legacy-string-table-id->card-id table-id)]
     (card metadata-providerable card-id)
     (table metadata-providerable table-id)))
+
+(mu/defn editable? :- :boolean
+  "Given a query, returns whether it is considered editable.
+
+  There's no editable flag! Instead, a query is **not** editable if:
+  - Database is missing from the metadata (no permissions at all);
+  - Database is present but tables (at least the `:source-table`) are missing (missing table permissions); or
+  - Similarly, the card specified by `:source-card` is missing from the metadata.
+  If metadata for the `:source-table` or `:source-card` can be found, then the query is editable."
+  [query :- ::lib.schema/query]
+  (let [{:keys [source-table source-card]} (lib.util/query-stage query 0)]
+    (boolean (and (database query)
+                  (or (and source-table (table query source-table))
+                      (and source-card  (card  query source-card)))))))

--- a/src/metabase/lib/metadata.cljc
+++ b/src/metabase/lib/metadata.cljc
@@ -219,7 +219,8 @@
   - Similarly, the card specified by `:source-card` is missing from the metadata.
   If metadata for the `:source-table` or `:source-card` can be found, then the query is editable."
   [query :- ::lib.schema/query]
-  (let [{:keys [source-table source-card]} (lib.util/query-stage query 0)]
+  (let [{:keys [source-table source-card] :as stage0} (lib.util/query-stage query 0)]
     (boolean (and (database query)
                   (or (and source-table (table query source-table))
-                      (and source-card  (card  query source-card)))))))
+                      (and source-card  (card  query source-card))
+                      (= (:lib/type stage0) :mbql.stage/native))))))

--- a/src/metabase/lib/schema/drill_thru.cljc
+++ b/src/metabase/lib/schema/drill_thru.cljc
@@ -158,7 +158,7 @@
    [:map
     [:type     [:= :drill-thru/automatic-insights]]
     [:lib/type [:= :metabase.lib.drill-thru/drill-thru]]
-    [:column-ref [:ref ::lib.schema.ref/ref]]
+    [:column-ref [:maybe [:ref ::lib.schema.ref/ref]]]
     [:dimensions [:ref ::context.row]]]])
 
 (mr/def ::drill-thru.zoom-in.timeseries.next-unit

--- a/src/metabase/lib/schema/drill_thru.cljc
+++ b/src/metabase/lib/schema/drill_thru.cljc
@@ -154,10 +154,12 @@
 
 (mr/def ::drill-thru.automatic-insights
   [:merge
-   ::drill-thru.common.with-column
+   ::drill-thru.common
    [:map
     [:type     [:= :drill-thru/automatic-insights]]
-    [:lib/type [:= :metabase.lib.drill-thru/drill-thru]]]])
+    [:lib/type [:= :metabase.lib.drill-thru/drill-thru]]
+    [:column-ref [:ref ::lib.schema.ref/ref]]
+    [:dimensions [:ref ::context.row]]]])
 
 (mr/def ::drill-thru.zoom-in.timeseries.next-unit
   [:enum :quarter :month :week :day :hour :minute])

--- a/test/metabase/lib/drill_thru/automatic_insights_test.cljc
+++ b/test/metabase/lib/drill_thru/automatic_insights_test.cljc
@@ -42,8 +42,6 @@
                   :column-ref [:aggregation {} u/uuid-regex]
                   :dimensions [{} {}]}}))
 
-;; START HERE - keep writing tests for automatic insights.
-;; It's similar to underlying-records but not identical. It doesn't convert the breakouts to top-level columns.
 (deftest ^:parallel do-not-return-fk-filter-for-non-fk-column-test
   (testing "underlying-records should only get shown once for aggregated query (#34439)"
     (let [test-case           {:click-type  :cell

--- a/test/metabase/lib/drill_thru/automatic_insights_test.cljc
+++ b/test/metabase/lib/drill_thru/automatic_insights_test.cljc
@@ -1,0 +1,262 @@
+(ns metabase.lib.drill-thru.automatic-insights-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [medley.core :as m]
+   [metabase.lib.core :as lib]
+   [metabase.lib.drill-thru :as lib.drill-thru]
+   [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
+   [metabase.lib.options :as lib.options]
+   [metabase.lib.test-metadata :as meta]
+   [metabase.lib.test-util.metadata-providers.mock :as providers.mock]
+   [metabase.util :as u]
+   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal])
+       :clj  ([java-time.api :as jt]))))
+
+(deftest ^:parallel returns-automatic-insights-test-1
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/automatic-insights
+    :click-type  :cell
+    :query-type  :aggregated
+    :column-name "count"
+    :expected    {:type :drill-thru/automatic-insights
+                  :column-ref [:aggregation {} u/uuid-regex]
+                  :dimensions [{} {}]}}))
+
+(deftest ^:parallel returns-automatic-insights-test-2
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/automatic-insights
+    :click-type  :cell
+    :query-type  :aggregated
+    :column-name "sum"
+    :expected    {:type :drill-thru/automatic-insights
+                  :column-ref [:aggregation {} u/uuid-regex]
+                  :dimensions [{} {}]}}))
+
+(deftest ^:parallel returns-automatic-insights-test-3
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/automatic-insights
+    :click-type  :cell
+    :query-type  :aggregated
+    :column-name "max"
+    :expected    {:type :drill-thru/automatic-insights
+                  :column-ref [:aggregation {} u/uuid-regex]
+                  :dimensions [{} {}]}}))
+
+;; START HERE - keep writing tests for automatic insights.
+;; It's similar to underlying-records but not identical. It doesn't convert the breakouts to top-level columns.
+(deftest ^:parallel do-not-return-fk-filter-for-non-fk-column-test
+  (testing "underlying-records should only get shown once for aggregated query (#34439)"
+    (let [test-case           {:click-type  :cell
+                               :query-type  :aggregated
+                               :column-name "max"}
+          {:keys [query row]} (lib.drill-thru.tu/query-and-row-for-test-case test-case)
+          context             (lib.drill-thru.tu/test-case-context query row test-case)]
+      (testing (str "\nQuery = \n"   (u/pprint-to-str query)
+                    "\nContext =\n" (u/pprint-to-str context))
+        (let [drills (lib/available-drill-thrus query context)]
+          (testing (str "\nAvailable drills =\n" (u/pprint-to-str drills))
+            (is (= 1
+                   (count (filter #(= (:type %) :drill-thru/underlying-records)
+                                  drills))))))))))
+
+
+#?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
+
+(def last-month
+  #?(:cljs (let [now    (js/Date.)
+                 year   (.getFullYear now)
+                 month  (.getMonth now)]
+             (-> (js/Date.UTC year (dec month))
+                 (js/Date.)
+                 (.toISOString)))
+     :clj  (let [last-month (-> (jt/zoned-date-time (jt/year) (jt/month))
+                                (jt/minus (jt/months 1)))]
+             (jt/format :iso-offset-date-time last-month))))
+
+(defn- underlying-state [query agg-index agg-value breakout-values exp-filters-fn]
+  (let [columns                         (lib/returned-columns query)
+        {aggs      :source/aggregations
+         breakouts :source/breakouts}   (group-by :lib/source columns)
+        agg-column                      (nth aggs agg-index)
+        agg-dim                         {:column     agg-column
+                                         :column-ref (lib/ref agg-column)
+                                         :value      agg-value}]
+    (is (= (count breakouts)
+           (count breakout-values)))
+    (let [breakout-dims (for [[breakout value] (map vector breakouts breakout-values)]
+                          {:column     breakout
+                           :column-ref (lib/ref breakout)
+                           :value      value})
+          context       (merge agg-dim
+                               {:row        (cons agg-dim breakout-dims)
+                                :dimensions breakout-dims})]
+      (is (=? {:lib/type :mbql/query
+               :stages [{:filters     (exp-filters-fn agg-dim breakout-dims)
+                         :aggregation (symbol "nil #_\"key is not present.\"")
+                         :breakout    (symbol "nil #_\"key is not present.\"")
+                         :fields      (symbol "nil #_\"key is not present.\"")}]}
+              (->> (lib.drill-thru/available-drill-thrus query context)
+                   (m/find-first #(= (:type %) :drill-thru/underlying-records))
+                   (lib.drill-thru/drill-thru query -1)))))))
+
+(deftest ^:parallel underlying-records-apply-test
+  (testing "sum(subtotal) over time"
+    (underlying-state (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                          (lib/aggregate (lib/sum (meta/field-metadata :orders :subtotal)))
+                          (lib/breakout (lib/with-temporal-bucket
+                                          (meta/field-metadata :orders :created-at)
+                                          :month)))
+                      0 #_agg-index
+                      42295.12
+                      [last-month]
+                      (fn [_agg-dim [breakout-dim]]
+                        [[:= {}
+                          (-> (:column-ref breakout-dim)
+                              (lib.options/with-options {:temporal-unit :month}))
+                          last-month]]))))
+
+(deftest ^:parallel underlying-records-apply-test-2
+  (testing "sum_where(subtotal, products.category = \"Doohickey\") over time"
+    (underlying-state (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                          (lib/aggregate (lib/sum-where
+                                           (meta/field-metadata :orders :subtotal)
+                                           (lib/= (meta/field-metadata :products :category)
+                                                  "Doohickey")))
+                          (lib/breakout (lib/with-temporal-bucket
+                                          (meta/field-metadata :orders :created-at)
+                                          :month)))
+                      0 #_agg-index
+                      6572.12
+                      [last-month]
+                      (fn [_agg-dim [breakout-dim]]
+                        [[:= {}
+                          (-> (:column-ref breakout-dim)
+                              (lib.options/with-options {:temporal-unit :month}))
+                          last-month]
+                         [:= {} (-> (meta/field-metadata :products :category)
+                                    lib/ref
+                                    (lib.options/with-options {}))
+                          "Doohickey"]]))))
+
+(deftest ^:parallel underlying-records-apply-test-3
+  (testing "metric over time"
+    (let [metric   {:description "Orders with a subtotal of $100 or more."
+                    :archived false
+                    :updated-at "2023-10-04T20:11:34.029582"
+                    :lib/type :metadata/metric
+                    :definition
+                    {"source-table" (meta/id :orders)
+                     "aggregation" [["count"]]
+                     "filter" [">=" ["field" (meta/id :orders :subtotal) nil] 100]}
+                    :table-id (meta/id :orders)
+                    :name "Large orders"
+                    :caveats nil
+                    :entity-id "NWMNcv_yhhZIT7winoIdi"
+                    :how-is-this-calculated nil
+                    :show-in-getting-started false
+                    :id 1
+                    :database (meta/id)
+                    :points-of-interest nil
+                    :creator-id 1
+                    :created-at "2023-10-04T20:11:34.029582"}
+          provider (lib/composed-metadata-provider
+                    meta/metadata-provider
+                    (providers.mock/mock-metadata-provider {:metrics [metric]}))]
+      (underlying-state (-> (lib/query provider (meta/table-metadata :orders))
+                            (lib/aggregate metric)
+                            (lib/breakout (lib/with-temporal-bucket
+                                            (meta/field-metadata :orders :created-at)
+                                            :month)))
+                        0 #_agg-index
+                        6572.12
+                        [last-month]
+                        (fn [_agg-dim [breakout-dim]]
+                          (let [monthly-breakout (-> (:column-ref breakout-dim)
+                                                     (lib.options/with-options {:temporal-unit :month}))
+                                subtotal         (-> (meta/field-metadata :orders :subtotal)
+                                                     lib/ref
+                                                     (lib.options/with-options {}))]
+                            [[:=  {} monthly-breakout last-month]
+                             [:>= {} subtotal 100]]))))))
+
+(deftest ^:parallel multiple-aggregations-multiple-breakouts-test
+  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                  (lib/aggregate (lib/count))
+                  (lib/aggregate (lib/sum (meta/field-metadata :orders :tax)))
+                  (lib/aggregate (lib/max (meta/field-metadata :orders :discount)))
+                  (lib/breakout  (meta/field-metadata :orders :product-id))
+                  (lib/breakout  (lib/with-temporal-bucket (meta/field-metadata :orders :created-at) :month)))]
+    (doseq [[agg-index agg-value] [[0 77]
+                                   [1 1]
+                                   [2 :null]]]
+      (underlying-state query agg-index agg-value
+                        [120 last-month]
+                        (fn [_agg-dim [product-id-dim created-at-dim]]
+                          [[:= {}
+                            (-> (:column-ref product-id-dim)
+                                (lib.options/update-options dissoc :lib/uuid))
+                            120]
+                           [:= {}
+                            (-> (:column-ref created-at-dim)
+                                (lib.options/with-options {:temporal-unit :month}))
+                            last-month]])))))
+
+(deftest ^:parallel temporal-unit-breakouts-test
+  (let [column (-> (meta/field-metadata :orders :created-at)
+                   (lib/with-temporal-bucket :day-of-month))]
+    (doseq [[types column] {:default column
+                            :forced  (-> column
+                                         (dissoc :semantic-type)
+                                         (assoc :base-type :type/Integer
+                                                :effective-type :type/Integer))}
+            :let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                            (lib/aggregate (lib/count))
+                            (lib/breakout  column))]]
+      (testing (str "breakout with temporal-unit with " (name types) " types")
+        (let [agg-index 0
+              agg-value 96]
+          (underlying-state query agg-index agg-value
+                            [1]
+                            (fn [_agg-dim [created-at-dim]]
+                              [[:= {}
+                                (-> (:column-ref created-at-dim)
+                                    (lib.options/with-options {:temporal-unit :day-of-month}))
+                                1]])))))))
+
+(deftest ^:parallel binned-column-test
+  (testing "Underlying records for a binned column should generate a filters for current bin's min/max values (#35431)"
+    (let [query                    (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                                       (lib/aggregate (lib/count))
+                                       (lib/breakout (-> (meta/field-metadata :orders :quantity)
+                                                         (lib/with-binning {:strategy :num-bins, :num-bins 10}))))
+          col-count                (m/find-first #(= (:name %) "count")
+                                                 (lib/returned-columns query))
+          _                        (is (some? col-count))
+          col-orders-quantity      (m/find-first #(= (:name %) "QUANTITY")
+                                                 (lib/returned-columns query))
+          _                        (is (some? col-orders-quantity))
+          context                  {:column     col-count
+                                    :column-ref (lib/ref col-count)
+                                    :value      1
+                                    :dimensions [{:column     col-orders-quantity
+                                                  :column-ref (lib/ref col-orders-quantity)
+                                                  :value      20}]}
+          available-drills         (lib/available-drill-thrus query context)
+          underlying-records-drill (m/find-first #(= (:type %) :drill-thru/underlying-records)
+                                                 available-drills)
+          _                        (is (some? underlying-records-drill))
+          query'                   (lib/drill-thru query underlying-records-drill)]
+      (is (=? {:stages [{:lib/type :mbql.stage/mbql
+                         :filters  [[:>=
+                                     {}
+                                     [:field
+                                      {:binning (symbol "nil #_\"key is not present.\"")}
+                                      (meta/id :orders :quantity)]
+                                     20]
+                                    [:<
+                                     {}
+                                     [:field
+                                      {:binning (symbol "nil #_\"key is not present.\"")}
+                                      (meta/id :orders :quantity)]
+                                     30.0]]}]}
+              query')))))

--- a/test/metabase/lib/drill_thru/automatic_insights_test.cljc
+++ b/test/metabase/lib/drill_thru/automatic_insights_test.cljc
@@ -3,14 +3,13 @@
    [clojure.test :refer [deftest is testing]]
    [medley.core :as m]
    [metabase.lib.core :as lib]
-   [metabase.lib.drill-thru :as lib.drill-thru]
    [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
-   [metabase.lib.options :as lib.options]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util.metadata-providers.mock :as providers.mock]
    [metabase.util :as u]
-   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal])
-       :clj  ([java-time.api :as jt]))))
+   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))))
+
+#?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
 (deftest ^:parallel returns-automatic-insights-test-1
   (lib.drill-thru.tu/test-returns-drill
@@ -42,101 +41,55 @@
                   :column-ref [:aggregation {} u/uuid-regex]
                   :dimensions [{} {}]}}))
 
-(deftest ^:parallel do-not-return-fk-filter-for-non-fk-column-test
-  (testing "underlying-records should only get shown once for aggregated query (#34439)"
-    (let [test-case           {:click-type  :cell
-                               :query-type  :aggregated
-                               :column-name "max"}
-          {:keys [query row]} (lib.drill-thru.tu/query-and-row-for-test-case test-case)
-          context             (lib.drill-thru.tu/test-case-context query row test-case)]
-      (testing (str "\nQuery = \n"   (u/pprint-to-str query)
-                    "\nContext =\n" (u/pprint-to-str context))
-        (let [drills (lib/available-drill-thrus query context)]
-          (testing (str "\nAvailable drills =\n" (u/pprint-to-str drills))
-            (is (= 1
-                   (count (filter #(= (:type %) :drill-thru/underlying-records)
-                                  drills))))))))))
+(defn- auto-insights [query exp-filters]
+  (let [[created-at sum] (lib/returned-columns query)
+        drills           (lib/available-drill-thrus
+                           query -1 {:column     sum
+                                     :column-ref (lib/ref sum)
+                                     :value      124.5
+                                     :dimensions [{:column     created-at
+                                                   :column-ref (lib/ref created-at)
+                                                   :value      "2023-12-01"}]})
+        drill            (m/find-first #(= (:type %) :drill-thru/automatic-insights) drills)]
+    (is (=? {:lib/type :mbql/query
+             :stages [{:filters     exp-filters
+                       :aggregation (symbol "nil #_\"key is not present.\"")
+                       :breakout    (symbol "nil #_\"key is not present.\"")
+                       :fields      (symbol "nil #_\"key is not present.\"")}]}
+            (lib/drill-thru query -1 drill)))) )
 
+(deftest ^:parallel automatic-insights-apply-test
+  (let [filters [[:= {} [:field {} (meta/id :orders :created-at)] "2023-12-01"]]]
+    (testing "breakouts are turned to filters, aggregations dropped"
+      (auto-insights (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                         (lib/aggregate (lib/sum (meta/field-metadata :orders :subtotal)))
+                         (lib/breakout (lib/with-temporal-bucket
+                                         (meta/field-metadata :orders :created-at)
+                                         :month)))
+                     filters))
+    (testing "existing filters are dropped"
+      (auto-insights (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                         (lib/filter (lib/= (meta/field-metadata :products :category) "Gizmo"))
+                         (lib/aggregate (lib/sum (meta/field-metadata :orders :subtotal)))
+                         (lib/breakout (lib/with-temporal-bucket
+                                         (meta/field-metadata :orders :created-at)
+                                         :month)))
+                     filters))))
 
-#?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
-
-(def last-month
-  #?(:cljs (let [now    (js/Date.)
-                 year   (.getFullYear now)
-                 month  (.getMonth now)]
-             (-> (js/Date.UTC year (dec month))
-                 (js/Date.)
-                 (.toISOString)))
-     :clj  (let [last-month (-> (jt/zoned-date-time (jt/year) (jt/month))
-                                (jt/minus (jt/months 1)))]
-             (jt/format :iso-offset-date-time last-month))))
-
-(defn- underlying-state [query agg-index agg-value breakout-values exp-filters-fn]
-  (let [columns                         (lib/returned-columns query)
-        {aggs      :source/aggregations
-         breakouts :source/breakouts}   (group-by :lib/source columns)
-        agg-column                      (nth aggs agg-index)
-        agg-dim                         {:column     agg-column
-                                         :column-ref (lib/ref agg-column)
-                                         :value      agg-value}]
-    (is (= (count breakouts)
-           (count breakout-values)))
-    (let [breakout-dims (for [[breakout value] (map vector breakouts breakout-values)]
-                          {:column     breakout
-                           :column-ref (lib/ref breakout)
-                           :value      value})
-          context       (merge agg-dim
-                               {:row        (cons agg-dim breakout-dims)
-                                :dimensions breakout-dims})]
-      (is (=? {:lib/type :mbql/query
-               :stages [{:filters     (exp-filters-fn agg-dim breakout-dims)
-                         :aggregation (symbol "nil #_\"key is not present.\"")
-                         :breakout    (symbol "nil #_\"key is not present.\"")
-                         :fields      (symbol "nil #_\"key is not present.\"")}]}
-              (->> (lib.drill-thru/available-drill-thrus query context)
-                   (m/find-first #(= (:type %) :drill-thru/underlying-records))
-                   (lib.drill-thru/drill-thru query -1)))))))
-
-(deftest ^:parallel underlying-records-apply-test
-  (testing "sum(subtotal) over time"
-    (underlying-state (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
-                          (lib/aggregate (lib/sum (meta/field-metadata :orders :subtotal)))
-                          (lib/breakout (lib/with-temporal-bucket
-                                          (meta/field-metadata :orders :created-at)
-                                          :month)))
-                      0 #_agg-index
-                      42295.12
-                      [last-month]
-                      (fn [_agg-dim [breakout-dim]]
-                        [[:= {}
-                          (-> (:column-ref breakout-dim)
-                              (lib.options/with-options {:temporal-unit :month}))
-                          last-month]]))))
-
-(deftest ^:parallel underlying-records-apply-test-2
+(deftest ^:parallel automatic-insights-apply-test-2
   (testing "sum_where(subtotal, products.category = \"Doohickey\") over time"
-    (underlying-state (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
-                          (lib/aggregate (lib/sum-where
-                                           (meta/field-metadata :orders :subtotal)
-                                           (lib/= (meta/field-metadata :products :category)
-                                                  "Doohickey")))
-                          (lib/breakout (lib/with-temporal-bucket
-                                          (meta/field-metadata :orders :created-at)
-                                          :month)))
-                      0 #_agg-index
-                      6572.12
-                      [last-month]
-                      (fn [_agg-dim [breakout-dim]]
-                        [[:= {}
-                          (-> (:column-ref breakout-dim)
-                              (lib.options/with-options {:temporal-unit :month}))
-                          last-month]
-                         [:= {} (-> (meta/field-metadata :products :category)
-                                    lib/ref
-                                    (lib.options/with-options {}))
-                          "Doohickey"]]))))
+    (auto-insights (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                       (lib/aggregate (lib/sum-where
+                                        (meta/field-metadata :orders :subtotal)
+                                        (lib/= (meta/field-metadata :products :category)
+                                               "Doohickey")))
+                       (lib/breakout (lib/with-temporal-bucket
+                                       (meta/field-metadata :orders :created-at)
+                                       :month)))
+                   [[:= {} [:field {} (meta/id :orders :created-at)] "2023-12-01"]
+                    [:= {} [:field {} (meta/id :products :category)] "Doohickey"]])))
 
-(deftest ^:parallel underlying-records-apply-test-3
+(deftest ^:parallel automatic-insights-apply-test-3
   (testing "metric over time"
     (let [metric   {:description "Orders with a subtotal of $100 or more."
                     :archived false
@@ -160,90 +113,37 @@
           provider (lib/composed-metadata-provider
                     meta/metadata-provider
                     (providers.mock/mock-metadata-provider {:metrics [metric]}))]
-      (underlying-state (-> (lib/query provider (meta/table-metadata :orders))
-                            (lib/aggregate metric)
-                            (lib/breakout (lib/with-temporal-bucket
-                                            (meta/field-metadata :orders :created-at)
-                                            :month)))
-                        0 #_agg-index
-                        6572.12
-                        [last-month]
-                        (fn [_agg-dim [breakout-dim]]
-                          (let [monthly-breakout (-> (:column-ref breakout-dim)
-                                                     (lib.options/with-options {:temporal-unit :month}))
-                                subtotal         (-> (meta/field-metadata :orders :subtotal)
-                                                     lib/ref
-                                                     (lib.options/with-options {}))]
-                            [[:=  {} monthly-breakout last-month]
-                             [:>= {} subtotal 100]]))))))
-
-(deftest ^:parallel multiple-aggregations-multiple-breakouts-test
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
-                  (lib/aggregate (lib/count))
-                  (lib/aggregate (lib/sum (meta/field-metadata :orders :tax)))
-                  (lib/aggregate (lib/max (meta/field-metadata :orders :discount)))
-                  (lib/breakout  (meta/field-metadata :orders :product-id))
-                  (lib/breakout  (lib/with-temporal-bucket (meta/field-metadata :orders :created-at) :month)))]
-    (doseq [[agg-index agg-value] [[0 77]
-                                   [1 1]
-                                   [2 :null]]]
-      (underlying-state query agg-index agg-value
-                        [120 last-month]
-                        (fn [_agg-dim [product-id-dim created-at-dim]]
-                          [[:= {}
-                            (-> (:column-ref product-id-dim)
-                                (lib.options/update-options dissoc :lib/uuid))
-                            120]
-                           [:= {}
-                            (-> (:column-ref created-at-dim)
-                                (lib.options/with-options {:temporal-unit :month}))
-                            last-month]])))))
-
-(deftest ^:parallel temporal-unit-breakouts-test
-  (let [column (-> (meta/field-metadata :orders :created-at)
-                   (lib/with-temporal-bucket :day-of-month))]
-    (doseq [[types column] {:default column
-                            :forced  (-> column
-                                         (dissoc :semantic-type)
-                                         (assoc :base-type :type/Integer
-                                                :effective-type :type/Integer))}
-            :let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
-                            (lib/aggregate (lib/count))
-                            (lib/breakout  column))]]
-      (testing (str "breakout with temporal-unit with " (name types) " types")
-        (let [agg-index 0
-              agg-value 96]
-          (underlying-state query agg-index agg-value
-                            [1]
-                            (fn [_agg-dim [created-at-dim]]
-                              [[:= {}
-                                (-> (:column-ref created-at-dim)
-                                    (lib.options/with-options {:temporal-unit :day-of-month}))
-                                1]])))))))
+      (auto-insights (-> (lib/query provider (meta/table-metadata :orders))
+                         (lib/aggregate metric)
+                         (lib/breakout (lib/with-temporal-bucket
+                                         (meta/field-metadata :orders :created-at)
+                                         :month)))
+                     [[:= {} [:field {} (meta/id :orders :created-at)] "2023-12-01"]
+                      [:>= {} [:field {} (meta/id :orders :subtotal)] 100]]))))
 
 (deftest ^:parallel binned-column-test
-  (testing "Underlying records for a binned column should generate a filters for current bin's min/max values (#35431)"
-    (let [query                    (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
-                                       (lib/aggregate (lib/count))
-                                       (lib/breakout (-> (meta/field-metadata :orders :quantity)
-                                                         (lib/with-binning {:strategy :num-bins, :num-bins 10}))))
-          col-count                (m/find-first #(= (:name %) "count")
-                                                 (lib/returned-columns query))
-          _                        (is (some? col-count))
-          col-orders-quantity      (m/find-first #(= (:name %) "QUANTITY")
-                                                 (lib/returned-columns query))
-          _                        (is (some? col-orders-quantity))
-          context                  {:column     col-count
-                                    :column-ref (lib/ref col-count)
-                                    :value      1
-                                    :dimensions [{:column     col-orders-quantity
-                                                  :column-ref (lib/ref col-orders-quantity)
-                                                  :value      20}]}
-          available-drills         (lib/available-drill-thrus query context)
-          underlying-records-drill (m/find-first #(= (:type %) :drill-thru/underlying-records)
-                                                 available-drills)
-          _                        (is (some? underlying-records-drill))
-          query'                   (lib/drill-thru query underlying-records-drill)]
+  (testing "Automatic insights for a binned column should generate filters for current bin's min/max values"
+    (let [query               (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                                  (lib/aggregate (lib/count))
+                                  (lib/breakout (-> (meta/field-metadata :orders :quantity)
+                                                    (lib/with-binning {:strategy :num-bins, :num-bins 10}))))
+          col-count           (m/find-first #(= (:name %) "count")
+                                            (lib/returned-columns query))
+          _                   (is (some? col-count))
+          col-orders-quantity (m/find-first #(= (:name %) "QUANTITY")
+                                            (lib/returned-columns query))
+          _                   (is (some? col-orders-quantity))
+          context             {:column     col-count
+                               :column-ref (lib/ref col-count)
+                               :value      1
+                               :dimensions [{:column     col-orders-quantity
+                                             :column-ref (lib/ref col-orders-quantity)
+                                             :value      20}]}
+          available-drills    (lib/available-drill-thrus query context)
+          auto-insights-drill (m/find-first #(= (:type %) :drill-thru/underlying-records)
+                                            available-drills)
+          _                   (is (some? auto-insights-drill))
+          query'              (lib/drill-thru query auto-insights-drill)]
       (is (=? {:stages [{:lib/type :mbql.stage/mbql
                          :filters  [[:>=
                                      {}

--- a/test/metabase/lib/drill_thru_test.cljc
+++ b/test/metabase/lib/drill_thru_test.cljc
@@ -92,16 +92,13 @@
          :drill-thru/pivot
          (log/warn "drill-thru-method is not yet implemented for :drill-thru/pivot (#33559)")
 
-         :drill-thru/underlying-records
-         (log/warn "drill-thru-method is not yet implemented for :drill-thru/underlying-records (#34233)")
-
          (testing (str "\nquery =\n" (u/pprint-to-str query)
                        "\ndrill =\n" (u/pprint-to-str drill)
                        "\nargs =\n" (u/pprint-to-str args))
            (try
              (let [query' (apply lib/drill-thru query -1 drill args)]
                (is (not (me/humanize (mc/validate ::lib.schema/query query'))))
-               (when (< depth test-drill-applications-max-depth)
+               (when (< (inc depth) test-drill-applications-max-depth)
                  (testing (str "\n\nDEPTH = " (inc depth) "\n\nquery =\n" (u/pprint-to-str query'))
                    (test-drill-applications query' context (inc depth)))))
              (catch #?(:clj Throwable :cljs :default) e
@@ -374,7 +371,14 @@
             _                 (assert created-at-column)
             row               [(basic-context created-at-column "2018-05-01T00:00:00Z")
                                (basic-context count-column 457)]
-            expected-drills   {:quick-filter       {:lib/type  :metabase.lib.drill-thru/drill-thru
+            expected-drills   {:automatic-insights {:lib/type   :metabase.lib.drill-thru/drill-thru
+                                                    :type       :drill-thru/automatic-insights
+                                                    :column-ref some?
+                                                    :dimensions [{:column     {:name                     "CREATED_AT"
+                                                                               ::lib.field/temporal-unit :month}
+                                                                  :column-ref some?
+                                                                  :value      "2018-05-01T00:00:00Z"}]}
+                               :quick-filter       {:lib/type  :metabase.lib.drill-thru/drill-thru
                                                     :type      :drill-thru/quick-filter
                                                     :operators [{:name "<"}
                                                                 {:name ">"}
@@ -408,7 +412,8 @@
                                {:row        row
                                 :dimensions [(basic-context created-at-column "2018-05-01T00:00:00Z")]})]
             (testing (str "\ncontext =\n" (u/pprint-to-str context))
-              (is (=? (map expected-drills [:pivot :quick-filter :underlying-records :zoom-in.timeseries])
+              (is (=? (map expected-drills [:automatic-insights :pivot :quick-filter :underlying-records
+                                            :zoom-in.timeseries])
                       (lib/available-drill-thrus query -1 context)))
               (test-drill-applications query context))))))))
 
@@ -504,6 +509,10 @@
                                 {:row   [breakout-dim sum-dim]
                                  :dimensions [breakout-dim]})]
         (is (=? [{:lib/type   :metabase.lib.drill-thru/drill-thru
+                  :type       :drill-thru/automatic-insights
+                  :dimensions [breakout-dim]
+                  :column-ref (:column-ref sum-dim)}
+                 {:lib/type   :metabase.lib.drill-thru/drill-thru
                   :type       :drill-thru/pivot
                   :pivots     {:category (repeat 5 {})
                                :location (repeat 3 {})}}
@@ -669,7 +678,10 @@
    {:click-type  :cell
     :query-type  :aggregated
     :column-name "count"
-    :expected    [{:type      :drill-thru/quick-filter
+    :expected    [{:type :drill-thru/automatic-insights
+                   :dimensions [{:column {:name "PRODUCT_ID"}}
+                                {:column {:name "CREATED_AT"}}]}
+                  {:type      :drill-thru/quick-filter
                    :operators [{:name "<"}
                                {:name ">"}
                                {:name "="}
@@ -688,7 +700,10 @@
      {:click-type  :cell
       :query-type  :aggregated
       :column-name "max"
-      :expected    [{:type :drill-thru/quick-filter, :operators [{:name "="}
+      :expected    [{:type :drill-thru/automatic-insights
+                     :dimensions [{:column {:name "PRODUCT_ID"}}
+                                  {:column {:name "CREATED_AT"}}]}
+                    {:type :drill-thru/quick-filter, :operators [{:name "="}
                                                                  {:name "≠"}]}
                     {:type :drill-thru/underlying-records, :row-count 2, :table-name "Orders"}
                     {:type :drill-thru/zoom-in.timeseries, :display-name "See this month by week"}]})))

--- a/test/metabase/lib/test_metadata.cljc
+++ b/test/metabase/lib/test_metadata.cljc
@@ -2391,7 +2391,8 @@
    :metadata-sync-schedule      "0 50 * * * ? *"
    :name                        "test-data"
    :settings                    {:breakout-bin-width 10.0
-                                 :breakout-bins-num  8}
+                                 :breakout-bins-num  8
+                                 :enable-xrays       true}
    :caveats                     nil
    :tables                      [(table-metadata-method :categories)
                                  (table-metadata-method :checkins)


### PR DESCRIPTION
[MLv2] Implement `automatic-insights` drill

Automatic insights drills have some unusual conditions.
This adds `metabase.lib.metadata/editable?` and checks it before
returning any drills.

On settings:
In the app, `MetabaseSettings` is a global singleton and the settings
are sometimes updated in place. In the JS testing environment several
mock settings instances can exist at once, and the global singleton does
not necessarily have the values we want for any given test.

This PR makes `metabase.lib.metadata/setting` check for `describe` and
`it` globals to see if this is the testing environment, and to trust the
metadata's `settings` in that case.

Implements the BE side of #33558.
