### PR TITLE
Bigquery - Ignore retry on query cancellation

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -281,9 +281,8 @@
             (when (future-done? res-fut) ; canceled received after it was finished; may as well return it
                 @res-fut)))))
       @res-fut)
-    (catch java.util.concurrent.CancellationException e
-     ; Throw exception so that it can be caught by the caller and handled appropriately
-     (throw e))
+    (catch java.util.concurrent.CancellationException _e
+      (throw (ex-info (tru "Query cancelled") {:sql sql :parameters parameters ::cancelled? true})))
     (catch BigQueryException e
       (if (.isRetryable e)
         (throw (ex-info (tru "BigQueryException executing query")
@@ -352,12 +351,9 @@
                                                  cancel-requested?))]
     (try
       (thunk)
-      (catch java.util.concurrent.CancellationException _e
-        ;; Handle cancellation exception without retrying
-        (throw (ex-info (tru "Query cancelled") {:sql sql :parameters parameters})))
       (catch Throwable e
         (let [ex-data (u/all-ex-data e)]
-          (if (or (:retryable? e) (not (qp.error-type/client-error? (:type ex-data))))
+          (if (and not (::cancelled? ex-data) (or (:retryable? e) (not (qp.error-type/client-error? (:type ex-data)))))
             (thunk)
             (throw e)))))))
 

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -267,7 +267,7 @@
           ;; check out com.google.cloud.bigquery.QueryRequestInfo.isFastQuerySupported for full details
           ;; Additional configuration here if needed
           job-builder (-> (JobId/newBuilder)
-                                (.setRandomJob))
+                          (.setRandomJob))
           job-id (.build job-builder)
           res-fut (future (.query client (.build request) job-id (u/varargs BigQuery$JobOption)))]
       (when cancel-chan
@@ -276,8 +276,8 @@
             (log/debugf "Received a message on the cancel channel; attempting to stop the BigQuery query execution")
             (reset! cancel-requested? true) ; signal the page iteration fn to stop
             (if-not (or (future-cancelled? res-fut) (future-done? res-fut))
-            (do (.cancel client job-id) ; Cancel running job before canceling task
-                (future-cancel res-fut))
+              (do (.cancel client job-id) ; Cancel running job before canceling task
+                  (future-cancel res-fut))
             (when (future-done? res-fut) ; canceled received after it was finished; may as well return it
                 @res-fut)))))
       @res-fut)

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -353,7 +353,8 @@
       (thunk)
       (catch Throwable e
         (let [ex-data (u/all-ex-data e)]
-          (if (and not (::cancelled? ex-data) (or (:retryable? e) (not (qp.error-type/client-error? (:type ex-data)))))
+          (if (and (not (::cancelled? ex-data))
+                   (or (:retryable? e) (not (qp.error-type/client-error? (:type ex-data)))))
             (thunk)
             (throw e)))))))
 

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -354,7 +354,7 @@
       (catch Throwable e
         (let [ex-data (u/all-ex-data e)]
           (if (and (not (::cancelled? ex-data))
-                   (or (:retryable? e) (not (qp.error-type/client-error? (:type ex-data)))))
+                   (or (:retryable? ex-data) (not (qp.error-type/client-error? (:type ex-data)))))
             (thunk)
             (throw e)))))))
 

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -265,7 +265,6 @@
           ;; as long as we don't set certain additional QueryJobConfiguration options, our queries *should* always be
           ;; following the fast query path (i.e. RPC)
           ;; check out com.google.cloud.bigquery.QueryRequestInfo.isFastQuerySupported for full details
-          ;; Additional configuration here if needed
           res-fut (future (.query client (.build request) (u/varargs BigQuery$JobOption)))]
       (when cancel-chan
         (future                       ; this needs to run in a separate thread, because the <!! operation blocks forever

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -31,7 +31,7 @@
    (clojure.lang PersistentList)
    (com.google.cloud.bigquery BigQuery BigQuery$DatasetListOption BigQuery$JobOption BigQuery$TableDataListOption
                               BigQuery$TableListOption BigQuery$TableOption BigQueryException BigQueryOptions Dataset
-                              DatasetId Field Field$Mode FieldValue FieldValueList JobId QueryJobConfiguration Schema Table
+                              DatasetId Field Field$Mode FieldValue FieldValueList QueryJobConfiguration Schema Table
                               TableDefinition$Type TableId TableResult)))
 
 (set! *warn-on-reflection* true)
@@ -266,19 +266,19 @@
           ;; following the fast query path (i.e. RPC)
           ;; check out com.google.cloud.bigquery.QueryRequestInfo.isFastQuerySupported for full details
           ;; Additional configuration here if needed
-          job-builder (-> (JobId/newBuilder)
-                          (.setRandomJob))
-          job-id (.build job-builder)
-          res-fut (future (.query client (.build request) job-id (u/varargs BigQuery$JobOption)))]
+          res-fut (future (.query client (.build request) (u/varargs BigQuery$JobOption)))]
       (when cancel-chan
         (future                       ; this needs to run in a separate thread, because the <!! operation blocks forever
           (when (a/<!! cancel-chan)
             (log/debugf "Received a message on the cancel channel; attempting to stop the BigQuery query execution")
             (reset! cancel-requested? true) ; signal the page iteration fn to stop
             (if-not (or (future-cancelled? res-fut) (future-done? res-fut))
-              (do (.cancel client job-id) ; Cancel running job before canceling task
-                  (future-cancel res-fut))
-            (when (future-done? res-fut) ; canceled received after it was finished; may as well return it
+              ;; somehow, even the FIRST page hasn't come back yet (i.e. the .query call above), so cancel the future to
+              ;; interrupt the thread waiting on that response to come back
+              ;; unfortunately, with this particular overload of .query, we have no access to (nor the ability to control)
+              ;; the jobId, so we have no way to use the BigQuery client to cancel any job that might be running
+              (future-cancel res-fut)
+              (when (future-done? res-fut) ; canceled received after it was finished; may as well return it
                 @res-fut)))))
       @res-fut)
     (catch java.util.concurrent.CancellationException _e

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -381,7 +381,7 @@
                                                   (if (and (re-find #"notRetryCancellationExceptionTest" sql) (not @fake-execute-called))
                                                     (do (reset! fake-execute-called true)
                                                         ;; Simulate a cancellation happening
-                                                        (throw (ex-info "Query cancelled" {:metabase.driver.bigquery-cloud-sdk/cancelled? true})))
+                                                        (throw (ex-info "Query cancelled" {::bigquery/cancelled? true})))
                                                     (orig-fn client sql parameters nil nil)))]
           (try
             (qp/process-query {:native {:query "SELECT CURRENT_TIMESTAMP() AS notRetryCancellationExceptionTest"} :database (mt/id)

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -380,8 +380,8 @@
                                                   ;; We dont want to retry the db setup queries, so only retry if the query contains "cancel_test"
                                                   (if (and (re-find #"cancel_test" sql) (not @fake-execute-called))
                                                     (do (reset! fake-execute-called true)
-                                                        ;; Simulate a CancellationException being thrown
-                                                        (throw (java.util.concurrent.CancellationException. "Query cancelled")))
+                                                        ;; Simulate a cancellation happening
+                                                        (throw (ex-info "Query cancelled" {::cancelled? true})))
                                                     (orig-fn client sql parameters nil nil)))]
           (try
             (qp/process-query {:native {:query "SELECT CURRENT_TIMESTAMP() AS cancel_test"} :database (mt/id)

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -377,14 +377,14 @@
           orig-fn        @#'bigquery/execute-bigquery]
       (testing "Should not retry query on cancellation"
         (with-redefs [bigquery/execute-bigquery (fn [^BigQuery client ^String sql parameters _ _]
-                                                  ;; We dont want to retry the db setup queries, so only retry if the query contains "cancel_test"
-                                                  (if (and (re-find #"cancel_test" sql) (not @fake-execute-called))
+                                                  ;; We only want to simulate exception on the query that we're testing and not on possible db setup queries
+                                                  (if (and (re-find #"not-retry-cancellation-exception-test" sql) (not @fake-execute-called))
                                                     (do (reset! fake-execute-called true)
                                                         ;; Simulate a cancellation happening
                                                         (throw (ex-info "Query cancelled" {::cancelled? true})))
                                                     (orig-fn client sql parameters nil nil)))]
           (try
-            (qp/process-query {:native {:query "SELECT CURRENT_TIMESTAMP() AS cancel_test"} :database (mt/id)
+            (qp/process-query {:native {:query "SELECT CURRENT_TIMESTAMP() AS not-retry-cancellation-exception-test"} :database (mt/id)
                                :type     :native})
             ;; If no exception is thrown, then the test should fail
             (is false "Query should have failed")

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -392,8 +392,7 @@
               ;; Verify exception as expected
               (is (= "Query cancelled" (.getMessage e)))
               ;; make sure that the fake exception was thrown
-              (is (true? @fake-execute-called))))))))
-)
+              (is (true? @fake-execute-called)))))))))
 
 (deftest query-cancel-test
   (mt/test-driver :bigquery-cloud-sdk

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -381,7 +381,7 @@
                                                   (if (and (re-find #"not-retry-cancellation-exception-test" sql) (not @fake-execute-called))
                                                     (do (reset! fake-execute-called true)
                                                         ;; Simulate a cancellation happening
-                                                        (throw (ex-info "Query cancelled" {::cancelled? true})))
+                                                        (throw (ex-info "Query cancelled" {:metabase.driver.bigquery-cloud-sdk/cancelled? true})))
                                                     (orig-fn client sql parameters nil nil)))]
           (try
             (qp/process-query {:native {:query "SELECT CURRENT_TIMESTAMP() AS not-retry-cancellation-exception-test"} :database (mt/id)

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -378,13 +378,13 @@
       (testing "Should not retry query on cancellation"
         (with-redefs [bigquery/execute-bigquery (fn [^BigQuery client ^String sql parameters _ _]
                                                   ;; We only want to simulate exception on the query that we're testing and not on possible db setup queries
-                                                  (if (and (re-find #"not-retry-cancellation-exception-test" sql) (not @fake-execute-called))
+                                                  (if (and (re-find #"notRetryCancellationExceptionTest" sql) (not @fake-execute-called))
                                                     (do (reset! fake-execute-called true)
                                                         ;; Simulate a cancellation happening
                                                         (throw (ex-info "Query cancelled" {:metabase.driver.bigquery-cloud-sdk/cancelled? true})))
                                                     (orig-fn client sql parameters nil nil)))]
           (try
-            (qp/process-query {:native {:query "SELECT CURRENT_TIMESTAMP() AS not-retry-cancellation-exception-test"} :database (mt/id)
+            (qp/process-query {:native {:query "SELECT CURRENT_TIMESTAMP() AS notRetryCancellationExceptionTest"} :database (mt/id)
                                :type     :native})
             ;; If no exception is thrown, then the test should fail
             (is false "Query should have failed")


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/36623 

### Description

Instead of retrying all types of exceptions, we only retry if its not a cancellation exception. 

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Run a (long running) query with Bigquery Conenctor
2. Cancel Query 
3. Verify in Bigquery Project history that only one query appears instead of two.

### Demo

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
