### PR TITLE
fix broken stacking

### DIFF
--- a/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
+++ b/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
@@ -130,8 +130,9 @@ export const computeStaticComboChartSettings = (
     getDefaultStackingValue(settings, mainCard),
     isStackingValueValid(
       settings,
-      seriesModels.map(seriesModel =>
-        settings.series(seriesModel.legacySeriesSettingsObjectKey),
+      seriesModels.map(
+        seriesModel =>
+          settings.series(seriesModel.legacySeriesSettingsObjectKey).display,
       ),
     ),
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -12679,11 +12679,6 @@ html-void-elements@^3.0.0:
   resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-3.0.0.tgz#fc9dbd84af9e747249034d4d62602def6517f1d7"
   integrity sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==
 
-html-webpack-harddisk-plugin@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/html-webpack-harddisk-plugin/-/html-webpack-harddisk-plugin-2.0.0.tgz#2de78316554e7aa37d07066d3687901beca4d5ce"
-  integrity sha512-fWKH72FyaQ5K/j+kYy6LnQsQucSDnsEkghmB6g29TtpJ4sxHYFduEeUV1hfDqyDpCRW+bP7yacjQ+1ikeIDqeg==
-
 html-webpack-plugin@5.5.0, html-webpack-plugin@^5.0.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-5.5.0.tgz#c3911936f57681c1f9f4d8b68c158cd9dfe52f50"


### PR DESCRIPTION
### Description

Fixes broken stacking caused by a mistake in the static combo chart settings computation, particularly, in stacking setting validation.

### How to verify

Check stacked combo stories

### Demo

<img width="567" alt="Screenshot 2023-12-06 at 8 01 26 PM" src="https://github.com/metabase/metabase/assets/14301985/a2a1ea3b-6629-4d66-99a6-047de7b361a5">

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
