### PR TITLE
Fix "instace analytics" typo

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/collections/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/collections/constants.ts
@@ -24,7 +24,7 @@ export const OFFICIAL_COLLECTION: CollectionAuthorityLevelConfig = {
 export const INSTANCE_ANALYTICS_COLLECTION: CollectionInstanceAnaltyicsConfig =
   {
     type: "instance-analytics",
-    name: t`Instace Analytics`,
+    name: t`Instance Analytics`,
     icon: "audit",
   };
 


### PR DESCRIPTION
A user helpfully emailed me about this. I'm not sure where exactly this string appears in the UI if anywhere, but it was misspelled and had translation tagging on it, so I figured I'd fix it real quick. 

This might necessitate pushing strings back up to poeditor; but, again, I couldn't see anywhere where this string actually appears in the UI.