### PR TITLE
Tweak code block in doc

### DIFF
--- a/docs/installation-and-operation/running-the-metabase-jar-file.md
+++ b/docs/installation-and-operation/running-the-metabase-jar-file.md
@@ -20,9 +20,10 @@ If you have Java installed:
 1. [Download the JAR file for Metabase OSS](https://metabase.com/start/oss/jar).
 2. Create a new directory and move the Metabase JAR into it.
 3. Change into your new Metabase directory and run the JAR.
-   ```
-   java -jar metabase.jar
-   ```
+
+```
+java -jar metabase.jar
+```
 
 Metabase will log its progress in the terminal as it starts up. Wait until you see "Metabase Initialization Complete" and visit `http://localhost:3000/setup`.
 


### PR DESCRIPTION
If you visit https://www.metabase.com/docs/latest/installation-and-operation/running-the-metabase-jar-file, you'll see a line of code that is displayed with way too much space.

![image](https://github.com/metabase/metabase/assets/380816/e82d59e9-754c-45a3-816b-d07f72bdd4c5)

This PR will have it be its own block of code, with the copy button.
