### PR TITLE
[MLv2] Skip implicit joinability checks if there's no `:table-id`

### DIFF
--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -579,6 +579,7 @@
                        (-> (lib.metadata/field query fk-target-field-id)
                            (assoc ::source-field-id source-field-id
                                   ::source-join-alias (:metabase.lib.join/join-alias source)))))
+                (filter :table-id)
                 (remove #(contains? existing-table-ids (:table-id %)))
                 (mapcat (fn [{:keys [table-id], ::keys [source-field-id source-join-alias]}]
                           (let [table-metadata (lib.metadata/table query table-id)


### PR DESCRIPTION
This happens with native query columns that do not correspond to a real
field.
