### PR TITLE
models/setting: return default value if JSON parsing fails

### DIFF
--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -654,7 +654,8 @@
             (and enabled? (not (enabled?))))
       default
       (binding [*disable-cache* disable-cache?]
-        (getter)))))
+        (try (getter)
+             (catch Exception _ default))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
Closes: #36182

Signed-off-by: Levente Kurusa <lev@metabase.com>

### Description

When getting a setting, the get-value-of-type function can fail with an exception, especially for JSONs.
Return the default value instead of silently escalating an exception all the way up to the template
rendering. A more ideal approach would be to catch this when MB starts up, but I couldn't (yet) find
a place to do some validation.

Any ideas instead of silently failing?

### How to verify

Describe the steps to verify that the changes are working as expected.

1. `MB_JETTY_PORT=3006 MB_CUSTOM_FORMATTING="{\"type/Temporal\":{\"time_style\":\"HH:mm\",\"date_abbreviate\":true}" clojure -M:run`
2. `echo 'GET /api/session/properties HTTP/1.1\nHost: localhost\n\n' | nc localhost 3006`
3. Verify that no exception is shown.