### PR TITLE
fix sending backport error message

### DIFF
--- a/.github/actions/notify-pull-request/action.yml
+++ b/.github/actions/notify-pull-request/action.yml
@@ -27,7 +27,7 @@ runs:
           }
 
           github.rest.issues.createComment({
-            issue_number: context.payload.number,
+            issue_number: context.payload.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
             body,


### PR DESCRIPTION
Right now it [breaks](https://github.com/metabase/metabase/actions/runs/7167473654/job/19513661473).