### PR TITLE
Metabase analytics everywhere

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/collections/components/CollectionInstanceAnalyticsIcon.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/collections/components/CollectionInstanceAnalyticsIcon.tsx
@@ -32,7 +32,7 @@ export function CollectionInstanceAnalyticsIcon({
     <Icon
       {...iconProps}
       name={collectionType.icon}
-      tooltip={t`This is a read-only Instance Analytics ${collectionIconTooltipNameMap[entity]}.`}
+      tooltip={t`This is a read-only Metabase Analytics ${collectionIconTooltipNameMap[entity]}.`}
       data-testid="instance-analytics-collection-marker"
     />
   );

--- a/enterprise/frontend/src/metabase-enterprise/collections/components/CollectionInstanceAnalyticsIcon.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/collections/components/CollectionInstanceAnalyticsIcon.unit.spec.tsx
@@ -59,7 +59,7 @@ describe("CollectionInstanceAnalyticsIcon", () => {
         expect(queryOfficialIcon()).toBeInTheDocument();
         userEvent.hover(queryOfficialIcon());
         expect(screen.getByRole("tooltip")).toHaveTextContent(
-          `This is a read-only Instance Analytics ${entity}`,
+          `This is a read-only Metabase Analytics ${entity}`,
         );
       });
     });

--- a/frontend/src/metabase/collections/components/CollectionHeader/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/tests/enterprise.unit.spec.tsx
@@ -6,7 +6,7 @@ import { setup } from "./setup";
 describe("Instance Analytics Collection Header", () => {
   const defaultOptions = {
     collection: {
-      name: "Instance Analytics",
+      name: "Metabase Analytics",
       type: "instance-analytics" as CollectionType,
       can_write: false,
     },

--- a/frontend/src/metabase/entities/collections/utils.unit.spec.ts
+++ b/frontend/src/metabase/entities/collections/utils.unit.spec.ts
@@ -349,7 +349,7 @@ describe("entities > collections > utils", () => {
         expectedIcon: "person",
       },
       {
-        name: "Instance Analytics",
+        name: "Metabase Analytics",
         collection: createMockCollection({ type: "instance-analytics" }),
         expectedIcon: "audit",
       },


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/36598

### Description

A couple strings still said "instance analytics" instead of "Metabase Analytics"

These also get whitelabeled if the instance is using a custom name

![Screen Shot 2023-12-08 at 2 34 28 PM](https://github.com/metabase/metabase/assets/30528226/4e40d69e-0d3e-4247-8dc9-ec3bda880559)
![Screen Shot 2023-12-08 at 2 34 19 PM](https://github.com/metabase/metabase/assets/30528226/23b75526-2e83-48a8-927c-352652d5f3f5)


### How to verify

- View an metabase analytics collection, model, or dashboard
- See the icon tooltip no longer says "instance analytics"


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
