### PR TITLE
Add embedding types to Dashboards and Cards

### DIFF
--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -13,6 +13,7 @@ export interface Card<Q extends DatasetQuery = DatasetQuery>
   description: string | null;
   dataset: boolean;
   public_uuid: string | null;
+  enable_embedding: boolean;
   can_write: boolean;
 
   database_id?: DatabaseId;

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -13,6 +13,8 @@ export interface Card<Q extends DatasetQuery = DatasetQuery>
   description: string | null;
   dataset: boolean;
   public_uuid: string | null;
+
+  /* Indicates whether static embedding for this card has been published */
   enable_embedding: boolean;
   can_write: boolean;
 

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -35,6 +35,8 @@ export interface Dashboard {
   auto_apply_filters: boolean;
   archived: boolean;
   public_uuid: string | null;
+
+  /* Indicates whether static embedding for this dashboard has been published */
   enable_embedding: boolean;
 }
 

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -35,6 +35,7 @@ export interface Dashboard {
   auto_apply_filters: boolean;
   archived: boolean;
   public_uuid: string | null;
+  enable_embedding: boolean;
 }
 
 export type DashCardId = number;

--- a/frontend/src/metabase-types/api/mocks/card.ts
+++ b/frontend/src/metabase-types/api/mocks/card.ts
@@ -32,6 +32,7 @@ export const createMockCard = (opts?: Partial<Card>): Card => ({
   last_query_start: null,
   average_query_time: null,
   archived: false,
+  enable_embedding: false,
   ...opts,
 });
 

--- a/frontend/src/metabase-types/api/mocks/dashboard.ts
+++ b/frontend/src/metabase-types/api/mocks/dashboard.ts
@@ -25,6 +25,7 @@ export const createMockDashboard = (opts?: Partial<Dashboard>): Dashboard => ({
   auto_apply_filters: true,
   archived: false,
   public_uuid: null,
+  enable_embedding: false,
   ...opts,
 });
 

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionContext/QueryActionContextProvider/QueryActionContextProvider.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionContext/QueryActionContextProvider/QueryActionContextProvider.tsx
@@ -75,6 +75,7 @@ function convertActionToQuestionCard(
     last_query_start: null,
     average_query_time: null,
     archived: false,
+    enable_embedding: false,
   };
 }
 

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/test-utils.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/test-utils.ts
@@ -65,6 +65,7 @@ export const TEST_DASHBOARD_STATE: DashboardState = {
         getDefaultTab({ tabId: 3, dashId: 1, name: "Tab 3" }),
       ],
       public_uuid: null,
+      enable_embedding: false,
     },
   },
   dashcards: {


### PR DESCRIPTION
For https://github.com/metabase/metabase/issues/35961

This just adds `enable_embedding` for the card and dashboard types, which is reflected in the API response that we get when we are accessing a card or dashboard already. For example:

_**Card**_
<img width="205" alt="image" src="https://github.com/metabase/metabase/assets/25306947/ca9b8d36-989d-41af-be9d-3746d48d4d04">

_**Dashboard**_

<img width="196" alt="image" src="https://github.com/metabase/metabase/assets/25306947/1a743bfc-0646-41d5-9a58-1e8fd7a05f2e">


So this is just updating the types to match what we're already getting