### PR TITLE
Fix dashboard filter width in edit mode

### DIFF
--- a/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.jsx
@@ -1,11 +1,11 @@
 /* eslint-disable react/prop-types */
 import { Component } from "react";
 import PropTypes from "prop-types";
-import { Icon } from "metabase/core/components/Icon";
 import ParameterValueWidget from "../ParameterValueWidget";
 import {
   ParameterContainer,
   ParameterFieldSet,
+  SettingsIcon,
 } from "./ParameterWidget.styled";
 
 export class ParameterWidget extends Component {
@@ -109,7 +109,7 @@ export class ParameterWidget extends Component {
           {dragHandle}
         </div>
         {parameter.name}
-        <Icon className="flex-align-right" name="gear" size={16} />
+        <SettingsIcon name="gear" size={16} />
       </ParameterContainer>
     );
 

--- a/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.styled.ts
+++ b/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.styled.ts
@@ -43,7 +43,7 @@ export const ParameterContainer = styled.div<ParameterContainerProps>`
   border-radius: 0.5rem;
   cursor: pointer;
   font-weight: bold;
-  width: 170px;
+  min-width: 170px;
   margin-right: 0.5rem;
   margin-bottom: 0.5rem;
   padding: 0.5rem;

--- a/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.styled.ts
+++ b/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.styled.ts
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import FieldSet from "metabase/components/FieldSet";
+import { Icon } from "metabase/core/components/Icon";
 import { color } from "metabase/lib/colors";
 
 interface ParameterFieldSetProps {
@@ -50,4 +51,9 @@ export const ParameterContainer = styled.div<ParameterContainerProps>`
   color: ${props => props.isEditingParameter && color("white")};
   background-color: ${props =>
     props.isEditingParameter ? color("brand") : color("white")};
+`;
+
+export const SettingsIcon = styled(Icon)`
+  margin-left: auto;
+  padding-left: 1rem;
 `;


### PR DESCRIPTION
Fixes #36438

The `ParameterWidget` component had a fixed width in edit mode which didn't work well with long titles

### To verify

1. Open a dashboard
2. Add a few dashboard filters with names of different lengths
3. Ensure they look fine in both view and edit dashboard modes

### Demo

<details>
<summary>Before</summary>

<img width="800" alt="before-view" src="https://github.com/metabase/metabase/assets/17258145/152570fb-12d6-4165-8e5f-8ee8c3c47dda">

<img width="800" alt="before-edit" src="https://github.com/metabase/metabase/assets/17258145/a433e86b-8781-45cf-88a4-25dd0302ffdc">

</details>

<details>
<summary>After</summary>

<img width="800" alt="after-view" src="https://github.com/metabase/metabase/assets/17258145/262231ec-b15a-4661-ad02-b8aa61fd6d38">

<img width="800" alt="after-edit" src="https://github.com/metabase/metabase/assets/17258145/52317d08-4268-449a-8e27-5a081613d387">

</details>