### PR TITLE
[MLv2] Unskip FE integration tests for automatic-insights drills

### DIFF
--- a/frontend/src/metabase-lib/tests/drills-automatic-insights.unit.spec.ts
+++ b/frontend/src/metabase-lib/tests/drills-automatic-insights.unit.spec.ts
@@ -22,8 +22,7 @@ import {
   createNotEditableQuery,
 } from "./drills-common";
 
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip("drill-thru/automatic-insights (metabase#33558)", () => {
+describe("drill-thru/automatic-insights (metabase#33558)", () => {
   const drillType = "drill-thru/automatic-insights";
   const stageIndex = 0;
   const metadataWithXraysEnabled = createMockMetadata(


### PR DESCRIPTION
This was missed from #36443.

Fixes #33558.
