### PR TITLE
[MLv2] Fix pivot drills integration with the FE

### DIFF
--- a/frontend/src/metabase-lib/tests/drills-pivot.unit.spec.ts
+++ b/frontend/src/metabase-lib/tests/drills-pivot.unit.spec.ts
@@ -19,7 +19,7 @@ import {
 } from "./drills-common";
 
 // eslint-disable-next-line
-describe.skip("drill-thru/pivot (metabase#33559)", () => {
+describe("drill-thru/pivot (metabase#33559)", () => {
   const drillType = "drill-thru/pivot";
   const stageIndex = 0;
 

--- a/frontend/src/metabase-lib/tests/drills-pivot.unit.spec.ts
+++ b/frontend/src/metabase-lib/tests/drills-pivot.unit.spec.ts
@@ -18,7 +18,6 @@ import {
   createNotEditableQuery,
 } from "./drills-common";
 
-// eslint-disable-next-line
 describe("drill-thru/pivot (metabase#33559)", () => {
   const drillType = "drill-thru/pivot";
   const stageIndex = 0;

--- a/src/metabase/lib/drill_thru.cljc
+++ b/src/metabase/lib/drill_thru.cljc
@@ -111,6 +111,6 @@
     stage-number :- :int
     drill        :- ::lib.schema.drill-thru/drill-thru
     & args]
-   (log/infof "Applying drill thru: %s"
-              (u/pprint-to-str {:query query, :stage-number stage-number, :drill drill, :args args}))
+   (log/debugf "Applying drill thru: %s"
+               (u/pprint-to-str {:query query, :stage-number stage-number, :drill drill, :args args}))
    (apply lib.drill-thru.common/drill-thru-method query stage-number drill args)))

--- a/src/metabase/lib/drill_thru/pivot.cljc
+++ b/src/metabase/lib/drill_thru/pivot.cljc
@@ -109,7 +109,7 @@
   "A helper for the FE. Returns the set of pivot types (category, location, time) that apply to this drill-thru."
   [drill-thru :- [:and ::lib.schema.drill-thru/drill-thru
                   [:map [:type [:= :drill-thru/pivot]]]]]
-  (keys (:pivots drill-thru)))
+  (-> drill-thru :pivots keys sort))
 
 (mu/defn pivot-columns-for-type :- [:sequential lib.metadata/ColumnMetadata]
   "A helper for the FE. Returns all the columns of the given type which can be used to pivot the query."

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -1006,12 +1006,14 @@
 (defn ^:export pivot-types
   "Returns an array of pivot types that are available in this drill-thru, which must be a pivot drill-thru."
   [a-drill-thru]
-  (to-array (lib.core/pivot-types a-drill-thru)))
+  (->> (lib.core/pivot-types a-drill-thru)
+       (map name)
+       to-array))
 
 (defn ^:export pivot-columns-for-type
   "Returns an array of pivotable columns of the specified type."
   [a-drill-thru pivot-type]
-  (lib.core/pivot-columns-for-type a-drill-thru pivot-type))
+  (to-array (lib.core/pivot-columns-for-type a-drill-thru (keyword pivot-type))))
 
 (defn ^:export with-different-table
   "Changes an existing query to use a different source table or card.


### PR DESCRIPTION
These were broken because `lib.js/pivot-types` was returning CLJS
keywords rather than strings.

Also makes applying drill-thrus less noisy (`log/info` -> `log/debug`).

Unskips the FE integration tests for pivot drills. Fixes #33559.

