### PR TITLE
Fix auto-connecting filter fails when adding a new question

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -31,6 +31,23 @@ const { ORDERS_ID, ORDERS, PRODUCTS, PRODUCTS_ID, REVIEWS_ID } =
   SAMPLE_DATABASE;
 
 describe("scenarios > dashboard > parameters", () => {
+  const cards = [
+    {
+      card_id: ORDERS_COUNT_QUESTION_ID,
+      row: 0,
+      col: 0,
+      size_x: 5,
+      size_y: 4,
+    },
+    {
+      card_id: ORDERS_COUNT_QUESTION_ID,
+      row: 0,
+      col: 5,
+      size_x: 5,
+      size_y: 4,
+    },
+  ];
+
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
@@ -43,22 +60,7 @@ describe("scenarios > dashboard > parameters", () => {
       // add the same question twice
       updateDashboardCards({
         dashboard_id: id,
-        cards: [
-          {
-            card_id: ORDERS_COUNT_QUESTION_ID,
-            row: 0,
-            col: 0,
-            size_x: 5,
-            size_y: 4,
-          },
-          {
-            card_id: ORDERS_COUNT_QUESTION_ID,
-            row: 0,
-            col: 4,
-            size_x: 5,
-            size_y: 4,
-          },
-        ],
+        cards,
       });
 
       visitDashboard(id);
@@ -615,24 +617,7 @@ describe("scenarios > dashboard > parameters", () => {
 
     describe("when wiring parameter to all cards for a filter", () => {
       it("should automatically wire parameters to cards with matching fields", () => {
-        createDashboardWithCards({
-          cards: [
-            {
-              card_id: ORDERS_BY_YEAR_QUESTION_ID,
-              row: 0,
-              col: 0,
-              size_x: 5,
-              size_y: 4,
-            },
-            {
-              card_id: ORDERS_COUNT_QUESTION_ID,
-              row: 0,
-              col: 4,
-              size_x: 5,
-              size_y: 4,
-            },
-          ],
-        }).then(dashboardId => {
+        createDashboardWithCards({ cards }).then(dashboardId => {
           visitDashboard(dashboardId);
         });
 
@@ -658,24 +643,7 @@ describe("scenarios > dashboard > parameters", () => {
       });
 
       it("should not automatically wire parameters to cards that already have a parameter, despite matching fields", () => {
-        createDashboardWithCards({
-          cards: [
-            {
-              card_id: ORDERS_BY_YEAR_QUESTION_ID,
-              row: 0,
-              col: 0,
-              size_x: 5,
-              size_y: 4,
-            },
-            {
-              card_id: ORDERS_COUNT_QUESTION_ID,
-              row: 0,
-              col: 4,
-              size_x: 5,
-              size_y: 4,
-            },
-          ],
-        }).then(dashboardId => {
+        createDashboardWithCards({ cards }).then(dashboardId => {
           visitDashboard(dashboardId);
         });
 
@@ -757,23 +725,6 @@ describe("scenarios > dashboard > parameters", () => {
       });
 
       it("should autowire parameters to cards in different tabs", () => {
-        const cards = [
-          {
-            card_id: ORDERS_BY_YEAR_QUESTION_ID,
-            row: 0,
-            col: 0,
-            size_x: 5,
-            size_y: 4,
-          },
-          {
-            card_id: ORDERS_COUNT_QUESTION_ID,
-            row: 0,
-            col: 4,
-            size_x: 5,
-            size_y: 4,
-          },
-        ];
-
         createDashboardWithCards({ cards }).then(dashboardId => {
           visitDashboardAndCreateTab({
             dashboardId,
@@ -803,24 +754,23 @@ describe("scenarios > dashboard > parameters", () => {
           .should("be.visible");
       });
 
-      it("should undo parameter wiring when 'Undo auto-connection' is clicked", () => {
-        const cards = [
-          {
-            card_id: ORDERS_BY_YEAR_QUESTION_ID,
-            row: 0,
-            col: 0,
-            size_x: 5,
-            size_y: 4,
-          },
-          {
-            card_id: ORDERS_COUNT_QUESTION_ID,
-            row: 0,
-            col: 4,
-            size_x: 5,
-            size_y: 4,
-          },
-        ];
+      it("should add and wire a card without a failing request during editing (metabase#36469)", () => {
+        createDashboardWithCards({ cards }).then(dashboardId =>
+          visitDashboard(dashboardId),
+        );
 
+        editDashboard();
+        setFilter("Time", "Relative Date");
+        selectDashboardFilter(getDashboardCard(0), "Created At");
+        saveDashboard();
+
+        editDashboard();
+
+        addCardToDashboard("Orders, Count");
+        getDashboardCard(2).findByText("Count").should("exist");
+      });
+
+      it("should undo parameter wiring when 'Undo auto-connection' is clicked", () => {
         createDashboardWithCards({ cards }).then(dashboardId => {
           visitDashboard(dashboardId);
         });
@@ -904,23 +854,6 @@ describe("scenarios > dashboard > parameters", () => {
 
     describe("wiring parameters when adding a card", () => {
       it("should automatically wire a parameters to cards that are added to the dashboard", () => {
-        const cards = [
-          {
-            card_id: ORDERS_BY_YEAR_QUESTION_ID,
-            row: 0,
-            col: 0,
-            size_x: 5,
-            size_y: 4,
-          },
-          {
-            card_id: ORDERS_COUNT_QUESTION_ID,
-            row: 0,
-            col: 5,
-            size_x: 5,
-            size_y: 4,
-          },
-        ];
-
         createDashboardWithCards({ cards }).then(dashboardId => {
           visitDashboard(dashboardId);
         });
@@ -950,23 +883,6 @@ describe("scenarios > dashboard > parameters", () => {
       });
 
       it("should automatically wire parameters to cards that are added to the dashboard in a different tab", () => {
-        const cards = [
-          {
-            card_id: ORDERS_BY_YEAR_QUESTION_ID,
-            row: 0,
-            col: 0,
-            size_x: 5,
-            size_y: 4,
-          },
-          {
-            card_id: ORDERS_COUNT_QUESTION_ID,
-            row: 0,
-            col: 5,
-            size_x: 5,
-            size_y: 4,
-          },
-        ];
-
         createDashboardWithCards({ cards }).then(dashboardId => {
           visitDashboard(dashboardId);
         });
@@ -994,23 +910,6 @@ describe("scenarios > dashboard > parameters", () => {
       });
 
       it("should undo parameter wiring when 'Undo auto-connection' is clicked", () => {
-        const cards = [
-          {
-            card_id: ORDERS_BY_YEAR_QUESTION_ID,
-            row: 0,
-            col: 0,
-            size_x: 5,
-            size_y: 4,
-          },
-          {
-            card_id: ORDERS_COUNT_QUESTION_ID,
-            row: 0,
-            col: 5,
-            size_x: 5,
-            size_y: 4,
-          },
-        ];
-
         createDashboardWithCards({ cards }).then(dashboardId => {
           visitDashboard(dashboardId);
         });

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -69,7 +69,8 @@ class DashboardInner extends Component {
 
     if (
       !_.isEqual(prevProps.parameterValues, this.props.parameterValues) ||
-      !_.isEqual(prevProps.parameters, this.props.parameters) ||
+      (!_.isEqual(prevProps.parameters, this.props.parameters) &&
+        !this.props.isEditing) ||
       (!prevProps.dashboard && this.props.dashboard)
     ) {
       this.props.fetchDashboardCardData({ reload: false, clearCache: true });

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.unit.spec.tsx
@@ -14,6 +14,7 @@ type SetupOpts = {
   parameters: Parameter[]; // when empty, is an empty array
   parameterValues?: Record<string, any>; // when empty, is undefined
   skipLoader?: boolean;
+  isEditing: boolean;
 };
 
 async function setup(overrides: Partial<SetupOpts> = {}) {
@@ -25,6 +26,7 @@ async function setup(overrides: Partial<SetupOpts> = {}) {
     selectedTabId: null,
     parameters: [],
     parameterValues: undefined,
+    isEditing: false,
     ...overrides,
   };
   const mockLoadDashboardParams = jest.fn();
@@ -49,7 +51,7 @@ async function setup(overrides: Partial<SetupOpts> = {}) {
         isFullscreen={false}
         isNightMode={false}
         isSharing={false}
-        isEditing={false}
+        isEditing={props.isEditing}
         isEditingParameter={false}
         isNavbarOpen={false}
         isHeaderVisible={false}
@@ -97,6 +99,7 @@ async function setup(overrides: Partial<SetupOpts> = {}) {
       selectedTabId={opts.selectedTabId}
       parameters={opts.parameters}
       parameterValues={opts.parameterValues}
+      isEditing={opts.isEditing}
     />,
   );
 
@@ -152,6 +155,17 @@ describe("Dashboard data fetching", () => {
     });
     expect(mocks.mockFetchDashboardCardMetadata).toHaveBeenCalledTimes(0);
     expect(mocks.mockFetchDashboardCardData).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not fetch card data when parameters change and isEditing", async () => {
+    const mocks = await setup();
+    jest.clearAllMocks();
+    mocks.rerender({
+      parameters: [createMockActionParameter()],
+      isEditing: true,
+    });
+    expect(mocks.mockFetchDashboardCardMetadata).toHaveBeenCalledTimes(0);
+    expect(mocks.mockFetchDashboardCardData).toHaveBeenCalledTimes(0);
   });
 
   it("should fetch card data when parameter properties change", async () => {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/36469

### Description

We were fetching card data even while editing the dashboard, which together with auto-wiring led to a wrong request sent and error shown.

### How to verify

To reproduce the bug, see the [issue's description](https://github.com/metabase/metabase/issues/36469).

To verify it is fixed, please do the following:
1. Create a dashboard
2. Create and add a question
3. Create a filter (I am using time filter on created_at) and connect 
4. Save and reload
5. Start editing again, add another question

The dashcard should be added and displayed correctly, as well as auto-wiring applied.

### Demo

https://github.com/metabase/metabase/assets/2196347/5482e7cf-f3c0-424c-a0d1-9fa1469ce765


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
