### PR TITLE
Enabling converting simple value expressions from pMBQL to legacy

### DIFF
--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -358,9 +358,12 @@
   [an-expression-clause :- ::lib.schema.expression/expression
    new-name :- :string]
   (lib.options/update-options
-   an-expression-clause
+   (if (lib.util/clause? an-expression-clause)
+     an-expression-clause
+     [:value {:effective-type (lib.schema.expression/type-of an-expression-clause)}
+      an-expression-clause])
    (fn [opts]
      (let [opts (assoc opts :lib/uuid (str (random-uuid)))]
        (if (:lib/expression-name opts)
          (assoc opts :lib/expression-name new-name)
-         (assoc opts :display-name new-name))))))
+         (assoc opts :name new-name :display-name new-name))))))

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -1087,5 +1087,6 @@
   (lib.convert/with-aggregation-list (lib.core/aggregations a-query stage-number)
     (let [legacy-expr (-> an-expression-clause lib.convert/->legacy-MBQL)]
       (clj->js (cond-> legacy-expr
-                 (= (first legacy-expr) :aggregation-options)
+                 (and (vector? legacy-expr)
+                      (= (first legacy-expr) :aggregation-options))
                  (get 1))))))

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -402,3 +402,8 @@
              (lib/display-name query agg)))
       (is (not= (lib.options/uuid orig-agg)
                 (lib.options/uuid agg))))))
+
+(deftest ^:parallel simple-value-with-expression-name-test
+  (testing "simple values can be named (#36459)"
+    (is (=? [:value {:name "zero", :display-name "zero", :effective-type :type/Integer} 0]
+            (lib/with-expression-name 0 "zero")))))

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -177,7 +177,13 @@
           agg-expr (-> query lib/aggregations first)
           legacy-agg-expr #js ["count"]
           legacy-agg-expr' (lib.js/legacy-expression-for-expression-clause query -1 agg-expr)]
-      (is (= (js->clj legacy-agg-expr) (js->clj legacy-agg-expr'))))))
+      (is (= (js->clj legacy-agg-expr) (js->clj legacy-agg-expr')))))
+  (testing "simple values can be converted properly (#36459)"
+    (let [query lib.tu/venues-query
+          legacy-expr 0
+          expr (lib.js/expression-clause-for-legacy-expression query 0 legacy-expr)
+          legacy-expr' (lib.js/legacy-expression-for-expression-clause query 0 expr)]
+      (is (= legacy-expr expr legacy-expr')))))
 
 (deftest ^:parallel filter-drill-details-test
   (testing ":value field on the filter drill"


### PR DESCRIPTION
Fixes #36459.

Also makes sure that legacy to pMBQL works and that simple value expressions can be named.
