### PR TITLE
Ensure that admin perms override group manager in GET /api/user

### DIFF
--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -209,6 +209,8 @@
         group-id-clause     (cond
                               ;; We know that the user is either admin or group manager of the given group_id (if it exists)
                               group_id                [group_id]
+                              ;; Superuser can see all users, so don't filter by group ID
+                              api/*is-superuser?*     nil
                               ;; otherwise, if the user is a group manager, only show them users in the groups they manage
                               api/*is-group-manager?* (vec manager-group-ids))
         clauses             (user-clauses status query group-id-clause include_deactivated)]

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -94,11 +94,11 @@
            :model/PermissionsGroup           {group-id3 :id} {:name "Good Folks"}
            :model/PermissionsGroupMembership _ {:user_id (mt/user->id :rasta) :group_id group-id1 :is_group_manager true}
            :model/PermissionsGroupMembership _ {:user_id (mt/user->id :lucky) :group_id group-id1 :is_group_manager false}
-           :model/PermissionsGroupMembership _ {:user_id (mt/user->id :crowberto) :group_id group-id2 :is_group_manager false}
+           :model/PermissionsGroupMembership _ {:user_id (mt/user->id :crowberto) :group_id group-id2 :is_group_manager true}
            :model/PermissionsGroupMembership _ {:user_id (mt/user->id :lucky) :group_id group-id2 :is_group_manager true}
            :model/PermissionsGroupMembership _ {:user_id (mt/user->id :rasta) :group_id group-id3 :is_group_manager false}
            :model/PermissionsGroupMembership _ {:user_id (mt/user->id :lucky) :group_id group-id3 :is_group_manager true}]
-        (testing "admin can get users from any group"
+        (testing "admin can get users from any group, even when they are also marked as a group manager"
           (is (= #{"lucky@metabase.com"
                    "rasta@metabase.com"}
                  (->> ((mt/user-http-request :crowberto :get 200 "user" :group_id group-id1) :data)
@@ -108,6 +108,13 @@
           (is (= #{"lucky@metabase.com"
                    "crowberto@metabase.com"}
                  (->> ((mt/user-http-request :crowberto :get 200 "user" :group_id group-id2) :data)
+                      (filter mt/test-user?)
+                      (map :email)
+                      set)))
+          (is (= #{"crowberto@metabase.com"
+                   "rasta@metabase.com"
+                   "lucky@metabase.com"}
+                 (->> ((mt/user-http-request :crowberto :get 200 "user") :data)
                       (filter mt/test-user?)
                       (map :email)
                       set))))


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/36412

When a user is promoted to admin after they were previously a group manager, we keep them marked a a group manager in the DB. I think this is intentional—so that if they are demoted again they retain their group manager status. (Though I could be remembering incorrectly)

This PR fixes the user list query so that admin users who are _also_ group managers can see all users.