### PR TITLE
Fix underlying-records drill with nil binned value

### DIFF
--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -72,10 +72,12 @@
    column       :- lib.metadata/ColumnMetadata
    value        :- :any]
   (let [filter-clauses (or (when (lib.binning/binning column)
-                             (when-let [{:keys [min-value max-value]} (lib.binning/resolve-bin-width query column value)]
-                               (let [unbinned-column (lib.binning/with-binning column nil)]
-                                 [(lib.filter/>= unbinned-column min-value)
-                                  (lib.filter/< unbinned-column max-value)])))
+                             (let [unbinned-column (lib.binning/with-binning column nil)]
+                               (if (some? value)
+                                 (when-let [{:keys [min-value max-value]} (lib.binning/resolve-bin-width query column value)]
+                                   [(lib.filter/>= unbinned-column min-value)
+                                    (lib.filter/< unbinned-column max-value)])
+                                 [(lib.filter/is-null unbinned-column)])))
                            [(lib.filter/= column value)])]
     (reduce
      (fn [query filter-clause]

--- a/test/metabase/lib/drill_thru/underlying_records_test.cljc
+++ b/test/metabase/lib/drill_thru/underlying_records_test.cljc
@@ -341,3 +341,35 @@
                  :row-count  2
                  :table-name "Orders"}
                 (lib/display-info query -1 drill)))))))
+
+(deftest ^:parallel nil-aggregation-value-test
+  (testing "nil dimension value for binned column should return a valid query (#11345 #36581)"
+    (let [query        (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                           (lib/aggregate (lib/count))
+                           (lib/breakout (-> (meta/field-metadata :orders :discount)
+                                             (lib/with-binning {:strategy :default}))))
+          count-col    (m/find-first #(= (:name %) "count")
+                                     (lib/returned-columns query))
+          _            (is (some? count-col))
+          discount-col (m/find-first #(= (:name %) "DISCOUNT")
+                                     (lib/returned-columns query))
+          _            (is (some? discount-col))
+          context      {:column     count-col
+                        :column-ref (lib/ref count-col)
+                        :value      16845
+                        :row        [{:column     discount-col
+                                      :column-ref (lib/ref discount-col)
+                                      :value      nil}
+                                     {:column     count-col
+                                      :column-ref (lib/ref count-col)
+                                      :value      16845}]
+                        :dimensions [{:column     discount-col
+                                      :column-ref (lib/ref discount-col)
+                                      :value      nil}]}
+          drill (m/find-first #(= (:type %) :drill-thru/underlying-records)
+                              (lib/available-drill-thrus query context))]
+      (is (some? drill))
+      (is (=? {:stages [{:filters [[:is-null
+                                    {}
+                                    [:field {:binning (symbol "nil #_\"key is not present.\"")} (meta/id :orders :discount)]]]}]}
+              (lib/drill-thru query drill))))))


### PR DESCRIPTION
If you try to do `underlying-records` on a binned column whose value is `nil` in that row, add an `:is-null` filter. 

Fixes #36581