### PR TITLE
[#35961 M2] Modify E2E Tests to match new Embed Setup Modal

### DIFF
--- a/e2e/support/helpers/e2e-embedding-helpers.js
+++ b/e2e/support/helpers/e2e-embedding-helpers.js
@@ -129,6 +129,10 @@ export function getIframeBody(selector = "iframe") {
     .then(cy.wrap);
 }
 
+export function getEmbedModalSharingPane() {
+  return cy.findByTestId("sharing-pane-container");
+}
+
 export function openPublicLinkPopoverFromMenu() {
   cy.icon("share").click();
   cy.findByTestId("embed-header-menu")
@@ -144,12 +148,9 @@ export function openEmbedModalFromMenu() {
 }
 
 export function openStaticEmbeddingModal() {
-  cy.intercept("GET", "/api/session/properties").as("sessionProperties");
-
   openEmbedModalFromMenu();
 
-  cy.get(".Modal--full").findByText("Embed in your application").click();
-  cy.wait("@sessionProperties");
+  cy.findByTestId("sharing-pane-static-embed-button").click();
 }
 
 // @param {("card"|"dashboard")} resourceType - The type of resource we are sharing

--- a/e2e/test/scenarios/dashboard-filters/reproductions/25322-loading-list-values.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/25322-loading-list-values.cy.spec.js
@@ -75,5 +75,5 @@ const throttleFieldValuesRequest = dashboard_id => {
     middleware: true,
   };
 
-  cy.intercept(matcher, req => req.on("response", res => res.setThrottle(10)));
+  cy.intercept(matcher, req => req.on("response", res => res.setThrottle(1)));
 };

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -877,10 +877,10 @@ describe("scenarios > dashboard", () => {
 
     openEmbedModalFromMenu();
 
-    cy.get(".Modal--full").within(() => {
+    modal().within(() => {
       cy.icon("close").click();
     });
-    cy.get(".Modal--full").should("not.exist");
+    modal().should("not.exist");
     assertScrollBarExists();
   });
 

--- a/e2e/test/scenarios/embedding/reproductions/30535-session-sandboxing.cy.spec.js
+++ b/e2e/test/scenarios/embedding/reproductions/30535-session-sandboxing.cy.spec.js
@@ -40,12 +40,13 @@ describeEE("issue 30535", () => {
   it("user session should not apply sandboxing to a signed embedded question (metabase#30535)", () => {
     openStaticEmbeddingModal();
 
-    cy.findByTestId("public-link-input").then($input => {
-      const iframeText = $input.val();
-      const publicLink = iframeText.match(/src="([^"]+)"/)[1];
+    cy.document().then(doc => {
+      const iframe = doc.querySelector("iframe");
+
       cy.signOut();
       cy.signInAsSandboxedUser();
-      cy.visit(publicLink);
+
+      cy.visit(iframe.src);
     });
 
     cy.findByRole("table").within(() => {

--- a/e2e/test/scenarios/embedding/reproductions/30535-session-sandboxing.cy.spec.js
+++ b/e2e/test/scenarios/embedding/reproductions/30535-session-sandboxing.cy.spec.js
@@ -40,13 +40,12 @@ describeEE("issue 30535", () => {
   it("user session should not apply sandboxing to a signed embedded question (metabase#30535)", () => {
     openStaticEmbeddingModal();
 
-    cy.document().then(doc => {
-      const iframe = doc.querySelector("iframe");
-
+    cy.findByTestId("public-link-input").then($input => {
+      const iframeText = $input.val();
+      const publicLink = iframeText.match(/src="([^"]+)"/)[1];
       cy.signOut();
       cy.signInAsSandboxedUser();
-
-      cy.visit(iframe.src);
+      cy.visit(publicLink);
     });
 
     cy.findByRole("table").within(() => {

--- a/e2e/test/scenarios/native-filters/reproductions/17019.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/reproductions/17019.cy.spec.js
@@ -37,10 +37,10 @@ describe("issue 17019", () => {
     openPublicLinkPopoverFromMenu();
 
     cy.findByTestId("public-link-popover-content")
-      .findByTestId("public-link-text")
-      .invoke("text")
-      .then(publicURL => {
-        cy.visit(publicURL);
+      .findByTestId("public-link-input")
+      .invoke("val")
+      .then(publicLink => {
+        cy.visit(publicLink);
       });
 
     cy.findByPlaceholderText("Filter").type("456{enter}");

--- a/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
@@ -102,19 +102,10 @@ describe("scenarios > public > dashboard", () => {
     cy.wait("@publicLink").then(({ response }) => {
       expect(response.body.uuid).not.to.be.null;
 
-      cy.findByRole("heading", { name: "Public link" })
-        // This click doesn't have any meaning in the context of the correctness of this test!
-        // It's simply here to prevent test flakiness, which happens because the Modal overlay
-        // is animating (disappearing) and we need to wait for it to stop the transition.
-        // Cypress will retry clicking this text until the DOM element is "actionable", or in
-        // our case - until there's no element on top of it blocking it. That's also when we
-        // expect this input field to be populated with the actual value.
-        .click()
-        .parent()
-        .findByText(/^http/)
-        .then($input => {
-          expect($input.text()).to.match(PUBLIC_DASHBOARD_REGEX);
-        });
+      cy.findByTestId("public-link-input").should("be.visible");
+      cy.findByTestId("public-link-input").then($input => {
+        expect($input.val()).to.match(PUBLIC_DASHBOARD_REGEX);
+      });
     });
   });
 
@@ -133,7 +124,9 @@ describe("scenarios > public > dashboard", () => {
 
       cy.findByTestId("public-link-popover-content").within(() => {
         cy.findByText("Public link").should("be.visible");
-        cy.findByTestId("public-link-text").contains(PUBLIC_DASHBOARD_REGEX);
+        cy.findByTestId("public-link-input").then($input =>
+          expect($input.val()).to.match(PUBLIC_DASHBOARD_REGEX),
+        );
         cy.findByText("Remove public URL").should("not.exist");
       });
     });

--- a/e2e/test/scenarios/sharing/public-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-question.cy.spec.js
@@ -112,7 +112,9 @@ describe("scenarios > public > question", () => {
 
       cy.findByTestId("public-link-popover-content").within(() => {
         cy.findByText("Public link").should("be.visible");
-        cy.findByTestId("public-link-text").contains(PUBLIC_QUESTION_REGEX);
+        cy.findByTestId("public-link-input").then($input =>
+          expect($input.val()).to.match(PUBLIC_QUESTION_REGEX),
+        );
         cy.findByText("Remove public URL").should("not.exist");
       });
     });
@@ -156,8 +158,8 @@ describe("scenarios > public > question", () => {
 });
 
 const visitPublicURL = () => {
-  cy.findByTestId("public-link-text")
-    .invoke("text")
+  cy.findByTestId("public-link-input")
+    .invoke("val")
     .then(publicURL => {
       // Copied URL has no get params
       expect(publicURL).to.match(PUBLIC_QUESTION_REGEX);

--- a/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
@@ -2,6 +2,7 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   createPublicDashboardLink,
   createPublicQuestionLink,
+  getEmbedModalSharingPane,
   openPublicLinkPopoverFromMenu,
   restore,
   visitDashboard,
@@ -87,7 +88,7 @@ const { PRODUCTS_ID } = SAMPLE_DATABASE;
 
             cy.findByTestId("public-link-popover-content").within(() => {
               cy.findByText("Public link").should("be.visible");
-              cy.findByTestId("public-link-text").should("be.visible");
+              cy.findByTestId("public-link-input").should("be.visible");
               cy.findByText("Remove public link").should("be.visible");
             });
           });
@@ -116,7 +117,7 @@ const { PRODUCTS_ID } = SAMPLE_DATABASE;
 
             cy.findByTestId("public-link-popover-content").within(() => {
               cy.findByText("Public link").should("be.visible");
-              cy.findByTestId("public-link-text").should("be.visible");
+              cy.findByTestId("public-link-input").should("be.visible");
               cy.findByText("Remove public link").should("be.visible");
             });
 
@@ -130,7 +131,7 @@ const { PRODUCTS_ID } = SAMPLE_DATABASE;
 
             cy.findByTestId("public-link-popover-content").within(() => {
               cy.findByText("Public link").should("be.visible");
-              cy.findByTestId("public-link-text").should("be.visible");
+              cy.findByTestId("public-link-input").should("be.visible");
               cy.findByText("Remove public link").should("not.exist");
             });
           });
@@ -160,9 +161,10 @@ const { PRODUCTS_ID } = SAMPLE_DATABASE;
 
             cy.findByTestId("embed-menu-embed-modal-item").click();
 
-            cy.get(".Modal--full")
-              .findByText("Embed in your application")
-              .should("be.visible");
+            getEmbedModalSharingPane().within(() => {
+              cy.findByText("Static embed").should("be.visible");
+              cy.findByText("Public embed").should("be.visible");
+            });
           });
         });
         describe("when user is non-admin", () => {

--- a/e2e/test/scenarios/sharing/reproductions/26988-embedding-dynamic-settings.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/26988-embedding-dynamic-settings.cy.spec.js
@@ -1,7 +1,7 @@
 import {
   describeEE,
   getIframeBody,
-  openEmbedModalFromMenu,
+  openStaticEmbeddingModal,
   popover,
   restore,
   setTokenFeatures,
@@ -34,8 +34,7 @@ describeEE("issue 26988", () => {
       visitDashboard(card.dashboard_id);
     });
 
-    openEmbedModalFromMenu();
-    cy.findByRole("button", { name: "Set up" }).click();
+    openStaticEmbeddingModal();
     cy.wait("@dashboard");
 
     getIframeBody().should("have.css", "font-family", `Lato, sans-serif`);

--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -20,6 +20,7 @@ import {
   viewEmailPage,
   openPublicLinkPopoverFromMenu,
   openEmbedModalFromMenu,
+  getEmbedModalSharingPane,
 } from "e2e/support/helpers";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 import { USERS } from "e2e/support/cypress_data";
@@ -48,9 +49,9 @@ describe("scenarios > dashboard > subscriptions", () => {
     cy.icon("share").click();
 
     openEmbedModalFromMenu();
-    cy.get(".Modal--full").within(() => {
+    getEmbedModalSharingPane().within(() => {
       cy.findByText("Public embed").should("be.visible");
-      cy.findByText("Embed in your application").should("be.visible");
+      cy.findByText("Static embed").should("be.visible");
     });
   });
 
@@ -69,9 +70,9 @@ describe("scenarios > dashboard > subscriptions", () => {
     // getting notifications with static text-only cards doesn't make a lot of sense
     cy.findByLabelText("subscriptions").should("not.exist");
 
-    cy.get(".Modal--full").within(() => {
+    getEmbedModalSharingPane().within(() => {
       cy.findByText("Public embed").should("be.visible");
-      cy.findByText("Embed in your application").should("be.visible");
+      cy.findByText("Static embed").should("be.visible");
     });
   });
 

--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -682,8 +682,8 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
         it("should display pivot table in a public link", () => {
           openPublicLinkPopoverFromMenu();
           cy.findByTestId("public-link-popover-content")
-            .findByTestId("public-link-text")
-            .invoke("text")
+            .findByTestId("public-link-input")
+            .invoke("val")
             .then($value => {
               cy.visit($value);
             });

--- a/frontend/src/metabase/dashboard/components/EmbedMenu/AdminEmbedMenu.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/EmbedMenu/AdminEmbedMenu.unit.spec.tsx
@@ -86,11 +86,15 @@ describe("AdminEmbedMenu", () => {
       expect(
         screen.getByText("Anyone can view this if you give them the link."),
       ).toBeInTheDocument();
-      expect(screen.getByTestId("public-link-text")).toHaveTextContent(
-        /public\/dashboard\/mock-uuid/,
-      );
+
+      const inputValue = screen
+        .getByTestId("public-link-input")
+        .getAttribute("value");
+
+      expect(inputValue).toMatch(/\/public\/dashboard\/mock-uuid/i);
+
       expect(screen.getByTestId("copy-button")).toBeInTheDocument();
-      expect(screen.getByText("Remove this public link")).toBeInTheDocument();
+      expect(screen.getByText("Remove public link")).toBeInTheDocument();
     });
 
     it("should open the embed modal when `Embed` is clicked", async () => {

--- a/frontend/src/metabase/dashboard/components/EmbedMenu/NonAdminEmbedMenu.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/EmbedMenu/NonAdminEmbedMenu.unit.spec.tsx
@@ -62,7 +62,7 @@ describe("NonAdminEmbedMenu", () => {
       expect(
         screen.getByText("Anyone can view this if you give them the link."),
       ).toBeInTheDocument();
-      expect(screen.getByTestId("public-link-text")).toHaveTextContent(
+      expect(screen.getByTestId("public-link-input")).toHaveDisplayValue(
         /public\/dashboard\/mock-uuid/,
       );
       expect(screen.getByTestId("copy-button")).toBeInTheDocument();

--- a/frontend/src/metabase/dashboard/components/PublicLinkPopover/DashboardPublicLinkPopover.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/PublicLinkPopover/DashboardPublicLinkPopover.unit.spec.tsx
@@ -65,11 +65,11 @@ const setup = ({
   );
 };
 describe("DashboardPublicLinkPopover", () => {
-  it("should display a question-specific public url", async () => {
+  it("should display a dashboard-specific public url", async () => {
     setup();
 
     expect(
-      await screen.findByText(`${SITE_URL}/public/dashboard/mock-uuid`),
+      await screen.findByDisplayValue(`${SITE_URL}/public/dashboard/mock-uuid`),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/metabase/dashboard/components/PublicLinkPopover/PublicLinkCopyPanel.tsx
+++ b/frontend/src/metabase/dashboard/components/PublicLinkPopover/PublicLinkCopyPanel.tsx
@@ -4,10 +4,8 @@ import {
   ExtensionOption,
   RemoveLinkAnchor,
 } from "metabase/dashboard/components/PublicLinkPopover/PublicLinkCopyPanel.styled";
-import type { exportFormats } from "metabase/lib/urls";
 import { Box, Group, Stack, Text, TextInput, Tooltip } from "metabase/ui";
-
-export type ExportFormatType = typeof exportFormats[number] | null;
+import type { ExportFormatType } from "./types";
 
 export const PublicLinkCopyPanel = ({
   loading = false,
@@ -32,6 +30,7 @@ export const PublicLinkCopyPanel = ({
     <Stack>
       <TextInput
         readOnly
+        data-testid="public-link-input"
         placeholder={loading ? t`Loading…` : undefined}
         value={url ?? undefined}
         inputWrapperOrder={["label", "input", "error", "description"]}

--- a/frontend/src/metabase/dashboard/components/PublicLinkPopover/PublicLinkPopover.tsx
+++ b/frontend/src/metabase/dashboard/components/PublicLinkPopover/PublicLinkPopover.tsx
@@ -1,12 +1,10 @@
 import { useAsync } from "react-use";
 import { t } from "ttag";
+import type { ExportFormatType } from "metabase/dashboard/components/PublicLinkPopover/types";
 import { PublicLinkCopyPanel } from "metabase/dashboard/components/PublicLinkPopover/PublicLinkCopyPanel";
 import { useSelector } from "metabase/lib/redux";
-import type { exportFormats } from "metabase/lib/urls";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { Box, Popover, Text, Title } from "metabase/ui";
-
-export type ExportFormatType = typeof exportFormats[number] | null;
 
 export type PublicLinkPopoverProps = {
   target: JSX.Element;

--- a/frontend/src/metabase/dashboard/components/PublicLinkPopover/PublicLinkPopover.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/PublicLinkPopover/PublicLinkPopover.unit.spec.tsx
@@ -99,7 +99,9 @@ describe("PublicLinkPopover", () => {
       expect(
         screen.getByText("Anyone can view this if you give them the link."),
       ).toBeInTheDocument();
-      expect(await screen.findByText("sample-public-link")).toBeInTheDocument();
+      expect(
+        await screen.findByDisplayValue("sample-public-link"),
+      ).toBeInTheDocument();
     });
 
     it("should render public link information for non-admins", async () => {
@@ -109,7 +111,9 @@ describe("PublicLinkPopover", () => {
       expect(
         screen.getByText("Anyone can view this if you give them the link."),
       ).toBeInTheDocument();
-      expect(await screen.findByText("sample-public-link")).toBeInTheDocument();
+      expect(
+        await screen.findByDisplayValue("sample-public-link"),
+      ).toBeInTheDocument();
     });
 
     it("should render `Remove public link` and warning tooltip for admins", async () => {
@@ -166,7 +170,9 @@ describe("PublicLinkPopover", () => {
       userEvent.click(screen.getByTestId("target"));
 
       expect(createPublicLink).not.toHaveBeenCalled();
-      expect(await screen.findByText("sample-public-link")).toBeInTheDocument();
+      expect(
+        await screen.findByDisplayValue("sample-public-link"),
+      ).toBeInTheDocument();
     });
   });
 
@@ -189,7 +195,9 @@ describe("PublicLinkPopover", () => {
     it("should allow admins to copy the link to the clipboard", async () => {
       setup({ hasUUID: true, isOpen: true });
 
-      expect(await screen.findByText("sample-public-link")).toBeInTheDocument();
+      expect(
+        await screen.findByDisplayValue("sample-public-link"),
+      ).toBeInTheDocument();
 
       userEvent.click(screen.getByLabelText("copy icon"));
 
@@ -199,7 +207,9 @@ describe("PublicLinkPopover", () => {
     it("should allow non-admins to copy the link to the clipboard", async () => {
       setup({ hasUUID: true, isOpen: true, isAdmin: false });
 
-      expect(await screen.findByText("sample-public-link")).toBeInTheDocument();
+      expect(
+        await screen.findByDisplayValue("sample-public-link"),
+      ).toBeInTheDocument();
 
       userEvent.click(screen.getByLabelText("copy icon"));
 
@@ -215,10 +225,14 @@ describe("PublicLinkPopover", () => {
         await screen.findByTestId("public-link-popover-content"),
       ).toBeInTheDocument();
 
-      expect(await screen.findByText("sample-public-link")).toBeInTheDocument();
+      expect(
+        await screen.findByDisplayValue("sample-public-link"),
+      ).toBeInTheDocument();
 
       userEvent.click(screen.getByText("csv"));
-      expect(screen.getByText("sample-public-link.csv")).toBeInTheDocument();
+      expect(
+        screen.getByDisplayValue("sample-public-link.csv"),
+      ).toBeInTheDocument();
     });
 
     it("should remove the extension when the extension is clicked on again", async () => {
@@ -228,14 +242,20 @@ describe("PublicLinkPopover", () => {
         await screen.findByTestId("public-link-popover-content"),
       ).toBeInTheDocument();
 
-      expect(await screen.findByText("sample-public-link")).toBeInTheDocument();
+      expect(
+        await screen.findByDisplayValue("sample-public-link"),
+      ).toBeInTheDocument();
 
       userEvent.click(screen.getByText("csv"));
-      expect(screen.getByText("sample-public-link.csv")).toBeInTheDocument();
+      expect(
+        screen.getByDisplayValue("sample-public-link.csv"),
+      ).toBeInTheDocument();
 
       userEvent.click(screen.getByText("csv"));
 
-      expect(await screen.findByText("sample-public-link")).toBeInTheDocument();
+      expect(
+        await screen.findByDisplayValue("sample-public-link"),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/dashboard/components/PublicLinkPopover/PublicLinkPopover.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/PublicLinkPopover/PublicLinkPopover.unit.spec.tsx
@@ -1,12 +1,10 @@
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
+import type { ExportFormatType } from "metabase/dashboard/components/PublicLinkPopover/types";
 import { renderWithProviders, screen } from "__support__/ui";
 import { createMockUser } from "metabase-types/api/mocks";
 import { createMockState } from "metabase-types/store/mocks";
-import type {
-  ExportFormatType,
-  PublicLinkPopoverProps,
-} from "./PublicLinkPopover";
+import type { PublicLinkPopoverProps } from "./PublicLinkPopover";
 import { PublicLinkPopover } from "./PublicLinkPopover";
 
 // https://github.com/nkbt/react-copy-to-clipboard/issues/106#issuecomment-605227151

--- a/frontend/src/metabase/dashboard/components/PublicLinkPopover/QuestionPublicLinkPopover.tsx
+++ b/frontend/src/metabase/dashboard/components/PublicLinkPopover/QuestionPublicLinkPopover.tsx
@@ -10,7 +10,7 @@ import {
 } from "metabase/query_builder/actions";
 import type Question from "metabase-lib/Question";
 import { PublicLinkPopover } from "./PublicLinkPopover";
-import type { ExportFormatType } from "./PublicLinkPopover";
+import type { ExportFormatType } from "./types";
 
 export const QuestionPublicLinkPopover = ({
   question,

--- a/frontend/src/metabase/dashboard/components/PublicLinkPopover/QuestionPublicLinkPopover.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/PublicLinkPopover/QuestionPublicLinkPopover.unit.spec.tsx
@@ -75,7 +75,7 @@ describe("QuestionPublicLinkPopover", () => {
     setup();
 
     expect(
-      await screen.findByText(`${SITE_URL}/public/question/mock-uuid`),
+      await screen.findByDisplayValue(`${SITE_URL}/public/question/mock-uuid`),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/metabase/dashboard/components/PublicLinkPopover/types.ts
+++ b/frontend/src/metabase/dashboard/components/PublicLinkPopover/types.ts
@@ -1,0 +1,3 @@
+import type { exportFormats } from "metabase/lib/urls";
+
+export type ExportFormatType = typeof exportFormats[number] | null;

--- a/frontend/src/metabase/public/components/widgets/EmbedModalContent.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/widgets/EmbedModalContent.unit.spec.tsx
@@ -45,9 +45,8 @@ describe("EmbedModalContent", () => {
       />,
     );
 
-    // expect(screen.getByText("Sharing")).toBeInTheDocument();
     expect(screen.getByText("Public embed")).toBeInTheDocument();
-    expect(screen.getByText("Embed in your application")).toBeInTheDocument();
+    expect(screen.getByText("Static embed")).toBeInTheDocument();
   });
 
   it("should render parameters", () => {
@@ -187,7 +186,7 @@ function renderWithConfiguredProviders(element: JSX.Element) {
 function openEmbedModal() {
   screen
     .getByRole("button", {
-      name: "Set up",
+      name: "Set this up",
     })
     .click();
 }

--- a/frontend/src/metabase/public/components/widgets/SharingPane/SharingPane.tsx
+++ b/frontend/src/metabase/public/components/widgets/SharingPane/SharingPane.tsx
@@ -69,7 +69,7 @@ function SharingPane({
   );
 
   return (
-    <Group p="lg">
+    <Group p="lg" data-testid="sharing-pane-container">
       <SharingPaneButton
         header={t`Static embed`}
         description={t`Securely embed this dashboard in your own application’s server code.`}
@@ -77,6 +77,7 @@ function SharingPane({
         onClick={() => onChangeEmbedType("application")}
       >
         <SharingPaneActionButton
+          data-testid="sharing-pane-static-embed-button"
           fullWidth
           onClick={() => onChangeEmbedType("application")}
         >

--- a/frontend/src/metabase/public/components/widgets/SharingPane/SharingPane.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/widgets/SharingPane/SharingPane.unit.spec.tsx
@@ -146,9 +146,8 @@ describe("SharingPane", () => {
           ),
         ).toBeInTheDocument();
 
-        expect(screen.getByTestId("public-link-text")).toBeInTheDocument();
-        expect(screen.getByTestId("public-link-text")).toHaveTextContent(
-          /<iframe src="mock-uuid".*<\/iframe>/i,
+        expect(screen.getByTestId("public-link-input")).toHaveDisplayValue(
+          /<iframe(\s+)src="mock-uuid".*<\/iframe>/s,
         );
 
         expect(screen.getByTestId("copy-button")).toBeInTheDocument();

--- a/frontend/src/metabase/query_builder/components/QuestionEmbedWidget/QuestionEmbedWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionEmbedWidget/QuestionEmbedWidget.tsx
@@ -1,6 +1,8 @@
 import type { Card } from "metabase-types/api";
 import type { EmbedOptions } from "metabase-types/store";
+import type { ExportFormatType } from "metabase/dashboard/components/PublicLinkPopover/types";
 import { useDispatch, useSelector } from "metabase/lib/redux";
+import { publicQuestion } from "metabase/lib/urls";
 import { EmbedModal } from "metabase/public/components/widgets/EmbedModal";
 import EmbedModalContent from "metabase/public/components/widgets/EmbedModalContent";
 import { getMetadata } from "metabase/selectors/metadata";
@@ -31,6 +33,15 @@ export const QuestionEmbedWidget = (props: QuestionEmbedWidgetProps) => {
   const updateQuestionEmbeddingParams = (embeddingParams: EmbedOptions) =>
     dispatch(updateEmbeddingParams(card, embeddingParams));
 
+  const getPublicQuestionUrl = (
+    {
+      public_uuid,
+    }: {
+      public_uuid: string;
+    },
+    extension: ExportFormatType,
+  ) => publicQuestion({ uuid: public_uuid, type: extension });
+
   return (
     <EmbedModal onClose={onClose}>
       {({ embedType, setEmbedType }) => (
@@ -46,6 +57,7 @@ export const QuestionEmbedWidget = (props: QuestionEmbedWidgetProps) => {
           onDeletePublicLink={deletePublicQuestionLink}
           onUpdateEnableEmbedding={updateQuestionEnableEmbedding}
           onUpdateEmbeddingParams={updateQuestionEmbeddingParams}
+          getPublicUrl={getPublicQuestionUrl}
         />
       )}
     </EmbedModal>


### PR DESCRIPTION
Epic #35961

Refactors the breaking tests to match the new redesigns. All of these tests account for the new modal now, using the helpers created in `e2e-embedding-helpers`