### PR TITLE
test: add e2e case to handle the oss/no-whitelabel enabled case

### DIFF
--- a/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
@@ -243,6 +243,18 @@ describeEE("formatting > whitelabel", () => {
         .and("include", "https://www.metabase.com/help?");
     });
 
+    it("should link to metabase help when the whitelabel feature is disabled (eg OSS)", () => {
+      setTokenFeatures("none");
+
+      cy.signInAsNormalUser();
+      cy.visit("/");
+      openSettingsMenu();
+
+      helpLink()
+        .should("have.attr", "href")
+        .and("include", "https://www.metabase.com/help?");
+    });
+
     it("it should validate the url", () => {
       cy.signInAsAdmin();
       cy.visit("/admin/settings/whitelabel");


### PR DESCRIPTION
### Description

This specific use case was missing from the [testing plan](https://github.com/metabase/metabase/issues/36250) but it's important to test that the feature doesn't break/crash when the token is not enabled.

I tested in e2e because I want there are some checks on the feature tokens on the BE.

I updated the testing plan accordingly, sorry for missing it in the first place.

The failing E2E is expected, as it's already expecting the error message that will come from https://github.com/metabase/metabase/pull/36328