### PR TITLE
Fix uploading CSV columns with boolean and integer values

### DIFF
--- a/src/metabase/upload/parsing.clj
+++ b/src/metabase/upload/parsing.clj
@@ -120,7 +120,7 @@
               e)))))
 
 (defmulti upload-type->parser
-  "Returns a function for the given `metabase.upload` type that will parse a string value (from a CSV) into a value
+  "Returns a function for the given `metabase.upload` column type that will parse a string value (from a CSV) into a value
   suitable for insertion."
   {:arglists '([upload-type settings])}
   (fn [upload-type _]

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -176,12 +176,14 @@
            [" 2022-01-01T01:00:00.00Z "       (t/offset-date-time "2022-01-01T01:00+00:00") offset-dt-type]
            [" 2022-01-01t01:00:00.00Z "       (t/offset-date-time "2022-01-01T01:00+00:00") offset-dt-type]
            [" 2022-01-01 01:00:00.00Z "       (t/offset-date-time "2022-01-01T01:00+00:00") offset-dt-type]]]
-    (let [settings {:number-separators (or seps ".,")}
-          type     (#'upload/value->type string-value settings)
-          parser   (upload-parsing/upload-type->parser type settings)]
+    (let [settings   {:number-separators (or seps ".,")}
+          value-type (#'upload/value->type string-value settings)
+          ;; get the type of the column, if it were filled with only that value
+          col-type   (first (#'upload/column-types-from-rows settings 1 [[string-value]]))
+          parser     (upload-parsing/upload-type->parser col-type settings)]
       (testing (format "\"%s\" is a %s" string-value type)
         (is (= expected-type
-               type)))
+               value-type)))
       (testing (format "\"%s\" is parsed into %s" string-value expected-value)
         (is (= expected-value
                (parser string-value)))))))

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -26,15 +26,16 @@
 
 (set! *warn-on-reflection* true)
 
-(def ^:private bool-type      ::upload/boolean)
-(def ^:private int-type       ::upload/int)
-(def ^:private float-type     ::upload/float)
-(def ^:private vchar-type     ::upload/varchar-255)
-(def ^:private date-type      ::upload/date)
-(def ^:private datetime-type  ::upload/datetime)
-(def ^:private offset-dt-type ::upload/offset-datetime)
-(def ^:private text-type      ::upload/text)
-(def ^:private auto-pk-type ::upload/auto-incrementing-int-pk)
+(def ^:private bool-type        ::upload/boolean)
+(def ^:private int-type         ::upload/int)
+(def ^:private bool-or-int-type ::upload/boolean-or-int)
+(def ^:private float-type       ::upload/float)
+(def ^:private vchar-type       ::upload/varchar-255)
+(def ^:private date-type        ::upload/date)
+(def ^:private datetime-type    ::upload/datetime)
+(def ^:private offset-dt-type   ::upload/offset-datetime)
+(def ^:private text-type        ::upload/text)
+(def ^:private auto-pk-type     ::upload/auto-incrementing-int-pk)
 
 (defn- local-infile-on? []
   (= "ON" (-> (sql-jdbc.conn/db->pooled-connection-spec (mt/db))
@@ -113,6 +114,10 @@
            ["9,986,000"  9986000        int-type ".,"]
            ["9.986.000"  9986000        int-type ",."]
            ["9’986’000"  9986000        int-type ".’"]
+           ["$0"         0              int-type]
+           ["-1"         -1             int-type]
+           ["0"          false          bool-or-int-type]
+           ["1"          true           bool-or-int-type]
            ["9.986.000"  "9.986.000"    vchar-type ".,"]
            ["3.14"       3.14           float-type]
            ["3.14"       3.14           float-type "."]
@@ -182,31 +187,34 @@
                (parser string-value)))))))
 
 (deftest ^:parallel type-coalescing-test
-  (doseq [[type-a          type-b        expected]
-          [[bool-type      bool-type     bool-type]
-           [bool-type      int-type      int-type]
-           [bool-type      date-type     vchar-type]
-           [bool-type      datetime-type vchar-type]
-           [bool-type      vchar-type    vchar-type]
-           [bool-type      text-type     text-type]
-           [int-type       bool-type     int-type]
-           [int-type       float-type    float-type]
-           [int-type       date-type     vchar-type]
-           [int-type       datetime-type vchar-type]
-           [int-type       vchar-type    vchar-type]
-           [int-type       text-type     text-type]
-           [float-type     vchar-type    vchar-type]
-           [float-type     text-type     text-type]
-           [float-type     date-type     vchar-type]
-           [float-type     datetime-type vchar-type]
-           [date-type      datetime-type datetime-type]
-           [date-type      vchar-type    vchar-type]
-           [date-type      text-type     text-type]
-           [datetime-type  vchar-type    vchar-type]
-           [offset-dt-type vchar-type    vchar-type]
-           [datetime-type  text-type     text-type]
-           [offset-dt-type text-type     text-type]
-           [vchar-type     text-type     text-type]]]
+  (doseq [[type-a            type-b           expected]
+          [[bool-type        bool-type        bool-type]
+           [bool-type        int-type         vchar-type]
+           [bool-type        bool-or-int-type bool-type]
+           [bool-type        date-type        vchar-type]
+           [bool-type        datetime-type    vchar-type]
+           [bool-type        vchar-type       vchar-type]
+           [bool-type        text-type        text-type]
+           [int-type         bool-type        vchar-type]
+           [int-type         float-type       float-type]
+           [int-type         date-type        vchar-type]
+           [int-type         datetime-type    vchar-type]
+           [int-type         vchar-type       vchar-type]
+           [int-type         text-type        text-type]
+           [int-type         bool-or-int-type int-type]
+           [bool-or-int-type bool-or-int-type bool-or-int-type]
+           [float-type       vchar-type       vchar-type]
+           [float-type       text-type        text-type]
+           [float-type       date-type        vchar-type]
+           [float-type       datetime-type    vchar-type]
+           [date-type        datetime-type    datetime-type]
+           [date-type        vchar-type       vchar-type]
+           [date-type        text-type        text-type]
+           [datetime-type    vchar-type       vchar-type]
+           [offset-dt-type   vchar-type       vchar-type]
+           [datetime-type    text-type        text-type]
+           [offset-dt-type   text-type        text-type]
+           [vchar-type       text-type        text-type]]]
     (is (= expected (#'upload/lowest-common-ancestor type-a type-b))
         (format "%s + %s = %s" (name type-a) (name type-b) (name expected)))))
 
@@ -258,16 +266,26 @@
                                "Rey Skywalker, 170, 15"
                                "Darth Vader, 202.0, 41.9BBY"])))))
     (testing "Boolean coalescing"
-      (is (=? (with-ai-id {:name          vchar-type
-                           :is_jedi_      bool-type
-                           :is_jedi__int_ int-type
-                           :is_jedi__vc_  vchar-type})
+      (is (=? (with-ai-id {:name                    vchar-type
+                           :is_jedi_                bool-type
+                           :is_jedi__int_and_bools_ vchar-type
+                           :is_jedi__vc_            vchar-type})
               (@#'upload/detect-schema
-               (csv-file-with ["Name, Is Jedi?, Is Jedi (int), Is Jedi (VC)"
-                               "Rey Skywalker, yes, true, t"
-                               "Darth Vader, YES, TRUE, Y"
-                               "Grogu, 1, 9001, probably?"
-                               "Han Solo, no, FaLsE, 0"])))))
+               (csv-file-with ["         Name, Is Jedi?, Is Jedi (int and bools), Is Jedi (VC)"
+                               "Rey Skywalker,      yes,                    true,            t"
+                               "  Darth Vader,      YES,                    TRUE,            Y"
+                               "        Grogu,        1,                    9001,    probably?"
+                               "     Han Solo,       no,                   FaLsE,            0"])))))
+    (testing "Boolean and integers together"
+      (is (=? (with-ai-id {:vchar       vchar-type
+                           :bool        bool-type
+                           :bool_or_int bool-type})
+              (@#'upload/detect-schema
+               (csv-file-with ["vchar,bool,bool-or-int"
+                               " true,true,          1"
+                               "    1,   1,          0"
+                               "    2,   0,          0"
+                               "   no,  no,          1"])))))
     (testing "Order is ensured"
       (let [header "a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,zz,yy,xx,ww,vv,uu,tt,ss,rr,qq,pp,oo,nn,mm,ll,kk,jj,ii,hh,gg,ff,ee,dd,cc,bb,aa"]
         (is (= (map keyword (str/split header #","))
@@ -584,6 +602,31 @@
               (testing "Check the data was uploaded into the table correctly"
                 (is (= [@#'upload/auto-pk-column-name "unknown" "unknown_2" "unknown_3" "unknown_2_2"]
                        (column-names-for-table table)))))))))))
+
+(deftest load-from-csv-bool-and-int-test
+  (testing "Upload a CSV file with integers and booleans in the same column"
+    (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
+      (with-mysql-local-infile-on-and-off
+        (mt/with-empty-db
+          (@#'upload/load-from-csv!
+           driver/*driver*
+           (mt/id)
+           "upload_test"
+           (csv-file-with ["vchar,bool,bool-or-int"
+                           " true,true,          1"
+                           "    1,   1,          0"
+                           "    2,   0,          0"
+                           "   no,  no,          1"]))
+          (testing "Table and Fields exist after sync"
+            (sync/sync-database! (mt/db))
+            (let [table (t2/select-one Table :db_id (mt/id))]
+              (is (=? {:name #"(?i)upload_test"} table))
+              (testing "Check the data was uploaded into the table correctly"
+                (is (= [[1 " true" true true]
+                        [2 "    1" true false]
+                        [3 "    2" false false]
+                        [4 "   no" false true]]
+                       (rows-for-table table)))))))))))
 
 (deftest load-from-csv-existing-id-column-test
   (testing "Upload a CSV file with an existing ID column"

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -281,13 +281,14 @@
     (testing "Boolean and integers together"
       (is (=? (with-ai-id {:vchar       vchar-type
                            :bool        bool-type
-                           :bool_or_int bool-type})
+                           :bool_or_int bool-type
+                           :int         int-type})
               (@#'upload/detect-schema
-               (csv-file-with ["vchar,bool,bool-or-int"
-                               " true,true,          1"
-                               "    1,   1,          0"
-                               "    2,   0,          0"
-                               "   no,  no,          1"])))))
+               (csv-file-with ["vchar,bool,bool-or-int,int"
+                               " true,true,          1,  1"
+                               "    1,   1,          0,  0"
+                               "    2,   0,          0,  0"
+                               "   no,  no,          1,  2"])))))
     (testing "Order is ensured"
       (let [header "a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,zz,yy,xx,ww,vv,uu,tt,ss,rr,qq,pp,oo,nn,mm,ll,kk,jj,ii,hh,gg,ff,ee,dd,cc,bb,aa"]
         (is (= (map keyword (str/split header #","))
@@ -614,20 +615,20 @@
            driver/*driver*
            (mt/id)
            "upload_test"
-           (csv-file-with ["vchar,bool,bool-or-int"
-                           " true,true,          1"
-                           "    1,   1,          0"
-                           "    2,   0,          0"
-                           "   no,  no,          1"]))
+           (csv-file-with ["vchar,bool,bool-or-int,int"
+                           " true,true,          1,  1"
+                           "    1,   1,          0,  0"
+                           "    2,   0,          0,  0"
+                           "   no,  no,          1,  2"]))
           (testing "Table and Fields exist after sync"
             (sync/sync-database! (mt/db))
             (let [table (t2/select-one Table :db_id (mt/id))]
               (is (=? {:name #"(?i)upload_test"} table))
               (testing "Check the data was uploaded into the table correctly"
-                (is (= [[1 " true" true true]
-                        [2 "    1" true false]
-                        [3 "    2" false false]
-                        [4 "   no" false true]]
+                (is (= [[1 " true"  true true  1]
+                        [2 "    1"  true false 0]
+                        [3 "    2" false false 0]
+                        [4 "   no" false true  2]]
                        (rows-for-table table)))))))))))
 
 (deftest load-from-csv-existing-id-column-test


### PR DESCRIPTION
Fixes #36629 by making columns with boolean and integer values to be of the text type.

Now a CSV upload with a column like this will succeed:
```
some_column_name
2
true
false
no
yes
```

The column will have the base-type `:type/Text`.

### Implementation details

Fixing this bug required some pretty fundamental changes to the assumptions made by our schema detection code.

Read this change to the documentation first
 https://github.com/metabase/metabase/pull/36641/files#diff-af3188166dbf14ec61d196f0e71de90a50f7e2c9de2c152d7cd2e20c6af4051bR43-R70

**Before:**
1. all types of values correspond to a parse function, via `upload-type->parser`
2. types form a tree coercion hierarchy
```
;;              text
;;               |
;;               |
;;          varchar-255┐
;;              / \    │
;;             /   \   └──────────┬
;;            /     \             │
;;         float   datetime  offset-datetime
;;           │       │
;;           │       │
;;          int     date
;;         /   \
;;        /     \
;;    boolean auto-incrementing-int-pk
```

**Now:**
1. there is now a distinction between the types a column can take (column types), and the types of a single value (value types). Only valid column types correspond to a parse function via `upload-type->parser`. For example, `::boolean-or-int` is a valid value type, but not a valid column type.
2. types form a directed acyclic graph coercion hierarchy

```
;;              text
;;               |
;;               |
;;          varchar-255┐
;;        /     / \    │
;;       /     /   \   └──────────┬
;;      /     /     \             │
;;  boolean float   datetime  offset-datetime
;;     |     │       │
;;     │     │       │
;;     |    int     date
;;     |   /   \
;;     |  /     \
;;     | /       \
;;     |/         \
;; boolean-or-int  auto-incrementing-int-pk
```

Because our coercion hierarchy was limited to a tree structure, we had to make `boolean` as a subtype of `int` to allow "0" and "1" to be able to be coerced to both booleans and integers. But that's incorrect, because not all `boolean` values should be coerced to an `int`. Only `"0"` and `"1"` should be able to be coerced to `int`, not other values like "true" or "no". That lead to us incorrectly inferring the type of a column with integer values mixed with boolean values that are not "0" or "1" to be of type integer.

The solution is to make the coercion hierarchy a graph structure, where types can be coerced to more than one parent. Then "0" and "1" have a special type `boolean-or-int` that can be coerced as `boolean` if they are the only values in that column, and coerced as `int` if they are combined with other `int` values that aren't "0" or "1".

Example: If you have a CSV with one column:
```
some_column_name
1
2
true
```

The type detected for each value would have previously been: 
```
value | value type before | value type now
──────────────────────────────────────────
1     | boolean           | boolean-or-int
2     | int               | int
true  | boolean           | boolean
```

Before, the column would be of type `int`, because `int` is an ancestor of `boolean` in the coercion hierarchy. Now, the column would be of type `varchar-255`, because the lowest common ancestor of `boolean`, `boolean-or-int`, and `int`, is `varchar-255`.