### PR TITLE
i18n() syntax errors caught while translating

### DIFF
--- a/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.tsx
@@ -282,7 +282,7 @@ const H2PersistenceWarning = () => (
   <Stack my="md" maw={620}>
     <Alert icon="warning" variant="warning">
       <Text>
-        {t`Warning: uploads to the Sample Database are for testing only and may disappear. If you want your data to stick around, you should upload to a PostgreSQL or MySQL database.`}
+        {t`Warning: uploads to the Sample Database are for testing only and may disappear. If you want your data to stick around, you should upload it to a PostgreSQL or MySQL database.`}
       </Text>
     </Alert>
   </Stack>

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -757,7 +757,7 @@
 (defmethod ->honeysql [:sql :-]
   [driver [_ & [first-arg & other-args :as args]]]
   (cond (interval? first-arg)
-        (throw (ex-info (tru "Interval as first argrument to subtraction is not allowed.")
+        (throw (ex-info (tru "An interval as the first argument to subtraction is not allowed.")
                         {:type qp.error-type/invalid-query
                          :args args}))
         (and (some interval? other-args)

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -445,7 +445,7 @@
   (when (< (try (.. ^PreparedStatement stmt getParameterMetaData getParameterCount)
                 (catch Throwable _ (count params)))
            (count params))
-    (throw (ex-info (tru "It looks like we got more parameters than we can handle, remember that parameters cannot be used in comments or as identifiers.")
+    (throw (ex-info (tru "It looks like we have more parameters than we can handle, remember that parameters cannot be used in comments or as identifiers.")
                     {:driver driver
                      :type   qp.error-type/driver
                      :statement (str/split-lines (str stmt))


### PR DESCRIPTION
minor syntax and semantic errors detected while translating to ES