### PR TITLE
Retry failed Cypress tests only once

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -132,7 +132,7 @@ const mainConfig = {
     toConsole: true,
   },
   retries: {
-    runMode: 2,
+    runMode: 1,
     openMode: 0,
   },
 };


### PR DESCRIPTION
This PR lowers the number of Cypress internal retries to only one attempt.