### PR TITLE
log x-axis for scatter plot

### DIFF
--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -112,7 +112,14 @@ export type VisualizationSettings = {
 
   // X-axis
   "graph.x_axis.title_text"?: string;
-  "graph.x_axis.scale"?: "ordinal" | "timeseries" | "linear" | "histogram";
+  "graph.x_axis.scale"?:
+    | "ordinal"
+    | "timeseries"
+    | "linear"
+    | "histogram"
+    // for scatter plot
+    | "log"
+    | "pow";
   "graph.x_axis.axis_enabled"?:
     | true
     | false

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
@@ -223,6 +223,9 @@ const getXAxisType = (settings: ComputedVisualizationSettings) => {
       return "time";
     case "linear":
       return "value";
+    // log x-axis is only for scatter plot
+    case "log":
+      return "log";
     default:
       return "category";
   }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/36289

### Description

Implements the log x-axis scale for the echarts static scatter plot.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a scatter plot
2. Set x-axis scale to log
3. Add to a dashboard and send a subscription
4. Confirm it renders correctly

### Demo

![Screenshot 2023-12-14 at 2.37.40 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/cb3282d8-0cd0-492d-86b6-7d7aaaa4faf0.png)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

Storybook example was added in a previous PR.
