### PR TITLE
add target branch name to backporting branch for less conflicts

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -66,7 +66,7 @@ jobs:
               ref: `heads/${targetBranch}`,
             });
 
-            const backportBranch = `backport-${originalPullRequest.head.ref}`
+            const backportBranch = `backport-${originalPullRequest.head.ref}-${targetBranch}`
 
             try {
               await github.rest.git.getRef({


### PR DESCRIPTION
I've got into conflicts using `@metabase-bot backport ...` command twice in a row, since it used the same branch name for both of backports (to 47 and 48). This fixes the issue.