### PR TITLE
[Help link] set error to null when typing

### DIFF
--- a/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
@@ -260,7 +260,14 @@ describeEE("formatting > whitelabel", () => {
         .should("exist");
 
       getHelpLinkCustomDestinationInput().clear().type("https://").blur();
+
       main().findByText("Please make sure this is a valid URL").should("exist");
+
+      getHelpLinkCustomDestinationInput().type("examp");
+
+      main()
+        .findByText("Please make sure this is a valid URL")
+        .should("not.exist");
     });
 
     it("should not create a race condition - scenario 1: default ->  custom  -> non custom", () => {

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/HelpLinkSettings/HelpLinkSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/HelpLinkSettings/HelpLinkSettings.tsx
@@ -78,6 +78,7 @@ export const HelpLinkSettings = ({
             // this makes it autofocus only when the value wasn't originally a custom destination
             // this prevents it to be focused on page load
             autoFocus={setting.originalValue !== "custom"}
+            onChange={() => setError(null)}
             aria-label={t`Help link custom destination`}
             placeholder={t`Enter a URL it should go to`}
             onBlurChange={e => handleChange(e.target.value)}


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/35915

### Description

From [this discussion](https://metaboat.slack.com/archives/C063Q3F1HPF/p1701797891625189?thread_ts=1701769982.351929&cid=C063Q3F1HPF) we decided to hide the error while a user is typing to have a better UX.

Scenario is:
1 user types "httpsssss://example.org" -> nothing happens
2 he blurs to save it -> error appears
3 he tries to edit it -> error goes away on the first keystroke
4 he blurs it -> if still invalid, it errors


See demo in loom here: https://www.loom.com/share/b477455ac6f746a2886e6f3957ea9086