### PR TITLE
Fix BE flake: metabase-enterprise.advanced-permissions.common-test/upload-csv-test

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -484,7 +484,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-postgres-ee'
-        test-args: ":exclude-tags '[:mb/once]' :only metabase-enterprise.advanced-permissions.common-test/upload-csv-test"
+        test-args: ":only metabase-enterprise.advanced-permissions.common-test/upload-csv-test"
 
   be-tests-postgres-latest-ee:
     needs: files-changed
@@ -518,6 +518,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-postgres-latest-ee'
+        test-args: ":only metabase-enterprise.advanced-permissions.common-test/upload-csv-test"
 
   be-tests-presto-jdbc-ee:
     needs: files-changed

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -484,6 +484,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-postgres-ee'
+        test-args: ":exclude-tags '[:mb/once]' :only metabase-enterprise.advanced-permissions.common-test/upload-csv-test"
 
   be-tests-postgres-latest-ee:
     needs: files-changed

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -484,6 +484,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-postgres-ee'
+        test-args: ":only metabase-enterprise.advanced-permissions.common-test/upload-csv-test"
 
   be-tests-postgres-latest-ee:
     needs: files-changed
@@ -517,6 +518,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-postgres-latest-ee'
+        test-args: ":only metabase-enterprise.advanced-permissions.common-test/upload-csv-test"
 
   be-tests-presto-jdbc-ee:
     needs: files-changed

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -484,7 +484,6 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-postgres-ee'
-        test-args: ":only metabase-enterprise.advanced-permissions.common-test/upload-csv-test"
 
   be-tests-postgres-latest-ee:
     needs: files-changed
@@ -518,7 +517,6 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-postgres-latest-ee'
-        test-args: ":only metabase-enterprise.advanced-permissions.common-test/upload-csv-test"
 
   be-tests-presto-jdbc-ee:
     needs: files-changed

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -22,6 +22,8 @@
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
+(set! *warn-on-reflection* true)
+
 (use-fixtures :once (fixtures/initialize :db :test-users))
 
 (defn- do-with-all-user-data-perms
@@ -730,9 +732,12 @@
                   (is (thrown-with-msg?
                         clojure.lang.ExceptionInfo
                         #"You don't have permissions to do that\."
-                        (upload-csv!)))))
-              (with-all-users-data-perms {db-id {:data {:native :write, :schemas ["not_public"]}}}
-                (is (some? (upload-csv!)))))))))))
+                        (upload-csv!))))))
+            ;; Cal: what is this testing?
+            (with-all-users-data-perms {db-id {:data {:native :write, :schemas ["not_public"]}}}
+              (is (some? (upload-csv!))))
+            ;; Wait for something to finish, otherwise this flakes
+            (Thread/sleep 1000)))))))
 
 (deftest get-database-can-upload-test
   (mt/test-drivers (disj (mt/normal-drivers-with-feature :uploads) :mysql) ; MySQL doesn't support schemas

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -707,37 +707,36 @@
   (perms/revoke-application-permissions! (perms-group/all-users) :setting))
 
 (deftest upload-csv-test
-  ;; TODO: remove stress test
-  (dotimes [_ 50]
-    (mt/test-drivers (disj (mt/normal-drivers-with-feature :uploads) :mysql) ; MySQL doesn't support schemas
-      (testing "Uploads should be blocked without data access"
-        (mt/with-empty-db
-          (let [conn-spec (sql-jdbc.conn/db->pooled-connection-spec (mt/db))]
+  (mt/test-drivers (disj (mt/normal-drivers-with-feature :uploads) :mysql) ; MySQL doesn't support schemas
+    (testing "Uploads should be blocked without data access"
+      (mt/with-empty-db
+        (let [conn-spec (sql-jdbc.conn/db->pooled-connection-spec (mt/db))]
           ;; Create not_public schema
-            (jdbc/execute! conn-spec "CREATE SCHEMA \"not_public\"; CREATE TABLE \"not_public\".\"table_name\" (id INTEGER)"))
-          (sync/sync-database! (mt/db))
-          (let [db-id    (u/the-id (mt/db))
-                table-id (t2/select-one-pk :model/Table :db_id db-id)
-                upload-csv! (fn []
-                              (upload-test/upload-example-csv! {:grant-permission? false
-                                                                :schema-name       "not_public"
-                                                                :table-prefix      "uploaded_magic_"}))]
-            (doseq [[schema-perms can-upload?] {:all            true
-                                                :none           false
-                                                {table-id :all} false}]
-              (with-all-users-data-perms {db-id {:data {:native :none, :schemas {"public"     :all
-                                                                                 "not_public" schema-perms}}}}
-                (if can-upload?
-                  (is (some? (upload-csv!)))
-                  (is (thrown-with-msg?
-                        clojure.lang.ExceptionInfo
-                        #"You don't have permissions to do that\."
-                        (upload-csv!))))))
-            ;; Cal: what is this testing?
-            (with-all-users-data-perms {db-id {:data {:native :write, :schemas ["not_public"]}}}
-              (is (some? (upload-csv!))))
-            ;; Wait for something to finish, otherwise this flakes
-            (Thread/sleep 1000)))))))
+          (jdbc/execute! conn-spec "CREATE SCHEMA \"not_public\"; CREATE TABLE \"not_public\".\"table_name\" (id INTEGER)"))
+        (sync/sync-database! (mt/db))
+        (let [db-id    (u/the-id (mt/db))
+              table-id (t2/select-one-pk :model/Table :db_id db-id)
+              upload-csv! (fn []
+                            (upload-test/upload-example-csv! {:grant-permission? false
+                                                              :schema-name       "not_public"
+                                                              :table-prefix      "uploaded_magic_"}))]
+          (doseq [[schema-perms can-upload?] {:all            true
+                                              :none           false
+                                              {table-id :all} false}]
+            (with-all-users-data-perms {db-id {:data {:native :none, :schemas {"public"     :all
+                                                                               "not_public" schema-perms}}}}
+              (if can-upload?
+                (is (some? (upload-csv!)))
+                (is (thrown-with-msg?
+                      clojure.lang.ExceptionInfo
+                      #"You don't have permissions to do that\."
+                      (upload-csv!))))))
+          ;; Cal 2023-12-7: what is this testing?
+          (with-all-users-data-perms {db-id {:data {:native :write, :schemas ["not_public"]}}}
+            (is (some? (upload-csv!))))
+          ;; TODO: this isn't ideal but it fixes the flake for now
+          ;; Wait for sessions to finish, otherwise this test flakes
+          (Thread/sleep 1000))))))
 
 (deftest get-database-can-upload-test
   (mt/test-drivers (disj (mt/normal-drivers-with-feature :uploads) :mysql) ; MySQL doesn't support schemas

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -705,7 +705,7 @@
   (perms/revoke-application-permissions! (perms-group/all-users) :setting))
 
 (deftest upload-csv-test
-  (dotimes [_ 10]
+  (dotimes [_ 20]
     (mt/test-drivers (disj (mt/normal-drivers-with-feature :uploads) :mysql) ; MySQL doesn't support schemas
       (testing "Uploads should be blocked without data access"
         (mt/with-empty-db

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -22,8 +22,6 @@
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
-(set! *warn-on-reflection* true)
-
 (use-fixtures :once (fixtures/initialize :db :test-users))
 
 (defn- do-with-all-user-data-perms
@@ -732,12 +730,9 @@
                   (is (thrown-with-msg?
                         clojure.lang.ExceptionInfo
                         #"You don't have permissions to do that\."
-                        (upload-csv!))))))
-            ;; Cal: what is this testing?
-            (with-all-users-data-perms {db-id {:data {:native :write, :schemas ["not_public"]}}}
-              (is (some? (upload-csv!))))
-            ;; Wait for something to finish, otherwise this flakes
-            (Thread/sleep 1000)))))))
+                        (upload-csv!)))))
+              (with-all-users-data-perms {db-id {:data {:native :write, :schemas ["not_public"]}}}
+                (is (some? (upload-csv!)))))))))))
 
 (deftest get-database-can-upload-test
   (mt/test-drivers (disj (mt/normal-drivers-with-feature :uploads) :mysql) ; MySQL doesn't support schemas

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -705,7 +705,8 @@
   (perms/revoke-application-permissions! (perms-group/all-users) :setting))
 
 (deftest upload-csv-test
-  (dotimes [_ 20]
+  ;; TODO: remove stress test
+  (dotimes [_ 50]
     (mt/test-drivers (disj (mt/normal-drivers-with-feature :uploads) :mysql) ; MySQL doesn't support schemas
       (testing "Uploads should be blocked without data access"
         (mt/with-empty-db

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -707,36 +707,37 @@
   (perms/revoke-application-permissions! (perms-group/all-users) :setting))
 
 (deftest upload-csv-test
-  (mt/test-drivers (disj (mt/normal-drivers-with-feature :uploads) :mysql) ; MySQL doesn't support schemas
-    (testing "Uploads should be blocked without data access"
-      (mt/with-empty-db
-        (let [conn-spec (sql-jdbc.conn/db->pooled-connection-spec (mt/db))]
+  ;; TODO: remove stress test
+  (dotimes [_ 50]
+    (mt/test-drivers (disj (mt/normal-drivers-with-feature :uploads) :mysql) ; MySQL doesn't support schemas
+      (testing "Uploads should be blocked without data access"
+        (mt/with-empty-db
+          (let [conn-spec (sql-jdbc.conn/db->pooled-connection-spec (mt/db))]
           ;; Create not_public schema
-          (jdbc/execute! conn-spec "CREATE SCHEMA \"not_public\"; CREATE TABLE \"not_public\".\"table_name\" (id INTEGER)"))
-        (sync/sync-database! (mt/db))
-        (let [db-id    (u/the-id (mt/db))
-              table-id (t2/select-one-pk :model/Table :db_id db-id)
-              upload-csv! (fn []
-                            (upload-test/upload-example-csv! {:grant-permission? false
-                                                              :schema-name       "not_public"
-                                                              :table-prefix      "uploaded_magic_"}))]
-          (doseq [[schema-perms can-upload?] {:all            true
-                                              :none           false
-                                              {table-id :all} false}]
-            (with-all-users-data-perms {db-id {:data {:native :none, :schemas {"public"     :all
-                                                                               "not_public" schema-perms}}}}
-              (if can-upload?
-                (is (some? (upload-csv!)))
-                (is (thrown-with-msg?
-                      clojure.lang.ExceptionInfo
-                      #"You don't have permissions to do that\."
-                      (upload-csv!))))))
-          ;; Cal 2023-12-7: what is this testing?
-          (with-all-users-data-perms {db-id {:data {:native :write, :schemas ["not_public"]}}}
-            (is (some? (upload-csv!))))
-          ;; TODO: this isn't ideal but it fixes the flake for now
-          ;; Wait for sessions to finish, otherwise this test flakes
-          (Thread/sleep 1000))))))
+            (jdbc/execute! conn-spec "CREATE SCHEMA \"not_public\"; CREATE TABLE \"not_public\".\"table_name\" (id INTEGER)"))
+          (sync/sync-database! (mt/db))
+          (let [db-id    (u/the-id (mt/db))
+                table-id (t2/select-one-pk :model/Table :db_id db-id)
+                upload-csv! (fn []
+                              (upload-test/upload-example-csv! {:grant-permission? false
+                                                                :schema-name       "not_public"
+                                                                :table-prefix      "uploaded_magic_"}))]
+            (doseq [[schema-perms can-upload?] {:all            true
+                                                :none           false
+                                                {table-id :all} false}]
+              (with-all-users-data-perms {db-id {:data {:native :none, :schemas {"public"     :all
+                                                                                 "not_public" schema-perms}}}}
+                (if can-upload?
+                  (is (some? (upload-csv!)))
+                  (is (thrown-with-msg?
+                        clojure.lang.ExceptionInfo
+                        #"You don't have permissions to do that\."
+                        (upload-csv!))))))
+            ;; Cal: what is this testing?
+            (with-all-users-data-perms {db-id {:data {:native :write, :schemas ["not_public"]}}}
+              (is (some? (upload-csv!))))
+            ;; Wait for something to finish, otherwise this flakes
+            (Thread/sleep 1000)))))))
 
 (deftest get-database-can-upload-test
   (mt/test-drivers (disj (mt/normal-drivers-with-feature :uploads) :mysql) ; MySQL doesn't support schemas

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -20,7 +20,7 @@
    [metabase.models.permissions :as perms]
    [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features]
-   [metabase.sync :as sync]
+   #_[metabase.sync :as sync]
    [metabase.sync.sync-metadata.fields :as sync-fields]
    [metabase.sync.sync-metadata.tables :as sync-tables]
    [metabase.upload.parsing :as upload-parsing]
@@ -358,7 +358,7 @@
 (defn- scan-and-sync-table!
   [database table]
   (sync-fields/sync-fields-for-table! database table)
-  (future
+  #_(future
     (sync/sync-table! table)))
 
 (defn- can-upload-error

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -20,7 +20,7 @@
    [metabase.models.permissions :as perms]
    [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features]
-   #_[metabase.sync :as sync]
+   [metabase.sync :as sync]
    [metabase.sync.sync-metadata.fields :as sync-fields]
    [metabase.sync.sync-metadata.tables :as sync-tables]
    [metabase.upload.parsing :as upload-parsing]
@@ -355,11 +355,18 @@
 ;;; |                                                 public interface                                               |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+(def ^:dynamic *sync-synchronously?*
+  "For testing purposes, often we'd like to sync synchronously so that we can test the results immediately and avoid
+  race conditions."
+  false)
+
 (defn- scan-and-sync-table!
   [database table]
   (sync-fields/sync-fields-for-table! database table)
-  #_(future
-    (sync/sync-table! table)))
+  (if *sync-synchronously?*
+    (sync/sync-table! table)
+    (future
+      (sync/sync-table! table))))
 
 (defn- can-upload-error
   "Returns an ExceptionInfo object if the user cannot upload to the given database and schema. Returns nil otherwise."

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -884,12 +884,13 @@
                                    grant-permission?)]
         (when grant?
           (perms/grant-permissions! group-id (perms/data-perms-path (mt/id))))
-        (u/prog1 (upload/upload-csv! {:collection-id collection-id
-                                      :filename      csv-file-name
-                                      :file          file
-                                      :db-id         db-id
-                                      :schema-name   schema-name
-                                      :table-prefix  table-prefix})
+        (u/prog1 (binding [upload/*sync-synchronously?* true]
+                   (upload/upload-csv! {:collection-id collection-id
+                                        :filename      csv-file-name
+                                        :file          file
+                                        :db-id         db-id
+                                        :schema-name   schema-name
+                                        :table-prefix  table-prefix}))
           (when grant?
             (perms/revoke-data-perms! group-id (mt/id))))))))
 

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -863,12 +863,13 @@
 (defn upload-example-csv!
   "Upload a small CSV file to the given collection ID. `grant-permission?` controls whether the
   current user is granted data permissions to the database."
-  [& {:keys [schema-name table-prefix collection-id grant-permission? uploads-enabled user-id db-id]
-      :or {collection-id     nil ;; root collection
-           grant-permission? true
-           uploads-enabled   true
-           user-id           (mt/user->id :rasta)
-           db-id             (mt/id)}}]
+  [& {:keys [schema-name table-prefix collection-id grant-permission? uploads-enabled user-id db-id sync-synchronously?]
+      :or {collection-id       nil ;; root collection
+           grant-permission?   true
+           uploads-enabled     true
+           user-id             (mt/user->id :rasta)
+           db-id               (mt/id)
+           sync-synchronously? true}}]
   (mt/with-temporary-setting-values [uploads-enabled uploads-enabled]
     (mt/with-current-user user-id
       (let [;; Make the file-name unique so the table names don't collide
@@ -884,7 +885,7 @@
                                    grant-permission?)]
         (when grant?
           (perms/grant-permissions! group-id (perms/data-perms-path (mt/id))))
-        (u/prog1 (binding [upload/*sync-synchronously?* true]
+        (u/prog1 (binding [upload/*sync-synchronously?* sync-synchronously?]
                    (upload/upload-csv! {:collection-id collection-id
                                         :filename      csv-file-name
                                         :file          file
@@ -913,7 +914,7 @@
               (let [details (mt/dbdef->connection-details driver/*driver* :db {:database-name (:name (mt/db))})]
                 (jdbc/execute! (sql-jdbc.conn/connection-details->spec driver/*driver* details)
                                ["CREATE SCHEMA \"not_public\";"]))
-              (let [new-model (upload-example-csv! :schema-name "not_public")
+              (let [new-model (upload-example-csv! :schema-name "not_public" :sync-synchronously? false)
                     new-table (t2/select-one Table :db_id db-id)]
                 (is (=? {:display          :table
                          :database_id      db-id


### PR DESCRIPTION
Issue: https://github.com/metabase/metabase/issues/36472

Based on the stack trace in [this failure](https://github.com/metabase/metabase/actions/runs/7114694327/job/19369278182?pr=36404#step:4:402), there was a race condition where sessions could still be using the database when we try to destroy it.

```
ERROR in metabase-enterprise.advanced-permissions.common-test/upload-csv-test (load_data.clj:236)
Uncaught exception, not in assertion.

       clojure.lang.ExceptionInfo: Error destroying database
     dbdef: {:database-name "G__278163", :table-definitions ()}
    driver: :postgres
org.postgresql.util.PSQLException: ERROR: database "G__278163" is being accessed by other users
                                     Detail: There are 2 other sessions using the database.
              SQLState: "55006"
             errorCode: 0
    serverErrorMessage: #object[org.postgresql.util.ServerErrorMessage 0x4507c787 "ERROR: database \"G__278163\" is being accessed by other users\n  Detail: There are 2 other sessions using the database."]
org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse    QueryExecutorImpl.java: 2713
      org.postgresql.core.v3.QueryExecutorImpl.processResults    QueryExecutorImpl.java: 2401
             org.postgresql.core.v3.QueryExecutorImpl.execute    QueryExecutorImpl.java:  368
              org.postgresql.jdbc.PgStatement.executeInternal          PgStatement.java:  498
                      org.postgresql.jdbc.PgStatement.execute          PgStatement.java:  415
     org.postgresql.jdbc.PgPreparedStatement.executeWithFlags  PgPreparedStatement.java:  190
        org.postgresql.jdbc.PgPreparedStatement.executeUpdate  PgPreparedStatement.java:  152
           clojure.java.jdbc/db-do-execute-prepared-statement                  jdbc.clj: 1050
                             clojure.java.jdbc/db-do-prepared                  jdbc.clj: 1080
                    clojure.java.jdbc/execute!/execute-helper                  jdbc.clj: 1464
                                   clojure.java.jdbc/execute!                  jdbc.clj: 1468
            metabase.test.data.sql-jdbc.execute/jdbc-execute!               execute.clj:   20
     metabase.test.data.sql-jdbc.execute/default-execute-sql!               execute.clj:   31
     metabase.test.data.sql-jdbc.execute/default-execute-sql!               execute.clj:   22
                                                          ...                                
            metabase.test.data.sql-jdbc.execute/eval264371/fn               execute.clj:   67
                                                          ...                                
            metabase.test.data.sql-jdbc.load-data/destroy-db!             load_data.clj:  234 
...
```

I figured this is caused by asynchronously analyzing the table while uploading the table. So I created a dynamic binding to make this synchronous during testing.

I verified this fixes the flake by wrapping it in a test body in a `(dotimes [_ 50] ...)` block. See the postgres driver runs on this [2acc253](https://github.com/metabase/metabase/pull/36475/commits/2acc253485d2e37e9003a57f71a5be0f84fe03c6) commit.