### PR TITLE
[Help-link] test: remove e2e for a the single setting scenario

### DIFF
--- a/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
@@ -264,52 +264,6 @@ describeEE("formatting > whitelabel", () => {
         .findByText(/Invalid URL/i)
         .should("exist");
     });
-
-    it("should not create a race condition - scenario 1: default ->  custom  -> non custom", () => {
-      cy.signInAsAdmin();
-      cy.visit("/admin/settings/whitelabel");
-
-      cy.findByTestId("help-link-setting")
-        .findByText("Go to a custom destination...")
-        .click();
-
-      getHelpLinkCustomDestinationInput().type(
-        "https://example.org/custom-destination",
-      );
-
-      cy.findByTestId("help-link-setting").findByText("Hide it").click();
-      cy.wait("@putHelpLink");
-
-      cy.visit("/");
-      openSettingsMenu();
-      helpLink().should("not.exist");
-    });
-
-    it("should not create a race condition - scenario 2: default ->  custom  -> non custom -> custom ", () => {
-      cy.signInAsAdmin();
-      cy.visit("/admin/settings/whitelabel");
-
-      cy.findByLabelText("Link to Metabase help").should("be.checked");
-
-      cy.findByTestId("help-link-setting")
-        .findByText("Go to a custom destination...")
-        .click();
-
-      getHelpLinkCustomDestinationInput().type(
-        "https://example.org/custom-destination",
-      );
-
-      cy.findByTestId("help-link-setting").findByText("Hide it").click();
-
-      cy.findByTestId("help-link-setting")
-        .findByText("Go to a custom destination...")
-        .click();
-
-      cy.reload();
-      cy.findByTestId("help-link-setting")
-        .findByLabelText("Go to a custom destination...")
-        .should("be.checked");
-    });
   });
 });
 


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/35915


### Description

Those two tests were only relevant when we had the 'single setting' scenario. I left them there when moving to the two settings because we weren't sure if we'd keep them separate.

Now that we settled two settings we should never ever run into that issue so we can save some time in CI.