### PR TITLE
Clear error message when unable to decrypt encrypted json field

### DIFF
--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -228,14 +228,15 @@
 (defn encrypted-json-out
   "Deserialize encrypted json."
   [v]
-  (try
-    (-> v encryption/maybe-decrypt (json/parse-string true))
-    (catch Throwable e
-      (if (or (encryption/possibly-encrypted-string? v)
-              (encryption/possibly-encrypted-bytes? v))
-        (log/error e "Could not decrypt encrypted field! Have you forgot to set MB_ENCRYPTION_SECRET_KEY?")
-        (log/error e "Error parsing JSON"))  ; same message as in `json-out`
-      v)))
+  (let [decrypted (encryption/maybe-decrypt v)]
+    (try
+      (json/parse-string decrypted true)
+      (catch Throwable e
+        (if (or (encryption/possibly-encrypted-string? decrypted)
+                (encryption/possibly-encrypted-bytes? decrypted))
+          (log/error e "Could not decrypt encrypted field! Have you forgot to set MB_ENCRYPTION_SECRET_KEY?")
+          (log/error e "Error parsing JSON"))  ; same message as in `json-out`
+        v))))
 
 ;; cache the decryption/JSON parsing because it's somewhat slow (~500µs vs ~100µs on a *fast* computer)
 ;; cache the decrypted JSON for one hour

--- a/src/metabase/util/encryption.clj
+++ b/src/metabase/util/encryption.clj
@@ -154,9 +154,9 @@
                              args
                              (cons default-secret-key args))
         log-error-fn (fn [kind ^Throwable e]
-                       (log/errorf e
-                                   "Cannot decrypt encrypted %s. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
-                                   kind))]
+                       (log/warnf e
+                                  "Cannot decrypt encrypted %s. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
+                                  kind))]
 
     (cond (nil? secret-key)
           v

--- a/src/metabase/util/encryption.clj
+++ b/src/metabase/util/encryption.clj
@@ -147,20 +147,16 @@
   "If `MB_ENCRYPTION_SECRET_KEY` is set and `v` is encrypted, decrypt `v`; otherwise return `s` as-is. Attempts to check
   whether `v` is an encrypted String, in which case the decrypted String is returned, or whether `v` is encrypted bytes,
   in which case the decrypted bytes are returned."
-  {:arglists '([secret-key? s & [{:keys [log-errors?], :or {log-errors? true}}]])}
+  {:arglists '([secret-key? s])}
   [& args]
   ;; secret-key as an argument so that tests can pass it directly without using `with-redefs` to run in parallel
-  (let [[secret-key v options]     (if (and (bytes? (first args)) (string? (second args)))
-                                     args
-                                     (cons default-secret-key args))
-        {:keys [log-errors?]
-         :or   {log-errors? true}} options
+  (let [[secret-key v]     (if (and (bytes? (first args)) (string? (second args)))
+                             args
+                             (cons default-secret-key args))
         log-error-fn (fn [kind ^Throwable e]
-                       (when log-errors?
-                         (log/warn (trs "Cannot decrypt encrypted {0}. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
-                                     kind)
-                                   (.getMessage e)
-                                   (u/pprint-to-str (u/filtered-stacktrace e)))))]
+                       (log/errorf e
+                                   "Cannot decrypt encrypted %s. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
+                                   kind))]
 
     (cond (nil? secret-key)
           v

--- a/test/metabase/models/interface_test.clj
+++ b/test/metabase/models/interface_test.clj
@@ -8,9 +8,12 @@
    [metabase.models.field :refer [Field]]
    [metabase.models.interface :as mi]
    [metabase.models.table :refer [Table]]
+   [metabase.test.util.log :as tu.log]
    [metabase.util :as u]
+   [metabase.util.encryption :as encryption]
    [toucan2.core :as t2]
-   [toucan2.tools.with-temp :as t2.with-temp]))
+   [toucan2.tools.with-temp :as t2.with-temp])
+  (:import (com.fasterxml.jackson.core JsonParseException)))
 
 ;; let's make sure the `transform-metabase-query`/`transform-metric-segment-definition`/`transform-parameters-list`
 ;; normalization functions respond gracefully to invalid stuff when pulling them out of the Database. See #8914
@@ -130,3 +133,11 @@
                (migrate {:pie.show_legend          legend
                          :pie.show_legend_perecent percent
                          :pie.show_data_labels     labels})))))))
+
+(deftest encrypted-data-with-no-secret-test
+  (is (= {:a 1}
+         (mi/encrypted-json-out "{\"a\": 1}")))
+  (is (=? [[:error JsonParseException "Could not decrypt encrypted field! Have you forgot to set MB_ENCRYPTION_SECRET_KEY?"]]
+          (tu.log/with-log-messages-for-level :error
+            (mi/encrypted-json-out
+             (encryption/encrypt (encryption/secret-key->hash "qwe") "qwe"))))))

--- a/test/metabase/models/interface_test.clj
+++ b/test/metabase/models/interface_test.clj
@@ -148,4 +148,14 @@
     (is (=? [[:error JsonParseException "Could not decrypt encrypted field! Have you forgot to set MB_ENCRYPTION_SECRET_KEY?"]]
             (tu.log/with-log-messages-for-level :error
               (mi/encrypted-json-out
-               (encryption/encrypt (encryption/secret-key->hash "qwe") "{\"a\": 1}")))))))
+               (encryption/encrypt (encryption/secret-key->hash "qwe") "{\"a\": 1}"))))))
+
+  (testing "Invalid JSON throws correct error"
+    (is (=? [[:error JsonParseException "Error parsing JSON"]]
+            (tu.log/with-log-messages-for-level :error
+              (mi/encrypted-json-out "{\"a\": 1"))))
+    (is (=? [[:error JsonParseException "Error parsing JSON"]]
+            (tu.log/with-log-messages-for-level :error
+              (encryption-test/with-secret-key "qwe"
+                (mi/encrypted-json-out
+                 (encryption/encrypt (encryption/secret-key->hash "qwe") "{\"a\": 1"))))))))

--- a/test/metabase/models/interface_test.clj
+++ b/test/metabase/models/interface_test.clj
@@ -136,26 +136,26 @@
                          :pie.show_data_labels     labels})))))))
 
 (deftest encrypted-data-with-no-secret-test
-  (testing "Just parses string normally when there is no key and the string is JSON"
-    (is (= {:a 1}
-           (mi/encrypted-json-out "{\"a\": 1}"))))
-  (testing "Also parses string if it's encrypted and JSON"
-    (is (= {:a 1}
-           (encryption-test/with-secret-key "qwe"
-             (mi/encrypted-json-out
-              (encryption/encrypt (encryption/secret-key->hash "qwe") "{\"a\": 1}"))))))
-  (testing "Logs an error message when incoming data looks encrypted"
-    (is (=? [[:error JsonParseException "Could not decrypt encrypted field! Have you forgot to set MB_ENCRYPTION_SECRET_KEY?"]]
-            (tu.log/with-log-messages-for-level :error
-              (mi/encrypted-json-out
-               (encryption/encrypt (encryption/secret-key->hash "qwe") "{\"a\": 1}"))))))
-
-  (testing "Invalid JSON throws correct error"
-    (is (=? [[:error JsonParseException "Error parsing JSON"]]
-            (tu.log/with-log-messages-for-level :error
-              (mi/encrypted-json-out "{\"a\": 1"))))
-    (is (=? [[:error JsonParseException "Error parsing JSON"]]
-            (tu.log/with-log-messages-for-level :error
-              (encryption-test/with-secret-key "qwe"
+  (encryption-test/with-secret-key nil
+    (testing "Just parses string normally when there is no key and the string is JSON"
+      (is (= {:a 1}
+             (mi/encrypted-json-out "{\"a\": 1}"))))
+    (testing "Also parses string if it's encrypted and JSON"
+      (is (= {:a 1}
+             (encryption-test/with-secret-key "qwe"
+               (mi/encrypted-json-out
+                (encryption/encrypt (encryption/secret-key->hash "qwe") "{\"a\": 1}"))))))
+    (testing "Logs an error message when incoming data looks encrypted"
+      (is (=? [[:error JsonParseException "Could not decrypt encrypted field! Have you forgot to set MB_ENCRYPTION_SECRET_KEY?"]]
+              (tu.log/with-log-messages-for-level :error
                 (mi/encrypted-json-out
-                 (encryption/encrypt (encryption/secret-key->hash "qwe") "{\"a\": 1"))))))))
+                 (encryption/encrypt (encryption/secret-key->hash "qwe") "{\"a\": 1}"))))))
+    (testing "Invalid JSON throws correct error"
+      (is (=? [[:error JsonParseException "Error parsing JSON"]]
+              (tu.log/with-log-messages-for-level :error
+                (mi/encrypted-json-out "{\"a\": 1"))))
+      (is (=? [[:error JsonParseException "Error parsing JSON"]]
+              (tu.log/with-log-messages-for-level :error
+                (encryption-test/with-secret-key "qwe"
+                  (mi/encrypted-json-out
+                   (encryption/encrypt (encryption/secret-key->hash "qwe") "{\"a\": 1")))))))))

--- a/test/metabase/util/encryption_test.clj
+++ b/test/metabase/util/encryption_test.clj
@@ -88,7 +88,7 @@
   (some (fn [[level _ message]]
           (and (= level :warn)
                (str/includes? message (str "Cannot decrypt encrypted String. Have you changed or forgot to set "
-                                           "MB_ENCRYPTION_SECRET_KEY? Message seems corrupt or manipulated."))))
+                                           "MB_ENCRYPTION_SECRET_KEY?"))))
         log-messages))
 
 (deftest no-errors-for-unencrypted-test


### PR DESCRIPTION
I've changed `maybe-decrypt` signature to remove this fiddling with argument, since it's never passed a secret key in real code (not in tests).

This logic will not help with other encrypted fields, but they at least won't die with a non-understandable message about being unable to parse JSON. Even though this message is not reporting which model/field is encrypted, it at least guides you to a thought that you shouldn't serialize encrypted DB with no key.

Resolves #31553