### PR TITLE
Add junit.xml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@
 bin/node_modules/
 bin/release/aws-eb/metabase-aws-eb.zip
 coverage-summary.json
+junit.xml
 pom.xml
 pom.xml.asc
 profiles.clj


### PR DESCRIPTION
#35929 caused unit tests to output `junit.xml`. This file should not be tracked. It's created locally every time unit tests are run.