### PR TITLE
Handle latest release check correctly for s3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,7 +182,7 @@ jobs:
       id: latest_path
       with:
         result-encoding: string
-        script: |
+        script: | # js
           const { isLatestRelease, getCanonicalVersion } = require('${{ github.workspace }}/release/dist/index.cjs');
 
           const version = '${{ inputs.version }}';
@@ -197,7 +197,9 @@ jobs:
             version: canonical_version,
           });
 
-          if (isLatest) {
+          console.log("Latest version?", isLatest);
+
+          if (isLatest === "true") {
             return edition === 'ee' ? 'enterprise/latest' : 'latest';
           }
           return "false";

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,7 +207,7 @@ jobs:
     - name: Upload to S3
       run: aws s3 cp ./metabase.jar s3://${{ vars.AWS_S3_DOWNLOADS_BUCKET }}/${{ steps.version_path.outputs.result }}/metabase.jar
     - name: Upload to s3 latest path
-      if: ${{ steps.is_latest.outputs.result != 'false' }}
+      if: ${{ steps.latest_path.outputs.result != 'false' }}
       run: aws s3 cp ./metabase.jar s3://${{ vars.AWS_S3_DOWNLOADS_BUCKET }}/${{ steps.latest_path.outputs.result }}/metabase.jar
     - name: Create cloudfront invalidation
       run: |

--- a/release/release-offline.ts
+++ b/release/release-offline.ts
@@ -265,7 +265,8 @@ async function s3() {
   );
 
   if (isLatest === 'true') {
-    await $`aws s3 cp ${JAR_PATH}/metabase.jar s3://${AWS_S3_DOWNLOADS_BUCKET}/latest/metabase.jar`.pipe(
+    const latestPath = edition === "ee" ? `enterprise/latest` : `latest`;
+    await $`aws s3 cp ${JAR_PATH}/metabase.jar s3://${AWS_S3_DOWNLOADS_BUCKET}/${latestPath}/metabase.jar`.pipe(
       process.stdout,
     );
   }


### PR DESCRIPTION
### Description

For release 48.0-RC1, we incorrectly pushed RC jars to the "latest" directory. This has been fixed manually, this is the fix to make sure it doesn't happen again. See the [full post-mortem doc](https://www.notion.so/metabase/48-RC1-latest-error-post-mortem-5adb35b6d8d2411ca7c7ddb6bf357c1b).

### How to verify

- Test on my fork: https://github.com/iethree/metabase/actions/runs/7143151633/job/19454078849


