### PR TITLE
Prevent release artifacts colliding with test artifacts

### DIFF
--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -187,7 +187,7 @@ jobs:
     - name: Upload JARs as artifact
       uses: actions/upload-artifact@v3
       with:
-        name: metabase-${{ matrix.edition }}-${{ inputs.commit }}-uberjar
+        name: metabase-release-${{ matrix.edition }}-${{ inputs.commit }}-uberjar
         path: |
           ./metabase.jar
           ./COMMIT-ID

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -35,7 +35,7 @@ jobs:
             const artifacts = await github.rest.actions.listArtifactsForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: `metabase-${{ matrix.edition }}-${{ inputs.commit }}-uberjar`,
+              name: `metabase-release-${{ matrix.edition }}-${{ inputs.commit }}-uberjar`,
               per_page: 1,
             });
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/github-script@v6
       id: canonical_version
       with:
-        script: |
+        script: | # js
           const { isValidVersionString, getCanonicalVersion, hasBeenReleased } = require('${{ github.workspace }}/release/dist/index.cjs');
 
           const version = '${{ inputs.version }}';
@@ -83,13 +83,13 @@ jobs:
       uses: actions/github-script@v6
       with:
         result-encoding: string
-        script: |
+        script: | # js
           const fs = require('fs');
 
           const artifacts = await github.rest.actions.listArtifactsForRepo({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            name: `metabase-${{ matrix.edition }}-${{ inputs.commit }}-uberjar`,
+            name: `metabase-release-${{ matrix.edition }}-${{ inputs.commit }}-uberjar`,
             per_page: 1,
           });
 


### PR DESCRIPTION
### Description

When we build a jar for release, we save it in our github artifacts and then use it for the pre-release testing job as well as the publish job. We know we're getting the correct artifact because we save it in this format:
```
metabase-${{ matrix.edition }}-${{ inputs.commit }}-uberjar
```

Unfortunately, tests use this same format to save their artifacts, so if a test builds a jar from the same commit after the release jar is built, we'll get an untagged jar in our publish job, which we don't want to release. There are checks to prevent the wrong jar from being released, but really, we should prevent the name collision altogether.

this implements a new naming convention for the release artifacts:
```
metabase-release-${{ matrix.edition }}-${{ inputs.commit }}-uberjar
```


### How to verify

fork test :  ✅
- [build](https://github.com/iethree/metabase/actions/runs/7183272916)
- [test](https://github.com/iethree/metabase/actions/runs/7183428299)
- [publish](https://github.com/iethree/metabase/actions/runs/7184263662)
