### PR TITLE
Make replace-clause use custom expression name if set

### DIFF
--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -339,24 +339,6 @@
                            {:query query, :stage-number stage-number, :x x}
                            e))))))))
 
-(defmulti custom-name-method
-  "Implementation for [[custom-name]]."
-  {:arglists '([x])}
-  lib.dispatch/dispatch-value
-  :hierarchy lib.hierarchy/hierarchy)
-
-(defn custom-name
-  "Return the user supplied name of `x`, if any."
-  [x]
-  (custom-name-method x))
-
-(defmethod custom-name-method :default
-  [x]
-  ;; We assume that clauses only get a :display-name option if the user explicitly specifies it.
-  ;; Expressions from the :expressions clause of pMBQL queries have custom names by default.
-  (when (lib.util/clause? x)
-    ((some-fn :display-name :lib/expression-name) (lib.options/options x))))
-
 (defn default-display-info
   "Default implementation of [[display-info-method]], available in case you want to use this in a different
   implementation and add additional information to it."
@@ -366,7 +348,7 @@
      ;; TODO -- not 100% convinced the FE should actually have access to `:name`, can't it use `:display-name`
      ;; everywhere? Determine whether or not this is the case.
      (select-keys x-metadata [:name :display-name :semantic-type])
-     (when-let [custom (custom-name x)]
+     (when-let [custom (lib.util/custom-name x)]
        {:display-name custom
         :named? true})
      (when-let [long-display-name (display-name query stage-number x :long)]

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -11,6 +11,7 @@
    [clojure.string :as str]
    [medley.core :as m]
    [metabase.lib.common :as lib.common]
+   [metabase.lib.dispatch :as lib.dispatch]
    [metabase.lib.hierarchy :as lib.hierarchy]
    [metabase.lib.options :as lib.options]
    [metabase.lib.schema :as lib.schema]
@@ -92,6 +93,24 @@
                                         (assoc :lib/expression-name a-name)
                                         (dissoc :name :display-name))))))
 
+(defmulti custom-name-method
+  "Implementation for [[custom-name]]."
+  {:arglists '([x])}
+  lib.dispatch/dispatch-value
+  :hierarchy lib.hierarchy/hierarchy)
+
+(defn custom-name
+  "Return the user supplied name of `x`, if any."
+  [x]
+  (custom-name-method x))
+
+(defmethod custom-name-method :default
+  [x]
+  ;; We assume that clauses only get a :display-name option if the user explicitly specifies it.
+  ;; Expressions from the :expressions clause of pMBQL queries have custom names by default.
+  (when (clause? x)
+    ((some-fn :display-name :lib/expression-name) (lib.options/options x))))
+
 (defn replace-clause
   "Replace the `target-clause` in `stage` `location` with `new-clause`.
    If a clause has :lib/uuid equal to the `target-clause` it is swapped with `new-clause`.
@@ -99,17 +118,18 @@
   [stage location target-clause new-clause]
   {:pre [((some-fn clause? #(= (:lib/type %) :mbql/join)) target-clause)]}
   (let [new-clause (if (= :expressions (first location))
-                     (top-level-expression-clause new-clause (expression-name target-clause))
+                     (top-level-expression-clause new-clause (or (custom-name new-clause)
+                                                                 (expression-name target-clause)))
                      new-clause)]
     (m/update-existing-in
-      stage
-      location
-      (fn [clause-or-clauses]
-        (->> (for [clause clause-or-clauses]
-               (if (= (lib.options/uuid clause) (lib.options/uuid target-clause))
-                 new-clause
-                 clause))
-             vec)))))
+     stage
+     location
+     (fn [clause-or-clauses]
+       (->> (for [clause clause-or-clauses]
+              (if (= (lib.options/uuid clause) (lib.options/uuid target-clause))
+                new-clause
+                clause))
+            vec)))))
 
 (defn remove-clause
   "Remove the `target-clause` in `stage` `location`.


### PR DESCRIPTION
This addresses the issue reported in https://github.com/metabase/metabase/pull/36533#discussion_r1420344447.

**TODO**
- [ ] Test