### PR TITLE
Add icon search to Storybook

### DIFF
--- a/frontend/src/metabase/core/components/Icon/Icon.stories.tsx
+++ b/frontend/src/metabase/core/components/Icon/Icon.stories.tsx
@@ -1,5 +1,5 @@
-import type { StoryObj } from "@storybook/react";
-import styled from "@emotion/styled";
+import { useState } from "react";
+import { Box, TextInput, Stack } from "metabase/ui";
 import { Icon } from "./Icon";
 import { iconNames } from "./icons";
 
@@ -8,25 +8,31 @@ export default {
   component: Icon,
 };
 
-type Story = StoryObj<typeof Icon>;
+const Template = () => {
+  const [searchQuery, setSearchQuery] = useState("");
 
-export const Default: Story = {
-  render: () => (
-    <div>
-      {iconNames.map(icon => (
-        <IconBlock key={icon}>
-          <p>{icon}</p>
-          <Icon name={icon} />
-        </IconBlock>
-      ))}
-    </div>
-  ),
+  const filteredIconNames = iconNames.filter(name =>
+    name.includes(searchQuery.toLowerCase()),
+  );
+
+  return (
+    <Stack>
+      <TextInput
+        value={searchQuery}
+        type="search"
+        placeholder="Search"
+        onChange={e => setSearchQuery(e.target.value)}
+      />
+      <Box>
+        {filteredIconNames.map(icon => (
+          <Box key={icon} display="inline-block" w="100px" m="20px" ta="center">
+            <p>{icon}</p>
+            <Icon name={icon} />
+          </Box>
+        ))}
+      </Box>
+    </Stack>
+  );
 };
 
-const IconBlock = styled.div`
-  display: inline-block;
-  width: 100px;
-  margin: 20px;
-
-  text-align: center;
-`;
+export const Default = Template.bind({});


### PR DESCRIPTION
Adds a search input to `Icon` components storybook files, so it's possible to filter icons by name

### To verify

1. `yarn storybook`
2. Go to `http://localhost:6006/?path=/story/components-icon--default`
3. Ensure you can see and use the "Search" input at the top to filter icons by names

### Demo


https://github.com/metabase/metabase/assets/17258145/2f2207a1-c63c-4899-b0ff-18d408b1b1b2

