### PR TITLE
Use stretch variant on switch

### DIFF
--- a/frontend/src/metabase/search/components/ToggleSidebarFilter/ToggleSidebarFilter.styled.tsx
+++ b/frontend/src/metabase/search/components/ToggleSidebarFilter/ToggleSidebarFilter.styled.tsx
@@ -1,8 +1,0 @@
-import styled from "@emotion/styled";
-import { Switch } from "metabase/ui";
-
-export const FilterSwitch = styled(Switch)`
-  .emotion-Switch-body {
-    justify-content: space-between;
-  }
-`;

--- a/frontend/src/metabase/search/components/ToggleSidebarFilter/ToggleSidebarFilter.tsx
+++ b/frontend/src/metabase/search/components/ToggleSidebarFilter/ToggleSidebarFilter.tsx
@@ -1,6 +1,5 @@
 import type { SearchFilterToggle } from "metabase/search/types";
-import { Text } from "metabase/ui";
-import { FilterSwitch } from "./ToggleSidebarFilter.styled";
+import { Text, Switch } from "metabase/ui";
 
 export type ToggleSidebarFilterProps = {
   filter: SearchFilterToggle;
@@ -16,10 +15,11 @@ export const ToggleSidebarFilter = ({
   "data-testid": dataTestId,
 }: ToggleSidebarFilterProps) => {
   return (
-    <FilterSwitch
+    <Switch
       wrapperProps={{
         "data-testid": dataTestId,
       }}
+      variant="stretch"
       data-testid="toggle-filter-switch"
       size="sm"
       labelPosition="left"


### PR DESCRIPTION
small nitpick tweak to #32624 

### Description

We don't need a styled component wrapper to get the flex: justify-between styling for the switch component, there is a `stretch` variant for that. Looks the same, less code. I think the variant may have been added after this component actually 🤔 .  

In general, if we're wrapping Mantine components to do simple things, we should consider making a variant, since they'll probably be needed elsewhere.

![Screen Shot 2023-12-06 at 3 31 45 PM](https://github.com/metabase/metabase/assets/30528226/152298ba-373f-43ab-bee2-a6edd1ff0f89)

