### PR TITLE
Prevent setting display name on top level expressions

### DIFF
--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -175,7 +175,7 @@
                           (mapv (fn [[k v]]
                                   (-> v
                                       ->pMBQL
-                                      (lib.util/named-expression-clause k))))
+                                      (lib.util/top-level-expression-clause k))))
                           not-empty)]
     (metabase.lib.convert/with-aggregation-list aggregations
       (let [stage (-> stage

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -215,7 +215,7 @@
       query stage-number
       add-expression-to-stage
       (-> (lib.common/->op-arg expressionable)
-          (lib.util/named-expression-clause expression-name))))))
+          (lib.util/top-level-expression-clause expression-name))))))
 
 (lib.common/defop + [x y & more])
 (lib.common/defop - [x y & more])
@@ -362,5 +362,7 @@
    (fn [opts]
      (let [opts (assoc opts :lib/uuid (str (random-uuid)))]
        (if (:lib/expression-name opts)
-         (assoc opts :lib/expression-name new-name)
-         (assoc opts :display-name new-name))))))
+         (-> opts
+             (dissoc :display-name :name)
+             (assoc :lib/expression-name new-name))
+         (assoc opts :name new-name :display-name new-name))))))

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -79,7 +79,7 @@
   (when (clause? clause)
     (:lib/expression-name (lib.options/options clause))))
 
-(defn named-expression-clause
+(defn top-level-expression-clause
   "Top level expressions must be clauses with :lib/expression-name, so if we get a literal, wrap it in :value."
   [clause a-name]
   (-> (if (clause? clause)
@@ -87,7 +87,10 @@
         [:value {:lib/uuid (str (random-uuid))
                  :effective-type (lib.schema.expression/type-of clause)}
          clause])
-      (lib.options/update-options assoc :lib/expression-name a-name)))
+      (lib.options/update-options (fn [opts]
+                                    (-> opts
+                                        (assoc :lib/expression-name a-name)
+                                        (dissoc :name :display-name))))))
 
 (defn replace-clause
   "Replace the `target-clause` in `stage` `location` with `new-clause`.
@@ -96,7 +99,7 @@
   [stage location target-clause new-clause]
   {:pre [((some-fn clause? #(= (:lib/type %) :mbql/join)) target-clause)]}
   (let [new-clause (if (= :expressions (first location))
-                     (named-expression-clause new-clause (expression-name target-clause))
+                     (top-level-expression-clause new-clause (expression-name target-clause))
                      new-clause)]
     (m/update-existing-in
       stage

--- a/test/metabase/lib/util_test.cljc
+++ b/test/metabase/lib/util_test.cljc
@@ -338,11 +338,11 @@
         (lib/with-temporal-bucket :day-of-week))
     :type/Temporal))
 
-(deftest ^:parallel named-expression-clause-do-not-wrap-values-test
+(deftest ^:parallel top-level-expression-clause-do-not-wrap-values-test
   (testing "named-expression-clause should not wrap a :value clause in another :value clause"
     (is (=? [:value {:semantic-type :type/Country, :base-type :type/Text, :lib/expression-name "Country"}
              "United States"]
-            (lib.util/named-expression-clause
+            (lib.util/top-level-expression-clause
              [:value {:semantic-type :type/Country, :base-type :type/Text, :lib/uuid (str (random-uuid))}
               "United States"]
              "Country")))))


### PR DESCRIPTION
Fixes #36464.

Unqualified properties in the options make the conversion to legacy MBQL treat any expression as an aggregation expression.
