### PR TITLE
Refactoring formatting code for common utility

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -298,6 +298,7 @@
     metabase.driver.sql.parameters.substitution                     sql.params.substitution
     metabase.email-test                                             et
     metabase.email.messages                                         messages
+    metabase.formatter                                              formatter
     metabase.http-client                                            client
     metabase.lib.util                                               lib.util
     metabase.mbql.normalize                                         mbql.normalize
@@ -336,7 +337,6 @@
     metabase.pulse.markdown                                         markdown
     metabase.pulse.render                                           render
     metabase.pulse.render.body                                      body
-    metabase.formatter                                              formatter
     metabase.pulse.render.style                                     style
     metabase.pulse.test-util                                        pulse.test-util
     metabase.pulse.parameters                                       pulse-params

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -336,7 +336,7 @@
     metabase.pulse.markdown                                         markdown
     metabase.pulse.render                                           render
     metabase.pulse.render.body                                      body
-    metabase.pulse.render.common                                    common
+    metabase.formatter                                              formatter
     metabase.pulse.render.style                                     style
     metabase.pulse.test-util                                        pulse.test-util
     metabase.pulse.parameters                                       pulse-params

--- a/src/metabase/formatter.clj
+++ b/src/metabase/formatter.clj
@@ -1,16 +1,19 @@
-(ns metabase.pulse.render.common
+(ns metabase.formatter
+  "Provides functions that support formatting results data. In particular, customizing formatting for when timezone,
+   column metadata, and visualization-settings are known. These functions can be used for uniform rendering of all
+   artifacts such as generated CSV or image files that need consistent formatting across the board."
   (:require
-    [clojure.pprint :refer [cl-format]]
-    [clojure.string :as str]
-    [hiccup.util]
-    [metabase.public-settings :as public-settings]
-    [metabase.pulse.render.datetime :as datetime]
-    [metabase.shared.models.visualization-settings :as mb.viz]
-    [metabase.shared.util.currency :as currency]
-    [metabase.types :as types]
-    [metabase.util.ui-logic :as ui-logic]
-    [potemkin.types :as p.types]
-    [schema.core :as s])
+   [clojure.pprint :refer [cl-format]]
+   [clojure.string :as str]
+   [hiccup.util]
+   [metabase.formatter.datetime :as datetime]
+   [metabase.public-settings :as public-settings]
+   [metabase.shared.models.visualization-settings :as mb.viz]
+   [metabase.shared.util.currency :as currency]
+   [metabase.types :as types]
+   [metabase.util.ui-logic :as ui-logic]
+   [potemkin.types :as p.types]
+   [schema.core :as s])
   (:import
    (java.math RoundingMode)
    (java.net URL)
@@ -192,8 +195,8 @@
        (filter (every-pred x-axis-fn y-axis-fn))
        (map coerce-bignum-to-int)))
 
-(s/defn get-format
-  "Get the format for a column based on its timezone, column metadata, and visualization-settings"
+(s/defn create-formatter
+  "Create a formatter for a column based on its timezone, column metadata, and visualization-settings"
   [timezone-id :- (s/maybe s/Str) col visualization-settings]
   (cond
     ;; for numbers, return a format function that has already computed the differences.

--- a/src/metabase/formatter/datetime.clj
+++ b/src/metabase/formatter/datetime.clj
@@ -1,5 +1,5 @@
-(ns metabase.pulse.render.datetime
-  "Logic for rendering datetimes inside Pulses."
+(ns metabase.formatter.datetime
+  "Logic for rendering datetimes when context such as timezone, column metadata, and visualization settings are known."
   (:require
    [clojure.string :as str]
    [java-time.api :as t]

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -1,10 +1,10 @@
 (ns metabase.pulse.render
   (:require
    [hiccup.core :refer [h]]
+   [metabase.formatter :as formatter]
    [metabase.models.dashboard-card :as dashboard-card]
    [metabase.pulse.markdown :as markdown]
    [metabase.pulse.render.body :as body]
-   [metabase.pulse.render.common :as common]
    [metabase.pulse.render.image-bundle :as image-bundle]
    [metabase.pulse.render.png :as png]
    [metabase.pulse.render.style :as style]
@@ -30,7 +30,7 @@
   [card]
   (h (urls/card-url (:id card))))
 
-(s/defn ^:private make-title-if-needed :- (s/maybe common/RenderedPulseCard)
+(s/defn ^:private make-title-if-needed :- (s/maybe formatter/RenderedPulseCard)
   [render-type card dashcard]
   (when *include-title*
     (let [card-name    (or (-> dashcard :visualization_settings :card.title)
@@ -57,7 +57,7 @@
                                  :width 16
                                  :src   (:image-src image-bundle)}])]]]]})))
 
-(s/defn ^:private make-description-if-needed :- (s/maybe common/RenderedPulseCard)
+(s/defn ^:private make-description-if-needed :- (s/maybe formatter/RenderedPulseCard)
   [dashcard card]
   (when *include-description*
     (when-let [description (or (get-in dashcard [:visualization_settings :card.description])
@@ -73,7 +73,7 @@
   [{display-type :display, card-name :name, :as card} maybe-dashcard {:keys [cols rows], :as data}]
   (let [col-sample-count          (delay (count (take 3 cols)))
         row-sample-count          (delay (count (take 2 rows)))
-        [col-1-rowfn col-2-rowfn] (common/graphing-column-row-fns card data)
+        [col-1-rowfn col-2-rowfn] (formatter/graphing-column-row-fns card data)
         col-1                     (delay (col-1-rowfn cols))
         col-2                     (delay (col-2-rowfn cols))]
     (letfn [(chart-type [tyype reason & args]
@@ -125,7 +125,7 @@
   [card]
   ((some-fn :include_csv :include_xls) card))
 
-(s/defn ^:private render-pulse-card-body :- common/RenderedPulseCard
+(s/defn ^:private render-pulse-card-body :- formatter/RenderedPulseCard
   [render-type timezone-id :- (s/maybe s/Str) card dashcard {:keys [data error] :as results}]
   (try
     (when error
@@ -146,7 +146,7 @@
           (body/render :render-error nil nil nil nil nil))))))
 
 
-(s/defn render-pulse-card :- common/RenderedPulseCard
+(s/defn render-pulse-card :- formatter/RenderedPulseCard
   "Render a single `card` for a `Pulse` to Hiccup HTML. `result` is the QP results. Returns a map with keys
 
 - attachments
@@ -191,7 +191,7 @@
   [timezone-id card results]
   (:content (render-pulse-card :inline timezone-id card nil results)))
 
-(s/defn render-pulse-section :- common/RenderedPulseCard
+(s/defn render-pulse-section :- formatter/RenderedPulseCard
   "Render a single Card section of a Pulse to a Hiccup form (representating HTML)."
   [timezone-id {card :card, dashcard :dashcard, result :result}]
   (let [{:keys [attachments content]} (binding [*include-title*       true
@@ -209,5 +209,5 @@
 
 (s/defn png-from-render-info :- bytes
   "Create a PNG file (as a byte array) from rendering info."
-  [rendered-info :- common/RenderedPulseCard width]
+  [rendered-info :- formatter/RenderedPulseCard width]
   (png/render-html-to-png rendered-info width))

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -3,10 +3,10 @@
    [clojure.string :as str]
    [hiccup.core :refer [h]]
    [medley.core :as m]
+   [metabase.formatter :as formatter]
+   [metabase.formatter.datetime :as datetime]
    [metabase.public-settings :as public-settings]
    [metabase.pulse.render.color :as color]
-   [metabase.pulse.render.common :as common]
-   [metabase.pulse.render.datetime :as datetime]
    [metabase.pulse.render.image-bundle :as image-bundle]
    [metabase.pulse.render.js-svg :as js-svg]
    [metabase.pulse.render.style :as style]
@@ -77,7 +77,7 @@
     (datetime/format-temporal-str timezone-id value col)
 
     (number? value)
-    (common/format-number value col visualization-settings)
+    (formatter/format-number value col visualization-settings)
 
     :else
     (str value)))
@@ -120,7 +120,7 @@
                     ;; in the output and should be skipped
                     :when              (not (:remapped_from maybe-remapped-col))]
                 (if (isa? ((some-fn :effective_type :base_type) col) :type/Number)
-                  (common/map->NumericWrapper {:num-str col-name :num-value col-name})
+                  (formatter/map->NumericWrapper {:num-str col-name :num-value col-name})
                   col-name))
    :bar-width (when include-bar? 99)})
 
@@ -142,7 +142,7 @@
    viz-settings
    {:keys [bar-column min-value max-value]}]
   (let [formatters (into []
-                         (map #(common/get-format timezone-id % viz-settings))
+                         (map #(formatter/create-formatter timezone-id % viz-settings))
                          cols)]
     (for [row rows]
       {:bar-width (some-> (and bar-column (bar-column row))
@@ -176,7 +176,7 @@
        data-attributes)))))
 
 (defn- strong-limit-text [number]
-  [:strong {:style (style/style {:color style/color-gray-3})} (h (common/format-number number))])
+  [:strong {:style (style/style {:color style/color-gray-3})} (h (formatter/format-number number))])
 
 (defn- render-truncation-warning
   [row-limit row-count]
@@ -218,7 +218,7 @@
       [ordered-cols ordered-rows])
     [(:cols data) (:rows data)]))
 
-(s/defmethod render :table :- common/RenderedPulseCard
+(s/defmethod render :table :- formatter/RenderedPulseCard
   [_ render-type timezone-id :- (s/maybe s/Str) card _dashcard {:keys [rows viz-settings] :as data}]
   (let [[ordered-cols ordered-rows] (order-data data viz-settings)
         data                        (-> data
@@ -467,11 +467,11 @@
             row))
         rows))
 
-(s/defmethod render :categorical/donut :- common/RenderedPulseCard
+(s/defmethod render :categorical/donut :- formatter/RenderedPulseCard
   [_ render-type timezone-id :- (s/maybe s/Str) card _dashcard {:keys [rows cols viz-settings] :as data}]
-  (let [[x-axis-rowfn y-axis-rowfn] (common/graphing-column-row-fns card data)
+  (let [[x-axis-rowfn y-axis-rowfn] (formatter/graphing-column-row-fns card data)
         rows                        (map (juxt (comp str x-axis-rowfn) y-axis-rowfn)
-                                         (common/row-preprocess x-axis-rowfn y-axis-rowfn (replace-nils rows)))
+                                         (formatter/row-preprocess x-axis-rowfn y-axis-rowfn (replace-nils rows)))
         slice-threshold             (or (get viz-settings :pie.slice_threshold)
                                         2.5)
         {:keys [rows percentages]}  (donut-info slice-threshold rows)
@@ -505,7 +505,7 @@
                                 label)}))
              rows))]}))
 
-(s/defmethod render :progress :- common/RenderedPulseCard
+(s/defmethod render :progress :- formatter/RenderedPulseCard
   [_ render-type _timezone-id _card _dashcard {:keys [cols rows viz-settings] :as _data}]
   (let [value        (ffirst rows)
         goal         (:progress.goal viz-settings)
@@ -776,7 +776,7 @@
         card-name       (:name card)
         viz-settings    (:visualization_settings card)
         joined-rows     (map (juxt x-fn y-fn)
-                             (common/row-preprocess x-fn y-fn (:rows data)))
+                             (formatter/row-preprocess x-fn y-fn (:rows data)))
         [x-cols y-cols] ((juxt x-fn y-fn) (get-in result [:result :data :cols]))
         combo-series-fn (if (= (count x-cols) 1) single-x-axis-combo-series double-x-axis-combo-series)]
     (combo-series-fn enforced-type joined-rows x-cols y-cols viz-settings card-name)))
@@ -831,23 +831,23 @@
      render-multiple-lab-chart)
    render-type card dashcard data))
 
-(s/defmethod render :line :- common/RenderedPulseCard
+(s/defmethod render :line :- formatter/RenderedPulseCard
   [_ render-type timezone-id card _dashcard data]
   (attach-image-bundle (lab-image-bundle :line render-type timezone-id card data)))
 
-(s/defmethod render :area :- common/RenderedPulseCard
+(s/defmethod render :area :- formatter/RenderedPulseCard
   [_ render-type timezone-id card _dashcard data]
   (attach-image-bundle (lab-image-bundle :area render-type timezone-id card data)))
 
-(s/defmethod render :bar :- common/RenderedPulseCard
+(s/defmethod render :bar :- formatter/RenderedPulseCard
   [_chart-type render-type timezone-id :- (s/maybe s/Str) card _dashcard data]
   (attach-image-bundle (lab-image-bundle :bar render-type timezone-id card data)))
 
-(s/defmethod render :combo :- common/RenderedPulseCard
+(s/defmethod render :combo :- formatter/RenderedPulseCard
   [_chart-type render-type timezone-id :- (s/maybe s/Str) card _dashcard data]
   (attach-image-bundle (lab-image-bundle :combo render-type timezone-id card data)))
 
-(s/defmethod render :gauge :- common/RenderedPulseCard
+(s/defmethod render :gauge :- formatter/RenderedPulseCard
   [_chart-type render-type _timezone-id :- (s/maybe s/Str) card _dashcard data]
   (let [image-bundle (image-bundle/make-image-bundle
                       render-type
@@ -861,7 +861,7 @@
       [:img {:style (style/style {:display :block :width :100%})
              :src   (:image-src image-bundle)}]]}))
 
-(s/defmethod render :row :- common/RenderedPulseCard
+(s/defmethod render :row :- formatter/RenderedPulseCard
   [_ render-type _timezone-id card _dashcard {:keys [rows cols] :as _data}]
   (let [viz-settings (get card :visualization_settings)
         data {:rows rows
@@ -878,7 +878,7 @@
       [:img {:style (style/style {:display :block :width :100%})
              :src   (:image-src image-bundle)}]]}))
 
-(s/defmethod render :scalar :- common/RenderedPulseCard
+(s/defmethod render :scalar :- formatter/RenderedPulseCard
   [_chart-type _render-type timezone-id _card _dashcard {:keys [cols rows viz-settings]}]
   (let [value (format-cell timezone-id (ffirst rows) (first cols) viz-settings)]
     {:attachments
@@ -889,7 +889,7 @@
       (h value)]
      :render/text (str value)}))
 
-(s/defmethod render :smartscalar :- common/RenderedPulseCard
+(s/defmethod render :smartscalar :- formatter/RenderedPulseCard
   [_chart-type _render-type timezone-id _card _dashcard {:keys [cols insights viz-settings]}]
   (letfn [(col-of-type [t c] (or (isa? (:effective_type c) t)
                                  ;; computed and agg columns don't have an effective type
@@ -937,13 +937,13 @@
          :render/text (str (format-cell timezone-id last-value metric-col viz-settings)
                            "\n" (trs "Nothing to compare to."))}))))
 
-(s/defmethod render :waterfall :- common/RenderedPulseCard
+(s/defmethod render :waterfall :- formatter/RenderedPulseCard
   [_ render-type _timezone-id card _dashcard {:keys [rows cols viz-settings] :as data}]
   (let [[x-axis-rowfn
-         y-axis-rowfn] (common/graphing-column-row-fns card data)
+         y-axis-rowfn] (formatter/graphing-column-row-fns card data)
         [x-col y-col]  ((juxt x-axis-rowfn y-axis-rowfn) cols)
         rows           (map (juxt x-axis-rowfn y-axis-rowfn)
-                            (common/row-preprocess x-axis-rowfn y-axis-rowfn rows))
+                            (formatter/row-preprocess x-axis-rowfn y-axis-rowfn rows))
         labels         (x-and-y-axis-label-info x-col y-col viz-settings)
         waterfall-type (if (isa? (-> cols x-axis-rowfn :effective_type) :type/Temporal)
                          :timeseries
@@ -973,12 +973,12 @@
       [:img {:style (style/style {:display :block :width :100%})
              :src   (:image-src image-bundle)}]]}))
 
-(s/defmethod render :funnel :- common/RenderedPulseCard
+(s/defmethod render :funnel :- formatter/RenderedPulseCard
   [_ render-type _timezone-id card _dashcard {:keys [rows cols viz-settings] :as data}]
   (let [[x-axis-rowfn
-         y-axis-rowfn] (common/graphing-column-row-fns card data)
+         y-axis-rowfn] (formatter/graphing-column-row-fns card data)
         rows           (map (juxt x-axis-rowfn y-axis-rowfn)
-                            (common/row-preprocess x-axis-rowfn y-axis-rowfn rows))
+                            (formatter/row-preprocess x-axis-rowfn y-axis-rowfn rows))
         [x-col y-col]  cols
         settings       (as-> (->js-viz x-col y-col viz-settings) jsviz-settings
                          (assoc jsviz-settings :step    {:name   (:display_name x-col)
@@ -994,7 +994,7 @@
       [:img {:style (style/style {:display :block :width :100%})
              :src   (:image-src image-bundle)}]]}))
 
-(s/defmethod render :empty :- common/RenderedPulseCard
+(s/defmethod render :empty :- formatter/RenderedPulseCard
   [_ render-type _ _ _ _]
   (let [image-bundle (image-bundle/no-results-image-bundle render-type)]
     {:attachments
@@ -1011,7 +1011,7 @@
        (trs "No results")]]
      :render/text (trs "No results")}))
 
-(s/defmethod render :attached :- common/RenderedPulseCard
+(s/defmethod render :attached :- formatter/RenderedPulseCard
   [_ render-type _ _ _ _]
   (let [image-bundle (image-bundle/attached-image-bundle render-type)]
     {:attachments
@@ -1027,7 +1027,7 @@
                       :color      style/color-gray-4})}
        (trs "This question has been included as a file attachment")]]}))
 
-(s/defmethod render :unknown :- common/RenderedPulseCard
+(s/defmethod render :unknown :- formatter/RenderedPulseCard
   [_ _ _ _ _ _]
   {:attachments
    nil
@@ -1041,10 +1041,10 @@
     [:br]
     (trs "Please view this card in Metabase.")]})
 
-(s/defmethod render :card-error :- common/RenderedPulseCard
+(s/defmethod render :card-error :- formatter/RenderedPulseCard
   [_ _ _ _ _ _]
   @card-error-rendered-info)
 
-(s/defmethod render :render-error :- common/RenderedPulseCard
+(s/defmethod render :render-error :- formatter/RenderedPulseCard
   [_ _ _ _ _ _]
   @error-rendered-info)

--- a/src/metabase/pulse/render/color.clj
+++ b/src/metabase/pulse/render/color.clj
@@ -4,6 +4,7 @@
   (:require
    [cheshire.core :as json]
    [clojure.java.io :as io]
+   [metabase.formatter]
    [metabase.pulse.render.js-engine :as js]
    [metabase.util.i18n :refer [trs]]
    [schema.core :as s])

--- a/src/metabase/pulse/render/color.clj
+++ b/src/metabase/pulse/render/color.clj
@@ -4,12 +4,11 @@
   (:require
    [cheshire.core :as json]
    [clojure.java.io :as io]
-   [metabase.pulse.render.common :as common]
    [metabase.pulse.render.js-engine :as js]
    [metabase.util.i18n :refer [trs]]
    [schema.core :as s])
   (:import
-    (metabase.pulse.render.common NumericWrapper)))
+    (metabase.formatter NumericWrapper)))
 
 
 (set! *warn-on-reflection* true)

--- a/src/metabase/pulse/render/common.clj
+++ b/src/metabase/pulse/render/common.clj
@@ -1,16 +1,16 @@
 (ns metabase.pulse.render.common
   (:require
-   [clojure.pprint :refer [cl-format]]
-   [clojure.string :as str]
-   [hiccup.util]
-   [metabase.public-settings :as public-settings]
-   [metabase.pulse.render.datetime :as datetime]
-   [metabase.shared.models.visualization-settings :as mb.viz]
-   [metabase.shared.util.currency :as currency]
-   [metabase.types :as types]
-   [metabase.util.ui-logic :as ui-logic]
-   [potemkin.types :as p.types]
-   [schema.core :as s])
+    [clojure.pprint :refer [cl-format]]
+    [clojure.string :as str]
+    [hiccup.util]
+    [metabase.public-settings :as public-settings]
+    [metabase.pulse.render.datetime :as datetime]
+    [metabase.shared.models.visualization-settings :as mb.viz]
+    [metabase.shared.util.currency :as currency]
+    [metabase.types :as types]
+    [metabase.util.ui-logic :as ui-logic]
+    [potemkin.types :as p.types]
+    [schema.core :as s])
   (:import
    (java.math RoundingMode)
    (java.net URL)

--- a/src/metabase/pulse/render/png.clj
+++ b/src/metabase/pulse/render/png.clj
@@ -8,7 +8,7 @@
   CSSBox JavaDoc is here: http://cssbox.sourceforge.net/api/index.html"
   (:require
    [hiccup.core :refer [html]]
-   [metabase.pulse.render.common :as common]
+   [metabase.formatter :as formatter]
    [metabase.pulse.render.style :as style]
    [metabase.util.i18n :refer [trs]]
    [metabase.util.log :as log]
@@ -76,7 +76,7 @@
 
 (s/defn render-html-to-png :- bytes
   "Render the Hiccup HTML `content` of a Pulse to a PNG image, returning a byte array."
-  [{:keys [content]} :- common/RenderedPulseCard
+  [{:keys [content]} :- formatter/RenderedPulseCard
    width]
   (try
     (let [html (html [:html [:body {:style (style/style

--- a/src/metabase/pulse/render/table.clj
+++ b/src/metabase/pulse/render/table.clj
@@ -3,13 +3,13 @@
    [clojure.string :as str]
    [hiccup.core :refer [h]]
    [medley.core :as m]
+   [metabase.formatter]
    [metabase.pulse.render.color :as color]
-   [metabase.pulse.render.common]
    [metabase.pulse.render.style :as style])
   (:import
-   (metabase.pulse.render.common NumericWrapper)))
+   (metabase.formatter NumericWrapper)))
 
-(comment metabase.pulse.render.common/keep-me)
+(comment metabase.formatter/keep-me)
 
 (defn- bar-th-style []
   (merge

--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -2,8 +2,7 @@
   (:require
    [clojure.data.csv :as csv]
    [java-time.api :as t]
-    #_{:clj-kondo/ignore [:consistent-alias]}
-   [metabase.pulse.render.common :as p.common]
+   [metabase.formatter :as formatter]
    [metabase.query-processor.streaming.common :as common]
    [metabase.query-processor.streaming.interface :as qp.si]
    [metabase.util.date-2 :as u.date])
@@ -32,7 +31,7 @@
       (begin! [_ {{:keys [ordered-cols results_timezone]} :data} viz-settings]
         (swap! ordered-formatters (constantly
                                     (mapv (fn [col]
-                                            (p.common/get-format results_timezone col viz-settings))
+                                            (formatter/create-formatter results_timezone col viz-settings))
                                           ordered-cols)))
         (csv/write-csv writer [(map (some-fn :display_name :name) ordered-cols)])
         (.flush writer))

--- a/test/metabase/formatter/datetime_test.clj
+++ b/test/metabase/formatter/datetime_test.clj
@@ -1,7 +1,7 @@
-(ns metabase.pulse.render.datetime-test
+(ns metabase.formatter.datetime-test
   (:require
    [clojure.test :refer :all]
-   [metabase.pulse.render.datetime :as datetime]
+   [metabase.formatter.datetime :as datetime]
    [metabase.shared.models.visualization-settings :as mb.viz]
    [metabase.test :as mt]))
 

--- a/test/metabase/formatter_test.clj
+++ b/test/metabase/formatter_test.clj
@@ -1,12 +1,12 @@
-(ns metabase.pulse.render.common-test
+(ns metabase.formatter-test
   (:refer-clojure :exclude [format])
   (:require
    [clojure.test :refer :all]
-   [metabase.pulse.render.common :as common]
+   [metabase.formatter :as formatter]
    [metabase.shared.models.visualization-settings :as mb.viz]))
 
 (defn format [value viz]
-  (str ((common/number-formatter {:id 1}
+  (str ((formatter/number-formatter {:id 1}
                                  {::mb.viz/column-settings
                                   {{::mb.viz/field-id 1} viz}})
         value)))
@@ -85,12 +85,12 @@
       (letfn [(fmt-with-type
                 ([type value] (fmt-with-type type value nil))
                 ([type value decimals]
-                 (let [fmt-fn (common/number-formatter {:id 1 :effective_type type}
-                                                       {::mb.viz/column-settings
-                                                        {{::mb.viz/field-id 1}
-                                                         (merge
-                                                          {:effective_type type}
-                                                          (when decimals {::mb.viz/decimals decimals}))}})]
+                 (let [fmt-fn (formatter/number-formatter {:id 1 :effective_type type}
+                                                          {::mb.viz/column-settings
+                                                           {{::mb.viz/field-id 1}
+                                                            (merge
+                                                              {:effective_type type}
+                                                              (when decimals {::mb.viz/decimals decimals}))}})]
                    (str (fmt-fn value)))))]
         (is (= "3" (fmt-with-type :type/Integer 3)))
         (is (= "3" (fmt-with-type :type/Integer 3.0)))
@@ -114,16 +114,16 @@
         (is (= "1000" (fmt-with-type :type/PK 1000)))
         (is (= "1000" (fmt-with-type :type/FK 1000)))))
     (testing "Does not throw on nils"
-        (is (nil?
-             ((common/number-formatter {:id 1}
-                                       {::mb.viz/column-settings
-                                        {{::mb.viz/column-id 1}
-                                         {::mb.viz/number-style "percent"}}})
-              nil))))
-    (testing "Does not throw on non-numeric types"
-        (is (= "bob"
-               ((common/number-formatter {:id 1}
+      (is (nil?
+            ((formatter/number-formatter {:id 1}
                                          {::mb.viz/column-settings
                                           {{::mb.viz/column-id 1}
                                            {::mb.viz/number-style "percent"}}})
-                "bob"))))))
+             nil))))
+    (testing "Does not throw on non-numeric types"
+      (is (= "bob"
+             ((formatter/number-formatter {:id 1}
+                                          {::mb.viz/column-settings
+                                           {{::mb.viz/column-id 1}
+                                            {::mb.viz/number-style "percent"}}})
+              "bob"))))))

--- a/test/metabase/formatter_test.clj
+++ b/test/metabase/formatter_test.clj
@@ -104,12 +104,12 @@
       (letfn [(fmt-with-type
                 ([type value] (fmt-with-type type value nil))
                 ([type value decimals]
-                 (let [fmt-fn (common/number-formatter {:id 1 :semantic_type type}
-                                                       {::mb.viz/column-settings
-                                                        {{::mb.viz/field-id 1}
-                                                         (merge
-                                                           {:effective_type type}
-                                                           (when decimals {::mb.viz/decimals decimals}))}})]
+                 (let [fmt-fn (formatter/number-formatter {:id 1 :semantic_type type}
+                                                          {::mb.viz/column-settings
+                                                           {{::mb.viz/field-id 1}
+                                                            (merge
+                                                              {:effective_type type}
+                                                              (when decimals {::mb.viz/decimals decimals}))}})]
                    (str (fmt-fn value)))))]
         (is (= "1000" (fmt-with-type :type/PK 1000)))
         (is (= "1000" (fmt-with-type :type/FK 1000)))))

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -4,8 +4,8 @@
    [clojure.test :refer :all]
    [clojure.walk :as walk]
    [hiccup.core :refer [html]]
+   [metabase.formatter :as formatter]
    [metabase.pulse.render.body :as body]
-   [metabase.pulse.render.common :as common]
    [metabase.pulse.render.test-util :as render.tu]))
 
 (use-fixtures :each
@@ -47,8 +47,8 @@
   (set (map (comp count :row) results)))
 
 (defn- number [num-str num-value]
-  (common/map->NumericWrapper {:num-str   (str num-str)
-                               :num-value num-value}))
+  (formatter/map->NumericWrapper {:num-str   (str num-str)
+                                  :num-value num-value}))
 
 (def ^:private default-header-result
   [{:row       [(number "ID" "ID") (number "Latitude" "Latitude") "Last Login" "Name"]

--- a/test/metabase/pulse/render/table_test.clj
+++ b/test/metabase/pulse/render/table_test.clj
@@ -1,9 +1,9 @@
 (ns metabase.pulse.render.table-test
   (:require
    [clojure.test :refer :all]
+   [metabase.formatter :as formatter]
    [metabase.pulse.render :as render]
    [metabase.pulse.render.color :as color]
-   [metabase.pulse.render.common :as common]
    [metabase.pulse.render.table :as table]
    [metabase.pulse.render.test-util :as render.tu]
    [metabase.test :as mt]))
@@ -62,9 +62,9 @@
                        :rows [[1 2 3]
                               [4 5 6]
                               [7 8 9]
-                              [7 8 (common/map->NumericWrapper {:num-str "4.5" :num-value 4.5})]
-                              [7 8 (common/map->NumericWrapper {:num-str "1,001.5" :num-value 1001.5})]    ;; default floating point seperator .
-                              [7 8 (common/map->NumericWrapper {:num-str "1.001,5" :num-value 1001.5})]]}] ;; floating point seperator is ,
+                              [7 8 (formatter/map->NumericWrapper {:num-str "4.5" :num-value 4.5})]
+                              [7 8 (formatter/map->NumericWrapper {:num-str "1,001.5" :num-value 1001.5})]    ;; default floating point seperator .
+                              [7 8 (formatter/map->NumericWrapper {:num-str "1.001,5" :num-value 1001.5})]]}] ;; floating point seperator is ,
     (is (= {"1"       nil
             "2"       nil
             "3"       "rgba(0, 255, 0, 0.75)"

--- a/test/metabase/pulse/render/test_util.clj
+++ b/test/metabase/pulse/render/test_util.clj
@@ -12,9 +12,9 @@
   (:require
    [clojure.string :as str]
    [clojure.zip :as zip]
+   [metabase.formatter.datetime :as datetime]
    [metabase.pulse.render :as render]
    [metabase.pulse.render.body :as body]
-   [metabase.pulse.render.datetime :as datetime]
    [metabase.pulse.render.image-bundle :as image-bundle]
    [metabase.pulse.render.js-svg :as js-svg]
    [metabase.shared.models.visualization-settings :as mb.viz]

--- a/test/metabase/pulse/render_test.clj
+++ b/test/metabase/pulse/render_test.clj
@@ -195,7 +195,7 @@
                            :as            question-card} {:dataset_query {:type     :query
                                                                           :database (mt/id)
                                                                           :query    {:source-table (format "card__%s" model-card-id)}}}]
-        ;; NOTE -- The logic in metabase.pulse.render.common/number-formatter renders values between 1 and 100 as an
+        ;; NOTE -- The logic in metabase.formatter/number-formatter renders values between 1 and 100 as an
         ;; integer value. IDK if this is what we want long term, but this captures the current logic. If we do extend
         ;; the significant digits in the formatter, we'll need to modify this test as well.
         (letfn [(create-comparison-results [query-results card]


### PR DESCRIPTION
This PR refactors `metabase.pulse.render.common` to `metabase.formatter` as this is code we want applied to several locations, not just in pulses. It also updates references to these nses and the consistent alias.

A key observation of this formatting code, and reason for the refactor, is that it is "metabase-aware" in that it takes into account metadata columns and visualization settings when building formatters rather than just being a simple generic date or number formatter. This is a common code path that should be used any time we are rendering static assets and could potentially be used as common FE code with future development.

Moves:
- `metabase.pulse.render.common` to `metabase.formatter`
- `metabase.pulse.render.datetime` to `metabase.formatter.datetime`
- `metabase.pulse.render.common-test` to `metabase.formatter-test`
- `metabase.pulse.render.datetime-test` to `metabase.formatter.datetime-test`

With this change and #36484 we will close #36320.