### PR TITLE
Apply column formatting to CSV exports

### DIFF
--- a/e2e/test/scenarios/sharing/downloads/reproductions/10803-timestamp-formatting.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/reproductions/10803-timestamp-formatting.cy.spec.js
@@ -51,7 +51,7 @@ describe("issue 10803", () => {
 
       // Excel and CSV will have different formats
       if (fileType === "csv") {
-        expect(sheet["A2"].v).to.eq("2026-06-03");
+        expect(sheet["A2"].v).to.eq("2026-06-03T00:00:00");
         expect(sheet["B2"].v).to.eq("2026-06-03T23:41:23");
       } else if (fileType === "xlsx") {
         // We tell the xlsx library to read raw and not parse dates

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -389,14 +389,14 @@
       (no "less than %d rows in results" body/rows-limit))))
 
 (defn- stream-api-results-to-export-format
-  "For legacy compatability. Takes QP results in the normal `:api` response format and streams them to a different
+  "For legacy compatibility. Takes QP results in the normal `:api` response format and streams them to a different
   format.
 
-  TODO -- this function is provided mainly because rewriting all of the Pulse/Alert code to stream results directly
+  TODO -- this function is provided mainly because rewriting all the Pulse/Alert code to stream results directly
   was a lot of work. I intend to rework that code so we can stream directly to the correct export format(s) at some
   point in the future; for now, this function is a stopgap.
 
-  Results are streamed synchronosuly. Caller is responsible for closing `os` when this call is complete."
+  Results are streamed synchronously. Caller is responsible for closing `os` when this call is complete."
   [export-format ^OutputStream os {{:keys [rows]} :data, database-id :database_id, :as results}]
   ;; make sure Database/driver info is available for the streaming results writers -- they might need this in order to
   ;; get timezone information when writing results

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -82,22 +82,6 @@
     :else
     (str value)))
 
-(s/defn ^:private get-format
-  [timezone-id :- (s/maybe s/Str) col visualization-settings]
-  (cond
-    ;; for numbers, return a format function that has already computed the differences.
-    ;; todo: do the same for temporal strings
-    (types/temporal-field? col)
-    #(datetime/format-temporal-str timezone-id % col visualization-settings)
-
-    ;; todo integer columns with a unit
-    (or (isa? (:effective_type col) :type/Number)
-        (isa? (:base_type col) :type/Number))
-    (common/number-formatter col visualization-settings)
-
-    :else
-    str))
-
 ;;; --------------------------------------------------- Rendering ----------------------------------------------------
 
 (defn- create-remapping-lookup
@@ -158,7 +142,7 @@
    viz-settings
    {:keys [bar-column min-value max-value]}]
   (let [formatters (into []
-                         (map #(get-format timezone-id % viz-settings))
+                         (map #(common/get-format timezone-id % viz-settings))
                          cols)]
     (for [row rows]
       {:bar-width (some-> (and bar-column (bar-column row))

--- a/src/metabase/pulse/render/common.clj
+++ b/src/metabase/pulse/render/common.clj
@@ -96,6 +96,7 @@
                                                                  (:type/Number global-settings)
                                                                  column-settings)
         integral?       (isa? (or effective_type base_type) :type/Integer)
+        relation?       (isa? semantic_type :Relation/*)
         percent?        (or (isa? semantic_type :type/Percentage) (= number-style "percent"))
         scientific?     (= number-style "scientific")
         [decimal grouping] (or number-separators
@@ -104,7 +105,7 @@
         symbols            (doto (DecimalFormatSymbols.)
                              (cond-> decimal (.setDecimalSeparator decimal))
                              (cond-> grouping (.setGroupingSeparator grouping)))
-        base               (cond-> (if (= number-style "scientific") "0" "#,##0")
+        base               (cond-> (if (or scientific? relation?) "0" "#,##0")
                              (not grouping) (str/replace #"," ""))]
     (fn [value]
       (if (number? value)

--- a/src/metabase/pulse/render/common.clj
+++ b/src/metabase/pulse/render/common.clj
@@ -1,16 +1,16 @@
 (ns metabase.pulse.render.common
   (:require
-    [clojure.pprint :refer [cl-format]]
-    [clojure.string :as str]
-    [hiccup.util]
-    [metabase.public-settings :as public-settings]
-    [metabase.pulse.render.datetime :as datetime]
-    [metabase.shared.models.visualization-settings :as mb.viz]
-    [metabase.shared.util.currency :as currency]
-    [metabase.types :as types]
-    [metabase.util.ui-logic :as ui-logic]
-    [potemkin.types :as p.types]
-    [schema.core :as s])
+   [clojure.pprint :refer [cl-format]]
+   [clojure.string :as str]
+   [hiccup.util]
+   [metabase.public-settings :as public-settings]
+   [metabase.pulse.render.datetime :as datetime]
+   [metabase.shared.models.visualization-settings :as mb.viz]
+   [metabase.shared.util.currency :as currency]
+   [metabase.types :as types]
+   [metabase.util.ui-logic :as ui-logic]
+   [potemkin.types :as p.types]
+   [schema.core :as s])
   (:import
    (java.math RoundingMode)
    (java.net URL)

--- a/src/metabase/pulse/render/datetime.clj
+++ b/src/metabase/pulse/render/datetime.clj
@@ -67,12 +67,15 @@
   "Reformat a temporal literal string `s` (i.e., an ISO-8601 string) with a human-friendly format based on the
   column `:unit`."
   ([timezone-id s col] (format-temporal-str timezone-id s col {}))
-  ([timezone-id s col viz-settings]
+  ([timezone-id s {:keys [effective_type base_type] :as col} viz-settings]
    (Locale/setDefault (Locale. (public-settings/site-locale)))
    (cond
      (str/blank? s) ""
 
-     (isa? (or (:effective_type col) (:base_type col)) :type/Time)
+     (isa? (or effective_type base_type) :type/DateTime)
+     (t/format DateTimeFormatter/ISO_LOCAL_DATE_TIME (u.date/parse s timezone-id))
+
+     (isa? (or effective_type base_type) :type/Time)
      (t/format DateTimeFormatter/ISO_LOCAL_TIME (u.date/parse s timezone-id))
 
      :else

--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -2,6 +2,8 @@
   (:require
    [clojure.data.csv :as csv]
    [java-time.api :as t]
+    #_{:clj-kondo/ignore [:consistent-alias]}
+   [metabase.pulse.render.common :as p.common]
    [metabase.query-processor.streaming.common :as common]
    [metabase.query-processor.streaming.interface :as qp.si]
    [metabase.util.date-2 :as u.date])
@@ -24,22 +26,34 @@
 
 (defmethod qp.si/streaming-results-writer :csv
   [_ ^OutputStream os]
-  (let [writer (BufferedWriter. (OutputStreamWriter. os StandardCharsets/UTF_8))]
+  (let [writer     (BufferedWriter. (OutputStreamWriter. os StandardCharsets/UTF_8))
+        formatters (atom {})]
     (reify qp.si/StreamingResultsWriter
-      (begin! [_ {{:keys [ordered-cols]} :data} _]
+      (begin! [_ {{:keys [ordered-cols results_timezone]} :data} viz-settings]
+        (swap! formatters (constantly (zipmap
+                                        ordered-cols
+                                        (map (fn [col]
+                                               (p.common/get-format results_timezone col viz-settings))
+                                             ordered-cols))))
         (csv/write-csv writer [(map (some-fn :display_name :name) ordered-cols)])
         (.flush writer))
 
-      (write-row! [_ row _row-num _ {:keys [output-order]}]
-        (let [ordered-row (if output-order
-                            (let [row-v (into [] row)]
-                              (for [i output-order] (row-v i)))
-                            row)]
-          (csv/write-csv writer [(map common/format-value ordered-row)])
+      (write-row! [_ row _row-num cols {:keys [output-order]}]
+        (let [[ordered-row
+               ordered-cols] (if output-order
+                               (let [row-v  (into [] row)
+                                     cols-v (into [] cols)]
+                                 [(for [i output-order] (row-v i))
+                                  (for [i output-order] (cols-v i))])
+                               [row cols])]
+          (csv/write-csv writer [(map (fn [c r]
+                                        (let [formatter (@formatters c)]
+                                          (formatter (common/format-value r))))
+                                      ordered-cols ordered-row)])
           (.flush writer)))
 
       (finish! [_ _]
-         ;; TODO -- not sure we need to flush both
+        ;; TODO -- not sure we need to flush both
         (.flush writer)
         (.flush os)
         (.close writer)))))

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -159,18 +159,18 @@
 
 ;; Basic test that result rows are formatted correctly (dates, floating point numbers etc)
 (deftest format-result-rows
-  (is (= [{:bar-width nil, :row [(number "1" 1) (number "34.1" 34.0996) "April 1, 2014" "Stout Burgers & Beers"]}
-          {:bar-width nil, :row [(number "2" 2) (number "34.04" 34.0406) "December 5, 2014" "The Apple Pan"]}
-          {:bar-width nil, :row [(number "3" 3) (number "34.05" 34.0474) "August 1, 2014" "The Gorbals"]}]
+  (is (= [{:bar-width nil, :row [(number "1" 1) (number "34.1" 34.0996) "2014-04-01T08:30:00" "Stout Burgers & Beers"]}
+          {:bar-width nil, :row [(number "2" 2) (number "34.04" 34.0406) "2014-12-05T15:15:00" "The Apple Pan"]}
+          {:bar-width nil, :row [(number "3" 3) (number "34.05" 34.0474) "2014-08-01T12:45:00" "The Gorbals"]}]
          (rest (#'body/prep-for-html-rendering pacific-tz {} {:cols test-columns :rows test-data})))))
 
 ;; Testing the bar-column, which is the % of this row relative to the max of that column
 (deftest bar-column
-  (is (= [{:bar-width (float 85.249),  :row [(number "1" 1) (number "34.1" 34.0996) "April 1, 2014" "Stout Burgers & Beers"]}
-          {:bar-width (float 85.1015), :row [(number "2" 2) (number "34.04" 34.0406) "December 5, 2014" "The Apple Pan"]}
-          {:bar-width (float 85.1185), :row [(number "3" 3) (number "34.05" 34.0474) "August 1, 2014" "The Gorbals"]}]
+  (is (= [{:bar-width (float 85.249), :row [(number "1" 1) (number "34.1" 34.0996) "2014-04-01T08:30:00" "Stout Burgers & Beers"]}
+          {:bar-width (float 85.1015), :row [(number "2" 2) (number "34.04" 34.0406) "2014-12-05T15:15:00" "The Apple Pan"]}
+          {:bar-width (float 85.1185), :row [(number "3" 3) (number "34.05" 34.0474) "2014-08-01T12:45:00" "The Gorbals"]}]
          (rest (#'body/prep-for-html-rendering pacific-tz {} {:cols test-columns :rows test-data}
-                                               {:bar-column second, :min-value 0, :max-value 40})))))
+                 {:bar-column second, :min-value 0, :max-value 40})))))
 
 (defn- add-rating
   "Injects `RATING-OR-COL` and `DESCRIPTION-OR-COL` into `COLUMNS-OR-ROW`"
@@ -209,12 +209,12 @@
 
 ;; Result rows should include only the remapped column value, not the original
 (deftest include-only-remapped-column-name
-  (is (= [[(number "1" 1) (number "34.1" 34.0996) "Bad" "April 1, 2014" "Stout Burgers & Beers"]
-          [(number "2" 2) (number "34.04" 34.0406) "Ok" "December 5, 2014" "The Apple Pan"]
-          [(number "3" 3) (number "34.05" 34.0474) "Good" "August 1, 2014" "The Gorbals"]]
-         (map :row (rest (#'body/prep-for-html-rendering  pacific-tz
-                                                          {}
-                                                          {:cols test-columns-with-remapping :rows test-data-with-remapping}))))))
+  (is (= [[(number "1" 1) (number "34.1" 34.0996) "Bad" "2014-04-01T08:30:00" "Stout Burgers & Beers"]
+          [(number "2" 2) (number "34.04" 34.0406) "Ok" "2014-12-05T15:15:00" "The Apple Pan"]
+          [(number "3" 3) (number "34.05" 34.0474) "Good" "2014-08-01T12:45:00" "The Gorbals"]]
+         (map :row (rest (#'body/prep-for-html-rendering pacific-tz
+                           {}
+                           {:cols test-columns-with-remapping :rows test-data-with-remapping}))))))
 
 ;; There should be no truncation warning if the number of rows/cols is fewer than the row/column limit
 (deftest no-truncation-warnig
@@ -233,12 +233,12 @@
                                 :coercion_strategy :Coercion/ISO8601->DateTime}))
 
 (deftest cols-with-semantic-types
-  (is (= [{:bar-width nil, :row [(number "1" 1) (number "34.1" 34.0996) "April 1, 2014" "Stout Burgers & Beers"]}
-          {:bar-width nil, :row [(number "2" 2) (number "34.04" 34.0406) "December 5, 2014" "The Apple Pan"]}
-          {:bar-width nil, :row [(number "3" 3) (number "34.05" 34.0474) "August 1, 2014" "The Gorbals"]}]
+  (is (= [{:bar-width nil, :row [(number "1" 1) (number "34.1" 34.0996) "2014-04-01T08:30:00" "Stout Burgers & Beers"]}
+          {:bar-width nil, :row [(number "2" 2) (number "34.04" 34.0406) "2014-12-05T15:15:00" "The Apple Pan"]}
+          {:bar-width nil, :row [(number "3" 3) (number "34.05" 34.0474) "2014-08-01T12:45:00" "The Gorbals"]}]
          (rest (#'body/prep-for-html-rendering pacific-tz
-                                               {}
-                                               {:cols test-columns-with-date-semantic-type :rows test-data})))))
+                 {}
+                 {:cols test-columns-with-date-semantic-type :rows test-data})))))
 
 (deftest error-test
   (testing "renders error"
@@ -276,7 +276,7 @@
                                          :semantic_type nil}]
                                  :rows [["foo"]]}))))
   (testing "renders date"
-    (is (= "April 1, 2014"
+    (is (= "2014-04-01T08:30:00"
            (render-scalar-value {:cols [{:name         "date",
                                          :display_name "DATE",
                                          :base_type    :type/DateTime

--- a/test/metabase/pulse/render/common_test.clj
+++ b/test/metabase/pulse/render/common_test.clj
@@ -100,6 +100,19 @@
         (is (= "3.1" (fmt-with-type :type/Decimal 3.1)))
         (is (= "3.01" (fmt-with-type :type/Decimal 3.010)))
         (is (= "0.25" (fmt-with-type :type/Decimal 0.254)))))
+    (testing "Relation types do not do special formatting"
+      (letfn [(fmt-with-type
+                ([type value] (fmt-with-type type value nil))
+                ([type value decimals]
+                 (let [fmt-fn (common/number-formatter {:id 1 :semantic_type type}
+                                                       {::mb.viz/column-settings
+                                                        {{::mb.viz/field-id 1}
+                                                         (merge
+                                                           {:effective_type type}
+                                                           (when decimals {::mb.viz/decimals decimals}))}})]
+                   (str (fmt-fn value)))))]
+        (is (= "1000" (fmt-with-type :type/PK 1000)))
+        (is (= "1000" (fmt-with-type :type/FK 1000)))))
     (testing "Does not throw on nils"
         (is (nil?
              ((common/number-formatter {:id 1}

--- a/test/metabase/pulse/render/datetime_test.clj
+++ b/test/metabase/pulse/render/datetime_test.clj
@@ -61,7 +61,11 @@
   (testing "Can render time types (#15146)"
     (is (= "08:05:06"
            (datetime/format-temporal-str "UTC" "08:05:06Z"
-                                         {:effective_type :type/Time})))))
+                                         {:effective_type :type/Time}))))
+  (testing "Can render date time types (Part of resolving #36484)"
+    (is (= "2014-04-01T08:30:00"
+           (datetime/format-temporal-str "UTC" "2014-04-01T08:30:00"
+                                         {:effective_type :type/DateTime})))))
 
 (deftest format-temporal-str-column-viz-settings-test
   (testing "Written Date Formatting"

--- a/test/metabase/query_processor/streaming/csv_test.clj
+++ b/test/metabase/query_processor/streaming/csv_test.clj
@@ -22,11 +22,11 @@
    (rest (csv/read-csv response))))
 
 (deftest date-columns-should-be-emitted-without-time
-  (is (= [["1" "2014-04-07" "5" "12"]
-          ["2" "2014-09-18" "1" "31"]
-          ["3" "2014-09-15" "8" "56"]
-          ["4" "2014-03-11" "5" "4"]
-          ["5" "2013-05-05" "3" "49"]]
+  (is (= [["1" "April 7, 2014" "5" "12"]
+          ["2" "September 18, 2014" "1" "31"]
+          ["3" "September 15, 2014" "8" "56"]
+          ["4" "March 11, 2014" "5" "4"]
+          ["5" "May 5, 2013" "3" "49"]]
          (let [result (mt/user-http-request :rasta :post 200 "dataset/csv" :query
                                             (json/generate-string (mt/mbql-query checkins)))]
            (take 5 (parse-and-sort-csv result))))))
@@ -36,15 +36,17 @@
     (mt/dataset defs/test-data-with-null-date-checkins
       (let [result (mt/user-http-request :rasta :post 200 "dataset/csv" :query
                                          (json/generate-string (mt/mbql-query checkins {:order-by [[:asc $id]], :limit 5})))]
-        (is (= [["1" "2014-04-07" "" "5" "12"]
-                ["2" "2014-09-18" "" "1" "31"]
-                ["3" "2014-09-15" "" "8" "56"]
-                ["4" "2014-03-11" "" "5" "4"]
-                ["5" "2013-05-05" "" "3" "49"]]
+        (is (= [["1" "April 7, 2014" "" "5" "12"]
+                ["2" "September 18, 2014" "" "1" "31"]
+                ["3" "September 15, 2014" "" "8" "56"]
+                ["4" "March 11, 2014" "" "5" "4"]
+                ["5" "May 5, 2013" "" "3" "49"]]
                (parse-and-sort-csv result)))))))
 
 (deftest sqlite-datetime-test
   (mt/test-driver :sqlite
+    ;; TODO - CSVs exported from :sqlite don't use `qp.si/streaming-results-writer` from `metabase.query-processor.streaming.csv`
+    ;; Fix this
     (let [result (mt/user-http-request :rasta :post 200 "dataset/csv" :query
                                        (json/generate-string (mt/mbql-query checkins {:order-by [[:asc $id]], :limit 5})))]
       (is (= [["1" "2014-04-07" "5" "12"]
@@ -72,7 +74,9 @@
       (with-open [bos (ByteArrayOutputStream.)
                   os  (BufferedOutputStream. bos)]
         (let [results-writer (qp.si/streaming-results-writer :csv os)]
-          (qp.si/begin! results-writer {:data {:ordered-cols []}} {})
+          (qp.si/begin! results-writer {:data {:ordered-cols [{:base_type :type/*}
+                                                              {:base_type :type/*}
+                                                              {:base_type :type/*}]}} {})
           (doall (map-indexed
                   (fn [i row] (qp.si/write-row! results-writer row i [] {}))
                   rows))

--- a/test/metabase/query_processor/streaming/csv_test.clj
+++ b/test/metabase/query_processor/streaming/csv_test.clj
@@ -45,15 +45,13 @@
 
 (deftest sqlite-datetime-test
   (mt/test-driver :sqlite
-    ;; TODO - CSVs exported from :sqlite don't use `qp.si/streaming-results-writer` from `metabase.query-processor.streaming.csv`
-    ;; Fix this
     (let [result (mt/user-http-request :rasta :post 200 "dataset/csv" :query
                                        (json/generate-string (mt/mbql-query checkins {:order-by [[:asc $id]], :limit 5})))]
-      (is (= [["1" "2014-04-07" "5" "12"]
-              ["2" "2014-09-18" "1" "31"]
-              ["3" "2014-09-15" "8" "56"]
-              ["4" "2014-03-11" "5" "4"]
-              ["5" "2013-05-05" "3" "49"]]
+      (is (= [["1" "April 7, 2014" "5" "12"]
+              ["2" "September 18, 2014" "1" "31"]
+              ["3" "September 15, 2014" "8" "56"]
+              ["4" "March 11, 2014" "5" "4"]
+              ["5" "May 5, 2013" "3" "49"]]
              (parse-and-sort-csv result))))))
 
 (deftest datetime-fields-are-untouched-when-exported

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -166,7 +166,17 @@
             (testing "UTC results"
               (test-results
                (case export-format
-                 (:csv :json)
+                 :csv
+                 {:date           "November 1, 2019"
+                  :datetime       "2019-11-01T00:23:18.331"
+                  :datetime-ltz   "2019-11-01T07:23:18.331"
+                  :datetime-tz    "2019-11-01T07:23:18.331"
+                  :datetime-tz-id "2019-11-01T07:23:18.331"
+                  :time           "00:23:18.331"
+                  :time-ltz       "07:23:18.331"
+                  :time-tz        "07:23:18.331"}
+
+                 :json
                  {:date           "2019-11-01"
                   :datetime       "2019-11-01T00:23:18.331"
                   :datetime-ltz   "2019-11-01T07:23:18.331Z"
@@ -200,7 +210,17 @@
             (mt/with-temporary-setting-values [report-timezone "US/Pacific"]
               (test-results
                (case export-format
-                 (:csv :json)
+                 :csv
+                 {:date           "November 1, 2019"
+                  :datetime       "2019-11-01T00:23:18.331"
+                  :datetime-ltz   "2019-11-01T00:23:18.331"
+                  :datetime-tz    "2019-11-01T00:23:18.331"
+                  :datetime-tz-id "2019-11-01T00:23:18.331"
+                  :time            "00:23:18.331"
+                  :time-ltz        "23:23:18.331"
+                  :time-tz         "23:23:18.331"}
+
+                 :json
                  {:date           "2019-11-01"
                   :datetime       "2019-11-01T00:23:18.331"
                   :datetime-ltz   "2019-11-01T00:23:18.331-07:00"


### PR DESCRIPTION
This PR applies the same formatting logic to CSV exports as it does to pulse bodies (e.g. HTML).

Formerly, there were two related formatting paths:
- `metabase.query-processor.streaming.common/format-value`, which is from a protocol that takes an object and returns a string. It is what was used to export csv data. It applies no actual formatting, only converts objects to strings.
- `metabase.pulse.render.body/get-format`, which builds a formatter from an optional time zone, column metadata, and visualization settings. This formatter takes a string and formats it. It was only used for rendering inline artifacts, such as embedded HTML in emails.

The first function is insufficient to format row data as it is unaware of the column metadata and viz settings. We need to use that data everywhere data is exported in a uniform way.

The solution is to lift `get-format` from `metabase.pulse.render.body` to a more common location (`metabase.pulse.render.common` in this PR step, but needs to be moved out of the pulse code to be a more shared concern) and use it everywhere artifacts are generated.

For csv export, this was achieved as follows in `metabase.query-processor.streaming.csv`:

```clojure
(defmethod qp.si/streaming-results-writer :csv
  [_ ^OutputStream os]
  (let [writer     (BufferedWriter. (OutputStreamWriter. os StandardCharsets/UTF_8))
        formatters (atom {})]
    (reify qp.si/StreamingResultsWriter
      (begin! [_ {{:keys [ordered-cols results_timezone]} :data} viz-settings]
        (swap! formatters (constantly (zipmap
                                        ordered-cols
                                        (map (fn [col]
                                               (p.common/get-format results_timezone col viz-settings))
                                             ordered-cols))))
        (csv/write-csv writer [(map (some-fn :display_name :name) ordered-cols)])
        (.flush writer))

      (write-row! [_ row _row-num cols {:keys [output-order]}]
        (let [[ordered-row
               ordered-cols] (if output-order
                               (let [row-v  (into [] row)
                                     cols-v (into [] cols)]
                                 [(for [i output-order] (row-v i))
                                  (for [i output-order] (cols-v i))])
                               [row cols])]
          (csv/write-csv writer [(map (fn [c r]
                                        (let [formatter (@formatters c)]
                                          (formatter (common/format-value r))))
                                      ordered-cols ordered-row)])
          (.flush writer)))

      (finish! [_ _]
        ;; TODO -- not sure we need to flush both
        (.flush writer)
        (.flush os)
        (.close writer)))))
```

The formatters for each column are built in the `begin!` function and then looked up in each `write-row!`.  The existing `format-value` is used to produce a string then passed into our looked up column formatter.

Note that the new unit tests simulate a pulse and grab the provided temp files as attachments and analyzes those for correctness. This should work in a CI environment so long as the test process has permission to both write attachments to the temp directory and read those attachments back out. Also note that these tests can be slow (but not terribly so).

Primary changes:
- `metabase.email.messages` - fix spelling
- `metabase.pulse.render.body` - move `get-format` out of this ns
- `metabase.pulse.render.common` - move `get-format` into this ns
- `metabase.query-processor.streaming.csv` - new logic to apply pulse renderer formatting to csv exports
- `metabase.pulse.pulse-integration-test` - adding unit tests

One TODO before we complete #36484 is a follow-on PR to move the `get-format` logic out of a pulse ns into something more general. Ultimately, it would be nice if this was a common capability used by both BE and FE. That will be a follow-on since it will be noisy and it would be nice to be able to see the changes independently.

The follow-on refactor PR is #36490.