### PR TITLE
HK in API client: move reversal of exponential delay list where it be…

### DIFF
--- a/frontend/src/metabase/lib/api.js
+++ b/frontend/src/metabase/lib/api.js
@@ -24,9 +24,9 @@ const DEFAULT_OPTIONS = {
   retryCount: MAX_RETRIES,
   // Creates an array with exponential backoff in millis
   // i.e. [1000, 2000, 4000, 8000...]
-  retryDelayIntervals: Array.from(new Array(MAX_RETRIES).keys()).map(
-    x => ONE_SECOND * Math.pow(2, x),
-  ),
+  retryDelayIntervals: new Array(MAX_RETRIES)
+    .fill(1)
+    .map((_, i) => ONE_SECOND * Math.pow(2, i)),
 };
 
 export class Api extends EventEmitter {

--- a/frontend/src/metabase/lib/api.js
+++ b/frontend/src/metabase/lib/api.js
@@ -24,9 +24,9 @@ const DEFAULT_OPTIONS = {
   retryCount: MAX_RETRIES,
   // Creates an array with exponential backoff in millis
   // i.e. [1000, 2000, 4000, 8000...]
-  retryDelayIntervals: Array.from(new Array(MAX_RETRIES).keys())
-    .map(x => ONE_SECOND * Math.pow(2, x))
-    .reverse(),
+  retryDelayIntervals: Array.from(new Array(MAX_RETRIES).keys()).map(
+    x => ONE_SECOND * Math.pow(2, x),
+  ),
 };
 
 export class Api extends EventEmitter {
@@ -132,8 +132,8 @@ export class Api extends EventEmitter {
   }
 
   async _makeRequestWithRetries(method, url, headers, body, data, options) {
-    // Get a copy of the delay intervals that we can remove items from as we retry
-    const retryDelays = options.retryDelayIntervals.slice();
+    // Get a copy of the delay intervals that we can pop items from as we retry
+    const retryDelays = options.retryDelayIntervals.slice().reverse();
     let retryCount = 0;
     // maxAttempts is the first attempt followed by the number of retries
     const maxAttempts = options.retryCount + 1;


### PR DESCRIPTION
I've been browsing the code and found a place where we create a list of [exponentially increasing request delays](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/lib/api.js#L27-L29) (standard stuff). However, we do at the same time `reverse()` the list, which confused me - like why would you use a 16 second delay first? 

I looked further and it turns out, we [create a copy of it](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/lib/api.js#L136) each time when we make a request and then pop[ items](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/lib/api.js#L156) from the list. That's why it's reversed. 

So the right place to do a reverse would be where it's sliced and popped, not where it is created. This PR applied the fix.