### PR TITLE
[MLv2] `fk-filter` drills should not appear on native queries

### DIFF
--- a/src/metabase/lib/drill_thru/fk_filter.cljc
+++ b/src/metabase/lib/drill_thru/fk_filter.cljc
@@ -9,6 +9,8 @@
 
   - Selected column is `type/FK`
 
+  - Structured (MBQL) query
+
   - Return `columnName` and `tableName` for the FK column. On the FE we strip `ID` suffix and turn `Product ID` into
     `Product's` and pluralize the table name.
 
@@ -44,12 +46,11 @@
   (when (and column
              (some? value)
              (not= value :null)         ; If the FK is null, don't show this option.
+             (lib.drill-thru.common/mbql-stage? query stage-number)
              (not (lib.types.isa/primary-key? column))
              (lib.types.isa/foreign-key? column))
     (let [source (or (some->> query lib.util/source-table-id (lib.metadata/table query))
-                     (some->> query lib.util/source-card-id (lib.metadata/card query))
-                     ;; native query
-                     (lib.util/query-stage query 0))]
+                     (some->> query lib.util/source-card-id (lib.metadata/card query)))]
       {:lib/type :metabase.lib.drill-thru/drill-thru
        :type     :drill-thru/fk-filter
        :filter   (lib.options/ensure-uuid [:= {} (lib.ref/ref column) value])


### PR DESCRIPTION
They were added incorrectly in fixing #35689.

Fixes #36633.

