### PR TITLE
Update server side relative datetime generation honeysql

### DIFF
--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -215,7 +215,7 @@
   [unit]
   (contains? #{:day :week :month :quarter :year} unit))
 
-(defn- server-side-relative-datetime-honeysql-form
+(defn- server-side-relative-date-honeysql-form
   "Compute `:relative-datetime` clause value server-side. Value is sql formatted (and not passed as date time) to avoid
    jdbc driver's timezone adjustments. Use of `qp.timezone/now` ensures correct timezone is used for the calculation.
    For details see the [[metabase.driver.redshift-test/server-side-relative-datetime-truncation-test]]."
@@ -230,7 +230,7 @@
 (defmethod sql.qp/->honeysql [:redshift :relative-datetime]
   [driver [_ amount unit]]
   (if (use-server-side-relative-datetime? unit)
-    (server-side-relative-datetime-honeysql-form amount unit)
+    (server-side-relative-date-honeysql-form amount unit)
     (let [now-hsql (sql.qp/current-datetime-honeysql-form driver)]
       (sql.qp/date driver unit (if (zero? amount)
                                  now-hsql

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -225,7 +225,7 @@
        (u.date/truncate unit)
        (u.date/add unit amount)
        (u.date/format-sql))
-   :timestamp])
+   :date])
 
 (defmethod sql.qp/->honeysql [:redshift :relative-datetime]
   [driver [_ amount unit]]


### PR DESCRIPTION
Fixes #36537

This PR addresses past UTC midnight failures of `server-side-relative-datetime-various-units-test`. The test was introduced by PR #35995. That PR modifies `:relative-datetime` transformation in a way, that when the unit is coarser (or eq) to `:day` timestamp is generated server-side to enable caching.

_What does it change?_
Cast in the `redshift/server-side-relative-datetime-honeysql-form` to date instead of a timestamp.

_Why that should solve the problem?_
Test that is failing does the following under the hood:
1. Generates sql select with 2 columns with `:relative-datetime`, one generated the old way, another with server-side generated datetime value (new way).
2. Test than compares those values.

While debugging, when I've added `::text` cast to those columns, I've found out that old way yield just date string, while the new way timestamp string. With correct values.

I believe that problem lies in that result transformation. That following values
```
2023-12-06
2023-12-06 00:00:00
```
are transformed to results
```
"2023-11-06T00:00:00Z"
"2023-11-07T00:00:00Z"
```

This PR aims to fix test failing and should have no effect on functionality. Prior to this PR temporal columns were compared to timestamp with zeroed time values (eg. `[:>= $some_datetime_field [:relative-datetime :day -1]`), now it is just the date (as the old pre server side generated relative datetime implementation used).

_Why not just modify how the test is handling return values?_
I've decided to go this path as the change is simpler and should have no effect on resulting functionality.

---

I've tested the change during the UTC night. Result can be found [here](https://github.com/metabase/metabase/actions/runs/7121576016/job/19391077359?pr=36413).

Also I'm about to further investigate if the probable cause described here is the real cause of the problem. Consider this PR its solution.

The PR to further examine the cause is #36413. More context can be found in [this slack thread](https://metaboat.slack.com/archives/C5XHN8GLW/p1701772468810829).
